### PR TITLE
[StoreKit] Remove XAMCORE_4_0 that seems incorrect.

### DIFF
--- a/src/StoreKit/Enums.cs
+++ b/src/StoreKit/Enums.cs
@@ -63,7 +63,6 @@ namespace StoreKit {
 		Waiting, Active, Paused, Finished, Failed, Cancelled
 	}
 
-#if !MONOMAC || !XAMCORE_4_0
 	[Watch (7,0)]
 	[iOS (9,3)]
 	[Native]
@@ -84,9 +83,6 @@ namespace StoreKit {
 		MusicCatalogSubscriptionEligible = 1 << 1,
 		AddToCloudMusicLibrary = 1 << 8
 	}
-#endif
-
-#if !XAMCORE_4_0
 
 	[iOS (11,0)][TV (11,0)][Mac (11,0)][NoWatch]
 	[Native]
@@ -95,7 +91,7 @@ namespace StoreKit {
 		Show,
 		Hide,
 	}
-#endif
+
 	[Watch (6, 2), iOS (11,2), TV (11,2), Mac (10,13,2)]
 	[Native]
 	public enum SKProductPeriodUnit : ulong {


### PR DESCRIPTION
From what I can see for current Apple API these XAMCORE_4_0 exclusions are
incorrect.

Fixes (when building with XAMCORE_4_0):

> storekit.cs(834,79): error CS0246: The type or namespace name 'SKProductStorePromotionVisibility' could not be found (are you missing a using directive or an assembly reference?)
> storekit.cs(838,16): error CS0246: The type or namespace name 'SKProductStorePromotionVisibility' could not be found (are you missing a using directive or an assembly reference?)