### PR TITLE
[dotnet] Import the aliased pack name, not the actual pack name.

### DIFF
--- a/dotnet/Workloads/Microsoft.NET.Sdk.iOS/WorkloadManifest.targets
+++ b/dotnet/Workloads/Microsoft.NET.Sdk.iOS/WorkloadManifest.targets
@@ -1,6 +1,6 @@
 <Project>
 	<Import Project="Sdk.props" Sdk="Microsoft.iOS.Sdk" Condition="'$(TargetPlatformIdentifier)' == 'iOS'" />
-	<Import Project="Sdk.props" Sdk="Microsoft.iOS.Windows.Sdk" Condition=" '$(TargetPlatformIdentifier)' == 'iOS' and $([MSBuild]::IsOSPlatform('windows'))" />
+	<Import Project="Sdk.props" Sdk="Microsoft.iOS.Windows.Sdk.Aliased" Condition=" '$(TargetPlatformIdentifier)' == 'iOS' and $([MSBuild]::IsOSPlatform('windows'))" />
 
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
 		<SdkSupportedTargetPlatformIdentifier Include="ios" DisplayName="iOS" />

--- a/dotnet/targets/WorkloadManifest.iOS.template.json
+++ b/dotnet/targets/WorkloadManifest.iOS.template.json
@@ -5,7 +5,7 @@
 			"description": ".NET SDK Workload for building @PLATFORM@ applications.",
 			"packs": [
 				"Microsoft.@PLATFORM@.Sdk",
-				"microsoft-@PLATFORM@-windows-sdk",
+				"Microsoft.@PLATFORM@.Windows.Sdk.Aliased",
 				"Microsoft.@PLATFORM@.Ref",
 				"Microsoft.@PLATFORM@.Runtime.ios-arm",
 				"Microsoft.@PLATFORM@.Runtime.ios-arm64",
@@ -23,7 +23,7 @@
 			"kind": "sdk",
 			"version": "@VERSION@"
 		},
-		"microsoft-@PLATFORM@-windows-sdk": {
+		"Microsoft.@PLATFORM@.Windows.Sdk.Aliased": {
 			"kind": "sdk",
 			"version": "@VERSION@",
 			"alias-to": {


### PR DESCRIPTION
This fixes an issue where dotnet restore would fail trying to find the pack.

Also make the aliased name look more like the other names.