### PR TITLE
[CGImageSource] Change CreateThumbnail to return null if the thumbnail creation fails.

### DIFF
--- a/src/CoreGraphics/CGImage.cs
+++ b/src/CoreGraphics/CGImage.cs
@@ -224,7 +224,7 @@ namespace CoreGraphics {
 		{
 		}
 
-		static CGImage? FromHandle (IntPtr handle, bool owns)
+		internal static CGImage? FromHandle (IntPtr handle, bool owns)
 		{
 			if (handle == IntPtr.Zero)
 				return null;

--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -290,11 +290,15 @@ namespace ImageIO {
 		[DllImport (Constants.ImageIOLibrary)]
 		extern static /* CGImageRef */ IntPtr CGImageSourceCreateThumbnailAtIndex (/* CGImageSourceRef */ IntPtr isrc, /* size_t */ nint index, /* CFDictionaryRef */ IntPtr options);
 
-		public CGImage CreateThumbnail (int index, CGImageThumbnailOptions? options)
+		public CGImage? CreateThumbnail (int index, CGImageThumbnailOptions? options)
 		{
 			using (var dict = options?.ToDictionary ()) {
 				var ret = CGImageSourceCreateThumbnailAtIndex (Handle, index, dict.GetHandle ());
+#if NET
+				return CGImage.FromHandle (ret, true);
+#else
 				return new CGImage (ret, true);
+#endif
 			}
 		}
 

--- a/tests/monotouch-test/ImageIO/CGImageSourceTest.cs
+++ b/tests/monotouch-test/ImageIO/CGImageSourceTest.cs
@@ -90,10 +90,20 @@ namespace MonoTouchFixtures.ImageIO {
 		{
 			using (var imgsrc = CGImageSource.FromUrl (fileUrl)) {
 				using (var img = imgsrc.CreateThumbnail (0, null)) {
+#if NET
+					Assert.Null (img, "#a1");
+#else
 					Assert.NotNull (img, "#a1");
+					Assert.AreEqual (IntPtr.Zero, img.Handle, "#a2");
+#endif
 				}
 				using (var img = imgsrc.CreateThumbnail (0, new CGImageThumbnailOptions ())) {
+#if NET
+					Assert.Null (img, "#b1");
+#else
 					Assert.NotNull (img, "#b1");
+					Assert.AreEqual (IntPtr.Zero, img.Handle, "#b2");
+#endif
 				}
 			}
 		}


### PR DESCRIPTION
Otherwise we'll create a CGImage with a zero Handle, which is usually not the
right thing to do. Still, keep the old behavior for legacy Xamarin for the
sake of backwards compat.