### PR TITLE
[xtro-sanity] Pass the included platforms as command line arguments.

### DIFF
--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -141,6 +141,7 @@ report-short:
 
 ifdef INCLUDE_IOS
 PCH_FILES+=$(XIOS_PCH)
+INCLUDED_PLATFORMS+=iOS
 
 classify-ios:
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XIOS_PCH) $(XIOS) $(XIOS_GL)
@@ -150,6 +151,7 @@ endif
 
 ifdef INCLUDE_TVOS
 PCH_FILES+=$(XTVOS_PCH)
+INCLUDED_PLATFORMS+=tvOS
 
 classify-tvos:
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XTVOS_PCH) $(XTVOS) $(XTVOS_GL)
@@ -159,6 +161,7 @@ endif
 
 ifdef INCLUDE_WATCH
 PCH_FILES+=$(XWATCHOS_PCH)
+INCLUDED_PLATFORMS+=watchOS
 
 classify-watchos:
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XWATCHOS_PCH) $(XWATCHOS)
@@ -168,6 +171,7 @@ endif
 
 ifdef INCLUDE_MAC
 PCH_FILES+=$(XMACOS_PCH)
+INCLUDED_PLATFORMS+=macOS
 classify-macos:
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XMACOS_PCH) $(XMACOS)
 else
@@ -176,6 +180,7 @@ endif
 
 ifdef INCLUDE_MACCATALYST
 PCH_FILES+=$(XMACCATALYST_PCH)
+INCLUDED_PLATFORMS+=MacCatalyst
 classify-maccatalyst: bin/Debug/xtro-sharpie.exe $(XMACCATALYST_PCH)
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XMACCATALYST_PCH) $(XMACCATALYST)
 else
@@ -185,7 +190,7 @@ endif
 classify: build $(PCH_FILES)
 	rm -f $(ANNOTATIONS_DIR)/*.unclassified
 	$(MAKE) -j8 classify-ios classify-tvos classify-watchos classify-macos classify-maccatalyst
-	$(MONO) xtro-sanity/bin/Debug/xtro-sanity.exe $(abspath $(ANNOTATIONS_DIR))
+	$(MONO) xtro-sanity/bin/Debug/xtro-sanity.exe $(abspath $(ANNOTATIONS_DIR)) $(INCLUDED_PLATFORMS)
 	rm -f $(ANNOTATIONS_DIR)/*.raw
 
 insane:

--- a/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
+++ b/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
@@ -6,42 +6,7 @@ using System.IO;
 namespace Extrospection {
 	class Sanitizer {
 
-		static List<string> platforms;
-
-		static List<string> Platforms {
-			get {
-				if (platforms != null)
-					return platforms;
-
-				platforms = new List<string> (4);
-				foreach (var line in File.ReadAllLines ("../../Make.config")) {
-					var eq = line.IndexOf ('=');
-					if (eq == -1)
-						continue;
-					if (!line.StartsWith ("INCLUDE_", StringComparison.Ordinal))
-						continue;
-
-					switch (line.Substring (0, eq)) {
-					case "INCLUDE_IOS":
-						platforms.Add ("iOS");
-						break;
-					case "INCLUDE_TVOS":
-						platforms.Add ("tvOS");
-						break;
-					case "INCLUDE_WATCH":
-						platforms.Add ("watchOS");
-						break;
-					case "INCLUDE_MAC":
-						platforms.Add ("macOS");
-						break;
-					case "INCLUDE_MACCATALYST":
-						platforms.Add ("MacCatalyst");
-						break;
-					}
-				}
-				return platforms;
-			}
-		}
+		static List<string> Platforms;
 
 		static bool IsEntry (string line)
 		{
@@ -209,7 +174,7 @@ namespace Extrospection {
 		public static int Main (string [] args)
 		{
 			directory = args.Length == 0 ? "." : args [0];
-			Environment.CurrentDirectory = directory;
+			Platforms = args.Skip (1).ToList ();
 
 			// cache stuff
 			foreach (var file in Directory.GetFiles (directory, "common-*.ignore")) {


### PR DESCRIPTION
This avoids the need to compute them, and makes it possible to have multiple sets
of platforms.