### PR TITLE
[tests] Don't import nunit.frameworks.target more than once.

### DIFF
--- a/tests/fsharp/dotnet/shared.fsproj
+++ b/tests/fsharp/dotnet/shared.fsproj
@@ -31,6 +31,4 @@
     <Compile Include="$(RootTestsDirectory)/common/mac/MacMain.fs" Condition="$(TargetFramework.EndsWith('-macos'))" />
     <Compile Include="$(FSharpTestDirectory)/Main.fs" Condition="!$(TargetFramework.EndsWith('-macos'))" />
   </ItemGroup>
-
-  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 </Project>

--- a/tests/interdependent-binding-projects/dotnet/shared.csproj
+++ b/tests/interdependent-binding-projects/dotnet/shared.csproj
@@ -21,7 +21,6 @@
   </PropertyGroup>
 
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
-  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 
   <ItemGroup>
     <ProjectReference Include="$(RootTestsDirectory)\bindings-test\dotnet\$(_PlatformName)\bindings-test.csproj" />

--- a/tests/introspection/dotnet/shared.csproj
+++ b/tests/introspection/dotnet/shared.csproj
@@ -19,7 +19,6 @@
   </PropertyGroup>
 
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
-  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 
   <ItemGroup Condition="$(TargetFramework.EndsWith('-macos'))">
     <Compile Include="$(IntrospectionTestDirectory)\Mac\MacApiCtorInitTest.cs" />

--- a/tests/linker/ios/dont link/dotnet/shared.csproj
+++ b/tests/linker/ios/dont link/dotnet/shared.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
-  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 
   <ItemGroup>
     <ProjectReference Include="$(RootTestsDirectory)\BundledResources\dotnet\$(_PlatformName)\BundledResources.csproj" />

--- a/tests/linker/ios/link all/dotnet/shared.csproj
+++ b/tests/linker/ios/link all/dotnet/shared.csproj
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
-  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 
   <!-- We use configurations like Debug64 and Release64, which doesn't work with the default logic we and .NET have -->
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">

--- a/tests/linker/ios/link sdk/dotnet/shared.csproj
+++ b/tests/linker/ios/link sdk/dotnet/shared.csproj
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
-  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 
   <ItemGroup>
     <Reference Include="support">

--- a/tests/monotouch-test/dotnet/shared.csproj
+++ b/tests/monotouch-test/dotnet/shared.csproj
@@ -205,6 +205,4 @@
       <DefineConstants Condition="'$(ComputedPlatform)' == 'iPhone'">$(DefineConstants);AOT</DefineConstants>
     </PropertyGroup>
   </Target>
-
-  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 </Project>

--- a/tests/xcframework-test/dotnet/shared.csproj
+++ b/tests/xcframework-test/dotnet/shared.csproj
@@ -33,6 +33,4 @@
     <Compile Include="$(FrameworkTestDirectory)\iOS\XCFrameworkTests.cs" />
     <Compile Include="$(RootTestsDirectory)\common\mac\MacMain.cs" Condition="$(TargetFramework.EndsWith('-macos'))" Link="MacMain.cs" />
   </ItemGroup>
-
-  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 </Project>


### PR DESCRIPTION
The nunit.framework.targets file is already imported in the
tests/common/shared-dotnet.targets file, which all these files imports as
well.