### PR TITLE
[LocalAuthentication] Adjust code for .NET and fix availability of LAContext.MaxBiometryFailures

### DIFF
--- a/src/LocalAuthentication/LAEnums.cs
+++ b/src/LocalAuthentication/LAEnums.cs
@@ -33,29 +33,36 @@ namespace LocalAuthentication {
 		SystemCancel         = -4,	    
 		/// Authentication could not start, because passcode is not set on the device.
 		PasscodeNotSet       = -5,
+
+#if !NET
 		/// Authentication could not start, because Touch ID is not available on the device.
 		[Deprecated (PlatformName.iOS, 11,0, message: "Use 'BiometryNotAvailable' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10,13, message: "Use 'BiometryNotAvailable' instead.")]
-		TouchIDNotAvailable  = -6,	    
+		TouchIDNotAvailable  = BiometryNotAvailable,
 
 		/// Authentication could not start, because Touch ID has no enrolled fingers.
 		[Deprecated (PlatformName.iOS, 11,0, message: "Use 'BiometryNotEnrolled' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10,13, message: "Use 'BiometryNotEnrolled' instead.")]
-		TouchIDNotEnrolled   = -7,
+		TouchIDNotEnrolled   = BiometryNotEnrolled,
 
 		[Deprecated (PlatformName.iOS, 11,0, message: "Use 'BiometryLockout' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10,13, message: "Use 'BiometryLockout' instead.")]
-		TouchIDLockout       = -8,
+		TouchIDLockout       = BiometryLockout,
+#endif
 		AppCancel            = -9,
 		InvalidContext       = -10,
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		WatchNotAvailable    = -11,
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		BiometryNotPaired    = -12,
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		BiometryDisconnected = -13,
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		InvalidDimension     = -14,
 
-		BiometryNotAvailable = TouchIDNotAvailable,
-		BiometryNotEnrolled = TouchIDNotEnrolled,
-		BiometryLockout = TouchIDLockout,
+		BiometryNotAvailable = -6,
+		BiometryNotEnrolled = -7,
+		BiometryLockout = -8,
 
 		NotInteractive       = -1004,
 	}

--- a/src/localauthentication.cs
+++ b/src/localauthentication.cs
@@ -12,7 +12,7 @@ namespace LocalAuthentication {
 		TouchId,
 		[Mac (10,15)]
 		FaceId,
-#if !XAMCORE_4_0
+#if !NET
 		[NoMac]
 		[Obsolete ("Use 'FaceId' instead.")]
 		TypeFaceId = FaceId,
@@ -29,7 +29,7 @@ namespace LocalAuthentication {
 		[Export ("localizedFallbackTitle")]
 		string LocalizedFallbackTitle { get; set; }
 
-#if !XAMCORE_4_0
+#if !NET
 		[iOS (8,3)]
 		[Field ("LAErrorDomain")]
 		NSString ErrorDomain { get; }
@@ -78,12 +78,12 @@ namespace LocalAuthentication {
 		[Export ("touchIDAuthenticationAllowableReuseDuration")]
 		double /* NSTimeInterval */ TouchIdAuthenticationAllowableReuseDuration { get; set; }
 
-#if !MONOMAC
 		[iOS (8, 3), Deprecated (PlatformName.iOS, 9, 0)]
+		[Mac (10, 10, 3), Deprecated (PlatformName.MacOSX, 10, 11)]
 		[NullAllowed]
 		[Export ("maxBiometryFailures")]
 		NSNumber MaxBiometryFailures { get; set; }
-#endif
+
 		[NoWatch, NoTV, Mac (10, 13), iOS (11, 0)]
 		[Export ("localizedReason")]
 		string LocalizedReason { get; set; }

--- a/tests/xtro-sharpie/MacCatalyst-LocalAuthentication.todo
+++ b/tests/xtro-sharpie/MacCatalyst-LocalAuthentication.todo
@@ -1,4 +1,0 @@
-!extra-enum-value! Managed value -11 for LAStatus.WatchNotAvailable is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value -12 for LAStatus.BiometryNotPaired is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value -13 for LAStatus.BiometryDisconnected is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value -14 for LAStatus.InvalidDimension is available for the current platform while the value in the native header is not

--- a/tests/xtro-sharpie/MacCatalyst-LocalAuthenticationEmbeddedUI.ignore
+++ b/tests/xtro-sharpie/MacCatalyst-LocalAuthenticationEmbeddedUI.ignore
@@ -1,1 +1,0 @@
-## No LocalAuthentication support for Catalyst

--- a/tests/xtro-sharpie/iOS-LocalAuthentication.todo
+++ b/tests/xtro-sharpie/iOS-LocalAuthentication.todo
@@ -1,4 +1,0 @@
-!extra-enum-value! Managed value -11 for LAStatus.WatchNotAvailable is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value -12 for LAStatus.BiometryNotPaired is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value -13 for LAStatus.BiometryDisconnected is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value -14 for LAStatus.InvalidDimension is available for the current platform while the value in the native header is not


### PR DESCRIPTION
* LAContext.MaxBiometryFailures is available in macOS, just deprecated, so mark
  it as such.
* Remove deprecated code from .NET.
* Update xtro definitions.