### PR TITLE
[CoreAnimation] Make CAGradientLayer.CreateColor private in .NET.

### DIFF
--- a/src/CoreAnimation/CADefs.cs
+++ b/src/CoreAnimation/CADefs.cs
@@ -46,7 +46,11 @@ namespace CoreAnimation {
 	}
 
 	public partial class CAGradientLayer {
+#if NET
+		CGColor CreateColor (IntPtr p)
+#else
 		public CGColor CreateColor (IntPtr p)
+#endif
 		{
 			return new CGColor (p);
 		}


### PR DESCRIPTION
I see no reason for this method to be public.