### PR TITLE
[devops] Install our provisioning profiles before the actual build as well.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -327,6 +327,27 @@ steps:
   displayName: "Configure build"
   timeoutInMinutes: 5
 
+# We'll need these profiles to build the hot restart prebuilt app during the build
+# (it's built for device, and thus needs a certificate available so that the app can be signed).
+# We do this again before running the tests further below.
+- bash: |
+    set -x
+    set -e
+
+    cd "$SOURCES_DIR/maccore/tools/"
+    ./install-qa-provisioning-profiles.sh -v
+  displayName: 'Add build provisioning profiles'
+  timeoutInMinutes: 30
+  continueOnError: true # should not stop the build
+  env:
+    AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
+    AUTH_TOKEN_LA_DEV_APPLE_P12: ${{ parameters.xqaCertPass }}
+    AUTH_TOKEN_LA_DISTR_APPLE_P12: ${{ parameters.xqaCertPass }}
+    AUTH_TOKEN_LA_MAC_INSTALLER_DISTR_P12: ${{ parameters.xqaCertPass }}
+    AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_P12: ${{ parameters.xqaCertPass }}
+    AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_2_P12: ${{ parameters.xqaCertPass }}
+    SOURCES_DIR: $(Build.SourcesDirectory)
+
 # Actual build of the project
 - bash: |
     set -x


### PR DESCRIPTION
Install our test provisioning profiles + certificates before the build,
because we might need them during the build for the hotrestart prebuilt app.

Ref: https://github.com/xamarin/xamarin-macios/issues/13355.