### PR TITLE
[src] Add a new ObjCRuntime.NativeHandle type to represent native handles for .NET. Fixes #13126.

### DIFF
--- a/dotnet/BreakingChanges.md
+++ b/dotnet/BreakingChanges.md
@@ -19,3 +19,25 @@ The `NMath` type moved from the `System` namespace to the `ObjCRuntime` namespac
 * Code that uses the `NMath` type won't compile unless the `ObjCRuntime` namespace is imported.
 
   Fix: add `using ObjCRuntime` to the file in question.
+
+## NSObject.Handle and INativeObject.Handle changed type from System.IntPtr to ObjCRuntime.NativeHandle
+
+The `NSObject.Handle` and `INativeObject.Handle` properties changed type from
+`System.IntPtr` to `ObjCRuntime.NativeHandle`. This also means that numerous
+other parameters and return values change type in the same way; most important
+are the constructors that previously took a `System.IntPtr`, or
+`System.IntPtr` + `bool`. Both variants now take a `ObjCRuntime.NativeHandle`
+instead.
+
+This is so that we can support API that take native-sized integers (`nint` /
+`nuint` - which map to `System.[U]IntPtr`) while at the same time have a
+different overload that takes a handle.
+
+The most common examples are constructors - all `NSObject` subclasses have a
+constructor that (now) take a single `ObjCRuntime.NativeHandle` parameter, and
+some types also need to expose a constructor that take a native-sized integer.
+For instance `NSMutableString` has a `nint capacity` constructor, which
+without this type change would be impossible to expose correctly.
+
+There are implicit conversions between `System.IntPtr` and
+`ObjCRuntime.NativeHandle`, so most code should compile without changes.

--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -1093,6 +1093,12 @@ xamarin_is_class_inativeobject (MonoClass *cls)
 }
 
 bool
+xamarin_is_class_nativehandle (MonoClass *cls)
+{
+	return xamarin_bridge_is_class_of_type (cls, XamarinLookupTypes_ObjCRuntime_NativeHandle);
+}
+
+bool
 xamarin_is_class_array (MonoClass *cls)
 {
 	return xamarin_bridge_is_class_of_type (cls, XamarinLookupTypes_System_Array);

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -34,6 +34,9 @@ static MonoClass* nsvalue_class = NULL;
 static MonoClass* nsnumber_class = NULL;
 static MonoClass* nsstring_class = NULL;
 static MonoClass* runtime_class = NULL;
+#if DOTNET
+static MonoClass* nativehandle_class = NULL;
+#endif
 
 #if !LEGACY_XAMARIN_MAC
 void
@@ -126,6 +129,9 @@ xamarin_bridge_call_runtime_initialize (struct InitializationOptions* options, G
 
 	runtime_class = get_class_from_name (platform_image, objcruntime, "Runtime");
 	inativeobject_class = get_class_from_name (platform_image, objcruntime, "INativeObject");
+#if DOTNET
+	nativehandle_class = get_class_from_name (platform_image, objcruntime, "NativeHandle");
+#endif
 	nsobject_class = get_class_from_name (platform_image, foundation, "NSObject");
 	nsnumber_class = get_class_from_name (platform_image, foundation, "NSNumber", true);
 	nsvalue_class = get_class_from_name (platform_image, foundation, "NSValue", true);
@@ -169,6 +175,16 @@ xamarin_get_inativeobject_class ()
 		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "INativeObject");
 	return inativeobject_class;
 }
+
+#if DOTNET
+MonoClass *
+xamarin_get_nativehandle_class ()
+{
+	if (nativehandle_class == NULL)
+		xamarin_assertion_message ("Internal consistency error, please file a bug (https://github.com/xamarin/xamarin-macios/issues/new). Additional data: can't get the %s class because it's been linked away.\n", "NativeHandle");
+	return nativehandle_class;
+}
+#endif
 
 MonoClass *
 xamarin_get_nsobject_class ()
@@ -314,6 +330,14 @@ xamarin_is_class_inativeobject (MonoClass *cls)
 
 	return mono_class_is_subclass_of (cls, xamarin_get_inativeobject_class (), true);
 }
+
+#if DOTNET
+bool
+xamarin_is_class_nativehandle (MonoClass *cls)
+{
+	return cls == xamarin_get_nativehandle_class ();
+}
+#endif
 
 bool
 xamarin_is_class_array (MonoClass *cls)

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -698,6 +698,15 @@ xamarin_check_for_gced_object (MonoObject *obj, SEL sel, id self, MonoMethod *me
 		return;
 	}
 	
+#if DOTNET
+	const char *m = "Failed to marshal the Objective-C object %p (type: %s). "
+	"Could not find an existing managed instance for this object, "
+	"nor was it possible to create a new managed instance "
+	"(because the type '%s' does not have a constructor that takes one NativeHandle argument).\n"
+	"Additional information:\n"
+	"\tSelector: %s\n"
+	"\tMethod: %s\n";
+#else
 	const char *m = "Failed to marshal the Objective-C object %p (type: %s). "
 	"Could not find an existing managed instance for this object, "
 	"nor was it possible to create a new managed instance "
@@ -705,6 +714,7 @@ xamarin_check_for_gced_object (MonoObject *obj, SEL sel, id self, MonoMethod *me
 	"Additional information:\n"
 	"\tSelector: %s\n"
 	"\tMethod: %s\n";
+#endif
 	
 	char *method_full_name = mono_method_full_name (method, TRUE);
 	char *type_name = xamarin_lookup_managed_type_name ([self class], exception_gchandle);

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -440,6 +440,13 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 						arg_ptrs [i + mofs] = &arg_frame [frameofs];
 						LOGZ (" argument %i is IntPtr: %p\n", i + 1, id_arg);
 						break;
+#if DOTNET
+					} else if (xamarin_is_class_nativehandle (p_klass)) {
+						arg_frame [ofs] = id_arg;
+						arg_ptrs [i + mofs] = &arg_frame [frameofs];
+						LOGZ (" argument %i is NativeHandle: %p\n", i + 1, id_arg);
+						break;
+#endif
 					} else if (!id_arg) {
 						arg_ptrs [i + mofs] = NULL;
 						break;

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -73,6 +73,7 @@ enum XamarinLookupTypes : int {
 	XamarinLookupTypes_Foundation_NSString,
 	XamarinLookupTypes_Foundation_NSValue,
 	XamarinLookupTypes_ObjCRuntime_INativeObject,
+	XamarinLookupTypes_ObjCRuntime_NativeHandle,
 };
 
 // Keep in sync with Runtime.ExceptionType in Runtime.CoreCLR.cs

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -165,6 +165,7 @@ void			xamarin_check_for_gced_object (MonoObject *obj, SEL sel, id self, MonoMet
 unsigned long 	xamarin_objc_type_size (const char *type);
 bool			xamarin_is_class_nsobject (MonoClass *cls);
 bool			xamarin_is_class_inativeobject (MonoClass *cls);
+bool			xamarin_is_class_nativehandle (MonoClass *cls);
 bool			xamarin_is_class_array (MonoClass *cls);
 bool			xamarin_is_class_nsnumber (MonoClass *cls);
 bool			xamarin_is_class_nsvalue (MonoClass *cls);
@@ -266,6 +267,7 @@ id				xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_i
 MonoType *		xamarin_get_nsnumber_type ();
 MonoType *		xamarin_get_nsvalue_type ();
 MonoClass *		xamarin_get_inativeobject_class ();
+MonoClass *		xamarin_get_nativehandle_class ();
 MonoClass *		xamarin_get_nsobject_class ();
 MonoClass *		xamarin_get_nsstring_class ();
 MonoClass *		xamarin_get_runtime_class ();

--- a/src/AVFoundation/AVAudioChannelLayout.cs
+++ b/src/AVFoundation/AVAudioChannelLayout.cs
@@ -32,7 +32,12 @@ namespace AVFoundation {
 		}
 
 		[DesignatedInitializer]
-		public AVAudioChannelLayout (AudioChannelLayout layout) : this ((nint) CreateLayoutPtr (layout))
+		public AVAudioChannelLayout (AudioChannelLayout layout)
+#if NET
+			: this (CreateLayoutPtr (layout))
+#else
+			: this ((nint) CreateLayoutPtr (layout))
+#endif
 		{
 			Marshal.FreeHGlobal (handleToLayout);
 		}

--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -235,6 +235,7 @@ namespace AVFoundation {
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		protected internal AVAssetDownloadDelegate (IntPtr handle)
+			: base (handle)
 		{
 			throw new NotImplementedException ();
 		}

--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -8,6 +8,10 @@ using Foundation;
 using ObjCRuntime;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AVFoundation {
 #if !XAMCORE_4_0
 	public delegate int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioToolbox.AudioBuffers outputData);
@@ -42,7 +46,7 @@ namespace AVFoundation {
 			throw new PlatformNotSupportedException ();
 		}
 
-		protected internal AVCaptureDataOutputSynchronizer (IntPtr handle) : base (handle)
+		protected internal AVCaptureDataOutputSynchronizer (NativeHandle handle) : base (handle)
 		{
 			throw new PlatformNotSupportedException ();
 		}
@@ -102,7 +106,7 @@ namespace AVFoundation {
 			throw new PlatformNotSupportedException ();
 		}
 
-		protected internal AVCaptureDataOutputSynchronizerDelegate (IntPtr handle) : base (handle)
+		protected internal AVCaptureDataOutputSynchronizerDelegate (NativeHandle handle) : base (handle)
 		{
 			throw new PlatformNotSupportedException ();
 		}
@@ -234,7 +238,7 @@ namespace AVFoundation {
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		protected internal AVAssetDownloadDelegate (IntPtr handle)
+		protected internal AVAssetDownloadDelegate (NativeHandle handle)
 			: base (handle)
 		{
 			throw new NotImplementedException ();
@@ -385,7 +389,7 @@ namespace AVFoundation {
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		protected internal AVAssetDownloadTask (IntPtr handle)
+		protected internal AVAssetDownloadTask (NativeHandle handle)
 		{
 			throw new NotImplementedException ();
 		}
@@ -413,7 +417,7 @@ namespace AVFoundation {
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		protected internal AVAssetDownloadUrlSession (IntPtr handle) : base (handle)
+		protected internal AVAssetDownloadUrlSession (NativeHandle handle) : base (handle)
 		{
 			throw new NotImplementedException ();
 		}
@@ -615,7 +619,7 @@ namespace AVFoundation {
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		protected internal AVPlayerInterstitialEventObserver (IntPtr handle) : base (handle) => throw new NotImplementedException ();
+		protected internal AVPlayerInterstitialEventObserver (NativeHandle handle) : base (handle) => throw new NotImplementedException ();
 
 		[DesignatedInitializer]
 		[BindingImpl (BindingImplOptions.Optimizable)]

--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -35,7 +35,7 @@ namespace AVFoundation {
 	[Obsolete ("This API is not available on this platform.")]
 	public partial class AVCaptureDataOutputSynchronizer : NSObject
 	{
-		public override IntPtr ClassHandle { get { throw new PlatformNotSupportedException (); } }
+		public override NativeHandle ClassHandle { get { throw new PlatformNotSupportedException (); } }
 
 		protected AVCaptureDataOutputSynchronizer (NSObjectFlag t) : base (t)
 		{
@@ -330,7 +330,7 @@ namespace AVFoundation {
 #endif
 	public class AVAssetDownloadTask : NSUrlSessionTask {
 
-		public override IntPtr ClassHandle {
+		public override NativeHandle ClassHandle {
 			get {
 				throw new NotImplementedException ();
 			}
@@ -406,7 +406,7 @@ namespace AVFoundation {
 			}
 		}
 
-		public override IntPtr ClassHandle {
+		public override NativeHandle ClassHandle {
 			get {
 				throw new NotImplementedException ();
 			}
@@ -607,7 +607,7 @@ namespace AVFoundation {
 		
 		public virtual AVPlayerInterstitialEvent[] InterstitialEvents => throw new NotImplementedException ();
 
-		public override IntPtr ClassHandle => throw new NotImplementedException ();
+		public override NativeHandle ClassHandle => throw new NotImplementedException ();
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]

--- a/src/AddressBook/ABAddressBook.cs
+++ b/src/AddressBook/ABAddressBook.cs
@@ -41,6 +41,10 @@ using Foundation;
 using CoreFoundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AddressBook {
 #if !NET
 	[Deprecated (PlatformName.iOS, 9, 0, message : "Use the 'Contacts' API instead.")]
@@ -162,7 +166,7 @@ namespace AddressBook {
 			return new ABAddressBook (handle, true);
 		}
 			
-		internal ABAddressBook (IntPtr handle, bool owns)
+		internal ABAddressBook (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 			InitConstants.Init ();

--- a/src/AddressBook/ABGroup.cs
+++ b/src/AddressBook/ABGroup.cs
@@ -40,6 +40,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AddressBook {
 	static class ABGroupProperty {
 
@@ -93,12 +97,12 @@ namespace AddressBook {
 			Handle = ABGroupCreateInSource (source.Handle);
 		}
 
-		internal ABGroup (IntPtr handle, bool owns)
+		internal ABGroup (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
 
-		internal ABGroup (IntPtr handle, ABAddressBook addressbook)
+		internal ABGroup (NativeHandle handle, ABAddressBook addressbook)
         	: base (handle, false)
 		{
 			AddressBook = addressbook;

--- a/src/AddressBook/ABMultiValue.cs
+++ b/src/AddressBook/ABMultiValue.cs
@@ -41,6 +41,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AddressBook {
 
 #if !NET
@@ -215,7 +219,7 @@ namespace AddressBook {
 		internal Converter<IntPtr, T> toManaged;
 		internal Converter<T, IntPtr> toNative;
 
-		internal ABMultiValue (IntPtr handle, bool owns)
+		internal ABMultiValue (NativeHandle handle, bool owns)
 			: this (handle, 
 					v => (T) (object) Runtime.GetNSObject (v)!,
 					v => ((INativeObject?) v).GetHandle (), owns)
@@ -224,7 +228,7 @@ namespace AddressBook {
 				throw new InvalidOperationException ("T must be an NSObject!");
 		}
 
-		internal ABMultiValue (IntPtr handle, Converter<IntPtr, T> toManaged, Converter<T, IntPtr> toNative, bool owns)
+		internal ABMultiValue (NativeHandle handle, Converter<IntPtr, T> toManaged, Converter<T, IntPtr> toNative, bool owns)
 			: base (handle, owns)
 		{
 			if (toManaged is null)
@@ -311,12 +315,12 @@ namespace AddressBook {
 #endif
 	public class ABMutableMultiValue<T> : ABMultiValue<T>
 	{
-		internal ABMutableMultiValue (IntPtr handle, bool owns)
+		internal ABMutableMultiValue (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
 
-		internal ABMutableMultiValue (IntPtr handle, Converter<IntPtr, T> toManaged, Converter<T, IntPtr> toNative)
+		internal ABMutableMultiValue (NativeHandle handle, Converter<IntPtr, T> toManaged, Converter<T, IntPtr> toNative)
 			: base (handle, toManaged, toNative, false)
 		{
 		}

--- a/src/AddressBook/ABPerson.cs
+++ b/src/AddressBook/ABPerson.cs
@@ -41,6 +41,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AddressBook {
 
 #if !NET
@@ -617,12 +621,12 @@ namespace AddressBook {
 		{
 		}
 
-		internal ABPerson (IntPtr handle, bool owns)
+		internal ABPerson (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
 
-		internal ABPerson (IntPtr handle, ABAddressBook? addressbook)
+		internal ABPerson (NativeHandle handle, ABAddressBook? addressbook)
 			: base (handle, false)
 		{
 			AddressBook = addressbook;

--- a/src/AddressBook/ABRecord.cs
+++ b/src/AddressBook/ABRecord.cs
@@ -39,6 +39,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AddressBook {
 
 #if !NET
@@ -61,7 +65,7 @@ namespace AddressBook {
 		public const int InvalidPropertyId = -1;
 
 		[Preserve (Conditional = true)]
-		internal ABRecord (IntPtr handle, bool owns)
+		internal ABRecord (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/AddressBook/ABSource.cs
+++ b/src/AddressBook/ABSource.cs
@@ -37,6 +37,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AddressBook {
 	
 #if !NET
@@ -54,12 +58,12 @@ namespace AddressBook {
 #endif
 #endif
 	public class ABSource : ABRecord {
-		internal ABSource (IntPtr handle, bool owns)
+		internal ABSource (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
 		
-		internal ABSource (IntPtr handle, ABAddressBook addressbook)
+		internal ABSource (NativeHandle handle, ABAddressBook addressbook)
 			: base (handle, false)
 		{
 			AddressBook = addressbook;

--- a/src/AppKit/NSGradient.cs
+++ b/src/AppKit/NSGradient.cs
@@ -73,11 +73,19 @@ namespace AppKit {
 			var nsa_colorArray = NSArray.FromNSObjects (colors);
 			
 			IntPtr locations = new IntPtr (locationPtr);
+#if NET
+			if (IsDirectBinding) {
+				Handle = ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle_NativeHandle_NativeHandle (this.Handle, selInitWithColorsAtLocationsColorSpace, nsa_colorArray.Handle, locations, colorSpace.Handle);
+			} else {
+				Handle = ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle_NativeHandle_NativeHandle (this.SuperHandle, selInitWithColorsAtLocationsColorSpace, nsa_colorArray.Handle, locations, colorSpace.Handle);
+			}
+#else
 			if (IsDirectBinding) {
 				Handle = ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr (this.Handle, selInitWithColorsAtLocationsColorSpace, nsa_colorArray.Handle, locations, colorSpace.Handle);
 			} else {
 				Handle = ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper_IntPtr_IntPtr_IntPtr (this.SuperHandle, selInitWithColorsAtLocationsColorSpace, nsa_colorArray.Handle, locations, colorSpace.Handle);
 			}
+#endif
 			nsa_colorArray.Dispose ();
 		}
 	}

--- a/src/AudioToolbox/AudioBuffers.cs
+++ b/src/AudioToolbox/AudioBuffers.cs
@@ -34,6 +34,10 @@ using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AudioToolbox
 {
 	// CoreAudio.framework - CoreAudioTypes.h
@@ -126,7 +130,7 @@ namespace AudioToolbox
 			}
 		}
 
-		public IntPtr Handle {
+		public NativeHandle Handle {
 			get { return address; }
 		}
 

--- a/src/AudioToolbox/AudioConverter.cs
+++ b/src/AudioToolbox/AudioConverter.cs
@@ -34,6 +34,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AudioToolbox
 {
 	public enum AudioConverterError // Impliclty cast to OSStatus in AudioConverter.h
@@ -98,7 +102,7 @@ namespace AudioToolbox
 
 		public event AudioConverterComplexInputData? InputData;
 
-		internal AudioConverter (IntPtr handle, bool owns)
+		internal AudioConverter (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/AudioToolbox/AudioFile.cs
+++ b/src/AudioToolbox/AudioFile.cs
@@ -43,6 +43,10 @@ using Foundation;
 using OSStatus = System.Int32;
 using AudioFileID = System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AudioToolbox {
 
 	public enum AudioFileType {  // UInt32 AudioFileTypeID
@@ -561,7 +565,7 @@ namespace AudioToolbox {
 		}
 #endif
 
-		internal AudioFile (IntPtr handle, bool owns)
+		internal AudioFile (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/AudioToolbox/AudioSession.cs
+++ b/src/AudioToolbox/AudioSession.cs
@@ -544,7 +544,7 @@ namespace AudioToolbox {
 			} else if (val == InputRoute_USBAudio) {
 				return AudioSessionInputRouteKind.USBAudio;
 			} else {
-				return (AudioSessionInputRouteKind) val.Handle;
+				return (AudioSessionInputRouteKind) (int) (IntPtr) val.Handle;
 			}
 		}
 
@@ -586,7 +586,7 @@ namespace AudioToolbox {
 				} else if (val == OutputRoute_AirPlay) {
 					result [i] = AudioSessionOutputRouteKind.AirPlay;
 				} else
-					result [i] = (AudioSessionOutputRouteKind) val.Handle;
+					result [i] = (AudioSessionOutputRouteKind) (int) (IntPtr) val.Handle;
 			}
 			return result;
 		}

--- a/src/AudioToolbox/MusicPlayer.cs
+++ b/src/AudioToolbox/MusicPlayer.cs
@@ -18,6 +18,10 @@ using System.Runtime.InteropServices;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AudioToolbox {
 
 	// untyped enum (used as an OSStatus in the API) -> MusicPlayer.h
@@ -79,7 +83,7 @@ namespace AudioToolbox {
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static /* OSStatus */ MusicPlayerStatus DisposeMusicPlayer (/* MusicPlayer */ IntPtr inPlayer);
 							      
-		MusicPlayer (IntPtr handle, bool owns)
+		MusicPlayer (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/AudioToolbox/MusicSequence.cs
+++ b/src/AudioToolbox/MusicSequence.cs
@@ -27,6 +27,10 @@ using AudioUnit;
 
 using MidiEndpointRef = System.Int32;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AudioToolbox {
 
 #if !COREBUILD
@@ -39,7 +43,7 @@ namespace AudioToolbox {
 	public class MusicSequence : DisposableObject
 	{
 #if !COREBUILD
-		internal MusicSequence (IntPtr handle, bool owns)
+		internal MusicSequence (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/AudioUnit/AUGraph.cs
+++ b/src/AudioUnit/AUGraph.cs
@@ -43,6 +43,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AudioUnit
 {
 	public enum AUGraphError // Implictly cast to OSType
@@ -76,7 +80,7 @@ namespace AudioUnit
 		readonly GCHandle gcHandle;
 
 		[Preserve (Conditional = true)]
-		internal AUGraph (IntPtr handle, bool owns)
+		internal AUGraph (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 			gcHandle = GCHandle.Alloc (this);

--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -47,6 +47,10 @@ using UIImage=AppKit.NSImage;
 #endif
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AudioUnit
 {
 
@@ -231,7 +235,7 @@ namespace AudioUnit
 
 	public class AudioComponent : DisposableObject {
 #if !COREBUILD
-		internal AudioComponent (IntPtr handle, bool owns)
+		internal AudioComponent (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{ 
 		}

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1010,7 +1010,7 @@ namespace AudioUnit
 	{
 		AURenderEvent *current;
 
-		public IntPtr Handle { get; private set; }
+		public NativeHandle Handle { get; private set; }
 		public bool IsEmpty { get { return Handle == IntPtr.Zero; } }
 		public bool IsAtEnd { get { return current is null; }}
 
@@ -1022,18 +1022,18 @@ namespace AudioUnit
 		internal AURenderEventEnumerator (IntPtr handle, bool owns)
 		{
 			Handle = handle;
-			current = (AURenderEvent *) handle;
+			current = (AURenderEvent *) (IntPtr) handle;
 		}
 
 		public void Dispose ()
 		{
-			Handle = IntPtr.Zero;
+			Handle = NativeHandle.Zero;
 			current = null;
 		}
 
 		public AURenderEvent * UnsafeFirst {
 			get {
-				return (AURenderEvent*) Handle;
+				return (AURenderEvent*) (IntPtr) Handle;
 			}
 		}
 
@@ -1041,7 +1041,7 @@ namespace AudioUnit
 			get {
 				if (IsEmpty)
 					throw new InvalidOperationException ("Can not get First on AURenderEventEnumerator when empty");
-				return *(AURenderEvent *) Handle;
+				return *(AURenderEvent *) (IntPtr) Handle;
 			}
 		}
 
@@ -1083,7 +1083,7 @@ namespace AudioUnit
 
 		public void /*IEnumerator<AURenderEvent>.*/Reset ()
 		{
-			current = (AURenderEvent *) Handle;
+			current = (AURenderEvent *) (IntPtr) Handle;
 		}
 	}
 #endif // !COREBUILD

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -836,6 +836,12 @@ namespace AudioUnit
 		static extern AudioUnitStatus AudioUnitSetProperty (IntPtr inUnit, AudioUnitPropertyIDType inID, AudioUnitScopeType inScope, uint inElement,
 						       ref IntPtr inData, int inDataSize);
 
+#if NET
+		[DllImport (Constants.AudioUnitLibrary)]
+		static extern AudioUnitStatus AudioUnitSetProperty (IntPtr inUnit, AudioUnitPropertyIDType inID, AudioUnitScopeType inScope, uint inElement,
+							   ref NativeHandle inData, int inDataSize);
+#endif
+
 		[DllImport(Constants.AudioUnitLibrary)]
 		static extern AudioUnitStatus AudioUnitSetProperty (IntPtr inUnit, AudioUnitPropertyIDType inID, AudioUnitScopeType inScope, uint inElement,
 						       ref AURenderCallbackStruct inData, int inDataSize);

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -42,6 +42,10 @@ using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AudioUnit
 {
 #if !COREBUILD
@@ -309,7 +313,7 @@ namespace AudioUnit
 		Dictionary<uint, RenderDelegate>? renderer;
 		Dictionary<uint, InputDelegate>? inputs;
 
-		internal AudioUnit (IntPtr handle, bool owns)
+		internal AudioUnit (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -1014,12 +1018,12 @@ namespace AudioUnit
 		public bool IsEmpty { get { return Handle == IntPtr.Zero; } }
 		public bool IsAtEnd { get { return current is null; }}
 
-		public AURenderEventEnumerator (IntPtr ptr)
+		public AURenderEventEnumerator (NativeHandle ptr)
 			: this (ptr, false)
 		{
 		}
 
-		internal AURenderEventEnumerator (IntPtr handle, bool owns)
+		internal AURenderEventEnumerator (NativeHandle handle, bool owns)
 		{
 			Handle = handle;
 			current = (AURenderEvent *) (IntPtr) handle;

--- a/src/CFNetwork/CFHTTPAuthentication.cs
+++ b/src/CFNetwork/CFHTTPAuthentication.cs
@@ -16,6 +16,10 @@ using Foundation;
 using CoreFoundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 // CFHTTPAuthentication is in CFNetwork.framework, no idea why it ended up in CoreServices when it was bound.
 #if XAMCORE_4_0
 namespace CFNetwork {
@@ -24,7 +28,7 @@ namespace CoreServices {
 #endif
 
 	public class CFHTTPAuthentication : CFType {
-		internal CFHTTPAuthentication (IntPtr handle, bool owns)
+		internal CFHTTPAuthentication (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -19,6 +19,10 @@ using Foundation;
 using CoreFoundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 // CFHTTPMessage is in CFNetwork.framework, no idea why it ended up in CoreServices when it was bound.
 #if XAMCORE_4_0
 namespace CFNetwork {
@@ -27,7 +31,7 @@ namespace CoreServices {
 #endif
 
 	public partial class CFHTTPMessage : CFType {
-		internal CFHTTPMessage (IntPtr handle, bool owns)
+		internal CFHTTPMessage (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CFNetwork/CFHTTPStream.cs
+++ b/src/CFNetwork/CFHTTPStream.cs
@@ -15,6 +15,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 // CFHttpStream is in CFNetwork.framework, no idea why it ended up in CoreServices when it was bound.
 #if XAMCORE_4_0
 namespace CFNetwork {
@@ -30,7 +34,7 @@ namespace CoreServices {
 #endif
 	public partial class CFHTTPStream : CFReadStream {
 
-		internal CFHTTPStream (IntPtr handle, bool owns)
+		internal CFHTTPStream (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CFNetwork/CFHost.cs
+++ b/src/CFNetwork/CFHost.cs
@@ -17,6 +17,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 // CFHost is in CFNetwork.framework, no idea why it ended up in CoreServices when it was bound.
 #if XAMCORE_4_0
 namespace CFNetwork {
@@ -46,7 +50,7 @@ namespace CoreServices {
 #endif
 #endif
 	class CFHost : NativeObject {
-		internal CFHost (IntPtr handle, bool owns)
+		internal CFHost (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CarPlay/CPCompat.cs
+++ b/src/CarPlay/CPCompat.cs
@@ -13,6 +13,10 @@ using ObjCRuntime;
 using System.ComponentModel;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #if !XAMCORE_4_0
 namespace CarPlay {
 	[Register (SkipRegistration = true)]
@@ -32,11 +36,11 @@ namespace CarPlay {
 
 		protected CPEntity (NSObjectFlag t) => throw new NotSupportedException ();
 
-		protected internal CPEntity (IntPtr handle) => throw new NotSupportedException ();
+		protected internal CPEntity (NativeHandle handle) : base (handle) => throw new NotSupportedException ();
 
 		public virtual void EncodeTo (NSCoder encoder) => throw new NotSupportedException ();
 
-		public override IntPtr ClassHandle => throw new NotSupportedException ();
+		public override NativeHandle ClassHandle => throw new NotSupportedException ();
 	}
 }
 #endif

--- a/src/CloudKit/CKCompat.cs
+++ b/src/CloudKit/CKCompat.cs
@@ -13,6 +13,10 @@ using CloudKit;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CloudKit {
 
 #if !XAMCORE_4_0
@@ -119,7 +123,7 @@ namespace CloudKit {
 			=> throw new NotSupportedException ();
 
 		[Obsolete ("Always throws 'NotSupportedException' (not a public API).")]
-		protected CKDiscoverUserInfosOperation (IntPtr handle)
+		protected CKDiscoverUserInfosOperation (NativeHandle handle)
 			=> throw new NotSupportedException ();
 
 #if !NET

--- a/src/CloudKit/CKCompat.cs
+++ b/src/CloudKit/CKCompat.cs
@@ -140,7 +140,7 @@ namespace CloudKit {
 
 #pragma warning disable CS0809
 		[Obsolete ("Empty stub (not a public API).")]
-		public override IntPtr ClassHandle { get; }
+		public override NativeHandle ClassHandle { get; }
 #pragma warning restore CS0809
 	}
 #endif

--- a/src/CoreFoundation/CFAllocator.cs
+++ b/src/CoreFoundation/CFAllocator.cs
@@ -34,6 +34,10 @@ using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {	
 
 	// CFBase.h
@@ -49,16 +53,16 @@ namespace CoreFoundation {
 
 #if !NET
 		[Obsolete ("Use the overload that takes a 'bool owns' parameter instead.")]
-		public CFAllocator (IntPtr handle)
+		public CFAllocator (NativeHandle handle)
 			: base (handle, true /* backwards compatibility means we have to pass true here as opposed to the general pattern */)
 		{
 		}
 #endif
 
 #if NET
-		internal CFAllocator (IntPtr handle, bool owns)
+		internal CFAllocator (NativeHandle handle, bool owns)
 #else
-		public CFAllocator (IntPtr handle, bool owns)
+		public CFAllocator (NativeHandle handle, bool owns)
 #endif
 			: base (handle, owns)
 		{

--- a/src/CoreFoundation/CFArray.cs
+++ b/src/CoreFoundation/CFArray.cs
@@ -40,20 +40,24 @@ using CFAllocatorRef = System.IntPtr;
 
 #nullable enable
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 	
 	// interesting bits: https://github.com/opensource-apple/CF/blob/master/CFArray.c
 	public partial class CFArray : NativeObject {
 
 #if !NET
-		internal CFArray (IntPtr handle)
+		internal CFArray (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional = true)]
-		internal CFArray (IntPtr handle, bool owns)
+		internal CFArray (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFBoolean.cs
+++ b/src/CoreFoundation/CFBoolean.cs
@@ -34,12 +34,16 @@ using System.Runtime.InteropServices;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	// CFNumber.h
 	partial class CFBoolean : NativeObject {
 		[Preserve (Conditional = true)]
-		internal CFBoolean (IntPtr handle, bool owns)
+		internal CFBoolean (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFBundle.cs
+++ b/src/CoreFoundation/CFBundle.cs
@@ -12,6 +12,10 @@ using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	public partial class CFBundle : NativeObject {
@@ -33,7 +37,7 @@ namespace CoreFoundation {
 			public string Creator { get; private set; }
 		}
 
-		internal CFBundle (IntPtr handle, bool owns)
+		internal CFBundle (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFData.cs
+++ b/src/CoreFoundation/CFData.cs
@@ -33,10 +33,14 @@ using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	class CFData : NativeObject {
-		internal CFData (IntPtr handle, bool owns)
+		internal CFData (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFDictionary.cs
+++ b/src/CoreFoundation/CFDictionary.cs
@@ -35,13 +35,17 @@ using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	class CFDictionary : NativeObject {
 		public static IntPtr KeyCallbacks;
 		public static IntPtr ValueCallbacks;
 
-		internal CFDictionary (IntPtr handle, bool owns)
+		internal CFDictionary (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFMachPort.cs
+++ b/src/CoreFoundation/CFMachPort.cs
@@ -16,6 +16,10 @@ using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation
 {
 
@@ -41,15 +45,15 @@ namespace CoreFoundation
 		delegate void CFMachPortCallBack (IntPtr cfmachport, IntPtr msg, nint len, IntPtr context);
 
 #if !NET
-		public CFMachPort (IntPtr handle) : base (handle, false)
+		public CFMachPort (NativeHandle handle) : base (handle, false)
 		{
 		}
 #endif
 
 #if NET
-		internal CFMachPort (IntPtr handle, bool owns)
+		internal CFMachPort (NativeHandle handle, bool owns)
 #else
-		public CFMachPort (IntPtr handle, bool owns)
+		public CFMachPort (NativeHandle handle, bool owns)
 #endif
 			: base (handle, owns)
 		{

--- a/src/CoreFoundation/CFMessagePort.cs
+++ b/src/CoreFoundation/CFMessagePort.cs
@@ -18,6 +18,10 @@ using ObjCRuntime;
 
 using dispatch_queue_t = System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	// untyped enum from CFMessagePort.h
@@ -132,7 +136,7 @@ namespace CoreFoundation {
 		}
 
 		[Preserve (Conditional = true)]
-		internal CFMessagePort (IntPtr handle, bool owns)
+		internal CFMessagePort (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFMutableString.cs
+++ b/src/CoreFoundation/CFMutableString.cs
@@ -8,12 +8,16 @@ using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 	
 	public class CFMutableString : CFString {
 
 #if !NET
-		protected CFMutableString (IntPtr handle)
+		protected CFMutableString (NativeHandle handle)
 			: this (handle, false)
 		{
 		}
@@ -21,9 +25,9 @@ namespace CoreFoundation {
 		
 		[Preserve (Conditional = true)]
 #if NET
-		internal CFMutableString (IntPtr handle, bool owns)
+		internal CFMutableString (NativeHandle handle, bool owns)
 #else
-		protected CFMutableString (IntPtr handle, bool owns)
+		protected CFMutableString (NativeHandle handle, bool owns)
 #endif
 			: base (handle, owns)
 		{

--- a/src/CoreFoundation/CFNotificationCenter.cs
+++ b/src/CoreFoundation/CFNotificationCenter.cs
@@ -21,6 +21,10 @@ using Foundation;
 using CoreFoundation;
 using System.Collections.Generic;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	[Native] // CFIndex
@@ -54,7 +58,7 @@ namespace CoreFoundation {
 	
 	public class CFNotificationCenter : NativeObject {
 		// If this becomes public for some reason, and more than three instances are created, you should revisit the lookup code
-		internal CFNotificationCenter (CFNotificationCenterRef handle, bool owns)
+		internal CFNotificationCenter (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFPropertyList.cs
+++ b/src/CoreFoundation/CFPropertyList.cs
@@ -14,6 +14,10 @@ using System.Runtime.InteropServices;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation
 {
 	public class CFPropertyList : NativeObject
@@ -35,16 +39,16 @@ namespace CoreFoundation
 		static nint CFNumberTypeID = CFNumberGetTypeID ();
 
 #if NET
-		internal CFPropertyList (IntPtr handle, bool owns)
+		internal CFPropertyList (NativeHandle handle, bool owns)
 #else
-		public CFPropertyList (IntPtr handle, bool owns)
+		public CFPropertyList (NativeHandle handle, bool owns)
 #endif
 			: base (handle, owns)
 		{
 		}
 
 #if !NET
-		public CFPropertyList (IntPtr handle) : this (handle, false)
+		public CFPropertyList (NativeHandle handle) : this (handle, false)
 		{
 		}
 #endif

--- a/src/CoreFoundation/CFReadStream.cs
+++ b/src/CoreFoundation/CFReadStream.cs
@@ -37,18 +37,22 @@ using ObjCRuntime;
 
 using CFIndex = System.nint;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	// CFStream.h
 	public class CFReadStream : CFStream {
 #if !NET
-		public CFReadStream (IntPtr handle)
+		public CFReadStream (NativeHandle handle)
 			: base (handle, true)
 		{
 		}
 #endif
 
-		internal CFReadStream (IntPtr handle, bool owns)
+		internal CFReadStream (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFRunLoop.cs
+++ b/src/CoreFoundation/CFRunLoop.cs
@@ -38,6 +38,10 @@ using Foundation;
 
 using CFIndex = System.nint;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	// anonymous and typeless native enum - System/Library/Frameworks/CoreFoundation.framework/Headers/CFRunLoop.h
@@ -65,16 +69,16 @@ namespace CoreFoundation {
 
 	public class CFRunLoopSource : NativeObject {
 #if !NET
-		public CFRunLoopSource (IntPtr handle)
+		public CFRunLoopSource (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 #if NET
-		internal CFRunLoopSource (IntPtr handle, bool owns)
+		internal CFRunLoopSource (NativeHandle handle, bool owns)
 #else
-		public CFRunLoopSource (IntPtr handle, bool owns)
+		public CFRunLoopSource (NativeHandle handle, bool owns)
 #endif
 			: base (handle, owns)
 		{
@@ -309,7 +313,7 @@ namespace CoreFoundation {
 		}
 
 		[Preserve (Conditional = true)]
-		internal CFRunLoop (IntPtr handle, bool owns)
+		internal CFRunLoop (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFSocket.cs
+++ b/src/CoreFoundation/CFSocket.cs
@@ -36,6 +36,10 @@ using System.Runtime.InteropServices;
 using CoreFoundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	[Flags]
@@ -331,7 +335,7 @@ namespace CoreFoundation {
 			}
 		}
 
-		CFSocket (IntPtr handle, bool owns)
+		CFSocket (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 			gch = GCHandle.Alloc (this);

--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -47,6 +47,10 @@ using Foundation;
 
 using CFIndex = System.nint;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	// CFOptionFlags
@@ -719,7 +723,7 @@ namespace CoreFoundation {
 		}
 #endif
 
-		protected CFStream (IntPtr handle, bool owns)
+		protected CFStream (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -39,6 +39,10 @@ using System.Runtime.InteropServices;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace CoreFoundation {
@@ -151,7 +155,7 @@ namespace CoreFoundation {
 		public extern static nint GetTypeID ();
 		
 #if !NET
-		public CFString (IntPtr handle)
+		public CFString (NativeHandle handle)
 			: this (handle, false)
 		{
 		}
@@ -159,9 +163,9 @@ namespace CoreFoundation {
 		
 		[Preserve (Conditional = true)]
 #if NET
-		internal CFString (IntPtr handle, bool owns)
+		internal CFString (NativeHandle handle, bool owns)
 #else
-		protected internal CFString (IntPtr handle, bool owns)
+		protected internal CFString (NativeHandle handle, bool owns)
 #endif
 			: base (handle, owns)
 		{

--- a/src/CoreFoundation/CFType.cs
+++ b/src/CoreFoundation/CFType.cs
@@ -10,6 +10,10 @@ using System.Runtime.InteropServices;
 using CoreFoundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 	public class CFType : NativeObject, ICFType {
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFGetTypeID")]
@@ -24,7 +28,7 @@ namespace CoreFoundation {
 		}
 #endif
 
-		internal CFType (IntPtr handle, bool owns)
+		internal CFType (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFUrl.cs
+++ b/src/CoreFoundation/CFUrl.cs
@@ -36,6 +36,10 @@ using System.Runtime.Versioning;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	// CFURLPathStyle -> CFIndex -> CFURL.h
@@ -56,7 +60,7 @@ namespace CoreFoundation {
 			/* CFURLPathStyle */ nint pathStyle, 
 			/* Boolean */ [MarshalAs (UnmanagedType.I1)] bool isDirectory);
 		
-		internal CFUrl (IntPtr handle, bool owns)
+		internal CFUrl (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFWriteStream.cs
+++ b/src/CoreFoundation/CFWriteStream.cs
@@ -37,10 +37,14 @@ using ObjCRuntime;
 
 using CFIndex = System.nint;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	public class CFWriteStream : CFStream {
-		internal CFWriteStream (IntPtr handle, bool owns)
+		internal CFWriteStream (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -123,7 +123,7 @@ namespace CoreFoundation {
 
 		public override int GetHashCode ()
 		{
-			return (int) Handle;
+			return ((IntPtr) Handle).ToInt32 ();
 		}
 
 #if !XAMCORE_4_0
@@ -599,7 +599,7 @@ namespace CoreFoundation {
 
 		public override int GetHashCode ()
 		{
-			return (int) Handle;
+			return ((IntPtr) Handle).ToInt32 ();
 		}
 		
 #if MONOMAC

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -38,6 +38,10 @@ using System.Threading;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	// The native constants are defined in usr/include/dispatch/queue.h, but since they're
@@ -67,7 +71,7 @@ namespace CoreFoundation {
 		// Constructors and lifecycle
 		//
 		[Preserve (Conditional = true)]
-		internal DispatchObject (IntPtr handle, bool owns)
+		internal DispatchObject (NativeHandle handle, bool owns)
 			: base (handle, owns, verify: true)
 		{
 		}
@@ -176,12 +180,12 @@ namespace CoreFoundation {
 	public sealed class DispatchQueue : DispatchObject  {
 #if !COREBUILD
 		[Preserve (Conditional = true)]
-		internal DispatchQueue (IntPtr handle, bool owns) : base (handle, owns)
+		internal DispatchQueue (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 		}
 
 #if !NET
-		public DispatchQueue (IntPtr handle) : base (handle, false)
+		public DispatchQueue (NativeHandle handle) : base (handle, false)
 		{
 		}
 #endif
@@ -756,7 +760,7 @@ namespace CoreFoundation {
 	public class DispatchGroup : DispatchObject
 	{
 #if !COREBUILD
-		private DispatchGroup (IntPtr handle, bool owns)
+		private DispatchGroup (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/DispatchBlock.cs
+++ b/src/CoreFoundation/DispatchBlock.cs
@@ -14,6 +14,10 @@ using System.Threading;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 #if !COREBUILD
 
@@ -22,7 +26,7 @@ namespace CoreFoundation {
 	[Mac (10, 10)]
 #endif
 	public sealed class DispatchBlock : NativeObject {
-		internal DispatchBlock (IntPtr handle, bool owns)
+		internal DispatchBlock (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/DispatchBlock.cs
+++ b/src/CoreFoundation/DispatchBlock.cs
@@ -181,9 +181,9 @@ namespace CoreFoundation {
 				return null;
 
 			unsafe {
-				BlockLiteral *handle = (BlockLiteral *) block.GetCheckedHandle ();
+				var handle = (BlockLiteral *) (IntPtr) block.GetCheckedHandle ();
 				var del = handle->GetDelegateForBlock<DispatchBlockCallback> ();
-				return new Action (() => del (block.GetCheckedHandle ()));
+				return new Action (() => del ((IntPtr) block.GetCheckedHandle ()));
 			}
 		}
 

--- a/src/CoreFoundation/DispatchData.cs
+++ b/src/CoreFoundation/DispatchData.cs
@@ -31,20 +31,24 @@ using System.Threading;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	public partial class DispatchData : DispatchObject {
 #if !COREBUILD
 #if NET
-		internal DispatchData (IntPtr handle, bool owns) : base (handle, owns)
+		internal DispatchData (NativeHandle handle, bool owns) : base (handle, owns)
 #else
-		public DispatchData (IntPtr handle, bool owns) : base (handle, owns)
+		public DispatchData (NativeHandle handle, bool owns) : base (handle, owns)
 #endif
 		{
 		}
 
 #if !NET
-		public DispatchData (IntPtr handle) : base (handle, false)
+		public DispatchData (NativeHandle handle) : base (handle, false)
 		{
 		}
 #endif

--- a/src/CoreFoundation/DispatchIO.cs
+++ b/src/CoreFoundation/DispatchIO.cs
@@ -36,19 +36,23 @@ using System.Threading;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	public delegate void DispatchIOHandler (DispatchData data, int error);
 
 	public class DispatchIO : DispatchObject {
 		[Preserve (Conditional = true)]
-		internal DispatchIO (IntPtr handle, bool owns) : base (handle, owns)
+		internal DispatchIO (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 		}
 
 #if !NET
 		[Preserve (Conditional = true)]
-		internal DispatchIO (IntPtr handle) : this (handle, false)
+		internal DispatchIO (NativeHandle handle) : this (handle, false)
 		{
 		}
 #endif

--- a/src/CoreFoundation/DispatchSource.cs
+++ b/src/CoreFoundation/DispatchSource.cs
@@ -17,6 +17,10 @@ using dispatch_source_type_t=System.IntPtr;
 using dispatch_source_t=System.IntPtr;
 using dispatch_queue_t=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 	[Flags]
@@ -48,13 +52,13 @@ namespace CoreFoundation {
 
 		// constructors for use in bindings
 		[Preserve (Conditional = true)]
-		internal DispatchSource (IntPtr handle, bool owns) : base (handle, owns)
+		internal DispatchSource (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 		}
 
 #if !NET
 		// constructors for use in bindings
-		internal DispatchSource (IntPtr handle) : base (handle, false)
+		internal DispatchSource (NativeHandle handle) : base (handle, false)
 		{
 		}
 #endif

--- a/src/CoreFoundation/NativeObject.cs
+++ b/src/CoreFoundation/NativeObject.cs
@@ -15,6 +15,10 @@ using Foundation;
 
 #nullable enable
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 	//
 	// The NativeObject class is intended to be a base class for many CoreFoundation
@@ -33,21 +37,21 @@ namespace CoreFoundation {
 		{
 		}
 
-		protected NativeObject (IntPtr handle, bool owns)
+		protected NativeObject (NativeHandle handle, bool owns)
 			: this (handle, owns, true)
 		{
 		}
 
-		protected NativeObject (IntPtr handle, bool owns, bool verify)
+		protected NativeObject (NativeHandle handle, bool owns, bool verify)
 			: base (handle, owns, verify)
 		{
-			if (!owns && handle != IntPtr.Zero)
+			if (!owns && handle != NativeHandle.Zero)
 				Retain ();
 		}
 
 		protected override void Dispose (bool disposing)
 		{
-			if (Handle != IntPtr.Zero)
+			if (Handle != NativeHandle.Zero)
 				Release ();
 			base.Dispose (disposing);
 		}

--- a/src/CoreFoundation/OSLog.cs
+++ b/src/CoreFoundation/OSLog.cs
@@ -25,6 +25,10 @@ using ObjCRuntime;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreFoundation {
 
 #if !NET
@@ -70,7 +74,7 @@ namespace CoreFoundation {
 		[DllImport ("__Internal")]
 		extern static void xamarin_os_log (IntPtr logHandle, OSLogLevel level, string message);
 
-		internal OSLog (IntPtr handle, bool owns)
+		internal OSLog (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGBitmapContext.cs
+++ b/src/CoreGraphics/CGBitmapContext.cs
@@ -34,6 +34,10 @@ using System.Runtime.InteropServices;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	public class CGBitmapContext : CGContext {
@@ -42,7 +46,7 @@ namespace CoreGraphics {
 		GCHandle buffer;
 		
 		[Preserve (Conditional=true)]
-		internal CGBitmapContext (IntPtr handle, bool owns) : base (handle, owns)
+		internal CGBitmapContext (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 		}
 

--- a/src/CoreGraphics/CGColor.cs
+++ b/src/CoreGraphics/CGColor.cs
@@ -36,6 +36,10 @@ using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGColor.h
@@ -43,14 +47,14 @@ namespace CoreGraphics {
 	{
 #if !COREBUILD
 #if !NET
-		public CGColor (IntPtr handle)
+		public CGColor (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGColor (IntPtr handle, bool owns)
+		internal CGColor (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGColorConversionInfo.cs
+++ b/src/CoreGraphics/CGColorConversionInfo.cs
@@ -17,6 +17,10 @@ using CoreFoundation;
 using Foundation;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 #if !NET
@@ -35,7 +39,7 @@ namespace CoreGraphics {
 #endif
 	public partial class CGColorConversionInfo : NativeObject {
 		[Preserve (Conditional=true)]
-		internal CGColorConversionInfo (IntPtr handle, bool owns)
+		internal CGColorConversionInfo (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -37,6 +37,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// untyped enum -> CGColorSpace.h
@@ -74,7 +78,7 @@ namespace CoreGraphics {
 #endif
 
 #if !NET
-		public CGColorSpace (IntPtr handle)
+		public CGColorSpace (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
@@ -106,7 +110,7 @@ namespace CoreGraphics {
 		}
 
 		[Preserve (Conditional=true)]
-		internal CGColorSpace (IntPtr handle, bool owns)
+		internal CGColorSpace (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -36,20 +36,24 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	public class CGContext : NativeObject
 	{
 #if !COREBUILD
 #if !NET
-		public CGContext (IntPtr handle)
+		public CGContext (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGContext (IntPtr handle, bool owns)
+		internal CGContext (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGDataConsumer.cs
+++ b/src/CoreGraphics/CGDataConsumer.cs
@@ -35,19 +35,23 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGDataConsumer.h
 	public partial class CGDataConsumer : NativeObject {
 #if !NET
-		public CGDataConsumer (IntPtr handle)
+		public CGDataConsumer (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGDataConsumer (IntPtr handle, bool owns)
+		internal CGDataConsumer (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGDataProvider.cs
+++ b/src/CoreGraphics/CGDataProvider.cs
@@ -35,19 +35,23 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGDataProvider.h
 	public partial class CGDataProvider : NativeObject {
 #if !NET
-		public CGDataProvider (IntPtr handle)
+		public CGDataProvider (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGDataProvider (IntPtr handle, bool owns)
+		internal CGDataProvider (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGEvent.cs
+++ b/src/CoreGraphics/CGEvent.cs
@@ -20,6 +20,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 #if !NET
@@ -77,13 +81,13 @@ namespace CoreGraphics {
 		}
 
 #if !NET
-		public CGEvent (IntPtr handle)
+		public CGEvent (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
-		internal CGEvent (IntPtr handle, bool owns)
+		internal CGEvent (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGEventSource.cs
+++ b/src/CoreGraphics/CGEventSource.cs
@@ -20,6 +20,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 #if !NET
 	[MacCatalyst (15,0)]
@@ -28,16 +32,16 @@ namespace CoreGraphics {
 #endif
 	public sealed class CGEventSource : NativeObject {
 #if !NET
-		public CGEventSource (IntPtr handle)
+		public CGEventSource (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 #if NET
-		internal CGEventSource (IntPtr handle, bool owns)
+		internal CGEventSource (NativeHandle handle, bool owns)
 #else
-		public CGEventSource (IntPtr handle, bool owns)
+		public CGEventSource (NativeHandle handle, bool owns)
 #endif
 			: base (handle, owns)
 		{

--- a/src/CoreGraphics/CGFont.cs
+++ b/src/CoreGraphics/CGFont.cs
@@ -37,6 +37,10 @@ using CoreFoundation;
 
 using CoreText;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGFont.h
@@ -44,7 +48,7 @@ namespace CoreGraphics {
 		{
 #if !COREBUILD
 		[Preserve (Conditional=true)]
-		internal CGFont (IntPtr handle, bool owns)
+		internal CGFont (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGFunction.cs
+++ b/src/CoreGraphics/CGFunction.cs
@@ -35,6 +35,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGFunction.h
@@ -51,14 +55,14 @@ namespace CoreGraphics {
 		}
 
 #if !NET
-		internal CGFunction (IntPtr handle)
+		internal CGFunction (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGFunction (IntPtr handle, bool owns)
+		internal CGFunction (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGGradient.cs
+++ b/src/CoreGraphics/CGGradient.cs
@@ -35,6 +35,10 @@ using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// uint32_t -> CGGradient.h
@@ -49,7 +53,7 @@ namespace CoreGraphics {
 	{
 #if !COREBUILD
 		[Preserve (Conditional=true)]
-		internal CGGradient (IntPtr handle, bool owns)
+		internal CGGradient (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGImage.cs
+++ b/src/CoreGraphics/CGImage.cs
@@ -36,6 +36,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 #if MONOMAC || __MACCATALYST__
@@ -132,14 +136,14 @@ namespace CoreGraphics {
 	{
 #if !COREBUILD
 #if !NET
-		public CGImage (IntPtr handle)
+		public CGImage (NativeHandle handle)
 			: base (handle, false, verify: false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGImage (IntPtr handle, bool owns)
+		internal CGImage (NativeHandle handle, bool owns)
 #if NET
 			: base (handle, owns)
 #else

--- a/src/CoreGraphics/CGLayer.cs
+++ b/src/CoreGraphics/CGLayer.cs
@@ -35,6 +35,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGLayer.h
@@ -42,7 +46,7 @@ namespace CoreGraphics {
 	{
 #if !COREBUILD
 		[Preserve (Conditional=true)]
-		internal CGLayer (IntPtr handle, bool owns)
+		internal CGLayer (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGPDFArray.cs
+++ b/src/CoreGraphics/CGPDFArray.cs
@@ -37,6 +37,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGPDFArray.h
@@ -46,7 +50,7 @@ namespace CoreGraphics {
 		// does not subclass NativeObject (there's no way to retain/release CGPDFObject instances). It's
 		// also why this constructor doesn't have a 'bool owns' parameter: it's always owned by the containing CGPDFDocument.
 #if NET
-		internal CGPDFArray (IntPtr handle)
+		internal CGPDFArray (NativeHandle handle)
 #else
 		public CGPDFArray (IntPtr handle)
 #endif

--- a/src/CoreGraphics/CGPDFContentStream.cs
+++ b/src/CoreGraphics/CGPDFContentStream.cs
@@ -14,6 +14,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGPDFContentStream.h
@@ -33,14 +37,14 @@ namespace CoreGraphics {
 		extern static void CGPDFContentStreamRelease (/* CGPDFContentStreamRef */ IntPtr cs);
 
 #if !NET
-		public CGPDFContentStream (IntPtr handle)
+		public CGPDFContentStream (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGPDFContentStream (IntPtr handle, bool owns)
+		internal CGPDFContentStream (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGPDFDictionary.cs
+++ b/src/CoreGraphics/CGPDFDictionary.cs
@@ -36,6 +36,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGPDFDictionary.h
@@ -45,7 +49,7 @@ namespace CoreGraphics {
 		// does not subclass NativeObject (there's no way to retain/release CGPDFObject instances). It's
 		// also why this constructor doesn't have a 'bool owns' parameter: it's always owned by the containing CGPDFDocument.
 #if NET
-		internal CGPDFDictionary (IntPtr handle)
+		internal CGPDFDictionary (NativeHandle handle)
 #else
 		public CGPDFDictionary (IntPtr handle)
 #endif

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -35,6 +35,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	public class CGPDFDocument : NativeObject
@@ -47,14 +51,14 @@ namespace CoreGraphics {
 		extern static /* CGPDFDocumentRef */ IntPtr CGPDFDocumentRetain (/* CGPDFDocumentRef */ IntPtr document);
 
 #if !NET
-		public CGPDFDocument (IntPtr handle)
+		public CGPDFDocument (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGPDFDocument (IntPtr handle, bool owns)
+		internal CGPDFDocument (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGPDFObject.cs
+++ b/src/CoreGraphics/CGPDFObject.cs
@@ -36,6 +36,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGPDFObject.h
@@ -47,9 +51,9 @@ namespace CoreGraphics {
 		// does not subclass NativeObject (there's no way to retain/release CGPDFObject instances). It's
 		// also why this constructor doesn't have a 'bool owns' parameter: it's always owned by the containing CGPDFDocument.
 #if NET
-		internal CGPDFObject (IntPtr handle)
+		internal CGPDFObject (NativeHandle handle)
 #else
-		public CGPDFObject (IntPtr handle)
+		public CGPDFObject (NativeHandle handle)
 #endif
 		{
 			Handle = handle;

--- a/src/CoreGraphics/CGPDFObject.cs
+++ b/src/CoreGraphics/CGPDFObject.cs
@@ -40,7 +40,7 @@ namespace CoreGraphics {
 
 	// CGPDFObject.h
 	public class CGPDFObject : INativeObject {
-		public IntPtr Handle { get; private set; }
+		public NativeHandle Handle { get; private set; }
 
 		// The lifetime management of CGPDFObject (and CGPDFArray, CGPDFDictionary and CGPDFStream) are tied to
 		// the containing CGPDFDocument, and not possible to handle independently, which is why this class

--- a/src/CoreGraphics/CGPDFOperatorTable.cs
+++ b/src/CoreGraphics/CGPDFOperatorTable.cs
@@ -15,6 +15,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGPDFOperatorTable.h
@@ -38,14 +42,14 @@ namespace CoreGraphics {
 		}
 
 #if !NET
-		public CGPDFOperatorTable (IntPtr handle)
+		public CGPDFOperatorTable (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGPDFOperatorTable (IntPtr handle, bool owns)
+		internal CGPDFOperatorTable (NativeHandle handle, bool owns)
 			 : base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGPDFPage-2.cs
+++ b/src/CoreGraphics/CGPDFPage-2.cs
@@ -32,6 +32,10 @@ using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// untyped enum -> CGPDFPage.h
@@ -47,13 +51,13 @@ namespace CoreGraphics {
 	public partial class CGPDFPage {
 #if !COREBUILD
 #if !NET
-		public CGPDFPage (IntPtr handle)
+		public CGPDFPage (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
-		internal CGPDFPage (IntPtr handle, bool owns)
+		internal CGPDFPage (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGPDFScanner.cs
+++ b/src/CoreGraphics/CGPDFScanner.cs
@@ -15,6 +15,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	public class CGPDFScanner : NativeObject {
@@ -45,14 +49,14 @@ namespace CoreGraphics {
 		}
 
 #if !NET
-		public CGPDFScanner (IntPtr handle)
+		public CGPDFScanner (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGPDFScanner (IntPtr handle, bool owns)
+		internal CGPDFScanner (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGPDFStream.cs
+++ b/src/CoreGraphics/CGPDFStream.cs
@@ -34,6 +34,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// untyped enum -> CGPDFStream.h
@@ -49,7 +53,7 @@ namespace CoreGraphics {
 		// the containing CGPDFDocument, and not possible to handle independently, which is why this class
 		// does not subclass NativeObject (there's no way to retain/release CGPDFObject instances). It's
 		// also why this constructor doesn't have a 'bool owns' parameter: it's always owned by the containing CGPDFDocument.
-		internal CGPDFStream (IntPtr handle)
+		internal CGPDFStream (NativeHandle handle)
 			: base (handle)
 		{
 		}

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -36,6 +36,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// untyped enum -> CGPath.h
@@ -94,14 +98,14 @@ namespace CoreGraphics {
 		}
 
 #if !NET
-		public CGPath (IntPtr handle)
+		public CGPath (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGPath (IntPtr handle, bool owns)
+		internal CGPath (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -32,6 +32,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// untyped enum -> CGPattern.h
@@ -57,14 +61,14 @@ namespace CoreGraphics {
 	{
 #if !COREBUILD
 #if !NET
-		public CGPattern (IntPtr handle)
+		public CGPattern (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGPattern (IntPtr handle, bool owns)
+		internal CGPattern (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreGraphics/CGShading.cs
+++ b/src/CoreGraphics/CGShading.cs
@@ -35,6 +35,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreGraphics {
 
 	// CGShading.h
@@ -42,14 +46,14 @@ namespace CoreGraphics {
 	{
 #if !COREBUILD
 #if !NET
-		public CGShading (IntPtr handle)
+		public CGShading (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGShading (IntPtr handle, bool owns)
+		internal CGShading (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreImage/CIFilter.cs
+++ b/src/CoreImage/CIFilter.cs
@@ -745,7 +745,7 @@ namespace CoreImage {
 #endif
 	}
 
-#if MONOMAC && !XAMCORE_3_0
+#if MONOMAC && !XAMCORE_3_0 && !NET
 	[Obsolete ("This type has been renamed to CICmykHalftone.")]
 	public class CICMYKHalftone : CICmykHalftone {
 		public CICMYKHalftone () {}

--- a/src/CoreMedia/CMBlockBuffer.cs
+++ b/src/CoreMedia/CMBlockBuffer.cs
@@ -19,6 +19,10 @@ using Foundation;
 using CoreFoundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreMedia {
 
 #if !NET
@@ -240,7 +244,7 @@ namespace CoreMedia {
 
 		public static CMBlockBuffer? FromMemoryBlock (IntPtr memoryBlock, nuint blockLength, CMCustomBlockAllocator? customBlockSource, nuint offsetToData, nuint dataLength, CMBlockBufferFlags flags, out CMBlockBufferError error)
 		{
-			var blockAllocator = memoryBlock == IntPtr.Zero ? IntPtr.Zero : CFAllocator.Null.Handle;
+			var blockAllocator = memoryBlock == IntPtr.Zero ? NativeHandle.Zero : CFAllocator.Null.Handle;
 			IntPtr buffer;
 			if (customBlockSource is null)
 				error = CMBlockBufferCreateWithMemoryBlock (IntPtr.Zero, memoryBlock, blockLength, blockAllocator, IntPtr.Zero, offsetToData, dataLength, flags, out buffer);
@@ -329,7 +333,7 @@ namespace CoreMedia {
 		
 		public CMBlockBufferError AppendMemoryBlock (IntPtr memoryBlock, nuint blockLength, CMCustomBlockAllocator customBlockSource, nuint offsetToData, nuint dataLength, CMBlockBufferFlags flags)
 		{
-			var blockAllocator = memoryBlock == IntPtr.Zero ? IntPtr.Zero : CFAllocator.Null.Handle;
+			var blockAllocator = memoryBlock == IntPtr.Zero ? NativeHandle.Zero : CFAllocator.Null.Handle;
 			if (customBlockSource is null)
 				return CMBlockBufferAppendMemoryBlock (GetCheckedHandle (), memoryBlock, blockLength, blockAllocator, IntPtr.Zero, offsetToData, dataLength, flags);
 			else

--- a/src/CoreMedia/CMBlockBuffer.cs
+++ b/src/CoreMedia/CMBlockBuffer.cs
@@ -32,7 +32,7 @@ namespace CoreMedia {
 		CMCustomBlockAllocator? customAllocator;
 
 		[Preserve (Conditional=true)]
-		internal CMBlockBuffer (IntPtr handle, bool owns)
+		internal CMBlockBuffer (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreMedia/CMFormatDescription.cs
+++ b/src/CoreMedia/CMFormatDescription.cs
@@ -25,6 +25,10 @@ using ObjCRuntime;
 using CoreVideo;
 using AudioToolbox;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreMedia {
 
 #if !NET
@@ -32,7 +36,7 @@ namespace CoreMedia {
 #endif
 	public class CMFormatDescription : NativeObject {
 		[Preserve (Conditional=true)]
-		internal CMFormatDescription (IntPtr handle, bool owns)
+		internal CMFormatDescription (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -289,7 +293,7 @@ namespace CoreMedia {
 	[Watch (6,0)]
 #endif
 	public class CMAudioFormatDescription : CMFormatDescription {
-		internal CMAudioFormatDescription (IntPtr handle, bool owns)
+		internal CMAudioFormatDescription (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -301,7 +305,7 @@ namespace CoreMedia {
 	[Watch (6,0)]
 #endif
 	public partial class CMVideoFormatDescription : CMFormatDescription {
-		internal CMVideoFormatDescription (IntPtr handle, bool owns)
+		internal CMVideoFormatDescription (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreMedia/CMSampleBuffer.cs
+++ b/src/CoreMedia/CMSampleBuffer.cs
@@ -29,6 +29,10 @@ using UIKit;
 #endif
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreMedia {
 
 #if !NET
@@ -40,7 +44,7 @@ namespace CoreMedia {
 		GCHandle invalidate;
 
 		[Preserve (Conditional=true)]
-		internal CMSampleBuffer (IntPtr handle, bool owns)
+		internal CMSampleBuffer (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -14,6 +14,10 @@ using Foundation;
 using CoreFoundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace CoreMedia {
@@ -25,12 +29,12 @@ namespace CoreMedia {
 	public class CMClock : CMClockOrTimebase
 	{
 #if !NET
-		public CMClock (IntPtr handle) : base (handle)
+		public CMClock (NativeHandle handle) : base (handle)
 		{
 		}
 #endif
 
-		internal CMClock (IntPtr handle, bool owns) 
+		internal CMClock (NativeHandle handle, bool owns) 
 			: base (handle, owns)
 		{
 		}
@@ -112,13 +116,13 @@ namespace CoreMedia {
 	public class CMTimebase : CMClockOrTimebase
 	{
 #if !NET
-		public CMTimebase (IntPtr handle)
+		public CMTimebase (NativeHandle handle)
 			: base (handle)
 		{
 		}
 #endif
 
-		private CMTimebase (IntPtr handle, bool owns) 
+		private CMTimebase (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -731,13 +735,13 @@ namespace CoreMedia {
 	public class CMClockOrTimebase : NativeObject
 	{
 #if !NET
-		public CMClockOrTimebase (IntPtr handle)
+		public CMClockOrTimebase (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
-		internal CMClockOrTimebase (IntPtr handle, bool owns)
+		internal CMClockOrTimebase (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -42,6 +42,10 @@ using Foundation;
 
 using CGGlyph = System.UInt16;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 	[Flags]
@@ -1481,7 +1485,7 @@ namespace CoreText {
 	}
 
 	public partial class CTFont : NativeObject {
-		internal CTFont (IntPtr handle, bool owns)
+		internal CTFont (NativeHandle handle, bool owns)
 			: base (handle, owns, true)
 		{
 		}

--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -40,6 +40,10 @@ using CoreGraphics;
 
 using CFIndex = System.nint;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 	public static class CTFontCollectionOptionKey {
@@ -91,7 +95,7 @@ namespace CoreText {
 	}
 
 	public class CTFontCollection : NativeObject {
-		internal CTFontCollection (IntPtr handle, bool owns)
+		internal CTFontCollection (NativeHandle handle, bool owns)
 			: base (handle, owns, verify: true)
 		{
 		}

--- a/src/CoreText/CTFontDescriptor.cs
+++ b/src/CoreText/CTFontDescriptor.cs
@@ -40,6 +40,10 @@ using CoreFoundation;
 using CoreGraphics;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 	// defined as uint32_t - /System/Library/Frameworks/CoreText.framework/Headers/CTFontDescriptor.h
@@ -351,7 +355,7 @@ namespace CoreText {
 	}
 
 	public class CTFontDescriptor : NativeObject {
-		internal CTFontDescriptor (IntPtr handle, bool owns)
+		internal CTFontDescriptor (NativeHandle handle, bool owns)
 			: base (handle, owns, true)
 		{
 		}

--- a/src/CoreText/CTFrame.cs
+++ b/src/CoreText/CTFrame.cs
@@ -36,6 +36,10 @@ using Foundation;
 using CoreFoundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 	[Flags]
@@ -108,7 +112,7 @@ namespace CoreText {
 	}
 
 	public class CTFrame : NativeObject {
-		internal CTFrame (IntPtr handle, bool owns)
+		internal CTFrame (NativeHandle handle, bool owns)
 			: base (handle, owns, verify: true)
 		{
 		}

--- a/src/CoreText/CTFramesetter.cs
+++ b/src/CoreText/CTFramesetter.cs
@@ -36,10 +36,14 @@ using Foundation;
 using CoreFoundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 	public class CTFramesetter : NativeObject {
-		internal CTFramesetter (IntPtr handle, bool owns)
+		internal CTFramesetter (NativeHandle handle, bool owns)
 			: base (handle, owns, true)
 		{
 		}

--- a/src/CoreText/CTGlyphInfo.cs
+++ b/src/CoreText/CTGlyphInfo.cs
@@ -38,6 +38,10 @@ using CoreFoundation;
 using CGGlyph     = System.UInt16;
 using CGFontIndex = System.UInt16;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 #region Glyph Info Values
@@ -52,7 +56,7 @@ namespace CoreText {
 #endregion
 
 	public class CTGlyphInfo : NativeObject {
-		internal CTGlyphInfo (IntPtr handle, bool owns)
+		internal CTGlyphInfo (NativeHandle handle, bool owns)
 			: base (handle, owns, true)
 		{
 		}

--- a/src/CoreText/CTLine.cs
+++ b/src/CoreText/CTLine.cs
@@ -38,6 +38,10 @@ using Foundation;
 using CoreFoundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 	// defined as uint32_t - /System/Library/Frameworks/CoreText.framework/Headers/CTLine.h
@@ -60,7 +64,7 @@ namespace CoreText {
     }
 	
 	public class CTLine : NativeObject {
-		internal CTLine (IntPtr handle, bool owns)
+		internal CTLine (NativeHandle handle, bool owns)
 			: base (handle, owns, true)
 		{
 		}

--- a/src/CoreText/CTParagraphStyle.cs
+++ b/src/CoreText/CTParagraphStyle.cs
@@ -38,6 +38,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 #region Paragraph Style Values
@@ -316,7 +320,7 @@ namespace CoreText {
 	}
 
 	public class CTParagraphStyle : NativeObject {
-		internal CTParagraphStyle (IntPtr handle, bool owns)
+		internal CTParagraphStyle (NativeHandle handle, bool owns)
 			: base (handle, owns, true)
 		{
 		}

--- a/src/CoreText/CTRun.cs
+++ b/src/CoreText/CTRun.cs
@@ -38,6 +38,10 @@ using Foundation;
 using CoreFoundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 	// defined as uint32_t - System/Library/Frameworks/CoreText.framework/Headers/CTRun.h
@@ -49,7 +53,7 @@ namespace CoreText {
 	}
 
 	public class CTRun : NativeObject {
-		internal CTRun (IntPtr handle, bool owns)
+		internal CTRun (NativeHandle handle, bool owns)
 			: base (handle, owns, true)
 		{
 		}

--- a/src/CoreText/CTRunDelegate.cs
+++ b/src/CoreText/CTRunDelegate.cs
@@ -32,6 +32,10 @@ using Foundation;
 using CoreFoundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 #region Run Delegate Callbacks
@@ -175,7 +179,7 @@ namespace CoreText {
 	}
 
 	public class CTRunDelegate : NativeObject, IDisposable {
-		internal CTRunDelegate (IntPtr handle, bool owns)
+		internal CTRunDelegate (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreText/CTTextTab.cs
+++ b/src/CoreText/CTTextTab.cs
@@ -34,6 +34,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 #region Text Tab Constants
@@ -80,7 +84,7 @@ namespace CoreText {
 #endregion
 
 	public class CTTextTab : NativeObject {
-		internal CTTextTab (IntPtr handle, bool owns)
+		internal CTTextTab (NativeHandle handle, bool owns)
 			: base (handle, owns, verify: true)
 		{
 		}

--- a/src/CoreText/CTTypesetter.cs
+++ b/src/CoreText/CTTypesetter.cs
@@ -38,6 +38,10 @@ using Foundation;
 using CoreFoundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreText {
 
 #region Typesetter Values
@@ -106,7 +110,7 @@ namespace CoreText {
 #endregion
 
 	public class CTTypesetter : NativeObject {
-		internal CTTypesetter (IntPtr handle, bool owns)
+		internal CTTypesetter (NativeHandle handle, bool owns)
 			: base (handle, owns, verify: true)
 		{
 		}

--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -35,6 +35,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace CoreVideo {
@@ -47,7 +51,7 @@ namespace CoreVideo {
 	{
 #if !COREBUILD
 		[Preserve (Conditional=true)]
-		internal CVBuffer (IntPtr handle, bool owns)
+		internal CVBuffer (NativeHandle handle, bool owns)
 			: base (handle, owns, verify: true)
 		{
 		}

--- a/src/CoreVideo/CVDisplayLink.cs
+++ b/src/CoreVideo/CVDisplayLink.cs
@@ -35,6 +35,10 @@ using ObjCRuntime;
 using Foundation;
 using OpenGL;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace CoreVideo {
@@ -42,14 +46,14 @@ namespace CoreVideo {
 		GCHandle callbackHandle;
 		
 #if !NET
-		public CVDisplayLink (IntPtr handle)
+		public CVDisplayLink (NativeHandle handle)
 			: base (handle, false, true)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CVDisplayLink (IntPtr handle, bool owns)
+		internal CVDisplayLink (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreVideo/CVImageBuffer.cs
+++ b/src/CoreVideo/CVImageBuffer.cs
@@ -33,6 +33,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace CoreVideo {
@@ -44,7 +48,7 @@ namespace CoreVideo {
 	public partial class CVImageBuffer : CVBuffer {
 #if !COREBUILD
 		[Preserve (Conditional=true)]
-		internal CVImageBuffer (IntPtr handle, bool owns)
+		internal CVImageBuffer (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreVideo/CVMetalTexture.cs
+++ b/src/CoreVideo/CVMetalTexture.cs
@@ -19,6 +19,10 @@ using CoreFoundation;
 using Foundation;
 using Metal;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace CoreVideo {
@@ -27,7 +31,7 @@ namespace CoreVideo {
 	[iOS (8,0), Mac (12,0), MacCatalyst (15,0)]
 #endif
 	public class CVMetalTexture : NativeObject {
-		internal CVMetalTexture (IntPtr handle, bool owns)
+		internal CVMetalTexture (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreVideo/CVMetalTextureCache.cs
+++ b/src/CoreVideo/CVMetalTextureCache.cs
@@ -18,6 +18,10 @@ using CoreFoundation;
 using Foundation;
 using Metal;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace CoreVideo {
@@ -38,7 +42,7 @@ namespace CoreVideo {
 			/* CFDictionaryRef __nullable */ IntPtr textureAttributes, 
 			/* CVMetalTextureCacheRef __nullable * __nonnull */ out IntPtr cacheOut);
 
-		internal CVMetalTextureCache (IntPtr handle, bool owns)
+		internal CVMetalTextureCache (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -18,6 +18,10 @@ using System.Runtime.Versioning;
 using CFDictionaryRef=System.IntPtr;
 using CVPixelBufferRef=System.IntPtr; 
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace CoreVideo {
@@ -31,7 +35,7 @@ namespace CoreVideo {
 		public extern static /* CFTypeID */ nint GetTypeID ();
 
 		[Preserve (Conditional=true)]
-		internal CVPixelBuffer (IntPtr handle, bool owns) : base (handle, owns)
+		internal CVPixelBuffer (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 		}
 

--- a/src/CoreVideo/CVPixelBufferPool.cs
+++ b/src/CoreVideo/CVPixelBufferPool.cs
@@ -17,6 +17,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace CoreVideo {
@@ -29,7 +33,7 @@ namespace CoreVideo {
 	{
 #if !COREBUILD
 		[Preserve (Conditional=true)]
-		internal CVPixelBufferPool (IntPtr handle, bool owns)
+		internal CVPixelBufferPool (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/Darwin/KernelNotification.cs
+++ b/src/Darwin/KernelNotification.cs
@@ -33,6 +33,10 @@ using ObjCRuntime;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Darwin {
 
 	[StructLayout (LayoutKind.Sequential)]
@@ -147,7 +151,7 @@ namespace Darwin {
 	public class KernelQueue : IDisposable, INativeObject {
 		int handle;
 
-		public IntPtr Handle { get { return (IntPtr) handle; } }
+		public NativeHandle Handle { get { return (NativeHandle) (IntPtr) handle; } }
 
 		[DllImport (Constants.SystemLibrary)]
 		extern static int /* int */ kqueue ();

--- a/src/Darwin/SystemLog.cs
+++ b/src/Darwin/SystemLog.cs
@@ -34,6 +34,10 @@ using ObjCRuntime;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Darwin {
 
 	public class SystemLog : DisposableObject {
@@ -68,7 +72,7 @@ namespace Darwin {
 		{
 		}
 
-		SystemLog (IntPtr handle, bool owns)
+		SystemLog (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -195,7 +199,7 @@ namespace Darwin {
 			True = 7
 		}
 
-		internal Message (IntPtr handle, bool owns)
+		internal Message (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/Foundation/NSArray_1.cs
+++ b/src/Foundation/NSArray_1.cs
@@ -14,6 +14,10 @@ using System.Runtime.InteropServices;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	[Register (SkipRegistration = true)]
 	public sealed partial class NSArray<TKey> : NSArray, IEnumerable<TKey> 
@@ -27,7 +31,7 @@ namespace Foundation {
 		{
 		}
 
-		internal NSArray (IntPtr handle) : base (handle)
+		internal NSArray (NativeHandle handle) : base (handle)
 		{
 		}
 

--- a/src/Foundation/NSAutoreleasePool.cs
+++ b/src/Foundation/NSAutoreleasePool.cs
@@ -31,6 +31,10 @@ using System.Runtime.InteropServices;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	[Register ("NSAutoreleasePool", true)]
 	public class NSAutoreleasePool : NSObject
@@ -39,7 +43,7 @@ namespace Foundation {
 #endif
 	{
 #if !COREBUILD
-		public override IntPtr ClassHandle { get { return Class.GetHandle ("NSAutoreleasePool"); } }
+		public override NativeHandle ClassHandle { get { return Class.GetHandle ("NSAutoreleasePool"); } }
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		[Export ("init")]

--- a/src/Foundation/NSDictionary.cs
+++ b/src/Foundation/NSDictionary.cs
@@ -26,6 +26,10 @@ using System.Collections;
 using System.Collections.Generic;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 
 	public partial class NSDictionary : NSObject, IDictionary, IDictionary<NSObject, NSObject> {
@@ -37,7 +41,7 @@ namespace Foundation {
 		{
 		}
 
-		internal NSDictionary (IntPtr handle, bool alloced) : base (handle, alloced)
+		internal NSDictionary (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 		}
 		

--- a/src/Foundation/NSDictionary_2.cs
+++ b/src/Foundation/NSDictionary_2.cs
@@ -28,6 +28,10 @@ using System.Collections;
 using System.Collections.Generic;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	[Register ("NSDictionary", SkipRegistration = true)]
 	public sealed partial class NSDictionary<TKey,TValue> : NSDictionary, IDictionary<TKey, TValue> 
@@ -53,7 +57,7 @@ namespace Foundation {
 		{
 		}
 
-		internal NSDictionary (IntPtr handle)
+		internal NSDictionary (NativeHandle handle)
 			: base (handle)
 		{
 		}

--- a/src/Foundation/NSEnumerator_1.cs
+++ b/src/Foundation/NSEnumerator_1.cs
@@ -30,6 +30,10 @@ using System.Collections.Generic;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	[Register ("NSEnumerator", SkipRegistration = true)]
 	public sealed class NSEnumerator<TKey> : NSEnumerator
@@ -41,7 +45,7 @@ namespace Foundation {
 		}
 #endif
 
-		internal NSEnumerator (IntPtr handle)
+		internal NSEnumerator (NativeHandle handle)
 			: base (handle)
 		{
 		}

--- a/src/Foundation/NSMutableArray_1.cs
+++ b/src/Foundation/NSMutableArray_1.cs
@@ -27,6 +27,10 @@ using System.Collections.Generic;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 
 	[Register ("NSMutableArray", SkipRegistration = true)]
@@ -42,7 +46,7 @@ namespace Foundation {
 		{
 		}
 
-		internal NSMutableArray (IntPtr handle)
+		internal NSMutableArray (NativeHandle handle)
 			: base (handle)
 		{
 		}

--- a/src/Foundation/NSMutableDictionary.cs
+++ b/src/Foundation/NSMutableDictionary.cs
@@ -27,12 +27,16 @@ using System.ComponentModel;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 
 	public partial class NSMutableDictionary : NSDictionary, IDictionary, IDictionary<NSObject, NSObject> {
 		
 		// some API, like SecItemCopyMatching, returns a retained NSMutableDictionary
-		internal NSMutableDictionary (IntPtr handle, bool owns)
+		internal NSMutableDictionary (NativeHandle handle, bool owns)
 			: base (handle)
 		{
 			if (!owns)

--- a/src/Foundation/NSMutableDictionary_2.cs
+++ b/src/Foundation/NSMutableDictionary_2.cs
@@ -30,6 +30,10 @@ using System.ComponentModel;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	[Register ("NSMutableDictionary", SkipRegistration = true)]
 	public sealed partial class NSMutableDictionary<TKey,TValue> : NSMutableDictionary, IDictionary<TKey, TValue> 
@@ -46,7 +50,7 @@ namespace Foundation {
 		{
 		}
 
-		internal NSMutableDictionary (IntPtr handle)
+		internal NSMutableDictionary (NativeHandle handle)
 			: base (handle)
 		{
 		}

--- a/src/Foundation/NSMutableOrderedSet_1.cs
+++ b/src/Foundation/NSMutableOrderedSet_1.cs
@@ -13,6 +13,10 @@ using System.Collections;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	[Register ("NSMutableOrderedSet", SkipRegistration = true)]
 	public sealed partial class NSMutableOrderedSet<TKey> : NSMutableOrderedSet, IEnumerable<TKey>
@@ -26,7 +30,7 @@ namespace Foundation {
 		{
 		}
 
-		internal NSMutableOrderedSet (IntPtr handle) : base (handle)
+		internal NSMutableOrderedSet (NativeHandle handle) : base (handle)
 		{
 		}
 

--- a/src/Foundation/NSMutableSet_1.cs
+++ b/src/Foundation/NSMutableSet_1.cs
@@ -30,6 +30,10 @@ using System.Collections.Generic;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	[Register ("NSMutableSet", SkipRegistration = true)]
 	public sealed partial class NSMutableSet<TKey> : NSMutableSet, IEnumerable<TKey>
@@ -44,7 +48,7 @@ namespace Foundation {
 		{
 		}
 
-		internal NSMutableSet (IntPtr handle)
+		internal NSMutableSet (NativeHandle handle)
 			: base (handle)
 		{
 		}

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -185,18 +185,18 @@ namespace Foundation {
 		}
 		
 #if NET
-		protected internal NSObject (IntPtr handle)
+		protected internal NSObject (NativeHandle handle)
 #else
-		public NSObject (IntPtr handle)
+		public NSObject (NativeHandle handle)
 #endif
 			: this (handle, false)
 		{
 		}
 		
 #if NET
-		protected NSObject (IntPtr handle, bool alloced)
+		protected NSObject (NativeHandle handle, bool alloced)
 #else
-		public NSObject (IntPtr handle, bool alloced)
+		public NSObject (NativeHandle handle, bool alloced)
 #endif
 		{
 			this.handle = handle;

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -254,7 +254,7 @@ namespace Foundation {
 			return super;
 		}
 
-		internal static IntPtr Initialize ()
+		internal static NativeHandle Initialize ()
 		{
 			return class_ptr;
 		}
@@ -425,7 +425,7 @@ namespace Foundation {
 		}
 
 		[Preserve]
-		bool InvokeConformsToProtocol (IntPtr protocol)
+		bool InvokeConformsToProtocol (NativeHandle protocol)
 		{
 			return ConformsToProtocol (protocol);
 		}
@@ -433,7 +433,7 @@ namespace Foundation {
 		[Export ("conformsToProtocol:")]
 		[Preserve ()]
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public virtual bool ConformsToProtocol (IntPtr protocol)
+		public virtual bool ConformsToProtocol (NativeHandle protocol)
 		{
 			bool does;
 			bool is_wrapper = IsDirectBinding;
@@ -497,7 +497,7 @@ namespace Foundation {
 			DangerousRelease (handle);
 		}
 
-		internal static void DangerousRelease (IntPtr handle)
+		internal static void DangerousRelease (NativeHandle handle)
 		{
 			if (handle == IntPtr.Zero)
 				return;
@@ -508,7 +508,7 @@ namespace Foundation {
 #endif
 		}
 
-		internal static void DangerousRetain (IntPtr handle)
+		internal static void DangerousRetain (NativeHandle handle)
 		{
 			if (handle == IntPtr.Zero)
 				return;
@@ -519,7 +519,7 @@ namespace Foundation {
 #endif
 		}
 			
-		internal static void DangerousAutorelease (IntPtr handle)
+		internal static void DangerousAutorelease (NativeHandle handle)
 		{
 #if MONOMAC
 			Messaging.void_objc_msgSend (handle, Selector.AutoreleaseHandle);
@@ -583,13 +583,13 @@ namespace Foundation {
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		protected void InitializeHandle (IntPtr handle)
+		protected void InitializeHandle (NativeHandle handle)
 		{
 			InitializeHandle (handle, "init*");
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		protected void InitializeHandle (IntPtr handle, string initSelector)
+		protected void InitializeHandle (NativeHandle handle, string initSelector)
 		{
 			if (this.handle == IntPtr.Zero && Class.ThrowOnInitFailure) {
 				if (ClassHandle == IntPtr.Zero)

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -789,6 +789,10 @@ namespace Foundation {
 			case TypeCode.String:
 				return new NSString ((string) obj);
 			default:
+#if NET
+				if (t == typeof (NativeHandle))
+					return NSValue.ValueFromPointer ((NativeHandle) obj);
+#endif
 				if (t == typeof (IntPtr))
 					return NSValue.ValueFromPointer ((IntPtr) obj);
 #if !NO_SYSTEM_DRAWING

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -46,6 +46,10 @@ using CoreAnimation;
 using CoreGraphics;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	public class NSObjectFlag {
 		public static readonly NSObjectFlag Empty;
@@ -74,7 +78,7 @@ namespace Foundation {
 		// replace older Mono[Touch|Mac]Assembly field (ease code sharing across platforms)
 		public static readonly Assembly PlatformAssembly = typeof (NSObject).Assembly;
 
-		IntPtr handle;
+		NativeHandle handle;
 		IntPtr super; /* objc_super* */
 
 #if !NET
@@ -555,7 +559,7 @@ namespace Foundation {
 			}
 		}
 		
-		public IntPtr Handle {
+		public NativeHandle Handle {
 			get { return handle; }
 			set {
 				if (handle == value)

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -658,10 +658,14 @@ namespace Foundation {
 
 		private void InvokeOnMainThread (Selector sel, NSObject obj, bool wait)
 		{
+#if NET
+			Messaging.void_objc_msgSend_NativeHandle_NativeHandle_bool (this.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), sel.Handle, obj.GetHandle (), wait);
+#else
 #if MONOMAC
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (this.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle, sel.Handle, obj.GetHandle (), wait);
 #else
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (this.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), sel.Handle, obj.GetHandle (), wait);
+#endif
 #endif
 		}
 		
@@ -678,6 +682,10 @@ namespace Foundation {
 		public void BeginInvokeOnMainThread (Action action)
 		{
 			var d = new NSAsyncActionDispatcher (action);
+#if NET
+			Messaging.void_objc_msgSend_NativeHandle_NativeHandle_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
+		                                                        NSDispatcher.Selector.Handle, d.Handle, false);
+#else
 #if MONOMAC
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle, 
 		                                                        NSDispatcher.Selector.Handle, d.Handle, false);
@@ -685,11 +693,16 @@ namespace Foundation {
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), 
 			                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, false);
 #endif
+#endif
 		}
 
 		internal void BeginInvokeOnMainThread (System.Threading.SendOrPostCallback cb, object state)
 		{
 			var d = new NSAsyncSynchronizationContextDispatcher (cb, state);
+#if NET
+			Messaging.void_objc_msgSend_NativeHandle_NativeHandle_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
+			                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, false);
+#else
 #if MONOMAC
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle,
 		                                                        NSDispatcher.Selector.Handle, d.Handle, false);
@@ -697,11 +710,16 @@ namespace Foundation {
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
 			                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, false);
 #endif
+#endif
 		}
 		
 		public void InvokeOnMainThread (Action action)
 		{
 			using (var d = new NSActionDispatcher (action)) {
+#if NET
+				Messaging.void_objc_msgSend_NativeHandle_NativeHandle_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), 
+				                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, true);
+#else
 #if MONOMAC
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle, 
 		                                                                NSDispatcher.Selector.Handle, d.Handle, true);
@@ -709,18 +727,24 @@ namespace Foundation {
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), 
 				                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, true);
 #endif
+#endif
 			}
 		}		
 
 		internal void InvokeOnMainThread (System.Threading.SendOrPostCallback cb, object state)
 		{
 			using (var d = new NSSynchronizationContextDispatcher (cb, state)) {
+#if NET
+				Messaging.void_objc_msgSend_NativeHandle_NativeHandle_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
+				                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, true);
+#else
 #if MONOMAC
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle,
 			                                                        NSDispatcher.Selector.Handle, d.Handle, true);
 #else
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
 				                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, true);
+#endif
 #endif
 			}
 		}
@@ -807,6 +831,13 @@ namespace Foundation {
 		{
 			if (keyPath == null)
 				throw new ArgumentNullException ("keyPath");
+#if NET
+			if (IsDirectBinding) {
+				ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, Selector.GetHandle ("setValue:forKeyPath:"), handle, keyPath.Handle);
+			} else {
+				ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.SuperHandle, Selector.GetHandle ("setValue:forKeyPath:"), handle, keyPath.Handle);
+			}
+#else
 #if MONOMAC
 			if (IsDirectBinding) {
 				ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, selSetValue_ForKeyPath_Handle, handle, keyPath.Handle);
@@ -819,6 +850,7 @@ namespace Foundation {
 			} else {
 				ObjCRuntime.Messaging.void_objc_msgSendSuper_IntPtr_IntPtr (this.SuperHandle, Selector.GetHandle ("setValue:forKeyPath:"), handle, keyPath.Handle);
 			}
+#endif
 #endif
 		}
 
@@ -926,10 +958,14 @@ namespace Foundation {
 				}
 				if (!call_drain)
 					return;
+#if NET
+				Messaging.void_objc_msgSend_NativeHandle_NativeHandle_bool (class_ptr, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), Selector.GetHandle ("drain:"), IntPtr.Zero, false);
+#else
 #if MONOMAC
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (class_ptr, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle, drainHandle, IntPtr.Zero, false);
 #else
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (class_ptr, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), Selector.GetHandle ("drain:"), IntPtr.Zero, false);
+#endif
 #endif
 			}
 			

--- a/src/Foundation/NSOrderedSet_1.cs
+++ b/src/Foundation/NSOrderedSet_1.cs
@@ -13,6 +13,10 @@ using System.Collections;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	[Register ("NSOrderedSet", SkipRegistration = true)]
 	public sealed partial class NSOrderedSet<TKey> : NSOrderedSet, IEnumerable<TKey>
@@ -26,7 +30,7 @@ namespace Foundation {
 		{
 		}
 
-		internal NSOrderedSet (IntPtr handle) : base (handle)
+		internal NSOrderedSet (NativeHandle handle) : base (handle)
 		{
 		}
 

--- a/src/Foundation/NSSet_1.cs
+++ b/src/Foundation/NSSet_1.cs
@@ -30,6 +30,10 @@ using System.Collections.Generic;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	[Register ("NSSet", SkipRegistration = true)]
 	public sealed class NSSet<TKey> : NSSet, IEnumerable<TKey>
@@ -44,7 +48,7 @@ namespace Foundation {
 		{
 		}
 
-		internal NSSet (IntPtr handle)
+		internal NSSet (NativeHandle handle)
 			: base (handle)
 		{
 		}

--- a/src/Foundation/NSString.cs
+++ b/src/Foundation/NSString.cs
@@ -32,6 +32,10 @@ using CoreGraphics;
 #endif
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 
 #if COREBUILD
@@ -59,7 +63,7 @@ namespace Foundation {
 
 		public static readonly NSString Empty = new NSString (String.Empty);
 
-		internal NSString (IntPtr handle, bool alloced) : base (handle, alloced)
+		internal NSString (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 		}
 

--- a/src/Foundation/NSString2.cs
+++ b/src/Foundation/NSString2.cs
@@ -40,10 +40,14 @@ namespace Foundation {
 
 		public NSData Encode (NSStringEncoding enc, bool allowLossyConversion = false)
 		{
+#if NET
+			return new NSData (Messaging.NativeHandle_objc_msgSend_NativeHandle_bool (Handle, Selector.GetHandle (selDataUsingEncodingAllow), (IntPtr) (int) enc, allowLossyConversion));
+#else
 #if MONOMAC
 			return new NSData (Messaging.IntPtr_objc_msgSend_IntPtr_bool (Handle, selDataUsingEncodingAllowHandle, (IntPtr) (int) enc, allowLossyConversion));
 #else
 			return new NSData (Messaging.IntPtr_objc_msgSend_IntPtr_bool (Handle, Selector.GetHandle (selDataUsingEncodingAllow), (IntPtr) (int) enc, allowLossyConversion));
+#endif
 #endif
 		}
 

--- a/src/Foundation/NSUrlConnection.cs
+++ b/src/Foundation/NSUrlConnection.cs
@@ -27,7 +27,11 @@ namespace Foundation {
 			IntPtr rhandle = (IntPtr) resp;
 			IntPtr ehandle = (IntPtr) errp;
 			
+#if NET
+			var res = Messaging.NativeHandle_objc_msgSend_NativeHandle_NativeHandle_NativeHandle (
+#else
 			var res = Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr (
+#endif
 				class_ptr,
 				Selector.GetHandle (selSendSynchronousRequestReturningResponseError),
 				request.Handle,

--- a/src/Foundation/NSUrlProtocol.cs
+++ b/src/Foundation/NSUrlProtocol.cs
@@ -27,7 +27,12 @@
 //
 
 using System;
+using System.Runtime.InteropServices;
 using ObjCRuntime;
+
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
 
 namespace Foundation {
 	public abstract partial class NSUrlProtocol : NSObject {
@@ -42,9 +47,9 @@ namespace Foundation {
 			if (client == null)
 				throw new ArgumentNullException ("client");
 			if (IsDirectBinding) {
-				InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr (this.Handle, selInitWithRequest_CachedResponse_Client_Handle, request.Handle, cachedResponse == null ? IntPtr.Zero : cachedResponse.Handle, client.Handle), "initWithRequest:cachedResponse:client:");
+				InitializeHandle (IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr (this.Handle, selInitWithRequest_CachedResponse_Client_Handle, request.Handle, cachedResponse == null ? IntPtr.Zero : cachedResponse.Handle, client.Handle), "initWithRequest:cachedResponse:client:");
 			} else {
-				InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper_IntPtr_IntPtr_IntPtr (this.SuperHandle, selInitWithRequest_CachedResponse_Client_Handle, request.Handle, cachedResponse == null ? IntPtr.Zero : cachedResponse.Handle, client.Handle), "initWithRequest:cachedResponse:client:");
+				InitializeHandle (IntPtr_objc_msgSendSuper_IntPtr_IntPtr_IntPtr (this.SuperHandle, selInitWithRequest_CachedResponse_Client_Handle, request.Handle, cachedResponse == null ? IntPtr.Zero : cachedResponse.Handle, client.Handle), "initWithRequest:cachedResponse:client:");
 			}
 		}
 
@@ -60,6 +65,12 @@ namespace Foundation {
 				return Runtime.GetNSObject (client.Handle);
 			}
 		}
+
+		[DllImport (Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
+		static extern IntPtr IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr (NativeHandle receiver, NativeHandle selector, NativeHandle arg0, NativeHandle arg1, NativeHandle arg2);
+
+		[DllImport (Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSendSuper")]
+		static extern IntPtr IntPtr_objc_msgSendSuper_IntPtr_IntPtr_IntPtr (NativeHandle receiver, NativeHandle selector, NativeHandle arg0, NativeHandle arg1, NativeHandle arg2);
 #endif
 	}
 }

--- a/src/Foundation/NSUrlProtocolClient.cs
+++ b/src/Foundation/NSUrlProtocolClient.cs
@@ -27,8 +27,13 @@
 //
 
 using System;
+using System.Runtime.InteropServices;
 
 using ObjCRuntime;
+
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
 
 namespace Foundation {
 #if MONOMAC && !NET
@@ -50,43 +55,55 @@ namespace Foundation {
 
 		public void Redirected (NSUrlProtocol protocol, NSUrlRequest redirectedToEequest, NSUrlResponse redirectResponse)
 		{
-			Messaging.void_objc_msgSend_IntPtr_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolWasRedirectedToRequestRedirectResponse_), protocol.Handle, redirectedToEequest.Handle, redirectResponse.Handle);
+			void_objc_msgSend_IntPtr_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolWasRedirectedToRequestRedirectResponse_), protocol.Handle, redirectedToEequest.Handle, redirectResponse.Handle);
 		}
 
 		public void CachedResponseIsValid (NSUrlProtocol protocol, NSCachedUrlResponse cachedResponse)
 		{
-			Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolCachedResponseIsValid_), protocol.Handle, cachedResponse.Handle);
+			void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolCachedResponseIsValid_), protocol.Handle, cachedResponse.Handle);
 		}
 
 		public void ReceivedResponse (NSUrlProtocol protocol, NSUrlResponse response, NSUrlCacheStoragePolicy policy)
 		{
-			Messaging.void_objc_msgSend_IntPtr_IntPtr_int (this.Handle, Selector.GetHandle (selUrlProtocolDidReceiveResponseCacheStoragePolicy_), protocol.Handle, response.Handle, (int)policy);
+			void_objc_msgSend_IntPtr_IntPtr_int (this.Handle, Selector.GetHandle (selUrlProtocolDidReceiveResponseCacheStoragePolicy_), protocol.Handle, response.Handle, (int)policy);
 		}
 
 		public void DataLoaded (NSUrlProtocol protocol, NSData data)
 		{
-			Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolDidLoadData_), protocol.Handle, data.Handle);
+			void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolDidLoadData_), protocol.Handle, data.Handle);
 		}
 
 		public void FinishedLoading (NSUrlProtocol protocol)
 		{
-			Messaging.void_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolDidFinishLoading_), protocol.Handle);
+			void_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolDidFinishLoading_), protocol.Handle);
 		}
 
 		public void FailedWithError (NSUrlProtocol protocol, NSError error)
 		{
-			Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolDidFailWithError_), protocol.Handle, error.Handle);
+			void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolDidFailWithError_), protocol.Handle, error.Handle);
 		}
 
 		public void ReceivedAuthenticationChallenge (NSUrlProtocol protocol, NSUrlAuthenticationChallenge challenge)
 		{
-			Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolDidReceiveAuthenticationChallenge_), protocol.Handle, challenge.Handle);
+			void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolDidReceiveAuthenticationChallenge_), protocol.Handle, challenge.Handle);
 		}
 
 		public void CancelledAuthenticationChallenge (NSUrlProtocol protocol, NSUrlAuthenticationChallenge challenge)
 		{
-			Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolDidCancelAuthenticationChallenge_), protocol.Handle, challenge.Handle);
+			void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle (selUrlProtocolDidCancelAuthenticationChallenge_), protocol.Handle, challenge.Handle);
 		}
+
+		[DllImport (Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
+		static extern void void_objc_msgSend_IntPtr_IntPtr_IntPtr (NativeHandle receiver, NativeHandle selector, NativeHandle arg0, NativeHandle arg1, NativeHandle arg2);
+
+		[DllImport (Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
+		static extern void void_objc_msgSend_IntPtr_IntPtr (NativeHandle receiver, NativeHandle selector, NativeHandle arg0, NativeHandle arg1);
+
+		[DllImport (Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
+		static extern void void_objc_msgSend_IntPtr_IntPtr_int (NativeHandle receiver, NativeHandle selector, NativeHandle arg0, NativeHandle arg1, int arg2);
+
+		[DllImport (Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
+		static extern void void_objc_msgSend_IntPtr (NativeHandle receiver, NativeHandle selector, NativeHandle arg0);
 	}
 #endif
 }

--- a/src/Foundation/NSZone.cs
+++ b/src/Foundation/NSZone.cs
@@ -39,7 +39,7 @@ namespace Foundation {
 			this.Handle = handle;
 		}
 
-		public IntPtr Handle { get; private set; }
+		public NativeHandle Handle { get; private set; }
 
 #if !COREBUILD
 		public string? Name {

--- a/src/Foundation/NSZone.cs
+++ b/src/Foundation/NSZone.cs
@@ -8,6 +8,10 @@ using System.Runtime.InteropServices;
 using CoreFoundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 
 	// Helper to (mostly) support NS[Mutable]Copying protocols
@@ -22,7 +26,7 @@ namespace Foundation {
 		static extern void NSSetZoneName (/* NSZone* */ IntPtr zone, /* NSString* */ IntPtr name);
 
 #if !NET
-		public NSZone (IntPtr handle)
+		public NSZone (NativeHandle handle)
 			: this (handle, false)
 		{
 		}
@@ -30,9 +34,9 @@ namespace Foundation {
 
 		[Preserve (Conditional = true)]
 #if NET
-		internal NSZone (IntPtr handle, bool owns)
+		internal NSZone (NativeHandle handle, bool owns)
 #else
-		public NSZone (IntPtr handle, bool owns)
+		public NSZone (NativeHandle handle, bool owns)
 #endif
 		{
 			// NSZone is just an opaque pointer without reference counting, so we ignore the 'owns' parameter.

--- a/src/GameplayKit/GKObstacleGraph.cs
+++ b/src/GameplayKit/GKObstacleGraph.cs
@@ -11,6 +11,10 @@ using System;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace GameplayKit {
 
 	public partial class GKObstacleGraph {
@@ -31,7 +35,7 @@ namespace GameplayKit {
 	public partial class GKObstacleGraph<NodeType> : GKObstacleGraph where NodeType : GKGraphNode2D {
 
 		[Preserve (Conditional = true)]
-		internal GKObstacleGraph (IntPtr handle) : base (handle)
+		internal GKObstacleGraph (NativeHandle handle) : base (handle)
 		{
 		}
 

--- a/src/ImageIO/CGImageDestination.cs
+++ b/src/ImageIO/CGImageDestination.cs
@@ -36,6 +36,10 @@ using Foundation;
 using CoreFoundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ImageIO {
 
 	public partial class CGImageDestinationOptions
@@ -133,14 +137,14 @@ namespace ImageIO {
 
 	public class CGImageDestination : NativeObject {
 #if !NET
-		internal CGImageDestination (IntPtr handle)
+		internal CGImageDestination (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGImageDestination (IntPtr handle, bool owns)
+		internal CGImageDestination (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/ImageIO/CGImageMetadata.cs
+++ b/src/ImageIO/CGImageMetadata.cs
@@ -17,6 +17,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ImageIO {
 
 #if !NET
@@ -46,14 +50,14 @@ namespace ImageIO {
 #endif
 	public partial class CGImageMetadata : NativeObject {
 #if !NET
-		public CGImageMetadata (IntPtr handle)
+		public CGImageMetadata (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional = true)]
-		internal CGImageMetadata (IntPtr handle, bool owns)
+		internal CGImageMetadata (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/ImageIO/CGImageMetadataTag.cs
+++ b/src/ImageIO/CGImageMetadataTag.cs
@@ -17,6 +17,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ImageIO {
 
 	// CGImageMetadata.h
@@ -32,14 +36,14 @@ namespace ImageIO {
 			/* CFStringRef __nonnull */ IntPtr name, CGImageMetadataType type, /* CFTypeRef __nonnull */ IntPtr value);
 
 #if !NET
-		public CGImageMetadataTag (IntPtr handle)
+		public CGImageMetadataTag (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGImageMetadataTag (IntPtr handle, bool owns)
+		internal CGImageMetadataTag (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -38,6 +38,10 @@ using Foundation;
 using CoreFoundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ImageIO {
 
 #if !COREBUILD
@@ -136,7 +140,7 @@ namespace ImageIO {
 		}
 #endif
 		[Preserve (Conditional=true)]
-		internal CGImageSource (IntPtr handle, bool owns)
+		internal CGImageSource (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/Intents/INIntentResolutionResult.cs
+++ b/src/Intents/INIntentResolutionResult.cs
@@ -12,6 +12,10 @@ using System.Runtime.Versioning;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Intents {
 
 #if NET
@@ -26,7 +30,7 @@ namespace Intents {
 	public sealed partial class INIntentResolutionResult<ObjectType> : INIntentResolutionResult
 		where ObjectType : class, INativeObject 
 	{
-		internal INIntentResolutionResult (IntPtr handle) : base (handle)
+		internal INIntentResolutionResult (NativeHandle handle) : base (handle)
 		{
 		}
 	}

--- a/src/Metal/MTLCompat.cs
+++ b/src/Metal/MTLCompat.cs
@@ -3,7 +3,12 @@ using System;
 
 using Foundation;
 using ObjCRuntime;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
 
 #nullable enable
 
@@ -33,9 +38,15 @@ namespace Metal {
 		{
 			if (descriptor == null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptor));
-			IntPtr errorValue = IntPtr.Zero;
+			var errorValue = NativeHandle.Zero;
 
-			var ret = Runtime.GetINativeObject<IMTLCounterSampleBuffer> (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_ref_IntPtr (This.Handle, Selector.GetHandle ("newCounterSampleBufferWithDescriptor:error:"), descriptor.Handle, ref errorValue), owns: false);
+#if NET
+			var rv = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle_ref_NativeHandle (This.Handle, Selector.GetHandle ("newCounterSampleBufferWithDescriptor:error:"), descriptor.Handle, ref errorValue);
+#else
+			var rv = global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_ref_IntPtr (This.Handle, Selector.GetHandle ("newCounterSampleBufferWithDescriptor:error:"), descriptor.Handle, ref errorValue);
+#endif
+
+			var ret = Runtime.GetINativeObject<IMTLCounterSampleBuffer> (rv, owns: false);
 			error = Runtime.GetNSObject<NSError> (errorValue);
 
 			return ret;
@@ -54,7 +65,11 @@ namespace Metal {
 		{
 			if (sampleBuffer == null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (sampleBuffer));
+#if NET
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_UIntPtr_bool (This.Handle, Selector.GetHandle ("sampleCountersInBuffer:atSampleIndex:withBarrier:"), sampleBuffer.Handle, (UIntPtr) sampleIndex, barrier);
+#else
 			global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_UIntPtr_bool (This.Handle, Selector.GetHandle ("sampleCountersInBuffer:atSampleIndex:withBarrier:"), sampleBuffer.Handle, (UIntPtr) sampleIndex, barrier);
+#endif
 		}
 	}
 #endif // MONOMAC

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -15,6 +15,10 @@ using System.Runtime.Versioning;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace Metal {
@@ -250,9 +254,14 @@ namespace Metal {
 		{
 			if (data is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
-			IntPtr errorValue = IntPtr.Zero;
+			var errorValue = NativeHandle.Zero;
 
-			var ret = Runtime.GetINativeObject<IMTLLibrary> (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_ref_IntPtr (This.Handle, Selector.GetHandle ("newLibraryWithData:error:"), data.Handle, ref errorValue), true);
+			IMTLLibrary? ret;
+#if NET
+			ret = Runtime.GetINativeObject<IMTLLibrary> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle_ref_NativeHandle (This.Handle, Selector.GetHandle ("newLibraryWithData:error:"), data.Handle, ref errorValue), true);
+#else
+			ret = Runtime.GetINativeObject<IMTLLibrary> (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_ref_IntPtr (This.Handle, Selector.GetHandle ("newLibraryWithData:error:"), data.Handle, ref errorValue), true);
+#endif
 			error = Runtime.GetNSObject<NSError> (errorValue);
 
 			return ret;

--- a/src/MetalPerformanceShaders/MPSCompat.cs
+++ b/src/MetalPerformanceShaders/MPSCompat.cs
@@ -83,7 +83,7 @@ namespace MetalPerformanceShaders {
 
 #pragma warning disable CS0809
 		[Obsolete ("Empty stub (not a public API).")]
-		public override IntPtr ClassHandle { get; }
+		public override NativeHandle ClassHandle { get; }
 #pragma warning restore CS0809
 	}
 }

--- a/src/MetalPerformanceShaders/MPSCompat.cs
+++ b/src/MetalPerformanceShaders/MPSCompat.cs
@@ -6,6 +6,10 @@ using System.Runtime.Versioning;
 
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MetalPerformanceShaders {
 
 	public partial class MPSCnnConvolutionTransposeNode {
@@ -63,7 +67,7 @@ namespace MetalPerformanceShaders {
 			=> throw new NotSupportedException ();
 
 		[Obsolete ("Always throws 'NotSupportedException' (not a public API).")]
-		protected MPSCnnConvolutionState (IntPtr handle) : base (handle)
+		protected MPSCnnConvolutionState (NativeHandle handle) : base (handle)
 			=> throw new NotSupportedException ();
 
 		[Obsolete ("Empty stub (not a public API).")]

--- a/src/Network/NWAdvertiseDescriptor.cs
+++ b/src/Network/NWAdvertiseDescriptor.cs
@@ -19,6 +19,10 @@ using nw_advertise_descriptor_t=System.IntPtr;
 using OS_nw_advertise_descriptor=System.IntPtr;
 using OS_nw_txt_record=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 #if !NET
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -29,9 +33,9 @@ namespace Network {
 #endif
 	public class NWAdvertiseDescriptor : NativeObject {
 #if NET
-		internal NWAdvertiseDescriptor (IntPtr handle, bool owns) : base (handle, owns)
+		internal NWAdvertiseDescriptor (NativeHandle handle, bool owns) : base (handle, owns)
 #else
-		public NWAdvertiseDescriptor (IntPtr handle, bool owns) : base (handle, owns)
+		public NWAdvertiseDescriptor (NativeHandle handle, bool owns) : base (handle, owns)
 #endif
 		{ }
 

--- a/src/Network/NWBrowseResult.cs
+++ b/src/Network/NWBrowseResult.cs
@@ -20,6 +20,10 @@ using OS_nw_browse_result=System.IntPtr;
 using OS_nw_endpoint=System.IntPtr;
 using OS_nw_txt_record=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -31,7 +35,7 @@ namespace Network {
 #endif
 	public class NWBrowseResult : NativeObject {
 
-		internal NWBrowseResult (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWBrowseResult (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_endpoint nw_browse_result_copy_endpoint (OS_nw_browse_result result);

--- a/src/Network/NWBrowser.cs
+++ b/src/Network/NWBrowser.cs
@@ -22,6 +22,10 @@ using OS_nw_browse_descriptor=System.IntPtr;
 using OS_nw_parameters=System.IntPtr;
 using dispatch_queue_t =System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 	public delegate void NWBrowserChangesDelegate (NWBrowseResult? oldResult, NWBrowseResult? newResult, bool completed);
@@ -41,7 +45,7 @@ namespace Network {
 		bool queueSet = false;
 		object startLock = new Object ();
 
-		internal NWBrowser (IntPtr handle, bool owns) : base (handle, owns)
+		internal NWBrowser (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 			SetChangesHandler (InternalChangesHandler);
 		}

--- a/src/Network/NWBrowserDescriptor.cs
+++ b/src/Network/NWBrowserDescriptor.cs
@@ -18,6 +18,10 @@ using CoreFoundation;
 
 using OS_nw_browse_descriptor=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -29,7 +33,7 @@ namespace Network {
 #endif
 	public class NWBrowserDescriptor: NativeObject {
 
-		internal NWBrowserDescriptor (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWBrowserDescriptor (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_browse_descriptor nw_browse_descriptor_create_bonjour_service (string type, string? domain);

--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -19,6 +19,10 @@ using nw_endpoint_t=System.IntPtr;
 using nw_parameters_t=System.IntPtr;
 using nw_establishment_report_t=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 	//
@@ -51,9 +55,9 @@ namespace Network {
 #endif
 	public class NWConnection : NativeObject {
 #if NET
-		internal NWConnection (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWConnection (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWConnection (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWConnection (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWConnectionGroup.cs
+++ b/src/Network/NWConnectionGroup.cs
@@ -15,6 +15,10 @@ using OS_nw_protocol_metadata=System.IntPtr;
 using OS_nw_protocol_definition=System.IntPtr;
 using OS_nw_protocol_options=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace Network {
@@ -41,7 +45,7 @@ namespace Network {
 	[SupportedOSPlatform ("maccatalyst14.0")]
 #endif
 	public class NWConnectionGroup : NativeObject {
-		protected internal NWConnectionGroup (IntPtr handle, bool owns) : base (handle, owns) {}
+		protected internal NWConnectionGroup (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_connection_group nw_connection_group_create (OS_nw_group_descriptor group_descriptor, OS_nw_parameters parameters);

--- a/src/Network/NWContentContext.cs
+++ b/src/Network/NWContentContext.cs
@@ -16,6 +16,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 	//
@@ -32,9 +36,9 @@ namespace Network {
 	public class NWContentContext : NativeObject {
 		bool global;
 #if NET
-		internal NWContentContext (IntPtr handle, bool owns) : base (handle, owns)
+		internal NWContentContext (NativeHandle handle, bool owns) : base (handle, owns)
 #else
-		public NWContentContext (IntPtr handle, bool owns) : base (handle, owns)
+		public NWContentContext (NativeHandle handle, bool owns) : base (handle, owns)
 #endif
 		{
 		}

--- a/src/Network/NWDataTransferReport.cs
+++ b/src/Network/NWDataTransferReport.cs
@@ -21,6 +21,10 @@ using OS_nw_data_transfer_report=System.IntPtr;
 using OS_nw_connection=System.IntPtr;
 using OS_nw_interface=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -32,7 +36,7 @@ namespace Network {
 #endif
 	public class NWDataTransferReport : NativeObject {
 
-		internal NWDataTransferReport (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWDataTransferReport (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_data_transfer_report nw_connection_create_new_data_transfer_report (OS_nw_connection connection);

--- a/src/Network/NWEndpoint.cs
+++ b/src/Network/NWEndpoint.cs
@@ -19,6 +19,10 @@ using CoreFoundation;
 
 using OS_nw_endpoint=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -31,9 +35,9 @@ namespace Network {
 #endif
 	public class NWEndpoint : NativeObject {
 #if NET
-		internal NWEndpoint (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWEndpoint (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWEndpoint (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWEndpoint (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWError.cs
+++ b/src/Network/NWError.cs
@@ -17,6 +17,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 #if !NET
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -27,9 +31,9 @@ namespace Network {
 #endif
 	public class NWError : NativeObject {
 #if NET
-		internal NWError (IntPtr handle, bool owns) : base (handle, owns)
+		internal NWError (NativeHandle handle, bool owns) : base (handle, owns)
 #else
-		public NWError (IntPtr handle, bool owns) : base (handle, owns)
+		public NWError (NativeHandle handle, bool owns) : base (handle, owns)
 #endif
 		{
 		}

--- a/src/Network/NWEstablishmentReport.cs
+++ b/src/Network/NWEstablishmentReport.cs
@@ -24,6 +24,10 @@ using nw_report_protocol_enumerator_t=System.IntPtr;
 using nw_protocol_definition_t=System.IntPtr;
 using nw_resolution_report_t=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -35,7 +39,7 @@ namespace Network {
 #endif
 	public class NWEstablishmentReport : NativeObject {
 
-		internal NWEstablishmentReport (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWEstablishmentReport (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]

--- a/src/Network/NWEthernetChannel.cs
+++ b/src/Network/NWEthernetChannel.cs
@@ -23,6 +23,10 @@ using OS_nw_ethernet_channel=System.IntPtr;
 using OS_nw_interface=System.IntPtr;
 using OS_dispatch_data=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -37,7 +41,7 @@ namespace Network {
 #endif
 	public class NWEthernetChannel : NativeObject {
 
-		internal NWEthernetChannel (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWEthernetChannel (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_ethernet_channel nw_ethernet_channel_create (ushort ether_type, OS_nw_interface networkInterface);

--- a/src/Network/NWFramer.cs
+++ b/src/Network/NWFramer.cs
@@ -25,6 +25,10 @@ using OS_nw_protocol_options=System.IntPtr;
 using OS_nw_endpoint=System.IntPtr;
 using OS_nw_parameters=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 	public delegate nuint NWFramerParseCompletionDelegate (Memory<byte> buffer, [MarshalAs (UnmanagedType.I1)] bool isCompleted);
@@ -38,7 +42,7 @@ namespace Network {
 	[SupportedOSPlatform ("macos10.15")]
 #endif
 	public class NWFramer : NativeObject {
-		internal NWFramer (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWFramer (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]

--- a/src/Network/NWFramerMessage.cs
+++ b/src/Network/NWFramerMessage.cs
@@ -25,6 +25,10 @@ using OS_nw_protocol_options=System.IntPtr;
 using OS_nw_endpoint=System.IntPtr;
 using OS_nw_parameters=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -35,7 +39,7 @@ namespace Network {
 	[SupportedOSPlatform ("macos10.15")]
 #endif
 	public class NWFramerMessage : NWProtocolMetadata {
-		internal NWFramerMessage (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWFramerMessage (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_protocol_metadata nw_framer_protocol_create_message (OS_nw_protocol_definition definition);

--- a/src/Network/NWIPMetadata.cs
+++ b/src/Network/NWIPMetadata.cs
@@ -15,6 +15,10 @@ using Foundation;
 using CoreFoundation;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -25,7 +29,7 @@ namespace Network {
 #endif
 	public class NWIPMetadata : NWProtocolMetadata {
 
-		internal NWIPMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWIPMetadata (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		public NWIPMetadata () : this (nw_ip_create_metadata (), owns: true) {}
 

--- a/src/Network/NWInterface.cs
+++ b/src/Network/NWInterface.cs
@@ -19,6 +19,10 @@ using CoreFoundation;
 
 using OS_nw_interface=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -30,9 +34,9 @@ namespace Network {
 #endif
 	public class NWInterface : NativeObject {
 #if NET
-		internal NWInterface (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWInterface (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWInterface (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWInterface (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWListener.cs
+++ b/src/Network/NWListener.cs
@@ -18,6 +18,10 @@ using CoreFoundation;
 
 using nw_connection_group_t=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -31,9 +35,9 @@ namespace Network {
 		bool connectionHandlerWasSet = false;
 		object connectionHandlerLock = new object ();
 #if NET
-		internal NWListener (IntPtr handle, bool owns) : base (handle, owns)
+		internal NWListener (NativeHandle handle, bool owns) : base (handle, owns)
 #else
-		public NWListener (IntPtr handle, bool owns) : base (handle, owns)
+		public NWListener (NativeHandle handle, bool owns) : base (handle, owns)
 #endif
 		{
 		}

--- a/src/Network/NWMulticastGroup.cs
+++ b/src/Network/NWMulticastGroup.cs
@@ -7,6 +7,10 @@ using CoreFoundation;
 using OS_nw_group_descriptor=System.IntPtr;
 using OS_nw_endpoint=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace Network {
@@ -21,7 +25,7 @@ namespace Network {
 	[SupportedOSPlatform ("maccatalyst14.0")]
 #endif
 	public class NWMulticastGroup : NativeObject {
-		internal NWMulticastGroup (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWMulticastGroup (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_group_descriptor nw_group_descriptor_create_multicast (OS_nw_endpoint multicast_group);

--- a/src/Network/NWMultiplexGroup.cs
+++ b/src/Network/NWMultiplexGroup.cs
@@ -7,6 +7,10 @@ using CoreFoundation;
 using OS_nw_group_descriptor=System.IntPtr;
 using OS_nw_endpoint=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace Network {
@@ -21,7 +25,7 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_group_descriptor nw_group_descriptor_create_multiplex (OS_nw_endpoint remoteEndpoint);
 		
-		internal NWMultiplexGroup (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWMultiplexGroup (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		public NWMultiplexGroup (NWEndpoint endpoint) 
 			: base (nw_group_descriptor_create_multiplex (endpoint.GetCheckedHandle ()), true)  { }

--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -20,6 +20,10 @@ using OS_nw_parameters=System.IntPtr;
 using nw_parameters_attribution_t=System.IntPtr;
 using OS_nw_privacy_context=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -31,9 +35,9 @@ namespace Network {
 #endif
 	public class NWParameters : NativeObject {
 #if NET
-		internal NWParameters (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWParameters (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWParameters (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWParameters (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		static unsafe BlockLiteral *DEFAULT_CONFIGURATION () => (BlockLiteral *) NWParametersConstants._DefaultConfiguration;

--- a/src/Network/NWPath.cs
+++ b/src/Network/NWPath.cs
@@ -17,6 +17,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -28,9 +32,9 @@ namespace Network {
 #endif
 	public class NWPath : NativeObject {
 #if NET
-		internal NWPath (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWPath (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWPath (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWPath (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWPathMonitor.cs
+++ b/src/Network/NWPathMonitor.cs
@@ -19,6 +19,10 @@ using CoreFoundation;
 
 using OS_nw_path_monitor=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -30,9 +34,9 @@ namespace Network {
 #endif
 	public class NWPathMonitor : NativeObject {
 #if NET
-		internal NWPathMonitor (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWPathMonitor (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWPathMonitor (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWPathMonitor (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWPrivacyContext.cs
+++ b/src/Network/NWPrivacyContext.cs
@@ -9,6 +9,10 @@ using Foundation;
 using OS_nw_privacy_context=System.IntPtr;
 using OS_nw_resolver_config=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 #if !NET
 	[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
@@ -21,9 +25,9 @@ namespace Network {
 			new NWPrivacyContext (NWPrivacyContextConstants._DefaultContext, false); 
 
 #if NET
-		internal NWPrivacyContext (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWPrivacyContext (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWPrivacyContext (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWPrivacyContext (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWProtocolDefinition.cs
+++ b/src/Network/NWProtocolDefinition.cs
@@ -19,6 +19,10 @@ using CoreFoundation;
 
 using OS_nw_protocol_definition=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -30,9 +34,9 @@ namespace Network {
 #endif
 	public class NWProtocolDefinition : NativeObject {
 #if NET
-		internal NWProtocolDefinition (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWProtocolDefinition (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWProtocolDefinition (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWProtocolDefinition (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWProtocolIPOptions.cs
+++ b/src/Network/NWProtocolIPOptions.cs
@@ -21,6 +21,10 @@ using OS_nw_protocol_definition=System.IntPtr;
 using OS_nw_protocol_options=System.IntPtr;
 using IntPtr=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -31,7 +35,7 @@ namespace Network {
 	[SupportedOSPlatform ("macos10.15")]
 #endif
 	public class NWProtocolIPOptions : NWProtocolOptions {
-		internal NWProtocolIPOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWProtocolIPOptions (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		public void SetVersion (NWIPVersion version)
 			=> nw_ip_options_set_version (GetCheckedHandle (), version);

--- a/src/Network/NWProtocolMetadata.cs
+++ b/src/Network/NWProtocolMetadata.cs
@@ -21,6 +21,10 @@ using OS_nw_protocol_definition=System.IntPtr;
 using OS_nw_protocol_metadata=System.IntPtr;
 using nw_service_class_t=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -55,9 +59,9 @@ namespace Network {
 #endif
 
 #if NET
-		internal NWProtocolMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWProtocolMetadata (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWProtocolMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWProtocolMetadata (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWProtocolOptions.cs
+++ b/src/Network/NWProtocolOptions.cs
@@ -20,6 +20,10 @@ using Security;
 using OS_nw_protocol_definition=System.IntPtr;
 using IntPtr=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -31,9 +35,9 @@ namespace Network {
 #endif
 	public class NWProtocolOptions : NativeObject {
 #if NET
-		internal NWProtocolOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWProtocolOptions (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWProtocolOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWProtocolOptions (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWProtocolQuicOptions.cs
+++ b/src/Network/NWProtocolQuicOptions.cs
@@ -9,6 +9,10 @@ using OS_nw_protocol_options = System.IntPtr;
 using OS_nw_protocol_metadata = System.IntPtr;
 using SecProtocolOptionsRef = System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace Network {
@@ -20,7 +24,7 @@ namespace Network {
 #endif
 	public class NWProtocolQuicOptions : NWProtocolOptions {
 
-		internal NWProtocolQuicOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWProtocolQuicOptions (NativeHandle handle, bool owns) : base (handle, owns) {}
 		
 		public NWProtocolQuicOptions () : this (nw_quic_create_options (), owns: true) {}
 

--- a/src/Network/NWProtocolStack.cs
+++ b/src/Network/NWProtocolStack.cs
@@ -22,6 +22,10 @@ using nw_service_class_t=System.IntPtr;
 using nw_protocol_stack_t=System.IntPtr;
 using nw_protocol_options_t=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -33,9 +37,9 @@ namespace Network {
 #endif
 	public class NWProtocolStack : NativeObject {
 #if NET
-		internal NWProtocolStack (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWProtocolStack (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWProtocolStack (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWProtocolStack (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWProtocolTcpOptions.cs
+++ b/src/Network/NWProtocolTcpOptions.cs
@@ -21,6 +21,10 @@ using OS_nw_protocol_definition=System.IntPtr;
 using OS_nw_protocol_options=System.IntPtr;
 using IntPtr=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -31,7 +35,7 @@ namespace Network {
 #endif
 	public class NWProtocolTcpOptions : NWProtocolOptions {
 		
-		internal NWProtocolTcpOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWProtocolTcpOptions (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		public NWProtocolTcpOptions () : this (nw_tcp_create_options (), owns: true) {}
 

--- a/src/Network/NWProtocolTlsOptions.cs
+++ b/src/Network/NWProtocolTlsOptions.cs
@@ -20,6 +20,10 @@ using Security;
 using OS_nw_protocol_definition=System.IntPtr;
 using IntPtr=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -29,7 +33,7 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWProtocolTlsOptions : NWProtocolOptions {
-		internal NWProtocolTlsOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWProtocolTlsOptions (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		public NWProtocolTlsOptions () : this (nw_tls_create_options (), owns: true) {}
 

--- a/src/Network/NWProtocolUdpOptions.cs
+++ b/src/Network/NWProtocolUdpOptions.cs
@@ -16,6 +16,10 @@ using CoreFoundation;
 using Security;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -25,7 +29,7 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWProtocolUdpOptions : NWProtocolOptions {
-		internal NWProtocolUdpOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWProtocolUdpOptions (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		public NWProtocolUdpOptions () : this (nw_udp_create_options (), owns: true) {}
 

--- a/src/Network/NWQuicMetadata.cs
+++ b/src/Network/NWQuicMetadata.cs
@@ -8,6 +8,10 @@ using Security;
 using OS_nw_protocol_metadata = System.IntPtr;
 using SecProtocolMetadataRef = System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace Network {
@@ -20,9 +24,9 @@ namespace Network {
 	public class NWQuicMetadata : NWProtocolMetadata {
 
 #if NET
-		internal NWQuicMetadata (IntPtr handle, bool owns) : base (handle, owns) { }
+		internal NWQuicMetadata (NativeHandle handle, bool owns) : base (handle, owns) { }
 #else
-		public NWQuicMetadata (IntPtr handle, bool owns) : base (handle, owns) { }
+		public NWQuicMetadata (NativeHandle handle, bool owns) : base (handle, owns) { }
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWResolutionReport.cs
+++ b/src/Network/NWResolutionReport.cs
@@ -10,6 +10,10 @@ using OS_nw_resolution_report=System.IntPtr;
 using OS_nw_endpoint=System.IntPtr;
 using nw_report_resolution_protocol_t=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace Network {
@@ -21,7 +25,7 @@ namespace Network {
 #endif
 	public class NWResolutionReport : NativeObject {
 
-		internal NWResolutionReport (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWResolutionReport (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern NWReportResolutionSource nw_resolution_report_get_source (OS_nw_resolution_report resolutionReport);

--- a/src/Network/NWResolverConfig.cs
+++ b/src/Network/NWResolverConfig.cs
@@ -9,6 +9,10 @@ using System.Runtime.Versioning;
 using OS_nw_resolver_config=System.IntPtr;
 using OS_nw_endpoint=System.IntPtr; 
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 	
 #if !NET
@@ -19,9 +23,9 @@ namespace Network {
 	public class NWResolverConfig : NativeObject {
 
 #if NET
-		internal NWResolverConfig (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWResolverConfig (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public NWResolverConfig (IntPtr handle, bool owns) : base (handle, owns) {}
+		public NWResolverConfig (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 		
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWTcpMetadata.cs
+++ b/src/Network/NWTcpMetadata.cs
@@ -15,6 +15,10 @@ using Foundation;
 using CoreFoundation;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -25,7 +29,7 @@ namespace Network {
 #endif
 	public class NWTcpMetadata : NWProtocolMetadata {
 
-		internal NWTcpMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWTcpMetadata (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		public uint AvailableReceiveBuffer => nw_tcp_get_available_receive_buffer (GetCheckedHandle ());
 

--- a/src/Network/NWTlsMetadata.cs
+++ b/src/Network/NWTlsMetadata.cs
@@ -16,6 +16,10 @@ using Security;
 using CoreFoundation;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -26,7 +30,7 @@ namespace Network {
 #endif
 	public class NWTlsMetadata : NWProtocolMetadata {
 
-		internal NWTlsMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWTlsMetadata (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		public SecProtocolMetadata SecProtocolMetadata
 			=> new SecProtocolMetadata (nw_tls_copy_sec_protocol_metadata (GetCheckedHandle ()), owns: true);

--- a/src/Network/NWTxtRecord.cs
+++ b/src/Network/NWTxtRecord.cs
@@ -22,6 +22,10 @@ using nw_advertise_descriptor_t=System.IntPtr;
 using OS_nw_advertise_descriptor=System.IntPtr;
 using OS_nw_txt_record=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 
 namespace Network {
 
@@ -33,7 +37,7 @@ namespace Network {
 	[SupportedOSPlatform ("macos10.15")]
 #endif
 	public class NWTxtRecord : NativeObject {
-		internal NWTxtRecord (IntPtr handle, bool owns) : base (handle, owns) { }
+		internal NWTxtRecord (NativeHandle handle, bool owns) : base (handle, owns) { }
 
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern IntPtr nw_txt_record_create_with_bytes (byte *txtBytes, nuint len);

--- a/src/Network/NWUdpMetadata.cs
+++ b/src/Network/NWUdpMetadata.cs
@@ -16,6 +16,10 @@ using Security;
 using CoreFoundation;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -26,7 +30,7 @@ namespace Network {
 #endif
 	public class NWUdpMetadata : NWProtocolMetadata {
 
-		internal NWUdpMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWUdpMetadata (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		public NWUdpMetadata () : this (nw_udp_create_metadata (), owns: true) {}
 	}

--- a/src/Network/NWWebSocketMetadata.cs
+++ b/src/Network/NWWebSocketMetadata.cs
@@ -21,6 +21,10 @@ using OS_nw_protocol_metadata=System.IntPtr;
 using OS_nw_ws_response=System.IntPtr;
 using dispatch_queue_t =System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -32,7 +36,7 @@ namespace Network {
 #endif
 	public class NWWebSocketMetadata : NWProtocolMetadata {
 
-		internal NWWebSocketMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWWebSocketMetadata (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_protocol_metadata nw_ws_create_metadata (NWWebSocketOpCode opcode);

--- a/src/Network/NWWebSocketOptions.cs
+++ b/src/Network/NWWebSocketOptions.cs
@@ -20,6 +20,10 @@ using CoreFoundation;
 using OS_nw_protocol_options=System.IntPtr;
 using nw_ws_request_t=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -34,7 +38,7 @@ namespace Network {
 		bool skipHandShake = false;
 		nuint maximumMessageSize;
 
-		internal NWWebSocketOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWWebSocketOptions (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		extern static IntPtr nw_ws_create_options (NWWebSocketVersion version);

--- a/src/Network/NWWebSocketRequest.cs
+++ b/src/Network/NWWebSocketRequest.cs
@@ -19,6 +19,10 @@ using CoreFoundation;
 
 using OS_nw_ws_request=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -29,7 +33,7 @@ namespace Network {
 	[SupportedOSPlatform ("macos10.15")]
 #endif
 	public class NWWebSocketRequest : NativeObject {
-		internal NWWebSocketRequest (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWWebSocketRequest (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]

--- a/src/Network/NWWebSocketResponse.cs
+++ b/src/Network/NWWebSocketResponse.cs
@@ -19,6 +19,10 @@ using CoreFoundation;
 
 using OS_nw_ws_response=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Network {
 
 #if !NET
@@ -30,7 +34,7 @@ namespace Network {
 #endif
 	public class NWWebSocketResponse : NativeObject {
 
-		internal NWWebSocketResponse (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal NWWebSocketResponse (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.NetworkLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
 		static extern unsafe OS_nw_ws_response nw_ws_response_create (NWWebSocketResponseStatus status, string selected_subprotocol);

--- a/src/ObjCRuntime/BaseWrapper.cs
+++ b/src/ObjCRuntime/BaseWrapper.cs
@@ -9,14 +9,18 @@ using System.Runtime.InteropServices;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ObjCRuntime {
 
 	public abstract class BaseWrapper : NativeObject {
 
 #if NET
-		protected BaseWrapper (IntPtr handle, bool owns)
+		protected BaseWrapper (NativeHandle handle, bool owns)
 #else
-		public BaseWrapper (IntPtr handle, bool owns)
+		public BaseWrapper (NativeHandle handle, bool owns)
 #endif
 			: base (handle, owns)
 		{

--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -358,7 +358,7 @@ namespace ObjCRuntime {
 			return -1;
 		}
 
-		internal unsafe static Type? FindType (IntPtr @class, out bool is_custom_type)
+		internal unsafe static Type? FindType (NativeHandle @class, out bool is_custom_type)
 		{
 			var map = Runtime.options->RegistrationMap;
 

--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -79,6 +79,13 @@ namespace ObjCRuntime {
 			this.handle = handle;
 		}
 
+#if NET
+		public Class (NativeHandle handle)
+		{
+			this.handle = handle;
+		}
+#endif
+
 		[Preserve (Conditional = true)]
 #if NET
 		internal Class (NativeHandle handle, bool owns)

--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -19,6 +19,10 @@ using Foundation;
 using Registrar;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ObjCRuntime {
 	public partial class Class : INativeObject
 #if !COREBUILD
@@ -26,7 +30,7 @@ namespace ObjCRuntime {
 #endif
 	{
 #if !COREBUILD
-		IntPtr handle;
+		NativeHandle handle;
 
 		public static bool ThrowOnInitFailure = true;
 
@@ -77,16 +81,16 @@ namespace ObjCRuntime {
 
 		[Preserve (Conditional = true)]
 #if NET
-		internal Class (IntPtr handle, bool owns)
+		internal Class (NativeHandle handle, bool owns)
 #else
-		public Class (IntPtr handle, bool owns)
+		public Class (NativeHandle handle, bool owns)
 #endif
 		{
 			// Class(es) can't be freed, so we ignore the 'owns' parameter.
 			this.handle = handle;
 		}
 
-		public IntPtr Handle {
+		public NativeHandle Handle {
 			get { return this.handle; }
 		}
 

--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -105,7 +105,7 @@ namespace ObjCRuntime {
 			}
 		}
 
-		public static IntPtr GetHandle (string name)
+		public static NativeHandle GetHandle (string name)
 		{
 			return objc_getClass (name);
 		}
@@ -133,11 +133,11 @@ namespace ObjCRuntime {
 		// class (it will be faster than GetHandle, but it will
 		// not compile unless the class in question actually exists
 		// as an ObjectiveC class in the binary).
-		public static IntPtr GetHandleIntrinsic (string name) {
+		public static NativeHandle GetHandleIntrinsic (string name) {
 			return objc_getClass (name);
 		}
 
-		public static IntPtr GetHandle (Type type) {
+		public static NativeHandle GetHandle (Type type) {
 			return GetClassHandle (type);
 		}
 

--- a/src/ObjCRuntime/DisposableObject.cs
+++ b/src/ObjCRuntime/DisposableObject.cs
@@ -13,6 +13,10 @@ using Foundation;
 
 #nullable enable
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ObjCRuntime {
 	//
 	// The DisposableObject class is intended to be a base class for many native data
@@ -23,10 +27,10 @@ namespace ObjCRuntime {
 	// pattern.
 	//
 	public abstract class DisposableObject : INativeObject, IDisposable {
-		IntPtr handle;
+		NativeHandle handle;
 		readonly bool owns;
 
-		public IntPtr Handle {
+		public NativeHandle Handle {
 			get => handle;
 			protected set => InitializeHandle (value);
 		}
@@ -37,12 +41,12 @@ namespace ObjCRuntime {
 		{
 		}
 
-		protected DisposableObject (IntPtr handle, bool owns)
+		protected DisposableObject (NativeHandle handle, bool owns)
 			: this (handle, owns, true)
 		{
 		}
 
-		protected DisposableObject (IntPtr handle, bool owns, bool verify)
+		protected DisposableObject (NativeHandle handle, bool owns, bool verify)
 		{
 			InitializeHandle (handle, verify);
 			this.owns = owns;
@@ -66,13 +70,13 @@ namespace ObjCRuntime {
 
 		protected void ClearHandle ()
 		{
-			handle = IntPtr.Zero;
+			handle = NativeHandle.Zero;
 		}
 
-		void InitializeHandle (IntPtr handle, bool verify)
+		void InitializeHandle (NativeHandle handle, bool verify)
 		{
 #if !COREBUILD
-			if (verify && handle == IntPtr.Zero && Class.ThrowOnInitFailure) {
+			if (verify && handle == NativeHandle.Zero && Class.ThrowOnInitFailure) {
 				throw new Exception ($"Could not initialize an instance of the type '{GetType ().FullName}': handle is null.\n" +
 				    "It is possible to ignore this condition by setting ObjCRuntime.Class.ThrowOnInitFailure to false.");
 			}
@@ -80,14 +84,14 @@ namespace ObjCRuntime {
 			this.handle = handle;
 		}
 
-		protected virtual void InitializeHandle (IntPtr handle)
+		protected virtual void InitializeHandle (NativeHandle handle)
 		{
 			InitializeHandle (handle, true);
 		}
 
-		public IntPtr GetCheckedHandle ()
+		public NativeHandle GetCheckedHandle ()
 		{
-			if (handle == IntPtr.Zero)
+			if (handle == NativeHandle.Zero)
 				ObjCRuntime.ThrowHelper.ThrowObjectDisposedException (this);
 			return handle;
 		}

--- a/src/ObjCRuntime/INativeObject.cs
+++ b/src/ObjCRuntime/INativeObject.cs
@@ -3,11 +3,15 @@
 using System;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ObjCRuntime {
 
 	public interface INativeObject {
 #if !COREBUILD
-		IntPtr Handle { 
+		NativeHandle Handle {
 			get;
 		}
 #endif
@@ -18,12 +22,12 @@ namespace ObjCRuntime {
 
 		// help to avoid the (too common pattern)
 		// 	var p = x == null ? IntPtr.Zero : x.Handle;
-		static public IntPtr GetHandle (this INativeObject? self)
+		static public NativeHandle GetHandle (this INativeObject? self)
 		{
-			return self is null ? IntPtr.Zero : self.Handle;
+			return self is null ? NativeHandle.Zero : self.Handle;
 		}
 
-		static public IntPtr GetNonNullHandle (this INativeObject self, string argumentName)
+		static public NativeHandle GetNonNullHandle (this INativeObject self, string argumentName)
 		{
 			if (self is null)
 				ThrowHelper.ThrowArgumentNullException (argumentName);

--- a/src/ObjCRuntime/NativeHandle.cs
+++ b/src/ObjCRuntime/NativeHandle.cs
@@ -1,0 +1,92 @@
+#if NET
+
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace ObjCRuntime {
+	public readonly struct NativeHandle : IEquatable<NativeHandle> {
+		readonly IntPtr handle;
+
+		public IntPtr Handle {
+			get { return handle; }
+		}
+
+		public static NativeHandle Zero = default (NativeHandle);
+
+		public NativeHandle (IntPtr handle)
+		{
+			this.handle = handle;
+		}
+
+		public static bool operator == (NativeHandle left, IntPtr right)
+		{
+			return left.handle == right;
+		}
+
+		public static bool operator == (NativeHandle left, NativeHandle right)
+		{
+			return left.handle == right.handle;
+		}
+
+		public static bool operator == (IntPtr left, NativeHandle right)
+		{
+			return left == right.Handle;
+		}
+
+		public static bool operator != (NativeHandle left, IntPtr right)
+		{
+			return left.handle != right;
+		}
+
+		public static bool operator != (IntPtr left, NativeHandle right)
+		{
+			return left != right.Handle;
+		}
+
+		public static bool operator != (NativeHandle left, NativeHandle right)
+		{
+			return left.handle != right.Handle;
+		}
+
+		// Should this be made explicit? The JIT seems to optimize conversions away to
+		// treat everything as a plain IntPtr, so I'm not sure there's any reason
+		// to not keep it implicit.
+		public static implicit operator IntPtr (NativeHandle value)
+		{
+			return value.Handle;
+		}
+
+		// Should this be made explicit? The JIT seems to optimize conversions away to
+		// treat everything as a plain IntPtr, so I'm not sure there's any reason
+		// to not keep it implicit.
+		public static implicit operator NativeHandle (IntPtr value)
+		{
+			return new NativeHandle (value);
+		}
+
+		public override bool Equals (object? o)
+		{
+			if (o is NativeHandle nh)
+				return nh.handle == this.handle;
+			return false;
+		}
+
+		public override int GetHashCode ()
+		{
+			return handle.GetHashCode ();
+		}
+
+		public bool Equals (NativeHandle other)
+		{
+			return other.handle == handle;
+		}
+
+		public override string ToString ()
+		{
+			return "0x" + handle.ToString ("x");
+		}
+	}
+}
+#endif

--- a/src/ObjCRuntime/Protocol.cs
+++ b/src/ObjCRuntime/Protocol.cs
@@ -11,10 +11,14 @@ using System.Runtime.InteropServices;
 
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ObjCRuntime {
 	public partial class Protocol : INativeObject {
 #if !COREBUILD
-		IntPtr handle;
+		NativeHandle handle;
 
 		public Protocol (string name)
 		{
@@ -35,13 +39,13 @@ namespace ObjCRuntime {
 		}
 
 		[Preserve (Conditional = true)]
-		internal Protocol (IntPtr handle, bool owns)
+		internal Protocol (NativeHandle handle, bool owns)
 		{
 			// protocols can't be freed, so we ignore the 'owns' parameter.
 			this.handle = handle;
 		}
 
-		public IntPtr Handle {
+		public NativeHandle Handle {
 			get { return this.handle; }
 		}
 

--- a/src/ObjCRuntime/Protocol.cs
+++ b/src/ObjCRuntime/Protocol.cs
@@ -38,6 +38,13 @@ namespace ObjCRuntime {
 			this.handle = handle;
 		}
 
+#if NET
+		public Protocol (NativeHandle handle)
+		{
+			this.handle = handle;
+		}
+#endif
+
 		[Preserve (Conditional = true)]
 		internal Protocol (NativeHandle handle, bool owns)
 		{

--- a/src/ObjCRuntime/Protocol.cs
+++ b/src/ObjCRuntime/Protocol.cs
@@ -33,17 +33,10 @@ namespace ObjCRuntime {
 			this.handle = Runtime.GetProtocolForType (type);
 		}
 
-		public Protocol (IntPtr handle)
-		{
-			this.handle = handle;
-		}
-
-#if NET
 		public Protocol (NativeHandle handle)
 		{
 			this.handle = handle;
 		}
-#endif
 
 		[Preserve (Conditional = true)]
 		internal Protocol (NativeHandle handle, bool owns)

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -45,6 +45,7 @@ namespace ObjCRuntime {
 			Foundation_NSString,
 			Foundation_NSValue,
 			ObjCRuntime_INativeObject,
+			ObjCRuntime_NativeHandle,
 		}
 
 		// Keep in sync with XamarinExceptionType in main.h
@@ -232,6 +233,9 @@ namespace ObjCRuntime {
 				break;
 			case TypeLookup.ObjCRuntime_INativeObject:
 				rv = typeof (ObjCRuntime.INativeObject).IsAssignableFrom (type);
+				break;
+			case TypeLookup.ObjCRuntime_NativeHandle:
+				rv = typeof (ObjCRuntime.NativeHandle).IsAssignableFrom (type);
 				break;
 			default:
 				throw new ArgumentOutOfRangeException (nameof (type));

--- a/src/ObjCRuntime/Selector.cs
+++ b/src/ObjCRuntime/Selector.cs
@@ -140,6 +140,7 @@ namespace ObjCRuntime {
 		extern static /* const char* */ IntPtr sel_getName (/* SEL */ IntPtr sel);
 
 		// objc/runtime.h
+		// Selector.GetHandle is optimized by the AOT compiler, and the current implementation only supports IntPtr, so we can't switch to NativeHandle quite yet (the AOT compiler crashes).
 		[DllImport ("/usr/lib/libobjc.dylib", EntryPoint="sel_registerName")]
 		public extern static /* SEL */ IntPtr GetHandle (/* const char* */ string name);
 

--- a/src/ObjCRuntime/Selector.cs
+++ b/src/ObjCRuntime/Selector.cs
@@ -122,7 +122,7 @@ namespace ObjCRuntime {
 
 		// return null, instead of throwing, if an invalid pointer is used (e.g. IntPtr.Zero)
 		// so this looks better in the debugger watch when no selector is assigned (ref: #10876)
-		public static Selector? FromHandle (IntPtr sel)
+		public static Selector? FromHandle (NativeHandle sel)
 		{
 			if (!sel_isMapped (sel))
 				return null;
@@ -130,7 +130,7 @@ namespace ObjCRuntime {
 			return new Selector (sel, false);
 		}
 
-		public static Selector Register (IntPtr handle)
+		public static Selector Register (NativeHandle handle)
 		{
 			return new Selector (handle);
 		}

--- a/src/ObjCRuntime/Selector.cs
+++ b/src/ObjCRuntime/Selector.cs
@@ -48,7 +48,7 @@ namespace ObjCRuntime {
 		NativeHandle handle;
 		string? name;
 
-		public Selector (IntPtr sel)
+		public Selector (NativeHandle sel)
 		{
 			if (!sel_isMapped (sel))
 				ObjCRuntime.ThrowHelper.ThrowArgumentException (nameof (sel), "Not a selector handle.");
@@ -59,7 +59,7 @@ namespace ObjCRuntime {
 		// this .ctor is required, like for any INativeObject implementation
 		// even if selectors are not disposable
 		[Preserve (Conditional = true)]
-		internal Selector (IntPtr handle, bool /* unused */ owns)
+		internal Selector (NativeHandle handle, bool /* unused */ owns)
 		{
 			this.handle = handle;
 		}

--- a/src/ObjCRuntime/Selector.cs
+++ b/src/ObjCRuntime/Selector.cs
@@ -28,6 +28,10 @@ using Foundation;
 
 #nullable enable
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ObjCRuntime {
 	public partial class Selector : IEquatable<Selector>, INativeObject {
 		internal const string Alloc = "alloc";
@@ -41,7 +45,7 @@ namespace ObjCRuntime {
 		internal const string PerformSelectorWithObjectAfterDelay = "performSelector:withObject:afterDelay:";
 #endif
 
-		IntPtr handle;
+		NativeHandle handle;
 		string? name;
 
 		public Selector (IntPtr sel)
@@ -66,7 +70,7 @@ namespace ObjCRuntime {
 			handle = GetHandle (name);
 		}
 
-		public IntPtr Handle {
+		public NativeHandle Handle {
 			get { return handle; }
 		}
 

--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -227,9 +227,14 @@ namespace ObjCRuntime
 				return false;
 
 #if NET
-			if (type.Namespace == "ObjCRuntime" && type.Name == "nfloat") {
-				type_size = is_64_bits ? 8 : 4;
-				return true;
+			if (type.Namespace == "ObjCRuntime") {
+				switch (type.Name) {
+				case "nfloat":
+				case "NativeHandle":
+					type_size = is_64_bits ? 8 : 4;
+					return true;
+				}
+				return false;
 			}
 #endif
 

--- a/src/OpenGL/CGLContext.cs
+++ b/src/OpenGL/CGLContext.cs
@@ -35,6 +35,10 @@ using ObjCRuntime;
 using Foundation;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace OpenGL {
 #if !NET
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'Metal' Framework instead.")]
@@ -47,14 +51,14 @@ namespace OpenGL {
 	public class CGLContext : NativeObject {
 #if !COREBUILD
 #if !NET
-		public CGLContext (IntPtr handle)
+		public CGLContext (NativeHandle handle)
 			: base (handle, false, verify: true)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal CGLContext (IntPtr handle, bool owns)
+		internal CGLContext (NativeHandle handle, bool owns)
 			: base (handle, owns, true)
 		{
 		}

--- a/src/OpenGL/CGLPixelFormat.cs
+++ b/src/OpenGL/CGLPixelFormat.cs
@@ -36,6 +36,10 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace OpenGL {
 #if !NET
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'Metal' Framework instead.")]
@@ -47,7 +51,7 @@ namespace OpenGL {
 #endif
 	public class CGLPixelFormat : NativeObject {
 #if !NET
-		public CGLPixelFormat (IntPtr handle)
+		public CGLPixelFormat (NativeHandle handle)
 			: base (handle, false, verify: true)
 		{
 		}
@@ -64,7 +68,7 @@ namespace OpenGL {
 		}
 
 		[Preserve (Conditional=true)]
-		internal CGLPixelFormat (IntPtr handle, bool owns)
+		internal CGLPixelFormat (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/PrintCore/PrintCore.cs
+++ b/src/PrintCore/PrintCore.cs
@@ -20,9 +20,13 @@ using CoreFoundation;
 using PMObject=System.IntPtr;
 using OSStatus=System.Int32;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace PrintCore {
 	public class PMPrintCoreBase : NativeObject {
-		internal PMPrintCoreBase (IntPtr handle, bool owns)
+		internal PMPrintCoreBase (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -52,7 +56,7 @@ namespace PrintCore {
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMCreateSession (out IntPtr session);
 
-		internal PMPrintSession (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal PMPrintSession (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		static IntPtr Create ()
 		{
@@ -156,7 +160,7 @@ namespace PrintCore {
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMCreatePrintSettings (out IntPtr session);
 		
-		internal PMPrintSettings (IntPtr handle, bool owns)
+		internal PMPrintSettings (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -315,7 +319,7 @@ namespace PrintCore {
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMCreatePageFormatWithPMPaper (out IntPtr handle, IntPtr paper);
 
-		internal PMPageFormat (IntPtr handle, bool owns): base (handle, owns) {}
+		internal PMPageFormat (NativeHandle handle, bool owns): base (handle, owns) {}
 
 		static IntPtr Create (PMPaper? paper = null)
 		{
@@ -394,7 +398,7 @@ namespace PrintCore {
 	}
 
 	public class PMPaper : PMPrintCoreBase {
-		internal PMPaper (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal PMPaper (NativeHandle handle, bool owns) : base (handle, owns) {}
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static PMStatusCode PMPaperGetID (IntPtr handle, out IntPtr str);
 		[DllImport (Constants.PrintCoreLibrary)]
@@ -461,7 +465,7 @@ namespace PrintCore {
 		[DllImport (Constants.PrintCoreLibrary)]
 		extern static IntPtr PMPrinterCreateFromPrinterID (IntPtr id);
 
-		internal PMPrinter (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal PMPrinter (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		static IntPtr Create ()
 		{

--- a/src/SearchKit/SearchKit.cs
+++ b/src/SearchKit/SearchKit.cs
@@ -27,6 +27,10 @@ using Foundation;
 
 using System.Runtime.InteropServices;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace SearchKit
 {
 	public enum SKIndexType {
@@ -43,7 +47,7 @@ namespace SearchKit
 
 	public class SKSearch : NativeObject
 	{
-		internal SKSearch (IntPtr handle, bool owns)
+		internal SKSearch (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -130,7 +134,7 @@ namespace SearchKit
 		{
 		}
 
-		internal SKDocument (IntPtr handle, bool owns)
+		internal SKDocument (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -193,7 +197,7 @@ namespace SearchKit
 		[DllImport (Constants.SearchKitLibrary)]
 		extern static void SKIndexClose (IntPtr handle);
 
-		SKIndex (IntPtr handle, bool owns)
+		SKIndex (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -486,7 +490,7 @@ namespace SearchKit
 
 	public class SKSummary : NativeObject
 	{
-		internal SKSummary (IntPtr handle, bool owns)
+		internal SKSummary (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/Security/Authorization.cs
+++ b/src/Security/Authorization.cs
@@ -35,6 +35,8 @@ using System;
 using System.Runtime.InteropServices;
 #if NET
 using System.Runtime.Versioning;
+#else
+using NativeHandle = System.IntPtr;
 #endif
 
 namespace Security {
@@ -152,7 +154,7 @@ namespace Security {
 		[DllImport (Constants.SecurityLibrary)]
 		extern static int /* OSStatus = int */ AuthorizationFree (IntPtr handle, AuthorizationFlags flags);
 		
-		internal Authorization (IntPtr handle, bool owns)
+		internal Authorization (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -43,18 +43,22 @@ using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Security {
 
 	public partial class SecCertificate : NativeObject {
 #if !NET
-		public SecCertificate (IntPtr handle)
+		public SecCertificate (NativeHandle handle)
 			: base (handle, false, verify: true)
 		{
 		}
 #endif // !NET
 
 		[Preserve (Conditional = true)]
-		internal SecCertificate (IntPtr handle, bool owns)
+		internal SecCertificate (NativeHandle handle, bool owns)
 			: base (handle, owns, verify: true)
 		{
 		}
@@ -528,14 +532,14 @@ namespace Security {
 
 	public partial class SecIdentity : NativeObject {
 #if !NET
-		public SecIdentity (IntPtr handle)
+		public SecIdentity (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional = true)]
-		internal SecIdentity (IntPtr handle, bool owns)
+		internal SecIdentity (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}
@@ -601,9 +605,9 @@ namespace Security {
 
 		[Preserve (Conditional = true)]
 #if NET
-		internal SecKey (IntPtr handle, bool owns)
+		internal SecKey (NativeHandle handle, bool owns)
 #else
-		public SecKey (IntPtr handle, bool owns)
+		public SecKey (NativeHandle handle, bool owns)
 #endif
 			: base (handle, owns)
 		{

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -44,6 +44,10 @@ using System.Runtime.Versioning;
 using UIKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Security {
 
 	public enum SecKind {
@@ -112,7 +116,7 @@ namespace Security {
 
 	public class SecKeyChain : INativeObject {
 
-		internal SecKeyChain (IntPtr handle)
+		internal SecKeyChain (NativeHandle handle)
 		{
 			Handle = handle;
 		}

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -117,7 +117,7 @@ namespace Security {
 			Handle = handle;
 		}
 
-		public IntPtr Handle { get; internal set; }
+		public NativeHandle Handle { get; internal set; }
 
 		static NSNumber? SetLimit (NSMutableDictionary dict, int max)
 		{

--- a/src/Security/Policy.cs
+++ b/src/Security/Policy.cs
@@ -102,7 +102,7 @@ namespace Security {
 
 		public override int GetHashCode ()
 		{
-			return (int) Handle;
+			return ((IntPtr) Handle).ToInt32 ();
 		}
 	}
 }

--- a/src/Security/Policy.cs
+++ b/src/Security/Policy.cs
@@ -36,17 +36,21 @@ using ObjCRuntime;
 using CoreFoundation;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Security {
 	public partial class SecPolicy : NativeObject {
 #if !NET
-		public SecPolicy (IntPtr handle)
+		public SecPolicy (NativeHandle handle)
 			: base (handle, false, true)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal SecPolicy (IntPtr handle, bool owns)
+		internal SecPolicy (NativeHandle handle, bool owns)
 			: base (handle, owns, true)
 		{
 		}

--- a/src/Security/SecAccessControl.cs
+++ b/src/Security/SecAccessControl.cs
@@ -21,6 +21,10 @@ using CoreFoundation;
 using Foundation;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Security {
 
 	[Flags]
@@ -102,7 +106,7 @@ namespace Security {
 #endif
 	public partial class SecAccessControl : NativeObject {
 #if !COREBUILD
-		internal SecAccessControl (IntPtr handle, bool owns)
+		internal SecAccessControl (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/Security/SecCertificate2.cs
+++ b/src/Security/SecCertificate2.cs
@@ -19,6 +19,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Security {
 
 #if !NET
@@ -30,9 +34,9 @@ namespace Security {
 #endif
 	public class SecCertificate2 : NativeObject {
 #if NET
-		internal SecCertificate2 (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal SecCertificate2 (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public SecCertificate2 (IntPtr handle, bool owns) : base (handle, owns) {}
+		public SecCertificate2 (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.SecurityLibrary)]

--- a/src/Security/SecIdentity2.cs
+++ b/src/Security/SecIdentity2.cs
@@ -19,6 +19,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Security {
 
 #if !NET
@@ -30,10 +34,10 @@ namespace Security {
 #endif
 	public class SecIdentity2 : NativeObject {
 #if NET
-		internal SecIdentity2 (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal SecIdentity2 (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		internal SecIdentity2 (IntPtr handle) : base (handle, false) {}
-		public SecIdentity2 (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal SecIdentity2 (NativeHandle handle) : base (handle, false) {}
+		public SecIdentity2 (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 #if !COREBUILD

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -17,6 +17,10 @@ using Security;
 using sec_protocol_metadata_t=System.IntPtr;
 using dispatch_queue_t=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Security {
 #if !NET
 	[TV (12,0), Mac (10,14), iOS (12,0), Watch (5,0)]
@@ -27,12 +31,12 @@ namespace Security {
 #endif
 	public class SecProtocolMetadata : NativeObject {
 #if !NET
-		internal SecProtocolMetadata (IntPtr handle) : base (handle, false) {}
+		internal SecProtocolMetadata (NativeHandle handle) : base (handle, false) {}
 #endif
 
 		// This type is only ever surfaced in response to callbacks in TLS/Network and documented as read-only
 		// if this ever changes, make this public[tv
-		internal SecProtocolMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal SecProtocolMetadata (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 #if !COREBUILD
 		[DllImport (Constants.SecurityLibrary)]

--- a/src/Security/SecProtocolOptions.cs
+++ b/src/Security/SecProtocolOptions.cs
@@ -18,6 +18,10 @@ using sec_protocol_options_t=System.IntPtr;
 using dispatch_queue_t=System.IntPtr;
 using sec_identity_t=System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Security {
 
 #if !NET
@@ -31,7 +35,7 @@ namespace Security {
 #if !COREBUILD
 		// This type is only ever surfaced in response to callbacks in TLS/Network and documented as read-only
 		// if this ever changes, make this public
-		internal SecProtocolOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal SecProtocolOptions (NativeHandle handle, bool owns) : base (handle, owns) {}
 
 		[DllImport (Constants.SecurityLibrary)]
 		static extern void sec_protocol_options_set_local_identity (sec_protocol_options_t handle, sec_identity_t identity);

--- a/src/Security/SecTrust2.cs
+++ b/src/Security/SecTrust2.cs
@@ -19,6 +19,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Security {
 
 #if !NET
@@ -30,9 +34,9 @@ namespace Security {
 #endif
 	public class SecTrust2 : NativeObject {
 #if NET
-		internal SecTrust2 (IntPtr handle, bool owns) : base (handle, owns) {}
+		internal SecTrust2 (NativeHandle handle, bool owns) : base (handle, owns) {}
 #else
-		public SecTrust2 (IntPtr handle, bool owns) : base (handle, owns) {}
+		public SecTrust2 (NativeHandle handle, bool owns) : base (handle, owns) {}
 #endif
 
 		[DllImport (Constants.SecurityLibrary)]

--- a/src/Security/Trust.cs
+++ b/src/Security/Trust.cs
@@ -39,19 +39,21 @@ using CoreFoundation;
 using Foundation;
 #if NET
 using System.Runtime.Versioning;
+#else
+using NativeHandle = System.IntPtr;
 #endif
 
 namespace Security {
 	public partial class SecTrust : NativeObject {
 #if !NET
-		public SecTrust (IntPtr handle) 
+		public SecTrust (NativeHandle handle) 
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal SecTrust (IntPtr handle, bool owns)
+		internal SecTrust (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/UIKit/UIAppearance.cs
+++ b/src/UIKit/UIAppearance.cs
@@ -27,7 +27,7 @@ namespace UIKit {
 
 		public override int GetHashCode ()
 		{
-			return (int) Handle;
+			return ((IntPtr) Handle).ToInt32 ();
 		}
 
 		public static bool operator == (UIAppearance a, UIAppearance b)

--- a/src/UIKit/UIAppearance.cs
+++ b/src/UIKit/UIAppearance.cs
@@ -125,8 +125,13 @@ namespace UIKit {
 					ptrs [1], // the rest is on the stack. This is where iOS/ARM64 expects the first varargs arguments.
 					ptrs [2], ptrs [3], ptrs [4], IntPtr.Zero);
 			} else {
+#if NET
+				return Messaging.NativeHandle_objc_msgSend_NativeHandle_NativeHandle_NativeHandle_NativeHandle_NativeHandle (class_ptr, Selector.GetHandle (UIAppearance.selAppearanceWhenContainedIn),
+					ptrs [0], ptrs [1], ptrs [2], ptrs [3], ptrs [4]);
+#else
 				return Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr_IntPtr_IntPtr (class_ptr, Selector.GetHandle (UIAppearance.selAppearanceWhenContainedIn), 
 					ptrs [0], ptrs [1], ptrs [2], ptrs [3], ptrs [4]);
+#endif
 			}
 		}
 
@@ -157,7 +162,11 @@ namespace UIKit {
 					ptrs [1], // the rest is on the stack. This is where iOS/ARM64 expects the first varargs arguments.
 					ptrs [2], ptrs [3], ptrs [4], IntPtr.Zero);
 			} else {
+#if NET
+				return Messaging.NativeHandle_objc_msgSend_NativeHandle_NativeHandle_NativeHandle_NativeHandle_NativeHandle (class_ptr, Selector.GetHandle (UIAppearance.selAppearanceForTraitCollectionWhenContainedIn),
+#else
 				return Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr_IntPtr_IntPtr (class_ptr, Selector.GetHandle (UIAppearance.selAppearanceForTraitCollectionWhenContainedIn), 
+#endif
 													 traits.Handle, ptrs [0], ptrs [1], ptrs [2], ptrs [3]);
 			}
 		}

--- a/src/UIKit/UIButton.cs
+++ b/src/UIKit/UIButton.cs
@@ -15,7 +15,12 @@ using ObjCRuntime;
 namespace UIKit {
 	public partial class UIButton {
 		
-		public UIButton (UIButtonType type) : base (ObjCRuntime.Messaging.IntPtr_objc_msgSend_int (class_ptr, Selector.GetHandle ("buttonWithType:"), (int)type))
+		public UIButton (UIButtonType type)
+#if NET
+		: base (ObjCRuntime.Messaging.NativeHandle_objc_msgSend_int (class_ptr, Selector.GetHandle ("buttonWithType:"), (int)type))
+#else
+		: base (ObjCRuntime.Messaging.IntPtr_objc_msgSend_int (class_ptr, Selector.GetHandle ("buttonWithType:"), (int)type))
+#endif
 		{
 			VerifyIsUIButton ();
 		}

--- a/src/UIKit/UIFontFeature.cs
+++ b/src/UIKit/UIFontFeature.cs
@@ -16,6 +16,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreText;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace UIKit {
 	public class UIFontFeature : INativeObject {
 		static NSObject [] keys = new NSObject [] { UIFontDescriptor.UIFontFeatureTypeIdentifierKey, UIFontDescriptor.UIFontFeatureSelectorIdentifierKey };
@@ -26,7 +30,7 @@ namespace UIKit {
 		FontFeatureGroup fontFeature;
 		object? fontFeatureValue;  
 
-		IntPtr INativeObject.Handle {
+		NativeHandle INativeObject.Handle {
 			get {
 				return dictionary.Handle;
 			}

--- a/src/UIKit/UIToolbar.cs
+++ b/src/UIKit/UIToolbar.cs
@@ -23,11 +23,19 @@ namespace UIKit {
 			// must be identical the [get|set]_Items
 			var nsa_items = NSArray.FromNSObjects (items);
 			
+#if NET
+			if (IsDirectBinding) {
+				ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_bool (this.Handle, Selector.GetHandle ("setItems:animated:"), nsa_items.Handle, animated);
+			} else {
+				ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_bool (this.SuperHandle, Selector.GetHandle ("setItems:animated:"), nsa_items.Handle, animated);
+			}
+#else
 			if (IsDirectBinding) {
 				ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_bool (this.Handle, Selector.GetHandle ("setItems:animated:"), nsa_items.Handle, animated);
 			} else {
 				ObjCRuntime.Messaging.void_objc_msgSendSuper_IntPtr_bool (this.SuperHandle, Selector.GetHandle ("setItems:animated:"), nsa_items.Handle, animated);
 			}
+#endif
 			nsa_items.Dispose ();
 		}
 	}

--- a/src/VideoToolbox/VTCompressionSession.cs
+++ b/src/VideoToolbox/VTCompressionSession.cs
@@ -17,6 +17,10 @@ using Foundation;
 using CoreMedia;
 using CoreVideo;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace VideoToolbox {
 
 #if NET
@@ -29,13 +33,13 @@ namespace VideoToolbox {
 
 #if !NET
 		/* invoked by marshallers */
-		protected internal VTCompressionSession (IntPtr handle) : base (handle)
+		protected internal VTCompressionSession (NativeHandle handle) : base (handle)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal VTCompressionSession (IntPtr handle, bool owns) : base (handle, owns)
+		internal VTCompressionSession (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 		}
 

--- a/src/VideoToolbox/VTDecompressionSession.cs
+++ b/src/VideoToolbox/VTDecompressionSession.cs
@@ -19,6 +19,10 @@ using Foundation;
 using CoreMedia;
 using CoreVideo;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace VideoToolbox {
 
 #if NET
@@ -31,13 +35,13 @@ namespace VideoToolbox {
 		GCHandle callbackHandle;
 
 #if !NET
-		protected internal VTDecompressionSession (IntPtr handle) : base (handle)
+		protected internal VTDecompressionSession (NativeHandle handle) : base (handle)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal VTDecompressionSession (IntPtr handle, bool owns) : base (handle, owns)
+		internal VTDecompressionSession (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 		}
 

--- a/src/VideoToolbox/VTFrameSilo.cs
+++ b/src/VideoToolbox/VTFrameSilo.cs
@@ -18,6 +18,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreMedia;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace VideoToolbox {
 
 #if NET
@@ -27,14 +31,14 @@ namespace VideoToolbox {
 #endif
 	public class VTFrameSilo : NativeObject {
 #if !NET
-		protected internal VTFrameSilo (IntPtr handle)
+		protected internal VTFrameSilo (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal VTFrameSilo (IntPtr handle, bool owns)
+		internal VTFrameSilo (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/VideoToolbox/VTMultiPassStorage.cs
+++ b/src/VideoToolbox/VTMultiPassStorage.cs
@@ -18,6 +18,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreMedia;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace VideoToolbox {
 
 #if NET
@@ -30,14 +34,14 @@ namespace VideoToolbox {
 		VTStatus closedStatus;
 
 #if !NET
-		protected internal VTMultiPassStorage (IntPtr handle)
+		protected internal VTMultiPassStorage (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal VTMultiPassStorage (IntPtr handle, bool owns)
+		internal VTMultiPassStorage (NativeHandle handle, bool owns)
 			: base (handle, false)
 		{
 		}

--- a/src/VideoToolbox/VTSession.cs
+++ b/src/VideoToolbox/VTSession.cs
@@ -19,6 +19,10 @@ using Foundation;
 using CoreMedia;
 using CoreVideo;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace VideoToolbox {		
 
 #if NET
@@ -28,14 +32,14 @@ namespace VideoToolbox {
 #endif
 	public class VTSession : NativeObject {
 #if !NET
-		protected internal VTSession (IntPtr handle)
+		protected internal VTSession (NativeHandle handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
 		[Preserve (Conditional=true)]
-		internal VTSession (IntPtr handle, bool owns)
+		internal VTSession (NativeHandle handle, bool owns)
 			: base (handle, owns)
 		{
 		}

--- a/src/Vision/VNCircle.cs
+++ b/src/Vision/VNCircle.cs
@@ -17,14 +17,22 @@ namespace Vision {
 		public static VNCircle CreateUsingRadius (VNPoint center, double radius)
 		{
 			var handle = Messaging.IntPtr_objc_msgSend (class_ptr, Selector.GetHandle ("alloc"));
+#if NET
+			handle = Messaging.NativeHandle_objc_msgSend_NativeHandle_Double (handle, Selector.GetHandle ("initWithCenter:radius:"), center.Handle, radius);
+#else
 			handle = Messaging.IntPtr_objc_msgSend_IntPtr_Double (handle, Selector.GetHandle ("initWithCenter:radius:"), center.Handle, radius);
+#endif
 			return Runtime.GetNSObject<VNCircle> (handle, true);
 		}
 
 		public static VNCircle CreateUsingDiameter (VNPoint center, double diameter)
 		{
 			var handle = Messaging.IntPtr_objc_msgSend (class_ptr, Selector.GetHandle ("alloc"));
+#if NET
+			handle = Messaging.NativeHandle_objc_msgSend_NativeHandle_Double (handle, Selector.GetHandle ("initWithCenter:diameter:"), center.Handle, diameter);
+#else
 			handle = Messaging.IntPtr_objc_msgSend_IntPtr_Double (handle, Selector.GetHandle ("initWithCenter:diameter:"), center.Handle, diameter);
+#endif
 			return Runtime.GetNSObject<VNCircle> (handle, true);
 		}
 	}

--- a/src/accessibility.cs
+++ b/src/accessibility.cs
@@ -3,6 +3,10 @@ using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Accessibility {
 
 	[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)] 
@@ -15,11 +19,11 @@ namespace Accessibility {
 
 		[Export ("initWithTitle:categoryOrder:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string title, string[] categoryOrder);
+		NativeHandle Constructor (string title, string[] categoryOrder);
 
 		[Export ("initWithAttributedTitle:categoryOrder:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSAttributedString attributedTitle, string[] categoryOrder);
+		NativeHandle Constructor (NSAttributedString attributedTitle, string[] categoryOrder);
 	}
 
 	[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)] 
@@ -76,18 +80,18 @@ namespace Accessibility {
 		IAXDataAxisDescriptor[] AdditionalAxes { get; set; }
 
 		[Export ("initWithTitle:summary:xAxisDescriptor:yAxisDescriptor:series:")]
-		IntPtr Constructor ([NullAllowed] string title, [NullAllowed] string summary, IAXDataAxisDescriptor xAxis, [NullAllowed] AXNumericDataAxisDescriptor yAxis, AXDataSeriesDescriptor[] series);
+		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] string summary, IAXDataAxisDescriptor xAxis, [NullAllowed] AXNumericDataAxisDescriptor yAxis, AXDataSeriesDescriptor[] series);
 
 		[Export ("initWithAttributedTitle:summary:xAxisDescriptor:yAxisDescriptor:series:")]
-		IntPtr Constructor ([NullAllowed] NSAttributedString attributedTitle, [NullAllowed] string summary, IAXDataAxisDescriptor xAxis, AXNumericDataAxisDescriptor yAxis, AXDataSeriesDescriptor[] series);
+		NativeHandle Constructor ([NullAllowed] NSAttributedString attributedTitle, [NullAllowed] string summary, IAXDataAxisDescriptor xAxis, AXNumericDataAxisDescriptor yAxis, AXDataSeriesDescriptor[] series);
 
 		[Export ("initWithTitle:summary:xAxisDescriptor:yAxisDescriptor:additionalAxes:series:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string title, [NullAllowed] string summary, IAXDataAxisDescriptor xAxis, [NullAllowed] AXNumericDataAxisDescriptor yAxis, [NullAllowed] IAXDataAxisDescriptor[] additionalAxes, AXDataSeriesDescriptor[] series);
+		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] string summary, IAXDataAxisDescriptor xAxis, [NullAllowed] AXNumericDataAxisDescriptor yAxis, [NullAllowed] IAXDataAxisDescriptor[] additionalAxes, AXDataSeriesDescriptor[] series);
 
 		[Export ("initWithAttributedTitle:summary:xAxisDescriptor:yAxisDescriptor:additionalAxes:series:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSAttributedString attributedTitle, [NullAllowed] string summary, IAXDataAxisDescriptor xAxis, [NullAllowed] AXNumericDataAxisDescriptor yAxis, [NullAllowed] IAXDataAxisDescriptor[] additionalAxes, AXDataSeriesDescriptor[] series);
+		NativeHandle Constructor ([NullAllowed] NSAttributedString attributedTitle, [NullAllowed] string summary, IAXDataAxisDescriptor xAxis, [NullAllowed] AXNumericDataAxisDescriptor yAxis, [NullAllowed] IAXDataAxisDescriptor[] additionalAxes, AXDataSeriesDescriptor[] series);
 	}
 
 	[Watch (7, 0), TV (14, 0), Mac (11, 0), iOS (14, 0)]
@@ -175,14 +179,14 @@ namespace Accessibility {
 		NSAttributedString AttributedLabel { get; set; }
 
 		[Export ("initWithX:y:")]
-		IntPtr Constructor (AXDataPointValue xValue, [NullAllowed] AXDataPointValue yValue);
+		NativeHandle Constructor (AXDataPointValue xValue, [NullAllowed] AXDataPointValue yValue);
 
 		[Export ("initWithX:y:additionalValues:")]
-		IntPtr Constructor (AXDataPointValue xValue, [NullAllowed] AXDataPointValue yValue, [NullAllowed] AXDataPointValue[] additionalValues);
+		NativeHandle Constructor (AXDataPointValue xValue, [NullAllowed] AXDataPointValue yValue, [NullAllowed] AXDataPointValue[] additionalValues);
 
 		[Export ("initWithX:y:additionalValues:label:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AXDataPointValue xValue, [NullAllowed] AXDataPointValue yValue, [NullAllowed] AXDataPointValue[] additionalValues, [NullAllowed] string label);
+		NativeHandle Constructor (AXDataPointValue xValue, [NullAllowed] AXDataPointValue yValue, [NullAllowed] AXDataPointValue[] additionalValues, [NullAllowed] string label);
 	}
 
 	[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)] 
@@ -224,11 +228,11 @@ namespace Accessibility {
 
 		[Export ("initWithName:isContinuous:dataPoints:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string name, bool isContinuous, AXDataPoint[] dataPoints);
+		NativeHandle Constructor (string name, bool isContinuous, AXDataPoint[] dataPoints);
 
 		[Export ("initWithAttributedName:isContinuous:dataPoints:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSAttributedString attributedName, bool isContinuous, AXDataPoint[] dataPoints);
+		NativeHandle Constructor (NSAttributedString attributedName, bool isContinuous, AXDataPoint[] dataPoints);
 	}
 
 	[Watch (8,0), NoTV, NoMac, iOS (15,0), MacCatalyst (15,0)]
@@ -307,10 +311,10 @@ namespace Accessibility {
 
 		[Export ("initWithTitle:lowerBound:upperBound:gridlinePositions:valueDescriptionProvider:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string title, double lowerBound, double upperBound, [NullAllowed] NSNumber[] gridlinePositions, Func<double, NSString> valueDescriptionProvider);
+		NativeHandle Constructor (string title, double lowerBound, double upperBound, [NullAllowed] NSNumber[] gridlinePositions, Func<double, NSString> valueDescriptionProvider);
 
 		[Export ("initWithAttributedTitle:lowerBound:upperBound:gridlinePositions:valueDescriptionProvider:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSAttributedString attributedTitle, double lowerBound, double upperBound, [NullAllowed] NSNumber[] gridlinePositions, Func<double, NSString> valueDescriptionProvider);
+		NativeHandle Constructor (NSAttributedString attributedTitle, double lowerBound, double upperBound, [NullAllowed] NSNumber[] gridlinePositions, Func<double, NSString> valueDescriptionProvider);
 	}
 }

--- a/src/accounts.cs
+++ b/src/accounts.cs
@@ -6,6 +6,10 @@ using System;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Accounts {
 	
 	[Deprecated (PlatformName.iOS, 15, 0, message: "Use the non-Apple SDK relating to your account type instead.")]
@@ -33,7 +37,7 @@ namespace Accounts {
 
 		[DesignatedInitializer]
 		[Export ("initWithAccountType:")]
-		IntPtr Constructor (ACAccountType type);
+		NativeHandle Constructor (ACAccountType type);
 
 #if !XAMCORE_3_0
 		// now exposed with the corresponding EABluetoothAccessoryPickerError enum
@@ -51,10 +55,10 @@ namespace Accounts {
 	[BaseType (typeof (NSObject))]
 	interface ACAccountCredential : NSSecureCoding {
 		[Export ("initWithOAuthToken:tokenSecret:")]
-		IntPtr Constructor (string oauthToken, string tokenSecret);
+		NativeHandle Constructor (string oauthToken, string tokenSecret);
 
 		[Export ("initWithOAuth2Token:refreshToken:expiryDate:")]
-		IntPtr Constructor (string oauth2Token, string refreshToken, NSDate expiryDate);
+		NativeHandle Constructor (string oauth2Token, string refreshToken, NSDate expiryDate);
 
 		[NullAllowed] // by default this property is null
 		[Export ("oauthToken", ArgumentSemantic.Copy)]

--- a/src/addressbookui.cs
+++ b/src/addressbookui.cs
@@ -17,6 +17,10 @@ using AddressBook;
 using System;
 using System.Runtime.Versioning;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AddressBookUI {
 
 	[Deprecated (PlatformName.iOS, 9, 0, message: "Use the 'Contacts' API instead.")]
@@ -24,7 +28,7 @@ namespace AddressBookUI {
 	interface ABNewPersonViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("displayedPerson"), Internal]
 		IntPtr _DisplayedPerson { get; set; }
@@ -59,11 +63,11 @@ namespace AddressBookUI {
 	interface ABPeoplePickerNavigationController : UIAppearance {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("initWithRootViewController:")]
 		[PostGet ("ViewControllers")] // that will PostGet TopViewController and VisibleViewController too
-		IntPtr Constructor (UIViewController rootViewController);
+		NativeHandle Constructor (UIViewController rootViewController);
 
 		[NullAllowed]
 		[Export ("displayedProperties", ArgumentSemantic.Copy), Internal]
@@ -128,7 +132,7 @@ namespace AddressBookUI {
 	interface ABPersonViewController : UIViewControllerRestoration {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("displayedPerson"), Internal]
 		IntPtr _DisplayedPerson {get; set;}
@@ -254,7 +258,7 @@ namespace AddressBookUI {
 	interface ABUnknownPersonViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[NullAllowed] // by default this property is null
 		[Export ("alternateName", ArgumentSemantic.Copy)]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -65,6 +65,10 @@ using NSColorList = Foundation.NSObject;
 using Color = AppKit.NSColor;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AppKit {
 	//[BaseType (typeof (NSObject))]
 	//interface CIImage {
@@ -79,10 +83,10 @@ namespace AppKit {
 	[BaseType (typeof (NSCell))]
 	interface NSActionCell {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 	
 		[Export ("target", ArgumentSemantic.Weak), NullAllowed]
 		NSObject Target  { get; set; }
@@ -163,7 +167,7 @@ namespace AppKit {
 	interface NSAnimation : NSCoding, NSCopying {
 		[Export ("initWithDuration:animationCurve:")]
 		[Sealed] // Just to avoid the duplicate selector error
-		IntPtr Constructor (double duration, NSAnimationCurve animationCurve);
+		NativeHandle Constructor (double duration, NSAnimationCurve animationCurve);
 
 #if !XAMCORE_4_0
 		[Obsolete ("Use the constructor instead.")]
@@ -394,7 +398,7 @@ namespace AppKit {
 	interface NSAppearance : NSSecureCoding {
 		[DesignatedInitializer]
 		[Export ("initWithAppearanceNamed:bundle:")]
-		IntPtr Constructor (string name, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor (string name, [NullAllowed] NSBundle bundle);
 
 		[Export ("name")]
 		string Name { get; }
@@ -1449,21 +1453,21 @@ namespace AppKit {
 	partial interface NSBitmapImageRep : NSSecureCoding {
 		[Export ("initWithFocusedViewRect:")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'NSView.CacheDisplay()' instead.")]
-		IntPtr Constructor (CGRect rect);
+		NativeHandle Constructor (CGRect rect);
 
 		[Export ("initWithBitmapDataPlanes:pixelsWide:pixelsHigh:bitsPerSample:samplesPerPixel:hasAlpha:isPlanar:colorSpaceName:bytesPerRow:bitsPerPixel:")]
-		IntPtr Constructor (IntPtr planes, nint width, nint height, nint bps, nint spp, bool alpha, bool isPlanar,
+		NativeHandle Constructor (IntPtr planes, nint width, nint height, nint bps, nint spp, bool alpha, bool isPlanar,
 				    string colorSpaceName, nint rBytes, nint pBits);
 
 		[Export ("initWithBitmapDataPlanes:pixelsWide:pixelsHigh:bitsPerSample:samplesPerPixel:hasAlpha:isPlanar:colorSpaceName:bitmapFormat:bytesPerRow:bitsPerPixel:")]
-		IntPtr Constructor (IntPtr planes, nint width, nint height, nint bps, nint spp, bool alpha, bool isPlanar, string colorSpaceName,
+		NativeHandle Constructor (IntPtr planes, nint width, nint height, nint bps, nint spp, bool alpha, bool isPlanar, string colorSpaceName,
 				    NSBitmapFormat bitmapFormat, nint rBytes, nint pBits);
 
 		[Export ("initWithCGImage:")]
-		IntPtr Constructor (CGImage cgImage);
+		NativeHandle Constructor (CGImage cgImage);
 
 		[Export ("initWithCIImage:")]
-		IntPtr Constructor (CIImage ciImage);
+		NativeHandle Constructor (CIImage ciImage);
 
 		[Static]
 		[Export ("imageRepsWithData:")]
@@ -1474,7 +1478,7 @@ namespace AppKit {
 		NSImageRep ImageRepFromData (NSData data);
 
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Export ("bitmapData")]
 		IntPtr BitmapData { get; }
@@ -1619,7 +1623,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	interface NSBox {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("borderType")]
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'Transparent' property for NSNoBorder instead.")]
@@ -1685,7 +1689,7 @@ namespace AppKit {
 		// , Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSBrowserDelegate)})]
 	partial interface NSBrowser {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("loadColumnZero")]
 		void LoadColumnZero ();
@@ -2080,12 +2084,12 @@ namespace AppKit {
 		[Mac (10,12)]
 		[Export ("initTextCell:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string str);
+		NativeHandle Constructor (string str);
 
 		[Mac (10,12)]
 		[Export ("initImageCell:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSImage image);
+		NativeHandle Constructor ([NullAllowed] NSImage image);
 
 		[Static]
 		[Export ("branchImage")]
@@ -2124,11 +2128,11 @@ namespace AppKit {
 	interface NSButtonCell {
 		[DesignatedInitializer]
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[DesignatedInitializer]
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage image);
+		NativeHandle Constructor (NSImage image);
 
 		[Export ("title")]
 		string Title { get; set; }
@@ -2240,7 +2244,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl))]
 	interface NSButton : NSAccessibilityButton, NSUserInterfaceCompression, NSUserInterfaceValidations {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Mac (10,12)]
 		[Static]
@@ -2382,11 +2386,11 @@ namespace AppKit {
 	interface NSCachedImageRep {
 		[Deprecated (PlatformName.MacOSX, 10, 6)]
 		[Export ("initWithWindow:rect:")]
-		IntPtr Constructor (NSWindow win, CGRect rect);
+		NativeHandle Constructor (NSWindow win, CGRect rect);
 
 		[Deprecated (PlatformName.MacOSX, 10, 6)]
 		[Export ("initWithSize:depth:separate:alpha:")]
-		IntPtr Constructor (CGSize size, NSWindowDepth depth, bool separate, bool alpha);
+		NativeHandle Constructor (CGSize size, NSWindowDepth depth, bool separate, bool alpha);
 
 		[Deprecated (PlatformName.MacOSX, 10, 6)]
 		[Export ("window")]
@@ -2406,11 +2410,11 @@ namespace AppKit {
 	
 		[DesignatedInitializer]
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[DesignatedInitializer]
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 	
 		[Export ("controlView")]
 		NSView ControlView { get; set; }
@@ -2738,7 +2742,7 @@ namespace AppKit {
 		NSCIImageRep FromCIImage (CIImage image);
 
 		[Export ("initWithCIImage:")]
-		IntPtr Constructor (CIImage image);
+		NativeHandle Constructor (CIImage image);
 
 		[Export ("CIImage")]
 		CIImage CIImage { get; }
@@ -2749,7 +2753,7 @@ namespace AppKit {
 	[BaseType (typeof (NSGestureRecognizer))]
 	interface NSClickGestureRecognizer : NSCoding {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("buttonMask")]
 		nuint ButtonMask { get; set; }
@@ -2766,7 +2770,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	interface NSClipView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("backgroundColor", ArgumentSemantic.Copy)]
 		NSColor BackgroundColor { get; set; }
@@ -2834,7 +2838,7 @@ namespace AppKit {
 	[BaseType (typeof (NSViewController))]
 	interface NSCollectionViewItem : NSCopying {
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[Export ("collectionView")]
 		[NullAllowed]
@@ -2861,7 +2865,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	interface NSCollectionView : NSDraggingSource, NSDraggingDestination {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("isFirstResponder")]
 		bool IsFirstResponder { get; } 
@@ -3658,7 +3662,7 @@ namespace AppKit {
 #if !XAMCORE_4_0
 		[Obsolete ("Use the constructor that allows you to set currentLayout and newLayout.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 #endif
 
 		[Export ("transitionProgress", ArgumentSemantic.Assign)]
@@ -3671,7 +3675,7 @@ namespace AppKit {
 		NSCollectionViewLayout NextLayout { get; }
 
 		[Export ("initWithCurrentLayout:nextLayout:")]
-		IntPtr Constructor (NSCollectionViewLayout currentLayout, NSCollectionViewLayout newLayout);
+		NativeHandle Constructor (NSCollectionViewLayout currentLayout, NSCollectionViewLayout newLayout);
 
 		[Export ("updateValue:forAnimatedKey:")]
 		void UpdateValue (nfloat value, string key);
@@ -4272,10 +4276,10 @@ namespace AppKit {
 		NSColorList ColorListNamed (string name);
 
 		[Export ("initWithName:")]
-		IntPtr Constructor (string name);
+		NativeHandle Constructor (string name);
 
 		[Export ("initWithName:fromFile:")]
-		IntPtr Constructor (string name, [NullAllowed] string path);
+		NativeHandle Constructor (string name, [NullAllowed] string path);
 
 		[Export ("name")]
 		string Name { get; }
@@ -4380,7 +4384,7 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	interface NSColorPicker {
 		[Export ("initWithPickerMask:colorPanel:")]
-		IntPtr Constructor (NSColorPanelFlags mask, NSColorPanel owningColorPanel);
+		NativeHandle Constructor (NSColorPanelFlags mask, NSColorPanel owningColorPanel);
 
 		[Export ("colorPanel")]
 		NSColorPanel ColorPanel { get; }
@@ -4415,20 +4419,20 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	interface NSColorSpace : NSCoding, NSSecureCoding {
 		[Export ("initWithICCProfileData:")]
-		IntPtr Constructor (NSData iccData);
+		NativeHandle Constructor (NSData iccData);
 
 		[Export ("ICCProfileData")]
 		NSData ICCProfileData { get; }
 
 		// Conflicts with the built-in handle intptr
 		//[Export ("initWithColorSyncProfile:")]
-		//IntPtr Constructor (IntPtr colorSyncProfile);
+		//NativeHandle Constructor (IntPtr colorSyncProfile);
 
 		[Export ("colorSyncProfile")]
 		IntPtr ColorSyncProfile { get; }
 
 		[Export ("initWithCGColorSpace:")]
-		IntPtr Constructor (CGColorSpace cgColorSpace);
+		NativeHandle Constructor (CGColorSpace cgColorSpace);
 
 		[Export ("CGColorSpace")]
 		CGColorSpace ColorSpace { get; }
@@ -4532,7 +4536,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl))]
 	interface NSColorWell {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("deactivate")]
 		void Deactivate ();
@@ -4566,7 +4570,7 @@ namespace AppKit {
 	partial interface NSComboBox {
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Wrap ("WeakDelegate")]
 		[Protocolize]
@@ -4694,7 +4698,7 @@ namespace AppKit {
 	[BaseType (typeof (NSTextFieldCell))]
 	partial interface NSComboBoxCell {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 
 		[Export ("hasVerticalScroller")]
 		bool HasVerticalScroller { get; set; }
@@ -4811,7 +4815,7 @@ namespace AppKit {
 	partial interface NSControl {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("sizeToFit")]
 		void SizeToFit ();
@@ -5171,12 +5175,12 @@ namespace AppKit {
 		
 		[DesignatedInitializer]
 		[Export ("initWithImage:hotSpot:")]
-		IntPtr Constructor (NSImage newImage, CGPoint aPoint);
+		NativeHandle Constructor (NSImage newImage, CGPoint aPoint);
 
 		[NoMacCatalyst]
 		[Deprecated (PlatformName.MacOSX, 10, 12, message: "Color hints are ignored. Use NSCursor (NSImage newImage, CGPoint aPoint) instead.")]
 		[Export ("initWithImage:foregroundColorHint:backgroundColorHint:hotSpot:")]
-		IntPtr Constructor (NSImage newImage, NSColor fg, NSColor bg, CGPoint hotSpot);
+		NativeHandle Constructor (NSImage newImage, NSColor fg, NSColor bg, CGPoint hotSpot);
 
 		[Static]
 		[Export ("hide")]
@@ -5241,7 +5245,7 @@ namespace AppKit {
 	[DisableDefaultCtor] // An uncaught exception was raised: -[NSCustomImageRep init]: unrecognized selector sent to instance 0x54a870
 	partial interface NSCustomImageRep {
 		[Export ("initWithDrawSelector:delegate:")]
-		IntPtr Constructor (Selector drawSelectorMethod, NSObject delegateObject);
+		NativeHandle Constructor (Selector drawSelectorMethod, NSObject delegateObject);
 
 		[NullAllowed]
 		[Export ("drawSelector")]
@@ -5256,7 +5260,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (NSDatePickerCellDelegate)})]
 	interface NSDatePicker {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		//Detected properties
 		[Export ("datePickerStyle")]
@@ -5324,10 +5328,10 @@ namespace AppKit {
 	interface NSDatePickerCell {
 		[DesignatedInitializer]
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 
 		//Detected properties
 		[Export ("datePickerStyle")]
@@ -5478,17 +5482,17 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	partial interface NSDocument /* : NSUserActivityRestoring radar://42781537 */ {
 		[Export ("initWithType:error:")]
-		IntPtr Constructor (string typeName, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (string typeName, [NullAllowed] out NSError outError);
 
 		[Static]
 		[Export ("canConcurrentlyReadDocumentsOfType:")]
 		bool CanConcurrentlyReadDocumentsOfType (string typeName);
 
 		[Export ("initWithContentsOfURL:ofType:error:")]
-		IntPtr Constructor (NSUrl url, string typeName, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (NSUrl url, string typeName, [NullAllowed] out NSError outError);
 
 		[Export ("initForURL:withContentsOfURL:ofType:error:")]
-		IntPtr Constructor ([NullAllowed] NSUrl documentUrl, NSUrl documentContentsUrl, string typeName, [NullAllowed] out NSError outError);
+		NativeHandle Constructor ([NullAllowed] NSUrl documentUrl, NSUrl documentContentsUrl, string typeName, [NullAllowed] out NSError outError);
 
 		[Export ("revertDocumentToSaved:")]
 		void RevertDocumentToSaved ([NullAllowed] NSObject sender);
@@ -6003,7 +6007,7 @@ namespace AppKit {
 
 		[Export ("initWithKey:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string key);
+		NativeHandle Constructor (string key);
 
 		[Field ("NSDraggingImageComponentIconKey")]
 		NSString IconKey { get; }
@@ -6029,7 +6033,7 @@ namespace AppKit {
 
 		[Export ("initWithPasteboardWriter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSPasteboardWriting pasteboardWriter);
+		NativeHandle Constructor (INSPasteboardWriting pasteboardWriter);
 
 		[Export ("setImageComponentsProvider:")]
 		void SetImagesContentProvider ([NullAllowed] NSDraggingItemImagesContentProvider provider);
@@ -6240,7 +6244,7 @@ namespace AppKit {
 	[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'NSSplitViewController' instead.")]
 	partial interface NSDrawer : NSAccessibilityElementProtocol, NSAccessibility {
 		[Export ("initWithContentSize:preferredEdge:")]
-		IntPtr Constructor (CGSize contentSize, NSRectEdge edge);
+		NativeHandle Constructor (CGSize contentSize, NSRectEdge edge);
 
 		[Export ("parentWindow")]
 		NSWindow ParentWindow { get; set; }
@@ -6869,7 +6873,7 @@ namespace AppKit {
 		NSFontDescriptor FromNameMatrix (string fontName, NSAffineTransform matrix);
 
 		[Export ("initWithFontAttributes:")]
-		IntPtr Constructor ([NullAllowed] NSDictionary attributes);
+		NativeHandle Constructor ([NullAllowed] NSDictionary attributes);
 
 		[Export ("matchingFontDescriptorsWithMandatoryKeys:")]
 		NSFontDescriptor [] MatchingFontDescriptors (NSSet mandatoryKeys);
@@ -7131,13 +7135,13 @@ namespace AppKit {
 	[BaseType (typeof (NSMatrix))]
 	partial interface NSForm  {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("initWithFrame:mode:prototype:numberOfRows:numberOfColumns:")]
-		IntPtr Constructor (CGRect frameRect, NSMatrixMode aMode, NSCell aCell, nint rowsHigh, nint colsWide);
+		NativeHandle Constructor (CGRect frameRect, NSMatrixMode aMode, NSCell aCell, nint rowsHigh, nint colsWide);
 
 		[Export ("initWithFrame:mode:cellClass:numberOfRows:numberOfColumns:")]
-		IntPtr Constructor (CGRect frameRect, NSMatrixMode aMode, Class factoryId, nint rowsHigh, nint colsWide);
+		NativeHandle Constructor (CGRect frameRect, NSMatrixMode aMode, Class factoryId, nint rowsHigh, nint colsWide);
 
 		[Export ("indexOfSelectedItem")]
 		nint SelectedItemIndex { get; }
@@ -7202,10 +7206,10 @@ namespace AppKit {
 	partial interface NSFormCell {
 		[DesignatedInitializer]
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 
 		[Export ("isOpaque")]
 		bool IsOpaque { get; }
@@ -7257,10 +7261,10 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	interface NSGradient : NSSecureCoding, NSCopying {
 		[Export ("initWithStartingColor:endingColor:")]
-		IntPtr Constructor  (NSColor startingColor, NSColor endingColor);
+		NativeHandle Constructor  (NSColor startingColor, NSColor endingColor);
 
 		[Export ("initWithColors:")]
-		IntPtr Constructor  (NSColor[] colorArray);
+		NativeHandle Constructor  (NSColor[] colorArray);
 
 		// See AppKit/NSGradiant.cs
 		//[Export ("initWithColorsAndLocations:")]
@@ -7388,7 +7392,7 @@ namespace AppKit {
 	{
 		[Export ("initWithFrame:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Static]
 		[Export ("gridViewWithNumberOfColumns:rows:")]
@@ -7599,7 +7603,7 @@ namespace AppKit {
 		NSObject FromData (NSData epsData);
 
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData epsData);
+		NativeHandle Constructor (NSData epsData);
 
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("prepareGState")]
@@ -7960,7 +7964,7 @@ namespace AppKit {
 	interface NSGestureRecognizer : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor ([NullAllowed] NSObject target, [NullAllowed] Selector action);
+		NativeHandle Constructor ([NullAllowed] NSObject target, [NullAllowed] Selector action);
 
 		[Export ("target", ArgumentSemantic.Weak), NullAllowed]
 		NSObject Target { get; set; }
@@ -8130,7 +8134,7 @@ namespace AppKit {
 	partial interface NSMenu : NSCoding, NSCopying, NSAccessibility, NSAccessibilityElement, NSAppearanceCustomization, NSUserInterfaceItemIdentification  {
 		[DesignatedInitializer]
 		[Export ("initWithTitle:")]
-		IntPtr Constructor (string title);
+		NativeHandle Constructor (string title);
 
 		[Static]
 		[Export ("popUpContextMenu:withEvent:forView:")]
@@ -8344,7 +8348,7 @@ namespace AppKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithTitle:action:keyEquivalent:")]
-		IntPtr Constructor (string title, [NullAllowed] Selector selectorAction, string charCode);
+		NativeHandle Constructor (string title, [NullAllowed] Selector selectorAction, string charCode);
 
 		[Export ("hasSubmenu")]
 		bool HasSubmenu { get; }
@@ -8458,10 +8462,10 @@ namespace AppKit {
 	interface NSMenuItemCell {
 		[DesignatedInitializer]
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 
 		[Export ("calcSize")]
 		void CalcSize ();
@@ -8538,11 +8542,11 @@ namespace AppKit {
 		nfloat MenuBarHeight { get; }
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		// <quote>Deprecated. Tear-off menus are not supported in OS X.</quote>
 		//[Export ("initAsTearOff")]
-		//IntPtr Constructor (int tokenInitAsTearOff);
+		//NativeHandle Constructor (int tokenInitAsTearOff);
 
 		[Export ("itemChanged:")]
 		void ItemChanged (NSNotification notification);
@@ -8652,13 +8656,13 @@ namespace AppKit {
 	partial interface NSNib : NSCoding {
 		[Export ("initWithContentsOfURL:")]
 		[Deprecated (PlatformName.MacOSX, 10, 8)]
-		IntPtr Constructor (NSUrl nibFileUrl);
+		NativeHandle Constructor (NSUrl nibFileUrl);
 
 		[Export ("initWithNibNamed:bundle:")]
-		IntPtr Constructor (string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor (string nibName, [NullAllowed] NSBundle bundle);
 		
 		[Export ("initWithNibData:bundle:")]
-		IntPtr Constructor (NSData nibData, NSBundle bundle);
+		NativeHandle Constructor (NSData nibData, NSBundle bundle);
 
 		[Deprecated (PlatformName.MacOSX, 10, 8)]
 		[Export ("instantiateNibWithExternalNameTable:")]
@@ -8673,7 +8677,7 @@ namespace AppKit {
 	interface NSObjectController {
 		[DesignatedInitializer]
 		[Export ("initWithContent:")]
-		IntPtr Constructor (NSObject content);
+		NativeHandle Constructor (NSObject content);
 
 		[Export ("content", ArgumentSemantic.Retain)]
 		NSObject Content { get; set; }
@@ -8748,7 +8752,7 @@ namespace AppKit {
 	[NoMacCatalyst]
 	interface NSOpenGLPixelFormat : NSCoding {
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData attribs);
+		NativeHandle Constructor (NSData attribs);
 
 		[Export ("getValues:forAttribute:forVirtualScreen:")]
 		void GetValue (ref int /* GLint = int32_t */ vals, NSOpenGLPixelFormatAttribute attrib, int /* GLint = int32_t */ screen);
@@ -8767,11 +8771,11 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	interface NSOpenGLPixelBuffer {
 		[Export ("initWithTextureTarget:textureInternalFormat:textureMaxMipMapLevel:pixelsWide:pixelsHigh:")]
-		IntPtr Constructor (NSGLTextureTarget targetGlEnum, NSGLFormat format, int /* GLint = int32_t */ maxLevel, int /* GLsizei = int32_t */ pixelsWide, int /* GLsizei = int32_t */ pixelsHigh);
+		NativeHandle Constructor (NSGLTextureTarget targetGlEnum, NSGLFormat format, int /* GLint = int32_t */ maxLevel, int /* GLsizei = int32_t */ pixelsWide, int /* GLsizei = int32_t */ pixelsHigh);
 
 		// FIXME: This conflicts with our internal ctor
 		// [Export ("initWithCGLPBufferObj:")]
-		// IntPtr Constructor (IntPtr pbuffer);
+		// NativeHandle Constructor (IntPtr pbuffer);
 
 		[Export ("CGLPBufferObj")]
 		IntPtr CGLPBuffer { get; }
@@ -8799,11 +8803,11 @@ namespace AppKit {
 	[NoMacCatalyst]
 	interface NSOpenGLContext {
 		[Export ("initWithFormat:shareContext:")]
-		IntPtr Constructor (NSOpenGLPixelFormat format, [NullAllowed] NSOpenGLContext shareContext);
+		NativeHandle Constructor (NSOpenGLPixelFormat format, [NullAllowed] NSOpenGLContext shareContext);
 
 		// FIXME: This conflicts with our internal ctor
 		// [Export ("initWithCGLContextObj:")]
-		// IntPtr Constructor (IntPtr cglContext);
+		// NativeHandle Constructor (IntPtr cglContext);
 
 		[Deprecated (PlatformName.MacOSX, 10, 7)]
 		[Export ("setFullScreen")]
@@ -8895,10 +8899,10 @@ namespace AppKit {
 		NSOpenGLPixelFormat DefaultPixelFormat { get; }
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("initWithFrame:pixelFormat:")]
-		IntPtr Constructor (CGRect frameRect, NSOpenGLPixelFormat format);
+		NativeHandle Constructor (CGRect frameRect, NSOpenGLPixelFormat format);
 
 		[Export ("clearGLContext")]
 		void ClearGLContext ();
@@ -8935,7 +8939,7 @@ namespace AppKit {
 		[Advice ("You must use 'OpenPanel' method if the application is sandboxed.")]
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "All open panels now run out-of-process, use 'OpenPanel' method instead")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("URLs")]
 		NSUrl [] Urls { get; }
@@ -9027,7 +9031,7 @@ namespace AppKit {
 	[BaseType (typeof (NSTableView))]
 	partial interface NSOutlineView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("outlineTableColumn"), NullAllowed]
 		NSTableColumn OutlineTableColumn { get; set; }
@@ -9360,19 +9364,19 @@ namespace AppKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithSize:")]
-		IntPtr Constructor (CGSize aSize);
+		NativeHandle Constructor (CGSize aSize);
 
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Export ("initWithContentsOfFile:")]
-		IntPtr Constructor (string fileName);
+		NativeHandle Constructor (string fileName);
 
 		[Export ("initWithContentsOfURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		//[Export ("initByReferencingURL:")]
-		//IntPtr Constructor (NSUrl url);
+		//NativeHandle Constructor (NSUrl url);
 
 		[Sealed, Export ("initWithContentsOfFile:"), Internal]
 		IntPtr InitWithContentsOfFile (string fileName);
@@ -9382,7 +9386,7 @@ namespace AppKit {
 
 		[NoMacCatalyst]
 		[Export ("initWithPasteboard:")]
-		IntPtr Constructor (NSPasteboard pasteboard);
+		NativeHandle Constructor (NSPasteboard pasteboard);
 
 		[Export ("initWithData:"), Internal]
 		[Sealed]
@@ -9497,7 +9501,7 @@ namespace AppKit {
 		string AccessibilityDescription	 { get; set; }
 
 		[Export ("initWithCGImage:size:")]
-		IntPtr Constructor (CGImage cgImage, CGSize size);
+		NativeHandle Constructor (CGImage cgImage, CGSize size);
 
 		[NoMacCatalyst]
 		[Export ("CGImageForProposedRect:context:hints:")]
@@ -10222,10 +10226,10 @@ namespace AppKit {
 
 		// Inlined from parent
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 	}
 
 	[NoMacCatalyst]
@@ -10386,7 +10390,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl))]
 	interface NSImageView : NSAccessibilityImage, NSMenuItemValidation {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		//Detected properties
 		[Export ("image", ArgumentSemantic.Retain)]
@@ -10430,13 +10434,13 @@ namespace AppKit {
 	[BaseType (typeof (NSControl), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSMatrixDelegate)})]
 	partial interface NSMatrix {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("initWithFrame:mode:prototype:numberOfRows:numberOfColumns:")]
-		IntPtr Constructor (CGRect frameRect, NSMatrixMode aMode, NSCell aCell, nint rowsHigh, nint colsWide);
+		NativeHandle Constructor (CGRect frameRect, NSMatrixMode aMode, NSCell aCell, nint rowsHigh, nint colsWide);
 
 		[Export ("initWithFrame:mode:cellClass:numberOfRows:numberOfColumns:")]
-		IntPtr Constructor (CGRect frameRect, NSMatrixMode aMode, Class factoryId, nint rowsHigh, nint colsWide);
+		NativeHandle Constructor (CGRect frameRect, NSMatrixMode aMode, Class factoryId, nint rowsHigh, nint colsWide);
 
 		[Export ("makeCellAtRow:column:")]
 		NSCell MakeCell (nint row, nint col);
@@ -10678,7 +10682,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl))]
 	interface NSLevelIndicator {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("minValue")]
 		double MinValue { get; set; }
@@ -10748,13 +10752,13 @@ namespace AppKit {
 	[BaseType (typeof (NSActionCell))]
 	interface NSLevelIndicatorCell {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 
 		[Export ("initWithLevelIndicatorStyle:")]
-		IntPtr Constructor (NSLevelIndicatorStyle levelIndicatorStyle);
+		NativeHandle Constructor (NSLevelIndicatorStyle levelIndicatorStyle);
 
 		[Export ("levelIndicatorStyle")]
 		NSLevelIndicatorStyle LevelIndicatorStyle { get; set; }
@@ -10853,7 +10857,7 @@ namespace AppKit {
 	[BaseType (typeof (NSGestureRecognizer))]
 	interface NSMagnificationGestureRecognizer {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("magnification")]
 		nfloat Magnification { get; set; }
@@ -10945,7 +10949,7 @@ namespace AppKit {
 		bool WorksWhenModal { get; set; }
 
 		[Export ("initWithContentRect:styleMask:backing:defer:")]
-		IntPtr Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation);
+		NativeHandle Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation);
 	}
 
 	[Mac (10,10)]
@@ -10953,7 +10957,7 @@ namespace AppKit {
 	[BaseType (typeof (NSGestureRecognizer))]
 	interface NSPanGestureRecognizer : NSCoding {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("buttonMask")]
 		nuint ButtonMask { get; set; }
@@ -10977,7 +10981,7 @@ namespace AppKit {
 	[BaseType (typeof (NSGestureRecognizer))]
 	interface NSPressGestureRecognizer {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("buttonMask")]
 		nuint ButtonMask { get; set; }
@@ -11354,10 +11358,10 @@ namespace AppKit {
 	[BaseType (typeof (NSActionCell), Events=new Type [] { typeof (NSPathCellDelegate) }, Delegates=new string [] { "WeakDelegate" })]
 	interface NSPathCell : NSMenuItemValidation {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 
 		[Export ("pathStyle")]
 		NSPathStyle PathStyle { get; set; }
@@ -11433,7 +11437,7 @@ namespace AppKit {
 	[BaseType (typeof (NSTextFieldCell))]
 	interface NSPathComponentCell {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 
 		[Export ("image", ArgumentSemantic.Copy)]
 		NSImage Image { get; set; }
@@ -11446,7 +11450,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl))]
 	interface NSPathControl {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("URL", ArgumentSemantic.Copy)]
 		NSUrl Url { get; set; }
@@ -11657,7 +11661,7 @@ namespace AppKit {
 	[BaseType (typeof (NSButton))]
 	partial interface NSPopUpButton {
 		[Export ("initWithFrame:pullsDown:")]
-		IntPtr Constructor (CGRect buttonFrame, bool pullsDown);
+		NativeHandle Constructor (CGRect buttonFrame, bool pullsDown);
 
 		[Export ("addItemWithTitle:")]
 		void AddItem (string title);
@@ -11763,14 +11767,14 @@ namespace AppKit {
 	[BaseType (typeof (NSMenuItemCell))]
 	partial interface NSPopUpButtonCell {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 
 		[DesignatedInitializer]
 		[Export ("initTextCell:pullsDown:")]
-		IntPtr Constructor (string stringValue, bool pullDown);
+		NativeHandle Constructor (string stringValue, bool pullDown);
 
 		[Export ("addItemWithTitle:")]
 		void AddItem (string title);
@@ -11965,7 +11969,7 @@ namespace AppKit {
 	interface NSPrintInfo : NSCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithDictionary:")]
-		IntPtr Constructor (NSDictionary attributes);
+		NativeHandle Constructor (NSDictionary attributes);
 
 		[Export ("dictionary")]
 		NSMutableDictionary Dictionary { get; }
@@ -12217,7 +12221,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	interface NSProgressIndicator : NSAccessibilityProgressIndicator {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("incrementBy:")]
 		void IncrementBy (double delta);
@@ -12780,7 +12784,7 @@ namespace AppKit {
 	[BaseType (typeof (NSGestureRecognizer))]
 	interface NSRotationGestureRecognizer {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("rotation")]
 		nfloat Rotation { get; set; }
@@ -12794,7 +12798,7 @@ namespace AppKit {
 	interface NSRulerMarker : NSCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithRulerView:markerLocation:image:imageOrigin:")]
-		IntPtr Constructor (NSRulerView ruler, nfloat location, NSImage image, CGPoint imageOrigin);
+		NativeHandle Constructor (NSRulerView ruler, nfloat location, NSImage image, CGPoint imageOrigin);
 
 		[Export ("ruler")]
 		NSRulerView Ruler { get; }
@@ -12838,7 +12842,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	partial interface NSRulerView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Static]
 		[Export ("registerUnitWithName:abbreviation:unitToPointsConversionFactor:stepUpCycle:stepDownCycle:")]
@@ -12846,7 +12850,7 @@ namespace AppKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithScrollView:orientation:")]
-		IntPtr Constructor (NSScrollView scrollView, NSRulerOrientation orientation);
+		NativeHandle Constructor (NSScrollView scrollView, NSRulerOrientation orientation);
 
 		[Export ("baselineLocation")]
 		nfloat BaselineLocation { get; }
@@ -12946,7 +12950,7 @@ namespace AppKit {
 		[Advice ("You must use 'SavePanel' method if the application is sandboxed.")]
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "All save panels now run out-of-process, use 'SavePanel' method instead")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("URL")]
 		NSUrl Url { get; }
@@ -13193,7 +13197,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl))]
 	interface NSScroller {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Deprecated (PlatformName.MacOSX, 10, 7, message: "Use GetScrollerWidth instead.")]
 		[Static]
@@ -13301,7 +13305,7 @@ namespace AppKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("contentSize")]
 		CGSize ContentSize { get; }
@@ -13474,7 +13478,7 @@ namespace AppKit {
 	[BaseType (typeof (NSTextField), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSSearchFieldDelegate)})]
 	interface NSSearchField {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("recentSearches")]
 		string [] RecentSearches { get; set; }
@@ -13561,7 +13565,7 @@ namespace AppKit {
 	interface NSSearchFieldCell {
 		[DesignatedInitializer]
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 
 		[Export ("searchButtonCell", ArgumentSemantic.Retain)]
 		NSButtonCell SearchButtonCell { get; set; }
@@ -13607,7 +13611,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl))]
 	interface NSSegmentedControl : NSUserInterfaceCompression {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("selectSegmentWithTag:")]
 		bool SelectSegment (nint tag);
@@ -13734,10 +13738,10 @@ namespace AppKit {
 	[BaseType (typeof (NSActionCell))]
 	interface NSSegmentedCell {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 
 		[Export ("selectSegmentWithTag:")]
 		bool SelectSegment (nint tag);
@@ -13825,7 +13829,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl))]
 	interface NSSlider : NSAccessibilitySlider {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("vertical")]
 		// Radar 27222357
@@ -13920,10 +13924,10 @@ namespace AppKit {
 	[BaseType (typeof (NSActionCell))]
 	interface NSSliderCell {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 
 		[Static]
 		[Export ("prefersTrackingUntilMouseUp")]
@@ -14021,7 +14025,7 @@ namespace AppKit {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[NoMacCatalyst]
 		[Export ("slider", ArgumentSemantic.Strong)]
@@ -14110,7 +14114,7 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	interface NSSpeechSynthesizer {
 		[Export ("initWithVoice:")]
-		IntPtr Constructor (string voice);
+		NativeHandle Constructor (string voice);
 
 		[Export ("startSpeakingString:")]
 		bool StartSpeakingString (string theString);
@@ -14410,13 +14414,13 @@ namespace AppKit {
 		NSSound FromName (string name);
 
 		[Export ("initWithContentsOfURL:byReference:")]
-		IntPtr Constructor (NSUrl url, bool byRef);
+		NativeHandle Constructor (NSUrl url, bool byRef);
 
 		[Export ("initWithContentsOfFile:byReference:")]
-		IntPtr Constructor (string path, bool byRef);
+		NativeHandle Constructor (string path, bool byRef);
 
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Static]
 		[Export ("canInitWithPasteboard:")]
@@ -14427,7 +14431,7 @@ namespace AppKit {
 		string [] SoundUnfilteredTypes ();
 
 		[Export ("initWithPasteboard:")]
-		IntPtr Constructor (NSPasteboard pasteboard);
+		NativeHandle Constructor (NSPasteboard pasteboard);
 
 		[Export ("writeToPasteboard:")]
 		void WriteToPasteboard (NSPasteboard pasteboard);
@@ -14493,7 +14497,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	partial interface NSSplitView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("drawDividerInRect:")]
 		void DrawDivider (CGRect rect);
@@ -14578,7 +14582,7 @@ namespace AppKit {
 	[BaseType (typeof (NSViewController))]
 	interface NSSplitViewController : NSSplitViewDelegate, NSUserInterfaceValidations {
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[Export ("splitView", ArgumentSemantic.Strong)]
 		NSSplitView SplitView { get; set; }
@@ -14777,7 +14781,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	interface NSStackView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("delegate", ArgumentSemantic.Weak)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -14911,7 +14915,7 @@ namespace AppKit {
 	[BaseType (typeof (NSButton))]
 	interface NSStatusBarButton {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("appearsDisabled")]
 		bool AppearsDisabled { get; set; }
@@ -15212,7 +15216,7 @@ namespace AppKit {
 	interface NSStoryboardSegue {
 		[DesignatedInitializer]
 		[Export ("initWithIdentifier:source:destination:")]
-		IntPtr Constructor (string identifier, NSObject sourceController, NSObject destinationController);
+		NativeHandle Constructor (string identifier, NSObject sourceController, NSObject destinationController);
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -15250,10 +15254,10 @@ namespace AppKit {
 	interface NSUserDefaultsController {
 		[DesignatedInitializer]
 		[Export ("initWithDefaults:initialValues:")]
-		IntPtr Constructor ([NullAllowed] NSUserDefaults defaults, [NullAllowed] NSDictionary initialValues);
+		NativeHandle Constructor ([NullAllowed] NSUserDefaults defaults, [NullAllowed] NSDictionary initialValues);
 //
 //		[Export ("initWithCoder:")]
-//		IntPtr Constructor (NSCoder coder);
+//		NativeHandle Constructor (NSCoder coder);
 //
 		[Export ("defaults", ArgumentSemantic.Strong)]
 		NSUserDefaults Defaults { get; }
@@ -15459,7 +15463,7 @@ namespace AppKit {
 	partial interface NSView : NSDraggingDestination, NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElementProtocol, NSAccessibility, NSObjectAccessibilityExtensions {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("window")]
 		NSWindow Window { get; }
@@ -16377,7 +16381,7 @@ namespace AppKit {
 	[BaseType (typeof (NSAnimation))]
 	interface NSViewAnimation { 
 		[Export ("initWithViewAnimations:")]
-		IntPtr Constructor (NSDictionary [] viewAnimations);
+		NativeHandle Constructor (NSDictionary [] viewAnimations);
 	
 		[Export ("viewAnimations", ArgumentSemantic.Copy)]
 		NSDictionary [] ViewAnimations { get; set; }
@@ -16433,7 +16437,7 @@ namespace AppKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[Export ("loadView")]
 		void LoadView ();
@@ -16614,7 +16618,7 @@ namespace AppKit {
 	partial interface NSPageController : NSAnimatablePropertyContainer {
 
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -16682,7 +16686,7 @@ namespace AppKit {
 	[DisableDefaultCtor] // -[NSPDFImageRep init]: unrecognized selector sent to instance 0x2652460
 	interface NSPdfImageRep {
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData pdfData);
+		NativeHandle Constructor (NSData pdfData);
 
 		[Export ("PDFRepresentation", ArgumentSemantic.Retain)]
 		NSData PdfRepresentation { get; }
@@ -16702,11 +16706,11 @@ namespace AppKit {
 	partial interface NSTableColumn : NSUserInterfaceItemIdentification, NSCoding {
 		[Export ("initWithIdentifier:")]
 		[Sealed]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[DesignatedInitializer]
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor (NSString identifier);
+		NativeHandle Constructor (NSString identifier);
 
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("dataCellForRow:")]
@@ -16757,7 +16761,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	interface NSTableRowView : NSAccessibilityRow {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("selectionHighlightStyle")]
 		NSTableViewSelectionHighlightStyle SelectionHighlightStyle { get; set;  }
@@ -16820,7 +16824,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	partial interface NSTableCellView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("backgroundStyle")]
 		NSBackgroundStyle BackgroundStyle {
@@ -16861,7 +16865,7 @@ namespace AppKit {
 	partial interface NSTableView : NSDraggingSource, NSAccessibilityTable {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("noteHeightOfRowsWithIndexesChanged:")]
 		void NoteHeightOfRowsWithIndexesChanged (NSIndexSet indexSet );
@@ -17514,7 +17518,7 @@ namespace AppKit {
 	[BaseType (typeof (NSTextFieldCell))]
 	interface NSTableHeaderCell {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 
 		[Export ("drawSortIndicatorWithFrame:inView:ascending:priority:")]
 		void DrawSortIndicator (CGRect cellFrame, NSView controlView, bool ascending, nint priority );
@@ -17527,7 +17531,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	interface NSTableHeaderView : NSViewToolTipOwner {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("draggedColumn")]
 		nint DraggedColumn { get; }
@@ -17577,7 +17581,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTabViewDelegate)})]
 	partial interface NSTabView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("selectTabViewItem:")]
 		void Select (NSTabViewItem tabViewItem);
@@ -17688,7 +17692,7 @@ namespace AppKit {
 	[BaseType (typeof (NSViewController))]
 	interface NSTabViewController : NSTabViewDelegate, NSToolbarDelegate {
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[Export ("tabStyle")]
 		NSTabViewControllerTabStyle TabStyle { get; set; }
@@ -17785,7 +17789,7 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	interface NSTabViewItem : NSCoding {
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor (NSObject identifier);
+		NativeHandle Constructor (NSObject identifier);
 
 		[Export ("identifier", ArgumentSemantic.Retain)]
 		NSObject Identifier { get; set; }
@@ -17835,7 +17839,7 @@ namespace AppKit {
 	partial interface NSText {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("replaceCharactersInRange:withString:")]
 		void Replace (NSRange range, string aString);
@@ -18077,10 +18081,10 @@ namespace AppKit {
 	[BaseType (typeof (NSCell))]
 	interface NSTextAttachmentCell : NSTextAttachmentCellProtocol {
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage image);
+		NativeHandle Constructor (NSImage image);
 
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	}
 
 	[NoMacCatalyst]
@@ -18148,7 +18152,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTextFieldDelegate)})]
 	partial interface NSTextField : NSAccessibilityNavigableStaticText, NSUserInterfaceValidations, NSTextContent {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 		
 		[Export ("selectText:")]
 		void SelectText (NSObject sender);
@@ -18286,7 +18290,7 @@ namespace AppKit {
 	interface NSSecureTextField 
 	{
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 	}
 
 	interface INSTextFieldDelegate { }
@@ -18400,10 +18404,10 @@ namespace AppKit {
 	interface NSTextFieldCell {
 		[DesignatedInitializer]
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 	
 		[Export ("initImageCell:")]
-		IntPtr Constructor (NSImage  image);
+		NativeHandle Constructor (NSImage  image);
 
 		[Export ("setUpFieldEditorAttributes:")]
 		NSText SetUpFieldEditorAttributes (NSText textObj);
@@ -18440,7 +18444,7 @@ namespace AppKit {
 	[DisableDefaultCtor]
 	interface NSTokenFieldCell {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 
 		[Export ("tokenStyle")]
 		NSTokenStyle TokenStyle { get; set; }
@@ -18471,7 +18475,7 @@ namespace AppKit {
 	[BaseType (typeof (NSTextFieldCell))]
 	interface NSSecureTextFieldCell {
 		[Export ("initTextCell:")]
-		IntPtr Constructor (string aString);
+		NativeHandle Constructor (string aString);
 
 		[Export ("echosBullets")]
 		bool EchosBullets { get; set; }
@@ -18484,7 +18488,7 @@ namespace AppKit {
 	partial interface NSTextInputContext {
 		[Export ("initWithClient:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([Protocolize]NSTextInputClient client);
+		NativeHandle Constructor ([Protocolize]NSTextInputClient client);
 
 		[Static]
 		[Export ("currentInputContext")]
@@ -18529,14 +18533,14 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	interface NSTextList : NSCoding, NSCopying, NSSecureCoding {
 		[Export ("initWithMarkerFormat:options:")]
-		IntPtr Constructor (
+		NativeHandle Constructor (
 #if XAMCORE_4_0
 		[BindAs (typeof (NSTextListMarkerFormats))] 
 #endif
 		string format, NSTextListOptions mask);
 
 		[Wrap ("this (format.GetConstant(), mask)")]
-		IntPtr Constructor (NSTextListMarkerFormats format, NSTextListOptions mask);
+		NativeHandle Constructor (NSTextListMarkerFormats format, NSTextListOptions mask);
 
 #if XAMCORE_4_0
 		[BindAs (typeof (NSTextListMarkerFormats))] 
@@ -18634,7 +18638,7 @@ namespace AppKit {
 	interface NSTextTableBlock {
 		[DesignatedInitializer]
 		[Export ("initWithTable:startingRow:rowSpan:startingColumn:columnSpan:")]
-		IntPtr Constructor (NSTextTable table, nint row, nint rowSpan, nint col, nint colSpan);
+		NativeHandle Constructor (NSTextTable table, nint row, nint rowSpan, nint col, nint colSpan);
 
 		[Export ("table")]
 		NSTextTable Table { get; }
@@ -18744,10 +18748,10 @@ namespace AppKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithFrame:textContainer:")]
-		IntPtr Constructor (CGRect frameRect, NSTextContainer container);
+		NativeHandle Constructor (CGRect frameRect, NSTextContainer container);
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("replaceTextContainer:")]
 		void ReplaceTextContainer (NSTextContainer newContainer);
@@ -19452,7 +19456,7 @@ namespace AppKit {
 	[BaseType (typeof (NSTextField))]
 	interface NSTokenField {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("tokenStyle")]
 		NSTokenStyle TokenStyle { get; set; }
@@ -19524,11 +19528,11 @@ namespace AppKit {
 	partial interface NSToolbar {
 		[Mac (10, 13)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[DesignatedInitializer]
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("insertItemWithItemIdentifier:atIndex:")]
 		void InsertItem (string itemIdentifier, nint index);
@@ -19696,7 +19700,7 @@ namespace AppKit {
 	interface NSToolbarItem : NSCopying, NSMenuItemValidation, NSValidatedUserInterfaceItem {
 		[DesignatedInitializer]
 		[Export ("initWithItemIdentifier:")]
-		IntPtr Constructor (string itemIdentifier);
+		NativeHandle Constructor (string itemIdentifier);
 
 		[Export ("itemIdentifier")]
 		string Identifier { get; }
@@ -19787,7 +19791,7 @@ namespace AppKit {
 	{
 		[Export ("initWithItemIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string itemIdentifier);
+		NativeHandle Constructor (string itemIdentifier);
 
 		[Export ("subitems", ArgumentSemantic.Copy)]
 		NSToolbarItem[] Subitems { get; set; }
@@ -19925,10 +19929,10 @@ namespace AppKit {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Wrap ("this (identifier.GetConstant ())")]
-		IntPtr Constructor (NSTouchBarItemIdentifier identifier);
+		NativeHandle Constructor (NSTouchBarItemIdentifier identifier);
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -20015,7 +20019,7 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	interface NSTrackingArea : NSCoding, NSCopying {
 		[Export ("initWithRect:options:owner:userInfo:")]
-		IntPtr Constructor (CGRect rect, NSTrackingAreaOptions options, NSObject owner, [NullAllowed] NSDictionary userInfo);
+		NativeHandle Constructor (CGRect rect, NSTrackingAreaOptions options, NSObject owner, [NullAllowed] NSDictionary userInfo);
 		
 		[Export ("rect")]
 		CGRect Rect { get; }
@@ -20037,7 +20041,7 @@ namespace AppKit {
 		NSTreeNode FromRepresentedObject (NSObject modelObject);
 
 		[Export ("initWithRepresentedObject:")]
-		IntPtr Constructor (NSObject modelObject);
+		NativeHandle Constructor (NSObject modelObject);
 
 		[Export ("representedObject")]
 		NSObject RepresentedObject { get; }
@@ -20216,16 +20220,16 @@ namespace AppKit {
 
 		[Export ("init")]
 		[PostSnippet ("if (!DisableReleasedWhenClosedInConstructor) { ReleasedWhenClosed = false; }", Optimizable = true)]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[DesignatedInitializer]
 		[Export ("initWithContentRect:styleMask:backing:defer:")]
 		[PostSnippet ("if (!DisableReleasedWhenClosedInConstructor) { ReleasedWhenClosed = false; }", Optimizable = true)]
-		IntPtr Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation);
+		NativeHandle Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation);
 	
 		[Export ("initWithContentRect:styleMask:backing:defer:screen:")]
 		[PostSnippet ("if (!DisableReleasedWhenClosedInConstructor) { ReleasedWhenClosed = false; }", Optimizable = true)]
-		IntPtr Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation, NSScreen  screen);
+		NativeHandle Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation, NSScreen  screen);
 	
 		[Export ("title")]
 		string Title  { get; set; }
@@ -21116,7 +21120,7 @@ namespace AppKit {
 	[BaseType (typeof (NSViewController))]
 	interface NSTitlebarAccessoryViewController : NSAnimationDelegate, NSAnimatablePropertyContainer {
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[Export ("layoutAttribute")]
 		NSLayoutAttribute LayoutAttribute { get; set; }
@@ -21150,7 +21154,7 @@ namespace AppKit {
 	[BaseType (typeof (NSView))]
 	interface NSVisualEffectView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("material")]
 		NSVisualEffectMaterial Material { get; set; }
@@ -21198,13 +21202,13 @@ namespace AppKit {
 	interface NSWindowController : NSCoding, NSSeguePerforming {
 		[DesignatedInitializer]
 		[Export ("initWithWindow:")]
-		IntPtr Constructor (NSWindow  window);
+		NativeHandle Constructor (NSWindow  window);
 	
 		[Export ("initWithWindowNibName:")]
-		IntPtr Constructor (string  windowNibName);
+		NativeHandle Constructor (string  windowNibName);
 	
 		[Export ("initWithWindowNibName:owner:")]
-		IntPtr Constructor (string  windowNibName, NSObject owner);
+		NativeHandle Constructor (string  windowNibName, NSObject owner);
 	
 		[Export ("windowNibName")]
 		string WindowNibName { get; }
@@ -21923,7 +21927,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl))]
 	interface NSStepper : NSAccessibilityStepper {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		//Detected properties
 		[Export ("minValue")]
@@ -21983,14 +21987,14 @@ namespace AppKit {
 
 		[Export ("initWithLeftExpressions:rightExpressions:modifier:operators:options:")]
 		//NSObject InitWithLeftExpressionsrightExpressionsmodifieroperatorsoptions (NSArray leftExpressions, NSArray rightExpressions, NSComparisonPredicateModifier modifier, NSArray operators, uint options);
-		IntPtr Constructor (NSExpression[] leftExpressions, NSExpression[] rightExpressions, NSComparisonPredicateModifier modifier, NSObject[] operators, NSComparisonPredicateOptions options);
+		NativeHandle Constructor (NSExpression[] leftExpressions, NSExpression[] rightExpressions, NSComparisonPredicateModifier modifier, NSObject[] operators, NSComparisonPredicateOptions options);
 
 		[Export ("initWithLeftExpressions:rightExpressionAttributeType:modifier:operators:options:")]
 		//NSObject InitWithLeftExpressionsrightExpressionAttributeTypemodifieroperatorsoptions (NSArray leftExpressions, NSAttributeType attributeType, NSComparisonPredicateModifier modifier, NSArray operators, uint options);
-		IntPtr Constructor (NSExpression[] leftExpressions, NSAttributeType attributeType, NSComparisonPredicateModifier modifier, NSObject[] operators, NSComparisonPredicateOptions options);
+		NativeHandle Constructor (NSExpression[] leftExpressions, NSAttributeType attributeType, NSComparisonPredicateModifier modifier, NSObject[] operators, NSComparisonPredicateOptions options);
 
 		[Export ("initWithCompoundTypes:")]
-		IntPtr Constructor (NSNumber[] compoundTypes);
+		NativeHandle Constructor (NSNumber[] compoundTypes);
 
 		[Export ("leftExpressions")]
 		NSExpression[] LeftExpressions { get; }
@@ -22030,7 +22034,7 @@ namespace AppKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithPressureBehavior:")]
-		IntPtr Constructor (NSPressureBehavior pressureBehavior);
+		NativeHandle Constructor (NSPressureBehavior pressureBehavior);
 
 		[Export ("set")]
 		void Set ();
@@ -22040,7 +22044,7 @@ namespace AppKit {
 	[BaseType (typeof (NSControl), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSRuleEditorDelegate)})]
 	partial interface NSRuleEditor {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("reloadCriteria")]
 		void ReloadCriteria ();
@@ -22218,7 +22222,7 @@ namespace AppKit {
 		
 		[DesignatedInitializer]
 		[Export ("initWithTitle:image:alternateImage:handler:")]
-		IntPtr Constructor (string title, NSImage image, NSImage alternateImage, NSSharingServiceHandler handler);
+		NativeHandle Constructor (string title, NSImage image, NSImage alternateImage, NSSharingServiceHandler handler);
 		
 		[Export ("canPerformWithItems:")]
 		bool CanPerformWithItems ([NullAllowed] NSObject [] items);
@@ -22401,7 +22405,7 @@ namespace AppKit {
 		
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
-		IntPtr Constructor (NSObject [] items);
+		NativeHandle Constructor (NSObject [] items);
 		
 		[Export ("showRelativeToRect:ofView:preferredEdge:")]
 		void ShowRelativeToRect (CGRect rect, NSView view, NSRectEdge preferredEdge);
@@ -23149,7 +23153,7 @@ namespace AppKit {
 	partial interface NSCustomImageRep {
 
 		[Export ("initWithSize:flipped:drawingHandler:")]
-		IntPtr Constructor (CGSize size, bool flipped, NSCustomImageRepDrawingHandler drawingHandler);
+		NativeHandle Constructor (CGSize size, bool flipped, NSCustomImageRepDrawingHandler drawingHandler);
 
 		[Export ("drawingHandler")]
 		NSCustomImageRepDrawingHandler DrawingHandler { get; }
@@ -23345,7 +23349,7 @@ namespace AppKit {
 	partial interface NSTextAlternatives : NSSecureCoding {
 
 		[Export ("initWithPrimaryString:alternativeStrings:")]
-		IntPtr Constructor (string primaryString, NSArray alternativeStrings);
+		NativeHandle Constructor (string primaryString, NSArray alternativeStrings);
 
 		[Export ("primaryString", ArgumentSemantic.Copy)]
 		string PrimaryString { get; }
@@ -25921,7 +25925,7 @@ namespace AppKit {
 		NSObject UserInfo { get; set; }
 
 		[Export ("initWithFileType:delegate:")]
-		IntPtr Constructor (string fileType, INSFilePromiseProviderDelegate @delegate);
+		NativeHandle Constructor (string fileType, INSFilePromiseProviderDelegate @delegate);
 	}
 
 	[Mac (10,12)]
@@ -26067,7 +26071,7 @@ namespace AppKit {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[NullAllowed, Export ("client", ArgumentSemantic.Weak)]
 		INSTextInputClient Client { get; set; }
@@ -26144,7 +26148,7 @@ namespace AppKit {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Static]
 		[Export ("colorPickerWithIdentifier:")]
@@ -26199,7 +26203,7 @@ namespace AppKit {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("view", ArgumentSemantic.Strong)]
 		NSView View { get; set; }
@@ -26234,7 +26238,7 @@ namespace AppKit {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Static]
 		[Export ("groupItemWithIdentifier:items:")]
@@ -26290,7 +26294,7 @@ namespace AppKit {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("popoverTouchBar", ArgumentSemantic.Strong)]
 		NSTouchBar PopoverTouchBar { get; set; }
@@ -26448,7 +26452,7 @@ namespace AppKit {
 
 		[Export ("initWithFrame:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("reloadData")]
 		void ReloadData ();
@@ -26490,7 +26494,7 @@ namespace AppKit {
 	interface NSScrubberArrangedView
 	{
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("selected")]
 		bool Selected { [Bind ("isSelected")] get; set; }
@@ -26643,7 +26647,7 @@ namespace AppKit {
 
 		[Export ("initWithNumberOfVisibleItems:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (nint numberOfVisibleItems);
+		NativeHandle Constructor (nint numberOfVisibleItems);
 	}
 
 	public interface INSSharingServicePickerTouchBarItemDelegate {}
@@ -26666,7 +26670,7 @@ namespace AppKit {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[NoMacCatalyst]
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
@@ -26742,10 +26746,10 @@ namespace AppKit {
 	interface NSAccessibilityCustomAction
 	{
 		[Export ("initWithName:handler:")]
-		IntPtr Constructor (string name, [NullAllowed] Func<bool> handler);
+		NativeHandle Constructor (string name, [NullAllowed] Func<bool> handler);
 
 		[Export ("initWithName:target:selector:")]
-		IntPtr Constructor (string name, NSObject target, Selector selector);
+		NativeHandle Constructor (string name, NSObject target, Selector selector);
 
 		[Export ("name")]
 		string Name { get; set; }
@@ -26767,10 +26771,10 @@ namespace AppKit {
 	interface NSAccessibilityCustomRotor
 	{
 		[Export ("initWithLabel:itemSearchDelegate:")]
-		IntPtr Constructor (string label, INSAccessibilityCustomRotorItemSearchDelegate itemSearchDelegate);
+		NativeHandle Constructor (string label, INSAccessibilityCustomRotorItemSearchDelegate itemSearchDelegate);
 
 		[Export ("initWithRotorType:itemSearchDelegate:")]
-		IntPtr Constructor (NSAccessibilityCustomRotorType rotorType, INSAccessibilityCustomRotorItemSearchDelegate itemSearchDelegate);
+		NativeHandle Constructor (NSAccessibilityCustomRotorType rotorType, INSAccessibilityCustomRotorItemSearchDelegate itemSearchDelegate);
 
 		[Export ("type", ArgumentSemantic.Assign)]
 		NSAccessibilityCustomRotorType Type { get; set; }
@@ -26808,11 +26812,11 @@ namespace AppKit {
 	{
 		[Export ("initWithTargetElement:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSAccessibilityElement targetElement);
+		NativeHandle Constructor (NSAccessibilityElement targetElement);
 
 		[Export ("initWithItemLoadingToken:customLabel:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSSecureCoding itemLoadingToken, string customLabel);
+		NativeHandle Constructor (INSSecureCoding itemLoadingToken, string customLabel);
 
 		[NullAllowed, Export ("targetElement", ArgumentSemantic.Weak)]
 		NSAccessibilityElement TargetElement { get; }
@@ -26882,7 +26886,7 @@ namespace AppKit {
 	{
 		[Export ("initWithFontDescriptors:options:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSFontDescriptor[] fontDescriptors, NSFontAssetRequestOptions options);
+		NativeHandle Constructor (NSFontDescriptor[] fontDescriptors, NSFontAssetRequestOptions options);
 
 		[Export ("downloadedFontDescriptors", ArgumentSemantic.Copy)]
 		NSFontDescriptor[] DownloadedFontDescriptors { get; }
@@ -26911,11 +26915,11 @@ namespace AppKit {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("initWithCompressionOptions:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSSet<NSUserInterfaceCompressionOptions> options);
+		NativeHandle Constructor (NSSet<NSUserInterfaceCompressionOptions> options);
 
 		[Export ("containsOptions:")]
 		bool Contains (NSUserInterfaceCompressionOptions options);
@@ -27030,7 +27034,7 @@ namespace AppKit {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Static]
 		[Export ("buttonTouchBarItemWithIdentifier:title:target:action:")]
@@ -27261,16 +27265,16 @@ namespace AppKit {
 	interface NSCollectionViewCompositionalLayout
 	{
 		[Export ("initWithSection:")]
-		IntPtr Constructor (NSCollectionLayoutSection section);
+		NativeHandle Constructor (NSCollectionLayoutSection section);
 
 		[Export ("initWithSection:configuration:")]
-		IntPtr Constructor (NSCollectionLayoutSection section, NSCollectionViewCompositionalLayoutConfiguration configuration);
+		NativeHandle Constructor (NSCollectionLayoutSection section, NSCollectionViewCompositionalLayoutConfiguration configuration);
 
 		[Export ("initWithSectionProvider:")]
-		IntPtr Constructor (NSCollectionViewCompositionalLayoutSectionProvider sectionProvider);
+		NativeHandle Constructor (NSCollectionViewCompositionalLayoutSectionProvider sectionProvider);
 
 		[Export ("initWithSectionProvider:configuration:")]
-		IntPtr Constructor (NSCollectionViewCompositionalLayoutSectionProvider sectionProvider, NSCollectionViewCompositionalLayoutConfiguration configuration);
+		NativeHandle Constructor (NSCollectionViewCompositionalLayoutSectionProvider sectionProvider, NSCollectionViewCompositionalLayoutConfiguration configuration);
 
 		[Export ("configuration", ArgumentSemantic.Copy)]
 		NSCollectionViewCompositionalLayoutConfiguration Configuration { get; set; }
@@ -27457,7 +27461,7 @@ namespace AppKit {
 	{
 		[Export ("initWithClient:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSTextCheckingClient client);
+		NativeHandle Constructor (INSTextCheckingClient client);
 
 		[Export ("client")]
 		INSTextCheckingClient Client { get; }
@@ -27534,7 +27538,7 @@ namespace AppKit {
 		where ItemIdentifierType : NSObject {
 
 		[Export ("initWithCollectionView:itemProvider:")]
-		IntPtr Constructor (NSCollectionView collectionView, NSCollectionViewDiffableDataSourceItemProvider itemProvider);
+		NativeHandle Constructor (NSCollectionView collectionView, NSCollectionViewDiffableDataSourceItemProvider itemProvider);
 
 		[Export ("snapshot")]
 		NSDiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType> Snapshot { get; }
@@ -27645,7 +27649,7 @@ namespace AppKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithItemIdentifier:")]
-		IntPtr Constructor (string itemIdentifier);
+		NativeHandle Constructor (string itemIdentifier);
 
 		[NoMacCatalyst]
 		[Export ("searchField", ArgumentSemantic.Strong)]
@@ -27679,7 +27683,7 @@ namespace AppKit {
 		where SectionIdentifierType : NSObject
 		where ItemIdentifierType : NSObject {
 		[Export ("initWithTableView:cellProvider:")]
-		IntPtr Constructor (NSTableView tableView, NSTableViewDiffableDataSourceCellProvider cellProvider);
+		NativeHandle Constructor (NSTableView tableView, NSTableViewDiffableDataSourceCellProvider cellProvider);
 
 		[Export ("snapshot")]
 		NSDiffableDataSourceSnapshot<SectionIdentifierType,ItemIdentifierType> Snapshot ();
@@ -27782,7 +27786,7 @@ namespace AppKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithItemIdentifier:")]
-		IntPtr Constructor (string itemIdentifier);
+		NativeHandle Constructor (string itemIdentifier);
 		
 		[Static]
 		[Export ("trackingSeparatorToolbarItemWithIdentifier:splitView:dividerIndex:")]

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -29,6 +29,10 @@ using Vector3 = global::OpenTK.NVector3;
 using Matrix3 = global::OpenTK.NMatrix3;
 using Matrix4 = global::OpenTK.NMatrix4;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ARKit {
 
 	[iOS (11,0)]
@@ -336,17 +340,17 @@ namespace ARKit {
 
 		[Export ("initWithTransform:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Matrix4 transform);
+		NativeHandle Constructor (Matrix4 transform);
 
 		[iOS (12,0)]
 		[Export ("initWithName:transform:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (string name, Matrix4 transform);
+		NativeHandle Constructor (string name, Matrix4 transform);
 
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
 		[iOS (12,0)]
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 	}
 
 	[iOS (11,0)]
@@ -549,7 +553,7 @@ namespace ARKit {
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
 		[iOS (12,0)]
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 
 		// [Export ("initWithTransform:")] marked as NS_UNAVAILABLE
 
@@ -671,10 +675,10 @@ namespace ARKit {
 		void Validate (Action<NSError> completionHandler);
 
 		[Export ("initWithCGImage:orientation:physicalWidth:")]
-		IntPtr Constructor (CGImage image, CGImagePropertyOrientation orientation, nfloat physicalWidth);
+		NativeHandle Constructor (CGImage image, CGImagePropertyOrientation orientation, nfloat physicalWidth);
 
 		[Export ("initWithPixelBuffer:orientation:physicalWidth:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, nfloat physicalWidth);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, nfloat physicalWidth);
 
 		[Static]
 		[Export ("referenceImagesInGroupNamed:bundle:")]
@@ -1444,12 +1448,12 @@ namespace ARKit {
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
 		[iOS (12,0)]
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 
 #if !XAMCORE_4_0
 		[Obsolete ("Constructor marked as unavailable.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 #endif
 
 		[Export ("geometry")]
@@ -1491,10 +1495,10 @@ namespace ARKit {
 	interface ARFaceGeometry : NSCopying, NSSecureCoding {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithBlendShapes:")]
-		IntPtr Constructor (NSDictionary blendShapes);
+		NativeHandle Constructor (NSDictionary blendShapes);
 
 		[Wrap ("this (blendShapes.GetDictionary ()!)")]
-		IntPtr Constructor (ARBlendShapeLocationOptions blendShapes);
+		NativeHandle Constructor (ARBlendShapeLocationOptions blendShapes);
 
 		[Export ("vertexCount")]
 		nuint VertexCount { get; }
@@ -1561,7 +1565,7 @@ namespace ARKit {
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
 		[iOS (12,0)]
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 
 		[Export ("referenceImage", ArgumentSemantic.Strong)]
 		ARReferenceImage ReferenceImage { get; }
@@ -1639,15 +1643,15 @@ namespace ARKit {
 	interface AREnvironmentProbeAnchor {
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 
 		[Export ("initWithTransform:extent:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Matrix4 transform, Vector3 extent);
+		NativeHandle Constructor (Matrix4 transform, Vector3 extent);
 
 		[Export ("initWithName:transform:extent:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (string name, Matrix4 transform, Vector3 extent);
+		NativeHandle Constructor (string name, Matrix4 transform, Vector3 extent);
 
 		[NullAllowed, Export ("environmentTexture", ArgumentSemantic.Strong)]
 		IMTLTexture EnvironmentTexture { get; }
@@ -1665,7 +1669,7 @@ namespace ARKit {
 	[DisableDefaultCtor]
 	interface ARReferenceObject : NSSecureCoding {
 		[Export ("initWithArchiveURL:error:")]
-		IntPtr Constructor (NSUrl archiveUrl, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSUrl archiveUrl, [NullAllowed] out NSError error);
 
 		[NullAllowed, Export ("name")]
 		string Name { get; set; }
@@ -1722,7 +1726,7 @@ namespace ARKit {
 	interface ARObjectAnchor {
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 
 		[Export ("referenceObject", ArgumentSemantic.Strong)]
 		ARReferenceObject ReferenceObject { get; }
@@ -1767,7 +1771,7 @@ namespace ARKit {
 	interface ARBodyAnchor : ARTrackable {
 
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 
 		// [Export ("initWithTransform:")] marked as NS_UNAVAILABLE
 		// [Export ("initWithName:")] marked as NS_UNAVAILABLE
@@ -1786,7 +1790,7 @@ namespace ARKit {
 		// inherited from UIView
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -1917,7 +1921,7 @@ namespace ARKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithDevice:matteResolution:")]
-		IntPtr Constructor (IMTLDevice device, ARMatteResolution matteResolution);
+		NativeHandle Constructor (IMTLDevice device, ARMatteResolution matteResolution);
 
 		[Export ("generateMatteFromFrame:commandBuffer:")]
 		IMTLTexture GenerateMatte (ARFrame frame, IMTLCommandBuffer commandBuffer);
@@ -1933,7 +1937,7 @@ namespace ARKit {
 
 		[Export ("initWithFileAtURL:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[NullAllowed, Export ("canonicalWebPageURL", ArgumentSemantic.Strong)]
 		NSUrl CanonicalWebPageUrl { get; set; }
@@ -1949,7 +1953,7 @@ namespace ARKit {
 
 		[Export ("initWithOrigin:direction:allowingTarget:alignment:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Vector3 origin, Vector3 direction, ARRaycastTarget target, ARRaycastTargetAlignment alignment);
+		NativeHandle Constructor (Vector3 origin, Vector3 direction, ARRaycastTarget target, ARRaycastTargetAlignment alignment);
 
 		[Export ("origin")]
 		Vector3 Origin {
@@ -2142,7 +2146,7 @@ namespace ARKit {
 
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 
 		// [Export ("initWithTransform:")] marked as NS_UNAVAILABLE
 		// [Export ("initWithName:")] marked as NS_UNAVAILABLE
@@ -2164,7 +2168,7 @@ namespace ARKit {
 
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 
 		// [Export ("initWithTransform:")] marked as NS_UNAVAILABLE
 		// [Export ("initWithName:")] marked as NS_UNAVAILABLE
@@ -2273,7 +2277,7 @@ namespace ARKit {
 	interface ARGeoAnchor : ARTrackable {
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 
 		[Export ("coordinate")]
 		CLLocationCoordinate2D Coordinate { get; }
@@ -2285,16 +2289,16 @@ namespace ARKit {
 		ARAltitudeSource AltitudeSource { get; }
 
 		[Export ("initWithCoordinate:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate);
 
 		[Export ("initWithCoordinate:altitude:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate, double altitude);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate, double altitude);
 
 		[Export ("initWithName:coordinate:")]
-		IntPtr Constructor (string name, CLLocationCoordinate2D coordinate);
+		NativeHandle Constructor (string name, CLLocationCoordinate2D coordinate);
 
 		[Export ("initWithName:coordinate:altitude:")]
-		IntPtr Constructor (string name, CLLocationCoordinate2D coordinate, double altitude);
+		NativeHandle Constructor (string name, CLLocationCoordinate2D coordinate, double altitude);
 	}
 
 	[iOS (14, 0)]
@@ -2375,7 +2379,7 @@ namespace ARKit {
 
 		// Inlined from 'ARAnchorCopying' protocol (we can't have constructors in interfaces)
 		[Export ("initWithAnchor:")]
-		IntPtr Constructor (ARAnchor anchor);
+		NativeHandle Constructor (ARAnchor anchor);
 
 		[NullAllowed, Export ("url", ArgumentSemantic.Copy)]
 		NSUrl Url { get; }

--- a/src/audiounit.cs
+++ b/src/audiounit.cs
@@ -32,6 +32,10 @@ using MediaToolbox;
 using AUViewControllerBase = UIKit.UIViewController;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AudioUnit {
 	delegate AudioUnitStatus AUInternalRenderBlock (ref AudioUnitRenderActionFlags actionFlags, ref AudioTimeStamp timestamp, uint frameCount, nint outputBusNumber, AudioBuffers outputData, AURenderEventEnumerator realtimeEventListHead, [BlockCallback][NullAllowed]AURenderPullInputBlock pullInputBlock);
 	delegate AudioUnitStatus AURenderBlock (ref AudioUnitRenderActionFlags actionFlags, ref AudioTimeStamp timestamp, uint frameCount, nint outputBusNumber, AudioBuffers outputData, [BlockCallback][NullAllowed] AURenderPullInputBlock pullInputBlock);
@@ -81,10 +85,10 @@ namespace AudioUnit {
 
 		[Export ("initWithComponentDescription:options:error:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AudioComponentDescription componentDescription, AudioComponentInstantiationOptions options, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (AudioComponentDescription componentDescription, AudioComponentInstantiationOptions options, [NullAllowed] out NSError outError);
 
 		[Export ("initWithComponentDescription:error:")]
-		IntPtr Constructor (AudioComponentDescription componentDescription, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (AudioComponentDescription componentDescription, [NullAllowed] out NSError outError);
 
 		[Static]
 		[Export ("instantiateWithComponentDescription:options:completionHandler:")]
@@ -400,7 +404,7 @@ namespace AudioUnit {
 	interface AUAudioUnitBus
 	{
 		[Export ("initWithFormat:error:")]
-		IntPtr Constructor (AVAudioFormat format, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (AVAudioFormat format, [NullAllowed] out NSError outError);
 
 		[Export ("format")]
 		AVAudioFormat Format { get; }
@@ -448,10 +452,10 @@ namespace AudioUnit {
 	{
 		[Export ("initWithAudioUnit:busType:busses:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AUAudioUnit owner, AUAudioUnitBusType busType, AUAudioUnitBus[] busArray);
+		NativeHandle Constructor (AUAudioUnit owner, AUAudioUnitBusType busType, AUAudioUnitBus[] busArray);
 
 		[Export ("initWithAudioUnit:busType:")]
-		IntPtr Constructor (AUAudioUnit owner, AUAudioUnitBusType busType);
+		NativeHandle Constructor (AUAudioUnit owner, AUAudioUnitBusType busType);
 
 		[Export ("count")]
 		nuint Count { get; }

--- a/src/authenticationservices.cs
+++ b/src/authenticationservices.cs
@@ -22,6 +22,10 @@ using UIViewController = Foundation.NSObject;
 using UIWindow = Foundation.NSObject;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AuthenticationServices {
 
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
@@ -161,7 +165,7 @@ namespace AuthenticationServices {
 	[DisableDefaultCtor]
 	interface ASCredentialServiceIdentifier : NSCopying, NSSecureCoding {
 		[Export ("initWithIdentifier:type:")]
-		IntPtr Constructor (string identifier, ASCredentialServiceIdentifierType type);
+		NativeHandle Constructor (string identifier, ASCredentialServiceIdentifierType type);
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -179,7 +183,7 @@ namespace AuthenticationServices {
 	interface ASPasswordCredentialIdentity : NSCopying, NSSecureCoding {
 		[Export ("initWithServiceIdentifier:user:recordIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ASCredentialServiceIdentifier serviceIdentifier, string user, [NullAllowed] string recordIdentifier);
+		NativeHandle Constructor (ASCredentialServiceIdentifier serviceIdentifier, string user, [NullAllowed] string recordIdentifier);
 
 		[Static]
 		[Export ("identityWithServiceIdentifier:user:recordIdentifier:")]
@@ -226,7 +230,7 @@ namespace AuthenticationServices {
 	[DisableDefaultCtor]
 	interface ASPasswordCredential : NSCopying, NSSecureCoding, ASAuthorizationCredential {
 		[Export ("initWithUser:password:")]
-		IntPtr Constructor (string user, string password);
+		NativeHandle Constructor (string user, string password);
 
 		[Static]
 		[Export ("credentialWithUser:password:")]
@@ -249,7 +253,7 @@ namespace AuthenticationServices {
 	[DisableDefaultCtor]
 	interface ASWebAuthenticationSession {
 		[Export ("initWithURL:callbackURLScheme:completionHandler:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] string callbackUrlScheme, ASWebAuthenticationSessionCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] string callbackUrlScheme, ASWebAuthenticationSessionCompletionHandler completionHandler);
 
 		[Export ("start")]
 		bool Start ();
@@ -407,7 +411,7 @@ namespace AuthenticationServices {
 
 		[Export ("initWithAuthorizationRequests:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ASAuthorizationRequest[] authorizationRequests);
+		NativeHandle Constructor (ASAuthorizationRequest[] authorizationRequests);
 
 		[Export ("authorizationRequests", ArgumentSemantic.Strong)]
 		ASAuthorizationRequest[] AuthorizationRequests { get; }
@@ -708,7 +712,7 @@ namespace AuthenticationServices {
 
 		[Export ("initWithAuthorizationButtonType:authorizationButtonStyle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ASAuthorizationAppleIdButtonType type, ASAuthorizationAppleIdButtonStyle style);
+		NativeHandle Constructor (ASAuthorizationAppleIdButtonType type, ASAuthorizationAppleIdButtonStyle style);
 
 		[NoTV]
 		[Export ("cornerRadius")]
@@ -895,7 +899,7 @@ namespace AuthenticationServices {
 	interface ASAccountAuthenticationModificationReplacePasswordWithSignInWithAppleRequest {
 
 		[Export ("initWithUser:serviceIdentifier:userInfo:")]
-		IntPtr Constructor (string user, ASCredentialServiceIdentifier serviceIdentifier, [NullAllowed] NSDictionary userInfo);
+		NativeHandle Constructor (string user, ASCredentialServiceIdentifier serviceIdentifier, [NullAllowed] NSDictionary userInfo);
 
 		[Export ("user")]
 		string User { get; }
@@ -915,7 +919,7 @@ namespace AuthenticationServices {
 	interface ASAccountAuthenticationModificationUpgradePasswordToStrongPasswordRequest {
 
 		[Export ("initWithUser:serviceIdentifier:userInfo:")]
-		IntPtr Constructor (string user, ASCredentialServiceIdentifier serviceIdentifier, [NullAllowed] NSDictionary userInfo);
+		NativeHandle Constructor (string user, ASCredentialServiceIdentifier serviceIdentifier, [NullAllowed] NSDictionary userInfo);
 
 		[Export ("user")]
 		string User { get; }
@@ -1153,7 +1157,7 @@ namespace AuthenticationServices {
 	{
 		[Export ("initWithCredentialID:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSData credentialId);
+		NativeHandle Constructor (NSData credentialId);
 	}
 
 	[NoWatch, Mac (12,0), iOS (15,0), MacCatalyst (15,0), NoTV]
@@ -1163,7 +1167,7 @@ namespace AuthenticationServices {
 	{
 		[Export ("initWithRelyingPartyIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string relyingPartyIdentifier);
+		NativeHandle Constructor (string relyingPartyIdentifier);
 
 		[Export ("createCredentialRegistrationRequestWithChallenge:name:userID:")]
 		ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest CreateCredentialRegistrationRequest (NSData challenge, string name, NSData userId);
@@ -1181,10 +1185,10 @@ namespace AuthenticationServices {
 	interface ASAuthorizationProviderExtensionAuthorizationResult
 	{
 		[Export ("initWithHTTPAuthorizationHeaders:")]
-		IntPtr Constructor (NSDictionary<NSString, NSString> httpAuthorizationHeaders);
+		NativeHandle Constructor (NSDictionary<NSString, NSString> httpAuthorizationHeaders);
 
 		[Export ("initWithHTTPResponse:httpBody:")]
-		IntPtr Constructor (NSHttpUrlResponse httpResponse, [NullAllowed] NSData httpBody);
+		NativeHandle Constructor (NSHttpUrlResponse httpResponse, [NullAllowed] NSData httpBody);
 
 		[NullAllowed, Export ("httpAuthorizationHeaders", ArgumentSemantic.Assign)]
 		NSDictionary<NSString, NSString> HttpAuthorizationHeaders { get; set; }
@@ -1205,7 +1209,7 @@ namespace AuthenticationServices {
 	interface ASAuthorizationPublicKeyCredentialParameters : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithAlgorithm:")]
-		IntPtr Constructor (ASCoseAlgorithmIdentifier algorithm);
+		NativeHandle Constructor (ASCoseAlgorithmIdentifier algorithm);
 
 		[Export ("algorithm")]
 		ASCoseAlgorithmIdentifier Algorithm { get; }
@@ -1218,7 +1222,7 @@ namespace AuthenticationServices {
 	{
 		[Export ("initWithCredentialID:transports:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSData credentialId, [BindAs (typeof (ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport[]))] NSString[] allowedTransports);
+		NativeHandle Constructor (NSData credentialId, [BindAs (typeof (ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport[]))] NSString[] allowedTransports);
 
 		[Export ("transports", ArgumentSemantic.Assign)]
 		[BindAs (typeof (ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport[]))]
@@ -1232,7 +1236,7 @@ namespace AuthenticationServices {
 	{
 		[Export ("initWithRelyingPartyIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string relyingPartyIdentifier);
+		NativeHandle Constructor (string relyingPartyIdentifier);
 
 		[Export ("createCredentialRegistrationRequestWithChallenge:displayName:name:userID:")]
 		ASAuthorizationSecurityKeyPublicKeyCredentialRegistrationRequest Create (NSData challenge, string displayName, string name, NSData userId);

--- a/src/automaticassessmentconfiguration.cs
+++ b/src/automaticassessmentconfiguration.cs
@@ -12,6 +12,10 @@ using System;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AutomaticAssessmentConfiguration {
 
 	[ErrorDomain ("AEAssessmentErrorDomain")]
@@ -106,7 +110,7 @@ namespace AutomaticAssessmentConfiguration {
 		bool Active { [Bind ("isActive")] get; }
 
 		[Export ("initWithConfiguration:")]
-		IntPtr Constructor (AEAssessmentConfiguration configuration);
+		NativeHandle Constructor (AEAssessmentConfiguration configuration);
 
 		[Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[Export ("configuration", ArgumentSemantic.Copy)]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -60,6 +60,10 @@ using UIImage = AppKit.NSImage;
 using UIKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #if WATCH
 using AVCaptureWhiteBalanceGains = Foundation.NSString;
 // stubs to ease compilation using [NoWatch]
@@ -237,7 +241,7 @@ namespace AVFoundation {
 	interface AVDateRangeMetadataGroup : NSCopying, NSMutableCopying
 	{
 		[Export ("initWithItems:startDate:endDate:")]
-		IntPtr Constructor (AVMetadataItem[] items, NSDate startDate, [NullAllowed] NSDate endDate);
+		NativeHandle Constructor (AVMetadataItem[] items, NSDate startDate, [NullAllowed] NSDate endDate);
 	
 		[Export ("startDate", ArgumentSemantic.Copy)]
 		NSDate StartDate { get; [NotImplemented] set; }
@@ -850,11 +854,11 @@ namespace AVFoundation {
 	[DisableDefaultCtor] // fails (nil handle on iOS 10)
 	interface AVAudioChannelLayout : NSSecureCoding {
 		[Export ("initWithLayoutTag:")]
-		IntPtr Constructor (/* UInt32 */ uint layoutTag);
+		NativeHandle Constructor (/* UInt32 */ uint layoutTag);
 
 		[DesignatedInitializer]
 		[Export ("initWithLayout:"), Internal]
-		IntPtr Constructor (nint /* This is really an IntPtr, but it conflicts with the default (Handle) ctor. */ layout);
+		NativeHandle Constructor (nint /* This is really an IntPtr, but it conflicts with the default (Handle) ctor. */ layout);
 
 		[Export ("layoutTag")]
 		uint /* AudioChannelLayoutTag = UInt32 */ LayoutTag { get; }
@@ -876,10 +880,10 @@ namespace AVFoundation {
 	interface AVAudioCompressedBuffer
 	{
 		[Export ("initWithFormat:packetCapacity:maximumPacketSize:")]
-		IntPtr Constructor (AVAudioFormat format, uint packetCapacity, nint maximumPacketSize);
+		NativeHandle Constructor (AVAudioFormat format, uint packetCapacity, nint maximumPacketSize);
 	
 		[Export ("initWithFormat:packetCapacity:")]
-		IntPtr Constructor (AVAudioFormat format, uint packetCapacity);
+		NativeHandle Constructor (AVAudioFormat format, uint packetCapacity);
 	
 		[Export ("packetCapacity")]
 		uint PacketCapacity { get; }
@@ -913,7 +917,7 @@ namespace AVFoundation {
 	{
 		[Export ("initWithNode:bus:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVAudioNode node, nuint bus);
+		NativeHandle Constructor (AVAudioNode node, nuint bus);
 	
 		[NullAllowed, Export ("node", ArgumentSemantic.Weak)]
 		AVAudioNode Node { get; }
@@ -1083,7 +1087,7 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("nextAvailableInputBus")]
 		nuint NextAvailableInputBus { get; }
@@ -1159,22 +1163,22 @@ namespace AVFoundation {
 	[BaseType (typeof (NSObject))]
 	interface AVAudioFile {
 		[Export ("initForReading:error:")]
-		IntPtr Constructor (NSUrl fileUrl, out NSError outError);
+		NativeHandle Constructor (NSUrl fileUrl, out NSError outError);
 
 		[Export ("initForReading:commonFormat:interleaved:error:")]
-		IntPtr Constructor (NSUrl fileUrl, AVAudioCommonFormat format, bool interleaved, out NSError outError);
+		NativeHandle Constructor (NSUrl fileUrl, AVAudioCommonFormat format, bool interleaved, out NSError outError);
 
 		[Export ("initForWriting:settings:error:"), Internal]
-		IntPtr Constructor (NSUrl fileUrl, NSDictionary settings, out NSError outError);
+		NativeHandle Constructor (NSUrl fileUrl, NSDictionary settings, out NSError outError);
 
 		[Wrap ("this (fileUrl, settings.GetDictionary ()!, out outError)")]
-		IntPtr Constructor (NSUrl fileUrl, AudioSettings settings, out NSError outError);
+		NativeHandle Constructor (NSUrl fileUrl, AudioSettings settings, out NSError outError);
 
 		[Export ("initForWriting:settings:commonFormat:interleaved:error:"), Internal]
-		IntPtr Constructor (NSUrl fileUrl, NSDictionary settings, AVAudioCommonFormat format, bool interleaved, out NSError outError);
+		NativeHandle Constructor (NSUrl fileUrl, NSDictionary settings, AVAudioCommonFormat format, bool interleaved, out NSError outError);
 		
 		[Wrap ("this (fileUrl, settings.GetDictionary ()!, format, interleaved, out outError)")]
-		IntPtr Constructor (NSUrl fileUrl, AudioSettings settings, AVAudioCommonFormat format, bool interleaved, out NSError outError);
+		NativeHandle Constructor (NSUrl fileUrl, AudioSettings settings, AVAudioCommonFormat format, bool interleaved, out NSError outError);
 
 		[Export ("url")]
 		NSUrl Url { get; }
@@ -1206,32 +1210,32 @@ namespace AVFoundation {
 	[BaseType (typeof (NSObject))]
 	interface AVAudioFormat : NSSecureCoding {
 		[Export ("initWithStreamDescription:")]
-		IntPtr Constructor (ref AudioStreamBasicDescription description);
+		NativeHandle Constructor (ref AudioStreamBasicDescription description);
 
 		[Export ("initWithStreamDescription:channelLayout:")]
-		IntPtr Constructor (ref AudioStreamBasicDescription description, [NullAllowed] AVAudioChannelLayout layout);
+		NativeHandle Constructor (ref AudioStreamBasicDescription description, [NullAllowed] AVAudioChannelLayout layout);
 
 		[Export ("initStandardFormatWithSampleRate:channels:")]
-		IntPtr Constructor (double sampleRate, uint /* AVAudioChannelCount = uint32_t */ channels);
+		NativeHandle Constructor (double sampleRate, uint /* AVAudioChannelCount = uint32_t */ channels);
 
 		[Export ("initStandardFormatWithSampleRate:channelLayout:")]
-		IntPtr Constructor (double sampleRate, AVAudioChannelLayout layout);
+		NativeHandle Constructor (double sampleRate, AVAudioChannelLayout layout);
 
 		[Export ("initWithCommonFormat:sampleRate:channels:interleaved:")]
-		IntPtr Constructor (AVAudioCommonFormat format, double sampleRate, uint /* AVAudioChannelCount = uint32_t */ channels, bool interleaved);
+		NativeHandle Constructor (AVAudioCommonFormat format, double sampleRate, uint /* AVAudioChannelCount = uint32_t */ channels, bool interleaved);
 
 		[Export ("initWithCommonFormat:sampleRate:interleaved:channelLayout:")]
-		IntPtr Constructor (AVAudioCommonFormat format, double sampleRate, bool interleaved, AVAudioChannelLayout layout);
+		NativeHandle Constructor (AVAudioCommonFormat format, double sampleRate, bool interleaved, AVAudioChannelLayout layout);
 
 		[Export ("initWithSettings:")]
-		IntPtr Constructor (NSDictionary settings);
+		NativeHandle Constructor (NSDictionary settings);
 
 		[Wrap ("this (settings.GetDictionary ()!)")]
-		IntPtr Constructor (AudioSettings settings);
+		NativeHandle Constructor (AudioSettings settings);
 
 		[iOS (9,0)][Mac (10,11)][Watch (6,0)]
 		[Export ("initWithCMAudioFormatDescription:")]
-		IntPtr Constructor (CMAudioFormatDescription formatDescription);
+		NativeHandle Constructor (CMAudioFormatDescription formatDescription);
 
 		[Export ("standard")]
 		bool Standard { [Bind ("isStandard")] get; }
@@ -1457,7 +1461,7 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("outputVolume")]
 		float OutputVolume { get; set; } /* float, not CGFloat */
@@ -1511,12 +1515,12 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithPCMFormat:frameCapacity:")]
-		IntPtr Constructor (AVAudioFormat format, uint /* AVAudioFrameCount = uint32_t */ frameCapacity);
+		NativeHandle Constructor (AVAudioFormat format, uint /* AVAudioFrameCount = uint32_t */ frameCapacity);
 
 		[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[Export ("initWithPCMFormat:bufferListNoCopy:deallocator:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVAudioFormat format, AudioBuffers bufferList, [NullAllowed] Action<AudioBuffers> deallocator);
+		NativeHandle Constructor (AVAudioFormat format, AudioBuffers bufferList, [NullAllowed] Action<AudioBuffers> deallocator);
 
 		[Export ("frameCapacity")]
 		uint FrameCapacity { get; } /* AVAudioFrameCount = uint32_t */ 
@@ -1542,10 +1546,10 @@ namespace AVFoundation {
 	[DisableDefaultCtor]
 	interface AVAudioPlayer {
 		[Export ("initWithContentsOfURL:error:")][Internal]
-		IntPtr Constructor (NSUrl url, IntPtr outError);
+		NativeHandle Constructor (NSUrl url, IntPtr outError);
 	
 		[Export ("initWithData:error:")][Internal]
-		IntPtr Constructor (NSData  data, IntPtr outError);
+		NativeHandle Constructor (NSData  data, IntPtr outError);
 
 		[Export ("prepareToPlay")]
 		bool PrepareToPlay ();
@@ -1631,10 +1635,10 @@ namespace AVFoundation {
 		AVAudioSessionChannelDescription [] ChannelAssignments { get; set; }
 #endif
 		[iOS (7,0), Mac (10,9), Export ("initWithData:fileTypeHint:error:")]
-		IntPtr Constructor (NSData data, [NullAllowed] string fileTypeHint, out NSError outError);
+		NativeHandle Constructor (NSData data, [NullAllowed] string fileTypeHint, out NSError outError);
 
 		[iOS (7,0), Mac (10,9), Export ("initWithContentsOfURL:fileTypeHint:error:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] string fileTypeHint, out NSError outError);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] string fileTypeHint, out NSError outError);
 
 		[iOS (10, 0), TV (10,0), Mac (10,12)]
 		[Watch (4,0)]
@@ -1680,7 +1684,7 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("playing")]
 		bool Playing { [Bind ("isPlaying")] get; }
@@ -2667,7 +2671,7 @@ namespace AVFoundation {
 	[DisableDefaultCtor] // returns a nil handle
 	interface AVAudioUnitEffect {
 		[Export ("initWithAudioComponentDescription:")]
-		IntPtr Constructor (AudioComponentDescription audioComponentDescription);
+		NativeHandle Constructor (AudioComponentDescription audioComponentDescription);
 
 		[Export ("bypass")]
 		bool Bypass { get; set; }
@@ -2678,7 +2682,7 @@ namespace AVFoundation {
 	[BaseType (typeof (AVAudioUnitEffect))]
 	interface AVAudioUnitEQ {
 		[Export ("initWithNumberOfBands:")]
-		IntPtr Constructor (nuint numberOfBands);
+		NativeHandle Constructor (nuint numberOfBands);
 
 		[Export ("bands")]
 		AVAudioUnitEQFilterParameters [] Bands { get; }
@@ -2713,7 +2717,7 @@ namespace AVFoundation {
 	[DisableDefaultCtor] // returns a nil handle
 	interface AVAudioUnitGenerator : AVAudioMixing {
 		[Export ("initWithAudioComponentDescription:")]
-		IntPtr Constructor (AudioComponentDescription audioComponentDescription);
+		NativeHandle Constructor (AudioComponentDescription audioComponentDescription);
 
 		[Export ("bypass")]
 		bool Bypass { get; set; }
@@ -2724,7 +2728,7 @@ namespace AVFoundation {
 	[DisableDefaultCtor] // returns a nil handle
 	interface AVAudioUnitMidiInstrument : AVAudioMixing { 
 		[Export ("initWithAudioComponentDescription:")]
-		IntPtr Constructor (AudioComponentDescription audioComponentDescription);
+		NativeHandle Constructor (AudioComponentDescription audioComponentDescription);
 
 		[Export ("startNote:withVelocity:onChannel:")]
 		void StartNote (byte note, byte velocity, byte channel);
@@ -2808,7 +2812,7 @@ namespace AVFoundation {
 	[DisableDefaultCtor] // returns a nil handle
 	interface AVAudioUnitTimeEffect {
 		[Export ("initWithAudioComponentDescription:")]
-		IntPtr Constructor (AudioComponentDescription audioComponentDescription);
+		NativeHandle Constructor (AudioComponentDescription audioComponentDescription);
 
 		[Export ("bypass")]
 		bool Bypass { get; set; }
@@ -2818,7 +2822,7 @@ namespace AVFoundation {
 	[BaseType (typeof (AVAudioUnitTimeEffect))]
 	interface AVAudioUnitTimePitch {
 		[Export ("initWithAudioComponentDescription:")]
-		IntPtr Constructor (AudioComponentDescription audioComponentDescription);
+		NativeHandle Constructor (AudioComponentDescription audioComponentDescription);
 
 
 		[Export ("rate")]
@@ -2835,7 +2839,7 @@ namespace AVFoundation {
 	[BaseType (typeof (AVAudioUnitTimeEffect))]
 	interface AVAudioUnitVarispeed {
 		[Export ("initWithAudioComponentDescription:")]
-		IntPtr Constructor (AudioComponentDescription audioComponentDescription);
+		NativeHandle Constructor (AudioComponentDescription audioComponentDescription);
 
 		[Export ("rate")]
 		float Rate { get; set; } /* float, not CGFloat */
@@ -2846,16 +2850,16 @@ namespace AVFoundation {
 	[BaseType (typeof (NSObject))]
 	interface AVAudioTime {
 		[Export ("initWithAudioTimeStamp:sampleRate:")]
-		IntPtr Constructor (ref AudioTimeStamp timestamp, double sampleRate);
+		NativeHandle Constructor (ref AudioTimeStamp timestamp, double sampleRate);
 
 		[Export ("initWithHostTime:")]
-		IntPtr Constructor (ulong hostTime);
+		NativeHandle Constructor (ulong hostTime);
 
 		[Export ("initWithSampleTime:atRate:")]
-		IntPtr Constructor (long sampleTime, double sampleRate);
+		NativeHandle Constructor (long sampleTime, double sampleRate);
 
 		[Export ("initWithHostTime:sampleTime:atRate:")]
-		IntPtr Constructor (ulong hostTime, long sampleTime, double sampleRate);
+		NativeHandle Constructor (ulong hostTime, long sampleTime, double sampleRate);
 
 		[Export ("hostTimeValid")]
 		bool HostTimeValid { [Bind ("isHostTimeValid")] get; }
@@ -2906,7 +2910,7 @@ namespace AVFoundation {
 	interface AVAudioConverter {
 
 		[Export ("initFromFormat:toFormat:")]
-		IntPtr Constructor (AVAudioFormat fromFormat, AVAudioFormat toFormat);
+		NativeHandle Constructor (AVAudioFormat fromFormat, AVAudioFormat toFormat);
 
 		[Export ("reset")]
 		void Reset ();
@@ -3240,7 +3244,7 @@ namespace AVFoundation {
 	interface AVFragmentedAsset : AVFragmentMinding {
 
 		[Export ("initWithURL:options:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] NSDictionary options);
 
 		[Static]
 		[Export ("fragmentedAssetWithURL:options:")]
@@ -3300,7 +3304,7 @@ namespace AVFoundation {
 
 		[Mac (10,14)]
 		[Export ("initWithAsset:mindingInterval:")]
-		IntPtr Constructor (IAVFragmentMinding asset, double mindingInterval);
+		NativeHandle Constructor (IAVFragmentMinding asset, double mindingInterval);
 
 		[Export ("mindingInterval")]
 		double MindingInterval { get; set; }
@@ -3403,7 +3407,7 @@ namespace AVFoundation {
 	interface AVCaptureDataOutputSynchronizer
 	{
 		[Export ("initWithDataOutputs:")]
-		IntPtr Constructor (AVCaptureOutput[] dataOutputs);
+		NativeHandle Constructor (AVCaptureOutput[] dataOutputs);
 
 		[Export ("dataOutputs", ArgumentSemantic.Retain)]
 		AVCaptureOutput[] DataOutputs { get; }
@@ -3621,7 +3625,7 @@ namespace AVFoundation {
 
 		[Export ("initWithAsset:timebase:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVAsset asset, [NullAllowed] CMTimebase timebase);
+		NativeHandle Constructor (AVAsset asset, [NullAllowed] CMTimebase timebase);
 
 		[Export ("createSampleBufferForRequest:")]
 		[return: Release]
@@ -3641,7 +3645,7 @@ namespace AVFoundation {
 
 		[Export ("initWithStartCursor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVSampleCursor startCursor);
+		NativeHandle Constructor (AVSampleCursor startCursor);
 
 		[Export ("startCursor", ArgumentSemantic.Retain)]
 		AVSampleCursor StartCursor { get; }
@@ -3689,7 +3693,7 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithAsset:")]
-		IntPtr Constructor (AVAsset asset);
+		NativeHandle Constructor (AVAsset asset);
 
 		[Export ("copyCGImageAtTime:actualTime:error:")]
 		[return: NullAllowed]
@@ -3756,7 +3760,7 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithAsset:error:")]
-		IntPtr Constructor (AVAsset asset, out NSError error);
+		NativeHandle Constructor (AVAsset asset, out NSError error);
 
 		[Export ("canAddOutput:")]
 		bool CanAddOutput (AVAssetReaderOutput output);
@@ -3807,7 +3811,7 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithAssetReaderTrackOutput:")]
-		IntPtr Constructor (AVAssetReaderTrackOutput trackOutput);
+		NativeHandle Constructor (AVAssetReaderTrackOutput trackOutput);
 
 		[Export ("assetReaderTrackOutput")]
 		AVAssetReaderTrackOutput AssetReaderTrackOutput { get; }
@@ -3828,7 +3832,7 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithTrack:")]
-		IntPtr Constructor (AVAssetTrack track);
+		NativeHandle Constructor (AVAssetTrack track);
 
 		[Export ("track")]
 		AVAssetTrack Track { get; }
@@ -3858,13 +3862,13 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithTrack:outputSettings:")]
-		IntPtr Constructor (AVAssetTrack track, [NullAllowed] NSDictionary outputSettings);
+		NativeHandle Constructor (AVAssetTrack track, [NullAllowed] NSDictionary outputSettings);
 
 		[Wrap ("this (track, settings.GetDictionary ())")]		
-		IntPtr Constructor (AVAssetTrack track, [NullAllowed] AudioSettings settings);
+		NativeHandle Constructor (AVAssetTrack track, [NullAllowed] AudioSettings settings);
 
 		[Wrap ("this (track, settings.GetDictionary ())")]		
-		IntPtr Constructor (AVAssetTrack track, [NullAllowed] AVVideoSettingsUncompressed settings);
+		NativeHandle Constructor (AVAssetTrack track, [NullAllowed] AVVideoSettingsUncompressed settings);
 
 		[Export ("outputSettings"), NullAllowed]
 		NSDictionary OutputSettings { get; }
@@ -3897,10 +3901,10 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithAudioTracks:audioSettings:")]
-		IntPtr Constructor (AVAssetTrack [] audioTracks, [NullAllowed] NSDictionary audioSettings);
+		NativeHandle Constructor (AVAssetTrack [] audioTracks, [NullAllowed] NSDictionary audioSettings);
 
 		[Wrap ("this (audioTracks, settings.GetDictionary ())")]
-		IntPtr Constructor (AVAssetTrack [] audioTracks, [NullAllowed] AudioSettings settings);
+		NativeHandle Constructor (AVAssetTrack [] audioTracks, [NullAllowed] AudioSettings settings);
 
 		[Internal]
 		[Advice ("Use 'Settings' property.")]
@@ -3940,10 +3944,10 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithVideoTracks:videoSettings:")]
-		IntPtr Constructor (AVAssetTrack [] videoTracks, [NullAllowed] NSDictionary videoSettings);
+		NativeHandle Constructor (AVAssetTrack [] videoTracks, [NullAllowed] NSDictionary videoSettings);
 
 		[Wrap ("this (videoTracks, settings.GetDictionary ())")]
-		IntPtr Constructor (AVAssetTrack [] videoTracks, [NullAllowed] CVPixelBufferAttributes settings);		
+		NativeHandle Constructor (AVAssetTrack [] videoTracks, [NullAllowed] CVPixelBufferAttributes settings);		
 
 		[Export ("videoSettings"), NullAllowed]
 		NSDictionary WeakVideoSettings { get; }
@@ -4189,12 +4193,12 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithURL:fileType:error:")]
-		IntPtr Constructor (NSUrl outputUrl, string outputFileType, out NSError error);
+		NativeHandle Constructor (NSUrl outputUrl, string outputFileType, out NSError error);
 
 		[TV (14,0), NoWatch, Mac (11,0), iOS (14,0)]
 		[Export ("initWithContentType:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UTType outputContentType);
+		NativeHandle Constructor (UTType outputContentType);
 
 		[Export ("canApplyOutputSettings:forMediaType:")]
 		bool CanApplyOutputSettings ([NullAllowed] NSDictionary outputSettings, string mediaType);
@@ -4300,13 +4304,13 @@ namespace AVFoundation {
 		[DesignatedInitializer]
 		[Protected]
 		[Export ("initWithMediaType:outputSettings:sourceFormatHint:")]
-		IntPtr Constructor (string mediaType, [NullAllowed] NSDictionary outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
+		NativeHandle Constructor (string mediaType, [NullAllowed] NSDictionary outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
 		[Wrap ("this (mediaType, outputSettings.GetDictionary (), sourceFormatHint)")]
-		IntPtr Constructor (string mediaType, [NullAllowed] AudioSettings outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
+		NativeHandle Constructor (string mediaType, [NullAllowed] AudioSettings outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
 		[Wrap ("this (mediaType, outputSettings.GetDictionary (), sourceFormatHint)")]
-		IntPtr Constructor (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
+		NativeHandle Constructor (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
 		[Static, Internal]
 		[Export ("assetWriterInputWithMediaType:outputSettings:sourceFormatHint:")]
@@ -4351,13 +4355,13 @@ namespace AVFoundation {
 
 		[Protected]
 		[Export ("initWithMediaType:outputSettings:")]
-		IntPtr Constructor (string mediaType, [NullAllowed] NSDictionary outputSettings);
+		NativeHandle Constructor (string mediaType, [NullAllowed] NSDictionary outputSettings);
 
 		[Wrap ("this (mediaType, outputSettings.GetDictionary ())")]		
-		IntPtr Constructor (string mediaType, [NullAllowed] AudioSettings outputSettings);
+		NativeHandle Constructor (string mediaType, [NullAllowed] AudioSettings outputSettings);
 
 		[Wrap ("this (mediaType, outputSettings.GetDictionary ())")]		
-		IntPtr Constructor (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings);
+		NativeHandle Constructor (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings);
 
 		[Export ("requestMediaDataWhenReadyOnQueue:usingBlock:")]
 		void RequestMediaData (DispatchQueue queue, Action action);
@@ -4462,7 +4466,7 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithAssetWriterInput:")]
-		IntPtr Constructor (AVAssetWriterInput assetWriterInput);
+		NativeHandle Constructor (AVAssetWriterInput assetWriterInput);
 
 		[Export ("assetWriterInput")]
 		AVAssetWriterInput AssetWriterInput { get; }
@@ -4484,7 +4488,7 @@ namespace AVFoundation {
 	
 		[DesignatedInitializer]
 		[Export ("initWithInputs:defaultInput:")]
-		IntPtr Constructor (AVAssetWriterInput [] inputs, [NullAllowed] AVAssetWriterInput defaultInput);
+		NativeHandle Constructor (AVAssetWriterInput [] inputs, [NullAllowed] AVAssetWriterInput defaultInput);
 	
 		[Export ("inputs")]
 		AVAssetWriterInput [] Inputs { get; }
@@ -4519,10 +4523,10 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithAssetWriterInput:sourcePixelBufferAttributes:")]
-		IntPtr Constructor (AVAssetWriterInput input, [NullAllowed] NSDictionary sourcePixelBufferAttributes);
+		NativeHandle Constructor (AVAssetWriterInput input, [NullAllowed] NSDictionary sourcePixelBufferAttributes);
 
 		[Wrap ("this (input, attributes.GetDictionary ())")]
-		IntPtr Constructor (AVAssetWriterInput input, [NullAllowed] CVPixelBufferAttributes attributes);		
+		NativeHandle Constructor (AVAssetWriterInput input, [NullAllowed] CVPixelBufferAttributes attributes);		
 
 		[Export ("appendPixelBuffer:withPresentationTime:")]
 		bool AppendPixelBufferWithPresentationTime (CVPixelBuffer pixelBuffer, CMTime presentationTime);
@@ -4568,13 +4572,13 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithURL:options:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] NSDictionary options);
 
 		[Wrap ("this (url, options.GetDictionary ())")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] AVUrlAssetOptions options);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] AVUrlAssetOptions options);
 
 		[Wrap ("this (url, (NSDictionary) null!)")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[return: NullAllowed]
 		[Export ("compatibleTrackForCompositionTrack:")]
@@ -7182,10 +7186,10 @@ namespace AVFoundation {
 	interface AVMidiPlayer {
 
 		[Export ("initWithContentsOfURL:soundBankURL:error:")]
-		IntPtr Constructor (NSUrl contentsUrl, [NullAllowed] NSUrl soundBankUrl, out NSError outError);
+		NativeHandle Constructor (NSUrl contentsUrl, [NullAllowed] NSUrl soundBankUrl, out NSError outError);
 
 		[Export ("initWithData:soundBankURL:error:")]
-		IntPtr Constructor (NSData data, [NullAllowed] NSUrl sounddBankUrl, out NSError outError);
+		NativeHandle Constructor (NSData data, [NullAllowed] NSUrl sounddBankUrl, out NSError outError);
 
 		[Export ("duration")]
 		double Duration { get; }
@@ -7232,7 +7236,7 @@ namespace AVFoundation {
 
 		[Export ("initWithURL:options:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl URL, [NullAllowed] NSDictionary<NSString, NSObject> options);
+		NativeHandle Constructor (NSUrl URL, [NullAllowed] NSDictionary<NSString, NSObject> options);
 
 		[Mac (10,11)]
 		[Static]
@@ -7242,7 +7246,7 @@ namespace AVFoundation {
 		[Mac (10,11)]
 		[Export ("initWithData:options:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary<NSString, NSObject> options);
+		NativeHandle Constructor (NSData data, [NullAllowed] NSDictionary<NSString, NSObject> options);
 
 		[NullAllowed, Export ("URL")]
 		NSUrl URL { get; }
@@ -7333,7 +7337,7 @@ namespace AVFoundation {
 
 		[Export ("initWithURL:options:error:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl URL, [NullAllowed] NSDictionary<NSString, NSObject> options, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (NSUrl URL, [NullAllowed] NSDictionary<NSString, NSObject> options, [NullAllowed] out NSError outError);
 
 		[Static]
 		[Export ("movieWithData:options:error:")]
@@ -7342,7 +7346,7 @@ namespace AVFoundation {
 
 		[Export ("initWithData:options:error:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary<NSString, NSObject> options, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (NSData data, [NullAllowed] NSDictionary<NSString, NSObject> options, [NullAllowed] out NSError outError);
 
 		[Static]
 		[Export ("movieWithSettingsFromMovie:options:error:")]
@@ -7351,7 +7355,7 @@ namespace AVFoundation {
 
 		[Export ("initWithSettingsFromMovie:options:error:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] AVMovie movie, [NullAllowed] NSDictionary<NSString, NSObject> options, [NullAllowed] out NSError outError);
+		NativeHandle Constructor ([NullAllowed] AVMovie movie, [NullAllowed] NSDictionary<NSString, NSObject> options, [NullAllowed] out NSError outError);
 
 		[Export ("preferredRate")]
 		float PreferredRate { get; set; }
@@ -7465,7 +7469,7 @@ namespace AVFoundation {
 	{
 		[Export ("initWithURL:options:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl URL, [NullAllowed] NSDictionary<NSString, NSObject> options);
+		NativeHandle Constructor (NSUrl URL, [NullAllowed] NSDictionary<NSString, NSObject> options);
 
 		[NullAllowed, Export ("URL")]
 		NSUrl URL { get; }
@@ -7478,12 +7482,12 @@ namespace AVFoundation {
 	{
 		[Export ("initWithURL:options:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl URL, [NullAllowed] NSDictionary<NSString, NSObject> options);
+		NativeHandle Constructor (NSUrl URL, [NullAllowed] NSDictionary<NSString, NSObject> options);
 
 		[Mac (10,11)]
 		[Export ("initWithData:options:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary<NSString, NSObject> options);
+		NativeHandle Constructor (NSData data, [NullAllowed] NSDictionary<NSString, NSObject> options);
 
 		[Export ("tracks")]
 		AVFragmentedMovieTrack[] Tracks { get; }
@@ -7548,7 +7552,7 @@ namespace AVFoundation {
 
 		[Export ("initWithMovie:mindingInterval:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVFragmentedMovie movie, double mindingInterval);
+		NativeHandle Constructor (AVFragmentedMovie movie, double mindingInterval);
 
 		[Export ("mindingInterval")]
 		double MindingInterval { get; set; }
@@ -8072,11 +8076,11 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithURL:trackID:sourceTimeRange:targetTimeRange:")]
-		IntPtr Constructor (NSUrl URL, int trackID /* CMPersistentTrackID = int32_t */, CMTimeRange sourceTimeRange, CMTimeRange targetTimeRange);
+		NativeHandle Constructor (NSUrl URL, int trackID /* CMPersistentTrackID = int32_t */, CMTimeRange sourceTimeRange, CMTimeRange targetTimeRange);
 
 		[DesignatedInitializer]
 		[Export ("initWithTimeRange:")]
-		IntPtr Constructor (CMTimeRange timeRange);
+		NativeHandle Constructor (CMTimeRange timeRange);
 
 		[Export ("empty")]
 		bool Empty { [Bind ("isEmpty")] get;  }
@@ -8149,10 +8153,10 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithAsset:presetName:")]
-		IntPtr Constructor (AVAsset asset, string presetName);
+		NativeHandle Constructor (AVAsset asset, string presetName);
 
 		[Wrap ("this (asset, preset.GetConstant ())")]
-		IntPtr Constructor (AVAsset asset, AVAssetExportSessionPreset preset);
+		NativeHandle Constructor (AVAsset asset, AVAssetExportSessionPreset preset);
 
 		[Export ("exportAsynchronouslyWithCompletionHandler:")]
 		[Async ("ExportTaskAsync")]
@@ -8975,11 +8979,11 @@ namespace AVFoundation {
 		
 		[iOS (8,0)]
 		[Export ("initWithInputPorts:output:")]
-		IntPtr Constructor (AVCaptureInputPort [] inputPorts, AVCaptureOutput output);
+		NativeHandle Constructor (AVCaptureInputPort [] inputPorts, AVCaptureOutput output);
 
 		[iOS (8,0)]
 		[Export ("initWithInputPort:videoPreviewLayer:")]
-		IntPtr Constructor (AVCaptureInputPort inputPort, AVCaptureVideoPreviewLayer layer);
+		NativeHandle Constructor (AVCaptureInputPort inputPort, AVCaptureVideoPreviewLayer layer);
 
 		[NullAllowed]
 		[Export ("output")]
@@ -9197,7 +9201,7 @@ namespace AVFoundation {
 		AVCaptureDeviceInput FromDevice (AVCaptureDevice device, out NSError error);
 
 		[Export ("initWithDevice:error:")]
-		IntPtr Constructor (AVCaptureDevice device, out NSError error);
+		NativeHandle Constructor (AVCaptureDevice device, out NSError error);
 
 		[NoWatch, NoTV, NoMac, iOS (12, 0)]
 		[Export ("unifiedAutoExposureDefaultsEnabled")]
@@ -9324,7 +9328,7 @@ namespace AVFoundation {
 	[BaseType (typeof (AVCaptureInput))]
 	interface AVCaptureScreenInput {
 		[Export ("initWithDisplayID:")]
-		IntPtr Constructor (uint /* CGDirectDisplayID = uint32_t */ displayID);
+		NativeHandle Constructor (uint /* CGDirectDisplayID = uint32_t */ displayID);
 
 		[Export ("minFrameDuration")]
 		CMTime MinFrameDuration { get; set; }
@@ -11501,10 +11505,10 @@ namespace AVFoundation {
 		AVPlayer FromPlayerItem ([NullAllowed] AVPlayerItem item);
 
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl URL);
+		NativeHandle Constructor (NSUrl URL);
 
 		[Export ("initWithPlayerItem:")]
-		IntPtr Constructor ([NullAllowed] AVPlayerItem item);
+		NativeHandle Constructor ([NullAllowed] AVPlayerItem item);
 
 		[Export ("play")]
 		void Play ();
@@ -11735,11 +11739,11 @@ namespace AVFoundation {
 		NSString [] PreferredMediaCharacteristics { get; }
 
 		[Export ("initWithPreferredLanguages:preferredMediaCharacteristics:")]
-		IntPtr Constructor ([NullAllowed] string [] preferredLanguages, [NullAllowed] NSString [] preferredMediaCharacteristics);
+		NativeHandle Constructor ([NullAllowed] string [] preferredLanguages, [NullAllowed] NSString [] preferredMediaCharacteristics);
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("initWithPrincipalMediaCharacteristics:preferredLanguages:preferredMediaCharacteristics:")]
-		IntPtr Constructor ([NullAllowed] [BindAs (typeof (AVMediaCharacteristics []))]NSString[] principalMediaCharacteristics, [NullAllowed] [BindAs (typeof (AVMediaCharacteristics []))] NSString[] preferredLanguages, [NullAllowed] string[] preferredMediaCharacteristics);
+		NativeHandle Constructor ([NullAllowed] [BindAs (typeof (AVMediaCharacteristics []))]NSString[] principalMediaCharacteristics, [NullAllowed] [BindAs (typeof (AVMediaCharacteristics []))] NSString[] preferredLanguages, [NullAllowed] string[] preferredMediaCharacteristics);
 
 		[BindAs (typeof (AVMediaCharacteristics []))]
 		[TV (13,0), Mac (10,15), iOS (13,0)]
@@ -11792,18 +11796,18 @@ namespace AVFoundation {
 
 		[Export ("initWithTextMarkupAttributes:")]
 		[Protected]
-		IntPtr Constructor (NSDictionary textMarkupAttributes);
+		NativeHandle Constructor (NSDictionary textMarkupAttributes);
 
 		[Wrap ("this (attributes.GetDictionary ()!)")]
-		IntPtr Constructor (CMTextMarkupAttributes attributes);
+		NativeHandle Constructor (CMTextMarkupAttributes attributes);
 
 		[DesignatedInitializer]
 		[Export ("initWithTextMarkupAttributes:textSelector:")]
 		[Protected]
-		IntPtr Constructor (NSDictionary textMarkupAttributes, [NullAllowed] string textSelector);
+		NativeHandle Constructor (NSDictionary textMarkupAttributes, [NullAllowed] string textSelector);
 	
 		[Wrap ("this (attributes.GetDictionary ()!, textSelector)")]
-		IntPtr Constructor (CMTextMarkupAttributes attributes, string textSelector);
+		NativeHandle Constructor (CMTextMarkupAttributes attributes, string textSelector);
 	}
 
 	[iOS (9,0)][Mac (10,11)][Watch (6,0)]
@@ -11835,7 +11839,7 @@ namespace AVFoundation {
 		AVMetadataItem [] Items { get; [NotImplemented] set; }
 
 		[Export ("initWithItems:timeRange:")]
-		IntPtr Constructor (AVMetadataItem [] items, CMTimeRange timeRange);
+		NativeHandle Constructor (AVMetadataItem [] items, CMTimeRange timeRange);
 
 		[return: NullAllowed]
 		[iOS (8,0)][Mac (10,10)]
@@ -11844,7 +11848,7 @@ namespace AVFoundation {
 
 		[iOS (8,0)][Mac (10,10)]
 		[Export ("initWithSampleBuffer:")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer);
 	}
 
 	[Watch (6,0)]
@@ -11942,10 +11946,10 @@ namespace AVFoundation {
 		AVPlayerItem FromAsset ([NullAllowed] AVAsset asset);
 
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl URL);
+		NativeHandle Constructor (NSUrl URL);
 
 		[Export ("initWithAsset:")]
-		IntPtr Constructor (AVAsset asset);
+		NativeHandle Constructor (AVAsset asset);
 
 		[Export ("stepByCount:")]
 		void StepByCount (nint stepCount);
@@ -12093,7 +12097,7 @@ namespace AVFoundation {
 		[iOS (7,0), Mac (10, 9)]
 		[DesignatedInitializer]
 		[Export ("initWithAsset:automaticallyLoadedAssetKeys:")]
-		IntPtr Constructor (AVAsset asset, [NullAllowed] params NSString [] automaticallyLoadedAssetKeys);
+		NativeHandle Constructor (AVAsset asset, [NullAllowed] params NSString [] automaticallyLoadedAssetKeys);
 
 		[iOS (7,0), Mac (10, 9)]
 		[Export ("automaticallyLoadedAssetKeys", ArgumentSemantic.Copy)]
@@ -12328,7 +12332,7 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithIdentifiers:")]
-		IntPtr Constructor ([NullAllowed] NSString [] metadataIdentifiers);
+		NativeHandle Constructor ([NullAllowed] NSString [] metadataIdentifiers);
 
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; }
@@ -12577,12 +12581,12 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Wrap ("this (attributes.GetDictionary (), AVPlayerItemVideoOutput.InitMode.PixelAttributes)")]
-		IntPtr Constructor (CVPixelBufferAttributes attributes);
+		NativeHandle Constructor (CVPixelBufferAttributes attributes);
 		
 		[DesignatedInitializer]
 		[iOS (10,0), TV (10,0), Mac (10,12)]
 		[Wrap ("this (settings.GetDictionary (), AVPlayerItemVideoOutput.InitMode.OutputSettings)")]
-		IntPtr Constructor (AVPlayerItemVideoOutputSettings settings);
+		NativeHandle Constructor (AVPlayerItemVideoOutputSettings settings);
 
 		[Export ("hasNewPixelBufferForItemTime:")]
 		bool HasNewPixelBufferForItemTime (CMTime itemTime);
@@ -12634,7 +12638,7 @@ namespace AVFoundation {
 	[BaseType (typeof (AVPlayerItemOutput))]
 	interface AVPlayerItemLegibleOutput {
 		[Export ("initWithMediaSubtypesForNativeRepresentation:")]
-		IntPtr Constructor (NSNumber [] subtypesFourCCcodes);
+		NativeHandle Constructor (NSNumber [] subtypesFourCCcodes);
 		
 		[Export ("setDelegate:queue:")]
 		void SetDelegate ([Protocolize][NullAllowed] AVPlayerItemLegibleOutputPushDelegate delegateObject, [NullAllowed] DispatchQueue delegateQueue);
@@ -12845,7 +12849,7 @@ namespace AVFoundation {
 	interface AVPlayerItemMetadataCollector
 	{
 		[Export ("initWithIdentifiers:classifyingLabels:")]
-		IntPtr Constructor ([NullAllowed] string[] identifiers, [NullAllowed] string[] classifyingLabels);
+		NativeHandle Constructor ([NullAllowed] string[] identifiers, [NullAllowed] string[] classifyingLabels);
 
 		[Export ("setDelegate:queue:")]
 		void SetDelegate ([NullAllowed] IAVPlayerItemMetadataCollectorPushDelegate pushDelegate, [NullAllowed] DispatchQueue delegateQueue);
@@ -12911,7 +12915,7 @@ namespace AVFoundation {
 
 		[Export ("initWithPlayer:templateItem:timeRange:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVQueuePlayer player, AVPlayerItem itemToLoop, CMTimeRange loopRange);
+		NativeHandle Constructor (AVQueuePlayer player, AVPlayerItem itemToLoop, CMTimeRange loopRange);
 
 #if !XAMCORE_4_0 // This API got introduced in Xcode 8.0 binding but is not currently present nor in Xcode 8.3 or Xcode 9.0 needs research
 		[PostSnippet ("loopingEnabled = false;", Optimizable = true)]
@@ -13059,7 +13063,7 @@ namespace AVFoundation {
 
 		[Export ("initWithPrimaryPlayer:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVPlayer primaryPlayer);
+		NativeHandle Constructor (AVPlayer primaryPlayer);
 
 		[NullAllowed, Export ("primaryPlayer", ArgumentSemantic.Weak)]
 		AVPlayer PrimaryPlayer { get; }
@@ -13086,7 +13090,7 @@ namespace AVFoundation {
 		AVPlayerInterstitialEventController GetInterstitialEventController (AVPlayer primaryPlayer);
 
 		[Export ("initWithPrimaryPlayer:")]
-		IntPtr Constructor (AVPlayer primaryPlayer);
+		NativeHandle Constructor (AVPlayer primaryPlayer);
 
 		[NullAllowed, Export ("events", ArgumentSemantic.Copy)]
 		AVPlayerInterstitialEvent[] Events { get; set; }
@@ -13120,7 +13124,7 @@ namespace AVFoundation {
 		AVQueuePlayer FromItems (AVPlayerItem [] items);
 
 		[Export ("initWithItems:")]
-		IntPtr Constructor (AVPlayerItem [] items);
+		NativeHandle Constructor (AVPlayerItem [] items);
 
 		[Export ("items")]
 		AVPlayerItem [] Items { get; }
@@ -13404,12 +13408,12 @@ namespace AVFoundation {
 		AVSpeechUtterance FromString (NSAttributedString speechString);
 
 		[Export ("initWithString:")]
-		IntPtr Constructor (string speechString);
+		NativeHandle Constructor (string speechString);
 		
 		[iOS (10,0)]
 		[TV (10,0)]
 		[Export ("initWithAttributedString:")]
-		IntPtr Constructor (NSAttributedString speechString);
+		NativeHandle Constructor (NSAttributedString speechString);
 
 		[NullAllowed] // by default this property is null
 		[Export ("voice", ArgumentSemantic.Retain)]
@@ -13826,7 +13830,7 @@ namespace AVFoundation {
 	interface AVAudioSequencer {
 
 		[Export ("initWithAudioEngine:")]
-		IntPtr Constructor (AVAudioEngine engine);
+		NativeHandle Constructor (AVAudioEngine engine);
 
 		[Export ("loadFromURL:options:error:")]
 		bool Load (NSUrl fileUrl, AVMusicSequenceLoadOptions options, out NSError outError);
@@ -14099,7 +14103,7 @@ namespace AVFoundation {
 
 		[Internal]
 		[Export ("initWithFormatDescription:clock:")] // FIXME: Add CMMetadataFormatDescription
-		IntPtr Constructor (IntPtr /*CMMetadataFormatDescription*/ desc, CMClock clock);
+		NativeHandle Constructor (IntPtr /*CMMetadataFormatDescription*/ desc, CMClock clock);
 
 		[Export ("appendTimedMetadataGroup:error:")]
 		bool AppendTimedMetadataGroup (AVTimedMetadataGroup metadata, out NSError outError);
@@ -14153,7 +14157,7 @@ namespace AVFoundation {
 
 		[Export ("initWithContentTimeForTransition:title:previewImage:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CMTime contentTimeForTransition, string title, [NullAllowed] UIImage previewImage);
+		NativeHandle Constructor (CMTime contentTimeForTransition, string title, [NullAllowed] UIImage previewImage);
 	}
 #endif
 
@@ -14452,7 +14456,7 @@ namespace AVFoundation {
 		AVContentKeySpecifier GetContentKeySpecifier (AVContentKeySystem keySystem, NSObject contentKeyIdentifier, NSDictionary<NSString, NSObject> options);
 
 		[Export ("initForKeySystem:identifier:options:")]
-		IntPtr Constructor (AVContentKeySystem keySystem, NSObject contentKeyIdentifier, NSDictionary<NSString, NSObject> options);
+		NativeHandle Constructor (AVContentKeySystem keySystem, NSObject contentKeyIdentifier, NSDictionary<NSString, NSObject> options);
 
 		[Export ("keySystem")]
 		AVContentKeySystem KeySystem { get; }
@@ -14737,17 +14741,17 @@ namespace AVFoundation {
 		[Export ("initWithRenderBlock:")]
 		[DesignatedInitializer]
 #if XAMCORE_4_0
-		IntPtr Constructor (AVAudioSourceNodeRenderHandler renderHandler);
+		NativeHandle Constructor (AVAudioSourceNodeRenderHandler renderHandler);
 #else
-		IntPtr Constructor (AVAudioSourceNodeRenderHandler2 renderHandler);
+		NativeHandle Constructor (AVAudioSourceNodeRenderHandler2 renderHandler);
 #endif
 
 		[Export ("initWithFormat:renderBlock:")]
 		[DesignatedInitializer]
 #if XAMCORE_4_0
-		IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler);
+		NativeHandle Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler);
 #else
-		IntPtr Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 renderHandler);
+		NativeHandle Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 renderHandler);
 #endif
 	}
 
@@ -14759,7 +14763,7 @@ namespace AVFoundation {
 	interface AVAudioSinkNode {
 		[Export ("initWithReceiverBlock:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVAudioSinkNodeReceiverHandler receiverHandler);
+		NativeHandle Constructor (AVAudioSinkNodeReceiverHandler receiverHandler);
 	}
 
 	[TV (13,0), NoWatch, Mac (10,15), iOS (13,0)]
@@ -15085,7 +15089,7 @@ namespace AVFoundation {
 	interface AVDelegatingPlaybackCoordinator
 	{
 		[Export ("initWithPlaybackControlDelegate:")]
-		IntPtr Constructor (IAVPlaybackCoordinatorPlaybackControlDelegate playbackControlDelegate);
+		NativeHandle Constructor (IAVPlaybackCoordinatorPlaybackControlDelegate playbackControlDelegate);
 
 		[Wrap ("WeakPlaybackControlDelegate")]
 		[NullAllowed]
@@ -15266,7 +15270,7 @@ namespace AVFoundation {
 		AVAssetReaderOutputCaptionAdaptor Create (AVAssetReaderTrackOutput trackOutput);
 
 		[Export ("initWithAssetReaderTrackOutput:")]
-		IntPtr Constructor (AVAssetReaderTrackOutput trackOutput);
+		NativeHandle Constructor (AVAssetReaderTrackOutput trackOutput);
 
 		[Export ("assetReaderTrackOutput")]
 		AVAssetReaderTrackOutput AssetReaderTrackOutput { get; }
@@ -15299,7 +15303,7 @@ namespace AVFoundation {
 		AVAssetWriterInputCaptionAdaptor Create (AVAssetWriterInput input);
 
 		[Export ("initWithAssetWriterInput:")]
-		IntPtr Constructor (AVAssetWriterInput input);
+		NativeHandle Constructor (AVAssetWriterInput input);
 
 		[Export ("assetWriterInput")]
 		AVAssetWriterInput AssetWriterInput { get; }
@@ -15319,10 +15323,10 @@ namespace AVFoundation {
 	interface AVCaptionGroup
 	{
 		[Export ("initWithCaptions:timeRange:")]
-		IntPtr Constructor (AVCaption[] captions, CMTimeRange timeRange);
+		NativeHandle Constructor (AVCaption[] captions, CMTimeRange timeRange);
 
 		[Export ("initWithTimeRange:")]
-		IntPtr Constructor (CMTimeRange timeRange);
+		NativeHandle Constructor (CMTimeRange timeRange);
 
 		[Export ("timeRange")]
 		CMTimeRange TimeRange { get; }
@@ -15338,7 +15342,7 @@ namespace AVFoundation {
 	{
 		[Export ("initWithText:timeRange:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string text, CMTimeRange timeRange);
+		NativeHandle Constructor (string text, CMTimeRange timeRange);
 
 		[Export ("text")]
 		string Text { get; }
@@ -15391,7 +15395,7 @@ namespace AVFoundation {
 	{
 		[Export ("initWithText:timeRange:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string text, CMTimeRange timeRange);
+		NativeHandle Constructor (string text, CMTimeRange timeRange);
 
 		[Export ("text")]
 		string Text { get; set; }
@@ -15506,7 +15510,7 @@ namespace AVFoundation {
 	interface AVMutableCaptionRegion
 	{
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 #if MONOMAC // needed structs are inside a #if
 		[Export ("origin", ArgumentSemantic.Assign)]
@@ -15533,10 +15537,10 @@ namespace AVFoundation {
 	{
 		[Export ("initWithText:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string text);
+		NativeHandle Constructor (string text);
 
 		[Export ("initWithText:position:alignment:")]
-		IntPtr Constructor (string text, AVCaptionRubyPosition position, AVCaptionRubyAlignment alignment);
+		NativeHandle Constructor (string text, AVCaptionRubyPosition position, AVCaptionRubyAlignment alignment);
 
 		[Export ("text")]
 		string Text { get; }
@@ -15635,10 +15639,10 @@ namespace AVFoundation {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithConversionSettings:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSDictionary conversionSettings);
+		NativeHandle Constructor (NSDictionary conversionSettings);
 
 		[Wrap ("this (conversionSettings.GetDictionary ()!)")]
-		IntPtr Constructor (AVCaptionSettings conversionSettings);
+		NativeHandle Constructor (AVCaptionSettings conversionSettings);
 
 		[Export ("conformsCaptionsToTimeRange")]
 		bool ConformsCaptionsToTimeRange { get; set; }
@@ -15679,7 +15683,7 @@ namespace AVFoundation {
 		AVCaptionConversionValidator Create (AVCaption[] captions, CMTimeRange timeRange, NSDictionary<NSString, NSObject> conversionSettings);
 
 		[Export ("initWithCaptions:timeRange:conversionSettings:")]
-		IntPtr Constructor (AVCaption[] captions, CMTimeRange timeRange, NSDictionary<NSString, NSObject> conversionSettings);
+		NativeHandle Constructor (AVCaption[] captions, CMTimeRange timeRange, NSDictionary<NSString, NSObject> conversionSettings);
 
 		[Export ("status")]
 		AVCaptionConversionValidatorStatus Status { get; }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -858,7 +858,11 @@ namespace AVFoundation {
 
 		[DesignatedInitializer]
 		[Export ("initWithLayout:"), Internal]
+#if NET
+		NativeHandle Constructor (IntPtr layout);
+#else
 		NativeHandle Constructor (nint /* This is really an IntPtr, but it conflicts with the default (Handle) ctor. */ layout);
+#endif
 
 		[Export ("layoutTag")]
 		uint /* AudioChannelLayoutTag = UInt32 */ LayoutTag { get; }

--- a/src/avkit.cs
+++ b/src/avkit.cs
@@ -38,6 +38,10 @@ using UIAction = Foundation.NSObject;
 using UIMenuElement = Foundation.NSObject;
 #endif // !MONOMAC
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace AVKit {
 	[TV (14, 0)]
 	[iOS (9,0)]
@@ -54,12 +58,12 @@ namespace AVKit {
 		bool IsPictureInPictureSupported { get; }
 	
 		[Export ("initWithPlayerLayer:")]
-		IntPtr Constructor (AVPlayerLayer playerLayer);
+		NativeHandle Constructor (AVPlayerLayer playerLayer);
 
 		[TV (15,0), NoWatch, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[Export ("initWithContentSource:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVPictureInPictureControllerContentSource contentSource);
+		NativeHandle Constructor (AVPictureInPictureControllerContentSource contentSource);
 	
 		[Export ("playerLayer")]
 		AVPlayerLayer PlayerLayer { get; }
@@ -161,7 +165,7 @@ namespace AVKit {
 	interface AVPlayerViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[NullAllowed] // by default this property is null
 		[Export ("player", ArgumentSemantic.Retain)]
@@ -466,7 +470,7 @@ namespace AVKit {
 	[BaseType (typeof (NSView))]
 	interface AVPlayerView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[NullAllowed]
 		[Export ("player")]
@@ -581,7 +585,7 @@ namespace AVKit {
 	[BaseType (typeof (NSView))]
 	interface AVCaptureView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("session"), NullAllowed]
 		AVCaptureSession Session { get; }
@@ -621,7 +625,7 @@ namespace AVKit {
 	interface AVInterstitialTimeRange : NSCopying, NSSecureCoding {
 		[Export ("initWithTimeRange:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CMTimeRange timeRange);
+		NativeHandle Constructor (CMTimeRange timeRange);
 
 		[Export ("timeRange")]
 		CMTimeRange TimeRange { get; }
@@ -634,11 +638,11 @@ namespace AVKit {
 	interface AVNavigationMarkersGroup {
 		[Export ("initWithTitle:timedNavigationMarkers:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string title, AVTimedMetadataGroup[] navigationMarkers);
+		NativeHandle Constructor ([NullAllowed] string title, AVTimedMetadataGroup[] navigationMarkers);
 
 		[Export ("initWithTitle:dateRangeNavigationMarkers:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string title, AVDateRangeMetadataGroup[] navigationMarkers);
+		NativeHandle Constructor ([NullAllowed] string title, AVDateRangeMetadataGroup[] navigationMarkers);
 
 		[NullAllowed, Export ("title")]
 		string Title { get; }
@@ -657,7 +661,7 @@ namespace AVKit {
 	{
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 		
 		[NullAllowed, Export ("contentProposal")]
 		AVContentProposal ContentProposal { get; }
@@ -717,7 +721,7 @@ namespace AVKit {
 	interface AVRoutePickerView {
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Wrap ("WeakDelegate", IsVirtual = true)]
 		[NullAllowed]
@@ -826,7 +830,7 @@ namespace AVKit {
 	interface AVPictureInPictureVideoCallViewController {
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 	}
 
 	[TV (15,0), NoWatch, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
@@ -835,7 +839,7 @@ namespace AVKit {
 	interface AVPictureInPictureControllerContentSource
 	{
 		[Export ("initWithPlayerLayer:")]
-		IntPtr Constructor (AVPlayerLayer playerLayer);
+		NativeHandle Constructor (AVPlayerLayer playerLayer);
 
 		[NullAllowed, Export ("playerLayer")]
 		AVPlayerLayer PlayerLayer { get; }
@@ -844,7 +848,7 @@ namespace AVKit {
 		[NoWatch, NoTV, NoMac]
 		[NoMacCatalyst] // doc as available, intro fails on macOS 12 beta 6
 		[Export ("initWithActiveVideoCallSourceView:contentViewController:")]
-		IntPtr Constructor (UIView sourceView, AVPictureInPictureVideoCallViewController contentViewController);
+		NativeHandle Constructor (UIView sourceView, AVPictureInPictureVideoCallViewController contentViewController);
 
 		[NullAllowed]
 		[NoWatch, NoTV, NoMac]
@@ -859,7 +863,7 @@ namespace AVKit {
 
 		// interface AVPictureInPictureControllerContentSource_AVSampleBufferDisplayLayerSupport
 		[Export ("initWithSampleBufferDisplayLayer:playbackDelegate:")]
-		IntPtr Constructor (AVSampleBufferDisplayLayer sampleBufferDisplayLayer, IAVPictureInPictureSampleBufferPlaybackDelegate playbackDelegate);
+		NativeHandle Constructor (AVSampleBufferDisplayLayer sampleBufferDisplayLayer, IAVPictureInPictureSampleBufferPlaybackDelegate playbackDelegate);
 
 		[NullAllowed, Export ("sampleBufferDisplayLayer")]
 		AVSampleBufferDisplayLayer SampleBufferDisplayLayer { get; }

--- a/src/backgroundtasks.cs
+++ b/src/backgroundtasks.cs
@@ -12,6 +12,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace BackgroundTasks {
 
 	[TV (13,0), NoWatch, NoMac, iOS (13,0)]
@@ -19,7 +23,7 @@ namespace BackgroundTasks {
 	[DisableDefaultCtor]
 	interface BGAppRefreshTaskRequest {
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 	}
 
 	[TV (13,0), NoWatch, NoMac, iOS (13,0)]
@@ -27,7 +31,7 @@ namespace BackgroundTasks {
 	[DisableDefaultCtor]
 	interface BGProcessingTaskRequest {
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("requiresNetworkConnectivity")]
 		bool RequiresNetworkConnectivity { get; set; }

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -73,7 +73,7 @@ public class BindingTouch : IDisposable {
 		get { return "bgen"; }
 	}
 
-	bool IsDotNet {
+	internal bool IsDotNet {
 		get { return TargetFramework.IsDotNet; }
 	}
 
@@ -438,6 +438,9 @@ public class BindingTouch : IDisposable {
 			cargs.Add ("-r:" + baselibdll);
 			foreach (var def in defines)
 				cargs.Add ("-define:" + def);
+#if NET
+			cargs.Add ("-define:NET");
+#endif
 			cargs.AddRange (paths);
 			if (nostdlib) {
 				cargs.Add ("-nostdlib");
@@ -559,6 +562,9 @@ public class BindingTouch : IDisposable {
 			cargs.Add ("-out:" + outfile);
 			foreach (var def in defines)
 				cargs.Add ("-define:" + def);
+#if NET
+			cargs.Add ("-define:NET");
+#endif
 			cargs.AddRange (g.GeneratedFiles);
 			cargs.AddRange (core_sources);
 			cargs.AddRange (extra_sources);

--- a/src/businesschat.cs
+++ b/src/businesschat.cs
@@ -18,6 +18,10 @@ using UIControl = AppKit.NSControl;
 using UIKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace BusinessChat {
 
 	[Mac (10,13,4), iOS (11,3)]
@@ -26,7 +30,7 @@ namespace BusinessChat {
 	interface BCChatButton {
 		[Export ("initWithStyle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (BCChatButtonStyle style);
+		NativeHandle Constructor (BCChatButtonStyle style);
 	}
 
 

--- a/src/callkit.cs
+++ b/src/callkit.cs
@@ -13,6 +13,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CallKit {
 
 	[iOS (10, 0), NoMac]
@@ -123,7 +127,7 @@ namespace CallKit {
 
 		[Export ("initWithType:value:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CXHandleType type, string value);
+		NativeHandle Constructor (CXHandleType type, string value);
 
 		[Export ("isEqualToHandle:")]
 		bool IsEqual (CXHandle handle);
@@ -136,7 +140,7 @@ namespace CallKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("UUID", ArgumentSemantic.Copy)]
 		NSUuid Uuid { get; }
@@ -161,7 +165,7 @@ namespace CallKit {
 
 		[Export ("initWithCallUUID:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUuid callUuid);
+		NativeHandle Constructor (NSUuid callUuid);
 
 		[Export ("fulfillWithDateConnected:")]
 		void Fulfill (NSDate dateConnected);
@@ -201,7 +205,7 @@ namespace CallKit {
 
 		[Export ("initWithCallUUID:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUuid callUuid);
+		NativeHandle Constructor (NSUuid callUuid);
 	}
 
 	[iOS (10, 0), Mac (11, 0)]
@@ -210,7 +214,7 @@ namespace CallKit {
 
 		[Export ("initWithQueue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (DispatchQueue queue);
+		NativeHandle Constructor (DispatchQueue queue);
 
 		[Export ("callObserver", ArgumentSemantic.Strong)]
 		CXCallObserver CallObserver { get; }
@@ -364,7 +368,7 @@ namespace CallKit {
 
 		[Export ("initWithCallUUID:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUuid callUuid);
+		NativeHandle Constructor (NSUuid callUuid);
 
 		[Export ("fulfillWithDateEnded:")]
 		void Fulfill (NSDate dateEnded);
@@ -377,7 +381,7 @@ namespace CallKit {
 
 		[Export ("initWithCallUUID:digits:type:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUuid callUuid, string digits, CXPlayDtmfCallActionType type);
+		NativeHandle Constructor (NSUuid callUuid, string digits, CXPlayDtmfCallActionType type);
 
 		[Export ("digits")]
 		string Digits { get; set; }
@@ -443,7 +447,7 @@ namespace CallKit {
 
 		[Export ("initWithConfiguration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CXProviderConfiguration configuration);
+		NativeHandle Constructor (CXProviderConfiguration configuration);
 
 		[Export ("setDelegate:queue:")]
 		void SetDelegate ([NullAllowed] ICXProviderDelegate aDelegate, [NullAllowed] DispatchQueue queue);
@@ -520,13 +524,13 @@ namespace CallKit {
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use the default constructor instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 14, 0, message: "Use the default constructor instead.")]
 		[Export ("initWithLocalizedName:")]
-		IntPtr Constructor (string localizedName);
+		NativeHandle Constructor (string localizedName);
 
 		[iOS (14, 0)]
 		[MacCatalyst (14,0)]
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 	}
 
 	[iOS (10, 0), Mac (11, 0)]
@@ -536,7 +540,7 @@ namespace CallKit {
 
 		[Export ("initWithCallUUID:callUUIDToGroupWith:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUuid callUuid, [NullAllowed] NSUuid callUuidToGroupWith);
+		NativeHandle Constructor (NSUuid callUuid, [NullAllowed] NSUuid callUuidToGroupWith);
 
 		[NullAllowed, Export ("callUUIDToGroupWith", ArgumentSemantic.Copy)]
 		NSUuid CallUuidToGroupWith { get; set; }
@@ -549,7 +553,7 @@ namespace CallKit {
 
 		[Export ("initWithCallUUID:onHold:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUuid callUuid, bool onHold);
+		NativeHandle Constructor (NSUuid callUuid, bool onHold);
 
 		[Export ("onHold")]
 		bool OnHold { [Bind ("isOnHold")] get; set; }
@@ -562,7 +566,7 @@ namespace CallKit {
 
 		[Export ("initWithCallUUID:muted:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUuid callUuid, bool muted);
+		NativeHandle Constructor (NSUuid callUuid, bool muted);
 
 		[Export ("muted")]
 		bool Muted { [Bind ("isMuted")] get; set; }
@@ -577,7 +581,7 @@ namespace CallKit {
 
 		[Export ("initWithCallUUID:handle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUuid callUuid, CXHandle callHandle);
+		NativeHandle Constructor (NSUuid callUuid, CXHandle callHandle);
 
 		[Export ("handle", ArgumentSemantic.Copy)]
 		CXHandle CallHandle { get; set; }
@@ -599,10 +603,10 @@ namespace CallKit {
 
 		[Export ("initWithActions:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CXAction[] actions);
+		NativeHandle Constructor (CXAction[] actions);
 
 		[Export ("initWithAction:")]
-		IntPtr Constructor (CXAction action);
+		NativeHandle Constructor (CXAction action);
 
 		[Export ("UUID", ArgumentSemantic.Copy)]
 		NSUuid Uuid { get; }

--- a/src/carplay.cs
+++ b/src/carplay.cs
@@ -14,6 +14,10 @@ using UIKit;
 using CoreGraphics;
 using MapKit;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CarPlay {
 
 	// Just to please the generator that at this point does not know the hierarchy
@@ -196,7 +200,7 @@ namespace CarPlay {
 	interface CPAlertAction : NSSecureCoding {
 
 		[Export ("initWithTitle:style:handler:")]
-		IntPtr Constructor (string title, CPAlertActionStyle style, Action<CPAlertAction> handler);
+		NativeHandle Constructor (string title, CPAlertActionStyle style, Action<CPAlertAction> handler);
 
 		[Export ("title")]
 		string Title { get; }
@@ -217,7 +221,7 @@ namespace CarPlay {
 
 		[Deprecated (PlatformName.iOS, 14, 0)]
 		[Export ("initWithType:handler:")]
-		IntPtr Constructor (CPBarButtonType type, [NullAllowed] Action<CPBarButton> handler);
+		NativeHandle Constructor (CPBarButtonType type, [NullAllowed] Action<CPBarButton> handler);
 
 		[Export ("enabled")]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
@@ -234,11 +238,11 @@ namespace CarPlay {
 
 		[iOS (14,0)]
 		[Export ("initWithImage:handler:")]
-		IntPtr Constructor (UIImage image, [NullAllowed] CPBarButtonHandler handler);
+		NativeHandle Constructor (UIImage image, [NullAllowed] CPBarButtonHandler handler);
 
 		[iOS (14,0)]
 		[Export ("initWithTitle:handler:")]
-		IntPtr Constructor (string title, [NullAllowed] CPBarButtonHandler handler);
+		NativeHandle Constructor (string title, [NullAllowed] CPBarButtonHandler handler);
 
 		[iOS (14, 0)]
 		[Export ("buttonStyle", ArgumentSemantic.Assign)]
@@ -274,7 +278,7 @@ namespace CarPlay {
 
 		[Export ("initWithTitleVariants:image:handler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string [] titleVariants, UIImage image, [NullAllowed] Action<CPGridButton> handler);
+		NativeHandle Constructor (string [] titleVariants, UIImage image, [NullAllowed] Action<CPGridButton> handler);
 
 		[Export ("enabled")]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
@@ -292,7 +296,7 @@ namespace CarPlay {
 	interface CPGridTemplate : CPBarButtonProviding{
 
 		[Export ("initWithTitle:gridButtons:")]
-		IntPtr Constructor ([NullAllowed] string title, CPGridButton [] gridButtons);
+		NativeHandle Constructor ([NullAllowed] string title, CPGridButton [] gridButtons);
 
 		[Export ("gridButtons")]
 		CPGridButton [] GridButtons { get; }
@@ -465,17 +469,17 @@ namespace CarPlay {
 
 		[Deprecated (PlatformName.iOS, 14, 0)]
 		[Export ("initWithText:detailText:image:showsDisclosureIndicator:")]
-		IntPtr Constructor ([NullAllowed] string text, [NullAllowed] string detailText, [NullAllowed] UIImage image, bool showsDisclosureIndicator);
+		NativeHandle Constructor ([NullAllowed] string text, [NullAllowed] string detailText, [NullAllowed] UIImage image, bool showsDisclosureIndicator);
 
 		[Export ("initWithText:detailText:image:")]
-		IntPtr Constructor ([NullAllowed] string text, [NullAllowed] string detailText, [NullAllowed] UIImage image);
+		NativeHandle Constructor ([NullAllowed] string text, [NullAllowed] string detailText, [NullAllowed] UIImage image);
 
 		[Export ("initWithText:detailText:")]
-		IntPtr Constructor ([NullAllowed] string text, [NullAllowed] string detailText);
+		NativeHandle Constructor ([NullAllowed] string text, [NullAllowed] string detailText);
 
 		[iOS (14, 0)]
 		[Export ("initWithText:detailText:image:accessoryImage:accessoryType:")]
-		IntPtr Constructor ([NullAllowed] string text, [NullAllowed] string detailText, [NullAllowed] UIImage image, [NullAllowed] UIImage accessoryImage, CPListItemAccessoryType accessoryType);
+		NativeHandle Constructor ([NullAllowed] string text, [NullAllowed] string detailText, [NullAllowed] UIImage image, [NullAllowed] UIImage accessoryImage, CPListItemAccessoryType accessoryType);
 
 		[NullAllowed, Export ("text")]
 		new string Text { get; }
@@ -553,14 +557,14 @@ namespace CarPlay {
 	interface CPListSection : NSSecureCoding {
 
 		[Export ("initWithItems:header:sectionIndexTitle:")]
-		IntPtr Constructor (CPListItem [] items, [NullAllowed] string header, [NullAllowed] string sectionIndexTitle);
+		NativeHandle Constructor (CPListItem [] items, [NullAllowed] string header, [NullAllowed] string sectionIndexTitle);
 
 		[Export ("initWithItems:")]
-		IntPtr Constructor (CPListItem [] items);
+		NativeHandle Constructor (CPListItem [] items);
 
 		[iOS (15,0), MacCatalyst (15,0)]
 		[Export ("initWithItems:header:headerSubtitle:headerImage:headerButton:sectionIndexTitle:")]
-		IntPtr Constructor (ICPListTemplateItem[] items, string header, [NullAllowed] string headerSubtitle, [NullAllowed] UIImage headerImage, [NullAllowed] CPButton headerButton, [NullAllowed] string sectionIndexTitle);
+		NativeHandle Constructor (ICPListTemplateItem[] items, string header, [NullAllowed] string headerSubtitle, [NullAllowed] UIImage headerImage, [NullAllowed] CPButton headerButton, [NullAllowed] string sectionIndexTitle);
 
 		[NullAllowed, Export ("header")]
 		string Header { get; }
@@ -605,11 +609,11 @@ namespace CarPlay {
 	interface CPListTemplate : CPBarButtonProviding {
 
 		[Export ("initWithTitle:sections:")]
-		IntPtr Constructor ([NullAllowed] string title, CPListSection[] sections);
+		NativeHandle Constructor ([NullAllowed] string title, CPListSection[] sections);
 
 		[iOS (15,0), MacCatalyst (15,0)]
 		[Export ("initWithTitle:sections:assistantCellConfiguration:")]
-		IntPtr Constructor ([NullAllowed] string title, CPListSection[] sections, [NullAllowed] CPAssistantCellConfiguration assistantCellConfiguration);
+		NativeHandle Constructor ([NullAllowed] string title, CPListSection[] sections, [NullAllowed] CPAssistantCellConfiguration assistantCellConfiguration);
 
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use 'CPListItem.Handler' instead.")]
 		[Wrap ("WeakDelegate")]
@@ -747,7 +751,7 @@ namespace CarPlay {
 
 		[Export ("initWithHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] Action<CPMapButton> handler);
+		NativeHandle Constructor ([NullAllowed] Action<CPMapButton> handler);
 
 		[Export ("enabled")]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
@@ -907,11 +911,11 @@ namespace CarPlay {
 		
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use constructor that takes in 'UIImage' instead of 'CPImageSet'.")]
 		[Export ("initWithTitleVariants:subtitleVariants:imageSet:primaryAction:secondaryAction:duration:")]
-		IntPtr Constructor (string[] titleVariants, [NullAllowed] string[] subtitleVariants, [NullAllowed] CPImageSet imageSet, CPAlertAction primaryAction, [NullAllowed] CPAlertAction secondaryAction, double duration);
+		NativeHandle Constructor (string[] titleVariants, [NullAllowed] string[] subtitleVariants, [NullAllowed] CPImageSet imageSet, CPAlertAction primaryAction, [NullAllowed] CPAlertAction secondaryAction, double duration);
 
 		[iOS (13,0)]
 		[Export ("initWithTitleVariants:subtitleVariants:image:primaryAction:secondaryAction:duration:")]
-		IntPtr Constructor (string[] titleVariants, [NullAllowed] string[] subtitleVariants, [NullAllowed] UIImage image, CPAlertAction primaryAction, [NullAllowed] CPAlertAction secondaryAction, double duration);
+		NativeHandle Constructor (string[] titleVariants, [NullAllowed] string[] subtitleVariants, [NullAllowed] UIImage image, CPAlertAction primaryAction, [NullAllowed] CPAlertAction secondaryAction, double duration);
 
 		[Export ("updateTitleVariants:subtitleVariants:")]
 		void UpdateTitleVariants (string [] newTitleVariants, string [] newSubtitleVariants);
@@ -1002,7 +1006,7 @@ namespace CarPlay {
 
 		[Export ("initWithDelegate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ICPSessionConfigurationDelegate @delegate);
+		NativeHandle Constructor (ICPSessionConfigurationDelegate @delegate);
 
 		[Export ("limitedUserInterfaces")]
 		CPLimitableUserInterface LimitedUserInterfaces { get; }
@@ -1069,7 +1073,7 @@ namespace CarPlay {
 
 		[Export ("initWithSummaryVariants:additionalInformationVariants:selectionSummaryVariants:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string [] summaryVariants, string [] additionalInformationVariants, string [] selectionSummaryVariants);
+		NativeHandle Constructor (string [] summaryVariants, string [] additionalInformationVariants, string [] selectionSummaryVariants);
 
 		[Export ("summaryVariants", ArgumentSemantic.Copy)]
 		string [] SummaryVariants { get; }
@@ -1093,7 +1097,7 @@ namespace CarPlay {
 
 		[Export ("initWithOrigin:destination:routeChoices:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MKMapItem origin, MKMapItem destination, CPRouteChoice [] routeChoices);
+		NativeHandle Constructor (MKMapItem origin, MKMapItem destination, CPRouteChoice [] routeChoices);
 
 		[Export ("origin", ArgumentSemantic.Strong)]
 		MKMapItem Origin { get; }
@@ -1113,7 +1117,7 @@ namespace CarPlay {
 	interface CPVoiceControlState : NSSecureCoding {
 
 		[Export ("initWithIdentifier:titleVariants:image:repeats:")]
-		IntPtr Constructor (string identifier, [NullAllowed] string [] titleVariants, [NullAllowed] UIImage image, bool repeats);
+		NativeHandle Constructor (string identifier, [NullAllowed] string [] titleVariants, [NullAllowed] UIImage image, bool repeats);
 
 		[NullAllowed, Export ("titleVariants", ArgumentSemantic.Copy)]
 		string [] TitleVariants { get; }
@@ -1134,7 +1138,7 @@ namespace CarPlay {
 	interface CPVoiceControlTemplate {
 
 		[Export ("initWithVoiceControlStates:")]
-		IntPtr Constructor (CPVoiceControlState [] voiceControlStates);
+		NativeHandle Constructor (CPVoiceControlState [] voiceControlStates);
 
 		[Export ("voiceControlStates", ArgumentSemantic.Copy)]
 		CPVoiceControlState [] VoiceControlStates { get; }
@@ -1152,7 +1156,7 @@ namespace CarPlay {
 	interface CPImageSet : NSSecureCoding {
 
 		[Export ("initWithLightContentImage:darkContentImage:")]
-		IntPtr Constructor (UIImage lightImage, UIImage darkImage);
+		NativeHandle Constructor (UIImage lightImage, UIImage darkImage);
 
 		[Export ("lightContentImage")]
 		UIImage LightContentImage { get; }
@@ -1194,7 +1198,7 @@ namespace CarPlay {
 	interface CPTemplateApplicationScene
 	{
 		[Export ("initWithSession:connectionOptions:")]
-		IntPtr Constructor (UISceneSession session, UISceneConnectionOptions connectionOptions);
+		NativeHandle Constructor (UISceneSession session, UISceneConnectionOptions connectionOptions);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -1219,7 +1223,7 @@ namespace CarPlay {
 	interface CPWindow {
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("mapButtonSafeAreaLayoutGuide")]
 		UILayoutGuide MapButtonSafeAreaLayoutGuide { get; }
@@ -1236,7 +1240,7 @@ namespace CarPlay {
 
 		[Export ("initWithDistanceRemaining:timeRemaining:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSMeasurement<NSUnitLength> distance, double time);
+		NativeHandle Constructor (NSMeasurement<NSUnitLength> distance, double time);
 
 		[Export ("distanceRemaining", ArgumentSemantic.Copy)]
 		NSMeasurement<NSUnitLength> DistanceRemaining { get; }
@@ -1250,7 +1254,7 @@ namespace CarPlay {
 	interface CPTripPreviewTextConfiguration : NSSecureCoding {
 
 		[Export ("initWithStartButtonTitle:additionalRoutesButtonTitle:overviewButtonTitle:")]
-		IntPtr Constructor ([NullAllowed] string startButtonTitle, [NullAllowed] string additionalRoutesButtonTitle, [NullAllowed] string overviewButtonTitle);
+		NativeHandle Constructor ([NullAllowed] string startButtonTitle, [NullAllowed] string additionalRoutesButtonTitle, [NullAllowed] string overviewButtonTitle);
 
 		[NullAllowed, Export ("startButtonTitle")]
 		string StartButtonTitle { get; }
@@ -1268,7 +1272,7 @@ namespace CarPlay {
 	interface CPActionSheetTemplate {
 
 		[Export ("initWithTitle:message:actions:")]
-		IntPtr Constructor ([NullAllowed] string title, [NullAllowed] string message, CPAlertAction [] actions);
+		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] string message, CPAlertAction [] actions);
 
 		[NullAllowed, Export ("title")]
 		string Title { get; }
@@ -1286,7 +1290,7 @@ namespace CarPlay {
 	interface CPAlertTemplate {
 
 		[Export ("initWithTitleVariants:actions:")]
-		IntPtr Constructor (string [] titleVariants, CPAlertAction [] actions);
+		NativeHandle Constructor (string [] titleVariants, CPAlertAction [] actions);
 
 		[Export ("titleVariants", ArgumentSemantic.Copy)]
 		string [] TitleVariants { get; }
@@ -1307,7 +1311,7 @@ namespace CarPlay {
 
 		[Export ("initWithTitleVariants:subtitleVariants:image:handler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string[] titleVariants, string[] subtitleVariants, UIImage image, [NullAllowed] Action<CPDashboardButton> handler);
+		NativeHandle Constructor (string[] titleVariants, string[] subtitleVariants, UIImage image, [NullAllowed] Action<CPDashboardButton> handler);
 
 		[Export ("image")]
 		UIImage Image { get; }
@@ -1351,7 +1355,7 @@ namespace CarPlay {
 
 		[Export ("initWithSession:connectionOptions:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UISceneSession session, UISceneConnectionOptions connectionOptions);
+		NativeHandle Constructor (UISceneSession session, UISceneConnectionOptions connectionOptions);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed, New]
@@ -1374,7 +1378,7 @@ namespace CarPlay {
 	{
 		[Export ("initWithImage:handler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIImage image, [NullAllowed] Action<CPButton> handler);
+		NativeHandle Constructor (UIImage image, [NullAllowed] Action<CPButton> handler);
 
 		[NullAllowed, Export ("image", ArgumentSemantic.Copy)]
 		UIImage Image { get; }
@@ -1394,7 +1398,7 @@ namespace CarPlay {
 	interface CPContact : NSSecureCoding
 	{
 		[Export ("initWithName:image:")]
-		IntPtr Constructor (string name, UIImage image);
+		NativeHandle Constructor (string name, UIImage image);
 
 		[Export ("name")]
 		string Name { get; set; }
@@ -1419,10 +1423,10 @@ namespace CarPlay {
 	{
 		[Export ("initWithImage:handler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIImage image, [NullAllowed] Action<CPButton> handler);
+		NativeHandle Constructor (UIImage image, [NullAllowed] Action<CPButton> handler);
 
 		[Export ("initWithHandler:")]
-		IntPtr Constructor ([NullAllowed] Action<CPButton> handler);
+		NativeHandle Constructor ([NullAllowed] Action<CPButton> handler);
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]
@@ -1432,10 +1436,10 @@ namespace CarPlay {
 	{
 		[Export ("initWithImage:handler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIImage image, [NullAllowed] Action<CPButton> handler);
+		NativeHandle Constructor (UIImage image, [NullAllowed] Action<CPButton> handler);
 
 		[Export ("initWithHandler:")]
-		IntPtr Constructor ([NullAllowed] Action<CPButton> handler);
+		NativeHandle Constructor ([NullAllowed] Action<CPButton> handler);
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]
@@ -1445,7 +1449,7 @@ namespace CarPlay {
 	{
 		[Export ("initWithContact:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CPContact contact);
+		NativeHandle Constructor (CPContact contact);
 
 		[Export ("contact", ArgumentSemantic.Strong)]
 		CPContact Contact { get; set; }
@@ -1458,7 +1462,7 @@ namespace CarPlay {
 	{
 		[Export ("initWithTitle:detail:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string title, [NullAllowed] string detail);
+		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] string detail);
 
 		[NullAllowed, Export ("title")]
 		string Title { get; }
@@ -1474,7 +1478,7 @@ namespace CarPlay {
 	{
 		[Export ("initWithTitle:layout:items:actions:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string title, CPInformationTemplateLayout layout, CPInformationItem[] items, CPTextButton[] actions);
+		NativeHandle Constructor (string title, CPInformationTemplateLayout layout, CPInformationItem[] items, CPTextButton[] actions);
 
 		[Export ("layout")]
 		CPInformationTemplateLayout Layout { get; }
@@ -1497,7 +1501,7 @@ namespace CarPlay {
 	interface CPListImageRowItem : CPSelectableListItem
 	{
 		[Export ("initWithText:images:")]
-		IntPtr Constructor (string text, UIImage[] images);
+		NativeHandle Constructor (string text, UIImage[] images);
 
 		[Export ("gridImages", ArgumentSemantic.Strong)]
 		UIImage[] GridImages { get; }
@@ -1537,7 +1541,7 @@ namespace CarPlay {
 	{
 		[Export ("initWithTitle:textStyle:handler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string title, CPTextButtonStyle textStyle, [NullAllowed] Action<CPTextButton> handler);
+		NativeHandle Constructor (string title, CPTextButtonStyle textStyle, [NullAllowed] Action<CPTextButton> handler);
 
 		[Export ("title")]
 		string Title { get; set; }
@@ -1556,7 +1560,7 @@ namespace CarPlay {
 		CPMessageComposeBarButton Create ();
 
 		[Export ("initWithImage:")]
-		IntPtr Constructor (UIImage image);
+		NativeHandle Constructor (UIImage image);
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]
@@ -1618,7 +1622,7 @@ namespace CarPlay {
 		UIImage LeadingImage { get; }
 
 		[Export ("initWithLeadingItem:leadingImage:unread:")]
-		IntPtr Constructor (CPMessageLeadingItem leadingItem, [NullAllowed] UIImage leadingImage, bool unread);
+		NativeHandle Constructor (CPMessageLeadingItem leadingItem, [NullAllowed] UIImage leadingImage, bool unread);
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]
@@ -1633,7 +1637,7 @@ namespace CarPlay {
 		UIImage TrailingImage { get; }
 
 		[Export ("initWithTrailingItem:trailingImage:")]
-		IntPtr Constructor (CPMessageTrailingItem trailingItem, [NullAllowed] UIImage trailingImage);
+		NativeHandle Constructor (CPMessageTrailingItem trailingItem, [NullAllowed] UIImage trailingImage);
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]
@@ -1642,7 +1646,7 @@ namespace CarPlay {
 	interface CPNowPlayingButton : NSSecureCoding
 	{
 		[Export ("initWithHandler:")]
-		IntPtr Constructor ([NullAllowed] Action<CPNowPlayingButton> handler);
+		NativeHandle Constructor ([NullAllowed] Action<CPNowPlayingButton> handler);
 
 		[Export ("enabled")]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
@@ -1660,7 +1664,7 @@ namespace CarPlay {
 	interface CPNowPlayingImageButton
 	{
 		[Export ("initWithImage:handler:")]
-		IntPtr Constructor (UIImage image, [NullAllowed] Action<CPNowPlayingButton> handler);
+		NativeHandle Constructor (UIImage image, [NullAllowed] Action<CPNowPlayingButton> handler);
 
 		[NullAllowed, Export ("image", ArgumentSemantic.Strong)]
 		UIImage Image { get; }
@@ -1673,7 +1677,7 @@ namespace CarPlay {
 	{
 		[Export ("initWithLocation:title:subtitle:summary:detailTitle:detailSubtitle:detailSummary:pinImage:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MKMapItem location, string title, [NullAllowed] string subtitle, [NullAllowed] string summary, [NullAllowed] string detailTitle, [NullAllowed] string detailSubtitle, [NullAllowed] string detailSummary, [NullAllowed] UIImage pinImage);
+		NativeHandle Constructor (MKMapItem location, string title, [NullAllowed] string subtitle, [NullAllowed] string summary, [NullAllowed] string detailTitle, [NullAllowed] string detailSubtitle, [NullAllowed] string detailSummary, [NullAllowed] UIImage pinImage);
 
 		[Export ("location", ArgumentSemantic.Strong)]
 		MKMapItem Location { get; set; }
@@ -1731,7 +1735,7 @@ namespace CarPlay {
 	{
 		[Export ("initWithTitle:pointsOfInterest:selectedIndex:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string title, CPPointOfInterest[] pointsOfInterest, nint selectedIndex);
+		NativeHandle Constructor (string title, CPPointOfInterest[] pointsOfInterest, nint selectedIndex);
 
 		[Export ("title")]
 		string Title { get; set; }
@@ -1772,7 +1776,7 @@ namespace CarPlay {
 	interface CPTabBarTemplate
 	{
 		[Export ("initWithTemplates:")]
-		IntPtr Constructor (CPTemplate[] templates);
+		NativeHandle Constructor (CPTemplate[] templates);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -1846,10 +1850,10 @@ namespace CarPlay {
 	{
 		[Export ("initWithImage:handler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIImage image, [NullAllowed] Action<CPButton> handler);
+		NativeHandle Constructor (UIImage image, [NullAllowed] Action<CPButton> handler);
 
 		[Export ("initWithPhoneOrEmail:")]
-		IntPtr Constructor (string phoneOrEmail);
+		NativeHandle Constructor (string phoneOrEmail);
 
 		[Export ("phoneOrEmail")]
 		string PhoneOrEmail { get; }
@@ -1917,7 +1921,7 @@ namespace CarPlay {
 	{
 		[Export ("initWithRating:maximumRating:title:detail:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSNumber rating, [NullAllowed] NSNumber maximumRating, [NullAllowed] string title, [NullAllowed] string detail);
+		NativeHandle Constructor ([NullAllowed] NSNumber rating, [NullAllowed] NSNumber maximumRating, [NullAllowed] string title, [NullAllowed] string detail);
 
 		[NullAllowed, Export ("rating")]
 		NSNumber Rating { get; }
@@ -1932,7 +1936,7 @@ namespace CarPlay {
 	interface CPAssistantCellConfiguration : NSSecureCoding
 	{
 		[Export ("initWithPosition:visibility:assistantAction:")]
-		IntPtr Constructor (CPAssistantCellPosition position, CPAssistantCellVisibility visibility, CPAssistantCellActionType assistantAction);
+		NativeHandle Constructor (CPAssistantCellPosition position, CPAssistantCellVisibility visibility, CPAssistantCellActionType assistantAction);
 
 		[Export ("position")]
 		CPAssistantCellPosition Position { get; }

--- a/src/chip.cs
+++ b/src/chip.cs
@@ -4,6 +4,10 @@ using Foundation;
 
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Chip {
 
 	[Mac (12,0), Watch (8,0), TV (15,0), iOS (15,0), MacCatalyst (15,0)]
@@ -90,7 +94,7 @@ namespace Chip {
 	{
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 	}
 
 	[Mac (12,0), Watch (8,0), TV (15,0), iOS (15,0), MacCatalyst (15,0)]
@@ -103,7 +107,7 @@ namespace Chip {
 	{
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeVendorNameWithResponseHandler:")]
@@ -147,7 +151,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("barrierControlGoToPercent:responseHandler:")]
@@ -186,7 +190,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Export ("mfgSpecificPing:")]
 		void GetMfgSpecificPing (ChipResponseHandler responseHandler);
@@ -284,7 +288,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("bind:groupId:endpointId:clusterId:responseHandler:")]
@@ -307,7 +311,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("moveColor:rateY:optionsMask:optionsOverride:responseHandler:")]
@@ -670,7 +674,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeDeviceListWithResponseHandler:")]
@@ -701,7 +705,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("clearAllPins:")]
@@ -828,7 +832,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("armFailSafe:breadcrumb:timeoutMs:responseHandler:")]
@@ -867,7 +871,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeGroupsWithResponseHandler:")]
@@ -890,7 +894,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("addGroup:groupName:responseHandler:")]
@@ -932,7 +936,7 @@ namespace Chip {
 	{
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("identify:responseHandler:")]
@@ -963,7 +967,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("move:rate:optionMask:optionOverride:responseHandler:")]
@@ -1022,7 +1026,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("sleep:")]
@@ -1041,7 +1045,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("addThreadNetwork:breadcrumb:timeoutMs:responseHandler:")]
@@ -1092,7 +1096,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("off:")]
@@ -1131,7 +1135,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[NoMac] // fails on macOS 12 beta 6
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
@@ -1175,7 +1179,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeMaxPressureWithResponseHandler:")]
@@ -1230,7 +1234,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("addScene:sceneId:transitionTime:sceneName:clusterId:length:value:responseHandler:")]
@@ -1293,7 +1297,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeNumberOfPositionsWithResponseHandler:")]
@@ -1324,7 +1328,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeMeasuredValueWithResponseHandler:")]
@@ -1358,7 +1362,7 @@ namespace Chip {
 	{
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("test:")]
@@ -1528,7 +1532,7 @@ namespace Chip {
 	{
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("clearWeeklySchedule:")]
@@ -1705,7 +1709,7 @@ namespace Chip {
 	interface ChipManualSetupPayloadParser
 	{
 		[Export ("initWithDecimalStringRepresentation:")]
-		IntPtr Constructor (string decimalStringRepresentation);
+		NativeHandle Constructor (string decimalStringRepresentation);
 
 		[Export ("populatePayload:")]
 		[return: NullAllowed]
@@ -1791,7 +1795,7 @@ namespace Chip {
 	interface ChipQRCodeSetupPayloadParser
 	{
 		[Export ("initWithBase38Representation:")]
-		IntPtr Constructor (string base38Representation);
+		NativeHandle Constructor (string base38Representation);
 
 		[Export ("populatePayload:")]
 		[return: NullAllowed]
@@ -1806,7 +1810,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("getSetupPIN:responseHandler:")]
@@ -1829,7 +1833,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("launchApp:catalogVendorId:applicationId:responseHandler:")]
@@ -1852,7 +1856,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("renameOutput:name:responseHandler:")]
@@ -1879,7 +1883,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeOutOfServiceWithResponseHandler:")]
@@ -1930,7 +1934,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeVendorNameWithResponseHandler:")]
@@ -2006,7 +2010,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("launchContent:data:responseHandler:")]
@@ -2037,7 +2041,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("resetCounts:")]
@@ -2076,7 +2080,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeLabelListWithResponseHandler:")]
@@ -2095,7 +2099,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeNetworkInterfacesWithResponseHandler:")]
@@ -2118,7 +2122,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("sendKey:responseHandler:")]
@@ -2137,7 +2141,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("hideInputStatus:")]
@@ -2172,7 +2176,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("mediaFastForward:")]
@@ -2232,7 +2236,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeMeasuredValueWithResponseHandler:")]
@@ -2267,7 +2271,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("resetWatermarks:")]
@@ -2290,7 +2294,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("navigateTarget:data:responseHandler:")]
@@ -2314,7 +2318,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("addTrustedRootCertificate:responseHandler:")]
@@ -2337,7 +2341,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("changeChannel:responseHandler:")]
@@ -2376,7 +2380,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[Async (ResultTypeName = "ChipReadAttributeResult")]
 		[Export ("readAttributeWakeOnLanMacAddressWithResponseHandler:")]
@@ -2395,7 +2399,7 @@ namespace Chip {
 
 		[Export ("initWithDevice:endpoint:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
+		NativeHandle Constructor (ChipDevice device, byte endpoint, DispatchQueue queue);
 
 		[NoMac] // fails on macOS 12 beta 6
 		[Async (ResultTypeName = "ChipReadAttributeResult")]

--- a/src/classkit.cs
+++ b/src/classkit.cs
@@ -13,6 +13,10 @@ using ObjCRuntime;
 using CoreGraphics;
 using System.Reflection;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ClassKit {
 
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
@@ -224,7 +228,7 @@ namespace ClassKit {
 
 		[Export ("initWithIdentifier:title:type:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier, string title, CLSBinaryValueType valueType);
+		NativeHandle Constructor (string identifier, string title, CLSBinaryValueType valueType);
 	}
 
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
@@ -270,7 +274,7 @@ namespace ClassKit {
 
 		[Export ("initWithType:identifier:title:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CLSContextType type, string identifier, string title);
+		NativeHandle Constructor (CLSContextType type, string identifier, string title);
 
 		[Export ("active")]
 		bool Active { [Bind ("isActive")] get; }
@@ -427,7 +431,7 @@ namespace ClassKit {
 
 		[Export ("initWithIdentifier:title:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier, string title);
+		NativeHandle Constructor (string identifier, string title);
 	}
 
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
@@ -444,7 +448,7 @@ namespace ClassKit {
 
 		[Export ("initWithIdentifier:title:score:maxScore:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier, string title, double score, double maxScore);
+		NativeHandle Constructor (string identifier, string title, double score, double maxScore);
 	}
 
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
@@ -469,7 +473,7 @@ namespace ClassKit {
 		string Details { get; }
 
 		[Export ("initWithKind:details:")]
-		IntPtr Constructor (CLSProgressReportingCapabilityKind kind, [NullAllowed] string details);
+		NativeHandle Constructor (CLSProgressReportingCapabilityKind kind, [NullAllowed] string details);
 	}
 
 }

--- a/src/clockkit.cs
+++ b/src/clockkit.cs
@@ -12,6 +12,10 @@ using Foundation;
 using ObjCRuntime;
 using UIKit;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ClockKit {
 
 	[Watch (7,0)]
@@ -159,7 +163,7 @@ namespace ClockKit {
 
 		[Deprecated (PlatformName.WatchOS, 7, 0, message: "Use the provided factories instead.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 	}
 
 	[BaseType (typeof (CLKComplicationTemplate))]
@@ -170,7 +174,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:")]
-		IntPtr Constructor (CLKTextProvider textProvider);
+		NativeHandle Constructor (CLKTextProvider textProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -186,7 +190,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithImageProvider:")]
-		IntPtr Constructor (CLKImageProvider imageProvider);
+		NativeHandle Constructor (CLKImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -208,7 +212,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:fillFraction:ringStyle:")]
-		IntPtr Constructor (CLKTextProvider textProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
+		NativeHandle Constructor (CLKTextProvider textProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
 
 		[Watch (7, 0)]
 		[Static]
@@ -230,7 +234,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithImageProvider:fillFraction:ringStyle:")]
-		IntPtr Constructor (CLKImageProvider imageProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
+		NativeHandle Constructor (CLKImageProvider imageProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
 
 		[Watch (7, 0)]
 		[Static]
@@ -252,7 +256,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithLine1TextProvider:line2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider line1TextProvider, CLKTextProvider line2TextProvider);
+		NativeHandle Constructor (CLKTextProvider line1TextProvider, CLKTextProvider line2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -274,7 +278,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithLine1ImageProvider:line2TextProvider:")]
-		IntPtr Constructor (CLKImageProvider line1ImageProvider, CLKTextProvider line2TextProvider);
+		NativeHandle Constructor (CLKImageProvider line1ImageProvider, CLKTextProvider line2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -305,7 +309,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithRow1Column1TextProvider:row1Column2TextProvider:row2Column1TextProvider:row2Column2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider);
+		NativeHandle Constructor (CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -332,19 +336,19 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderTextProvider:body1TextProvider:")]
-		IntPtr Constructor (CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider);
+		NativeHandle Constructor (CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderTextProvider:body1TextProvider:body2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, [NullAllowed] CLKTextProvider body2TextProvider);
+		NativeHandle Constructor (CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, [NullAllowed] CLKTextProvider body2TextProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderImageProvider:headerTextProvider:body1TextProvider:")]
-		IntPtr Constructor ([NullAllowed] CLKImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider);
+		NativeHandle Constructor ([NullAllowed] CLKImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderImageProvider:headerTextProvider:body1TextProvider:body2TextProvider:")]
-		IntPtr Constructor ([NullAllowed] CLKImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, [NullAllowed] CLKTextProvider body2TextProvider);
+		NativeHandle Constructor ([NullAllowed] CLKImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, [NullAllowed] CLKTextProvider body2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -378,7 +382,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderTextProvider:bodyTextProvider:")]
-		IntPtr Constructor (CLKTextProvider headerTextProvider, CLKTextProvider bodyTextProvider);
+		NativeHandle Constructor (CLKTextProvider headerTextProvider, CLKTextProvider bodyTextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -413,11 +417,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderTextProvider:row1Column1TextProvider:row1Column2TextProvider:row2Column1TextProvider:row2Column2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider headerTextProvider, CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider);
+		NativeHandle Constructor (CLKTextProvider headerTextProvider, CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderImageProvider:headerTextProvider:row1Column1TextProvider:row1Column2TextProvider:row2Column1TextProvider:row2Column2TextProvider:")]
-		IntPtr Constructor ([NullAllowed] CLKImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider);
+		NativeHandle Constructor ([NullAllowed] CLKImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -468,11 +472,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithRow1Column1TextProvider:row1Column2TextProvider:row2Column1TextProvider:row2Column2TextProvider:row3Column1TextProvider:row3Column2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider, CLKTextProvider row3Column1TextProvider, CLKTextProvider row3Column2TextProvider);
+		NativeHandle Constructor (CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider, CLKTextProvider row3Column1TextProvider, CLKTextProvider row3Column2TextProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithRow1ImageProvider:row1Column1TextProvider:row1Column2TextProvider:row2ImageProvider:row2Column1TextProvider:row2Column2TextProvider:row3ImageProvider:row3Column1TextProvider:row3Column2TextProvider:")]
-		IntPtr Constructor ([NullAllowed] CLKImageProvider row1ImageProvider, CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, [NullAllowed] CLKImageProvider row2ImageProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider, [NullAllowed] CLKImageProvider row3ImageProvider, CLKTextProvider row3Column1TextProvider, CLKTextProvider row3Column2TextProvider);
+		NativeHandle Constructor ([NullAllowed] CLKImageProvider row1ImageProvider, CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, [NullAllowed] CLKImageProvider row2ImageProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider, [NullAllowed] CLKImageProvider row3ImageProvider, CLKTextProvider row3Column1TextProvider, CLKTextProvider row3Column2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -497,11 +501,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:")]
-		IntPtr Constructor (CLKTextProvider textProvider);
+		NativeHandle Constructor (CLKTextProvider textProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:imageProvider:")]
-		IntPtr Constructor (CLKTextProvider textProvider, [NullAllowed] CLKImageProvider imageProvider);
+		NativeHandle Constructor (CLKTextProvider textProvider, [NullAllowed] CLKImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -522,7 +526,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithImageProvider:")]
-		IntPtr Constructor (CLKImageProvider imageProvider);
+		NativeHandle Constructor (CLKImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -544,7 +548,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:fillFraction:ringStyle:")]
-		IntPtr Constructor (CLKTextProvider textProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
+		NativeHandle Constructor (CLKTextProvider textProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
 
 		[Watch (7, 0)]
 		[Static]
@@ -566,7 +570,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithImageProvider:fillFraction:ringStyle:")]
-		IntPtr Constructor (CLKImageProvider imageProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
+		NativeHandle Constructor (CLKImageProvider imageProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
 
 		[Watch (7, 0)]
 		[Static]
@@ -586,11 +590,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:")]
-		IntPtr Constructor (CLKTextProvider textProvider);
+		NativeHandle Constructor (CLKTextProvider textProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:imageProvider:")]
-		IntPtr Constructor (CLKTextProvider textProvider, [NullAllowed] CLKImageProvider imageProvider);
+		NativeHandle Constructor (CLKTextProvider textProvider, [NullAllowed] CLKImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -611,7 +615,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:")]
-		IntPtr Constructor (CLKTextProvider textProvider);
+		NativeHandle Constructor (CLKTextProvider textProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -627,7 +631,7 @@ namespace ClockKit {
 
 		[Watch (7,0)]
 		[Export ("initWithImageProvider:")]
-		IntPtr Constructor (CLKImageProvider imageProvider);
+		NativeHandle Constructor (CLKImageProvider imageProvider);
 
 		[Watch (7,0)]
 		[Static]
@@ -649,7 +653,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:fillFraction:ringStyle:")]
-		IntPtr Constructor (CLKTextProvider textProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
+		NativeHandle Constructor (CLKTextProvider textProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
 
 		[Watch (7, 0)]
 		[Static]
@@ -671,7 +675,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithImageProvider:fillFraction:ringStyle:")]
-		IntPtr Constructor (CLKImageProvider imageProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
+		NativeHandle Constructor (CLKImageProvider imageProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
 
 		[Watch (7, 0)]
 		[Static]
@@ -690,7 +694,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithLine1TextProvider:line2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider line1TextProvider, CLKTextProvider line2TextProvider);
+		NativeHandle Constructor (CLKTextProvider line1TextProvider, CLKTextProvider line2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -709,7 +713,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithLine1ImageProvider:line2TextProvider:")]
-		IntPtr Constructor (CLKImageProvider line1ImageProvider, CLKTextProvider line2TextProvider);
+		NativeHandle Constructor (CLKImageProvider line1ImageProvider, CLKTextProvider line2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -726,7 +730,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:")]
-		IntPtr Constructor (CLKTextProvider textProvider);
+		NativeHandle Constructor (CLKTextProvider textProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -743,7 +747,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithImageProvider:")]
-		IntPtr Constructor (CLKImageProvider imageProvider);
+		NativeHandle Constructor (CLKImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -766,7 +770,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:fillFraction:ringStyle:")]
-		IntPtr Constructor (CLKTextProvider textProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
+		NativeHandle Constructor (CLKTextProvider textProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
 
 		[Watch (7, 0)]
 		[Static]
@@ -789,7 +793,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithImageProvider:fillFraction:ringStyle:")]
-		IntPtr Constructor (CLKImageProvider imageProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
+		NativeHandle Constructor (CLKImageProvider imageProvider, float fillFraction, CLKComplicationRingStyle ringStyle);
 
 		[Watch (7, 0)]
 		[Static]
@@ -812,7 +816,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithLine1TextProvider:line2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider line1TextProvider, CLKTextProvider line2TextProvider);
+		NativeHandle Constructor (CLKTextProvider line1TextProvider, CLKTextProvider line2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -835,7 +839,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithLine1ImageProvider:line2TextProvider:")]
-		IntPtr Constructor (CLKImageProvider line1ImageProvider, CLKTextProvider line2TextProvider);
+		NativeHandle Constructor (CLKImageProvider line1ImageProvider, CLKTextProvider line2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -867,7 +871,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithRow1Column1TextProvider:row1Column2TextProvider:row2Column1TextProvider:row2Column2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider);
+		NativeHandle Constructor (CLKTextProvider row1Column1TextProvider, CLKTextProvider row1Column2TextProvider, CLKTextProvider row2Column1TextProvider, CLKTextProvider row2Column2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -902,7 +906,7 @@ namespace ClockKit {
 
 		[Deprecated (PlatformName.WatchOS, 7, 0)] 
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Static]
 		[Export ("imageProviderWithOnePieceImage:")]
@@ -930,11 +934,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithOnePieceImage:")]
-		IntPtr Constructor (UIImage onePieceImage);
+		NativeHandle Constructor (UIImage onePieceImage);
 
 		[Watch (7, 0)]
 		[Export ("initWithOnePieceImage:twoPieceImageBackground:twoPieceImageForeground:")]
-		IntPtr Constructor (UIImage onePieceImage, [NullAllowed] UIImage twoPieceImageBackground, [NullAllowed] UIImage twoPieceImageForeground);
+		NativeHandle Constructor (UIImage onePieceImage, [NullAllowed] UIImage twoPieceImageBackground, [NullAllowed] UIImage twoPieceImageForeground);
 	}
 
 	[BaseType (typeof (NSObject))]
@@ -943,7 +947,7 @@ namespace ClockKit {
  
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use overloaded constructors.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		// FIXME: expose gracefully
 		[Static, Internal]
@@ -1001,15 +1005,15 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithText:")]
-		IntPtr Constructor (string text);
+		NativeHandle Constructor (string text);
 
 		[Watch (7, 0)]
 		[Export ("initWithText:shortText:")]
-		IntPtr Constructor (string text, [NullAllowed] string shortText);
+		NativeHandle Constructor (string text, [NullAllowed] string shortText);
 
 		[Watch (7, 0)]
 		[Export ("initWithText:shortText:accessibilityLabel:")]
-		IntPtr Constructor (string text, [NullAllowed] string shortText, [NullAllowed] string accessibilityLabel);
+		NativeHandle Constructor (string text, [NullAllowed] string shortText, [NullAllowed] string accessibilityLabel);
 	}
 
 	[BaseType (typeof (CLKTextProvider))]
@@ -1039,11 +1043,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithDate:units:")]
-		IntPtr Constructor (NSDate date, NSCalendarUnit calendarUnits);
+		NativeHandle Constructor (NSDate date, NSCalendarUnit calendarUnits);
 
 		[Watch (7, 0)]
 		[Export ("initWithDate:units:timeZone:")]
-		IntPtr Constructor (NSDate date, NSCalendarUnit calendarUnits, [NullAllowed] NSTimeZone timeZone);
+		NativeHandle Constructor (NSDate date, NSCalendarUnit calendarUnits, [NullAllowed] NSTimeZone timeZone);
 	}
 
 	[BaseType (typeof (CLKTextProvider))]
@@ -1066,11 +1070,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithDate:")]
-		IntPtr Constructor (NSDate date);
+		NativeHandle Constructor (NSDate date);
 
 		[Watch (7, 0)]
 		[Export ("initWithDate:timeZone:")]
-		IntPtr Constructor (NSDate date, [NullAllowed] NSTimeZone timeZone);
+		NativeHandle Constructor (NSDate date, [NullAllowed] NSTimeZone timeZone);
 	}
 
 	[BaseType (typeof (CLKTextProvider))]
@@ -1096,11 +1100,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithStartDate:endDate:")]
-		IntPtr Constructor (NSDate startDate, NSDate endDate);
+		NativeHandle Constructor (NSDate startDate, NSDate endDate);
 
 		[Watch (7, 0)]
 		[Export ("initWithStartDate:endDate:timeZone:")]
-		IntPtr Constructor (NSDate startDate, NSDate endDate, [NullAllowed] NSTimeZone timeZone);
+		NativeHandle Constructor (NSDate startDate, NSDate endDate, [NullAllowed] NSTimeZone timeZone);
 	}
 
 	[BaseType (typeof (CLKTextProvider))]
@@ -1121,11 +1125,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithDate:style:units:")]
-		IntPtr Constructor (NSDate date, CLKRelativeDateStyle style, NSCalendarUnit calendarUnits);
+		NativeHandle Constructor (NSDate date, CLKRelativeDateStyle style, NSCalendarUnit calendarUnits);
 
 		[Watch (7, 0)]
 		[Export ("initWithDate:relativeToDate:style:units:")]
-		IntPtr Constructor (NSDate date, [NullAllowed] NSDate relativeDate, CLKRelativeDateStyle style, NSCalendarUnit calendarUnits);
+		NativeHandle Constructor (NSDate date, [NullAllowed] NSDate relativeDate, CLKRelativeDateStyle style, NSCalendarUnit calendarUnits);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1159,11 +1163,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithCircularTemplate:")]
-		IntPtr Constructor (CLKComplicationTemplateGraphicCircular circularTemplate);
+		NativeHandle Constructor (CLKComplicationTemplateGraphicCircular circularTemplate);
 
 		[Watch (7, 0)]
 		[Export ("initWithCircularTemplate:textProvider:")]
-		IntPtr Constructor (CLKComplicationTemplateGraphicCircular circularTemplate, [NullAllowed] CLKTextProvider textProvider);
+		NativeHandle Constructor (CLKComplicationTemplateGraphicCircular circularTemplate, [NullAllowed] CLKTextProvider textProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1194,7 +1198,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithGaugeProvider:imageProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKFullColorImageProvider imageProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKFullColorImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1213,7 +1217,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithGaugeProvider:centerTextProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider centerTextProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider centerTextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1229,7 +1233,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithImageProvider:")]
-		IntPtr Constructor (CLKFullColorImageProvider imageProvider);
+		NativeHandle Constructor (CLKFullColorImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1251,7 +1255,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithGaugeProvider:bottomImageProvider:centerTextProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKFullColorImageProvider bottomImageProvider, CLKTextProvider centerTextProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKFullColorImageProvider bottomImageProvider, CLKTextProvider centerTextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1276,7 +1280,7 @@ namespace ClockKit {
 	
 		[Watch (7, 0)]
 		[Export ("initWithGaugeProvider:leadingTextProvider:trailingTextProvider:centerTextProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider leadingTextProvider, CLKTextProvider trailingTextProvider, CLKTextProvider centerTextProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider leadingTextProvider, CLKTextProvider trailingTextProvider, CLKTextProvider centerTextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1298,7 +1302,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithGaugeProvider:bottomTextProvider:centerTextProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider bottomTextProvider, CLKTextProvider centerTextProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider bottomTextProvider, CLKTextProvider centerTextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1314,7 +1318,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithImageProvider:")]
-		IntPtr Constructor (CLKFullColorImageProvider imageProvider);
+		NativeHandle Constructor (CLKFullColorImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1339,11 +1343,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithGaugeProvider:imageProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKFullColorImageProvider imageProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKFullColorImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithGaugeProvider:leadingTextProvider:trailingTextProvider:imageProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, [NullAllowed] CLKTextProvider leadingTextProvider, [NullAllowed] CLKTextProvider trailingTextProvider, CLKFullColorImageProvider imageProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, [NullAllowed] CLKTextProvider leadingTextProvider, [NullAllowed] CLKTextProvider trailingTextProvider, CLKFullColorImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1373,11 +1377,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithGaugeProvider:outerTextProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider outerTextProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider outerTextProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithGaugeProvider:leadingTextProvider:trailingTextProvider:outerTextProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, [NullAllowed] CLKTextProvider leadingTextProvider, [NullAllowed] CLKTextProvider trailingTextProvider, CLKTextProvider outerTextProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, [NullAllowed] CLKTextProvider leadingTextProvider, [NullAllowed] CLKTextProvider trailingTextProvider, CLKTextProvider outerTextProvider);
 
 		[Watch (7,0)]
 		[Static]
@@ -1401,7 +1405,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithInnerTextProvider:outerTextProvider:")]
-		IntPtr Constructor (CLKTextProvider innerTextProvider, CLKTextProvider outerTextProvider);
+		NativeHandle Constructor (CLKTextProvider innerTextProvider, CLKTextProvider outerTextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1420,7 +1424,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:imageProvider:")]
-		IntPtr Constructor (CLKTextProvider textProvider, CLKFullColorImageProvider imageProvider);
+		NativeHandle Constructor (CLKTextProvider textProvider, CLKFullColorImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1439,7 +1443,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithTextProvider:imageProvider:")]
-		IntPtr Constructor (CLKTextProvider textProvider, CLKFullColorImageProvider imageProvider);
+		NativeHandle Constructor (CLKTextProvider textProvider, CLKFullColorImageProvider imageProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1464,19 +1468,19 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderTextProvider:body1TextProvider:")]
-		IntPtr Constructor (CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider);
+		NativeHandle Constructor (CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderTextProvider:body1TextProvider:body2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, [NullAllowed] CLKTextProvider body2TextProvider);
+		NativeHandle Constructor (CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, [NullAllowed] CLKTextProvider body2TextProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderImageProvider:headerTextProvider:body1TextProvider:")]
-		IntPtr Constructor ([NullAllowed] CLKFullColorImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider);
+		NativeHandle Constructor ([NullAllowed] CLKFullColorImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderImageProvider:headerTextProvider:body1TextProvider:body2TextProvider:")]
-		IntPtr Constructor ([NullAllowed] CLKFullColorImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, [NullAllowed] CLKTextProvider body2TextProvider);
+		NativeHandle Constructor ([NullAllowed] CLKFullColorImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, [NullAllowed] CLKTextProvider body2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1516,11 +1520,11 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderTextProvider:body1TextProvider:gaugeProvider:")]
-		IntPtr Constructor (CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, CLKGaugeProvider gaugeProvider);
+		NativeHandle Constructor (CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, CLKGaugeProvider gaugeProvider);
 
 		[Watch (7, 0)]
 		[Export ("initWithHeaderImageProvider:headerTextProvider:body1TextProvider:gaugeProvider:")]
-		IntPtr Constructor ([NullAllowed] CLKFullColorImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, CLKGaugeProvider gaugeProvider);
+		NativeHandle Constructor ([NullAllowed] CLKFullColorImageProvider headerImageProvider, CLKTextProvider headerTextProvider, CLKTextProvider body1TextProvider, CLKGaugeProvider gaugeProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1558,15 +1562,15 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Watch (7, 0)]
 		[Export ("initWithFullColorImage:")]
-		IntPtr Constructor (UIImage fullColorImage);
+		NativeHandle Constructor (UIImage fullColorImage);
 
 		[Watch (7, 0)]
 		[Export ("initWithFullColorImage:tintedImageProvider:")]
-		IntPtr Constructor (UIImage fullColorImage, [NullAllowed] CLKImageProvider tintedImageProvider);
+		NativeHandle Constructor (UIImage fullColorImage, [NullAllowed] CLKImageProvider tintedImageProvider);
 	}
 
 	[Watch (5,0)]
@@ -1645,7 +1649,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithLine1TextProvider:line2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider line1TextProvider, CLKTextProvider line2TextProvider);
+		NativeHandle Constructor (CLKTextProvider line1TextProvider, CLKTextProvider line2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1665,7 +1669,7 @@ namespace ClockKit {
 
 		[Watch (7, 0)]
 		[Export ("initWithLine1ImageProvider:line2TextProvider:")]
-		IntPtr Constructor (CLKFullColorImageProvider line1ImageProvider, CLKTextProvider line2TextProvider);
+		NativeHandle Constructor (CLKFullColorImageProvider line1ImageProvider, CLKTextProvider line2TextProvider);
 
 		[Watch (7, 0)]
 		[Static]
@@ -1688,7 +1692,7 @@ namespace ClockKit {
 		CLKFullColorImageProvider ImageProvider { get; set; }
 
 		[Export ("initWithImageProvider:")]
-		IntPtr Constructor (CLKFullColorImageProvider imageProvider);
+		NativeHandle Constructor (CLKFullColorImageProvider imageProvider);
 
 		[Static]
 		[Export ("templateWithImageProvider:")]
@@ -1711,7 +1715,7 @@ namespace ClockKit {
 		CLKTextProvider Line2TextProvider { get; set; }
 
 		[Export ("initWithLine1TextProvider:line2TextProvider:")]
-		IntPtr Constructor (CLKTextProvider line1TextProvider, CLKTextProvider line2TextProvider);
+		NativeHandle Constructor (CLKTextProvider line1TextProvider, CLKTextProvider line2TextProvider);
 
 		[Static]
 		[Export ("templateWithLine1TextProvider:line2TextProvider:")]
@@ -1728,7 +1732,7 @@ namespace ClockKit {
 		CLKTextProvider Line2TextProvider { get; set; }
 
 		[Export ("initWithLine1ImageProvider:line2TextProvider:")]
-		IntPtr Constructor (CLKFullColorImageProvider line1ImageProvider, CLKTextProvider line2TextProvider);
+		NativeHandle Constructor (CLKFullColorImageProvider line1ImageProvider, CLKTextProvider line2TextProvider);
 
 		[Static]
 		[Export ("templateWithLine1ImageProvider:line2TextProvider:")]
@@ -1748,7 +1752,7 @@ namespace ClockKit {
 		CLKTextProvider CenterTextProvider { get; set; }
 
 		[Export ("initWithGaugeProvider:bottomTextProvider:centerTextProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider bottomTextProvider, CLKTextProvider centerTextProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider bottomTextProvider, CLKTextProvider centerTextProvider);
 
 		[Static]
 		[Export ("templateWithGaugeProvider:bottomTextProvider:centerTextProvider:")]
@@ -1771,7 +1775,7 @@ namespace ClockKit {
 		CLKTextProvider CenterTextProvider { get; set; }
 
 		[Export ("initWithGaugeProvider:leadingTextProvider:trailingTextProvider:centerTextProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider leadingTextProvider, CLKTextProvider trailingTextProvider, CLKTextProvider centerTextProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider leadingTextProvider, CLKTextProvider trailingTextProvider, CLKTextProvider centerTextProvider);
 
 		[Static]
 		[Export ("templateWithGaugeProvider:leadingTextProvider:trailingTextProvider:centerTextProvider:")]
@@ -1791,7 +1795,7 @@ namespace ClockKit {
 		CLKTextProvider CenterTextProvider { get; set; }
 
 		[Export ("initWithGaugeProvider:bottomImageProvider:centerTextProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKFullColorImageProvider bottomImageProvider, CLKTextProvider centerTextProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKFullColorImageProvider bottomImageProvider, CLKTextProvider centerTextProvider);
 
 		[Static]
 		[Export ("templateWithGaugeProvider:bottomImageProvider:centerTextProvider:")]
@@ -1805,7 +1809,7 @@ namespace ClockKit {
 		CLKFullColorImageProvider ImageProvider { get; set; }
 
 		[Export ("initWithImageProvider:")]
-		IntPtr Constructor (CLKFullColorImageProvider imageProvider);
+		NativeHandle Constructor (CLKFullColorImageProvider imageProvider);
 
 		[Static]
 		[Export ("templateWithImageProvider:")]
@@ -1822,7 +1826,7 @@ namespace ClockKit {
 		CLKTextProvider CenterTextProvider { get; set; }
 
 		[Export ("initWithGaugeProvider:centerTextProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider centerTextProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKTextProvider centerTextProvider);
 
 		[Static]
 		[Export ("templateWithGaugeProvider:centerTextProvider:")]
@@ -1839,7 +1843,7 @@ namespace ClockKit {
 		CLKFullColorImageProvider ImageProvider { get; set; }
 
 		[Export ("initWithGaugeProvider:imageProvider:")]
-		IntPtr Constructor (CLKGaugeProvider gaugeProvider, CLKFullColorImageProvider imageProvider);
+		NativeHandle Constructor (CLKGaugeProvider gaugeProvider, CLKFullColorImageProvider imageProvider);
 
 		[Static]
 		[Export ("templateWithGaugeProvider:imageProvider:")]
@@ -1867,13 +1871,13 @@ namespace ClockKit {
 		NSUserActivity UserActivity { get; }
 
 		[Export ("initWithIdentifier:displayName:supportedFamilies:")]
-		IntPtr Constructor (string identifier, string displayName, [BindAs (typeof (CLKComplicationFamily []))] NSNumber[] supportedFamilies);
+		NativeHandle Constructor (string identifier, string displayName, [BindAs (typeof (CLKComplicationFamily []))] NSNumber[] supportedFamilies);
 
 		[Export ("initWithIdentifier:displayName:supportedFamilies:userInfo:")]
-		IntPtr Constructor (string identifier, string displayName, [BindAs (typeof (CLKComplicationFamily []))] NSNumber[] supportedFamilies, NSDictionary userInfo);
+		NativeHandle Constructor (string identifier, string displayName, [BindAs (typeof (CLKComplicationFamily []))] NSNumber[] supportedFamilies, NSDictionary userInfo);
 
 		[Export ("initWithIdentifier:displayName:supportedFamilies:userActivity:")]
-		IntPtr Constructor (string identifier, string displayName, [BindAs (typeof (CLKComplicationFamily []))] NSNumber[] supportedFamilies, NSUserActivity userActivity);
+		NativeHandle Constructor (string identifier, string displayName, [BindAs (typeof (CLKComplicationFamily []))] NSNumber[] supportedFamilies, NSUserActivity userActivity);
 	}
 
 

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -6,6 +6,10 @@ using CoreLocation;
 using Contacts;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CloudKit {
 
 	[Watch (3,0)]
@@ -15,7 +19,7 @@ namespace CloudKit {
 	interface CKAsset : NSCoding, NSSecureCoding, CKRecordValue {
 
 		[Export ("initWithFileURL:")]
-		IntPtr Constructor (NSUrl fileUrl);
+		NativeHandle Constructor (NSUrl fileUrl);
 
 		[Export ("fileURL", ArgumentSemantic.Copy)]
 		[NullAllowed]
@@ -132,16 +136,16 @@ namespace CloudKit {
 	interface CKShare
 	{
 		[Export ("initWithRootRecord:")]
-		IntPtr Constructor (CKRecord rootRecord);
+		NativeHandle Constructor (CKRecord rootRecord);
 
 		[Export ("initWithRootRecord:shareID:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CKRecord rootRecord, CKRecordID shareID);
+		NativeHandle Constructor (CKRecord rootRecord, CKRecordID shareID);
 
 		[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[Export ("initWithRecordZoneID:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CKRecordZoneID recordZoneId);
+		NativeHandle Constructor (CKRecordZoneID recordZoneId);
 
 		[Export ("publicPermission", ArgumentSemantic.Assign)]
 		CKShareParticipantPermission PublicPermission { get; set; }
@@ -423,7 +427,7 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 	}
 
@@ -439,7 +443,7 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[NullAllowed]
 		[Export ("userRecordID", ArgumentSemantic.Copy)]
@@ -488,10 +492,10 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithPreviousServerChangeToken:")]
-		IntPtr Constructor ([NullAllowed] CKServerChangeToken previousServerChangeToken);
+		NativeHandle Constructor ([NullAllowed] CKServerChangeToken previousServerChangeToken);
 
 		[NullAllowed] // by default this property is null
 		[Export ("previousServerChangeToken", ArgumentSemantic.Copy)]
@@ -540,10 +544,10 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithRecordZoneID:previousServerChangeToken:")]
-		IntPtr Constructor (CKRecordZoneID recordZoneID, [NullAllowed] CKServerChangeToken previousServerChangeToken);
+		NativeHandle Constructor (CKRecordZoneID recordZoneID, [NullAllowed] CKServerChangeToken previousServerChangeToken);
 
 		[NullAllowed] // by default this property is null
 		[Export ("recordZoneID", ArgumentSemantic.Copy)]
@@ -603,18 +607,18 @@ namespace CloudKit {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use the overload with the 'NSDictionary<CKRecordZoneID, CKFetchRecordZoneChangesConfiguration>' parameter instead.")]
 		[Deprecated (PlatformName.TvOS, 12, 0, message: "Use the overload with the 'NSDictionary<CKRecordZoneID, CKFetchRecordZoneChangesConfiguration>' parameter instead.")]
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use the overload with the 'NSDictionary<CKRecordZoneID, CKFetchRecordZoneChangesConfiguration>' parameter instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use the overload with the 'NSDictionary<CKRecordZoneID, CKFetchRecordZoneChangesConfiguration>' parameter instead.")]
 		[Export ("initWithRecordZoneIDs:optionsByRecordZoneID:")]
-		IntPtr Constructor (CKRecordZoneID[] recordZoneIDs, [NullAllowed] NSDictionary<CKRecordZoneID, CKFetchRecordZoneChangesOptions> optionsByRecordZoneID);
+		NativeHandle Constructor (CKRecordZoneID[] recordZoneIDs, [NullAllowed] NSDictionary<CKRecordZoneID, CKFetchRecordZoneChangesOptions> optionsByRecordZoneID);
 
 		[iOS (12,0), Watch (5,0), TV (12,0), Mac (10,14)]
 		[Export ("initWithRecordZoneIDs:configurationsByRecordZoneID:")]
-		IntPtr Constructor (CKRecordZoneID[] recordZoneIDs, [NullAllowed] NSDictionary<CKRecordZoneID, CKFetchRecordZoneChangesConfiguration> configurationsByRecordZoneID);
+		NativeHandle Constructor (CKRecordZoneID[] recordZoneIDs, [NullAllowed] NSDictionary<CKRecordZoneID, CKFetchRecordZoneChangesConfiguration> configurationsByRecordZoneID);
 
 		[NullAllowed]
 		[Export ("recordZoneIDs", ArgumentSemantic.Copy)]
@@ -705,7 +709,7 @@ namespace CloudKit {
 	interface CKFetchRecordsOperation {
 
 		[Export ("initWithRecordIDs:")]
-		IntPtr Constructor (CKRecordID [] recordIds);
+		NativeHandle Constructor (CKRecordID [] recordIds);
 
 		[NullAllowed] // by default this property is null
 		[Export ("recordIDs", ArgumentSemantic.Copy)]
@@ -757,7 +761,7 @@ namespace CloudKit {
 	interface CKFetchRecordZonesOperation {
 
 		[Export ("initWithRecordZoneIDs:")]
-		IntPtr Constructor (CKRecordZoneID [] zoneIds);
+		NativeHandle Constructor (CKRecordZoneID [] zoneIds);
 
 		[NullAllowed] // by default this property is null
 		[Export ("recordZoneIDs", ArgumentSemantic.Copy)]
@@ -795,10 +799,10 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithSubscriptionIDs:")]
-		IntPtr Constructor (string [] subscriptionIds);
+		NativeHandle Constructor (string [] subscriptionIds);
 
 		[NullAllowed] // by default this property is null
 		[Export ("subscriptionIDs", ArgumentSemantic.Copy)]
@@ -829,7 +833,7 @@ namespace CloudKit {
 	interface CKLocationSortDescriptor : NSSecureCoding {
 		[DesignatedInitializer]
 		[Export ("initWithKey:relativeLocation:")]
-		IntPtr Constructor (string key, CLLocation relativeLocation);
+		NativeHandle Constructor (string key, CLLocation relativeLocation);
 
 		[Export ("relativeLocation", ArgumentSemantic.Copy)]
 		CLLocation RelativeLocation { get; }
@@ -850,7 +854,7 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithNotificationIDsToMarkRead:")]
-		IntPtr Constructor (CKNotificationID [] notificationIds);
+		NativeHandle Constructor (CKNotificationID [] notificationIds);
 
 		[NullAllowed]
 		[Export ("notificationIDs", ArgumentSemantic.Copy)]
@@ -878,7 +882,7 @@ namespace CloudKit {
 	interface CKModifyBadgeOperation {
 
 		[Export ("initWithBadgeValue:")]
-		IntPtr Constructor (nuint badgeValue);
+		NativeHandle Constructor (nuint badgeValue);
 
 		[Export ("badgeValue", ArgumentSemantic.UnsafeUnretained)]
 		nuint BadgeValue { get; set; }
@@ -910,7 +914,7 @@ namespace CloudKit {
 	interface CKModifyRecordsOperation {
 
 		[Export ("initWithRecordsToSave:recordIDsToDelete:")]
-		IntPtr Constructor ([NullAllowed] CKRecord [] recordsToSave, [NullAllowed] CKRecordID [] recordsToDelete);
+		NativeHandle Constructor ([NullAllowed] CKRecord [] recordsToSave, [NullAllowed] CKRecordID [] recordsToDelete);
 
 		[NullAllowed] // by default this property is null
 		[Export ("recordsToSave", ArgumentSemantic.Copy)]
@@ -987,7 +991,7 @@ namespace CloudKit {
 	interface CKModifyRecordZonesOperation {
 
 		[Export ("initWithRecordZonesToSave:recordZoneIDsToDelete:")]
-		IntPtr Constructor ([NullAllowed] CKRecordZone [] recordZonesToSave, [NullAllowed] CKRecordZoneID [] recordZoneIdsToDelete);
+		NativeHandle Constructor ([NullAllowed] CKRecordZone [] recordZonesToSave, [NullAllowed] CKRecordZoneID [] recordZoneIdsToDelete);
 
 		[NullAllowed] // by default this property is null
 		[Export ("recordZonesToSave", ArgumentSemantic.Copy)]
@@ -1032,10 +1036,10 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithSubscriptionsToSave:subscriptionIDsToDelete:")]
-		IntPtr Constructor ([NullAllowed] CKSubscription [] subscriptionsToSave, [NullAllowed] string [] subscriptionIdsToDelete);
+		NativeHandle Constructor ([NullAllowed] CKSubscription [] subscriptionsToSave, [NullAllowed] string [] subscriptionIdsToDelete);
 
 		[NullAllowed] // by default this property is null
 		[Export ("subscriptionsToSave", ArgumentSemantic.Copy)]
@@ -1245,7 +1249,7 @@ namespace CloudKit {
 		[Protected] // since it should (and will) be `abstract`
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		// Apple removed, without deprecation, this property in iOS 9.3 SDK
 		// [Mac (10,11), iOS (9,0)]
@@ -1345,7 +1349,7 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithRecordType:predicate:")]
-		IntPtr Constructor (string recordType, NSPredicate predicate);
+		NativeHandle Constructor (string recordType, NSPredicate predicate);
 
 		[Export ("recordType")]
 		string RecordType { get; }
@@ -1373,10 +1377,10 @@ namespace CloudKit {
 		IntPtr _MaximumResults { get; set; }
 
 		[Export ("initWithQuery:")]
-		IntPtr Constructor (CKQuery query);
+		NativeHandle Constructor (CKQuery query);
 
 		[Export ("initWithCursor:")]
-		IntPtr Constructor (CKQueryCursor cursor);
+		NativeHandle Constructor (CKQueryCursor cursor);
 
 		[NullAllowed] // by default this property is null
 		[Export ("query", ArgumentSemantic.Copy)]
@@ -1458,13 +1462,13 @@ namespace CloudKit {
 		NSString NameZoneWideShare { get; }
 
 		[Export ("initWithRecordType:")]
-		IntPtr Constructor (string recordType);
+		NativeHandle Constructor (string recordType);
 
 		[Export ("initWithRecordType:recordID:")]
-		IntPtr Constructor (string recordType, CKRecordID recordId);
+		NativeHandle Constructor (string recordType, CKRecordID recordId);
 
 		[Export ("initWithRecordType:zoneID:")]
-		IntPtr Constructor (string recordType, CKRecordZoneID zoneId);
+		NativeHandle Constructor (string recordType, CKRecordZoneID zoneId);
 
 		[Export ("recordType")]
 		string RecordType { get; }
@@ -1537,11 +1541,11 @@ namespace CloudKit {
 	interface CKRecordID : NSSecureCoding, NSCopying {
 
 		[Export ("initWithRecordName:")]
-		IntPtr Constructor (string recordName);
+		NativeHandle Constructor (string recordName);
 
 		[DesignatedInitializer]
 		[Export ("initWithRecordName:zoneID:")]
-		IntPtr Constructor (string recordName, CKRecordZoneID zoneId);
+		NativeHandle Constructor (string recordName, CKRecordZoneID zoneId);
 
 		[Export ("recordName", ArgumentSemantic.Retain)]
 		string RecordName { get; }
@@ -1562,10 +1566,10 @@ namespace CloudKit {
 		NSString DefaultName { get; }
 
 		[Export ("initWithZoneName:")]
-		IntPtr Constructor (string zoneName);
+		NativeHandle Constructor (string zoneName);
 
 		[Export ("initWithZoneID:")]
-		IntPtr Constructor (CKRecordZoneID zoneId);
+		NativeHandle Constructor (CKRecordZoneID zoneId);
 
 		[Export ("zoneID", ArgumentSemantic.Retain)]
 		CKRecordZoneID ZoneId { get; }
@@ -1590,7 +1594,7 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithZoneName:ownerName:")]
-		IntPtr Constructor (string zoneName, string ownerName);
+		NativeHandle Constructor (string zoneName, string ownerName);
 
 		[Export ("zoneName", ArgumentSemantic.Retain)]
 		string ZoneName { get; }
@@ -1607,10 +1611,10 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithRecordID:action:")]
-		IntPtr Constructor (CKRecordID recordId, CKReferenceAction action);
+		NativeHandle Constructor (CKRecordID recordId, CKReferenceAction action);
 
 		[Export ("initWithRecord:action:")]
-		IntPtr Constructor (CKRecord record, CKReferenceAction action);
+		NativeHandle Constructor (CKRecord record, CKReferenceAction action);
 
 		[Export ("referenceAction", ArgumentSemantic.Assign)]
 		CKReferenceAction ReferenceAction { get; }
@@ -1626,11 +1630,11 @@ namespace CloudKit {
 	interface CKQuerySubscription : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithRecordType:predicate:options:")]
-		IntPtr Constructor (string recordType, NSPredicate predicate, CKQuerySubscriptionOptions querySubscriptionOptions);
+		NativeHandle Constructor (string recordType, NSPredicate predicate, CKQuerySubscriptionOptions querySubscriptionOptions);
 
 		[Export ("initWithRecordType:predicate:subscriptionID:options:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string recordType, NSPredicate predicate, string subscriptionID, CKQuerySubscriptionOptions querySubscriptionOptions);
+		NativeHandle Constructor (string recordType, NSPredicate predicate, string subscriptionID, CKQuerySubscriptionOptions querySubscriptionOptions);
 
 		[Export ("recordType")]
 		string RecordType { get; }
@@ -1652,11 +1656,11 @@ namespace CloudKit {
 	interface CKRecordZoneSubscription : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithZoneID:")]
-		IntPtr Constructor (CKRecordZoneID zoneID);
+		NativeHandle Constructor (CKRecordZoneID zoneID);
 
 		[Export ("initWithZoneID:subscriptionID:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CKRecordZoneID zoneID, string subscriptionID);
+		NativeHandle Constructor (CKRecordZoneID zoneID, string subscriptionID);
 
 		[Export ("zoneID", ArgumentSemantic.Copy)]
 		// we need the setter since it was bound in the base type
@@ -1673,7 +1677,7 @@ namespace CloudKit {
 	{
 		[Export ("initWithSubscriptionID:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string subscriptionID);
+		NativeHandle Constructor (string subscriptionID);
 
 		[NullAllowed, Export ("recordType")]
 		string RecordType { get; set; }
@@ -1689,13 +1693,13 @@ namespace CloudKit {
 		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'CKQuerySubscription'.")]
 		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use 'CKQuerySubscription'.")]
 		[Export ("initWithRecordType:predicate:options:")]
-		IntPtr Constructor (string recordType, NSPredicate predicate, CKSubscriptionOptions subscriptionOptions);
+		NativeHandle Constructor (string recordType, NSPredicate predicate, CKSubscriptionOptions subscriptionOptions);
 
 		[NoWatch]
 		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'CKQuerySubscription'.")]
 		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use 'CKQuerySubscription'.")]
 		[Export ("initWithRecordType:predicate:subscriptionID:options:")]
-		IntPtr Constructor (string recordType, NSPredicate predicate, string subscriptionId, CKSubscriptionOptions subscriptionOptions);
+		NativeHandle Constructor (string recordType, NSPredicate predicate, string subscriptionId, CKSubscriptionOptions subscriptionOptions);
 
 		[Export ("subscriptionID")]
 		string SubscriptionId { get; }
@@ -1835,10 +1839,10 @@ namespace CloudKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithAPIToken:")]
-		IntPtr Constructor (string token);
+		NativeHandle Constructor (string token);
 
 		[NullAllowed]
 		[Export ("APIToken")]
@@ -1856,10 +1860,10 @@ namespace CloudKit {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithUserIdentityLookupInfos:")]
-		IntPtr Constructor (CKUserIdentityLookupInfo[] userIdentityLookupInfos);
+		NativeHandle Constructor (CKUserIdentityLookupInfo[] userIdentityLookupInfos);
 
 		[Export ("userIdentityLookupInfos", ArgumentSemantic.Copy)]
 		CKUserIdentityLookupInfo[] UserIdentityLookupInfos { get; set; }
@@ -1878,7 +1882,7 @@ namespace CloudKit {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[NullAllowed, Export ("userIdentityDiscoveredBlock", ArgumentSemantic.Copy)]
 		Action<CKUserIdentity> Discovered { get; set; }
@@ -1897,10 +1901,10 @@ namespace CloudKit {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithUserIdentityLookupInfos:")]
-		IntPtr Constructor (CKUserIdentityLookupInfo[] userIdentityLookupInfos);
+		NativeHandle Constructor (CKUserIdentityLookupInfo[] userIdentityLookupInfos);
 
 		[NullAllowed]
 		[Export ("userIdentityLookupInfos", ArgumentSemantic.Copy)]
@@ -1933,10 +1937,10 @@ namespace CloudKit {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithShareMetadatas:")]
-		IntPtr Constructor (CKShareMetadata[] shareMetadatas);
+		NativeHandle Constructor (CKShareMetadata[] shareMetadatas);
 
 		[Export ("shareMetadatas", ArgumentSemantic.Copy)]
 		[NullAllowed]
@@ -1959,10 +1963,10 @@ namespace CloudKit {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithShareURLs:")]
-		IntPtr Constructor (NSUrl[] shareUrls);
+		NativeHandle Constructor (NSUrl[] shareUrls);
 
 		[NullAllowed]
 		[Export ("shareURLs", ArgumentSemantic.Copy)]
@@ -1991,10 +1995,10 @@ namespace CloudKit {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithPreviousServerChangeToken:")]
-		IntPtr Constructor ([NullAllowed] CKServerChangeToken previousServerChangeToken);
+		NativeHandle Constructor ([NullAllowed] CKServerChangeToken previousServerChangeToken);
 
 		[NullAllowed, Export ("previousServerChangeToken", ArgumentSemantic.Copy)]
 		CKServerChangeToken PreviousServerChangeToken { get; set; }

--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -12,6 +12,9 @@ using System.ComponentModel;
 using ObjCRuntime;
 using Foundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
 
 namespace Contacts {
 
@@ -295,7 +298,7 @@ namespace Contacts {
 		[DesignatedInitializer]
 		[Export ("initWithKeysToFetch:")]
 		[Protected] // we cannot use ICNKeyDescriptor as Apple (and others) can adopt it from categories
-		IntPtr Constructor (NSArray keysToFetch);
+		NativeHandle Constructor (NSArray keysToFetch);
 
 		[NullAllowed]
 		[Export ("predicate", ArgumentSemantic.Copy)]
@@ -400,7 +403,7 @@ namespace Contacts {
 		CNContactRelation FromName (string name);
 
 		[Export ("initWithName:")]
-		IntPtr Constructor (string name);
+		NativeHandle Constructor (string name);
 
 		[Export ("name")]
 		string Name { get; }
@@ -1756,7 +1759,7 @@ namespace Contacts {
 	interface CNInstantMessageAddress : NSCopying, NSSecureCoding, INSCopying, INSSecureCoding {
 
 		[Export ("initWithUsername:service:")]
-		IntPtr Constructor (string username, string service);
+		NativeHandle Constructor (string username, string service);
 
 		[Export ("username")]
 		string Username { get; }
@@ -1842,7 +1845,7 @@ namespace Contacts {
 		ValueType FromLabel ([NullAllowed] string label, ValueType value);
 
 		[Export ("initWithLabel:value:")]
-		IntPtr Constructor ([NullAllowed] string label, ValueType value);
+		NativeHandle Constructor ([NullAllowed] string label, ValueType value);
 
 		[Export ("labeledValueBySettingLabel:")]
 		ValueType GetLabeledValue ([NullAllowed] string label);
@@ -2065,7 +2068,7 @@ namespace Contacts {
 		CNPhoneNumber PhoneNumberWithStringValue (string stringValue);
 
 		[Export ("initWithStringValue:")]
-		IntPtr Constructor (string stringValue);
+		NativeHandle Constructor (string stringValue);
 
 		[Export ("stringValue")]
 		string StringValue { get; }
@@ -2294,7 +2297,7 @@ namespace Contacts {
 		string Service { get; }
 
 		[Export ("initWithUrlString:username:userIdentifier:service:")]
-		IntPtr Constructor ([NullAllowed] string url, [NullAllowed] string username, [NullAllowed] string userIdentifier, [NullAllowed] string service);
+		NativeHandle Constructor ([NullAllowed] string url, [NullAllowed] string username, [NullAllowed] string userIdentifier, [NullAllowed] string service);
 
 		[Static]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]

--- a/src/contactsui.cs
+++ b/src/contactsui.cs
@@ -18,6 +18,10 @@ using AppKit;
 using UIKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ContactsUI {
 
 #if !MONOMAC
@@ -26,7 +30,7 @@ namespace ContactsUI {
 	interface CNContactPickerViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[NullAllowed] // TODO: Maybe we can Strongify this puppy
 		[Export ("displayedPropertyKeys")]
@@ -98,7 +102,7 @@ namespace ContactsUI {
 	interface CNContactViewController
 	{
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Static]
 		[Export ("descriptorForRequiredKeys")]
@@ -113,7 +117,7 @@ namespace ContactsUI {
 	interface CNContactViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Static]
 		[Export ("descriptorForRequiredKeys")]

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -50,6 +50,10 @@ using ObjCRuntime;
 using Metal;
 using SceneKit; // For SCNAnimationEvent
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreAnimation {
 
 	[BaseType (typeof (NSObject))]
@@ -126,7 +130,7 @@ namespace CoreAnimation {
 		CAConstraint Create (CAConstraintAttribute attribute, string relativeToSource, CAConstraintAttribute srcAttribute);
 
 		[Export ("initWithAttribute:relativeTo:attribute:scale:offset:")]
-		IntPtr Constructor (CAConstraintAttribute attribute, string relativeToSource, CAConstraintAttribute srcAttr, nfloat scale, nfloat offset);
+		NativeHandle Constructor (CAConstraintAttribute attribute, string relativeToSource, CAConstraintAttribute srcAttr, nfloat scale, nfloat offset);
 	}
 #endif
 
@@ -1450,7 +1454,7 @@ namespace CoreAnimation {
 		CAMediaTimingFunction FromControlPoints (float c1x, float c1y, float c2x, float c2y); /* all float, not CGFloat */
 	
 		[Export ("initWithControlPoints::::")]
-		IntPtr Constructor (float c1x, float c1y, float c2x, float c2y); /* all float, not CGFloat */
+		NativeHandle Constructor (float c1x, float c1y, float c2x, float c2y); /* all float, not CGFloat */
 	
 		[Export ("getControlPointAtIndex:values:"), Internal]
 		void GetControlPointAtIndex (nint idx, IntPtr /* float[2] */ point);
@@ -1787,7 +1791,7 @@ namespace CoreAnimation {
 	interface CAEmitterBehavior : NSSecureCoding {
 
 		// [Export ("initWithType:")]
-		// IntPtr Constructor (NSString type);
+		// NativeHandle Constructor (NSString type);
 
 		[Export ("enabled")]
 		bool Enabled { [Bind ("isEnabled")] get; set; }

--- a/src/coreaudiokit.cs
+++ b/src/coreaudiokit.cs
@@ -28,6 +28,10 @@ using NSWindowController = Foundation.NSObject;
 using NSViewController = Foundation.NSObject;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreAudioKit {
 	[NoiOS]
 	[Mac (10,11)]
@@ -43,14 +47,14 @@ namespace CoreAudioKit {
 	interface AUViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 	}
 
 	[iOS (11,0)][Mac (10,13)]
 	[BaseType (typeof (NSObject))]
 	interface AUAudioUnitViewConfiguration : NSSecureCoding {
 		[Export ("initWithWidth:height:hostHasController:")]
-		IntPtr Constructor (nfloat width, nfloat height, bool hostHasController);
+		NativeHandle Constructor (nfloat width, nfloat height, bool hostHasController);
 
 		[Export ("width")]
 		nfloat Width { get; }
@@ -96,10 +100,10 @@ namespace CoreAudioKit {
 		bool ShowsExpertParameters { get; set; }
 
 		[Export ("initWithAudioUnit:")]
-		IntPtr Constructor (AudioUnit.AudioUnit au);
+		NativeHandle Constructor (AudioUnit.AudioUnit au);
 
 		[Export ("initWithAudioUnit:displayFlags:")]
-		IntPtr Constructor (AudioUnit.AudioUnit au, AUGenericViewDisplayFlags inFlags);
+		NativeHandle Constructor (AudioUnit.AudioUnit au, AUGenericViewDisplayFlags inFlags);
 	}
 
 	[NoiOS]
@@ -122,7 +126,7 @@ namespace CoreAudioKit {
 	interface CABtleMidiWindowController {
 
 		[Export ("initWithWindow:")]
-		IntPtr Constructor ([NullAllowed] NSWindow window);
+		NativeHandle Constructor ([NullAllowed] NSWindow window);
 	}
 
 	[NoiOS]
@@ -131,7 +135,7 @@ namespace CoreAudioKit {
 	interface CAInterDeviceAudioViewController {
 
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 	}
 
 	[NoiOS]
@@ -141,7 +145,7 @@ namespace CoreAudioKit {
 	interface CANetworkBrowserWindowController {
 
 		[Export ("initWithWindow:")]
-		IntPtr Constructor ([NullAllowed] NSWindow window);
+		NativeHandle Constructor ([NullAllowed] NSWindow window);
 
 		[Static]
 		[Export ("isAVBSupported")]
@@ -155,11 +159,11 @@ namespace CoreAudioKit {
 	interface CABTMidiCentralViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[iOS (8,3)]
 		[Export ("initWithStyle:")]
-		IntPtr Constructor (UITableViewStyle withStyle);
+		NativeHandle Constructor (UITableViewStyle withStyle);
 	}
 
 	[iOS (8,0)]
@@ -167,7 +171,7 @@ namespace CoreAudioKit {
 	interface CABTMidiLocalPeripheralViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 	}
 
 	[iOS (8,0)]
@@ -176,7 +180,7 @@ namespace CoreAudioKit {
 	[BaseType (typeof (UIView))]
 	interface CAInterAppAudioSwitcherView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect bounds);
+		NativeHandle Constructor (CGRect bounds);
 		
 		[Export ("showingAppNames")]
 		bool ShowingAppNames { [Bind ("isShowingAppNames")] get; set; }
@@ -194,7 +198,7 @@ namespace CoreAudioKit {
 	[BaseType (typeof (UIView))]
 	interface CAInterAppAudioTransportView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect bounds);
+		NativeHandle Constructor (CGRect bounds);
 		
 		[Export ("enabled")]
 		bool Enabled { [Bind ("isEnabled")] get; set; }

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -14,6 +14,10 @@ using Foundation;
 using System;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreBluetooth {
 
 	[Watch (4,0)]
@@ -128,17 +132,17 @@ namespace CoreBluetooth {
 		
 		[Export ("initWithDelegate:queue:")]
 		[PostGet ("WeakDelegate")]
-		IntPtr Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue);
+		NativeHandle Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue);
 
 		[DesignatedInitializer]
 		[iOS (7,0), Mac (10,9)]
 		[Export ("initWithDelegate:queue:options:")]
 		[PostGet ("WeakDelegate")]
-		IntPtr Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
 
 		[iOS (7,0), Mac (10,9)]
 		[Wrap ("this (centralDelegate, queue, options.GetDictionary ())")]
-		IntPtr Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, CBCentralInitOptions options);
+		NativeHandle Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, CBCentralInitOptions options);
 
 		[Export ("scanForPeripheralsWithServices:options:"), Internal]
 		void ScanForPeripherals ([NullAllowed] NSArray serviceUUIDs, [NullAllowed] NSDictionary options);
@@ -437,7 +441,7 @@ namespace CoreBluetooth {
 		[Export ("initWithType:properties:value:permissions:")]
 		[PostGet ("UUID")]
 		[PostGet ("Value")]
-		IntPtr Constructor (CBUUID uuid, CBCharacteristicProperties properties, [NullAllowed] NSData value, CBAttributePermissions permissions);
+		NativeHandle Constructor (CBUUID uuid, CBCharacteristicProperties properties, [NullAllowed] NSData value, CBAttributePermissions permissions);
 
 		[Export ("permissions", ArgumentSemantic.Assign)]
 		CBAttributePermissions Permissions { get; set; }
@@ -486,7 +490,7 @@ namespace CoreBluetooth {
 		[Export ("initWithType:value:")]
 		[PostGet ("UUID")]
 		[PostGet ("Value")]
-		IntPtr Constructor (CBUUID uuid, [NullAllowed] NSObject descriptorValue);
+		NativeHandle Constructor (CBUUID uuid, [NullAllowed] NSObject descriptorValue);
 	}
 
 	[Watch (4,0)]
@@ -686,7 +690,7 @@ namespace CoreBluetooth {
 		[DesignatedInitializer]
 		[Export ("initWithType:primary:")]
 		[PostGet ("UUID")]
-		IntPtr Constructor (CBUUID uuid, bool primary);
+		NativeHandle Constructor (CBUUID uuid, bool primary);
 
 		[Export ("includedServices", ArgumentSemantic.Retain)]
 		[Override]
@@ -865,13 +869,13 @@ namespace CoreBluetooth {
 	interface CBPeripheralManager {
 
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[NoTV]
 		[NoWatch]
 		[Export ("initWithDelegate:queue:")]
 		[PostGet ("WeakDelegate")]
-		IntPtr Constructor ([NullAllowed][Protocolize] CBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue);
+		NativeHandle Constructor ([NullAllowed][Protocolize] CBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue);
 
 		[NoTV]
 		[NoWatch]
@@ -879,7 +883,7 @@ namespace CoreBluetooth {
 		[iOS (7,0)]
 		[Export ("initWithDelegate:queue:options:")]
 		[PostGet ("WeakDelegate")]
-		IntPtr Constructor ([NullAllowed][Protocolize] CBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor ([NullAllowed][Protocolize] CBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
 
 		[NullAllowed]
 		[Wrap ("WeakDelegate")]

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -18,6 +18,10 @@ using AppKit;
 using CoreSpotlight;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreData
 {
 	[StrongDictionary ("UserInfoKeys")]
@@ -84,7 +88,7 @@ namespace CoreData
 	interface NSAtomicStore {
 
 		[Export ("initWithPersistentStoreCoordinator:configurationName:URL:options:")]
-		IntPtr Constructor ([NullAllowed] NSPersistentStoreCoordinator coordinator, [NullAllowed] string configurationName, NSUrl url, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor ([NullAllowed] NSPersistentStoreCoordinator coordinator, [NullAllowed] string configurationName, NSUrl url, [NullAllowed] NSDictionary options);
 
 		[Export ("load:")]
 		bool Load (out NSError error);
@@ -139,7 +143,7 @@ namespace CoreData
 	interface NSFetchIndexElementDescription : NSCoding, NSCopying
 	{
 		[Export ("initWithProperty:collationType:")]
-		IntPtr Constructor (NSPropertyDescription property, NSFetchIndexElementType collationType);
+		NativeHandle Constructor (NSPropertyDescription property, NSFetchIndexElementType collationType);
 
 		[NullAllowed, Export ("property", ArgumentSemantic.Retain)]
 		NSPropertyDescription Property { get; }
@@ -162,7 +166,7 @@ namespace CoreData
 	interface NSFetchIndexDescription : NSCoding, NSCopying
 	{
 		[Export ("initWithName:elements:")]
-		IntPtr Constructor (string name, [NullAllowed] NSFetchIndexElementDescription[] elements);
+		NativeHandle Constructor (string name, [NullAllowed] NSFetchIndexElementDescription[] elements);
 
 		[Export ("name")]
 		string Name { get; set; }
@@ -183,7 +187,7 @@ namespace CoreData
 	interface NSAtomicStoreCacheNode {
 
 		[Export ("initWithObjectID:")]
-		IntPtr Constructor (NSManagedObjectID moid);
+		NativeHandle Constructor (NSManagedObjectID moid);
 
 		[Export ("objectID", ArgumentSemantic.Strong)]
 		NSManagedObjectID ObjectID { get; }
@@ -440,7 +444,7 @@ namespace CoreData
 		[Internal]
 		[DesignatedInitializer]
 		[Export ("initWithExpressionType:")]
-		IntPtr Constructor (NSExpressionType type);
+		NativeHandle Constructor (NSExpressionType type);
 
 		[Static, Export ("expressionForFetch:context:countOnly:")]
 		NSFetchRequestExpression FromFetch (NSExpression fetch, NSExpression context, bool countOnly);
@@ -467,7 +471,7 @@ namespace CoreData
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("entity", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -523,7 +527,7 @@ namespace CoreData
 		NSFetchRequest FromEntityName (string entityName);
 
 		[Export ("initWithEntityName:")]
-		IntPtr Constructor (string entityName);
+		NativeHandle Constructor (string entityName);
 
 		[NullAllowed, Export ("entityName", ArgumentSemantic.Strong)]
 		string EntityName { get; }
@@ -552,7 +556,7 @@ namespace CoreData
 	interface NSFetchedResultsController {
 
 		[Export ("initWithFetchRequest:managedObjectContext:sectionNameKeyPath:cacheName:")]
-		IntPtr Constructor (NSFetchRequest fetchRequest, NSManagedObjectContext context, [NullAllowed] string sectionNameKeyPath, [NullAllowed] string name);
+		NativeHandle Constructor (NSFetchRequest fetchRequest, NSManagedObjectContext context, [NullAllowed] string sectionNameKeyPath, [NullAllowed] string name);
 
 		[Wrap ("WeakDelegate")]
 		[Protocolize]
@@ -672,7 +676,7 @@ namespace CoreData
 		[Protected]
 #endif
 		[Export ("initWithPersistentStoreCoordinator:configurationName:URL:options:")]
-		IntPtr Constructor (NSPersistentStoreCoordinator root, string name, NSUrl url, NSDictionary options);
+		NativeHandle Constructor (NSPersistentStoreCoordinator root, string name, NSUrl url, NSDictionary options);
 
 		[Export ("loadMetadata:")]
 		bool LoadMetadata (out NSError error);
@@ -719,9 +723,9 @@ namespace CoreData
 	interface NSIncrementalStoreNode {
 		[Export ("initWithObjectID:withValues:version:")]
 #if XAMCORE_4_0
-		IntPtr Constructor (NSManagedObjectID objectID, NSDictionary<NSString, NSObject> values, ulong version);
+		NativeHandle Constructor (NSManagedObjectID objectID, NSDictionary<NSString, NSObject> values, ulong version);
 #else 
-		IntPtr Constructor (NSManagedObjectID objectId, NSDictionary values, ulong version);
+		NativeHandle Constructor (NSManagedObjectID objectId, NSDictionary values, ulong version);
 #endif
 
 		[Export ("updateWithValues:version:")]
@@ -749,11 +753,11 @@ namespace CoreData
 	interface NSManagedObject : NSFetchRequestResult {
 		[DesignatedInitializer]
 		[Export ("initWithEntity:insertIntoManagedObjectContext:")]
-		IntPtr Constructor (NSEntityDescription entity, [NullAllowed] NSManagedObjectContext context);
+		NativeHandle Constructor (NSEntityDescription entity, [NullAllowed] NSManagedObjectContext context);
 
 		[Watch (3,0), TV (10,0), iOS (10,0), Mac (10,12)]
 		[Export ("initWithContext:")]
-		IntPtr Constructor (NSManagedObjectContext moc);
+		NativeHandle Constructor (NSManagedObjectContext moc);
 
 		[Watch (3, 0), TV (10, 0), iOS (10, 0), Mac (10,12)]
 		[Static]
@@ -935,7 +939,7 @@ namespace CoreData
 		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'NSManagedObjectContext (NSManagedObjectContextConcurrencyType)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSManagedObjectContext (NSManagedObjectContextConcurrencyType)' instead.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 		
 		[NullAllowed] // by default this property is null
 		[Export ("persistentStoreCoordinator", ArgumentSemantic.Retain)]
@@ -1072,7 +1076,7 @@ namespace CoreData
 
 		[DesignatedInitializer]
 		[Export ("initWithConcurrencyType:")]
-		IntPtr Constructor (NSManagedObjectContextConcurrencyType ct);
+		NativeHandle Constructor (NSManagedObjectContextConcurrencyType ct);
 
 		[Export ("performBlock:")]
 		void Perform (/* non null */ Action action);
@@ -1225,7 +1229,7 @@ namespace CoreData
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Static, Export ("mergedModelFromBundles:")]
 		[return: NullAllowed]
@@ -1236,7 +1240,7 @@ namespace CoreData
 		NSManagedObjectModel ModelByMergingModels ([NullAllowed] NSManagedObjectModel[] models);
 
 		[Export ("initWithContentsOfURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("entitiesByName", ArgumentSemantic.Copy)]
 #if XAMCORE_4_0
@@ -1342,7 +1346,7 @@ namespace CoreData
 		NSMappingModel GetInferredMappingModel (NSManagedObjectModel source, NSManagedObjectModel destination, out NSError error);
 
 		[Export ("initWithContentsOfURL:")]
-		IntPtr Constructor ([NullAllowed] NSUrl url);
+		NativeHandle Constructor ([NullAllowed] NSUrl url);
 
 		[Export ("entityMappings", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -1396,9 +1400,9 @@ namespace CoreData
 		[DesignatedInitializer]
 		[Export ("initWithSource:newVersion:oldVersion:cachedSnapshot:persistedSnapshot:")]
 #if XAMCORE_4_0
-		IntPtr Constructor (NSManagedObject srcObject, nuint newvers, nuint oldvers, [NullAllowed] NSDictionary<NSString, NSObject> cachesnap, [NullAllowed] NSDictionary<NSString, NSObject> persnap);
+		NativeHandle Constructor (NSManagedObject srcObject, nuint newvers, nuint oldvers, [NullAllowed] NSDictionary<NSString, NSObject> cachesnap, [NullAllowed] NSDictionary<NSString, NSObject> persnap);
 #else
-		IntPtr Constructor (NSManagedObject srcObject, nuint newvers, nuint oldvers, [NullAllowed] NSDictionary cachesnap, [NullAllowed] NSDictionary persnap);
+		NativeHandle Constructor (NSManagedObject srcObject, nuint newvers, nuint oldvers, [NullAllowed] NSDictionary cachesnap, [NullAllowed] NSDictionary persnap);
 #endif
 	}
 
@@ -1410,7 +1414,7 @@ namespace CoreData
 
 		[DesignatedInitializer]
 		[Export ("initWithMergeType:")]
-		IntPtr Constructor (NSMergePolicyType ty);
+		NativeHandle Constructor (NSMergePolicyType ty);
 
 		[Export ("resolveConflicts:error:")]
 #if XAMCORE_4_0
@@ -1452,7 +1456,7 @@ namespace CoreData
 	interface NSMigrationManager {
 
 		[Export ("initWithSourceModel:destinationModel:")]
-		IntPtr Constructor (NSManagedObjectModel sourceModel, NSManagedObjectModel destinationModel);
+		NativeHandle Constructor (NSManagedObjectModel sourceModel, NSManagedObjectModel destinationModel);
 
 		[Export ("migrateStoreFromURL:type:options:withMappingModel:toDestinationURL:destinationType:destinationOptions:error:")]
 		bool MigrateStoreFromUrl (NSUrl sourceUrl, string sStoreType, [NullAllowed] NSDictionary sOptions, [NullAllowed] NSMappingModel mappings, NSUrl dUrl, string dStoreType, [NullAllowed] NSDictionary dOptions, out NSError error);
@@ -1680,7 +1684,7 @@ namespace CoreData
 		[Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[Export ("initForStoreWithDescription:coordinator:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSPersistentStoreDescription description, NSPersistentStoreCoordinator psc);
+		NativeHandle Constructor (NSPersistentStoreDescription description, NSPersistentStoreCoordinator psc);
 
 		[Export ("domainIdentifier")]
 		string DomainIdentifier { get; }
@@ -1691,7 +1695,7 @@ namespace CoreData
 		[Deprecated (PlatformName.iOS, 15,0, message: "Use the constructor that takes a NSPersistentStoreCoordinator instead.")]
 		[Deprecated (PlatformName.MacOSX, 12,0, message: "Use the constructor that takes a NSPersistentStoreCoordinator instead.")]
 		[Export ("initForStoreWithDescription:model:")]
-		IntPtr Constructor (NSPersistentStoreDescription description, NSManagedObjectModel model);
+		NativeHandle Constructor (NSPersistentStoreDescription description, NSManagedObjectModel model);
 
 		[Export ("attributeSetForObject:")]
 		[return: NullAllowed]
@@ -1755,7 +1759,7 @@ namespace CoreData
 #endif
 		[DesignatedInitializer]
 		[Export ("initWithPersistentStoreCoordinator:configurationName:URL:options:")]
-		IntPtr Constructor ([NullAllowed] NSPersistentStoreCoordinator root, [NullAllowed] string name, NSUrl url, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor ([NullAllowed] NSPersistentStoreCoordinator root, [NullAllowed] string name, NSUrl url, [NullAllowed] NSDictionary options);
 		
 		[Export ("loadMetadata:")]
 		bool LoadMetadata (out NSError error);
@@ -1875,7 +1879,7 @@ namespace CoreData
 
 		[Export ("initWithURL:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		// NSPersistentStoreDescription_NSPersistentCloudKitContainerAdditions category
 		[Watch (6, 0), TV (13, 0), Mac (10, 15), iOS (13, 0)]
@@ -1916,11 +1920,11 @@ namespace CoreData
 		NSPersistentStoreDescription[] PersistentStoreDescriptions { get; set; }
 
 		[Export ("initWithName:")]
-		IntPtr Constructor (string name);
+		NativeHandle Constructor (string name);
 
 		[Export ("initWithName:managedObjectModel:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string name, NSManagedObjectModel model);
+		NativeHandle Constructor (string name, NSManagedObjectModel model);
 
 		[Export ("loadPersistentStoresWithCompletionHandler:")]
 		[Async]
@@ -1989,7 +1993,7 @@ namespace CoreData
 
 		[DesignatedInitializer]
 		[Export ("initWithManagedObjectModel:")]
-		IntPtr Constructor (NSManagedObjectModel model);
+		NativeHandle Constructor (NSManagedObjectModel model);
 
 		[Export ("managedObjectModel", ArgumentSemantic.Strong)]
 		NSManagedObjectModel ManagedObjectModel { get; }
@@ -2319,7 +2323,7 @@ namespace CoreData
 	[BaseType (typeof (NSPersistentStoreRequest))]
 	interface NSAsynchronousFetchRequest {
 		[Export ("initWithFetchRequest:completionBlock:")]
-		IntPtr Constructor (NSFetchRequest request, [NullAllowed] Action<NSAsynchronousFetchResult> completion);
+		NativeHandle Constructor (NSFetchRequest request, [NullAllowed] Action<NSAsynchronousFetchResult> completion);
 
 		[Export ("fetchRequest", ArgumentSemantic.Retain)]
 		NSFetchRequest FetchRequest { get; }
@@ -2436,9 +2440,9 @@ namespace CoreData
 	interface NSSaveChangesRequest {
 		[Export ("initWithInsertedObjects:updatedObjects:deletedObjects:lockedObjects:")]
 #if XAMCORE_4_0
-		IntPtr Constructor ([NullAllowed] NSSet<NSManagedObject> insertedObjects, [NullAllowed] NSSet<NSManagedObject> updatedObjects, [NullAllowed] NSSet<NSManagedObject> deletedObjects, [NullAllowed] NSSet<NSManagedObject> lockedObjects);
+		NativeHandle Constructor ([NullAllowed] NSSet<NSManagedObject> insertedObjects, [NullAllowed] NSSet<NSManagedObject> updatedObjects, [NullAllowed] NSSet<NSManagedObject> deletedObjects, [NullAllowed] NSSet<NSManagedObject> lockedObjects);
 #else
-		IntPtr Constructor ([NullAllowed] NSSet insertedObjects, [NullAllowed] NSSet updatedObjects, [NullAllowed] NSSet deletedObjects, [NullAllowed] NSSet lockedObjects);
+		NativeHandle Constructor ([NullAllowed] NSSet insertedObjects, [NullAllowed] NSSet updatedObjects, [NullAllowed] NSSet deletedObjects, [NullAllowed] NSSet lockedObjects);
 #endif
 
 		[NullAllowed, Export ("insertedObjects", ArgumentSemantic.Strong)]
@@ -2475,11 +2479,11 @@ namespace CoreData
 	interface NSBatchUpdateRequest {
 		[Export ("initWithEntityName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string entityName);
+		NativeHandle Constructor (string entityName);
 
 		[Export ("initWithEntity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSEntityDescription entity);
+		NativeHandle Constructor (NSEntityDescription entity);
 
 		[Export ("entityName")]
 		string EntityName { get; }
@@ -2512,10 +2516,10 @@ namespace CoreData
 	{
 		[Export ("initWithFetchRequest:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSFetchRequest fetch);
+		NativeHandle Constructor (NSFetchRequest fetch);
 
 		[Export ("initWithObjectIDs:")]
-		IntPtr Constructor (NSManagedObjectID[] objects);
+		NativeHandle Constructor (NSManagedObjectID[] objects);
 
 		[Export ("resultType", ArgumentSemantic.Assign)]
 		NSBatchDeleteRequestResultType ResultType { get; set; }
@@ -2541,7 +2545,7 @@ namespace CoreData
 	{
 		[Export ("initWithConstraint:databaseObject:databaseSnapshot:conflictingObjects:conflictingSnapshots:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string[] contraint, [NullAllowed] NSManagedObject databaseObject, [NullAllowed] NSDictionary databaseSnapshot, NSManagedObject[] conflictingObjects, NSObject[] conflictingSnapshots);
+		NativeHandle Constructor (string[] contraint, [NullAllowed] NSManagedObject databaseObject, [NullAllowed] NSDictionary databaseSnapshot, NSManagedObject[] conflictingObjects, NSObject[] conflictingSnapshots);
 
 #if MONOMAC
 		[Export ("constraint", ArgumentSemantic.Copy)]
@@ -2596,23 +2600,23 @@ namespace CoreData
 		[Deprecated (PlatformName.MacOSX, 10,16, message: "Use another constructor instead.")]
 		[NoMacCatalyst]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Watch (7,0), TV (14,0), Mac (11,0), iOS (14,0)]
 		[Export ("initWithEntity:dictionaryHandler:")]
-		IntPtr Constructor (NSEntityDescription entity, NSBatchInsertRequestDictionaryHandler handler);
+		NativeHandle Constructor (NSEntityDescription entity, NSBatchInsertRequestDictionaryHandler handler);
 
 		[Watch (7,0), TV (14,0), Mac (11,0), iOS (14,0)]
 		[Export ("initWithEntity:managedObjectHandler:")]
-		IntPtr Constructor (NSEntityDescription entity, NSBatchInsertRequestManagedObjectHandler handler);
+		NativeHandle Constructor (NSEntityDescription entity, NSBatchInsertRequestManagedObjectHandler handler);
 
 		[Watch (7,0), TV (14,0), Mac (11,0), iOS (14,0)]
 		[Export ("initWithEntityName:dictionaryHandler:")]
-		IntPtr Constructor (string entityName, NSBatchInsertRequestDictionaryHandler handler);
+		NativeHandle Constructor (string entityName, NSBatchInsertRequestDictionaryHandler handler);
 
 		[Watch (7,0), TV (14,0), Mac (11,0), iOS (14,0)]
 		[Export ("initWithEntityName:managedObjectHandler:")]
-		IntPtr Constructor (string entityName, NSBatchInsertRequestManagedObjectHandler handler);
+		NativeHandle Constructor (string entityName, NSBatchInsertRequestManagedObjectHandler handler);
 
 		[Export ("entityName")]
 		string EntityName { get; }
@@ -2632,11 +2636,11 @@ namespace CoreData
 
 		[DesignatedInitializer]
 		[Export ("initWithEntityName:objects:")]
-		IntPtr Constructor (string entityName, NSDictionary<NSString, NSObject>[] dictionaries);
+		NativeHandle Constructor (string entityName, NSDictionary<NSString, NSObject>[] dictionaries);
 
 		[DesignatedInitializer]
 		[Export ("initWithEntity:objects:")]
-		IntPtr Constructor (NSEntityDescription entity, NSDictionary<NSString, NSObject>[] dictionaries);
+		NativeHandle Constructor (NSEntityDescription entity, NSDictionary<NSString, NSObject>[] dictionaries);
 
 		[Watch (7, 0), TV (14, 0), Mac (11, 0), iOS (14, 0)]
 		[NullAllowed, Export ("dictionaryHandler", ArgumentSemantic.Copy)]
@@ -2696,7 +2700,7 @@ namespace CoreData
 
 		[Export ("initWithName:managedObjectModel:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string name, NSManagedObjectModel model);
+		NativeHandle Constructor (string name, NSManagedObjectModel model);
 
 		[Export ("initializeCloudKitSchemaWithOptions:error:")]
 		bool Initialize (NSPersistentCloudKitContainerSchemaInitializationOptions options, [NullAllowed] out NSError error);
@@ -2774,7 +2778,7 @@ namespace CoreData
 
 		[Export ("initWithContainerIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string containerIdentifier);
+		NativeHandle Constructor (string containerIdentifier);
 
 		[Watch (7, 0), TV (14, 0), Mac (11, 0), iOS (14, 0)]
 		[Export ("databaseScope", ArgumentSemantic.Assign)]

--- a/src/corehaptics.cs
+++ b/src/corehaptics.cs
@@ -14,6 +14,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreHaptics {
 
 // we are not binding the API on Mac OS X yet due to an issue on Apples side: https://github.com/xamarin/maccore/issues/1951
@@ -34,7 +38,7 @@ namespace CoreHaptics {
 
 		[Export ("initWithParameterID:value:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([BindAs (typeof (CHHapticEventParameterId))] NSString parameterId, float value);
+		NativeHandle Constructor ([BindAs (typeof (CHHapticEventParameterId))] NSString parameterId, float value);
 	}
 
 	[Mac (10,15), iOS (13,0), TV (14,0)]
@@ -53,7 +57,7 @@ namespace CoreHaptics {
 
 		[Export ("initWithParameterID:value:relativeTime:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([BindAs (typeof (CHHapticDynamicParameterId))] NSString parameterId, float value, double time);
+		NativeHandle Constructor ([BindAs (typeof (CHHapticDynamicParameterId))] NSString parameterId, float value, double time);
 	}
 
 	[Mac (10,15), iOS (13,0), TV (14,0)]
@@ -68,7 +72,7 @@ namespace CoreHaptics {
 
 		[Export ("initWithRelativeTime:value:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double time, float value);
+		NativeHandle Constructor (double time, float value);
 	}
 
 	[Mac (10,15), iOS (13,0), TV (14,0)]
@@ -87,7 +91,7 @@ namespace CoreHaptics {
 
 		[Export ("initWithParameterID:controlPoints:relativeTime:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([BindAs (typeof (CHHapticDynamicParameterId))]NSString parameterId, CHHapticParameterCurveControlPoint[] controlPoints, double relativeTime);
+		NativeHandle Constructor ([BindAs (typeof (CHHapticDynamicParameterId))]NSString parameterId, CHHapticParameterCurveControlPoint[] controlPoints, double relativeTime);
 	}
 
 	[Mac (10,15), iOS (13,0),  TV (14,0)]
@@ -108,16 +112,16 @@ namespace CoreHaptics {
 		double Duration { get; set; }
 
 		[Export ("initWithEventType:parameters:relativeTime:")]
-		IntPtr Constructor ([BindAs (typeof (CHHapticEventType))] NSString type, CHHapticEventParameter[] eventParams, double time);
+		NativeHandle Constructor ([BindAs (typeof (CHHapticEventType))] NSString type, CHHapticEventParameter[] eventParams, double time);
 
 		[Export ("initWithEventType:parameters:relativeTime:duration:")]
-		IntPtr Constructor ([BindAs (typeof (CHHapticEventType))] NSString type, CHHapticEventParameter[] eventParams, double time, double duration);
+		NativeHandle Constructor ([BindAs (typeof (CHHapticEventType))] NSString type, CHHapticEventParameter[] eventParams, double time, double duration);
 
 		[Export ("initWithAudioResourceID:parameters:relativeTime:")]
-		IntPtr Constructor (nuint resourceId, CHHapticEventParameter[] eventParams, double time);
+		NativeHandle Constructor (nuint resourceId, CHHapticEventParameter[] eventParams, double time);
 
 		[Export ("initWithAudioResourceID:parameters:relativeTime:duration:")]
-		IntPtr Constructor (nuint resourceId, CHHapticEventParameter[] eventParams, double time, double duration);
+		NativeHandle Constructor (nuint resourceId, CHHapticEventParameter[] eventParams, double time, double duration);
 	}
 
 	interface ICHHapticParameterAttributes { }
@@ -264,12 +268,12 @@ namespace CoreHaptics {
 
 		[Export ("initAndReturnError:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] out NSError error);
+		NativeHandle Constructor ([NullAllowed] out NSError error);
 
 		[NoMac, NoTV]
 		[Export ("initWithAudioSession:error:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] AVAudioSession audioSession, [NullAllowed] out NSError error);
+		NativeHandle Constructor ([NullAllowed] AVAudioSession audioSession, [NullAllowed] out NSError error);
 
 		[Async]
 		[Export ("startWithCompletionHandler:")]
@@ -390,16 +394,16 @@ namespace CoreHaptics {
 		double Duration { get; }
 
 		[Export ("initWithEvents:parameters:error:")]
-		IntPtr Constructor (CHHapticEvent[] events, CHHapticDynamicParameter[] parameters, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (CHHapticEvent[] events, CHHapticDynamicParameter[] parameters, [NullAllowed] out NSError outError);
 
 		[Export ("initWithEvents:parameterCurves:error:")]
-		IntPtr Constructor (CHHapticEvent[] events, CHHapticParameterCurve[] parameterCurves, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (CHHapticEvent[] events, CHHapticParameterCurve[] parameterCurves, [NullAllowed] out NSError outError);
 
 		[Export ("initWithDictionary:error:")]
-		IntPtr Constructor (NSDictionary patternDict, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (NSDictionary patternDict, [NullAllowed] out NSError outError);
 
 		[Wrap ("this (patternDefinition.GetDictionary ()!, out outError)")]
-		IntPtr Constructor (CHHapticPatternDefinition patternDefinition, [NullAllowed] out NSError outError);
+		NativeHandle Constructor (CHHapticPatternDefinition patternDefinition, [NullAllowed] out NSError outError);
 
 		[Internal]
 		[Export ("exportDictionaryAndReturnError:")]

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -47,6 +47,10 @@ using AppKit;
 using ImageKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreImage {
 
 	[BaseType (typeof (NSObject))]
@@ -84,25 +88,25 @@ namespace CoreImage {
 
 		[DesignatedInitializer]
 		[Export ("initWithCGColor:")]
-		IntPtr Constructor (CGColor c);
+		NativeHandle Constructor (CGColor c);
 
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("initWithRed:green:blue:")]
-		IntPtr Constructor (nfloat red, nfloat green, nfloat blue);
+		NativeHandle Constructor (nfloat red, nfloat green, nfloat blue);
 
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
 		[Export ("initWithRed:green:blue:colorSpace:")]
-		IntPtr Constructor (nfloat red, nfloat green, nfloat blue, CGColorSpace colorSpace);
+		NativeHandle Constructor (nfloat red, nfloat green, nfloat blue, CGColorSpace colorSpace);
 
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("initWithRed:green:blue:alpha:")]
-		IntPtr Constructor (nfloat red, nfloat green, nfloat blue, nfloat alpha);
+		NativeHandle Constructor (nfloat red, nfloat green, nfloat blue, nfloat alpha);
 
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
 		[Export ("initWithRed:green:blue:alpha:colorSpace:")]
-		IntPtr Constructor (nfloat red, nfloat green, nfloat blue, nfloat alpha, CGColorSpace colorSpace);
+		NativeHandle Constructor (nfloat red, nfloat green, nfloat blue, nfloat alpha, CGColorSpace colorSpace);
 
 		[Export ("numberOfComponents")]
 		nint NumberOfComponents { get; }
@@ -194,10 +198,10 @@ namespace CoreImage {
 
 #if !MONOMAC
 		[Export ("initWithColor:")]
-		IntPtr Constructor (UIColor color);
+		NativeHandle Constructor (UIColor color);
 #else
 		[Export ("initWithColor:")]
-		IntPtr Constructor (NSColor color);
+		NativeHandle Constructor (NSColor color);
 #endif
 	}
 
@@ -207,7 +211,7 @@ namespace CoreImage {
 		// marked iOS5 but it's not working in iOS8.0
 		[iOS (9,0)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[iOS (9,0)][Mac (10,11)]
 		[Static]
@@ -237,7 +241,7 @@ namespace CoreImage {
 		[iOS (9,0)] // documented as earlier but missing
 		[Internal]
 		[Export ("initWithOptions:")]
-		IntPtr Constructor ([NullAllowed] NSDictionary options);
+		NativeHandle Constructor ([NullAllowed] NSDictionary options);
 
 		[Static]
 		[Export ("context")]
@@ -1461,7 +1465,7 @@ namespace CoreImage {
 		CIFilterGenerator FromUrl (NSUrl aURL);
 
 		[Export ("initWithContentsOfURL:")]
-		IntPtr Constructor (NSUrl aURL);
+		NativeHandle Constructor (NSUrl aURL);
 
 		[Export ("connectObject:withKey:toObject:withKey:")]
 		void ConnectObject (NSObject sourceObject, [NullAllowed] string withSourceKey, NSObject targetObject, string targetKey);
@@ -1514,7 +1518,7 @@ namespace CoreImage {
 		CIFilterShape FromRect (CGRect rect);
 
 		[Export ("initWithRect:")]
-		IntPtr Constructor (CGRect rect);
+		NativeHandle Constructor (CGRect rect);
 
 		[Export ("transformBy:interior:")]
 		CIFilterShape Transform (CGAffineTransform transformation, bool interiorFlag);
@@ -1791,127 +1795,127 @@ namespace CoreImage {
 		CIImage EmptyImage { get; }
 		
 		[Export ("initWithCGImage:")]
-		IntPtr Constructor (CGImage image);
+		NativeHandle Constructor (CGImage image);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithCGImage:options:")]
-		IntPtr Constructor (CGImage image, [NullAllowed] NSDictionary d);
+		NativeHandle Constructor (CGImage image, [NullAllowed] NSDictionary d);
 
 		[Wrap ("this (image, options.GetDictionary ())")]
-		IntPtr Constructor (CGImage image, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
+		NativeHandle Constructor (CGImage image, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
 
 		[iOS (13,0)][TV (13,0)][Mac (10,15)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithCGImageSource:index:options:")]
-		IntPtr Constructor (CGImageSource source, nuint index, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (CGImageSource source, nuint index, [NullAllowed] NSDictionary options);
 
 		[iOS (13,0)][TV (13,0)][Mac (10,15)]
 		[Wrap ("this (source, index, options.GetDictionary ())")]
-		IntPtr Constructor (CGImageSource source, nuint index, CIImageInitializationOptionsWithMetadata options);
+		NativeHandle Constructor (CGImageSource source, nuint index, CIImageInitializationOptionsWithMetadata options);
 
 #if MONOMAC
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'CIImage (CGImage)' instead.")]
 		[Export ("initWithCGLayer:")]
-		IntPtr Constructor (CGLayer layer);
+		NativeHandle Constructor (CGLayer layer);
 
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'CIImage (CGImage)' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithCGLayer:options:")]
-		IntPtr Constructor (CGLayer layer, [NullAllowed] NSDictionary d);
+		NativeHandle Constructor (CGLayer layer, [NullAllowed] NSDictionary d);
 
 		[Wrap ("this (layer, options.GetDictionary ())")]
-		IntPtr Constructor (CGLayer layer, [NullAllowed] CIImageInitializationOptions options);
+		NativeHandle Constructor (CGLayer layer, [NullAllowed] CIImageInitializationOptions options);
 #endif
 
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Export ("initWithData:options:")]
-		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary d);
+		NativeHandle Constructor (NSData data, [NullAllowed] NSDictionary d);
 
 		[Wrap ("this (data, options.GetDictionary ())")]
-		IntPtr Constructor (NSData data, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
+		NativeHandle Constructor (NSData data, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
 
 		[Export ("initWithBitmapData:bytesPerRow:size:format:colorSpace:")]
-		IntPtr Constructor (NSData d, nint bytesPerRow, CGSize size, int /* CIFormat = int */ pixelFormat, [NullAllowed] CGColorSpace colorSpace);
+		NativeHandle Constructor (NSData d, nint bytesPerRow, CGSize size, int /* CIFormat = int */ pixelFormat, [NullAllowed] CGColorSpace colorSpace);
 
 		[Deprecated (PlatformName.iOS, 12, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithTexture:size:flipped:colorSpace:")]
-		IntPtr Constructor (int /* unsigned int */ glTextureName, CGSize size, bool flipped, [NullAllowed] CGColorSpace colorSpace);
+		NativeHandle Constructor (int /* unsigned int */ glTextureName, CGSize size, bool flipped, [NullAllowed] CGColorSpace colorSpace);
 
 		[Export ("initWithContentsOfURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("initWithContentsOfURL:options:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary d);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] NSDictionary d);
 
 		[Wrap ("this (url, options.GetDictionary ())")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] CIImageInitializationOptions options);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] CIImageInitializationOptions options);
 
 		[iOS (11,0)] // IOSurface was not exposed before Xcode 9
 		[TV (11,0)]
 		[Mac (10,13)]
 		[Export ("initWithIOSurface:")]
-		IntPtr Constructor (IOSurface.IOSurface surface);
+		NativeHandle Constructor (IOSurface.IOSurface surface);
 		
 		[iOS (11,0)] // IOSurface was not exposed before Xcode 9
 		[TV (11,0)]
 		[Mac (10,13)]
 		[Export ("initWithIOSurface:options:")]
-		IntPtr Constructor (IOSurface.IOSurface surface, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (IOSurface.IOSurface surface, [NullAllowed] NSDictionary options);
 
 		[iOS (11,0)] // IOSurface was not exposed before Xcode 9
 		[TV (11,0)]
 		[Mac (10,13)]
 		[Wrap ("this (surface, options.GetDictionary ())")]
-		IntPtr Constructor (IOSurface.IOSurface surface, [NullAllowed] CIImageInitializationOptions options);
+		NativeHandle Constructor (IOSurface.IOSurface surface, [NullAllowed] CIImageInitializationOptions options);
 
 		[iOS(9,0)]
 		[Export ("initWithCVImageBuffer:")]
-		IntPtr Constructor (CVImageBuffer imageBuffer);
+		NativeHandle Constructor (CVImageBuffer imageBuffer);
 
 #if MONOMAC && !XAMCORE_4_0
 		[Export ("initWithCVImageBuffer:options:")]
-		IntPtr Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
+		NativeHandle Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
 #else
 		[iOS(9,0)]
 		[Export ("initWithCVImageBuffer:options:")]
-		IntPtr Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary<NSString, NSObject> dict);
+		NativeHandle Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary<NSString, NSObject> dict);
 
 		[iOS(9,0)]
 		[Internal] // This overload is needed for our strong dictionary support (but only for Unified, since for Classic the generic version is transformed to this signature)
 		[Sealed]
 		[Export ("initWithCVImageBuffer:options:")]
-		IntPtr Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
+		NativeHandle Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
 #endif
 
 		[iOS(9,0)]
 		[Wrap ("this (imageBuffer, options.GetDictionary ())")]
-		IntPtr Constructor (CVImageBuffer imageBuffer, [NullAllowed] CIImageInitializationOptions options);
+		NativeHandle Constructor (CVImageBuffer imageBuffer, [NullAllowed] CIImageInitializationOptions options);
 
 		[Mac (10,11)]
 		[Export ("initWithCVPixelBuffer:")]
-		IntPtr Constructor (CVPixelBuffer buffer);
+		NativeHandle Constructor (CVPixelBuffer buffer);
 
 		[Mac (10,11)]
 		[Export ("initWithCVPixelBuffer:options:")]
-		IntPtr Constructor (CVPixelBuffer buffer, [NullAllowed] NSDictionary dict);
+		NativeHandle Constructor (CVPixelBuffer buffer, [NullAllowed] NSDictionary dict);
 
 		[Mac (10,11)]
 		[Wrap ("this (buffer, options.GetDictionary ())")]
-		IntPtr Constructor (CVPixelBuffer buffer, [NullAllowed] CIImageInitializationOptions options);
+		NativeHandle Constructor (CVPixelBuffer buffer, [NullAllowed] CIImageInitializationOptions options);
 
 		[Export ("initWithColor:")]
-		IntPtr Constructor (CIColor color);
+		NativeHandle Constructor (CIColor color);
 
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("initWithMTLTexture:options:")]
-		IntPtr Constructor (IMTLTexture texture, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (IMTLTexture texture, [NullAllowed] NSDictionary options);
 
 #if MONOMAC
 		[Export ("initWithBitmapImageRep:")]
-		IntPtr Constructor (NSImageRep imageRep);
+		NativeHandle Constructor (NSImageRep imageRep);
 		
 		[Export ("drawAtPoint:fromRect:operation:fraction:")]
 		void Draw (CGPoint point, CGRect srcRect, NSCompositingOperation op, nfloat delta);
@@ -2050,13 +2054,13 @@ namespace CoreImage {
 #if !MONOMAC
 		// UIKit extensions
 		[Export ("initWithImage:")]
-		IntPtr Constructor (UIImage image);
+		NativeHandle Constructor (UIImage image);
 
 		[Export ("initWithImage:options:")]
-		IntPtr Constructor (UIImage image, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (UIImage image, [NullAllowed] NSDictionary options);
 
 		[Wrap ("this (image, options.GetDictionary ())")]
-		IntPtr Constructor (UIImage image, [NullAllowed] CIImageInitializationOptions options);
+		NativeHandle Constructor (UIImage image, [NullAllowed] CIImageInitializationOptions options);
 #endif
 	
 		[Field ("kCIImageAutoAdjustFeatures"), Internal]
@@ -2140,7 +2144,7 @@ namespace CoreImage {
 		[iOS (9,0)]
 		[Internal]
 		[Export ("initWithImageProvider:size::format:colorSpace:options:")]
-		IntPtr Constructor (ICIImageProvider provider, nuint width, nuint height, int f, [NullAllowed] CGColorSpace colorSpace, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (ICIImageProvider provider, nuint width, nuint height, int f, [NullAllowed] CGColorSpace colorSpace, [NullAllowed] NSDictionary options);
 
 		[iOS (9,0)][Mac (10,11)]
 		[Static]
@@ -2234,11 +2238,11 @@ namespace CoreImage {
 
 		[TV (12,0), iOS (12,0), Mac (10, 14)]
 		[Export ("initWithPortaitEffectsMatte:options:")] // selector typo, rdar filled 42894821
-		IntPtr Constructor (AVPortraitEffectsMatte matte, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (AVPortraitEffectsMatte matte, [NullAllowed] NSDictionary options);
 
 		[TV (12,0), iOS (12,0), Mac (10, 14)]
 		[Export ("initWithPortaitEffectsMatte:")] // selector typo, rdar filled 42894821
-		IntPtr Constructor (AVPortraitEffectsMatte matte);
+		NativeHandle Constructor (AVPortraitEffectsMatte matte);
 
 		[TV (12,0), iOS (12,0), Mac (10, 14)]
 		[Static]
@@ -2260,11 +2264,11 @@ namespace CoreImage {
 
 		[TV (13,0), iOS (13,0), Mac (10,15)]
 		[Export ("initWithSemanticSegmentationMatte:options:")]
-		IntPtr Constructor (AVSemanticSegmentationMatte matte, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (AVSemanticSegmentationMatte matte, [NullAllowed] NSDictionary options);
 
 		[TV (13,0), iOS (13,0), Mac (10,15)]
 		[Export ("initWithSemanticSegmentationMatte:")]
-		IntPtr Constructor (AVSemanticSegmentationMatte matte);
+		NativeHandle Constructor (AVSemanticSegmentationMatte matte);
 
 		[TV (13,0), iOS (13,0), Mac (10,15)]
 		[Static]
@@ -2282,11 +2286,11 @@ namespace CoreImage {
 
 		[TV (11, 0), iOS (11, 0), Mac (10,13)]
 		[Export ("initWithDepthData:options:")]
-		IntPtr Constructor (AVDepthData data, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (AVDepthData data, [NullAllowed] NSDictionary options);
 
 		[TV (11, 0), iOS (11, 0), Mac (10,13)]
 		[Export ("initWithDepthData:")]
-		IntPtr Constructor (AVDepthData data);
+		NativeHandle Constructor (AVDepthData data);
 
 		[TV (11, 0), iOS (11, 0), Mac (10,13)]
 		[Static]
@@ -2566,7 +2570,7 @@ namespace CoreImage {
 #if !XAMCORE_4_0
 		[Obsolete ("The default initializer does not work in recent iOS version (11b4).")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 #endif
 
 		[Static]
@@ -2588,16 +2592,16 @@ namespace CoreImage {
 		CIImageAccumulator FromRectangle (CGRect extent, CIFormat format, CGColorSpace colorSpace);
 		
 		[Export ("initWithExtent:format:")]
-		IntPtr Constructor (CGRect rectangle, CIFormat format);
+		NativeHandle Constructor (CGRect rectangle, CIFormat format);
 
 #if MONOMAC && !XAMCORE_4_0
 		[Obsolete ("Use the overload acceping a 'CIFormat' enum instead of an 'int'.")]
 		[Wrap ("this (rectangle, (CIFormat) ciImageFormat)")]
-		IntPtr Constructor (CGRect rectangle, int ciImageFormat);
+		NativeHandle Constructor (CGRect rectangle, int ciImageFormat);
 #endif
 
 		[Export ("initWithExtent:format:colorSpace:")]
-		IntPtr Constructor (CGRect extent, CIFormat format, CGColorSpace colorSpace);
+		NativeHandle Constructor (CGRect extent, CIFormat format, CGColorSpace colorSpace);
 		
 		[Export ("extent")]
 		CGRect Extent { get; }
@@ -2652,7 +2656,7 @@ namespace CoreImage {
 		CISampler FromImage (CIImage sourceImag, [NullAllowed] NSDictionary options);
 
 		[Export ("initWithImage:")]
-		IntPtr Constructor (CIImage sourceImage);
+		NativeHandle Constructor (CIImage sourceImage);
 
 		[DesignatedInitializer]
 		[Internal, Export ("initWithImage:options:")]
@@ -2732,31 +2736,31 @@ namespace CoreImage {
 
 		[Mac (10,9)]
 		[Export ("initWithCGPoint:")]
-		IntPtr Constructor (CGPoint p);
+		NativeHandle Constructor (CGPoint p);
 
 		[Mac (10,9)]
 		[Export ("initWithCGRect:")]
-		IntPtr Constructor (CGRect r);
+		NativeHandle Constructor (CGRect r);
 
 		[Mac (10,9)]
 		[Export ("initWithCGAffineTransform:")]
-		IntPtr Constructor (CGAffineTransform r);
+		NativeHandle Constructor (CGAffineTransform r);
 		
 		
 		[Export ("initWithX:")]
-		IntPtr Constructor(nfloat x);
+		NativeHandle Constructor(nfloat x);
 
 		[Export ("initWithX:Y:")]
-		IntPtr Constructor (nfloat x, nfloat y);
+		NativeHandle Constructor (nfloat x, nfloat y);
 
 		[Export ("initWithX:Y:Z:")]
-		IntPtr Constructor (nfloat x, nfloat y, nfloat z);
+		NativeHandle Constructor (nfloat x, nfloat y, nfloat z);
 
 		[Export ("initWithX:Y:Z:W:")]
-		IntPtr Constructor (nfloat x, nfloat y, nfloat z, nfloat w);
+		NativeHandle Constructor (nfloat x, nfloat y, nfloat z, nfloat w);
 
 		[Export ("initWithString:")]
-		IntPtr Constructor (string representation);
+		NativeHandle Constructor (string representation);
 
 		[Export ("valueAtIndex:"), Internal]
 		nfloat ValueAtIndex (nint index);
@@ -5622,7 +5626,7 @@ namespace CoreImage {
 		CIQRCodeErrorCorrectionLevel ErrorCorrectionLevel { get; }
 
 		[Export ("initWithPayload:symbolVersion:maskPattern:errorCorrectionLevel:")]
-		IntPtr Constructor (NSData errorCorrectedPayload, nint symbolVersion, byte maskPattern, CIQRCodeErrorCorrectionLevel errorCorrectionLevel);
+		NativeHandle Constructor (NSData errorCorrectedPayload, nint symbolVersion, byte maskPattern, CIQRCodeErrorCorrectionLevel errorCorrectionLevel);
 
 		[Static]
 		[Export ("descriptorWithPayload:symbolVersion:maskPattern:errorCorrectionLevel:")]
@@ -5649,7 +5653,7 @@ namespace CoreImage {
 		nint DataCodewordCount { get; }
 
 		[Export ("initWithPayload:isCompact:layerCount:dataCodewordCount:")]
-		IntPtr Constructor (NSData errorCorrectedPayload, bool isCompact, nint layerCount, nint dataCodewordCount);
+		NativeHandle Constructor (NSData errorCorrectedPayload, bool isCompact, nint layerCount, nint dataCodewordCount);
 
 		[Static]
 		[Export ("descriptorWithPayload:isCompact:layerCount:dataCodewordCount:")]
@@ -5676,7 +5680,7 @@ namespace CoreImage {
 		nint ColumnCount { get; }
 
 		[Export ("initWithPayload:isCompact:rowCount:columnCount:")]
-		IntPtr Constructor (NSData errorCorrectedPayload, bool isCompact, nint rowCount, nint columnCount);
+		NativeHandle Constructor (NSData errorCorrectedPayload, bool isCompact, nint rowCount, nint columnCount);
 
 		[Static]
 		[Export ("descriptorWithPayload:isCompact:rowCount:columnCount:")]
@@ -5703,7 +5707,7 @@ namespace CoreImage {
 		CIDataMatrixCodeEccVersion EccVersion { get; }
 
 		[Export ("initWithPayload:rowCount:columnCount:eccVersion:")]
-		IntPtr Constructor (NSData errorCorrectedPayload, nint rowCount, nint columnCount, CIDataMatrixCodeEccVersion eccVersion);
+		NativeHandle Constructor (NSData errorCorrectedPayload, nint rowCount, nint columnCount, CIDataMatrixCodeEccVersion eccVersion);
 
 		[Static]
 		[Export ("descriptorWithPayload:rowCount:columnCount:eccVersion:")]
@@ -5909,22 +5913,22 @@ namespace CoreImage {
 	interface CIRenderDestination {
 
 		[Export ("initWithPixelBuffer:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer);
 
 		[Export ("initWithIOSurface:")]
-		IntPtr Constructor (IOSurface.IOSurface surface);
+		NativeHandle Constructor (IOSurface.IOSurface surface);
 
 		[Export ("initWithMTLTexture:commandBuffer:")]
-		IntPtr Constructor (IMTLTexture texture, [NullAllowed] IMTLCommandBuffer commandBuffer);
+		NativeHandle Constructor (IMTLTexture texture, [NullAllowed] IMTLCommandBuffer commandBuffer);
 
 		[Export ("initWithWidth:height:pixelFormat:commandBuffer:mtlTextureProvider:")]
-		IntPtr Constructor (nuint width, nuint height, MTLPixelFormat pixelFormat, [NullAllowed] IMTLCommandBuffer commandBuffer, [NullAllowed] Func<IMTLTexture> block);
+		NativeHandle Constructor (nuint width, nuint height, MTLPixelFormat pixelFormat, [NullAllowed] IMTLCommandBuffer commandBuffer, [NullAllowed] Func<IMTLTexture> block);
 
 		[Export ("initWithGLTexture:target:width:height:")]
-		IntPtr Constructor (uint texture, uint target, nuint width, nuint height);
+		NativeHandle Constructor (uint texture, uint target, nuint width, nuint height);
 
 		[Export ("initWithBitmapData:width:height:bytesPerRow:format:")]
-		IntPtr Constructor (IntPtr data, nuint width, nuint height, nuint bytesPerRow, CIFormat format);
+		NativeHandle Constructor (IntPtr data, nuint width, nuint height, nuint bytesPerRow, CIFormat format);
 
 		[Export ("width")]
 		nuint Width { get; }

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -22,6 +22,10 @@ using Contacts;
 #endif
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreLocation {
 
 	[NoTV][NoWatch]
@@ -121,24 +125,24 @@ namespace CoreLocation {
 		NSDate Timestamp { get;  }
 	
 		[Export ("initWithLatitude:longitude:")]
-		IntPtr Constructor (double latitude, double longitude);
+		NativeHandle Constructor (double latitude, double longitude);
 	
 		[Export ("initWithCoordinate:altitude:horizontalAccuracy:verticalAccuracy:timestamp:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, NSDate timestamp);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, NSDate timestamp);
 
 		[Export ("distanceFromLocation:")]
 		double DistanceFrom (CLLocation location);
 
 		[Export ("initWithCoordinate:altitude:horizontalAccuracy:verticalAccuracy:course:speed:timestamp:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, double course, double speed, NSDate timestamp);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, double course, double speed, NSDate timestamp);
 
 		[Watch (6,2), TV (13,4), Mac (10,15,4), iOS (13,4)]
 		[Export ("initWithCoordinate:altitude:horizontalAccuracy:verticalAccuracy:course:courseAccuracy:speed:speedAccuracy:timestamp:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, double course, double courseAccuracy, double speed, double speedAccuracy, NSDate timestamp);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, double course, double courseAccuracy, double speed, double speedAccuracy, NSDate timestamp);
 
 		[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[Export ("initWithCoordinate:altitude:horizontalAccuracy:verticalAccuracy:course:courseAccuracy:speed:speedAccuracy:timestamp:sourceInfo:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate, double altitude, double horizontalAccuracy, double verticalAccuracy, double course, double courseAccuracy, double speed, double speedAccuracy, NSDate timestamp, CLLocationSourceInformation sourceInfo);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate, double altitude, double horizontalAccuracy, double verticalAccuracy, double course, double courseAccuracy, double speed, double speedAccuracy, NSDate timestamp, CLLocationSourceInformation sourceInfo);
 
 		// Apple keep changing the 'introduction' of this field (5.0->8.0->5.0) but it was not available in 6.1
 		// nor in 7.0 - but it works on my iPad3 running iOS 7.1
@@ -607,7 +611,7 @@ namespace CoreLocation {
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'CLCircularRegion' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'CLCircularRegion' instead.")]
 		[Export ("initCircularRegionWithCenter:radius:identifier:")]
-		IntPtr Constructor (CLLocationCoordinate2D center, double radius, string identifier);
+		NativeHandle Constructor (CLLocationCoordinate2D center, double radius, string identifier);
 
 		[NoTV]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'CLCircularRegion' instead.")]
@@ -664,7 +668,7 @@ namespace CoreLocation {
 		string [] AreasOfInterest { get;  }
 
 		[Export ("initWithPlacemark:")]
-		IntPtr Constructor (CLPlacemark placemark);
+		NativeHandle Constructor (CLPlacemark placemark);
 
 		[NullAllowed, Export ("inlandWater")]
 		string InlandWater { get;  }
@@ -700,7 +704,7 @@ namespace CoreLocation {
 	partial interface CLCircularRegion {
 
 		[Export ("initWithCenter:radius:identifier:")]
-		IntPtr Constructor (CLLocationCoordinate2D center, double radius, string identifier);
+		NativeHandle Constructor (CLLocationCoordinate2D center, double radius, string identifier);
 
 		[Export ("center")]
 		CLLocationCoordinate2D Center { get; }
@@ -720,7 +724,7 @@ namespace CoreLocation {
 		[NoMac]
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use the 'Create' method or the constructor using 'CLBeaconIdentityConstraint' instead.")]
 		[Export ("initWithProximityUUID:identifier:")]
-		IntPtr Constructor (NSUuid proximityUuid, string identifier);
+		NativeHandle Constructor (NSUuid proximityUuid, string identifier);
 
 		[NoMac]
 		[iOS (13,0)]
@@ -731,7 +735,7 @@ namespace CoreLocation {
 		[NoMac]
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use the 'Create' method or the constructor using 'CLBeaconIdentityConstraint' instead.")]
 		[Export ("initWithProximityUUID:major:identifier:")]
-		IntPtr Constructor (NSUuid proximityUuid, ushort major, string identifier);
+		NativeHandle Constructor (NSUuid proximityUuid, ushort major, string identifier);
 
 		[iOS (13,0)]
 		[Internal] // signature conflict with deprecated API
@@ -741,7 +745,7 @@ namespace CoreLocation {
 		[NoMac]
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use the 'Create' method or the constructor using 'CLBeaconIdentityConstraint' instead.")]
 		[Export ("initWithProximityUUID:major:minor:identifier:")]
-		IntPtr Constructor (NSUuid proximityUuid, ushort major, ushort minor, string identifier);
+		NativeHandle Constructor (NSUuid proximityUuid, ushort major, ushort minor, string identifier);
 
 		[iOS (13,0)]
 		[Internal] // signature conflict with deprecated API
@@ -750,7 +754,7 @@ namespace CoreLocation {
 
 		[iOS (13,0)]
 		[Export ("initWithBeaconIdentityConstraint:identifier:")]
-		IntPtr Constructor (CLBeaconIdentityConstraint beaconIdentityConstraint, string identifier);
+		NativeHandle Constructor (CLBeaconIdentityConstraint beaconIdentityConstraint, string identifier);
 
 		[Export ("peripheralDataWithMeasuredPower:")]
 		NSMutableDictionary GetPeripheralData ([NullAllowed] NSNumber measuredPower);
@@ -887,13 +891,13 @@ namespace CoreLocation {
 	interface CLBeaconIdentityConstraint : NSCopying, NSSecureCoding {
 
 		[Export ("initWithUUID:")]
-		IntPtr Constructor (NSUuid uuid);
+		NativeHandle Constructor (NSUuid uuid);
 
 		[Export ("initWithUUID:major:")]
-		IntPtr Constructor (NSUuid uuid, ushort major);
+		NativeHandle Constructor (NSUuid uuid, ushort major);
 
 		[Export ("initWithUUID:major:minor:")]
-		IntPtr Constructor (NSUuid uuid, ushort major, ushort minor);
+		NativeHandle Constructor (NSUuid uuid, ushort major, ushort minor);
 
 		[Export ("UUID", ArgumentSemantic.Copy)]
 		NSUuid Uuid { get; }
@@ -928,7 +932,7 @@ namespace CoreLocation {
 	interface CLLocationSourceInformation : NSCopying, NSSecureCoding
 	{
 		[Export ("initWithSoftwareSimulationState:andExternalAccessoryState:")]
-		IntPtr Constructor (bool isSoftware, bool isAccessory);
+		NativeHandle Constructor (bool isSoftware, bool isAccessory);
 
 		[Export ("isSimulatedBySoftware")]
 		bool IsSimulatedBySoftware { get; }

--- a/src/corelocationui.cs
+++ b/src/corelocationui.cs
@@ -5,6 +5,10 @@ using UIKit;
 
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreLocationUI {
 
 	[NoTV, NoMac, NoWatch, iOS (15,0), MacCatalyst (15,0)]
@@ -32,7 +36,7 @@ namespace CoreLocationUI {
 
 		[Export ("initWithFrame:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("icon", ArgumentSemantic.Assign)]
 		CLLocationButtonIcon Icon { get; set; }

--- a/src/coremidi.cs
+++ b/src/coremidi.cs
@@ -33,6 +33,10 @@ using ObjCRuntime;
 
 using MidiObjectRef = System.Int32;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreMidi {
 
 	[Mac (11, 0), iOS (14, 0)]
@@ -241,12 +245,12 @@ namespace CoreMidi {
 		NSData ProfileId { get; }
 
 		[Export ("initWithData:name:")]
-		IntPtr Constructor (NSData data, string inName);
+		NativeHandle Constructor (NSData data, string inName);
 
 		[Mac (11, 0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 	}
 
 	[NoWatch, NoTV, Mac (10,14), iOS (12,0)]
@@ -263,12 +267,12 @@ namespace CoreMidi {
 		[Deprecated (PlatformName.iOS, 14, 0, message : "Use the '(byte midiChannel, MidiCIProfile[] enabled, MidiCIProfile[] disabled)' constructor instead.")]
 		[Deprecated (PlatformName.MacOSX, 11, 0, message : "Use the '(byte midiChannel, MidiCIProfile[] enabled, MidiCIProfile[] disabled)' constructor instead.")]
 		[Export ("initWithEnabledProfiles:disabledProfiles:")]
-		IntPtr Constructor (MidiCIProfile[] enabled, MidiCIProfile[] disabled);
+		NativeHandle Constructor (MidiCIProfile[] enabled, MidiCIProfile[] disabled);
 
 		[Mac (11, 0), iOS (14, 0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithChannel:enabledProfiles:disabledProfiles:")]
-		IntPtr Constructor (byte midiChannelNumber, MidiCIProfile[] enabled, MidiCIProfile[] disabled);
+		NativeHandle Constructor (byte midiChannelNumber, MidiCIProfile[] enabled, MidiCIProfile[] disabled);
 
 		[Mac (11, 0), iOS (14, 0)]
 		[MacCatalyst (14,0)]
@@ -314,7 +318,7 @@ namespace CoreMidi {
 		[Mac (11, 0), iOS (14, 0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithDiscoveredNode:dataReadyHandler:disconnectHandler:")]
-		IntPtr Constructor (MidiCIDiscoveredNode discoveredNode, Action dataReadyHandler, MidiCISessionDisconnectHandler disconnectHandler);
+		NativeHandle Constructor (MidiCIDiscoveredNode discoveredNode, Action dataReadyHandler, MidiCISessionDisconnectHandler disconnectHandler);
 
 		[Mac (11, 0), iOS (14, 0)]
 		[MacCatalyst (14,0)]
@@ -377,10 +381,10 @@ namespace CoreMidi {
 
 		[Internal]
 		[Export ("initWithDestination:manufacturer:family:model:revision:")]
-		IntPtr Constructor (MidiObjectRef midiDestination, NSData manufacturer, NSData family, NSData modelNumber, NSData revisionLevel);
+		NativeHandle Constructor (MidiObjectRef midiDestination, NSData manufacturer, NSData family, NSData modelNumber, NSData revisionLevel);
 
 		[Wrap ("this (midiDestination?.Handle ?? throw new ArgumentNullException (nameof (midiDestination)), manufacturer, family, modelNumber, revisionLevel)")]
-		IntPtr Constructor (MidiEndpoint midiDestination, NSData manufacturer, NSData family, NSData modelNumber, NSData revisionLevel);
+		NativeHandle Constructor (MidiEndpoint midiDestination, NSData manufacturer, NSData family, NSData modelNumber, NSData revisionLevel);
 	}
 
 	[Mac (11, 0), iOS (14, 0)]
@@ -469,7 +473,7 @@ namespace CoreMidi {
 		MidiCIDeviceInfo DeviceInfo { get; }
 
 		[Export ("initWithDeviceInfo:profileDelegate:profileStates:supportProperties:")]
-		IntPtr Constructor (MidiCIDeviceInfo deviceInfo, IMidiCIProfileResponderDelegate @delegate, MidiCIProfileState[] profileList, bool propertiesSupported);
+		NativeHandle Constructor (MidiCIDeviceInfo deviceInfo, IMidiCIProfileResponderDelegate @delegate, MidiCIProfileState[] profileList, bool propertiesSupported);
 
 		[Export ("notifyProfile:onChannel:isEnabled:")]
 		bool NotifyProfile (MidiCIProfile profile, byte channel, bool enabledState);

--- a/src/coreml.cs
+++ b/src/coreml.cs
@@ -26,6 +26,10 @@ using IMTLDevice = global::Foundation.NSObject;
 using VNImageCropAndScaleOption = global::System.nuint;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreML {
 
 	[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
@@ -125,7 +129,7 @@ namespace CoreML {
 		NSDictionary<NSString, MLFeatureValue> Dictionary { get; }
 
 		[Export ("initWithDictionary:error:")]
-		IntPtr Constructor (NSDictionary<NSString, NSObject> dictionary, out NSError error);
+		NativeHandle Constructor (NSDictionary<NSString, NSObject> dictionary, out NSError error);
 	}
 
 	[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
@@ -528,10 +532,10 @@ namespace CoreML {
 		// From MLMultiArray (Creation) Category
 
 		[Export ("initWithShape:dataType:error:")]
-		IntPtr Constructor (NSNumber [] shape, MLMultiArrayDataType dataType, out NSError error);
+		NativeHandle Constructor (NSNumber [] shape, MLMultiArrayDataType dataType, out NSError error);
 
 		[Export ("initWithDataPointer:shape:dataType:strides:deallocator:error:")]
-		IntPtr Constructor (IntPtr dataPointer, NSNumber [] shape, MLMultiArrayDataType dataType, NSNumber [] strides, [NullAllowed] Action<IntPtr> deallocator, out NSError error);
+		NativeHandle Constructor (IntPtr dataPointer, NSNumber [] shape, MLMultiArrayDataType dataType, NSNumber [] strides, [NullAllowed] Action<IntPtr> deallocator, out NSError error);
 
 		[NoWatch, NoTV, NoiOS, Mac (12,0)]
 		[Export ("initWithPixelBuffer:shape:")]
@@ -641,7 +645,7 @@ namespace CoreML {
 		// Must be manually inlined in classes implementing this protocol
 		//[Abstract]
 		//[Export ("initWithParameterDictionary:error:")]
-		//IntPtr Constructor (NSDictionary<NSString, NSObject> parameters, [NullAllowed] out NSError error);
+		//NativeHandle Constructor (NSDictionary<NSString, NSObject> parameters, [NullAllowed] out NSError error);
 
 		[Abstract]
 		[Export ("setWeightData:error:")]
@@ -669,10 +673,10 @@ namespace CoreML {
 		IMLFeatureProvider[] Array { get; }
 
 		[Export ("initWithFeatureProviderArray:")]
-		IntPtr Constructor (IMLFeatureProvider[] array);
+		NativeHandle Constructor (IMLFeatureProvider[] array);
 
 		[Export ("initWithDictionary:error:")]
-		IntPtr Constructor (NSDictionary<NSString, NSArray> dictionary, out NSError error);
+		NativeHandle Constructor (NSDictionary<NSString, NSArray> dictionary, out NSError error);
 	}
 
 	interface IMLBatchProvider {}
@@ -697,7 +701,7 @@ namespace CoreML {
 
 		// [Abstract]
 		[Export ("initWithModelDescription:parameterDictionary:error:")]
-		IntPtr Constructor (MLModelDescription modelDescription, NSDictionary<NSString, NSObject> parameters, out NSError error);
+		NativeHandle Constructor (MLModelDescription modelDescription, NSDictionary<NSString, NSObject> parameters, out NSError error);
 
 		[Abstract]
 		[Export ("predictionFromFeatures:options:error:")]
@@ -997,7 +1001,7 @@ namespace CoreML {
 	interface MLUpdateProgressHandlers {
 
 		[Export ("initForEvents:progressHandler:completionHandler:")]
-		IntPtr Constructor (MLUpdateProgressEvent interestedEvents, [NullAllowed] Action<MLUpdateContext> progressHandler, Action<MLUpdateContext> completionHandler);
+		NativeHandle Constructor (MLUpdateProgressEvent interestedEvents, [NullAllowed] Action<MLUpdateContext> progressHandler, Action<MLUpdateContext> completionHandler);
 	}
 
 	[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]

--- a/src/corenfc.cs
+++ b/src/corenfc.cs
@@ -19,6 +19,8 @@ using NFCFeliCaPollingTimeSlot = CoreNFC.PollingTimeSlot;
 using NFCIso15693RequestFlag = CoreNFC.RequestFlag;
 using NFCVasErrorCode = CoreNFC.VasErrorCode;
 using NFCVasMode = CoreNFC.VasMode;
+
+using NativeHandle = System.IntPtr;
 #endif
 
 namespace CoreNFC {
@@ -91,7 +93,7 @@ namespace CoreNFC {
 
 		[Export ("initWithDelegate:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INFCReaderSessionDelegate @delegate, [NullAllowed] DispatchQueue queue);
+		NativeHandle Constructor (INFCReaderSessionDelegate @delegate, [NullAllowed] DispatchQueue queue);
 
 		[Static]
 		[Export ("readingAvailable")]
@@ -116,10 +118,10 @@ namespace CoreNFC {
 		NSData RequestParameters { get; set; }
 
 		[Export ("initWithManufacturerCode:customCommandCode:requestParameters:")]
-		IntPtr Constructor (nuint manufacturerCode, nuint customCommandCode, [NullAllowed] NSData requestParameters);
+		NativeHandle Constructor (nuint manufacturerCode, nuint customCommandCode, [NullAllowed] NSData requestParameters);
 
 		[Export ("initWithManufacturerCode:customCommandCode:requestParameters:maximumRetries:retryInterval:")]
-		IntPtr Constructor (nuint manufacturerCode, nuint customCommandCode, [NullAllowed] NSData requestParameters, nuint maximumRetries, double retryInterval);
+		NativeHandle Constructor (nuint manufacturerCode, nuint customCommandCode, [NullAllowed] NSData requestParameters, nuint maximumRetries, double retryInterval);
 	}
 
 	//[iOS (11,0), NoTV, NoWatch, NoMac]
@@ -134,10 +136,10 @@ namespace CoreNFC {
 		nuint ChunkSize { get; set; }
 
 		[Export ("initWithRange:chunkSize:")]
-		IntPtr Constructor (NSRange range, nuint chunkSize);
+		NativeHandle Constructor (NSRange range, nuint chunkSize);
 
 		[Export ("initWithRange:chunkSize:maximumRetries:retryInterval:")]
-		IntPtr Constructor (NSRange range, nuint chunkSize, nuint maximumRetries, double retryInterval);
+		NativeHandle Constructor (NSRange range, nuint chunkSize, nuint maximumRetries, double retryInterval);
 	}
 
 	delegate void NFCGetSystemInfoCompletionHandler (nint dsfid, nint afi, nint blockSize, nint blockCount, nint icReference, NSError error);
@@ -432,11 +434,11 @@ namespace CoreNFC {
 
 		[iOS (13,0)]
 		[Export ("initWithFormat:type:identifier:payload:")]
-		IntPtr Constructor (NFCTypeNameFormat format, NSData type, NSData identifier, NSData payload);
+		NativeHandle Constructor (NFCTypeNameFormat format, NSData type, NSData identifier, NSData payload);
 
 		[iOS (13,0)]
 		[Export ("initWithFormat:type:identifier:payload:chunkSize:")]
-		IntPtr Constructor (NFCTypeNameFormat format, NSData type, NSData identifier, NSData payload, nuint chunkSize);
+		NativeHandle Constructor (NFCTypeNameFormat format, NSData type, NSData identifier, NSData payload, nuint chunkSize);
 	}
 
 	[iOS (11,0)]
@@ -455,7 +457,7 @@ namespace CoreNFC {
 
 		[iOS (13,0)]
 		[Export ("initWithNDEFRecords:")]
-		IntPtr Constructor (NFCNdefPayload[] records);
+		NativeHandle Constructor (NFCNdefPayload[] records);
 
 		[iOS (13,0)]
 		[Export ("length")]
@@ -493,7 +495,7 @@ namespace CoreNFC {
 
 		[Export ("initWithDelegate:queue:invalidateAfterFirstRead:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INFCNdefReaderSessionDelegate @delegate, [NullAllowed] DispatchQueue queue, bool invalidateAfterFirstRead);
+		NativeHandle Constructor (INFCNdefReaderSessionDelegate @delegate, [NullAllowed] DispatchQueue queue, bool invalidateAfterFirstRead);
 
 		[Static]
 		[Export ("readingAvailable")]
@@ -920,10 +922,10 @@ namespace CoreNFC {
 	interface NFCIso7816Apdu : NSCopying {
 
 		[Export ("initWithInstructionClass:instructionCode:p1Parameter:p2Parameter:data:expectedResponseLength:")]
-		IntPtr Constructor (byte instructionClass, byte instructionCode, byte p1Parameter, byte p2Parameter, NSData data, nint expectedResponseLength);
+		NativeHandle Constructor (byte instructionClass, byte instructionCode, byte p1Parameter, byte p2Parameter, NSData data, nint expectedResponseLength);
 
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Export ("instructionClass")]
 		byte InstructionClass { get; }
@@ -1000,7 +1002,7 @@ namespace CoreNFC {
 	interface NFCTagReaderSession {
 
 		[Export ("initWithPollingOption:delegate:queue:")]
-		IntPtr Constructor (NFCPollingOption pollingOption, INFCTagReaderSessionDelegate @delegate, [NullAllowed] DispatchQueue queue);
+		NativeHandle Constructor (NFCPollingOption pollingOption, INFCTagReaderSessionDelegate @delegate, [NullAllowed] DispatchQueue queue);
 
 		[NullAllowed, Export ("connectedTag", ArgumentSemantic.Retain)]
 		INFCTag ConnectedTag { get; }
@@ -1057,7 +1059,7 @@ namespace CoreNFC {
 
 		[Export ("initWithVASMode:passTypeIdentifier:url:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NFCVasMode mode, string passTypeIdentifier, [NullAllowed] NSUrl url);
+		NativeHandle Constructor (NFCVasMode mode, string passTypeIdentifier, [NullAllowed] NSUrl url);
 
 		[Export ("mode", ArgumentSemantic.Assign)]
 		NFCVasMode Mode { get; set; }
@@ -1077,6 +1079,6 @@ namespace CoreNFC {
 
 		[Export ("initWithVASCommandConfigurations:delegate:queue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NFCVasCommandConfiguration[] commandConfigurations, INFCVasReaderSessionDelegate @delegate, [NullAllowed] DispatchQueue queue);
+		NativeHandle Constructor (NFCVasCommandConfiguration[] commandConfigurations, INFCVasReaderSessionDelegate @delegate, [NullAllowed] DispatchQueue queue);
 	}
 }

--- a/src/corespotlight.cs
+++ b/src/corespotlight.cs
@@ -13,6 +13,10 @@ using ObjCRuntime;
 using Foundation;
 using UniformTypeIdentifiers;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreSpotlight {
 
 	[NoTV] // CS_TVOS_UNAVAILABLE
@@ -30,7 +34,7 @@ namespace CoreSpotlight {
 	interface CSPerson : NSSecureCoding, NSCopying {
 
 		[Export ("initWithDisplayName:handles:handleIdentifier:")]
-		IntPtr Constructor ([NullAllowed] string displayName, string [] handles, NSString handleIdentifier);
+		NativeHandle Constructor ([NullAllowed] string displayName, string [] handles, NSString handleIdentifier);
 
 		[NullAllowed]
 		[Export ("displayName")]
@@ -65,11 +69,11 @@ namespace CoreSpotlight {
 		CSSearchableIndex DefaultSearchableIndex { get; }
 
 		[Export ("initWithName:")]
-		IntPtr Constructor (string name);
+		NativeHandle Constructor (string name);
 
 #if !MONOMAC
 		[Export ("initWithName:protectionClass:")]
-		IntPtr Constructor (string name, [NullAllowed] NSString protectionClass);
+		NativeHandle Constructor (string name, [NullAllowed] NSString protectionClass);
 #endif
 
 		[Export ("indexSearchableItems:completionHandler:")]
@@ -163,7 +167,7 @@ namespace CoreSpotlight {
 		NSString QueryString { get; }
 
 		[Export ("initWithUniqueIdentifier:domainIdentifier:attributeSet:")]
-		IntPtr Constructor ([NullAllowed] string uniqueIdentifier, [NullAllowed] string domainIdentifier, CSSearchableItemAttributeSet attributeSet);
+		NativeHandle Constructor ([NullAllowed] string uniqueIdentifier, [NullAllowed] string domainIdentifier, CSSearchableItemAttributeSet attributeSet);
 
 		[Export ("uniqueIdentifier")]
 		string UniqueIdentifier { get; set; }
@@ -188,7 +192,7 @@ namespace CoreSpotlight {
 	interface CSLocalizedString : NSCoding {
 
 		[Export ("initWithLocalizedStrings:")]
-		IntPtr Constructor (NSDictionary localizedStrings);
+		NativeHandle Constructor (NSDictionary localizedStrings);
 
 		[Export ("localizedString")]
 		string GetLocalizedString ();
@@ -202,11 +206,11 @@ namespace CoreSpotlight {
 	interface CSCustomAttributeKey : NSCopying, NSSecureCoding {
 
 		[Export ("initWithKeyName:")]
-		IntPtr Constructor (string keyName);
+		NativeHandle Constructor (string keyName);
 
 		[DesignatedInitializer]
 		[Export ("initWithKeyName:searchable:searchableByDefault:unique:multiValued:")]
-		IntPtr Constructor (string keyName, bool searchable, bool searchableByDefault, bool unique, bool multiValued);
+		NativeHandle Constructor (string keyName, bool searchable, bool searchableByDefault, bool unique, bool multiValued);
 
 		[Export ("keyName")]
 		string KeyName { get; }
@@ -261,12 +265,12 @@ namespace CoreSpotlight {
 		[Deprecated (PlatformName.iOS, 14,0, message: "Use '.ctor(UTType)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 11,0, message: "Use '.ctor(UTType)' instead.")]
 		[Export ("initWithItemContentType:")]
-		IntPtr Constructor (string itemContentType);
+		NativeHandle Constructor (string itemContentType);
 
 		[iOS (14,0)][TV (14,0)][Mac (11,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithContentType:")]
-		IntPtr Constructor (UTType contentType);
+		NativeHandle Constructor (UTType contentType);
 
 		// FIXME: Should we keep all the following Categories inline? or should we make them actual [Category] interfaces
 		// There are no methods on any of the following categories, just properties
@@ -1071,7 +1075,7 @@ namespace CoreSpotlight {
 	[DisableDefaultCtor]
 	interface CSSearchQuery {
 		[Export ("initWithQueryString:attributes:")]
-		IntPtr Constructor (string queryString, [NullAllowed] string[] attributes);
+		NativeHandle Constructor (string queryString, [NullAllowed] string[] attributes);
 
 		[Export ("cancelled")]
 		bool Cancelled { [Bind ("isCancelled")] get; }

--- a/src/corewlan.cs
+++ b/src/corewlan.cs
@@ -28,6 +28,10 @@ using ObjCRuntime;
 using Security;
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace CoreWlan {
 
 	[NoMacCatalyst]
@@ -137,7 +141,7 @@ namespace CoreWlan {
 		bool RememberJoinedNetworks { get; }
  
 		[Export ("initWithConfiguration:")]
-		IntPtr Constructor (CWConfiguration configuration);
+		NativeHandle Constructor (CWConfiguration configuration);
 
 		[Export ("isEqualToConfiguration:")]
 		bool IsEqualToConfiguration (CWConfiguration configuration);
@@ -412,7 +416,7 @@ namespace CoreWlan {
 		 
 		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'CWWiFiClient.FromName' instead.")]
 		[Export ("initWithInterfaceName:")]
-		IntPtr Constructor ([NullAllowed]string name);
+		NativeHandle Constructor ([NullAllowed]string name);
 		 
 		[Export ("setPower:error:")]
 		bool SetPower (bool power, out NSError error);
@@ -600,7 +604,7 @@ namespace CoreWlan {
 		NSObject NetworkProfile ();
 
 		[Export ("initWithNetworkProfile:")]
-		IntPtr Constructor (CWNetworkProfile networkProfile);
+		NativeHandle Constructor (CWNetworkProfile networkProfile);
 
 		[Static]
 		[Export ("networkProfileWithNetworkProfile:")]

--- a/src/eventkit.cs
+++ b/src/eventkit.cs
@@ -24,6 +24,10 @@ using AppKit;
 using UIKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace EventKit {
 
 	[BaseType (typeof (NSObject))]
@@ -423,9 +427,9 @@ namespace EventKit {
 
 		[Export ("initWithDayOfTheWeek:weekNumber:")]
 #if XAMCORE_4_0
-		IntPtr Constructor (EKWeekday dayOfTheWeek, nint weekNumber);
+		NativeHandle Constructor (EKWeekday dayOfTheWeek, nint weekNumber);
 #else
-		IntPtr Constructor (nint dayOfTheWeek, nint weekNumber);
+		NativeHandle Constructor (nint dayOfTheWeek, nint weekNumber);
 #endif
 	}
 
@@ -481,10 +485,10 @@ namespace EventKit {
 #endif
 
 		[Export ("initRecurrenceWithFrequency:interval:end:")]
-		IntPtr Constructor (EKRecurrenceFrequency type, nint interval, [NullAllowed] EKRecurrenceEnd end);
+		NativeHandle Constructor (EKRecurrenceFrequency type, nint interval, [NullAllowed] EKRecurrenceEnd end);
 
 		[Export ("initRecurrenceWithFrequency:interval:daysOfTheWeek:daysOfTheMonth:monthsOfTheYear:weeksOfTheYear:daysOfTheYear:setPositions:end:")]
-		IntPtr Constructor (EKRecurrenceFrequency type, nint interval, [NullAllowed] EKRecurrenceDayOfWeek [] days, [NullAllowed] NSNumber [] monthDays, [NullAllowed] NSNumber [] months,
+		NativeHandle Constructor (EKRecurrenceFrequency type, nint interval, [NullAllowed] EKRecurrenceDayOfWeek [] days, [NullAllowed] NSNumber [] monthDays, [NullAllowed] NSNumber [] months,
 				    [NullAllowed] NSNumber [] weeksOfTheYear, [NullAllowed] NSNumber [] daysOfTheYear, [NullAllowed] NSNumber [] setPositions, [NullAllowed] EKRecurrenceEnd end);
 
 	}
@@ -493,7 +497,7 @@ namespace EventKit {
 	interface EKEventStore {
 		[NoiOS, Mac (10,11), NoWatch, NoMacCatalyst]
 		[Export ("initWithSources:")]
-		IntPtr Constructor (EKSource[] sources);
+		NativeHandle Constructor (EKSource[] sources);
 
 		[Export ("eventStoreIdentifier")]
 		string EventStoreIdentifier { get;  }
@@ -611,7 +615,7 @@ namespace EventKit {
 #if MONOMAC
 		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("initWithAccessToEntityTypes:")]
-		IntPtr Constructor (EKEntityMask accessToEntityTypes);
+		NativeHandle Constructor (EKEntityMask accessToEntityTypes);
 #endif
 		[Mac (10,11), Watch (5,0), iOS (12,0)]
 		[Export ("delegateSources")]
@@ -665,7 +669,7 @@ namespace EventKit {
 	{
 		[Export ("initWithTitle:URLDescriptors:conferenceDetails:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string title, EKVirtualConferenceUrlDescriptor[] urlDescriptors, [NullAllowed] string conferenceDetails);
+		NativeHandle Constructor ([NullAllowed] string title, EKVirtualConferenceUrlDescriptor[] urlDescriptors, [NullAllowed] string conferenceDetails);
 
 		[NullAllowed, Export ("title")]
 		string Title { get; }
@@ -700,7 +704,7 @@ namespace EventKit {
 	{
 		[Export ("initWithTitle:identifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string title, string identifier);
+		NativeHandle Constructor (string title, string identifier);
 
 		[Export ("title")]
 		string Title { get; }
@@ -716,7 +720,7 @@ namespace EventKit {
 	{
 		[Export ("initWithTitle:URL:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string title, NSUrl url);
+		NativeHandle Constructor ([NullAllowed] string title, NSUrl url);
 
 		[NullAllowed, Export ("title")]
 		string Title { get; }

--- a/src/eventkitui.cs
+++ b/src/eventkitui.cs
@@ -15,12 +15,16 @@ using UIKit;
 using EventKit;
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace EventKitUI {
 	[BaseType (typeof (UIViewController), Delegates = new string [] { "WeakDelegate"}, Events=new Type [] {typeof (EKEventViewDelegate)})]
 	interface EKEventViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[NullAllowed] // by default this property is null
 		[Export ("event")]
@@ -53,11 +57,11 @@ namespace EventKitUI {
 	interface EKEventEditViewController : UIAppearance {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("initWithRootViewController:")]
 		[PostGet ("ViewControllers")] // that will PostGet TopViewController and VisibleViewController too
-		IntPtr Constructor (UIViewController rootViewController);
+		NativeHandle Constructor (UIViewController rootViewController);
 
 		[Export ("editViewDelegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakEditViewDelegate { get; set; }
@@ -95,13 +99,13 @@ namespace EventKitUI {
 	interface EKCalendarChooser {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("initWithSelectionStyle:displayStyle:eventStore:")]
-		IntPtr Constructor (EKCalendarChooserSelectionStyle selectionStyle, EKCalendarChooserDisplayStyle displayStyle, EKEventStore eventStore);
+		NativeHandle Constructor (EKCalendarChooserSelectionStyle selectionStyle, EKCalendarChooserDisplayStyle displayStyle, EKEventStore eventStore);
 
 		[Export ("initWithSelectionStyle:displayStyle:entityType:eventStore:")]
-		IntPtr Constructor (EKCalendarChooserSelectionStyle selectionStyle, EKCalendarChooserDisplayStyle displayStyle, EKEntityType entityType, EKEventStore eventStore);
+		NativeHandle Constructor (EKCalendarChooserSelectionStyle selectionStyle, EKCalendarChooserDisplayStyle displayStyle, EKEntityType entityType, EKEventStore eventStore);
 
 		[Export ("selectionStyle")]
 		EKCalendarChooserSelectionStyle SelectionStyle { get; 

--- a/src/externalaccessory.cs
+++ b/src/externalaccessory.cs
@@ -12,6 +12,10 @@ using ObjCRuntime;
 using UIKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ExternalAccessory {
 
 	[Mac (10, 13)][TV (10,0)]
@@ -124,7 +128,7 @@ namespace ExternalAccessory {
 	[DisableDefaultCtor]
 	interface EASession {
 		[Export ("initWithAccessory:forProtocol:")]
-		IntPtr Constructor (EAAccessory accessory, string protocol);
+		NativeHandle Constructor (EAAccessory accessory, string protocol);
 
 		[NullAllowed]
 		[Export ("accessory")]
@@ -190,7 +194,7 @@ namespace ExternalAccessory {
 		[NoTV]
 		[Export ("initWithDelegate:queue:")]
 		[DesignatedInitializer] // according to header comment (but not in attributes)
-		IntPtr Constructor ([NullAllowed] IEAWiFiUnconfiguredAccessoryBrowserDelegate accessoryBrowserDelegate, [NullAllowed] DispatchQueue queue);
+		NativeHandle Constructor ([NullAllowed] IEAWiFiUnconfiguredAccessoryBrowserDelegate accessoryBrowserDelegate, [NullAllowed] DispatchQueue queue);
 
 		[NoTV] // no member is available
 		[Export ("delegate", ArgumentSemantic.Weak)][NullAllowed]

--- a/src/fileprovider.cs
+++ b/src/fileprovider.cs
@@ -15,6 +15,10 @@ using CoreGraphics;
 using Foundation;
 using UniformTypeIdentifiers;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #if IOS && !XAMCORE_4_0 && !__MACCATALYST__
 using FileProvider;
 
@@ -300,11 +304,11 @@ namespace FileProvider {
 
 		[NoMac]
 		[Export ("initWithIdentifier:displayName:pathRelativeToDocumentStorage:")]
-		IntPtr Constructor (string identifier, string displayName, string pathRelativeToDocumentStorage);
+		NativeHandle Constructor (string identifier, string displayName, string pathRelativeToDocumentStorage);
 
 		[NoiOS]
 		[Export ("initWithIdentifier:displayName:")]
-		IntPtr Constructor (string identifier, string displayName);
+		NativeHandle Constructor (string identifier, string displayName);
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -789,7 +793,7 @@ namespace FileProvider {
 	interface NSFileProviderItemVersion {
 
 		[Export ("initWithContentVersion:metadataVersion:")]
-		IntPtr Constructor (NSData contentVersion, NSData metadataVersion);
+		NativeHandle Constructor (NSData contentVersion, NSData metadataVersion);
 
 		[Export ("contentVersion")]
 		NSData ContentVersion { get; }
@@ -976,7 +980,7 @@ namespace FileProvider {
 		/* see Advice above
 		[Abstract]
 		[Export ("initWithDomain:")]
-		IntPtr Constructor (NSFileProviderDomain domain);
+		NativeHandle Constructor (NSFileProviderDomain domain);
 		*/
 
 		[Abstract]

--- a/src/fileproviderui.cs
+++ b/src/fileproviderui.cs
@@ -17,6 +17,10 @@ using AppKit;
 #endif
 using FileProvider;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace FileProviderUI {
 
 	[iOS (11,0)]
@@ -55,7 +59,7 @@ namespace FileProviderUI {
 
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("extensionContext", ArgumentSemantic.Strong)]
 		FPUIActionExtensionContext ExtensionContext { get; }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -166,7 +166,7 @@ namespace Foundation
 		nuint Count { get; }
 
 		[Export ("objectAtIndex:")]
-		IntPtr ValueAt (nuint idx);
+		NativeHandle ValueAt (nuint idx);
 
 		[Static]
 		[Internal]
@@ -203,7 +203,7 @@ namespace Foundation
 		[Internal]
 		[Sealed]
 		[Export ("containsObject:")]
-		bool _Contains (IntPtr anObject);
+		bool _Contains (NativeHandle anObject);
 
 		[Export ("containsObject:")]
 		bool Contains (NSObject anObject);
@@ -211,7 +211,7 @@ namespace Foundation
 		[Internal]
 		[Sealed]
 		[Export ("indexOfObject:")]
-		nuint _IndexOf (IntPtr anObject);
+		nuint _IndexOf (NativeHandle anObject);
 
 		[Export ("indexOfObject:")]
 		nuint IndexOf (NSObject anObject);

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -124,6 +124,10 @@ using NSNotificationSuspensionBehavior = Foundation.NSObject;
 using NSNotificationFlags = Foundation.NSObject;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Foundation {
 	delegate void NSFilePresenterReacquirer ([BlockCallback] Action reacquirer);
 }
@@ -276,7 +280,7 @@ namespace Foundation
 		bool IsEqual (NSAttributedString other);
 
 		[Export ("initWithString:")]
-		IntPtr Constructor (string str);
+		NativeHandle Constructor (string str);
 
 #if !MONOMAC
 
@@ -298,20 +302,20 @@ namespace Foundation
 #elif TVOS || WATCH
 		[iOS (9,0)]
 		[Export ("initWithURL:options:documentAttributes:error:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
 #endif
 
 		[iOS (7,0)]
 		[Wrap ("this (url, options.GetDictionary (), out resultDocumentAttributes, ref error)")]
-		IntPtr Constructor (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
+		NativeHandle Constructor (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
 		[iOS (7,0)]
 		[Export ("initWithData:options:documentAttributes:error:")]
-		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
+		NativeHandle Constructor (NSData data, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
 		[iOS (7,0)]
 		[Wrap ("this (data, options.GetDictionary (), out resultDocumentAttributes, ref error)")]
-		IntPtr Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
+		NativeHandle Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
 		[iOS (7,0)]
 		[Export ("dataFromRange:documentAttributes:error:")]
@@ -333,10 +337,10 @@ namespace Foundation
 		
 		[Export ("initWithString:attributes:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		IntPtr Constructor (string str, [NullAllowed] NSDictionary attributes);
+		NativeHandle Constructor (string str, [NullAllowed] NSDictionary attributes);
 
 		[Export ("initWithAttributedString:")]
-		IntPtr Constructor (NSAttributedString other);
+		NativeHandle Constructor (NSAttributedString other);
 
 		[Export ("enumerateAttributesInRange:options:usingBlock:")]
 		void EnumerateAttributes (NSRange range, NSAttributedStringEnumeration options, NSAttributedRangeCallback callback);
@@ -349,13 +353,13 @@ namespace Foundation
 		CGSize Size { get; }
 
 		[Export ("initWithData:options:documentAttributes:error:")]
-		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary options, out NSDictionary docAttributes, out NSError error);
+		NativeHandle Constructor (NSData data, [NullAllowed] NSDictionary options, out NSDictionary docAttributes, out NSError error);
 
 		[Export ("initWithDocFormat:documentAttributes:")]
-		IntPtr Constructor(NSData wordDocFormat, out NSDictionary docAttributes);
+		NativeHandle Constructor(NSData wordDocFormat, out NSDictionary docAttributes);
 
 		[Export ("initWithHTML:baseURL:documentAttributes:")]
-		IntPtr Constructor (NSData htmlData, NSUrl baseUrl, out NSDictionary docAttributes);
+		NativeHandle Constructor (NSData htmlData, NSUrl baseUrl, out NSDictionary docAttributes);
 		
 		[Export ("drawAtPoint:")]
 		void DrawString (CGPoint point);
@@ -367,21 +371,21 @@ namespace Foundation
 		void DrawString (CGRect rect, NSStringDrawingOptions options);	
 
 		[Export ("initWithURL:options:documentAttributes:error:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, out NSError error);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, out NSError error);
 
 		[Wrap ("this (url, options.GetDictionary (), out resultDocumentAttributes, out error)")]
-		IntPtr Constructor (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, out NSError error);
+		NativeHandle Constructor (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, out NSError error);
 
 		[Wrap ("this (data, options.GetDictionary (), out resultDocumentAttributes, out error)")]
-		IntPtr Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, out NSError error);
+		NativeHandle Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, out NSError error);
 
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSAttributedString (NSUrl, NSDictionary, out NSDictionary, ref NSError)' instead.")]
 		[Export ("initWithPath:documentAttributes:")]
-		IntPtr Constructor (string path, out NSDictionary resultDocumentAttributes);
+		NativeHandle Constructor (string path, out NSDictionary resultDocumentAttributes);
 
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSAttributedString (NSUrl, NSDictionary, out NSDictionary, ref NSError)' instead.")]
 		[Export ("initWithURL:documentAttributes:")]
-		IntPtr Constructor (NSUrl url, out NSDictionary resultDocumentAttributes);
+		NativeHandle Constructor (NSUrl url, out NSDictionary resultDocumentAttributes);
 
 		[Internal, Export ("initWithRTF:documentAttributes:")]
 		IntPtr InitWithRtf (NSData data, out NSDictionary resultDocumentAttributes);
@@ -393,13 +397,13 @@ namespace Foundation
 		IntPtr InitWithHTML (NSData data, out NSDictionary resultDocumentAttributes);
 
 		[Export ("initWithHTML:options:documentAttributes:")]
-		IntPtr Constructor (NSData data, [NullAllowed]  NSDictionary options, out NSDictionary resultDocumentAttributes);
+		NativeHandle Constructor (NSData data, [NullAllowed]  NSDictionary options, out NSDictionary resultDocumentAttributes);
 
 		[Wrap ("this (data, options.GetDictionary (), out resultDocumentAttributes)")]
-		IntPtr Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes);
+		NativeHandle Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes);
 
 		[Export ("initWithRTFDFileWrapper:documentAttributes:")]
-		IntPtr Constructor (NSFileWrapper wrapper, out NSDictionary resultDocumentAttributes);
+		NativeHandle Constructor (NSFileWrapper wrapper, out NSDictionary resultDocumentAttributes);
 
 		[Export ("containsAttachments")]
 		bool ContainsAttachments { get; }
@@ -627,10 +631,10 @@ namespace Foundation
 	[DisableDefaultCtor]
 	interface NSCachedUrlResponse : NSCoding, NSSecureCoding, NSCopying {
 		[Export ("initWithResponse:data:userInfo:storagePolicy:")]
-		IntPtr Constructor (NSUrlResponse response, NSData data, [NullAllowed] NSDictionary userInfo, NSUrlCacheStoragePolicy storagePolicy);
+		NativeHandle Constructor (NSUrlResponse response, NSData data, [NullAllowed] NSDictionary userInfo, NSUrlCacheStoragePolicy storagePolicy);
 
 		[Export ("initWithResponse:data:")]
-		IntPtr Constructor (NSUrlResponse response, NSData data);
+		NativeHandle Constructor (NSUrlResponse response, NSData data);
           
 		[Export ("response")]
 		NSUrlResponse Response { get; }
@@ -651,7 +655,7 @@ namespace Foundation
 	interface NSCalendar : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithCalendarIdentifier:")]
-		IntPtr Constructor (NSString identifier);
+		NativeHandle Constructor (NSString identifier);
 
 		[Export ("calendarIdentifier")]
 		string Identifier { get; }
@@ -943,19 +947,19 @@ namespace Foundation
 	interface NSCalendarDate {
 		[Export ("initWithString:calendarFormat:locale:")]
 		[Deprecated (PlatformName.MacOSX, 10, 0)]
-		IntPtr Constructor (string description, string calendarFormat, NSObject locale);
+		NativeHandle Constructor (string description, string calendarFormat, NSObject locale);
 
 		[Export ("initWithString:calendarFormat:")]
 		[Deprecated (PlatformName.MacOSX, 10, 0)]
-		IntPtr Constructor (string description, string calendarFormat);
+		NativeHandle Constructor (string description, string calendarFormat);
 
 		[Export ("initWithString:")]
 		[Deprecated (PlatformName.MacOSX, 10, 0)]
-		IntPtr Constructor (string description);
+		NativeHandle Constructor (string description);
 
 		[Export ("initWithYear:month:day:hour:minute:second:timeZone:")]
 		[Deprecated (PlatformName.MacOSX, 10, 0)]
-		IntPtr Constructor (nint year, nuint month, nuint day, nuint hour, nuint minute, nuint second, [NullAllowed] NSTimeZone aTimeZone);
+		NativeHandle Constructor (nint year, nuint month, nuint day, nuint hour, nuint minute, nuint second, [NullAllowed] NSTimeZone aTimeZone);
 
 		[Deprecated (PlatformName.MacOSX, 10, 0)]
 		[Export ("dateByAddingYears:months:days:hours:minutes:seconds:")]
@@ -1379,11 +1383,11 @@ namespace Foundation
 
 		[DesignatedInitializer]
 		[Export ("initWithLeftExpression:rightExpression:modifier:type:options:")]
-		IntPtr Constructor (NSExpression leftExpression, NSExpression rightExpression, NSComparisonPredicateModifier comparisonModifier, NSPredicateOperatorType operatorType, NSComparisonPredicateOptions comparisonOptions);
+		NativeHandle Constructor (NSExpression leftExpression, NSExpression rightExpression, NSComparisonPredicateModifier comparisonModifier, NSPredicateOperatorType operatorType, NSComparisonPredicateOptions comparisonOptions);
 		
 		[DesignatedInitializer]
 		[Export ("initWithLeftExpression:rightExpression:customSelector:")]
-		IntPtr Constructor (NSExpression leftExpression, NSExpression rightExpression, Selector selector);
+		NativeHandle Constructor (NSExpression leftExpression, NSExpression rightExpression, Selector selector);
 
 		[Export ("predicateOperatorType")]
 		NSPredicateOperatorType PredicateOperatorType { get; }
@@ -1410,7 +1414,7 @@ namespace Foundation
 	interface NSCompoundPredicate : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithType:subpredicates:")]
-		IntPtr Constructor (NSCompoundPredicateType type, NSPredicate[] subpredicates);
+		NativeHandle Constructor (NSCompoundPredicateType type, NSPredicate[] subpredicates);
 
 		[Export ("compoundPredicateType")]
 		NSCompoundPredicateType Type { get; }
@@ -1502,11 +1506,11 @@ namespace Foundation
 
 		[iOS (7,0), Mac (10, 9)] // 10.9
 		[Export ("initWithBase64EncodedString:options:")]
-		IntPtr Constructor (string base64String, NSDataBase64DecodingOptions options);
+		NativeHandle Constructor (string base64String, NSDataBase64DecodingOptions options);
 
 		[iOS (7,0), Mac (10, 9)] // 10.9
 		[Export ("initWithBase64EncodedData:options:")]
-		IntPtr Constructor (NSData base64Data, NSDataBase64DecodingOptions options);
+		NativeHandle Constructor (NSData base64Data, NSDataBase64DecodingOptions options);
 
 		[iOS (7,0), Mac (10, 9)] // 10.9
 		[Export ("base64EncodedDataWithOptions:")]
@@ -1522,7 +1526,7 @@ namespace Foundation
 
 		[iOS (7,0), Mac (10, 9)]
 		[Export ("initWithBytesNoCopy:length:deallocator:")]
-		IntPtr Constructor (IntPtr bytes, nuint length, [NullAllowed] Action<IntPtr,nuint> deallocator);
+		NativeHandle Constructor (IntPtr bytes, nuint length, [NullAllowed] Action<IntPtr,nuint> deallocator);
 
 		// NSDataCompression (NSData)
 
@@ -1541,10 +1545,10 @@ namespace Foundation
 	interface NSDataDetector : NSCopying, NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithTypes:error:")]
-		IntPtr Constructor (NSTextCheckingTypes options, out NSError error);
+		NativeHandle Constructor (NSTextCheckingTypes options, out NSError error);
 
 		[Wrap ("this ((NSTextCheckingTypes) options, out error)")]
-		IntPtr Constructor (NSTextCheckingType options, out NSError error);
+		NativeHandle Constructor (NSTextCheckingType options, out NSError error);
 
 		[Export ("dataDetectorWithTypes:error:"), Static]
 		NSDataDetector Create (NSTextCheckingTypes checkingTypes, out NSError error);
@@ -2126,10 +2130,10 @@ namespace Foundation
 		
 		[DesignatedInitializer]
 		[Export ("initWithFileDescriptor:closeOnDealloc:")]
-		IntPtr Constructor (int /* int, not NSInteger */ fd, bool closeOnDealloc);
+		NativeHandle Constructor (int /* int, not NSInteger */ fd, bool closeOnDealloc);
 		
 		[Export ("initWithFileDescriptor:")]
-		IntPtr Constructor (int /* int, not NSInteger */ fd);
+		NativeHandle Constructor (int /* int, not NSInteger */ fd);
 
 		[Export ("fileDescriptor")]
 		int FileDescriptor { get; } /* int, not NSInteger */
@@ -2301,7 +2305,7 @@ namespace Foundation
 	interface NSCoding {
 		// [Abstract]
 		[Export ("initWithCoder:")]
-		IntPtr Constructor (NSCoder decoder);
+		NativeHandle Constructor (NSCoder decoder);
 
 		[Abstract]
 		[Export ("encodeWithCoder:")]
@@ -2384,7 +2388,7 @@ namespace Foundation
 
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Export ("initRequiringSecureCoding:")]
-		IntPtr Constructor (bool requiresSecureCoding);
+		NativeHandle Constructor (bool requiresSecureCoding);
 
 		// hack so we can decorate the default .ctor with availability attributes
 		[Deprecated (PlatformName.TvOS, 12, 0, message: "Use 'NSKeyedArchiver (bool)' instead.")]
@@ -2393,14 +2397,14 @@ namespace Foundation
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'NSKeyedArchiver (bool)' instead.")]
 		[iOS (10,0)][TV (10,0)][Watch (3,0)][Mac (10,12)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Deprecated (PlatformName.TvOS, 12, 0, message: "Use 'NSKeyedArchiver (bool)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use 'NSKeyedArchiver (bool)' instead.")]
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use 'NSKeyedArchiver (bool)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'NSKeyedArchiver (bool)' instead.")]
 		[Export ("initForWritingWithMutableData:")]
-		IntPtr Constructor (NSMutableData data);
+		NativeHandle Constructor (NSMutableData data);
 	
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Static]
@@ -2474,7 +2478,7 @@ namespace Foundation
 	interface NSKeyedUnarchiver {
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Export ("initForReadingFromData:error:")]
-		IntPtr Constructor (NSData data, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSData data, [NullAllowed] out NSError error);
 
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Static]
@@ -2506,7 +2510,7 @@ namespace Foundation
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use 'NSKeyedUnarchiver (NSData, out NSError)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'NSKeyedUnarchiver (NSData, out NSError)' instead.")]
 		[MarshalNativeExceptions]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 	
 		[Static, Export ("unarchiveObjectWithData:")]
 		[Deprecated (PlatformName.TvOS, 12, 0, message: "Use 'GetUnarchivedObject ()' instead.")]
@@ -3455,7 +3459,7 @@ namespace Foundation
 		[Mac (10,9)]
 		[DesignatedInitializer]
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("valueForAttribute:")]
 		NSObject ValueForAttribute (string key);
@@ -3513,7 +3517,7 @@ namespace Foundation
 	interface NSMutableArray {
 		[DesignatedInitializer]
 		[Export ("initWithCapacity:")]
-		IntPtr Constructor (nuint capacity);
+		NativeHandle Constructor (nuint capacity);
 
 		[Internal]
 		[Sealed]
@@ -3577,13 +3581,13 @@ namespace Foundation
 	[BaseType (typeof (NSAttributedString))]
 	interface NSMutableAttributedString {
 		[Export ("initWithString:")]
-		IntPtr Constructor (string str);
+		NativeHandle Constructor (string str);
 		
 		[Export ("initWithString:attributes:")]
-		IntPtr Constructor (string str, [NullAllowed] NSDictionary attributes);
+		NativeHandle Constructor (string str, [NullAllowed] NSDictionary attributes);
 
 		[Export ("initWithAttributedString:")]
-		IntPtr Constructor (NSAttributedString other);
+		NativeHandle Constructor (NSAttributedString other);
 
 		[Export ("replaceCharactersInRange:withString:")]
 		void Replace (NSRange range, string newValue);
@@ -3682,7 +3686,7 @@ namespace Foundation
 
 		[Export ("initWithCapacity:")]
 		[PreSnippet ("if (capacity > (ulong) nint.MaxValue) throw new ArgumentOutOfRangeException ();", Optimizable = true)]
-		IntPtr Constructor (nuint capacity);
+		NativeHandle Constructor (nuint capacity);
 
 		[Export ("appendData:")]
 		void AppendData (NSData other);
@@ -3793,7 +3797,7 @@ namespace Foundation
 		[NoWatch, NoTV, NoMac]
 		[iOS (14,0)]
 		[Export ("initWithSRAbsoluteTime:")]
-		IntPtr Constructor (double srAbsoluteTime);
+		NativeHandle Constructor (double srAbsoluteTime);
 
 		[NoWatch, NoTV, NoMac]
 		[iOS (14,0)]
@@ -3845,31 +3849,31 @@ namespace Foundation
 		NSDictionary FromObjectsAndKeysInternal ([NullAllowed] NSArray objects, [NullAllowed] NSArray keys);
 
 		[Export ("initWithDictionary:")]
-		IntPtr Constructor (NSDictionary other);
+		NativeHandle Constructor (NSDictionary other);
 
 		[Export ("initWithDictionary:copyItems:")]
-		IntPtr Constructor (NSDictionary other, bool copyItems);
+		NativeHandle Constructor (NSDictionary other, bool copyItems);
 
 		[Deprecated (PlatformName.MacOSX, 10,15, message: "Use 'NSMutableDictionary(string)' constructor instead.")]
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'NSMutableDictionary(string)' constructor instead.")]
 		[Deprecated (PlatformName.WatchOS, 6,0, message: "Use 'NSMutableDictionary(string)' constructor instead.")]
 		[Deprecated (PlatformName.TvOS, 13,0, message: "Use 'NSMutableDictionary(string)' constructor instead.")]
 		[Export ("initWithContentsOfFile:")]
-		IntPtr Constructor (string fileName);
+		NativeHandle Constructor (string fileName);
 
 		[Export ("initWithObjects:forKeys:"), Internal]
-		IntPtr Constructor (NSArray objects, NSArray keys);
+		NativeHandle Constructor (NSArray objects, NSArray keys);
 
 		[Deprecated (PlatformName.MacOSX, 10,15, message: "Use 'NSMutableDictionary(NSUrl)' constructor instead.")]
 		[Deprecated (PlatformName.iOS, 13,0, message: "Use 'NSMutableDictionary(NSUrl)' constructor instead.")]
 		[Deprecated (PlatformName.WatchOS, 6,0, message: "Use 'NSMutableDictionary(NSUrl)' constructor instead.")]
 		[Deprecated (PlatformName.TvOS, 13,0, message: "Use 'NSMutableDictionary(NSUrl)' constructor instead.")]
 		[Export ("initWithContentsOfURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Export ("initWithContentsOfURL:error:")]
-		IntPtr Constructor (NSUrl url, out NSError error);
+		NativeHandle Constructor (NSUrl url, out NSError error);
 
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Static]
@@ -3967,7 +3971,7 @@ namespace Foundation
 
 		[DesignatedInitializer]
 		[Export ("initWithDomain:code:userInfo:")]
-		IntPtr Constructor (NSString domain, nint code, [NullAllowed] NSDictionary userInfo);
+		NativeHandle Constructor (NSString domain, nint code, [NullAllowed] NSDictionary userInfo);
 		
 		[Export ("domain")]
 		string Domain { get; }
@@ -4156,7 +4160,7 @@ namespace Foundation
 	interface NSException : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithName:reason:userInfo:")]
-		IntPtr Constructor (string name, string reason, [NullAllowed] NSDictionary userInfo);
+		NativeHandle Constructor (string name, string reason, [NullAllowed] NSDictionary userInfo);
 
 		[Export ("name")]
 		string Name { get; }
@@ -4255,7 +4259,7 @@ namespace Foundation
 		
 		[DesignatedInitializer]
 		[Export ("initWithExpressionType:")]
-		IntPtr Constructor (NSExpressionType type);
+		NativeHandle Constructor (NSExpressionType type);
 
 		[Export ("expressionType")]
 		NSExpressionType ExpressionType { get; }
@@ -4429,7 +4433,7 @@ namespace Foundation
 	interface NSLinguisticTagger {
 		[DesignatedInitializer]
 		[Export ("initWithTagSchemes:options:")]
-		IntPtr Constructor (NSString [] tagSchemes, NSLinguisticTaggerOptions opts);
+		NativeHandle Constructor (NSString [] tagSchemes, NSLinguisticTaggerOptions opts);
 
 		[Export ("tagSchemes")]
 		NSString [] TagSchemes { get; }
@@ -4657,7 +4661,7 @@ namespace Foundation
 		
 		[DesignatedInitializer]
 		[Export ("initWithLocaleIdentifier:")]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("localeIdentifier")]
 		string LocaleIdentifier { get; }
@@ -4791,7 +4795,7 @@ namespace Foundation
 	interface NSRegularExpression : NSCopying, NSSecureCoding {
 		[DesignatedInitializer]
 		[Export ("initWithPattern:options:error:")]
-		IntPtr Constructor (NSString pattern, NSRegularExpressionOptions options, out NSError error);
+		NativeHandle Constructor (NSString pattern, NSRegularExpressionOptions options, out NSError error);
 
 		[Static]
 		[Export ("regularExpressionWithPattern:options:error:")]
@@ -4949,10 +4953,10 @@ namespace Foundation
 		NSSet CreateSet ();
 
 		[Export ("initWithSet:")]
-		IntPtr Constructor (NSSet other);
+		NativeHandle Constructor (NSSet other);
 		
 		[Export ("initWithArray:")]
-		IntPtr Constructor (NSArray other);
+		NativeHandle Constructor (NSArray other);
 		
 		[Export ("count")]
 		nuint Count { get; }
@@ -5034,13 +5038,13 @@ namespace Foundation
 	[BaseType (typeof (NSObject))]
 	interface NSSortDescriptor : NSSecureCoding, NSCopying {
 		[Export ("initWithKey:ascending:")]
-		IntPtr Constructor (string key, bool ascending);
+		NativeHandle Constructor (string key, bool ascending);
 
 		[Export ("initWithKey:ascending:selector:")]
-		IntPtr Constructor (string key, bool ascending, [NullAllowed] Selector selector);
+		NativeHandle Constructor (string key, bool ascending, [NullAllowed] Selector selector);
 
 		[Export ("initWithKey:ascending:comparator:")]
-		IntPtr Constructor (string key, bool ascending, NSComparator comparator);
+		NativeHandle Constructor (string key, bool ascending, NSComparator comparator);
 
 		[Export ("key")]
 		string Key { get; }
@@ -5107,11 +5111,11 @@ namespace Foundation
 
 		[DesignatedInitializer]
 		[Export ("initWithFireDate:interval:target:selector:userInfo:repeats:")]
-		IntPtr Constructor (NSDate date, double seconds, NSObject target, Selector selector, [NullAllowed] NSObject userInfo, bool repeats);
+		NativeHandle Constructor (NSDate date, double seconds, NSObject target, Selector selector, [NullAllowed] NSObject userInfo, bool repeats);
 
 		[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 		[Export ("initWithFireDate:interval:repeats:block:")]
-		IntPtr Constructor (NSDate date, double seconds, bool repeats, Action<NSTimer> block);
+		NativeHandle Constructor (NSDate date, double seconds, bool repeats, Action<NSTimer> block);
 
 		[Export ("fire")]
 		void Fire ();
@@ -5145,10 +5149,10 @@ namespace Foundation
 	[DisableDefaultCtor]
 	interface NSTimeZone : NSSecureCoding, NSCopying {
 		[Export ("initWithName:")]
-		IntPtr Constructor (string name);
+		NativeHandle Constructor (string name);
 		
 		[Export ("initWithName:data:")]
-		IntPtr Constructor (string name, NSData data);
+		NativeHandle Constructor (string name, NSData data);
 
 		[Export ("name")]
 		string Name { get; } 
@@ -5306,11 +5310,11 @@ namespace Foundation
 	[DesignatedDefaultCtor]
 	interface NSUuid : NSSecureCoding, NSCopying {
 		[Export ("initWithUUIDString:")]
-		IntPtr Constructor (string str);
+		NativeHandle Constructor (string str);
 
 		// bound manually to keep the managed/native signatures identical
 		//[Export ("initWithUUIDBytes:"), Internal]
-		//IntPtr Constructor (IntPtr bytes, bool unused);
+		//NativeHandle Constructor (IntPtr bytes, bool unused);
 
 		[Export ("getUUIDBytes:"), Internal]
 		void GetUuidBytes (IntPtr uuid);
@@ -5329,7 +5333,7 @@ namespace Foundation
 	{
 		[DesignatedInitializer]
 		[Export ("initWithActivityType:")]
-		IntPtr Constructor (string activityType);
+		NativeHandle Constructor (string activityType);
 
 		[Export ("activityType")]
 		string ActivityType { get; }
@@ -5681,18 +5685,18 @@ namespace Foundation
 		[Deprecated (PlatformName.TvOS, 9, 0, message : "Use 'NSUrlComponents' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'NSUrlComponents' instead.")]
 		[Export ("initWithScheme:host:path:")]
-		IntPtr Constructor (string scheme, string host, string path);
+		NativeHandle Constructor (string scheme, string host, string path);
 
 		[DesignatedInitializer]
 		[Export ("initFileURLWithPath:isDirectory:")]
-		IntPtr Constructor (string path, bool isDir);
+		NativeHandle Constructor (string path, bool isDir);
 
 		[Export ("initWithString:")]
-		IntPtr Constructor (string urlString);
+		NativeHandle Constructor (string urlString);
 
 		[DesignatedInitializer]
 		[Export ("initWithString:relativeToURL:")]
-		IntPtr Constructor (string urlString, NSUrl relativeToUrl);
+		NativeHandle Constructor (string urlString, NSUrl relativeToUrl);
 
 		[Export ("URLWithString:")][Static]
 		NSUrl FromString (string s);
@@ -5803,7 +5807,7 @@ namespace Foundation
 		[DesignatedInitializer]
 		[iOS (7,0), Mac (10, 9)]
 		[Export ("initFileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
-		IntPtr Constructor (IntPtr ptrUtf8path, bool isDir, [NullAllowed] NSUrl baseURL);
+		NativeHandle Constructor (IntPtr ptrUtf8path, bool isDir, [NullAllowed] NSUrl baseURL);
 
 		[iOS (7,0), Mac (10, 9), Static, Export ("fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
 		NSUrl FromUTF8Pointer (IntPtr ptrUtf8path, bool isDir, [NullAllowed] NSUrl baseURL);
@@ -6209,7 +6213,7 @@ namespace Foundation
 		NSData CreateBookmarkData (NSUrlBookmarkCreationOptions options, [NullAllowed] string [] resourceValues, [NullAllowed] NSUrl relativeUrl, out NSError error);
 
 		[Export ("initByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:")]
-		IntPtr Constructor (NSData bookmarkData, NSUrlBookmarkResolutionOptions resolutionOptions, [NullAllowed] NSUrl relativeUrl, out bool bookmarkIsStale, out NSError error);
+		NativeHandle Constructor (NSData bookmarkData, NSUrlBookmarkResolutionOptions resolutionOptions, [NullAllowed] NSUrl relativeUrl, out bool bookmarkIsStale, out NSError error);
 
 		[Field ("NSURLPathKey")]
 		NSString PathKey { get; }
@@ -6288,7 +6292,7 @@ namespace Foundation
 		[DesignatedInitializer]
 		[iOS (9,0), Mac(10,11)]
 		[Export ("initFileURLWithPath:isDirectory:relativeToURL:")]
-		IntPtr Constructor (string path, bool isDir, [NullAllowed] NSUrl relativeToUrl);
+		NativeHandle Constructor (string path, bool isDir, [NullAllowed] NSUrl relativeToUrl);
 
 		[iOS (9,0), Mac(10,11)]
 		[Static]
@@ -6418,7 +6422,7 @@ namespace Foundation
 	interface NSUrlQueryItem : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithName:value:")]
-		IntPtr Constructor (string name, string value);
+		NativeHandle Constructor (string name, string value);
 
 		[Export ("name")]
 		string Name { get; }
@@ -6458,11 +6462,11 @@ namespace Foundation
 		[Deprecated (PlatformName.WatchOS, 6,0, message : "Use the overload that accepts an 'NSUrl' parameter instead.")]
 		[Deprecated (PlatformName.TvOS, 13,0, message : "Use the overload that accepts an 'NSUrl' parameter instead.")]
 		[Export ("initWithMemoryCapacity:diskCapacity:diskPath:")]
-		IntPtr Constructor (nuint memoryCapacity, nuint diskCapacity, [NullAllowed] string diskPath);
+		NativeHandle Constructor (nuint memoryCapacity, nuint diskCapacity, [NullAllowed] string diskPath);
 
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("initWithMemoryCapacity:diskCapacity:directoryURL:")]
-		IntPtr Constructor (nuint memoryCapacity, nuint diskCapacity, [NullAllowed] NSUrl directoryUrl);
+		NativeHandle Constructor (nuint memoryCapacity, nuint diskCapacity, [NullAllowed] NSUrl directoryUrl);
 
 		[Export ("cachedResponseForRequest:")]
 		NSCachedUrlResponse CachedResponseForRequest (NSUrlRequest request);
@@ -6510,13 +6514,13 @@ namespace Foundation
 	[BaseType (typeof (NSObject), Name="NSURLComponents")]
 	partial interface NSUrlComponents : NSCopying {
 		[Export ("initWithURL:resolvingAgainstBaseURL:")]
-		IntPtr Constructor (NSUrl url, bool resolveAgainstBaseUrl);
+		NativeHandle Constructor (NSUrl url, bool resolveAgainstBaseUrl);
 	
 		[Static, Export ("componentsWithURL:resolvingAgainstBaseURL:")]
 		NSUrlComponents FromUrl (NSUrl url, bool resolvingAgainstBaseUrl);
 	
 		[Export ("initWithString:")]
-		IntPtr Constructor (string urlString);
+		NativeHandle Constructor (string urlString);
 	
 		[Static, Export ("componentsWithString:")]
 		NSUrlComponents FromString (string urlString);
@@ -6634,10 +6638,10 @@ namespace Foundation
 	[DisableDefaultCtor]
 	interface NSUrlAuthenticationChallenge : NSSecureCoding {
 		[Export ("initWithProtectionSpace:proposedCredential:previousFailureCount:failureResponse:error:sender:")]
-		IntPtr Constructor (NSUrlProtectionSpace space, NSUrlCredential credential, nint previousFailureCount, [NullAllowed] NSUrlResponse response, [NullAllowed] NSError error, NSUrlConnection sender);
+		NativeHandle Constructor (NSUrlProtectionSpace space, NSUrlCredential credential, nint previousFailureCount, [NullAllowed] NSUrlResponse response, [NullAllowed] NSError error, NSUrlConnection sender);
 		
 		[Export ("initWithAuthenticationChallenge:sender:")]
-		IntPtr Constructor (NSUrlAuthenticationChallenge  challenge, NSUrlConnection sender);
+		NativeHandle Constructor (NSUrlAuthenticationChallenge  challenge, NSUrlConnection sender);
 	
 		[Export ("protectionSpace")]
 		NSUrlProtectionSpace ProtectionSpace { get; }
@@ -6708,12 +6712,12 @@ namespace Foundation
 		[Deprecated (PlatformName.iOS, 9,0, message: "Use 'NSUrlSession' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10,11, message: "Use 'NSUrlSession' instead.")]
 		[Export ("initWithRequest:delegate:")]
-		IntPtr Constructor (NSUrlRequest request, [Protocolize] NSUrlConnectionDelegate connectionDelegate);
+		NativeHandle Constructor (NSUrlRequest request, [Protocolize] NSUrlConnectionDelegate connectionDelegate);
 	
 		[Deprecated (PlatformName.iOS, 9,0, message: "Use 'NSUrlSession' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10,11, message: "Use 'NSUrlSession' instead.")]
 		[Export ("initWithRequest:delegate:startImmediately:")]
-		IntPtr Constructor (NSUrlRequest request, [Protocolize] NSUrlConnectionDelegate connectionDelegate, bool startImmediately);
+		NativeHandle Constructor (NSUrlRequest request, [Protocolize] NSUrlConnectionDelegate connectionDelegate, bool startImmediately);
 	
 		[Export ("start")]
 		void Start ();
@@ -6837,13 +6841,13 @@ namespace Foundation
 	interface NSUrlCredential : NSSecureCoding, NSCopying {
 
 		[Export ("initWithTrust:")]
-		IntPtr Constructor (SecTrust trust);
+		NativeHandle Constructor (SecTrust trust);
 
 		[Export ("persistence")]
 		NSUrlCredentialPersistence Persistence { get; }
 
 		[Export ("initWithUser:password:persistence:")]
-		IntPtr Constructor (string user, string password, NSUrlCredentialPersistence persistence);
+		NativeHandle Constructor (string user, string password, NSUrlCredentialPersistence persistence);
 	
 		[Static]
 		[Export ("credentialWithUser:password:persistence:")]
@@ -6860,7 +6864,7 @@ namespace Foundation
 	
 		[Export ("initWithIdentity:certificates:persistence:")]
 		[Internal]
-		IntPtr Constructor (IntPtr identity, IntPtr certificates, NSUrlCredentialPersistence persistance);
+		NativeHandle Constructor (IntPtr identity, IntPtr certificates, NSUrlCredentialPersistence persistance);
 	
 		[Static]
 		[Internal]
@@ -6876,7 +6880,7 @@ namespace Foundation
 	
 		// bound manually to keep the managed/native signatures identical
 		//[Export ("initWithTrust:")]
-		//IntPtr Constructor (IntPtr SecTrustRef_trust, bool ignored);
+		//NativeHandle Constructor (IntPtr SecTrustRef_trust, bool ignored);
 	
 		[Internal]
 		[Static]
@@ -7213,7 +7217,7 @@ namespace Foundation
 		[Deprecated (PlatformName.WatchOS, 6, 0, message:  "This type is not meant to be user created.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message:  "This type is not meant to be user created.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("taskIdentifier")]
 		nuint TaskIdentifier { get; }
@@ -7310,7 +7314,7 @@ namespace Foundation
 		[Deprecated (PlatformName.WatchOS, 6, 0, message:  "Use 'NSURLSession.CreateDataTask' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message:  "Use 'NSURLSession.CreateDataTask' instead.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 	}
 
 	[iOS (7,0)]
@@ -7323,7 +7327,7 @@ namespace Foundation
 		[Deprecated (PlatformName.WatchOS, 6, 0, message:  "Use 'NSURLSession.CreateUploadTask' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message:  "Use 'NSURLSession.CreateUploadTask' instead.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 	}
 
 	[iOS (7,0)]
@@ -7336,7 +7340,7 @@ namespace Foundation
 		[Deprecated (PlatformName.WatchOS, 6, 0, message:  "Use 'NSURLSession.CreateDownloadTask' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message:  "Use 'NSURLSession.CreateDownloadTask' instead.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("cancelByProducingResumeData:")]
 		void Cancel (Action<NSData> resumeCallback);
@@ -7859,11 +7863,11 @@ namespace Foundation
 	[BaseType (typeof (NSObject), Name="NSURLRequest")]
 	interface NSUrlRequest : NSSecureCoding, NSMutableCopying {
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[DesignatedInitializer]
 		[Export ("initWithURL:cachePolicy:timeoutInterval:")]
-		IntPtr Constructor (NSUrl url, NSUrlRequestCachePolicy cachePolicy, double timeoutInterval);
+		NativeHandle Constructor (NSUrl url, NSUrlRequestCachePolicy cachePolicy, double timeoutInterval);
 
 		[Export ("requestWithURL:")][Static]
 		NSUrlRequest FromUrl (NSUrl url);
@@ -7946,20 +7950,20 @@ namespace Foundation
 		NSMutableDictionary FromObjectsAndKeysInternal (NSArray objects, NSArray Keys);
 		
 		[Export ("initWithDictionary:")]
-		IntPtr Constructor (NSDictionary other);
+		NativeHandle Constructor (NSDictionary other);
 
 		[Export ("initWithDictionary:copyItems:")]
-		IntPtr Constructor (NSDictionary other, bool copyItems);
+		NativeHandle Constructor (NSDictionary other, bool copyItems);
 
 		[Export ("initWithContentsOfFile:")]
-		IntPtr Constructor (string fileName);
+		NativeHandle Constructor (string fileName);
 
 		[Export ("initWithContentsOfURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Internal]
 		[Export ("initWithObjects:forKeys:")]
-		IntPtr Constructor (NSArray objects, NSArray keys);
+		NativeHandle Constructor (NSArray objects, NSArray keys);
 
 		[Export ("removeAllObjects"), Internal]
 		void RemoveAllObjects ();
@@ -7992,14 +7996,14 @@ namespace Foundation
 	[DesignatedDefaultCtor]
 	interface NSMutableSet {
 		[Export ("initWithArray:")]
-		IntPtr Constructor (NSArray other);
+		NativeHandle Constructor (NSArray other);
 
 		[Export ("initWithSet:")]
-		IntPtr Constructor (NSSet other);
+		NativeHandle Constructor (NSSet other);
 		
 		[DesignatedInitializer]
 		[Export ("initWithCapacity:")]
-		IntPtr Constructor (nint capacity);
+		NativeHandle Constructor (nint capacity);
 
 		[Internal]
 		[Sealed]
@@ -8038,10 +8042,10 @@ namespace Foundation
 	[BaseType (typeof (NSUrlRequest), Name="NSMutableURLRequest")]
 	interface NSMutableUrlRequest {
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("initWithURL:cachePolicy:timeoutInterval:")]
-		IntPtr Constructor (NSUrl url, NSUrlRequestCachePolicy cachePolicy, double timeoutInterval);
+		NativeHandle Constructor (NSUrl url, NSUrlRequestCachePolicy cachePolicy, double timeoutInterval);
 
 		[NullAllowed] // by default this property is null
 		[New][Export ("URL")]
@@ -8102,7 +8106,7 @@ namespace Foundation
 	interface NSUrlResponse : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithURL:MIMEType:expectedContentLength:textEncodingName:")]
-		IntPtr Constructor (NSUrl url, string mimetype, nint expectedContentLength, [NullAllowed] string textEncodingName);
+		NativeHandle Constructor (NSUrl url, string mimetype, nint expectedContentLength, [NullAllowed] string textEncodingName);
 
 		[Export ("URL")]
 		NSUrl Url { get; }
@@ -8275,7 +8279,7 @@ namespace Foundation
 		, NSItemProviderReading, NSItemProviderWriting
 	{
 		[Export ("initWithData:encoding:")]
-		IntPtr Constructor (NSData data, NSStringEncoding encoding);
+		NativeHandle Constructor (NSData data, NSStringEncoding encoding);
 #if MONOMAC
 		[Bind ("sizeWithAttributes:")]
 		CGSize StringSize ([NullAllowed] NSDictionary attributedStringAttributes);
@@ -8518,7 +8522,7 @@ namespace Foundation
 	// hack: it seems that generator.cs can't track NSCoding correctly ? maybe because the type is named NSString2 at that time
 	interface NSMutableString : NSCoding {
 		[Export ("initWithCapacity:")]
-		IntPtr Constructor (nint capacity);
+		NativeHandle Constructor (nint capacity);
 
 		[PreSnippet ("Check (index);", Optimizable = true)]
 		[Export ("insertString:atIndex:")]
@@ -8602,15 +8606,15 @@ namespace Foundation
 		bool HasBytesAvailable ();
 	
 		[Export ("initWithFileAtPath:")]
-		IntPtr Constructor (string path);
+		NativeHandle Constructor (string path);
 
 		[DesignatedInitializer]
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[DesignatedInitializer]
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Static]
 		[Export ("inputStreamWithData:")]
@@ -8678,7 +8682,7 @@ namespace Foundation
 #pragma warning disable 108
 		[Manual]
 		[Export ("conformsToProtocol:")]
-		bool ConformsToProtocol (IntPtr /* Protocol */ aProtocol);
+		bool ConformsToProtocol (NativeHandle /* Protocol */ aProtocol);
 
 		[Manual]
 		[Export ("retain")]
@@ -9036,7 +9040,7 @@ namespace Foundation
 		[Abstract]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("conformsToProtocol:")]
-		bool ConformsToProtocol ([NullAllowed] IntPtr /* Protocol */ aProtocol);
+		bool ConformsToProtocol ([NullAllowed] NativeHandle /* Protocol */ aProtocol);
 
 		[Abstract]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
@@ -9218,16 +9222,16 @@ namespace Foundation
 	[DesignatedDefaultCtor]
 	interface NSOrderedSet : NSSecureCoding, NSMutableCopying {
 		[Export ("initWithObject:")]
-		IntPtr Constructor (NSObject start);
+		NativeHandle Constructor (NSObject start);
 
 		[Export ("initWithArray:"), Internal]
-		IntPtr Constructor (NSArray array);
+		NativeHandle Constructor (NSArray array);
 
 		[Export ("initWithSet:")]
-		IntPtr Constructor (NSSet source);
+		NativeHandle Constructor (NSSet source);
 
 		[Export ("initWithOrderedSet:")]
-		IntPtr Constructor (NSOrderedSet source);
+		NativeHandle Constructor (NSOrderedSet source);
 
 		[Export ("count")]
 		nint Count { get; }
@@ -9311,20 +9315,20 @@ namespace Foundation
 	[DesignatedDefaultCtor]
 	interface NSMutableOrderedSet {
 		[Export ("initWithObject:")]
-		IntPtr Constructor (NSObject start);
+		NativeHandle Constructor (NSObject start);
 
 		[Export ("initWithSet:")]
-		IntPtr Constructor (NSSet source);
+		NativeHandle Constructor (NSSet source);
 
 		[Export ("initWithOrderedSet:")]
-		IntPtr Constructor (NSOrderedSet source);
+		NativeHandle Constructor (NSOrderedSet source);
 
 		[DesignatedInitializer]
 		[Export ("initWithCapacity:")]
-		IntPtr Constructor (nint capacity);
+		NativeHandle Constructor (nint capacity);
 
 		[Export ("initWithArray:"), Internal]
-		IntPtr Constructor (NSArray array);
+		NativeHandle Constructor (NSArray array);
 
 		[Export ("unionSet:"), Internal]
 		void UnionSet (NSSet other);
@@ -9471,7 +9475,7 @@ namespace Foundation
 
 		[DesignatedInitializer]
 		[Export ("initWithDominantScript:languageMap:")]
-		IntPtr Constructor (string dominantScript, [NullAllowed] NSDictionary languageMap);
+		NativeHandle Constructor (string dominantScript, [NullAllowed] NSDictionary languageMap);
 	}
 	
 	[BaseType (typeof (NSStream))]
@@ -9479,16 +9483,16 @@ namespace Foundation
 	interface NSOutputStream {
 		[DesignatedInitializer]
 		[Export ("initToMemory")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("hasSpaceAvailable")]
 		bool HasSpaceAvailable ();
 	
 		//[Export ("initToBuffer:capacity:")]
-		//IntPtr Constructor (uint8_t  buffer, NSUInteger capacity);
+		//NativeHandle Constructor (uint8_t  buffer, NSUInteger capacity);
 
 		[Export ("initToFileAtPath:append:")]
-		IntPtr Constructor (string path, bool shouldAppend);
+		NativeHandle Constructor (string path, bool shouldAppend);
 
 		[Static]
 		[Export ("outputStreamToMemory")]
@@ -9517,7 +9521,7 @@ namespace Foundation
 	[DisableDefaultCtor]
 	interface NSHttpCookie {
 		[Export ("initWithProperties:")]
-		IntPtr Constructor (NSDictionary properties);
+		NativeHandle Constructor (NSDictionary properties);
 
 		[Export ("cookieWithProperties:"), Static]
 		NSHttpCookie CookieFromProperties (NSDictionary properties);
@@ -9682,10 +9686,10 @@ namespace Foundation
 	[BaseType (typeof (NSUrlResponse), Name="NSHTTPURLResponse")]
 	interface NSHttpUrlResponse {
 		[Export ("initWithURL:MIMEType:expectedContentLength:textEncodingName:")]
-		IntPtr Constructor (NSUrl url, string mimetype, nint expectedContentLength, [NullAllowed] string textEncodingName);
+		NativeHandle Constructor (NSUrl url, string mimetype, nint expectedContentLength, [NullAllowed] string textEncodingName);
 
 		[Export ("initWithURL:statusCode:HTTPVersion:headerFields:")]
-		IntPtr Constructor (NSUrl url, nint statusCode, [NullAllowed] string httpVersion, [NullAllowed] NSDictionary headerFields);
+		NativeHandle Constructor (NSUrl url, nint statusCode, [NullAllowed] string httpVersion, [NullAllowed] NSDictionary headerFields);
 		
 		[Export ("statusCode")]
 		nint StatusCode { get; }
@@ -9715,7 +9719,7 @@ namespace Foundation
 
 		[DesignatedInitializer]
 		[Export ("initWithPath:")]
-		IntPtr Constructor (string path);
+		NativeHandle Constructor (string path);
 
 		[Export ("bundleForClass:")][Static]
 		NSBundle FromClass (Class c);
@@ -9850,7 +9854,7 @@ namespace Foundation
 		NSUrl BuiltInPluginsUrl { get; }
 
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 		
 		[Static, Export ("bundleWithURL:")]
 		NSBundle FromUrl (NSUrl url);
@@ -9913,11 +9917,11 @@ namespace Foundation
 	interface NSBundleResourceRequest : NSProgressReporting
 	{
 		[Export ("initWithTags:")]
-		IntPtr Constructor (NSSet<NSString> tags);
+		NativeHandle Constructor (NSSet<NSString> tags);
 	
 		[Export ("initWithTags:bundle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSSet<NSString> tags, NSBundle bundle);
+		NativeHandle Constructor (NSSet<NSString> tags, NSBundle bundle);
 	
 		[Export ("loadingPriority")]
 		double LoadingPriority { get; set; }
@@ -10026,11 +10030,11 @@ namespace Foundation
 		NSIndexSet FromNSRange (NSRange indexRange);
 		
 		[Export ("initWithIndex:")]
-		IntPtr Constructor (nuint index);
+		NativeHandle Constructor (nuint index);
 
 		[DesignatedInitializer]
 		[Export ("initWithIndexSet:")]
-		IntPtr Constructor (NSIndexSet other);
+		NativeHandle Constructor (NSIndexSet other);
 
 		[Export ("count")]
 		nint Count { get; }
@@ -10121,10 +10125,10 @@ namespace Foundation
 	partial interface NSItemProvider : NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithItem:typeIdentifier:")]
-		IntPtr Constructor ([NullAllowed] NSObject item, string typeIdentifier);
+		NativeHandle Constructor ([NullAllowed] NSObject item, string typeIdentifier);
 
 		[Export ("initWithContentsOfURL:")]
-		IntPtr Constructor (NSUrl fileUrl);
+		NativeHandle Constructor (NSUrl fileUrl);
 
 		[Export ("registeredTypeIdentifiers", ArgumentSemantic.Copy)]
 		string [] RegisteredTypeIdentifiers { get; }
@@ -10216,7 +10220,7 @@ namespace Foundation
 
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Export ("initWithObject:")]
-		IntPtr Constructor (INSItemProviderWriting @object);
+		NativeHandle Constructor (INSItemProviderWriting @object);
 
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Export ("registerObject:visibility:")]
@@ -10412,10 +10416,10 @@ namespace Foundation
 	[BaseType (typeof (NSIndexSet))]
 	interface NSMutableIndexSet : NSSecureCoding {
 		[Export ("initWithIndex:")]
-		IntPtr Constructor (nuint index);
+		NativeHandle Constructor (nuint index);
 
 		[Export ("initWithIndexSet:")]
-		IntPtr Constructor (NSIndexSet other);
+		NativeHandle Constructor (NSIndexSet other);
 
 		[Export ("addIndexes:")]
 		void Add (NSIndexSet other);
@@ -10448,10 +10452,10 @@ namespace Foundation
 	interface NSNetService {
 		[DesignatedInitializer]
 		[Export ("initWithDomain:type:name:port:")]
-		IntPtr Constructor (string domain, string type, string name, int /* int, not NSInteger */ port);
+		NativeHandle Constructor (string domain, string type, string name, int /* int, not NSInteger */ port);
 
 		[Export ("initWithDomain:type:name:")]
-		IntPtr Constructor (string domain, string type, string name);
+		NativeHandle Constructor (string domain, string type, string name);
 		
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -10722,7 +10726,7 @@ namespace Foundation
 
 		[Export ("initWithPath:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string path);
+		NativeHandle Constructor (string path);
 
 		[Export ("tryLock")]
 		bool TryLock ();
@@ -10791,7 +10795,7 @@ namespace Foundation
 
 		[DesignatedInitializer]
 		[Export ("initWithNotificationCenter:")]
-		IntPtr Constructor (NSNotificationCenter notificationCenter);
+		NativeHandle Constructor (NSNotificationCenter notificationCenter);
 
 		[Export ("enqueueNotification:postingStyle:")]
 		void EnqueueNotification (NSNotification notification, NSPostingStyle postingStyle);
@@ -11202,61 +11206,61 @@ namespace Foundation
 
 		[DesignatedInitializer]
 		[Export ("initWithChar:")]
-		IntPtr Constructor (sbyte value);
+		NativeHandle Constructor (sbyte value);
 	
 		[DesignatedInitializer]
 		[Export ("initWithUnsignedChar:")]
-		IntPtr Constructor (byte value);
+		NativeHandle Constructor (byte value);
 	
 		[DesignatedInitializer]
 		[Export ("initWithShort:")]
-		IntPtr Constructor (short value);
+		NativeHandle Constructor (short value);
 	
 		[DesignatedInitializer]
 		[Export ("initWithUnsignedShort:")]
-		IntPtr Constructor (ushort value);
+		NativeHandle Constructor (ushort value);
 	
 		[DesignatedInitializer]
 		[Export ("initWithInt:")]
-		IntPtr Constructor (int /* int, not NSInteger */ value);
+		NativeHandle Constructor (int /* int, not NSInteger */ value);
 	
 		[DesignatedInitializer]
 		[Export ("initWithUnsignedInt:")]
-		IntPtr Constructor (uint /* unsigned int, not NSUInteger */value);
+		NativeHandle Constructor (uint /* unsigned int, not NSUInteger */value);
 	
 		//[Export ("initWithLong:")]
-		//IntPtr Constructor (long value);
+		//NativeHandle Constructor (long value);
 		//
 		//[Export ("initWithUnsignedLong:")]
-		//IntPtr Constructor (ulong value);
+		//NativeHandle Constructor (ulong value);
 	
 		[DesignatedInitializer]
 		[Export ("initWithLongLong:")]
-		IntPtr Constructor (long value);
+		NativeHandle Constructor (long value);
 	
 		[DesignatedInitializer]
 		[Export ("initWithUnsignedLongLong:")]
-		IntPtr Constructor (ulong value);
+		NativeHandle Constructor (ulong value);
 	
 		[DesignatedInitializer]
 		[Export ("initWithFloat:")]
-		IntPtr Constructor (float /* float, not CGFloat */ value);
+		NativeHandle Constructor (float /* float, not CGFloat */ value);
 	
 		[DesignatedInitializer]
 		[Export ("initWithDouble:")]
-		IntPtr Constructor (double value);
+		NativeHandle Constructor (double value);
 	
 		[DesignatedInitializer]
 		[Export ("initWithBool:")]
-		IntPtr Constructor (bool value);
+		NativeHandle Constructor (bool value);
 
 		[DesignatedInitializer]
 		[Export ("initWithInteger:")]
-		IntPtr Constructor (nint value);
+		NativeHandle Constructor (nint value);
 
 		[DesignatedInitializer]
 		[Export ("initWithUnsignedInteger:")]
-		IntPtr Constructor (nuint value);
+		NativeHandle Constructor (nuint value);
 	
 		[Export ("numberWithChar:")][Static]
 		NSNumber FromSByte (sbyte value);
@@ -11519,17 +11523,17 @@ namespace Foundation
 	[BaseType (typeof (NSNumber))]
 	interface NSDecimalNumber : NSSecureCoding {
 		[Export ("initWithMantissa:exponent:isNegative:")]
-		IntPtr Constructor (long mantissa, short exponent, bool isNegative);
+		NativeHandle Constructor (long mantissa, short exponent, bool isNegative);
 		
 		[DesignatedInitializer]
 		[Export ("initWithDecimal:")]
-		IntPtr Constructor (NSDecimal dec);
+		NativeHandle Constructor (NSDecimal dec);
 
 		[Export ("initWithString:")]
-		IntPtr Constructor (string numberValue);
+		NativeHandle Constructor (string numberValue);
 
 		[Export ("initWithString:locale:")]
-		IntPtr Constructor (string numberValue, NSObject locale);
+		NativeHandle Constructor (string numberValue, NSObject locale);
 
 		[Export ("descriptionWithLocale:")]
 		[Override]
@@ -11739,7 +11743,7 @@ namespace Foundation
 #if MONOMAC || __MACCATALYST__
 		[DesignatedInitializer]
 		[Export ("initWithSendPort:receivePort:components:")]
-		IntPtr Constructor (NSPort sendPort, NSPort recvPort, NSArray components);
+		NativeHandle Constructor (NSPort sendPort, NSPort recvPort, NSArray components);
 
 		[Export ("components")]
 		NSArray Components { get; }
@@ -11767,11 +11771,11 @@ namespace Foundation
 	interface NSMachPort {
 		[DesignatedInitializer]
 		[Export ("initWithMachPort:")]
-		IntPtr Constructor (uint /* uint32_t */ machPort);
+		NativeHandle Constructor (uint /* uint32_t */ machPort);
 
 		[DesignatedInitializer]
 		[Export ("initWithMachPort:options:")]
-		IntPtr Constructor (uint /* uint32_t */ machPort, NSMachPortRights options);
+		NativeHandle Constructor (uint /* uint32_t */ machPort, NSMachPortRights options);
 		
 		[Static, Export ("portWithMachPort:")]
 		NSPort FromMachPort (uint /* uint32_t */ port);
@@ -11968,7 +11972,7 @@ namespace Foundation
 	
 		[DesignatedInitializer]
 		[Export ("initWithParent:userInfo:")]
-		IntPtr Constructor ([NullAllowed] NSProgress parentProgress, [NullAllowed] NSDictionary userInfo);
+		NativeHandle Constructor ([NullAllowed] NSProgress parentProgress, [NullAllowed] NSDictionary userInfo);
 	
 		[Export ("becomeCurrentWithPendingUnitCount:")]
 		void BecomeCurrent (long pendingUnitCount);
@@ -12205,12 +12209,12 @@ namespace Foundation
 
 		[DesignatedInitializer]
 		[Export ("initWithFilePresenter:")]
-		IntPtr Constructor ([NullAllowed] INSFilePresenter filePresenterOrNil);
+		NativeHandle Constructor ([NullAllowed] INSFilePresenter filePresenterOrNil);
 
 #if !XAMCORE_4_0
 		[Obsolete ("Use '.ctor(INSFilePresenter)' instead.")]
 		[Wrap ("this (filePresenterOrNil as INSFilePresenter)")]
-		IntPtr Constructor ([NullAllowed] NSFilePresenter filePresenterOrNil);
+		NativeHandle Constructor ([NullAllowed] NSFilePresenter filePresenterOrNil);
 #endif
 
 		[Export ("coordinateReadingItemAtURL:options:error:byAccessor:")]
@@ -12827,23 +12831,23 @@ namespace Foundation
 	interface NSFileWrapper : NSSecureCoding {
 		[DesignatedInitializer]
 		[Export ("initWithURL:options:error:")]
-		IntPtr Constructor (NSUrl url, NSFileWrapperReadingOptions options, out NSError outError);
+		NativeHandle Constructor (NSUrl url, NSFileWrapperReadingOptions options, out NSError outError);
 
 		[DesignatedInitializer]
 		[Export ("initDirectoryWithFileWrappers:")]
-		IntPtr Constructor (NSDictionary childrenByPreferredName);
+		NativeHandle Constructor (NSDictionary childrenByPreferredName);
 
 		[DesignatedInitializer]
 		[Export ("initRegularFileWithContents:")]
-		IntPtr Constructor (NSData contents);
+		NativeHandle Constructor (NSData contents);
 
 		[DesignatedInitializer]
 		[Export ("initSymbolicLinkWithDestinationURL:")]
-		IntPtr Constructor (NSUrl urlToSymbolicLink);
+		NativeHandle Constructor (NSUrl urlToSymbolicLink);
 
 		// Constructor clash
 		//[Export ("initWithSerializedRepresentation:")]
-		//IntPtr Constructor (NSData serializeRepresentation);
+		//NativeHandle Constructor (NSData serializeRepresentation);
 
 		[Export ("isDirectory")]
 		bool IsDirectory { get; }
@@ -13012,11 +13016,11 @@ namespace Foundation
 
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSURLSession' instead.")]
 		[Export ("initWithRequest:delegate:")]
-		IntPtr Constructor (NSUrlRequest request, NSObject delegate1);
+		NativeHandle Constructor (NSUrlRequest request, NSObject delegate1);
 
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSURLSession' instead.")]
 		[Export ("initWithResumeData:delegate:path:")]
-		IntPtr Constructor (NSData resumeData, NSObject delegate1, string path);
+		NativeHandle Constructor (NSData resumeData, NSObject delegate1, string path);
 
 		[Export ("cancel")]
 		void Cancel ();
@@ -13123,7 +13127,7 @@ namespace Foundation
 	interface NSUrlProtocol {
 		[DesignatedInitializer]
 		[Export ("initWithRequest:cachedResponse:client:")]
-		IntPtr Constructor (NSUrlRequest request, [NullAllowed] NSCachedUrlResponse cachedResponse, INSUrlProtocolClient client);
+		NativeHandle Constructor (NSUrlRequest request, [NullAllowed] NSCachedUrlResponse cachedResponse, INSUrlProtocolClient client);
 
 		[Export ("client")]
 		INSUrlProtocolClient Client { get; }
@@ -13184,7 +13188,7 @@ namespace Foundation
 
 //		[iOS (8,0)]
 //		[Export ("initWithTask:cachedResponse:client:")]
-//		IntPtr Constructor (NSUrlSessionTask task, [NullAllowed] NSCachedUrlResponse cachedResponse, INSUrlProtocolClient client);
+//		NativeHandle Constructor (NSUrlSessionTask task, [NullAllowed] NSCachedUrlResponse cachedResponse, INSUrlProtocolClient client);
 //
 //		[iOS (8,0)]
 //		[Export ("task", ArgumentSemantic.Copy)]
@@ -13473,7 +13477,7 @@ namespace Foundation
 
 		[DesignatedInitializer]
 		[Export ("initWithCondition:")]
-		IntPtr Constructor (nint condition);
+		NativeHandle Constructor (nint condition);
 
 		[Export ("condition")]
 		nint Condition { get; }
@@ -13627,10 +13631,10 @@ namespace Foundation
 
 		[Export ("initWithStartDate:duration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSDate startDate, double duration);
+		NativeHandle Constructor (NSDate startDate, double duration);
 
 		[Export ("initWithStartDate:endDate:")]
-		IntPtr Constructor (NSDate startDate, NSDate endDate);
+		NativeHandle Constructor (NSDate startDate, NSDate endDate);
 
 		[Export ("compare:")]
 		NSComparisonResult Compare (NSDateInterval dateInterval);
@@ -13658,7 +13662,7 @@ namespace Foundation
 
 		[Export ("initWithSymbol:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol);
+		NativeHandle Constructor (string symbol);
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13682,11 +13686,11 @@ namespace Foundation
 		double Constant { get; }
 
 		[Export ("initWithCoefficient:")]
-		IntPtr Constructor (double coefficient);
+		NativeHandle Constructor (double coefficient);
 
 		[Export ("initWithCoefficient:constant:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double coefficient, double constant);
+		NativeHandle Constructor (double coefficient, double constant);
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13697,14 +13701,14 @@ namespace Foundation
 		// Inlined from base type
 		[Export ("initWithSymbol:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol);
+		NativeHandle Constructor (string symbol);
 
 		[Export ("converter", ArgumentSemantic.Copy)]
 		NSUnitConverter Converter { get; }
 
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		// needs to be overriden in suubclasses
 		//	NSInvalidArgumentException Reason: *** You must override baseUnit in your class NSDimension to define its base unit.
@@ -13721,7 +13725,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("kelvin", ArgumentSemantic.Copy)]
@@ -13838,7 +13842,7 @@ namespace Foundation
 		[Internal]
 		[DesignatedInitializer]
 		[Export ("initWithCommandDescription:")]
-		IntPtr Constructor (NSScriptCommandDescription cmdDescription);
+		NativeHandle Constructor (NSScriptCommandDescription cmdDescription);
 
 		[Internal]
 		[Static]
@@ -13885,7 +13889,7 @@ namespace Foundation
 		[Internal]
 		[DesignatedInitializer]
 		[Export ("initWithSuiteName:commandName:dictionary:")]
-		IntPtr Constructor (NSString suiteName, NSString commandName, NSDictionary commandDeclaration);
+		NativeHandle Constructor (NSString suiteName, NSString commandName, NSDictionary commandDeclaration);
 
 		[Internal]
 		[Export ("appleEventClassCode")]
@@ -13937,7 +13941,7 @@ namespace Foundation
 	[MacCatalyst (13, 0)]
 	interface NSAffineTransform : NSSecureCoding, NSCopying {
 		[Export ("initWithTransform:")]
-		IntPtr Constructor (NSAffineTransform transform);
+		NativeHandle Constructor (NSAffineTransform transform);
 
 		[Export ("translateXBy:yBy:")]
 		void Translate (nfloat deltaX, nfloat deltaY);
@@ -14666,12 +14670,12 @@ namespace Foundation
 		// @required - (instancetype)initWithContentsOfURL:(NSURL *)url error:(NSDictionary **)errorInfo;
 		[DesignatedInitializer]
 		[Export ("initWithContentsOfURL:error:")]
-		IntPtr Constructor (NSUrl url, out NSDictionary errorInfo);
+		NativeHandle Constructor (NSUrl url, out NSDictionary errorInfo);
 
 		// @required - (instancetype)initWithSource:(NSString *)source;
 		[DesignatedInitializer]
 		[Export ("initWithSource:")]
-		IntPtr Constructor (string source);
+		NativeHandle Constructor (string source);
 
 		// @property (readonly, copy) NSString * source;
 		[NullAllowed]
@@ -14732,7 +14736,7 @@ namespace Foundation
 		[Deprecated (PlatformName.WatchOS, 6, 0, message:  "This type is not meant to be user created.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message:  "This type is not meant to be user created.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("request", ArgumentSemantic.Copy)]
 		NSUrlRequest Request { get; }
@@ -14876,7 +14880,7 @@ namespace Foundation
 		[Deprecated (PlatformName.WatchOS, 6, 0, message:  "This type is not meant to be user created.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message:  "This type is not meant to be user created.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("transactionMetrics", ArgumentSemantic.Copy)]
 		NSUrlSessionTaskTransactionMetrics[] TransactionMetrics { get; }
@@ -14895,7 +14899,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("metersPerSecondSquared", ArgumentSemantic.Copy)]
@@ -14918,7 +14922,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("degrees", ArgumentSemantic.Copy)]
@@ -14957,7 +14961,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("squareMegameters", ArgumentSemantic.Copy)]
@@ -15028,7 +15032,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("gramsPerLiter", ArgumentSemantic.Copy)]
@@ -15055,7 +15059,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("partsPerMillion", ArgumentSemantic.Copy)]
@@ -15074,7 +15078,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("seconds", ArgumentSemantic.Copy)]
@@ -15121,7 +15125,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("coulombs", ArgumentSemantic.Copy)]
@@ -15160,7 +15164,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("megaamperes", ArgumentSemantic.Copy)]
@@ -15195,7 +15199,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 		
 		[Static]
 		[Export ("megavolts", ArgumentSemantic.Copy)]
@@ -15230,7 +15234,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("megaohms", ArgumentSemantic.Copy)]
@@ -15265,7 +15269,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("kilojoules", ArgumentSemantic.Copy)]
@@ -15300,7 +15304,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("terahertz", ArgumentSemantic.Copy)]
@@ -15352,7 +15356,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("litersPer100Kilometers", ArgumentSemantic.Copy)]
@@ -15379,7 +15383,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("megameters", ArgumentSemantic.Copy)]
@@ -15482,7 +15486,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("lux", ArgumentSemantic.Copy)]
@@ -15501,7 +15505,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("kilograms", ArgumentSemantic.Copy)]
@@ -15580,7 +15584,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("terawatts", ArgumentSemantic.Copy)]
@@ -15639,7 +15643,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("newtonsPerMetersSquared", ArgumentSemantic.Copy)]
@@ -15694,7 +15698,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("metersPerSecond", ArgumentSemantic.Copy)]
@@ -15725,7 +15729,7 @@ namespace Foundation
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("megaliters", ArgumentSemantic.Copy)]
@@ -15870,7 +15874,7 @@ namespace Foundation
 
 		[Export ("initWithDoubleValue:unit:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double doubleValue, NSUnit unit);
+		NativeHandle Constructor (double doubleValue, NSUnit unit);
 
 		[Export ("canBeConvertedToUnit:")]
 		bool CanBeConvertedTo (NSUnit unit);
@@ -15914,17 +15918,17 @@ namespace Foundation
 	{
 		[Export ("initWithServiceName:")]
 		[NoiOS][NoWatch][NoTV]
-		IntPtr Constructor (string xpcServiceName);
+		NativeHandle Constructor (string xpcServiceName);
 
 		[Export ("serviceName")]
 		string ServiceName { get; }
 
 		[Export ("initWithMachServiceName:options:")]
 		[NoiOS][NoWatch][NoTV]
-		IntPtr Constructor (string machServiceName, NSXpcConnectionOptions options);
+		NativeHandle Constructor (string machServiceName, NSXpcConnectionOptions options);
 
 		[Export ("initWithListenerEndpoint:")]
-		IntPtr Constructor (NSXpcListenerEndpoint endpoint);
+		NativeHandle Constructor (NSXpcListenerEndpoint endpoint);
 
 		[Export ("endpoint")]
 		NSXpcListenerEndpoint Endpoint { get; }
@@ -16004,7 +16008,7 @@ namespace Foundation
 		[Export ("initWithMachServiceName:")]
 		[DesignatedInitializer]
 		[NoiOS][NoTV][NoWatch]
-		IntPtr Constructor (string machServiceName);
+		NativeHandle Constructor (string machServiceName);
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -16156,12 +16160,12 @@ namespace Foundation
 		// Inlined from base type
 		[Export ("initWithSymbol:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol);
+		NativeHandle Constructor (string symbol);
 
 		// Inlined from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("bytes", ArgumentSemantic.Copy)]
@@ -16318,11 +16322,11 @@ namespace Foundation
 
 		[Export ("initWithData:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Export ("initWithString:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string @string);
+		NativeHandle Constructor (string @string);
 
 		[Export ("type")]
 		NSUrlSessionWebSocketMessageType Type { get; }
@@ -16421,7 +16425,7 @@ namespace Foundation
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("identifier")]
 		string Identifier { get; }

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1847,6 +1847,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/INativeObject.cs \
 	ObjCRuntime/LinkWithAttribute.cs \
 	ObjCRuntime/NativeAttribute.cs \
+	ObjCRuntime/NativeHandle.cs \
 	ObjCRuntime/ObsoleteConstants.cs \
 	ObjCRuntime/PlatformAvailability.cs \
 	ObjCRuntime/PlatformAvailability2.cs \

--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -28,6 +28,10 @@ using UIKit;
 using BezierPath = UIKit.UIBezierPath;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace GameController {
 
 	[iOS (7,0)]
@@ -245,10 +249,10 @@ namespace GameController {
 		NSData SnapshotData { get; set; }
 
 		[Export ("initWithSnapshotData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Export ("initWithController:snapshotData:")]
-		IntPtr Constructor (GCController controller, NSData data);
+		NativeHandle Constructor (GCController controller, NSData data);
 	}
 
 	delegate void GCExtendedGamepadValueChangedHandler (GCExtendedGamepad gamepad, GCControllerElement element);
@@ -344,10 +348,10 @@ namespace GameController {
 		NSData SnapshotData { get; set; }
 
 		[Export ("initWithSnapshotData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Export ("initWithController:snapshotData:")]
-		IntPtr Constructor (GCController controller, NSData data);
+		NativeHandle Constructor (GCController controller, NSData data);
 
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.GetExtendedGamepadController()' instead.")]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetExtendedGamepadController()' instead.")]
@@ -652,10 +656,10 @@ namespace GameController {
 		NSData SnapshotData { get; set; }
 
 		[Export ("initWithSnapshotData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Export ("initWithController:snapshotData:")]
-		IntPtr Constructor (GCController controller, NSData data);
+		NativeHandle Constructor (GCController controller, NSData data);
 
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
@@ -674,7 +678,7 @@ namespace GameController {
 		// inlined ctor
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("controllerUserInteractionEnabled")]
 		bool ControllerUserInteractionEnabled { get; set; }
@@ -687,7 +691,7 @@ namespace GameController {
 	interface GCColor : NSCopying, NSSecureCoding
 	{
 		[Export ("initWithRed:green:blue:")]
-		IntPtr Constructor (float red, float green, float blue);
+		NativeHandle Constructor (float red, float green, float blue);
 
 		[Export ("red")]
 		float Red { get; }
@@ -2071,7 +2075,7 @@ namespace GameController {
 
 		[Export ("initWithConfiguration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (GCVirtualControllerConfiguration configuration);
+		NativeHandle Constructor (GCVirtualControllerConfiguration configuration);
 
 		[Async]
 		[Export ("connectWithReplyHandler:")]

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -29,6 +29,10 @@ using NSViewController = Foundation.NSObject;
 using NSWindow = Foundation.NSObject;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace GameKit {
 
 	delegate void GKFriendsHandler      (string [] friends, NSError error);
@@ -209,7 +213,7 @@ namespace GameKit {
 		[Export ("initWithSessionID:displayName:sessionMode:")]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
-		IntPtr Constructor ([NullAllowed] string sessionID, [NullAllowed] string displayName, GKSessionMode mode);
+		NativeHandle Constructor ([NullAllowed] string sessionID, [NullAllowed] string displayName, GKSessionMode mode);
 
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -344,13 +348,13 @@ namespace GameKit {
 		[Deprecated (PlatformName.MacOSX, 11, 0, message: "Use 'LoadLeaderboards' instead.")]
 		[Deprecated (PlatformName.WatchOS, 7, 0, message: "Use 'LoadLeaderboards' instead.")]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use '.ctor (GKPlayer [] players)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use '.ctor (GKPlayer [] players)' instead.")]
 		[Export ("initWithPlayerIDs:")]
-		IntPtr Constructor ([NullAllowed] string [] players);
+		NativeHandle Constructor ([NullAllowed] string [] players);
 
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use 'LoadEntries' instead.")]
 		[Deprecated (PlatformName.TvOS, 14, 0, message: "Use 'LoadEntries' instead.")]
@@ -412,7 +416,7 @@ namespace GameKit {
 		[Deprecated (PlatformName.WatchOS, 7, 0, message: "Use 'LoadEntries' instead.")]
 		[iOS (8,0), Mac (10,10)]
 		[Export ("initWithPlayers:")]
-		IntPtr Constructor (GKPlayer [] players);
+		NativeHandle Constructor (GKPlayer [] players);
 
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use 'LoadEntries' instead.")]
 		[Deprecated (PlatformName.TvOS, 14, 0, message: "Use 'LoadEntries' instead.")]
@@ -639,13 +643,13 @@ namespace GameKit {
 
 		[iOS (8,0)][Mac (10,10)]
 		[Export ("initWithLeaderboardIdentifier:player:")]
-		IntPtr Constructor (string identifier, GKPlayer player);
+		NativeHandle Constructor (string identifier, GKPlayer player);
 
 		[NoWatch]
 		[iOS (7,0)][Mac (10,10)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use the overload that takes a 'GKPlayer' instead.")]
 		[Export ("initWithLeaderboardIdentifier:forPlayer:")]
-		IntPtr Constructor (string identifier, string playerID);
+		NativeHandle Constructor (string identifier, string playerID);
 
 		[iOS (7,0)][Mac (10,10)]
 		[Internal]
@@ -1390,7 +1394,7 @@ namespace GameKit {
 	{
 		[NoiOS]
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 		
 		[NullAllowed]
 		[Export ("matchmakerDelegate", ArgumentSemantic.Assign)]
@@ -1408,10 +1412,10 @@ namespace GameKit {
 		bool Hosted { [Bind ("isHosted")] get; set;  }
 
 		[Export ("initWithMatchRequest:")]
-		IntPtr Constructor (GKMatchRequest request);
+		NativeHandle Constructor (GKMatchRequest request);
 
 		[Export ("initWithInvite:")]
-		IntPtr Constructor (GKInvite invite);
+		NativeHandle Constructor (GKInvite invite);
 
 #if !MONOMAC
 		[NoTV]
@@ -1529,16 +1533,16 @@ namespace GameKit {
 		void ResetAchivements ([NullAllowed] Action<NSError> completionHandler);
 
 		[Wrap ("this ((string) null!)")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor ([NullAllowed] string identifier);
+		NativeHandle Constructor ([NullAllowed] string identifier);
 
 #if !MONOMAC
 		[iOS (7,0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'ctor (string identifier, GKPlayer player)' instead.")]
 		[Export ("initWithIdentifier:forPlayer:")]
-		IntPtr Constructor ([NullAllowed] string identifier, string playerId);
+		NativeHandle Constructor ([NullAllowed] string identifier, string playerId);
 #endif
 
 		[Export ("reportAchievementWithCompletionHandler:")]
@@ -1595,7 +1599,7 @@ namespace GameKit {
 
 		[iOS (8,0), Mac (10,10)]
 		[Export ("initWithIdentifier:player:")]
-		IntPtr Constructor ([NullAllowed] string identifier, GKPlayer player);
+		NativeHandle Constructor ([NullAllowed] string identifier, GKPlayer player);
 
 
 #if MONOMAC
@@ -1763,7 +1767,7 @@ namespace GameKit {
 	[BaseType (typeof (NSViewController), Events=new Type [] { typeof (GKFriendRequestComposeViewControllerDelegate)}, Delegates=new string[] {"WeakComposeViewDelegate"})]
 	interface GKFriendRequestComposeViewController : GKViewController {
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 #else
 	[NoTV]
 	[Deprecated (PlatformName.iOS, 10, 0)]
@@ -2095,7 +2099,7 @@ namespace GameKit {
 		{
 		[NoiOS]
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[Export ("showExistingMatches", ArgumentSemantic.Assign)]
 		bool ShowExistingMatches { get; set;  }
@@ -2105,7 +2109,7 @@ namespace GameKit {
 		GKMatchmakingMode MatchmakingMode { get; set; }
 
 		[Export ("initWithMatchRequest:")]
-		IntPtr Constructor (GKMatchRequest request);
+		NativeHandle Constructor (GKMatchRequest request);
 
 		[Export ("turnBasedMatchmakerDelegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -2238,23 +2242,23 @@ namespace GameKit {
 	{
 		[NoiOS]
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[TV (14,0), NoWatch, Mac (11,0), iOS (14,0)]
 		[Export ("initWithLeaderboardID:playerScope:timeScope:")]
-		IntPtr Constructor (string leaderboardId, GKLeaderboardPlayerScope playerScope, GKLeaderboardTimeScope timeScope);
+		NativeHandle Constructor (string leaderboardId, GKLeaderboardPlayerScope playerScope, GKLeaderboardTimeScope timeScope);
 
 		[TV (14,0), NoWatch, Mac (11,0), iOS (14,0)]
 		[Export ("initWithLeaderboard:playerScope:")]
-		IntPtr Constructor (GKLeaderboard leaderboard, GKLeaderboardPlayerScope playerScope);
+		NativeHandle Constructor (GKLeaderboard leaderboard, GKLeaderboardPlayerScope playerScope);
 
 		[TV (14,0), NoWatch, Mac (11,0), iOS (14,0)]
 		[Export ("initWithAchievementID:")]
-		IntPtr Constructor (string achievementId);
+		NativeHandle Constructor (string achievementId);
 
 		[TV (14,0), NoWatch, Mac (11,0), iOS (14,0)]
 		[Export ("initWithState:")]
-		IntPtr Constructor (GKGameCenterViewControllerState state);
+		NativeHandle Constructor (GKGameCenterViewControllerState state);
 
 		[Export ("gameCenterDelegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -2667,7 +2671,7 @@ namespace GameKit {
 	{
 		// inlined ctor
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("session", ArgumentSemantic.Strong)]
 		GKGameSession Session { get; }
@@ -2676,7 +2680,7 @@ namespace GameKit {
 		IGKGameSessionSharingViewControllerDelegate Delegate { get; set; }
 
 		[Export ("initWithSession:")]
-		IntPtr Constructor (GKGameSession session);
+		NativeHandle Constructor (GKGameSession session);
 	}
 
 	interface IGKGameSessionSharingViewControllerDelegate {}
@@ -2711,7 +2715,7 @@ namespace GameKit {
 	interface GKChallengesViewController : GKViewController {
 
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 		
 		[NullAllowed, Export ("challengeDelegate", ArgumentSemantic.Assign)]
 		IGKChallengesViewControllerDelegate ChallengeDelegate { get; set; }

--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -27,6 +27,10 @@ using SKColor = AppKit.NSColor;
 using SKColor = UIKit.UIColor;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace GameplayKit {
 
 	[Native]
@@ -256,7 +260,7 @@ namespace GameplayKit {
 		TComponent ObjectAtIndexedSubscript (nuint idx);
 
 		[Export ("initWithComponentClass:")]
-		IntPtr Constructor (Class cls);
+		NativeHandle Constructor (Class cls);
 
 		[Export ("addComponent:")]
 		void AddComponent (TComponent component);
@@ -350,10 +354,10 @@ namespace GameplayKit {
 		GKRandomSource RandomSource { get; set; }
 
 		[Export ("initWithAttribute:")]
-		IntPtr Constructor (NSObject attribute);
+		NativeHandle Constructor (NSObject attribute);
 
 		[Export ("initWithExamples:actions:attributes:")]
-		IntPtr Constructor (NSArray<NSObject> [] examples, NSObject [] actions, NSObject [] attributes);
+		NativeHandle Constructor (NSArray<NSObject> [] examples, NSObject [] actions, NSObject [] attributes);
 
 		[Export ("findActionForAnswers:")]
 		[return: NullAllowed]
@@ -362,7 +366,7 @@ namespace GameplayKit {
 		[iOS (11,0), TV (11,0)]
 		[Mac (10,13)]
 		[Export ("initWithURL:error:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] NSError error);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] NSError error);
 
 		[iOS (11,0), TV (11,0)]
 		[Mac (10,13)]
@@ -377,7 +381,7 @@ namespace GameplayKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Static]
 		[Export ("entity")]
@@ -545,7 +549,7 @@ namespace GameplayKit {
 		GKGraph FromNodes (GKGraphNode [] nodes);
 
 		[Export ("initWithNodes:")]
-		IntPtr Constructor (GKGraphNode [] nodes);
+		NativeHandle Constructor (GKGraphNode [] nodes);
 
 		[Export ("connectNodeToLowestCostNode:bidirectional:")]
 		void ConnectNodeToLowestCostNode (GKGraphNode node, bool bidirectional);
@@ -577,7 +581,7 @@ namespace GameplayKit {
 		GKObstacleGraph FromObstacles (GKPolygonObstacle[] obstacles, float bufferRadius);
 
 		[Export ("initWithObstacles:bufferRadius:")]
-		IntPtr Constructor (GKPolygonObstacle [] obstacles, float bufferRadius);
+		NativeHandle Constructor (GKPolygonObstacle [] obstacles, float bufferRadius);
 
 		[Internal]
 		[iOS (10,0), TV (10,0), Mac (10,12)]
@@ -588,7 +592,7 @@ namespace GameplayKit {
 		[Internal]
 		[iOS (10,0), TV (10,0), Mac (10,12)]
 		[Export ("initWithObstacles:bufferRadius:nodeClass:")]
-		IntPtr Constructor (GKPolygonObstacle [] obstacles, float bufferRadius, Class nodeClass);
+		NativeHandle Constructor (GKPolygonObstacle [] obstacles, float bufferRadius, Class nodeClass);
 
 		[Export ("connectNodeUsingObstacles:")]
 		void ConnectNodeUsingObstacles (GKGraphNode2D node);
@@ -662,7 +666,7 @@ namespace GameplayKit {
 
 		[Export ("initFromGridStartingAt:width:height:diagonalsAllowed:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Vector2i position, int width, int height, bool diagonalsAllowed);
+		NativeHandle Constructor (Vector2i position, int width, int height, bool diagonalsAllowed);
 
 		[iOS (10,0), TV (10,0), Mac (10,12)]
 		[Static]
@@ -678,11 +682,11 @@ namespace GameplayKit {
 		[iOS (10,0), TV (10,0), Mac (10,12)]
 		[Export ("initFromGridStartingAt:width:height:diagonalsAllowed:nodeClass:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Vector2i position, int width, int height, bool diagonalsAllowed, Class aClass);
+		NativeHandle Constructor (Vector2i position, int width, int height, bool diagonalsAllowed, Class aClass);
 
 		[iOS (10,0), TV (10,0), Mac (10,12)]
 		[Wrap ("this (position, width, height, diagonalsAllowed, new Class (nodeType))")]
-		IntPtr Constructor (Vector2i position, int width, int height, bool diagonalsAllowed, Type nodeType);
+		NativeHandle Constructor (Vector2i position, int width, int height, bool diagonalsAllowed, Type nodeType);
 
 		[Internal]
 		[Export ("nodeAtGridPosition:")]
@@ -730,10 +734,10 @@ namespace GameplayKit {
 
 		[Export ("initWithBufferRadius:minCoordinate:maxCoordinate:nodeClass:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (float bufferRadius, Vector2 min, Vector2 max, Class nodeClass);
+		NativeHandle Constructor (float bufferRadius, Vector2 min, Vector2 max, Class nodeClass);
 
 		[Wrap ("this (bufferRadius, min, max, new Class (nodeType))")]
-		IntPtr Constructor (float bufferRadius, Vector2 min, Vector2 max, Type nodeType);
+		NativeHandle Constructor (float bufferRadius, Vector2 min, Vector2 max, Type nodeType);
 
 		[Static]
 		[Export ("graphWithBufferRadius:minCoordinate:maxCoordinate:")]
@@ -742,7 +746,7 @@ namespace GameplayKit {
 
 		[Export ("initWithBufferRadius:minCoordinate:maxCoordinate:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (float bufferRadius, Vector2 min, Vector2 max);
+		NativeHandle Constructor (float bufferRadius, Vector2 min, Vector2 max);
 
 		[Export ("addObstacles:")]
 		void AddObstacles (GKPolygonObstacle [] obstacles);
@@ -814,7 +818,7 @@ namespace GameplayKit {
 
 		[Export ("initWithPoint:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Vector2 point);
+		NativeHandle Constructor (Vector2 point);
 	}
 
 	[iOS (10,0), TV (10,0), Mac (10,12)]
@@ -837,7 +841,7 @@ namespace GameplayKit {
 
 		[Export ("initWithPoint:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Vector3 point);
+		NativeHandle Constructor (Vector3 point);
 	}
 
 	[DisableDefaultCtor]
@@ -862,7 +866,7 @@ namespace GameplayKit {
 
 		[Export ("initWithGridPosition:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Vector2i gridPosition);
+		NativeHandle Constructor (Vector2i gridPosition);
 	}
 
 	[iOS (9,0), Mac (10,11)]
@@ -908,7 +912,7 @@ namespace GameplayKit {
 
 		[Export ("initWithRadius:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (float radius);
+		NativeHandle Constructor (float radius);
 	}
 
 	[iOS (9,0), Mac (10,11)]
@@ -926,7 +930,7 @@ namespace GameplayKit {
 		[Internal]
 		[Export ("initWithPoints:count:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IntPtr points, nuint numPoints);
+		NativeHandle Constructor (IntPtr points, nuint numPoints);
 
 		[Export ("vertexAtIndex:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
@@ -955,7 +959,7 @@ namespace GameplayKit {
 
 		[Export ("initWithRadius:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (float radius);
+		NativeHandle Constructor (float radius);
 	}
 
 	[iOS (9,0), Mac (10,11)]
@@ -999,10 +1003,10 @@ namespace GameplayKit {
 		GKPath FromGraphNodes (GKGraphNode2D [] graphNodes, float radius);
 
 		[Export ("initWithGraphNodes:radius:")]
-		IntPtr Constructor (GKGraphNode [] nodes, float radius);
+		NativeHandle Constructor (GKGraphNode [] nodes, float radius);
 
 		[Wrap ("this (nodes: graphNodes, radius: radius)")] // Avoid breaking change
-		IntPtr Constructor (GKGraphNode2D [] graphNodes, float radius);
+		NativeHandle Constructor (GKGraphNode2D [] graphNodes, float radius);
 
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'GetVector2Point' instead.")]
 		[Deprecated (PlatformName.TvOS, 10, 0, message: "Use 'GetVector2Point' instead.")]
@@ -1038,7 +1042,7 @@ namespace GameplayKit {
 
 		[Export ("initWithRandomSource:lowestValue:highestValue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IGKRandom source, nint lowestInclusive, nint highestInclusive);
+		NativeHandle Constructor (IGKRandom source, nint lowestInclusive, nint highestInclusive);
 
 //		The following guys are already present in the GKRandom Protocol
 //		[Export ("nextInt")]
@@ -1083,11 +1087,11 @@ namespace GameplayKit {
 
 		[Export ("initWithRandomSource:lowestValue:highestValue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IGKRandom source, nint lowestInclusive, nint highestInclusive);
+		NativeHandle Constructor (IGKRandom source, nint lowestInclusive, nint highestInclusive);
 
 		[Export ("initWithRandomSource:mean:deviation:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IGKRandom source, float mean, float deviation);
+		NativeHandle Constructor (IGKRandom source, float mean, float deviation);
 	}
 
 	[iOS (9,0), Mac (10,11)]
@@ -1098,7 +1102,7 @@ namespace GameplayKit {
 		// inlined from base type
 		[Export ("initWithRandomSource:lowestValue:highestValue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IGKRandom source, nint lowestInclusive, nint highestInclusive);
+		NativeHandle Constructor (IGKRandom source, nint lowestInclusive, nint highestInclusive);
 	}
 
 	interface IGKRandom { }
@@ -1131,7 +1135,7 @@ namespace GameplayKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Static]
 		[Export ("sharedRandom")]
@@ -1150,7 +1154,7 @@ namespace GameplayKit {
 
 		[Export ("initWithSeed:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSData seed);
+		NativeHandle Constructor (NSData seed);
 
 		[Export ("dropValuesWithCount:")]
 		void DropValues (nuint count);
@@ -1165,7 +1169,7 @@ namespace GameplayKit {
 
 		[Export ("initWithSeed:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ulong seed);
+		NativeHandle Constructor (ulong seed);
 	}
 
 	[iOS (9,0), Mac (10,11)]
@@ -1177,7 +1181,7 @@ namespace GameplayKit {
 
 		[Export ("initWithSeed:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ulong seed);
+		NativeHandle Constructor (ulong seed);
 	}
 
 	[iOS (9,0), Mac (10,11)]
@@ -1187,7 +1191,7 @@ namespace GameplayKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("evaluate")]
 		void Evaluate ();
@@ -1275,7 +1279,7 @@ namespace GameplayKit {
 		NSPredicate Predicate { get; }
 
 		[Export ("initWithPredicate:")]
-		IntPtr Constructor (NSPredicate predicate);
+		NativeHandle Constructor (NSPredicate predicate);
 
 		[Export ("evaluatePredicateWithSystem:"), New]
 		bool EvaluatePredicate (GKRuleSystem system);
@@ -1290,7 +1294,7 @@ namespace GameplayKit {
 		[Protected]
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[NullAllowed]
 		[Export ("stateMachine", ArgumentSemantic.Weak)]
@@ -1330,7 +1334,7 @@ namespace GameplayKit {
 
 		[Export ("initWithStates:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (GKState[] states);
+		NativeHandle Constructor (GKState[] states);
 
 		[Export ("updateWithDeltaTime:")]
 		void Update (double deltaTimeInSeconds);
@@ -1405,11 +1409,11 @@ namespace GameplayKit {
 		GKNoise FromNoiseSource (GKNoiseSource noiseSource, NSDictionary<NSNumber, SKColor> gradientColors);
 
 		[Export ("initWithNoiseSource:")]
-		IntPtr Constructor (GKNoiseSource noiseSource);
+		NativeHandle Constructor (GKNoiseSource noiseSource);
 
 		[Export ("initWithNoiseSource:gradientColors:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (GKNoiseSource noiseSource, NSDictionary<NSNumber, SKColor> gradientColors);
+		NativeHandle Constructor (GKNoiseSource noiseSource, NSDictionary<NSNumber, SKColor> gradientColors);
 
 		[Static]
 		[Export ("noiseWithComponentNoises:selectionNoise:")]
@@ -1516,12 +1520,12 @@ namespace GameplayKit {
 		GKNoiseMap FromNoise (GKNoise noise, Vector2d size, Vector2d origin, Vector2i sampleCount, bool seamless);
 
 		[Export ("initWithNoise:")]
-		IntPtr Constructor (GKNoise noise);
+		NativeHandle Constructor (GKNoise noise);
 
 		[Export ("initWithNoise:size:origin:sampleCount:seamless:")]
 		[DesignatedInitializer]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (GKNoise noise, Vector2d size, Vector2d origin, Vector2i sampleCount, bool seamless);
+		NativeHandle Constructor (GKNoise noise, Vector2d size, Vector2d origin, Vector2i sampleCount, bool seamless);
 
 		[Export ("valueAtPosition:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
@@ -1576,7 +1580,7 @@ namespace GameplayKit {
 
 		[Export ("initWithFrequency:octaveCount:persistence:lacunarity:seed:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double frequency, nint octaveCount, double persistence, double lacunarity, int seed);
+		NativeHandle Constructor (double frequency, nint octaveCount, double persistence, double lacunarity, int seed);
 	}
 
 	[iOS (10,0), TV (10,0), Mac (10,12)]
@@ -1593,7 +1597,7 @@ namespace GameplayKit {
 
 		[Export ("initWithFrequency:octaveCount:persistence:lacunarity:seed:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double frequency, nint octaveCount, double persistence, double lacunarity, int seed);
+		NativeHandle Constructor (double frequency, nint octaveCount, double persistence, double lacunarity, int seed);
 	}
 
 	[iOS (10,0), TV (10,0), Mac (10,12)]
@@ -1607,7 +1611,7 @@ namespace GameplayKit {
 
 		[Export ("initWithFrequency:octaveCount:lacunarity:seed:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double frequency, nint octaveCount, double lacunarity, int seed);
+		NativeHandle Constructor (double frequency, nint octaveCount, double lacunarity, int seed);
 	}
 
 	[iOS (10,0), TV (10,0), Mac (10,12)]
@@ -1633,7 +1637,7 @@ namespace GameplayKit {
 
 		[Export ("initWithFrequency:displacement:distanceEnabled:seed:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double frequency, double displacement, bool distanceEnabled, int seed);
+		NativeHandle Constructor (double frequency, double displacement, bool distanceEnabled, int seed);
 	}
 
 	[iOS (10,0), TV (10,0), Mac (10,12)]
@@ -1650,7 +1654,7 @@ namespace GameplayKit {
 
 		[Export ("initWithValue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double value);
+		NativeHandle Constructor (double value);
 	}
 
 	[iOS (10, 0), TV (10, 0), Mac (10, 12)]
@@ -1667,7 +1671,7 @@ namespace GameplayKit {
 
 		[Export ("initWithFrequency:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double frequency);
+		NativeHandle Constructor (double frequency);
 	}
 
 	[iOS (10,0), TV (10,0), Mac (10,12)]
@@ -1684,7 +1688,7 @@ namespace GameplayKit {
 
 		[Export ("initWithFrequency:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double frequency);
+		NativeHandle Constructor (double frequency);
 	}
 
 	[iOS (10,0), TV (10,0), Mac (10,12)]
@@ -1701,7 +1705,7 @@ namespace GameplayKit {
 
 		[Export ("initWithSquareSize:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double squareSize);
+		NativeHandle Constructor (double squareSize);
 	}
 
 	[iOS (10,0), TV (10,0), Mac (10,12)]
@@ -1727,7 +1731,7 @@ namespace GameplayKit {
 
 		[Export ("initWithBoundingBox:minimumCellSize:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (GKBox box, float minCellSize);
+		NativeHandle Constructor (GKBox box, float minCellSize);
 
 		[Export ("addElement:withPoint:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
@@ -1766,7 +1770,7 @@ namespace GameplayKit {
 
 		[Export ("initWithMaxNumberOfChildren:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (nuint maxNumberOfChildren);
+		NativeHandle Constructor (nuint maxNumberOfChildren);
 
 		[Export ("addElement:boundingRectMin:boundingRectMax:splitStrategy:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
@@ -1791,7 +1795,7 @@ namespace GameplayKit {
 		GKSKNodeComponent FromNode (SKNode node);
 
 		[Export ("initWithNode:")]
-		IntPtr Constructor (SKNode node);
+		NativeHandle Constructor (SKNode node);
 
 		[Export ("node", ArgumentSemantic.Strong)]
 		SKNode Node { get; set; }
@@ -1852,7 +1856,7 @@ namespace GameplayKit {
 		GKSCNNodeComponent FromNode (SCNNode node);
 
 		[Export ("initWithNode:")]
-		IntPtr Constructor (SCNNode node);
+		NativeHandle Constructor (SCNNode node);
 
 		[Export ("node")]
 		SCNNode Node { get; }
@@ -1921,7 +1925,7 @@ namespace GameplayKit {
 		[Export ("initWithBoundingQuad:minimumCellSize:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		[DesignatedInitializer]
-		IntPtr Constructor (GKQuad quad, float minCellSize);
+		NativeHandle Constructor (GKQuad quad, float minCellSize);
 
 		[Export ("addElement:withPoint:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
@@ -1954,7 +1958,7 @@ namespace GameplayKit {
 		[Export ("initWithMinPosition:maxPosition:minCellSize:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		[MarshalNativeExceptions]
-		IntPtr Constructor (Vector2 min, Vector2 max, float minCellSize);
+		NativeHandle Constructor (Vector2 min, Vector2 max, float minCellSize);
 
 		[Deprecated (PlatformName.iOS, 10, 0)]
 		[Deprecated (PlatformName.TvOS, 10, 0)]

--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -61,14 +61,16 @@ public partial class Generator {
 		var intptrctor_visibility = filter.IntPtrCtorVisibility;
 		if (intptrctor_visibility == MethodAttributes.PrivateScope) {
 			// since it was not generated code we never fixed the .ctor(IntPtr) visibility for unified
-			if (XamcoreVersion >= 3) {
+			if (BindingTouch.IsDotNet) {
+				intptrctor_visibility = MethodAttributes.FamORAssem;
+			} else if (XamcoreVersion >= 3) {
 				intptrctor_visibility = MethodAttributes.FamORAssem;
 			} else {
 				intptrctor_visibility = MethodAttributes.Public;
 			}
 		}
 		print_generated_code ();
-		print ("{0}{1} (IntPtr handle) : base (handle)", GetVisibility (intptrctor_visibility), type_name);
+		print ("{0}{1} ({2} handle) : base (handle)", GetVisibility (intptrctor_visibility), type_name, NativeHandleType);
 		PrintEmptyBody ();
 
 		// NSObjectFlag constructor - always present (needed to implement NSCoder for subclasses)
@@ -88,14 +90,14 @@ public partial class Generator {
 		indent++;
 		print ("throw new ArgumentNullException (nameof (coder));");
 		indent--;
-		print ("IntPtr h;");
+		print ("{0} h;", NativeHandleType);
 		print ("if (IsDirectBinding) {");
 		indent++;
-		print ("h = global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle (\"initWithCoder:\"), coder.Handle);");
+		print ("h = global::ObjCRuntime.Messaging.{0}_objc_msgSend_{0} (this.Handle, Selector.GetHandle (\"initWithCoder:\"), coder.Handle);", NativeHandleType);
 		indent--;
 		print ("} else {");
 		indent++;
-		print ("h = global::ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper_IntPtr (this.SuperHandle, Selector.GetHandle (\"initWithCoder:\"), coder.Handle);");
+		print ("h = global::ObjCRuntime.Messaging.{0}_objc_msgSendSuper_{0} (this.SuperHandle, Selector.GetHandle (\"initWithCoder:\"), coder.Handle);", NativeHandleType);
 		indent--;
 		print ("}");
 		print ("InitializeHandle (h, \"initWithCoder:\");");

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -851,7 +851,7 @@ public partial class Frameworks {
 
 public partial class Generator : IMemberGatherer {
 	internal bool IsPublicMode;
-
+	internal static string NativeHandleType;
 	NamespaceManager ns;
 	BindingTouch BindingTouch;
 	Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
@@ -933,7 +933,7 @@ public partial class Generator : IMemberGatherer {
 		public MarshalType (Type t, string encode = null, string fetch = null, string create = null, string closingCreate = ")")
 		{
 			Type = t;
-			Encoding = encode ?? "IntPtr";
+			Encoding = encode ?? Generator.NativeHandleType;
 			ParameterMarshal = fetch ?? "{0}.Handle";
 			if (create == null) {
 				CreateFromRet = $"Runtime.GetINativeObject<global::{t.FullName}> (";
@@ -1154,7 +1154,14 @@ public partial class Generator : IMemberGatherer {
 			return PrimitiveType (mai.Type, formatted);
 
 		if (IsWrappedType (mai.Type))
-			return mai.Type.IsByRef ? "ref IntPtr" : "IntPtr";
+			return mai.Type.IsByRef ? "ref " + NativeHandleType : NativeHandleType;
+
+		if (mai.Type.Namespace == "System") {
+			if (mai.Type.Name == "nint")
+				return "IntPtr";
+			if (mai.Type.Name == "nuint")
+				return "UIntPtr";
+		}
 
 		if (mai.Type.Namespace == "System") {
 			if (mai.Type.Name == "nint")
@@ -1171,7 +1178,7 @@ public partial class Generator : IMemberGatherer {
 				return "string";
 
 			// We will do NSString
-			return "IntPtr";
+			return NativeHandleType;
 		} 
 
 		MarshalType mt;
@@ -1183,7 +1190,7 @@ public partial class Generator : IMemberGatherer {
 
 		// Arrays are returned as NSArrays
 		if (mai.Type.IsArray)
-			return "IntPtr";
+			return NativeHandleType;
 
 		//
 		// Pass "out ValueType" directly
@@ -1195,11 +1202,11 @@ public partial class Generator : IMemberGatherer {
 		}
 
 		if (mai.Type.IsSubclassOf (TypeManager.System_Delegate)){
-			return "IntPtr";
+			return NativeHandleType;
 		}
 
 		if (IsDictionaryContainerType(mai.Type)){
-			return "IntPtr";
+			return NativeHandleType;
 		}
 		
 		//
@@ -1207,10 +1214,10 @@ public partial class Generator : IMemberGatherer {
 		//
 		
 		if (mai.Type.IsByRef && mai.Type.GetElementType ().IsValueType == false)
-			return "ref IntPtr";
+			return "ref " + NativeHandleType;
 		
 		if (mai.Type.IsGenericParameter)
-			return "IntPtr";
+			return NativeHandleType;
 
 		throw new BindingException (1017, true, mai.Type);
 	}
@@ -1621,26 +1628,26 @@ public partial class Generator : IMemberGatherer {
 		var returnformat = "return {0};";
 
 		if (mi.ReturnType.IsArray && IsWrappedType (mi.ReturnType.GetElementType())) {
-			returntype = "IntPtr";
+			returntype = NativeHandleType;
 			returnformat = "return NSArray.FromNSObjects({0}).Handle;";
 		}
 		else if (IsWrappedType (mi.ReturnType)) {
-			returntype = "IntPtr";
+			returntype = Generator.NativeHandleType;
 			returnformat = "return {0}.GetHandle ();";
 		} else if (mi.ReturnType == TypeManager.System_String) {
-			returntype = "IntPtr";
+			returntype = Generator.NativeHandleType;
 			returnformat = "return NSString.CreateNative ({0}, true);";
 		} else if (GetNativeEnumToNativeExpression (mi.ReturnType, out var preExpression, out var postExpression, out var nativeType)) {
 			returntype = nativeType;
 			returnformat = "return " + preExpression+ "{0}" + postExpression + ";";
 		} else if (TypeManager.INativeObject.IsAssignableFrom (mi.ReturnType)) {
-			returntype = "IntPtr";
+			returntype = Generator.NativeHandleType;
 			returnformat = "return {0}.GetHandle ();";
 		} else {
 			returntype = FormatType (mi.DeclaringType, mi.ReturnType);
 		}
 		
-		pars.Append ("IntPtr block");
+		pars.Append ($"IntPtr block");
 		var parameters = mi.GetParameters ();
 		foreach (var pi in parameters){
 			string isForcedOwns;
@@ -1652,8 +1659,8 @@ public partial class Generator : IMemberGatherer {
 
 			var safe_name = pi.Name.GetSafeParamName ();
 
-			if (IsWrappedType (pi.ParameterType)){
-				pars.AppendFormat ("IntPtr {0}", safe_name);
+			if (IsWrappedType (pi.ParameterType)) {
+				pars.AppendFormat ("{1} {0}", safe_name, NativeHandleType);
 				if (IsProtocolInterface (pi.ParameterType)) {
 					invoke.AppendFormat (" Runtime.GetINativeObject<{1}> ({0}, false)!", safe_name, pi.ParameterType);
 				} else if (isForced) {
@@ -1667,7 +1674,7 @@ public partial class Generator : IMemberGatherer {
 			if (Frameworks.HaveCoreMedia) {
 				// special case (false) so it needs to be before the _real_ INativeObject check
 				if (pi.ParameterType == TypeManager.CMSampleBuffer) {
-					pars.AppendFormat ("IntPtr {0}", safe_name);
+					pars.AppendFormat ("{1} {0}", safe_name, NativeHandleType);
 					if (BindThirdPartyLibrary)
 						invoke.AppendFormat ("{0} == IntPtr.Zero ? null! : Runtime.GetINativeObject<CMSampleBuffer> ({0}, false)!", safe_name);
 					else
@@ -1678,14 +1685,14 @@ public partial class Generator : IMemberGatherer {
 
 			if (Frameworks.HaveAudioToolbox) {
 				if (pi.ParameterType == TypeManager.AudioBuffers){
-					pars.AppendFormat ("IntPtr {0}", safe_name);
+					pars.AppendFormat ("{1} {0}", safe_name, NativeHandleType);
 					invoke.AppendFormat ("new global::AudioToolbox.AudioBuffers ({0})", safe_name);
 					continue;
 				}
 			}
 
 			if (TypeManager.INativeObject.IsAssignableFrom (pi.ParameterType)) {
-				pars.AppendFormat ("IntPtr {0}", safe_name);
+				pars.AppendFormat ("{1} {0}", safe_name, NativeHandleType);
 				invoke.AppendFormat ("new {0} ({1}, false)", pi.ParameterType, safe_name);
 				continue;
 			}
@@ -1720,8 +1727,8 @@ public partial class Generator : IMemberGatherer {
 				} else if (pi.ParameterType.IsByRef) {
 					var refname = $"__xamarin_pref{pi.Position}";
 					convert.Append ($"var {refname} = Runtime.GetINativeObject<{RenderType (nt)}> ({safe_name}, false)!;");
-					pars.Append ($"ref IntPtr {safe_name}");
-					postConvert.Append ($"{safe_name} = {refname} is null ? IntPtr.Zero : {refname}.Handle;");
+					pars.Append ($"ref {NativeHandleType} {safe_name}");
+					postConvert.Append ($"{safe_name} = {refname}.GetHandle ();");
 					if (pi.IsOut)
 						invoke.Append ("out ");
 					else
@@ -1740,20 +1747,20 @@ public partial class Generator : IMemberGatherer {
 			}
 		
 			if (pi.ParameterType == TypeManager.System_String_Array){
-				pars.AppendFormat ("IntPtr {0}", safe_name);
+				pars.AppendFormat ("{1} {0}", safe_name, NativeHandleType);
 				invoke.AppendFormat ("CFArray.StringArrayFromHandle ({0})!", safe_name);
 				continue;
 			}
-			if (pi.ParameterType == TypeManager.System_String){
-				pars.AppendFormat ("IntPtr {0}", safe_name);
+			if (pi.ParameterType == TypeManager.System_String) {
+				pars.AppendFormat ("{1} {0}", safe_name, NativeHandleType);
 				invoke.AppendFormat ("CFString.FromHandle ({0})!", safe_name);
 				continue;
 			}
 
 			if (pi.ParameterType.IsArray){
 				Type et = pi.ParameterType.GetElementType ();
-				if (IsWrappedType (et)){
-					pars.AppendFormat ("IntPtr {0}", safe_name);
+				if (IsWrappedType (et)) {
+					pars.AppendFormat ("{1} {0}", safe_name, NativeHandleType);
 					invoke.AppendFormat ("CFArray.ArrayFromHandle<{0}> ({1})!", FormatType (null, et), safe_name);
 					continue;
 				}
@@ -1764,7 +1771,7 @@ public partial class Generator : IMemberGatherer {
 					delegate_types [pi.ParameterType.FullName] = pi.ParameterType.GetMethod ("Invoke");
 				}
 				if (AttributeManager.HasAttribute<BlockCallbackAttribute> (pi)) {
-					pars.AppendFormat ("IntPtr {0}", safe_name);
+					pars.AppendFormat ("{1} {0}", safe_name, NativeHandleType);
 					invoke.AppendFormat ("NID{0}.Create ({1})!", MakeTrampolineName (pi.ParameterType), safe_name);
 					// The trampoline will eventually be generated in the final loop
 				} else {
@@ -1775,7 +1782,7 @@ public partial class Generator : IMemberGatherer {
 							ErrorHelper.Warning (1115, safe_name, t.FullName);
 						}
 					}
-					pars.AppendFormat ("IntPtr {0}", safe_name);
+					pars.AppendFormat ("{1} {0}", safe_name, NativeHandleType);
 					invoke.AppendFormat ("({0}) Marshal.GetDelegateForFunctionPointer ({1}, typeof ({0}))", pi.ParameterType, safe_name);
 				}
 				continue;
@@ -1818,9 +1825,9 @@ public partial class Generator : IMemberGatherer {
 		}
 
 		if (HasBindAsAttribute (pi))
-			return string.Format ("nsb_{0} is null ? IntPtr.Zero : nsb_{0}.Handle", pi.Name);
+			return string.Format ("nsb_{0}.GetHandle ()", pi.Name);
 		if (propInfo != null && HasBindAsAttribute (propInfo))
-			return string.Format ("nsb_{0} is null ? IntPtr.Zero : nsb_{0}.Handle", propInfo.Name);
+			return string.Format ("nsb_{0}.GetHandle ()", propInfo.Name);
 
 		var safe_name = pi.Name.GetSafeParamName ();
 
@@ -1875,7 +1882,7 @@ public partial class Generator : IMemberGatherer {
 			//Type etype = pi.ParameterType.GetElementType ();
 
 			if (null_allowed_override || AttributeManager.HasAttribute<NullAllowedAttribute> (pi))
-				return String.Format ("nsa_{0} is null ? IntPtr.Zero : nsa_{0}.Handle", pi.Name);
+				return String.Format ("nsa_{0}.GetHandle ()", pi.Name);
 			return "nsa_" + pi.Name + ".Handle";
 		}
 
@@ -1897,13 +1904,13 @@ public partial class Generator : IMemberGatherer {
 
 		if (IsDictionaryContainerType(pi.ParameterType)){
 			if (null_allowed_override || AttributeManager.HasAttribute<NullAllowedAttribute> (pi))
-				return String.Format ("{0} is null ? IntPtr.Zero : {0}.Dictionary.Handle", safe_name);
+				return String.Format ("{0} is null ? NativeHandle.Zero : {0}.Dictionary.Handle", safe_name);
 			return safe_name + ".Dictionary.Handle";
 		}
 
 		if (pi.ParameterType.IsGenericParameter) {
 			if (null_allowed_override || AttributeManager.HasAttribute<NullAllowedAttribute> (pi))
-				return string.Format ("{0} is null ? IntPtr.Zero : {0}.Handle", safe_name);
+				return string.Format ("{0}.GetHandle ()", safe_name);
 			return safe_name + ".Handle";
 		}
 
@@ -2309,6 +2316,7 @@ public partial class Generator : IMemberGatherer {
 		this.types = types;
 		this.strong_dictionaries = strong_dictionaries;
 		basedir = ".";
+		NativeHandleType = binding_touch.IsDotNet ? "NativeHandle" : "IntPtr";
 	}
 
 	bool SkipGenerationOfType (Type t)
@@ -3097,7 +3105,7 @@ public partial class Generator : IMemberGatherer {
 					       nullable_type ? "?" : "",
 					       prop.Name);
 					indent += 2;
-					print ("IntPtr value;");
+					print ("{0} value;", NativeHandleType);
 					print ("using (var str = new NSString (\"{0}\")){{", export.Selector);
 					kn = "str.Handle";
 					indent++;
@@ -3116,7 +3124,7 @@ public partial class Generator : IMemberGatherer {
 					indent++;
 					print ("get {");
 					indent++;
-					print ("IntPtr value;");
+					print ("{0} value;", NativeHandleType);
 					print ("if ({0} == IntPtr.Zero)", kn);
 					indent++;
 					var libname = BindThirdPartyLibrary ? "__Internal" : lib;
@@ -3837,6 +3845,9 @@ public partial class Generator : IMemberGatherer {
 		print (w, "");
 		print (w, "#nullable enable");
 		print (w, "");
+		print (w, "#if !NET");
+		print (w, "using NativeHandle = System.IntPtr;");
+		print (w, "#endif");
 	}
 
 	//
@@ -3887,7 +3898,7 @@ public partial class Generator : IMemberGatherer {
 				var formattedReturnType = FormatType (declaringType, GetCorrectGenericType (mi.ReturnType));
 				if (mi.ReturnType == TypeManager.NSString) {
 					if (isNullable) {
-						print ("IntPtr retvaltmp;");
+						print ("{0} retvaltmp;", NativeHandleType);
 						cast_a = "((retvaltmp = ";
 						cast_b = $") == IntPtr.Zero ? default ({formattedBindAsType}) : ({wrapper}Runtime.GetNSObject<{formattedReturnType}> (retvaltmp)!){suffix})";
 					} else {
@@ -3896,7 +3907,7 @@ public partial class Generator : IMemberGatherer {
 					}
 				} else {
 					var enumCast = (bindAsType.IsEnum && !minfo.type.IsArray) ? $"({formattedBindAsType}) " : string.Empty;
-					print ("IntPtr retvaltmp;");
+					print ("{0} retvaltmp;", NativeHandleType);
 					cast_a = "((retvaltmp = ";
 					cast_b = $") == IntPtr.Zero ? default ({formattedBindAsType}) : ({enumCast}Runtime.GetNSObject<{formattedReturnType}> (retvaltmp)!{wrapper})){suffix}";
 				}
@@ -3922,7 +3933,7 @@ public partial class Generator : IMemberGatherer {
 				}
 				var bindAsT = bindAttrType.GetElementType ();
 				var suffix = string.Empty;
-				print ("IntPtr retvalarrtmp;");
+				print ("{0} retvalarrtmp;", NativeHandleType);
 				cast_a = "((retvalarrtmp = ";
 				cast_b = ") == IntPtr.Zero ? null! : (";
 				cast_b += $"NSArray.ArrayFromHandleFunc <{FormatType (bindAsT.DeclaringType, bindAsT)}> (retvalarrtmp, {GetFromBindAsWrapper (minfo, out suffix)})" + suffix;
@@ -4375,20 +4386,20 @@ public partial class Generator : IMemberGatherer {
 				}
 
 				if (pi.IsOut) {
-					by_ref_init.AppendFormat ("IntPtr {0}Value = IntPtr.Zero;\n", pi.Name.GetSafeParamName ());
+					by_ref_init.AppendFormat ("{1} {0}Value = IntPtr.Zero;\n", pi.Name.GetSafeParamName (), NativeHandleType);
 				} else {
-					by_ref_init.AppendFormat ("IntPtr {0}Value = ", pi.Name.GetSafeParamName ());
+					by_ref_init.AppendFormat ("{1} {0}Value = ", pi.Name.GetSafeParamName (), NativeHandleType);
 					if (isString) {
 						by_ref_init.AppendFormat ("NSString.CreateNative ({0}, true);\n", pi.Name.GetSafeParamName ());
-						by_ref_init.AppendFormat ("IntPtr {0}OriginalValue = {0}Value;\n", pi.Name.GetSafeParamName ());
+						by_ref_init.AppendFormat ("{1} {0}OriginalValue = {0}Value;\n", pi.Name.GetSafeParamName (), NativeHandleType);
 					} else if (isArrayOfNSObject || isArrayOfINativeObjectSubclass) {
 						by_ref_init.Insert (0, string.Format ("NSArray {0}ArrayValue = NSArray.FromNSObjects ({0});\n", pi.Name.GetSafeParamName ()));
-						by_ref_init.AppendFormat ("{0}ArrayValue is null ? IntPtr.Zero : {0}ArrayValue.Handle;\n", pi.Name.GetSafeParamName ());
+						by_ref_init.AppendFormat ("{0}ArrayValue is null ? NativeHandle.Zero : {0}ArrayValue.Handle;\n", pi.Name.GetSafeParamName ());
 					} else if (isArrayOfString) {
 						by_ref_init.Insert (0, string.Format ("NSArray {0}ArrayValue = {0} is null ? null : NSArray.FromStrings ({0});\n", pi.Name.GetSafeParamName ()));
-						by_ref_init.AppendFormat ("{0}ArrayValue is null ? IntPtr.Zero : {0}ArrayValue.Handle;\n", pi.Name.GetSafeParamName ());
+						by_ref_init.AppendFormat ("{0}ArrayValue is null ? NativeHandle.Zero : {0}ArrayValue.Handle;\n", pi.Name.GetSafeParamName ());
 					} else if (isNSObject || isINativeObjectSubclass) {
-						by_ref_init.AppendFormat ("{0} is null ? IntPtr.Zero : {0}.Handle;\n", pi.Name.GetSafeParamName ());
+						by_ref_init.AppendFormat ("{0} is null ? NativeHandle.Zero : {0}.Handle;\n", pi.Name.GetSafeParamName ());
 					} else {
 						throw ErrorHelper.CreateError (88, mai.Type, mi);
 					}
@@ -4400,7 +4411,7 @@ public partial class Generator : IMemberGatherer {
 					by_ref_processing.AppendFormat ("{0} = CFString.FromHandle ({0}Value)!;\n", pi.Name.GetSafeParamName ());
 				} else if (isArray) {
 					if (!pi.IsOut)
-						by_ref_processing.AppendFormat ("if ({0}Value != ({0}ArrayValue is null ? IntPtr.Zero : {0}ArrayValue.Handle))\n\t", pi.Name.GetSafeParamName ());
+						by_ref_processing.AppendFormat ("if ({0}Value != ({0}ArrayValue is null ? NativeHandle.Zero : {0}ArrayValue.Handle))\n\t", pi.Name.GetSafeParamName ());
 
 					if (isArrayOfNSObject || isArrayOfINativeObjectSubclass) {
 						by_ref_processing.AppendFormat ("{0} = CFArray.ArrayFromHandle<{1}> ({0}Value)!;\n", pi.Name.GetSafeParamName (), RenderType (elementType.GetElementType ()));
@@ -4416,7 +4427,7 @@ public partial class Generator : IMemberGatherer {
 					by_ref_processing.AppendFormat ("{0} = Runtime.GetNSObject<{1}> ({0}Value)!;\n", pi.Name.GetSafeParamName (), RenderType (elementType));
 				} else if (isINativeObjectSubclass) {
 					if (!pi.IsOut)
-						by_ref_processing.AppendFormat ("if ({0}Value != ({0} is null ? IntPtr.Zero : {0}.Handle))\n\t", pi.Name.GetSafeParamName ());
+						by_ref_processing.AppendFormat ("if ({0}Value != ({0} is null ? NativeHandle.Zero : {0}.Handle))\n\t", pi.Name.GetSafeParamName ());
 					by_ref_processing.AppendFormat ("{0} = Runtime.GetINativeObject<{1}> ({0}Value, {2}, {3})!;\n", pi.Name.GetSafeParamName (), RenderType (elementType), isForcedType ? "true" : "false", isForcedType ? isForcedOwns : "false");
 				} else {
 					throw ErrorHelper.CreateError (88, mai.Type, mi);
@@ -4591,7 +4602,7 @@ public partial class Generator : IMemberGatherer {
 		if (use_temp_return) {
 			// for properties we (most often) put the attribute on the property itself, not the getter/setter methods
 			if (mi.ReturnType.IsSubclassOf (TypeManager.System_Delegate)) {
-				print ("IntPtr ret;");
+				print ("{0} ret;", NativeHandleType);
 				trampoline_info = MakeTrampoline (mi.ReturnType);
 			} else if (align != null) {
 				print ("{0} ret = default({0});", FormatType (mi.DeclaringType, mi.ReturnType));
@@ -6066,7 +6077,7 @@ public partial class Generator : IMemberGatherer {
 		indent++;
 		// ctor (IntPtr, bool)
 		print ("[Preserve (Conditional = true)]");
-		print ("public {0}Wrapper (IntPtr handle, bool owns)", TypeName);
+		print ("public {0}Wrapper ({1} handle, bool owns)", TypeName, NativeHandleType);
 		print ("\t: base (handle, owns)");
 		print ("{");
 		print ("}");
@@ -6634,7 +6645,7 @@ public partial class Generator : IMemberGatherer {
 						selectorField = selectorField.Substring (0, selectorField.Length - 6 /* Handle */);
 						print_generated_code ();
 						print ("const string {0} = \"{1}\";", selectorField, ea);
-						print ("static readonly IntPtr {0} = Selector.GetHandle (\"{1}\");", SelectorField (ea), ea);
+						print ("static readonly {2} {0} = Selector.GetHandle (\"{1}\");", SelectorField (ea), ea, NativeHandleType);
 					}
 				}
 			}
@@ -6652,11 +6663,11 @@ public partial class Generator : IMemberGatherer {
 						// potentially avoid a .cctor and extra, unusable code
 						print ("#if ARCH_32");
 						print ("#pragma warning disable {0}", is_static_class ? "169" : "649");
-						print ("static readonly IntPtr class_ptr;");
+						print ("static readonly {0} class_ptr;", NativeHandleType);
 						print ("#pragma warning restore {0}", is_static_class ? "169" : "649");
 						print ("#else");
 					}
-					print ("static readonly IntPtr class_ptr = Class.GetHandle (\"{0}\");", objc_type_name);
+					print ("static readonly {1} class_ptr = Class.GetHandle (\"{0}\");", objc_type_name, NativeHandleType);
 					if (is32BitNotSupported)
 						print ("#endif");
 					print ("");
@@ -6665,7 +6676,7 @@ public partial class Generator : IMemberGatherer {
 			
 			if (!is_static_class && !is_partial){
 				if (!is_model && !external) {
-					print ("public {1} IntPtr ClassHandle {{ get {{ return class_ptr; }} }}\n", objc_type_name, TypeName == "NSObject" ? "virtual" : "override");
+					print ("public {1} {2} ClassHandle {{ get {{ return class_ptr; }} }}\n", objc_type_name, TypeName == "NSObject" ? "virtual" : "override", NativeHandleType);
 				}
 
 				var ctor_visibility = "public";
@@ -6800,7 +6811,7 @@ public partial class Generator : IMemberGatherer {
 					sw.Write ($"\t\t");
 					if (!is_sealed)
 						sw.Write ("protected ");
-					sw.WriteLine ($"internal {TypeName} (IntPtr handle) : base (handle)");
+					sw.WriteLine ($"internal {TypeName} ({NativeHandleType} handle) : base (handle)");
 					sw.WriteLine ("\t\t{");
 					if (is_direct_binding_value != null)
 						sw.WriteLine ("\t\t\tIsDirectBinding = {0};", is_direct_binding_value);
@@ -7381,9 +7392,9 @@ public partial class Generator : IMemberGatherer {
 						if (!InlineSelectors) {
 							foreach (var mi in noDefaultValue) {
 								var export = AttributeManager.GetCustomAttribute<ExportAttribute> (mi);
-								print ("static IntPtr sel{0}Handle = Selector.GetHandle (\"{1}\");", mi.Name, export.Selector);
+								print ("static {2} sel{0}Handle = Selector.GetHandle (\"{1}\");", mi.Name, export.Selector, NativeHandleType);
 							}
-							print ("static IntPtr selRespondsToSelector = " + selRespondsToSelector + ";");
+							print ("static {0} selRespondsToSelector = " + selRespondsToSelector + ";", NativeHandleType);
 							selRespondsToSelector = "selRespondsToSelector";
 						}
 
@@ -7395,7 +7406,7 @@ public partial class Generator : IMemberGatherer {
 						++indent;
 						print ("return false;");
 						--indent;
-						print ("IntPtr selHandle = sel.Handle;");
+						print ("{0} selHandle = sel.Handle;", NativeHandleType);
 						foreach (var mi in noDefaultValue.OrderBy (m => m.Name, StringComparer.Ordinal)) {
 							if (InlineSelectors) {
 								var export = AttributeManager.GetCustomAttribute<ExportAttribute> (mi);

--- a/src/glkit.cs
+++ b/src/glkit.cs
@@ -55,6 +55,10 @@ using UIKit;
 using pfloat = System.Single;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace GLKit {
 
 	[Deprecated (PlatformName.iOS, 12,0, message: "Use 'Metal' instead.")]
@@ -267,7 +271,7 @@ namespace GLKit {
 	interface GLKMesh
 	{
 		[Export ("initWithMesh:error:")]
-		IntPtr Constructor (MDLMesh mesh, out NSError error);
+		NativeHandle Constructor (MDLMesh mesh, out NSError error);
 
 		// generator does not like `out []` -> https://trello.com/c/sZYNalbB/524-generator-support-out
 		[Internal] // there's another, manual, public API exposed
@@ -501,10 +505,10 @@ namespace GLKit {
 
 #if MONOMAC
 		[Export ("initWithShareContext:")]
-		IntPtr Constructor (NSOpenGLContext context);
+		NativeHandle Constructor (NSOpenGLContext context);
 #else
 		[Export ("initWithSharegroup:")]
-		IntPtr Constructor (EAGLSharegroup sharegroup);
+		NativeHandle Constructor (EAGLSharegroup sharegroup);
 #endif
 
 		[Export ("textureWithContentsOfFile:options:queue:completionHandler:")]
@@ -574,7 +578,7 @@ namespace GLKit {
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof (GLKViewDelegate)})]
 	interface GLKView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set;  }
@@ -609,7 +613,7 @@ namespace GLKit {
 		bool EnableSetNeedsDisplay { get; set;  }
 
 		[Export ("initWithFrame:context:")]
-		IntPtr Constructor (CGRect frame, EAGLContext context);
+		NativeHandle Constructor (CGRect frame, EAGLContext context);
 
 		[Export ("bindDrawable")]
 		void BindDrawable ();
@@ -641,7 +645,7 @@ namespace GLKit {
 	interface GLKViewController : GLKViewDelegate {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("preferredFramesPerSecond")]
 		nint PreferredFramesPerSecond { get; set;  }

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -17,6 +17,10 @@ using System;
 using System.ComponentModel;
 using CoreLocation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace HealthKit {
 
 	[Watch (3,0), iOS (10,0)]
@@ -143,21 +147,21 @@ namespace HealthKit {
 		[Obsolete ("Use the overload that takes HKAnchoredObjectResultHandler2 instead")]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		[Export ("initWithType:predicate:anchor:limit:completionHandler:")]
-		IntPtr Constructor (HKSampleType type, [NullAllowed] NSPredicate predicate, nuint anchor, nuint limit, HKAnchoredObjectResultHandler completion);
+		NativeHandle Constructor (HKSampleType type, [NullAllowed] NSPredicate predicate, nuint anchor, nuint limit, HKAnchoredObjectResultHandler completion);
 
 		[NoWatch]
 		[Sealed]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		[Export ("initWithType:predicate:anchor:limit:completionHandler:")]
-		IntPtr Constructor (HKSampleType type, [NullAllowed] NSPredicate predicate, nuint anchor, nuint limit, HKAnchoredObjectResultHandler2 completion);
+		NativeHandle Constructor (HKSampleType type, [NullAllowed] NSPredicate predicate, nuint anchor, nuint limit, HKAnchoredObjectResultHandler2 completion);
 
 		[iOS (9,0)]
 		[Export ("initWithType:predicate:anchor:limit:resultsHandler:")]
-		IntPtr Constructor (HKSampleType type, [NullAllowed] NSPredicate predicate, [NullAllowed] HKQueryAnchor anchor, nuint limit, HKAnchoredObjectUpdateHandler handler);
+		NativeHandle Constructor (HKSampleType type, [NullAllowed] NSPredicate predicate, [NullAllowed] HKQueryAnchor anchor, nuint limit, HKAnchoredObjectUpdateHandler handler);
 
 		[Watch (8,0), iOS (15,0)]
 		[Export ("initWithQueryDescriptors:anchor:limit:resultsHandler:")]
-		IntPtr Constructor (HKQueryDescriptor[] queryDescriptors, [NullAllowed] HKQueryAnchor anchor, nint limit, HKAnchoredObjectUpdateHandler resultsHandler);
+		NativeHandle Constructor (HKQueryDescriptor[] queryDescriptors, [NullAllowed] HKQueryAnchor anchor, nint limit, HKAnchoredObjectUpdateHandler resultsHandler);
 
 		[iOS (9,0)]
 		[NullAllowed, Export ("updateHandler", ArgumentSemantic.Copy)]
@@ -437,7 +441,7 @@ namespace HealthKit {
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKCorrelationQuery
 	interface HKCorrelationQuery {
 		[Export ("initWithType:predicate:samplePredicates:completion:")]
-		IntPtr Constructor (HKCorrelationType correlationType, [NullAllowed] NSPredicate predicate, [NullAllowed] NSDictionary samplePredicates, HKCorrelationQueryResultHandler completion);
+		NativeHandle Constructor (HKCorrelationType correlationType, [NullAllowed] NSPredicate predicate, [NullAllowed] NSDictionary samplePredicates, HKCorrelationQueryResultHandler completion);
 
 		[Export ("correlationType", ArgumentSemantic.Copy)]
 		HKCorrelationType CorrelationType { get; }
@@ -1232,11 +1236,11 @@ namespace HealthKit {
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKObserverQuery
 	interface HKObserverQuery {
 		[Export ("initWithSampleType:predicate:updateHandler:")]
-		IntPtr Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate predicate, HKObserverQueryUpdateHandler updateHandler);
+		NativeHandle Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate predicate, HKObserverQueryUpdateHandler updateHandler);
 
 		[Watch (8,0), iOS (15,0)]
 		[Export ("initWithQueryDescriptors:updateHandler:")]
-		IntPtr Constructor (HKQueryDescriptor[] queryDescriptors, HKObserverQueryDescriptorUpdateHandler updateHandler);
+		NativeHandle Constructor (HKQueryDescriptor[] queryDescriptors, HKObserverQueryDescriptorUpdateHandler updateHandler);
 	}
 
 	[Watch (2,0)]
@@ -1508,15 +1512,15 @@ namespace HealthKit {
 		NSSortDescriptor[] SortDescriptors { get; }
 
 		[Export ("initWithSampleType:predicate:limit:sortDescriptors:resultsHandler:")]
-		IntPtr Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate predicate, nuint limit, [NullAllowed] NSSortDescriptor[] sortDescriptors, HKSampleQueryResultsHandler resultsHandler);
+		NativeHandle Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate predicate, nuint limit, [NullAllowed] NSSortDescriptor[] sortDescriptors, HKSampleQueryResultsHandler resultsHandler);
 
 		[Watch (8,0), iOS (15,0)]
 		[Export ("initWithQueryDescriptors:limit:resultsHandler:")]
-		IntPtr Constructor (HKQueryDescriptor[] queryDescriptors, nint limit, HKSampleQueryResultsHandler resultsHandler);
+		NativeHandle Constructor (HKQueryDescriptor[] queryDescriptors, nint limit, HKSampleQueryResultsHandler resultsHandler);
 
 		[Watch (8,0), iOS (15,0)]
 		[Export ("initWithQueryDescriptors:limit:sortDescriptors:resultsHandler:")]
-		IntPtr Constructor (HKQueryDescriptor[] queryDescriptors, nint limit, NSSortDescriptor[] sortDescriptors, HKSampleQueryResultsHandler resultsHandler);
+		NativeHandle Constructor (HKQueryDescriptor[] queryDescriptors, nint limit, NSSortDescriptor[] sortDescriptors, HKSampleQueryResultsHandler resultsHandler);
 	}
 
 	[Watch (2,0)]
@@ -1544,7 +1548,7 @@ namespace HealthKit {
 	interface HKSourceQuery {
 
 		[Export ("initWithSampleType:samplePredicate:completionHandler:")]
-		IntPtr Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate objectPredicate, HKSourceQueryCompletionHandler completionHandler);
+		NativeHandle Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate objectPredicate, HKSourceQueryCompletionHandler completionHandler);
 	}
 
 	[Watch (2,0)]
@@ -1663,7 +1667,7 @@ namespace HealthKit {
 		HKStatisticsCollectionQueryStatisticsUpdateHandler StatisticsUpdated { get; set; }
 
 		[Export ("initWithQuantityType:quantitySamplePredicate:options:anchorDate:intervalComponents:")]
-		IntPtr Constructor (HKQuantityType quantityType, [NullAllowed] NSPredicate quantitySamplePredicate, HKStatisticsOptions options, NSDate anchorDate, NSDateComponents intervalComponents);
+		NativeHandle Constructor (HKQuantityType quantityType, [NullAllowed] NSPredicate quantitySamplePredicate, HKStatisticsOptions options, NSDate anchorDate, NSDateComponents intervalComponents);
 	}
 
 	delegate void HKStatisticsQueryHandler (HKStatisticsQuery query, HKStatistics result, NSError error);
@@ -1675,7 +1679,7 @@ namespace HealthKit {
 	interface HKStatisticsQuery {
 
 		[Export ("initWithQuantityType:quantitySamplePredicate:options:completionHandler:")]
-		IntPtr Constructor (HKQuantityType quantityType, [NullAllowed] NSPredicate quantitySamplePredicate, HKStatisticsOptions options, HKStatisticsQueryHandler handler);
+		NativeHandle Constructor (HKQuantityType quantityType, [NullAllowed] NSPredicate quantitySamplePredicate, HKStatisticsOptions options, HKStatisticsQueryHandler handler);
 	}
 
 	[Watch (2,0)]
@@ -2809,7 +2813,7 @@ namespace HealthKit {
 		string UdiDeviceIdentifier { get; }
 
 		[Export ("initWithName:manufacturer:model:hardwareVersion:firmwareVersion:softwareVersion:localIdentifier:UDIDeviceIdentifier:")]
-		IntPtr Constructor ([NullAllowed] string name, [NullAllowed] string manufacturer, [NullAllowed] string model, [NullAllowed] string hardwareVersion, [NullAllowed] string firmwareVersion, [NullAllowed] string softwareVersion, [NullAllowed] string localIdentifier, [NullAllowed] string udiDeviceIdentifier);
+		NativeHandle Constructor ([NullAllowed] string name, [NullAllowed] string manufacturer, [NullAllowed] string model, [NullAllowed] string hardwareVersion, [NullAllowed] string firmwareVersion, [NullAllowed] string softwareVersion, [NullAllowed] string localIdentifier, [NullAllowed] string udiDeviceIdentifier);
 
 		[Static]
 		[Export ("localDevice")]
@@ -2831,7 +2835,7 @@ namespace HealthKit {
 		bool IncludeDocumentData { get; }
 
 		[Export ("initWithDocumentType:predicate:limit:sortDescriptors:includeDocumentData:resultsHandler:")]
-		IntPtr Constructor (HKDocumentType documentType, [NullAllowed] NSPredicate predicate, nuint limit, [NullAllowed] NSSortDescriptor[] sortDescriptors, bool includeDocumentData, Action<HKDocumentQuery, HKDocumentSample [], bool, NSError> resultsHandler);
+		NativeHandle Constructor (HKDocumentType documentType, [NullAllowed] NSPredicate predicate, nuint limit, [NullAllowed] NSSortDescriptor[] sortDescriptors, bool includeDocumentData, Action<HKDocumentQuery, HKDocumentSample [], bool, NSError> resultsHandler);
 	}
 
 	[Watch (2,0)]
@@ -2890,7 +2894,7 @@ namespace HealthKit {
 		string Version { get; }
 
 		[Export ("initWithSource:version:")]
-		IntPtr Constructor (HKSource source, [NullAllowed] string version);
+		NativeHandle Constructor (HKSource source, [NullAllowed] string version);
 
 		[Watch (4, 0), iOS (11, 0)]
 		[NullAllowed, Export ("productType")]
@@ -2902,7 +2906,7 @@ namespace HealthKit {
 
 		[Watch (4, 0), iOS (11, 0)]
 		[Export ("initWithSource:version:productType:operatingSystemVersion:")]
-		IntPtr Constructor (HKSource source, [NullAllowed] string version, [NullAllowed] string productType, NSOperatingSystemVersion operatingSystemVersion);
+		NativeHandle Constructor (HKSource source, [NullAllowed] string version, [NullAllowed] string productType, NSOperatingSystemVersion operatingSystemVersion);
 	}
 
 	[Watch (4,0), iOS (11,0)]
@@ -2972,16 +2976,16 @@ namespace HealthKit {
 
 		[Deprecated (PlatformName.WatchOS, 3, 0, message: "Use HKWorkoutSession (HKHealthStore, HKWorkoutConfiguration, out NSError) instead.")]
 		[Export ("initWithActivityType:locationType:")]
-		IntPtr Constructor (HKWorkoutActivityType activityType, HKWorkoutSessionLocationType locationType);
+		NativeHandle Constructor (HKWorkoutActivityType activityType, HKWorkoutSessionLocationType locationType);
 
 		[Watch (3,0)]
 		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use HKWorkoutSession (HKHealthStore, HKWorkoutConfiguration, out NSError) instead.")]
 		[Export ("initWithConfiguration:error:")]
-		IntPtr Constructor (HKWorkoutConfiguration workoutConfiguration, out NSError error);
+		NativeHandle Constructor (HKWorkoutConfiguration workoutConfiguration, out NSError error);
 
 		[Watch (5,0)]
 		[Export ("initWithHealthStore:configuration:error:")]
-		IntPtr Constructor (HKHealthStore healthStore, HKWorkoutConfiguration workoutConfiguration, [NullAllowed] out NSError error);
+		NativeHandle Constructor (HKHealthStore healthStore, HKWorkoutConfiguration workoutConfiguration, [NullAllowed] out NSError error);
 
 		[Watch (5,0)]
 		[Export ("prepare")]
@@ -3075,7 +3079,7 @@ namespace HealthKit {
 		Action<HKActivitySummaryQuery, HKActivitySummary[], NSError> UpdateHandler { get; set; }
 
 		[Export ("initWithPredicate:resultsHandler:")]
-		IntPtr Constructor ([NullAllowed] NSPredicate predicate, Action<HKActivitySummaryQuery, HKActivitySummary[], NSError> handler);
+		NativeHandle Constructor ([NullAllowed] NSPredicate predicate, Action<HKActivitySummaryQuery, HKActivitySummary[], NSError> handler);
 	}
 
 	[iOS (9,3), Watch (2,2)]
@@ -3148,7 +3152,7 @@ namespace HealthKit {
 	[DisableDefaultCtor]
 	interface HKWorkoutRouteBuilder {
 		[Export ("initWithHealthStore:device:")]
-		IntPtr Constructor (HKHealthStore healthStore, [NullAllowed] HKDevice device);
+		NativeHandle Constructor (HKHealthStore healthStore, [NullAllowed] HKDevice device);
 
 		[Async, Export ("insertRouteData:completion:")]
 		void InsertRouteData (CLLocation [] routeData, Action<bool, NSError> completion);
@@ -3174,7 +3178,7 @@ namespace HealthKit {
 	interface HKWorkoutRouteQuery {
 		[Export ("initWithRoute:dataHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (HKWorkoutRoute workoutRoute, HKWorkoutRouteBuilderDataHandler dataHandler);
+		NativeHandle Constructor (HKWorkoutRoute workoutRoute, HKWorkoutRouteBuilderDataHandler dataHandler);
 	}
 
 	delegate void HKWorkoutBuilderCompletionHandler (bool success, NSError error);
@@ -3206,7 +3210,7 @@ namespace HealthKit {
 		HKWorkoutEvent[] WorkoutEvents { get; }
 
 		[Export ("initWithHealthStore:configuration:device:")]
-		IntPtr Constructor (HKHealthStore healthStore, HKWorkoutConfiguration configuration, [NullAllowed] HKDevice device);
+		NativeHandle Constructor (HKHealthStore healthStore, HKWorkoutConfiguration configuration, [NullAllowed] HKDevice device);
 
 		[Async]
 		[Export ("beginCollectionWithStartDate:completion:")]
@@ -3267,12 +3271,12 @@ namespace HealthKit {
 
 		[Watch (6,0), iOS (13,0)]
 		[Export ("initWithQuantityType:predicate:quantityHandler:")]
-		IntPtr Constructor (HKQuantityType quantityType, [NullAllowed] NSPredicate predicate, HKQuantitySeriesSampleQueryQuantityHandler quantityHandler);
+		NativeHandle Constructor (HKQuantityType quantityType, [NullAllowed] NSPredicate predicate, HKQuantitySeriesSampleQueryQuantityHandler quantityHandler);
 
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use Constructor that takes 'NSDateInterval' instead.")]
 		[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use Constructor that takes 'NSDateInterval' instead.")]
 		[Export ("initWithSample:quantityHandler:")]
-		IntPtr Constructor (HKQuantitySample quantitySample, HKQuantitySeriesSampleQueryQuantityDelegate quantityHandler);
+		NativeHandle Constructor (HKQuantitySample quantitySample, HKQuantitySeriesSampleQueryQuantityDelegate quantityHandler);
 	}
 
 	delegate void HKQuantitySeriesSampleBuilderFinishSeriesDelegate (HKQuantitySample [] samples, NSError error);
@@ -3283,7 +3287,7 @@ namespace HealthKit {
 	interface HKQuantitySeriesSampleBuilder
 	{
 		[Export ("initWithHealthStore:quantityType:startDate:device:")]
-		IntPtr Constructor (HKHealthStore healthStore, HKQuantityType quantityType, NSDate startDate, [NullAllowed] HKDevice device);
+		NativeHandle Constructor (HKHealthStore healthStore, HKQuantityType quantityType, NSDate startDate, [NullAllowed] HKDevice device);
 
 		[Export ("quantityType", ArgumentSemantic.Copy)]
 		HKQuantityType QuantityType { get; }
@@ -3334,7 +3338,7 @@ namespace HealthKit {
 
 		[Export ("initWithHealthStore:workoutConfiguration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (HKHealthStore healthStore, [NullAllowed] HKWorkoutConfiguration configuration);
+		NativeHandle Constructor (HKHealthStore healthStore, [NullAllowed] HKWorkoutConfiguration configuration);
 
 		[Export ("enableCollectionForType:predicate:")]
 		void EnableCollection (HKQuantityType quantityType, [NullAllowed] NSPredicate predicate);
@@ -3516,7 +3520,7 @@ namespace HealthKit {
 
 		[Export ("initWithHealthStore:device:startDate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (HKHealthStore healthStore, [NullAllowed] HKDevice device, NSDate startDate);
+		NativeHandle Constructor (HKHealthStore healthStore, [NullAllowed] HKDevice device, NSDate startDate);
 
 		[Export ("addHeartbeatWithTimeIntervalSinceSeriesStartDate:precededByGap:completion:")]
 		[Async]
@@ -3539,7 +3543,7 @@ namespace HealthKit {
 	{
 		[Export ("initWithHeartbeatSeries:dataHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (HKHeartbeatSeriesSample heartbeatSeries, HKHeartbeatSeriesQueryDataHandler dataHandler);
+		NativeHandle Constructor (HKHeartbeatSeriesSample heartbeatSeries, HKHeartbeatSeriesQueryDataHandler dataHandler);
 	}
 
 	[Watch (7,0), iOS (14,0)]
@@ -3573,7 +3577,7 @@ namespace HealthKit {
 
 		[Export ("initWithElectrocardiogram:dataHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (HKElectrocardiogram electrocardiogram, HKElectrocardiogramQueryDataHandler dataHandler);
+		NativeHandle Constructor (HKElectrocardiogram electrocardiogram, HKElectrocardiogramQueryDataHandler dataHandler);
 	}
 
 	[Watch (7,0), iOS (14,0)]
@@ -3663,7 +3667,7 @@ namespace HealthKit {
 
 		[Export ("initWithSampleType:predicate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate predicate);
+		NativeHandle Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate predicate);
 	}
 
 	[NoWatch, iOS (15,0)]
@@ -3707,7 +3711,7 @@ namespace HealthKit {
 		string[] RecordTypes { get; }
 
 		[Export ("initWithRecordTypes:predicate:resultsHandler:")]
-		IntPtr Constructor (string[] recordTypes, [NullAllowed] NSPredicate predicate, HKVerifiableClinicalRecordQueryResultHandler handler);
+		NativeHandle Constructor (string[] recordTypes, [NullAllowed] NSPredicate predicate, HKVerifiableClinicalRecordQueryResultHandler handler);
 	}
 
 	[NoWatch, iOS (15,0)]

--- a/src/healthkitui.cs
+++ b/src/healthkitui.cs
@@ -7,6 +7,10 @@ using HealthKit;
 using ObjCRuntime;
 using UIKit;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace HealthKitUI {
 
 	[iOS (9,3), Watch (2,2)]
@@ -17,7 +21,7 @@ namespace HealthKitUI {
 		// inlined from UIView
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NullAllowed, Export ("activitySummary", ArgumentSemantic.Strong)]
 		HKActivitySummary ActivitySummary { get; set; }

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -6,6 +6,10 @@ using UIKit;
 using System;
 using System.ComponentModel;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #if WATCH
 interface UIView {}
 #endif
@@ -533,9 +537,9 @@ namespace HomeKit {
 		[DesignatedInitializer]
 		[Export ("initWithCharacteristic:targetValue:")]
 #if XAMCORE_3_0
-		IntPtr Constructor (HMCharacteristic characteristic, INSCopying targetValue);
+		NativeHandle Constructor (HMCharacteristic characteristic, INSCopying targetValue);
 #else
-		IntPtr Constructor (HMCharacteristic characteristic, NSObject targetValue);
+		NativeHandle Constructor (HMCharacteristic characteristic, NSObject targetValue);
 #endif
 
 		[Export ("characteristic", ArgumentSemantic.Retain)]
@@ -1012,7 +1016,7 @@ namespace HomeKit {
 		[NoWatch]
 		[DesignatedInitializer]
 		[Export ("initWithName:fireDate:timeZone:recurrence:recurrenceCalendar:")]
-		IntPtr Constructor (string name, NSDate fireDate, [NullAllowed] NSTimeZone timeZone, [NullAllowed] NSDateComponents recurrence, [NullAllowed] NSCalendar recurrenceCalendar);
+		NativeHandle Constructor (string name, NSDate fireDate, [NullAllowed] NSTimeZone timeZone, [NullAllowed] NSDateComponents recurrence, [NullAllowed] NSCalendar recurrenceCalendar);
 
 		[Export ("fireDate", ArgumentSemantic.Copy)]
 		NSDate FireDate { get; }
@@ -1210,7 +1214,7 @@ namespace HomeKit {
 		[NoTV]
 		[NoWatch]
 		[Export ("initWithCharacteristic:triggerValue:")]
-		IntPtr Constructor (HMCharacteristic characteristic, [NullAllowed] INSCopying triggerValue);
+		NativeHandle Constructor (HMCharacteristic characteristic, [NullAllowed] INSCopying triggerValue);
 
 		[Export ("characteristic", ArgumentSemantic.Strong)]
 		HMCharacteristic Characteristic { get; [NotImplemented] set; }
@@ -1254,13 +1258,13 @@ namespace HomeKit {
 		[NoTV]
 		[NoWatch]
 		[Export ("initWithName:events:predicate:")]
-		IntPtr Constructor (string name, HMEvent[] events, [NullAllowed] NSPredicate predicate);
+		NativeHandle Constructor (string name, HMEvent[] events, [NullAllowed] NSPredicate predicate);
 
 		[NoTV]
 		[NoWatch]
 		[iOS (11,0)]
 		[Export ("initWithName:events:endEvents:recurrences:predicate:")]
-		IntPtr Constructor (string name, HMEvent[] events, [NullAllowed] HMEvent[] endEvents, [NullAllowed] NSDateComponents[] recurrences, [NullAllowed] NSPredicate predicate);
+		NativeHandle Constructor (string name, HMEvent[] events, [NullAllowed] HMEvent[] endEvents, [NullAllowed] NSDateComponents[] recurrences, [NullAllowed] NSPredicate predicate);
 
 		[Export ("events", ArgumentSemantic.Copy)]
 		HMEvent[] Events { get; }
@@ -1401,7 +1405,7 @@ namespace HomeKit {
 		[NoTV]
 		[NoWatch]
 		[Export ("initWithRegion:")]
-		IntPtr Constructor (CLRegion region);
+		NativeHandle Constructor (CLRegion region);
 
 		[NullAllowed, Export ("region", ArgumentSemantic.Strong)]
 		CLRegion Region { get; [NotImplemented] set; }
@@ -1420,7 +1424,7 @@ namespace HomeKit {
 	interface HMMutableLocationEvent {
 
 		[Export ("initWithRegion:")]
-		IntPtr Constructor (CLRegion region);
+		NativeHandle Constructor (CLRegion region);
 
 		[Override]
 		[NullAllowed, Export ("region", ArgumentSemantic.Strong)]
@@ -1434,7 +1438,7 @@ namespace HomeKit {
 	{
 		// inlined ctor
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NullAllowed, Export ("cameraSource", ArgumentSemantic.Strong)]
 		HMCameraSource CameraSource { get; set; }
@@ -1612,7 +1616,7 @@ namespace HomeKit {
 	interface HMCalendarEvent : NSMutableCopying {
 
 		[Export ("initWithFireDateComponents:")]
-		IntPtr Constructor (NSDateComponents fireDateComponents);
+		NativeHandle Constructor (NSDateComponents fireDateComponents);
 
 		[Export ("fireDateComponents", ArgumentSemantic.Strong)]
 		NSDateComponents FireDateComponents { get; [NotImplemented] set; }
@@ -1624,7 +1628,7 @@ namespace HomeKit {
 	interface HMMutableCalendarEvent {
 
 		[Export ("initWithFireDateComponents:")]
-		IntPtr Constructor (NSDateComponents fireDateComponents);
+		NativeHandle Constructor (NSDateComponents fireDateComponents);
 
 		[Override]
 		[Export ("fireDateComponents", ArgumentSemantic.Strong)]
@@ -1637,7 +1641,7 @@ namespace HomeKit {
 	interface HMMutableCharacteristicEvent : NSMutableCopying {
 
 		[Export ("initWithCharacteristic:triggerValue:")]
-		IntPtr Constructor (HMCharacteristic characteristic, [NullAllowed] INSCopying triggerValue);
+		NativeHandle Constructor (HMCharacteristic characteristic, [NullAllowed] INSCopying triggerValue);
 
 		[Override]
 		[Export ("characteristic", ArgumentSemantic.Strong)]
@@ -1654,7 +1658,7 @@ namespace HomeKit {
 	interface HMCharacteristicThresholdRangeEvent : NSMutableCopying {
 
 		[Export ("initWithCharacteristic:thresholdRange:")]
-		IntPtr Constructor (HMCharacteristic characteristic, HMNumberRange thresholdRange);
+		NativeHandle Constructor (HMCharacteristic characteristic, HMNumberRange thresholdRange);
 
 		[Export ("characteristic", ArgumentSemantic.Strong)]
 		HMCharacteristic Characteristic { get; [NotImplemented] set; }
@@ -1669,7 +1673,7 @@ namespace HomeKit {
 	interface HMMutableCharacteristicThresholdRangeEvent {
 
 		[Export ("initWithCharacteristic:thresholdRange:")]
-		IntPtr Constructor (HMCharacteristic characteristic, HMNumberRange thresholdRange);
+		NativeHandle Constructor (HMCharacteristic characteristic, HMNumberRange thresholdRange);
 
 		[Override]
 		[Export ("characteristic", ArgumentSemantic.Strong)]
@@ -1686,7 +1690,7 @@ namespace HomeKit {
 	interface HMDurationEvent : NSMutableCopying {
 
 		[Export ("initWithDuration:")]
-		IntPtr Constructor (double duration);
+		NativeHandle Constructor (double duration);
 
 		[Export ("duration")]
 		double Duration { get; [NotImplemented] set; }
@@ -1698,7 +1702,7 @@ namespace HomeKit {
 	interface HMMutableDurationEvent {
 
 		[Export ("initWithDuration:")]
-		IntPtr Constructor (double duration);
+		NativeHandle Constructor (double duration);
 
 		[Override]
 		[Export ("duration")]
@@ -1734,7 +1738,7 @@ namespace HomeKit {
 	[DisableDefaultCtor]
 	interface HMAccessoryOwnershipToken {
 		[Export("initWithData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 	}
 
 	[iOS (13,0), NoWatch, NoMac, NoTV]
@@ -1801,12 +1805,12 @@ namespace HomeKit {
 	[DisableDefaultCtor]
 	interface HMAccessorySetupPayload {
 		[Export ("initWithURL:")]
-		IntPtr Constructor ([NullAllowed] NSUrl setupPayloadUrl);
+		NativeHandle Constructor ([NullAllowed] NSUrl setupPayloadUrl);
 		
 		[iOS (13,0)]
 		[Export ("initWithURL:ownershipToken:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl setupPayloadUrl, [NullAllowed] HMAccessoryOwnershipToken ownershipToken);
+		NativeHandle Constructor (NSUrl setupPayloadUrl, [NullAllowed] HMAccessoryOwnershipToken ownershipToken);
 	}
 
 	[Watch (4,0), TV (11,0), iOS (11,0), MacCatalyst (14,0)]
@@ -1815,7 +1819,7 @@ namespace HomeKit {
 	interface HMPresenceEvent : NSMutableCopying {
 
 		[Export ("initWithPresenceEventType:presenceUserType:")]
-		IntPtr Constructor (HMPresenceEventType presenceEventType, HMPresenceEventUserType presenceUserType);
+		NativeHandle Constructor (HMPresenceEventType presenceEventType, HMPresenceEventUserType presenceUserType);
 
 		[Export ("presenceEventType")]
 		HMPresenceEventType PresenceEventType { get;  [NotImplemented] set; }
@@ -1847,10 +1851,10 @@ namespace HomeKit {
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithSignificantEvent:offset:")]
-		IntPtr Constructor (NSString significantEvent, [NullAllowed] NSDateComponents offset);
+		NativeHandle Constructor (NSString significantEvent, [NullAllowed] NSDateComponents offset);
 
 		[Wrap ("this (HMSignificantEventExtensions.GetConstant (significantEvent)!, offset)")]
-		IntPtr Constructor (HMSignificantEvent significantEvent, [NullAllowed] NSDateComponents offset);
+		NativeHandle Constructor (HMSignificantEvent significantEvent, [NullAllowed] NSDateComponents offset);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("significantEvent", ArgumentSemantic.Strong)]
@@ -1874,10 +1878,10 @@ namespace HomeKit {
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithSignificantEvent:offset:")]
-		IntPtr Constructor (NSString significantEvent, [NullAllowed] NSDateComponents offset);
+		NativeHandle Constructor (NSString significantEvent, [NullAllowed] NSDateComponents offset);
 
 		[Wrap ("this (HMSignificantEventExtensions.GetConstant (significantEvent)!, offset)")]
-		IntPtr Constructor (HMSignificantEvent significantEvent, [NullAllowed] NSDateComponents offset);
+		NativeHandle Constructor (HMSignificantEvent significantEvent, [NullAllowed] NSDateComponents offset);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Override]
@@ -1930,7 +1934,7 @@ namespace HomeKit {
 
 		[Export ("initWithUUID:name:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUuid uuid, string name);
+		NativeHandle Constructor (NSUuid uuid, string name);
 	}
 
 	delegate void FetchRoomHandler (NSArray<HMChipServiceRoom> rooms, NSError error); 
@@ -1965,7 +1969,7 @@ namespace HomeKit {
 
 		[Export ("initWithUUID:name:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUuid uuid, string name);
+		NativeHandle Constructor (NSUuid uuid, string name);
 	}
 
 	[iOS (15,0), Watch (8,0), TV (15,0), MacCatalyst (15,0)]
@@ -1974,7 +1978,7 @@ namespace HomeKit {
 	interface HMChipServiceTopology : NSCopying, NSSecureCoding
 	{
 		[Export ("initWithHomes:")]
-		IntPtr Constructor (HMChipServiceHome[] homes);
+		NativeHandle Constructor (HMChipServiceHome[] homes);
 
 		[Export ("homes", ArgumentSemantic.Copy)]
 		HMChipServiceHome[] Homes { get; }

--- a/src/iAd/ADCompat.cs
+++ b/src/iAd/ADCompat.cs
@@ -241,6 +241,7 @@ namespace iAd {
 		}
 
 		protected internal ADBannerViewDelegate (IntPtr handle)
+			: base (handle)
 		{
 		}
 
@@ -313,6 +314,7 @@ namespace iAd {
 	public class ADInterstitialAd : NSObject {
 
 		protected internal ADInterstitialAd (IntPtr handle)
+			: base (handle)
 		{
 		}
 
@@ -441,6 +443,7 @@ namespace iAd {
 		}
 
 		protected internal ADInterstitialAdDelegate (IntPtr handle)
+			: base (handle)
 		{
 		}
 

--- a/src/iAd/ADCompat.cs
+++ b/src/iAd/ADCompat.cs
@@ -244,7 +244,7 @@ namespace iAd {
 		{
 		}
 
-		protected internal ADBannerViewDelegate (IntPtr handle)
+		protected internal ADBannerViewDelegate (NativeHandle handle)
 			: base (handle)
 		{
 		}
@@ -446,7 +446,7 @@ namespace iAd {
 		{
 		}
 
-		protected internal ADInterstitialAdDelegate (IntPtr handle)
+		protected internal ADInterstitialAdDelegate (NativeHandle handle)
 			: base (handle)
 		{
 		}

--- a/src/iAd/ADCompat.cs
+++ b/src/iAd/ADCompat.cs
@@ -12,6 +12,10 @@ using MediaPlayer;
 using ObjCRuntime;
 using UIKit;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #nullable enable
 
 namespace iAd {
@@ -31,8 +35,8 @@ namespace iAd {
 		{
 		}
 
-		public unsafe override IntPtr ClassHandle {
-			get { return default (IntPtr); }
+		public unsafe override NativeHandle ClassHandle {
+			get { return default (NativeHandle); }
 		}
 
 		public virtual ADAdType AdType {
@@ -318,7 +322,7 @@ namespace iAd {
 		{
 		}
 
-		public unsafe override IntPtr ClassHandle {
+		public unsafe override NativeHandle ClassHandle {
 			get { return default (IntPtr); }
 		}
 
@@ -466,8 +470,8 @@ namespace iAd {
 	[Obsoleted (PlatformName.iOS, 15, 0, PlatformArchitecture.None, Constants.iAdRemoved)]
 	public class ADInterstitialAdPresentationViewController : UIViewController {
 
-		public unsafe override IntPtr ClassHandle {
-			get { return default (IntPtr); }
+		public unsafe override NativeHandle ClassHandle {
+			get { return default (NativeHandle); }
 		}
 
 		public ADInterstitialAdPresentationViewController (NSCoder coder)

--- a/src/identitylookup.cs
+++ b/src/identitylookup.cs
@@ -12,6 +12,10 @@ using System;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace IdentityLookup {
 
 	[iOS (11,0)]
@@ -169,7 +173,7 @@ namespace IdentityLookup {
 
 		[Export ("initWithClassificationAction:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (ILClassificationAction action);
+		NativeHandle Constructor (ILClassificationAction action);
 	}
 
 	[Abstract]

--- a/src/imagekit.cs
+++ b/src/imagekit.cs
@@ -35,6 +35,10 @@ using ImageCaptureCore;
 using CoreGraphics;
 using CoreAnimation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ImageKit {
 
 	enum IKToolMode { // Constants introduced in 10.5 and 10.6
@@ -77,7 +81,7 @@ namespace ImageKit {
 	[BaseType (typeof (NSView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (IKCameraDeviceViewDelegate)})]
 	interface IKCameraDeviceView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -197,7 +201,7 @@ namespace ImageKit {
 	[BaseType (typeof (NSView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (IKDeviceBrowserViewDelegate)})]
 	interface IKDeviceBrowserView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -295,7 +299,7 @@ namespace ImageKit {
 	[BaseType (typeof (NSView))]
 	interface IKFilterBrowserView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("setPreviewState:")]
 		void SetPreviewState (bool showPreview);
@@ -341,10 +345,10 @@ namespace ImageKit {
 	[BaseType (typeof (NSView))]
 	interface IKFilterUIView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("initWithFrame:filter:")]
-		IntPtr Constructor (CGRect frame, CIFilter filter);
+		NativeHandle Constructor (CGRect frame, CIFilter filter);
 
 		[Export ("filter")]
 		CIFilter Filter { get; }
@@ -420,7 +424,7 @@ namespace ImageKit {
 	interface IKImageBrowserView : NSDraggingSource {
 		//@category IKImageBrowserView (IKMainMethods)
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		//Having a weak and strong datasource seems to work.
 		[Export ("dataSource", ArgumentSemantic.Assign), NullAllowed]
@@ -760,7 +764,7 @@ namespace ImageKit {
 	[BaseType (typeof (NSView))]
 	interface IKImageView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		//There is no protocol for this delegate.  used to respond to messages in the responder chain
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
@@ -971,7 +975,7 @@ namespace ImageKit {
 		IKSaveOptionsDelegate Delegate { get; set; }
 
 		[Export ("initWithImageProperties:imageUTType:")]
-		IntPtr Constructor (NSDictionary imageProperties, string imageUTType);
+		NativeHandle Constructor (NSDictionary imageProperties, string imageUTType);
 
 		[Export ("addSaveOptionsAccessoryViewToSavePanel:")]
 		void AddSaveOptionsToPanel (NSSavePanel savePanel);
@@ -995,7 +999,7 @@ namespace ImageKit {
 	[BaseType (typeof (NSView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (IKScannerDeviceViewDelegate)})]
 	interface IKScannerDeviceView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }

--- a/src/inputmethodkit.cs
+++ b/src/inputmethodkit.cs
@@ -15,6 +15,10 @@ using ObjCRuntime;
 using Foundation;
 using AppKit;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace InputMethodKit {
 
 	partial interface IMKGlobal {
@@ -41,10 +45,10 @@ namespace InputMethodKit {
 	partial interface IMKServer : IMKServerProxy {
 
 		[Export ("initWithName:bundleIdentifier:")]
-		IntPtr Constructor (string name, string bundleIdentifier);
+		NativeHandle Constructor (string name, string bundleIdentifier);
 
 		[Export ("initWithName:controllerClass:delegateClass:")]
-		IntPtr Constructor (string name, Class controllerClassId, Class delegateClassId);
+		NativeHandle Constructor (string name, Class controllerClassId, Class delegateClassId);
 
 		[Export ("bundle")]
 		NSBundle Bundle { get; }
@@ -132,7 +136,7 @@ namespace InputMethodKit {
 	partial interface IMKInputController : IMKStateSetting, IMKMouseHandling {
 
 		[Export ("initWithServer:delegate:client:")]
-		IntPtr Constructor (IMKServer server, NSObject delegateObject, NSObject inputClient);
+		NativeHandle Constructor (IMKServer server, NSObject delegateObject, NSObject inputClient);
 
 		[Export ("updateComposition")]
 		void UpdateComposition ();
@@ -187,10 +191,10 @@ namespace InputMethodKit {
 	partial interface IMKCandidates {
 
 		[Export ("initWithServer:panelType:")]
-		IntPtr Constructor (IMKServer server, IMKCandidatePanelType panelType);
+		NativeHandle Constructor (IMKServer server, IMKCandidatePanelType panelType);
 
 		[Export ("initWithServer:panelType:styleType:")]
-		IntPtr Constructor (IMKServer server, IMKCandidatePanelType panelType, IMKStyleType style);
+		NativeHandle Constructor (IMKServer server, IMKCandidatePanelType panelType, IMKStyleType style);
 
 		[Export ("panelType")]
 		IMKCandidatePanelType PanelType { get; set; }

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -29,6 +29,10 @@ using UIImage = Foundation.NSObject;
 using UIKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Intents {
 
 	// HACK only to please the generator - which does not (normally) know the type hierarchy in the
@@ -2404,10 +2408,10 @@ namespace Intents {
 		[iOS (11,0)]
 		[Export ("initWithRestaurant:bookingDateComponents:partySize:bookingIdentifier:guest:selectedOffer:guestProvidedSpecialRequestText:")]
 #if XAMCORE_4_0
-		IntPtr Constructor (INRestaurant restaurant, NSDateComponents bookingDateComponents, nuint partySize, [NullAllowed] string bookingIdentifier, [NullAllowed] INRestaurantGuest guest, [NullAllowed] INRestaurantOffer selectedOffer, [NullAllowed] string guestProvidedSpecialRequestText);
+		NativeHandle Constructor (INRestaurant restaurant, NSDateComponents bookingDateComponents, nuint partySize, [NullAllowed] string bookingIdentifier, [NullAllowed] INRestaurantGuest guest, [NullAllowed] INRestaurantOffer selectedOffer, [NullAllowed] string guestProvidedSpecialRequestText);
 #else
 		// This is correctly nuint but a bug in PMCS generated incorrect code which has shipped.
-		IntPtr Constructor (INRestaurant restaurant, NSDateComponents bookingDateComponents, ulong partySize, [NullAllowed] string bookingIdentifier, [NullAllowed] INRestaurantGuest guest, [NullAllowed] INRestaurantOffer selectedOffer, [NullAllowed] string guestProvidedSpecialRequestText);
+		NativeHandle Constructor (INRestaurant restaurant, NSDateComponents bookingDateComponents, ulong partySize, [NullAllowed] string bookingIdentifier, [NullAllowed] INRestaurantGuest guest, [NullAllowed] INRestaurantOffer selectedOffer, [NullAllowed] string guestProvidedSpecialRequestText);
 #endif
 		[Export ("restaurant", ArgumentSemantic.Copy)]
 		INRestaurant Restaurant { get; set; }
@@ -2475,7 +2479,7 @@ namespace Intents {
 	interface INBookRestaurantReservationIntentResponse {
 
 		[Export ("initWithCode:userActivity:")]
-		IntPtr Constructor (INBookRestaurantReservationIntentCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INBookRestaurantReservationIntentCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INBookRestaurantReservationIntentCode Code { get; }
@@ -2607,7 +2611,7 @@ namespace Intents {
 
 		[Export ("initWithWorkoutName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INSpeakableString workoutName);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString workoutName);
 
 		[NullAllowed, Export ("workoutName", ArgumentSemantic.Copy)]
 		INSpeakableString WorkoutName { get; }
@@ -2647,7 +2651,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INCancelWorkoutIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INCancelWorkoutIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INCancelWorkoutIntentResponseCode Code { get; }
@@ -2918,7 +2922,7 @@ namespace Intents {
 
 		[Export ("initWithAmount:currencyCode:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSDecimalNumber amount, string currencyCode);
+		NativeHandle Constructor (NSDecimalNumber amount, string currencyCode);
 
 		[NullAllowed, Export ("amount", ArgumentSemantic.Copy)]
 		NSDecimalNumber Amount { get; }
@@ -2987,16 +2991,16 @@ namespace Intents {
 	interface INDateComponentsRange : NSCopying, NSSecureCoding {
 
 		[Export ("initWithStartDateComponents:endDateComponents:")]
-		IntPtr Constructor ([NullAllowed] NSDateComponents startDateComponents, [NullAllowed] NSDateComponents endDateComponents);
+		NativeHandle Constructor ([NullAllowed] NSDateComponents startDateComponents, [NullAllowed] NSDateComponents endDateComponents);
 
 		[Watch (4,0), Mac (10,13), iOS (11,0), NoTV]
 		[Export ("initWithEKRecurrenceRule:")]
-		IntPtr Constructor (EKRecurrenceRule recurrenceRule);
+		NativeHandle Constructor (EKRecurrenceRule recurrenceRule);
 
 		[Watch (4,0), Mac (10,13), iOS (11,0), NoTV]
 		[Export ("initWithStartDateComponents:endDateComponents:recurrenceRule:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSDateComponents startDateComponents, [NullAllowed] NSDateComponents endDateComponents, [NullAllowed] INRecurrenceRule recurrenceRule);
+		NativeHandle Constructor ([NullAllowed] NSDateComponents startDateComponents, [NullAllowed] NSDateComponents endDateComponents, [NullAllowed] INRecurrenceRule recurrenceRule);
 
 		[NullAllowed, Export ("startDateComponents", ArgumentSemantic.Copy)]
 		NSDateComponents StartDateComponents { get; }
@@ -3300,7 +3304,7 @@ namespace Intents {
 
 		[Export ("initWithWorkoutName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INSpeakableString workoutName);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString workoutName);
 
 		[NullAllowed, Export ("workoutName", ArgumentSemantic.Copy)]
 		INSpeakableString WorkoutName { get; }
@@ -3340,7 +3344,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INEndWorkoutIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INEndWorkoutIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INEndWorkoutIntentResponseCode Code { get; }
@@ -3374,7 +3378,7 @@ namespace Intents {
 
 		[iOS (11,0)]
 		[Export ("initWithRestaurant:")]
-		IntPtr Constructor ([NullAllowed] INRestaurant restaurant);
+		NativeHandle Constructor ([NullAllowed] INRestaurant restaurant);
 
 		[NullAllowed, Export ("restaurant", ArgumentSemantic.Copy)]
 		INRestaurant Restaurant { get; set; }
@@ -3428,7 +3432,7 @@ namespace Intents {
 
 		[Export ("initWithDefaultPartySize:defaultBookingDate:code:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (nuint defaultPartySize, NSDate defaultBookingDate, INGetAvailableRestaurantReservationBookingDefaultsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (nuint defaultPartySize, NSDate defaultBookingDate, INGetAvailableRestaurantReservationBookingDefaultsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INGetAvailableRestaurantReservationBookingDefaultsIntentResponseCode Code { get; }
@@ -3443,7 +3447,7 @@ namespace Intents {
 
 		[iOS (11,0)]
 		[Export ("initWithRestaurant:partySize:preferredBookingDateComponents:maximumNumberOfResults:earliestBookingDateForResults:latestBookingDateForResults:")]
-		IntPtr Constructor (INRestaurant restaurant, nuint partySize, [NullAllowed] NSDateComponents preferredBookingDateComponents, [NullAllowed] NSNumber maximumNumberOfResults, [NullAllowed] NSDate earliestBookingDateForResults, [NullAllowed] NSDate latestBookingDateForResults);
+		NativeHandle Constructor (INRestaurant restaurant, nuint partySize, [NullAllowed] NSDateComponents preferredBookingDateComponents, [NullAllowed] NSNumber maximumNumberOfResults, [NullAllowed] NSDate earliestBookingDateForResults, [NullAllowed] NSDate latestBookingDateForResults);
 
 		[Export ("restaurant", ArgumentSemantic.Copy)]
 		INRestaurant Restaurant { get; set; }
@@ -3503,7 +3507,7 @@ namespace Intents {
 
 		[Export ("initWithAvailableBookings:code:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INRestaurantReservationBooking [] availableBookings, INGetAvailableRestaurantReservationBookingsIntentCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INRestaurantReservationBooking [] availableBookings, INGetAvailableRestaurantReservationBookingsIntentCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INGetAvailableRestaurantReservationBookingsIntentCode Code { get; }
@@ -3559,7 +3563,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INGetRestaurantGuestIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INGetRestaurantGuestIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[NullAllowed, Export ("guest", ArgumentSemantic.Copy)]
 		INRestaurantGuest Guest { get; set; }
@@ -3581,7 +3585,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 	}
 
 	[iOS (10, 0)]
@@ -3637,7 +3641,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INGetRideStatusIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INGetRideStatusIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INGetRideStatusIntentResponseCode Code { get; }
@@ -3655,11 +3659,11 @@ namespace Intents {
 
 		[iOS (11,0)]
 		[Export ("initWithRestaurant:reservationIdentifier:maximumNumberOfResults:earliestBookingDateForResults:")]
-		IntPtr Constructor ([NullAllowed] INRestaurant restaurant, [NullAllowed] string reservationIdentifier, [NullAllowed] NSNumber maximumNumberOfResults, [NullAllowed] NSDate earliestBookingDateForResults);
+		NativeHandle Constructor ([NullAllowed] INRestaurant restaurant, [NullAllowed] string reservationIdentifier, [NullAllowed] NSNumber maximumNumberOfResults, [NullAllowed] NSDate earliestBookingDateForResults);
 
 		[iOS (11,0)]
 		[Wrap ("this (restaurant, reservationIdentifier, NSNumber.FromNInt (maximumNumberOfResults), earliestBookingDateForResults)")]
-		IntPtr Constructor ([NullAllowed] INRestaurant restaurant, [NullAllowed] string reservationIdentifier, nint maximumNumberOfResults, [NullAllowed] NSDate earliestBookingDateForResults);
+		NativeHandle Constructor ([NullAllowed] INRestaurant restaurant, [NullAllowed] string reservationIdentifier, nint maximumNumberOfResults, [NullAllowed] NSDate earliestBookingDateForResults);
 
 		[NullAllowed, Export ("restaurant", ArgumentSemantic.Copy)]
 		INRestaurant Restaurant { get; set; }
@@ -3707,7 +3711,7 @@ namespace Intents {
 
 		[Export ("initWithUserCurrentBookings:code:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INRestaurantReservationUserBooking [] userCurrentBookings, INGetUserCurrentRestaurantReservationBookingsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INRestaurantReservationUserBooking [] userCurrentBookings, INGetUserCurrentRestaurantReservationBookingsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INGetUserCurrentRestaurantReservationBookingsIntentResponseCode Code { get; }
@@ -3943,7 +3947,7 @@ namespace Intents {
 
 		[Export ("initWithIntent:response:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INIntent intent, [NullAllowed] INIntentResponse response);
+		NativeHandle Constructor (INIntent intent, [NullAllowed] INIntentResponse response);
 
 		[Async]
 		[Export ("donateInteractionWithCompletion:")]
@@ -4002,7 +4006,7 @@ namespace Intents {
 
 		[Export ("initWithPickupLocation:dropOffLocation:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation);
+		NativeHandle Constructor ([NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation);
 
 		[NullAllowed, Export ("pickupLocation", ArgumentSemantic.Copy)]
 		CLPlacemark PickupLocation { get; }
@@ -4048,7 +4052,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INListRideOptionsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INListRideOptionsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INListRideOptionsIntentResponseCode Code { get; }
@@ -4078,19 +4082,19 @@ namespace Intents {
 		[Watch (6,1), NoMac, iOS (13,2)]
 		[Export ("initWithIdentifier:conversationIdentifier:content:dateSent:sender:recipients:groupName:messageType:serviceName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier, [NullAllowed] string conversationIdentifier, [NullAllowed] string content, [NullAllowed] NSDate dateSent, [NullAllowed] INPerson sender, [NullAllowed] INPerson[] recipients, [NullAllowed] INSpeakableString groupName, INMessageType messageType, [NullAllowed] string serviceName);
+		NativeHandle Constructor (string identifier, [NullAllowed] string conversationIdentifier, [NullAllowed] string content, [NullAllowed] NSDate dateSent, [NullAllowed] INPerson sender, [NullAllowed] INPerson[] recipients, [NullAllowed] INSpeakableString groupName, INMessageType messageType, [NullAllowed] string serviceName);
 		
 		[Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Export ("initWithIdentifier:conversationIdentifier:content:dateSent:sender:recipients:groupName:messageType:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier, [NullAllowed] string conversationIdentifier, [NullAllowed] string content, [NullAllowed] NSDate dateSent, [NullAllowed] INPerson sender, [NullAllowed] INPerson [] recipients, [NullAllowed] INSpeakableString groupName, INMessageType messageType);
+		NativeHandle Constructor (string identifier, [NullAllowed] string conversationIdentifier, [NullAllowed] string content, [NullAllowed] NSDate dateSent, [NullAllowed] INPerson sender, [NullAllowed] INPerson [] recipients, [NullAllowed] INSpeakableString groupName, INMessageType messageType);
 
 		[Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Export ("initWithIdentifier:conversationIdentifier:content:dateSent:sender:recipients:messageType:")]
-		IntPtr Constructor (string identifier, [NullAllowed] string conversationIdentifier, [NullAllowed] string content, [NullAllowed] NSDate dateSent, [NullAllowed] INPerson sender, [NullAllowed] INPerson [] recipients, INMessageType messageType);
+		NativeHandle Constructor (string identifier, [NullAllowed] string conversationIdentifier, [NullAllowed] string content, [NullAllowed] NSDate dateSent, [NullAllowed] INPerson sender, [NullAllowed] INPerson [] recipients, INMessageType messageType);
 
 		[Export ("initWithIdentifier:content:dateSent:sender:recipients:")]
-		IntPtr Constructor (string identifier, [NullAllowed] string content, [NullAllowed] NSDate dateSent, [NullAllowed] INPerson sender, [NullAllowed] INPerson [] recipients);
+		NativeHandle Constructor (string identifier, [NullAllowed] string content, [NullAllowed] NSDate dateSent, [NullAllowed] INPerson sender, [NullAllowed] INPerson [] recipients);
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -4275,7 +4279,7 @@ namespace Intents {
 
 		[Export ("initWithWorkoutName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INSpeakableString workoutName);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString workoutName);
 
 		[NullAllowed, Export ("workoutName", ArgumentSemantic.Copy)]
 		INSpeakableString WorkoutName { get; }
@@ -4315,7 +4319,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INPauseWorkoutIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INPauseWorkoutIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INPauseWorkoutIntentResponseCode Code { get; }
@@ -4330,7 +4334,7 @@ namespace Intents {
 
 		[Export ("initWithType:name:identificationHint:icon:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INPaymentMethodType type, [NullAllowed] string name, [NullAllowed] string identificationHint, [NullAllowed] INImage icon);
+		NativeHandle Constructor (INPaymentMethodType type, [NullAllowed] string name, [NullAllowed] string identificationHint, [NullAllowed] INImage icon);
 
 		[Export ("type", ArgumentSemantic.Assign)]
 		INPaymentMethodType Type { get; }
@@ -4359,10 +4363,10 @@ namespace Intents {
 
 		[Export ("initWithPayee:payer:currencyAmount:paymentMethod:note:status:feeAmount:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INPerson payee, [NullAllowed] INPerson payer, [NullAllowed] INCurrencyAmount currencyAmount, [NullAllowed] INPaymentMethod paymentMethod, [NullAllowed] string note, INPaymentStatus status, [NullAllowed] INCurrencyAmount feeAmount);
+		NativeHandle Constructor ([NullAllowed] INPerson payee, [NullAllowed] INPerson payer, [NullAllowed] INCurrencyAmount currencyAmount, [NullAllowed] INPaymentMethod paymentMethod, [NullAllowed] string note, INPaymentStatus status, [NullAllowed] INCurrencyAmount feeAmount);
 
 		[Export ("initWithPayee:payer:currencyAmount:paymentMethod:note:status:")]
-		IntPtr Constructor ([NullAllowed] INPerson payee, [NullAllowed] INPerson payer, [NullAllowed] INCurrencyAmount currencyAmount, [NullAllowed] INPaymentMethod paymentMethod, [NullAllowed] string note, INPaymentStatus status);
+		NativeHandle Constructor ([NullAllowed] INPerson payee, [NullAllowed] INPerson payer, [NullAllowed] INCurrencyAmount currencyAmount, [NullAllowed] INPaymentMethod paymentMethod, [NullAllowed] string note, INPaymentStatus status);
 
 		[NullAllowed, Export ("payee", ArgumentSemantic.Copy)]
 		INPerson Payee { get; }
@@ -4395,17 +4399,17 @@ namespace Intents {
 	interface INPerson : NSCopying, NSSecureCoding, INSpeakable {
 
 		[Export ("initWithPersonHandle:nameComponents:displayName:image:contactIdentifier:customIdentifier:")]
-		IntPtr Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string contactIdentifier, [NullAllowed] string customIdentifier);
+		NativeHandle Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string contactIdentifier, [NullAllowed] string customIdentifier);
 
 		[Watch (7,0), iOS (14,0), Mac (11,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithPersonHandle:nameComponents:displayName:image:contactIdentifier:customIdentifier:relationship:")]
-		IntPtr Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string contactIdentifier, [NullAllowed] string customIdentifier, [NullAllowed] string relationship);
+		NativeHandle Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string contactIdentifier, [NullAllowed] string customIdentifier, [NullAllowed] string relationship);
 
 		[Watch (5,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithPersonHandle:nameComponents:displayName:image:contactIdentifier:customIdentifier:isMe:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string contactIdentifier, [NullAllowed] string customIdentifier, bool isMe);
+		NativeHandle Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string contactIdentifier, [NullAllowed] string customIdentifier, bool isMe);
 
 		[Internal]
 		[Watch (8,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
@@ -4450,7 +4454,7 @@ namespace Intents {
 		INPersonSuggestionType SuggestionType { get; }
 
 		[Export ("initWithPersonHandle:nameComponents:displayName:image:contactIdentifier:customIdentifier:aliases:suggestionType:")]
-		IntPtr Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string contactIdentifier, [NullAllowed] string customIdentifier, [NullAllowed] INPersonHandle [] aliases, INPersonSuggestionType suggestionType);
+		NativeHandle Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string contactIdentifier, [NullAllowed] string customIdentifier, [NullAllowed] INPersonHandle [] aliases, INPersonSuggestionType suggestionType);
 
 		// Inlined from INInteraction (INPerson) Category
 
@@ -4495,16 +4499,16 @@ namespace Intents {
 		[iOS (10, 2)]
 		[Mac (10, 12, 2)]
 		[Wrap ("this (value, type, label.GetConstant ())")]
-		IntPtr Constructor (string value, INPersonHandleType type, INPersonHandleLabel label);
+		NativeHandle Constructor (string value, INPersonHandleType type, INPersonHandleLabel label);
 
 		[DesignatedInitializer]
 		[iOS (10, 2)]
 		[Mac (10, 12, 2)]
 		[Export ("initWithValue:type:label:"), Protected]
-		IntPtr Constructor ([NullAllowed] string value, INPersonHandleType type, [NullAllowed] NSString stringLabel);
+		NativeHandle Constructor ([NullAllowed] string value, INPersonHandleType type, [NullAllowed] NSString stringLabel);
 
 		[Export ("initWithValue:type:")]
-		IntPtr Constructor ([NullAllowed] string value, INPersonHandleType type);
+		NativeHandle Constructor ([NullAllowed] string value, INPersonHandleType type);
 	}
 
 	[iOS (10, 0)]
@@ -4645,7 +4649,7 @@ namespace Intents {
 
 		[Export ("initWithRangeBetweenPrice:andPrice:currencyCode:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSDecimalNumber firstPrice, NSDecimalNumber secondPrice, string currencyCode);
+		NativeHandle Constructor (NSDecimalNumber firstPrice, NSDecimalNumber secondPrice, string currencyCode);
 
 		[Internal]
 		[Export ("initWithMaximumPrice:currencyCode:")]
@@ -4656,7 +4660,7 @@ namespace Intents {
 		IntPtr InitWithMinimumPrice (NSDecimalNumber minimumPrice, string currencyCode);
 
 		[Export ("initWithPrice:currencyCode:")]
-		IntPtr Constructor (NSDecimalNumber price, string currencyCode);
+		NativeHandle Constructor (NSDecimalNumber price, string currencyCode);
 
 		[NullAllowed, Export ("minimumPrice")]
 		NSDecimalNumber MinimumPrice { get; }
@@ -4869,7 +4873,7 @@ namespace Intents {
 
 		[Export ("initWithPayer:currencyAmount:note:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INPerson payer, [NullAllowed] INCurrencyAmount currencyAmount, [NullAllowed] string note);
+		NativeHandle Constructor ([NullAllowed] INPerson payer, [NullAllowed] INCurrencyAmount currencyAmount, [NullAllowed] string note);
 
 		[NullAllowed, Export ("payer", ArgumentSemantic.Copy)]
 		INPerson Payer { get; }
@@ -4933,7 +4937,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INRequestPaymentIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INRequestPaymentIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INRequestPaymentIntentResponseCode Code { get; }
@@ -4952,12 +4956,12 @@ namespace Intents {
 		[Deprecated (PlatformName.iOS, 10, 3, message: "Use the INDateComponentsRange overload")]
 		[Unavailable (PlatformName.WatchOS)]
 		[Export ("initWithPickupLocation:dropOffLocation:rideOptionName:partySize:paymentMethod:")]
-		IntPtr Constructor ([NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation, [NullAllowed] INSpeakableString rideOptionName, [NullAllowed] NSNumber partySize, [NullAllowed] INPaymentMethod paymentMethod);
+		NativeHandle Constructor ([NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation, [NullAllowed] INSpeakableString rideOptionName, [NullAllowed] NSNumber partySize, [NullAllowed] INPaymentMethod paymentMethod);
 
 		[iOS (10, 3)]
 		[Export ("initWithPickupLocation:dropOffLocation:rideOptionName:partySize:paymentMethod:scheduledPickupTime:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation, [NullAllowed] INSpeakableString rideOptionName, [NullAllowed] NSNumber partySize, [NullAllowed] INPaymentMethod paymentMethod, [NullAllowed] INDateComponentsRange scheduledPickupTime);
+		NativeHandle Constructor ([NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation, [NullAllowed] INSpeakableString rideOptionName, [NullAllowed] NSNumber partySize, [NullAllowed] INPaymentMethod paymentMethod, [NullAllowed] INDateComponentsRange scheduledPickupTime);
 
 		[NullAllowed, Export ("pickupLocation", ArgumentSemantic.Copy)]
 		CLPlacemark PickupLocation { get; }
@@ -5026,7 +5030,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INRequestRideIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INRequestRideIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INRequestRideIntentResponseCode Code { get; }
@@ -5044,7 +5048,7 @@ namespace Intents {
 
 		[Export ("initWithLocation:name:vendorIdentifier:restaurantIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CLLocation location, string name, string vendorIdentifier, string restaurantIdentifier);
+		NativeHandle Constructor (CLLocation location, string name, string vendorIdentifier, string restaurantIdentifier);
 
 		[Export ("location", ArgumentSemantic.Copy)]
 		CLLocation Location { get; set; }
@@ -5069,7 +5073,7 @@ namespace Intents {
 
 		[Export ("initWithNameComponents:phoneNumber:emailAddress:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string phoneNumber, [NullAllowed] string emailAddress);
+		NativeHandle Constructor ([NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string phoneNumber, [NullAllowed] string emailAddress);
 
 		[NullAllowed, Export ("phoneNumber")]
 		string PhoneNumber { get; set; }
@@ -5187,7 +5191,7 @@ namespace Intents {
 
 		[Export ("initWithRestaurant:bookingDate:partySize:bookingIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INRestaurant restaurant, NSDate bookingDate, nuint partySize, string bookingIdentifier);
+		NativeHandle Constructor (INRestaurant restaurant, NSDate bookingDate, nuint partySize, string bookingIdentifier);
 
 		[Export ("restaurant", ArgumentSemantic.Copy)]
 		INRestaurant Restaurant { get; set; }
@@ -5232,10 +5236,10 @@ namespace Intents {
 
 		[Export ("initWithRestaurant:bookingDate:partySize:bookingIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INRestaurant restaurant, NSDate bookingDate, nuint partySize, string bookingIdentifier);
+		NativeHandle Constructor (INRestaurant restaurant, NSDate bookingDate, nuint partySize, string bookingIdentifier);
 
 		[Export ("initWithRestaurant:bookingDate:partySize:bookingIdentifier:guest:status:dateStatusModified:")]
-		IntPtr Constructor (INRestaurant restaurant, NSDate bookingDate, nuint partySize, string bookingIdentifier, INRestaurantGuest guest, INRestaurantReservationUserBookingStatus status, NSDate dateStatusModified);
+		NativeHandle Constructor (INRestaurant restaurant, NSDate bookingDate, nuint partySize, string bookingIdentifier, INRestaurantGuest guest, INRestaurantReservationUserBookingStatus status, NSDate dateStatusModified);
 
 		[Export ("guest", ArgumentSemantic.Copy)]
 		INRestaurantGuest Guest { get; set; }
@@ -5316,7 +5320,7 @@ namespace Intents {
 
 		[Export ("initWithWorkoutName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INSpeakableString workoutName);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString workoutName);
 
 		[NullAllowed, Export ("workoutName", ArgumentSemantic.Copy)]
 		INSpeakableString WorkoutName { get; }
@@ -5356,7 +5360,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INResumeWorkoutIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INResumeWorkoutIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INResumeWorkoutIntentResponseCode Code { get; }
@@ -5437,12 +5441,12 @@ namespace Intents {
 		[Export ("initWithPersonHandle:nameComponents:displayName:image:rating:phoneNumber:")]
 		[Deprecated (PlatformName.iOS, 10,2, message:"Use the overload signature instead.")]
 		[Unavailable (PlatformName.WatchOS)]
-		IntPtr Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string rating, [NullAllowed] string phoneNumber);
+		NativeHandle Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string rating, [NullAllowed] string phoneNumber);
 
 		[Export ("initWithPhoneNumber:nameComponents:displayName:image:rating:")]
 		[iOS (10,2)]
 		[DesignatedInitializer]
-		IntPtr Constructor (string phoneNumber, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string rating);
+		NativeHandle Constructor (string phoneNumber, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string rating);
 
 		[NullAllowed, Export ("rating")]
 		string Rating { get; }
@@ -5461,7 +5465,7 @@ namespace Intents {
 
 		[Export ("initWithTitle:price:currencyCode:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string title, NSDecimalNumber price, string currencyCode);
+		NativeHandle Constructor (string title, NSDecimalNumber price, string currencyCode);
 
 		[Export ("title")]
 		string Title { get; }
@@ -5483,7 +5487,7 @@ namespace Intents {
 
 		[Export ("initWithName:estimatedPickupDate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string name, NSDate estimatedPickupDate);
+		NativeHandle Constructor (string name, NSDate estimatedPickupDate);
 
 		[Export ("name")]
 		string Name { get; set; }
@@ -5530,7 +5534,7 @@ namespace Intents {
 
 		[Export ("initWithPartySizeRange:sizeDescription:priceRange:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSRange partySizeRange, string sizeDescription, [NullAllowed] INPriceRange priceRange);
+		NativeHandle Constructor (NSRange partySizeRange, string sizeDescription, [NullAllowed] INPriceRange priceRange);
 
 		[Export ("partySizeRange")]
 		NSRange PartySizeRange { get; }
@@ -5689,7 +5693,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSaveProfileInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSaveProfileInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSaveProfileInCarIntentResponseCode Code { get; }
@@ -5711,17 +5715,17 @@ namespace Intents {
 		[Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Export ("initWithDateCreated:recipient:callCapabilities:callTypes:unseen:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INDateComponentsRange dateCreated, [NullAllowed] INPerson recipient, INCallCapabilityOptions callCapabilities, INCallRecordTypeOptions callTypes, [NullAllowed] NSNumber unseen);
+		NativeHandle Constructor ([NullAllowed] INDateComponentsRange dateCreated, [NullAllowed] INPerson recipient, INCallCapabilityOptions callCapabilities, INCallRecordTypeOptions callTypes, [NullAllowed] NSNumber unseen);
 
 		[Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Wrap ("this (dateCreated, recipient, callCapabilities, callTypes, new NSNumber (unseen))")]
-		IntPtr Constructor ([NullAllowed] INDateComponentsRange dateCreated, [NullAllowed] INPerson recipient, INCallCapabilityOptions callCapabilities, INCallRecordTypeOptions callTypes, bool unseen);
+		NativeHandle Constructor ([NullAllowed] INDateComponentsRange dateCreated, [NullAllowed] INPerson recipient, INCallCapabilityOptions callCapabilities, INCallRecordTypeOptions callTypes, bool unseen);
 
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use '.ctor (INDateComponentsRange, INPerson, INCallCapabilityOptions, INCallRecordTypeOptions, NSNumber)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use '.ctor (INDateComponentsRange, INPerson, INCallCapabilityOptions, INCallRecordTypeOptions, NSNumber)' instead.")]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use '.ctor (INDateComponentsRange, INPerson, INCallCapabilityOptions, INCallRecordTypeOptions, NSNumber)' instead.")]
 		[Export ("initWithCallType:dateCreated:recipient:callCapabilities:")]
-		IntPtr Constructor (INCallRecordType callType, [NullAllowed] INDateComponentsRange dateCreated, [NullAllowed] INPerson recipient, INCallCapabilityOptions callCapabilities);
+		NativeHandle Constructor (INCallRecordType callType, [NullAllowed] INDateComponentsRange dateCreated, [NullAllowed] INPerson recipient, INCallCapabilityOptions callCapabilities);
 
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'CallTypes' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'CallTypes' instead.")]
@@ -5811,7 +5815,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSearchCallHistoryIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSearchCallHistoryIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSearchCallHistoryIntentResponseCode Code { get; }
@@ -5837,18 +5841,18 @@ namespace Intents {
 		[Deprecated (PlatformName.iOS, 12,0, message: "Use the overload that takes 'conversationIdentifiers' instead.")]
 		[Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Export ("initWithRecipients:senders:searchTerms:attributes:dateTimeRange:identifiers:notificationIdentifiers:speakableGroupNames:")]
-		IntPtr Constructor ([NullAllowed] INPerson [] recipients, [NullAllowed] INPerson [] senders, [NullAllowed] string [] searchTerms, INMessageAttributeOptions attributes, [NullAllowed] INDateComponentsRange dateTimeRange, [NullAllowed] string [] identifiers, [NullAllowed] string [] notificationIdentifiers, [NullAllowed] INSpeakableString [] speakableGroupNames);
+		NativeHandle Constructor ([NullAllowed] INPerson [] recipients, [NullAllowed] INPerson [] senders, [NullAllowed] string [] searchTerms, INMessageAttributeOptions attributes, [NullAllowed] INDateComponentsRange dateTimeRange, [NullAllowed] string [] identifiers, [NullAllowed] string [] notificationIdentifiers, [NullAllowed] INSpeakableString [] speakableGroupNames);
 
 		[Watch (5,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithRecipients:senders:searchTerms:attributes:dateTimeRange:identifiers:notificationIdentifiers:speakableGroupNames:conversationIdentifiers:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INPerson [] recipients, [NullAllowed] INPerson [] senders, [NullAllowed] string [] searchTerms, INMessageAttributeOptions attributes, [NullAllowed] INDateComponentsRange dateTimeRange, [NullAllowed] string [] identifiers, [NullAllowed] string [] notificationIdentifiers, [NullAllowed] INSpeakableString [] speakableGroupNames, [NullAllowed] string [] conversationIdentifiers);
+		NativeHandle Constructor ([NullAllowed] INPerson [] recipients, [NullAllowed] INPerson [] senders, [NullAllowed] string [] searchTerms, INMessageAttributeOptions attributes, [NullAllowed] INDateComponentsRange dateTimeRange, [NullAllowed] string [] identifiers, [NullAllowed] string [] notificationIdentifiers, [NullAllowed] INSpeakableString [] speakableGroupNames, [NullAllowed] string [] conversationIdentifiers);
 
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use '.ctor (INPerson [], INPerson [], string [], INMessageAttributeOptions, INDateComponentsRange, string [], string [], INSpeakableString [])' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use '.ctor (INPerson [], INPerson [], string [], INMessageAttributeOptions, INDateComponentsRange, string [], string [], INSpeakableString [])' instead.")]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use '.ctor (INPerson [], INPerson [], string [], INMessageAttributeOptions, INDateComponentsRange, string [], string [], INSpeakableString [])' instead.")]
 		[Export ("initWithRecipients:senders:searchTerms:attributes:dateTimeRange:identifiers:notificationIdentifiers:groupNames:")]
-		IntPtr Constructor ([NullAllowed] INPerson [] recipients, [NullAllowed] INPerson [] senders, [NullAllowed] string [] searchTerms, INMessageAttributeOptions attributes, [NullAllowed] INDateComponentsRange dateTimeRange, [NullAllowed] string [] identifiers, [NullAllowed] string [] notificationIdentifiers, [NullAllowed] string [] groupNames);
+		NativeHandle Constructor ([NullAllowed] INPerson [] recipients, [NullAllowed] INPerson [] senders, [NullAllowed] string [] searchTerms, INMessageAttributeOptions attributes, [NullAllowed] INDateComponentsRange dateTimeRange, [NullAllowed] string [] identifiers, [NullAllowed] string [] notificationIdentifiers, [NullAllowed] string [] groupNames);
 
 		[NullAllowed, Export ("recipients", ArgumentSemantic.Copy)]
 		INPerson [] Recipients { get; }
@@ -5976,7 +5980,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSearchForMessagesIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSearchForMessagesIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSearchForMessagesIntentResponseCode Code { get; }
@@ -5996,7 +6000,7 @@ namespace Intents {
 
 		[Export ("initWithDateCreated:locationCreated:albumName:searchTerms:includedAttributes:excludedAttributes:peopleInPhoto:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INDateComponentsRange dateCreated, [NullAllowed] CLPlacemark locationCreated, [NullAllowed] string albumName, [NullAllowed] string [] searchTerms, INPhotoAttributeOptions includedAttributes, INPhotoAttributeOptions excludedAttributes, [NullAllowed] INPerson [] peopleInPhoto);
+		NativeHandle Constructor ([NullAllowed] INDateComponentsRange dateCreated, [NullAllowed] CLPlacemark locationCreated, [NullAllowed] string albumName, [NullAllowed] string [] searchTerms, INPhotoAttributeOptions includedAttributes, INPhotoAttributeOptions excludedAttributes, [NullAllowed] INPerson [] peopleInPhoto);
 
 		[NullAllowed, Export ("dateCreated", ArgumentSemantic.Copy)]
 		INDateComponentsRange DateCreated { get; }
@@ -6077,7 +6081,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSearchForPhotosIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSearchForPhotosIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSearchForPhotosIntentResponseCode Code { get; }
@@ -6097,20 +6101,20 @@ namespace Intents {
 		[MacCatalyst (14,0)]
 		[Export ("initWithRecipients:outgoingMessageType:content:speakableGroupName:conversationIdentifier:serviceName:sender:attachments:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INPerson[] recipients, INOutgoingMessageType outgoingMessageType, [NullAllowed] string content, [NullAllowed] INSpeakableString speakableGroupName, [NullAllowed] string conversationIdentifier, [NullAllowed] string serviceName, [NullAllowed] INPerson sender, [NullAllowed] INSendMessageAttachment[] attachments);
+		NativeHandle Constructor ([NullAllowed] INPerson[] recipients, INOutgoingMessageType outgoingMessageType, [NullAllowed] string content, [NullAllowed] INSpeakableString speakableGroupName, [NullAllowed] string conversationIdentifier, [NullAllowed] string serviceName, [NullAllowed] INPerson sender, [NullAllowed] INSendMessageAttachment[] attachments);
 
 		[Deprecated (PlatformName.MacOSX, 12, 0, message: "Use '.ctor (INPerson[], INOutgoingMessageType, string, INSpeakableString, string, string, INPerson, INSendMessageAttachment[])' instead.")]
 		[Deprecated (PlatformName.WatchOS, 7, 0, message: "Use '.ctor (INPerson[], INOutgoingMessageType, string, INSpeakableString, string, string, INPerson, INSendMessageAttachment[])' instead.")]
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use '.ctor (INPerson[], INOutgoingMessageType, string, INSpeakableString, string, string, INPerson, INSendMessageAttachment[])' instead.")]
 		[Watch (4,0), iOS (11,0)]
 		[Export ("initWithRecipients:content:speakableGroupName:conversationIdentifier:serviceName:sender:")]
-		IntPtr Constructor ([NullAllowed] INPerson [] recipients, [NullAllowed] string content, [NullAllowed] INSpeakableString speakableGroupName, [NullAllowed] string conversationIdentifier, [NullAllowed] string serviceName, [NullAllowed] INPerson sender);
+		NativeHandle Constructor ([NullAllowed] INPerson [] recipients, [NullAllowed] string content, [NullAllowed] INSpeakableString speakableGroupName, [NullAllowed] string conversationIdentifier, [NullAllowed] string serviceName, [NullAllowed] INPerson sender);
 
 		[Deprecated (PlatformName.MacOSX, 12, 0, message: "Use '.ctor (INPerson [], string, INSpeakableString, string, string, INPerson)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use '.ctor (INPerson [], string, INSpeakableString, string, string, INPerson)' instead.")]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use '.ctor (INPerson [], string, INSpeakableString, string, string, INPerson)' instead.")]
 		[Export ("initWithRecipients:content:groupName:serviceName:sender:")]
-		IntPtr Constructor ([NullAllowed] INPerson [] recipients, [NullAllowed] string content, [NullAllowed] string groupName, [NullAllowed] string serviceName, [NullAllowed] INPerson sender);
+		NativeHandle Constructor ([NullAllowed] INPerson [] recipients, [NullAllowed] string content, [NullAllowed] string groupName, [NullAllowed] string serviceName, [NullAllowed] INPerson sender);
 
 		[NullAllowed, Export ("recipients", ArgumentSemantic.Copy)]
 		INPerson [] Recipients { get; }
@@ -6157,7 +6161,7 @@ namespace Intents {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("mentionsCurrentUser")]
 		bool MentionsCurrentUser { get; set; }
@@ -6231,7 +6235,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSendMessageIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSendMessageIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSendMessageIntentResponseCode Code { get; }
@@ -6250,7 +6254,7 @@ namespace Intents {
 
 		[Export ("initWithPayee:currencyAmount:note:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INPerson payee, [NullAllowed] INCurrencyAmount currencyAmount, [NullAllowed] string note);
+		NativeHandle Constructor ([NullAllowed] INPerson payee, [NullAllowed] INCurrencyAmount currencyAmount, [NullAllowed] string note);
 
 		[NullAllowed, Export ("payee", ArgumentSemantic.Copy)]
 		INPerson Payee { get; }
@@ -6314,7 +6318,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSendPaymentIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSendPaymentIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSendPaymentIntentResponseCode Code { get; }
@@ -6333,7 +6337,7 @@ namespace Intents {
 
 		[Export ("initWithAudioSource:relativeAudioSourceReference:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INCarAudioSource audioSource, INRelativeReference relativeAudioSourceReference);
+		NativeHandle Constructor (INCarAudioSource audioSource, INRelativeReference relativeAudioSourceReference);
 
 		[Export ("audioSource", ArgumentSemantic.Assign)]
 		INCarAudioSource AudioSource { get; }
@@ -6381,7 +6385,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSetAudioSourceInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSetAudioSourceInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSetAudioSourceInCarIntentResponseCode Code { get; }
@@ -6398,12 +6402,12 @@ namespace Intents {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use the overload that takes 'INSpeakableString carName'.")]
 		[Protected]
 		[Export ("initWithEnableFan:enableAirConditioner:enableClimateControl:enableAutoMode:airCirculationMode:fanSpeedIndex:fanSpeedPercentage:relativeFanSpeedSetting:temperature:relativeTemperatureSetting:climateZone:")]
-		IntPtr Constructor ([NullAllowed] NSNumber enableFan, [NullAllowed] NSNumber enableAirConditioner, [NullAllowed] NSNumber enableClimateControl, [NullAllowed] NSNumber enableAutoMode, INCarAirCirculationMode airCirculationMode, [NullAllowed] NSNumber fanSpeedIndex, [NullAllowed] NSNumber fanSpeedPercentage, INRelativeSetting relativeFanSpeedSetting, [NullAllowed] NSMeasurement<NSUnitTemperature> temperature, INRelativeSetting relativeTemperatureSetting, INCarSeat climateZone);
+		NativeHandle Constructor ([NullAllowed] NSNumber enableFan, [NullAllowed] NSNumber enableAirConditioner, [NullAllowed] NSNumber enableClimateControl, [NullAllowed] NSNumber enableAutoMode, INCarAirCirculationMode airCirculationMode, [NullAllowed] NSNumber fanSpeedIndex, [NullAllowed] NSNumber fanSpeedPercentage, INRelativeSetting relativeFanSpeedSetting, [NullAllowed] NSMeasurement<NSUnitTemperature> temperature, INRelativeSetting relativeTemperatureSetting, INCarSeat climateZone);
 
 		[iOS (12,0)]
 		[Export ("initWithEnableFan:enableAirConditioner:enableClimateControl:enableAutoMode:airCirculationMode:fanSpeedIndex:fanSpeedPercentage:relativeFanSpeedSetting:temperature:relativeTemperatureSetting:climateZone:carName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] [BindAs (typeof (bool?))] NSNumber enableFan, [NullAllowed] [BindAs (typeof (bool?))] NSNumber enableAirConditioner, [NullAllowed] [BindAs (typeof (bool?))] NSNumber enableClimateControl, [NullAllowed] [BindAs (typeof (bool?))] NSNumber enableAutoMode, INCarAirCirculationMode airCirculationMode, [NullAllowed] [BindAs (typeof (int?))] NSNumber fanSpeedIndex, [NullAllowed] [BindAs (typeof (double?))] NSNumber fanSpeedPercentage, INRelativeSetting relativeFanSpeedSetting, [NullAllowed] NSMeasurement<NSUnitTemperature> temperature, INRelativeSetting relativeTemperatureSetting, INCarSeat climateZone, [NullAllowed] INSpeakableString carName);
+		NativeHandle Constructor ([NullAllowed] [BindAs (typeof (bool?))] NSNumber enableFan, [NullAllowed] [BindAs (typeof (bool?))] NSNumber enableAirConditioner, [NullAllowed] [BindAs (typeof (bool?))] NSNumber enableClimateControl, [NullAllowed] [BindAs (typeof (bool?))] NSNumber enableAutoMode, INCarAirCirculationMode airCirculationMode, [NullAllowed] [BindAs (typeof (int?))] NSNumber fanSpeedIndex, [NullAllowed] [BindAs (typeof (double?))] NSNumber fanSpeedPercentage, INRelativeSetting relativeFanSpeedSetting, [NullAllowed] NSMeasurement<NSUnitTemperature> temperature, INRelativeSetting relativeTemperatureSetting, INCarSeat climateZone, [NullAllowed] INSpeakableString carName);
 
 		[BindAs (typeof (bool?))]
 		[NullAllowed, Export ("enableFan", ArgumentSemantic.Copy)]
@@ -6523,7 +6527,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSetClimateSettingsInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSetClimateSettingsInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSetClimateSettingsInCarIntentResponseCode Code { get; }
@@ -6540,12 +6544,12 @@ namespace Intents {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use the overload that takes 'INSpeakableString carName'.")]
 		[Protected]
 		[Export ("initWithEnable:defroster:")]
-		IntPtr Constructor ([NullAllowed] NSNumber enable, INCarDefroster defroster);
+		NativeHandle Constructor ([NullAllowed] NSNumber enable, INCarDefroster defroster);
 
 		[iOS (12,0)]
 		[Export ("initWithEnable:defroster:carName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] [BindAs (typeof (bool?))] NSNumber enable, INCarDefroster defroster, [NullAllowed] INSpeakableString carName);
+		NativeHandle Constructor ([NullAllowed] [BindAs (typeof (bool?))] NSNumber enable, INCarDefroster defroster, [NullAllowed] INSpeakableString carName);
 
 		[BindAs (typeof (bool?))]
 		[NullAllowed, Export ("enable", ArgumentSemantic.Copy)]
@@ -6602,7 +6606,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSetDefrosterSettingsInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSetDefrosterSettingsInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSetDefrosterSettingsInCarIntentResponseCode Code { get; }
@@ -6617,7 +6621,7 @@ namespace Intents {
 
 		[Export ("initWithIdentifiers:attribute:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string [] identifiers, INMessageAttribute attribute);
+		NativeHandle Constructor ([NullAllowed] string [] identifiers, INMessageAttribute attribute);
 
 		[NullAllowed, Export ("identifiers", ArgumentSemantic.Copy)]
 		string [] Identifiers { get; }
@@ -6660,7 +6664,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSetMessageAttributeIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSetMessageAttributeIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSetMessageAttributeIntentResponseCode Code { get; }
@@ -6686,7 +6690,7 @@ namespace Intents {
 		[iOS (12,0)]
 		[Export ("initWithProfileNumber:profileName:defaultProfile:carName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] [BindAs (typeof (int?))] NSNumber profileNumber, [NullAllowed] string profileName, [NullAllowed] [BindAs (typeof (bool?))] NSNumber defaultProfile, [NullAllowed] INSpeakableString carName);
+		NativeHandle Constructor ([NullAllowed] [BindAs (typeof (int?))] NSNumber profileNumber, [NullAllowed] string profileName, [NullAllowed] [BindAs (typeof (bool?))] NSNumber defaultProfile, [NullAllowed] INSpeakableString carName);
 
 #if XAMCORE_4_0 // Breaking change
 		[BindAs (typeof (int?))]
@@ -6759,7 +6763,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSetProfileInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSetProfileInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSetProfileInCarIntentResponseCode Code { get; }
@@ -6775,7 +6779,7 @@ namespace Intents {
 
 		[Export ("initWithRadioType:frequency:stationName:channel:presetNumber:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INRadioType radioType, [NullAllowed] NSNumber frequency, [NullAllowed] string stationName, [NullAllowed] string channel, [NullAllowed] NSNumber presetNumber);
+		NativeHandle Constructor (INRadioType radioType, [NullAllowed] NSNumber frequency, [NullAllowed] string stationName, [NullAllowed] string channel, [NullAllowed] NSNumber presetNumber);
 
 		[Export ("radioType", ArgumentSemantic.Assign)]
 		INRadioType RadioType { get; }
@@ -6841,7 +6845,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSetRadioStationIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSetRadioStationIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSetRadioStationIntentResponseCode Code { get; }
@@ -6858,12 +6862,12 @@ namespace Intents {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use the overload that takes 'INSpeakableString carName'.")]
 		[Protected] // allow subclassing
 		[Export ("initWithEnableHeating:enableCooling:enableMassage:seat:level:relativeLevelSetting:")]
-		IntPtr Constructor ([NullAllowed] NSNumber enableHeating, [NullAllowed] NSNumber enableCooling, [NullAllowed] NSNumber enableMassage, INCarSeat seat, [NullAllowed] NSNumber level, INRelativeSetting relativeLevelSetting);
+		NativeHandle Constructor ([NullAllowed] NSNumber enableHeating, [NullAllowed] NSNumber enableCooling, [NullAllowed] NSNumber enableMassage, INCarSeat seat, [NullAllowed] NSNumber level, INRelativeSetting relativeLevelSetting);
 
 		[iOS (12,0)]
 		[Export ("initWithEnableHeating:enableCooling:enableMassage:seat:level:relativeLevelSetting:carName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] [BindAs (typeof (bool?))] NSNumber enableHeating, [NullAllowed] [BindAs (typeof (bool?))] NSNumber enableCooling, [NullAllowed] [BindAs (typeof (bool?))] NSNumber enableMassage, INCarSeat seat, [NullAllowed] [BindAs (typeof (int?))] NSNumber level, INRelativeSetting relativeLevelSetting, [NullAllowed] INSpeakableString carName);
+		NativeHandle Constructor ([NullAllowed] [BindAs (typeof (bool?))] NSNumber enableHeating, [NullAllowed] [BindAs (typeof (bool?))] NSNumber enableCooling, [NullAllowed] [BindAs (typeof (bool?))] NSNumber enableMassage, INCarSeat seat, [NullAllowed] [BindAs (typeof (int?))] NSNumber level, INRelativeSetting relativeLevelSetting, [NullAllowed] INSpeakableString carName);
 
 		[BindAs (typeof (bool?))]
 		[NullAllowed, Export ("enableHeating", ArgumentSemantic.Copy)]
@@ -6949,7 +6953,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSetSeatSettingsInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSetSeatSettingsInCarIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSetSeatSettingsInCarIntentResponseCode Code { get; }
@@ -6962,7 +6966,7 @@ namespace Intents {
 	{
 		[Export ("initWithFocusStatus:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INFocusStatus focusStatus);
+		NativeHandle Constructor ([NullAllowed] INFocusStatus focusStatus);
 
 		[NullAllowed, Export ("focusStatus", ArgumentSemantic.Copy)]
 		INFocusStatus FocusStatus { get; }
@@ -6999,7 +7003,7 @@ namespace Intents {
 	{
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INShareFocusStatusIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INShareFocusStatusIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INShareFocusStatusIntentResponseCode Code { get; }
@@ -7067,7 +7071,7 @@ namespace Intents {
 		[iOS (10, 2)]
 		[Mac (10, 12, 2)]
 		[Export ("initWithSpokenPhrase:")]
-		IntPtr Constructor (string spokenPhrase);
+		NativeHandle Constructor (string spokenPhrase);
 	}
 
 #if XAMCORE_4_0
@@ -7142,12 +7146,12 @@ namespace Intents {
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use '.ctor (INCallDestinationType, INPerson [])' instead.")]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use '.ctor (INCallDestinationType, INPerson [])' instead.")]
 		[Export ("initWithContacts:")]
-		IntPtr Constructor ([NullAllowed] INPerson [] contacts);
+		NativeHandle Constructor ([NullAllowed] INPerson [] contacts);
 
 		[Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Export ("initWithDestinationType:contacts:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INCallDestinationType destinationType, [NullAllowed] INPerson [] contacts);
+		NativeHandle Constructor (INCallDestinationType destinationType, [NullAllowed] INPerson [] contacts);
 
 		[Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Export ("destinationType", ArgumentSemantic.Assign)]
@@ -7207,7 +7211,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INStartAudioCallIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INStartAudioCallIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INStartAudioCallIntentResponseCode Code { get; }
@@ -7224,7 +7228,7 @@ namespace Intents {
 
 		[Export ("initWithDateCreated:locationCreated:albumName:searchTerms:includedAttributes:excludedAttributes:peopleInPhoto:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INDateComponentsRange dateCreated, [NullAllowed] CLPlacemark locationCreated, [NullAllowed] string albumName, [NullAllowed] string [] searchTerms, INPhotoAttributeOptions includedAttributes, INPhotoAttributeOptions excludedAttributes, [NullAllowed] INPerson [] peopleInPhoto);
+		NativeHandle Constructor ([NullAllowed] INDateComponentsRange dateCreated, [NullAllowed] CLPlacemark locationCreated, [NullAllowed] string albumName, [NullAllowed] string [] searchTerms, INPhotoAttributeOptions includedAttributes, INPhotoAttributeOptions excludedAttributes, [NullAllowed] INPerson [] peopleInPhoto);
 
 		[NullAllowed, Export ("dateCreated", ArgumentSemantic.Copy)]
 		INDateComponentsRange DateCreated { get; }
@@ -7301,7 +7305,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INStartPhotoPlaybackIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INStartPhotoPlaybackIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INStartPhotoPlaybackIntentResponseCode Code { get; }
@@ -7325,7 +7329,7 @@ namespace Intents {
 
 		[Export ("initWithContacts:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INPerson [] contacts);
+		NativeHandle Constructor ([NullAllowed] INPerson [] contacts);
 
 		[NullAllowed, Export ("contacts", ArgumentSemantic.Copy)]
 		INPerson [] Contacts { get; }
@@ -7374,7 +7378,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INStartVideoCallIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INStartVideoCallIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INStartVideoCallIntentResponseCode Code { get; }
@@ -7390,7 +7394,7 @@ namespace Intents {
 		[Protected]
 		[Export ("initWithWorkoutName:goalValue:workoutGoalUnitType:workoutLocationType:isOpenEnded:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INSpeakableString workoutName, [NullAllowed] NSNumber goalValue, INWorkoutGoalUnitType workoutGoalUnitType, INWorkoutLocationType workoutLocationType, [NullAllowed] NSNumber isOpenEnded);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString workoutName, [NullAllowed] NSNumber goalValue, INWorkoutGoalUnitType workoutGoalUnitType, INWorkoutLocationType workoutLocationType, [NullAllowed] NSNumber isOpenEnded);
 
 		[NullAllowed, Export ("workoutName", ArgumentSemantic.Copy)]
 		INSpeakableString WorkoutName { get; }
@@ -7455,7 +7459,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INStartWorkoutIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INStartWorkoutIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INStartWorkoutIntentResponseCode Code { get; }
@@ -7574,7 +7578,7 @@ namespace Intents {
 
 		[Export ("initWithLocalizedTermsAndConditionsText:privacyPolicyURL:termsAndConditionsURL:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string localizedTermsAndConditionsText, [NullAllowed] NSUrl privacyPolicyUrl, [NullAllowed] NSUrl termsAndConditionsUrl);
+		NativeHandle Constructor (string localizedTermsAndConditionsText, [NullAllowed] NSUrl privacyPolicyUrl, [NullAllowed] NSUrl termsAndConditionsUrl);
 
 		[Export ("localizedTermsAndConditionsText")]
 		string LocalizedTermsAndConditionsText { get; }
@@ -7782,7 +7786,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithCarName:signals:")]
-		IntPtr Constructor ([NullAllowed] INSpeakableString carName, INCarSignalOptions signals);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString carName, INCarSignalOptions signals);
 
 		[Export ("carName", ArgumentSemantic.Copy), NullAllowed]
 		INSpeakableString CarName { get; }
@@ -7830,7 +7834,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithBillType:paymentStatus:billPayee:amountDue:minimumDue:lateFee:dueDate:paymentDate:")]
-		IntPtr Constructor (INBillType billType, INPaymentStatus paymentStatus, [NullAllowed] INBillPayee billPayee, [NullAllowed] INCurrencyAmount amountDue, [NullAllowed] INCurrencyAmount minimumDue, [NullAllowed] INCurrencyAmount lateFee, [NullAllowed] NSDateComponents dueDate, [NullAllowed] NSDateComponents paymentDate);
+		NativeHandle Constructor (INBillType billType, INPaymentStatus paymentStatus, [NullAllowed] INBillPayee billPayee, [NullAllowed] INCurrencyAmount amountDue, [NullAllowed] INCurrencyAmount minimumDue, [NullAllowed] INCurrencyAmount lateFee, [NullAllowed] NSDateComponents dueDate, [NullAllowed] NSDateComponents paymentDate);
 
 		[Export ("billType", ArgumentSemantic.Assign)]
 		INBillType BillType { get; set; }
@@ -7869,7 +7873,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithNickname:number:organizationName:")]
-		IntPtr Constructor (INSpeakableString nickname, [NullAllowed] string accountNumber, [NullAllowed] INSpeakableString organizationName);
+		NativeHandle Constructor (INSpeakableString nickname, [NullAllowed] string accountNumber, [NullAllowed] INSpeakableString organizationName);
 
 		[Export ("nickname", ArgumentSemantic.Copy), NullAllowed]
 		INSpeakableString Nickname { get; }
@@ -8076,7 +8080,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithCarName:")]
-		IntPtr Constructor ([NullAllowed] INSpeakableString carName);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString carName);
 
 		[Export ("carName", ArgumentSemantic.Copy), NullAllowed]
 		INSpeakableString CarName { get; }
@@ -8116,7 +8120,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithCode:userActivity:")]
-		IntPtr Constructor (INGetCarLockStatusIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INGetCarLockStatusIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INGetCarLockStatusIntentResponseCode Code { get; }
@@ -8139,7 +8143,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithCarName:")]
-		IntPtr Constructor ([NullAllowed] INSpeakableString carName);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString carName);
 
 		[Export ("carName", ArgumentSemantic.Copy), NullAllowed]
 		INSpeakableString CarName { get; }
@@ -8204,7 +8208,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithCode:userActivity:")]
-		IntPtr Constructor (INGetCarPowerLevelStatusIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INGetCarPowerLevelStatusIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INGetCarPowerLevelStatusIntentResponseCode Code { get; }
@@ -8315,7 +8319,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithBillPayee:fromAccount:transactionAmount:transactionScheduledDate:transactionNote:billType:dueDate:")]
-		IntPtr Constructor ([NullAllowed] INBillPayee billPayee, [NullAllowed] INPaymentAccount fromAccount, [NullAllowed] INPaymentAmount transactionAmount, [NullAllowed] INDateComponentsRange transactionScheduledDate, [NullAllowed] string transactionNote, INBillType billType, [NullAllowed] INDateComponentsRange dueDate);
+		NativeHandle Constructor ([NullAllowed] INBillPayee billPayee, [NullAllowed] INPaymentAccount fromAccount, [NullAllowed] INPaymentAmount transactionAmount, [NullAllowed] INDateComponentsRange transactionScheduledDate, [NullAllowed] string transactionNote, INBillType billType, [NullAllowed] INDateComponentsRange dueDate);
 
 		[Export ("billPayee", ArgumentSemantic.Copy), NullAllowed]
 		INBillPayee BillPayee { get; }
@@ -8397,7 +8401,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithCode:userActivity:")]
-		IntPtr Constructor (INPayBillIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INPayBillIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INPayBillIntentResponseCode Code { get; }
@@ -8429,12 +8433,12 @@ namespace Intents {
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Please use '.ctor (INSpeakableString, string, INAccountType, INSpeakableString, INBalanceAmount, INBalanceAmount)' instead.")]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Please use '.ctor (INSpeakableString, string, INAccountType, INSpeakableString, INBalanceAmount, INBalanceAmount)' instead.")]
 		[Export ("initWithNickname:number:accountType:organizationName:")]
-		IntPtr Constructor (INSpeakableString nickname, [NullAllowed] string accountNumber, INAccountType accountType, [NullAllowed] INSpeakableString organizationName);
+		NativeHandle Constructor (INSpeakableString nickname, [NullAllowed] string accountNumber, INAccountType accountType, [NullAllowed] INSpeakableString organizationName);
 
 		[Watch (4,0), iOS (11,0)]
 		[Export ("initWithNickname:number:accountType:organizationName:balance:secondaryBalance:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString nickname, [NullAllowed] string accountNumber, INAccountType accountType, [NullAllowed] INSpeakableString organizationName, [NullAllowed] INBalanceAmount balance, [NullAllowed] INBalanceAmount secondaryBalance);
+		NativeHandle Constructor (INSpeakableString nickname, [NullAllowed] string accountNumber, INAccountType accountType, [NullAllowed] INSpeakableString organizationName, [NullAllowed] INBalanceAmount balance, [NullAllowed] INBalanceAmount secondaryBalance);
 
 		[Export ("nickname", ArgumentSemantic.Copy), NullAllowed]
 		INSpeakableString Nickname { get; }
@@ -8518,7 +8522,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithAmountType:amount:")]
-		IntPtr Constructor (INAmountType amountType, INCurrencyAmount amount);
+		NativeHandle Constructor (INAmountType amountType, INCurrencyAmount amount);
 
 		[Export ("amount", ArgumentSemantic.Copy), NullAllowed]
 		INCurrencyAmount Amount { get; }
@@ -8655,7 +8659,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithBillPayee:paymentDateRange:billType:status:dueDateRange:")]
-		IntPtr Constructor ([NullAllowed] INBillPayee billPayee, [NullAllowed] INDateComponentsRange paymentDateRange, INBillType billType, INPaymentStatus status, [NullAllowed] INDateComponentsRange dueDateRange);
+		NativeHandle Constructor ([NullAllowed] INBillPayee billPayee, [NullAllowed] INDateComponentsRange paymentDateRange, INBillType billType, INPaymentStatus status, [NullAllowed] INDateComponentsRange dueDateRange);
 
 		[Export ("billPayee", ArgumentSemantic.Copy), NullAllowed]
 		INBillPayee BillPayee { get; }
@@ -8725,7 +8729,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithCode:userActivity:")]
-		IntPtr Constructor (INSearchForBillsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSearchForBillsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSearchForBillsIntentResponseCode Code { get; }
@@ -8745,7 +8749,7 @@ namespace Intents {
 		[Protected]
 		[DesignatedInitializer]
 		[Export ("initWithLocked:carName:")]
-		IntPtr Constructor ([NullAllowed] NSNumber locked, [NullAllowed] INSpeakableString carName);
+		NativeHandle Constructor ([NullAllowed] NSNumber locked, [NullAllowed] INSpeakableString carName);
 
 #if false // I wish BindAs was a thing right now
 		[BindAs (typeof (bool?))]
@@ -8795,7 +8799,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithCode:userActivity:")]
-		IntPtr Constructor (INSetCarLockStatusIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSetCarLockStatusIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSetCarLockStatusIntentResponseCode Code { get; }
@@ -8811,7 +8815,7 @@ namespace Intents {
 
 		[DesignatedInitializer]
 		[Export ("initWithCode:userActivity:")]
-		IntPtr Constructor (INActivateCarSignalIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INActivateCarSignalIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INActivateCarSignalIntentResponseCode Code { get; }
@@ -8871,12 +8875,12 @@ namespace Intents {
 		[Watch (6,0), iOS (13,0)]
 		[Export ("initWithTargetTaskList:taskTitles:spatialEventTrigger:temporalEventTrigger:priority:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INTaskList targetTaskList, [NullAllowed] INSpeakableString[] taskTitles, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger, INTaskPriority priority);
+		NativeHandle Constructor ([NullAllowed] INTaskList targetTaskList, [NullAllowed] INSpeakableString[] taskTitles, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger, INTaskPriority priority);
 
 		[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use the constructor with 'INTaskPriority priority' instead.")]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use the constructor with 'INTaskPriority priority' instead.")]
 		[Export ("initWithTargetTaskList:taskTitles:spatialEventTrigger:temporalEventTrigger:")]
-		IntPtr Constructor ([NullAllowed] INTaskList targetTaskList, [NullAllowed] INSpeakableString[] taskTitles, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger);
+		NativeHandle Constructor ([NullAllowed] INTaskList targetTaskList, [NullAllowed] INSpeakableString[] taskTitles, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger);
 
 		[NullAllowed, Export ("targetTaskList", ArgumentSemantic.Copy)]
 		INTaskList TargetTaskList { get; }
@@ -8942,7 +8946,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INAddTasksIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INAddTasksIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INAddTasksIntentResponseCode Code { get; }
@@ -8962,7 +8966,7 @@ namespace Intents {
 
 		[Export ("initWithTargetNote:content:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INNote targetNote, [NullAllowed] INNoteContent content);
+		NativeHandle Constructor ([NullAllowed] INNote targetNote, [NullAllowed] INNoteContent content);
 
 		[NullAllowed, Export ("targetNote", ArgumentSemantic.Copy)]
 		INNote TargetNote { get; }
@@ -9000,7 +9004,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INAppendToNoteIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INAppendToNoteIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INAppendToNoteIntentResponseCode Code { get; }
@@ -9016,11 +9020,11 @@ namespace Intents {
 
 		[Export ("initWithAmount:balanceType:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSDecimalNumber amount, INBalanceType balanceType);
+		NativeHandle Constructor (NSDecimalNumber amount, INBalanceType balanceType);
 
 		[Export ("initWithAmount:currencyCode:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSDecimalNumber amount, string currencyCode);
+		NativeHandle Constructor (NSDecimalNumber amount, string currencyCode);
 
 		[NullAllowed, Export ("amount", ArgumentSemantic.Copy)]
 		NSDecimalNumber Amount { get; }
@@ -9131,31 +9135,31 @@ namespace Intents {
 		[MacCatalyst (14,5)]
 		[Export ("initWithIdentifier:dateCreated:callRecordType:callCapability:callDuration:unseen:participants:numberOfCalls:isCallerIdBlocked:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier, [NullAllowed] NSDate dateCreated, INCallRecordType callRecordType, INCallCapability callCapability, [NullAllowed] [BindAs (typeof (double?))] NSNumber callDuration, [NullAllowed] [BindAs (typeof (bool?))] NSNumber unseen, [NullAllowed] INPerson[] participants, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfCalls, [NullAllowed] [BindAs (typeof (bool?))] NSNumber isCallerIdBlocked);
+		NativeHandle Constructor (string identifier, [NullAllowed] NSDate dateCreated, INCallRecordType callRecordType, INCallCapability callCapability, [NullAllowed] [BindAs (typeof (double?))] NSNumber callDuration, [NullAllowed] [BindAs (typeof (bool?))] NSNumber unseen, [NullAllowed] INPerson[] participants, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfCalls, [NullAllowed] [BindAs (typeof (bool?))] NSNumber isCallerIdBlocked);
 
 		[Deprecated (PlatformName.iOS, 14, 5, message: "Use '.ctor (string, NSDate, INCallRecordType, INCallCapability, double?, bool?, int?)' instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 14, 5, message: "Use '.ctor (string, NSDate, INCallRecordType, INCallCapability, double?, bool?, int?)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 7, 4, message: "Use '.ctor (string, NSDate, INCallRecordType, INCallCapability, double?, bool?, int?)' instead.")]
 		[Watch (6,0), iOS (13,0)]
 		[Export ("initWithIdentifier:dateCreated:caller:callRecordType:callCapability:callDuration:unseen:numberOfCalls:")]
-		IntPtr Constructor (string identifier, [NullAllowed] NSDate dateCreated, [NullAllowed] INPerson caller, INCallRecordType callRecordType, INCallCapability callCapability, [NullAllowed] [BindAs (typeof (double?))] NSNumber callDuration, [NullAllowed] [BindAs (typeof (bool?))] NSNumber unseen, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfCalls);
+		NativeHandle Constructor (string identifier, [NullAllowed] NSDate dateCreated, [NullAllowed] INPerson caller, INCallRecordType callRecordType, INCallCapability callCapability, [NullAllowed] [BindAs (typeof (double?))] NSNumber callDuration, [NullAllowed] [BindAs (typeof (bool?))] NSNumber unseen, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfCalls);
 
 		[Watch (7,4), iOS (14,5)]
 		[MacCatalyst (14,5)]
 		[Export ("initWithIdentifier:dateCreated:callRecordType:callCapability:callDuration:unseen:numberOfCalls:")]
-		IntPtr Constructor (string identifier, [NullAllowed] NSDate dateCreated, INCallRecordType callRecordType, INCallCapability callCapability, [NullAllowed] [BindAs (typeof (double?))] NSNumber callDuration, [NullAllowed] [BindAs (typeof (bool?))] NSNumber unseen, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfCalls);
+		NativeHandle Constructor (string identifier, [NullAllowed] NSDate dateCreated, INCallRecordType callRecordType, INCallCapability callCapability, [NullAllowed] [BindAs (typeof (double?))] NSNumber callDuration, [NullAllowed] [BindAs (typeof (bool?))] NSNumber unseen, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfCalls);
 
 		[Deprecated (PlatformName.iOS, 14, 5, message: "Use '.ctor (string, NSDate, INCallRecordType, INCallCapability, double?, bool?)' instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 14, 5, message: "Use '.ctor (string, NSDate, INCallRecordType, INCallCapability, double?, bool?)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 7, 4, message: "Use '.ctor (string, NSDate, INCallRecordType, INCallCapability, double?, bool?)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 11, 3, message: "Use '.ctor (string, NSDate, INCallRecordType, INCallCapability, double?, bool?)' instead.")]
 		[Export ("initWithIdentifier:dateCreated:caller:callRecordType:callCapability:callDuration:unseen:")]
-		IntPtr Constructor (string identifier, [NullAllowed] NSDate dateCreated, [NullAllowed] INPerson caller, INCallRecordType callRecordType, INCallCapability callCapability, [NullAllowed] NSNumber callDuration, [NullAllowed] NSNumber unseen);
+		NativeHandle Constructor (string identifier, [NullAllowed] NSDate dateCreated, [NullAllowed] INPerson caller, INCallRecordType callRecordType, INCallCapability callCapability, [NullAllowed] NSNumber callDuration, [NullAllowed] NSNumber unseen);
 
 		[Watch (7,4), iOS (14,5)]
 		[MacCatalyst (14,5)]
 		[Export ("initWithIdentifier:dateCreated:callRecordType:callCapability:callDuration:unseen:")]
-		IntPtr Constructor (string identifier, [NullAllowed] NSDate dateCreated, INCallRecordType callRecordType, INCallCapability callCapability, [NullAllowed] [BindAs (typeof (double?))] NSNumber callDuration, [NullAllowed] [BindAs (typeof (bool?))] NSNumber unseen);
+		NativeHandle Constructor (string identifier, [NullAllowed] NSDate dateCreated, INCallRecordType callRecordType, INCallCapability callCapability, [NullAllowed] [BindAs (typeof (double?))] NSNumber callDuration, [NullAllowed] [BindAs (typeof (bool?))] NSNumber unseen);
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -9254,7 +9258,7 @@ namespace Intents {
 
 		[Export ("initWithRideIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string rideIdentifier);
+		NativeHandle Constructor (string rideIdentifier);
 
 		[Export ("rideIdentifier")]
 		string RideIdentifier { get; }
@@ -9279,7 +9283,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INCancelRideIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INCancelRideIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INCancelRideIntentResponseCode Code { get; }
@@ -9298,7 +9302,7 @@ namespace Intents {
 
 		[Export ("initWithTitle:content:groupName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INSpeakableString title, [NullAllowed] INNoteContent content, [NullAllowed] INSpeakableString groupName);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString title, [NullAllowed] INNoteContent content, [NullAllowed] INSpeakableString groupName);
 
 		[NullAllowed, Export ("title", ArgumentSemantic.Copy)]
 		INSpeakableString Title { get; }
@@ -9338,7 +9342,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INCreateNoteIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INCreateNoteIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INCreateNoteIntentResponseCode Code { get; }
@@ -9356,7 +9360,7 @@ namespace Intents {
 
 		[Export ("initWithTitle:taskTitles:groupName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INSpeakableString title, [NullAllowed] INSpeakableString [] taskTitles, [NullAllowed] INSpeakableString groupName);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString title, [NullAllowed] INSpeakableString [] taskTitles, [NullAllowed] INSpeakableString groupName);
 
 		[NullAllowed, Export ("title", ArgumentSemantic.Copy)]
 		INSpeakableString Title { get; }
@@ -9400,7 +9404,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INCreateTaskListIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INCreateTaskListIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INCreateTaskListIntentResponseCode Code { get; }
@@ -9462,7 +9466,7 @@ namespace Intents {
 
 		[Export ("initWithVisualCodeType:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INVisualCodeType visualCodeType);
+		NativeHandle Constructor (INVisualCodeType visualCodeType);
 
 		[Export ("visualCodeType", ArgumentSemantic.Assign)]
 		INVisualCodeType VisualCodeType { get; }
@@ -9494,7 +9498,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INGetVisualCodeIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INGetVisualCodeIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INGetVisualCodeIntentResponseCode Code { get; }
@@ -9508,7 +9512,7 @@ namespace Intents {
 	interface INImageNoteContent : NSSecureCoding, NSCopying {
 
 		[Export ("initWithImage:")]
-		IntPtr Constructor (INImage image);
+		NativeHandle Constructor (INImage image);
 
 		[NullAllowed, Export ("image", ArgumentSemantic.Copy)]
 		INImage Image { get; }
@@ -9564,7 +9568,7 @@ namespace Intents {
 
 		[Export ("initWithTitle:contents:groupName:createdDateComponents:modifiedDateComponents:identifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString title, INNoteContent [] contents, [NullAllowed] INSpeakableString groupName, [NullAllowed] NSDateComponents createdDateComponents, [NullAllowed] NSDateComponents modifiedDateComponents, [NullAllowed] string identifier);
+		NativeHandle Constructor (INSpeakableString title, INNoteContent [] contents, [NullAllowed] INSpeakableString groupName, [NullAllowed] NSDateComponents createdDateComponents, [NullAllowed] NSDateComponents modifiedDateComponents, [NullAllowed] string identifier);
 
 		[Export ("title", ArgumentSemantic.Copy)]
 		INSpeakableString Title { get; }
@@ -9825,13 +9829,13 @@ namespace Intents {
 	interface INRecurrenceRule : NSCopying, NSSecureCoding {
 
 		[Export ("initWithInterval:frequency:")]
-		IntPtr Constructor (nuint interval, INRecurrenceFrequency frequency);
+		NativeHandle Constructor (nuint interval, INRecurrenceFrequency frequency);
 
 		[Watch (7,0), NoMac, iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithInterval:frequency:weeklyRecurrenceDays:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (nuint interval, INRecurrenceFrequency frequency, INDayOfWeekOptions weeklyRecurrenceDays);
+		NativeHandle Constructor (nuint interval, INRecurrenceFrequency frequency, INDayOfWeekOptions weeklyRecurrenceDays);
 
 		[Export ("interval")]
 		nuint Interval { get; }
@@ -9855,7 +9859,7 @@ namespace Intents {
 		INRequestPaymentCurrencyAmountResolutionResult GetUnsupported (INRequestPaymentCurrencyAmountUnsupportedReason reason);
 
 		[Export ("initWithCurrencyAmountResolutionResult:")]
-		IntPtr Constructor (INCurrencyAmountResolutionResult currencyAmountResolutionResult);
+		NativeHandle Constructor (INCurrencyAmountResolutionResult currencyAmountResolutionResult);
 
 		// Fixes bug 43205. We need to return the inherited type not the base type
 		// because users won't be able to downcast easily
@@ -9898,7 +9902,7 @@ namespace Intents {
 		INRequestPaymentPayerResolutionResult GetUnsupported (INRequestPaymentPayerUnsupportedReason reason);
 
 		[Export ("initWithPersonResolutionResult:")]
-		IntPtr Constructor (INPersonResolutionResult personResolutionResult);
+		NativeHandle Constructor (INPersonResolutionResult personResolutionResult);
 
 		// Inlined from parent class to avoid bug 43205 scenario
 		[New]
@@ -9953,7 +9957,7 @@ namespace Intents {
 
 		[Export ("initWithAccountNickname:accountType:organizationName:requestedBalanceType:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INSpeakableString accountNickname, INAccountType accountType, [NullAllowed] INSpeakableString organizationName, INBalanceType requestedBalanceType);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString accountNickname, INAccountType accountType, [NullAllowed] INSpeakableString organizationName, INBalanceType requestedBalanceType);
 
 		[NullAllowed, Export ("accountNickname", ArgumentSemantic.Copy)]
 		INSpeakableString AccountNickname { get; }
@@ -9999,7 +10003,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSearchForAccountsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSearchForAccountsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSearchForAccountsIntentResponseCode Code { get; }
@@ -10015,18 +10019,18 @@ namespace Intents {
 		[Deprecated (PlatformName.WatchOS, 4, 2, message: "Use the constructor with 'string notebookItemIdentifier' instead.")]
 		[Deprecated (PlatformName.iOS, 11, 2, message: "Use the constructor with 'string notebookItemIdentifier' instead.")]
 		[Export ("initWithTitle:content:itemType:status:location:locationSearchType:dateTime:dateSearchType:")]
-		IntPtr Constructor ([NullAllowed] INSpeakableString title, [NullAllowed] string content, INNotebookItemType itemType, INTaskStatus status, [NullAllowed] CLPlacemark location, INLocationSearchType locationSearchType, [NullAllowed] INDateComponentsRange dateTime, INDateSearchType dateSearchType);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString title, [NullAllowed] string content, INNotebookItemType itemType, INTaskStatus status, [NullAllowed] CLPlacemark location, INLocationSearchType locationSearchType, [NullAllowed] INDateComponentsRange dateTime, INDateSearchType dateSearchType);
 
 		[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use the constructor with 'INTemporalEventTriggerTypeOptions temporalEventTriggerTypes' instead.")]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use the constructor with 'INTemporalEventTriggerTypeOptions temporalEventTriggerTypes' instead.")]
 		[Watch (4,2), iOS (11,2)]
 		[Export ("initWithTitle:content:itemType:status:location:locationSearchType:dateTime:dateSearchType:notebookItemIdentifier:")]
-		IntPtr Constructor ([NullAllowed] INSpeakableString title, [NullAllowed] string content, INNotebookItemType itemType, INTaskStatus status, [NullAllowed] CLPlacemark location, INLocationSearchType locationSearchType, [NullAllowed] INDateComponentsRange dateTime, INDateSearchType dateSearchType, [NullAllowed] string notebookItemIdentifier);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString title, [NullAllowed] string content, INNotebookItemType itemType, INTaskStatus status, [NullAllowed] CLPlacemark location, INLocationSearchType locationSearchType, [NullAllowed] INDateComponentsRange dateTime, INDateSearchType dateSearchType, [NullAllowed] string notebookItemIdentifier);
 
 		[Watch (6,0), Mac (10,15), iOS (13,0)]
 		[Export ("initWithTitle:content:itemType:status:location:locationSearchType:dateTime:dateSearchType:temporalEventTriggerTypes:taskPriority:notebookItemIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INSpeakableString title, [NullAllowed] string content, INNotebookItemType itemType, INTaskStatus status, [NullAllowed] CLPlacemark location, INLocationSearchType locationSearchType, [NullAllowed] INDateComponentsRange dateTime, INDateSearchType dateSearchType, INTemporalEventTriggerTypeOptions temporalEventTriggerTypes, INTaskPriority taskPriority, [NullAllowed] string notebookItemIdentifier);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString title, [NullAllowed] string content, INNotebookItemType itemType, INTaskStatus status, [NullAllowed] CLPlacemark location, INLocationSearchType locationSearchType, [NullAllowed] INDateComponentsRange dateTime, INDateSearchType dateSearchType, INTemporalEventTriggerTypeOptions temporalEventTriggerTypes, INTaskPriority taskPriority, [NullAllowed] string notebookItemIdentifier);
 		
 		[NullAllowed, Export ("title", ArgumentSemantic.Copy)]
 		INSpeakableString Title { get; }
@@ -10116,7 +10120,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSearchForNotebookItemsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSearchForNotebookItemsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSearchForNotebookItemsIntentResponseCode Code { get; }
@@ -10145,7 +10149,7 @@ namespace Intents {
 		INSendMessageRecipientResolutionResult GetUnsupported (INSendMessageRecipientUnsupportedReason reason);
 
 		[Export ("initWithPersonResolutionResult:")]
-		IntPtr Constructor (INPersonResolutionResult personResolutionResult);
+		NativeHandle Constructor (INPersonResolutionResult personResolutionResult);
 
 		// Inlined from parent class to avoid bug 43205 scenario
 		[New]
@@ -10204,7 +10208,7 @@ namespace Intents {
 		INSendPaymentCurrencyAmountResolutionResult GetUnsupported (INSendPaymentCurrencyAmountUnsupportedReason reason);
 
 		[Export ("initWithCurrencyAmountResolutionResult:")]
-		IntPtr Constructor (INCurrencyAmountResolutionResult currencyAmountResolutionResult);
+		NativeHandle Constructor (INCurrencyAmountResolutionResult currencyAmountResolutionResult);
 
 		// Fixes bug 43205. We need to return the inherited type not the base type
 		// because users won't be able to downcast easily
@@ -10247,7 +10251,7 @@ namespace Intents {
 		INSendPaymentPayeeResolutionResult GetUnsupported (INSendPaymentPayeeUnsupportedReason reason);
 
 		[Export ("initWithPersonResolutionResult:")]
-		IntPtr Constructor (INPersonResolutionResult personResolutionResult);
+		NativeHandle Constructor (INPersonResolutionResult personResolutionResult);
 
 		// Inlined from parent class to avoid bug 43205 scenario
 		[New]
@@ -10303,7 +10307,7 @@ namespace Intents {
 
 		[Export ("initWithRideIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string rideIdentifier);
+		NativeHandle Constructor (string rideIdentifier);
 
 		[Export ("rideIdentifier")]
 		string RideIdentifier { get; }
@@ -10334,7 +10338,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSendRideFeedbackIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSendRideFeedbackIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSendRideFeedbackIntentResponseCode Code { get; }
@@ -10347,12 +10351,12 @@ namespace Intents {
 		[Watch (6,0), iOS (13,0)]
 		[Export ("initWithTargetTask:taskTitle:status:priority:spatialEventTrigger:temporalEventTrigger:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INTask targetTask, [NullAllowed] INSpeakableString taskTitle, INTaskStatus status, INTaskPriority priority, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger);
+		NativeHandle Constructor ([NullAllowed] INTask targetTask, [NullAllowed] INSpeakableString taskTitle, INTaskStatus status, INTaskPriority priority, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger);
 
 		[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use the 'INTaskPriority priority' overload instead.")]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use the 'INTaskPriority priority' overload instead.")]
 		[Export ("initWithTargetTask:status:spatialEventTrigger:temporalEventTrigger:")]
-		IntPtr Constructor ([NullAllowed] INTask targetTask, INTaskStatus status, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger);
+		NativeHandle Constructor ([NullAllowed] INTask targetTask, INTaskStatus status, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger);
 
 		[NullAllowed, Export ("targetTask", ArgumentSemantic.Copy)]
 		INTask TargetTask { get; }
@@ -10420,7 +10424,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSetTaskAttributeIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSetTaskAttributeIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSetTaskAttributeIntentResponseCode Code { get; }
@@ -10436,7 +10440,7 @@ namespace Intents {
 
 		[Export ("initWithPlacemark:event:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CLPlacemark placemark, INSpatialEvent @event);
+		NativeHandle Constructor (CLPlacemark placemark, INSpatialEvent @event);
 
 		[Export ("placemark", ArgumentSemantic.Copy)]
 		CLPlacemark Placemark { get; }
@@ -10501,10 +10505,10 @@ namespace Intents {
 		[Watch (6,0), iOS (13,0)]
 		[Export ("initWithTitle:status:taskType:spatialEventTrigger:temporalEventTrigger:createdDateComponents:modifiedDateComponents:identifier:priority:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString title, INTaskStatus status, INTaskType taskType, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger, [NullAllowed] NSDateComponents createdDateComponents, [NullAllowed] NSDateComponents modifiedDateComponents, [NullAllowed] string identifier, INTaskPriority priority);
+		NativeHandle Constructor (INSpeakableString title, INTaskStatus status, INTaskType taskType, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger, [NullAllowed] NSDateComponents createdDateComponents, [NullAllowed] NSDateComponents modifiedDateComponents, [NullAllowed] string identifier, INTaskPriority priority);
 		
 		[Export ("initWithTitle:status:taskType:spatialEventTrigger:temporalEventTrigger:createdDateComponents:modifiedDateComponents:identifier:")]
-		IntPtr Constructor (INSpeakableString title, INTaskStatus status, INTaskType taskType, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger, [NullAllowed] NSDateComponents createdDateComponents, [NullAllowed] NSDateComponents modifiedDateComponents, [NullAllowed] string identifier);
+		NativeHandle Constructor (INSpeakableString title, INTaskStatus status, INTaskType taskType, [NullAllowed] INSpatialEventTrigger spatialEventTrigger, [NullAllowed] INTemporalEventTrigger temporalEventTrigger, [NullAllowed] NSDateComponents createdDateComponents, [NullAllowed] NSDateComponents modifiedDateComponents, [NullAllowed] string identifier);
 
 		[Export ("title", ArgumentSemantic.Copy)]
 		INSpeakableString Title { get; }
@@ -10542,7 +10546,7 @@ namespace Intents {
 
 		[Export ("initWithTitle:tasks:groupName:createdDateComponents:modifiedDateComponents:identifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString title, INTask [] tasks, [NullAllowed] INSpeakableString groupName, [NullAllowed] NSDateComponents createdDateComponents, [NullAllowed] NSDateComponents modifiedDateComponents, [NullAllowed] string identifier);
+		NativeHandle Constructor (INSpeakableString title, INTask [] tasks, [NullAllowed] INSpeakableString groupName, [NullAllowed] NSDateComponents createdDateComponents, [NullAllowed] NSDateComponents modifiedDateComponents, [NullAllowed] string identifier);
 
 		[Export ("title", ArgumentSemantic.Copy)]
 		INSpeakableString Title { get; }
@@ -10710,7 +10714,7 @@ namespace Intents {
 
 		[Export ("initWithDateComponentsRange:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INDateComponentsRange dateComponentsRange);
+		NativeHandle Constructor (INDateComponentsRange dateComponentsRange);
 
 		[Export ("dateComponentsRange", ArgumentSemantic.Copy)]
 		INDateComponentsRange DateComponentsRange { get; }
@@ -10770,7 +10774,7 @@ namespace Intents {
 	interface INTextNoteContent : NSSecureCoding, NSCopying {
 
 		[Export ("initWithText:")]
-		IntPtr Constructor (string text);
+		NativeHandle Constructor (string text);
 
 		[NullAllowed, Export ("text")]
 		string Text { get; }
@@ -10785,7 +10789,7 @@ namespace Intents {
 
 		[Export ("initWithFromAccount:toAccount:transactionAmount:transactionScheduledDate:transactionNote:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INPaymentAccount fromAccount, [NullAllowed] INPaymentAccount toAccount, [NullAllowed] INPaymentAmount transactionAmount, [NullAllowed] INDateComponentsRange transactionScheduledDate, [NullAllowed] string transactionNote);
+		NativeHandle Constructor ([NullAllowed] INPaymentAccount fromAccount, [NullAllowed] INPaymentAccount toAccount, [NullAllowed] INPaymentAmount transactionAmount, [NullAllowed] INDateComponentsRange transactionScheduledDate, [NullAllowed] string transactionNote);
 
 		[NullAllowed, Export ("fromAccount", ArgumentSemantic.Copy)]
 		INPaymentAccount FromAccount { get; }
@@ -10841,7 +10845,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INTransferMoneyIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INTransferMoneyIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INTransferMoneyIntentResponseCode Code { get; }
@@ -10927,7 +10931,7 @@ namespace Intents {
 
 		[Export ("initWithTitle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string title);
+		NativeHandle Constructor (string title);
 	}
 
 	[Watch (5,0), TV (14,0), NoMac, iOS (12,0)]
@@ -10938,10 +10942,10 @@ namespace Intents {
 		[Watch (6,0), iOS (13,0)]
 		[Export ("initWithIdentifier:title:type:artwork:artist:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string identifier, [NullAllowed] string title, INMediaItemType type, [NullAllowed] INImage artwork, [NullAllowed] string artist);
+		NativeHandle Constructor ([NullAllowed] string identifier, [NullAllowed] string title, INMediaItemType type, [NullAllowed] INImage artwork, [NullAllowed] string artist);
 
 		[Export ("initWithIdentifier:title:type:artwork:")]
-		IntPtr Constructor ([NullAllowed] string identifier, [NullAllowed] string title, INMediaItemType type, [NullAllowed] INImage artwork);
+		NativeHandle Constructor ([NullAllowed] string identifier, [NullAllowed] string title, INMediaItemType type, [NullAllowed] INImage artwork);
 
 		[NullAllowed, Export ("identifier")]
 		string Identifier { get; }
@@ -10967,20 +10971,20 @@ namespace Intents {
 
 		[Export ("initWithIdentifier:displayString:pronunciationHint:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string identifier, string displayString, [NullAllowed] string pronunciationHint);
+		NativeHandle Constructor ([NullAllowed] string identifier, string displayString, [NullAllowed] string pronunciationHint);
 
 		[Export ("initWithIdentifier:displayString:")]
-		IntPtr Constructor ([NullAllowed] string identifier, string displayString);
+		NativeHandle Constructor ([NullAllowed] string identifier, string displayString);
 
 		[Watch (7,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithIdentifier:displayString:subtitleString:displayImage:")]
-		IntPtr Constructor ([NullAllowed] string identifier, string displayString, [NullAllowed] string subtitleString, [NullAllowed] INImage displayImage);
+		NativeHandle Constructor ([NullAllowed] string identifier, string displayString, [NullAllowed] string subtitleString, [NullAllowed] INImage displayImage);
 
 		[Watch (7,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithIdentifier:displayString:pronunciationHint:subtitleString:displayImage:")]
-		IntPtr Constructor ([NullAllowed] string identifier, string displayString, [NullAllowed] string pronunciationHint, [NullAllowed] string subtitleString, [NullAllowed] INImage displayImage);
+		NativeHandle Constructor ([NullAllowed] string identifier, string displayString, [NullAllowed] string pronunciationHint, [NullAllowed] string subtitleString, [NullAllowed] INImage displayImage);
 
 		// Inlined by INSpeakable
 		//[NullAllowed, Export ("identifier", ArgumentSemantic.Strong)]
@@ -11023,12 +11027,12 @@ namespace Intents {
 		[Watch (6,0), Mac (10,15), iOS (13,0)]
 		[Export ("initWithMediaItems:mediaContainer:playShuffled:playbackRepeatMode:resumePlayback:playbackQueueLocation:playbackSpeed:mediaSearch:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INMediaItem [] mediaItems, [NullAllowed] INMediaItem mediaContainer, [NullAllowed, BindAs (typeof (bool?))] NSNumber playShuffled, INPlaybackRepeatMode playbackRepeatMode, [NullAllowed, BindAs (typeof (bool?))] NSNumber resumePlayback, INPlaybackQueueLocation playbackQueueLocation, [NullAllowed, BindAs (typeof (double?))] NSNumber playbackSpeed, [NullAllowed] INMediaSearch mediaSearch);
+		NativeHandle Constructor ([NullAllowed] INMediaItem [] mediaItems, [NullAllowed] INMediaItem mediaContainer, [NullAllowed, BindAs (typeof (bool?))] NSNumber playShuffled, INPlaybackRepeatMode playbackRepeatMode, [NullAllowed, BindAs (typeof (bool?))] NSNumber resumePlayback, INPlaybackQueueLocation playbackQueueLocation, [NullAllowed, BindAs (typeof (double?))] NSNumber playbackSpeed, [NullAllowed] INMediaSearch mediaSearch);
 		
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use the '.ctor (INMediaItem [], INMediaItem, bool?, INPlaybackRepeatMode, bool?, INPlaybackQueueLocation, double?, INMediaSearch)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use the '.ctor (INMediaItem [], INMediaItem, bool?, INPlaybackRepeatMode, bool?, INPlaybackQueueLocation, double?, INMediaSearch)' instead.")]
 		[Export ("initWithMediaItems:mediaContainer:playShuffled:playbackRepeatMode:resumePlayback:")]
-		IntPtr Constructor ([NullAllowed] INMediaItem [] mediaItems, [NullAllowed] INMediaItem mediaContainer, [NullAllowed, BindAs (typeof (bool?))] NSNumber playShuffled, INPlaybackRepeatMode playbackRepeatMode, [NullAllowed, BindAs (typeof (bool?))] NSNumber resumePlayback);
+		NativeHandle Constructor ([NullAllowed] INMediaItem [] mediaItems, [NullAllowed] INMediaItem mediaContainer, [NullAllowed, BindAs (typeof (bool?))] NSNumber playShuffled, INPlaybackRepeatMode playbackRepeatMode, [NullAllowed, BindAs (typeof (bool?))] NSNumber resumePlayback);
 
 		[NullAllowed, Export ("mediaItems", ArgumentSemantic.Copy)]
 		INMediaItem [] MediaItems { get; }
@@ -11104,7 +11108,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INPlayMediaIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INPlayMediaIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INPlayMediaIntentResponseCode Code { get; }
@@ -11134,7 +11138,7 @@ namespace Intents {
 
 		[Export ("initWithStartDate:endDate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSDate startDate, [NullAllowed] NSDate endDate);
+		NativeHandle Constructor (NSDate startDate, [NullAllowed] NSDate endDate);
 	}
 
 	[Watch (5,0), NoTV, NoMac, iOS (12,0)]
@@ -11147,7 +11151,7 @@ namespace Intents {
 
 		[Export ("initWithRegion:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CLRegion region);
+		NativeHandle Constructor (CLRegion region);
 	}
 
 	[Watch (5,0), NoTV, NoMac, iOS (12,0)]
@@ -11160,7 +11164,7 @@ namespace Intents {
 
 		[Export ("initWithSituation:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INDailyRoutineSituation situation);
+		NativeHandle Constructor (INDailyRoutineSituation situation);
 	}
 
 	[Watch (5,0), NoTV, NoMac, iOS (12,0)]
@@ -11186,7 +11190,7 @@ namespace Intents {
 
 		[Export ("initWithShortcut:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INShortcut shortcut);
+		NativeHandle Constructor (INShortcut shortcut);
 	}
 
 	[Watch (5,0), NoTV, NoMac, iOS (12,0)]
@@ -11215,10 +11219,10 @@ namespace Intents {
 		NSUserActivity UserActivity { get; }
 
 		[Export ("initWithIntent:")]
-		IntPtr Constructor (INIntent intent);
+		NativeHandle Constructor (INIntent intent);
 
 		[Export ("initWithUserActivity:")]
-		IntPtr Constructor (NSUserActivity userActivity);
+		NativeHandle Constructor (NSUserActivity userActivity);
 	}
 
 	[Watch (5,0), NoTV, NoMac, iOS (12,0)]
@@ -11303,7 +11307,7 @@ namespace Intents {
 
 		[Export ("initWithMediaItems:mediaSearch:mediaDestination:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INMediaItem[] mediaItems, [NullAllowed] INMediaSearch mediaSearch, [NullAllowed] INMediaDestination mediaDestination);
+		NativeHandle Constructor ([NullAllowed] INMediaItem[] mediaItems, [NullAllowed] INMediaSearch mediaSearch, [NullAllowed] INMediaDestination mediaDestination);
 
 		[NullAllowed, Export ("mediaItems", ArgumentSemantic.Copy)]
 		INMediaItem [] MediaItems { get; }
@@ -11340,7 +11344,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INAddMediaIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INAddMediaIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INAddMediaIntentResponseCode Code { get; }
@@ -11356,7 +11360,7 @@ namespace Intents {
 		INAddMediaMediaItemResolutionResult GetUnsupported (INAddMediaMediaItemUnsupportedReason reason);
 
 		[Export ("initWithMediaItemResolutionResult:")]
-		IntPtr Constructor (INMediaItemResolutionResult mediaItemResolutionResult);
+		NativeHandle Constructor (INMediaItemResolutionResult mediaItemResolutionResult);
 
 		// Inlined from parent class to avoid bug like 43205
 
@@ -11419,7 +11423,7 @@ namespace Intents {
 		INAddTasksTargetTaskListResolutionResult GetConfirmationRequired ([NullAllowed] INTaskList taskListToConfirm, INAddTasksTargetTaskListConfirmationReason reason);
 
 		[Export ("initWithTaskListResolutionResult:")]
-		IntPtr Constructor (INTaskListResolutionResult taskListResolutionResult);
+		NativeHandle Constructor (INTaskListResolutionResult taskListResolutionResult);
 
 		// Inlined from parent class to avoid bug like 43205
 		[New]
@@ -11476,7 +11480,7 @@ namespace Intents {
 		INAddTasksTemporalEventTriggerResolutionResult GetUnsupported (INAddTasksTemporalEventTriggerUnsupportedReason reason);
 
 		[Export ("initWithTemporalEventTriggerResolutionResult:")]
-		IntPtr Constructor (INTemporalEventTriggerResolutionResult temporalEventTriggerResolutionResult);
+		NativeHandle Constructor (INTemporalEventTriggerResolutionResult temporalEventTriggerResolutionResult);
 
 		// Inlined from parent to avoid bug like 43205
 
@@ -11531,7 +11535,7 @@ namespace Intents {
 
 		[Export ("initWithName:iataCode:icaoCode:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string name, [NullAllowed] string iataCode, [NullAllowed] string icaoCode);
+		NativeHandle Constructor ([NullAllowed] string name, [NullAllowed] string iataCode, [NullAllowed] string icaoCode);
 
 		[NullAllowed, Export ("name")]
 		string Name { get; }
@@ -11550,7 +11554,7 @@ namespace Intents {
 
 		[Export ("initWithName:iataCode:icaoCode:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string name, [NullAllowed] string iataCode, [NullAllowed] string icaoCode);
+		NativeHandle Constructor ([NullAllowed] string name, [NullAllowed] string iataCode, [NullAllowed] string icaoCode);
 
 		[NullAllowed, Export ("name")]
 		string Name { get; }
@@ -11569,7 +11573,7 @@ namespace Intents {
 
 		[Export ("initWithAirport:terminal:gate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INAirport airport, [NullAllowed] string terminal, [NullAllowed] string gate);
+		NativeHandle Constructor (INAirport airport, [NullAllowed] string terminal, [NullAllowed] string gate);
 
 		[Export ("airport", ArgumentSemantic.Copy)]
 		INAirport Airport { get; }
@@ -11632,7 +11636,7 @@ namespace Intents {
 
 		[Export ("initWithTaskList:tasks:all:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INTaskList taskList, [NullAllowed] INTask[] tasks, [NullAllowed] [BindAs (typeof (bool?))] NSNumber all);
+		NativeHandle Constructor ([NullAllowed] INTaskList taskList, [NullAllowed] INTask[] tasks, [NullAllowed] [BindAs (typeof (bool?))] NSNumber all);
 
 		[NullAllowed, Export ("taskList", ArgumentSemantic.Copy)]
 		INTaskList TaskList { get; }
@@ -11674,7 +11678,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INDeleteTasksIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INDeleteTasksIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INDeleteTasksIntentResponseCode Code { get; }
@@ -11695,7 +11699,7 @@ namespace Intents {
 		INDeleteTasksTaskListResolutionResult GetUnsupported (INDeleteTasksTaskListUnsupportedReason reason);
 
 		[Export ("initWithTaskListResolutionResult:")]
-		IntPtr Constructor (INTaskListResolutionResult taskListResolutionResult);
+		NativeHandle Constructor (INTaskListResolutionResult taskListResolutionResult);
 
 		// Inlined from parent class to avoid bug like 43205
 		[New]
@@ -11754,7 +11758,7 @@ namespace Intents {
 		INDeleteTasksTaskResolutionResult GetUnsupported (INDeleteTasksTaskUnsupportedReason reason);
 
 		[Export ("initWithTaskResolutionResult:")]
-		IntPtr Constructor (INTaskResolutionResult taskResolutionResult);
+		NativeHandle Constructor (INTaskResolutionResult taskResolutionResult);
 
 		// Inlined from parent class to avoid bug 43205 scenario
 		[New]
@@ -11968,7 +11972,7 @@ namespace Intents {
 
 		[Export ("initWithAirline:flightNumber:boardingTime:flightDuration:departureAirportGate:arrivalAirportGate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INAirline airline, string flightNumber, [NullAllowed] INDateComponentsRange boardingTime, INDateComponentsRange flightDuration, INAirportGate departureAirportGate, INAirportGate arrivalAirportGate);
+		NativeHandle Constructor (INAirline airline, string flightNumber, [NullAllowed] INDateComponentsRange boardingTime, INDateComponentsRange flightDuration, INAirportGate departureAirportGate, INAirportGate arrivalAirportGate);
 
 		[Export ("airline", ArgumentSemantic.Copy)]
 		INAirline Airline { get; }
@@ -11998,10 +12002,10 @@ namespace Intents {
 		[MacCatalyst (14,0)]
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:URL:reservedSeat:flight:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, [NullAllowed] INSeat reservedSeat, INFlight flight);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, [NullAllowed] INSeat reservedSeat, INFlight flight);
 		
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:reservedSeat:flight:")]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] INSeat reservedSeat, INFlight flight);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] INSeat reservedSeat, INFlight flight);
 
 		[NullAllowed, Export ("reservedSeat", ArgumentSemantic.Copy)]
 		INSeat ReservedSeat { get; }
@@ -12027,7 +12031,7 @@ namespace Intents {
 	{
 		[Export ("initWithIsFocused:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] [BindAs (typeof (bool?))] NSNumber isFocused);
+		NativeHandle Constructor ([NullAllowed] [BindAs (typeof (bool?))] NSNumber isFocused);
 
 		[Export ("isFocused", ArgumentSemantic.Copy)]
 		[BindAs (typeof (bool?))]
@@ -12061,7 +12065,7 @@ namespace Intents {
 
 		[Export ("initWithReservationContainerReference:reservationItemReferences:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INSpeakableString reservationContainerReference, [NullAllowed] INSpeakableString[] reservationItemReferences);
+		NativeHandle Constructor ([NullAllowed] INSpeakableString reservationContainerReference, [NullAllowed] INSpeakableString[] reservationItemReferences);
 
 		[NullAllowed, Export ("reservationContainerReference", ArgumentSemantic.Copy)]
 		INSpeakableString ReservationContainerReference { get; }
@@ -12077,7 +12081,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INGetReservationDetailsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INGetReservationDetailsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INGetReservationDetailsIntentResponseCode Code { get; }
@@ -12141,10 +12145,10 @@ namespace Intents {
 		[MacCatalyst (14,0)]
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:URL:lodgingBusinessLocation:reservationDuration:numberOfAdults:numberOfChildren:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, CLPlacemark lodgingBusinessLocation, INDateComponentsRange reservationDuration, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfAdults, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfChildren);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, CLPlacemark lodgingBusinessLocation, INDateComponentsRange reservationDuration, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfAdults, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfChildren);
 
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:lodgingBusinessLocation:reservationDuration:numberOfAdults:numberOfChildren:")]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, CLPlacemark lodgingBusinessLocation, INDateComponentsRange reservationDuration, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfAdults, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfChildren);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, CLPlacemark lodgingBusinessLocation, INDateComponentsRange reservationDuration, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfAdults, [NullAllowed] [BindAs (typeof (int?))] NSNumber numberOfChildren);
 
 		[Export ("lodgingBusinessLocation", ArgumentSemantic.Copy)]
 		CLPlacemark LodgingBusinessLocation { get; }
@@ -12372,7 +12376,7 @@ namespace Intents {
 
 		[Export ("initWithMediaType:sortOrder:mediaName:artistName:albumName:genreNames:moodNames:releaseDate:reference:mediaIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INMediaItemType mediaType, INMediaSortOrder sortOrder, [NullAllowed] string mediaName, [NullAllowed] string artistName, [NullAllowed] string albumName, [NullAllowed] string[] genreNames, [NullAllowed] string[] moodNames, [NullAllowed] INDateComponentsRange releaseDate, INMediaReference reference, [NullAllowed] string mediaIdentifier);
+		NativeHandle Constructor (INMediaItemType mediaType, INMediaSortOrder sortOrder, [NullAllowed] string mediaName, [NullAllowed] string artistName, [NullAllowed] string albumName, [NullAllowed] string[] genreNames, [NullAllowed] string[] moodNames, [NullAllowed] INDateComponentsRange releaseDate, INMediaReference reference, [NullAllowed] string mediaIdentifier);
 
 		[Export ("mediaType", ArgumentSemantic.Assign)]
 		INMediaItemType MediaType { get; }
@@ -12519,7 +12523,7 @@ namespace Intents {
 		INPlayMediaMediaItemResolutionResult GetUnsupported (INPlayMediaMediaItemUnsupportedReason reason);
 
 		[Export ("initWithMediaItemResolutionResult:")]
-		IntPtr Constructor (INMediaItemResolutionResult mediaItemResolutionResult);
+		NativeHandle Constructor (INMediaItemResolutionResult mediaItemResolutionResult);
 
 		// Inlined from parent class to avoid bug like 43205
 
@@ -12582,7 +12586,7 @@ namespace Intents {
 		INPlayMediaPlaybackSpeedResolutionResult UnsupportedForReason (INPlayMediaPlaybackSpeedUnsupportedReason reason);
 
 		[Export ("initWithDoubleResolutionResult:")]
-		IntPtr Constructor (INDoubleResolutionResult doubleResolutionResult);
+		NativeHandle Constructor (INDoubleResolutionResult doubleResolutionResult);
 
 		// Inlined from parent class to avoid bug like 43205
 
@@ -12714,7 +12718,7 @@ namespace Intents {
 
 		[Export ("initWithRentalCompanyName:type:make:model:rentalCarDescription:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string rentalCompanyName, [NullAllowed] string type, [NullAllowed] string make, [NullAllowed] string model, [NullAllowed] string rentalCarDescription);
+		NativeHandle Constructor (string rentalCompanyName, [NullAllowed] string type, [NullAllowed] string make, [NullAllowed] string model, [NullAllowed] string rentalCarDescription);
 
 		[Export ("rentalCompanyName")]
 		string RentalCompanyName { get; }
@@ -12741,10 +12745,10 @@ namespace Intents {
 		[MacCatalyst (14,0)]
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:URL:rentalCar:rentalDuration:pickupLocation:dropOffLocation:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, INRentalCar rentalCar, INDateComponentsRange rentalDuration, [NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, INRentalCar rentalCar, INDateComponentsRange rentalDuration, [NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation);
 
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:rentalCar:rentalDuration:pickupLocation:dropOffLocation:")]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, INRentalCar rentalCar, INDateComponentsRange rentalDuration, [NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, INRentalCar rentalCar, INDateComponentsRange rentalDuration, [NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation);
 
 		[Export ("rentalCar", ArgumentSemantic.Copy)]
 		INRentalCar RentalCar { get; }
@@ -12795,7 +12799,7 @@ namespace Intents {
 
 		[Export ("initWithType:validDuration:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INReservationActionType type, INDateComponentsRange validDuration, NSUserActivity userActivity);
+		NativeHandle Constructor (INReservationActionType type, INDateComponentsRange validDuration, NSUserActivity userActivity);
 
 		[Export ("type", ArgumentSemantic.Assign)]
 		INReservationActionType Type { get; }
@@ -12816,10 +12820,10 @@ namespace Intents {
 		[MacCatalyst (14,0)]
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:URL:reservationDuration:partySize:restaurantLocation:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, INDateComponentsRange reservationDuration, [NullAllowed] [BindAs (typeof (int?))] NSNumber partySize, CLPlacemark restaurantLocation);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, INDateComponentsRange reservationDuration, [NullAllowed] [BindAs (typeof (int?))] NSNumber partySize, CLPlacemark restaurantLocation);
 
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:reservationDuration:partySize:restaurantLocation:")]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction [] actions, INDateComponentsRange reservationDuration, [NullAllowed] [BindAs (typeof (int?))] NSNumber partySize, CLPlacemark restaurantLocation);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction [] actions, INDateComponentsRange reservationDuration, [NullAllowed] [BindAs (typeof (int?))] NSNumber partySize, CLPlacemark restaurantLocation);
 
 		[Export ("reservationDuration", ArgumentSemantic.Copy)]
 		INDateComponentsRange ReservationDuration { get; }
@@ -12839,7 +12843,7 @@ namespace Intents {
 
 		[Export ("initWithMediaItems:mediaSearch:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INMediaItem [] mediaItems, [NullAllowed] INMediaSearch mediaSearch);
+		NativeHandle Constructor ([NullAllowed] INMediaItem [] mediaItems, [NullAllowed] INMediaSearch mediaSearch);
 
 		[NullAllowed, Export ("mediaItems", ArgumentSemantic.Copy)]
 		INMediaItem [] MediaItems { get; }
@@ -12870,7 +12874,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSearchForMediaIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSearchForMediaIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSearchForMediaIntentResponseCode Code { get; }
@@ -12886,7 +12890,7 @@ namespace Intents {
 
 		[Export ("initWithSeatSection:seatRow:seatNumber:seatingType:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string seatSection, [NullAllowed] string seatRow, [NullAllowed] string seatNumber, [NullAllowed] string seatingType);
+		NativeHandle Constructor ([NullAllowed] string seatSection, [NullAllowed] string seatRow, [NullAllowed] string seatNumber, [NullAllowed] string seatingType);
 
 		[NullAllowed, Export ("seatSection")]
 		string SeatSection { get; }
@@ -12911,7 +12915,7 @@ namespace Intents {
 		INSetTaskAttributeTemporalEventTriggerResolutionResult GetUnsupported (INSetTaskAttributeTemporalEventTriggerUnsupportedReason reason);
 
 		[Export ("initWithTemporalEventTriggerResolutionResult:")]
-		IntPtr Constructor (INTemporalEventTriggerResolutionResult temporalEventTriggerResolutionResult);
+		NativeHandle Constructor (INTemporalEventTriggerResolutionResult temporalEventTriggerResolutionResult);
 
 		// Inlined from parent to avoid bug like 43205
 
@@ -12966,7 +12970,7 @@ namespace Intents {
 
 		[Export ("initWithTasks:nextTriggerTime:all:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INTask[] tasks, [NullAllowed] INDateComponentsRange nextTriggerTime, [NullAllowed] [BindAs (typeof (bool?))] NSNumber all);
+		NativeHandle Constructor ([NullAllowed] INTask[] tasks, [NullAllowed] INDateComponentsRange nextTriggerTime, [NullAllowed] [BindAs (typeof (bool?))] NSNumber all);
 
 		[NullAllowed, Export ("tasks", ArgumentSemantic.Copy)]
 		INTask[] Tasks { get; }
@@ -13004,7 +13008,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSnoozeTasksIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INSnoozeTasksIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INSnoozeTasksIntentResponseCode Code { get; }
@@ -13023,7 +13027,7 @@ namespace Intents {
 		INSnoozeTasksTaskResolutionResult GetUnsupported (INSnoozeTasksTaskUnsupportedReason reason);
 
 		[Export ("initWithTaskResolutionResult:")]
-		IntPtr Constructor (INTaskResolutionResult taskResolutionResult);
+		NativeHandle Constructor (INTaskResolutionResult taskResolutionResult);
 
 		// Inlined from parent class to avoid bug 43205 scenario
 		[New]
@@ -13126,7 +13130,7 @@ namespace Intents {
 		INStartCallCallCapabilityResolutionResult GetUnsupported (INStartCallCallCapabilityUnsupportedReason reason);
 
 		[Export ("initWithCallCapabilityResolutionResult:")]
-		IntPtr Constructor (INCallCapabilityResolutionResult callCapabilityResolutionResult);
+		NativeHandle Constructor (INCallCapabilityResolutionResult callCapabilityResolutionResult);
 
 		// Inlined from parent class to avoid bug 43205 scenario
 		[New]
@@ -13178,7 +13182,7 @@ namespace Intents {
 		INStartCallContactResolutionResult GetUnsupported (INStartCallContactUnsupportedReason reason);
 
 		[Export ("initWithPersonResolutionResult:")]
-		IntPtr Constructor (INPersonResolutionResult personResolutionResult);
+		NativeHandle Constructor (INPersonResolutionResult personResolutionResult);
 
 		// Inlined from parent class to avoid bug 43205 scenario
 		[New]
@@ -13234,12 +13238,12 @@ namespace Intents {
 		[MacCatalyst (14,0)]
 		[Export ("initWithCallRecordFilter:callRecordToCallBack:audioRoute:destinationType:contacts:callCapability:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INCallRecordFilter callRecordFilter, [NullAllowed] INCallRecord callRecordToCallBack, INCallAudioRoute audioRoute, INCallDestinationType destinationType, [NullAllowed] INPerson[] contacts, INCallCapability callCapability);
+		NativeHandle Constructor ([NullAllowed] INCallRecordFilter callRecordFilter, [NullAllowed] INCallRecord callRecordToCallBack, INCallAudioRoute audioRoute, INCallDestinationType destinationType, [NullAllowed] INPerson[] contacts, INCallCapability callCapability);
 
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use '.ctor (INCallRecordFilter, INCallRecord, INCallAudioRoute, INCallDestinationType, INPerson[], INCallCapability)' overload instead.")]
 		[Deprecated (PlatformName.WatchOS, 7, 0, message: "Use '.ctor (INCallRecordFilter, INCallRecord, INCallAudioRoute, INCallDestinationType, INPerson[], INCallCapability)' overload instead.")]
 		[Export ("initWithAudioRoute:destinationType:contacts:recordTypeForRedialing:callCapability:")]
-		IntPtr Constructor (INCallAudioRoute audioRoute, INCallDestinationType destinationType, [NullAllowed] INPerson[] contacts, INCallRecordType recordTypeForRedialing, INCallCapability callCapability);
+		NativeHandle Constructor (INCallAudioRoute audioRoute, INCallDestinationType destinationType, [NullAllowed] INPerson[] contacts, INCallRecordType recordTypeForRedialing, INCallCapability callCapability);
 
 		[Watch (7,0), NoTV, iOS (14,0)]
 		[MacCatalyst (14,0)]
@@ -13304,7 +13308,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INStartCallIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INStartCallIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INStartCallIntentResponseCode Code { get; }
@@ -13401,7 +13405,7 @@ namespace Intents {
 
 		[Export ("initWithCategory:name:eventDuration:location:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INTicketedEventCategory category, string name, INDateComponentsRange eventDuration, [NullAllowed] CLPlacemark location);
+		NativeHandle Constructor (INTicketedEventCategory category, string name, INDateComponentsRange eventDuration, [NullAllowed] CLPlacemark location);
 
 		[Export ("category", ArgumentSemantic.Assign)]
 		INTicketedEventCategory Category { get; }
@@ -13425,10 +13429,10 @@ namespace Intents {
 		[MacCatalyst (14,0)]
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:URL:reservedSeat:event:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, [NullAllowed] INSeat reservedSeat, INTicketedEvent @event);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, [NullAllowed] INSeat reservedSeat, INTicketedEvent @event);
 
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:reservedSeat:event:")]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] INSeat reservedSeat, INTicketedEvent @event);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] INSeat reservedSeat, INTicketedEvent @event);
 
 		[Export ("event", ArgumentSemantic.Copy)]
 		INTicketedEvent Event { get; }
@@ -13488,10 +13492,10 @@ namespace Intents {
 		[MacCatalyst (14,0)]
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:URL:reservedSeat:trainTrip:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, [NullAllowed] INSeat reservedSeat, INTrainTrip trainTrip);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, [NullAllowed] INSeat reservedSeat, INTrainTrip trainTrip);
 
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:reservedSeat:trainTrip:")]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] INSeat reservedSeat, INTrainTrip trainTrip);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] INSeat reservedSeat, INTrainTrip trainTrip);
 
 		[NullAllowed, Export ("reservedSeat", ArgumentSemantic.Copy)]
 		INSeat ReservedSeat { get; }
@@ -13507,7 +13511,7 @@ namespace Intents {
 
 		[Export ("initWithProvider:trainName:trainNumber:tripDuration:departureStationLocation:departurePlatform:arrivalStationLocation:arrivalPlatform:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string provider, [NullAllowed] string trainName, [NullAllowed] string trainNumber, INDateComponentsRange tripDuration, CLPlacemark departureStationLocation, [NullAllowed] string departurePlatform, CLPlacemark arrivalStationLocation, [NullAllowed] string arrivalPlatform);
+		NativeHandle Constructor ([NullAllowed] string provider, [NullAllowed] string trainName, [NullAllowed] string trainNumber, INDateComponentsRange tripDuration, CLPlacemark departureStationLocation, [NullAllowed] string departurePlatform, CLPlacemark arrivalStationLocation, [NullAllowed] string arrivalPlatform);
 
 		[NullAllowed, Export ("provider")]
 		string Provider { get; }
@@ -13587,7 +13591,7 @@ namespace Intents {
 
 		[Export ("initWithMediaItems:mediaSearch:affinityType:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INMediaItem[] mediaItems, [NullAllowed] INMediaSearch mediaSearch, INMediaAffinityType affinityType);
+		NativeHandle Constructor ([NullAllowed] INMediaItem[] mediaItems, [NullAllowed] INMediaSearch mediaSearch, INMediaAffinityType affinityType);
 
 		[NullAllowed, Export ("mediaItems", ArgumentSemantic.Copy)]
 		INMediaItem[] MediaItems { get; }
@@ -13624,7 +13628,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INUpdateMediaAffinityIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INUpdateMediaAffinityIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INUpdateMediaAffinityIntentResponseCode Code { get; }
@@ -13640,7 +13644,7 @@ namespace Intents {
 		INUpdateMediaAffinityMediaItemResolutionResult GetUnsupported (INUpdateMediaAffinityMediaItemUnsupportedReason reason);
 
 		[Export ("initWithMediaItemResolutionResult:")]
-		IntPtr Constructor (INMediaItemResolutionResult mediaItemResolutionResult);
+		NativeHandle Constructor (INMediaItemResolutionResult mediaItemResolutionResult);
 
 		// Inlined from parent class to avoid bug like 43205
 
@@ -13758,7 +13762,7 @@ namespace Intents {
 		INAddMediaMediaDestinationResolutionResult GetUnsupported (INAddMediaMediaDestinationUnsupportedReason reason);
 
 		[Export ("initWithMediaDestinationResolutionResult:")]
-		IntPtr Constructor (INMediaDestinationResolutionResult mediaDestinationResolutionResult);
+		NativeHandle Constructor (INMediaDestinationResolutionResult mediaDestinationResolutionResult);
 
 		// Inlined from parent class to avoid bug like 43205
 
@@ -13815,7 +13819,7 @@ namespace Intents {
 		INSearchForMediaMediaItemResolutionResult GetUnsupported (INSearchForMediaMediaItemUnsupportedReason reason);
 
 		[Export ("initWithMediaItemResolutionResult:")]
-		IntPtr Constructor (INMediaItemResolutionResult mediaItemResolutionResult);
+		NativeHandle Constructor (INMediaItemResolutionResult mediaItemResolutionResult);
 
 		// Inlined from parent class to avoid bug like 43205
 
@@ -13888,7 +13892,7 @@ namespace Intents {
 
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:URL:reservedSeat:boatTrip:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction [] actions, [NullAllowed] NSUrl url, [NullAllowed] INSeat reservedSeat, [NullAllowed] INBoatTrip boatTrip);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction [] actions, [NullAllowed] NSUrl url, [NullAllowed] INSeat reservedSeat, [NullAllowed] INBoatTrip boatTrip);
 
 		[NullAllowed, Export ("reservedSeat", ArgumentSemantic.Copy)]
 		INSeat ReservedSeat { get; }
@@ -13905,7 +13909,7 @@ namespace Intents {
 
 		[Export ("initWithProvider:boatName:boatNumber:tripDuration:departureBoatTerminalLocation:arrivalBoatTerminalLocation:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string provider, [NullAllowed] string boatName, [NullAllowed] string boatNumber, INDateComponentsRange tripDuration, CLPlacemark departureBoatTerminalLocation, CLPlacemark arrivalBoatTerminalLocation);
+		NativeHandle Constructor ([NullAllowed] string provider, [NullAllowed] string boatName, [NullAllowed] string boatNumber, INDateComponentsRange tripDuration, CLPlacemark departureBoatTerminalLocation, CLPlacemark arrivalBoatTerminalLocation);
 
 		[NullAllowed, Export ("provider")]
 		string Provider { get; }
@@ -13934,7 +13938,7 @@ namespace Intents {
 
 		[Export ("initWithItemReference:reservationNumber:bookingTime:reservationStatus:reservationHolderName:actions:URL:reservedSeat:busTrip:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, [NullAllowed] INSeat reservedSeat, [NullAllowed] INBusTrip busTrip);
+		NativeHandle Constructor (INSpeakableString itemReference, [NullAllowed] string reservationNumber, [NullAllowed] NSDate bookingTime, INReservationStatus reservationStatus, [NullAllowed] string reservationHolderName, [NullAllowed] INReservationAction[] actions, [NullAllowed] NSUrl url, [NullAllowed] INSeat reservedSeat, [NullAllowed] INBusTrip busTrip);
 
 		[NullAllowed, Export ("reservedSeat", ArgumentSemantic.Copy)]
 		INSeat ReservedSeat { get; }
@@ -13951,7 +13955,7 @@ namespace Intents {
 
 		[Export ("initWithProvider:busName:busNumber:tripDuration:departureBusStopLocation:departurePlatform:arrivalBusStopLocation:arrivalPlatform:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string provider, [NullAllowed] string busName, [NullAllowed] string busNumber, INDateComponentsRange tripDuration, CLPlacemark departureBusStopLocation, [NullAllowed] string departurePlatform, CLPlacemark arrivalBusStopLocation, [NullAllowed] string arrivalPlatform);
+		NativeHandle Constructor ([NullAllowed] string provider, [NullAllowed] string busName, [NullAllowed] string busNumber, INDateComponentsRange tripDuration, CLPlacemark departureBusStopLocation, [NullAllowed] string departurePlatform, CLPlacemark arrivalBusStopLocation, [NullAllowed] string arrivalPlatform);
 
 		[NullAllowed, Export ("provider")]
 		string Provider { get; }
@@ -13986,7 +13990,7 @@ namespace Intents {
 
 		[Export ("initWithParticipants:callTypes:callCapability:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] INPerson [] participants, INCallRecordTypeOptions callTypes, INCallCapability callCapability);
+		NativeHandle Constructor ([NullAllowed] INPerson [] participants, INCallRecordTypeOptions callTypes, INCallCapability callCapability);
 
 		[NullAllowed, Export ("participants", ArgumentSemantic.Copy)]
 		INPerson [] Participants { get; }
@@ -14052,7 +14056,7 @@ namespace Intents {
 
 		[Export ("initWithCarIdentifier:displayName:year:make:model:color:headUnit:supportedChargingConnectors:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string carIdentifier, [NullAllowed] string displayName, [NullAllowed] string year, [NullAllowed] string make, [NullAllowed] string model, [NullAllowed] CGColor color, [NullAllowed] INCarHeadUnit headUnit, [BindAs (typeof (INCarChargingConnectorType []))] NSString [] supportedChargingConnectors);
+		NativeHandle Constructor (string carIdentifier, [NullAllowed] string displayName, [NullAllowed] string year, [NullAllowed] string make, [NullAllowed] string model, [NullAllowed] CGColor color, [NullAllowed] INCarHeadUnit headUnit, [BindAs (typeof (INCarChargingConnectorType []))] NSString [] supportedChargingConnectors);
 
 		[Export ("carIdentifier")]
 		string CarIdentifier { get; }
@@ -14095,7 +14099,7 @@ namespace Intents {
 
 		[Export ("initWithBluetoothIdentifier:iAP2Identifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string bluetoothIdentifier, [NullAllowed] string iAP2Identifier);
+		NativeHandle Constructor ([NullAllowed] string bluetoothIdentifier, [NullAllowed] string iAP2Identifier);
 
 		[NullAllowed, Export ("bluetoothIdentifier")]
 		string BluetoothIdentifier { get; }
@@ -14135,7 +14139,7 @@ namespace Intents {
 
 		[Export ("initWithCode:userActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INListCarsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
+		NativeHandle Constructor (INListCarsIntentResponseCode code, [NullAllowed] NSUserActivity userActivity);
 
 		[Export ("code")]
 		INListCarsIntentResponseCode Code { get; }
@@ -14162,10 +14166,10 @@ namespace Intents {
 
 		[Export ("initWithSections:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INObjectSection<ObjectType> [] sections);
+		NativeHandle Constructor (INObjectSection<ObjectType> [] sections);
 
 		[Export ("initWithItems:")]
-		IntPtr Constructor (ObjectType[] items);
+		NativeHandle Constructor (ObjectType[] items);
 	}
 
 	[Watch (7,0), NoTV, Mac (11,0), iOS (14,0)]
@@ -14183,7 +14187,7 @@ namespace Intents {
 
 		[Export ("initWithTitle:items:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string title, ObjectType[] items);
+		NativeHandle Constructor ([NullAllowed] string title, ObjectType[] items);
 	}
 
 	[Watch (7,0), NoTV, Mac (12,0), iOS (14,0)]
@@ -14266,7 +14270,7 @@ namespace Intents {
 		INStartCallCallRecordToCallBackResolutionResult GetUnsupported (INStartCallCallRecordToCallBackUnsupportedReason reason);
 
 		[Export ("initWithCallRecordResolutionResult:")]
-		IntPtr Constructor (INCallRecordResolutionResult callRecordResolutionResult);
+		NativeHandle Constructor (INCallRecordResolutionResult callRecordResolutionResult);
 
 		// Fixes bug 43205. We need to return the inherited type not the base type
 		// because users won't be able to downcast easily
@@ -14305,7 +14309,7 @@ namespace Intents {
 
 		[Export ("initWithGroupName:groupId:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string groupName, [NullAllowed] string groupId);
+		NativeHandle Constructor ([NullAllowed] string groupName, [NullAllowed] string groupId);
 
 		[NullAllowed, Export ("groupName")]
 		string GroupName { get; }

--- a/src/intentsui.cs
+++ b/src/intentsui.cs
@@ -18,6 +18,10 @@ using AppKit;
 using UIKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace IntentsUI {
 
 	[NoMac]
@@ -127,7 +131,7 @@ namespace IntentsUI {
 
 		[MacCatalyst (13,4)]
 		[Export ("initWithShortcut:")]
-		IntPtr Constructor (INShortcut shortcut);
+		NativeHandle Constructor (INShortcut shortcut);
 	}
 
 	interface IINUIAddVoiceShortcutViewControllerDelegate { }
@@ -166,7 +170,7 @@ namespace IntentsUI {
 
 		[MacCatalyst (13,4)]
 		[Export ("initWithVoiceShortcut:")]
-		IntPtr Constructor (INVoiceShortcut voiceShortcut);
+		NativeHandle Constructor (INVoiceShortcut voiceShortcut);
 	}
 
 	interface IINUIEditVoiceShortcutViewControllerDelegate { }
@@ -202,7 +206,7 @@ namespace IntentsUI {
 		[MacCatalyst (13, 4)]
 		[Export ("initWithStyle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INUIAddVoiceShortcutButtonStyle style);
+		NativeHandle Constructor (INUIAddVoiceShortcutButtonStyle style);
 
 		[Export ("style")]
 		INUIAddVoiceShortcutButtonStyle Style { get; }

--- a/src/iosurface.cs
+++ b/src/iosurface.cs
@@ -13,6 +13,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace IOSurface {
 
 	[Static]
@@ -124,10 +128,10 @@ namespace IOSurface {
 	interface IOSurface : NSSecureCoding
 	{
 		[Internal, Export ("initWithProperties:")]
-		IntPtr Constructor (NSDictionary properties);
+		NativeHandle Constructor (NSDictionary properties);
 
 		[Wrap ("this (properties.GetDictionary ()!)")]
-		IntPtr Constructor (IOSurfaceOptions properties);
+		NativeHandle Constructor (IOSurfaceOptions properties);
 	
 		[Internal, Export ("lockWithOptions:seed:")]
 		int _Lock (IOSurfaceLockOptions options, IntPtr seedPtr);

--- a/src/ituneslibrary.cs
+++ b/src/ituneslibrary.cs
@@ -26,6 +26,10 @@ using AppKit;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace iTunesLibrary {
 
 	[Mac (10,14)]
@@ -377,11 +381,11 @@ namespace iTunesLibrary {
 		ITLibrary GetLibrary (string requestedAPIVersion, ITLibInitOptions options, [NullAllowed] out NSError error);
 
 		[Export ("initWithAPIVersion:error:")]
-		IntPtr Constructor (string requestedAPIVersion, [NullAllowed] out NSError error);
+		NativeHandle Constructor (string requestedAPIVersion, [NullAllowed] out NSError error);
 
 		[DesignatedInitializer]
 		[Export ("initWithAPIVersion:options:error:")]
-		IntPtr Constructor (string requestedAPIVersion, ITLibInitOptions options, [NullAllowed] out NSError error);
+		NativeHandle Constructor (string requestedAPIVersion, ITLibInitOptions options, [NullAllowed] out NSError error);
 
 		[Export ("artworkForMediaFile:")]
 		[return: NullAllowed]

--- a/src/javascriptcore.cs
+++ b/src/javascriptcore.cs
@@ -11,6 +11,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace JavaScriptCore {
 
 	delegate void JSContextExceptionHandler (JSContext context, JSValue exception);
@@ -21,10 +25,10 @@ namespace JavaScriptCore {
 	partial interface JSContext {
 
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithVirtualMachine:")]
-		IntPtr Constructor (JSVirtualMachine virtualMachine);
+		NativeHandle Constructor (JSVirtualMachine virtualMachine);
 
 		[Mac (10,10), iOS (8,0)]
 		[NullAllowed] // by default this property is null
@@ -319,7 +323,7 @@ namespace JavaScriptCore {
 		JSManagedValue Get (JSValue value, NSObject owner);
 
 		[Export ("initWithValue:")]
-		IntPtr Constructor (JSValue value);
+		NativeHandle Constructor (JSValue value);
 
 		[Export ("value")]
 		JSValue Value { get; }
@@ -331,7 +335,7 @@ namespace JavaScriptCore {
 	partial interface JSVirtualMachine {
 
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("addManagedReference:withOwner:")]
 		void AddManagedReference (NSObject obj, NSObject owner);

--- a/src/linkpresentation.cs
+++ b/src/linkpresentation.cs
@@ -19,6 +19,10 @@ using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace LinkPresentation {
 
 	[ErrorDomain ("LPErrorDomain")]
@@ -66,13 +70,13 @@ namespace LinkPresentation {
 
 		[Export ("initWithFrame:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect rect);
+		NativeHandle Constructor (CGRect rect);
 
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("initWithMetadata:")]
-		IntPtr Constructor (LPLinkMetadata metadata);
+		NativeHandle Constructor (LPLinkMetadata metadata);
 
 		[Export ("metadata", ArgumentSemantic.Copy)]
 		LPLinkMetadata Metadata { get; set; }

--- a/src/localauthenticationembeddedui.cs
+++ b/src/localauthenticationembeddedui.cs
@@ -14,6 +14,10 @@ using AppKit;
 using CoreGraphics;
 using LocalAuthentication;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace LocalAuthenticationEmbeddedUI {
     
     [NoWatch, NoTV, NoiOS, NoMacCatalyst, Mac (12,0)]
@@ -21,13 +25,13 @@ namespace LocalAuthenticationEmbeddedUI {
     interface LAAuthenticationView
     {
         [Export ("initWithFrame:")]
-        IntPtr Constructor (CGRect frameRect);
+        NativeHandle Constructor (CGRect frameRect);
 
         [Export ("initWithContext:")]
-        IntPtr Constructor (LAContext context);
+        NativeHandle Constructor (LAContext context);
 
         [Export ("initWithContext:controlSize:")]
-        IntPtr Constructor (LAContext context, NSControlSize controlSize);
+        NativeHandle Constructor (LAContext context, NSControlSize controlSize);
 
         [Export ("context")]
         LAContext Context { get; }

--- a/src/mailkit.cs
+++ b/src/mailkit.cs
@@ -5,6 +5,10 @@ using ObjCRuntime;
 using AVFoundation;
 using AppKit;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MailKit {
 	[NoWatch, NoTV, NoiOS, NoMacCatalyst, Mac (12,0)]
 	[Native]
@@ -169,7 +173,7 @@ namespace MailKit {
 	{
 		[Export ("initWithEncodedMessage:signingError:encryptionError:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] MEEncodedOutgoingMessage encodedMessage, [NullAllowed] NSError signingError, [NullAllowed] NSError encryptionError);
+		NativeHandle Constructor ([NullAllowed] MEEncodedOutgoingMessage encodedMessage, [NullAllowed] NSError signingError, [NullAllowed] NSError encryptionError);
 
 		[NullAllowed, Export ("encodedMessage", ArgumentSemantic.Copy)]
 		MEEncodedOutgoingMessage EncodedMessage { get; }
@@ -187,10 +191,10 @@ namespace MailKit {
 	interface MEMessageSecurityInformation : NSSecureCoding
 	{
 		[Export ("initWithSigners:isEncrypted:signingError:encryptionError:")]
-		IntPtr Constructor (MEMessageSigner[] signers, bool isEncrypted, [NullAllowed] NSError signingError, [NullAllowed] NSError encryptionError);
+		NativeHandle Constructor (MEMessageSigner[] signers, bool isEncrypted, [NullAllowed] NSError signingError, [NullAllowed] NSError encryptionError);
 
 		[Export ("initWithSigners:isEncrypted:signingError:encryptionError:shouldBlockRemoteContent:localizedRemoteContentBlockingReason:")]
-		IntPtr Constructor (MEMessageSigner[] signers, bool isEncrypted, [NullAllowed] NSError signingError, [NullAllowed] NSError encryptionError, bool shouldBlockRemoteContent, [NullAllowed] string localizedRemoteContentBlockingReason);
+		NativeHandle Constructor (MEMessageSigner[] signers, bool isEncrypted, [NullAllowed] NSError signingError, [NullAllowed] NSError encryptionError, bool shouldBlockRemoteContent, [NullAllowed] string localizedRemoteContentBlockingReason);
 
 		[Export ("signers", ArgumentSemantic.Strong)]
 		MEMessageSigner[] Signers { get; }
@@ -217,7 +221,7 @@ namespace MailKit {
 	interface MEMessageSigner : NSSecureCoding
 	{
 		[Export ("initWithEmailAddresses:signatureLabel:context:")]
-		IntPtr Constructor (MEEmailAddress[] emailAddresses, string label, [NullAllowed] NSData context);
+		NativeHandle Constructor (MEEmailAddress[] emailAddresses, string label, [NullAllowed] NSData context);
 
 		[Export ("emailAddresses", ArgumentSemantic.Copy)]
 		MEEmailAddress[] EmailAddresses { get; }
@@ -235,7 +239,7 @@ namespace MailKit {
 	interface MEOutgoingMessageEncodingStatus : NSSecureCoding
 	{
 		[Export ("initWithCanSign:canEncrypt:securityError:addressesFailingEncryption:")]
-		IntPtr Constructor (bool canSign, bool canEncrypt, [NullAllowed] NSError securityError, MEEmailAddress[] addressesFailingEncryption);
+		NativeHandle Constructor (bool canSign, bool canEncrypt, [NullAllowed] NSError securityError, MEEmailAddress[] addressesFailingEncryption);
 
 		[Export ("canSign")]
 		bool CanSign { get; }
@@ -305,10 +309,10 @@ namespace MailKit {
 		MEDecodedMessageBanner Banner { get; }
 
 		[Export ("initWithData:securityInformation:context:")]
-		IntPtr Constructor ([NullAllowed] NSData rawData, MEMessageSecurityInformation securityInformation, [NullAllowed] NSData context);
+		NativeHandle Constructor ([NullAllowed] NSData rawData, MEMessageSecurityInformation securityInformation, [NullAllowed] NSData context);
 
 		[Export ("initWithData:securityInformation:context:banner:")]
-		IntPtr Constructor ([NullAllowed] NSData rawData, MEMessageSecurityInformation securityInformation, [NullAllowed] NSData context, [NullAllowed] MEDecodedMessageBanner banner);
+		NativeHandle Constructor ([NullAllowed] NSData rawData, MEMessageSecurityInformation securityInformation, [NullAllowed] NSData context, [NullAllowed] MEDecodedMessageBanner banner);
 	}
 
 	[NoWatch, NoTV, NoiOS, NoMacCatalyst, Mac (12,0)]
@@ -316,7 +320,7 @@ namespace MailKit {
 	interface MEEncodedOutgoingMessage : NSSecureCoding
 	{
 		[Export ("initWithRawData:isSigned:isEncrypted:")]
-		IntPtr Constructor (NSData rawData, bool isSigned, bool isEncrypted);
+		NativeHandle Constructor (NSData rawData, bool isSigned, bool isEncrypted);
 
 		[Export ("rawData", ArgumentSemantic.Copy)]
 		NSData RawData { get; }
@@ -334,7 +338,7 @@ namespace MailKit {
 	interface MEEmailAddress : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithRawString:")]
-		IntPtr Constructor (string rawString);
+		NativeHandle Constructor (string rawString);
 
 		[Export ("rawString")]
 		string RawString { get; }
@@ -474,7 +478,7 @@ namespace MailKit {
 		[DesignatedInitializer]
 		[Protected]
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 	}
 
 	[NoWatch, NoTV, NoMacCatalyst, NoiOS, Mac (12,0)]

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -45,6 +45,10 @@ using MKPolyline = Foundation.NSObject;
 using MKOverlayPathRenderer = Foundation.NSObject;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MapKit {
 
 	[BaseType (typeof (NSObject))]
@@ -100,10 +104,10 @@ namespace MapKit {
 		[DesignatedInitializer]
 		[Export ("initWithAnnotation:reuseIdentifier:")]
 		[PostGet ("Annotation")]
-		IntPtr Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
+		NativeHandle Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
 	
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("reuseIdentifier")]
 		[NullAllowed]
@@ -235,14 +239,14 @@ namespace MapKit {
 	[Deprecated (PlatformName.iOS, 7, 0, message: "Use 'MKCircleRenderer' instead.")]
 	interface MKCircleView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("circle")]
 		MKCircle Circle { get;  }
 
 		[Export ("initWithCircle:")]
 		[PostGet ("Circle")]
-		IntPtr Constructor (MKCircle circle);
+		NativeHandle Constructor (MKCircle circle);
 	}
 #endif
 	
@@ -259,7 +263,7 @@ namespace MapKit {
 		MKMapItem Source { get; [iOS (7,0)] set; }
 
 		[Export ("initWithContentsOfURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Static]
 		[Export ("isDirectionsRequestURL:")]
@@ -312,7 +316,7 @@ namespace MapKit {
 		MKMapItem MapItemForCurrentLocation ();
 
 		[Export ("initWithPlacemark:")]
-		IntPtr Constructor (MKPlacemark placemark);
+		NativeHandle Constructor (MKPlacemark placemark);
 
 		[NoTV]
 		[Export ("openInMapsWithLaunchOptions:"), Internal]
@@ -402,7 +406,7 @@ namespace MapKit {
 	[Mac (10,9)]
 	interface MKMapView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("delegate", ArgumentSemantic.Weak)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -780,10 +784,10 @@ namespace MapKit {
 	[Deprecated (PlatformName.TvOS, 15, 0)]	
 	interface MKPinAnnotationView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("initWithAnnotation:reuseIdentifier:")]
-		IntPtr Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
+		NativeHandle Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
 
 		[NoTV]
 		[Export ("pinColor")]
@@ -840,25 +844,25 @@ namespace MapKit {
 	[Mac (10,9)]
 	interface MKPlacemark : MKAnnotation, NSCopying {
 		[Export ("initWithCoordinate:addressDictionary:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate, [NullAllowed] NSDictionary addressDictionary);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate, [NullAllowed] NSDictionary addressDictionary);
 
 #if IOS
 		// This requires the AddressBook framework, which afaict isn't bound on Mac, tvOS and watchOS yet
 		[Wrap ("this (coordinate, addressDictionary.GetDictionary ())")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate, MKPlacemarkAddress addressDictionary);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate, MKPlacemarkAddress addressDictionary);
 #endif // !MONOMAC && !WATCH
 
 		[Watch (3,0)][TV (10,0)][iOS (10,0)]
 		[Mac (10,12)]
 		[Export ("initWithCoordinate:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate);
 
 #if !TVOS
 		[Watch (3,0)][iOS (10,0)]
 		[Mac (10,12)]
 		[NoTV]
 		[Export ("initWithCoordinate:postalAddress:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate, CNPostalAddress postalAddress);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate, CNPostalAddress postalAddress);
 #endif
 	
 		[Export ("countryCode")]
@@ -873,7 +877,7 @@ namespace MapKit {
 	[DisableDefaultCtor]
 	interface MKReverseGeocoder {
 		[Export ("initWithCoordinate:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate);
 	
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -920,11 +924,11 @@ namespace MapKit {
 		IMKOverlay Overlay { get; }
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[DesignatedInitializer]
 		[Export ("initWithOverlay:")]
-		IntPtr Constructor (IMKOverlay overlay);
+		NativeHandle Constructor (IMKOverlay overlay);
 
 		[Export ("pointForMapPoint:")]
 		[ThreadSafe]
@@ -960,10 +964,10 @@ namespace MapKit {
 	[BaseType (typeof (MKOverlayView))]
 	interface MKOverlayPathView {
 		[Export ("initWithOverlay:")]
-		IntPtr Constructor (IMKOverlay overlay);
+		NativeHandle Constructor (IMKOverlay overlay);
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NullAllowed] // by default this property is null
 		[Export ("fillColor", ArgumentSemantic.Retain)]
@@ -1038,11 +1042,11 @@ namespace MapKit {
 	interface MKPointAnnotation : MKGeoJsonObject {
 		[TV (13,0), NoWatch, Mac (10,15), iOS (13,0)]
 		[Export ("initWithCoordinate:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate);
 
 		[TV (13,0), NoWatch, Mac (10,15), iOS (13,0)]
 		[Export ("initWithCoordinate:title:subtitle:")]
-		IntPtr Constructor (CLLocationCoordinate2D coordinate, [NullAllowed] string title, [NullAllowed] string subtitle);
+		NativeHandle Constructor (CLLocationCoordinate2D coordinate, [NullAllowed] string title, [NullAllowed] string subtitle);
 
 		[Export ("coordinate")]
 		CLLocationCoordinate2D Coordinate { get; set; }
@@ -1053,11 +1057,11 @@ namespace MapKit {
 	[BaseType (typeof (MKOverlayPathView))]
 	interface MKPolygonView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("initWithPolygon:")]
 		[PostGet ("Polygon")]
-		IntPtr Constructor (MKPolygon polygon);
+		NativeHandle Constructor (MKPolygon polygon);
 		
 		[Export ("polygon")]
 		MKPolygon Polygon { get;  }
@@ -1126,11 +1130,11 @@ namespace MapKit {
 	[BaseType (typeof (MKOverlayPathView))]
 	interface MKPolylineView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("initWithPolyline:")]
 		[PostGet ("Polyline")]
-		IntPtr Constructor (MKPolyline polyline);
+		NativeHandle Constructor (MKPolyline polyline);
 		
 		[Export ("polyline")]
 		MKPolyline Polyline { get;  }
@@ -1202,7 +1206,7 @@ namespace MapKit {
 		[DesignatedInitializer]
 		[Export ("initWithMapView:")]
 		[PostGet ("MapView")]
-		IntPtr Constructor ([NullAllowed] MKMapView mapView);
+		NativeHandle Constructor ([NullAllowed] MKMapView mapView);
 	}
 #endif // !MONOMAC
 
@@ -1217,13 +1221,13 @@ namespace MapKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithRequest:")]
-		IntPtr Constructor (MKLocalSearchRequest request);
+		NativeHandle Constructor (MKLocalSearchRequest request);
 
 		[TV (14,0), NoWatch, Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithPointsOfInterestRequest:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MKLocalPointsOfInterestRequest request);
+		NativeHandle Constructor (MKLocalPointsOfInterestRequest request);
 
 		[Export ("startWithCompletionHandler:")]
 		[Async]
@@ -1246,15 +1250,15 @@ namespace MapKit {
 		[DesignatedInitializer]
 		[NoWatch][iOS (9,3)][Mac (10,11,4)]
 		[Export ("initWithCompletion:")]
-		IntPtr Constructor (MKLocalSearchCompletion completion);
+		NativeHandle Constructor (MKLocalSearchCompletion completion);
 
 		[TV (13,0), NoWatch, Mac (10,15), iOS (13,0)]
 		[Export ("initWithNaturalLanguageQuery:")]
-		IntPtr Constructor (string naturalLanguageQuery);
+		NativeHandle Constructor (string naturalLanguageQuery);
 
 		[TV (13,0), NoWatch, Mac (10,15), iOS (13,0)]
 		[Export ("initWithNaturalLanguageQuery:region:")]
-		IntPtr Constructor (string naturalLanguageQuery, MKCoordinateRegion region);
+		NativeHandle Constructor (string naturalLanguageQuery, MKCoordinateRegion region);
 
 		[Export ("naturalLanguageQuery", ArgumentSemantic.Copy)]
 		[NullAllowed]
@@ -1293,7 +1297,7 @@ namespace MapKit {
 	partial interface MKCircleRenderer {
 
 		[Export ("initWithCircle:")]
-		IntPtr Constructor (MKCircle circle);
+		NativeHandle Constructor (MKCircle circle);
 
 		[Export ("circle")]
 		MKCircle Circle { get; }
@@ -1317,7 +1321,7 @@ namespace MapKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithRequest:")]
-		IntPtr Constructor (MKDirectionsRequest request);
+		NativeHandle Constructor (MKDirectionsRequest request);
 
 		[Export ("calculateDirectionsWithCompletionHandler:")]
 		[Async]
@@ -1588,7 +1592,7 @@ namespace MapKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithOptions:")]
-		IntPtr Constructor (MKMapSnapshotOptions options);
+		NativeHandle Constructor (MKMapSnapshotOptions options);
 
 		[Export ("startWithCompletionHandler:")]
 		[Async]
@@ -1614,7 +1618,7 @@ namespace MapKit {
 	partial interface MKOverlayPathRenderer {
 
 		[Export ("initWithOverlay:")]
-		IntPtr Constructor (IMKOverlay overlay);
+		NativeHandle Constructor (IMKOverlay overlay);
 
 		[NullAllowed] // by default this property is null
 		[Export ("fillColor", ArgumentSemantic.Retain)]
@@ -1677,7 +1681,7 @@ namespace MapKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithOverlay:")]
-		IntPtr Constructor (IMKOverlay overlay);
+		NativeHandle Constructor (IMKOverlay overlay);
 
 		[Export ("overlay")]
 		IMKOverlay Overlay { get; }
@@ -1727,7 +1731,7 @@ namespace MapKit {
 	partial interface MKPolygonRenderer {
 
 		[Export ("initWithPolygon:")]
-		IntPtr Constructor (MKPolygon polygon);
+		NativeHandle Constructor (MKPolygon polygon);
 
 		[Export ("polygon")]
 		MKPolygon Polygon { get; }
@@ -1749,7 +1753,7 @@ namespace MapKit {
 	partial interface MKPolylineRenderer {
 
 		[Export ("initWithPolyline:")]
-		IntPtr Constructor (MKPolyline polyline);
+		NativeHandle Constructor (MKPolyline polyline);
 
 		[Export ("polyline")]
 		MKPolyline Polyline { get; }
@@ -1788,7 +1792,7 @@ namespace MapKit {
 	partial interface MKTileOverlay : MKOverlay {
 		[DesignatedInitializer]
 		[Export ("initWithURLTemplate:")]
-		IntPtr Constructor ([NullAllowed] string URLTemplate);
+		NativeHandle Constructor ([NullAllowed] string URLTemplate);
 
 		[Export ("tileSize")]
 		CGSize TileSize { get; set; }
@@ -1829,10 +1833,10 @@ namespace MapKit {
 	partial interface MKTileOverlayRenderer {
 		// This ctor is not allowed: NSInvalidArgumentEception Expected a MKTileOverlay
 //		[Export ("initWithOverlay:")]
-//		IntPtr Constructor (IMKOverlay toverlay);
+//		NativeHandle Constructor (IMKOverlay toverlay);
 
 		[Export ("initWithTileOverlay:")]
-		IntPtr Constructor (MKTileOverlay overlay);
+		NativeHandle Constructor (MKTileOverlay overlay);
 
 		[Export ("reloadData")]
 		void ReloadData ();
@@ -1941,7 +1945,7 @@ namespace MapKit {
 
 		[Export ("initWithMemberAnnotations:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMKAnnotation[] memberAnnotations);
+		NativeHandle Constructor (IMKAnnotation[] memberAnnotations);
 	}
 
 	[NoTV][iOS (11,0)][Mac (11, 0)][NoWatch]
@@ -1966,7 +1970,7 @@ namespace MapKit {
 		// inlined from base type
 		[Export ("initWithAnnotation:reuseIdentifier:")]
 		[PostGet ("Annotation")]
-		IntPtr Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
+		NativeHandle Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
 
 		[Export ("titleVisibility", ArgumentSemantic.Assign)]
 		MKFeatureVisibility TitleVisibility { get; set; }
@@ -2095,7 +2099,7 @@ namespace MapKit {
 	{
 		[Export ("initWithMinCenterCoordinateDistance:maxCenterCoordinateDistance:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double minDistance, double maxDistance);
+		NativeHandle Constructor (double minDistance, double maxDistance);
 
 		[Internal]
 		[Export ("initWithMinCenterCoordinateDistance:")]
@@ -2121,11 +2125,11 @@ namespace MapKit {
 	{
 		[Export ("initWithMapRect:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MKMapRect mapRect);
+		NativeHandle Constructor (MKMapRect mapRect);
 
 		[Export ("initWithCoordinateRegion:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MKCoordinateRegion region);
+		NativeHandle Constructor (MKCoordinateRegion region);
 
 		[Export ("mapRect")]
 		MKMapRect MapRect { get; }
@@ -2140,7 +2144,7 @@ namespace MapKit {
 	{
 		[Export ("initWithPolygons:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MKPolygon[] polygons);
+		NativeHandle Constructor (MKPolygon[] polygons);
 
 		[Export ("polygons", ArgumentSemantic.Copy)]
 		MKPolygon[] Polygons { get; }
@@ -2151,7 +2155,7 @@ namespace MapKit {
 	interface MKMultiPolygonRenderer
 	{
 		[Export ("initWithMultiPolygon:")]
-		IntPtr Constructor (MKMultiPolygon multiPolygon);
+		NativeHandle Constructor (MKMultiPolygon multiPolygon);
 
 		[Export ("multiPolygon")]
 		MKMultiPolygon MultiPolygon { get; }
@@ -2163,7 +2167,7 @@ namespace MapKit {
 	{
 		[Export ("initWithPolylines:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MKPolyline[] polylines);
+		NativeHandle Constructor (MKPolyline[] polylines);
 
 		[Export ("polylines", ArgumentSemantic.Copy)]
 		MKPolyline[] Polylines { get; }
@@ -2174,7 +2178,7 @@ namespace MapKit {
 	interface MKMultiPolylineRenderer
 	{
 		[Export ("initWithMultiPolyline:")]
-		IntPtr Constructor (MKMultiPolyline multiPolyline);
+		NativeHandle Constructor (MKMultiPolyline multiPolyline);
 
 		[Export ("multiPolyline")]
 		MKMultiPolyline MultiPolyline { get; }
@@ -2185,10 +2189,10 @@ namespace MapKit {
 	interface MKUserLocationView { 
 		[DesignatedInitializer]
 		[Export ("initWithAnnotation:reuseIdentifier:")]
-		IntPtr Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
+		NativeHandle Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
 	
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 	}
 
 	[TV (14, 0), NoWatch, Mac (11, 0), iOS (14, 0)]
@@ -2202,11 +2206,11 @@ namespace MapKit {
 
 		[Export ("initWithCenterCoordinate:radius:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CLLocationCoordinate2D centerCoordinate, double radius);
+		NativeHandle Constructor (CLLocationCoordinate2D centerCoordinate, double radius);
 
 		[Export ("initWithCoordinateRegion:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MKCoordinateRegion region);
+		NativeHandle Constructor (MKCoordinateRegion region);
 
 		[Export ("coordinate")]
 		CLLocationCoordinate2D Coordinate { get; }
@@ -2229,7 +2233,7 @@ namespace MapKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Static]
 		[Export ("pitchControlWithMapView:")]
@@ -2248,7 +2252,7 @@ namespace MapKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Static]
 		[Export ("zoomControlWithMapView:")]

--- a/src/medialibrary.cs
+++ b/src/medialibrary.cs
@@ -25,6 +25,10 @@ using AppKit;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MediaLibrary {
 	[Static]
 	[Mac (10,9)]
@@ -425,7 +429,7 @@ namespace MediaLibrary {
 	{
 		[Export ("initWithOptions:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSDictionary<NSString, NSObject> options);
+		NativeHandle Constructor (NSDictionary<NSString, NSObject> options);
 
 		[NullAllowed, Export ("mediaSources", ArgumentSemantic.Copy)]
 		NSDictionary<NSString, MLMediaSource> MediaSources { get; }

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -21,6 +21,10 @@ using UIKit;
 #endif
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MediaPlayer {
 	[Mac (10,12,2)] // type exists only to expose fields
 	[BaseType (typeof (NSObject))]
@@ -263,11 +267,11 @@ namespace MediaPlayer {
 		[TV (10,0)]
 		[Export ("initWithBoundsSize:requestHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGSize boundsSize, Func<CGSize, UIImage> requestHandler);
+		NativeHandle Constructor (CGSize boundsSize, Func<CGSize, UIImage> requestHandler);
 
 		[Deprecated (PlatformName.iOS, 10, 0)]
 		[Export ("initWithImage:")]
-		IntPtr Constructor (UIImage image);
+		NativeHandle Constructor (UIImage image);
 		
 		[Export ("imageWithSize:")]
 		[return: NullAllowed]
@@ -275,7 +279,7 @@ namespace MediaPlayer {
 #else
 		[Export ("initWithBoundsSize:requestHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGSize boundsSize, Func<CGSize, NSImage> requestHandler);
+		NativeHandle Constructor (CGSize boundsSize, Func<CGSize, NSImage> requestHandler);
 
 		[Export ("imageWithSize:")]
 		[return: NullAllowed]
@@ -314,7 +318,7 @@ namespace MediaPlayer {
 
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
-		IntPtr Constructor (MPMediaItem [] items);
+		NativeHandle Constructor (MPMediaItem [] items);
 
 		[Export ("items")]
 		MPMediaItem [] Items { get; }
@@ -383,7 +387,7 @@ namespace MediaPlayer {
 	interface MPMediaPickerController {
 		[DesignatedInitializer]
 		[Export ("initWithMediaTypes:")]
-		IntPtr Constructor (MPMediaType mediaTypes);
+		NativeHandle Constructor (MPMediaType mediaTypes);
 
 		[Export ("mediaTypes")]
 		MPMediaType MediaTypes { get; }
@@ -431,7 +435,7 @@ namespace MediaPlayer {
 	[DisableDefaultCtor]
 	interface MPMediaPlaylist : NSSecureCoding {
 		[Export ("initWithItems:")]
-		IntPtr Constructor (MPMediaItem [] items);
+		NativeHandle Constructor (MPMediaItem [] items);
 
 		[Static, Export ("canFilterByProperty:")]
 		bool CanFilterByProperty (string property);
@@ -519,7 +523,7 @@ namespace MediaPlayer {
 	interface MPMediaQuery : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithFilterPredicates:")]
-		IntPtr Constructor ([NullAllowed] NSSet filterPredicates);
+		NativeHandle Constructor ([NullAllowed] NSSet filterPredicates);
 
 		[NullAllowed] // by default this property is null
 		[Export ("filterPredicates", ArgumentSemantic.Retain)]
@@ -824,7 +828,7 @@ namespace MediaPlayer {
 		[NoWatch]
 		[DesignatedInitializer]
 		[Export ("initWithContentURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 #if !NET
 		[NoWatch]
@@ -1172,7 +1176,7 @@ namespace MediaPlayer {
 	interface MPMoviePlayerViewController {
 		[DesignatedInitializer]
 		[Export ("initWithContentURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("moviePlayer")]
 		MPMoviePlayerController MoviePlayer { get; }
@@ -1197,7 +1201,7 @@ namespace MediaPlayer {
 		[Export ("init")]
 		[Deprecated (PlatformName.iOS, 11,3)]
 		[NoTV]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Static, Export ("applicationMusicPlayer")]
 		MPMusicPlayerController ApplicationMusicPlayer { get; }
@@ -1299,7 +1303,7 @@ namespace MediaPlayer {
 	[BaseType (typeof (UIView))]
 	interface MPVolumeView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'AVRoutePickerView' instead.")]
 		[Export ("showsRouteButton")]
@@ -1507,7 +1511,7 @@ namespace MediaPlayer {
 
 		[DesignatedInitializer]
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[NullAllowed]
 		[Export ("artwork")]
@@ -1965,7 +1969,7 @@ namespace MediaPlayer {
 	[DisableDefaultCtor] // pre-emptive
 	interface MPNowPlayingInfoLanguageOption {
 		[Export ("initWithType:languageTag:characteristics:displayName:identifier:")]
-		IntPtr Constructor (MPNowPlayingInfoLanguageOptionType languageOptionType, string languageTag, [NullAllowed] NSString[] languageOptionCharacteristics, string displayName, string identifier);
+		NativeHandle Constructor (MPNowPlayingInfoLanguageOptionType languageOptionType, string languageTag, [NullAllowed] NSString[] languageOptionCharacteristics, string displayName, string identifier);
 
 		[Export ("languageOptionType")]
 		MPNowPlayingInfoLanguageOptionType LanguageOptionType { get; }
@@ -1998,7 +2002,7 @@ namespace MediaPlayer {
 	[DisableDefaultCtor] // pre-emptive
 	interface MPNowPlayingInfoLanguageOptionGroup {
 		[Export ("initWithLanguageOptions:defaultLanguageOption:allowEmptySelection:")]
-		IntPtr Constructor (MPNowPlayingInfoLanguageOption[] languageOptions, [NullAllowed] MPNowPlayingInfoLanguageOption defaultLanguageOption, bool allowEmptySelection);
+		NativeHandle Constructor (MPNowPlayingInfoLanguageOption[] languageOptions, [NullAllowed] MPNowPlayingInfoLanguageOption defaultLanguageOption, bool allowEmptySelection);
 
 		[Export ("languageOptions")]
 		MPNowPlayingInfoLanguageOption[] LanguageOptions { get; }
@@ -2071,7 +2075,7 @@ namespace MediaPlayer {
 	interface MPMediaPlaylistCreationMetadata {
 		[Export ("initWithName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string name);
+		NativeHandle Constructor (string name);
 
 		[Export ("name")]
 		string Name { get; }
@@ -2094,7 +2098,7 @@ namespace MediaPlayer {
 
 		[Export ("init")]
 		[Deprecated (PlatformName.iOS, 11,3)]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 	}
 
 	[NoMac]
@@ -2105,10 +2109,10 @@ namespace MediaPlayer {
 	interface MPMusicPlayerMediaItemQueueDescriptor
 	{
 		[Export ("initWithQuery:")]
-		IntPtr Constructor (MPMediaQuery query);
+		NativeHandle Constructor (MPMediaQuery query);
 
 		[Export ("initWithItemCollection:")]
-		IntPtr Constructor (MPMediaItemCollection itemCollection);
+		NativeHandle Constructor (MPMediaItemCollection itemCollection);
 
 		[Export ("query", ArgumentSemantic.Copy)]
 		MPMediaQuery Query { get; }
@@ -2134,7 +2138,7 @@ namespace MediaPlayer {
 	interface MPMusicPlayerStoreQueueDescriptor
 	{
 		[Export ("initWithStoreIDs:")]
-		IntPtr Constructor (string[] storeIDs);
+		NativeHandle Constructor (string[] storeIDs);
 
 		[NullAllowed, Export ("storeIDs", ArgumentSemantic.Copy)]
 		string[] StoreIDs { get; set; }
@@ -2199,7 +2203,7 @@ namespace MediaPlayer {
 	[DisableDefaultCtor]
 	interface MPMusicPlayerPlayParameters : NSSecureCoding {
 		[Export ("initWithDictionary:")]
-		IntPtr Constructor (NSDictionary dictionary);
+		NativeHandle Constructor (NSDictionary dictionary);
 
 		[Export ("dictionary", ArgumentSemantic.Copy)]
 		NSDictionary Dictionary { get; }
@@ -2213,7 +2217,7 @@ namespace MediaPlayer {
 	[DisableDefaultCtor]
 	interface MPMusicPlayerPlayParametersQueueDescriptor {
 		[Export ("initWithPlayParametersQueue:")]
-		IntPtr Constructor (MPMusicPlayerPlayParameters[] playParametersQueue);
+		NativeHandle Constructor (MPMusicPlayerPlayParameters[] playParametersQueue);
 
 		[Export ("playParametersQueue", ArgumentSemantic.Copy)]
 		MPMusicPlayerPlayParameters[] PlayParametersQueue { get; set; }
@@ -2297,7 +2301,7 @@ namespace MediaPlayer {
 	interface MPNowPlayingSession {
 
 		[Export ("initWithPlayers:")]
-		IntPtr Constructor (AVPlayer[] players);
+		NativeHandle Constructor (AVPlayer[] players);
 
 		[Export ("players", ArgumentSemantic.Strong)]
 		AVPlayer[] Players { get; }

--- a/src/mediasetup.cs
+++ b/src/mediasetup.cs
@@ -3,6 +3,10 @@ using Foundation;
 using ObjCRuntime;
 using UIKit;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MediaSetup {
 
 	[NoTV][NoWatch][NoMac]
@@ -13,7 +17,7 @@ namespace MediaSetup {
 
 		[Export ("initWithServiceName:accountName:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string serviceName, string accountName);
+		NativeHandle Constructor (string serviceName, string accountName);
 
 		[Export ("serviceName")]
 		string ServiceName { get; }
@@ -56,7 +60,7 @@ namespace MediaSetup {
 	interface MSSetupSession {
 
 		[Export ("initWithServiceAccount:")]
-		IntPtr Constructor (MSServiceAccount serviceAccount);
+		NativeHandle Constructor (MSServiceAccount serviceAccount);
 
 		[Export ("startWithError:")]
 		bool Start ([NullAllowed] out NSError error);

--- a/src/messages.cs
+++ b/src/messages.cs
@@ -14,6 +14,10 @@ using Foundation;
 using ObjCRuntime;
 using UIKit;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #if !MONOMAC
 namespace Messages {
 
@@ -76,7 +80,7 @@ namespace Messages {
 	{
 		// inlined ctor
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[NullAllowed, Export ("activeConversation", ArgumentSemantic.Strong)]
 		MSConversation ActiveConversation { get; }
@@ -185,11 +189,11 @@ namespace Messages {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithSession:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MSSession session);
+		NativeHandle Constructor (MSSession session);
 
 		[NullAllowed, Export ("session")]
 		MSSession Session { get; }
@@ -266,7 +270,7 @@ namespace Messages {
 	{
 		[Export ("initWithContentsOfFileURL:localizedDescription:error:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl fileUrl, string localizedDescription, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSUrl fileUrl, string localizedDescription, [NullAllowed] out NSError error);
 
 		[Export ("imageFileURL", ArgumentSemantic.Strong)]
 		NSUrl ImageFileUrl { get; }
@@ -281,10 +285,10 @@ namespace Messages {
 	{
 		// inlined ctor
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("initWithFrame:sticker:")]
-		IntPtr Constructor (CGRect frame, [NullAllowed] MSSticker sticker);
+		NativeHandle Constructor (CGRect frame, [NullAllowed] MSSticker sticker);
 
 		[NullAllowed, Export ("sticker", ArgumentSemantic.Strong)]
 		MSSticker Sticker { get; set; }
@@ -324,11 +328,11 @@ namespace Messages {
 	{
 		[Export ("initWithFrame:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("initWithFrame:stickerSize:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect frame, MSStickerSize stickerSize);
+		NativeHandle Constructor (CGRect frame, MSStickerSize stickerSize);
 
 		[Export ("stickerSize", ArgumentSemantic.Assign)]
 		MSStickerSize StickerSize { get; }
@@ -355,7 +359,7 @@ namespace Messages {
 	{
 		[Export ("initWithStickerSize:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MSStickerSize stickerSize);
+		NativeHandle Constructor (MSStickerSize stickerSize);
 
 		[Export ("stickerBrowserView", ArgumentSemantic.Strong)]
 		MSStickerBrowserView StickerBrowserView { get; }
@@ -371,7 +375,7 @@ namespace Messages {
 	{
 		[Export ("initWithAlternateLayout:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MSMessageTemplateLayout alternateLayout);
+		NativeHandle Constructor (MSMessageTemplateLayout alternateLayout);
 
 		[Export ("alternateLayout")]
 		MSMessageTemplateLayout AlternateLayout { get; }

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -24,6 +24,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Metal {
 
 	delegate void MTLDeallocator (IntPtr pointer, nuint length);
@@ -2447,7 +2451,7 @@ namespace Metal {
 	{
 		[iOS (11,0), TV (11,0), Mac (10,13)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("setConstantValue:type:atIndex:")]
 		void SetConstantValue (IntPtr value, MTLDataType type, nuint index);
@@ -4442,7 +4446,7 @@ namespace Metal {
 	interface MTLSharedEventListener {
 		[Export ("initWithDispatchQueue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (DispatchQueue dispatchQueue);
+		NativeHandle Constructor (DispatchQueue dispatchQueue);
 
 		[Export ("dispatchQueue")]
 		DispatchQueue DispatchQueue { get; }
@@ -4646,11 +4650,11 @@ namespace Metal {
 
 		[Export ("initWithSampleCount:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MTLSize sampleCount);
+		NativeHandle Constructor (MTLSize sampleCount);
 
 		[Internal]
 		[Export ("initWithSampleCount:horizontal:vertical:")]
-		IntPtr Constructor (MTLSize sampleCount, IntPtr horizontal, IntPtr vertical);
+		NativeHandle Constructor (MTLSize sampleCount, IntPtr horizontal, IntPtr vertical);
 		
 		[MacCatalyst (15,0)]
 		[Internal]
@@ -5637,7 +5641,7 @@ namespace Metal {
 		nuint ArgumentIndex { get; set; }
 
 		[Export ("initWithArgumentIndex:")]
-		IntPtr Constructor (nuint argument);
+		NativeHandle Constructor (nuint argument);
 	}
 
 	[Mac (12,0), iOS (15,0), TV (15,0), MacCatalyst (15, 0), NoWatch]
@@ -5658,7 +5662,7 @@ namespace Metal {
 		IMTLFunctionStitchingAttribute[] Attributes { get; set; }
 
 		[Export ("initWithFunctionName:nodes:outputNode:attributes:")]
-		IntPtr Constructor (string functionName, MTLFunctionStitchingFunctionNode[] nodes, [NullAllowed] MTLFunctionStitchingFunctionNode outputNode, IMTLFunctionStitchingAttribute[] attributes);
+		NativeHandle Constructor (string functionName, MTLFunctionStitchingFunctionNode[] nodes, [NullAllowed] MTLFunctionStitchingFunctionNode outputNode, IMTLFunctionStitchingAttribute[] attributes);
 	}
 	
 	[Mac (12,0), iOS (15,0), TV (15,0), MacCatalyst (15, 0), NoWatch]
@@ -5676,7 +5680,7 @@ namespace Metal {
 		MTLFunctionStitchingFunctionNode[] ControlDependencies { get; set; }
 
 		[Export ("initWithName:arguments:controlDependencies:")]
-		IntPtr Constructor (string name, IMTLFunctionStitchingNode[] arguments, MTLFunctionStitchingFunctionNode[] controlDependencies);
+		NativeHandle Constructor (string name, IMTLFunctionStitchingNode[] arguments, MTLFunctionStitchingFunctionNode[] controlDependencies);
 	}
 	
 	[Mac (12,0), iOS (15,0), NoTV, MacCatalyst (15, 0), NoWatch]

--- a/src/metalkit.cs
+++ b/src/metalkit.cs
@@ -12,6 +12,10 @@ using OpenTK;
 using AppKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MetalKit {
 
 #if !MONOMAC
@@ -39,7 +43,7 @@ namespace MetalKit {
 	interface MTKView : NSCoding, CALayerDelegate {
 		[Export ("initWithFrame:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect frameRect, [NullAllowed] IMTLDevice device);
+		NativeHandle Constructor (CGRect frameRect, [NullAllowed] IMTLDevice device);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -235,7 +239,7 @@ namespace MetalKit {
 		IMTLDevice Device { get; }
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("newTextureWithContentsOfURL:options:completionHandler:"), Internal]
 		void FromUrl (NSUrl url, [NullAllowed] NSDictionary options, MTKTextureLoaderCallback completionHandler);
@@ -398,7 +402,7 @@ namespace MetalKit {
 	[DisableDefaultCtor] // init is NS_UNAVAILABLE
 	interface MTKMeshBufferAllocator : MDLMeshBufferAllocator {
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("device")]
 		IMTLDevice Device { get; }
@@ -443,7 +447,7 @@ namespace MetalKit {
 	[DisableDefaultCtor] // init NS_UNAVAILABLE
 	interface MTKMesh {
 		[Export ("initWithMesh:device:error:")]
-		IntPtr Constructor (MDLMesh mesh, IMTLDevice device, out NSError error);
+		NativeHandle Constructor (MDLMesh mesh, IMTLDevice device, out NSError error);
 
 		// generator does not like `out []` -> https://trello.com/c/sZYNalbB/524-generator-support-out
 		[Internal] // there's another, manual, public API exposed

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -5,6 +5,10 @@ using Metal;
 using ObjCRuntime;
 using Vector4 = global::OpenTK.Vector4;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MetalPerformanceShaders {
 	// MPSImageConvolution.h
 
@@ -24,17 +28,17 @@ namespace MetalPerformanceShaders {
 		[Export ("initWithDevice:kernelWidth:kernelHeight:weights:")]
 		[DesignatedInitializer]
 		[Internal]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, IntPtr kernelWeights);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, IntPtr kernelWeights);
 
 		// inlining .ctor from base class
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -48,13 +52,13 @@ namespace MetalPerformanceShaders {
 		// inlining .ctor from base class
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -64,7 +68,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("kernelHeight")]
 		nuint KernelHeight { get; }
@@ -74,7 +78,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
 		// [Export ("initWithDevice:")] marked as NS_UNAVAILABLE - You must use initWithDevice:kernelWidth:kernelHeight: instead.
 	}
@@ -88,7 +92,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -98,11 +102,11 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("initWithDevice:sigma:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, float sigma);
+		NativeHandle Constructor (IMTLDevice device, float sigma);
 
 		// [Export ("initWithDevice:")] marked as NS_UNAVAILABLE - You must use initWithDevice:sigma: instead.
 
@@ -118,10 +122,10 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithDevice:linearGrayColorTransform:")]
 		[Internal]
@@ -139,13 +143,13 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithDevice:centerWeight:")]
-		IntPtr Constructor (IMTLDevice device, float centerWeight);
+		NativeHandle Constructor (IMTLDevice device, float centerWeight);
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:weights:")]
 		[Internal]
@@ -173,7 +177,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	// MPSImageHistogram.h
@@ -185,7 +189,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("clipRectSource", ArgumentSemantic.Assign)]
 		MTLRegion ClipRectSource { get; set; }
@@ -200,12 +204,12 @@ namespace MetalPerformanceShaders {
 
 		// Could not initialize an instance of the type 'MetalPerformanceShaders.MPSImageHistogram': the native 'initWithDevice:' method returned nil.
 //		[Export ("initWithDevice:")]
-//		IntPtr Constructor (IMTLDevice device);
+//		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithDevice:histogramInfo:")]
 		[DesignatedInitializer]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (IMTLDevice device, ref MPSImageHistogramInfo histogramInfo);
+		NativeHandle Constructor (IMTLDevice device, ref MPSImageHistogramInfo histogramInfo);
 
 		[Export ("encodeToCommandBuffer:sourceTexture:histogram:histogramOffset:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, IMTLTexture source, IMTLBuffer histogram, nuint histogramOffset);
@@ -228,7 +232,7 @@ namespace MetalPerformanceShaders {
 		[Export ("initWithDevice:histogramInfo:")]
 		[DesignatedInitializer]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (IMTLDevice device, ref MPSImageHistogramInfo histogramInfo);
+		NativeHandle Constructor (IMTLDevice device, ref MPSImageHistogramInfo histogramInfo);
 
 		[Export ("histogramInfo")]
 		MPSImageHistogramInfo HistogramInfo {
@@ -241,7 +245,7 @@ namespace MetalPerformanceShaders {
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -251,7 +255,7 @@ namespace MetalPerformanceShaders {
 		[Export ("initWithDevice:histogramInfo:")]
 		[DesignatedInitializer]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (IMTLDevice device, ref MPSImageHistogramInfo histogramInfo);
+		NativeHandle Constructor (IMTLDevice device, ref MPSImageHistogramInfo histogramInfo);
 
 		[Export ("histogramInfo")]
 		MPSImageHistogramInfo HistogramInfo {
@@ -264,7 +268,7 @@ namespace MetalPerformanceShaders {
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	// MPSImageIntegral.h
@@ -276,13 +280,13 @@ namespace MetalPerformanceShaders {
 		// inlining .ctor from base class
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -292,13 +296,13 @@ namespace MetalPerformanceShaders {
 		// inlining .ctor from base class
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	// MPSImageKernel.h
@@ -334,12 +338,12 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -349,7 +353,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 		
 		[Export ("primaryOffset", ArgumentSemantic.Assign)]
 		MPSOffset PrimaryOffset { get; set; }
@@ -391,7 +395,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	// MPSImageMedian.h
@@ -405,7 +409,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelDiameter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelDiameter);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelDiameter);
 
 		// [Export ("initWithDevice:")] is NS_UNAVAILABLE - You must use initWithDevice:kernelDiameter: instead.
 
@@ -420,7 +424,7 @@ namespace MetalPerformanceShaders {
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	// MPSImageMorphology.h
@@ -437,12 +441,12 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		// [Export ("initWithDevice:")] is NS_UNAVAILABLE - You must use initWithDevice:kernelWidth:kernelHeight: instead.
 	}
@@ -455,7 +459,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -478,7 +482,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -492,7 +496,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	// MPSImageResampling.h
@@ -505,13 +509,13 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	// MPSImageThreshold.h
@@ -540,7 +544,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -567,7 +571,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -591,7 +595,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -615,7 +619,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (9,0)][Mac (10, 13)]
@@ -639,7 +643,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	// MPSKernel.h
@@ -651,7 +655,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("options", ArgumentSemantic.Assign)]
 		MPSKernelOptions Options { get; set; }
@@ -664,7 +668,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release ()]
@@ -681,13 +685,13 @@ namespace MetalPerformanceShaders {
 		// inlining .ctor from base class
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	// MPSCNN.h
@@ -701,7 +705,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("offset", ArgumentSemantic.Assign)]
 		MPSOffset Offset { get; set; }
@@ -745,7 +749,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("isBackwards")]
@@ -844,13 +848,13 @@ namespace MetalPerformanceShaders {
 		// inlining .ctor from base class
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// inlining ctor from base class
 		[TV (11,0), iOS (11,0)]
 		[DesignatedInitializer]
 		[Export ("initWithCoder:device:")]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[TV (11,0), Mac (10,13,4), iOS (11,3)]
 		[Export ("neuronType")]
@@ -875,7 +879,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -893,12 +897,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:a:b:")]
-		IntPtr Constructor (IMTLDevice device, float a, float b);
+		NativeHandle Constructor (IMTLDevice device, float a, float b);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -913,12 +917,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:a:")]
-		IntPtr Constructor (IMTLDevice device, float a);
+		NativeHandle Constructor (IMTLDevice device, float a);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -930,12 +934,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -953,14 +957,14 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:a:b:")]
-		IntPtr Constructor (IMTLDevice device, float a, float b);
+		NativeHandle Constructor (IMTLDevice device, float a, float b);
 
 		// [Export ("initWithDevice:")] marked as NS_UNAVAILABLE - Use initWithDevice:a:b: instead
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -973,12 +977,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -1134,12 +1138,12 @@ namespace MetalPerformanceShaders {
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithDevice:weights:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
+		NativeHandle Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("dilationRateX")]
@@ -1248,12 +1252,12 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithDevice:weights:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
+		NativeHandle Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -1278,18 +1282,18 @@ namespace MetalPerformanceShaders {
 		nuint StrideInPixelsY { get; }
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		// [Export ("initWithDevice:")] marked as NS_UNAVAILABLE - Use initWithDevice:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY: instead
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -1301,12 +1305,12 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -1318,12 +1322,12 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("zeroPadSizeX")]
@@ -1358,14 +1362,14 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
 		// [Export ("initWithDevice:")] marked as NS_UNAVAILABLE - Use initWithDevice:kernelWidth:kernelHeight instead
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -1384,11 +1388,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -1424,14 +1428,14 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
 		// [Export ("initWithDevice:")] marked as NS_UNAVAILABLE - Use initWithDevice:kernelWidth:kernelHeight instead
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -1459,11 +1463,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -1485,14 +1489,14 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelSize:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelSize);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelSize);
 
 		// [Export ("initWithDevice:")] marked as NS_UNAVAILABLE - Use initWithDevice:kernelSize: instead
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -1514,11 +1518,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelSize:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelSize);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelSize);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -1530,7 +1534,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -1540,11 +1544,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13)]
@@ -1556,7 +1560,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -1566,11 +1570,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	// MPSImage.h
@@ -1681,15 +1685,15 @@ namespace MetalPerformanceShaders {
 		MPSImage Parent { get; }
 
 		[Export ("initWithDevice:imageDescriptor:")]
-		IntPtr Constructor (IMTLDevice device, MPSImageDescriptor imageDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSImageDescriptor imageDescriptor);
 
 		[DesignatedInitializer]
 		[iOS (11,3), TV (11,3), Mac (10,13,4)]
 		[Export ("initWithParentImage:sliceRange:featureChannels:")]
-		IntPtr Constructor (MPSImage parent, NSRange sliceRange, nuint featureChannels);
+		NativeHandle Constructor (MPSImage parent, NSRange sliceRange, nuint featureChannels);
 
 		[Export ("initWithTexture:featureChannels:")]
-		IntPtr Constructor (IMTLTexture texture, nuint featureChannels);
+		NativeHandle Constructor (IMTLTexture texture, nuint featureChannels);
 
 		[Export ("batchRepresentation")]
 		NSArray<MPSImage> BatchRepresentation { get; }
@@ -1755,7 +1759,7 @@ namespace MetalPerformanceShaders {
 		[DesignatedInitializer]
 		[iOS (11,3), TV (11,3), Mac (10,13,4)]
 		[Export ("initWithParentImage:sliceRange:featureChannels:")]
-		IntPtr Constructor (MPSImage parent, NSRange sliceRange, nuint featureChannels);
+		NativeHandle Constructor (MPSImage parent, NSRange sliceRange, nuint featureChannels);
 
 		[Static]
 		[Export ("temporaryImageWithCommandBuffer:imageDescriptor:")]
@@ -1794,11 +1798,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithBuffer:offset:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLBuffer buffer, nuint offset);
+		NativeHandle Constructor (IMTLBuffer buffer, nuint offset);
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	interface IMPSHeapProvider {}
@@ -1843,7 +1847,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCommandBuffer:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLCommandBuffer commandBuffer);
+		NativeHandle Constructor (IMTLCommandBuffer commandBuffer);
 
 		[Export ("commitAndContinue")]
 		void CommitAndContinue ();
@@ -1874,7 +1878,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	// MPSMatrix.h
@@ -1958,15 +1962,15 @@ namespace MetalPerformanceShaders {
 		IMTLBuffer Data { get; }
 
 		[Export ("initWithBuffer:descriptor:")]
-		IntPtr Constructor (IMTLBuffer buffer, MPSMatrixDescriptor descriptor);
+		NativeHandle Constructor (IMTLBuffer buffer, MPSMatrixDescriptor descriptor);
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("initWithBuffer:offset:descriptor:")]
-		IntPtr Constructor (IMTLBuffer buffer, nuint offset, MPSMatrixDescriptor descriptor);
+		NativeHandle Constructor (IMTLBuffer buffer, nuint offset, MPSMatrixDescriptor descriptor);
 
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Export ("initWithDevice:descriptor:")]
-		IntPtr Constructor (IMTLDevice device, MPSMatrixDescriptor descriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSMatrixDescriptor descriptor);
 
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Export ("synchronizeOnCommandBuffer:")]
@@ -1997,7 +2001,7 @@ namespace MetalPerformanceShaders {
 	interface MPSMatrixMultiplication {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithDevice:resultRows:resultColumns:interiorColumns:")]
-		IntPtr Constructor (IMTLDevice device, nuint resultRows, nuint resultColumns, nuint interiorColumns);
+		NativeHandle Constructor (IMTLDevice device, nuint resultRows, nuint resultColumns, nuint interiorColumns);
 
 		[Export ("resultMatrixOrigin", ArgumentSemantic.Assign)]
 		MTLOrigin ResultMatrixOrigin { get; set; }
@@ -2009,7 +2013,7 @@ namespace MetalPerformanceShaders {
 		MTLOrigin RightMatrixOrigin { get; set; }
 
 		[Export ("initWithDevice:transposeLeft:transposeRight:resultRows:resultColumns:interiorColumns:alpha:beta:")]
-		IntPtr Constructor (IMTLDevice device, bool transposeLeft, bool transposeRight, nuint resultRows, nuint resultColumns, nuint interiorColumns, double alpha, double beta);
+		NativeHandle Constructor (IMTLDevice device, bool transposeLeft, bool transposeRight, nuint resultRows, nuint resultColumns, nuint interiorColumns, double alpha, double beta);
 
 		[Export ("encodeToCommandBuffer:leftMatrix:rightMatrix:resultMatrix:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, MPSMatrix leftMatrix, MPSMatrix rightMatrix, MPSMatrix resultMatrix);
@@ -2020,7 +2024,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[TV (11,0), iOS (11,0)]
 		[Export ("batchStart")]
@@ -2053,19 +2057,19 @@ namespace MetalPerformanceShaders {
 
 		[iOS (11,3), TV (11,3), Mac (10,13,4)]
 		[Export ("initWithDevice:bufferSize:")]
-		IntPtr Constructor (IMTLDevice device, nuint bufferSize);
+		NativeHandle Constructor (IMTLDevice device, nuint bufferSize);
 
 		[iOS (11,3), TV (11,3), Mac (10,13,4)]
 		[Export ("initWithDevice:textureDescriptor:")]
-		IntPtr Constructor (IMTLDevice device, MTLTextureDescriptor descriptor);
+		NativeHandle Constructor (IMTLDevice device, MTLTextureDescriptor descriptor);
 
 		[iOS (11,3), TV (11,3), Mac (10,13,4)]
 		[Export ("initWithResource:")]
-		IntPtr Constructor ([NullAllowed] IMTLResource resource);
+		NativeHandle Constructor ([NullAllowed] IMTLResource resource);
 
 		[iOS (11,3), TV (11,3), Mac (10,13,4)]
 		[Export ("initWithDevice:resourceList:")]
-		IntPtr Constructor (IMTLDevice device, MPSStateResourceList resourceList);
+		NativeHandle Constructor (IMTLDevice device, MPSStateResourceList resourceList);
 
 		[iOS (11,3), TV (11,3), Mac (10,13,4)]
 		[Static]
@@ -2074,7 +2078,7 @@ namespace MetalPerformanceShaders {
 
 		[iOS (11,3), TV (11,3), Mac (10,13,4)]
 		[Export ("initWithResources:")]
-		IntPtr Constructor ([NullAllowed] IMTLResource [] resources);
+		NativeHandle Constructor ([NullAllowed] IMTLResource [] resources);
 
 		[iOS (11,3), TV (11,3), Mac (10,13,4)]
 		[Export ("resourceCount")]
@@ -2165,15 +2169,15 @@ namespace MetalPerformanceShaders {
 		IMTLBuffer Data { get; }
 
 		[Export ("initWithBuffer:descriptor:")]
-		IntPtr Constructor (IMTLBuffer buffer, MPSVectorDescriptor descriptor);
+		NativeHandle Constructor (IMTLBuffer buffer, MPSVectorDescriptor descriptor);
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("initWithBuffer:offset:descriptor:")]
-		IntPtr Constructor (IMTLBuffer buffer, nuint offset, MPSVectorDescriptor descriptor);
+		NativeHandle Constructor (IMTLBuffer buffer, nuint offset, MPSVectorDescriptor descriptor);
 
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Export ("initWithDevice:descriptor:")]
-		IntPtr Constructor (IMTLDevice device, MPSVectorDescriptor descriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSVectorDescriptor descriptor);
 
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Export ("synchronizeOnCommandBuffer:")]
@@ -2236,11 +2240,11 @@ namespace MetalPerformanceShaders {
 		// inlining ctor from base class
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2265,11 +2269,11 @@ namespace MetalPerformanceShaders {
 		// inlining ctor from base class
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 	
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2277,10 +2281,10 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // According to docs needs a Metal Device so initWithDevice: makes more sense.
 	interface MPSMatrixVectorMultiplication {
 		[Export ("initWithDevice:transpose:rows:columns:alpha:beta:")]
-		IntPtr Constructor (IMTLDevice device, bool transpose, nuint rows, nuint columns, double alpha, double beta);
+		NativeHandle Constructor (IMTLDevice device, bool transpose, nuint rows, nuint columns, double alpha, double beta);
 
 		[Export ("initWithDevice:rows:columns:")]
-		IntPtr Constructor (IMTLDevice device, nuint rows, nuint columns);
+		NativeHandle Constructor (IMTLDevice device, nuint rows, nuint columns);
 
 		[Export ("encodeToCommandBuffer:inputMatrix:inputVector:resultVector:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, MPSMatrix inputMatrix, MPSVector inputVector, MPSVector resultVector);
@@ -2288,11 +2292,11 @@ namespace MetalPerformanceShaders {
 		// inlining ctor from base class
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2300,7 +2304,7 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // According to docs needs a Metal Device so initWithDevice: makes more sense.
 	interface MPSMatrixSolveTriangular {
 		[Export ("initWithDevice:right:upper:transpose:unit:order:numberOfRightHandSides:alpha:")]
-		IntPtr Constructor (IMTLDevice device, bool right, bool upper, bool transpose, bool unit, nuint order, nuint numberOfRightHandSides, double alpha);
+		NativeHandle Constructor (IMTLDevice device, bool right, bool upper, bool transpose, bool unit, nuint order, nuint numberOfRightHandSides, double alpha);
 
 		[Export ("encodeToCommandBuffer:sourceMatrix:rightHandSideMatrix:solutionMatrix:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, MPSMatrix sourceMatrix, MPSMatrix rightHandSideMatrix, MPSMatrix solutionMatrix);
@@ -2308,11 +2312,11 @@ namespace MetalPerformanceShaders {
 		// inlining ctor from base class
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2320,7 +2324,7 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // According to docs needs a Metal Device so initWithDevice: makes more sense.
 	interface MPSMatrixSolveLU {
 		[Export ("initWithDevice:transpose:order:numberOfRightHandSides:")]
-		IntPtr Constructor (IMTLDevice device, bool transpose, nuint order, nuint numberOfRightHandSides);
+		NativeHandle Constructor (IMTLDevice device, bool transpose, nuint order, nuint numberOfRightHandSides);
 
 		[Export ("encodeToCommandBuffer:sourceMatrix:rightHandSideMatrix:pivotIndices:solutionMatrix:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, MPSMatrix sourceMatrix, MPSMatrix rightHandSideMatrix, MPSMatrix pivotIndices, MPSMatrix solutionMatrix);
@@ -2328,11 +2332,11 @@ namespace MetalPerformanceShaders {
 		// inlining ctor from base class
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2340,7 +2344,7 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // According to docs needs a Metal Device so initWithDevice: makes more sense.
 	interface MPSMatrixSolveCholesky {
 		[Export ("initWithDevice:upper:order:numberOfRightHandSides:")]
-		IntPtr Constructor (IMTLDevice device, bool upper, nuint order, nuint numberOfRightHandSides);
+		NativeHandle Constructor (IMTLDevice device, bool upper, nuint order, nuint numberOfRightHandSides);
 
 		[Export ("encodeToCommandBuffer:sourceMatrix:rightHandSideMatrix:solutionMatrix:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, MPSMatrix sourceMatrix, MPSMatrix rightHandSideMatrix, MPSMatrix solutionMatrix);
@@ -2348,11 +2352,11 @@ namespace MetalPerformanceShaders {
 		// inlining ctor from base class
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2360,7 +2364,7 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // According to docs needs a Metal Device so initWithDevice: makes more sense.
 	interface MPSMatrixDecompositionLU {
 		[Export ("initWithDevice:rows:columns:")]
-		IntPtr Constructor (IMTLDevice device, nuint rows, nuint columns);
+		NativeHandle Constructor (IMTLDevice device, nuint rows, nuint columns);
 
 		[Export ("encodeToCommandBuffer:sourceMatrix:resultMatrix:pivotIndices:status:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, MPSMatrix sourceMatrix, MPSMatrix resultMatrix, MPSMatrix pivotIndices, [NullAllowed] IMTLBuffer status);
@@ -2368,11 +2372,11 @@ namespace MetalPerformanceShaders {
 		// inlining ctor from base class
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2380,7 +2384,7 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // According to docs needs a Metal Device so initWithDevice: makes more sense.
 	interface MPSMatrixDecompositionCholesky {
 		[Export ("initWithDevice:lower:order:")]
-		IntPtr Constructor (IMTLDevice device, bool lower, nuint order);
+		NativeHandle Constructor (IMTLDevice device, bool lower, nuint order);
 
 		[Export ("encodeToCommandBuffer:sourceMatrix:resultMatrix:status:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, MPSMatrix sourceMatrix, MPSMatrix resultMatrix, [NullAllowed] IMTLBuffer status);
@@ -2388,11 +2392,11 @@ namespace MetalPerformanceShaders {
 		// inlining ctor from base class
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2405,14 +2409,14 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:count:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint count);
+		NativeHandle Constructor (IMTLDevice device, nuint count);
 
 		[Export ("setCopyOperationAtIndex:sourceMatrix:destinationMatrix:offsets:")]
 		void SetCopyOperation (nuint index, MPSMatrix sourceMatrix, MPSMatrix destinationMatrix, MPSMatrixCopyOffsets offsets);
 
 		[Export ("initWithSourceMatrices:destinationMatrices:offsetVector:offset:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSMatrix[] sourceMatrices, MPSMatrix[] destinationMatrices, [NullAllowed] MPSVector offsets, nuint byteOffset);
+		NativeHandle Constructor (MPSMatrix[] sourceMatrices, MPSMatrix[] destinationMatrices, [NullAllowed] MPSVector offsets, nuint byteOffset);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2421,7 +2425,7 @@ namespace MetalPerformanceShaders {
 	interface MPSMatrixCopy {
 		[Export ("initWithDevice:copyRows:copyColumns:sourcesAreTransposed:destinationsAreTransposed:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint copyRows, nuint copyColumns, bool areSourcesTransposed, bool areDestinationsTransposed);
+		NativeHandle Constructor (IMTLDevice device, nuint copyRows, nuint copyColumns, bool areSourcesTransposed, bool areDestinationsTransposed);
 
 		[Export ("copyRows")]
 		nuint CopyRows { get; }
@@ -2444,7 +2448,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (13,0), Mac (10,15), iOS (13,0)]
@@ -2505,21 +2509,21 @@ namespace MetalPerformanceShaders {
 	interface MPSMatrixRandomMtgp32
 	{
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithDevice:destinationDataType:seed:distributionDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSDataType destinationDataType, nuint seed, MPSMatrixRandomDistributionDescriptor distributionDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSDataType destinationDataType, nuint seed, MPSMatrixRandomDistributionDescriptor distributionDescriptor);
 
 		[Export ("synchronizeStateOnCommandBuffer:")]
 		void Synchronize (IMTLCommandBuffer commandBuffer);
 
 		[Export ("initWithDevice:destinationDataType:seed:")]
-		IntPtr Constructor (IMTLDevice device, MPSDataType destinationDataType, nuint seed);
+		NativeHandle Constructor (IMTLDevice device, MPSDataType destinationDataType, nuint seed);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[DisableDefaultCtor]
@@ -2528,18 +2532,18 @@ namespace MetalPerformanceShaders {
 	interface MPSMatrixRandomPhilox
 	{
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithDevice:destinationDataType:seed:distributionDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSDataType destinationDataType, nuint seed, MPSMatrixRandomDistributionDescriptor distributionDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSDataType destinationDataType, nuint seed, MPSMatrixRandomDistributionDescriptor distributionDescriptor);
 
 		[Export ("initWithDevice:destinationDataType:seed:")]
-		IntPtr Constructor (IMTLDevice device, MPSDataType destinationDataType, nuint seed);
+		NativeHandle Constructor (IMTLDevice device, MPSDataType destinationDataType, nuint seed);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 
@@ -2558,11 +2562,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:dataLayout:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSDataLayout dataLayout);
+		NativeHandle Constructor (IMTLDevice device, MPSDataLayout dataLayout);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:sourceImage:destinationMatrix:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, MPSImage sourceImage, MPSMatrix destinationMatrix);
@@ -2581,11 +2585,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:info:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSImageKeypointRangeInfo info);
+		NativeHandle Constructor (IMTLDevice device, MPSImageKeypointRangeInfo info);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:sourceTexture:regions:numberOfRegions:keypointCountBuffer:keypointCountBufferOffset:keypointDataBuffer:keypointDataBufferOffset:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, IMTLTexture source, MTLRegion regions, nuint numberOfRegions, IMTLBuffer keypointCountBuffer, nuint keypointCountBufferOffset, IMTLBuffer keypointDataBuffer, nuint keypointDataBufferOffset);
@@ -2623,7 +2627,7 @@ namespace MetalPerformanceShaders {
 		//inlining ctor from base class
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2632,7 +2636,7 @@ namespace MetalPerformanceShaders {
 	interface MPSImageAdd {
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2641,7 +2645,7 @@ namespace MetalPerformanceShaders {
 	interface MPSImageSubtract {
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2650,7 +2654,7 @@ namespace MetalPerformanceShaders {
 	interface MPSImageMultiply {
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2659,7 +2663,7 @@ namespace MetalPerformanceShaders {
 	interface MPSImageDivide {
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2668,7 +2672,7 @@ namespace MetalPerformanceShaders {
 	interface MPSImageScale {
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// scaleTransform property should be like:
 		// unsafe MPSScaleTransform* ScaleTransform { get; set; }
@@ -2683,7 +2687,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2692,11 +2696,11 @@ namespace MetalPerformanceShaders {
 	interface MPSImageBilinearScale {
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2708,11 +2712,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2724,11 +2728,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2740,11 +2744,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2772,7 +2776,7 @@ namespace MetalPerformanceShaders {
 	interface MPSCnnBinaryKernel {
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("primaryOffset", ArgumentSemantic.Assign)]
 		MPSOffset PrimaryOffset { get; set; }
@@ -2885,7 +2889,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:primaryImage:secondaryImage:destinationImage:")]
 		void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, MPSImage primaryImage, MPSImage secondaryImage, MPSImage destinationImage);
@@ -2953,12 +2957,12 @@ namespace MetalPerformanceShaders {
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 
 		// inlining ctor from base class
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2976,12 +2980,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:a:b:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, float a, float b);
+		NativeHandle Constructor (IMTLDevice device, float a, float b);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -2998,12 +3002,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:a:b:")]
-		IntPtr Constructor (IMTLDevice device, float a, float b);
+		NativeHandle Constructor (IMTLDevice device, float a, float b);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3015,12 +3019,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3034,12 +3038,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:a:")]
-		IntPtr Constructor (IMTLDevice device, float a);
+		NativeHandle Constructor (IMTLDevice device, float a);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3056,12 +3060,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:a:b:")]
-		IntPtr Constructor (IMTLDevice device, float a, float b);
+		NativeHandle Constructor (IMTLDevice device, float a, float b);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3073,12 +3077,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:a:b:c:")]
-		IntPtr Constructor (IMTLDevice device, float a, float b, float c);
+		NativeHandle Constructor (IMTLDevice device, float a, float b, float c);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3090,12 +3094,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:a:b:c:")]
-		IntPtr Constructor (IMTLDevice device, float a, float b, float c);
+		NativeHandle Constructor (IMTLDevice device, float a, float b, float c);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3107,12 +3111,12 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Please use '.ctor (IMTLDevice, MPSNNNeuronDescriptor)' overload instead.")]
 		[Export ("initWithDevice:a:b:c:")]
-		IntPtr Constructor (IMTLDevice device, float a, float b, float c);
+		NativeHandle Constructor (IMTLDevice device, float a, float b, float c);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3156,11 +3160,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:weights:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
+		NativeHandle Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Export ("encodeToCommandBuffer:sourceImage:convolutionGradientState:")]
@@ -3190,14 +3194,14 @@ namespace MetalPerformanceShaders {
 		nuint OutputFeatureChannels { get; }
 
 		[Export ("initWithDevice:convolutionData:scaleValue:type:flags:")]
-		IntPtr Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource convolutionData, float scaleValue, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags);
+		NativeHandle Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource convolutionData, float scaleValue, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags);
 
 		[Internal, Sealed, Export ("initWithDevice:convolutionData:outputBiasTerms:outputScaleTerms:inputBiasTerms:inputScaleTerms:type:flags:")]
 		IntPtr InitWithDevice (IMTLDevice device, IMPSCnnConvolutionDataSource convolutionData, [NullAllowed] IntPtr /* float* */ outputBiasTerms, [NullAllowed] IntPtr /* float* */ outputScaleTerms, [NullAllowed] IntPtr /* float* */ inputBiasTerms, [NullAllowed] IntPtr /* float* */ inputScaleTerms,MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3205,14 +3209,14 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor]
 	interface MPSCnnBinaryFullyConnected {
 		[Export ("initWithDevice:convolutionData:scaleValue:type:flags:")]
-		IntPtr Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource convolutionData, float scaleValue, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags);
+		NativeHandle Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource convolutionData, float scaleValue, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags);
 
 		[Internal, Sealed, Export ("initWithDevice:convolutionData:outputBiasTerms:outputScaleTerms:inputBiasTerms:inputScaleTerms:type:flags:")]
 		IntPtr InitWithDevice (IMTLDevice device, IMPSCnnConvolutionDataSource convolutionData, [NullAllowed] IntPtr /* float* */ outputBiasTerms, [NullAllowed] IntPtr /* float* */ outputScaleTerms, [NullAllowed] IntPtr /* float* */ inputBiasTerms, [NullAllowed] IntPtr /* float* */ inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3221,11 +3225,11 @@ namespace MetalPerformanceShaders {
 	interface MPSCnnPoolingL2Norm {
 		[Export ("initWithDevice:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3240,11 +3244,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:dilationRateX:dilationRateY:strideInPixelsX:strideInPixelsY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint dilationRateX, nuint dilationRateY, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint dilationRateX, nuint dilationRateY, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3256,15 +3260,15 @@ namespace MetalPerformanceShaders {
 		MTLSize SourceSize { get; set; }
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3280,11 +3284,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3294,11 +3298,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3308,11 +3312,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3322,11 +3326,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:dilationRateX:dilationRateY:strideInPixelsX:strideInPixelsY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint dilationRateX, nuint dilationRateY, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight, nuint dilationRateX, nuint dilationRateY, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3346,7 +3350,7 @@ namespace MetalPerformanceShaders {
 		// inlining ctor from base class
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3355,7 +3359,7 @@ namespace MetalPerformanceShaders {
 	interface MPSCnnUpsamplingNearest {
 		[Export ("initWithDevice:integerScaleFactorX:integerScaleFactorY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint integerScaleFactorX, nuint integerScaleFactorY);
+		NativeHandle Constructor (IMTLDevice device, nuint integerScaleFactorX, nuint integerScaleFactorY);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3363,12 +3367,12 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // failed assertion.
 	interface MPSCnnUpsamplingBilinear {
 		[Export ("initWithDevice:integerScaleFactorX:integerScaleFactorY:")]
-		IntPtr Constructor (IMTLDevice device, nuint integerScaleFactorX, nuint integerScaleFactorY);
+		NativeHandle Constructor (IMTLDevice device, nuint integerScaleFactorX, nuint integerScaleFactorY);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:integerScaleFactorX:integerScaleFactorY:alignCorners:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint integerScaleFactorX, nuint integerScaleFactorY, bool alignCorners);
+		NativeHandle Constructor (IMTLDevice device, nuint integerScaleFactorX, nuint integerScaleFactorY, bool alignCorners);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3384,11 +3388,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3398,7 +3402,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:integerScaleFactorX:integerScaleFactorY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint integerScaleFactorX, nuint integerScaleFactorY);
+		NativeHandle Constructor (IMTLDevice device, nuint integerScaleFactorX, nuint integerScaleFactorY);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3408,7 +3412,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:integerScaleFactorX:integerScaleFactorY:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint integerScaleFactorX, nuint integerScaleFactorY);
+		NativeHandle Constructor (IMTLDevice device, nuint integerScaleFactorX, nuint integerScaleFactorY);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3576,11 +3580,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:rnnDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSRnnDescriptor rnnDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSRnnDescriptor rnnDescriptor);
 
 		[Export ("initWithDevice:rnnDescriptors:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSRnnDescriptor[] rnnDescriptors);
+		NativeHandle Constructor (IMTLDevice device, MPSRnnDescriptor[] rnnDescriptors);
 
 		[Export ("encodeSequenceToCommandBuffer:sourceImages:destinationImages:recurrentInputState:recurrentOutputStates:")]
 		void EncodeSequence (IMTLCommandBuffer commandBuffer, MPSImage[] sourceImages, MPSImage[] destinationImages, [NullAllowed] MPSRnnRecurrentImageState recurrentInputState, [NullAllowed] NSMutableArray<MPSRnnRecurrentImageState> recurrentOutputStates);
@@ -3590,7 +3594,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release ()]
@@ -3634,11 +3638,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:rnnDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSRnnDescriptor rnnDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSRnnDescriptor rnnDescriptor);
 
 		[Export ("initWithDevice:rnnDescriptors:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSRnnDescriptor[] rnnDescriptors);
+		NativeHandle Constructor (IMTLDevice device, MPSRnnDescriptor[] rnnDescriptors);
 
 		[Export ("encodeSequenceToCommandBuffer:sourceMatrices:destinationMatrices:recurrentInputState:recurrentOutputStates:")]
 		void EncodeSequence (IMTLCommandBuffer commandBuffer, MPSMatrix[] sourceMatrices, MPSMatrix[] destinationMatrices, [NullAllowed] MPSRnnRecurrentMatrixState recurrentInputState, [NullAllowed] NSMutableArray<MPSRnnRecurrentMatrixState> recurrentOutputStates);
@@ -3652,7 +3656,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release ()]
@@ -3665,7 +3669,7 @@ namespace MetalPerformanceShaders {
 	interface MPSNNImageNode {
 		[Export ("initWithHandle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] IMPSHandle handle);
+		NativeHandle Constructor ([NullAllowed] IMPSHandle handle);
 
 		[Static]
 		[Export ("nodeWithHandle:")]
@@ -3775,7 +3779,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnConvolutionNode Create (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights);
 
 		[Export ("initWithSource:weights:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights);
 
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[NullAllowed, Export ("convolutionGradientState")]
@@ -3791,7 +3795,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnFullyConnectedNode Create (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights);
 
 		[Export ("initWithSource:weights:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3803,7 +3807,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnBinaryConvolutionNode Create (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float scaleValue,MPSCnnBinaryConvolutionType type,MPSCnnBinaryConvolutionFlags flags);
 
 		[Export ("initWithSource:weights:scaleValue:type:flags:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float scaleValue,MPSCnnBinaryConvolutionType type,MPSCnnBinaryConvolutionFlags flags);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float scaleValue,MPSCnnBinaryConvolutionType type,MPSCnnBinaryConvolutionFlags flags);
 
 		[Internal]
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3826,7 +3830,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnBinaryFullyConnectedNode Create (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float scaleValue,MPSCnnBinaryConvolutionType type,MPSCnnBinaryConvolutionFlags flags);
 
 		[Export ("initWithSource:weights:scaleValue:type:flags:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float scaleValue,MPSCnnBinaryConvolutionType type,MPSCnnBinaryConvolutionFlags flags);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float scaleValue,MPSCnnBinaryConvolutionType type,MPSCnnBinaryConvolutionFlags flags);
 
 		[Internal]
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3851,7 +3855,7 @@ namespace MetalPerformanceShaders {
 
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Export ("initWithSource:convolutionGradientState:weights:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, [NullAllowed] MPSCnnConvolutionGradientStateNode convolutionGradientState, IMPSCnnConvolutionDataSource weights);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, [NullAllowed] MPSCnnConvolutionGradientStateNode convolutionGradientState, IMPSCnnConvolutionDataSource weights);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3864,7 +3868,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnConvolutionGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSCnnConvolutionGradientStateNode gradientState, [NullAllowed] IMPSCnnConvolutionDataSource weights);
 
 		[Export ("initWithSourceGradient:sourceImage:convolutionGradientState:weights:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSCnnConvolutionGradientStateNode gradientState, [NullAllowed] IMPSCnnConvolutionDataSource weights);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSCnnConvolutionGradientStateNode gradientState, [NullAllowed] IMPSCnnConvolutionDataSource weights);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -3898,14 +3902,14 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronPowerNode Create (MPSNNImageNode sourceNode, float a, float b, float c);
 
 		[Export ("initWithSource:a:b:c:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, float a, float b, float c);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, float a, float b, float c);
 
 		[Static]
 		[Export ("nodeWithSource:")]
 		MPSCnnNeuronPowerNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3918,14 +3922,14 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronExponentialNode Create (MPSNNImageNode sourceNode, float a, float b, float c);
 
 		[Export ("initWithSource:a:b:c:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, float a, float b, float c);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, float a, float b, float c);
 
 		[Static]
 		[Export ("nodeWithSource:")]
 		MPSCnnNeuronExponentialNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3938,14 +3942,14 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronLogarithmNode Create (MPSNNImageNode sourceNode, float a, float b, float c);
 
 		[Export ("initWithSource:a:b:c:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, float a, float b, float c);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, float a, float b, float c);
 
 		[Static]
 		[Export ("nodeWithSource:")]
 		MPSCnnNeuronLogarithmNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -3958,7 +3962,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, MPSNNNeuronDescriptor descriptor);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:descriptor:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, MPSNNNeuronDescriptor descriptor);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, MPSNNNeuronDescriptor descriptor);
 
 		[Export ("descriptor")]
 		MPSNNNeuronDescriptor Descriptor { get; }
@@ -3977,7 +3981,7 @@ namespace MetalPerformanceShaders {
 		MPSNNUnaryReductionNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -3990,7 +3994,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionRowMinNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4003,7 +4007,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionColumnMinNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4016,7 +4020,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionFeatureChannelsMinNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4029,7 +4033,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionFeatureChannelsArgumentMinNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4042,7 +4046,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionRowMaxNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4055,7 +4059,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionColumnMaxNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4068,7 +4072,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionFeatureChannelsMaxNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4081,7 +4085,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionFeatureChannelsArgumentMaxNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4094,7 +4098,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionRowMeanNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4107,7 +4111,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionColumnMeanNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4120,7 +4124,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionFeatureChannelsMeanNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4133,7 +4137,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionSpatialMeanNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4146,7 +4150,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionRowSumNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4159,7 +4163,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionColumnSumNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -4172,7 +4176,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionFeatureChannelsSumNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 
 		[Export ("weight")]
 		float Weight { get; set; }
@@ -4187,7 +4191,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronAbsoluteNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4203,10 +4207,10 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronEluNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:a:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, float a);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, float a);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4218,14 +4222,14 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronReLunNode Create (MPSNNImageNode sourceNode, float a, float b);
 
 		[Export ("initWithSource:a:b:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, float a, float b);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, float a, float b);
 
 		[Static]
 		[Export ("nodeWithSource:")]
 		MPSCnnNeuronReLunNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4240,14 +4244,14 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 12, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithSource:a:b:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, float a, float b);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, float a, float b);
 
 		[Static]
 		[Export ("nodeWithSource:")]
 		MPSCnnNeuronLinearNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4263,10 +4267,10 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronReLUNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:a:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, float a);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, float a);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4278,7 +4282,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronSigmoidNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4290,14 +4294,14 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronHardSigmoidNode Create (MPSNNImageNode sourceNode, float a, float b);
 
 		[Export ("initWithSource:a:b:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, float a, float b);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, float a, float b);
 
 		[Static]
 		[Export ("nodeWithSource:")]
 		MPSCnnNeuronHardSigmoidNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4309,14 +4313,14 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronSoftPlusNode Create (MPSNNImageNode sourceNode, float a, float b);
 
 		[Export ("initWithSource:a:b:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, float a, float b);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, float a, float b);
 
 		[Static]
 		[Export ("nodeWithSource:")]
 		MPSCnnNeuronSoftPlusNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4328,7 +4332,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronSoftSignNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4340,14 +4344,14 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronTanHNode Create (MPSNNImageNode sourceNode, float a, float b);
 
 		[Export ("initWithSource:a:b:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, float a, float b);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, float a, float b);
 
 		[Static]
 		[Export ("nodeWithSource:")]
 		MPSCnnNeuronTanHNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4359,7 +4363,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnNeuronPReLUNode Create (MPSNNImageNode sourceNode, NSData aData);
 
 		[Export ("initWithSource:aData:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, NSData aData);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, NSData aData);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4392,13 +4396,13 @@ namespace MetalPerformanceShaders {
 		MPSCnnPoolingNode Create (MPSNNImageNode sourceNode, nuint size, nuint stride);
 
 		[Export ("initWithSource:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithSource:filterSize:stride:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint size, nuint stride);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint size, nuint stride);
 
 		[Export ("initWithSource:filterSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint size);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -4411,7 +4415,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnPoolingGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:paddingPolicy:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
 
 		[Export ("kernelWidth")]
 		nuint KernelWidth { get; }
@@ -4436,7 +4440,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnPoolingMaxGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:paddingPolicy:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -4449,7 +4453,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnPoolingAverageGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:paddingPolicy:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -4462,7 +4466,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnPoolingL2NormGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:paddingPolicy:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, [NullAllowed] IMPSNNPadding paddingPolicy);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -4475,7 +4479,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnDilatedPoolingMaxGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, nuint dilationRateX, nuint dilationRateY);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:dilationRateX:dilationRateY:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, nuint dilationRateX, nuint dilationRateY);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, nuint dilationRateX, nuint dilationRateY);
 
 		[Export ("dilationRateX")]
 		nuint DilationRateX { get; }
@@ -4500,7 +4504,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnSpatialNormalizationGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelSize);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:kernelSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelSize);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelSize);
 
 		[Export ("alpha")]
 		float Alpha { get; set; }
@@ -4522,7 +4526,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnLocalContrastNormalizationGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:kernelWidth:kernelHeight:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelWidth, nuint kernelHeight);
 
 		[Export ("alpha")]
 		float Alpha { get; set; }
@@ -4559,7 +4563,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnCrossChannelNormalizationGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelSize);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:kernelSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelSize);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, nuint kernelSize);
 
 		[Export ("kernelSize")]
 		nuint KernelSize { get; }
@@ -4575,7 +4579,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnInstanceNormalizationNode Create (MPSNNImageNode source, IMPSCnnInstanceNormalizationDataSource dataSource);
 
 		[Export ("initWithSource:dataSource:")]
-		IntPtr Constructor (MPSNNImageNode source, IMPSCnnInstanceNormalizationDataSource dataSource);
+		NativeHandle Constructor (MPSNNImageNode source, IMPSCnnInstanceNormalizationDataSource dataSource);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -4588,7 +4592,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnInstanceNormalizationGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -4604,7 +4608,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnBatchNormalizationNode Create (MPSNNImageNode source, IMPSCnnBatchNormalizationDataSource dataSource);
 
 		[Export ("initWithSource:dataSource:")]
-		IntPtr Constructor (MPSNNImageNode source, IMPSCnnBatchNormalizationDataSource dataSource);
+		NativeHandle Constructor (MPSNNImageNode source, IMPSCnnBatchNormalizationDataSource dataSource);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -4617,7 +4621,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnBatchNormalizationGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4639,13 +4643,13 @@ namespace MetalPerformanceShaders {
 		MPSCnnDilatedPoolingMaxNode Create (MPSNNImageNode sourceNode, nuint size, nuint stride, nuint dilationRate);
 
 		[Export ("initWithSource:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:dilationRateX:dilationRateY:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, nuint dilationRateX, nuint dilationRateY);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY, nuint dilationRateX, nuint dilationRateY);
 
 		[Export ("initWithSource:filterSize:stride:dilationRate:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint size, nuint stride, nuint dilationRate);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint size, nuint stride, nuint dilationRate);
 
 		[Export ("initWithSource:filterSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint size);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4667,7 +4671,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithSource:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4686,11 +4690,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithSource:kernelSize:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint kernelSize);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint kernelSize);
 
 		[Export ("initWithSource:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4718,11 +4722,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithSource:kernelSize:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint kernelSize);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint kernelSize);
 
 		[Export ("initWithSource:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4738,11 +4742,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithSource:kernelSize:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint kernelSize);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint kernelSize);
 
 		[Export ("initWithSource:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4758,10 +4762,10 @@ namespace MetalPerformanceShaders {
 		MPSNNScaleNode Create (MPSNNImageNode sourceNode, [NullAllowed] IMPSImageTransformProvider transformProvider, MTLSize size);
 
 		[Export ("initWithSource:outputSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, MTLSize size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, MTLSize size);
 
 		[Export ("initWithSource:transformProvider:outputSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, [NullAllowed] IMPSImageTransformProvider transformProvider, MTLSize size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, [NullAllowed] IMPSImageTransformProvider transformProvider, MTLSize size);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -4777,10 +4781,10 @@ namespace MetalPerformanceShaders {
 		MPSNNBinaryArithmeticNode Create (MPSNNImageNode left, MPSNNImageNode right);
 
 		[Export ("initWithSources:")]
-		IntPtr Constructor (MPSNNImageNode[] sourceNodes);
+		NativeHandle Constructor (MPSNNImageNode[] sourceNodes);
 
 		[Export ("initWithLeftSource:rightSource:")]
-		IntPtr Constructor (MPSNNImageNode left, MPSNNImageNode right);
+		NativeHandle Constructor (MPSNNImageNode left, MPSNNImageNode right);
 
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Export ("gradientClass")]
@@ -4843,10 +4847,10 @@ namespace MetalPerformanceShaders {
 		MPSNNArithmeticGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:isSecondarySourceFilter:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
 
 		[Export ("initWithGradientImages:forwardFilter:isSecondarySourceFilter:")]
-		IntPtr Constructor (MPSNNImageNode[] gradientImages, MPSNNFilterNode filter, bool isSecondarySourceFilter);
+		NativeHandle Constructor (MPSNNImageNode[] gradientImages, MPSNNFilterNode filter, bool isSecondarySourceFilter);
 
 		[Export ("primaryScale")]
 		float PrimaryScale { get; set; }
@@ -4886,10 +4890,10 @@ namespace MetalPerformanceShaders {
 		MPSNNAdditionGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:isSecondarySourceFilter:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
 
 		[Export ("initWithGradientImages:forwardFilter:isSecondarySourceFilter:")]
-		IntPtr Constructor (MPSNNImageNode[] gradientImages, MPSNNFilterNode filter, bool isSecondarySourceFilter);
+		NativeHandle Constructor (MPSNNImageNode[] gradientImages, MPSNNFilterNode filter, bool isSecondarySourceFilter);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -4902,10 +4906,10 @@ namespace MetalPerformanceShaders {
 		MPSNNSubtractionGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:isSecondarySourceFilter:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
 
 		[Export ("initWithGradientImages:forwardFilter:isSecondarySourceFilter:")]
-		IntPtr Constructor (MPSNNImageNode[] gradientImages, MPSNNFilterNode filter, bool isSecondarySourceFilter);
+		NativeHandle Constructor (MPSNNImageNode[] gradientImages, MPSNNFilterNode filter, bool isSecondarySourceFilter);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -4918,10 +4922,10 @@ namespace MetalPerformanceShaders {
 		MPSNNMultiplicationGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:isSecondarySourceFilter:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNBinaryGradientStateNode gradientState, bool isSecondarySourceFilter);
 
 		[Export ("initWithGradientImages:forwardFilter:isSecondarySourceFilter:")]
-		IntPtr Constructor (MPSNNImageNode[] gradientImages, MPSNNFilterNode filter, bool isSecondarySourceFilter);
+		NativeHandle Constructor (MPSNNImageNode[] gradientImages, MPSNNFilterNode filter, bool isSecondarySourceFilter);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -4934,14 +4938,14 @@ namespace MetalPerformanceShaders {
 		MPSCnnDropoutNode Create (MPSNNImageNode source);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode source);
+		NativeHandle Constructor (MPSNNImageNode source);
 
 		[Static]
 		[Export ("nodeWithSource:keepProbability:")]
 		MPSCnnDropoutNode Create (MPSNNImageNode source, float keepProbability);
 
 		[Export ("initWithSource:keepProbability:")]
-		IntPtr Constructor (MPSNNImageNode source, float keepProbability);
+		NativeHandle Constructor (MPSNNImageNode source, float keepProbability);
 
 		[Static]
 		[Export ("nodeWithSource:keepProbability:seed:maskStrideInPixels:")]
@@ -4949,7 +4953,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithSource:keepProbability:seed:maskStrideInPixels:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSNNImageNode source, float keepProbability, nuint seed, MTLSize maskStrideInPixels);
+		NativeHandle Constructor (MPSNNImageNode source, float keepProbability, nuint seed, MTLSize maskStrideInPixels);
 
 		[Export ("keepProbability")]
 		float KeepProbability { get; }
@@ -4971,7 +4975,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnDropoutGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, float keepProbability, nuint seed, MTLSize maskStrideInPixels);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:keepProbability:seed:maskStrideInPixels:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, float keepProbability, nuint seed, MTLSize maskStrideInPixels);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, float keepProbability, nuint seed, MTLSize maskStrideInPixels);
 
 		[Export ("keepProbability")]
 		float KeepProbability { get; }
@@ -5000,7 +5004,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnLossNode Create (MPSNNImageNode source, MPSCnnLossDescriptor descriptor);
 
 		[Export ("initWithSource:lossDescriptor:")]
-		IntPtr Constructor (MPSNNImageNode source, MPSCnnLossDescriptor descriptor);
+		NativeHandle Constructor (MPSNNImageNode source, MPSCnnLossDescriptor descriptor);
 
 		[Export ("inputLabels", ArgumentSemantic.Retain)]
 		MPSNNLabelsNode InputLabels { get; }
@@ -5017,7 +5021,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnYoloLossNode Create (MPSNNImageNode source, MPSCnnYoloLossDescriptor descriptor);
 
 		[Export ("initWithSource:lossDescriptor:")]
-		IntPtr Constructor (MPSNNImageNode source, MPSCnnYoloLossDescriptor descriptor);
+		NativeHandle Constructor (MPSNNImageNode source, MPSCnnYoloLossDescriptor descriptor);
 
 		[Export ("inputLabels", ArgumentSemantic.Retain)]
 		MPSNNLabelsNode InputLabels { get; }
@@ -5032,7 +5036,7 @@ namespace MetalPerformanceShaders {
 		MPSNNConcatenationNode Create (MPSNNImageNode[] sourceNodes);
 
 		[Export ("initWithSources:")]
-		IntPtr Constructor (MPSNNImageNode[] sourceNodes);
+		NativeHandle Constructor (MPSNNImageNode[] sourceNodes);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -5045,7 +5049,7 @@ namespace MetalPerformanceShaders {
 		MPSNNConcatenationGradientNode Create (MPSNNImageNode gradientSourceNode, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:")]
-		IntPtr Constructor (MPSNNImageNode gradientSourceNode, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
+		NativeHandle Constructor (MPSNNImageNode gradientSourceNode, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -5058,7 +5062,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReshapeNode Create (MPSNNImageNode source, nuint resultWidth, nuint resultHeight, nuint resultFeatureChannels);
 
 		[Export ("initWithSource:resultWidth:resultHeight:resultFeatureChannels:")]
-		IntPtr Constructor (MPSNNImageNode source, nuint resultWidth, nuint resultHeight, nuint resultFeatureChannels);
+		NativeHandle Constructor (MPSNNImageNode source, nuint resultWidth, nuint resultHeight, nuint resultFeatureChannels);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -5071,7 +5075,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReshapeGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -5084,7 +5088,7 @@ namespace MetalPerformanceShaders {
 		MPSNNReductionSpatialMeanGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -5100,7 +5104,7 @@ namespace MetalPerformanceShaders {
 		MPSNNPadNode Create (MPSNNImageNode source, MPSImageCoordinate paddingSizeBefore, MPSImageCoordinate paddingSizeAfter, MPSImageEdgeMode edgeMode);
 
 		[Export ("initWithSource:paddingSizeBefore:paddingSizeAfter:edgeMode:")]
-		IntPtr Constructor (MPSNNImageNode source, MPSImageCoordinate paddingSizeBefore, MPSImageCoordinate paddingSizeAfter, MPSImageEdgeMode edgeMode);
+		NativeHandle Constructor (MPSNNImageNode source, MPSImageCoordinate paddingSizeBefore, MPSImageCoordinate paddingSizeAfter, MPSImageEdgeMode edgeMode);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -5113,7 +5117,7 @@ namespace MetalPerformanceShaders {
 		MPSNNPadGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -5126,7 +5130,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnSoftMaxGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -5139,7 +5143,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnLogSoftMaxGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -5151,7 +5155,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnSoftMaxNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -5163,7 +5167,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnLogSoftMaxNode Create (MPSNNImageNode sourceNode);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode);
+		NativeHandle Constructor (MPSNNImageNode sourceNode);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -5175,7 +5179,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnUpsamplingNearestNode Create (MPSNNImageNode sourceNode, nuint integerScaleFactorX, nuint integerScaleFactorY);
 
 		[Export ("initWithSource:integerScaleFactorX:integerScaleFactorY:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint integerScaleFactorX, nuint integerScaleFactorY);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint integerScaleFactorX, nuint integerScaleFactorY);
 
 		[Export ("scaleFactorX")]
 		double ScaleFactorX { get; }
@@ -5198,11 +5202,11 @@ namespace MetalPerformanceShaders {
 		MPSCnnUpsamplingBilinearNode Create (MPSNNImageNode sourceNode, nuint integerScaleFactorX, nuint integerScaleFactorY, bool alignCorners);
 
 		[Export ("initWithSource:integerScaleFactorX:integerScaleFactorY:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint integerScaleFactorX, nuint integerScaleFactorY);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint integerScaleFactorX, nuint integerScaleFactorY);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithSource:integerScaleFactorX:integerScaleFactorY:alignCorners:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint integerScaleFactorX, nuint integerScaleFactorY, bool alignCorners);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint integerScaleFactorX, nuint integerScaleFactorY, bool alignCorners);
 
 		[Export ("scaleFactorX")]
 		double ScaleFactorX { get; }
@@ -5225,7 +5229,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnUpsamplingNearestGradientNode Create (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, double scaleFactorX, double scaleFactorY);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:scaleFactorX:scaleFactorY:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, double scaleFactorX, double scaleFactorY);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, double scaleFactorX, double scaleFactorY);
 
 		[Export ("scaleFactorX")]
 		double ScaleFactorX { get; }
@@ -5244,7 +5248,7 @@ namespace MetalPerformanceShaders {
 		MPSCnnUpsamplingBilinearGradientNode NodeWithSourceGradient (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, double scaleFactorX, double scaleFactorY);
 
 		[Export ("initWithSourceGradient:sourceImage:gradientState:scaleFactorX:scaleFactorY:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, double scaleFactorX, double scaleFactorY);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNGradientStateNode gradientState, double scaleFactorX, double scaleFactorY);
 
 		[Export ("scaleFactorX")]
 		double ScaleFactorX { get; }
@@ -5305,13 +5309,13 @@ namespace MetalPerformanceShaders {
 		MPSNNForwardLossNode Create (MPSNNImageNode[] sourceNodes, MPSCnnLossDescriptor descriptor);
 
 		[Export ("initWithSource:labels:weights:lossDescriptor:")]
-		IntPtr Constructor (MPSNNImageNode source, MPSNNImageNode labels, [NullAllowed] MPSNNImageNode weights, MPSCnnLossDescriptor descriptor);
+		NativeHandle Constructor (MPSNNImageNode source, MPSNNImageNode labels, [NullAllowed] MPSNNImageNode weights, MPSCnnLossDescriptor descriptor);
 
 		[Export ("initWithSource:labels:lossDescriptor:")]
-		IntPtr Constructor (MPSNNImageNode source, MPSNNImageNode labels, MPSCnnLossDescriptor descriptor);
+		NativeHandle Constructor (MPSNNImageNode source, MPSNNImageNode labels, MPSCnnLossDescriptor descriptor);
 
 		[Export ("initWithSources:lossDescriptor:")]
-		IntPtr Constructor (MPSNNImageNode[] sourceNodes, MPSCnnLossDescriptor descriptor);
+		NativeHandle Constructor (MPSNNImageNode[] sourceNodes, MPSCnnLossDescriptor descriptor);
 
 		[Export ("gradientFilterWithSources:")]
 		MPSNNLossGradientNode GetFilter (MPSNNImageNode[] sourceGradient);
@@ -5371,13 +5375,13 @@ namespace MetalPerformanceShaders {
 		MPSNNLossGradientNode Create (MPSNNImageNode[] sourceNodes, [NullAllowed] MPSNNGradientStateNode gradientState, MPSCnnLossDescriptor descriptor, bool isLabelsGradientFilter);
 
 		[Export ("initWithSourceGradient:sourceImage:labels:weights:gradientState:lossDescriptor:isLabelsGradientFilter:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNImageNode labels, [NullAllowed] MPSNNImageNode weights, [NullAllowed] MPSNNGradientStateNode gradientState, MPSCnnLossDescriptor descriptor, bool isLabelsGradientFilter);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNImageNode labels, [NullAllowed] MPSNNImageNode weights, [NullAllowed] MPSNNGradientStateNode gradientState, MPSCnnLossDescriptor descriptor, bool isLabelsGradientFilter);
 
 		[Export ("initWithSourceGradient:sourceImage:labels:gradientState:lossDescriptor:isLabelsGradientFilter:")]
-		IntPtr Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNImageNode labels, [NullAllowed] MPSNNGradientStateNode gradientState, MPSCnnLossDescriptor descriptor, bool isLabelsGradientFilter);
+		NativeHandle Constructor (MPSNNImageNode sourceGradient, MPSNNImageNode sourceImage, MPSNNImageNode labels, [NullAllowed] MPSNNGradientStateNode gradientState, MPSCnnLossDescriptor descriptor, bool isLabelsGradientFilter);
 
 		[Export ("initWithSources:gradientState:lossDescriptor:isLabelsGradientFilter:")]
-		IntPtr Constructor (MPSNNImageNode[] sourceNodes, [NullAllowed] MPSNNGradientStateNode gradientState, MPSCnnLossDescriptor descriptor, bool isLabelsGradientFilter);
+		NativeHandle Constructor (MPSNNImageNode[] sourceNodes, [NullAllowed] MPSNNGradientStateNode gradientState, MPSCnnLossDescriptor descriptor, bool isLabelsGradientFilter);
 	}
 
 	[DisableDefaultCtor]
@@ -5390,7 +5394,7 @@ namespace MetalPerformanceShaders {
 		MPSNNInitialGradientNode Create (MPSNNImageNode source);
 
 		[Export ("initWithSource:")]
-		IntPtr Constructor (MPSNNImageNode source);
+		NativeHandle Constructor (MPSNNImageNode source);
 	}
 
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
@@ -5401,7 +5405,7 @@ namespace MetalPerformanceShaders {
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Export ("initWithDevice:resultImage:resultImageIsNeeded:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNImageNode resultImage, bool resultIsNeeded);
+		NativeHandle Constructor (IMTLDevice device, MPSNNImageNode resultImage, bool resultIsNeeded);
 
 		[TV (11,3), Mac (10,13,4), iOS (11,3)]
 		[Static]
@@ -5413,7 +5417,7 @@ namespace MetalPerformanceShaders {
 		[Deprecated (PlatformName.iOS, 11, 3, message: "Use '.ctor (IMTLDevice, MPSNNImageNode, bool)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, 4, message: "Use '.ctor (IMTLDevice, MPSNNImageNode, bool)' instead.")]
 		[Export ("initWithDevice:resultImage:")]
-		IntPtr Constructor (IMTLDevice device, MPSNNImageNode resultImage);
+		NativeHandle Constructor (IMTLDevice device, MPSNNImageNode resultImage);
 
 		// Not added because the generated constructor is too hard to use
 		// and there is an alternative Create method that accomplishes the same
@@ -5421,7 +5425,7 @@ namespace MetalPerformanceShaders {
 		// [TV (13,0), Mac (10,15), iOS (13,0)]
 		// [Export ("initWithDevice:resultImages:resultsAreNeeded:")]
 		// [DesignatedInitializer]
-		// IntPtr Constructor (IMTLDevice device, MPSNNImageNode[] resultImages, IntPtr resultsAreNeeded);
+		// NativeHandle Constructor (IMTLDevice device, MPSNNImageNode[] resultImages, IntPtr resultsAreNeeded);
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
@@ -5440,7 +5444,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("sourceImageHandles", ArgumentSemantic.Copy)]
 		IMPSHandle[] SourceImageHandles { get; }
@@ -5673,13 +5677,13 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // 'init' is unavailable
 	interface MPSCnnPoolingAverageNode {
 		[Export ("initWithSource:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithSource:filterSize:stride:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint size, nuint stride);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint size, nuint stride);
 
 		[Export ("initWithSource:filterSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint size);
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -5687,13 +5691,13 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // 'init' is unavailable
 	interface MPSCnnPoolingL2NormNode {
 		[Export ("initWithSource:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithSource:filterSize:stride:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint size, nuint stride);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint size, nuint stride);
 
 		[Export ("initWithSource:filterSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint size);
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -5701,13 +5705,13 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // 'init' is unavailable
 	interface MPSCnnPoolingMaxNode {
 		[Export ("initWithSource:kernelWidth:kernelHeight:strideInPixelsX:strideInPixelsY:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint kernelWidth, nuint kernelHeight, nuint strideInPixelsX, nuint strideInPixelsY);
 
 		[Export ("initWithSource:filterSize:stride:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint size, nuint stride);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint size, nuint stride);
 
 		[Export ("initWithSource:filterSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, nuint size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, nuint size);
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -5715,10 +5719,10 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // 'init' is unavailable
 	interface MPSNNAdditionNode {
 		[Export ("initWithSources:")]
-		IntPtr Constructor (MPSNNImageNode[] sourceNodes);
+		NativeHandle Constructor (MPSNNImageNode[] sourceNodes);
 
 		[Export ("initWithLeftSource:rightSource:")]
-		IntPtr Constructor (MPSNNImageNode left, MPSNNImageNode right);
+		NativeHandle Constructor (MPSNNImageNode left, MPSNNImageNode right);
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -5726,10 +5730,10 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // 'init' is unavailable
 	interface MPSNNBilinearScaleNode {
 		[Export ("initWithSource:outputSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, MTLSize size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, MTLSize size);
 
 		[Export ("initWithSource:transformProvider:outputSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, [NullAllowed] IMPSImageTransformProvider transformProvider, MTLSize size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, [NullAllowed] IMPSImageTransformProvider transformProvider, MTLSize size);
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -5737,10 +5741,10 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // 'init' is unavailable
 	interface MPSNNDivisionNode {
 		[Export ("initWithSources:")]
-		IntPtr Constructor (MPSNNImageNode[] sourceNodes);
+		NativeHandle Constructor (MPSNNImageNode[] sourceNodes);
 
 		[Export ("initWithLeftSource:rightSource:")]
-		IntPtr Constructor (MPSNNImageNode left, MPSNNImageNode right);
+		NativeHandle Constructor (MPSNNImageNode left, MPSNNImageNode right);
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -5748,10 +5752,10 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // 'init' is unavailable
 	interface MPSNNLanczosScaleNode {
 		[Export ("initWithSource:outputSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, MTLSize size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, MTLSize size);
 
 		[Export ("initWithSource:transformProvider:outputSize:")]
-		IntPtr Constructor (MPSNNImageNode sourceNode, [NullAllowed] IMPSImageTransformProvider transformProvider, MTLSize size);
+		NativeHandle Constructor (MPSNNImageNode sourceNode, [NullAllowed] IMPSImageTransformProvider transformProvider, MTLSize size);
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -5759,10 +5763,10 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // 'init' is unavailable
 	interface MPSNNMultiplicationNode {
 		[Export ("initWithSources:")]
-		IntPtr Constructor (MPSNNImageNode[] sourceNodes);
+		NativeHandle Constructor (MPSNNImageNode[] sourceNodes);
 
 		[Export ("initWithLeftSource:rightSource:")]
-		IntPtr Constructor (MPSNNImageNode left, MPSNNImageNode right);
+		NativeHandle Constructor (MPSNNImageNode left, MPSNNImageNode right);
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -5770,10 +5774,10 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor] // 'init' is unavailable
 	interface MPSNNSubtractionNode {
 		[Export ("initWithSources:")]
-		IntPtr Constructor (MPSNNImageNode[] sourceNodes);
+		NativeHandle Constructor (MPSNNImageNode[] sourceNodes);
 
 		[Export ("initWithLeftSource:rightSource:")]
-		IntPtr Constructor (MPSNNImageNode left, MPSNNImageNode right);
+		NativeHandle Constructor (MPSNNImageNode left, MPSNNImageNode right);
 	}
 
 	[TV (11,2), Mac (10,13,2), iOS (11,2)]
@@ -5800,7 +5804,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:count:rows:columns:transpose:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint count, nuint rows, nuint columns, bool transpose);
+		NativeHandle Constructor (IMTLDevice device, nuint count, nuint rows, nuint columns, bool transpose);
 
 		[Export ("rows")]
 		nuint Rows { get; }
@@ -5835,7 +5839,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,2), Mac (10,13,2), iOS (11,2)]
@@ -5851,7 +5855,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// Keeping the same name as in the parent class so it ends up in an overload
 		[Export ("encodeToCommandBuffer:inputMatrix:resultMatrix:")]
@@ -5859,7 +5863,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release ()]
@@ -5900,7 +5904,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// Keeping the same name as in the parent class so it ends up in an overload
 		[Export ("encodeToCommandBuffer:inputMatrix:biasVector:resultMatrix:")]
@@ -5908,7 +5912,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release ()]
@@ -5949,14 +5953,14 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:gradientMatrix:inputMatrix:biasVector:resultGradientForDataMatrix:resultGradientForBiasVector:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSMatrix gradientMatrix, MPSMatrix inputMatrix, [NullAllowed] MPSVector biasVector, MPSMatrix resultGradientForDataMatrix, [NullAllowed] MPSVector resultGradientForBiasVector);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release]
@@ -5982,7 +5986,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("encodeGradientForDataToCommandBuffer:gradientMatrix:weightMatrix:resultGradientForDataMatrix:")]
 		void EncodeGradientForData (IMTLCommandBuffer commandBuffer, MPSMatrix gradientMatrix, MPSMatrix weightMatrix, MPSMatrix resultGradientForDataMatrix);
@@ -5992,7 +5996,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release]
@@ -6006,11 +6010,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,2), Mac (10,13,2), iOS (11,2)]
@@ -6047,7 +6051,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// Keeping the same name as in the parent class so it ends up in an overload
 		[Export ("encodeToCommandBuffer:inputMatrix:weightMatrix:biasVector:resultMatrix:")]
@@ -6055,7 +6059,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release ()]
@@ -6081,7 +6085,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:numberOfTopKValues:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint numberOfTopKValues);
+		NativeHandle Constructor (IMTLDevice device, nuint numberOfTopKValues);
 
 		// Keeping the same name as in the parent class so it ends up in an overload
 		[Export ("encodeToCommandBuffer:inputMatrix:resultIndexMatrix:resultValueMatrix:")]
@@ -6089,7 +6093,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release ()]
@@ -6139,7 +6143,7 @@ namespace MetalPerformanceShaders {
 
 		[TV (12,0), iOS (12,0), Mac (10,14)]
 		[Export ("initForReadingFromData:device:error:")]
-		IntPtr Constructor (NSData data, IMTLDevice device, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSData data, IMTLDevice device, [NullAllowed] out NSError error);
 
 		// Comes from MPSDeviceProvider
 		//[Export ("mpsMTLDevice")]
@@ -6181,14 +6185,14 @@ namespace MetalPerformanceShaders {
 		//[Deprecated (PlatformName.iOS, 12, 0)]
 		//[Deprecated (PlatformName.MacOSX, 10, 14)]
 		//[Export ("initWithDevice:")]
-		//IntPtr Constructor (IMTLDevice device);
+		//NativeHandle Constructor (IMTLDevice device);
 
 		//[TV (11,3), iOS (11,3), Mac (10,13,4)]
 		//[Deprecated (PlatformName.TvOS, 12, 0)]
 		//[Deprecated (PlatformName.iOS, 12, 0)]
 		//[Deprecated (PlatformName.MacOSX, 10, 14)]
 		//[Export ("initForReadingWithData:device:")]
-		//IntPtr Constructor (NSData data, IMTLDevice device);
+		//NativeHandle Constructor (NSData data, IMTLDevice device);
 	}
 
 	[TV (13,0), Mac (10,15), iOS (13,0)]
@@ -6281,10 +6285,10 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:descriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNDArrayDescriptor descriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNDArrayDescriptor descriptor);
 
 		[Export ("initWithDevice:scalar:")]
-		IntPtr Constructor (IMTLDevice device, double value);
+		NativeHandle Constructor (IMTLDevice device, double value);
 
 		[Export ("resourceSize")]
 		nuint ResourceSize { get; }
@@ -6343,13 +6347,13 @@ namespace MetalPerformanceShaders {
 		// .ctors inlined from parent class
 
 		[Export ("initWithCoder:device:")]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithDevice:centerWeight:")]
-		IntPtr Constructor (IMTLDevice device, float centerWeight);
+		NativeHandle Constructor (IMTLDevice device, float centerWeight);
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:weights:")]
 		[Internal]
@@ -6369,13 +6373,13 @@ namespace MetalPerformanceShaders {
 		// .ctors inlined from parent class
 
 		[Export ("initWithCoder:device:")]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithDevice:centerWeight:")]
-		IntPtr Constructor (IMTLDevice device, float centerWeight);
+		NativeHandle Constructor (IMTLDevice device, float centerWeight);
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:weights:")]
 		[Internal]
@@ -6390,13 +6394,13 @@ namespace MetalPerformanceShaders {
 		// .ctors inlined from parent class
 
 		[Export ("initWithCoder:device:")]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithDevice:centerWeight:")]
-		IntPtr Constructor (IMTLDevice device, float centerWeight);
+		NativeHandle Constructor (IMTLDevice device, float centerWeight);
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:weights:")]
 		[Internal]
@@ -6419,11 +6423,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:dataLayout:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSDataLayout dataLayout);
+		NativeHandle Constructor (IMTLDevice device, MPSDataLayout dataLayout);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:sourceMatrix:destinationImage:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSMatrix sourceMatrix, MPSImage destinationImage);
@@ -6439,11 +6443,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -6465,11 +6469,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:kernelDiameter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint kernelDiameter);
+		NativeHandle Constructor (IMTLDevice device, nuint kernelDiameter);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("encodeRegressionToCommandBuffer:sourceTexture:guidanceTexture:weightsTexture:destinationCoefficientsTexture:")]
 		void EncodeRegression (IMTLCommandBuffer commandBuffer, IMTLTexture sourceTexture, IMTLTexture guidanceTexture, [NullAllowed] IMTLTexture weightsTexture, IMTLTexture destinationCoefficientsTexture);
@@ -6498,11 +6502,11 @@ namespace MetalPerformanceShaders {
 		[Export ("initWithDevice:histogramInfo:")]
 		[DesignatedInitializer]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (IMTLDevice device, ref MPSImageHistogramInfo histogramInfo);
+		NativeHandle Constructor (IMTLDevice device, ref MPSImageHistogramInfo histogramInfo);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:sourceTexture:minmaxTexture:histogram:histogramOffset:")]
 		void Encode (IMTLCommandBuffer commandBuffer, IMTLTexture source, IMTLTexture minmaxTexture, IMTLBuffer histogram, nuint histogramOffset);
@@ -6527,7 +6531,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -6537,7 +6541,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -6547,7 +6551,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -6557,7 +6561,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -6567,7 +6571,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -6577,7 +6581,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -6587,7 +6591,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -6597,7 +6601,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -6613,7 +6617,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		// Keeping the same name as in the parent class so it ends up in an overload
 		[Export ("encodeToCommandBuffer:gradientMatrix:forwardOutputMatrix:resultMatrix:")]
@@ -6621,7 +6625,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release]
@@ -6635,11 +6639,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -6676,11 +6680,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release]
@@ -6708,7 +6712,7 @@ namespace MetalPerformanceShaders {
 		IMTLDevice Device { get; }
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -6745,19 +6749,19 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("initWithGroup:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSAccelerationStructureGroup group);
+		NativeHandle Constructor (MPSAccelerationStructureGroup group);
 
 		[Export ("initWithCoder:group:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, MPSAccelerationStructureGroup group);
+		NativeHandle Constructor (NSCoder aDecoder, MPSAccelerationStructureGroup group);
 	}
 
 	delegate void MPSAccelerationStructureCompletionHandler ([NullAllowed] MPSAccelerationStructure structure);
@@ -6784,19 +6788,19 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("initWithGroup:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSAccelerationStructureGroup group);
+		NativeHandle Constructor (MPSAccelerationStructureGroup group);
 
 		[Export ("initWithCoder:group:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, MPSAccelerationStructureGroup group);
+		NativeHandle Constructor (NSCoder aDecoder, MPSAccelerationStructureGroup group);
 
 		[Export ("rebuild")]
 		void Rebuild ();
@@ -6854,19 +6858,19 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("initWithGroup:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (MPSAccelerationStructureGroup group);
+		NativeHandle Constructor (MPSAccelerationStructureGroup group);
 
 		[Export ("initWithCoder:group:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, MPSAccelerationStructureGroup group);
+		NativeHandle Constructor (NSCoder aDecoder, MPSAccelerationStructureGroup group);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -6911,7 +6915,7 @@ namespace MetalPerformanceShaders {
 		IMTLBuffer Variance { get; }
 
 		[Export ("initWithMean:variance:")]
-		IntPtr Constructor (IMTLBuffer mean, IMTLBuffer variance);
+		NativeHandle Constructor (IMTLBuffer mean, IMTLBuffer variance);
 
 		[Static]
 		[Export ("temporaryStateWithCommandBuffer:numberOfFeatureChannels:")]
@@ -6980,7 +6984,7 @@ namespace MetalPerformanceShaders {
 		void Encode (NSCoder coder);
 
 		[Export ("initWithCoder:")]
-		IntPtr Constructor (NSCoder decoder);
+		NativeHandle Constructor (NSCoder decoder);
 
 		[Static]
 		[Export ("supportsSecureCoding")]
@@ -7007,16 +7011,16 @@ namespace MetalPerformanceShaders {
 		IMPSCnnBatchNormalizationDataSource DataSource { get; }
 
 		[Export ("initWithDevice:dataSource:")]
-		IntPtr Constructor (IMTLDevice device, IMPSCnnBatchNormalizationDataSource dataSource);
+		NativeHandle Constructor (IMTLDevice device, IMPSCnnBatchNormalizationDataSource dataSource);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:dataSource:fusedNeuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, IMPSCnnBatchNormalizationDataSource dataSource, [NullAllowed] MPSNNNeuronDescriptor fusedNeuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, IMPSCnnBatchNormalizationDataSource dataSource, [NullAllowed] MPSNNNeuronDescriptor fusedNeuronDescriptor);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:sourceImage:batchNormalizationState:destinationImage:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSImage sourceImage, MPSCnnBatchNormalizationState batchNormalizationState, MPSImage destinationImage);
@@ -7061,11 +7065,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("encodeBatchToCommandBuffer:sourceImages:batchNormalizationState:")]
 		void EncodeBatch (IMTLCommandBuffer commandBuffer, NSArray<MPSImage> sourceImages, MPSCnnBatchNormalizationState batchNormalizationState);
@@ -7079,11 +7083,11 @@ namespace MetalPerformanceShaders {
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:fusedNeuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, [NullAllowed] MPSNNNeuronDescriptor fusedNeuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, [NullAllowed] MPSNNNeuronDescriptor fusedNeuronDescriptor);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:sourceGradient:sourceImage:batchNormalizationState:destinationGradient:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSImage sourceGradient, MPSImage sourceImage, MPSCnnBatchNormalizationState batchNormalizationState, MPSImage destinationGradient);
@@ -7106,11 +7110,11 @@ namespace MetalPerformanceShaders {
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("initWithDevice:fusedNeuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, [NullAllowed] MPSNNNeuronDescriptor fusedNeuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, [NullAllowed] MPSNNNeuronDescriptor fusedNeuronDescriptor);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 
 		[Export ("encodeBatchToCommandBuffer:sourceGradients:sourceImages:batchNormalizationState:")]
 		void EncodeBatch (IMTLCommandBuffer commandBuffer, NSArray<MPSImage> sourceGradients, NSArray<MPSImage> sourceImages, MPSCnnBatchNormalizationState batchNormalizationState);
@@ -7143,10 +7147,10 @@ namespace MetalPerformanceShaders {
 		IMTLBuffer Biases { get; }
 
 		[Export ("initWithWeights:biases:")]
-		IntPtr Constructor (IMTLBuffer weights, [NullAllowed] IMTLBuffer biases);
+		NativeHandle Constructor (IMTLBuffer weights, [NullAllowed] IMTLBuffer biases);
 
 		[Export ("initWithDevice:cnnConvolutionDescriptor:")]
-		IntPtr Constructor (IMTLDevice device, MPSCnnConvolutionDescriptor descriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSCnnConvolutionDescriptor descriptor);
 
 		[Static]
 		[Export ("temporaryCNNConvolutionWeightsAndBiasesStateWithCommandBuffer:cnnConvolutionDescriptor:")]
@@ -7185,11 +7189,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:weights:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
+		NativeHandle Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[TV (12,0), Mac (10,14), iOS (12,0)]
 		[Export ("reloadWeightsAndBiasesFromDataSource")]
@@ -7206,11 +7210,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:weights:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
+		NativeHandle Constructor (IMTLDevice device, IMPSCnnConvolutionDataSource weights);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7238,11 +7242,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("initWithDevice:keepProbability:seed:maskStrideInPixels:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, float keepProbability, nuint seed, MTLSize maskStrideInPixels);
+		NativeHandle Constructor (IMTLDevice device, float keepProbability, nuint seed, MTLSize maskStrideInPixels);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7261,11 +7265,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("initWithDevice:keepProbability:seed:maskStrideInPixels:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, float keepProbability, nuint seed, MTLSize maskStrideInPixels);
+		NativeHandle Constructor (IMTLDevice device, float keepProbability, nuint seed, MTLSize maskStrideInPixels);
 	}
 
 	[TV (11, 3), Mac (10, 13, 4), iOS (11, 3)]
@@ -7326,7 +7330,7 @@ namespace MetalPerformanceShaders {
 		void Encode (NSCoder coder);
 
 		[Export ("initWithCoder:")]
-		IntPtr Constructor (NSCoder decoder);
+		NativeHandle Constructor (NSCoder decoder);
 
 		// This needs to be inlined in classes that implement 'IMPSCnnInstanceNormalizationDataSource'.
 		//[Static]
@@ -7352,11 +7356,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:dataSource:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, IMPSCnnInstanceNormalizationDataSource dataSource);
+		NativeHandle Constructor (IMTLDevice device, IMPSCnnInstanceNormalizationDataSource dataSource);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Deprecated (PlatformName.TvOS, 12, 0, message: "Please use 'ReloadGammaAndBetaFromDataSource' instead.")]
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Please use 'ReloadGammaAndBetaFromDataSource' instead.")]
@@ -7387,11 +7391,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7401,11 +7405,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("kernelOffsetX")]
 		nint KernelOffsetX { get; set; }
@@ -7455,11 +7459,11 @@ namespace MetalPerformanceShaders {
 	interface MPSCnnLossLabels {
 
 		[Export ("initWithDevice:labelsDescriptor:")]
-		IntPtr Constructor (IMTLDevice device, MPSCnnLossDataDescriptor labelsDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSCnnLossDataDescriptor labelsDescriptor);
 
 		[Export ("initWithDevice:lossImageSize:labelsDescriptor:weightsDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MTLSize lossImageSize, MPSCnnLossDataDescriptor labelsDescriptor, [NullAllowed] MPSCnnLossDataDescriptor weightsDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MTLSize lossImageSize, MPSCnnLossDataDescriptor labelsDescriptor, [NullAllowed] MPSCnnLossDataDescriptor weightsDescriptor);
 
 		[Export ("lossImage")]
 		MPSImage LossImage { get; }
@@ -7532,11 +7536,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:lossDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSCnnLossDescriptor lossDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSCnnLossDescriptor lossDescriptor);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:sourceImage:labels:destinationImage:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSImage sourceImage, MPSCnnLossLabels labels, MPSImage destinationImage);
@@ -7655,11 +7659,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:lossDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSCnnYoloLossDescriptor lossDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSCnnYoloLossDescriptor lossDescriptor);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:sourceImage:labels:destinationImage:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSImage sourceImage, MPSCnnLossLabels labels, MPSImage destinationImage);
@@ -7689,11 +7693,11 @@ namespace MetalPerformanceShaders {
 		// Inlined but you are not supposed to use this class, only its subclasses
 		//[Export ("initWithDevice:")]
 		//[DesignatedInitializer]
-		//IntPtr Constructor (IMTLDevice device);
+		//NativeHandle Constructor (IMTLDevice device);
 
 		//[Export ("initWithCoder:device:")]
 		//[DesignatedInitializer]
-		//IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		//NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("primaryScale")]
 		float PrimaryScale { get; set; }
@@ -7730,7 +7734,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7740,7 +7744,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7750,7 +7754,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7760,7 +7764,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -7776,7 +7780,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7787,11 +7791,11 @@ namespace MetalPerformanceShaders {
 		// Inlined but you are not supposed to use this class, only its subclasses
 		//[Export ("initWithDevice:")]
 		//[DesignatedInitializer]
-		//IntPtr Constructor (IMTLDevice device);
+		//NativeHandle Constructor (IMTLDevice device);
 
 		//[Export ("initWithCoder:device:")]
 		//[DesignatedInitializer]
-		//IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		//NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("primaryScale")]
 		float PrimaryScale { get; set; }
@@ -7822,7 +7826,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:isSecondarySourceFilter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, bool isSecondarySourceFilter);
+		NativeHandle Constructor (IMTLDevice device, bool isSecondarySourceFilter);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7832,7 +7836,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:isSecondarySourceFilter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, bool isSecondarySourceFilter);
+		NativeHandle Constructor (IMTLDevice device, bool isSecondarySourceFilter);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7842,7 +7846,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:isSecondarySourceFilter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, bool isSecondarySourceFilter);
+		NativeHandle Constructor (IMTLDevice device, bool isSecondarySourceFilter);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7908,11 +7912,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:neuronDescriptor:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
+		NativeHandle Constructor (IMTLDevice device, MPSNNNeuronDescriptor neuronDescriptor);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -7927,7 +7931,7 @@ namespace MetalPerformanceShaders {
 		IMTLBuffer Beta { get; }
 
 		[Export ("initWithGamma:beta:")]
-		IntPtr Constructor (IMTLBuffer gamma, IMTLBuffer beta);
+		NativeHandle Constructor (IMTLBuffer gamma, IMTLBuffer beta);
 
 		[Static]
 		[Export ("temporaryStateWithCommandBuffer:numberOfFeatureChannels:")]
@@ -7968,14 +7972,14 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:inputMatrix:meanVector:varianceVector:gammaVector:betaVector:resultMatrix:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSMatrix inputMatrix, MPSVector meanVector, MPSVector varianceVector, [NullAllowed] MPSVector gammaVector, [NullAllowed] MPSVector betaVector, MPSMatrix resultMatrix);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release]
@@ -8013,14 +8017,14 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("encodeToCommandBuffer:gradientMatrix:inputMatrix:meanVector:varianceVector:gammaVector:betaVector:resultGradientForDataMatrix:resultGradientForGammaVector:resultGradientForBetaVector:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSMatrix gradientMatrix, MPSMatrix inputMatrix, MPSVector meanVector, MPSVector varianceVector, [NullAllowed] MPSVector gammaVector, [NullAllowed] MPSVector betaVector, MPSMatrix resultGradientForDataMatrix, [NullAllowed] MPSVector resultGradientForGammaVector, [NullAllowed] MPSVector resultGradientForBetaVector);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release]
@@ -8048,16 +8052,16 @@ namespace MetalPerformanceShaders {
 		MPSNNGradientState CreateTemporaryState (IMTLCommandBuffer commandBuffer);
 
 		[Export ("initWithDevice:bufferSize:")]
-		IntPtr Constructor (IMTLDevice device, nuint bufferSize);
+		NativeHandle Constructor (IMTLDevice device, nuint bufferSize);
 
 		[Export ("initWithDevice:textureDescriptor:")]
-		IntPtr Constructor (IMTLDevice device, MTLTextureDescriptor descriptor);
+		NativeHandle Constructor (IMTLDevice device, MTLTextureDescriptor descriptor);
 
 		[Export ("initWithResource:")]
-		IntPtr Constructor ([NullAllowed] IMTLResource resource);
+		NativeHandle Constructor ([NullAllowed] IMTLResource resource);
 
 		[Export ("initWithDevice:resourceList:")]
-		IntPtr Constructor (IMTLDevice device, MPSStateResourceList resourceList);
+		NativeHandle Constructor (IMTLDevice device, MPSStateResourceList resourceList);
 
 		[New]
 		[Static]
@@ -8065,7 +8069,7 @@ namespace MetalPerformanceShaders {
 		MPSNNGradientState CreateTemporaryState (IMTLCommandBuffer commandBuffer, MPSStateResourceList resourceList);
 
 		[Export ("initWithResources:")]
-		IntPtr Constructor ([NullAllowed] IMTLResource [] resources);
+		NativeHandle Constructor ([NullAllowed] IMTLResource [] resources);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8089,16 +8093,16 @@ namespace MetalPerformanceShaders {
 		MPSNNBinaryGradientState CreateTemporaryState (IMTLCommandBuffer commandBuffer);
 
 		[Export ("initWithDevice:bufferSize:")]
-		IntPtr Constructor (IMTLDevice device, nuint bufferSize);
+		NativeHandle Constructor (IMTLDevice device, nuint bufferSize);
 
 		[Export ("initWithDevice:textureDescriptor:")]
-		IntPtr Constructor (IMTLDevice device, MTLTextureDescriptor descriptor);
+		NativeHandle Constructor (IMTLDevice device, MTLTextureDescriptor descriptor);
 
 		[Export ("initWithResource:")]
-		IntPtr Constructor ([NullAllowed] IMTLResource resource);
+		NativeHandle Constructor ([NullAllowed] IMTLResource resource);
 
 		[Export ("initWithDevice:resourceList:")]
-		IntPtr Constructor (IMTLDevice device, MPSStateResourceList resourceList);
+		NativeHandle Constructor (IMTLDevice device, MPSStateResourceList resourceList);
 
 		[New]
 		[Static]
@@ -8106,7 +8110,7 @@ namespace MetalPerformanceShaders {
 		MPSNNBinaryGradientState CreateTemporaryState (IMTLCommandBuffer commandBuffer, MPSStateResourceList resourceList);
 
 		[Export ("initWithResources:")]
-		IntPtr Constructor ([NullAllowed] IMTLResource [] resources);
+		NativeHandle Constructor ([NullAllowed] IMTLResource [] resources);
 	}
 
 	interface IMPSNNTrainableNode { }
@@ -8146,10 +8150,10 @@ namespace MetalPerformanceShaders {
 		MPSNNRegularizationType RegularizationType { get; set; }
 
 		[Export ("initWithLearningRate:gradientRescale:regularizationType:regularizationScale:")]
-		IntPtr Constructor (float learningRate, float gradientRescale, MPSNNRegularizationType regularizationType, float regularizationScale);
+		NativeHandle Constructor (float learningRate, float gradientRescale, MPSNNRegularizationType regularizationType, float regularizationScale);
 
 		[Export ("initWithLearningRate:gradientRescale:applyGradientClipping:gradientClipMax:gradientClipMin:regularizationType:regularizationScale:")]
-		IntPtr Constructor (float learningRate, float gradientRescale, bool applyGradientClipping, float gradientClipMax, float gradientClipMin, MPSNNRegularizationType regularizationType, float regularizationScale);
+		NativeHandle Constructor (float learningRate, float gradientRescale, bool applyGradientClipping, float gradientClipMax, float gradientClipMin, MPSNNRegularizationType regularizationType, float regularizationScale);
 
 		[Static]
 		[Export ("optimizerDescriptorWithLearningRate:gradientRescale:regularizationType:regularizationScale:")]
@@ -8202,10 +8206,10 @@ namespace MetalPerformanceShaders {
 		bool UseNestrovMomentum { get; }
 
 		[Export ("initWithDevice:learningRate:")]
-		IntPtr Constructor (IMTLDevice device, float learningRate);
+		NativeHandle Constructor (IMTLDevice device, float learningRate);
 
 		[Export ("initWithDevice:momentumScale:useNestrovMomentum:optimizerDescriptor:")]
-		IntPtr Constructor (IMTLDevice device, float momentumScale, bool useNestrovMomentum, MPSNNOptimizerDescriptor optimizerDescriptor);
+		NativeHandle Constructor (IMTLDevice device, float momentumScale, bool useNestrovMomentum, MPSNNOptimizerDescriptor optimizerDescriptor);
 
 		[Export ("encodeToCommandBuffer:inputGradientVector:inputValuesVector:inputMomentumVector:resultValuesVector:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSVector inputGradientVector, MPSVector inputValuesVector, [NullAllowed] MPSVector inputMomentumVector, MPSVector resultValuesVector);
@@ -8232,10 +8236,10 @@ namespace MetalPerformanceShaders {
 		float Epsilon { get; }
 
 		[Export ("initWithDevice:learningRate:")]
-		IntPtr Constructor (IMTLDevice device, float learningRate);
+		NativeHandle Constructor (IMTLDevice device, float learningRate);
 
 		[Export ("initWithDevice:decay:epsilon:optimizerDescriptor:")]
-		IntPtr Constructor (IMTLDevice device, double decay, float epsilon, MPSNNOptimizerDescriptor optimizerDescriptor);
+		NativeHandle Constructor (IMTLDevice device, double decay, float epsilon, MPSNNOptimizerDescriptor optimizerDescriptor);
 
 		[Export ("encodeToCommandBuffer:inputGradientVector:inputValuesVector:inputSumOfSquaresVector:resultValuesVector:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSVector inputGradientVector, MPSVector inputValuesVector, MPSVector inputSumOfSquaresVector, MPSVector resultValuesVector);
@@ -8268,10 +8272,10 @@ namespace MetalPerformanceShaders {
 		nuint TimeStep { get; set; }
 
 		[Export ("initWithDevice:learningRate:")]
-		IntPtr Constructor (IMTLDevice device, float learningRate);
+		NativeHandle Constructor (IMTLDevice device, float learningRate);
 
 		[Export ("initWithDevice:beta1:beta2:epsilon:timeStep:optimizerDescriptor:")]
-		IntPtr Constructor (IMTLDevice device, double beta1, double beta2, float epsilon, nuint timeStep, MPSNNOptimizerDescriptor optimizerDescriptor);
+		NativeHandle Constructor (IMTLDevice device, double beta1, double beta2, float epsilon, nuint timeStep, MPSNNOptimizerDescriptor optimizerDescriptor);
 
 		[Export ("encodeToCommandBuffer:inputGradientVector:inputValuesVector:inputMomentumVector:inputVelocityVector:resultValuesVector:")]
 		void Encode (IMTLCommandBuffer commandBuffer, MPSVector inputGradientVector, MPSVector inputValuesVector, MPSVector inputMomentumVector, MPSVector inputVelocityVector, MPSVector resultValuesVector);
@@ -8302,7 +8306,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8312,7 +8316,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8322,7 +8326,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -8332,7 +8336,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8342,7 +8346,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8352,7 +8356,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8362,7 +8366,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -8372,7 +8376,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8382,7 +8386,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8392,7 +8396,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8402,7 +8406,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8412,7 +8416,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8422,7 +8426,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8435,7 +8439,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8457,7 +8461,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8469,11 +8473,11 @@ namespace MetalPerformanceShaders {
 		bool DoWeightedSumByNonZeroWeights { get; }
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithDevice:doWeightedSumByNonZeroWeights:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, bool doWeightedSumByNonZeroWeights);
+		NativeHandle Constructor (IMTLDevice device, bool doWeightedSumByNonZeroWeights);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8483,11 +8487,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -8497,11 +8501,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -8519,18 +8523,18 @@ namespace MetalPerformanceShaders {
 		float FillValue { get; set; }
 
 		[Export ("initWithDevice:")]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithDevice:paddingSizeBefore:paddingSizeAfter:")]
-		IntPtr Constructor (IMTLDevice device, MPSImageCoordinate paddingSizeBefore, MPSImageCoordinate paddingSizeAfter);
+		NativeHandle Constructor (IMTLDevice device, MPSImageCoordinate paddingSizeBefore, MPSImageCoordinate paddingSizeAfter);
 
 		[Export ("initWithDevice:paddingSizeBefore:paddingSizeAfter:fillValueArray:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSImageCoordinate paddingSizeBefore, MPSImageCoordinate paddingSizeAfter, [NullAllowed] NSData fillValueArray);
+		NativeHandle Constructor (IMTLDevice device, MPSImageCoordinate paddingSizeBefore, MPSImageCoordinate paddingSizeAfter, [NullAllowed] NSData fillValueArray);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (12,1), Mac (10,14,1), iOS (12,1)]
@@ -8540,11 +8544,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -8563,11 +8567,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:resizeWidth:resizeHeight:alignCorners:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint resizeWidth, nuint resizeHeight, bool alignCorners);
+		NativeHandle Constructor (IMTLDevice device, nuint resizeWidth, nuint resizeHeight, bool alignCorners);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -8589,11 +8593,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:resizeWidth:resizeHeight:numberOfRegions:regions:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, nuint resizeWidth, nuint resizeHeight, nuint numberOfRegions, IntPtr regions);
+		NativeHandle Constructor (IMTLDevice device, nuint resizeWidth, nuint resizeHeight, nuint numberOfRegions, IntPtr regions);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder aDecoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder aDecoder, IMTLDevice device);
 	}
 
 	[TV (11,3), Mac (10,13,4), iOS (11,3)]
@@ -8603,11 +8607,11 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device);
+		NativeHandle Constructor (IMTLDevice device);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 	}
 
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -8628,23 +8632,23 @@ namespace MetalPerformanceShaders {
 		MPSRnnMatrixTrainingState CreateTemporaryState (IMTLCommandBuffer commandBuffer);
 
 		[Export ("initWithDevice:bufferSize:")]
-		IntPtr Constructor (IMTLDevice device, nuint bufferSize);
+		NativeHandle Constructor (IMTLDevice device, nuint bufferSize);
 
 		[Export ("initWithDevice:textureDescriptor:")]
-		IntPtr Constructor (IMTLDevice device, MTLTextureDescriptor descriptor);
+		NativeHandle Constructor (IMTLDevice device, MTLTextureDescriptor descriptor);
 
 		[Export ("initWithResource:")]
-		IntPtr Constructor ([NullAllowed] IMTLResource resource);
+		NativeHandle Constructor ([NullAllowed] IMTLResource resource);
 
 		[Export ("initWithDevice:resourceList:")]
-		IntPtr Constructor (IMTLDevice device, MPSStateResourceList resourceList);
+		NativeHandle Constructor (IMTLDevice device, MPSStateResourceList resourceList);
 
 		[Static][New]
 		[Export ("temporaryStateWithCommandBuffer:resourceList:")]
 		MPSRnnMatrixTrainingState CreateTemporaryState (IMTLCommandBuffer commandBuffer, MPSStateResourceList resourceList);
 
 		[Export ("initWithResources:")]
-		IntPtr Constructor ([NullAllowed] IMTLResource [] resources);
+		NativeHandle Constructor ([NullAllowed] IMTLResource [] resources);
 	}
 
 	[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -8672,7 +8676,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithDevice:rnnDescriptor:trainableWeights:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IMTLDevice device, MPSRnnDescriptor rnnDescriptor, NSMutableArray<MPSMatrix> trainableWeights);
+		NativeHandle Constructor (IMTLDevice device, MPSRnnDescriptor rnnDescriptor, NSMutableArray<MPSMatrix> trainableWeights);
 
 		[Export ("createWeightGradientMatrices:dataType:")]
 		void CreateWeightGradientMatrices (NSMutableArray<MPSMatrix> matrices, MPSDataType dataType);
@@ -8700,7 +8704,7 @@ namespace MetalPerformanceShaders {
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSCoder decoder, IMTLDevice device);
+		NativeHandle Constructor (NSCoder decoder, IMTLDevice device);
 
 		[Export ("copyWithZone:device:")]
 		[return: Release]

--- a/src/metrickit.cs
+++ b/src/metrickit.cs
@@ -13,6 +13,10 @@ using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MetricKit {
 
 	interface NSUnitDuration : NSUnit { }
@@ -64,7 +68,7 @@ namespace MetricKit {
 
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("bars", ArgumentSemantic.Copy)]
@@ -80,7 +84,7 @@ namespace MetricKit {
 
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string symbol, NSUnitConverter converter);
+		NativeHandle Constructor (string symbol, NSUnitConverter converter);
 
 		[Static]
 		[Export ("apl", ArgumentSemantic.Copy)]

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -51,6 +51,10 @@ using UIKit;
 using AUViewControllerBase = UIKit.UIViewController;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ModelIO {
 
 	[iOS (11,0), Mac(10,13), TV (11,0)]
@@ -106,19 +110,19 @@ namespace ModelIO {
 	interface MDLAsset : NSCopying
 	{
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("initWithURL:vertexDescriptor:bufferAllocator:")]
-		IntPtr Constructor ([NullAllowed] NSUrl url, [NullAllowed] MDLVertexDescriptor vertexDescriptor, [NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
+		NativeHandle Constructor ([NullAllowed] NSUrl url, [NullAllowed] MDLVertexDescriptor vertexDescriptor, [NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
 
 		[iOS (10,0)]
 		[TV (10,0)]
 		[Mac (10,12)]
 		[Export ("initWithBufferAllocator:")]
-		IntPtr Constructor ([NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
+		NativeHandle Constructor ([NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
 
 		[Export ("initWithURL:vertexDescriptor:bufferAllocator:preserveTopology:error:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] MDLVertexDescriptor vertexDescriptor, [NullAllowed] IMDLMeshBufferAllocator bufferAllocator, bool preserveTopology, out NSError error);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] MDLVertexDescriptor vertexDescriptor, [NullAllowed] IMDLMeshBufferAllocator bufferAllocator, bool preserveTopology, out NSError error);
 
 		// note: by choice we do not export "exportAssetToURL:"
 		[Export ("exportAssetToURL:error:")]
@@ -421,12 +425,12 @@ namespace ModelIO {
 	{
 		[Export ("initWithData:topLeftOrigin:name:dimensions:rowStride:channelCount:channelEncoding:isCube:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
+		NativeHandle Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
 
 		// -(instancetype __nonnull)initWithDivisions:(float)divisions name:(NSString * __nullable)name dimensions:(vector_int2)dimensions channelCount:(int)channelCount channelEncoding:(MDLTextureChannelEncoding)channelEncoding color1:(CGColorRef __nonnull)color1 color2:(CGColorRef __nonnull)color2;
 		[Export ("initWithDivisions:name:dimensions:channelCount:channelEncoding:color1:color2:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (float divisions, [NullAllowed] string name, Vector2i dimensions, int channelCount, MDLTextureChannelEncoding channelEncoding, CGColor color1, CGColor color2);
+		NativeHandle Constructor (float divisions, [NullAllowed] string name, Vector2i dimensions, int channelCount, MDLTextureChannelEncoding channelEncoding, CGColor color1, CGColor color2);
 
 		[Export ("divisions")]
 		float Divisions { get; set; }
@@ -447,15 +451,15 @@ namespace ModelIO {
 	{
 		[Export ("initWithData:topLeftOrigin:name:dimensions:rowStride:channelCount:channelEncoding:isCube:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
+		NativeHandle Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
 
 		[Export ("initWithColorTemperatureGradientFrom:toColorTemperature:name:textureDimensions:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (float colorTemperature1, float colorTemperature2, [NullAllowed] string name, Vector2i textureDimensions);
+		NativeHandle Constructor (float colorTemperature1, float colorTemperature2, [NullAllowed] string name, Vector2i textureDimensions);
 
 		[Export ("initWithColorGradientFrom:toColor:name:textureDimensions:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (CGColor color1, CGColor color2, [NullAllowed] string name, Vector2i textureDimensions);
+		NativeHandle Constructor (CGColor color1, CGColor color2, [NullAllowed] string name, Vector2i textureDimensions);
 	}
 
 
@@ -491,7 +495,7 @@ namespace ModelIO {
 	interface MDLLightProbe
 	{
 		[Export ("initWithReflectiveTexture:irradianceTexture:")]
-		IntPtr Constructor ([NullAllowed] MDLTexture reflectiveTexture, [NullAllowed] MDLTexture irradianceTexture);
+		NativeHandle Constructor ([NullAllowed] MDLTexture reflectiveTexture, [NullAllowed] MDLTexture irradianceTexture);
 
 		[Export ("generateSphericalHarmonicsFromIrradiance:")]
 		void GenerateSphericalHarmonicsFromIrradiance (nuint sphericalHarmonicsLevel);
@@ -522,7 +526,7 @@ namespace ModelIO {
 	interface MDLMaterial : MDLNamed, INSFastEnumeration
 	{
 		[Export ("initWithName:scatteringFunction:")]
-		IntPtr Constructor (string name, MDLScatteringFunction scatteringFunction);
+		NativeHandle Constructor (string name, MDLScatteringFunction scatteringFunction);
 
 		[Export ("setProperty:")]
 		void SetProperty (MDLMaterialProperty property);
@@ -591,49 +595,49 @@ namespace ModelIO {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithName:semantic:")]
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic);
 
 		[Export ("initWithName:semantic:float:")]
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic, float value);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic, float value);
 
 		[Export ("initWithName:semantic:float2:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic, Vector2 value);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic, Vector2 value);
 
 		[Export ("initWithName:semantic:float3:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic, Vector3 value);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic, Vector3 value);
 
 		[Export ("initWithName:semantic:float4:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic, Vector4 value);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic, Vector4 value);
 
 		[Export ("initWithName:semantic:matrix4x4:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 #if !XAMCORE_4_0
 		[Obsolete ("Use the '(string, MDLMaterialSemantic, MatrixFloat4x4)' overload instead.")]
 #endif
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic, Matrix4 value);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic, Matrix4 value);
 
 
 #if !XAMCORE_4_0
 		[Sealed]
 		[Export ("initWithName:semantic:matrix4x4:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic, MatrixFloat4x4 value);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic, MatrixFloat4x4 value);
 #endif
 
 		[Export ("initWithName:semantic:URL:")]
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic, [NullAllowed] NSUrl url);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic, [NullAllowed] NSUrl url);
 
 		[Export ("initWithName:semantic:string:")]
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic, [NullAllowed] string stringValue);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic, [NullAllowed] string stringValue);
 
 		[Export ("initWithName:semantic:textureSampler:")]
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic, [NullAllowed] MDLTextureSampler textureSampler);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic, [NullAllowed] MDLTextureSampler textureSampler);
 
 		[Export ("initWithName:semantic:color:")]
-		IntPtr Constructor (string name, MDLMaterialSemantic semantic, CGColor color);
+		NativeHandle Constructor (string name, MDLMaterialSemantic semantic, CGColor color);
 
 		[Export ("setProperties:")]
 		void SetProperties (MDLMaterialProperty property);
@@ -714,7 +718,7 @@ namespace ModelIO {
 	interface MDLMaterialPropertyConnection : MDLNamed
 	{
 		[Export ("initWithOutput:input:")]
-		IntPtr Constructor (MDLMaterialProperty output, MDLMaterialProperty input);
+		NativeHandle Constructor (MDLMaterialProperty output, MDLMaterialProperty input);
 
 		[NullAllowed, Export ("output", ArgumentSemantic.Weak)]
 		MDLMaterialProperty Output { get; }
@@ -730,7 +734,7 @@ namespace ModelIO {
 	interface MDLMaterialPropertyNode : MDLNamed
 	{
 		[Export ("initWithInputs:outputs:evaluationFunction:")]
-		IntPtr Constructor (MDLMaterialProperty[] inputs, MDLMaterialProperty[] outputs, Action<MDLMaterialPropertyNode> function);
+		NativeHandle Constructor (MDLMaterialProperty[] inputs, MDLMaterialProperty[] outputs, Action<MDLMaterialPropertyNode> function);
 
 		[Export ("evaluationFunction", ArgumentSemantic.Copy)]
 		Action<MDLMaterialPropertyNode> EvaluationFunction { get; set; }
@@ -749,7 +753,7 @@ namespace ModelIO {
 	interface MDLMaterialPropertyGraph
 	{
 		[Export ("initWithNodes:connections:")]
-		IntPtr Constructor (MDLMaterialPropertyNode[] nodes, MDLMaterialPropertyConnection[] connections);
+		NativeHandle Constructor (MDLMaterialPropertyNode[] nodes, MDLMaterialPropertyConnection[] connections);
 
 		[Export ("evaluate")]
 		void Evaluate ();
@@ -769,13 +773,13 @@ namespace ModelIO {
 		[Mac (10,12)]
 		[TV (10,0)]
 		[Export ("initWithBufferAllocator:")]
-		IntPtr Constructor ([NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
+		NativeHandle Constructor ([NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
 
 		[Export ("initWithVertexBuffer:vertexCount:descriptor:submeshes:")]
-		IntPtr Constructor (IMDLMeshBuffer vertexBuffer, nuint vertexCount, MDLVertexDescriptor descriptor, MDLSubmesh [] submeshes);
+		NativeHandle Constructor (IMDLMeshBuffer vertexBuffer, nuint vertexCount, MDLVertexDescriptor descriptor, MDLSubmesh [] submeshes);
 
 		[Export ("initWithVertexBuffers:vertexCount:descriptor:submeshes:")]
-		IntPtr Constructor (IMDLMeshBuffer[] vertexBuffers, nuint vertexCount, MDLVertexDescriptor descriptor, MDLSubmesh[] submeshes);
+		NativeHandle Constructor (IMDLMeshBuffer[] vertexBuffers, nuint vertexCount, MDLVertexDescriptor descriptor, MDLSubmesh[] submeshes);
 
 		[Internal]
 		[Export ("vertexAttributeDataForAttributeNamed:")]
@@ -1109,10 +1113,10 @@ namespace ModelIO {
 	interface MDLMeshBufferData : MDLMeshBuffer, NSCopying
 	{
 		[Export ("initWithType:length:")]
-		IntPtr Constructor (MDLMeshBufferType type, nuint length);
+		NativeHandle Constructor (MDLMeshBufferType type, nuint length);
 
 		[Export ("initWithType:data:")]
-		IntPtr Constructor (MDLMeshBufferType type, [NullAllowed] NSData data);
+		NativeHandle Constructor (MDLMeshBufferType type, [NullAllowed] NSData data);
 
 		[Export ("data", ArgumentSemantic.Retain)]
 		NSData Data { get; }
@@ -1145,7 +1149,7 @@ namespace ModelIO {
 	{
 		[Export ("initWithData:topLeftOrigin:name:dimensions:rowStride:channelCount:channelEncoding:isCube:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
+		NativeHandle Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
 
 		[Internal]
 		[Export ("initVectorNoiseWithSmoothness:name:textureDimensions:channelEncoding:")]
@@ -1154,7 +1158,7 @@ namespace ModelIO {
 
 		[Export ("initScalarNoiseWithSmoothness:name:textureDimensions:channelCount:channelEncoding:grayscale:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (float smoothness, [NullAllowed] string name, Vector2i textureDimensions, int channelCount, MDLTextureChannelEncoding channelEncoding, bool grayscale);
+		NativeHandle Constructor (float smoothness, [NullAllowed] string name, Vector2i textureDimensions, int channelCount, MDLTextureChannelEncoding channelEncoding, bool grayscale);
 
 		[Internal]
 		[iOS (10,2), Mac (10,12,2)]
@@ -1170,10 +1174,10 @@ namespace ModelIO {
 	{
 		[Export ("initWithData:topLeftOrigin:name:dimensions:rowStride:channelCount:channelEncoding:isCube:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
+		NativeHandle Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
 
 		[Export ("initByGeneratingNormalMapWithTexture:name:smoothness:contrast:")]
-		IntPtr Constructor (MDLTexture sourceTexture, [NullAllowed] string name, float smoothness, float contrast);
+		NativeHandle Constructor (MDLTexture sourceTexture, [NullAllowed] string name, float smoothness, float contrast);
 	}
 
 	[iOS (9,0), Mac(10,11)]
@@ -1313,7 +1317,7 @@ namespace ModelIO {
 	interface MDLPhotometricLight
 	{
 		[Export ("initWithIESProfile:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("generateSphericalHarmonicsFromLight:")]
 		void GenerateSphericalHarmonics (nuint sphericalHarmonicsLevel);
@@ -1438,16 +1442,16 @@ namespace ModelIO {
 	{
 		[Export ("initWithData:topLeftOrigin:name:dimensions:rowStride:channelCount:channelEncoding:isCube:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
+		NativeHandle Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
 
 		[Export ("initWithName:channelEncoding:textureDimensions:turbidity:sunElevation:upperAtmosphereScattering:groundAlbedo:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor ([NullAllowed] string name, MDLTextureChannelEncoding channelEncoding, Vector2i textureDimensions, float turbidity, float sunElevation, float upperAtmosphereScattering, float groundAlbedo);
+		NativeHandle Constructor ([NullAllowed] string name, MDLTextureChannelEncoding channelEncoding, Vector2i textureDimensions, float turbidity, float sunElevation, float upperAtmosphereScattering, float groundAlbedo);
 
 		[TV (11,0), Mac (10,13), iOS (11,0)]
 		[Export ("initWithName:channelEncoding:textureDimensions:turbidity:sunElevation:sunAzimuth:upperAtmosphereScattering:groundAlbedo:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor ([NullAllowed] string name, MDLTextureChannelEncoding channelEncoding, Vector2i textureDimensions, float turbidity, float sunElevation, float sunAzimuth, float upperAtmosphereScattering, float groundAlbedo);
+		NativeHandle Constructor ([NullAllowed] string name, MDLTextureChannelEncoding channelEncoding, Vector2i textureDimensions, float turbidity, float sunElevation, float sunAzimuth, float upperAtmosphereScattering, float groundAlbedo);
 
 		[Export ("updateTexture")]
 		void UpdateTexture ();
@@ -1591,16 +1595,16 @@ namespace ModelIO {
 	interface MDLSubmesh : MDLNamed
 	{
 		[Export ("initWithName:indexBuffer:indexCount:indexType:geometryType:material:")]
-		IntPtr Constructor (string name, IMDLMeshBuffer indexBuffer, nuint indexCount, MDLIndexBitDepth indexType, MDLGeometryType geometryType, [NullAllowed] MDLMaterial material);
+		NativeHandle Constructor (string name, IMDLMeshBuffer indexBuffer, nuint indexCount, MDLIndexBitDepth indexType, MDLGeometryType geometryType, [NullAllowed] MDLMaterial material);
 
 		[Export ("initWithIndexBuffer:indexCount:indexType:geometryType:material:")]
-		IntPtr Constructor (IMDLMeshBuffer indexBuffer, nuint indexCount, MDLIndexBitDepth indexType, MDLGeometryType geometryType, [NullAllowed] MDLMaterial material);
+		NativeHandle Constructor (IMDLMeshBuffer indexBuffer, nuint indexCount, MDLIndexBitDepth indexType, MDLGeometryType geometryType, [NullAllowed] MDLMaterial material);
 
 		[Export ("initWithName:indexBuffer:indexCount:indexType:geometryType:material:topology:")]
-		IntPtr Constructor (string name, IMDLMeshBuffer indexBuffer, nuint indexCount, MDLIndexBitDepth indexType, MDLGeometryType geometryType, [NullAllowed] MDLMaterial material, [NullAllowed] MDLSubmeshTopology topology);
+		NativeHandle Constructor (string name, IMDLMeshBuffer indexBuffer, nuint indexCount, MDLIndexBitDepth indexType, MDLGeometryType geometryType, [NullAllowed] MDLMaterial material, [NullAllowed] MDLSubmeshTopology topology);
 
 		[Export ("initWithMDLSubmesh:indexType:geometryType:")]
-		IntPtr Constructor (MDLSubmesh indexBuffer, MDLIndexBitDepth indexType, MDLGeometryType geometryType);
+		NativeHandle Constructor (MDLSubmesh indexBuffer, MDLIndexBitDepth indexType, MDLGeometryType geometryType);
 
 		[Export ("indexBuffer", ArgumentSemantic.Retain)]
 		IMDLMeshBuffer IndexBuffer { get; }
@@ -1648,7 +1652,7 @@ namespace ModelIO {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 #if !XAMCORE_4_0
 		[Static]
@@ -1705,7 +1709,7 @@ namespace ModelIO {
 		[Export ("initWithData:topLeftOrigin:name:dimensions:rowStride:channelCount:channelEncoding:isCube:")]
 		[DesignatedInitializer]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
+		NativeHandle Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
 
 		[Export ("writeToURL:")]
 		bool WriteToUrl (NSUrl url);
@@ -1815,26 +1819,26 @@ namespace ModelIO {
 	interface MDLTransform : MDLTransformComponent, NSCopying {
 
 		[Export ("initWithTransformComponent:")]
-		IntPtr Constructor (IMDLTransformComponent component);
+		NativeHandle Constructor (IMDLTransformComponent component);
 
 		[iOS (10,0)]
 		[Mac (10,12)]
 		[TV (10,0)]
 		[Export ("initWithTransformComponent:resetsTransform:")]
-		IntPtr Constructor (IMDLTransformComponent component, bool resetsTransform);
+		NativeHandle Constructor (IMDLTransformComponent component, bool resetsTransform);
 
 #if !XAMCORE_4_0
 		[Obsolete ("Use the '(MatrixFloat4x4)' overload instead.")]
 #endif
 		[Export ("initWithMatrix:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Matrix4 matrix);
+		NativeHandle Constructor (Matrix4 matrix);
 
 #if !XAMCORE_4_0
 		[Sealed]
 		[Export ("initWithMatrix:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (MatrixFloat4x4 matrix);
+		NativeHandle Constructor (MatrixFloat4x4 matrix);
 #endif
 
 #if !XAMCORE_4_0
@@ -1845,14 +1849,14 @@ namespace ModelIO {
 		[TV (10,0)]
 		[Export ("initWithMatrix:resetsTransform:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Matrix4 matrix, bool resetsTransform);
+		NativeHandle Constructor (Matrix4 matrix, bool resetsTransform);
 
 #if !XAMCORE_4_0
 		[Sealed]
 		[iOS (10,0), Mac (10,12), TV (10,0)]
 		[Export ("initWithMatrix:resetsTransform:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (MatrixFloat4x4 matrix, bool resetsTransform);
+		NativeHandle Constructor (MatrixFloat4x4 matrix, bool resetsTransform);
 #endif
 
 		[Export ("setIdentity")]
@@ -2018,10 +2022,10 @@ namespace ModelIO {
 	{
 		[Export ("initWithData:topLeftOrigin:name:dimensions:rowStride:channelCount:channelEncoding:isCube:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
+		NativeHandle Constructor ([NullAllowed] NSData pixelData, bool topLeftOrigin, [NullAllowed] string name, Vector2i dimensions, nint rowStride, nuint channelCount, MDLTextureChannelEncoding channelEncoding, bool isCube);
 
 		[Export ("initWithURL:name:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] string name);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] string name);
 
 		[Export ("URL", ArgumentSemantic.Copy)]
 		NSUrl Url { get; set; }
@@ -2032,7 +2036,7 @@ namespace ModelIO {
 	interface MDLVertexAttribute : NSCopying
 	{
 		[Export ("initWithName:format:offset:bufferIndex:")]
-		IntPtr Constructor (string name, MDLVertexFormat format, nuint offset, nuint bufferIndex);
+		NativeHandle Constructor (string name, MDLVertexFormat format, nuint offset, nuint bufferIndex);
 
 		[Export ("name")]
 		string Name { get; set; }
@@ -2087,7 +2091,7 @@ namespace ModelIO {
 	{
 		// FIXME: provide better API.
 		[Export ("initWithBytes:deallocator:")]
-		IntPtr Constructor (IntPtr bytes, [NullAllowed] Action deallocator);
+		NativeHandle Constructor (IntPtr bytes, [NullAllowed] Action deallocator);
 
 		[Export ("bytes")]
 		IntPtr Bytes { get; }
@@ -2098,7 +2102,7 @@ namespace ModelIO {
 	interface MDLVertexDescriptor : NSCopying
 	{
 		[Export ("initWithVertexDescriptor:")]
-		IntPtr Constructor (MDLVertexDescriptor vertexDescriptor);
+		NativeHandle Constructor (MDLVertexDescriptor vertexDescriptor);
 
 		[Export ("attributeNamed:")]
 		[return: NullAllowed]
@@ -2137,22 +2141,22 @@ namespace ModelIO {
 
 		[Deprecated (PlatformName.MacOSX, 10, 12, message: "Use 'new MDLVoxelArray (MDLAsset, int, float)'.")]
 		[Export ("initWithAsset:divisions:interiorShells:exteriorShells:patchRadius:")]
-		IntPtr Constructor (MDLAsset asset, int divisions, int interiorShells, int exteriorShells, float patchRadius);
+		NativeHandle Constructor (MDLAsset asset, int divisions, int interiorShells, int exteriorShells, float patchRadius);
 
 		[Deprecated (PlatformName.MacOSX, 10, 12, message: "Use 'new MDLVoxelArray (MDLAsset, int, float)'.")]
 		[Obsoleted (PlatformName.iOS, 10, 0, message: "Use new MDLVoxelArray (MDLAsset, int, float)")]
 		[Export ("initWithAsset:divisions:interiorNBWidth:exteriorNBWidth:patchRadius:")]
-		IntPtr Constructor (MDLAsset asset, int divisions, float interiorNBWidth, float exteriorNBWidth, float patchRadius);
+		NativeHandle Constructor (MDLAsset asset, int divisions, float interiorNBWidth, float exteriorNBWidth, float patchRadius);
 
 		[iOS (10,0)]
 		[Mac (10,12)]
 		[TV (10,0)]
 		[Export ("initWithAsset:divisions:patchRadius:")]
-		IntPtr Constructor (MDLAsset asset, int divisions, float patchRadius);
+		NativeHandle Constructor (MDLAsset asset, int divisions, float patchRadius);
 
 		[Export ("initWithData:boundingBox:voxelExtent:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (NSData voxelData, MDLAxisAlignedBoundingBox boundingBox, float voxelExtent);
+		NativeHandle Constructor (NSData voxelData, MDLAxisAlignedBoundingBox boundingBox, float voxelExtent);
 		
 		[Export ("meshUsingAllocator:")]
 		[return: NullAllowed]
@@ -2342,7 +2346,7 @@ namespace ModelIO {
 		[Mac (10,12)]
 		[TV (10,0)]
 		[Export ("initWithStride:")]
-		IntPtr Constructor (nuint stride);
+		NativeHandle Constructor (nuint stride);
 
 		[Export ("stride", ArgumentSemantic.Assign)]
 		nuint Stride { get; set; }
@@ -2354,7 +2358,7 @@ namespace ModelIO {
 		[iOS (10,2), Mac (10,12,2)]
 		[TV (10,1)]
 		[Export ("initWithSubmesh:")]
-		IntPtr Constructor (MDLSubmesh submesh);
+		NativeHandle Constructor (MDLSubmesh submesh);
 
 		[NullAllowed, Export ("faceTopology", ArgumentSemantic.Retain)]
 		IMDLMeshBuffer FaceTopology { get; set; }
@@ -2429,7 +2433,7 @@ namespace ModelIO {
 		nuint ElementCount { get; }
 
 		[Export ("initWithElementCount:")]
-		IntPtr Constructor (nuint arrayElementCount);
+		NativeHandle Constructor (nuint arrayElementCount);
 
 		[Internal]
 		[Export ("setFloatArray:count:atTime:")]
@@ -2472,7 +2476,7 @@ namespace ModelIO {
 		nuint ElementCount { get; }
 
 		[Export ("initWithElementCount:")]
-		IntPtr Constructor (nuint arrayElementCount);
+		NativeHandle Constructor (nuint arrayElementCount);
 
 		[Internal]
 		[Export ("setFloat3Array:count:atTime:")]
@@ -2515,7 +2519,7 @@ namespace ModelIO {
 		nuint ElementCount { get; }
 
 		[Export ("initWithElementCount:")]
-		IntPtr Constructor (nuint arrayElementCount);
+		NativeHandle Constructor (nuint arrayElementCount);
 
 		[Internal]
 		[Export ("setFloatQuaternionArray:count:atTime:")]
@@ -2747,7 +2751,7 @@ namespace ModelIO {
 		MDLMatrix4x4Array JointRestTransforms { get; }
 
 		[Export ("initWithName:jointPaths:")]
-		IntPtr Constructor (string name, string[] jointPaths);
+		NativeHandle Constructor (string name, string[] jointPaths);
 	}
 
 	interface IMDLJointAnimation { }
@@ -2775,7 +2779,7 @@ namespace ModelIO {
 		MDLAnimatedVector3Array Scales { get; }
 
 		[Export ("initWithName:jointPaths:")]
-		IntPtr Constructor (string name, string [] jointPaths);
+		NativeHandle Constructor (string name, string [] jointPaths);
 	}
 
 	[iOS (11,0), Mac (10,13), TV (11,0)]
@@ -2821,7 +2825,7 @@ namespace ModelIO {
 	interface MDLRelativeAssetResolver : MDLAssetResolver {
 
 		[Export ("initWithAsset:")]
-		IntPtr Constructor (MDLAsset asset);
+		NativeHandle Constructor (MDLAsset asset);
 
 		[NullAllowed, Export ("asset", ArgumentSemantic.Weak)]
 		MDLAsset Asset { get; set; }
@@ -2833,7 +2837,7 @@ namespace ModelIO {
 	interface MDLPathAssetResolver : MDLAssetResolver {
 
 		[Export ("initWithPath:")]
-		IntPtr Constructor (string path);
+		NativeHandle Constructor (string path);
 
 		[Export ("path")]
 		string Path { get; set; }
@@ -2845,7 +2849,7 @@ namespace ModelIO {
 	interface MDLBundleAssetResolver : MDLAssetResolver {
 
 		[Export ("initWithBundle:")]
-		IntPtr Constructor (string path);
+		NativeHandle Constructor (string path);
 
 		[Export ("path")]
 		string Path { get; set; }
@@ -3038,7 +3042,7 @@ namespace ModelIO {
 		void Clear ();
 
 		[Export ("initWithElementCount:")]
-		IntPtr Constructor (nuint arrayElementCount);
+		NativeHandle Constructor (nuint arrayElementCount);
 
 		[Internal]
 		[Export ("setFloat4x4Array:count:")]

--- a/src/multipeerconnectivity.cs
+++ b/src/multipeerconnectivity.cs
@@ -17,6 +17,10 @@ using AppKit;
 using UIKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MultipeerConnectivity {
 
 	[TV (10,0)]
@@ -27,7 +31,7 @@ namespace MultipeerConnectivity {
 
 		[DesignatedInitializer]
 		[Export ("initWithDisplayName:")]
-		IntPtr Constructor (string myDisplayName);
+		NativeHandle Constructor (string myDisplayName);
 
 		[Export ("displayName")]
 		string DisplayName { get; }
@@ -42,7 +46,7 @@ namespace MultipeerConnectivity {
 	partial interface MCSession {
 
 		[Export ("initWithPeer:")]
-		IntPtr Constructor (MCPeerID myPeerID);
+		NativeHandle Constructor (MCPeerID myPeerID);
 
 		// Note: it should be a constructor but it's use of an NSArray of different types makes it hard to provide a 
 		// nice binding, i.e. the first item of NSArray must be an SecIdentity followed by (0...) SecCertificate
@@ -145,7 +149,7 @@ namespace MultipeerConnectivity {
 
 		[DesignatedInitializer]
 		[Export ("initWithPeer:discoveryInfo:serviceType:")]
-		IntPtr Constructor (MCPeerID myPeerID, [NullAllowed] NSDictionary info, string serviceType);
+		NativeHandle Constructor (MCPeerID myPeerID, [NullAllowed] NSDictionary info, string serviceType);
 
 		[Export ("startAdvertisingPeer")]
 		void StartAdvertisingPeer ();
@@ -196,7 +200,7 @@ namespace MultipeerConnectivity {
 
 		[DesignatedInitializer]
 		[Export ("initWithPeer:serviceType:")]
-		IntPtr Constructor (MCPeerID myPeerID, string serviceType);
+		NativeHandle Constructor (MCPeerID myPeerID, string serviceType);
 
 		[Export ("startBrowsingForPeers")]
 		void StartBrowsingForPeers ();
@@ -254,14 +258,14 @@ namespace MultipeerConnectivity {
 	partial interface MCBrowserViewController : MCNearbyServiceBrowserDelegate {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[DesignatedInitializer]
 		[Export ("initWithBrowser:session:")]
-		IntPtr Constructor (MCNearbyServiceBrowser browser, MCSession session);
+		NativeHandle Constructor (MCNearbyServiceBrowser browser, MCSession session);
 
 		[Export ("initWithServiceType:session:")]
-		IntPtr Constructor (string serviceType, MCSession session);
+		NativeHandle Constructor (string serviceType, MCSession session);
 
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -315,7 +319,7 @@ namespace MultipeerConnectivity {
 
 		[DesignatedInitializer]
 		[Export ("initWithServiceType:discoveryInfo:session:")]
-		IntPtr Constructor (string serviceType, [NullAllowed] NSDictionary info, MCSession session);
+		NativeHandle Constructor (string serviceType, [NullAllowed] NSDictionary info, MCSession session);
 
 		[NullAllowed]
 		[Export ("discoveryInfo")]

--- a/src/naturallanguage.cs
+++ b/src/naturallanguage.cs
@@ -26,6 +26,10 @@ using Foundation;
 using CoreML;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace NaturalLanguage {
 
 	[iOS (12,0), Mac (10,14), TV (12,0), Watch (5,0)]
@@ -35,7 +39,7 @@ namespace NaturalLanguage {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Static]
 		[Internal]
@@ -150,7 +154,7 @@ namespace NaturalLanguage {
 	{
 		[Export ("initWithUnit:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NLTokenUnit unit);
+		NativeHandle Constructor (NLTokenUnit unit);
 
 		[Export ("unit")]
 		NLTokenUnit Unit { get; }
@@ -190,10 +194,10 @@ namespace NaturalLanguage {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithTagSchemes:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([Params] NSString[] tagSchemes);
+		NativeHandle Constructor ([Params] NSString[] tagSchemes);
 
 		[Wrap ("this (Array.ConvertAll (tagSchemes, e => e.GetConstant ()!))")]
-		IntPtr Constructor ([Params] NLTagScheme[] tagSchemes);
+		NativeHandle Constructor ([Params] NLTagScheme[] tagSchemes);
 
 		[Internal]
 		[Export ("tagSchemes", ArgumentSemantic.Copy)]
@@ -595,21 +599,21 @@ namespace NaturalLanguage {
 
 		[Export ("initWithContentsOfURL:error:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl url, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] out NSError error);
 
 		[Export ("initWithData:error:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSData data, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSData data, [NullAllowed] out NSError error);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithDictionary:language:error:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSDictionary dictionary, [NullAllowed] NSString language, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSDictionary dictionary, [NullAllowed] NSString language, [NullAllowed] out NSError error);
 
 		// sadly `language?.GetConstant ()` does not cut it :(
 		// error CS1929: 'NLLanguage?' does not contain a definition for 'GetConstant' and the best extension method overload 'NLLanguageExtensions.GetConstant(NLLanguage)' requires a receiver of type 'NLLanguage'
 		[Wrap ("this (dictionary.GetDictionary ()!, language.HasValue ? language.Value.GetConstant () : null, out error)")]
-		IntPtr Constructor (NLStrongDictionary dictionary, NLLanguage? language, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NLStrongDictionary dictionary, NLLanguage? language, [NullAllowed] out NSError error);
 
 		[Export ("labelForString:")]
 		[return: NullAllowed]

--- a/src/nearbyinteraction.cs
+++ b/src/nearbyinteraction.cs
@@ -13,6 +13,10 @@ using CoreFoundation;
 using System;
 using Vector3 = global::OpenTK.Vector3;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace NearbyInteraction {
 
 	[Watch (8,0), NoTV, NoMac, iOS (14,0)]
@@ -37,7 +41,7 @@ namespace NearbyInteraction {
 		NIDiscoveryToken PeerDiscoveryToken { get; }
 
 		[Export ("initWithPeerToken:")]
-		IntPtr Constructor (NIDiscoveryToken peerToken);
+		NativeHandle Constructor (NIDiscoveryToken peerToken);
 	}
 
 	[Watch (8,0), NoTV, NoMac, iOS (14,0)]
@@ -135,7 +139,7 @@ namespace NearbyInteraction {
 		NIDiscoveryToken AccessoryDiscoveryToken { get; }
 
 		[Export ("initWithData:error:")]
-		IntPtr Constructor (NSData data, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSData data, [NullAllowed] out NSError error);
 	}
 
 }

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -10,6 +10,10 @@ using Network;
 using OS_nw_parameters = System.IntPtr;
 using OS_nw_interface = System.IntPtr;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace NetworkExtension {
 
 	// Just to satisfy the core dll contract, the right type will be used on the generated file
@@ -300,11 +304,11 @@ namespace NetworkExtension {
 	interface NEAppRule : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithSigningIdentifier:")]
-		IntPtr Constructor (string signingIdentifier);
+		NativeHandle Constructor (string signingIdentifier);
 
 		[NoiOS, NoTV, NoWatch, MacCatalyst (15,0)]
 		[Export ("initWithSigningIdentifier:designatedRequirement:")]
-		IntPtr Constructor (string signingIdentifier, string designatedRequirement);
+		NativeHandle Constructor (string signingIdentifier, string designatedRequirement);
 
 		[NoiOS, NoTV, NoWatch, MacCatalyst (15,0)]
 		[Export ("matchDesignatedRequirement")]
@@ -331,7 +335,7 @@ namespace NetworkExtension {
 	interface NEDnsSettings : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithServers:")]
-		IntPtr Constructor (string[] servers);
+		NativeHandle Constructor (string[] servers);
 	
 		[Export ("servers")]
 		string[] Servers { get; }
@@ -846,7 +850,7 @@ namespace NetworkExtension {
 	interface NEIPv4Route : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithDestinationAddress:subnetMask:")]
-		IntPtr Constructor (string address, string subnetMask);
+		NativeHandle Constructor (string address, string subnetMask);
 	
 		[Export ("destinationAddress")]
 		string DestinationAddress { get; }
@@ -868,7 +872,7 @@ namespace NetworkExtension {
 	interface NEIPv6Route : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithDestinationAddress:networkPrefixLength:")]
-		IntPtr Constructor (string address, NSNumber networkPrefixLength);
+		NativeHandle Constructor (string address, NSNumber networkPrefixLength);
 	
 		[Export ("destinationAddress")]
 		string DestinationAddress { get; }
@@ -890,7 +894,7 @@ namespace NetworkExtension {
 	interface NEIPv4Settings : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithAddresses:subnetMasks:")]
-		IntPtr Constructor (string[] addresses, string[] subnetMasks);
+		NativeHandle Constructor (string[] addresses, string[] subnetMasks);
 	
 		[Export ("addresses")]
 		string[] Addresses { get; }
@@ -911,7 +915,7 @@ namespace NetworkExtension {
 	interface NEIPv6Settings : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithAddresses:networkPrefixLengths:")]
-		IntPtr Constructor (string[] addresses, NSNumber[] networkPrefixLengths);
+		NativeHandle Constructor (string[] addresses, NSNumber[] networkPrefixLengths);
 	
 		[Export ("addresses")]
 		string[] Addresses { get; }
@@ -1002,7 +1006,7 @@ namespace NetworkExtension {
 	interface NEProxyServer : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithAddress:port:")]
-		IntPtr Constructor (string address, nint port);
+		NativeHandle Constructor (string address, nint port);
 	
 		[Export ("address")]
 		string Address { get; }
@@ -1026,7 +1030,7 @@ namespace NetworkExtension {
 	interface NETunnelNetworkSettings : NSSecureCoding, NSCopying
 	{
 		[Export ("initWithTunnelRemoteAddress:")]
-		IntPtr Constructor (string address);
+		NativeHandle Constructor (string address);
 	
 		[Export ("tunnelRemoteAddress")]
 		string TunnelRemoteAddress { get; }
@@ -1454,7 +1458,7 @@ namespace NetworkExtension {
 	interface NEEvaluateConnectionRule : NSSecureCoding, NSCopying {
 
 		[Export ("initWithMatchDomains:andAction:")]
-		IntPtr Constructor (string [] domains, NEEvaluateConnectionRuleAction action);
+		NativeHandle Constructor (string [] domains, NEEvaluateConnectionRuleAction action);
 
 		[Export ("action")]
 		NEEvaluateConnectionRuleAction Action { get; }
@@ -1537,7 +1541,7 @@ namespace NetworkExtension {
 	interface NWTcpConnection
 	{
 		[Export ("initWithUpgradeForConnection:")]
-		IntPtr Constructor (NWTcpConnection connection);
+		NativeHandle Constructor (NWTcpConnection connection);
 	
 		[Export ("state")]
 		NWTcpConnectionState State { get; }
@@ -1629,7 +1633,7 @@ namespace NetworkExtension {
 	interface NWUdpSession
 	{
 		[Export ("initWithUpgradeForSession:")]
-		IntPtr Constructor (NWUdpSession session);
+		NativeHandle Constructor (NWUdpSession session);
 	
 		[Export ("state")]
 		NWUdpSessionState State { get; }
@@ -1760,7 +1764,7 @@ namespace NetworkExtension {
 	[DisableDefaultCtor]
 	interface NEPacketTunnelNetworkSettings {
 		[Export ("initWithTunnelRemoteAddress:")]
-		IntPtr Constructor (string address);
+		NativeHandle Constructor (string address);
 
 		[Export ("IPv4Settings", ArgumentSemantic.Copy)]
 		[NullAllowed]
@@ -1850,7 +1854,7 @@ namespace NetworkExtension {
 	[BaseType (typeof (NSObject))]
 	interface NEPacket : NSCopying, NSSecureCoding {
 		[Export ("initWithData:protocolFamily:")]
-		IntPtr Constructor (NSData data, /* sa_family_t */ byte protocolFamily);
+		NativeHandle Constructor (NSData data, /* sa_family_t */ byte protocolFamily);
 
 		[Export ("data", ArgumentSemantic.Copy)]
 		NSData Data { get; }
@@ -1962,7 +1966,7 @@ namespace NetworkExtension {
 		string [] MccAndMncs { get; set; }
 
 		[Export ("initWithDomainName:roamingEnabled:")]
-		IntPtr Constructor (string domainName, bool roamingEnabled);
+		NativeHandle Constructor (string domainName, bool roamingEnabled);
 	}
 
 	[iOS (11,0), NoMac]
@@ -2024,10 +2028,10 @@ namespace NetworkExtension {
 		IntPtr initWithSsid (string ssid, string passphrase, bool isWep);
 
 		[Export ("initWithSSID:eapSettings:")]
-		IntPtr Constructor (string ssid, NEHotspotEapSettings eapSettings);
+		NativeHandle Constructor (string ssid, NEHotspotEapSettings eapSettings);
 
 		[Export ("initWithHS20Settings:eapSettings:")]
-		IntPtr Constructor (NEHotspotHS20Settings hs20Settings, NEHotspotEapSettings eapSettings);
+		NativeHandle Constructor (NEHotspotHS20Settings hs20Settings, NEHotspotEapSettings eapSettings);
 	
 		[Internal]
 		[iOS (13,0)]
@@ -2078,13 +2082,13 @@ namespace NetworkExtension {
 	interface NENetworkRule : NSSecureCoding, NSCopying {
 
 		[Export ("initWithDestinationNetwork:prefix:protocol:")]
-		IntPtr Constructor (NWHostEndpoint networkEndpoint, nuint destinationPrefix, NENetworkRuleProtocol protocol);
+		NativeHandle Constructor (NWHostEndpoint networkEndpoint, nuint destinationPrefix, NENetworkRuleProtocol protocol);
 
 		[Export ("initWithDestinationHost:protocol:")]
-		IntPtr Constructor (NWHostEndpoint hostEndpoint, NENetworkRuleProtocol protocol);
+		NativeHandle Constructor (NWHostEndpoint hostEndpoint, NENetworkRuleProtocol protocol);
 
 		[Export ("initWithRemoteNetwork:remotePrefix:localNetwork:localPrefix:protocol:direction:")]
-		IntPtr Constructor ([NullAllowed] NWHostEndpoint remoteNetwork, nuint remotePrefix, [NullAllowed] NWHostEndpoint localNetwork, nuint localPrefix, NENetworkRuleProtocol protocol, NETrafficDirection direction);
+		NativeHandle Constructor ([NullAllowed] NWHostEndpoint remoteNetwork, nuint remotePrefix, [NullAllowed] NWHostEndpoint localNetwork, nuint localPrefix, NENetworkRuleProtocol protocol, NETrafficDirection direction);
 
 		[NullAllowed, Export ("matchRemoteEndpoint")]
 		NWHostEndpoint MatchRemoteEndpoint { get; }
@@ -2112,7 +2116,7 @@ namespace NetworkExtension {
 	interface NEFilterRule : NSSecureCoding, NSCopying {
 
 		[Export ("initWithNetworkRule:action:")]
-		IntPtr Constructor (NENetworkRule networkRule, NEFilterAction action);
+		NativeHandle Constructor (NENetworkRule networkRule, NEFilterAction action);
 
 		[Export ("networkRule", ArgumentSemantic.Copy)]
 		NENetworkRule NetworkRule { get; }
@@ -2128,7 +2132,7 @@ namespace NetworkExtension {
 	interface NEFilterSettings : NSSecureCoding, NSCopying {
 
 		[Export ("initWithRules:defaultAction:")]
-		IntPtr Constructor (NEFilterRule[] rules, NEFilterAction defaultAction);
+		NativeHandle Constructor (NEFilterRule[] rules, NEFilterAction defaultAction);
 
 		[Export ("rules", ArgumentSemantic.Copy)]
 		NEFilterRule[] Rules { get; }

--- a/src/notificationcenter.cs
+++ b/src/notificationcenter.cs
@@ -10,6 +10,10 @@ using UIKit;
 using AppKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace NotificationCenter {
 	[iOS (8,0)][Mac (10,10)]
 	[BaseType (typeof (NSObject))]
@@ -129,7 +133,7 @@ namespace NotificationCenter {
 	interface NCWidgetListViewController
 	{
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 		
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		INCWidgetListViewDelegate Delegate { get; set; }
@@ -190,7 +194,7 @@ namespace NotificationCenter {
 	interface NCWidgetSearchViewController
 	{
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		INCWidgetSearchViewDelegate Delegate { get; set; }

--- a/src/opengles.cs
+++ b/src/opengles.cs
@@ -15,6 +15,10 @@ using CoreLocation;
 using UIKit;
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace OpenGLES {
 
 	[Deprecated (PlatformName.iOS, 12,0, message: "Use 'Metal' instead.")]
@@ -35,11 +39,11 @@ namespace OpenGLES {
 	[DisableDefaultCtor] // init now marked with NS_UNAVAILABLE
 	interface EAGLContext {
 		[Export ("initWithAPI:")]
-		IntPtr Constructor (EAGLRenderingAPI api);
+		NativeHandle Constructor (EAGLRenderingAPI api);
 
 		[DesignatedInitializer]
 		[Export ("initWithAPI:sharegroup:")]
-		IntPtr Constructor (EAGLRenderingAPI api, EAGLSharegroup sharegroup);
+		NativeHandle Constructor (EAGLRenderingAPI api, EAGLSharegroup sharegroup);
 
 		[Static, Export("setCurrentContext:")]
 		bool SetCurrentContext([NullAllowed] EAGLContext context);

--- a/src/oslog.cs
+++ b/src/oslog.cs
@@ -3,6 +3,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace OSLog {
 
 	[Watch (8,0), TV (15,0), iOS (15,0), Mac (11,0), MacCatalyst (15,0)]
@@ -217,7 +221,7 @@ namespace OSLog {
 
 		[NoWatch, NoTV, NoiOS, Mac (12,0), MacCatalyst (15,0)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 		
 		[NoWatch, NoTV, NoiOS, MacCatalyst (15,0)]
 		[Static]

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -32,6 +32,10 @@ using UIWindow = Foundation.NSObject;
 #endif // IOS
 #endif // MONOMAC
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace PassKit {
 
 	[Watch (3,0)]
@@ -364,7 +368,7 @@ namespace PassKit {
 	interface PKPaymentAuthorizationViewController {
 		[DesignatedInitializer]
 		[Export ("initWithPaymentRequest:")]
-		IntPtr Constructor (PKPaymentRequest request);
+		NativeHandle Constructor (PKPaymentRequest request);
 
 		[Export ("delegate", ArgumentSemantic.UnsafeUnretained)]
 		[NullAllowed]
@@ -648,14 +652,14 @@ namespace PassKit {
 
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("initWithPass:")]
-		IntPtr Constructor (PKPass pass);
+		NativeHandle Constructor (PKPass pass);
 
 		[iOS (7,0)]
 		[Export ("initWithPasses:")]
-		IntPtr Constructor (PKPass[] pass);
+		NativeHandle Constructor (PKPass[] pass);
 
 		[iOS (8,0)]
 		[Static]
@@ -689,7 +693,7 @@ namespace PassKit {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[NullAllowed, Export ("encryptedPassData", ArgumentSemantic.Copy)]
 		NSData EncryptedPassData { get; set; }
@@ -713,7 +717,7 @@ namespace PassKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithEncryptionScheme:")]
-		IntPtr Constructor (NSString encryptionScheme);
+		NativeHandle Constructor (NSString encryptionScheme);
 
 		[Export ("encryptionScheme")]
 		NSString EncryptionScheme { get; }
@@ -766,12 +770,12 @@ namespace PassKit {
 	
 		[DesignatedInitializer]
 		[Export ("initWithRequestConfiguration:delegate:")]
-		IntPtr Constructor (PKAddPaymentPassRequestConfiguration configuration, [NullAllowed] IPKAddPaymentPassViewControllerDelegate viewControllerDelegate);
+		NativeHandle Constructor (PKAddPaymentPassRequestConfiguration configuration, [NullAllowed] IPKAddPaymentPassViewControllerDelegate viewControllerDelegate);
 
 #if !XAMCORE_4_0
 		[Obsolete ("Use the overload accepting a IPKAddPaymentPassViewControllerDelegate")]
 		[Wrap ("this (configuration, (IPKAddPaymentPassViewControllerDelegate) viewControllerDelegate)")]
-		IntPtr Constructor (PKAddPaymentPassRequestConfiguration configuration, PKAddPaymentPassViewControllerDelegate viewControllerDelegate);
+		NativeHandle Constructor (PKAddPaymentPassRequestConfiguration configuration, PKAddPaymentPassViewControllerDelegate viewControllerDelegate);
 #endif
 
 		[Wrap ("WeakDelegate")]
@@ -803,7 +807,7 @@ namespace PassKit {
 	[BaseType (typeof (PKObject))]
 	interface PKPass : NSSecureCoding, NSCopying {
 		[Export ("initWithData:error:")]
-		IntPtr Constructor (NSData data, out NSError error);
+		NativeHandle Constructor (NSData data, out NSError error);
 
 		[Export ("authenticationToken", ArgumentSemantic.Copy)]
 		string AuthenticationToken { get; }
@@ -1052,7 +1056,7 @@ namespace PassKit {
 		[iOS (9,0)]
 		[Export ("initWithPaymentButtonType:paymentButtonStyle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PKPaymentButtonType type, PKPaymentButtonStyle style);
+		NativeHandle Constructor (PKPaymentButtonType type, PKPaymentButtonStyle style);
 
 		[iOS (12, 0)]
 		[Export ("cornerRadius")]
@@ -1070,7 +1074,7 @@ namespace PassKit {
 
 		[Export ("initWithAddPassButtonStyle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PKAddPassButtonStyle style);
+		NativeHandle Constructor (PKAddPassButtonStyle style);
 
 		[Appearance]
 		[Export ("addPassButtonStyle", ArgumentSemantic.Assign)]
@@ -1114,7 +1118,7 @@ namespace PassKit {
 
 		[Export ("initWithPaymentRequest:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PKPaymentRequest request);
+		NativeHandle Constructor (PKPaymentRequest request);
 
 		[Async]
 		[Export ("presentWithCompletion:")]
@@ -1211,7 +1215,7 @@ namespace PassKit {
 	{
 		[Export ("initWithLabel:value:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string label, string value);
+		NativeHandle Constructor (string label, string value);
 
 		[Export ("label")]
 		string Label { get; }
@@ -1316,7 +1320,7 @@ namespace PassKit {
 	interface PKPaymentAuthorizationResult {
 		[Export ("initWithStatus:errors:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PKPaymentAuthorizationStatus status, [NullAllowed] NSError[] errors);
+		NativeHandle Constructor (PKPaymentAuthorizationStatus status, [NullAllowed] NSError[] errors);
 
 		[Export ("status", ArgumentSemantic.Assign)]
 		PKPaymentAuthorizationStatus Status { get; set; }
@@ -1333,7 +1337,7 @@ namespace PassKit {
 
 		[Export ("initWithPaymentSummaryItems:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PKPaymentSummaryItem[] paymentSummaryItems);
+		NativeHandle Constructor (PKPaymentSummaryItem[] paymentSummaryItems);
 
 		[Export ("status", ArgumentSemantic.Assign)]
 		PKPaymentAuthorizationStatus Status { get; set; }
@@ -1354,7 +1358,7 @@ namespace PassKit {
 
 		[Export ("initWithErrors:paymentSummaryItems:shippingMethods:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSError[] errors, PKPaymentSummaryItem[] paymentSummaryItems, PKShippingMethod[] shippingMethods);
+		NativeHandle Constructor ([NullAllowed] NSError[] errors, PKPaymentSummaryItem[] paymentSummaryItems, PKShippingMethod[] shippingMethods);
 
 		[Export ("shippingMethods", ArgumentSemantic.Copy)]
 		PKShippingMethod[] ShippingMethods { get; set; }
@@ -1372,7 +1376,7 @@ namespace PassKit {
 		// inlined
 		[Export ("initWithPaymentSummaryItems:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PKPaymentSummaryItem[] paymentSummaryItems);
+		NativeHandle Constructor (PKPaymentSummaryItem[] paymentSummaryItems);
 	}
 
 	[Mac (11,0)]
@@ -1384,7 +1388,7 @@ namespace PassKit {
 		[Watch (6,0), iOS (13,0)]
 		[Export ("initWithErrors:paymentSummaryItems:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSError[] errors, PKPaymentSummaryItem [] paymentSummaryItems);
+		NativeHandle Constructor ([NullAllowed] NSError[] errors, PKPaymentSummaryItem [] paymentSummaryItems);
 
 		[Watch (6,0), iOS (13,0)]
 		[Export ("errors", ArgumentSemantic.Copy)]
@@ -1393,7 +1397,7 @@ namespace PassKit {
 		// inlined
 		[Export ("initWithPaymentSummaryItems:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PKPaymentSummaryItem[] paymentSummaryItems);
+		NativeHandle Constructor (PKPaymentSummaryItem[] paymentSummaryItems);
 	}
 
 	[Mac (11,0)]
@@ -1434,7 +1438,7 @@ namespace PassKit {
 	interface PKDisbursementAuthorizationController {
 
 		[Export ("initWithDisbursementRequest:delegate:")]
-		IntPtr Constructor (PKDisbursementRequest disbursementRequest, IPKDisbursementAuthorizationControllerDelegate @delegate);
+		NativeHandle Constructor (PKDisbursementRequest disbursementRequest, IPKDisbursementAuthorizationControllerDelegate @delegate);
 
 		[Wrap ("WeakDelegate")]
 		IPKDisbursementAuthorizationControllerDelegate Delegate { get; }
@@ -1614,7 +1618,7 @@ namespace PassKit {
 		bool CanAddSecureElementPass (PKAddSecureElementPassConfiguration configuration);
 
 		[Export ("initWithConfiguration:delegate:")]
-		IntPtr Constructor (PKAddSecureElementPassConfiguration configuration, [NullAllowed] IPKAddSecureElementPassViewControllerDelegate @delegate);
+		NativeHandle Constructor (PKAddSecureElementPassConfiguration configuration, [NullAllowed] IPKAddSecureElementPassViewControllerDelegate @delegate);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -1633,11 +1637,11 @@ namespace PassKit {
 	interface PKShareablePassMetadata {
 
 		[Export ("initWithProvisioningCredentialIdentifier:cardConfigurationIdentifier:sharingInstanceIdentifier:passThumbnailImage:ownerDisplayName:localizedDescription:")]
-		IntPtr Constructor (string credentialIdentifier, string cardConfigurationIdentifier, string sharingInstanceIdentifier, CGImage passThumbnailImage, string ownerDisplayName, string localizedDescription);
+		NativeHandle Constructor (string credentialIdentifier, string cardConfigurationIdentifier, string sharingInstanceIdentifier, CGImage passThumbnailImage, string ownerDisplayName, string localizedDescription);
 
 		[Watch (8,0), iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
 		[Export ("initWithProvisioningCredentialIdentifier:sharingInstanceIdentifier:passThumbnailImage:ownerDisplayName:localizedDescription:accountHash:templateIdentifier:relyingPartyIdentifier:requiresUnifiedAccessCapableDevice:")]
-		IntPtr Constructor (string credentialIdentifier, string sharingInstanceIdentifier, CGImage passThumbnailImage, string ownerDisplayName, string localizedDescription, string accountHash, string templateIdentifier, string relyingPartyIdentifier, bool requiresUnifiedAccessCapableDevice);
+		NativeHandle Constructor (string credentialIdentifier, string sharingInstanceIdentifier, CGImage passThumbnailImage, string ownerDisplayName, string localizedDescription, string accountHash, string templateIdentifier, string relyingPartyIdentifier, bool requiresUnifiedAccessCapableDevice);
 
 		[Export ("credentialIdentifier", ArgumentSemantic.Strong)]
 		string CredentialIdentifier { get; }
@@ -1739,7 +1743,7 @@ namespace PassKit {
 	interface PKBarcodeEventMetadataResponse {
 
 		[Export ("initWithPaymentInformation:")]
-		IntPtr Constructor (NSData paymentInformation);
+		NativeHandle Constructor (NSData paymentInformation);
 
 		[Export ("paymentInformation", ArgumentSemantic.Copy)]
 		NSData PaymentInformation { get; set; }
@@ -1794,7 +1798,7 @@ namespace PassKit {
 	interface PKBarcodeEventSignatureResponse {
 
 		[Export ("initWithSignedData:")]
-		IntPtr Constructor (NSData signedData);
+		NativeHandle Constructor (NSData signedData);
 
 		[Export ("signedData", ArgumentSemantic.Copy)]
 		NSData SignedData { get; set; }
@@ -1911,7 +1915,7 @@ namespace PassKit {
 
 		[Export ("initWithIdentifier:title:art:addRequestConfiguration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier, string title, CGImage art, PKAddPaymentPassRequestConfiguration configuration);
+		NativeHandle Constructor (string identifier, string title, CGImage art, PKAddPaymentPassRequestConfiguration configuration);
 
 		[Export ("addRequestConfiguration")]
 		PKAddPaymentPassRequestConfiguration AddRequestConfiguration { get; }
@@ -1925,7 +1929,7 @@ namespace PassKit {
 	interface PKPaymentMerchantSession {
 
 		[Export ("initWithDictionary:")]
-		IntPtr Constructor (NSDictionary dictionary);
+		NativeHandle Constructor (NSDictionary dictionary);
 	}
 
 	[NoTV]
@@ -1935,7 +1939,7 @@ namespace PassKit {
 	interface PKPaymentRequestMerchantSessionUpdate {
 
 		[Export ("initWithStatus:merchantSession:")]
-		IntPtr Constructor (PKPaymentAuthorizationStatus status, [NullAllowed] PKPaymentMerchantSession session);
+		NativeHandle Constructor (PKPaymentAuthorizationStatus status, [NullAllowed] PKPaymentMerchantSession session);
 
 		[Export ("status", ArgumentSemantic.Assign)]
 		PKPaymentAuthorizationStatus Status { get; set; }
@@ -1951,11 +1955,11 @@ namespace PassKit {
 	{
 		[Export ("initWithPaymentSummaryItems:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PKPaymentSummaryItem[] paymentSummaryItems);
+		NativeHandle Constructor (PKPaymentSummaryItem[] paymentSummaryItems);
 
 		[Export ("initWithErrors:paymentSummaryItems:shippingMethods:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSError[] errors, PKPaymentSummaryItem[] paymentSummaryItems, PKShippingMethod[] shippingMethods);
+		NativeHandle Constructor ([NullAllowed] NSError[] errors, PKPaymentSummaryItem[] paymentSummaryItems, PKShippingMethod[] shippingMethods);
 
 		[NullAllowed, Export ("errors", ArgumentSemantic.Copy)]
 		NSError[] Errors { get; set; }
@@ -1984,7 +1988,7 @@ namespace PassKit {
 	{
 		[Export ("initWithStartDateComponents:endDateComponents:")]
 		[return: NullAllowed]
-		IntPtr Constructor (NSDateComponents startDateComponents, NSDateComponents endDateComponents);
+		NativeHandle Constructor (NSDateComponents startDateComponents, NSDateComponents endDateComponents);
 
 		[Export ("startDateComponents", ArgumentSemantic.Copy)]
 		NSDateComponents StartDateComponents { get; }

--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -51,6 +51,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 // Verify/Test Delegate Models
 // Check for missing NullAllowed on all object properties
 // Test methods returning typed arrays in lieu of NSArray
@@ -491,7 +495,7 @@ namespace PdfKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithDestination:")]
-		IntPtr Constructor (PdfDestination destination);
+		NativeHandle Constructor (PdfDestination destination);
 
 		[Export ("destination")]
 		PdfDestination Destination { get; set; }
@@ -503,7 +507,7 @@ namespace PdfKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithName:")]
-		IntPtr Constructor (PdfActionNamedName name);
+		NativeHandle Constructor (PdfActionNamedName name);
 
 		[Export ("name")]
 		PdfActionNamedName Name { get; set; }
@@ -515,7 +519,7 @@ namespace PdfKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithPageIndex:atPoint:fileURL:")]
-		IntPtr Constructor (nint pageIndex, CGPoint point, NSUrl fileUrl);
+		NativeHandle Constructor (nint pageIndex, CGPoint point, NSUrl fileUrl);
 
 		[Export ("pageIndex")]
 		nint PageIndex { get; set; }
@@ -534,7 +538,7 @@ namespace PdfKit {
 		// - (instancetype)init NS_DESIGNATED_INITIALIZER;
 		[Export ("init")]
 		[DesignatedInitializer]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 		
 		//NSArray of NSString
 		[Export ("fields"), NullAllowed]
@@ -550,7 +554,7 @@ namespace PdfKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("URL"), NullAllowed]
 		NSUrl Url { get; set; }
@@ -563,17 +567,17 @@ namespace PdfKit {
 		[Mac (10,13)]
 		[Export ("initWithBounds:forType:withProperties:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect bounds, NSString annotationType, [NullAllowed] NSDictionary properties);
+		NativeHandle Constructor (CGRect bounds, NSString annotationType, [NullAllowed] NSDictionary properties);
 
 		[Mac (10,13)]
 		[Wrap ("this (bounds, annotationType.GetConstant ()!, properties)")]
-		IntPtr Constructor (CGRect bounds, PdfAnnotationKey annotationType, [NullAllowed] NSDictionary properties);
+		NativeHandle Constructor (CGRect bounds, PdfAnnotationKey annotationType, [NullAllowed] NSDictionary properties);
 
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use '.ctor (CGRect, PDFAnnotationKey, NSDictionary)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 12, message: "Use '.ctor (CGRect, PDFAnnotationKey, NSDictionary)' instead.")]
 		[NoMacCatalyst]
 		[Export ("initWithBounds:")]
-		IntPtr Constructor (CGRect bounds);
+		NativeHandle Constructor (CGRect bounds);
 
 		[Export ("page")]
 		[NullAllowed]
@@ -1115,7 +1119,7 @@ namespace PdfKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithPage:atPoint:")]
-		IntPtr Constructor (PdfPage page, CGPoint point);
+		NativeHandle Constructor (PdfPage page, CGPoint point);
 
 		[Export ("page")]
 		[NullAllowed]
@@ -1189,15 +1193,15 @@ namespace PdfKit {
 		// - (instancetype)init NS_DESIGNATED_INITIALIZER;
 		[Export ("init")]
 		[DesignatedInitializer]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithURL:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("initWithData:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Export ("documentURL")]
 		[NullAllowed]
@@ -1469,7 +1473,7 @@ namespace PdfKit {
 		// - (instancetype)init NS_DESIGNATED_INITIALIZER;
 		[Export ("init")]
 		[DesignatedInitializer]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("document")]
 		[NullAllowed]
@@ -1517,11 +1521,11 @@ namespace PdfKit {
 		// - (instancetype)init NS_DESIGNATED_INITIALIZER;
 		[Export ("init")]
 		[DesignatedInitializer]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[DesignatedInitializer]
 		[Export ("initWithImage:")]
-		IntPtr Constructor (NSImage image);
+		NativeHandle Constructor (NSImage image);
 
 		[Export ("document"), NullAllowed]
 		PdfDocument Document { get; }
@@ -1634,7 +1638,7 @@ namespace PdfKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithDocument:")]
-		IntPtr Constructor (PdfDocument document);
+		NativeHandle Constructor (PdfDocument document);
 
 		[Export ("pages")]
 		PdfPage [] Pages { get; }
@@ -1688,7 +1692,7 @@ namespace PdfKit {
 	interface PdfThumbnailView : NSCoding {
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Field ("PDFThumbnailViewDocumentEditedNotification", "+PDFKit")]
 		[Notification]
@@ -1744,7 +1748,7 @@ namespace PdfKit {
 #endif
 	{
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("document"), NullAllowed]
 		PdfDocument Document { get; set; }

--- a/src/pencilkit.cs
+++ b/src/pencilkit.cs
@@ -32,6 +32,10 @@ using ObjCRuntime;
 using Foundation;
 using CoreGraphics;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace PencilKit {
 
 	[iOS (13, 0), Mac (11, 0)]
@@ -131,11 +135,11 @@ namespace PencilKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithData:error:")]
-		IntPtr Constructor (NSData data, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSData data, [NullAllowed] out NSError error);
 
 		[Mac (11, 0), iOS (14, 0)]
 		[Export ("initWithStrokes:")]
-		IntPtr Constructor (PKStroke[] strokes);
+		NativeHandle Constructor (PKStroke[] strokes);
 
 		[Export ("dataRepresentation")]
 		NSData DataRepresentation { get; }
@@ -172,7 +176,7 @@ namespace PencilKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithEraserType:")]
-		IntPtr Constructor (PKEraserType eraserType);
+		NativeHandle Constructor (PKEraserType eraserType);
 	}
 
 	[iOS (13, 0), Mac (11, 0)]
@@ -183,14 +187,14 @@ namespace PencilKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithInkType:color:width:")]
-		IntPtr Constructor ([BindAs (typeof (PKInkType))] NSString type, UIColor color, nfloat width);
+		NativeHandle Constructor ([BindAs (typeof (PKInkType))] NSString type, UIColor color, nfloat width);
 
 		[Export ("initWithInkType:color:")]
-		IntPtr Constructor ([BindAs (typeof (PKInkType))] NSString type, UIColor color);
+		NativeHandle Constructor ([BindAs (typeof (PKInkType))] NSString type, UIColor color);
 
 		[iOS (14, 0)]
 		[Export ("initWithInk:width:")]
-		IntPtr Constructor (PKInk ink, nfloat width);
+		NativeHandle Constructor (PKInk ink, nfloat width);
 
 		[Static]
 		[Export ("defaultWidthForInkType:")]
@@ -264,7 +268,7 @@ namespace PencilKit {
 
 		[iOS (14, 0)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("addObserver:")]
 		void AddObserver (IPKToolPickerObserver observer);
@@ -318,10 +322,10 @@ namespace PencilKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithInkType:color:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (/* enum PKInkType */ NSString type, UIColor color);
+		NativeHandle Constructor (/* enum PKInkType */ NSString type, UIColor color);
 
 		[Wrap ("this (type.GetConstant ()!, color)")]
-		IntPtr Constructor (PKInkType type, UIColor color);
+		NativeHandle Constructor (PKInkType type, UIColor color);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("inkType")]
@@ -341,7 +345,7 @@ namespace PencilKit {
 	interface PKFloatRange : NSCopying
 	{
 		[Export ("initWithLowerBound:upperBound:")]
-		IntPtr Constructor (nfloat lowerBound, nfloat upperBound);
+		NativeHandle Constructor (nfloat lowerBound, nfloat upperBound);
 
 		[Export ("lowerBound")]
 		nfloat LowerBound { get; }
@@ -357,7 +361,7 @@ namespace PencilKit {
 	interface PKStroke : NSCopying
 	{
 		[Export ("initWithInk:strokePath:transform:mask:")]
-		IntPtr Constructor (PKInk ink, PKStrokePath path, CGAffineTransform transform, [NullAllowed] BezierPath mask);
+		NativeHandle Constructor (PKInk ink, PKStrokePath path, CGAffineTransform transform, [NullAllowed] BezierPath mask);
 
 		[Export ("ink")]
 		PKInk Ink { get; }
@@ -388,7 +392,7 @@ namespace PencilKit {
 	{
 		[Export ("initWithControlPoints:creationDate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PKStrokePoint[] controlPoints, NSDate creationDate);
+		NativeHandle Constructor (PKStrokePoint[] controlPoints, NSDate creationDate);
 
 		[Export ("count")]
 		nuint Count { get; }
@@ -432,7 +436,7 @@ namespace PencilKit {
 	{
 		[Export ("initWithLocation:timeOffset:size:opacity:force:azimuth:altitude:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGPoint location, double timeOffset, CGSize size, nfloat opacity, nfloat force, nfloat azimuth, nfloat altitude);
+		NativeHandle Constructor (CGPoint location, double timeOffset, CGSize size, nfloat opacity, nfloat force, nfloat azimuth, nfloat altitude);
 
 		[Export ("location")]
 		CGPoint Location { get; }

--- a/src/phase.cs
+++ b/src/phase.cs
@@ -12,6 +12,10 @@ using NMatrix4 = global::OpenTK.NMatrix4;
 
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Phase {
 
 	[Mac (12,0), NoWatch, NoTV, iOS (15,0), MacCatalyst (15,0)]
@@ -231,7 +235,7 @@ namespace Phase {
 	interface PhaseNumericPair
 	{
 		[Export ("initWithFirstValue:secondValue:")]
-		IntPtr Constructor (double first, double second);
+		NativeHandle Constructor (double first, double second);
 
 		[Export ("first")]
 		double First { get; set; }
@@ -246,7 +250,7 @@ namespace Phase {
 	{
 		[Export ("initWithEndPoint:curveType:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Vector2d endPoint, PhaseCurveType curveType);
+		NativeHandle Constructor (Vector2d endPoint, PhaseCurveType curveType);
 
 		[Export ("endPoint", ArgumentSemantic.Assign)]	
 		Vector2d EndPoint { 
@@ -267,7 +271,7 @@ namespace Phase {
 		[Export ("initWithStartPoint:segments:")]
 		[DesignatedInitializer]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (Vector2d startPoint, PhaseEnvelopeSegment[] segments);
+		NativeHandle Constructor (Vector2d startPoint, PhaseEnvelopeSegment[] segments);
 
 		[Export ("evaluateForValue:")]
 		double Evaluate (double x);
@@ -311,17 +315,17 @@ namespace Phase {
 	interface PhaseNumberMetaParameterDefinition
 	{
 		[Export ("initWithValue:identifier:")]
-		IntPtr Constructor (double value, string identifier);
+		NativeHandle Constructor (double value, string identifier);
 
 		[Export ("initWithValue:")]
-		IntPtr Constructor (double value);
+		NativeHandle Constructor (double value);
 
 		[Export ("initWithValue:minimum:maximum:identifier:")]
-		IntPtr Constructor (double value, double minimum, double maximum, string identifier);
+		NativeHandle Constructor (double value, double minimum, double maximum, string identifier);
 
 		[Export ("initWithValue:minimum:maximum:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double value, double minimum, double maximum);
+		NativeHandle Constructor (double value, double minimum, double maximum);
 
 		[Export ("minimum")]
 		double Minimum { get; }
@@ -336,11 +340,11 @@ namespace Phase {
 	interface PhaseStringMetaParameterDefinition
 	{
 		[Export ("initWithValue:identifier:")]
-		IntPtr Constructor (string value, string identifier);
+		NativeHandle Constructor (string value, string identifier);
 
 		[Export ("initWithValue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string value);
+		NativeHandle Constructor (string value);
 	}
 
 	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
@@ -349,18 +353,18 @@ namespace Phase {
 	interface PhaseMappedMetaParameterDefinition
 	{
 		[Export ("initWithValue:identifier:")]
-		IntPtr Constructor (double value, string identifier);
+		NativeHandle Constructor (double value, string identifier);
 
 		[Export ("initWithValue:minimum:maximum:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double value, double minimum, double maximum);
+		NativeHandle Constructor (double value, double minimum, double maximum);
 
 		[Export ("initWithInputMetaParameterDefinition:envelope:identifier:")]
-		IntPtr Constructor (PhaseNumberMetaParameterDefinition inputMetaParameterDefinition, PhaseEnvelope envelope, string identifier);
+		NativeHandle Constructor (PhaseNumberMetaParameterDefinition inputMetaParameterDefinition, PhaseEnvelope envelope, string identifier);
 
 		[Export ("initWithInputMetaParameterDefinition:envelope:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseNumberMetaParameterDefinition inputMetaParameterDefinition, PhaseEnvelope envelope);
+		NativeHandle Constructor (PhaseNumberMetaParameterDefinition inputMetaParameterDefinition, PhaseEnvelope envelope);
 
 		[Export ("envelope", ArgumentSemantic.Strong)]
 		PhaseEnvelope Envelope { get; }
@@ -420,10 +424,10 @@ namespace Phase {
 	{
 		[Export ("initWithSpatialPipeline:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseSpatialPipeline spatialPipeline);
+		NativeHandle Constructor (PhaseSpatialPipeline spatialPipeline);
 
 		[Export ("initWithSpatialPipeline:identifier:")]
-		IntPtr Constructor (PhaseSpatialPipeline spatialPipeline, string identifier);
+		NativeHandle Constructor (PhaseSpatialPipeline spatialPipeline, string identifier);
 
 		[Export ("spatialPipeline", ArgumentSemantic.Strong)]
 		PhaseSpatialPipeline SpatialPipeline { get; }
@@ -445,12 +449,12 @@ namespace Phase {
 	{
 		[Export ("initWithChannelLayout:orientation:identifier:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (AVAudioChannelLayout layout, Quaternion orientation, NSString identifier);
+		NativeHandle Constructor (AVAudioChannelLayout layout, Quaternion orientation, NSString identifier);
 
 		[Export ("initWithChannelLayout:orientation:")]
 		[DesignatedInitializer]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (AVAudioChannelLayout layout, Quaternion orientation);
+		NativeHandle Constructor (AVAudioChannelLayout layout, Quaternion orientation);
 
 		[Export ("orientation")]
 		Quaternion Orientation {
@@ -468,11 +472,11 @@ namespace Phase {
 	interface PhaseChannelMixerDefinition
 	{
 		[Export ("initWithChannelLayout:identifier:")]
-		IntPtr Constructor (AVAudioChannelLayout layout, string identifier);
+		NativeHandle Constructor (AVAudioChannelLayout layout, string identifier);
 
 		[Export ("initWithChannelLayout:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVAudioChannelLayout layout);
+		NativeHandle Constructor (AVAudioChannelLayout layout);
 
 		[Export ("inputChannelLayout", ArgumentSemantic.Strong)]
 		AVAudioChannelLayout InputChannelLayout { get; }
@@ -511,7 +515,7 @@ namespace Phase {
 	{
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("registerWithEngine:")]
 		void Register (PhaseEngine engine);
@@ -598,11 +602,11 @@ namespace Phase {
 	interface PhaseSamplerNodeDefinition
 	{
 		[Export ("initWithSoundAssetIdentifier:mixerDefinition:identifier:")]
-		IntPtr Constructor (string soundAssetIdentifier, PhaseMixerDefinition mixerDefinition, string identifier);
+		NativeHandle Constructor (string soundAssetIdentifier, PhaseMixerDefinition mixerDefinition, string identifier);
 
 		[Export ("initWithSoundAssetIdentifier:mixerDefinition:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string soundAssetIdentifier, PhaseMixerDefinition mixerDefinition);
+		NativeHandle Constructor (string soundAssetIdentifier, PhaseMixerDefinition mixerDefinition);
 
 		[Export ("assetIdentifier", ArgumentSemantic.Strong)]
 		string AssetIdentifier { get; }
@@ -624,7 +628,7 @@ namespace Phase {
 		PhaseContainerNodeDefinition Create ();
 
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("addSubtree:")]
 		void Add (PhaseSoundEventNodeDefinition subtree);
@@ -636,18 +640,18 @@ namespace Phase {
 	interface PhaseBlendNodeDefinition
 	{
 		[Export ("initWithBlendMetaParameterDefinition:identifier:")]
-		IntPtr Constructor (PhaseNumberMetaParameterDefinition blendMetaParameterDefinition, string identifier);
+		NativeHandle Constructor (PhaseNumberMetaParameterDefinition blendMetaParameterDefinition, string identifier);
 
 		[Export ("initWithBlendMetaParameterDefinition:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseNumberMetaParameterDefinition blendMetaParameterDefinition);
+		NativeHandle Constructor (PhaseNumberMetaParameterDefinition blendMetaParameterDefinition);
 
 		[Export ("initDistanceBlendWithSpatialMixerDefinition:identifier:")]
-		IntPtr Constructor (PhaseSpatialMixerDefinition spatialMixerDefinition, string identifier);
+		NativeHandle Constructor (PhaseSpatialMixerDefinition spatialMixerDefinition, string identifier);
 
 		[Export ("initDistanceBlendWithSpatialMixerDefinition:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseSpatialMixerDefinition spatialMixerDefinition);
+		NativeHandle Constructor (PhaseSpatialMixerDefinition spatialMixerDefinition);
 
 		[NullAllowed, Export ("blendParameterDefinition", ArgumentSemantic.Strong)]
 		PhaseNumberMetaParameterDefinition BlendParameterDefinition { get; }
@@ -674,11 +678,11 @@ namespace Phase {
 	interface PhaseSwitchNodeDefinition
 	{
 		[Export ("initWithSwitchMetaParameterDefinition:identifier:")]
-		IntPtr Constructor (PhaseStringMetaParameterDefinition switchMetaParameterDefinition, string identifier);
+		NativeHandle Constructor (PhaseStringMetaParameterDefinition switchMetaParameterDefinition, string identifier);
 
 		[Export ("initWithSwitchMetaParameterDefinition:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseStringMetaParameterDefinition switchMetaParameterDefinition);
+		NativeHandle Constructor (PhaseStringMetaParameterDefinition switchMetaParameterDefinition);
 
 		[Export ("addSubtree:switchValue:")]
 		void AddSubtree (PhaseSoundEventNodeDefinition subtree, string switchValue);
@@ -694,10 +698,10 @@ namespace Phase {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("addSubtree:weight:")]
 		void AddSubtree (PhaseSoundEventNodeDefinition subtree, NSNumber weight);
@@ -712,11 +716,11 @@ namespace Phase {
 	interface PhasePushStreamNodeDefinition
 	{
 		[Export ("initWithMixerDefinition:format:identifier:")]
-		IntPtr Constructor (PhaseMixerDefinition mixerDefinition, AVAudioFormat format, string identifier);
+		NativeHandle Constructor (PhaseMixerDefinition mixerDefinition, AVAudioFormat format, string identifier);
 
 		[Export ("initWithMixerDefinition:format:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseMixerDefinition mixerDefinition, AVAudioFormat format);
+		NativeHandle Constructor (PhaseMixerDefinition mixerDefinition, AVAudioFormat format);
 
 		[Export ("format", ArgumentSemantic.Strong)]
 		AVAudioFormat Format { get; }
@@ -869,7 +873,7 @@ namespace Phase {
 	interface PhaseCardioidDirectivityModelParameters
 	{
 		[Export ("initWithSubbandParameters:")]
-		IntPtr Constructor (PhaseCardioidDirectivityModelSubbandParameters[] subbandParameters);
+		NativeHandle Constructor (PhaseCardioidDirectivityModelSubbandParameters[] subbandParameters);
 
 		[Export ("subbandParameters", ArgumentSemantic.Strong)]
 		PhaseCardioidDirectivityModelSubbandParameters[] SubbandParameters { get; }
@@ -880,7 +884,7 @@ namespace Phase {
 	interface PhaseConeDirectivityModelParameters
 	{
 		[Export ("initWithSubbandParameters:")]
-		IntPtr Constructor (PhaseConeDirectivityModelSubbandParameters[] subbandParameters);
+		NativeHandle Constructor (PhaseConeDirectivityModelSubbandParameters[] subbandParameters);
 
 		[Export ("subbandParameters", ArgumentSemantic.Strong)]
 		PhaseConeDirectivityModelSubbandParameters[] SubbandParameters { get; }
@@ -893,7 +897,7 @@ namespace Phase {
 	{
 		[Export ("initWithCullDistance:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double cullDistance);
+		NativeHandle Constructor (double cullDistance);
 
 		[Export ("cullDistance")]
 		double CullDistance { get; }
@@ -923,7 +927,7 @@ namespace Phase {
 	{
 		[Export ("initWithEnvelope:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseEnvelope envelope);
+		NativeHandle Constructor (PhaseEnvelope envelope);
 
 		[Export ("envelope", ArgumentSemantic.Strong)]
 		PhaseEnvelope Envelope { get; }
@@ -935,7 +939,7 @@ namespace Phase {
 	interface PhaseDucker
 	{
 		[Export ("initWithEngine:sourceGroups:targetGroups:gain:attackTime:releaseTime:attackCurve:releaseCurve:")]
-		IntPtr Constructor (PhaseEngine engine, NSSet<PhaseGroup> sourceGroups, NSSet<PhaseGroup> targetGroups, double gain, double attackTime, double releaseTime, PhaseCurveType attackCurve, PhaseCurveType releaseCurve);
+		NativeHandle Constructor (PhaseEngine engine, NSSet<PhaseGroup> sourceGroups, NSSet<PhaseGroup> targetGroups, double gain, double attackTime, double releaseTime, PhaseCurveType attackCurve, PhaseCurveType releaseCurve);
 
 		[Export ("activate")]
 		void Activate ();
@@ -977,7 +981,7 @@ namespace Phase {
 	interface PhaseGroupPresetSetting
 	{
 		[Export ("initWithGain:rate:gainCurveType:rateCurveType:")]
-		IntPtr Constructor (double gain, double rate, PhaseCurveType gainCurveType, PhaseCurveType rateCurveType);
+		NativeHandle Constructor (double gain, double rate, PhaseCurveType gainCurveType, PhaseCurveType rateCurveType);
 
 		[Export ("gain")]
 		double Gain { get; }
@@ -999,7 +1003,7 @@ namespace Phase {
 	{
 		[Export ("initWithEngine:settings:timeToTarget:timeToReset:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseEngine engine, NSDictionary<NSString, PhaseGroupPresetSetting> settings, double timeToTarget, double timeToReset);
+		NativeHandle Constructor (PhaseEngine engine, NSDictionary<NSString, PhaseGroupPresetSetting> settings, double timeToTarget, double timeToReset);
 
 		[Export ("settings")]
 		NSDictionary<NSString, PhaseGroupPresetSetting> Settings { get; }
@@ -1029,7 +1033,7 @@ namespace Phase {
 	interface PhaseMedium
 	{
 		[Export ("initWithEngine:preset:")]
-		IntPtr Constructor (PhaseEngine engine, PhaseMediumPreset preset);
+		NativeHandle Constructor (PhaseEngine engine, PhaseMediumPreset preset);
 	}
 
 	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
@@ -1039,7 +1043,7 @@ namespace Phase {
 	{
 		[Export ("initWithEngine:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseEngine engine);
+		NativeHandle Constructor (PhaseEngine engine);
 
 		[Export ("addChild:error:")]
 		bool AddChild (PhaseObject child, [NullAllowed] out NSError error);
@@ -1093,10 +1097,10 @@ namespace Phase {
 	interface PhaseSoundEvent
 	{
 		[Export ("initWithEngine:assetIdentifier:mixerParameters:error:")]
-		IntPtr Constructor (PhaseEngine engine, string assetIdentifier, PhaseMixerParameters mixerParameters, [NullAllowed] out NSError error);
+		NativeHandle Constructor (PhaseEngine engine, string assetIdentifier, PhaseMixerParameters mixerParameters, [NullAllowed] out NSError error);
 
 		[Export ("initWithEngine:assetIdentifier:error:")]
-		IntPtr Constructor (PhaseEngine engine, string assetIdentifier, [NullAllowed] out NSError error);
+		NativeHandle Constructor (PhaseEngine engine, string assetIdentifier, [NullAllowed] out NSError error);
 
 		[Async]
 		[Export ("prepareWithCompletion:")]
@@ -1151,7 +1155,7 @@ namespace Phase {
 	{
 		[Export ("initWithUpdateMode:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseUpdateMode updateMode);
+		NativeHandle Constructor (PhaseUpdateMode updateMode);
 
 		[Export ("startAndReturnError:")]
 		bool Start ([NullAllowed] out NSError error);
@@ -1209,7 +1213,7 @@ namespace Phase {
 	{
 		[Export ("initWithEngine:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseEngine engine);
+		NativeHandle Constructor (PhaseEngine engine);
 
 		[Export ("gain")]
 		double Gain { get; set; }
@@ -1221,7 +1225,7 @@ namespace Phase {
 	interface PhaseMaterial
 	{
 		[Export ("initWithEngine:preset:")]
-		IntPtr Constructor (PhaseEngine engine, PhaseMaterialPreset preset);
+		NativeHandle Constructor (PhaseEngine engine, PhaseMaterialPreset preset);
 	}
 
 	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
@@ -1240,10 +1244,10 @@ namespace Phase {
 	{
 		[Export ("initWithEngine:mesh:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseEngine engine, MDLMesh mesh);
+		NativeHandle Constructor (PhaseEngine engine, MDLMesh mesh);
 
 		[Export ("initWithEngine:mesh:materials:")]
-		IntPtr Constructor (PhaseEngine engine, MDLMesh mesh, PhaseMaterial[] materials);
+		NativeHandle Constructor (PhaseEngine engine, MDLMesh mesh, PhaseMaterial[] materials);
 
 		[Export ("elements", ArgumentSemantic.Copy)]
 		PhaseShapeElement[] Elements { get; }
@@ -1256,11 +1260,11 @@ namespace Phase {
 	{
 		[Export ("initWithEngine:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseEngine engine);
+		NativeHandle Constructor (PhaseEngine engine);
 
 		[Export ("initWithEngine:shapes:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseEngine engine, PhaseShape[] shapes);
+		NativeHandle Constructor (PhaseEngine engine, PhaseShape[] shapes);
 
 		[Export ("shapes", ArgumentSemantic.Copy)]
 		PhaseShape[] Shapes { get; }
@@ -1273,11 +1277,11 @@ namespace Phase {
 	{
 		[Export ("initWithEngine:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseEngine engine);
+		NativeHandle Constructor (PhaseEngine engine);
 
 		[Export ("initWithEngine:shapes:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseEngine engine, PhaseShape[] shapes);
+		NativeHandle Constructor (PhaseEngine engine, PhaseShape[] shapes);
 
 		[Export ("gain")]
 		double Gain { get; set; }
@@ -1304,7 +1308,7 @@ namespace Phase {
 	{
 		[Export ("initWithFlags:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PhaseSpatialPipelineFlags flags);
+		NativeHandle Constructor (PhaseSpatialPipelineFlags flags);
 
 		// @property (readonly, nonatomic) PHASESpatialPipelineFlags flags;
 		[Export ("flags")]

--- a/src/photos.cs
+++ b/src/photos.cs
@@ -16,6 +16,10 @@ using AppKit;
 using UIImage = AppKit.NSImage;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Photos
 {
 	[iOS (8,0)]
@@ -25,7 +29,7 @@ namespace Photos
 	interface PHAdjustmentData : NSCoding, NSSecureCoding {
 
 		[Export ("initWithFormatIdentifier:formatVersion:data:")]
-		IntPtr Constructor (string formatIdentifier, string formatVersion, NSData data);
+		NativeHandle Constructor (string formatIdentifier, string formatVersion, NSData data);
 
 		[Export ("formatIdentifier", ArgumentSemantic.Copy)]
 		string FormatIdentifier { get; }
@@ -793,10 +797,10 @@ namespace Photos
 	interface PHContentEditingOutput : NSCoding, NSSecureCoding {
 
 		[Export ("initWithContentEditingInput:")]
-		IntPtr Constructor (PHContentEditingInput contentEditingInput);
+		NativeHandle Constructor (PHContentEditingInput contentEditingInput);
 
 		[Export ("initWithPlaceholderForCreatedAsset:")]
-		IntPtr Constructor (PHObjectPlaceholder placeholderForCreatedAsset);
+		NativeHandle Constructor (PHObjectPlaceholder placeholderForCreatedAsset);
 
 		[NullAllowed] // by default this property is null
 		[Export ("adjustmentData", ArgumentSemantic.Strong)]
@@ -1277,7 +1281,7 @@ namespace Photos
 	interface PHLivePhotoEditingContext {
 		[Export ("initWithLivePhotoEditingInput:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PHContentEditingInput livePhotoInput);
+		NativeHandle Constructor (PHContentEditingInput livePhotoInput);
 
 		[Export ("fullSizeImage")]
 		CIImage FullSizeImage { get; }
@@ -1404,7 +1408,7 @@ namespace Photos
 	interface PHProjectChangeRequest {
 
 		[Export ("initWithProject:")]
-		IntPtr Constructor (PHProject project);
+		NativeHandle Constructor (PHProject project);
 
 		[Export ("title")]
 		string Title { get; set; }
@@ -1442,7 +1446,7 @@ namespace Photos
 		string StringValue { get; }
 
 		[Export ("initWithStringValue:")]
-		IntPtr Constructor (string stringValue);
+		NativeHandle Constructor (string stringValue);
 	}
 
 	[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]

--- a/src/photosui.cs
+++ b/src/photosui.cs
@@ -20,6 +20,10 @@ using MapKit;
 using Photos;
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace PhotosUI {
 	[NoTV]
 	[iOS (8, 0)]
@@ -67,7 +71,7 @@ namespace PhotosUI {
 
 		// inlined (designated initializer)
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NoMac]
 		[Static]
@@ -249,25 +253,25 @@ namespace PhotosUI {
 
 		[Export ("initWithProjectType:title:description:image:subtypeDescriptions:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSString projectType, string localizedTitle, [NullAllowed] string localizedDescription, [NullAllowed] UIImage image, PHProjectTypeDescription[] subtypeDescriptions);
+		NativeHandle Constructor (NSString projectType, string localizedTitle, [NullAllowed] string localizedDescription, [NullAllowed] UIImage image, PHProjectTypeDescription[] subtypeDescriptions);
 
 		[Export ("initWithProjectType:title:description:image:")]
-		IntPtr Constructor (NSString projectType, string localizedTitle, [NullAllowed] string localizedDescription, [NullAllowed] UIImage image);
+		NativeHandle Constructor (NSString projectType, string localizedTitle, [NullAllowed] string localizedDescription, [NullAllowed] UIImage image);
 
 		[Mac (10,14)]
 		[Export ("initWithProjectType:title:attributedDescription:image:subtypeDescriptions:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSString projectType, string localizedTitle, [NullAllowed] NSAttributedString localizedAttributedDescription, [NullAllowed] UIImage image, PHProjectTypeDescription[] subtypeDescriptions);
+		NativeHandle Constructor (NSString projectType, string localizedTitle, [NullAllowed] NSAttributedString localizedAttributedDescription, [NullAllowed] UIImage image, PHProjectTypeDescription[] subtypeDescriptions);
 
 		[Mac (10,14)]
 		[Export ("initWithProjectType:title:attributedDescription:image:canProvideSubtypes:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSString projectType, string localizedTitle, [NullAllowed] NSAttributedString localizedAttributedDescription, [NullAllowed] UIImage image, bool canProvideSubtypes);
+		NativeHandle Constructor (NSString projectType, string localizedTitle, [NullAllowed] NSAttributedString localizedAttributedDescription, [NullAllowed] UIImage image, bool canProvideSubtypes);
 
 		[Mac (10,14)]
 		[Export ("initWithProjectType:title:description:image:canProvideSubtypes:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSString projectType, string localizedTitle, [NullAllowed] string localizedDescription, [NullAllowed] UIImage image, bool canProvideSubtypes);
+		NativeHandle Constructor (NSString projectType, string localizedTitle, [NullAllowed] string localizedDescription, [NullAllowed] UIImage image, bool canProvideSubtypes);
 
 		[Mac (10, 14)]
 		[Export ("canProvideSubtypes")]
@@ -515,7 +519,7 @@ namespace PhotosUI {
 
 		[Export ("initWithConfiguration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (PHPickerConfiguration configuration);
+		NativeHandle Constructor (PHPickerConfiguration configuration);
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]
@@ -538,7 +542,7 @@ namespace PhotosUI {
 		PHPickerFilter Filter { get; set; }
 
 		[Export ("initWithPhotoLibrary:")]
-		IntPtr Constructor (PHPhotoLibrary photoLibrary);
+		NativeHandle Constructor (PHPhotoLibrary photoLibrary);
 
 		[iOS (15,0), MacCatalyst (15,0)]
 		[Export ("preselectedAssetIdentifiers", ArgumentSemantic.Copy)]

--- a/src/pushkit.cs
+++ b/src/pushkit.cs
@@ -3,6 +3,10 @@ using Foundation;
 using CoreFoundation;
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace PushKit 
 {
 	[Watch (6,0)]
@@ -53,7 +57,7 @@ namespace PushKit
 
 		[DesignatedInitializer]
 		[Export ("initWithQueue:")]
-		IntPtr Constructor ([NullAllowed] DispatchQueue queue);
+		NativeHandle Constructor ([NullAllowed] DispatchQueue queue);
 	}
 	
 	[iOS (8,0)]

--- a/src/quartzcomposer.cs
+++ b/src/quartzcomposer.cs
@@ -32,6 +32,10 @@ using CoreAnimation;
 using CoreImage;
 using CoreVideo;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace QuartzComposer {
 
 	[Deprecated (PlatformName.MacOSX, 10,15)]
@@ -184,10 +188,10 @@ namespace QuartzComposer {
 		QCCompositionLayer Create (QCComposition composition);
 
 		[Export ("initWithFile:")]
-		IntPtr Constructor (string path);
+		NativeHandle Constructor (string path);
 
 		[Export ("initWithComposition:")]
-		IntPtr Constructor (QCComposition composition);
+		NativeHandle Constructor (QCComposition composition);
 
 		[Export ("composition")]
 		QCComposition Composition { get; }

--- a/src/quicklook.cs
+++ b/src/quicklook.cs
@@ -41,13 +41,17 @@ using System;
 using System.ComponentModel;
 using UniformTypeIdentifiers;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace QuickLook {
 #if !MONOMAC
 	[BaseType (typeof (UIViewController), Delegates = new string [] { "WeakDelegate" }, Events=new Type [] { typeof (QLPreviewControllerDelegate)})]
 	interface QLPreviewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("dataSource", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDataSource { get; set; }
@@ -190,17 +194,17 @@ namespace QuickLook {
 		string Title { get; set; }
 
 		[Export ("initWithContextSize:isBitmap:drawingBlock:")]
-		IntPtr Constructor (CGSize contextSize, bool isBitmap, QLPreviewReplyDrawingHandler drawingHandler);
+		NativeHandle Constructor (CGSize contextSize, bool isBitmap, QLPreviewReplyDrawingHandler drawingHandler);
 
 		[Export ("initWithFileURL:")]
-		IntPtr Constructor (NSUrl fileUrl);
+		NativeHandle Constructor (NSUrl fileUrl);
 
 		[Export ("initWithDataOfContentType:contentSize:dataCreationBlock:")]
-		IntPtr Constructor (UTType contentType, CGSize contentSize, QLPreviewReplyDataCreationHandler dataCreationHandler);
+		NativeHandle Constructor (UTType contentType, CGSize contentSize, QLPreviewReplyDataCreationHandler dataCreationHandler);
 
 		// QLPreviewReply_UI
 		[Export ("initForPDFWithPageSize:documentCreationBlock:")]
-		IntPtr Constructor (CGSize defaultPageSize, QLPreviewReplyUIDocumentCreationHandler documentCreationHandler);
+		NativeHandle Constructor (CGSize defaultPageSize, QLPreviewReplyUIDocumentCreationHandler documentCreationHandler);
 	}
 
 	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
@@ -215,7 +219,7 @@ namespace QuickLook {
 		UTType ContentType { get; }
 
 		[Export ("initWithData:contentType:")]
-		IntPtr Constructor (NSData data, UTType contentType);
+		NativeHandle Constructor (NSData data, UTType contentType);
 	}
 
 	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
@@ -250,11 +254,11 @@ namespace QuickLook {
 		[Export ("initWithItemsAtURLs:options:")]
 
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl[] urls, [NullAllowed] QLPreviewSceneOptions options);
+		NativeHandle Constructor (NSUrl[] urls, [NullAllowed] QLPreviewSceneOptions options);
 
 		[Export ("initWithUserActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUserActivity userActivity);
+		NativeHandle Constructor (NSUserActivity userActivity);
 	}
 
 	[iOS (11,0)]

--- a/src/quicklookUI.cs
+++ b/src/quicklookUI.cs
@@ -7,6 +7,10 @@ using System;
 using System.ComponentModel;
 using UniformTypeIdentifiers;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace QuickLookUI {
 
 	[Native]
@@ -137,10 +141,10 @@ namespace QuickLookUI {
 	interface QLPreviewView {
 
 		[Export ("initWithFrame:style:")]
-		IntPtr Constructor (CGRect frame, QLPreviewViewStyle style);
+		NativeHandle Constructor (CGRect frame, QLPreviewViewStyle style);
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("previewItem", ArgumentSemantic.Retain)]
 		IQLPreviewItem PreviewItem { get; set; }
@@ -207,7 +211,7 @@ namespace QuickLookUI {
 		UTType ContentType { get; }
 
 		[Export ("initWithData:contentType:")]
-		IntPtr Constructor (NSData data, UTType contentType);
+		NativeHandle Constructor (NSData data, UTType contentType);
 	}
 
 	delegate bool QLPreviewReplyDrawingHandler (CGContext context, QLPreviewReply reply, out NSError error);
@@ -228,16 +232,16 @@ namespace QuickLookUI {
 		string Title { get; set; }
 
 		[Export ("initWithContextSize:isBitmap:drawingBlock:")]
-		IntPtr Constructor (CGSize contextSize, bool isBitmap, QLPreviewReplyDrawingHandler drawingHandler);
+		NativeHandle Constructor (CGSize contextSize, bool isBitmap, QLPreviewReplyDrawingHandler drawingHandler);
 
 		[Export ("initWithFileURL:")]
-		IntPtr Constructor (NSUrl fileUrl);
+		NativeHandle Constructor (NSUrl fileUrl);
 
 		[Export ("initWithDataOfContentType:contentSize:dataCreationBlock:")]
-		IntPtr Constructor (UTType contentType, CGSize contentSize, QLPreviewReplyDataCreationHandler dataCreationHandler);
+		NativeHandle Constructor (UTType contentType, CGSize contentSize, QLPreviewReplyDataCreationHandler dataCreationHandler);
 
 		// QLPreviewReply_UI
 		[Export ("initForPDFWithPageSize:documentCreationBlock:")]
-		IntPtr Constructor (CGSize defaultPageSize, QLPreviewReplyUIDocumentCreationHandler documentCreationHandler);
+		NativeHandle Constructor (CGSize defaultPageSize, QLPreviewReplyUIDocumentCreationHandler documentCreationHandler);
 	}
 }

--- a/src/quicklookthumbnailing.cs
+++ b/src/quicklookthumbnailing.cs
@@ -15,6 +15,10 @@ using UIKit;
 using NSImage = Foundation.NSObject;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace QuickLookThumbnailing {
 
 	[Mac (10,15), iOS (13,0)]
@@ -79,7 +83,7 @@ namespace QuickLookThumbnailing {
 	interface QLThumbnailGenerationRequest : NSCopying, NSSecureCoding {
 
 		[Export ("initWithFileAtURL:size:scale:representationTypes:")]
-		IntPtr Constructor (NSUrl url, CGSize size, nfloat scale, QLThumbnailGenerationRequestRepresentationTypes representationTypes);
+		NativeHandle Constructor (NSUrl url, CGSize size, nfloat scale, QLThumbnailGenerationRequestRepresentationTypes representationTypes);
 
 		[Export ("minimumDimension")]
 		nfloat MinimumDimension { get; set; }

--- a/src/replaykit.cs
+++ b/src/replaykit.cs
@@ -23,6 +23,10 @@ using UIKit;
 using NSWindow = Foundation.NSObject;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ReplayKit {
 
 	[iOS (9,0)]
@@ -32,7 +36,7 @@ namespace ReplayKit {
 	interface RPPreviewViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("previewControllerDelegate", ArgumentSemantic.Weak)][NullAllowed]
 		IRPPreviewViewControllerDelegate PreviewControllerDelegate { get; set; }
@@ -184,7 +188,7 @@ namespace ReplayKit {
 		// inlined
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Static]
 		[Async]
@@ -384,7 +388,7 @@ namespace ReplayKit {
 	interface RPSystemBroadcastPickerView : NSCoding {
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NullAllowed, Export ("preferredExtension")]
 		string PreferredExtension { get; set; }

--- a/src/safariservices.cs
+++ b/src/safariservices.cs
@@ -20,6 +20,10 @@ using AppKit;
 using UIImage = AppKit.NSImage;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace SafariServices {
 	delegate void SFExtensionValidationHandler (bool shouldHide, NSString text);
 
@@ -77,20 +81,20 @@ namespace SafariServices {
 	interface SFSafariViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[iOS (11,0)]
 		[Export ("initWithURL:configuration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl url, SFSafariViewControllerConfiguration configuration);
+		NativeHandle Constructor (NSUrl url, SFSafariViewControllerConfiguration configuration);
 
 		[Deprecated (PlatformName.iOS, 11,0, message: "Use '.ctor (NSUrl, SFSafariViewControllerConfiguration)' instead.")]
 		[DesignatedInitializer]
 		[Export ("initWithURL:entersReaderIfAvailable:")]
-		IntPtr Constructor (NSUrl url, bool entersReaderIfAvailable);
+		NativeHandle Constructor (NSUrl url, bool entersReaderIfAvailable);
 
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[NullAllowed] // by default this property is null
 		[Export ("delegate", ArgumentSemantic.Assign)]
@@ -175,7 +179,7 @@ namespace SafariServices {
 	[Deprecated (PlatformName.iOS, 12,0, message: "Use 'ASWebAuthenticationSession' instead.")]
 	interface SFAuthenticationSession {
 		[Export ("initWithURL:callbackURLScheme:completionHandler:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] string callbackUrlScheme, SFAuthenticationCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] string callbackUrlScheme, SFAuthenticationCompletionHandler completionHandler);
 
 		[Export ("start")]
 		bool Start ();
@@ -418,7 +422,7 @@ namespace SafariServices {
 	interface SFSafariExtensionViewController
 	{
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[Mac (10,14,4)]
 		[Export ("dismissPopover")]
@@ -455,7 +459,7 @@ namespace SafariServices {
 	interface SFUniversalLink {
 
 		[Export ("initWithWebpageURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("webpageURL")]
 		NSUrl WebpageUrl { get; }
@@ -483,7 +487,7 @@ namespace SafariServices {
 	{
 		[Export ("initWithTemplateImage:extensionIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIImage templateImage, string extensionIdentifier);
+		NativeHandle Constructor (UIImage templateImage, string extensionIdentifier);
 
 		[NullAllowed, Export ("templateImage", ArgumentSemantic.Copy)]
 		UIImage TemplateImage { get; }

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -87,6 +87,10 @@ using NSImage = global::UIKit.UIImage;
 using NSBezierPath = global::UIKit.UIBezierPath;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace SceneKit {
 
 #if WATCH
@@ -253,11 +257,11 @@ namespace SceneKit {
 	{
 		[Export ("initWithSource:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (SCNAudioSource source);
+		NativeHandle Constructor (SCNAudioSource source);
 	
 		[Export ("initWithAVAudioNode:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (AVAudioNode audioNode);
+		NativeHandle Constructor (AVAudioNode audioNode);
 	
 		[Static]
 		[Export ("audioPlayerWithSource:")]
@@ -289,11 +293,11 @@ namespace SceneKit {
 	interface SCNAudioSource : NSCopying, NSSecureCoding
 	{
 		[Export ("initWithFileNamed:")]
-		IntPtr Constructor (string filename);
+		NativeHandle Constructor (string filename);
 	
 		[Export ("initWithURL:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 	
 		[Static]
 		[Export ("audioSourceNamed:")]
@@ -2838,17 +2842,17 @@ namespace SceneKit {
 
 		[Export ("initWithURL:options:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] NSDictionary options);
 
 		[Wrap ("this (url, options.GetDictionary ())")]
-		IntPtr Constructor (NSUrl url, SCNSceneLoadingOptions options);
+		NativeHandle Constructor (NSUrl url, SCNSceneLoadingOptions options);
 
 		[Export ("initWithData:options:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (NSData data, [NullAllowed] NSDictionary options);
 
 		[Wrap ("this (data, options.GetDictionary ())")]
-		IntPtr Constructor (NSData data, SCNSceneLoadingOptions options);
+		NativeHandle Constructor (NSData data, SCNSceneLoadingOptions options);
 		
 		[Export ("sceneWithOptions:statusHandler:")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
@@ -3503,14 +3507,14 @@ namespace SceneKit {
 #if !WATCH
 		[iOS (9,0)][Mac (10,11)]
 		[Wrap ("this (frame, options.GetDictionary ())")]
-		IntPtr Constructor (CGRect frame, [NullAllowed] SCNRenderingOptions options);
+		NativeHandle Constructor (CGRect frame, [NullAllowed] SCNRenderingOptions options);
 #endif
 
 		[Export ("initWithFrame:options:")]
-		IntPtr Constructor (CGRect frame, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (CGRect frame, [NullAllowed] NSDictionary options);
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("play:")]
 		void Play ([NullAllowed] NSObject sender);
@@ -3714,7 +3718,7 @@ namespace SceneKit {
 
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("initWithChainRootNode:")]
-		IntPtr Constructor (SCNNode chainRootNode);
+		NativeHandle Constructor (SCNNode chainRootNode);
 		
 	}
 
@@ -5039,7 +5043,7 @@ namespace SceneKit {
 	interface SCNReferenceNode : NSCoding {
 		[Export ("initWithURL:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl referenceUrl);
+		NativeHandle Constructor (NSUrl referenceUrl);
 
 		[Static]
 		[Export ("referenceNodeWithURL:")]

--- a/src/screentime.cs
+++ b/src/screentime.cs
@@ -10,6 +10,10 @@ using AppKit;
 using UIViewController = AppKit.NSViewController;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ScreenTime {
 
 	[Mac (11, 0), iOS (14, 0)]
@@ -28,7 +32,7 @@ namespace ScreenTime {
 	interface STScreenTimeConfigurationObserver {
 		[Export ("initWithUpdateQueue:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (DispatchQueue updateQueue);
+		NativeHandle Constructor (DispatchQueue updateQueue);
 
 		[Export ("startObserving")]
 		void StartObserving ();
@@ -47,7 +51,7 @@ namespace ScreenTime {
 	interface STWebHistory {
 
 		[Export ("initWithBundleIdentifier:error:")]
-		IntPtr Constructor (string bundleIdentifier, [NullAllowed] out NSError error);
+		NativeHandle Constructor (string bundleIdentifier, [NullAllowed] out NSError error);
 
 		[Export ("deleteHistoryForURL:")]
 		void DeleteHistory (NSUrl url);
@@ -67,7 +71,7 @@ namespace ScreenTime {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
+		NativeHandle Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
 		[Export ("suppressUsageRecording")]
 		bool SuppressUsageRecording { get; set; }

--- a/src/scriptingbridge.cs
+++ b/src/scriptingbridge.cs
@@ -30,6 +30,10 @@ using AppKit;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ScriptingBridge {
 	
 	
@@ -37,10 +41,10 @@ namespace ScriptingBridge {
 	interface SBObject : NSCoding {
 
 		[Export ("initWithProperties:")]
-		IntPtr Constructor (NSDictionary properties);
+		NativeHandle Constructor (NSDictionary properties);
 
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSObject data);
+		NativeHandle Constructor (NSObject data);
 
 		[Export ("get")]
 		NSObject Get { get; }
@@ -55,7 +59,7 @@ namespace ScriptingBridge {
 	[DisableDefaultCtor] // *** -[SBElementArray init]: should never be used.
 	interface SBElementArray {
 		[Export ("initWithCapacity:")]
-		IntPtr Constructor (nuint capacity);
+		NativeHandle Constructor (nuint capacity);
 
 		[Export ("objectWithName:")]
 		NSObject ObjectWithName (string name);
@@ -104,13 +108,13 @@ namespace ScriptingBridge {
 	[DisableDefaultCtor] // An uncaught exception was raised: *** -[SBApplication init]: should never be used.
 	interface SBApplication : NSCoding {
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("initWithProcessIdentifier:")]
-		IntPtr Constructor (int /* pid_t = int */ pid);
+		NativeHandle Constructor (int /* pid_t = int */ pid);
 
 		[Export ("initWithBundleIdentifier:")]
-		IntPtr Constructor (string ident);
+		NativeHandle Constructor (string ident);
 
 		[Internal]
 		[Static]

--- a/src/sensorkit.cs
+++ b/src/sensorkit.cs
@@ -4,6 +4,10 @@ using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace SensorKit {
 
 	// helpers for code generation
@@ -794,10 +798,10 @@ namespace SensorKit {
 	interface SRSensorReader {
 
 		[Export ("initWithSensor:")]
-		IntPtr Constructor (NSString sensor);
+		NativeHandle Constructor (NSString sensor);
 
 		[Wrap ("this (sensor.GetConstant ()!)")]
-		IntPtr Constructor (SRSensor sensor);
+		NativeHandle Constructor (SRSensor sensor);
 
 		[Export ("startRecording")]
 		void StartRecording ();

--- a/src/shazamkit.cs
+++ b/src/shazamkit.cs
@@ -4,6 +4,10 @@ using Foundation;
 using ObjCRuntime;
 using AVFoundation;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ShazamKit {
 
 	[Native]
@@ -209,7 +213,7 @@ namespace ShazamKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Export ("initWithCatalog:")]
-		IntPtr Constructor (SHCatalog catalog);
+		NativeHandle Constructor (SHCatalog catalog);
 
 		[Export ("matchStreamingBuffer:atTime:")]
 		void Match (AVAudioPcmBuffer buffer, [NullAllowed] AVAudioTime time);
@@ -225,7 +229,7 @@ namespace ShazamKit {
 	{
 		[Export ("initWithDataRepresentation:error:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSData dataRepresentation, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSData dataRepresentation, [NullAllowed] out NSError error);
 
 		[Export ("duration")]
 		double Duration { get; }

--- a/src/social.cs
+++ b/src/social.cs
@@ -19,6 +19,10 @@ using UIKit;
 using AppKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Social {
 	[Static]
 	interface SLServiceType {
@@ -96,7 +100,7 @@ namespace Social {
 	interface SLComposeViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("serviceType")]
 		NSString ServiceType { get;  }
@@ -144,7 +148,7 @@ namespace Social {
 	#endif
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("presentationAnimationDidFinish")]
 		void PresentationAnimationDidFinish ();
@@ -214,7 +218,7 @@ namespace Social {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[NullAllowed] // by default this property is null
 		[Export ("title")]

--- a/src/soundanalysis.cs
+++ b/src/soundanalysis.cs
@@ -14,6 +14,10 @@ using Foundation;
 using ObjCRuntime;
 using CoreMedia;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace SoundAnalysis {
 
 	[ErrorDomain ("SNErrorDomain")]
@@ -42,7 +46,7 @@ namespace SoundAnalysis {
 
 		[DesignatedInitializer]
 		[Export ("initWithFormat:")]
-		IntPtr Constructor (AVAudioFormat format);
+		NativeHandle Constructor (AVAudioFormat format);
 
 		[Export ("addRequest:withObserver:error:")]
 		bool AddRequest (ISNRequest request, ISNResultsObserving observer, [NullAllowed] out NSError error);
@@ -69,7 +73,7 @@ namespace SoundAnalysis {
 
 		[DesignatedInitializer]
 		[Export ("initWithURL:error:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] out NSError error);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] out NSError error);
 
 		[Export ("addRequest:withObserver:error:")]
 		bool AddRequest (ISNRequest request, ISNResultsObserving observer, [NullAllowed] out NSError error);
@@ -129,11 +133,11 @@ namespace SoundAnalysis {
 		double OverlapFactor { get; set; }
 
 		[Export ("initWithMLModel:error:")]
-		IntPtr Constructor (MLModel mlModel, [NullAllowed] out NSError error);
+		NativeHandle Constructor (MLModel mlModel, [NullAllowed] out NSError error);
 
 		[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[Export ("initWithClassifierIdentifier:error:")]
-		IntPtr Constructor (string classifierIdentifier, [NullAllowed] out NSError error);
+		NativeHandle Constructor (string classifierIdentifier, [NullAllowed] out NSError error);
 
 		[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[Export ("knownClassifications", ArgumentSemantic.Copy)]
@@ -189,10 +193,10 @@ namespace SoundAnalysis {
 	interface SNTimeDurationConstraint /* privately conforms to NSCoding, NSCopying, and NSSecureCoding */
 	{
 		[Export ("initWithEnumeratedDurations:")]
-		IntPtr Constructor ([BindAs (typeof (CMTime[]))] NSValue[] enumeratedDurations);
+		NativeHandle Constructor ([BindAs (typeof (CMTime[]))] NSValue[] enumeratedDurations);
 
 		[Export ("initWithDurationRange:")]
-		IntPtr Constructor (CMTimeRange durationRange);
+		NativeHandle Constructor (CMTimeRange durationRange);
 
 		[Export ("type", ArgumentSemantic.Assign)]
 		SNTimeDurationConstraintType Type { get; }

--- a/src/speech.cs
+++ b/src/speech.cs
@@ -15,6 +15,10 @@ using CoreMedia;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Speech {
 
 	[Native]
@@ -76,7 +80,7 @@ namespace Speech {
 
 		[Export ("initWithURL:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("URL", ArgumentSemantic.Copy)]
 		NSUrl Url { get; }
@@ -196,7 +200,7 @@ namespace Speech {
 
 		[Export ("initWithLocale:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSLocale locale);
+		NativeHandle Constructor (NSLocale locale);
 
 		[Export ("available")]
 		bool Available { [Bind ("isAvailable")] get; }

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -56,6 +56,10 @@ using UIView = global::UIKit.UIView;
 #endif
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace SpriteKit {
 
 #if WATCH
@@ -80,7 +84,7 @@ namespace SpriteKit {
 	interface SK3DNode {
 		[DesignatedInitializer]
 		[Export ("initWithViewportSize:")]
-		IntPtr Constructor (CGSize viewportSize);
+		NativeHandle Constructor (CGSize viewportSize);
 
 		[Export ("viewportSize")]
 		CGSize ViewportSize { get; set; }
@@ -143,7 +147,7 @@ namespace SpriteKit {
 #endif
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Static, Export ("node")]
 		SKNode Create ();
@@ -545,7 +549,7 @@ namespace SpriteKit {
 #endif
 	{
 		[Export ("initWithSize:")]
-		IntPtr Constructor (CGSize size);
+		NativeHandle Constructor (CGSize size);
 
 		[Static, Export ("sceneWithSize:")]
 		SKScene FromSize (CGSize size);
@@ -660,10 +664,10 @@ namespace SpriteKit {
 	[BaseType (typeof (NSObject))]
 	interface SKShader : NSCopying, NSSecureCoding {
 		[Export ("initWithSource:")]
-		IntPtr Constructor (string shaderSourceCode);
+		NativeHandle Constructor (string shaderSourceCode);
 
 		[Export ("initWithSource:uniforms:")]
-		IntPtr Constructor (string sharedSourceCode, SKUniform [] uniforms);
+		NativeHandle Constructor (string sharedSourceCode, SKUniform [] uniforms);
 
 		[NullAllowed] // by default this property is null
 		[Export ("source")]
@@ -721,17 +725,17 @@ namespace SpriteKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithTexture:color:size:")]
-		IntPtr Constructor ([NullAllowed] SKTexture texture, UIColor color, CGSize size);
+		NativeHandle Constructor ([NullAllowed] SKTexture texture, UIColor color, CGSize size);
 
 		[Export ("initWithTexture:")]
-		IntPtr Constructor ([NullAllowed] SKTexture texture);
+		NativeHandle Constructor ([NullAllowed] SKTexture texture);
 
 		// can't be null -> crash
 		[Export ("initWithImageNamed:")]
-		IntPtr Constructor (string name);
+		NativeHandle Constructor (string name);
 
 		[Export ("initWithColor:size:")]
-		IntPtr Constructor (UIColor color, CGSize size);
+		NativeHandle Constructor (UIColor color, CGSize size);
 
 		[Export ("texture", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -818,10 +822,10 @@ namespace SpriteKit {
 		[DesignatedInitializer]
 		[Export ("initWithKeyframeValues:times:")]
 		[Internal]
-		IntPtr Constructor ([NullAllowed] NSObject [] values, [NullAllowed] NSArray times);
+		NativeHandle Constructor ([NullAllowed] NSObject [] values, [NullAllowed] NSArray times);
 
 		[Export ("initWithCapacity:")]
-		IntPtr Constructor (nuint numItems);
+		NativeHandle Constructor (nuint numItems);
 
 		[Export ("count")]
 		nuint Count { get; }
@@ -1189,7 +1193,7 @@ namespace SpriteKit {
 	interface SKReachConstraints : NSSecureCoding {
 		[DesignatedInitializer]
 		[Export ("initWithLowerAngleLimit:upperAngleLimit:")]
-		IntPtr Constructor (nfloat lowerAngleLimit, nfloat upperAngleLimit);
+		NativeHandle Constructor (nfloat lowerAngleLimit, nfloat upperAngleLimit);
 
 		[Export ("lowerAngleLimit", ArgumentSemantic.UnsafeUnretained)]
 		nfloat LowerAngleLimit { get; set; }
@@ -1203,13 +1207,13 @@ namespace SpriteKit {
 	[BaseType (typeof (NSObject))]
 	interface SKRegion : NSCopying, NSSecureCoding {
 		[Export ("initWithRadius:")]
-		IntPtr Constructor (float /* float, not CGFloat */ radius);
+		NativeHandle Constructor (float /* float, not CGFloat */ radius);
 
 		[Export ("initWithSize:")]
-		IntPtr Constructor (CGSize size);
+		NativeHandle Constructor (CGSize size);
 
 		[Export ("initWithPath:")]
-		IntPtr Constructor (CGPath path);
+		NativeHandle Constructor (CGPath path);
 
 		[Export ("path")]
 		[NullAllowed]
@@ -1244,7 +1248,7 @@ namespace SpriteKit {
 		SKLabelNode FromFont ([NullAllowed] string fontName);
 
 		[Export ("initWithFontNamed:")]
-		IntPtr Constructor ([NullAllowed] string fontName);
+		NativeHandle Constructor ([NullAllowed] string fontName);
 
 		[iOS (8,0), Mac (10,10)] // this method is missing the NS_AVAILABLE macro, but it shows up in the 10.10 sdk, but not the 10.9 sdk.
 		[Static, Export ("labelNodeWithText:")]
@@ -1341,11 +1345,11 @@ namespace SpriteKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithFileNamed:")]
-		IntPtr Constructor (string videoFile);
+		NativeHandle Constructor (string videoFile);
 
 		[DesignatedInitializer]
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 #else
 		[Static, Export ("videoNodeWithAVPlayer:")]
 		SKVideoNode FromPlayer (AVPlayer player);
@@ -1364,7 +1368,7 @@ namespace SpriteKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithAVPlayer:")]
-		IntPtr Constructor (AVPlayer player);
+		NativeHandle Constructor (AVPlayer player);
 
 		[Export ("initWithVideoFileNamed:"), Internal]
 		IntPtr InitWithVideoFileNamed (string videoFile);
@@ -1459,7 +1463,7 @@ namespace SpriteKit {
 	partial interface SKView {
 #endif
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("paused")]
 		bool Paused { [Bind ("isPaused")] get; set; }
@@ -1711,10 +1715,10 @@ namespace SpriteKit {
 	[DisableDefaultCtor] // cannot be created (like SKTexture) by calling `init`
 	interface SKMutableTexture {
 		[Export ("initWithSize:")]
-		IntPtr Constructor (CGSize size);
+		NativeHandle Constructor (CGSize size);
 
 		[Export ("initWithSize:pixelFormat:")]
-		IntPtr Constructor (CGSize size, CVPixelFormatType pixelFormat);
+		NativeHandle Constructor (CGSize size, CVPixelFormatType pixelFormat);
 
 		[Static, Export ("mutableTextureWithSize:")]
 		SKMutableTexture Create (CGSize size);
@@ -1768,13 +1772,13 @@ namespace SpriteKit {
 	[BaseType (typeof (NSObject))]
 	interface SKUniform : NSCopying, NSSecureCoding {
 		[Export ("initWithName:")]
-		IntPtr Constructor (string name);
+		NativeHandle Constructor (string name);
 
 		[Export ("initWithName:texture:")]
-		IntPtr Constructor (string name, [NullAllowed] SKTexture texture);
+		NativeHandle Constructor (string name, [NullAllowed] SKTexture texture);
 
 		[Export ("initWithName:float:")]
-		IntPtr Constructor (string name, float /* float, not CGFloat */ value);
+		NativeHandle Constructor (string name, float /* float, not CGFloat */ value);
 
 		[Internal]
 		[NoWatch]
@@ -1789,7 +1793,7 @@ namespace SpriteKit {
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		[MarshalNativeExceptions]
 #if WATCH
-		IntPtr Constructor (string name, Vector2 value);
+		NativeHandle Constructor (string name, Vector2 value);
 #else
 		[Internal]
 		IntPtr InitWithNameVectorFloat2 (string name, Vector2 value);
@@ -1807,7 +1811,7 @@ namespace SpriteKit {
 		[Export ("initWithName:vectorFloat3:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 #if WATCH
-		IntPtr Constructor (string name, Vector3 value);
+		NativeHandle Constructor (string name, Vector3 value);
 #else
 		[Internal]
 		IntPtr InitWithNameVectorFloat3 (string name, Vector3 value);
@@ -1825,7 +1829,7 @@ namespace SpriteKit {
 		[Export ("initWithName:vectorFloat4:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 #if WATCH
-		IntPtr Constructor (string name, Vector4 value);
+		NativeHandle Constructor (string name, Vector4 value);
 #else
 		[Internal]
 		IntPtr InitWithNameVectorFloat4 (string name, Vector4 value);
@@ -1848,7 +1852,7 @@ namespace SpriteKit {
 		[Export ("initWithName:matrixFloat2x2:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 #if WATCH
-		IntPtr Constructor (string name, Matrix2 value);
+		NativeHandle Constructor (string name, Matrix2 value);
 #else
 		[Internal]
 		IntPtr InitWithNameMatrixFloat2x2 (string name, Matrix2 value);
@@ -1859,7 +1863,7 @@ namespace SpriteKit {
 		[TV (10,0)]
 		[Export ("initWithName:matrixFloat2x2:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (string name, MatrixFloat2x2 value);
+		NativeHandle Constructor (string name, MatrixFloat2x2 value);
 
 #if !XAMCORE_4_0
 		[Internal]
@@ -1876,7 +1880,7 @@ namespace SpriteKit {
 		[Export ("initWithName:matrixFloat3x3:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 #if WATCH
-		IntPtr Constructor (string name, Matrix3 value);
+		NativeHandle Constructor (string name, Matrix3 value);
 #else
 		[Internal]
 		IntPtr InitWithNameMatrixFloat3x3 (string name, Matrix3 value);
@@ -1887,7 +1891,7 @@ namespace SpriteKit {
 		[TV (10,0)]
 		[Export ("initWithName:matrixFloat3x3:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (string name, MatrixFloat3x3 value);
+		NativeHandle Constructor (string name, MatrixFloat3x3 value);
 
 #if !XAMCORE_4_0
 		[Internal]
@@ -1906,7 +1910,7 @@ namespace SpriteKit {
 		[Sealed]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 #if WATCH
-		IntPtr Constructor (string name, Matrix4 value);
+		NativeHandle Constructor (string name, Matrix4 value);
 #else
 		[Internal]
 		IntPtr InitWithNameMatrixFloat4x4 (string name, Matrix4 value);
@@ -1917,7 +1921,7 @@ namespace SpriteKit {
 		[TV (10,0)]
 		[Export ("initWithName:matrixFloat4x4:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr Constructor (string name, MatrixFloat4x4 value);
+		NativeHandle Constructor (string name, MatrixFloat4x4 value);
 
 		[Export ("name")]
 		string Name { get; }
@@ -2950,7 +2954,7 @@ namespace SpriteKit {
 	interface SKRange : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithLowerLimit:upperLimit:")]
-		IntPtr Constructor (nfloat lowerLimit, nfloat upperLimier);
+		NativeHandle Constructor (nfloat lowerLimit, nfloat upperLimier);
 
 		[Export ("lowerLimit")]
 		nfloat LowerLimit { get; set; }
@@ -2985,13 +2989,13 @@ namespace SpriteKit {
 	interface SKAudioNode : NSSecureCoding {
 		[Export ("initWithAVAudioNode:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] AVAudioNode node);
+		NativeHandle Constructor ([NullAllowed] AVAudioNode node);
 
 		[Export ("initWithFileNamed:")]
-		IntPtr Constructor (string fileName);
+		NativeHandle Constructor (string fileName);
 
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[NullAllowed, Export ("avAudioNode", ArgumentSemantic.Retain)]
 		AVAudioNode AvAudioNode { get; set; }
@@ -3023,11 +3027,11 @@ namespace SpriteKit {
 	interface SKReferenceNode {
 		[Export ("initWithURL:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSUrl url);
+		NativeHandle Constructor ([NullAllowed] NSUrl url);
 
 		[Export ("initWithFileNamed:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string fileName);
+		NativeHandle Constructor ([NullAllowed] string fileName);
 
 		[Static]
 		[Export ("referenceNodeWithFileNamed:")]
@@ -3055,7 +3059,7 @@ namespace SpriteKit {
 
 		[Export ("initWithName:type:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string name, SKAttributeType type);
+		NativeHandle Constructor (string name, SKAttributeType type);
 
 		[Export ("name")]
 		string Name { get; }
@@ -3071,7 +3075,7 @@ namespace SpriteKit {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Static]
 		[Export ("valueWithFloat:")]
@@ -3142,19 +3146,19 @@ namespace SpriteKit {
 		SKTileDefinition Create (SKTexture[] textures, SKTexture[] normalTextures, CGSize size, nfloat timePerFrame);
 
 		[Export ("initWithTexture:")]
-		IntPtr Constructor (SKTexture texture);
+		NativeHandle Constructor (SKTexture texture);
 
 		[Export ("initWithTexture:size:")]
-		IntPtr Constructor (SKTexture texture, CGSize size);
+		NativeHandle Constructor (SKTexture texture, CGSize size);
 
 		[Export ("initWithTexture:normalTexture:size:")]
-		IntPtr Constructor (SKTexture texture, SKTexture normalTexture, CGSize size);
+		NativeHandle Constructor (SKTexture texture, SKTexture normalTexture, CGSize size);
 
 		[Export ("initWithTextures:size:timePerFrame:")]
-		IntPtr Constructor (SKTexture[] textures, CGSize size, nfloat timePerFrame);
+		NativeHandle Constructor (SKTexture[] textures, CGSize size, nfloat timePerFrame);
 
 		[Export ("initWithTextures:normalTextures:size:timePerFrame:")]
-		IntPtr Constructor (SKTexture[] textures, SKTexture[] normalTextures, CGSize size, nfloat timePerFrame);
+		NativeHandle Constructor (SKTexture[] textures, SKTexture[] normalTextures, CGSize size, nfloat timePerFrame);
 
 		[Export ("textures", ArgumentSemantic.Copy)]
 		SKTexture[] Textures { get; set; }
@@ -3206,13 +3210,13 @@ namespace SpriteKit {
 		SKTileMapNode Create (SKTileSet tileSet, nuint columns, nuint rows, CGSize tileSize, SKTileGroup[] tileGroupLayout);
 
 		[Export ("initWithTileSet:columns:rows:tileSize:")]
-		IntPtr Constructor (SKTileSet tileSet, nuint columns, nuint rows, CGSize tileSize);
+		NativeHandle Constructor (SKTileSet tileSet, nuint columns, nuint rows, CGSize tileSize);
 
 		[Export ("initWithTileSet:columns:rows:tileSize:fillWithTileGroup:")]
-		IntPtr Constructor (SKTileSet tileSet, nuint columns, nuint rows, CGSize tileSize, SKTileGroup tileGroup);
+		NativeHandle Constructor (SKTileSet tileSet, nuint columns, nuint rows, CGSize tileSize, SKTileGroup tileGroup);
 
 		[Export ("initWithTileSet:columns:rows:tileSize:tileGroupLayout:")]
-		IntPtr Constructor (SKTileSet tileSet, nuint columns, nuint rows, CGSize tileSize, SKTileGroup[] tileGroupLayout);
+		NativeHandle Constructor (SKTileSet tileSet, nuint columns, nuint rows, CGSize tileSize, SKTileGroup[] tileGroupLayout);
 
 		[Export ("numberOfColumns")]
 		nuint NumberOfColumns { get; set; }
@@ -3310,10 +3314,10 @@ namespace SpriteKit {
 		SKTileSet Create (SKTileGroup[] tileGroups, SKTileSetType tileSetType);
 
 		[Export ("initWithTileGroups:")]
-		IntPtr Constructor (SKTileGroup[] tileGroups);
+		NativeHandle Constructor (SKTileGroup[] tileGroups);
 
 		[Export ("initWithTileGroups:tileSetType:")]
-		IntPtr Constructor (SKTileGroup[] tileGroups, SKTileSetType tileSetType);
+		NativeHandle Constructor (SKTileGroup[] tileGroups, SKTileSetType tileSetType);
 
 		[Static]
 		[Export ("tileSetNamed:")]
@@ -3360,10 +3364,10 @@ namespace SpriteKit {
 		SKTileGroup CreateEmpty ();
 
 		[Export ("initWithTileDefinition:")]
-		IntPtr Constructor (SKTileDefinition tileDefinition);
+		NativeHandle Constructor (SKTileDefinition tileDefinition);
 
 		[Export ("initWithRules:")]
-		IntPtr Constructor (SKTileGroupRule[] rules);
+		NativeHandle Constructor (SKTileGroupRule[] rules);
 
 		[Export ("rules", ArgumentSemantic.Copy)]
 		SKTileGroupRule[] Rules { get; set; }
@@ -3383,7 +3387,7 @@ namespace SpriteKit {
 		SKTileGroupRule Create (SKTileAdjacencyMask adjacency, SKTileDefinition[] tileDefinitions);
 
 		[Export ("initWithAdjacency:tileDefinitions:")]
-		IntPtr Constructor (SKTileAdjacencyMask adjacency, SKTileDefinition[] tileDefinitions);
+		NativeHandle Constructor (SKTileAdjacencyMask adjacency, SKTileDefinition[] tileDefinitions);
 
 		[Export ("adjacency", ArgumentSemantic.Assign)]
 		SKTileAdjacencyMask Adjacency { get; set; }

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -26,6 +26,10 @@ using UIViewController = Foundation.NSObject;
 #endif
 using System;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace StoreKit {
 
 	[Watch (6, 2)]
@@ -460,10 +464,10 @@ namespace StoreKit {
 	[BaseType (typeof (SKRequest))]
 	interface SKReceiptRefreshRequest {
 		[Export ("initWithReceiptProperties:")]
-		IntPtr Constructor ([NullAllowed] NSDictionary properties);
+		NativeHandle Constructor ([NullAllowed] NSDictionary properties);
 
 		[Wrap ("this (receiptProperties.GetDictionary ())")]
-		IntPtr Constructor ([NullAllowed] SKReceiptProperties receiptProperties);
+		NativeHandle Constructor ([NullAllowed] SKReceiptProperties receiptProperties);
 
 		[NullAllowed]
 		[Export ("receiptProperties")]
@@ -493,7 +497,7 @@ namespace StoreKit {
 	[BaseType (typeof (SKRequest), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (SKProductsRequestDelegate)})]
 	interface SKProductsRequest {
 		[Export ("initWithProductIdentifiers:")]
-		IntPtr Constructor (NSSet productIdentifiersStringSet);
+		NativeHandle Constructor (NSSet productIdentifiersStringSet);
 		
 		[Export ("delegate", ArgumentSemantic.Weak)][NullAllowed][New]
 		NSObject WeakDelegate { get; set; }
@@ -531,7 +535,7 @@ namespace StoreKit {
 		// SKStoreProductViewController is an OS View Controller which can't be customized
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 #endif
 
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
@@ -947,7 +951,7 @@ namespace StoreKit {
 	[DisableDefaultCtor]
 	interface SKPaymentDiscount {
 		[Export ("initWithIdentifier:keyIdentifier:nonce:signature:timestamp:")]
-		IntPtr Constructor (string identifier, string keyIdentifier, NSUuid nonce, string signature, NSNumber timestamp);
+		NativeHandle Constructor (string identifier, string keyIdentifier, NSUuid nonce, string signature, NSNumber timestamp);
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -1069,7 +1073,7 @@ namespace StoreKit {
 	interface SKOverlayAppConfiguration {
 		[Export ("initWithAppIdentifier:position:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string appIdentifier, SKOverlayPosition position);
+		NativeHandle Constructor (string appIdentifier, SKOverlayPosition position);
 
 		[Export ("appIdentifier", ArgumentSemantic.Retain)]
 		string AppIdentifier { get; set; }
@@ -1111,7 +1115,7 @@ namespace StoreKit {
 	interface SKOverlayAppClipConfiguration {
 		[Export ("initWithPosition:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (SKOverlayPosition position);
+		NativeHandle Constructor (SKOverlayPosition position);
 
 		[NullAllowed, Export ("campaignToken", ArgumentSemantic.Retain)]
 		string CampaignToken { get; set; }
@@ -1170,7 +1174,7 @@ namespace StoreKit {
 	interface SKOverlay {
 		[Export ("initWithConfiguration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (SKOverlayConfiguration configuration);
+		NativeHandle Constructor (SKOverlayConfiguration configuration);
 
 		[Export ("presentInScene:")]
 		void PresentInScene (UIWindowScene scene);

--- a/src/tvmlkit.cs
+++ b/src/tvmlkit.cs
@@ -9,6 +9,10 @@ using JavaScriptCore;
 using ObjCRuntime;
 using UIKit;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace TVMLKit {
 
 	[TV (9,0)]
@@ -251,7 +255,7 @@ namespace TVMLKit {
 	interface TVApplicationController {
 		[Export ("initWithContext:window:delegate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (TVApplicationControllerContext context, [NullAllowed] UIWindow window, [NullAllowed] ITVApplicationControllerDelegate @delegate);
+		NativeHandle Constructor (TVApplicationControllerContext context, [NullAllowed] UIWindow window, [NullAllowed] ITVApplicationControllerDelegate @delegate);
 
 		[NullAllowed, Export ("window")]
 		UIWindow Window { get; }
@@ -949,7 +953,7 @@ namespace TVMLKit {
 	[DisableDefaultCtor]
 	interface TVPlaybackCustomEventUserInfo : TVPlaybackEventMarshaling {
 		[Export ("initWithProperties:expectsReturnValue:")]
-		IntPtr Constructor ([NullAllowed] NSDictionary<NSString, NSObject> properties, bool expectsReturnValue);
+		NativeHandle Constructor ([NullAllowed] NSDictionary<NSString, NSObject> properties, bool expectsReturnValue);
 
 		[Export ("expectsReturnValue")]
 		bool ExpectsReturnValue { get; set; }
@@ -1074,7 +1078,7 @@ namespace TVMLKit {
 	[DisableDefaultCtor]
 	interface TVPlayer {
 		[Export ("initWithPlayer:")]
-		IntPtr Constructor (AVPlayer player);
+		NativeHandle Constructor (AVPlayer player);
 
 		[Export ("player", ArgumentSemantic.Strong)]
 		AVPlayer Player { get; }
@@ -1156,7 +1160,7 @@ namespace TVMLKit {
 		// inlined from base class
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("viewElement", ArgumentSemantic.Strong)]
 		TVViewElement ViewElement { get; }

--- a/src/tvservices.cs
+++ b/src/tvservices.cs
@@ -6,6 +6,10 @@ using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace TVServices {
 
 	[TV (9,0)]
@@ -21,7 +25,7 @@ namespace TVServices {
 
 		[Export ("initWithIdentifier:container:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier, [NullAllowed] TVContentIdentifier container);
+		NativeHandle Constructor (string identifier, [NullAllowed] TVContentIdentifier container);
 	}
 
 	[TV (9,0)]
@@ -74,7 +78,7 @@ namespace TVServices {
 
 		[Export ("initWithContentIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (TVContentIdentifier ident);
+		NativeHandle Constructor (TVContentIdentifier ident);
 
 		[TV (11,0)]
 		[Export ("imageURLForTraits:")]
@@ -112,7 +116,7 @@ namespace TVServices {
 	interface TVAppProfileDescriptor : NSCopying, NSSecureCoding {
 
 		[Export("initWithName:")]
-		IntPtr Constructor (string name);
+		NativeHandle Constructor (string name);
 
 		[Export("name")]
 		string Name { get; set; }
@@ -127,7 +131,7 @@ namespace TVServices {
 
 		[Export ("initWithURL:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 	}
 
 	[TV (13,0)]
@@ -155,7 +159,7 @@ namespace TVServices {
 
 		[Export ("initWithStyle:items:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (TVTopShelfCarouselContentStyle style, TVTopShelfCarouselItem[] items);
+		NativeHandle Constructor (TVTopShelfCarouselContentStyle style, TVTopShelfCarouselItem[] items);
 	}
 
 	[TV (13,0)]
@@ -180,7 +184,7 @@ namespace TVServices {
 		// inlined from base class
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[NullAllowed, Export ("contextTitle")]
 		string ContextTitle { get; set; }
@@ -234,7 +238,7 @@ namespace TVServices {
 		CGSize ImageSize { get; }
 
 		[Export ("initWithItems:")]
-		IntPtr Constructor (TVTopShelfItem[] items);
+		NativeHandle Constructor (TVTopShelfItem[] items);
 	}
 
 	[TV (13,0)]
@@ -263,7 +267,7 @@ namespace TVServices {
 
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 	}
 
 	[TV (13,0)]
@@ -279,7 +283,7 @@ namespace TVServices {
 
 		[Export ("initWithName:values:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string name, string[] values);
+		NativeHandle Constructor (string name, string[] values);
 	}
 
 	[TV (13,0)]
@@ -331,7 +335,7 @@ namespace TVServices {
 		TVTopShelfItem[] Items { get; }
 
 		[Export ("initWithItems:")]
-		IntPtr Constructor (TVTopShelfItem[] items);
+		NativeHandle Constructor (TVTopShelfItem[] items);
 	}
 
 	[TV (13,0)]
@@ -344,7 +348,7 @@ namespace TVServices {
 
 		[Export("initWithSections:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (TVTopShelfItemCollection[] sections);
+		NativeHandle Constructor (TVTopShelfItemCollection[] sections);
 
 		[Static]
 		[Export("imageSizeForImageShape:")]
@@ -367,7 +371,7 @@ namespace TVServices {
 		// inlined from base type
 		[Export ("initWithIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("imageShape", ArgumentSemantic.Assign)]
 		TVTopShelfSectionedItemImageShape ImageShape { get; set; }

--- a/src/tvuikit.cs
+++ b/src/tvuikit.cs
@@ -7,6 +7,10 @@ using Foundation;
 using ObjCRuntime;
 using UIKit;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace TVUIKit {
 
 	[TV (12,0)]
@@ -34,7 +38,7 @@ namespace TVUIKit {
 
 		[DesignatedInitializer] // inlined
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("contentView", ArgumentSemantic.Strong)]
 		UIView ContentView { get; }
@@ -63,7 +67,7 @@ namespace TVUIKit {
 
 		[DesignatedInitializer] // inlined
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("motionDirection", ArgumentSemantic.Assign)]
 		TVCaptionButtonViewMotionDirection MotionDirection { get; set; }
@@ -87,7 +91,7 @@ namespace TVUIKit {
 
 		[DesignatedInitializer] // inlined
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NullAllowed, Export ("cardBackgroundColor", ArgumentSemantic.Strong)]
 		UIColor CardBackgroundColor { get; set; }
@@ -130,7 +134,7 @@ namespace TVUIKit {
 
 		[DesignatedInitializer] // inlined
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NullAllowed, Export ("titleLabel", ArgumentSemantic.Strong)]
 		UILabel TitleLabel { get; }
@@ -149,7 +153,7 @@ namespace TVUIKit {
 
 		[DesignatedInitializer] // inlined
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NullAllowed, Export ("personNameComponents", ArgumentSemantic.Strong)]
 		NSPersonNameComponents PersonNameComponents { get; set; }
@@ -170,10 +174,10 @@ namespace TVUIKit {
 
 		[DesignatedInitializer] // inlined
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("initWithImage:")]
-		IntPtr Constructor ([NullAllowed] UIImage image);
+		NativeHandle Constructor ([NullAllowed] UIImage image);
 
 		[NullAllowed, Export ("image", ArgumentSemantic.Strong)]
 		UIImage Image { get; set; }
@@ -194,7 +198,7 @@ namespace TVUIKit {
 
 		// inlined from base type
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("cornerRadius")]
 		nfloat CornerRadius { get; }
@@ -345,7 +349,7 @@ namespace TVUIKit {
 
 		[Export ("initWithConfiguration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (TVMediaItemContentConfiguration configuration);
+		NativeHandle Constructor (TVMediaItemContentConfiguration configuration);
 
 		// Conflicts with IUIContentView.Configuration property unfortunately
 		[Sealed]
@@ -432,7 +436,7 @@ namespace TVUIKit {
 
 		[Export ("initWithConfiguration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (TVMonogramContentConfiguration configuration);
+		NativeHandle Constructor (TVMonogramContentConfiguration configuration);
 
 		// Conflicts with IUIContentView.Configuration property unfortunately
 		[Sealed]

--- a/src/twitter.cs
+++ b/src/twitter.cs
@@ -12,6 +12,10 @@ using UIKit;
 using Twitter;
 using Accounts;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Twitter {
 
 	delegate void TWRequestHandler (NSData responseData, NSHttpUrlResponse urlResponse, NSError error);
@@ -34,7 +38,7 @@ namespace Twitter {
 		NSDictionary Parameters { get;  }
 
 		[Export ("initWithURL:parameters:requestMethod:")]
-		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary parameters, TWRequestMethod requestMethod);
+		NativeHandle Constructor (NSUrl url, [NullAllowed] NSDictionary parameters, TWRequestMethod requestMethod);
 
 		[Export ("addMultiPartData:withName:type:")]
 		void AddMultiPartData (NSData data, string name, string type);
@@ -52,7 +56,7 @@ namespace Twitter {
 	interface TWTweetComposeViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("completionHandler")]
 		Action<TWTweetComposeViewControllerResult> CompletionHandler { get; set; }

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -102,6 +102,10 @@ using NSWritingDirection = UIKit.UITextWritingDirection;
 using System;
 using System.ComponentModel;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace UIKit {
 
 	[NoWatch]
@@ -272,7 +276,7 @@ namespace UIKit {
 	interface UIImpactFeedbackGenerator {
 
 		[Export ("initWithStyle:")]
-		IntPtr Constructor (UIImpactFeedbackStyle style);
+		NativeHandle Constructor (UIImpactFeedbackStyle style);
 
 		[Export ("impactOccurred")]
 		void ImpactOccurred ();
@@ -316,7 +320,7 @@ namespace UIKit {
 
 		[Export ("initWithPresentedViewController:presentingViewController:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);
+		NativeHandle Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -400,13 +404,13 @@ namespace UIKit {
 
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("initWithPreparationHandler:")]
-		IntPtr Constructor (UICloudSharingControllerPreparationHandler preparationHandler);
+		NativeHandle Constructor (UICloudSharingControllerPreparationHandler preparationHandler);
 
 		[Export ("initWithShare:container:")]
-		IntPtr Constructor (CKShare share, CKContainer container);
+		NativeHandle Constructor (CKShare share, CKContainer container);
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		IUICloudSharingControllerDelegate Delegate { get; set; }
@@ -1007,35 +1011,35 @@ namespace UIKit {
 	[DisableDefaultCtor] // NSInvalidArgumentException Please use the designated initializer
 	partial interface UIAccessibilityCustomAction {
 	    [Export ("initWithName:target:selector:")]
-	    IntPtr Constructor (string name, NSObject target, Selector selector);
+	    NativeHandle Constructor (string name, NSObject target, Selector selector);
 	
 		[TV (11,0), iOS (11,0)]
 		[Export ("initWithAttributedName:target:selector:")]
-		IntPtr Constructor (NSAttributedString attributedName, [NullAllowed] NSObject target, Selector selector);
+		NativeHandle Constructor (NSAttributedString attributedName, [NullAllowed] NSObject target, Selector selector);
 
 		[TV (13,0), iOS (13,0)]
 		[Export ("initWithName:actionHandler:")]
-		IntPtr Constructor (string name, [NullAllowed] UIAccessibilityCustomActionHandler actionHandler);
+		NativeHandle Constructor (string name, [NullAllowed] UIAccessibilityCustomActionHandler actionHandler);
 
 		[TV (13,0), iOS (13,0)]
 		[Export ("initWithAttributedName:actionHandler:")]
-		IntPtr Constructor (NSAttributedString attributedName, [NullAllowed] UIAccessibilityCustomActionHandler actionHandler);
+		NativeHandle Constructor (NSAttributedString attributedName, [NullAllowed] UIAccessibilityCustomActionHandler actionHandler);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithName:image:target:selector:")]
-		IntPtr Constructor (string name, [NullAllowed] UIImage image, [NullAllowed] NSObject target, Selector selector);
+		NativeHandle Constructor (string name, [NullAllowed] UIImage image, [NullAllowed] NSObject target, Selector selector);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithAttributedName:image:target:selector:")]
-		IntPtr Constructor (NSAttributedString attributedName, [NullAllowed] UIImage image, [NullAllowed] NSObject target, Selector selector);
+		NativeHandle Constructor (NSAttributedString attributedName, [NullAllowed] UIImage image, [NullAllowed] NSObject target, Selector selector);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithName:image:actionHandler:")]
-		IntPtr Constructor (string name, [NullAllowed] UIImage image, UIAccessibilityCustomActionHandler actionHandler);
+		NativeHandle Constructor (string name, [NullAllowed] UIImage image, UIAccessibilityCustomActionHandler actionHandler);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithAttributedName:image:actionHandler:")]
-		IntPtr Constructor (NSAttributedString attributedName, [NullAllowed] UIImage image, UIAccessibilityCustomActionHandler actionHandler);
+		NativeHandle Constructor (NSAttributedString attributedName, [NullAllowed] UIImage image, UIAccessibilityCustomActionHandler actionHandler);
 
 		[NullAllowed] // by default this property is null
 	    [Export ("name")]
@@ -1069,15 +1073,15 @@ namespace UIKit {
 	interface UIAccessibilityCustomRotor {
 
 		[Export ("initWithName:itemSearchBlock:")]
-		IntPtr Constructor (string name, UIAccessibilityCustomRotorSearch itemSearchHandler);
+		NativeHandle Constructor (string name, UIAccessibilityCustomRotorSearch itemSearchHandler);
 
 		[iOS (11,0), TV (11,0)]
 		[Export ("initWithAttributedName:itemSearchBlock:")]
-		IntPtr Constructor (NSAttributedString attributedName, UIAccessibilityCustomRotorSearch itemSearchBlock);
+		NativeHandle Constructor (NSAttributedString attributedName, UIAccessibilityCustomRotorSearch itemSearchBlock);
 
 		[iOS (11,0), TV (11,0)]
 		[Export ("initWithSystemType:itemSearchBlock:")]
-		IntPtr Constructor (UIAccessibilityCustomSystemRotorType type, UIAccessibilityCustomRotorSearch itemSearchBlock);
+		NativeHandle Constructor (UIAccessibilityCustomSystemRotorType type, UIAccessibilityCustomRotorSearch itemSearchBlock);
 
 		[Export ("name")]
 		string Name { get; set; }
@@ -1112,7 +1116,7 @@ namespace UIKit {
 	interface UIAccessibilityCustomRotorItemResult {
 
 		[Export ("initWithTargetElement:targetRange:")]
-		IntPtr Constructor (NSObject targetElement, [NullAllowed] UITextRange targetRange);
+		NativeHandle Constructor (NSObject targetElement, [NullAllowed] UITextRange targetRange);
 
 		[NullAllowed, Export ("targetElement", ArgumentSemantic.Weak)]
 		NSObject TargetElement { get; set; }
@@ -1137,7 +1141,7 @@ namespace UIKit {
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Use initWithAccessibilityContainer:
 	interface UIAccessibilityElement : UIAccessibilityIdentification {
 		[Export ("initWithAccessibilityContainer:")]
-		IntPtr Constructor (NSObject container);
+		NativeHandle Constructor (NSObject container);
 
 		[NullAllowed] // by default this property is null
 		[Export ("accessibilityContainer", ArgumentSemantic.UnsafeUnretained)]
@@ -1223,14 +1227,14 @@ namespace UIKit {
 	[DisableDefaultCtor]
 	interface UIAccessibilityLocationDescriptor {
 		[Export ("initWithName:view:")]
-		IntPtr Constructor (string name, UIView view);
+		NativeHandle Constructor (string name, UIView view);
 
 		[Export ("initWithName:point:inView:")]
-		IntPtr Constructor (string name, CGPoint point, UIView view);
+		NativeHandle Constructor (string name, CGPoint point, UIView view);
 
 		[Export ("initWithAttributedName:point:inView:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSAttributedString attributedName, CGPoint point, UIView view);
+		NativeHandle Constructor (NSAttributedString attributedName, CGPoint point, UIView view);
 
 		[NullAllowed, Export ("view", ArgumentSemantic.Weak)]
 		UIView View { get; }
@@ -1259,11 +1263,11 @@ namespace UIKit {
 	[Deprecated (PlatformName.iOS, 8, 3, message: "Use 'UIAlertController' with 'UIAlertControllerStyle.ActionSheet' instead.")]
 	interface UIActionSheet {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'UIAlertController' instead.")]
 		[Export ("initWithTitle:delegate:cancelButtonTitle:destructiveButtonTitle:otherButtonTitles:")][Internal][PostGet ("WeakDelegate")]
-		IntPtr Constructor ([NullAllowed] string title, [NullAllowed] IUIActionSheetDelegate Delegate, [NullAllowed] string cancelTitle, [NullAllowed] string destroy, [NullAllowed] string other);
+		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] IUIActionSheetDelegate Delegate, [NullAllowed] string cancelTitle, [NullAllowed] string destroy, [NullAllowed] string other);
 
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -1506,7 +1510,7 @@ namespace UIKit {
 		[DesignatedInitializer]
 		[Export ("initWithPlaceholderItem:")]
 		[PostGet ("PlaceholderItem")]
-		IntPtr Constructor (NSObject placeholderItem);
+		NativeHandle Constructor (NSObject placeholderItem);
 		
 		[Export ("placeholderItem", ArgumentSemantic.Retain)]
 		NSObject PlaceholderItem { get;  }
@@ -1558,7 +1562,7 @@ namespace UIKit {
 	interface UIActivityViewController {
 		[DesignatedInitializer]
 		[Export ("initWithActivityItems:applicationActivities:")]
-		IntPtr Constructor (NSObject [] activityItems, [NullAllowed] UIActivity [] applicationActivities);
+		NativeHandle Constructor (NSObject [] activityItems, [NullAllowed] UIActivity [] applicationActivities);
 		
 		[NullAllowed] // by default this property is null
 		[Export ("completionHandler", ArgumentSemantic.Copy)]
@@ -1577,7 +1581,7 @@ namespace UIKit {
 
 		[iOS (14,0)]
 		[Export ("initWithActivityItemsConfiguration:")]
-		IntPtr Constructor (IUIActivityItemsConfigurationReading activityItemsConfiguration);
+		NativeHandle Constructor (IUIActivityItemsConfigurationReading activityItemsConfiguration);
 	}
 
 	[iOS (8,0)]
@@ -1605,7 +1609,7 @@ namespace UIKit {
 	{
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("actions")]
 		UIAlertAction [] Actions { get; }
@@ -1645,7 +1649,7 @@ namespace UIKit {
 	interface UIAlertView : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 		
 		[Sealed]
 		[Export ("initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:", IsVariadic = true)][Internal][PostGet ("WeakDelegate")]
@@ -1657,7 +1661,7 @@ namespace UIKit {
 		// arguments (id, SEL), which means we only need 7 more. And 'mustAlsoBeNull' is that 7th argument.
 		// So on ARM64 the 8th argument ('mustBeNull') is ignored, and iOS sees the 9th argument ('mustAlsoBeNull') as the 8th argument.
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'UIAlertController' instead.")]
-		IntPtr Constructor ([NullAllowed] string title, [NullAllowed] string message, [NullAllowed] IUIAlertViewDelegate viewDelegate, [NullAllowed] string cancelButtonTitle, IntPtr otherButtonTitles, IntPtr mustBeNull, IntPtr mustAlsoBeNull);
+		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] string message, [NullAllowed] IUIAlertViewDelegate viewDelegate, [NullAllowed] string cancelButtonTitle, IntPtr otherButtonTitles, IntPtr mustBeNull, IntPtr mustAlsoBeNull);
 
 		[Wrap ("WeakDelegate")]
 		[Protocolize]
@@ -1753,10 +1757,10 @@ namespace UIKit {
 	interface UIStackView {
 		[Export ("initWithFrame:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("initWithArrangedSubviews:")]
-		IntPtr Constructor (UIView [] views);
+		NativeHandle Constructor (UIView [] views);
 
 		[Export ("arrangedSubviews")]
 		UIView[] ArrangedSubviews { get; }
@@ -1932,16 +1936,16 @@ namespace UIKit {
 	
 		[Export ("initWithDuration:timingParameters:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double duration, IUITimingCurveProvider parameters);
+		NativeHandle Constructor (double duration, IUITimingCurveProvider parameters);
 	
 		[Export ("initWithDuration:curve:animations:")]
-		IntPtr Constructor (double duration, UIViewAnimationCurve curve, [NullAllowed] Action animations);
+		NativeHandle Constructor (double duration, UIViewAnimationCurve curve, [NullAllowed] Action animations);
 	
 		[Export ("initWithDuration:controlPoint1:controlPoint2:animations:")]
-		IntPtr Constructor (double duration, CGPoint point1, CGPoint point2, [NullAllowed] Action animations);
+		NativeHandle Constructor (double duration, CGPoint point1, CGPoint point2, [NullAllowed] Action animations);
 	
 		[Export ("initWithDuration:dampingRatio:animations:")]
-		IntPtr Constructor (double duration, nfloat ratio, [NullAllowed] Action animations);
+		NativeHandle Constructor (double duration, nfloat ratio, [NullAllowed] Action animations);
 	
 		[Static]
 		[Export ("runningPropertyAnimatorWithDuration:delay:options:animations:completion:")]
@@ -2639,10 +2643,10 @@ namespace UIKit {
 	{
 		[Export ("initWithType:localizedTitle:localizedSubtitle:icon:userInfo:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string type, string localizedTitle, [NullAllowed] string localizedSubtitle, [NullAllowed] UIApplicationShortcutIcon icon, [NullAllowed] NSDictionary<NSString,NSObject> userInfo);
+		NativeHandle Constructor (string type, string localizedTitle, [NullAllowed] string localizedSubtitle, [NullAllowed] UIApplicationShortcutIcon icon, [NullAllowed] NSDictionary<NSString,NSObject> userInfo);
 	
 		[Export ("initWithType:localizedTitle:")]
-		IntPtr Constructor (string type, string localizedTitle);
+		NativeHandle Constructor (string type, string localizedTitle);
 	
 		[Export ("type")]
 		string Type { get; [NotImplemented] set; }
@@ -2672,11 +2676,11 @@ namespace UIKit {
 	{
 		// inlined
 		[Export ("initWithType:localizedTitle:localizedSubtitle:icon:userInfo:")]
-		IntPtr Constructor (string type, string localizedTitle, [NullAllowed] string localizedSubtitle, [NullAllowed] UIApplicationShortcutIcon icon, [NullAllowed] NSDictionary<NSString,NSObject> userInfo);
+		NativeHandle Constructor (string type, string localizedTitle, [NullAllowed] string localizedSubtitle, [NullAllowed] UIApplicationShortcutIcon icon, [NullAllowed] NSDictionary<NSString,NSObject> userInfo);
 
 		// inlined
 		[Export ("initWithType:localizedTitle:")]
-		IntPtr Constructor (string type, string localizedTitle);
+		NativeHandle Constructor (string type, string localizedTitle);
 
 		[Export ("type")]
 		[Override]
@@ -2726,18 +2730,18 @@ namespace UIKit {
 		nfloat Frequency { get; set;  }
 
 		[Export ("initWithItem:attachedToAnchor:")]
-		IntPtr Constructor (IUIDynamicItem item, CGPoint anchorPoint);
+		NativeHandle Constructor (IUIDynamicItem item, CGPoint anchorPoint);
 
 		[DesignatedInitializer]
 		[Export ("initWithItem:offsetFromCenter:attachedToAnchor:")]
-		IntPtr Constructor (IUIDynamicItem item, UIOffset offset, CGPoint anchorPoint);
+		NativeHandle Constructor (IUIDynamicItem item, UIOffset offset, CGPoint anchorPoint);
 
 		[Export ("initWithItem:attachedToItem:")]
-		IntPtr Constructor (IUIDynamicItem item, IUIDynamicItem attachedToItem);
+		NativeHandle Constructor (IUIDynamicItem item, IUIDynamicItem attachedToItem);
 
 		[DesignatedInitializer]
 		[Export ("initWithItem:offsetFromCenter:attachedToItem:offsetFromCenter:")]
-		IntPtr Constructor (IUIDynamicItem item, UIOffset offsetFromCenter, IUIDynamicItem attachedToItem, UIOffset attachOffsetFromCenter);
+		NativeHandle Constructor (IUIDynamicItem item, UIOffset offsetFromCenter, IUIDynamicItem attachedToItem, UIOffset attachOffsetFromCenter);
 
 		[Static]
 		[iOS (9,0)]
@@ -2895,7 +2899,7 @@ namespace UIKit {
 
 		[Export ("initWithDelegate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IUIContextMenuInteractionDelegate @delegate);
+		NativeHandle Constructor (IUIContextMenuInteractionDelegate @delegate);
 
 		[Export ("locationInView:")]
 		CGPoint GetLocation ([NullAllowed] UIView inView);
@@ -3270,39 +3274,39 @@ namespace UIKit {
 		[Export ("initWithImage:style:target:action:")]
 		[PostGet ("Image")]
 		[PostGet ("Target")]
-		IntPtr Constructor ([NullAllowed] UIImage image, UIBarButtonItemStyle style, [NullAllowed] NSObject target, [NullAllowed] Selector action);
+		NativeHandle Constructor ([NullAllowed] UIImage image, UIBarButtonItemStyle style, [NullAllowed] NSObject target, [NullAllowed] Selector action);
 		
 		[Export ("initWithTitle:style:target:action:")]
 		[PostGet ("Target")]
-		IntPtr Constructor ([NullAllowed] string title, UIBarButtonItemStyle style, [NullAllowed] NSObject target, [NullAllowed] Selector action);
+		NativeHandle Constructor ([NullAllowed] string title, UIBarButtonItemStyle style, [NullAllowed] NSObject target, [NullAllowed] Selector action);
 
 		[Export ("initWithBarButtonSystemItem:target:action:")]
 		[PostGet ("Target")]
-		IntPtr Constructor (UIBarButtonSystemItem systemItem, [NullAllowed] NSObject target, [NullAllowed] Selector action);
+		NativeHandle Constructor (UIBarButtonSystemItem systemItem, [NullAllowed] NSObject target, [NullAllowed] Selector action);
 
 		[Export ("initWithCustomView:")]
 		[PostGet ("CustomView")]
-		IntPtr Constructor (UIView customView);
+		NativeHandle Constructor (UIView customView);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithBarButtonSystemItem:primaryAction:")]
-		IntPtr Constructor (UIBarButtonSystemItem systemItem, [NullAllowed] UIAction primaryAction);
+		NativeHandle Constructor (UIBarButtonSystemItem systemItem, [NullAllowed] UIAction primaryAction);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithPrimaryAction:")]
-		IntPtr Constructor ([NullAllowed] UIAction primaryAction);
+		NativeHandle Constructor ([NullAllowed] UIAction primaryAction);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithBarButtonSystemItem:menu:")]
-		IntPtr Constructor (UIBarButtonSystemItem systemItem, [NullAllowed] UIMenu menu);
+		NativeHandle Constructor (UIBarButtonSystemItem systemItem, [NullAllowed] UIMenu menu);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithTitle:menu:")]
-		IntPtr Constructor ([NullAllowed] string title, [NullAllowed] UIMenu menu);
+		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] UIMenu menu);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithImage:menu:")]
-		IntPtr Constructor ([NullAllowed] UIImage image, [NullAllowed] UIMenu menu);
+		NativeHandle Constructor ([NullAllowed] UIImage image, [NullAllowed] UIMenu menu);
 
 		[TV (14,0), iOS (14,0)]
 		[Static]
@@ -3378,7 +3382,7 @@ namespace UIKit {
 		[PostGet ("LandscapeImagePhone")]
 #endif
 		[PostGet ("Target")]
-		IntPtr Constructor ([NullAllowed] UIImage image, [NullAllowed] UIImage landscapeImagePhone, UIBarButtonItemStyle style, [NullAllowed] NSObject target, [NullAllowed] Selector action);
+		NativeHandle Constructor ([NullAllowed] UIImage image, [NullAllowed] UIImage landscapeImagePhone, UIBarButtonItemStyle style, [NullAllowed] NSObject target, [NullAllowed] Selector action);
 
 		[Export ("setBackgroundImage:forState:barMetrics:")]
 		[Appearance]
@@ -3453,7 +3457,7 @@ namespace UIKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithBarButtonItems:representativeItem:")]
-		IntPtr Constructor (UIBarButtonItem[] barButtonItems, [NullAllowed] UIBarButtonItem representativeItem);
+		NativeHandle Constructor (UIBarButtonItem[] barButtonItems, [NullAllowed] UIBarButtonItem representativeItem);
 	
 		[Export ("barButtonItems", ArgumentSemantic.Copy)]
 		UIBarButtonItem[] BarButtonItems { get; set; }
@@ -3468,7 +3472,7 @@ namespace UIKit {
 	[BaseType (typeof (UIView))]
 	interface UICollectionReusableView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 		
 		[Export ("reuseIdentifier", ArgumentSemantic.Copy)]
 		NSString ReuseIdentifier { get;  }
@@ -3501,7 +3505,7 @@ namespace UIKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithFrame:collectionViewLayout:"), PostGet ("CollectionViewLayout")]
-		IntPtr Constructor (CGRect frame, UICollectionViewLayout layout);
+		NativeHandle Constructor (CGRect frame, UICollectionViewLayout layout);
 
 		[Export ("collectionViewLayout", ArgumentSemantic.Retain)]
 		UICollectionViewLayout CollectionViewLayout { get; set;  }
@@ -3978,7 +3982,7 @@ namespace UIKit {
 	[BaseType (typeof (UICollectionReusableView))]
 	interface UICollectionViewCell {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Watch (7,0), TV (14,0), iOS (14,0)]
 		[Export ("configurationState")]
@@ -4040,7 +4044,7 @@ namespace UIKit {
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("collectionView", ArgumentSemantic.Retain)]
 		UICollectionView CollectionView { get; set;  }
@@ -4052,7 +4056,7 @@ namespace UIKit {
 		// note: we can't use [PostGet] since it would not work before iOS7 so the hack must remain...
 		[DesignatedInitializer]
 		[Export ("initWithCollectionViewLayout:")]
-		IntPtr Constructor (UICollectionViewLayout layout);
+		NativeHandle Constructor (UICollectionViewLayout layout);
 
 		[iOS (7,0)]
 		[Export ("collectionViewLayout")]
@@ -4432,7 +4436,7 @@ namespace UIKit {
 		[Export ("initWithCurrentLayout:nextLayout:")]
 		[PostGet ("CurrentLayout")]
 		[PostGet ("NextLayout")]
-		IntPtr Constructor (UICollectionViewLayout currentLayout, UICollectionViewLayout newLayout);
+		NativeHandle Constructor (UICollectionViewLayout currentLayout, UICollectionViewLayout newLayout);
 
 		[Export ("updateValue:forAnimatedKey:")]
 		void UpdateValue (nfloat value, string animatedKey);
@@ -4515,16 +4519,16 @@ namespace UIKit {
 		UIColor FromPatternImage (UIImage image);
 
 		[Export ("initWithRed:green:blue:alpha:")]
-		IntPtr Constructor (nfloat red, nfloat green, nfloat blue, nfloat alpha);
+		NativeHandle Constructor (nfloat red, nfloat green, nfloat blue, nfloat alpha);
 
 		[Export ("initWithPatternImage:")]
-		IntPtr Constructor (UIImage patternImage);
+		NativeHandle Constructor (UIImage patternImage);
 
 		[Export ("initWithWhite:alpha:")]
-		IntPtr Constructor (nfloat white, nfloat alpha);
+		NativeHandle Constructor (nfloat white, nfloat alpha);
 
 		// [Export ("initWithHue:saturation:brightness:alpha:")]
-		// IntPtr Constructor (nfloat red, nfloat green, nfloat blue, nfloat alpha);
+		// NativeHandle Constructor (nfloat red, nfloat green, nfloat blue, nfloat alpha);
 		// 
 		// This method is not bound as a constructor because the binding already has a constructor that
 		// takes 4 doubles (RGBA constructor) meaning that we would need to use an enum to diff between them making the API
@@ -4532,7 +4536,7 @@ namespace UIKit {
 		// instead.
 		
 		[Export ("initWithCGColor:")]
-		IntPtr Constructor (CGColor color);
+		NativeHandle Constructor (CGColor color);
 
 		[Static] [Export ("clearColor")]
 		UIColor Clear { get; }
@@ -4634,7 +4638,7 @@ namespace UIKit {
 
 		[NoWatch]
 		[Export ("initWithCIColor:")]
-		IntPtr Constructor (CIColor ciColor);
+		NativeHandle Constructor (CIColor ciColor);
 
 		[Export ("getWhite:alpha:")]
 		bool GetWhite (out nfloat white, out nfloat alpha);
@@ -4686,7 +4690,7 @@ namespace UIKit {
 
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Export ("initWithDynamicProvider:")]
-		IntPtr Constructor (Func<UITraitCollection, UIColor> dynamicProvider);
+		NativeHandle Constructor (Func<UITraitCollection, UIColor> dynamicProvider);
 
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Export ("resolvedColorWithTraitCollection:")]
@@ -4897,7 +4901,7 @@ namespace UIKit {
 	interface UICollisionBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
-		IntPtr Constructor ([Params] IUIDynamicItem [] items);
+		NativeHandle Constructor ([Params] IUIDynamicItem [] items);
 		
 		[Export ("items", ArgumentSemantic.Copy)]
 		IUIDynamicItem [] Items { get;  }
@@ -4984,7 +4988,7 @@ namespace UIKit {
 		[DesignatedInitializer]
 		[Export ("initWithFileURL:")]
 		[PostGet ("FileUrl")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("fileURL")]
 		NSUrl FileUrl { get; }
@@ -5108,7 +5112,7 @@ namespace UIKit {
 	interface UIDynamicAnimator {
 		[DesignatedInitializer]
 		[Export ("initWithReferenceView:")]
-		IntPtr Constructor (UIView referenceView);
+		NativeHandle Constructor (UIView referenceView);
 		
 		[Export ("referenceView")]
 		UIView ReferenceView { get;  }
@@ -5151,7 +5155,7 @@ namespace UIKit {
 		// From UIDynamicAnimator (UICollectionViewAdditions)
 		//
 		[Export ("initWithCollectionViewLayout:")]
-		IntPtr Constructor (UICollectionViewLayout layout);
+		NativeHandle Constructor (UICollectionViewLayout layout);
 		
 		[Export ("layoutAttributesForCellAtIndexPath:")]
 		UICollectionViewLayoutAttributes GetLayoutAttributesForCell (NSIndexPath cellIndexPath);
@@ -5169,7 +5173,7 @@ namespace UIKit {
 	interface UIDynamicItemBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
-		IntPtr Constructor ([Params] IUIDynamicItem [] items);
+		NativeHandle Constructor ([Params] IUIDynamicItem [] items);
 		
 		[Export ("items", ArgumentSemantic.Copy)]
 		IUIDynamicItem [] Items { get;  }
@@ -5252,7 +5256,7 @@ namespace UIKit {
 	interface UIDynamicItemGroup : UIDynamicItem
 	{
 		[Export ("initWithItems:")]
-		IntPtr Constructor (IUIDynamicItem[] items);
+		NativeHandle Constructor (IUIDynamicItem[] items);
 	
 		[Export ("items", ArgumentSemantic.Copy)]
 		IUIDynamicItem[] Items { get; }
@@ -5621,11 +5625,11 @@ namespace UIKit {
 	
 		[DesignatedInitializer]
 		[Export ("initWithFontAttributes:")]
-		IntPtr Constructor (NSDictionary attributes);
+		NativeHandle Constructor (NSDictionary attributes);
 		
 		[DesignatedInitializer]
 		[Wrap ("this (attributes.GetDictionary ()!)")]
-		IntPtr Constructor (UIFontAttributes attributes);
+		NativeHandle Constructor (UIFontAttributes attributes);
 
 		[Export ("fontDescriptorByAddingAttributes:")]
 		UIFontDescriptor CreateWithAttributes (NSDictionary attributes);
@@ -5727,12 +5731,12 @@ namespace UIKit {
 	interface UIGestureRecognizer {
 		[DesignatedInitializer]
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("initWithTarget:action:")]
 		[Sealed]
 		[Internal]
-		IntPtr Constructor (NSObject target, IntPtr /* SEL */ action);
+		NativeHandle Constructor (NSObject target, IntPtr /* SEL */ action);
 		
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -5961,11 +5965,11 @@ namespace UIKit {
 	interface UIGraphicsRenderer
 	{
 		[Export ("initWithBounds:")]
-		IntPtr Constructor (CGRect bounds);
+		NativeHandle Constructor (CGRect bounds);
 	
 		[Export ("initWithBounds:format:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect bounds, UIGraphicsRendererFormat format);
+		NativeHandle Constructor (CGRect bounds, UIGraphicsRendererFormat format);
 	
 		[Export ("format")]
 		UIGraphicsRendererFormat Format { get; }
@@ -6038,15 +6042,15 @@ namespace UIKit {
 	interface UIGraphicsImageRenderer
 	{
 		[Export ("initWithSize:")]
-		IntPtr Constructor (CGSize size);
+		NativeHandle Constructor (CGSize size);
 
 		[Export ("initWithSize:format:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGSize size, UIGraphicsImageRendererFormat format);
+		NativeHandle Constructor (CGSize size, UIGraphicsImageRendererFormat format);
 
 		[Export ("initWithBounds:format:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect bounds, UIGraphicsImageRendererFormat format);
+		NativeHandle Constructor (CGRect bounds, UIGraphicsImageRendererFormat format);
 
 		[Export ("imageWithActions:")]
 		UIImage CreateImage (Action<UIGraphicsImageRendererContext> actions);
@@ -6106,7 +6110,7 @@ namespace UIKit {
 	{
 		[Export ("initWithBounds:format:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect bounds, UIGraphicsPdfRendererFormat format);
+		NativeHandle Constructor (CGRect bounds, UIGraphicsPdfRendererFormat format);
 
 		[Export ("writePDFToURL:withActions:error:")]
 		bool WritePdf (NSUrl url, Action<UIGraphicsPdfRendererContext> actions, out NSError error);
@@ -6120,7 +6124,7 @@ namespace UIKit {
 	interface UIGravityBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
-		IntPtr Constructor ([Params] IUIDynamicItem [] items);
+		NativeHandle Constructor ([Params] IUIDynamicItem [] items);
 		
 		[Export ("items", ArgumentSemantic.Copy)]
 		IUIDynamicItem [] Items { get;  }
@@ -6746,7 +6750,7 @@ namespace UIKit {
 	[BaseType (typeof (NSObject))]
 	interface UITextInputStringTokenizer : UITextInputTokenizer{
 		[Export ("initWithTextInput:")]
-		IntPtr Constructor (IUITextInput textInput);
+		NativeHandle Constructor (IUITextInput textInput);
 	}
 
 	[BaseType (typeof (NSObject))]
@@ -6840,7 +6844,7 @@ namespace UIKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("fireDate", ArgumentSemantic.Copy)]
 		[NullAllowed]
@@ -6911,7 +6915,7 @@ namespace UIKit {
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UILongPressGestureRecognizer {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[NoTV]
 		[Export ("numberOfTouchesRequired")]
@@ -6930,7 +6934,7 @@ namespace UIKit {
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UITapGestureRecognizer {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("numberOfTapsRequired")]
 		nuint NumberOfTapsRequired { get; set; }
@@ -6947,7 +6951,7 @@ namespace UIKit {
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIPanGestureRecognizer {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[NoTV]
 		[Export ("minimumNumberOfTouches")]
@@ -6978,7 +6982,7 @@ namespace UIKit {
 
 		// inherit .ctor
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("edges", ArgumentSemantic.Assign)]
 		UIRectEdge Edges { get; set; }
@@ -7014,10 +7018,10 @@ namespace UIKit {
 		UIRegion Infinite { get; }
 
 		[Export ("initWithRadius:")]
-		IntPtr Constructor (nfloat radius);
+		NativeHandle Constructor (nfloat radius);
 
 		[Export ("initWithSize:")]
-		IntPtr Constructor (CGSize size);
+		NativeHandle Constructor (CGSize size);
 
 		[Export ("inverseRegion")]
 		UIRegion Inverse ();
@@ -7039,7 +7043,7 @@ namespace UIKit {
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIRotationGestureRecognizer {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("rotation")]
 		nfloat Rotation { get; set; }
@@ -7052,7 +7056,7 @@ namespace UIKit {
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIPinchGestureRecognizer {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("scale")]
 		nfloat Scale { get; set; }
@@ -7064,7 +7068,7 @@ namespace UIKit {
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UISwipeGestureRecognizer {
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[Export ("direction")]
 		UISwipeGestureRecognizerDirection Direction { get; set; }
@@ -7078,11 +7082,11 @@ namespace UIKit {
 	interface UIActivityIndicatorView : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[DesignatedInitializer]
 		[Export ("initWithActivityIndicatorStyle:")]
-		IntPtr Constructor (UIActivityIndicatorViewStyle style);
+		NativeHandle Constructor (UIActivityIndicatorViewStyle style);
 
 		[Export ("activityIndicatorViewStyle")]
 		UIActivityIndicatorViewStyle ActivityIndicatorViewStyle { get; set; }
@@ -7125,11 +7129,11 @@ namespace UIKit {
 	{
 		[ThreadSafe]
 		[Export ("initWithContentsOfFile:")]
-		IntPtr Constructor (string filename);
+		NativeHandle Constructor (string filename);
 
 		[ThreadSafe]
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 		
 		[ThreadSafe]
 		[Export ("size")]
@@ -7277,17 +7281,17 @@ namespace UIKit {
 
 		[Export ("initWithCGImage:")]
 		[ThreadSafe]
-		IntPtr Constructor (CGImage cgImage);
+		NativeHandle Constructor (CGImage cgImage);
 
 #if !WATCH
 		[Export ("initWithCIImage:")]
 		[ThreadSafe]
-		IntPtr Constructor (CIImage ciImage);
+		NativeHandle Constructor (CIImage ciImage);
 #endif // !WATCH
 
 		[Export ("initWithCGImage:scale:orientation:")]
 		[ThreadSafe]
-		IntPtr Constructor (CGImage cgImage, nfloat scale,  UIImageOrientation orientation);
+		NativeHandle Constructor (CGImage cgImage, nfloat scale,  UIImageOrientation orientation);
 
 #if !WATCH
 		[Export ("CIImage")]
@@ -7335,12 +7339,12 @@ namespace UIKit {
 
 		[Export ("initWithData:scale:")]
 		[ThreadSafe]
-		IntPtr Constructor (NSData data, nfloat scale);
+		NativeHandle Constructor (NSData data, nfloat scale);
 
 #if !WATCH
 		[Export ("initWithCIImage:scale:orientation:")]
 		[ThreadSafe]
-		IntPtr Constructor (CIImage ciImage, nfloat scale, UIImageOrientation orientation);
+		NativeHandle Constructor (CIImage ciImage, nfloat scale, UIImageOrientation orientation);
 #endif // !WATCH
 	
 		[Export ("resizableImageWithCapInsets:resizingMode:")]
@@ -7673,7 +7677,7 @@ namespace UIKit {
 	interface UIPreviewParameters : NSCopying {
 
 		[Export ("initWithTextLineRects:")]
-		IntPtr Constructor (NSValue [] textLineRects);
+		NativeHandle Constructor (NSValue [] textLineRects);
 
 		[NullAllowed, Export ("visiblePath", ArgumentSemantic.Copy)]
 		UIBezierPath VisiblePath { get; set; }
@@ -7693,10 +7697,10 @@ namespace UIKit {
 
 		[Export ("initWithContainer:center:transform:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIView container, CGPoint center, CGAffineTransform transform);
+		NativeHandle Constructor (UIView container, CGPoint center, CGAffineTransform transform);
 
 		[Export ("initWithContainer:center:")]
-		IntPtr Constructor (UIView container, CGPoint center);
+		NativeHandle Constructor (UIView container, CGPoint center);
 
 		[Export ("container")]
 		UIView Container { get; }
@@ -7715,13 +7719,13 @@ namespace UIKit {
 
 		[Export ("initWithView:parameters:target:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIView view, UIPreviewParameters parameters, UIPreviewTarget target);
+		NativeHandle Constructor (UIView view, UIPreviewParameters parameters, UIPreviewTarget target);
 
 		[Export ("initWithView:parameters:")]
-		IntPtr Constructor (UIView view, UIPreviewParameters parameters);
+		NativeHandle Constructor (UIView view, UIPreviewParameters parameters);
 
 		[Export ("initWithView:")]
-		IntPtr Constructor (UIView view);
+		NativeHandle Constructor (UIView view);
 
 		[Export ("target")]
 		UIPreviewTarget Target { get; }
@@ -7830,7 +7834,7 @@ namespace UIKit {
 
 		[iOS (13,0), TV (13,0)]
 		[Export ("initWithWindowScene:")]
-		IntPtr Constructor (UIWindowScene windowScene);
+		NativeHandle Constructor (UIWindowScene windowScene);
 
 		[iOS (13,0), TV (13,0)]
 		[NullAllowed, Export ("windowScene", ArgumentSemantic.Weak)]
@@ -7841,7 +7845,7 @@ namespace UIKit {
 		bool CanResizeToFitContent { get; [Bind ("setCanResizeToFitContent:")] set; }
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("makeKeyAndVisible")]
 		void MakeKeyAndVisible ();
@@ -7921,11 +7925,11 @@ namespace UIKit {
 	{
 		[Export ("initWithFrame:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithFrame:primaryAction:")]
-		IntPtr Constructor (CGRect frame, [NullAllowed] UIAction primaryAction);
+		NativeHandle Constructor (CGRect frame, [NullAllowed] UIAction primaryAction);
 
 		[Export ("enabled")]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
@@ -8074,7 +8078,7 @@ namespace UIKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		// initWithFrame: --> unrecognized selector
 
@@ -8202,11 +8206,11 @@ namespace UIKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NoWatch, TV (14,0), iOS (14,0)]
 		[Export ("initWithFrame:primaryAction:")]
-		IntPtr Constructor (CGRect frame, [NullAllowed] UIAction primaryAction);
+		NativeHandle Constructor (CGRect frame, [NullAllowed] UIAction primaryAction);
 
 		[Watch (6,0), TV (13,0), iOS (13,0)]
 		[Static]
@@ -8460,7 +8464,7 @@ namespace UIKit {
 	[BaseType (typeof (UIView))]
 	interface UILabel : UIContentSizeCategoryAdjusting {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("text", ArgumentSemantic.Copy)][NullAllowed]
 		string Text { get; set; }
@@ -8562,16 +8566,16 @@ namespace UIKit {
 #endif // !WATCH
 	{
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("initWithImage:")]
 		[PostGet ("Image")]
-		IntPtr Constructor ([NullAllowed] UIImage image);
+		NativeHandle Constructor ([NullAllowed] UIImage image);
 
 		[Export ("initWithImage:highlightedImage:")]
 		[PostGet ("Image")]
 		[PostGet ("HighlightedImage")]
-		IntPtr Constructor ([NullAllowed] UIImage image, [NullAllowed] UIImage highlightedImage);
+		NativeHandle Constructor ([NullAllowed] UIImage image, [NullAllowed] UIImage highlightedImage);
 
 		[Export ("image", ArgumentSemantic.Retain)][NullAllowed]
 		UIImage Image { get; set; }
@@ -8630,7 +8634,7 @@ namespace UIKit {
 	[BaseType (typeof (UIControl))]
 	interface UIDatePicker {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("datePickerMode")]
 		UIDatePickerMode Mode { get; set; }
@@ -9043,7 +9047,7 @@ namespace UIKit {
 		// https://developer.apple.com/library/ios/#documentation/UIKit/Reference/UIManagedDocument_Class/Reference/Reference.html
 		[Export ("initWithFileURL:")]
 		[PostGet ("FileUrl")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("managedObjectContext", ArgumentSemantic.Retain)]
 		NSManagedObjectContext ManagedObjectContext { get;  }
@@ -9145,7 +9149,7 @@ namespace UIKit {
 	interface UIMenuItem {
 		[DesignatedInitializer] // TODO: Add an overload that takes an Action maybe?
 		[Export ("initWithTitle:action:")]
-		IntPtr Constructor (string title, Selector action);
+		NativeHandle Constructor (string title, Selector action);
 
 		[NullAllowed] // by default this property is null
 		[Export ("title", ArgumentSemantic.Copy)]
@@ -9159,7 +9163,7 @@ namespace UIKit {
 	[BaseType (typeof (UIView))]
 	interface UINavigationBar : UIBarPositioning, NSCoding {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NoTV]
 		// [Appearance] rdar://22818366
@@ -9328,7 +9332,7 @@ namespace UIKit {
 	interface UINavigationItem : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithTitle:")]
-		IntPtr Constructor (string title);
+		NativeHandle Constructor (string title);
 
 		[NullAllowed] // by default this property is null
 		[Export ("title", ArgumentSemantic.Copy)]
@@ -9441,16 +9445,16 @@ namespace UIKit {
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("ViewControllers")] // that will PostGet TopViewController and VisibleViewController too
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[DesignatedInitializer]
 		[Internal, Export ("initWithNavigationBarClass:toolbarClass:")]
-		IntPtr Constructor (IntPtr navigationBarClass, IntPtr toolbarClass);
+		NativeHandle Constructor (IntPtr navigationBarClass, IntPtr toolbarClass);
 
 		[DesignatedInitializer]
 		[Export ("initWithRootViewController:")]
 		[PostGet ("ViewControllers")] // that will PostGet TopViewController and VisibleViewController too
-		IntPtr Constructor (UIViewController rootViewController);
+		NativeHandle Constructor (UIViewController rootViewController);
 
 		[Export ("pushViewController:animated:")]
 		[PostGet ("ViewControllers")] // that will PostGet TopViewController and VisibleViewController too
@@ -9616,7 +9620,7 @@ namespace UIKit {
 	[BaseType (typeof (UIControl))]
 	interface UIPageControl : UIAppearance {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("numberOfPages")]
 		nint Pages { get; set; }
@@ -9683,7 +9687,7 @@ namespace UIKit {
 	interface UIPageViewController : NSCoding {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set;  }
@@ -9719,7 +9723,7 @@ namespace UIKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithTransitionStyle:navigationOrientation:options:")]
-		IntPtr Constructor (UIPageViewControllerTransitionStyle style, UIPageViewControllerNavigationOrientation navigationOrientation, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor (UIPageViewControllerTransitionStyle style, UIPageViewControllerNavigationOrientation navigationOrientation, [NullAllowed] NSDictionary options);
 
 		[Export ("setViewControllers:direction:animated:completion:")]
 		[PostGet ("ViewControllers")]
@@ -10016,7 +10020,7 @@ namespace UIKit {
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" })]
 	interface UIPickerView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NullAllowed] // by default this property is null
 		[Export ("dataSource", ArgumentSemantic.Assign)]
@@ -10192,7 +10196,7 @@ namespace UIKit {
 	partial interface UIPresentationController : UIAppearanceContainer, UITraitEnvironment, UIContentContainer, UIFocusEnvironment {
 		[Export ("initWithPresentedViewController:presentingViewController:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);
+		NativeHandle Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);
 
 		[Export ("presentingViewController", ArgumentSemantic.Retain)]
 		UIViewController PresentingViewController { get; }
@@ -10291,10 +10295,10 @@ namespace UIKit {
 	interface UIProgressView : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("initWithProgressViewStyle:")]
-		IntPtr Constructor (UIProgressViewStyle style);
+		NativeHandle Constructor (UIProgressViewStyle style);
 
 		[Export ("progressViewStyle")]
 		UIProgressViewStyle Style { get; set; }
@@ -10336,7 +10340,7 @@ namespace UIKit {
 	partial interface UIPushBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItems:mode:")]
-		IntPtr Constructor (IUIDynamicItem [] items, UIPushBehaviorMode mode);
+		NativeHandle Constructor (IUIDynamicItem [] items, UIPushBehaviorMode mode);
 	
 		[Export ("addItem:")]
 		[PostGet ("Items")]
@@ -10381,7 +10385,7 @@ namespace UIKit {
 	partial interface UISnapBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItem:snapToPoint:")]
-		IntPtr Constructor (IUIDynamicItem dynamicItem, CGPoint point);
+		NativeHandle Constructor (IUIDynamicItem dynamicItem, CGPoint point);
 
 		[Export ("damping", ArgumentSemantic.Assign)]
 		nfloat Damping { get; set; }
@@ -10399,14 +10403,14 @@ namespace UIKit {
 	partial interface UIReferenceLibraryViewController : NSCoding {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("dictionaryHasDefinitionForTerm:"), Static]
 		bool DictionaryHasDefinitionForTerm (string term);
 
 		[DesignatedInitializer]
 		[Export ("initWithTerm:")]
-		IntPtr Constructor (string term);
+		NativeHandle Constructor (string term);
 	}
 
 	[BaseType (typeof (NSObject))]
@@ -10788,7 +10792,7 @@ namespace UIKit {
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIScrollViewDelegate)})]
 	interface UIScrollView : UIFocusItemScrollableContainer {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		// moved to UIFocusItemScrollableContainer in iOS 12 - but that makes the availability information incorrect (so `new` is used to avoid compiler warnings)
 		[Export ("contentOffset")]
@@ -11043,7 +11047,7 @@ namespace UIKit {
 		[NoTV]
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NoTV]
 		[Export ("barStyle")]
@@ -11256,13 +11260,13 @@ namespace UIKit {
 		// inlined
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("searchController", ArgumentSemantic.Strong)]
 		UISearchController SearchController { get; }
 	
 		[Export ("initWithSearchController:")]
-		IntPtr Constructor (UISearchController searchController);
+		NativeHandle Constructor (UISearchController searchController);
 	}
 	
 	[iOS (8,0)]
@@ -11272,17 +11276,17 @@ namespace UIKit {
 	{
 		[Export ("init")]
 		[Advice ("It's recommended to use the constructor that takes a 'UIViewController searchResultsController' in order to create/initialize an attached 'UISearchBar'.")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("initWithSearchResultsController:")]
 		[Advice ("You can pass a null 'UIViewController' to display the search results in the same view.")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] UIViewController searchResultsController);
+		NativeHandle Constructor ([NullAllowed] UIViewController searchResultsController);
 		
 		[NullAllowed] // by default this property is null
 		[Export ("searchResultsUpdater", ArgumentSemantic.UnsafeUnretained)]
@@ -11371,7 +11375,7 @@ namespace UIKit {
 		[Export ("initWithSearchBar:contentsController:")]
 		[PostGet ("SearchBar")]
 		[PostGet ("SearchContentsController")]
-		IntPtr Constructor (UISearchBar searchBar, UIViewController viewController);
+		NativeHandle Constructor (UISearchBar searchBar, UIViewController viewController);
 
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		NSObject WeakDelegate { get; set; } 
@@ -11497,15 +11501,15 @@ namespace UIKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
-		IntPtr Constructor (NSArray items);
+		NativeHandle Constructor (NSArray items);
 
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NoWatch, TV (14,0), iOS (14,0)]
 		[Export ("initWithFrame:actions:")]
-		IntPtr Constructor (CGRect frame, UIAction [] actions);
+		NativeHandle Constructor (CGRect frame, UIAction [] actions);
 
 		[NoWatch, TV (14,0), iOS (14,0)]
 		[Export ("insertSegmentWithAction:atIndex:animated:")]
@@ -11625,7 +11629,7 @@ namespace UIKit {
 	[BaseType (typeof(UIControl))]
 	interface UISlider {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("value")]
 		float Value { get; set; } // This is float, not nfloat
@@ -11900,7 +11904,7 @@ namespace UIKit {
 	interface UISwitch : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("on")]
 		bool On { [Bind ("isOn")] get; set; }
@@ -11950,7 +11954,7 @@ namespace UIKit {
 #endif
 	{
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("delegate", ArgumentSemantic.Weak)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -12065,7 +12069,7 @@ namespace UIKit {
 	interface UITabBarController : UITabBarDelegate {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[NullAllowed] // by default this property is null
 		[Export ("viewControllers", ArgumentSemantic.Copy)]
@@ -12205,10 +12209,10 @@ namespace UIKit {
 
 		[Export ("initWithTitle:image:tag:")]
 		[PostGet ("Image")]
-		IntPtr Constructor ([NullAllowed] string title, [NullAllowed] UIImage image, nint tag);
+		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] UIImage image, nint tag);
 
 		[Export ("initWithTabBarSystemItem:tag:")]
-		IntPtr Constructor (UITabBarSystemItem systemItem, nint tag);
+		NativeHandle Constructor (UITabBarSystemItem systemItem, nint tag);
 
 		[Export ("badgeValue", ArgumentSemantic.Copy)][NullAllowed]
 		string BadgeValue { get; set; } 
@@ -12238,7 +12242,7 @@ namespace UIKit {
 		[Export ("initWithTitle:image:selectedImage:")]
 		[PostGet ("Image")]
 		[PostGet ("SelectedImage")]
-		IntPtr Constructor ([NullAllowed] string title, [NullAllowed] UIImage image, [NullAllowed] UIImage selectedImage);
+		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] UIImage image, [NullAllowed] UIImage selectedImage);
 
 		[iOS (7,0)]
 		[Export ("selectedImage", ArgumentSemantic.Retain)][NullAllowed]
@@ -12288,11 +12292,11 @@ namespace UIKit {
 #endif
 	{
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[DesignatedInitializer]
 		[Export ("initWithFrame:style:")]
-		IntPtr Constructor (CGRect frame, UITableViewStyle style);
+		NativeHandle Constructor (CGRect frame, UITableViewStyle style);
 
 		[Export ("style")]
 		UITableViewStyle Style { get; }
@@ -12895,11 +12899,11 @@ namespace UIKit {
 	[BaseType (typeof (UIView))]
 	interface UITableViewCell : NSCoding, UIGestureRecognizerDelegate {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[DesignatedInitializer]
 		[Export ("initWithStyle:reuseIdentifier:")]
-		IntPtr Constructor (UITableViewCellStyle style, [NullAllowed] NSString reuseIdentifier);
+		NativeHandle Constructor (UITableViewCellStyle style, [NullAllowed] NSString reuseIdentifier);
 
 		[Watch (7,0), TV (14,0), iOS (14,0)]
 		[Export ("configurationState")]
@@ -13052,11 +13056,11 @@ namespace UIKit {
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[DesignatedInitializer]
 		[Export ("initWithStyle:")]
-		IntPtr Constructor (UITableViewStyle withStyle);
+		NativeHandle Constructor (UITableViewStyle withStyle);
 
 		[Export ("tableView", ArgumentSemantic.Retain)]
 		UITableView TableView { get; set; }
@@ -13319,7 +13323,7 @@ namespace UIKit {
 	[BaseType (typeof (UIView))]
 	interface UITableViewHeaderFooterView : UIAppearance, NSCoding {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Watch (7, 0), TV (14, 0), iOS (14, 0)]
 		[Export ("configurationState")]
@@ -13377,7 +13381,7 @@ namespace UIKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithReuseIdentifier:")]
-		IntPtr Constructor (NSString reuseIdentifier);
+		NativeHandle Constructor (NSString reuseIdentifier);
 
 		[RequiresSuper]
 		[Export ("prepareForReuse")]
@@ -13417,7 +13421,7 @@ namespace UIKit {
 #endif // IOS
 	{
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("text", ArgumentSemantic.Copy)]
 		[NullAllowed]
@@ -13613,7 +13617,7 @@ namespace UIKit {
 #endif // IOS
 	{
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("text", ArgumentSemantic.Copy)][NullAllowed]
 		string Text { get; set; }
@@ -13702,7 +13706,7 @@ namespace UIKit {
 		[iOS (7,0)]
 		[Export ("initWithFrame:textContainer:")]
 		[PostGet ("TextContainer")]
-		IntPtr Constructor (CGRect frame, [NullAllowed] NSTextContainer textContainer);
+		NativeHandle Constructor (CGRect frame, [NullAllowed] NSTextContainer textContainer);
 	
 		[iOS (7,0)]
 		[Export ("textContainer", ArgumentSemantic.Copy)]
@@ -13784,7 +13788,7 @@ namespace UIKit {
 	[BaseType (typeof (UIView))]
 	interface UIToolbar : UIBarPositioning {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Appearance]
 		[Export ("barStyle")]
@@ -14014,7 +14018,7 @@ namespace UIKit {
 	{
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 		
 		[Export ("addSubview:")][PostGet ("Subviews")]
 		void AddSubview (UIView view);
@@ -14719,7 +14723,7 @@ namespace UIKit {
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 		
 		[Export ("view", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -15854,7 +15858,7 @@ namespace UIKit {
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIWebViewDelegate)})]
 	interface UIWebView : UIScrollViewDelegate {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -16113,12 +16117,12 @@ namespace UIKit {
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("initWithStyle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UISplitViewControllerStyle style);
+		NativeHandle Constructor (UISplitViewControllerStyle style);
 
 		[TV (14,0), iOS (14,0)]
 		[Export ("style")]
@@ -16371,7 +16375,7 @@ namespace UIKit {
 	[BaseType (typeof (UIControl))]
 	interface UIStepper {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("continuous")]
 		bool Continuous { [Bind ("isContinuous")] get; set;  }
@@ -16460,7 +16464,7 @@ namespace UIKit {
 	[BaseType (typeof (UIStoryboardSegue))]
 	interface UIStoryboardPopoverSegue {
 		[Export ("initWithIdentifier:source:destination:"), PostGet ("SourceViewController"), PostGet ("DestinationViewController")]
-		IntPtr Constructor ([NullAllowed] string identifier, UIViewController source, UIViewController destination);
+		NativeHandle Constructor ([NullAllowed] string identifier, UIViewController source, UIViewController destination);
 
 		[Export ("popoverController", ArgumentSemantic.Retain)]
 		UIPopoverController PopoverController { get;  }
@@ -16471,7 +16475,7 @@ namespace UIKit {
 	interface UIStoryboardSegue {
 		[DesignatedInitializer]
 		[Export ("initWithIdentifier:source:destination:"), PostGet ("SourceViewController"), PostGet ("DestinationViewController")]
-		IntPtr Constructor ([NullAllowed] string identifier, UIViewController source, UIViewController destination);
+		NativeHandle Constructor ([NullAllowed] string identifier, UIViewController source, UIViewController destination);
 		
 		[Export ("identifier")]
 		[NullAllowed]
@@ -16527,7 +16531,7 @@ namespace UIKit {
 	[BaseType (typeof (UIView))]
 	interface UIPopoverBackgroundView : UIPopoverBackgroundViewMethods {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("arrowOffset")]
 		nfloat ArrowOffset { get; set; }
@@ -16547,7 +16551,7 @@ namespace UIKit {
 	[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'UIViewController' with style of 'UIModalPresentationStyle.Popover' or UIPopoverPresentationController' instead.")]
 	interface UIPopoverController : UIAppearanceContainer {
 		[Export ("initWithContentViewController:")][PostGet ("ContentViewController")]
-		IntPtr Constructor (UIViewController viewController);
+		NativeHandle Constructor (UIViewController viewController);
 
 		[Export ("contentViewController", ArgumentSemantic.Retain)]
 		UIViewController ContentViewController { get; set; }
@@ -16624,7 +16628,7 @@ namespace UIKit {
 	partial interface UIPopoverPresentationController {
 		// re-exposed from base class
 		[Export ("initWithPresentedViewController:presentingViewController:")]
-		IntPtr Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);
+		NativeHandle Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);
 
 		[NullAllowed]
 		[Export ("delegate", ArgumentSemantic.UnsafeUnretained)]
@@ -17126,7 +17130,7 @@ namespace UIKit {
 	
 		[DesignatedInitializer]
 		[Export ("initWithEffect:")]
-		IntPtr Constructor ([NullAllowed] UIVisualEffect effect);
+		NativeHandle Constructor ([NullAllowed] UIVisualEffect effect);
 	
 	    [Export ("contentView", ArgumentSemantic.Retain)]
 	    UIView ContentView { get; }
@@ -17158,11 +17162,11 @@ namespace UIKit {
 		UITextAlignment TextAlignment { get; set; }
 
 		[Export ("initWithText:")]
-		IntPtr Constructor ([NullAllowed] string text);
+		NativeHandle Constructor ([NullAllowed] string text);
 
 		[iOS (7,0)]
 		[Export ("initWithAttributedText:")]
-		IntPtr Constructor ([NullAllowed] NSAttributedString text);
+		NativeHandle Constructor ([NullAllowed] NSAttributedString text);
 
 		[iOS (7,0)]
 		[NullAllowed]
@@ -17216,7 +17220,7 @@ namespace UIKit {
 		string MarkupText { get; set; }
 
 		[Export ("initWithMarkupText:")]
-		IntPtr Constructor ([NullAllowed] string text);
+		NativeHandle Constructor ([NullAllowed] string text);
 	}
 
 	[iOS (7,0)]
@@ -17232,7 +17236,7 @@ namespace UIKit {
 	interface UIInterpolatingMotionEffect : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithKeyPath:type:")]
-		IntPtr Constructor (string keyPath, UIInterpolatingMotionEffectType type);
+		NativeHandle Constructor (string keyPath, UIInterpolatingMotionEffectType type);
 		
 		[Export ("keyPath")]
 		string KeyPath { get;  }
@@ -17264,21 +17268,21 @@ namespace UIKit {
 	{
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("initialVelocity")]
 		CGVector InitialVelocity { get; }
 
 		[Export ("initWithDampingRatio:initialVelocity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (nfloat ratio, CGVector velocity);
+		NativeHandle Constructor (nfloat ratio, CGVector velocity);
 
 		[Export ("initWithMass:stiffness:damping:initialVelocity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (nfloat mass, nfloat stiffness, nfloat damping, CGVector velocity);
+		NativeHandle Constructor (nfloat mass, nfloat stiffness, nfloat damping, CGVector velocity);
 
 		[Export ("initWithDampingRatio:")]
-		IntPtr Constructor (nfloat ratio);
+		NativeHandle Constructor (nfloat ratio);
 	}
 		
 	[NoTV]
@@ -17394,7 +17398,7 @@ namespace UIKit {
 	interface UIInputView : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:inputViewStyle:")]
-		IntPtr Constructor (CGRect frame, UIInputViewStyle inputViewStyle);
+		NativeHandle Constructor (CGRect frame, UIInputViewStyle inputViewStyle);
 
 		[Export ("inputViewStyle")]
 		UIInputViewStyle InputViewStyle { get; }
@@ -17416,7 +17420,7 @@ namespace UIKit {
 
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("inputView", ArgumentSemantic.Retain), NullAllowed]
 		UIInputView InputView { get; set; }
@@ -17774,11 +17778,11 @@ namespace UIKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithDocumentTypes:inMode:")]
-		IntPtr Constructor (string [] allowedUTIs, UIDocumentPickerMode mode);
+		NativeHandle Constructor (string [] allowedUTIs, UIDocumentPickerMode mode);
 
 		[DesignatedInitializer]
 		[Export ("initWithURL:inMode:")]
-		IntPtr Constructor (NSUrl url, UIDocumentPickerMode mode);
+		NativeHandle Constructor (NSUrl url, UIDocumentPickerMode mode);
 
 		[Wrap ("WeakDelegate")]
 		[Protocolize]
@@ -17820,37 +17824,37 @@ namespace UIKit {
 		[Deprecated (PlatformName.iOS, 14, 0)]
 		[DesignatedInitializer]
 		[Export ("initWithDocumentTypes:inMode:")]
-		IntPtr Constructor (string [] allowedUTIs, UIDocumentPickerMode mode);
+		NativeHandle Constructor (string [] allowedUTIs, UIDocumentPickerMode mode);
 
 		[NoTV, iOS (14,0)]
 		[Export ("initForOpeningContentTypes:asCopy:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UTType[] contentTypes, bool asCopy);
+		NativeHandle Constructor (UTType[] contentTypes, bool asCopy);
 
 		[NoTV, iOS (14,0)]
 		[Export ("initForOpeningContentTypes:")]
-		IntPtr Constructor (UTType[] contentTypes);
+		NativeHandle Constructor (UTType[] contentTypes);
 
 		[Deprecated (PlatformName.iOS, 14, 0)]
 		[Advice ("Use 'UTType' constructor overloads.")]
 		[DesignatedInitializer]
 		[Export ("initWithURL:inMode:")]
-		IntPtr Constructor (NSUrl url, UIDocumentPickerMode mode);
+		NativeHandle Constructor (NSUrl url, UIDocumentPickerMode mode);
 
 		[Deprecated (PlatformName.iOS, 14, 0)]
 		[iOS (11,0)]
 		[Export ("initWithURLs:inMode:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl[] urls, UIDocumentPickerMode mode);
+		NativeHandle Constructor (NSUrl[] urls, UIDocumentPickerMode mode);
 
 		[NoTV, iOS (14,0)]
 		[Export ("initForExportingURLs:asCopy:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl[] urls, bool asCopy);
+		NativeHandle Constructor (NSUrl[] urls, bool asCopy);
 
 		[NoTV, iOS (14,0)]
 		[Export ("initForExportingURLs:")]
-		IntPtr Constructor (NSUrl[] urls);
+		NativeHandle Constructor (NSUrl[] urls);
 
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -17905,7 +17909,7 @@ namespace UIKit {
 	partial interface UIDocumentPickerExtensionViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Export ("documentPickerMode", ArgumentSemantic.Assign)]
 		UIDocumentPickerMode DocumentPickerMode { get; }
@@ -18025,11 +18029,11 @@ namespace UIKit {
 
 		[Export ("initWithAnimationCurve:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIViewAnimationCurve curve);
+		NativeHandle Constructor (UIViewAnimationCurve curve);
 
 		[Export ("initWithControlPoint1:controlPoint2:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (CGPoint point1, CGPoint point2);
+		NativeHandle Constructor (CGPoint point1, CGPoint point2);
 	}
 
 	interface IUIFocusAnimationContext {}
@@ -18293,7 +18297,7 @@ namespace UIKit {
 
 		[Export ("initWithView:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIView view);
+		NativeHandle Constructor (UIView view);
 
 		[NullAllowed, Export ("view", ArgumentSemantic.Weak)]
 		UIView View { get; }
@@ -18529,7 +18533,7 @@ namespace UIKit {
 	{
 		[Export ("initWithItemProvider:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSItemProvider itemProvider);
+		NativeHandle Constructor (NSItemProvider itemProvider);
 	
 		[Export ("itemProvider")]
 		NSItemProvider ItemProvider { get; }
@@ -18548,10 +18552,10 @@ namespace UIKit {
 	{
 		[Export ("initWithView:parameters:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIView view, UIDragPreviewParameters parameters);
+		NativeHandle Constructor (UIView view, UIDragPreviewParameters parameters);
 	
 		[Export ("initWithView:")]
-		IntPtr Constructor (UIView view);
+		NativeHandle Constructor (UIView view);
 	
 		[Export ("view")]
 		UIView View { get; }
@@ -18576,7 +18580,7 @@ namespace UIKit {
 	interface UIDragPreviewParameters : NSCopying {
 
 		[Export ("initWithTextLineRects:")]
-		IntPtr Constructor (NSValue[] textLineRects);
+		NativeHandle Constructor (NSValue[] textLineRects);
 
 		// Now they come from the base class
 	
@@ -18594,10 +18598,10 @@ namespace UIKit {
 	{
 		[Export ("initWithContainer:center:transform:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIView container, CGPoint center, CGAffineTransform transform);
+		NativeHandle Constructor (UIView container, CGPoint center, CGAffineTransform transform);
 	
 		[Export ("initWithContainer:center:")]
-		IntPtr Constructor (UIView container, CGPoint center);
+		NativeHandle Constructor (UIView container, CGPoint center);
 	}
 	
 	[NoWatch, NoTV, iOS (11,0)]
@@ -18616,7 +18620,7 @@ namespace UIKit {
 	interface UIDragInteraction : UIInteraction {
 		[Export ("initWithDelegate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IUIDragInteractionDelegate @delegate);
+		NativeHandle Constructor (IUIDragInteractionDelegate @delegate);
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		IUIDragInteractionDelegate Delegate { get; }
@@ -18697,7 +18701,7 @@ namespace UIKit {
 	{
 		[Export ("initWithDelegate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IUIDropInteractionDelegate @delegate);
+		NativeHandle Constructor (IUIDropInteractionDelegate @delegate);
 	
 		[Export ("delegate", ArgumentSemantic.Weak)]
 		[NullAllowed]
@@ -18748,7 +18752,7 @@ namespace UIKit {
 	{
 		[Export ("initWithDropOperation:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIDropOperation operation);
+		NativeHandle Constructor (UIDropOperation operation);
 	
 		[Export ("operation")]
 		UIDropOperation Operation { get; }
@@ -18784,13 +18788,13 @@ namespace UIKit {
 	{
 		[Export ("initWithView:parameters:target:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIView view, UIDragPreviewParameters parameters, UIDragPreviewTarget target);
+		NativeHandle Constructor (UIView view, UIDragPreviewParameters parameters, UIDragPreviewTarget target);
 	
 		[Export ("initWithView:parameters:")]
-		IntPtr Constructor (UIView view, UIDragPreviewParameters parameters);
+		NativeHandle Constructor (UIView view, UIDragPreviewParameters parameters);
 	
 		[Export ("initWithView:")]
-		IntPtr Constructor (UIView view);
+		NativeHandle Constructor (UIView view);
 	
 		[Export ("target")]
 		UIDragPreviewTarget Target { get; }
@@ -18885,10 +18889,10 @@ namespace UIKit {
 		// inline from base type
 		[Export ("initWithDropOperation:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIDropOperation operation);
+		NativeHandle Constructor (UIDropOperation operation);
 
 		[Export ("initWithDropOperation:intent:")]
-		IntPtr Constructor (UIDropOperation operation, UICollectionViewDropIntent intent);
+		NativeHandle Constructor (UIDropOperation operation, UICollectionViewDropIntent intent);
 
 		[Export ("intent")]
 		UICollectionViewDropIntent Intent { get; }
@@ -18938,7 +18942,7 @@ namespace UIKit {
 	interface UICollectionViewPlaceholder {
 		[Export ("initWithInsertionIndexPath:reuseIdentifier:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSIndexPath insertionIndexPath, string reuseIdentifier);
+		NativeHandle Constructor (NSIndexPath insertionIndexPath, string reuseIdentifier);
 
 		[NullAllowed, Export ("cellUpdateHandler", ArgumentSemantic.Copy)]
 		Action<UICollectionViewCell> CellUpdateHandler { get; set; }
@@ -18950,7 +18954,7 @@ namespace UIKit {
 	interface UICollectionViewDropPlaceholder {
 		// inlined
 		[Export ("initWithInsertionIndexPath:reuseIdentifier:")]
-		IntPtr Constructor (NSIndexPath insertionIndexPath, string reuseIdentifier);
+		NativeHandle Constructor (NSIndexPath insertionIndexPath, string reuseIdentifier);
 
 		[NullAllowed, Export ("previewParametersProvider", ArgumentSemantic.Copy)]
 		Func<UICollectionViewCell, UIDragPreviewParameters> PreviewParametersProvider { get; set; }
@@ -19061,10 +19065,10 @@ namespace UIKit {
 		// inline from base type
 		[Export ("initWithDropOperation:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIDropOperation operation);
+		NativeHandle Constructor (UIDropOperation operation);
 
 		[Export ("initWithDropOperation:intent:")]
-		IntPtr Constructor (UIDropOperation operation, UITableViewDropIntent intent);
+		NativeHandle Constructor (UIDropOperation operation, UITableViewDropIntent intent);
 
 		[Export ("intent")]
 		UITableViewDropIntent Intent { get; }
@@ -19114,7 +19118,7 @@ namespace UIKit {
 	interface UITableViewPlaceholder {
 		[Export ("initWithInsertionIndexPath:reuseIdentifier:rowHeight:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSIndexPath insertionIndexPath, string reuseIdentifier, nfloat rowHeight);
+		NativeHandle Constructor (NSIndexPath insertionIndexPath, string reuseIdentifier, nfloat rowHeight);
 
 		[NullAllowed, Export ("cellUpdateHandler", ArgumentSemantic.Copy)]
 		Action<UITableViewCell> CellUpdateHandler { get; set; }
@@ -19126,7 +19130,7 @@ namespace UIKit {
 	interface UITableViewDropPlaceholder {
 		// inlined
 		[Export ("initWithInsertionIndexPath:reuseIdentifier:rowHeight:")]
-		IntPtr Constructor (NSIndexPath insertionIndexPath, string reuseIdentifier, nfloat rowHeight);
+		NativeHandle Constructor (NSIndexPath insertionIndexPath, string reuseIdentifier, nfloat rowHeight);
 
 		[NullAllowed, Export ("previewParametersProvider", ArgumentSemantic.Copy)]
 		Func<UITableViewCell, UIDragPreviewParameters> PreviewParametersProvider { get; set; }
@@ -19170,11 +19174,11 @@ namespace UIKit {
 	[DisableDefaultCtor]
 	interface UITextDragPreviewRenderer {
 		[Export ("initWithLayoutManager:range:")]
-		IntPtr Constructor (NSLayoutManager layoutManager, NSRange range);
+		NativeHandle Constructor (NSLayoutManager layoutManager, NSRange range);
 
 		[Export ("initWithLayoutManager:range:unifyRects:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSLayoutManager layoutManager, NSRange range, bool unifyRects);
+		NativeHandle Constructor (NSLayoutManager layoutManager, NSRange range, bool unifyRects);
 
 		[Export ("layoutManager")]
 		NSLayoutManager LayoutManager { get; }
@@ -19270,7 +19274,7 @@ namespace UIKit {
 	interface UITextDropProposal : NSCopying {
 		// inlined
 		[Export ("initWithDropOperation:")]
-		IntPtr Constructor (UIDropOperation operation);
+		NativeHandle Constructor (UIDropOperation operation);
 
 		[Export ("dropAction", ArgumentSemantic.Assign)]
 		UITextDropAction DropAction { get; set; }
@@ -19389,10 +19393,10 @@ namespace UIKit {
 	interface UISpringLoadedInteraction : UIInteraction {
 		[Export ("initWithInteractionBehavior:interactionEffect:activationHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] IUISpringLoadedInteractionBehavior interactionBehavior, [NullAllowed] IUISpringLoadedInteractionEffect interactionEffect, Action<UISpringLoadedInteraction, IUISpringLoadedInteractionContext> handler);
+		NativeHandle Constructor ([NullAllowed] IUISpringLoadedInteractionBehavior interactionBehavior, [NullAllowed] IUISpringLoadedInteractionEffect interactionEffect, Action<UISpringLoadedInteraction, IUISpringLoadedInteractionContext> handler);
 
 		[Export ("initWithActivationHandler:")]
-		IntPtr Constructor (Action<UISpringLoadedInteraction, IUISpringLoadedInteractionContext> handler);
+		NativeHandle Constructor (Action<UISpringLoadedInteraction, IUISpringLoadedInteractionContext> handler);
 
 		[Export ("interactionBehavior", ArgumentSemantic.Strong)]
 		IUISpringLoadedInteractionBehavior InteractionBehavior { get; }
@@ -19588,16 +19592,16 @@ namespace UIKit {
 		string[] AcceptableTypeIdentifiers { get; set; }
 
 		[Export ("initWithAcceptableTypeIdentifiers:")]
-		IntPtr Constructor (string[] acceptableTypeIdentifiers);
+		NativeHandle Constructor (string[] acceptableTypeIdentifiers);
 
 		[Export ("addAcceptableTypeIdentifiers:")]
 		void AddAcceptableTypeIdentifiers (string[] acceptableTypeIdentifiers);
 
 		[Export ("initWithTypeIdentifiersForAcceptingClass:")]
-		IntPtr Constructor (Class itemProviderReadingClass);
+		NativeHandle Constructor (Class itemProviderReadingClass);
 
 		[Wrap ("this (new Class (itemProviderReadingType))")]
-		IntPtr Constructor (Type itemProviderReadingType);
+		NativeHandle Constructor (Type itemProviderReadingType);
 
 		[Export ("addTypeIdentifiersForAcceptingClass:")]
 		void AddTypeIdentifiers (Class itemProviderReadingClass);
@@ -19630,12 +19634,12 @@ namespace UIKit {
 		[Deprecated (PlatformName.iOS, 14, 0)]
 		[Export ("initForOpeningFilesWithContentTypes:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string[] allowedContentTypes);
+		NativeHandle Constructor ([NullAllowed] string[] allowedContentTypes);
 
 		[iOS (14,0)]
 		[Export ("initForOpeningContentTypes:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] UTType [] contentTypes);
+		NativeHandle Constructor ([NullAllowed] UTType [] contentTypes);
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		IUIDocumentBrowserViewControllerDelegate Delegate { get; set; }
@@ -19751,7 +19755,7 @@ namespace UIKit {
 	interface UIDocumentBrowserAction {
 		[Export ("initWithIdentifier:localizedTitle:availability:handler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string identifier, string localizedTitle, UIDocumentBrowserActionAvailability availability, Action<NSUrl[]> handler);
+		NativeHandle Constructor (string identifier, string localizedTitle, UIDocumentBrowserActionAvailability availability, Action<NSUrl[]> handler);
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -19829,7 +19833,7 @@ namespace UIKit {
 
 		[Export ("initForTextStyle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string textStyle);
+		NativeHandle Constructor (string textStyle);
 
 		[Export ("scaledFontForFont:")]
 		UIFont GetScaledFont (UIFont font);
@@ -19921,7 +19925,7 @@ namespace UIKit {
 
 		[Export ("initWithSession:connectionOptions:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UISceneSession session, UISceneConnectionOptions connectionOptions);
+		NativeHandle Constructor (UISceneSession session, UISceneConnectionOptions connectionOptions);
 
 		[Export ("session")]
 		UISceneSession Session { get; }
@@ -20075,7 +20079,7 @@ namespace UIKit {
 
 		[Export ("initWithName:sessionRole:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] string name, [BindAs (typeof (UIWindowSceneSessionRole))] NSString sessionRole);
+		NativeHandle Constructor ([NullAllowed] string name, [BindAs (typeof (UIWindowSceneSessionRole))] NSString sessionRole);
 
 		[NullAllowed, Export ("name")]
 		string Name { get; }
@@ -20223,14 +20227,14 @@ namespace UIKit {
 		
 		[Export ("initWithIdiom:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIUserInterfaceIdiom idiom);
+		NativeHandle Constructor (UIUserInterfaceIdiom idiom);
 
 		[Export ("idiom", ArgumentSemantic.Assign)]
 		UIUserInterfaceIdiom Idiom { get; }
 
 		[Export ("initWithBarAppearance:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIBarAppearance barAppearance);
+		NativeHandle Constructor (UIBarAppearance barAppearance);
 
 		[Export ("configureWithDefaultBackground")]
 		void ConfigureWithDefaultBackground ();
@@ -20284,7 +20288,7 @@ namespace UIKit {
 
 		[Export ("initWithStyle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIBarButtonItemStyle style);
+		NativeHandle Constructor (UIBarButtonItemStyle style);
 
 		[Export ("configureWithDefaultForStyle:")]
 		void ConfigureWithDefault (UIBarButtonItemStyle style);
@@ -20329,16 +20333,16 @@ namespace UIKit {
 	interface UICollectionViewCompositionalLayout {
 
 		[Export ("initWithSection:")]
-		IntPtr Constructor (NSCollectionLayoutSection section);
+		NativeHandle Constructor (NSCollectionLayoutSection section);
 
 		[Export ("initWithSection:configuration:")]
-		IntPtr Constructor (NSCollectionLayoutSection section, UICollectionViewCompositionalLayoutConfiguration configuration);
+		NativeHandle Constructor (NSCollectionLayoutSection section, UICollectionViewCompositionalLayoutConfiguration configuration);
 
 		[Export ("initWithSectionProvider:")]
-		IntPtr Constructor (UICollectionViewCompositionalLayoutSectionProvider sectionProvider);
+		NativeHandle Constructor (UICollectionViewCompositionalLayoutSectionProvider sectionProvider);
 
 		[Export ("initWithSectionProvider:configuration:")]
-		IntPtr Constructor (UICollectionViewCompositionalLayoutSectionProvider sectionProvider, UICollectionViewCompositionalLayoutConfiguration configuration);
+		NativeHandle Constructor (UICollectionViewCompositionalLayoutSectionProvider sectionProvider, UICollectionViewCompositionalLayoutConfiguration configuration);
 
 		[Export ("configuration", ArgumentSemantic.Copy)]
 		UICollectionViewCompositionalLayoutConfiguration Configuration { get; set; }
@@ -20432,7 +20436,7 @@ namespace UIKit {
 
 		[Export ("initWithConfiguration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIFontPickerViewControllerConfiguration configuration);
+		NativeHandle Constructor (UIFontPickerViewControllerConfiguration configuration);
 
 		[Export ("configuration", ArgumentSemantic.Copy)]
 		UIFontPickerViewControllerConfiguration Configuration { get; }
@@ -20477,11 +20481,11 @@ namespace UIKit {
 
 		[DesignatedInitializer]
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor (NSObject target, Selector action);
+		NativeHandle Constructor (NSObject target, Selector action);
 
 		[DesignatedInitializer]
 		[Wrap ("base (action)")]
-		IntPtr Constructor (Action action);
+		NativeHandle Constructor (Action action);
 	}
 
 	interface IUILargeContentViewerItem { }
@@ -20522,7 +20526,7 @@ namespace UIKit {
 
 		[Export ("initWithDelegate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] IUILargeContentViewerInteractionDelegate @delegate);
+		NativeHandle Constructor ([NullAllowed] IUILargeContentViewerInteractionDelegate @delegate);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -20637,11 +20641,11 @@ namespace UIKit {
 
 		[Export ("initWithIdiom:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIUserInterfaceIdiom idiom);
+		NativeHandle Constructor (UIUserInterfaceIdiom idiom);
 
 		[Export ("initWithBarAppearance:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIBarAppearance barAppearance);
+		NativeHandle Constructor (UIBarAppearance barAppearance);
 		
 		[Export ("titleTextAttributes", ArgumentSemantic.Copy)]
 		NSDictionary WeakTitleTextAttributes { get; set; }
@@ -20714,7 +20718,7 @@ namespace UIKit {
 	interface UISearchTextField {
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("tokens", ArgumentSemantic.Copy)]
 		UISearchToken [] Tokens { get; set; }
@@ -20836,11 +20840,11 @@ namespace UIKit {
 
 		[Export ("initWithIdiom:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIUserInterfaceIdiom idiom);
+		NativeHandle Constructor (UIUserInterfaceIdiom idiom);
 
 		[Export ("initWithBarAppearance:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIBarAppearance barAppearance);
+		NativeHandle Constructor (UIBarAppearance barAppearance);
 
 		[Export ("stackedLayoutAppearance", ArgumentSemantic.Copy)]
 		UITabBarItemAppearance StackedLayoutAppearance { get; set; }
@@ -20904,7 +20908,7 @@ namespace UIKit {
 
 		[Export ("initWithWindowScene:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIWindowScene windowScene);
+		NativeHandle Constructor (UIWindowScene windowScene);
 
 		[Export ("setSelectedAttributes:isMultiple:")]
 		void SetSelectedAttributes (NSDictionary attributes, bool flag);
@@ -20971,11 +20975,11 @@ namespace UIKit {
 
 		[Export ("initWithIdiom:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIUserInterfaceIdiom idiom);
+		NativeHandle Constructor (UIUserInterfaceIdiom idiom);
 
 		[Export ("initWithBarAppearance:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIBarAppearance barAppearance);
+		NativeHandle Constructor (UIBarAppearance barAppearance);
 
 		[Export ("buttonAppearance", ArgumentSemantic.Copy)]
 		UIBarButtonItemAppearance ButtonAppearance { get; set; }
@@ -20991,7 +20995,7 @@ namespace UIKit {
 
 		[Export ("initWithSession:connectionOptions:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UISceneSession session, UISceneConnectionOptions connectionOptions);
+		NativeHandle Constructor (UISceneSession session, UISceneConnectionOptions connectionOptions);
 
 		[Export ("screen")]
 		UIScreen Screen { get; }
@@ -21076,7 +21080,7 @@ namespace UIKit {
 
 		[Export ("initWithStyle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UITabBarItemAppearanceStyle style);
+		NativeHandle Constructor (UITabBarItemAppearanceStyle style);
 
 		[Export ("configureWithDefaultForStyle:")]
 		void ConfigureWithDefault (UITabBarItemAppearanceStyle style);
@@ -21108,7 +21112,7 @@ namespace UIKit {
 		where ItemIdentifierType : NSObject {
 
 		[Export ("initWithCollectionView:cellProvider:")]
-		IntPtr Constructor (UICollectionView collectionView, UICollectionViewDiffableDataSourceCellProvider cellProvider);
+		NativeHandle Constructor (UICollectionView collectionView, UICollectionViewDiffableDataSourceCellProvider cellProvider);
 
 		[NullAllowed, Export ("supplementaryViewProvider", ArgumentSemantic.Copy)]
 		UICollectionViewDiffableDataSourceSupplementaryViewProvider SupplementaryViewProvider { get; set; }
@@ -21186,7 +21190,7 @@ namespace UIKit {
 		where ItemIdentifierType : NSObject {
 
 		[Export ("initWithTableView:cellProvider:")]
-		IntPtr Constructor (UITableView tableView, UITableViewDiffableDataSourceCellProvider cellProvider);
+		NativeHandle Constructor (UITableView tableView, UITableViewDiffableDataSourceCellProvider cellProvider);
 
 		[Export ("snapshot")]
 		NSDiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType> Snapshot { get; }
@@ -21282,11 +21286,11 @@ namespace UIKit {
 
 		[Export ("initWithObjects:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSItemProviderWriting[] objects);
+		NativeHandle Constructor (INSItemProviderWriting[] objects);
 
 		[Export ("initWithItemProviders:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSItemProvider[] itemProviders);
+		NativeHandle Constructor (NSItemProvider[] itemProviders);
 	}
 
 	interface IUIActivityItemsConfigurationReading { }
@@ -21382,7 +21386,7 @@ namespace UIKit {
 
 		[Export ("initWithDelegate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] IUIPointerInteractionDelegate @delegate);
+		NativeHandle Constructor ([NullAllowed] IUIPointerInteractionDelegate @delegate);
 
 		[Export ("invalidate")]
 		void Invalidate ();
@@ -21815,7 +21819,7 @@ namespace UIKit {
 
 		[Export ("initWithText:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string text);
+		NativeHandle Constructor (string text);
 
 		[Export ("text")]
 		string Text { get; }
@@ -21839,7 +21843,7 @@ namespace UIKit {
 
 		[Export ("initWithCustomView:placement:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIView customView, UICellAccessoryPlacement placement);
+		NativeHandle Constructor (UIView customView, UICellAccessoryPlacement placement);
 
 		[Export ("customView", ArgumentSemantic.Strong)]
 		UIView CustomView { get; }
@@ -21862,7 +21866,7 @@ namespace UIKit {
 
 		[Export ("initWithTraitCollection:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UITraitCollection traitCollection);
+		NativeHandle Constructor (UITraitCollection traitCollection);
 
 		[Export ("editing")]
 		bool Editing { [Bind ("isEditing")] get; set; }
@@ -21899,7 +21903,7 @@ namespace UIKit {
 
 		[Export ("initWithAppearance:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UICollectionLayoutListAppearance appearance);
+		NativeHandle Constructor (UICollectionLayoutListAppearance appearance);
 
 		[Export ("appearance")]
 		UICollectionLayoutListAppearance Appearance { get; }
@@ -22022,7 +22026,7 @@ namespace UIKit {
 	interface UICollectionViewListCell {
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("defaultContentConfiguration")]
 		UIListContentConfiguration DefaultContentConfiguration { get; }
@@ -22071,7 +22075,7 @@ namespace UIKit {
 	interface UIColorPickerViewController
 	{
 		[Export ("initWithNibName:bundle:")]
-		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+		NativeHandle Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -22093,7 +22097,7 @@ namespace UIKit {
 	interface UIColorWell {
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[NullAllowed, Export ("title")]
 		string Title { get; set; }
@@ -22115,7 +22119,7 @@ namespace UIKit {
 		// Needs to be manually inlined in adopting classes
 		// [Abstract]
 		// [Export ("initWithTraitCollection:")]
-		// IntPtr Constructor (UITraitCollection traitCollection);
+		// NativeHandle Constructor (UITraitCollection traitCollection);
 
 		[Abstract]
 		[Export ("traitCollection", ArgumentSemantic.Strong)]
@@ -22242,7 +22246,7 @@ namespace UIKit {
 
 		[Export ("initWithDelegate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IUIIndirectScribbleInteractionDelegate @delegate);
+		NativeHandle Constructor (IUIIndirectScribbleInteractionDelegate @delegate);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -22409,7 +22413,7 @@ namespace UIKit {
 
 		[Export ("initWithConfiguration:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIListContentConfiguration configuration);
+		NativeHandle Constructor (UIListContentConfiguration configuration);
 
 		// UIContentView interface wants IUIContentConfiguration, covariant types can't come soon enough
 		[Sealed, Export ("configuration", ArgumentSemantic.Copy)]
@@ -22534,7 +22538,7 @@ namespace UIKit {
 
 		[Export ("initWithDelegate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (IUIScribbleInteractionDelegate @delegate);
+		NativeHandle Constructor (IUIScribbleInteractionDelegate @delegate);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -22626,13 +22630,13 @@ namespace UIKit {
 		UISearchSuggestionItem Create (NSString localizedSuggestion, [NullAllowed] string description, [NullAllowed] UIImage iconImage);
 
 		[Export ("initWithLocalizedSuggestion:")]
-		IntPtr Constructor (NSString localizedSuggestion);
+		NativeHandle Constructor (NSString localizedSuggestion);
 
 		[Export ("initWithLocalizedSuggestion:localizedDescription:")]
-		IntPtr Constructor (NSString localizedSuggestion, [NullAllowed] string description);
+		NativeHandle Constructor (NSString localizedSuggestion, [NullAllowed] string description);
 
 		[Export ("initWithLocalizedSuggestion:localizedDescription:iconImage:")]
-		IntPtr Constructor (NSString localizedSuggestion, [NullAllowed] string description, [NullAllowed] UIImage iconImage);
+		NativeHandle Constructor (NSString localizedSuggestion, [NullAllowed] string description, [NullAllowed] UIImage iconImage);
 
 		// Inlined by the adopted protocol
 		// [NullAllowed, Export ("localizedSuggestion")]
@@ -22653,7 +22657,7 @@ namespace UIKit {
 
 		[Export ("initWithTraitCollection:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UITraitCollection traitCollection);
+		NativeHandle Constructor (UITraitCollection traitCollection);
 
 		[Export ("traitCollection", ArgumentSemantic.Strong)]
 		new UITraitCollection TraitCollection { get; set; }
@@ -22749,7 +22753,7 @@ namespace UIKit {
 		string Purchaser { get; }
 
 		[Export ("initWithSourceIdentifier:destinationURL:sourceDescription:purchaser:")]
-		IntPtr Constructor (byte sourceIdentifier, NSUrl destinationUrl, string sourceDescription, string purchaser);
+		NativeHandle Constructor (byte sourceIdentifier, NSUrl destinationUrl, string sourceDescription, string purchaser);
 	}
 
 	[NoWatch, NoTV, iOS (14,5)]
@@ -22758,7 +22762,7 @@ namespace UIKit {
 	interface UIEventAttributionView {
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 	}
 
 	[NoWatch, NoTV, iOS (14,5)]
@@ -22778,7 +22782,7 @@ namespace UIKit {
 
 		[Export ("initWithListAppearance:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UICollectionLayoutListAppearance listAppearance);
+		NativeHandle Constructor (UICollectionLayoutListAppearance listAppearance);
 
 		[Export ("topSeparatorVisibility", ArgumentSemantic.Assign)]
 		UIListSeparatorVisibility TopSeparatorVisibility { get; set; }
@@ -22810,7 +22814,7 @@ namespace UIKit {
 	interface UIPrinterDestination : NSSecureCoding {
 
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl url);
+		NativeHandle Constructor (NSUrl url);
 
 		[Export ("URL", ArgumentSemantic.Copy)]
 		NSUrl Url { get; set; }
@@ -22857,7 +22861,7 @@ namespace UIKit {
 		UIBandSelectionInteractionShouldBeginHandler ShouldBeginHandler { get; set; }
 
 		[Export ("initWithSelectionHandler:")]
-		IntPtr Constructor (Action<UIBandSelectionInteraction> selectionHandler);
+		NativeHandle Constructor (Action<UIBandSelectionInteraction> selectionHandler);
 	}
 
 	[TV (15,0), NoWatch, iOS (15,0), MacCatalyst (15,0)]
@@ -23056,7 +23060,7 @@ namespace UIKit {
 		string DefaultToolTip { get; set; }
 
 		[Export ("initWithDefaultToolTip:")]
-		IntPtr Constructor (string defaultToolTip);
+		NativeHandle Constructor (string defaultToolTip);
 	}
 
 	[NoWatch, NoTV, iOS (15,0), MacCatalyst (15,0)]
@@ -23143,7 +23147,7 @@ namespace UIKit {
 
 		[Export ("initWithUserActivity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSUserActivity userActivity);
+		NativeHandle Constructor (NSUserActivity userActivity);
 	}
 
 	[NoWatch, NoTV, iOS (15,0), MacCatalyst (15,0)]
@@ -23156,7 +23160,7 @@ namespace UIKit {
 
 		[Export ("initWithConfigurationProvider:errorHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (UIWindowSceneActivationInteractionConfigurationProvider configurationProvider, Action<NSError> errorHandler);
+		NativeHandle Constructor (UIWindowSceneActivationInteractionConfigurationProvider configurationProvider, Action<NSError> errorHandler);
 	}
 
 	[TV (15,0), NoWatch, iOS (15,0), MacCatalyst (15,0)]

--- a/src/videosubscriberaccount.cs
+++ b/src/videosubscriberaccount.cs
@@ -17,6 +17,10 @@ using UIViewController = AppKit.NSViewController;
 using UIKit;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace VideoSubscriberAccount {
 
 	[Native]
@@ -354,7 +358,7 @@ namespace VideoSubscriberAccount {
 	interface VSAccountApplicationProvider {
 
 		[Export ("initWithLocalizedDisplayName:identifier:")]
-		IntPtr Constructor (string localizedDisplayName, string identifier);
+		NativeHandle Constructor (string localizedDisplayName, string identifier);
 
 		[Export ("localizedDisplayName")]
 		string LocalizedDisplayName { get; }

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -23,6 +23,10 @@ using Matrix3 = global::OpenTK.NMatrix3;
 using Vector2 = global::OpenTK.Vector2;
 using Vector3 = global::OpenTK.Vector3;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Vision {
 
 	[ErrorDomain ("VNErrorDomain")]
@@ -697,15 +701,15 @@ namespace Vision {
 		VNImageCropAndScaleOption ImageCropAndScaleOption { get; set; }
 
 		[Export ("initWithModel:")]
-		IntPtr Constructor (VNCoreMLModel model);
+		NativeHandle Constructor (VNCoreMLModel model);
 
 		[Export ("initWithModel:completionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (VNCoreMLModel model, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (VNCoreMLModel model, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		// We must inline the following 5 properties
 		// ('Revision', 'WeakSupportedRevisions', 'SupportedRevisions', 'DefaultRevision' and 'CurrentRevision')
@@ -743,7 +747,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Deprecated (PlatformName.MacOSX, 12, 0, message: "Use 'GetSupportedSymbologies' instead.")]
 		[Deprecated (PlatformName.iOS, 15, 0, message: "Use 'GetSupportedSymbologies' instead.")]
@@ -811,7 +815,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		[Static]
@@ -862,7 +866,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
@@ -904,7 +908,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
@@ -946,7 +950,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("minimumAspectRatio")]
 		float MinimumAspectRatio { get; set; }
@@ -1006,7 +1010,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("reportCharacterBoxes")]
 		bool ReportCharacterBoxes { get; set; }
@@ -1147,124 +1151,124 @@ namespace Vision {
 
 		// Inlined from parent class
 		[Export ("initWithTargetedCVPixelBuffer:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, options.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (pixelBuffer, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:options:")]
-		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
+		NativeHandle Constructor (CGImage cgImage, NSDictionary optionsDict);
 
 		[Wrap ("this (cgImage, options.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
+		NativeHandle Constructor (CGImage cgImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:options:completionHandler:")]
-		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (cgImage, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:orientation:options:")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:options:")]
-		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
+		NativeHandle Constructor (CIImage ciImage, NSDictionary optionsDict);
 
 		[Wrap ("this (ciImage, options.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
+		NativeHandle Constructor (CIImage ciImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:options:completionHandler:")]
-		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (ciImage, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:orientation:options:")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:options:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary optionsDict);
 
 		[Wrap ("this (imageUrl, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:options:completionHandler:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageUrl, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:orientation:options:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:options:")]
-		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
+		NativeHandle Constructor (NSData imageData, NSDictionary optionsDict);
 
 		[Wrap ("this (imageData, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions options);
+		NativeHandle Constructor (NSData imageData, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:options:completionHandler:")]
-		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageData, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:orientation:options:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (imageData, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageData, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -1278,124 +1282,124 @@ namespace Vision {
 
 		// Inlined from parent class
 		[Export ("initWithTargetedCVPixelBuffer:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, options.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (pixelBuffer, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:options:")]
-		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
+		NativeHandle Constructor (CGImage cgImage, NSDictionary optionsDict);
 
 		[Wrap ("this (cgImage, options.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
+		NativeHandle Constructor (CGImage cgImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:options:completionHandler:")]
-		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (cgImage, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:orientation:options:")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:options:")]
-		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
+		NativeHandle Constructor (CIImage ciImage, NSDictionary optionsDict);
 
 		[Wrap ("this (ciImage, options.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
+		NativeHandle Constructor (CIImage ciImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:options:completionHandler:")]
-		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (ciImage, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:orientation:options:")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:options:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary optionsDict);
 
 		[Wrap ("this (imageUrl, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:options:completionHandler:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageUrl, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:orientation:options:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:options:")]
-		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
+		NativeHandle Constructor (NSData imageData, NSDictionary optionsDict);
 
 		[Wrap ("this (imageData, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions options);
+		NativeHandle Constructor (NSData imageData, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:options:completionHandler:")]
-		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageData, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:orientation:options:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (imageData, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageData, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		// into subclasses so the correct class_ptr is used.
 		[TV (12,0), Mac (10,14), iOS (12,0)]
@@ -1430,124 +1434,124 @@ namespace Vision {
 
 		// Inlined from parent class
 		[Export ("initWithTargetedCVPixelBuffer:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, options.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (pixelBuffer, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:options:")]
-		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
+		NativeHandle Constructor (CGImage cgImage, NSDictionary optionsDict);
 
 		[Wrap ("this (cgImage, options.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
+		NativeHandle Constructor (CGImage cgImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:options:completionHandler:")]
-		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (cgImage, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:orientation:options:")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:options:")]
-		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
+		NativeHandle Constructor (CIImage ciImage, NSDictionary optionsDict);
 
 		[Wrap ("this (ciImage, options.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
+		NativeHandle Constructor (CIImage ciImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:options:completionHandler:")]
-		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (ciImage, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:orientation:options:")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:options:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary optionsDict);
 
 		[Wrap ("this (imageUrl, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:options:completionHandler:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageUrl, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:orientation:options:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:options:")]
-		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
+		NativeHandle Constructor (NSData imageData, NSDictionary optionsDict);
 
 		[Wrap ("this (imageData, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions options);
+		NativeHandle Constructor (NSData imageData, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:options:completionHandler:")]
-		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageData, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:orientation:options:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (imageData, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageData, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		// We must inline the following 5 properties
 		// ('Revision', 'WeakSupportedRevisions', 'SupportedRevisions', 'DefaultRevision' and 'CurrentRevision')
@@ -1875,7 +1879,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("preferBackgroundProcessing")]
 		bool PreferBackgroundProcessing { get; set; }
@@ -1934,7 +1938,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("regionOfInterest", ArgumentSemantic.Assign)]
 		CGRect RegionOfInterest { get; set; }
@@ -1973,84 +1977,84 @@ namespace Vision {
 	interface VNImageRequestHandler {
 
 		[Export ("initWithCVPixelBuffer:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary options);
 
 		[Wrap ("this (pixelBuffer, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions imageOptions);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions imageOptions);
 
 		[Export ("initWithCVPixelBuffer:orientation:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary options);
 
 		[Wrap ("this (pixelBuffer, orientation, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithCGImage:options:")]
-		IntPtr Constructor (CGImage image, NSDictionary options);
+		NativeHandle Constructor (CGImage image, NSDictionary options);
 
 		[Wrap ("this (image, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage image, VNImageOptions imageOptions);
+		NativeHandle Constructor (CGImage image, VNImageOptions imageOptions);
 
 		[Export ("initWithCGImage:orientation:options:")]
-		IntPtr Constructor (CGImage image, CGImagePropertyOrientation orientation, NSDictionary options);
+		NativeHandle Constructor (CGImage image, CGImagePropertyOrientation orientation, NSDictionary options);
 
 		[Wrap ("this (image, orientation, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage image, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
+		NativeHandle Constructor (CGImage image, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithCIImage:options:")]
-		IntPtr Constructor (CIImage image, NSDictionary options);
+		NativeHandle Constructor (CIImage image, NSDictionary options);
 
 		[Wrap ("this (image, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage image, VNImageOptions imageOptions);
+		NativeHandle Constructor (CIImage image, VNImageOptions imageOptions);
 
 		[Export ("initWithCIImage:orientation:options:")]
-		IntPtr Constructor (CIImage image, CGImagePropertyOrientation orientation, NSDictionary options);
+		NativeHandle Constructor (CIImage image, CGImagePropertyOrientation orientation, NSDictionary options);
 
 		[Wrap ("this (image, orientation, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage image, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
+		NativeHandle Constructor (CIImage image, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithURL:options:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary options);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary options);
 
 		[Wrap ("this (imageUrl, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions imageOptions);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions imageOptions);
 
 		[Export ("initWithURL:orientation:options:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary options);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary options);
 
 		[Wrap ("this (imageUrl, orientation, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithData:options:")]
-		IntPtr Constructor (NSData imageData, NSDictionary options);
+		NativeHandle Constructor (NSData imageData, NSDictionary options);
 
 		[Wrap ("this (imageData, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions imageOptions);
+		NativeHandle Constructor (NSData imageData, VNImageOptions imageOptions);
 
 		[Export ("initWithData:orientation:options:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary options);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary options);
 
 		[Wrap ("this (imageData, orientation, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithCMSampleBuffer:options:")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, NSDictionary options);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, NSDictionary options);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Wrap ("this (sampleBuffer, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, VNImageOptions imageOptions);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, VNImageOptions imageOptions);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithCMSampleBuffer:orientation:options:")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, NSDictionary options);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, NSDictionary options);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Wrap ("this (sampleBuffer, orientation, imageOptions.GetDictionary ()!)")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("performRequests:error:")]
 		bool Perform (VNRequest [] requests, out NSError error);
@@ -2063,7 +2067,7 @@ namespace Vision {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("performRequests:onCVPixelBuffer:error:")]
 		bool Perform (VNRequest [] requests, CVPixelBuffer pixelBuffer, out NSError error);
@@ -2113,164 +2117,164 @@ namespace Vision {
 	interface VNTargetedImageRequest {
 
 		[Export ("initWithTargetedCVPixelBuffer:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, options.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (pixelBuffer, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:options:")]
-		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
+		NativeHandle Constructor (CGImage cgImage, NSDictionary optionsDict);
 
 		[Wrap ("this (cgImage, options.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
+		NativeHandle Constructor (CGImage cgImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:options:completionHandler:")]
-		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (cgImage, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:orientation:options:")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:options:")]
-		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
+		NativeHandle Constructor (CIImage ciImage, NSDictionary optionsDict);
 
 		[Wrap ("this (ciImage, options.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
+		NativeHandle Constructor (CIImage ciImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:options:completionHandler:")]
-		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (ciImage, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:orientation:options:")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:options:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary optionsDict);
 
 		[Wrap ("this (imageUrl, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:options:completionHandler:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageUrl, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:orientation:options:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:options:")]
-		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
+		NativeHandle Constructor (NSData imageData, NSDictionary optionsDict);
 
 		[Wrap ("this (imageData, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions options);
+		NativeHandle Constructor (NSData imageData, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:options:completionHandler:")]
-		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageData, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:orientation:options:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (imageData, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageData, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithTargetedCMSampleBuffer:options:")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, NSDictionary optionsDict);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, NSDictionary optionsDict);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Wrap ("this (sampleBuffer, options.GetDictionary ()!)")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, VNImageOptions options);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, VNImageOptions options);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithTargetedCMSampleBuffer:options:completionHandler:")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Wrap ("this (sampleBuffer, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithTargetedCMSampleBuffer:orientation:options:")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Wrap ("this (sampleBuffer, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithTargetedCMSampleBuffer:orientation:options:completionHandler:")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (14,0), Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Wrap ("this (sampleBuffer, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CMSampleBuffer sampleBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 	}
 
 	[TV (11,0), Mac (10,13), iOS (11,0)]
@@ -2280,13 +2284,13 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithDetectedObjectObservation:")]
-		IntPtr Constructor (VNDetectedObjectObservation observation);
+		NativeHandle Constructor (VNDetectedObjectObservation observation);
 
 		[Export ("initWithDetectedObjectObservation:completionHandler:")]
-		IntPtr Constructor (VNDetectedObjectObservation observation, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (VNDetectedObjectObservation observation, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		// We must inline the following 5 properties
 		// ('Revision', 'WeakSupportedRevisions', 'SupportedRevisions', 'DefaultRevision' and 'CurrentRevision')
@@ -2324,14 +2328,14 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithRectangleObservation:")]
-		IntPtr Constructor (VNRectangleObservation observation);
+		NativeHandle Constructor (VNRectangleObservation observation);
 
 		[Export ("initWithRectangleObservation:completionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (VNRectangleObservation observation, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (VNRectangleObservation observation, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		// We must inline the following 5 properties
 		// ('Revision', 'WeakSupportedRevisions', 'SupportedRevisions', 'DefaultRevision' and 'CurrentRevision')
@@ -2370,7 +2374,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("inputObservation", ArgumentSemantic.Strong)]
 		VNDetectedObjectObservation InputObservation { get; set; }
@@ -2398,7 +2402,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Deprecated (PlatformName.MacOSX, 12, 0, message: "Use 'GetSupportedIdentifiers' instead.")]
 		[Deprecated (PlatformName.iOS, 15, 0, message: "Use 'GetSupportedIdentifiers' instead.")]
@@ -2448,7 +2452,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
@@ -2485,7 +2489,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[Export ("upperBodyOnly")]
@@ -2526,7 +2530,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
@@ -2566,7 +2570,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
@@ -2603,7 +2607,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
@@ -2726,7 +2730,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
@@ -2791,7 +2795,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
@@ -2859,7 +2863,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
@@ -2935,7 +2939,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		// We must inline the following 5 properties
 		// ('Revision', 'WeakSupportedRevisions', 'SupportedRevisions', 'DefaultRevision' and 'CurrentRevision')
@@ -3014,7 +3018,7 @@ namespace Vision {
 
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		// We must inline the following 5 properties
 		// ('Revision', 'WeakSupportedRevisions', 'SupportedRevisions', 'DefaultRevision' and 'CurrentRevision')
@@ -3047,7 +3051,7 @@ namespace Vision {
 	interface VNDetectTrajectoriesRequest {
 
 		[Export ("initWithFrameAnalysisSpacing:trajectoryLength:completionHandler:")]
-		IntPtr Constructor (CMTime frameAnalysisSpacing, nint trajectoryLength, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CMTime frameAnalysisSpacing, nint trajectoryLength, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("trajectoryLength")]
 		nint TrajectoryLength { get; }
@@ -3108,10 +3112,10 @@ namespace Vision {
 
 		[Export ("initWithX:y:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double x, double y);
+		NativeHandle Constructor (double x, double y);
 
 		[Export ("initWithLocation:")]
-		IntPtr Constructor (CGPoint location);
+		NativeHandle Constructor (CGPoint location);
 
 		[Export ("location")]
 		CGPoint Location { get; }
@@ -3155,14 +3159,14 @@ namespace Vision {
 
 		[Export ("initWithXComponent:yComponent:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double x, double y);
+		NativeHandle Constructor (double x, double y);
 
 		[Internal]
 		[Export ("initWithR:theta:")]
 		IntPtr InitWithRTheta (double r, double theta);
 
 		[Export ("initWithVectorHead:tail:")]
-		IntPtr Constructor (VNPoint head, VNPoint tail);
+		NativeHandle Constructor (VNPoint head, VNPoint tail);
 
 		[Export ("x")]
 		double X { get; }
@@ -3326,124 +3330,124 @@ namespace Vision {
 
 		// Inlined from parent class
 		[Export ("initWithTargetedCVPixelBuffer:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, options.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (pixelBuffer, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (pixelBuffer, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:options:")]
-		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
+		NativeHandle Constructor (CGImage cgImage, NSDictionary optionsDict);
 
 		[Wrap ("this (cgImage, options.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
+		NativeHandle Constructor (CGImage cgImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:options:completionHandler:")]
-		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (cgImage, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCGImage:orientation:options:")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (cgImage, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:options:")]
-		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
+		NativeHandle Constructor (CIImage ciImage, NSDictionary optionsDict);
 
 		[Wrap ("this (ciImage, options.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
+		NativeHandle Constructor (CIImage ciImage, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:options:completionHandler:")]
-		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (ciImage, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedCIImage:orientation:options:")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (ciImage, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:options:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary optionsDict);
 
 		[Wrap ("this (imageUrl, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:options:completionHandler:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageUrl, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageURL:orientation:options:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageUrl, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:options:")]
-		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
+		NativeHandle Constructor (NSData imageData, NSDictionary optionsDict);
 
 		[Wrap ("this (imageData, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions options);
+		NativeHandle Constructor (NSData imageData, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:options:completionHandler:")]
-		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageData, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithTargetedImageData:orientation:options:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
 		[Wrap ("this (imageData, orientation, options.GetDictionary ()!)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
 
 		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Wrap ("this (imageData, orientation, options.GetDictionary ()!, completionHandler)")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
 		// We must inline the following 5 properties
 		// ('Revision', 'WeakSupportedRevisions', 'SupportedRevisions', 'DefaultRevision' and 'CurrentRevision')
@@ -3479,10 +3483,10 @@ namespace Vision {
 		VNGeneratePersonSegmentationRequest Create ();
 
 		[Export ("initWithCompletionHandler:")]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("initWithFrameAnalysisSpacing:completionHandler:")]
-		IntPtr Constructor (CMTime frameAnalysisSpacing, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CMTime frameAnalysisSpacing, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("qualityLevel", ArgumentSemantic.Assign)]
 		VNGeneratePersonSegmentationRequestQualityLevel QualityLevel { get; set; }
@@ -3597,7 +3601,7 @@ namespace Vision {
 	interface VNStatefulRequest {
 
 		[Export ("initWithFrameAnalysisSpacing:completionHandler:")]
-		IntPtr Constructor (CMTime frameAnalysisSpacing, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor (CMTime frameAnalysisSpacing, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Export ("minimumLatencyFrameCount")]
 		nint MinimumLatencyFrameCount { get; }
@@ -3636,7 +3640,7 @@ namespace Vision {
 	interface VNVideoProcessor {
 
 		[Export ("initWithURL:")]
-		IntPtr Constructor (NSUrl videoUrl);
+		NativeHandle Constructor (NSUrl videoUrl);
 
 		[Export ("addRequest:processingOptions:error:")]
 		bool AddRequest (VNRequest request, VNVideoProcessorRequestProcessingOptions processingOptions, [NullAllowed] out NSError error);
@@ -3667,7 +3671,7 @@ namespace Vision {
 
 		[Export ("initWithFrameRate:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (nint frameRate);
+		NativeHandle Constructor (nint frameRate);
 
 		[Export ("frameRate")]
 		nint FrameRate { get; }
@@ -3681,7 +3685,7 @@ namespace Vision {
 
 		[Export ("initWithTimeInterval:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (double timeInterval);
+		NativeHandle Constructor (double timeInterval);
 
 		[Export ("timeInterval")]
 		double TimeInterval { get; }
@@ -3702,7 +3706,7 @@ namespace Vision {
 	{
 		[Export ("initWithCompletionHandler:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+		NativeHandle Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
 		VNRectangleObservation[] Results { get; }

--- a/src/watchkit.cs
+++ b/src/watchkit.cs
@@ -25,6 +25,10 @@ using UserNotifications;
 using System;
 using System.ComponentModel;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace WatchKit {
 	[Unavailable (PlatformName.iOS)]
 	[BaseType (typeof (NSObject))]
@@ -34,7 +38,7 @@ namespace WatchKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("awakeWithContext:")]
 		void Awake ([NullAllowed] NSObject context);
@@ -273,7 +277,7 @@ namespace WatchKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Deprecated (PlatformName.WatchOS, 3,0, message: "Use 'DidReceiveNotification' instead.")]
 		[Export ("didReceiveRemoteNotification:withCompletion:")]
@@ -675,7 +679,7 @@ namespace WatchKit {
 		[Deprecated (PlatformName.WatchOS, 7,0, message: "Use 'MKMapView' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("addAnnotation:withImage:centerOffset:")]
 		void AddAnnotation (CLLocationCoordinate2D location, [NullAllowed] UIImage image, CGPoint offset);
@@ -1124,7 +1128,7 @@ namespace WatchKit {
 		[Watch (6,0)][Advice ("This API exists for SwiftUI and is not generally needed.")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("setActivitySummary:animated:")]
 		void SetActivitySummary ([NullAllowed] HKActivitySummary activitySummary, bool animated);
@@ -1139,7 +1143,7 @@ namespace WatchKit {
 		[Deprecated (PlatformName.WatchOS, 7,0, message: "Use 'AVVideoPlayer' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("setMovieURL:")]
 		void SetMovieUrl (NSUrl url);
@@ -1433,7 +1437,7 @@ namespace WatchKit {
 		[Deprecated (PlatformName.WatchOS, 7,0, message: "Use 'HMCameraView' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("setCameraSource:")]
 		void SetCameraSource ([NullAllowed] HMCameraSource cameraSource);
@@ -1447,7 +1451,7 @@ namespace WatchKit {
 		[Watch (6,0)][Advice ("This API exists for SwiftUI and is not generally needed.")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("setMovieURL:")]
 		void SetMovieUrl (NSUrl url);
@@ -1481,7 +1485,7 @@ namespace WatchKit {
 
 		[Watch (6,0)]
 		[Export ("initWithTarget:action:")]
-		IntPtr Constructor ([NullAllowed] NSObject target, Selector action);
+		NativeHandle Constructor ([NullAllowed] NSObject target, Selector action);
 	}
 
 	[Watch (3,0)][NoiOS]
@@ -1493,7 +1497,7 @@ namespace WatchKit {
 		[Deprecated (PlatformName.WatchOS, 7,0, message: "Use 'SCNSceneView' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("snapshot")]
 		UIImage GetSnapshot ();
@@ -1514,7 +1518,7 @@ namespace WatchKit {
 		[Deprecated (PlatformName.WatchOS, 7,0, message: "Use 'SKSpriteView' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Export ("paused")]
 		bool Paused { [Bind ("isPaused")] get; set; }
@@ -1546,7 +1550,7 @@ namespace WatchKit {
 	interface WKInterfaceVolumeControl {
 		[Watch (6,0)]
 		[Export ("initWithOrigin:")]
-		IntPtr Constructor (WKInterfaceVolumeControlOrigin origin);
+		NativeHandle Constructor (WKInterfaceVolumeControlOrigin origin);
 
 		[Export ("setTintColor:")]
 		void SetTintColor ([NullAllowed] UIColor tintColor);
@@ -1686,11 +1690,11 @@ namespace WatchKit {
 	interface WKInterfaceAuthorizationAppleIdButton {
 		[Export ("initWithTarget:action:")]
 		[Deprecated (PlatformName.WatchOS, 6,1, message: "Use 'new WKInterfaceAuthorizationAppleIdButton (WKInterfaceVolumeControlOrigin,NSObject,Selector)' instead.")]
-		IntPtr Constructor ([NullAllowed] NSObject target, Selector action);
+		NativeHandle Constructor ([NullAllowed] NSObject target, Selector action);
 
 		[Watch (6,1)]
 		[Export ("initWithStyle:target:action:")]
-		IntPtr Constructor (WKInterfaceAuthorizationAppleIdButtonStyle style, [NullAllowed] NSObject target, Selector action);
+		NativeHandle Constructor (WKInterfaceAuthorizationAppleIdButtonStyle style, [NullAllowed] NSObject target, Selector action);
 	}
 
 	[Watch (6,0), NoiOS]

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -29,6 +29,10 @@ using CoreGraphics;
 using ObjCRuntime;
 using JavaScriptCore;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace WebKit {
 
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "No longer supported.")]
@@ -1115,7 +1119,7 @@ namespace WebKit {
 
 		[Sealed] // Just to avoid the duplicate selector error
 		[Export ("initEvent:canBubbleArg:cancelableArg:")]
-		IntPtr Constructor (string eventTypeArg, bool canBubbleArg, bool cancelableArg);
+		NativeHandle Constructor (string eventTypeArg, bool canBubbleArg, bool cancelableArg);
 	}
 
 	// Note: DOMMutationEvent is not bound since it is deprecated
@@ -1132,7 +1136,7 @@ namespace WebKit {
 #endif
 		[Sealed] // Just to avoid the duplicate selector error
 		[Export ("initOverflowEvent:horizontalOverflow:verticalOverflow:")]
-		IntPtr Constructor (ushort orient, bool hasHorizontalOverflow, bool hasVerticalOverflow);
+		NativeHandle Constructor (ushort orient, bool hasHorizontalOverflow, bool hasVerticalOverflow);
 
 		[Export ("orient")]
 		ushort Orient { get; }
@@ -1169,7 +1173,7 @@ namespace WebKit {
 #endif
 		[Sealed] // Just to avoid the duplicate selector error
 		[Export ("initUIEvent:canBubble:cancelable:view:detail:")]
-		IntPtr Constructor (string eventType, bool canBubble, bool cancelable, DomAbstractView view, int /* int, not NSInteger */ detail);
+		NativeHandle Constructor (string eventType, bool canBubble, bool cancelable, DomAbstractView view, int /* int, not NSInteger */ detail);
 
 		[Export ("view", ArgumentSemantic.Retain)]
 		DomAbstractView View { get; }
@@ -1212,11 +1216,11 @@ namespace WebKit {
 
 		[Sealed] // Just to avoid the duplicate selector error
 		[Export ("initKeyboardEvent:canBubble:cancelable:view:keyIdentifier:keyLocation:ctrlKey:altKey:shiftKey:metaKey:altGraphKey:")]
-		IntPtr Constructor (string eventType, bool canBubble, bool cancelable, DomAbstractView view, string keyIdentifier, DomKeyLocation keyLocation, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, bool altGraphKey);
+		NativeHandle Constructor (string eventType, bool canBubble, bool cancelable, DomAbstractView view, string keyIdentifier, DomKeyLocation keyLocation, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, bool altGraphKey);
 
 		[Sealed] // Just to avoid the duplicate selector error
 		[Export ("initKeyboardEvent:canBubble:cancelable:view:keyIdentifier:keyLocation:ctrlKey:altKey:shiftKey:metaKey:")]
-		IntPtr Constructor (string eventType, bool canBubble, bool cancelable, DomAbstractView view, string keyIdentifier, DomKeyLocation keyLocation, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
+		NativeHandle Constructor (string eventType, bool canBubble, bool cancelable, DomAbstractView view, string keyIdentifier, DomKeyLocation keyLocation, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
 
 		[Export ("getModifierState:")]
 		bool GetModifierState (string keyIdentifier);
@@ -1260,7 +1264,7 @@ namespace WebKit {
 #endif
 		[Sealed] // Just to avoid the duplicate selector error
 		[Export ("initMouseEvent:canBubble:cancelable:view:detail:screenX:screenY:clientX:clientY:ctrlKey:altKey:shiftKey:metaKey:button:relatedTarget:")]
-		IntPtr Constructor (string eventType, bool canBubble, bool cancelable, DomAbstractView view, int /* int, not NSInteger */ detail, int /* int, not NSInteger */ screenX, int /* int, not NSInteger */ screenY, int /* int, not NSInteger */ clientX, int /* int, not NSInteger */ clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, ushort button, [Protocolize] DomEventTarget relatedTarget);
+		NativeHandle Constructor (string eventType, bool canBubble, bool cancelable, DomAbstractView view, int /* int, not NSInteger */ detail, int /* int, not NSInteger */ screenX, int /* int, not NSInteger */ screenY, int /* int, not NSInteger */ clientX, int /* int, not NSInteger */ clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, ushort button, [Protocolize] DomEventTarget relatedTarget);
 
 		[Export ("screenX")]
 		int ScreenX { get; } /* int, not NSInteger */
@@ -1323,7 +1327,7 @@ namespace WebKit {
 #endif
 		[Sealed] // Just to avoid the duplicate selector error
 		[Export ("initWheelEvent:wheelDeltaY:view:screenX:screenY:clientX:clientY:ctrlKey:altKey:shiftKey:metaKey:")]
-		IntPtr Constructor (int /* int, not NSInteger */ wheelDeltaX, int /* int, not NSInteger */ wheelDeltaY, DomAbstractView view, int /* int, not NSInteger */ screenX, int /* int, not NSInteger */ screnY, int /* int, not NSInteger */ clientX, int /* int, not NSInteger */ clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
+		NativeHandle Constructor (int /* int, not NSInteger */ wheelDeltaX, int /* int, not NSInteger */ wheelDeltaY, DomAbstractView view, int /* int, not NSInteger */ screenX, int /* int, not NSInteger */ screnY, int /* int, not NSInteger */ clientX, int /* int, not NSInteger */ clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
 
 		[Export ("wheelDeltaX")]
 		int WheelDeltaX { get; } /* int, not NSInteger */
@@ -1662,10 +1666,10 @@ namespace WebKit {
 	[BaseType (typeof (NSObject))]
 	partial interface WebArchive : NSCoding, NSCopying {
 		[Export ("initWithMainResource:subresources:subframeArchives:")]
-		IntPtr Constructor (WebResource mainResource, NSArray subresources, NSArray subframeArchives);
+		NativeHandle Constructor (WebResource mainResource, NSArray subresources, NSArray subframeArchives);
 
 		[Export ("initWithData:")]
-		IntPtr Constructor (NSData data);
+		NativeHandle Constructor (NSData data);
 
 		[Export ("mainResource")]
 		WebResource MainResource { get; }
@@ -1731,7 +1735,7 @@ namespace WebKit {
 	[BaseType (typeof (NSObject))]
 	partial interface WebDataSource {
 		[Export ("initWithRequest:")]
-		IntPtr Constructor (NSUrlRequest request);
+		NativeHandle Constructor (NSUrlRequest request);
 
 		[Export ("data")]
 		NSData Data { get; }
@@ -1867,7 +1871,7 @@ namespace WebKit {
 	[DisableDefaultCtor] // invalid handle returned
 	partial interface WebFrame {
 		[Export ("initWithName:webFrameView:webView:")]
-		IntPtr Constructor (string name, WebFrameView view, WebView webView);
+		NativeHandle Constructor (string name, WebFrameView view, WebView webView);
 
 		[Export ("name")]
 		string Name { get; }
@@ -1989,7 +1993,7 @@ namespace WebKit {
 	[BaseType (typeof (NSView))]
 	partial interface WebFrameView {
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frameRect);
+		NativeHandle Constructor (CGRect frameRect);
 
 		[Export ("webFrame")]
 		WebFrame WebFrame { get; }
@@ -2059,7 +2063,7 @@ namespace WebKit {
 	[BaseType (typeof (NSObject))]
 	partial interface WebHistoryItem : NSCopying {
 		[Export ("initWithURLString:title:lastVisitedTimeInterval:")]
-		IntPtr Constructor (string urlString, string title, double lastVisitedTimeInterval);
+		NativeHandle Constructor (string urlString, string title, double lastVisitedTimeInterval);
 
 		[Export ("originalURLString")]
 		string OriginalUrlString { get; }
@@ -2143,7 +2147,7 @@ namespace WebKit {
 		WebPreferences StandardPreferences { get; }
 
 		[Export ("initWithIdentifier:")]
-		IntPtr Constructor (string identifier);
+		NativeHandle Constructor (string identifier);
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -2231,7 +2235,7 @@ namespace WebKit {
 	[BaseType (typeof (NSObject))]
 	partial interface WebResource : NSCoding, NSCopying {
 		[Export ("initWithData:URL:MIMEType:textEncodingName:frameName:")]
-		IntPtr Constructor (NSData data, NSUrl url, string mimeType, string textEncodingName, string frameName);
+		NativeHandle Constructor (NSData data, NSUrl url, string mimeType, string textEncodingName, string frameName);
 
 		[Export ("data")]
 		NSData Data { get; }
@@ -2496,10 +2500,10 @@ namespace WebKit {
 		void RegisterUrlSchemeAsLocal (string scheme);
 
 		[Export ("initWithFrame:frameName:groupName:")]
-		IntPtr Constructor (CGRect frame, [NullAllowed] string frameName, [NullAllowed]string groupName);
+		NativeHandle Constructor (CGRect frame, [NullAllowed] string frameName, [NullAllowed]string groupName);
 
 		[Export ("initWithFrame:")]
-		IntPtr Constructor (CGRect frame);
+		NativeHandle Constructor (CGRect frame);
 
 		[Export ("close")]
 		void Close ();

--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -23,6 +23,10 @@ using NSPrintInfo = Foundation.NSObject;
 using NSPrintOperation = Foundation.NSObject;
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace WebKit
 {
 	[iOS (8,0), Mac (10,10)] // Not defined in 32-bit
@@ -655,12 +659,12 @@ namespace WebKit
 	interface WKUserScript : NSCopying {
 
 		[Export ("initWithSource:injectionTime:forMainFrameOnly:")]
-		IntPtr Constructor (NSString source, WKUserScriptInjectionTime injectionTime, bool isForMainFrameOnly);
+		NativeHandle Constructor (NSString source, WKUserScriptInjectionTime injectionTime, bool isForMainFrameOnly);
 
 		[Mac (11,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Export ("initWithSource:injectionTime:forMainFrameOnly:inContentWorld:")]
-		IntPtr Constructor (NSString source, WKUserScriptInjectionTime injectionTime, bool isForMainFrameOnly, WKContentWorld contentWorld);
+		NativeHandle Constructor (NSString source, WKUserScriptInjectionTime injectionTime, bool isForMainFrameOnly, WKContentWorld contentWorld);
 
 		[Export ("source", ArgumentSemantic.Copy)]
 		NSString Source { get; }
@@ -690,13 +694,13 @@ namespace WebKit
 
 		[DesignatedInitializer]
 		[Export ("initWithFrame:configuration:")]
-		IntPtr Constructor (CGRect frame, WKWebViewConfiguration configuration);
+		NativeHandle Constructor (CGRect frame, WKWebViewConfiguration configuration);
 
 		// (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
 		// [Unavailable (PlatformName.iOS)]
 		// [Unavailable (PlatformName.MacOSX)]
 		// [Export ("initWithCoder:")]
-		// IntPtr Constructor (NSCoder coder);
+		// NativeHandle Constructor (NSCoder coder);
 
 		[Export ("configuration", ArgumentSemantic.Copy)]
 		WKWebViewConfiguration Configuration { get; }

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -74,6 +74,10 @@ using View=UIKit.UIView;
 #endif
 #endif
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 #if MONOMAC
 namespace AppKit {
 #else
@@ -2375,13 +2379,13 @@ namespace UIKit {
 	{
 		[NoiOS][NoTV][NoMacCatalyst]
 		[Export ("initWithFileWrapper:")]
-		IntPtr Constructor (NSFileWrapper fileWrapper);
+		NativeHandle Constructor (NSFileWrapper fileWrapper);
 
 		[Mac (10,11)]
 		[DesignatedInitializer]
 		[Export ("initWithData:ofType:")]
 		[PostGet ("Contents")]
-		IntPtr Constructor ([NullAllowed] NSData contentData, [NullAllowed] string uti);
+		NativeHandle Constructor ([NullAllowed] NSData contentData, [NullAllowed] string uti);
 
 		[Mac (10,11)]
 		[NullAllowed]
@@ -2466,7 +2470,7 @@ namespace UIKit {
 	partial interface NSTextStorage : NSSecureCoding {
 #if MONOMAC && !XAMCORE_4_0
 		[Export ("initWithString:")]
-		IntPtr Constructor (string str);
+		NativeHandle Constructor (string str);
 #endif
 
 		[Export ("layoutManagers")]
@@ -2862,11 +2866,11 @@ namespace UIKit {
 	interface NSDataAsset : NSCopying
 	{
 		[Export ("initWithName:")]
-		IntPtr Constructor (string name);
+		NativeHandle Constructor (string name);
 
 		[Export ("initWithName:bundle:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (string name, NSBundle bundle);
+		NativeHandle Constructor (string name, NSBundle bundle);
 
 		[Export ("name")]
 		string Name { get; }
@@ -2908,11 +2912,11 @@ namespace UIKit {
 		[DesignatedInitializer]
 		[Export ("initWithTextAlignment:location:options:")]
 		[PostGet ("Options")]
-		IntPtr Constructor (TextAlignment alignment, nfloat location, NSDictionary options);
+		NativeHandle Constructor (TextAlignment alignment, nfloat location, NSDictionary options);
 
 		[NoiOS][NoMacCatalyst][NoTV][NoWatch]
 		[Export ("initWithType:location:")]
-		IntPtr Constructor (NSTextTabType type, nfloat location);
+		NativeHandle Constructor (NSTextTabType type, nfloat location);
 
 		[Export ("alignment")]
 		TextAlignment Alignment { get; }
@@ -2959,7 +2963,7 @@ namespace UIKit {
 		[NoMac]
 		[DesignatedInitializer]
 		[Export ("initWithSize:")]
-		IntPtr Constructor (CGSize size);
+		NativeHandle Constructor (CGSize size);
 
 		[NoiOS][NoMacCatalyst][NoTV]
 		[Export ("initWithContainerSize:"), Internal]
@@ -3284,7 +3288,7 @@ namespace UIKit {
 
 		[DesignatedInitializer]
 		[Export ("init")]
-		IntPtr Constructor ();
+		NativeHandle Constructor ();
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -3346,7 +3350,7 @@ namespace UIKit {
 	{
 		[Export ("initWithTextContentManager:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSTextContentManager textContentManager);
+		NativeHandle Constructor ([NullAllowed] NSTextContentManager textContentManager);
 
 		[NullAllowed, Export ("textContentManager", ArgumentSemantic.Weak)]
 		NSTextContentManager TextContentManager { get; set; }
@@ -3361,11 +3365,11 @@ namespace UIKit {
 	{
 		[Export ("initWithAttributedString:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSAttributedString attributedString);
+		NativeHandle Constructor ([NullAllowed] NSAttributedString attributedString);
 
 		[Export ("initWithTextContentManager:")]
 		[DesignatedInitializer]
-		IntPtr Constructor ([NullAllowed] NSTextContentManager textContentManager);
+		NativeHandle Constructor ([NullAllowed] NSTextContentManager textContentManager);
 
 		[Export ("attributedString", ArgumentSemantic.Strong)]
 		NSAttributedString AttributedString { get; }
@@ -3384,10 +3388,10 @@ namespace UIKit {
 	{
 		[Export ("initWithAttributedString:range:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSAttributedString attributedString, NSRange range);
+		NativeHandle Constructor (NSAttributedString attributedString, NSRange range);
 
 		[Export ("initWithString:attributes:range:")]
-		IntPtr Constructor (string @string, NSDictionary<NSString, NSObject> attributes, NSRange range);
+		NativeHandle Constructor (string @string, NSDictionary<NSString, NSObject> attributes, NSRange range);
 
 		[Export ("attributedString", ArgumentSemantic.Strong)]
 		NSAttributedString AttributedString { get; }
@@ -3430,7 +3434,7 @@ namespace UIKit {
 	{
 		[Export ("initWithTextAttachment:parentView:textLayoutManager:location:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSTextAttachment textAttachment, [NullAllowed] View parentView, [NullAllowed] NSTextLayoutManager textLayoutManager, INSTextLocation location);
+		NativeHandle Constructor (NSTextAttachment textAttachment, [NullAllowed] View parentView, [NullAllowed] NSTextLayoutManager textLayoutManager, INSTextLocation location);
 
 		[NullAllowed, Export ("textAttachment", ArgumentSemantic.Weak)]
 		NSTextAttachment TextAttachment { get; }
@@ -3461,7 +3465,7 @@ namespace UIKit {
 	{
 		[Export ("initWithTextElement:range:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSTextElement textElement, [NullAllowed] NSTextRange rangeInElement);
+		NativeHandle Constructor (NSTextElement textElement, [NullAllowed] NSTextRange rangeInElement);
 
 		[NullAllowed, Export ("textLayoutManager", ArgumentSemantic.Weak)]
 		NSTextLayoutManager TextLayoutManager { get; }
@@ -3519,10 +3523,10 @@ namespace UIKit {
 	{
 		[Export ("initWithLocation:endLocation:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSTextLocation location, [NullAllowed] INSTextLocation endLocation);
+		NativeHandle Constructor (INSTextLocation location, [NullAllowed] INSTextLocation endLocation);
 
 		[Export ("initWithLocation:")]
-		IntPtr Constructor (INSTextLocation location);
+		NativeHandle Constructor (INSTextLocation location);
 
 		[Export ("empty")]
 		bool Empty { [Bind ("isEmpty")] get; }
@@ -3582,7 +3586,7 @@ namespace UIKit {
 	{
 		[Export ("initWithTextLayoutManager:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSTextLayoutManager textLayoutManager);
+		NativeHandle Constructor (NSTextLayoutManager textLayoutManager);
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
@@ -3636,13 +3640,13 @@ namespace UIKit {
 	{
 		[Export ("initWithRanges:affinity:granularity:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSTextRange[] textRanges, NSTextSelectionAffinity affinity, NSTextSelectionGranularity granularity);
+		NativeHandle Constructor (NSTextRange[] textRanges, NSTextSelectionAffinity affinity, NSTextSelectionGranularity granularity);
 
 		[Export ("initWithRange:affinity:granularity:")]
-		IntPtr Constructor (NSTextRange range, NSTextSelectionAffinity affinity, NSTextSelectionGranularity granularity);
+		NativeHandle Constructor (NSTextRange range, NSTextSelectionAffinity affinity, NSTextSelectionGranularity granularity);
 
 		[Export ("initWithLocation:affinity:")]
-		IntPtr Constructor (INSTextLocation location, NSTextSelectionAffinity affinity);
+		NativeHandle Constructor (INSTextLocation location, NSTextSelectionAffinity affinity);
 
 		[Export ("textRanges", ArgumentSemantic.Copy)]
 		NSTextRange[] TextRanges { get; }
@@ -3783,7 +3787,7 @@ namespace UIKit {
 	{
 		[Export ("initWithDataSource:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (INSTextSelectionDataSource dataSource);
+		NativeHandle Constructor (INSTextSelectionDataSource dataSource);
 
 		[Wrap ("WeakTextSelectionDataSource")]
 		[NullAllowed]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -76,6 +76,7 @@ test.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.De
 	@echo "MACOS_SDK_VERSION=$(MACOS_SDK_VERSION)" >> $@
 	@echo "DOTNET6_BCL_DIR=$(DOTNET6_BCL_DIR)" >> $@
 	@echo "ENABLE_DOTNET=$(ENABLE_DOTNET)" >> $@
+	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),DOTNET_$(platform)_RUNTIME_IDENTIFIERS=$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS)\\n)" | sed 's/^ //' >> $@
 
 test-system.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.Details.xml
 	@rm -f $@

--- a/tests/api-shared/ObjCRuntime/RegistrarTest.cs
+++ b/tests/api-shared/ObjCRuntime/RegistrarTest.cs
@@ -34,7 +34,11 @@ namespace XamarinTests.ObjCRuntime {
 				ptr = Messaging.IntPtr_objc_msgSend (ptr, Selector.GetHandle ("init"));
 				var ex = Assert.Throws<RuntimeException> (() => Messaging.bool_objc_msgSend_IntPtr (ptr, Selector.GetHandle ("conformsToProtocol:"), IntPtr.Zero));
 				var lines = new List<string> ();
+#if NET
+				lines.Add (string.Format ("Failed to marshal the Objective-C object 0x{0} (type: IntPtrCtorTestClass). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'XamarinTests.ObjCRuntime.RegistrarSharedTest+IntPtrCtorTestClass' does not have a constructor that takes one NativeHandle argument).", ptr.ToString ("x")));
+#else
 				lines.Add (string.Format ("Failed to marshal the Objective-C object 0x{0} (type: IntPtrCtorTestClass). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'XamarinTests.ObjCRuntime.RegistrarSharedTest+IntPtrCtorTestClass' does not have a constructor that takes one IntPtr argument).", ptr.ToString ("x")));
+#endif
 				lines.Add ("Additional information:");
 				lines.Add ("Selector: conformsToProtocol:");
 				lines.Add ("InvokeConformsToProtocol");

--- a/tests/cecil-tests/CecilExtensions.cs
+++ b/tests/cecil-tests/CecilExtensions.cs
@@ -1,0 +1,12 @@
+using Mono.Cecil;
+
+namespace Xamarin.Utils {
+	public static partial class CecilExtensions {
+
+		// note: direct check, no inheritance
+		public static bool Is (this TypeReference type, string @namespace, string name)
+		{
+			return (type is not null) && (type.Name == name) && (type.Namespace == @namespace);
+		}
+	}
+}

--- a/tests/cecil-tests/ConstructorTest.cs
+++ b/tests/cecil-tests/ConstructorTest.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using NUnit.Framework;
+
+using Xamarin.Tests;
+using Xamarin.Utils;
+
+namespace Cecil.Tests {
+	public class ConstructorTest {
+		static bool IsMatch (MethodDefinition ctor, params (string Namespace, string Name) [] parameterTypes)
+		{
+			if (!ctor.IsConstructor)
+				return false;
+			if (ctor.IsStatic)
+				return false;
+			if (!ctor.HasParameters)
+				return false;
+			var parameters = ctor.Parameters;
+			if (parameters.Count != parameterTypes.Length)
+				return false;
+			for (var i = 0; i < parameters.Count; i++) {
+				if (!parameters [i].ParameterType.Is (parameterTypes [i].Namespace, parameterTypes [i].Name))
+					return false;
+			}
+			return true;
+		}
+
+		static MethodDefinition GetConstructor (TypeDefinition type, params (string Namespace, string Name) [] parameterTypes)
+		{
+			foreach (var ctor in type.Methods) {
+				if (IsMatch (ctor, parameterTypes))
+					return ctor;
+			}
+			return null;
+		}
+
+		static string GetLocation (MethodDefinition method)
+		{
+			if (method.DebugInformation.HasSequencePoints) {
+				var seq = method.DebugInformation.SequencePoints [0];
+				return seq.Document.Url + ":" + seq.StartLine + ": ";
+			}
+			return string.Empty;
+		}
+
+		static bool IsFunctionEnd (IList<Instruction> instructions, int index)
+		{
+			if (instructions.Count == index + 1 && instructions [index].OpCode == OpCodes.Ret)
+				return true;
+			if (instructions.Count == index + 2 && instructions [index].OpCode == OpCodes.Newobj && ((MethodReference) instructions [index].Operand).Resolve ().Parameters.Count == 0 && instructions [index + 1].OpCode == OpCodes.Throw)
+				return true;
+			if (instructions.Count == index + 3 && instructions [index].OpCode == OpCodes.Ldstr && instructions [index + 1].OpCode == OpCodes.Newobj && ((MethodReference) instructions [index + 1].Operand).Resolve ().Parameters.Count == 1 && instructions [index + 2].OpCode == OpCodes.Throw)
+				return true;
+			return false;
+		}
+
+		static bool VerifyInstructions (MethodDefinition method, IList<Instruction> instructions, out string reason)
+		{
+			reason = null;
+
+			// base (owns)
+			// optional additional statements (either statement, not both):
+			//     IsDirectBinding = false;
+			//     MarkDirtyIfDerived ()
+			if (instructions.Count >= 3 &&
+				instructions [0].OpCode == OpCodes.Ldarg_0 &&
+				instructions [1].OpCode == OpCodes.Ldarg_1 &&
+				instructions [2].OpCode == OpCodes.Call) {
+				var targetMethod = (instructions [2].Operand as MethodReference).Resolve ();
+				if (!targetMethod.IsConstructor) {
+					reason = $"Calls another method which is not a constructor: {targetMethod.FullName}";
+					return false;
+				}
+				var isChainedCtorCall = targetMethod.DeclaringType == method.DeclaringType || targetMethod.DeclaringType == method.DeclaringType.BaseType;
+				if (!isChainedCtorCall) {
+					reason = $"Calls unknown (unchained) constructor: {targetMethod.FullName}";
+					return false;
+				}
+
+				if (IsFunctionEnd (instructions, 3))
+					return true;
+
+				if (instructions [3].OpCode == OpCodes.Ldarg_0 && instructions [4].OpCode == OpCodes.Ldc_I4_0 && instructions [5].OpCode == OpCodes.Call) {
+					targetMethod = (instructions [5].Operand as MethodReference).Resolve ();
+					if (targetMethod.Name != "set_IsDirectBinding") {
+						reason = $"Calls unknown method: {targetMethod.FullName}";
+						return false;
+					}
+
+					if (IsFunctionEnd (instructions, 6))
+						return true;
+				}
+
+				if (instructions [3].OpCode == OpCodes.Ldarg_0 && instructions [4].OpCode == OpCodes.Call) {
+					targetMethod = (instructions [4].Operand as MethodReference).Resolve ();
+					if (targetMethod.Name != "MarkDirtyIfDerived") {
+						reason = $"Calls unknown method: {targetMethod.FullName}";
+						return false;
+					}
+
+					if (IsFunctionEnd (instructions, 5))
+						return true;
+				}
+			}
+
+			// base (handle, owns|false)
+			if (instructions.Count >= 4 &&
+				instructions [0].OpCode == OpCodes.Ldarg_0 &&
+				instructions [1].OpCode == OpCodes.Ldarg_1 &&
+				(instructions [2].OpCode == OpCodes.Ldarg_2 || instructions [2].OpCode == OpCodes.Ldc_I4_0) &&
+				instructions [3].OpCode == OpCodes.Call) {
+				var targetMethod = (instructions [3].Operand as MethodReference).Resolve ();
+				if (!targetMethod.IsConstructor) {
+					reason = $"Calls another method which is not a constructor (2): {targetMethod.FullName}";
+					return false;
+				}
+				var isChainedCtorCall = targetMethod.DeclaringType.Resolve () == method.DeclaringType.Resolve () || targetMethod.DeclaringType.Resolve () == method.DeclaringType.BaseType.Resolve ();
+				if (!isChainedCtorCall) {
+					reason = $"Calls unknown (unchained) constructor (2): {targetMethod.FullName}";
+					return false;
+				}
+
+				if (IsFunctionEnd (instructions, 4))
+					return true;
+			}
+
+			// base (handle, owns|false, validate: false|true)
+			if (instructions.Count >= 5 &&
+				instructions [0].OpCode == OpCodes.Ldarg_0 &&
+				instructions [1].OpCode == OpCodes.Ldarg_1 &&
+				(instructions [2].OpCode == OpCodes.Ldarg_2 || instructions [2].OpCode == OpCodes.Ldc_I4_0) &&
+				(instructions [3].OpCode == OpCodes.Ldc_I4_0 || instructions [3].OpCode == OpCodes.Ldc_I4_1) &&
+				instructions [4].OpCode == OpCodes.Call) {
+				var targetMethod = (instructions [4].Operand as MethodReference).Resolve ();
+				if (!targetMethod.IsConstructor) {
+					reason = $"Calls another method which is not a constructor (2): {targetMethod.FullName}";
+					return false;
+				}
+				var isChainedCtorCall = targetMethod.DeclaringType == method.DeclaringType || targetMethod.DeclaringType == method.DeclaringType.BaseType;
+				if (!isChainedCtorCall) {
+					reason = $"Calls unknown (unchained) constructor (2): {targetMethod.FullName}";
+					return false;
+				}
+
+				if (IsFunctionEnd (instructions, 5))
+					return true;
+			}
+
+			if (reason is null)
+				reason = $"Sequence of instructions didn't match any known sequence.";
+
+			return false;
+		}
+
+		static bool VerifyConstructor (MethodDefinition ctor, out string failureReason)
+		{
+			failureReason = null;
+			// There's nothing wrong with a constructor that doesn't exist
+			if (ctor is null)
+				return true;
+
+			// Verify that the constructor only does valid stuff
+			if (!VerifyInstructions (ctor, ctor.Body.Instructions, out failureReason)) {
+				Console.WriteLine (ctor.FullName);
+				foreach (var instr in ctor.Body.Instructions)
+					Console.WriteLine (instr);
+
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool ImplementsINativeObject (TypeDefinition type)
+		{
+			if (type is null)
+				return false;
+
+			foreach (var id in type.Interfaces) {
+				if (id.InterfaceType.Name == "INativeObject") {
+					return true;
+				}
+			}
+
+			return ImplementsINativeObject (type.BaseType?.Resolve ());
+		}
+
+		public static bool SubclassesNSObject (TypeDefinition type)
+		{
+			if (type is null)
+				return false;
+
+			if (type.Namespace == "Foundation" && type.Name == "NSObject")
+				return true;
+
+			return SubclassesNSObject (type.BaseType?.Resolve ());
+		}
+
+		static bool IsVisible (TypeDefinition type)
+		{
+			if (type.IsNested) {
+				if (!IsVisible (type.DeclaringType))
+					return false;
+				return type.IsNestedPublic || type.IsNestedFamily || type.IsNestedFamilyOrAssembly;
+			} else {
+				return type.IsPublic;
+			}
+		}
+
+		static bool IsVisible (MethodDefinition method)
+		{
+			if (!IsVisible (method.DeclaringType))
+				return false;
+			return method.IsPublic || method.IsFamilyOrAssembly || method.IsFamily;
+		}
+
+		static bool IsPublic (MethodDefinition method)
+		{
+			if (!IsVisible (method.DeclaringType))
+				return false;
+			return method.IsPublic;
+		}
+
+		[Test]
+		[TestCase (ApplePlatform.iOS)]
+		[TestCase (ApplePlatform.TVOS)]
+		[TestCase (ApplePlatform.MacCatalyst)]
+		[TestCase (ApplePlatform.MacOSX)]
+		public void INativeObjectIntPtrConstructorDoesNotOwnHandle (ApplePlatform platform)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var failures = new List<string> ();
+			foreach (var dll in Configuration.GetBaseLibraryImplementations (platform)) {
+				Console.WriteLine (dll);
+				using (var ad = AssemblyDefinition.ReadAssembly (dll, new ReaderParameters (ReadingMode.Deferred) { ReadSymbols = true })) {
+					foreach (var type in ad.MainModule.Types) {
+						// Skip classes we know aren't (properly) reference counted.
+						switch (type.Name) {
+						case "Selector": // not really refcounted
+						case "Class": // not really refcounted
+						case "Protocol": // not really refcounted
+						case "AURenderEventEnumerator": // this class shouldn't really be an INativeObject in the first place
+						case "AudioBuffers": // this class shouldn't really be an INativeObject in the first place
+						case "AVAudioChannelLayout": // has a private IntPtr constructor which is a void* in native code (i.e. not a mistake).
+							continue;
+						}
+
+						// Find classes that implement INativeObject, but doesn't subclass NSObject.
+						if (!type.IsClass)
+							continue;
+
+						// Does type implement INativeObject?
+						if (!ImplementsINativeObject (type))
+							continue;
+
+						var isNSObjectSubclass = SubclassesNSObject (type);
+
+						// Find the constructors constructors we care about
+						var intptrCtor = GetConstructor (type, ("System", "IntPtr"));
+						var intptrBoolCtor = GetConstructor (type, ("System", "IntPtr"), ("System", "Boolean"));
+						var nativeHandleCtor = GetConstructor (type, ("ObjCRuntime", "NativeHandle"));
+						var nativeHandleBoolCtor = GetConstructor (type, ("ObjCRuntime", "NativeHandle"), ("System", "Boolean"));
+
+						if (intptrCtor is not null) {
+							if (IsVisible (intptrCtor)) {
+								var msg = $"{type}: (IntPtr) constructor found. It should not exist.";
+								Console.WriteLine ($"{GetLocation (intptrCtor)}{msg}");
+								failures.Add (msg);
+							} else {
+								var msg = $"{type}: private (IntPtr) constructor found. It should probably not exist.";
+								Console.WriteLine ($"{GetLocation (intptrCtor)}{msg}");
+							}
+						}
+
+						if (intptrBoolCtor is not null) {
+							var msg = $"{type}: (IntPtr, bool) constructor found. It should not exist.";
+							Console.WriteLine ($"{GetLocation (intptrBoolCtor)}{msg}");
+							failures.Add (msg);
+						}
+
+						if (nativeHandleCtor is not null) {
+							if (IsPublic (nativeHandleCtor)) {
+								var msg = $"{type}: public (NativeHandle) constructor found. If it exists it should not be public.";
+								Console.WriteLine ($"{GetLocation (nativeHandleCtor)}{msg}");
+								failures.Add (msg);
+							}
+						}
+
+						if (nativeHandleBoolCtor is not null) {
+							if (IsPublic (nativeHandleBoolCtor)) {
+								var msg = $"{type}: public (NativeHandle, bool) constructor found. If it exists it should not be public.";
+								Console.WriteLine ($"{GetLocation (nativeHandleBoolCtor)}{msg}");
+								failures.Add (msg);
+							}
+						}
+
+						var skipILVerification = isNSObjectSubclass;
+						switch (type.Name) {
+						case "CGPDFObject": // root class
+						case "SecKeyChain": // root class
+						case "NSObject": // NSObject is a base class and needs custom constructor logic
+						case "NSZone": // root class
+						case "ABAddressBook": // needs a custom ctor implementation
+						case "CFSocket": // needs a custom ctor implementation
+						case "NWBrowser": // needs a custom ctor implementation
+						case "NWListener": // needs a custom ctor implementation
+						case "CFNotificationCenter": // needs a custom ctor implementation
+						case "AUGraph": // needs a custom ctor implementation
+						case "ABMultiValue`1": // has a custom ctor implementation
+							skipILVerification = true;
+							break;
+						}
+
+						if (!skipILVerification) {
+							if (!VerifyConstructor (nativeHandleCtor, out var failureReason)) {
+								var msg = $"{type}: (NativeHandle) ctor failed IL verification: {failureReason}";
+								Console.WriteLine ($"{GetLocation (nativeHandleCtor)}{msg}");
+								failures.Add (msg);
+							}
+
+							if (!VerifyConstructor (nativeHandleBoolCtor, out failureReason)) {
+								var msg = $"{type}: (NativeHandle, bool) ctor failed IL verification: {failureReason}";
+								Console.WriteLine ($"{GetLocation (nativeHandleBoolCtor)}{msg}");
+								failures.Add (msg);
+							}
+						}
+					}
+				}
+			}
+			Assert.That (failures, Is.Empty, "No failures");
+		}
+	}
+}

--- a/tests/cecil-tests/cecil-tests.sln
+++ b/tests/cecil-tests/cecil-tests.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.810.10
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cecil-tests", "cecil-tests.csproj", "{53D05E6F-0FD4-4B09-8BA5-01BA35FECFE7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{53D05E6F-0FD4-4B09-8BA5-01BA35FECFE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53D05E6F-0FD4-4B09-8BA5-01BA35FECFE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53D05E6F-0FD4-4B09-8BA5-01BA35FECFE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53D05E6F-0FD4-4B09-8BA5-01BA35FECFE7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {431814EB-3233-4BB3-A897-C1996072E1F5}
+	EndGlobalSection
+EndGlobal

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -33,6 +33,10 @@ using ObjCRuntime;
 
 using Xamarin.Utils;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 partial class TestRuntime
 {
 
@@ -1245,3 +1249,12 @@ partial class TestRuntime
 		}
 	}
 }
+
+#if NET
+internal static class NativeHandleExtensions {
+	public static string ToString (this NativeHandle @this, string format)
+	{
+		return ((IntPtr) @this).ToString (format);
+	}
+}
+#endif

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -207,8 +207,13 @@ namespace GeneratorTests
 			bgen.AssertExecute ("build");
 			bgen.AssertNoWarnings ();
 
+#if NET
+			bgen.AssertApiCallsMethod ("Test", "MarshalInProperty", "get_Shared", "xamarin_NativeHandle_objc_msgSend_exception", "MarshalInProperty.Shared getter");
+			bgen.AssertApiCallsMethod ("Test", "MarshalOnProperty", "get_Shared", "xamarin_NativeHandle_objc_msgSend_exception", "MarshalOnProperty.Shared getter");
+#else
 			bgen.AssertApiCallsMethod ("Test", "MarshalInProperty", "get_Shared", "xamarin_IntPtr_objc_msgSend_exception", "MarshalInProperty.Shared getter");
 			bgen.AssertApiCallsMethod ("Test", "MarshalOnProperty", "get_Shared", "xamarin_IntPtr_objc_msgSend_exception", "MarshalOnProperty.Shared getter");
+#endif
 		}
 
 		[Test]
@@ -761,7 +766,11 @@ namespace GeneratorTests
 			var type = bgen.ApiAssembly.MainModule.GetType ("ObjCRuntime", "Trampolines").NestedTypes.First (v => v.Name == "DMyHandler");
 			Assert.NotNull (type, "DMyHandler");
 			var method = type.Methods.First (v => v.Name == "Invoke");
+#if NET
+			Assert.AreEqual ("ObjCRuntime.NativeHandle", method.ReturnType.FullName, "Return type");
+#else
 			Assert.AreEqual ("System.IntPtr", method.ReturnType.FullName, "Return type");
+#endif
 		}
 
 		BGenTool BuildFile (Profile profile, params string [] filenames)

--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -138,7 +138,11 @@ namespace Introspection {
 				nativeObj = obj;
 			}
 
+#if NET
+			public NativeHandle Handle
+#else
 			public IntPtr Handle
+#endif
 			{
 				get { return nativeObj.Handle; }
 			}

--- a/tests/introspection/ApiClassPtrTest.cs
+++ b/tests/introspection/ApiClassPtrTest.cs
@@ -17,6 +17,10 @@ using System.Runtime.CompilerServices;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Introspection {
 
 	public abstract class ApiClassPtrTest : ApiBaseTest {
@@ -82,7 +86,7 @@ namespace Introspection {
 				FieldInfo fi = t.GetField ("class_ptr", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
 				if (fi == null)
 					continue;			
-				IntPtr class_ptr = (IntPtr) fi.GetValue (null);
+				IntPtr class_ptr = (IntPtr) (NativeHandle) fi.GetValue (null);
 				IntPtr register_class_ptr = GetClassPtrFromRegister (t);
 
 				Assert.AreEqual (class_ptr, register_class_ptr, "class_ptr and RegisterAttribute are different: " + t.Name);
@@ -99,7 +103,7 @@ namespace Introspection {
 				FieldInfo fi = t.GetField ("class_ptr", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
 				if (fi == null)
 					continue;
-				IntPtr class_ptr = (IntPtr)fi.GetValue (null);
+				IntPtr class_ptr = (IntPtr) (NativeHandle) fi.GetValue (null);
 
 				var extendedType = GetExtendedType (t);
 				IntPtr extended_class_ptr;

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -26,6 +26,10 @@ using NUnit.Framework;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Introspection {
 
 	public abstract class ApiSelectorTest : ApiBaseTest {
@@ -952,7 +956,11 @@ namespace Introspection {
 			var fi = type.GetField ("class_ptr", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
 			if (fi == null)
 				return IntPtr.Zero; // e.g. *Delegate
+#if NET
+			return (NativeHandle) fi.GetValue (null);
+#else
 			return (IntPtr) fi.GetValue (null);
+#endif
 		}
 
 		[Test]
@@ -1131,7 +1139,7 @@ namespace Introspection {
 				FieldInfo fi = t.GetField ("class_ptr", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
 				if (fi == null)
 					continue; // e.g. *Delegate
-				IntPtr class_ptr = (IntPtr) fi.GetValue (null);
+				IntPtr class_ptr = (IntPtr) (NativeHandle) fi.GetValue (null);
 				
 				foreach (var m in t.GetMethods (BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)) {
 					if (SkipDueToAttribute (m))

--- a/tests/introspection/ApiSignatureTest.cs
+++ b/tests/introspection/ApiSignatureTest.cs
@@ -30,6 +30,10 @@ using System.Linq;
 using Foundation;
 using ObjCRuntime;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Introspection {
 
 	public abstract class ApiSignatureTest : ApiBaseTest {
@@ -211,7 +215,7 @@ namespace Introspection {
 				FieldInfo fi = null;
 				if (!static_type)
 					fi = t.GetField ("class_ptr", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
-				IntPtr class_ptr = fi == null ? IntPtr.Zero : (IntPtr) fi.GetValue (null);
+				IntPtr class_ptr = fi == null ? IntPtr.Zero : (IntPtr) (NativeHandle) fi.GetValue (null);
 
 				foreach (MethodBase m in t.GetMethods (Flags)) 
 					CheckMemberSignature (m, t, class_ptr, ref n);

--- a/tests/monotouch-test/AppKit/NSCellTest.cs
+++ b/tests/monotouch-test/AppKit/NSCellTest.cs
@@ -8,6 +8,10 @@ using ObjCRuntime;
 
 using NUnit.Framework;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MonoMacFixtures.AppKit
 {
 	[TestFixture]
@@ -65,9 +69,9 @@ namespace MonoMacFixtures.AppKit
 	}
 
 	class CustomCell : NSCell {
-		public static IntPtr expectedHandle;
+		public static NativeHandle expectedHandle;
 
-		public CustomCell (IntPtr ptr) : base (ptr) { }
+		public CustomCell (NativeHandle ptr) : base (ptr) { }
 		public CustomCell () { }
 
 		[Export ("foo:")]
@@ -79,7 +83,7 @@ namespace MonoMacFixtures.AppKit
 
 	class DerivedCell : CustomCell
 	{
-		public DerivedCell (IntPtr ptr) : base (ptr) { }
+		public DerivedCell (NativeHandle ptr) : base (ptr) { }
 		public DerivedCell () {	}
 
 		public override NSObject Copy (NSZone zone)

--- a/tests/monotouch-test/AudioUnit/AUGraphTest.cs
+++ b/tests/monotouch-test/AudioUnit/AUGraphTest.cs
@@ -99,7 +99,7 @@ namespace MonoTouchFixtures.AudioUnit {
 
 			using (var aug = Runtime.GetINativeObject<AUGraph> (ret, true)) {
 				Assert.NotNull (aug, "CreateTest");
-				Assert.That (aug.Handle, Is.EqualTo (ret), "Handle");
+				Assert.That ((IntPtr) aug.Handle, Is.EqualTo (ret), "Handle");
 
 				// Make sure it is a working instance
 				aug.Open ();

--- a/tests/monotouch-test/CoreGraphics/ColorSpaceTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ColorSpaceTest.cs
@@ -19,6 +19,10 @@ using CoreGraphics;
 using ObjCRuntime;
 using NUnit.Framework;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MonoTouchFixtures.CoreGraphics {
 	
 	[TestFixture]
@@ -28,7 +32,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 		void CheckUnknown (CGColorSpace cs)
 		{
 			Assert.That (cs.Components, Is.EqualTo ((nint) 0), "Unknown-0");
-			Assert.That (cs.Handle, Is.EqualTo (IntPtr.Zero), "Unknown-Handle");
+			Assert.That (cs.Handle, Is.EqualTo (NativeHandle.Zero), "Unknown-Handle");
 			Assert.That (cs.Model, Is.EqualTo (CGColorSpaceModel.Unknown), "Unknown-Model");
 			Assert.That (cs.GetColorTable ().Length, Is.EqualTo (0), "Unknown-GetColorTable");
 		}

--- a/tests/monotouch-test/Foundation/ArrayTest.cs
+++ b/tests/monotouch-test/Foundation/ArrayTest.cs
@@ -13,6 +13,10 @@ using ObjCRuntime;
 using Security;
 using NUnit.Framework;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MonoTouchFixtures.Foundation {
 	
 	[TestFixture]
@@ -46,7 +50,11 @@ namespace MonoTouchFixtures.Foundation {
 		NSComparisonResult Comparator (NSObject obj1, NSObject obj2)
 		{
 			comparator_count++;
+#if NET
+			return (NSComparisonResult) (((long) (IntPtr) obj2.Handle - (long) (IntPtr) obj1.Handle));
+#else
 			return (NSComparisonResult) (long) ((nint) obj2.Handle - (nint) obj1.Handle);
+#endif
 		}
 		
 		[Test]
@@ -60,8 +68,8 @@ namespace MonoTouchFixtures.Foundation {
 				a.Add (a);
 				a.Add (obj2);
 				using (var s = a.Sort (Comparator)) {
-					Assert.That ((nuint) s.ValueAt (0), Is.GreaterThan ((nuint) s.ValueAt (1)), "0");
-					Assert.That ((nuint) s.ValueAt (1), Is.GreaterThan ((nuint) s.ValueAt (2)), "1");
+					Assert.That ((long) (IntPtr) s.ValueAt (0), Is.GreaterThan ((long) (IntPtr) s.ValueAt (1)), "0");
+					Assert.That ((long) (IntPtr) s.ValueAt (1), Is.GreaterThan ((long) (IntPtr) s.ValueAt (2)), "1");
 				}
 			}
 			Assert.That (comparator_count, Is.GreaterThanOrEqualTo (2), "2+");

--- a/tests/monotouch-test/Foundation/CookieTest.cs
+++ b/tests/monotouch-test/Foundation/CookieTest.cs
@@ -13,6 +13,10 @@ using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MonoTouchFixtures.Foundation {
 	
 	[TestFixture]
@@ -106,7 +110,7 @@ namespace MonoTouchFixtures.Foundation {
 			// an invalid NSDictionary returns null from Objective-C but that
 			// results in an 'empty' instance inside MonoTouch
 			using (var cookie = new NSHttpCookie (new Cookie ())) {
-				Assert.That (cookie.Handle, Is.EqualTo (IntPtr.Zero), "ctor");
+				Assert.That (cookie.Handle, Is.EqualTo (NativeHandle.Zero), "ctor");
 			}
 		}
 

--- a/tests/monotouch-test/Metal/DeviceTest.cs
+++ b/tests/monotouch-test/Metal/DeviceTest.cs
@@ -5,8 +5,13 @@ using System;
 
 using Foundation;
 using Metal;
+using ObjCRuntime;
 
 using NUnit.Framework;
+
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
 
 namespace MonoTouchFixtures.Metal {
 	
@@ -25,14 +30,14 @@ namespace MonoTouchFixtures.Metal {
 				Assert.Inconclusive ("Metal is not supported");
 
 			// if we get an instance it must be valid, i.e. not an empty wrapper
-			Assert.That (d.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+			Assert.That (d.Handle, Is.Not.EqualTo (NativeHandle.Zero), "Handle");
 
 			// and if we ask again we need to get a valid instance again
 			d.Dispose ();
-			Assert.That (d.Handle, Is.EqualTo (IntPtr.Zero), "Disposed");
+			Assert.That (d.Handle, Is.EqualTo (NativeHandle.Zero), "Disposed");
 
 			d = MTLDevice.SystemDefault;
-			Assert.That (d.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle-2");
+			Assert.That (d.Handle, Is.Not.EqualTo (NativeHandle.Zero), "Handle-2");
 		}
 	}
 }

--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -16,6 +16,10 @@ using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MonoTouchFixtures.ObjCRuntime {
 
 	[TestFixture]
@@ -37,7 +41,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Assert.Ignore ("This test requires the dynamic registrar to be available.");
 
 			using (var obj = new TestClass ()) {
-				TestClass.OnCallback = ((IntPtr blockArgument, IntPtr self, IntPtr argument) => 
+				TestClass.OnCallback = ((IntPtr blockArgument, NativeHandle self, IntPtr argument) => 
 					{
 						Assert.AreNotEqual (IntPtr.Zero, blockArgument, "block");
 						Assert.AreEqual (obj.Handle, self, "self");
@@ -49,14 +53,14 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		class TestClass : NSObject {
 			[MonoPInvokeCallback (typeof (TestBlockCallbackDelegate))]
-			static void TestBlockCallback (IntPtr block, IntPtr self, IntPtr argument)
+			static void TestBlockCallback (IntPtr block, NativeHandle self, IntPtr argument)
 			{
 				OnCallback (block, self, argument);
 			}
 
 			static TestBlockCallbackDelegate callback = new TestBlockCallbackDelegate (TestBlockCallback);
 
-			public delegate void TestBlockCallbackDelegate (IntPtr block, IntPtr self, IntPtr argument);
+			public delegate void TestBlockCallbackDelegate (IntPtr block, NativeHandle self, IntPtr argument);
 			public static TestBlockCallbackDelegate OnCallback;
 
 			static TestClass ()

--- a/tests/monotouch-test/ObjCRuntime/ClassTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ClassTest.cs
@@ -17,6 +17,10 @@ using Foundation;
 using ObjCRuntime;
 using NUnit.Framework;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MonoTouchFixtures.ObjCRuntime {
 	
 	[TestFixture]
@@ -55,7 +59,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		{
 			Assert.DoesNotThrow (() => new Class (typeof (NSObject)), "NSObject");
 			if (Runtime.DynamicRegistrationSupported) {
-				Assert.AreEqual (IntPtr.Zero, new Class (typeof (string)).Handle, "string");
+				Assert.AreEqual (NativeHandle.Zero, new Class (typeof (string)).Handle, "string");
 			} else {
 				try {
 					new Class (typeof (string));
@@ -69,9 +73,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void GetHandle ()
 		{
-			Assert.AreNotEqual (IntPtr.Zero, Class.GetHandle (typeof (NSObject)), "NSObject");
+			Assert.AreNotEqual (NativeHandle.Zero, Class.GetHandle (typeof (NSObject)), "NSObject");
 			if (Runtime.DynamicRegistrationSupported) {
-				Assert.AreEqual (IntPtr.Zero, Class.GetHandle (typeof (string)), "string 1");
+				Assert.AreEqual (NativeHandle.Zero, Class.GetHandle (typeof (string)), "string 1");
 			} else {
 				try {
 					Class.GetHandle (typeof (string));
@@ -80,9 +84,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 					Assert.AreEqual ("Can't register the class System.String when the dynamic registrar has been linked away.", e.Message, "exc message");
 				}
 			}
-			Assert.AreEqual (IntPtr.Zero, Class.GetHandle (typeof (NSObject).MakeByRefType ()), "NSObject&");
-			Assert.AreEqual (IntPtr.Zero, Class.GetHandle (typeof (NSObject).MakeArrayType ()), "NSObject[]");
-			Assert.AreEqual (IntPtr.Zero, Class.GetHandle (typeof (NSObject).MakePointerType ()), "NSObject*");
+			Assert.AreEqual (NativeHandle.Zero, Class.GetHandle (typeof (NSObject).MakeByRefType ()), "NSObject&");
+			Assert.AreEqual (NativeHandle.Zero, Class.GetHandle (typeof (NSObject).MakeArrayType ()), "NSObject[]");
+			Assert.AreEqual (NativeHandle.Zero, Class.GetHandle (typeof (NSObject).MakePointerType ()), "NSObject*");
 		}
 
 		[Test]
@@ -139,7 +143,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		[Register ("Inexistent", true)]
 		public class InexistentClass : NSObject {
-			public override IntPtr ClassHandle {
+			public override NativeHandle ClassHandle {
 				get {
 					return Class.GetHandle (GetType ().Name);
 				}

--- a/tests/monotouch-test/ObjCRuntime/Messaging.cs
+++ b/tests/monotouch-test/ObjCRuntime/Messaging.cs
@@ -12,6 +12,10 @@ using CoreGraphics;
 using Foundation;
 using OpenTK;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace ObjCRuntime
 {
 	public static class Messaging
@@ -232,6 +236,11 @@ namespace ObjCRuntime
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public extern static void void_objc_msgSend_int_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, int p1, ref IntPtr p2, out IntPtr p3);
+
+#if NET
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static void void_objc_msgSend_int_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, int p1, ref NativeHandle p2, out NativeHandle p3);
+#endif
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public extern static void void_objc_msgSend_int_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, int p1, IntPtr p2, IntPtr p3);

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -49,6 +49,10 @@ using CategoryAttribute = ObjCRuntime.CategoryAttribute;
 using XamarinTests.ObjCRuntime;
 using Xamarin.Utils;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MonoTouchFixtures.ObjCRuntime {
 
 	[TestFixture]
@@ -165,37 +169,37 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void TestINativeObject ()
 		{
-			IntPtr receiver = Class.GetHandle ("RegistrarTestClass");
-			IntPtr ptr;
+			var receiver = Class.GetHandle ("RegistrarTestClass");
+			NativeHandle ptr;
 			CGPath path;
 			
 			if ((CurrentRegistrar & Registrars.AllStatic) == 0)
 				Assert.Ignore ("This test only passes with the static registrars.");
 			
-			Assert.False (Messaging.bool_objc_msgSend_IntPtr (receiver, new Selector ("INativeObject1:").Handle, IntPtr.Zero), "#a1");
+			Assert.False (Messaging.bool_objc_msgSend_IntPtr (receiver, new Selector ("INativeObject1:").Handle, NativeHandle.Zero), "#a1");
 			Assert.True (Messaging.bool_objc_msgSend_IntPtr (receiver, new Selector ("INativeObject1:").Handle, new CGPath ().Handle), "#a2");
 			
-			Assert.That (Messaging.IntPtr_objc_msgSend_bool (receiver, new Selector ("INativeObject2:").Handle, false), Is.EqualTo (IntPtr.Zero), "#b1");
-			Assert.That (Messaging.IntPtr_objc_msgSend_bool (receiver, new Selector ("INativeObject2:").Handle, true), Is.Not.EqualTo (IntPtr.Zero), "#b2");
+			Assert.That ((NativeHandle) Messaging.IntPtr_objc_msgSend_bool (receiver, new Selector ("INativeObject2:").Handle, false), Is.EqualTo (NativeHandle.Zero), "#b1");
+			Assert.That ((NativeHandle) Messaging.IntPtr_objc_msgSend_bool (receiver, new Selector ("INativeObject2:").Handle, true), Is.Not.EqualTo (NativeHandle.Zero), "#b2");
 			
 			void_objc_msgSend_out_IntPtr_bool (receiver, new Selector ("INativeObject3:create:").Handle, out ptr, true);
-			Assert.That (ptr, Is.Not.EqualTo (IntPtr.Zero), "#c1");
+			Assert.That (ptr, Is.Not.EqualTo (NativeHandle.Zero), "#c1");
 			void_objc_msgSend_out_IntPtr_bool (receiver, new Selector ("INativeObject3:create:").Handle, out ptr, false);
-			Assert.That (ptr, Is.EqualTo (IntPtr.Zero), "#c2");
+			Assert.That (ptr, Is.EqualTo (NativeHandle.Zero), "#c2");
 			
 			path = null;
-			ptr = IntPtr.Zero;
+			ptr = NativeHandle.Zero;
 			Assert.False (bool_objc_msgSend_ref_intptr (receiver, new Selector ("INativeObject4:").Handle, ref ptr), "#d1");
-			Assert.That (ptr, Is.EqualTo (IntPtr.Zero), "#d2");
+			Assert.That (ptr, Is.EqualTo (NativeHandle.Zero), "#d2");
 			path = new CGPath ();
 			ptr = path.Handle;
 			Assert.True (bool_objc_msgSend_ref_intptr (receiver, new Selector ("INativeObject4:").Handle, ref ptr), "#d3");
 			Assert.That (ptr, Is.EqualTo (path.Handle), "#d4");
 			
 			ptr = Messaging.IntPtr_objc_msgSend_bool (receiver, new Selector ("INativeObject5:").Handle, false);
-			Assert.That (ptr, Is.EqualTo (IntPtr.Zero), "#e1");
+			Assert.That (ptr, Is.EqualTo (NativeHandle.Zero), "#e1");
 			ptr = Messaging.IntPtr_objc_msgSend_bool (receiver, new Selector ("INativeObject5:").Handle, true);
-			Assert.That (ptr, Is.Not.EqualTo (IntPtr.Zero), "#e2");
+			Assert.That (ptr, Is.Not.EqualTo (NativeHandle.Zero), "#e2");
 			path = Runtime.GetINativeObject<CGPath> (ptr, false);
 			path.AddArc (1, 2, 3, 4, 5, false); // this should crash if we get back a bogus ptr
 		}
@@ -220,9 +224,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		{
 			var obj = new RegistrarTestClass ();
 			var sel = new Selector ("testOutNSString:");
-			IntPtr ptr;
 
-			void_objc_msgSend_out_IntPtr (obj.Handle, sel.Handle, out ptr);
+			void_objc_msgSend_out_IntPtr (obj.Handle, sel.Handle, out var ptr);
 
 			Assert.AreEqual ("Santa is coming", NSString.FromHandle (ptr), "#santa");
 		}
@@ -245,7 +248,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			var obj = new RegistrarTestClass ();
 			var sel = new Selector ("testOutParametersWithStructs:in:out:");
 			NSError value = new NSError ();
-			IntPtr ptr;
+			NativeHandle ptr;
 			SizeF size = new CGSize (1, 2);
 
 			void_objc_msgSend_SizeF_IntPtr_out_IntPtr (obj.Handle, sel.Handle, size, value.Handle, out ptr);
@@ -696,19 +699,19 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		const string LIBOBJC_DYLIB = "/usr/lib/libobjc.dylib";
 		
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
-		extern static void void_objc_msgSend_out_IntPtr (IntPtr receiver, IntPtr selector, out IntPtr value);
+		extern static void void_objc_msgSend_out_IntPtr (IntPtr receiver, IntPtr selector, out NativeHandle value);
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
-		extern static void void_objc_msgSend_ref_IntPtr (IntPtr receiver, IntPtr selector, ref IntPtr value);
+		extern static void void_objc_msgSend_ref_IntPtr (IntPtr receiver, IntPtr selector, ref NativeHandle value);
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
-		extern static void void_objc_msgSend_out_IntPtr_bool (IntPtr receiver, IntPtr selector, out IntPtr path, bool create);
+		extern static void void_objc_msgSend_out_IntPtr_bool (IntPtr receiver, IntPtr selector, out NativeHandle path, bool create);
 		
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
-		extern static bool bool_objc_msgSend_ref_intptr (IntPtr receiver, IntPtr selector, ref IntPtr path);
+		extern static bool bool_objc_msgSend_ref_intptr (IntPtr receiver, IntPtr selector, ref NativeHandle path);
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
-		extern static void void_objc_msgSend_SizeF_IntPtr_out_IntPtr (IntPtr receiver, IntPtr selector, SizeF size, IntPtr input, out IntPtr value);
+		extern static void void_objc_msgSend_SizeF_IntPtr_out_IntPtr (IntPtr receiver, IntPtr selector, SizeF size, IntPtr input, out NativeHandle value);
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
 		extern static void void_objc_msgSend_ref_BlockLiteral (IntPtr receiver, IntPtr selector, ref BlockLiteral block);
@@ -1290,33 +1293,33 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void TestConstrainedGenericType ()
 		{
-			IntPtr value;
+			NativeHandle value;
 
 			using (var obj = new ConstrainedGenericType<NSSet> ()) {
 				using (var view = new NSSet ()) {
 					using (var nsobj = new NSObject ()) {
 						// m1
-						Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("m1:"), IntPtr.Zero);
+						Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("m1:"), NativeHandle.Zero);
 						Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("m1:"), view.Handle);
 						ThrowsICEIfDebug (() => Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("m1:"), nsobj.Handle), "m1: ICE");
 
 						// m2
-						value = IntPtr.Zero;
+						value = NativeHandle.Zero;
 						void_objc_msgSend_out_IntPtr (obj.Handle, Selector.GetHandle ("m2:"), out value);
-						Assert.AreEqual (IntPtr.Zero, value);
+						Assert.AreEqual (NativeHandle.Zero, value);
 
 						value = view.Handle;
 						void_objc_msgSend_out_IntPtr (obj.Handle, Selector.GetHandle ("m2:"), out value);
-						Assert.AreEqual (IntPtr.Zero, value);
+						Assert.AreEqual (NativeHandle.Zero, value);
 
-						value = new IntPtr ((unchecked ((int) 0xdeadbeef)));
+						value = (NativeHandle) new IntPtr ((unchecked ((int) 0xdeadbeef)));
 						void_objc_msgSend_out_IntPtr (obj.Handle, Selector.GetHandle ("m2:"), out value);
-						Assert.AreEqual (IntPtr.Zero, value);
+						Assert.AreEqual (NativeHandle.Zero, value);
 
 						// m3
-						value = IntPtr.Zero;
+						value = NativeHandle.Zero;
 						void_objc_msgSend_ref_IntPtr (obj.Handle, Selector.GetHandle ("m3:"), ref value);
-						Assert.AreEqual (IntPtr.Zero, value);
+						Assert.AreEqual (NativeHandle.Zero, value);
 
 						value = view.Handle;
 						void_objc_msgSend_ref_IntPtr (obj.Handle, Selector.GetHandle ("m3:"), ref value);
@@ -1326,7 +1329,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 						ThrowsICEIfDebug (() => void_objc_msgSend_ref_IntPtr (obj.Handle, Selector.GetHandle ("m3:"), ref value), "m3 ICE");
 
 						// m4
-						Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("m4:"), IntPtr.Zero);
+						Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("m4:"), NativeHandle.Zero);
 						ThrowsICEIfDebug (() => Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("m4:"), nsobj.Handle), "m4 ICE", false);
 						using (var arr = NSArray.FromNSObjects (nsobj)) {
 							ThrowsICEIfDebug (() => Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("m4:"), arr.Handle), "m4 ICE 2");
@@ -1337,20 +1340,20 @@ namespace MonoTouchFixtures.ObjCRuntime {
 						}
 
 						// r1
-						Assert.AreEqual (IntPtr.Zero, Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("r1")));
+						Assert.AreEqual (NativeHandle.Zero, (NativeHandle) Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("r1")));
 
 						// r2
-						Assert.AreEqual (IntPtr.Zero, Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("r2")));
+						Assert.AreEqual (NativeHandle.Zero, (NativeHandle) Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("r2")));
 
 						// p1
-						Assert.AreEqual (IntPtr.Zero, Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("p1")));
-						Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("setP1:"), IntPtr.Zero);
+						Assert.AreEqual (NativeHandle.Zero, (NativeHandle) Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("p1")));
+						Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("setP1:"), NativeHandle.Zero);
 						Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("setP1:"), view.Handle);
 						ThrowsICEIfDebug (() => Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("setP1:"), nsobj.Handle), "setP1: ICE");
 
 						// p2
-						Assert.AreEqual (IntPtr.Zero, Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("p2")));
-						Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("setP2:"), IntPtr.Zero);
+						Assert.AreEqual (NativeHandle.Zero, (NativeHandle) Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("p2")));
+						Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("setP2:"), NativeHandle.Zero);
 						ThrowsICEIfDebug (() => Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("setP2:"), nsobj.Handle), "setP2: ICE", false);
 
 						using (var arr = NSArray.FromNSObjects (nsobj)) {
@@ -1371,7 +1374,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		public void TestCopyWithZone ()
 		{
 			using (var cc = new CopyClass ()) {
-				Assert.AreEqual (cc.Handle, Messaging.IntPtr_objc_msgSend_IntPtr (cc.Handle, Selector.GetHandle ("copyWithZone:"), IntPtr.Zero), "a");
+				Assert.AreEqual (cc.Handle, (NativeHandle) Messaging.IntPtr_objc_msgSend_IntPtr (cc.Handle, Selector.GetHandle ("copyWithZone:"), NativeHandle.Zero), "a");
 				Assert.IsFalse (cc.had_zone.Value, "had_zone");
 			}
 		}
@@ -1729,7 +1732,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		[Register ("FakeType1")]
 		class FakeType1 : NSObject {
-			public FakeType1 (IntPtr ptr)
+			public FakeType1 (NativeHandle ptr)
 				: base (ptr)
 			{
 			}
@@ -1952,11 +1955,11 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			// Yet we've created these in btouch, so we need to define what they
 			// actually do (nothing at all).
 
-			Assert.AreEqual (IntPtr.Zero, Class.GetHandle ("TestProtocolRegister"));
+			Assert.AreEqual (NativeHandle.Zero, Class.GetHandle ("TestProtocolRegister"));
 
 			// However deriving from those nonsensical classes must do something
 			// (at the very least because anything else would be a breaking change).
-			Assert.AreNotEqual (IntPtr.Zero, Class.GetHandle ("DerivedTestProtocolRegister"));
+			Assert.AreNotEqual (NativeHandle.Zero, Class.GetHandle ("DerivedTestProtocolRegister"));
 		}
 
 		[Protocol]
@@ -1994,7 +1997,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		class E1 : NSObject {
-			protected E1 (IntPtr ptr) : base (ptr)
+			protected E1 (NativeHandle ptr) : base (ptr)
 			{
 			}
 
@@ -2012,7 +2015,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		class E2 : E1 {
 			public readonly int Value = 3;
 
-			protected E2 (IntPtr ptr) : base (ptr)
+			protected E2 (NativeHandle ptr) : base (ptr)
 			{
 			}
 
@@ -2029,7 +2032,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		class G1<T> : NSObject {
-			protected G1 (IntPtr ptr) : base (ptr)
+			protected G1 (NativeHandle ptr) : base (ptr)
 			{
 			}
 
@@ -2043,7 +2046,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		class G2 : G1<int> {
 			public readonly int Value = 3;
 
-			protected G2 (IntPtr ptr) : base (ptr)
+			protected G2 (NativeHandle ptr) : base (ptr)
 			{
 			}
 
@@ -2319,7 +2322,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		class ABPeoplePickerNavigationControllerDelegateImpl : ABPeoplePickerNavigationControllerDelegate
 		{
-			public IntPtr personHandle;
+			public NativeHandle personHandle;
 			public override void DidSelectPerson (ABPeoplePickerNavigationController peoplePicker, ABPerson selectedPerson)
 			{
 				personHandle = selectedPerson.Handle;
@@ -2420,10 +2423,10 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		public void SelectorReturnValue ()
 		{
 			using (var obj = new Bug34440Class ()) {
-				var ptr = Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("bug34440"));
+				var ptr = (IntPtr) Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("bug34440"));
 				Assert.AreEqual (Selector.GetHandle ("bug34440"), ptr, "selector");
 				ptr = Messaging.IntPtr_objc_msgSend (obj.Handle, Selector.GetHandle ("classReturn"));
-				Assert.AreEqual (Class.GetHandle (typeof (Bug34440Class)), ptr, "class");
+				Assert.AreEqual ((IntPtr) Class.GetHandle (typeof (Bug34440Class)), (IntPtr) ptr, "class");
 			}
 		}
 
@@ -2833,8 +2836,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void RefOutTest_CFBundle ()
 		{
-			IntPtr refValue = IntPtr.Zero;
-			IntPtr outValue = IntPtr.Zero;
+			var refValue = NativeHandle.Zero;
+			var outValue = NativeHandle.Zero;
 
 			using (var obj = new RefOutParametersSubclass ()) {
 				var sel = Selector.GetHandle ("testCFBundle:a:b:");
@@ -2864,15 +2867,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "CFBundle-1DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "CFBundle-1DA-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "CFBundle-1DA-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "CFBundle-1DA-out");
 
 				// direct managed
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "CFBundle-1DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "CFBundle-1DM-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "CFBundle-1DM-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "CFBundle-1DM-out");
 
 				/// 2: verify that refValue points to something
 				action = 2;
@@ -2898,14 +2901,14 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj.Handle, refValue, "CFBundle-2DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "CFBundle-2DA-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "CFBundle-2DA-out");
 
 				// direct managed
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj.Handle, refValue, "CFBundle-2DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "CFBundle-2DM-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "CFBundle-2DM-out");
 
 
 				/// 3 set both parameteres to the same pointer of a CFBundle
@@ -2951,32 +2954,32 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refObj = null; // set to null
 				outObj = null; // set to null
 				obj.TestCFBundle (action << 0, ref refObj, out outObj);
-				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "CFBundle-4A-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "CFBundle-4A-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refObj.Handle, "CFBundle-4A-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outObj.Handle, "CFBundle-4A-out");
 				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "CBundle-4A-ref-distinct");
 
 				// managed
 				refObj = null; // set to null
 				outObj = null; // set to null
 				obj.TestCFBundle (action << 8, ref refObj, out outObj);
-				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "CFBundle-4M-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "CFBundle-4M-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refObj.Handle, "CFBundle-4M-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outObj.Handle, "CFBundle-4M-out");
 				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "CBundle-4M-ref-distinct");
 
 				// direct native
-				refValue = IntPtr.Zero; // set to null
-				outValue = IntPtr.Zero; // set to null
+				refValue = NativeHandle.Zero; // set to null
+				outValue = NativeHandle.Zero; // set to null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreNotEqual (IntPtr.Zero, refValue, "CFBundle-4DA-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outValue, "CFBundle-4DA-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refValue, "CFBundle-4DA-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outValue, "CFBundle-4DA-out");
 				Assert.AreNotEqual (refValue, outValue, "CBundle-4DA-ref-distinct");
 
 				// direct managed
-				refValue = IntPtr.Zero; // set to null
-				outValue = IntPtr.Zero; // set to null
+				refValue = NativeHandle.Zero; // set to null
+				outValue = NativeHandle.Zero; // set to null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreNotEqual (IntPtr.Zero, refValue, "CFBundle-4DM-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outValue, "CFBundle-4DM-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refValue, "CFBundle-4DM-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outValue, "CFBundle-4DM-out");
 				Assert.AreNotEqual (refValue, outValue, "CBundle-4DM-ref-distinct");
 			}
 		}
@@ -2984,8 +2987,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void RefOutTest_INSCoding ()
 		{
-			IntPtr refValue = IntPtr.Zero;
-			IntPtr outValue = IntPtr.Zero;
+			var refValue = NativeHandle.Zero;
+			var outValue = NativeHandle.Zero;
 
 			using (var obj = new RefOutParametersSubclass ()) {
 				var sel = Selector.GetHandle ("testINSCoding:a:b:");
@@ -3015,15 +3018,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "NSCoding-1DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSCoding-1DA-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "NSCoding-1DA-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSCoding-1DA-out");
 
 				// direct managed
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "NSCoding-1DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSCoding-1DM-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "NSCoding-1DM-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSCoding-1DM-out");
 
 				/// 2: verify that refValue points to something
 				action = 2;
@@ -3049,14 +3052,14 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj.Handle, refValue, "NSCoding-2DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSCoding-2DA-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSCoding-2DA-out");
 
 				// direct managed
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj.Handle, refValue, "NSCoding-2DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSCoding-2DM-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSCoding-2DM-out");
 
 
 				/// 3 set both parameteres to the same pointer of a NSCoding
@@ -3116,8 +3119,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refObj = null; // set to null
 				outObj = null; // set to null
 				obj.TestINSCoding (action << 0, ref refObj, out outObj);
-				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSCoding-4A-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSCoding-4A-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refObj.Handle, "NSCoding-4A-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outObj.Handle, "NSCoding-4A-out");
 				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSCoding-4A-ref-distinct");
 				Assert.That (refObj.GetType ().FullName, Does.Contain ("CodingWrapper"), "NSCoding-4A-ref-wrapper-type");
 				Assert.That (outObj.GetType ().FullName, Does.Contain ("CodingWrapper"), "NSCoding-4A-ref-wrapper-type");
@@ -3126,28 +3129,28 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refObj = null; // set to null
 				outObj = null; // set to null
 				obj.TestINSCoding (action << 8, ref refObj, out outObj);
-				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSCoding-4M-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSCoding-4M-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refObj.Handle, "NSCoding-4M-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outObj.Handle, "NSCoding-4M-out");
 				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSCoding-4M-ref-distinct");
 				Assert.That (refObj, Is.TypeOf<NSString> (), "NSCoding-4M-ref-wrapper-type");
 				Assert.That (outObj, Is.TypeOf<NSString> (), "NSCoding-4M-ref-wrapper-type");
 
 				// direct native
-				refValue = IntPtr.Zero; // set to null
-				outValue = IntPtr.Zero; // set to null
+				refValue = NativeHandle.Zero; // set to null
+				outValue = NativeHandle.Zero; // set to null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSCoding-4DA-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSCoding-4DA-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refValue, "NSCoding-4DA-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outValue, "NSCoding-4DA-out");
 				Assert.AreNotEqual (refValue, outValue, "NSCoding-4DA-ref-distinct");
 				Assert.That (refObj, Is.TypeOf<NSString> (), "NSCoding-4DA-ref-wrapper-type");
 				Assert.That (outObj, Is.TypeOf<NSString> (), "NSCoding-4DA-ref-wrapper-type");
 
 				// direct managed
-				refValue = IntPtr.Zero; // set to null
-				outValue = IntPtr.Zero; // set to null
+				refValue = NativeHandle.Zero; // set to null
+				outValue = NativeHandle.Zero; // set to null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSCoding-4DM-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSCoding-4DM-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refValue, "NSCoding-4DM-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outValue, "NSCoding-4DM-out");
 				Assert.AreNotEqual (refValue, outValue, "NSCoding-4DM-ref-distinct");
 				Assert.That (refObj, Is.TypeOf<NSString> (), "NSCoding-4DM-ref-wrapper-type");
 				Assert.That (outObj, Is.TypeOf<NSString> (), "NSCoding-4DM-ref-wrapper-type");
@@ -3157,8 +3160,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void RefOutTest_NSObject ()
 		{
-			IntPtr refValue = IntPtr.Zero;
-			IntPtr outValue = IntPtr.Zero;
+			var refValue = NativeHandle.Zero;
+			var outValue = NativeHandle.Zero;
 
 			using (var obj = new RefOutParametersSubclass ()) {
 				var sel = Selector.GetHandle ("testNSObject:a:b:");
@@ -3188,15 +3191,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "NSObject-1DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSObject-1DA-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "NSObject-1DA-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSObject-1DA-out");
 
 				// direct managed
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "NSObject-1DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSObject-1DM-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "NSObject-1DM-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSObject-1DM-out");
 
 				/// 2: verify that refValue points to something
 				action = 2;
@@ -3222,14 +3225,14 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj.Handle, refValue, "NSObject-2DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSObject-2DA-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSObject-2DA-out");
 
 				// direct managed
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj.Handle, refValue, "NSObject-2DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSObject-2DM-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSObject-2DM-out");
 
 
 				/// 3 set both parameteres to the same pointer of a NSObject
@@ -3283,8 +3286,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refObj = null; // set to null
 				outObj = null; // set to null
 				obj.TestNSObject (action << 0, ref refObj, out outObj);
-				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSObject-4A-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSObject-4A-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refObj.Handle, "NSObject-4A-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outObj.Handle, "NSObject-4A-out");
 				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSObject-4A-ref-distinct");
 				Assert.That (refObj, Is.TypeOf<NSObject> (), "NSObject-4A-ref-wrapper-type");
 				Assert.That (outObj, Is.TypeOf<NSObject> (), "NSObject-4A-ref-wrapper-type");
@@ -3293,28 +3296,28 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refObj = null; // set to null
 				outObj = null; // set to null
 				obj.TestNSObject (action << 8, ref refObj, out outObj);
-				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSObject-4M-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSObject-4M-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refObj.Handle, "NSObject-4M-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outObj.Handle, "NSObject-4M-out");
 				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSObject-4M-ref-distinct");
 				Assert.That (refObj, Is.TypeOf<NSObject> (), "NSObject-4M-ref-wrapper-type");
 				Assert.That (outObj, Is.TypeOf<NSObject> (), "NSObject-4M-ref-wrapper-type");
 
 				// direct native
-				refValue = IntPtr.Zero; // set to null
-				outValue = IntPtr.Zero; // set to null
+				refValue = NativeHandle.Zero; // set to null
+				outValue = NativeHandle.Zero; // set to null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSObject-4DA-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSObject-4DA-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refValue, "NSObject-4DA-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outValue, "NSObject-4DA-out");
 				Assert.AreNotEqual (refValue, outValue, "NSObject-4DA-ref-distinct");
 				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSObject> (), "NSObject-4DA-ref-wrapper-type");
 				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSObject> (), "NSObject-4DA-ref-wrapper-type");
 
 				// direct managed
-				refValue = IntPtr.Zero; // set to null
-				outValue = IntPtr.Zero; // set to null
+				refValue = NativeHandle.Zero; // set to null
+				outValue = NativeHandle.Zero; // set to null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSObject-4DM-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSObject-4DM-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refValue, "NSObject-4DM-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outValue, "NSObject-4DM-out");
 				Assert.AreNotEqual (refValue, outValue, "NSObject-4DM-ref-distinct");
 				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSObject> (), "NSObject-4DM-ref-wrapper-type");
 				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSObject> (), "NSObject-4DM-ref-wrapper-type");
@@ -3324,8 +3327,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void RefOutTest_NSValue ()
 		{
-			IntPtr refValue = IntPtr.Zero;
-			IntPtr outValue = IntPtr.Zero;
+			var refValue = NativeHandle.Zero;
+			var outValue = NativeHandle.Zero;
 
 			using (var obj = new RefOutParametersSubclass ()) {
 				var sel = Selector.GetHandle ("testNSValue:a:b:");
@@ -3355,15 +3358,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "NSValue-1DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSValue-1DA-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "NSValue-1DA-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSValue-1DA-out");
 
 				// direct managed
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "NSValue-1DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSValue-1DM-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "NSValue-1DM-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSValue-1DM-out");
 
 				/// 2: verify that refValue points to something
 				action = 2;
@@ -3389,14 +3392,14 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj.Handle, refValue, "NSValue-2DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSValue-2DA-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSValue-2DA-out");
 
 				// direct managed
 				refValue = dummyObj.Handle; // set to non-null
 				outValue = dummyObj.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj.Handle, refValue, "NSValue-2DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSValue-2DM-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSValue-2DM-out");
 
 
 				/// 3 set both parameteres to the same pointer of a NSValue
@@ -3450,8 +3453,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refObj = null; // set to null
 				outObj = null; // set to null
 				obj.TestValue (action << 0, ref refObj, out outObj);
-				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSValue-4A-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSValue-4A-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refObj.Handle, "NSValue-4A-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outObj.Handle, "NSValue-4A-out");
 				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSValue-4A-ref-distinct");
 				Assert.That (refObj, Is.TypeOf<NSValue> (), "NSValue-4A-ref-wrapper-type");
 				Assert.That (outObj, Is.TypeOf<NSValue> (), "NSValue-4A-ref-wrapper-type");
@@ -3460,28 +3463,28 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refObj = null; // set to null
 				outObj = null; // set to null
 				obj.TestValue (action << 8, ref refObj, out outObj);
-				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSValue-4M-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSValue-4M-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refObj.Handle, "NSValue-4M-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outObj.Handle, "NSValue-4M-out");
 				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSValue-4M-ref-distinct");
 				Assert.That (refObj, Is.TypeOf<NSValue> (), "NSValue-4M-ref-wrapper-type");
 				Assert.That (outObj, Is.TypeOf<NSValue> (), "NSValue-4M-ref-wrapper-type");
 
 				// direct native
-				refValue = IntPtr.Zero; // set to null
-				outValue = IntPtr.Zero; // set to null
+				refValue = NativeHandle.Zero; // set to null
+				outValue = NativeHandle.Zero; // set to null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSValue-4DA-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSValue-4DA-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refValue, "NSValue-4DA-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outValue, "NSValue-4DA-out");
 				Assert.AreNotEqual (refValue, outValue, "NSValue-4DA-ref-distinct");
 				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSValue> (), "NSValue-4DA-ref-wrapper-type");
 				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSValue> (), "NSValue-4DA-ref-wrapper-type");
 
 				// direct managed
-				refValue = IntPtr.Zero; // set to null
-				outValue = IntPtr.Zero; // set to null
+				refValue = NativeHandle.Zero; // set to null
+				outValue = NativeHandle.Zero; // set to null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSValue-4DM-ref");
-				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSValue-4DM-out");
+				Assert.AreNotEqual (NativeHandle.Zero, refValue, "NSValue-4DM-ref");
+				Assert.AreNotEqual (NativeHandle.Zero, outValue, "NSValue-4DM-out");
 				Assert.AreNotEqual (refValue, outValue, "NSValue-4DM-ref-distinct");
 				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSValue> (), "NSValue-4DM-ref-wrapper-type");
 				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSValue> (), "NSValue-4DM-ref-wrapper-type");
@@ -3491,8 +3494,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void RefOutTest_String ()
 		{
-			IntPtr refValue = IntPtr.Zero;
-			IntPtr outValue = IntPtr.Zero;
+			var refValue = NativeHandle.Zero;
+			var outValue = NativeHandle.Zero;
 
 			using (var obj = new RefOutParametersSubclass ()) {
 				var sel = Selector.GetHandle ("testString:a:b:");
@@ -3523,15 +3526,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refValue = dummyObjHandle; // set to non-null
 				outValue = dummyObjHandle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "String-1DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "String-1DA-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "String-1DA-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "String-1DA-out");
 
 				// direct managed
 				refValue = dummyObjHandle; // set to non-null
 				outValue = dummyObjHandle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "String-1DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "String-1DM-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "String-1DM-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "String-1DM-out");
 
 				/// 2: verify that refValue points to something
 				action = 2;
@@ -3555,14 +3558,14 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				outValue = dummyObjHandle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj, NSString.FromHandle (refValue), "String-2DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "String-2DA-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "String-2DA-out");
 
 				// direct managed
 				refValue = dummyObjHandle; // set to non-null
 				outValue = dummyObjHandle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj, NSString.FromHandle (refValue), "String-2DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "String-2DM-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "String-2DM-out");
 
 
 				/// 3 set both parameteres to the same pointer of a String
@@ -3755,8 +3758,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void RefOutTest_Sel ()
 		{
-			IntPtr refValue = IntPtr.Zero;
-			IntPtr outValue = IntPtr.Zero;
+			var refValue = IntPtr.Zero;
+			var outValue = IntPtr.Zero;
 
 			using (var obj = new RefOutParametersSubclass ()) {
 				var sel = Selector.GetHandle ("testSelector:a:b:");
@@ -3823,14 +3826,14 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refValue = dummyObjHandle; // set to non-null
 				outValue = dummyObjHandle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreEqual (dummyObj.Handle, refValue, "Selector-2DA-ref");
+				Assert.AreEqual ((IntPtr) dummyObj.Handle, refValue, "Selector-2DA-ref");
 				Assert.AreEqual (IntPtr.Zero, outValue, "Selector-2DA-out");
 
 				// direct managed
 				refValue = dummyObjHandle; // set to non-null
 				outValue = dummyObjHandle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreEqual (dummyObj.Handle, refValue, "Selector-2DM-ref");
+				Assert.AreEqual ((IntPtr) dummyObj.Handle, refValue, "Selector-2DM-ref");
 				Assert.AreEqual (IntPtr.Zero, outValue, "Selector-2DM-out");
 
 
@@ -3841,15 +3844,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refObj = dummyObj; // set to non-null
 				outObj = dummyObj; // set to non-null
 				test (action << 0, ref refObj, out outObj);
-				Assert.AreEqual (Selector.GetHandle ("testSelector"), refObj.Handle, "Selector-3A-ref");
-				Assert.AreEqual (Selector.GetHandle ("testSelector"), outObj.Handle, "Selector-3A-out");
+				Assert.AreEqual (Selector.GetHandle ("testSelector"), (IntPtr) refObj.Handle, "Selector-3A-ref");
+				Assert.AreEqual (Selector.GetHandle ("testSelector"), (IntPtr) outObj.Handle, "Selector-3A-out");
 
 				// managed
 				refObj = dummyObj; // set to non-null
 				outObj = dummyObj; // set to non-null
 				test (action << 8, ref refObj, out outObj);
-				Assert.AreEqual (Selector.GetHandle ("testManagedSelector"), refObj.Handle, "Selector-3M-ref");
-				Assert.AreEqual (Selector.GetHandle ("testManagedSelector"), outObj.Handle, "Selector-3M-out");
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelector"), (IntPtr) refObj.Handle, "Selector-3M-ref");
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelector"), (IntPtr) outObj.Handle, "Selector-3M-out");
 
 				// direct native
 				refValue = dummyObjHandle; // set to non-null
@@ -3875,15 +3878,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refObj = null; // set to null
 				outObj = null; // set to null
 				test (action << 0, ref refObj, out outObj);
-				Assert.AreEqual (Selector.GetHandle ("testSelector:a:"), refObj.Handle, "Selector-4A-ref-value");
-				Assert.AreEqual (Selector.GetHandle ("testSelector:b:"), outObj.Handle, "Selector-4A-out-value");
+				Assert.AreEqual (Selector.GetHandle ("testSelector:a:"), (IntPtr) refObj.Handle, "Selector-4A-ref-value");
+				Assert.AreEqual (Selector.GetHandle ("testSelector:b:"), (IntPtr) outObj.Handle, "Selector-4A-out-value");
 
 				// managed
 				refObj = null; // set to null
 				outObj = null; // set to null
 				test (action << 8, ref refObj, out outObj);
-				Assert.AreEqual (Selector.GetHandle ("testManagedSelectorA"), refObj.Handle, "Selector-4M-ref-value");
-				Assert.AreEqual (Selector.GetHandle ("testManagedSelectorB"), outObj.Handle, "Selector-4M-out-value");
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelectorA"), (IntPtr) refObj.Handle, "Selector-4M-ref-value");
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelectorB"), (IntPtr) outObj.Handle, "Selector-4M-out-value");
 
 				// direct native
 				refValue = IntPtr.Zero; // set to null
@@ -3904,8 +3907,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void RefOutTest_Class ()
 		{
-			IntPtr refValue = IntPtr.Zero;
-			IntPtr outValue = IntPtr.Zero;
+			var refValue = NativeHandle.Zero;
+			var outValue = NativeHandle.Zero;
 
 			using (var obj = new RefOutParametersSubclass ()) {
 				var sel = Selector.GetHandle ("testClass:a:b:");
@@ -3937,15 +3940,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refValue = dummyObjHandle; // set to non-null
 				outValue = dummyObjHandle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "Class-1DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "Class-1DA-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "Class-1DA-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "Class-1DA-out");
 
 				// direct managed
 				refValue = dummyObjHandle; // set to non-null
 				outValue = dummyObjHandle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "Class-1DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "Class-1DM-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "Class-1DM-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "Class-1DM-out");
 
 				/// 2: verify that refValue points to something
 				action = 2;
@@ -3969,14 +3972,14 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				outValue = dummyObjHandle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj.Handle, refValue, "Class-2DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "Class-2DA-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "Class-2DA-out");
 
 				// direct managed
 				refValue = dummyObjHandle; // set to non-null
 				outValue = dummyObjHandle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
 				Assert.AreEqual (dummyObj.Handle, refValue, "Class-2DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "Class-2DM-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "Class-2DM-out");
 
 
 				/// 3 set both parameteres to the same Class
@@ -4565,8 +4568,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public unsafe void RefOutTest_StringArray ()
 		{
-			IntPtr refValue = IntPtr.Zero;
-			IntPtr outValue = IntPtr.Zero;
+			var refValue = NativeHandle.Zero;
+			var outValue = NativeHandle.Zero;
 
 			using (var obj = new RefOutParametersSubclass ()) {
 				var sel = Selector.GetHandle ("testStringArray:a:b:");
@@ -4598,15 +4601,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refValue = dummyArray.Handle; // set to non-null
 				outValue = dummyArray.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "NSStringArray-1DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSStringArray-1DA-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "NSStringArray-1DA-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSStringArray-1DA-out");
 
 				// direct managed
 				refValue = dummyArray.Handle; // set to non-null
 				outValue = dummyArray.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "NSStringArray-1DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSStringArray-1DM-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "NSStringArray-1DM-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSStringArray-1DM-out");
 
 				/// 2: verify that refValue points to something
 				action = 2;
@@ -4633,7 +4636,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
 				Assert.That (dummyObj, Is.EquivalentTo (NSArray.StringArrayFromHandle (refValue)), "NSStringArray-2DA-ref");
 				Assert.AreEqual (dummyArray.Handle, refValue, "NSStringArray-2DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSStringArray-2DA-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSStringArray-2DA-out");
 
 				// direct managed
 				refValue = dummyArray.Handle; // set to non-null
@@ -4641,7 +4644,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
 				Assert.That (dummyObj, Is.EquivalentTo (NSArray.StringArrayFromHandle (refValue)), "NSStringArray-2DM-ref");
 				Assert.AreEqual (dummyArray.Handle, refValue, "NSStringArray-2DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSStringArray-2DM-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSStringArray-2DM-out");
 
 
 				/// 3 set both parameters to the same pointer of an NSStringArray array
@@ -4750,8 +4753,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public unsafe void RefOutTest_ClassArray ()
 		{
-			IntPtr refValue = IntPtr.Zero;
-			IntPtr outValue = IntPtr.Zero;
+			var refValue = NativeHandle.Zero;
+			var outValue = NativeHandle.Zero;
 
 			using (var obj = new RefOutParametersSubclass ()) {
 				var sel = Selector.GetHandle ("testClassArray:a:b:");
@@ -4783,15 +4786,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				refValue = dummyArray.Handle; // set to non-null
 				outValue = dummyArray.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "NSClassArray-1DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSClassArray-1DA-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "NSClassArray-1DA-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSClassArray-1DA-out");
 
 				// direct managed
 				refValue = dummyArray.Handle; // set to non-null
 				outValue = dummyArray.Handle; // set to non-null
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
-				Assert.AreEqual (IntPtr.Zero, refValue, "NSClassArray-1DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSClassArray-1DM-out");
+				Assert.AreEqual (NativeHandle.Zero, refValue, "NSClassArray-1DM-ref");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSClassArray-1DM-out");
 
 				/// 2: verify that refValue points to something
 				action = 2;
@@ -4818,7 +4821,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
 				Assert.That (dummyObj, Is.EquivalentTo (NSArray.ArrayFromHandle<Class> (refValue)), "NSClassArray-2DA-ref");
 				Assert.AreEqual (dummyArray.Handle, refValue, "NSClassArray-2DA-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSClassArray-2DA-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSClassArray-2DA-out");
 
 				// direct managed
 				refValue = dummyArray.Handle; // set to non-null
@@ -4826,7 +4829,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
 				Assert.That (dummyObj, Is.EquivalentTo (NSArray.ArrayFromHandle<Class> (refValue)), "NSClassArray-2DM-ref");
 				Assert.AreEqual (dummyArray.Handle, refValue, "NSClassArray-2DM-ref");
-				Assert.AreEqual (IntPtr.Zero, outValue, "NSClassArray-2DM-out");
+				Assert.AreEqual (NativeHandle.Zero, outValue, "NSClassArray-2DM-out");
 
 
 				/// 3 set both parameters to the same pointer of an Class array

--- a/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
+++ b/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
@@ -9,6 +9,10 @@ using Photos;
 using CoreGraphics;
 using NUnit.Framework;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MonoTouchFixtures.Photos {
 
 	[TestFixture]
@@ -29,7 +33,7 @@ namespace MonoTouchFixtures.Photos {
 			return null;
 		};
 
-		delegate IntPtr DPHLivePhotoFrameProcessingBlock2 (IntPtr block, IntPtr frame, ref IntPtr error);
+		delegate NativeHandle DPHLivePhotoFrameProcessingBlock2 (IntPtr block, NativeHandle frame, ref NativeHandle error);
 
 #if !MONOMAC
 		// on macOS `initWithLivePhotoEditingInput:` returns `nil` and we throw
@@ -66,13 +70,13 @@ namespace MonoTouchFixtures.Photos {
 				var b = (IntPtr) block;
 
 				// simulate a call that does not produce an error
-				var args = new object [] { b, IntPtr.Zero, IntPtr.Zero };
+				var args = new object [] { b, NativeHandle.Zero, NativeHandle.Zero };
 				error_faker = null;
-				Assert.That (m.Invoke (null, args), Is.EqualTo (IntPtr.Zero), "1");
+				Assert.That (m.Invoke (null, args), Is.EqualTo (NativeHandle.Zero), "1");
 
 				// simulate a call that does produce an error
 				error_faker = new NSError ((NSString) "domain", 42);
-				Assert.That (m.Invoke (null, args), Is.EqualTo (IntPtr.Zero), "2");
+				Assert.That (m.Invoke (null, args), Is.EqualTo (NativeHandle.Zero), "2");
 				Assert.That (args [2], Is.EqualTo (error_faker.Handle), "error");
 			}
 			finally {

--- a/tests/monotouch-test/ScriptingBridge/SBApplicationTest.cs
+++ b/tests/monotouch-test/ScriptingBridge/SBApplicationTest.cs
@@ -7,6 +7,10 @@ using ObjCRuntime;
 using Foundation;
 using ScriptingBridge;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace Xamarin.Mac.Tests {
 
 	public class MySBApp : SBApplication {
@@ -22,7 +26,7 @@ namespace Xamarin.Mac.Tests {
 
 		protected MySBApp (NSObjectFlag t) : base (t) { }
 
-		protected internal MySBApp (IntPtr handle) : base (handle) { }
+		protected internal MySBApp (NativeHandle handle) : base (handle) { }
 	}
 
 	[TestFixture]

--- a/tests/monotouch-test/UIKit/FontTest.cs
+++ b/tests/monotouch-test/UIKit/FontTest.cs
@@ -8,6 +8,10 @@ using UIKit;
 using ObjCRuntime;
 using NUnit.Framework;
 
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
 namespace MonoTouchFixtures.UIKit {
 	
 	[TestFixture]
@@ -64,9 +68,9 @@ namespace MonoTouchFixtures.UIKit {
 				// IEquatable<NSObject> is only in unified - otherwise it would be the same call as above
 				Assert.True (f1.Equals (f2), "{0} Equals", api);
 			}
-			Assert.That (f1.Handle, Is.EqualTo (IntPtr.Zero), "{0} 1", api);
+			Assert.That (f1.Handle, Is.EqualTo (NativeHandle.Zero), "{0} 1", api);
 			// without our "fix" that would be the same managed instance (as f1) and the handle would be nil
-			Assert.That (f2.Handle, Is.Not.EqualTo (IntPtr.Zero), "{0} 2", api);
+			Assert.That (f2.Handle, Is.Not.EqualTo (NativeHandle.Zero), "{0} 2", api);
 		}
 
 		[Test]

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3194,8 +3194,13 @@ namespace Registrar {
 					continue;
 				if (method.Parameters.Count != 2)
 					continue;
-				if (!method.Parameters [0].ParameterType.Is ("System", "IntPtr"))
-					continue;
+				if (Driver.IsDotNet) {
+					if (!method.Parameters [0].ParameterType.Is ("ObjCRuntime", "NativeHandle"))
+						continue;
+				} else {
+					if (!method.Parameters [0].ParameterType.Is ("System", "IntPtr"))
+						continue;
+				}
 				if (method.Parameters [1].ParameterType.Is ("System", "Boolean"))
 					return true;
 			}

--- a/tools/linker/MarkNSObjects.cs
+++ b/tools/linker/MarkNSObjects.cs
@@ -126,7 +126,11 @@ namespace Xamarin.Linker.Steps {
 				if (!constructor.HasParameters)
 					continue;
 
+#if NET
+				if (constructor.Parameters.Count != 1 || !constructor.Parameters [0].ParameterType.Is ("ObjCRuntime", "NativeHandle"))
+#else
 				if (constructor.Parameters.Count != 1 || !constructor.Parameters [0].ParameterType.Is ("System", "IntPtr"))
+#endif
 					continue;
 
 				Annotations.AddPreservedMethod (type, constructor);


### PR DESCRIPTION
Add a new struct, ObjCRuntime.NativeHandle, which will be used to represent
native handles for .NET (instead of using IntPtr). The main purpose is to be
able to use 'nint' as a number in API while not being prevented from using
native handles as well.

One example is NSMutableString, which has a constructor that takes a single
'nint capacity' parameter. With this change, we'll also be able to have a
constructor that takes a native handle in .NET - otherwise we'd have two
constructors with the same signature, because a C# 'nint' is just an 'IntPtr'.

This change required numerous changes pretty much everywhere. The work is
split up in commits as well as I was able to, and each commit explains what it
does.

Fixes https://github.com/xamarin/xamarin-macios/issues/13126.

This pull request is best reviewed commit-by-commit, with a cup of ☕️ or 🫖 in
hand, and a good chunk of free time.