### PR TITLE
[tests] Automatically run/exit tests executed from the command line.

### DIFF
--- a/tests/common/shared-dotnet.mk
+++ b/tests/common/shared-dotnet.mk
@@ -33,7 +33,7 @@ run: prepare
 	$(Q) $(DOTNET6) build "/bl:$@-$(BINLOG_TIMESTAMP).binlog" *.?sproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS) -t:Run
 
 run-bare:
-	$(Q) ./bin/Debug/net6.0-*/*/"$(TESTNAME)".app/Contents/MacOS/"$(TESTNAME)"
+	$(Q) ./bin/Debug/net6.0-*/*/"$(TESTNAME)".app/Contents/MacOS/"$(TESTNAME)" --autostart --autoexit
 
 BINLOGS:=$(wildcard *.binlog)
 diag: prepare


### PR DESCRIPTION
This is already the default for macOS apps, but this way it behaves the same
for Mac Catalyst as well.