### PR TITLE
[tests] Don't run SCNViewTests on a VM.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -163,7 +163,7 @@ partial class TestRuntime
 
 	public static void AssertNotVirtualMachine ()
 	{
-#if MONOMAC
+#if MONOMAC || __MACCATALYST__
 		// enviroment variable set by the CI when running on a VM
 		var vmVendor = Environment.GetEnvironmentVariable ("VM_VENDOR");
 		if (!string.IsNullOrEmpty (vmVendor))

--- a/tests/monotouch-test/SceneKit/SCNViewTests.cs
+++ b/tests/monotouch-test/SceneKit/SCNViewTests.cs
@@ -27,6 +27,7 @@ namespace MonoTouchFixtures.SceneKit {
 		{
 			// Issue: https://github.com/xamarin/xamarin-macios/issues/3392
 			TestRuntime.AssertXcodeVersion (7, 0);
+			TestRuntime.AssertNotVirtualMachine ();
 
 			var view = new SCNView (new CGRect (), (NSDictionary) null);
 			Assert.NotNull (view, "View not null");


### PR DESCRIPTION
Hopefully fixes this crash:

    0x7fff6fbad5fd - /usr/lib/system/libsystem_platform.dylib : _sigtramp
    0x354861360 - Unknown
    0x7fff71fb9707 - /System/iOSSupport/System/Library/Frameworks/SceneKit.framework/Versions/A/SceneKit : C3DEngineContextSetRenderContext
    0x7fff720802c0 - /System/iOSSupport/System/Library/Frameworks/SceneKit.framework/Versions/A/SceneKit : -[SCNRenderer _initWithOptions:isPrivateRenderer:privateRendererOwner:clearsOnDraw:context:renderingAPI:]
    0x7fff72126352 - /System/iOSSupport/System/Library/Frameworks/SceneKit.framework/Versions/A/SceneKit : -[SCNView _commonInit:]
    0x7fff72126551 - /System/iOSSupport/System/Library/Frameworks/SceneKit.framework/Versions/A/SceneKit : -[SCNView initWithFrame:options:]