### PR TITLE
[NWWebSocketOptions] No need to initialize to default value.

### DIFF
--- a/src/Network/NWWebSocketOptions.cs
+++ b/src/Network/NWWebSocketOptions.cs
@@ -32,7 +32,7 @@ namespace Network {
 	public class NWWebSocketOptions : NWProtocolOptions {
 		bool autoReplyPing = false;
 		bool skipHandShake = false;
-		nuint maximumMessageSize = (nuint) 0;
+		nuint maximumMessageSize;
 
 		internal NWWebSocketOptions (IntPtr handle, bool owns) : base (handle, owns) {}
 


### PR DESCRIPTION
This ends up as actual code in all the constructors, so this saves a tiny bit
of code (most importantly it doesn't trigger an upcoming test that verifies
what constructors do).