### PR TITLE
[Security] Add kSecUseNoAuthenticationUI for macOS.

### DIFF
--- a/src/security.cs
+++ b/src/security.cs
@@ -733,11 +733,10 @@ namespace Security {
 		[Field ("kSecUseOperationPrompt")]
 		IntPtr UseOperationPrompt { get; }
 
-#if !MONOMAC // Don't break compat API
 		[iOS (8, 0), Deprecated (PlatformName.iOS, 9, 0)]
+		[Mac (10, 10), Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Field ("kSecUseNoAuthenticationUI")]
 		IntPtr UseNoAuthenticationUI { get; }
-#endif
 
 		[iOS (9,0)][Mac (10,11)]
 		[Field ("kSecUseAuthenticationUI")]


### PR DESCRIPTION
The kSecUseNoAuthenticationUI field is available on macOS, just deprecated,
and I don't see how having the field bound would be a breaking change like the
comment says (git history seems to indicate it's referring to the
Classic/Unified switchover - i.e. quite outdated), so add the field to macOS.