### PR TITLE
[src] Don't use deprecated API.

### DIFF
--- a/src/CoreAnimation/CAKeyFrameAnimation.cs
+++ b/src/CoreAnimation/CAKeyFrameAnimation.cs
@@ -30,8 +30,8 @@ namespace CoreAnimation {
 				NSString result;
 				if (value == CAAnimation.AnimationLinear)
 					result = CAAnimation.AnimationLinear;
-				else if (value == CAAnimation.AnimationDescrete)
-					result = CAAnimation.AnimationDescrete;
+				else if (value == CAAnimation.AnimationDiscrete)
+					result = CAAnimation.AnimationDiscrete;
 				else if (value == CAAnimation.AnimationPaced)
 					result = CAAnimation.AnimationPaced;
 				else if (value == CAAnimation.AnimationCubic)

--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -48,15 +48,15 @@ namespace Network {
 				using (var definition = tempOptions.ProtocolDefinition) {
 					NWProtocolOptions? castedOptions = null;
 
-					if (definition.Equals (NWProtocolDefinition.TcpDefinition)) {
+					if (definition.Equals (NWProtocolDefinition.CreateTcpDefinition ())) {
 						castedOptions = new NWProtocolTcpOptions (iface, owns: false);
-					} else if (definition.Equals (NWProtocolDefinition.UdpDefinition)) {
+					} else if (definition.Equals (NWProtocolDefinition.CreateUdpDefinition ())) {
 						castedOptions = new NWProtocolUdpOptions (iface, owns: false);
-					} else if (definition.Equals (NWProtocolDefinition.TlsDefinition)) {
+					} else if (definition.Equals (NWProtocolDefinition.CreateTlsDefinition ())) {
 						castedOptions = new NWProtocolTlsOptions (iface, owns: false);
-					} else if (definition.Equals (NWProtocolDefinition.IPDefinition)) {
+					} else if (definition.Equals (NWProtocolDefinition.CreateIPDefinition ())) {
 						castedOptions = new NWProtocolIPOptions (iface, owns: false);
-					} else if (definition.Equals (NWProtocolDefinition.WebSocketDefinition)) {
+					} else if (definition.Equals (NWProtocolDefinition.CreateWebSocketDefinition ())) {
 						castedOptions = new NWWebSocketOptions (iface, owns: false);
 					} 
 

--- a/src/Network/NWProtocolStack.cs
+++ b/src/Network/NWProtocolStack.cs
@@ -64,15 +64,15 @@ namespace Network {
 				using (var definition = tempOptions.ProtocolDefinition) {
 					NWProtocolOptions? castedOptions = null;
 
-					if (definition.Equals (NWProtocolDefinition.TcpDefinition)) {
+					if (definition.Equals (NWProtocolDefinition.CreateTcpDefinition ())) {
 						castedOptions = new NWProtocolTcpOptions (options, owns: false);
-					} else if (definition.Equals (NWProtocolDefinition.UdpDefinition)) {
+					} else if (definition.Equals (NWProtocolDefinition.CreateUdpDefinition ())) {
 						castedOptions = new NWProtocolUdpOptions (options, owns: false);
-					} else if (definition.Equals (NWProtocolDefinition.TlsDefinition)) {
+					} else if (definition.Equals (NWProtocolDefinition.CreateTlsDefinition ())) {
 						castedOptions = new NWProtocolTlsOptions (options, owns: false);
-					} else if (definition.Equals (NWProtocolDefinition.IPDefinition)) {
+					} else if (definition.Equals (NWProtocolDefinition.CreateIPDefinition ())) {
 						castedOptions = new NWProtocolIPOptions (options, owns: false);
-					} else if (definition.Equals (NWProtocolDefinition.WebSocketDefinition)) {
+					} else if (definition.Equals (NWProtocolDefinition.CreateWebSocketDefinition ())) {
 						castedOptions = new NWWebSocketOptions (options, owns: false);
 					} 
 
@@ -113,10 +113,10 @@ namespace Network {
 
 				using (var definition = tempOptions.ProtocolDefinition) {
 					NWProtocolOptions? castedOptions = null;
-					if (definition.Equals (NWProtocolDefinition.TcpDefinition)) {
+					if (definition.Equals (NWProtocolDefinition.CreateTcpDefinition ())) {
 						castedOptions = new NWProtocolTcpOptions (pHandle, owns: true);
 					}
-					if (definition.Equals (NWProtocolDefinition.UdpDefinition)) {
+					if (definition.Equals (NWProtocolDefinition.CreateUdpDefinition ())) {
 						castedOptions = new NWProtocolUdpOptions (pHandle, owns: true);
 					} 
 					if (castedOptions == null) {


### PR DESCRIPTION
Use the non-deprecated version, which will work in both legacy Xamarin and .NET.