### PR TITLE
[runtime] Implement storing the original working directory for later retrieval for .NET. Fixes #13392.

### DIFF
--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -31,6 +31,14 @@
 #include "../tools/mtouch/monotouch-fixes.c"
 #endif
 
+static char original_working_directory_path [MAXPATHLEN];
+
+const char * const
+xamarin_get_original_working_directory_path ()
+{
+	return original_working_directory_path;
+}
+
 #if !defined (CORECLR_RUNTIME)
 unsigned char *
 xamarin_load_aot_data (MonoAssembly *assembly, int size, gpointer user_data, void **out_handle)
@@ -270,6 +278,10 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 
 	MonoAssembly *assembly;
 	GCHandle exception_gchandle = NULL;
+
+	// Get the original working directory, and store it somewhere.
+	if (getcwd (original_working_directory_path, sizeof (original_working_directory_path)) == NULL)
+		original_working_directory_path [0] = '\0';
 
 	// For legacy Xamarin.Mac, we used to chdir to $appdir/Contents/Resources (I'm not sure where this comes from, earliest commit I could find was this: https://github.com/xamarin/maccore/commit/20045dd7f85cb038cea673a9281bb6131711069c)
 	// For mobile platforms, we chdir to $appdir

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -218,6 +218,7 @@ void			xamarin_bridge_free_mono_signature (MonoMethodSignature **signature);
 bool			xamarin_register_monoassembly (MonoAssembly *assembly, GCHandle *exception_gchandle);
 void			xamarin_install_nsautoreleasepool_hooks ();
 void			xamarin_enable_new_refcount ();
+const char * const	xamarin_get_original_working_directory_path ();
 
 MonoObject *	xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle);
 bool			xamarin_has_managed_ref (id self);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1994,6 +1994,18 @@ namespace ObjCRuntime {
 		{
 			return (nuint) value;
 		}
+
+#if NET || !MONOMAC // legacy Xamarin.Mac has a different implementation in Runtime.mac.cs
+		public static string? OriginalWorkingDirectory {
+			get {
+				return Marshal.PtrToStringUTF8 (xamarin_get_original_working_directory_path ());
+			}
+		}
+
+		[DllImport ("__Internal")]
+		static extern IntPtr xamarin_get_original_working_directory_path ();
+#endif // NET || !__MACOS__
+
 	}
 	
 	internal class IntPtrEqualityComparer : IEqualityComparer<IntPtr>

--- a/src/ObjCRuntime/Runtime.mac.cs
+++ b/src/ObjCRuntime/Runtime.mac.cs
@@ -53,6 +53,7 @@ namespace ObjCRuntime {
 		delegate void initialize_func ();
 		unsafe delegate sbyte *get_sbyteptr_func ();
 
+#if !NET // There's a different implementation for other platforms + .NET macOS in Runtime.cs
 		static volatile bool originalWorkingDirectoryIsSet;
 		static string? originalWorkingDirectory;
 
@@ -76,6 +77,7 @@ namespace ObjCRuntime {
 		{
 			Directory.SetCurrentDirectory (OriginalWorkingDirectory!);
 		}
+#endif // !NET
 
 		static IntPtr runtime_library;
 

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -864,5 +864,11 @@ Additional information:
 		{
 			Assert.That (AppDomain.CurrentDomain.BaseDirectory, Is.Not.Null.And.Not.Empty, "AppDomain.CurrentDomain.BaseDirectory");
 		}
+
+		[Test]
+		public void OriginalWorkingDirectoryTest ()
+		{
+			Assert.That (Runtime.OriginalWorkingDirectory, Is.Not.Null.And.Not.Empty, "OriginalWorkingDirectory");
+		}
 	}
 }


### PR DESCRIPTION
This also adds the Runtime.OriginalWorkingDirectory to all platforms.

Fixes https://github.com/xamarin/xamarin-macios/issues/13392.