### PR TITLE
[mtouch] Remove duplicated source file from project file.

### DIFF
--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -462,9 +462,6 @@
     <Compile Include="..\linker\CustomSymbolWriter.cs">
       <Link>tools\linker\CustomSymbolWriter.cs</Link>
     </Compile>
-    <Compile Include="Errors.Designer.cs">
-      <DependentUpon>Errors.resx</DependentUpon>
-    </Compile>
     <Compile Include="..\linker\ScanTypeReferenceStep.cs">
       <Link>tools\linker\ScanTypeReferenceStep.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes:

> CSC : warning CS2002: Source file '.../xamarin-macios/tools/mtouch/Errors.Designer.cs' specified multiple times [.../xamarin-macios/tools/mtouch/mtouch.csproj]