### PR TITLE
[CFMessagePort] Simplify construction and fix c&p error in Dispose.

### DIFF
--- a/src/CoreFoundation/CFMessagePort.cs
+++ b/src/CoreFoundation/CFMessagePort.cs
@@ -68,7 +68,7 @@ namespace CoreFoundation {
 
 		static CFMessagePortInvalidationCallBackProxy messageInvalidationCallback = new CFMessagePortInvalidationCallBackProxy (MessagePortInvalidationCallback);
 
-		IntPtr contextHandle = IntPtr.Zero;
+		IntPtr contextHandle;
 
 		public bool IsRemote {
 			get {
@@ -151,7 +151,7 @@ namespace CoreFoundation {
 
 				lock (messagePortContexts) {
 					if (messagePortContexts.ContainsKey (contextHandle))
-						invalidationHandles.Remove (contextHandle);
+						messagePortContexts.Remove (contextHandle);
 				}
 
 				contextHandle = IntPtr.Zero;


### PR DESCRIPTION
* There's no need to initialize the contextHandle field to IntPtr.Zero, since
  that's the default value anyway. This avoid adding useless code to all the
  constructors.
* Fix removing the contextHandle entry from the messagePortContexts
  dictionary, by not trying to remove it from the wrong dictionary.