### PR TITLE
[msbuild] Don't sign the prebuilt hotrestart app with a specific certificate.

### DIFF
--- a/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
@@ -11,6 +11,8 @@
     <_LinkMode>None</_LinkMode>
     <UseInterpreter>true</UseInterpreter>
     <MtouchExtraArgs>--registrar:dynamic</MtouchExtraArgs>
+    <!-- this app will be re-signed during the build on customers' machines, so no need to sign it here -->
+    <EnableCodeSigning>false</EnableCodeSigning>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.iOS.HotRestart.Application" Version="1.1.2" />

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -581,6 +581,16 @@ namespace Xamarin.MacDev.Tasks
 
 					return !Log.HasLoggedErrors;
 				}
+
+				if (!SdkIsSimulator && !RequireCodeSigning) {
+					// The "-" key is a special value allowed by the codesign utility that
+					// allows us to get away with not having an actual codesign key.
+					DetectedCodeSigningKey = "-";
+
+					ReportDetectedCodesignInfo ();
+
+					return !Log.HasLoggedErrors;
+				}
 			}
 
 			// Note: if we make it this far, we absolutely need a codesigning certificate

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -137,8 +137,12 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 	<!-- RequireCodeSigning -->
 	<!-- iOS/watchOS/tvOS is simple: device builds require code signing, simulator builds do not. This is a big lie, for some simulator builds need to be signed, but the _DetectCodeSigning task handles those cases. -->
 	<PropertyGroup Condition="'$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'">
-		<_RequireCodeSigning Condition="'$(_RequireCodeSigning)' == ''">false</_RequireCodeSigning> <!-- Xamarin.iOS builds are not signed by default -->
-		<_RequireCodeSigning Condition="'$(ComputedPlatform)' == 'iPhone'">true</_RequireCodeSigning> <!-- except that device builds must be signed -->
+		<!-- Support the 'EnableCodeSigning' variable to enable/disable code signing -->
+		<_RequireCodeSigning Condition="'$(_RequireCodeSigning)' == ''">$(EnableCodeSigning)</_RequireCodeSigning>
+		<!-- device builds must be signed -->
+		<_RequireCodeSigning Condition="'$(_RequireCodeSigning)' == '' And '$(ComputedPlatform)' == 'iPhone'">true</_RequireCodeSigning>
+		<!-- Otherwise code signing is disabled by default -->
+		<_RequireCodeSigning Condition="'$(_RequireCodeSigning)' == ''">false</_RequireCodeSigning>
 	</PropertyGroup>
 	<!-- macOS is a bit more complicated:
 		* 'EnableCodeSigning' specifies whether the app is signed or not, and this defaults to false if it's not set.


### PR DESCRIPTION
* Add support for using the 'EnableCodeSigning' property to enable/disable
  code signing with a specific certificate in mobile projects (will still
  sign, just with a generic '-' key).
* Use the new support when building the prebuilt hotrestart app, since the
  code signature for the app is redundant because it will be re-signed anyways
  when building on a customer machine.

This hopefully fixes an issue where the signing would hang on bots.

Ref: https://github.com/xamarin/xamarin-macios/issues/13355