### PR TITLE
[Foundation] Exclude NSUrlProtocolClient from macOS on .NET.

### DIFF
--- a/src/Foundation/NSUrlProtocol.cs
+++ b/src/Foundation/NSUrlProtocol.cs
@@ -31,7 +31,7 @@ using ObjCRuntime;
 
 namespace Foundation {
 	public abstract partial class NSUrlProtocol : NSObject {
-#if MONOMAC && !XAMCORE_4_0
+#if MONOMAC && !NET
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		[Obsolete ("Use the overload that takes an 'INSUrlProtocolClient' instead.")]
 		public NSUrlProtocol (NSUrlRequest request, NSCachedUrlResponse cachedResponse, NSUrlProtocolClient client)

--- a/src/Foundation/NSUrlProtocolClient.cs
+++ b/src/Foundation/NSUrlProtocolClient.cs
@@ -31,7 +31,7 @@ using System;
 using ObjCRuntime;
 
 namespace Foundation {
-#if MONOMAC && !XAMCORE_4_0
+#if MONOMAC && !NET
 	public sealed class NSUrlProtocolClient : NSObject
 	{
 		public NSUrlProtocolClient (IntPtr handle)


### PR DESCRIPTION
Just like the XAMCORE_4_0 define says.