### PR TITLE
[src] Adjust visibility of numerous (IntPtr) and (IntPtr, bool) constructors

### DIFF
--- a/src/AppKit/NSGraphicsContext.cs
+++ b/src/AppKit/NSGraphicsContext.cs
@@ -41,7 +41,7 @@ namespace AppKit {
 		}
 
 		public virtual CGContext GraphicsPort {
-			get { return new CGContext (GraphicsPortHandle); }
+			get { return new CGContext (GraphicsPortHandle, false); }
 		}
 	}
 }

--- a/src/AudioToolbox/AudioSession.cs
+++ b/src/AudioToolbox/AudioSession.cs
@@ -482,7 +482,7 @@ namespace AudioToolbox {
 
 		static AccessoryInfo[] ExtractAccessoryInfo (IntPtr ptr, NSString id, NSString description)
 		{
-			using (var array = new CFArray (ptr)) {
+			using (var array = new CFArray (ptr, false)) {
 				var res = new AccessoryInfo [array.Count];
 				for (int i = 0; i < res.Length; ++i) {
 					var dict = array.GetValue (i);

--- a/src/CoreAnimation/CADefs.cs
+++ b/src/CoreAnimation/CADefs.cs
@@ -52,7 +52,7 @@ namespace CoreAnimation {
 		public CGColor CreateColor (IntPtr p)
 #endif
 		{
-			return new CGColor (p);
+			return new CGColor (p, false);
 		}
 		
 		public CGColor [] Colors {

--- a/src/CoreFoundation/CFAllocator.cs
+++ b/src/CoreFoundation/CFAllocator.cs
@@ -47,7 +47,7 @@ namespace CoreFoundation {
 		static CFAllocator? Null_cf;
 #endif
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the overload that takes a 'bool owns' parameter instead.")]
 		public CFAllocator (IntPtr handle)
 			: base (handle, true /* backwards compatibility means we have to pass true here as opposed to the general pattern */)
@@ -55,7 +55,7 @@ namespace CoreFoundation {
 		}
 #endif
 
-#if XAMCORE_4_0
+#if NET
 		internal CFAllocator (IntPtr handle, bool owns)
 #else
 		public CFAllocator (IntPtr handle, bool owns)

--- a/src/CoreFoundation/CFArray.cs
+++ b/src/CoreFoundation/CFArray.cs
@@ -45,10 +45,12 @@ namespace CoreFoundation {
 	// interesting bits: https://github.com/opensource-apple/CF/blob/master/CFArray.c
 	public partial class CFArray : NativeObject {
 
+#if !NET
 		internal CFArray (IntPtr handle)
 			: base (handle, false)
 		{
 		}
+#endif
 
 		[Preserve (Conditional = true)]
 		internal CFArray (IntPtr handle, bool owns)

--- a/src/CoreFoundation/CFBundle.cs
+++ b/src/CoreFoundation/CFBundle.cs
@@ -87,7 +87,7 @@ namespace CoreFoundation {
 			// might be modified by a diff thread. We are going to clone the array and make sure
 			// that Apple does not modify the array while we work with it. That avoids changes
 			// in the index or in the bundles returned.
-			using (var cfBundles = new CFArray (CFBundleGetAllBundles ()))
+			using (var cfBundles = new CFArray (CFBundleGetAllBundles (), false))
 			using (var cfBundlesCopy = cfBundles.Clone () ) {
 				return CFArray.ArrayFromHandleFunc<CFBundle> (cfBundlesCopy.Handle, (handle) => new CFBundle (handle, false), false);
 			}

--- a/src/CoreFoundation/CFMachPort.cs
+++ b/src/CoreFoundation/CFMachPort.cs
@@ -40,13 +40,13 @@ namespace CoreFoundation
 	{
 		delegate void CFMachPortCallBack (IntPtr cfmachport, IntPtr msg, nint len, IntPtr context);
 
-#if !XAMCORE_4_0
+#if !NET
 		public CFMachPort (IntPtr handle) : base (handle, false)
 		{
 		}
 #endif
 
-#if XAMCORE_4_0
+#if NET
 		internal CFMachPort (IntPtr handle, bool owns)
 #else
 		public CFMachPort (IntPtr handle, bool owns)

--- a/src/CoreFoundation/CFMutableString.cs
+++ b/src/CoreFoundation/CFMutableString.cs
@@ -12,13 +12,19 @@ namespace CoreFoundation {
 	
 	public class CFMutableString : CFString {
 
+#if !NET
 		protected CFMutableString (IntPtr handle)
 			: this (handle, false)
 		{
 		}
+#endif
 		
 		[Preserve (Conditional = true)]
+#if NET
+		internal CFMutableString (IntPtr handle, bool owns)
+#else
 		protected CFMutableString (IntPtr handle, bool owns)
+#endif
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/CFPropertyList.cs
+++ b/src/CoreFoundation/CFPropertyList.cs
@@ -34,7 +34,7 @@ namespace CoreFoundation
 
 		static nint CFNumberTypeID = CFNumberGetTypeID ();
 
-#if XAMCORE_4_0
+#if NET
 		internal CFPropertyList (IntPtr handle, bool owns)
 #else
 		public CFPropertyList (IntPtr handle, bool owns)
@@ -43,7 +43,7 @@ namespace CoreFoundation
 		{
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		public CFPropertyList (IntPtr handle) : this (handle, false)
 		{
 		}

--- a/src/CoreFoundation/CFReadStream.cs
+++ b/src/CoreFoundation/CFReadStream.cs
@@ -41,7 +41,7 @@ namespace CoreFoundation {
 
 	// CFStream.h
 	public class CFReadStream : CFStream {
-#if !XAMCORE_4_0
+#if !NET
 		public CFReadStream (IntPtr handle)
 			: base (handle, true)
 		{

--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -763,7 +763,7 @@ namespace CoreFoundation {
 #endif
 		public DispatchQueue ReadDispatchQueue {
 			get {
-				return new DispatchQueue (CFReadStreamCopyDispatchQueue (Handle));
+				return new DispatchQueue (CFReadStreamCopyDispatchQueue (Handle), true);
 			}
 			set {
 				CFReadStreamSetDispatchQueue (Handle, value.GetHandle ());
@@ -775,7 +775,7 @@ namespace CoreFoundation {
 #endif
 		public DispatchQueue WriteDispatchQueue {
 			get {
-				return new DispatchQueue (CFWriteStreamCopyDispatchQueue (Handle));
+				return new DispatchQueue (CFWriteStreamCopyDispatchQueue (Handle), true);
 			}
 			set {
 				CFWriteStreamSetDispatchQueue (Handle, value.GetHandle ());

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -150,13 +150,19 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFStringGetTypeID")]
 		public extern static nint GetTypeID ();
 		
+#if !NET
 		public CFString (IntPtr handle)
 			: this (handle, false)
 		{
 		}
+#endif
 		
 		[Preserve (Conditional = true)]
+#if NET
+		internal CFString (IntPtr handle, bool owns)
+#else
 		protected internal CFString (IntPtr handle, bool owns)
+#endif
 			: base (handle, owns)
 		{
 		}

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -68,10 +68,8 @@ namespace CoreFoundation {
 		//
 		[Preserve (Conditional = true)]
 		internal DispatchObject (IntPtr handle, bool owns)
-			: base (handle, owns)
+			: base (handle, owns, verify: true)
 		{
-			if (handle == IntPtr.Zero)
-				throw new ArgumentNullException ("handle");
 		}
 
 		internal DispatchObject ()
@@ -182,9 +180,11 @@ namespace CoreFoundation {
 		{
 		}
 
+#if !NET
 		public DispatchQueue (IntPtr handle) : base (handle, false)
 		{
 		}
+#endif
 		
 		public DispatchQueue (string label)
 			: base (dispatch_queue_create (label, IntPtr.Zero), true)

--- a/src/CoreFoundation/DispatchData.cs
+++ b/src/CoreFoundation/DispatchData.cs
@@ -35,13 +35,19 @@ namespace CoreFoundation {
 
 	public partial class DispatchData : DispatchObject {
 #if !COREBUILD
+#if NET
+		internal DispatchData (IntPtr handle, bool owns) : base (handle, owns)
+#else
 		public DispatchData (IntPtr handle, bool owns) : base (handle, owns)
+#endif
 		{
 		}
 
+#if !NET
 		public DispatchData (IntPtr handle) : base (handle, false)
 		{
 		}
+#endif
 
 		[DllImport (Constants.libcLibrary)]
 		extern static IntPtr dispatch_data_create (IntPtr buffer, nuint size, IntPtr dispatchQueue, IntPtr destructor);

--- a/src/CoreFoundation/DispatchIO.cs
+++ b/src/CoreFoundation/DispatchIO.cs
@@ -45,10 +45,13 @@ namespace CoreFoundation {
 		internal DispatchIO (IntPtr handle, bool owns) : base (handle, owns)
 		{
 		}
+
+#if !NET
 		[Preserve (Conditional = true)]
 		internal DispatchIO (IntPtr handle) : this (handle, false)
 		{
 		}
+#endif
 
 		delegate void DispatchReadWrite (IntPtr block, IntPtr dispatchData, int error);
 		static DispatchReadWrite static_DispatchReadWriteHandler = Trampoline_DispatchReadWriteHandler;

--- a/src/CoreFoundation/DispatchSource.cs
+++ b/src/CoreFoundation/DispatchSource.cs
@@ -52,10 +52,12 @@ namespace CoreFoundation {
 		{
 		}
 
+#if !NET
 		// constructors for use in bindings
 		internal DispatchSource (IntPtr handle) : base (handle, false)
 		{
 		}
+#endif
 
 		// Invoked by subclasses in this file that fully initialize both
 		// queue and handle

--- a/src/CoreGraphics/CGColor.cs
+++ b/src/CoreGraphics/CGColor.cs
@@ -42,10 +42,12 @@ namespace CoreGraphics {
 	public class CGColor : NativeObject
 	{
 #if !COREBUILD
+#if !NET
 		public CGColor (IntPtr handle)
 			: base (handle, false)
 		{
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal CGColor (IntPtr handle, bool owns)

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -73,7 +73,7 @@ namespace CoreGraphics {
 		public readonly static CGColorSpace Null = CreateNull ();
 #endif
 
-#if !XAMCORE_4_0
+#if !NET
 		public CGColorSpace (IntPtr handle)
 			: base (handle, false)
 		{

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -41,7 +41,7 @@ namespace CoreGraphics {
 	public class CGContext : NativeObject
 	{
 #if !COREBUILD
-#if !XAMCORE_4_0
+#if !NET
 		public CGContext (IntPtr handle)
 			: base (handle, false)
 		{

--- a/src/CoreGraphics/CGDataConsumer.cs
+++ b/src/CoreGraphics/CGDataConsumer.cs
@@ -39,7 +39,7 @@ namespace CoreGraphics {
 
 	// CGDataConsumer.h
 	public partial class CGDataConsumer : NativeObject {
-#if !XAMCORE_4_0
+#if !NET
 		public CGDataConsumer (IntPtr handle)
 			: base (handle, false)
 		{

--- a/src/CoreGraphics/CGDataProvider.cs
+++ b/src/CoreGraphics/CGDataProvider.cs
@@ -39,10 +39,12 @@ namespace CoreGraphics {
 
 	// CGDataProvider.h
 	public partial class CGDataProvider : NativeObject {
+#if !NET
 		public CGDataProvider (IntPtr handle)
 			: base (handle, false)
 		{
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal CGDataProvider (IntPtr handle, bool owns)

--- a/src/CoreGraphics/CGEvent.cs
+++ b/src/CoreGraphics/CGEvent.cs
@@ -76,7 +76,7 @@ namespace CoreGraphics {
 		{
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		public CGEvent (IntPtr handle)
 			: base (handle, false)
 		{

--- a/src/CoreGraphics/CGEventSource.cs
+++ b/src/CoreGraphics/CGEventSource.cs
@@ -27,14 +27,14 @@ namespace CoreGraphics {
 	[SupportedOSPlatform ("maccatalyst15.0")]
 #endif
 	public sealed class CGEventSource : NativeObject {
-#if !XAMCORE_4_0
+#if !NET
 		public CGEventSource (IntPtr handle)
 			: base (handle, false)
 		{
 		}
 #endif
 
-#if XAMCORE_4_0
+#if NET
 		internal CGEventSource (IntPtr handle, bool owns)
 #else
 		public CGEventSource (IntPtr handle, bool owns)

--- a/src/CoreGraphics/CGFunction.cs
+++ b/src/CoreGraphics/CGFunction.cs
@@ -50,7 +50,7 @@ namespace CoreGraphics {
 			cbacks.release = new CGFunctionReleaseCallback (ReleaseCallback);
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		internal CGFunction (IntPtr handle)
 			: base (handle, false)
 		{

--- a/src/CoreGraphics/CGImage.cs
+++ b/src/CoreGraphics/CGImage.cs
@@ -131,7 +131,7 @@ namespace CoreGraphics {
 	public class CGImage : NativeObject
 	{
 #if !COREBUILD
-#if !XAMCORE_4_0
+#if !NET
 		public CGImage (IntPtr handle)
 			: base (handle, false, verify: false)
 		{
@@ -140,7 +140,7 @@ namespace CoreGraphics {
 
 		[Preserve (Conditional=true)]
 		internal CGImage (IntPtr handle, bool owns)
-#if XAMCORE_4_0
+#if NET
 			: base (handle, owns)
 #else
 			: base (handle, owns, verify: false)

--- a/src/CoreGraphics/CGLayer.cs
+++ b/src/CoreGraphics/CGLayer.cs
@@ -77,7 +77,7 @@ namespace CoreGraphics {
 
 		public CGContext Context {
 			get {
-				return new CGContext (CGLayerGetContext (Handle));
+				return new CGContext (CGLayerGetContext (Handle), false);
 			}
 		}
 

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -93,7 +93,7 @@ namespace CoreGraphics {
 		{
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		public CGPath (IntPtr handle)
 			: base (handle, false)
 		{

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -56,11 +56,12 @@ namespace CoreGraphics {
 	public class CGPattern : NativeObject
 	{
 #if !COREBUILD
-		/* invoked by marshallers */
+#if !NET
 		public CGPattern (IntPtr handle)
 			: base (handle, false)
 		{
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal CGPattern (IntPtr handle, bool owns)
@@ -102,7 +103,7 @@ namespace CoreGraphics {
 		{
 			GCHandle gch = GCHandle.FromIntPtr (voidptr);
 			DrawPattern draw_pattern = (DrawPattern) gch.Target;
-			using (var ctx = new CGContext (cgcontextptr))
+			using (var ctx = new CGContext (cgcontextptr, false))
 				draw_pattern (ctx);
 		}
 

--- a/src/CoreGraphics/CGShading.cs
+++ b/src/CoreGraphics/CGShading.cs
@@ -41,7 +41,7 @@ namespace CoreGraphics {
 	public class CGShading : NativeObject
 	{
 #if !COREBUILD
-#if !XAMCORE_4_0
+#if !NET
 		public CGShading (IntPtr handle)
 			: base (handle, false)
 		{

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -24,7 +24,7 @@ namespace CoreMedia {
 #endif
 	public class CMClock : CMClockOrTimebase
 	{
-#if !XAMCORE_4_0
+#if !NET
 		public CMClock (IntPtr handle) : base (handle)
 		{
 		}
@@ -66,7 +66,7 @@ namespace CoreMedia {
 		{
 			IntPtr ptr;
 			clockError = CMAudioClockCreate (IntPtr.Zero, out ptr);
-			return clockError == CMClockError.None ? new CMClock (ptr) : null;
+			return clockError == CMClockError.None ? new CMClock (ptr, true) : null;
 		}
 #endif
 
@@ -111,10 +111,12 @@ namespace CoreMedia {
 #endif
 	public class CMTimebase : CMClockOrTimebase
 	{
+#if !NET
 		public CMTimebase (IntPtr handle)
 			: base (handle)
 		{
 		}
+#endif
 
 		private CMTimebase (IntPtr handle, bool owns) 
 			: base (handle, owns)
@@ -728,7 +730,7 @@ namespace CoreMedia {
 #endif
 	public class CMClockOrTimebase : NativeObject
 	{
-#if !XAMCORE_4_0
+#if !NET
 		public CMClockOrTimebase (IntPtr handle)
 			: base (handle, false)
 		{

--- a/src/CoreServices/FSEvents.cs
+++ b/src/CoreServices/FSEvents.cs
@@ -253,7 +253,7 @@ namespace CoreServices
 			}
 
 			var events = new FSEvent[numEvents];
-			var pathArray = new CFArray (eventPaths);
+			var pathArray = new CFArray (eventPaths, false);
 
 			for (int i = 0; i < events.Length; i++) {
 				events[i].Flags = (FSEventStreamEventFlags)(uint)Marshal.ReadInt32 (eventFlags, i * 4);

--- a/src/CoreText/CTStringAttributes.cs
+++ b/src/CoreText/CTStringAttributes.cs
@@ -188,7 +188,7 @@ namespace CoreText {
 		public CGColor ForegroundColor {
 			get {
 				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.ForegroundColor.Handle);
-				return h == IntPtr.Zero ? null : new CGColor (h);
+				return h == IntPtr.Zero ? null : new CGColor (h, false);
 			}
 			set {Adapter.SetNativeValue (Dictionary, CTStringAttributeKey.ForegroundColor, value);}
 		}
@@ -202,7 +202,7 @@ namespace CoreText {
 				var x = CTStringAttributeKey.BackgroundColor;
 				if (x != null)
 					h = CFDictionary.GetValue (Dictionary.Handle, x.Handle);
-				return h == IntPtr.Zero ? null : new CGColor (h);
+				return h == IntPtr.Zero ? null : new CGColor (h, false);
 			}
 			set {
 				var x = CTStringAttributeKey.BackgroundColor;
@@ -228,7 +228,7 @@ namespace CoreText {
 		public CGColor StrokeColor {
 			get {
 				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.StrokeColor.Handle);
-				return h == IntPtr.Zero ? null : new CGColor (h);
+				return h == IntPtr.Zero ? null : new CGColor (h, false);
 			}
 			set {Adapter.SetNativeValue (Dictionary, CTStringAttributeKey.StrokeColor, value);}
 		}
@@ -294,7 +294,7 @@ namespace CoreText {
 		public CGColor UnderlineColor {
 			get {
 				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.UnderlineColor.Handle);
-				return h == IntPtr.Zero ? null : new CGColor (h);
+				return h == IntPtr.Zero ? null : new CGColor (h, false);
 			}
 			set {Adapter.SetNativeValue (Dictionary, CTStringAttributeKey.UnderlineColor, value);}
 		}

--- a/src/Foundation/NSEnumerator_1.cs
+++ b/src/Foundation/NSEnumerator_1.cs
@@ -35,9 +35,11 @@ namespace Foundation {
 	public sealed class NSEnumerator<TKey> : NSEnumerator
 		where TKey : class, INativeObject
 	{
+#if !NET
 		public NSEnumerator ()
 		{
 		}
+#endif
 
 		internal NSEnumerator (IntPtr handle)
 			: base (handle)

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -180,10 +180,21 @@ namespace Foundation {
 			InitializeObject (alloced);
 		}
 		
-		public NSObject (IntPtr handle) : this (handle, false) {
+#if NET
+		protected internal NSObject (IntPtr handle)
+#else
+		public NSObject (IntPtr handle)
+#endif
+			: this (handle, false)
+		{
 		}
 		
-		public NSObject (IntPtr handle, bool alloced) {
+#if NET
+		protected NSObject (IntPtr handle, bool alloced)
+#else
+		public NSObject (IntPtr handle, bool alloced)
+#endif
+		{
 			this.handle = handle;
 			InitializeObject (alloced);
 		}

--- a/src/ImageIO/CGImageAnimation.cs
+++ b/src/ImageIO/CGImageAnimation.cs
@@ -125,7 +125,7 @@ namespace ImageIO
             {
                 var del = BlockLiteral.GetTarget<CGImageSourceAnimationHandler> (block);
                 if (del != null)
-                    del (index, new CoreGraphics.CGImage (image), out stop);
+                    del (index, new CoreGraphics.CGImage (image, false), out stop);
                 else
                     stop = false;
             }

--- a/src/Network/NWAdvertiseDescriptor.cs
+++ b/src/Network/NWAdvertiseDescriptor.cs
@@ -28,7 +28,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWAdvertiseDescriptor : NativeObject {
+#if NET
+		internal NWAdvertiseDescriptor (IntPtr handle, bool owns) : base (handle, owns)
+#else
 		public NWAdvertiseDescriptor (IntPtr handle, bool owns) : base (handle, owns)
+#endif
 		{ }
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -50,7 +50,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWConnection : NativeObject {
+#if NET
+		internal NWConnection (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWConnection (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern nw_connection_t nw_connection_create (nw_endpoint_t endpoint, nw_parameters_t parameters);

--- a/src/Network/NWContentContext.cs
+++ b/src/Network/NWContentContext.cs
@@ -31,7 +31,11 @@ namespace Network {
 #endif
 	public class NWContentContext : NativeObject {
 		bool global;
+#if NET
+		internal NWContentContext (IntPtr handle, bool owns) : base (handle, owns)
+#else
 		public NWContentContext (IntPtr handle, bool owns) : base (handle, owns)
+#endif
 		{
 		}
 

--- a/src/Network/NWEndpoint.cs
+++ b/src/Network/NWEndpoint.cs
@@ -30,7 +30,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWEndpoint : NativeObject {
+#if NET
+		internal NWEndpoint (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWEndpoint (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		extern static NWEndpointType nw_endpoint_get_type (OS_nw_endpoint handle);

--- a/src/Network/NWError.cs
+++ b/src/Network/NWError.cs
@@ -26,7 +26,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWError : NativeObject {
+#if NET
+		internal NWError (IntPtr handle, bool owns) : base (handle, owns)
+#else
 		public NWError (IntPtr handle, bool owns) : base (handle, owns)
+#endif
 		{
 		}
 

--- a/src/Network/NWInterface.cs
+++ b/src/Network/NWInterface.cs
@@ -29,7 +29,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWInterface : NativeObject {
+#if NET
+		internal NWInterface (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWInterface (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern NWInterfaceType nw_interface_get_type (OS_nw_interface iface);

--- a/src/Network/NWListener.cs
+++ b/src/Network/NWListener.cs
@@ -30,7 +30,11 @@ namespace Network {
 	public class NWListener : NativeObject {
 		bool connectionHandlerWasSet = false;
 		object connectionHandlerLock = new object ();
+#if NET
+		internal NWListener (IntPtr handle, bool owns) : base (handle, owns)
+#else
 		public NWListener (IntPtr handle, bool owns) : base (handle, owns)
+#endif
 		{
 		}
 

--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -30,7 +30,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWParameters : NativeObject {
+#if NET
+		internal NWParameters (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWParameters (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		static unsafe BlockLiteral *DEFAULT_CONFIGURATION () => (BlockLiteral *) NWParametersConstants._DefaultConfiguration;
 

--- a/src/Network/NWPath.cs
+++ b/src/Network/NWPath.cs
@@ -27,7 +27,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWPath : NativeObject {
+#if NET
+		internal NWPath (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWPath (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		extern static NWPathStatus nw_path_get_status (IntPtr handle);

--- a/src/Network/NWPathMonitor.cs
+++ b/src/Network/NWPathMonitor.cs
@@ -29,7 +29,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWPathMonitor : NativeObject {
+#if NET
+		internal NWPathMonitor (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWPathMonitor (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		extern static IntPtr nw_path_monitor_create ();

--- a/src/Network/NWPrivacyContext.cs
+++ b/src/Network/NWPrivacyContext.cs
@@ -20,7 +20,11 @@ namespace Network {
 		public static NWPrivacyContext Default =>
 			new NWPrivacyContext (NWPrivacyContextConstants._DefaultContext, false); 
 
+#if NET
+		internal NWPrivacyContext (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWPrivacyContext (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern unsafe OS_nw_privacy_context nw_privacy_context_create (string description);

--- a/src/Network/NWProtocolDefinition.cs
+++ b/src/Network/NWProtocolDefinition.cs
@@ -29,7 +29,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWProtocolDefinition : NativeObject {
+#if NET
+		internal NWProtocolDefinition (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWProtocolDefinition (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]

--- a/src/Network/NWProtocolMetadata.cs
+++ b/src/Network/NWProtocolMetadata.cs
@@ -54,7 +54,11 @@ namespace Network {
 		}
 #endif
 
+#if NET
+		internal NWProtocolMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWProtocolMetadata (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern OS_nw_protocol_definition nw_protocol_metadata_copy_definition (OS_nw_protocol_metadata metadata);

--- a/src/Network/NWProtocolOptions.cs
+++ b/src/Network/NWProtocolOptions.cs
@@ -30,7 +30,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWProtocolOptions : NativeObject {
+#if NET
+		internal NWProtocolOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWProtocolOptions (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern OS_nw_protocol_definition nw_protocol_options_copy_definition (IntPtr options);

--- a/src/Network/NWProtocolStack.cs
+++ b/src/Network/NWProtocolStack.cs
@@ -32,7 +32,11 @@ namespace Network {
 	[SupportedOSPlatform ("tvos12.0")]
 #endif
 	public class NWProtocolStack : NativeObject {
+#if NET
+		internal NWProtocolStack (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWProtocolStack (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern void nw_protocol_stack_prepend_application_protocol (nw_protocol_stack_t stack, nw_protocol_options_t options);

--- a/src/Network/NWQuicMetadata.cs
+++ b/src/Network/NWQuicMetadata.cs
@@ -19,7 +19,11 @@ namespace Network {
 #endif
 	public class NWQuicMetadata : NWProtocolMetadata {
 
+#if NET
+		internal NWQuicMetadata (IntPtr handle, bool owns) : base (handle, owns) { }
+#else
 		public NWQuicMetadata (IntPtr handle, bool owns) : base (handle, owns) { }
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern ulong nw_quic_get_remote_idle_timeout (OS_nw_protocol_metadata metadata);

--- a/src/Network/NWResolverConfig.cs
+++ b/src/Network/NWResolverConfig.cs
@@ -18,7 +18,11 @@ namespace Network {
 #endif
 	public class NWResolverConfig : NativeObject {
 
+#if NET
+		internal NWResolverConfig (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public NWResolverConfig (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 		
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_resolver_config nw_resolver_config_create_https (OS_nw_endpoint urlEndpoint);

--- a/src/ObjCRuntime/BaseWrapper.cs
+++ b/src/ObjCRuntime/BaseWrapper.cs
@@ -13,7 +13,11 @@ namespace ObjCRuntime {
 
 	public abstract class BaseWrapper : NativeObject {
 
+#if NET
+		protected BaseWrapper (IntPtr handle, bool owns)
+#else
 		public BaseWrapper (IntPtr handle, bool owns)
+#endif
 			: base (handle, owns)
 		{
 		}

--- a/src/Security/Policy.cs
+++ b/src/Security/Policy.cs
@@ -38,7 +38,7 @@ using Foundation;
 
 namespace Security {
 	public partial class SecPolicy : NativeObject {
-#if !XAMCORE_4_0
+#if !NET
 		public SecPolicy (IntPtr handle)
 			: base (handle, false, true)
 		{

--- a/src/Security/SecCertificate2.cs
+++ b/src/Security/SecCertificate2.cs
@@ -29,7 +29,11 @@ namespace Security {
 	[SupportedOSPlatform ("macos10.14")]
 #endif
 	public class SecCertificate2 : NativeObject {
+#if NET
+		internal SecCertificate2 (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public SecCertificate2 (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.SecurityLibrary)]
 		extern static IntPtr sec_certificate_create (IntPtr seccertificateHandle);

--- a/src/Security/SecIdentity2.cs
+++ b/src/Security/SecIdentity2.cs
@@ -29,8 +29,12 @@ namespace Security {
 	[SupportedOSPlatform ("macos10.14")]
 #endif
 	public class SecIdentity2 : NativeObject {
+#if NET
+		internal SecIdentity2 (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		internal SecIdentity2 (IntPtr handle) : base (handle, false) {}
 		public SecIdentity2 (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 #if !COREBUILD
 		[DllImport (Constants.SecurityLibrary)]

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -26,7 +26,9 @@ namespace Security {
 	[SupportedOSPlatform ("macos10.14")]
 #endif
 	public class SecProtocolMetadata : NativeObject {
+#if !NET
 		internal SecProtocolMetadata (IntPtr handle) : base (handle, false) {}
+#endif
 
 		// This type is only ever surfaced in response to callbacks in TLS/Network and documented as read-only
 		// if this ever changes, make this public[tv

--- a/src/Security/SecTrust.cs
+++ b/src/Security/SecTrust.cs
@@ -167,7 +167,7 @@ namespace Security {
 		{
 			var del = BlockLiteral.GetTarget<SecTrustCallback> (block);
 			if (del != null) {
-				var t = trust == IntPtr.Zero ? null : new SecTrust (trust);
+				var t = trust == IntPtr.Zero ? null : new SecTrust (trust, false);
 				del (t, trustResult);
 			}
 		}
@@ -230,7 +230,7 @@ namespace Security {
 		{
 			var del = BlockLiteral.GetTarget<SecTrustWithErrorCallback> (block);
 			if (del != null) {
-				var t = trust == IntPtr.Zero ? null : new SecTrust (trust);
+				var t = trust == IntPtr.Zero ? null : new SecTrust (trust, false);
 				var e = error == IntPtr.Zero ? null : new NSError (error);
 				del (t, result, e);
 			}

--- a/src/Security/SecTrust2.cs
+++ b/src/Security/SecTrust2.cs
@@ -29,8 +29,11 @@ namespace Security {
 	[SupportedOSPlatform ("macos10.14")]
 #endif
 	public class SecTrust2 : NativeObject {
-		internal SecTrust2 (IntPtr handle) : base (handle, false) {}
+#if NET
+		internal SecTrust2 (IntPtr handle, bool owns) : base (handle, owns) {}
+#else
 		public SecTrust2 (IntPtr handle, bool owns) : base (handle, owns) {}
+#endif
 
 		[DllImport (Constants.SecurityLibrary)]
 		extern static IntPtr sec_trust_create (IntPtr sectrustHandle);

--- a/src/Security/Trust.cs
+++ b/src/Security/Trust.cs
@@ -43,7 +43,7 @@ using System.Runtime.Versioning;
 
 namespace Security {
 	public partial class SecTrust : NativeObject {
-#if !XAMCORE_4_0
+#if !NET
 		public SecTrust (IntPtr handle) 
 			: base (handle, false)
 		{

--- a/src/UIKit/UIGraphics.cs
+++ b/src/UIKit/UIGraphics.cs
@@ -144,7 +144,7 @@ namespace UIKit {
 			if (ctx == IntPtr.Zero)
 				return null;
 
-			return new CGContext (ctx);
+			return new CGContext (ctx, false);
 		}
 
 		public static void PushContext (CGContext ctx)

--- a/src/VideoToolbox/VTCompressionSession.cs
+++ b/src/VideoToolbox/VTCompressionSession.cs
@@ -27,10 +27,12 @@ namespace VideoToolbox {
 	public class VTCompressionSession : VTSession {
 		GCHandle callbackHandle;
 
+#if !NET
 		/* invoked by marshallers */
 		protected internal VTCompressionSession (IntPtr handle) : base (handle)
 		{
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal VTCompressionSession (IntPtr handle, bool owns) : base (handle, owns)

--- a/src/VideoToolbox/VTDecompressionSession.cs
+++ b/src/VideoToolbox/VTDecompressionSession.cs
@@ -30,7 +30,7 @@ namespace VideoToolbox {
 
 		GCHandle callbackHandle;
 
-#if !XAMCORE_4_0
+#if !NET
 		protected internal VTDecompressionSession (IntPtr handle) : base (handle)
 		{
 		}

--- a/src/VideoToolbox/VTFrameSilo.cs
+++ b/src/VideoToolbox/VTFrameSilo.cs
@@ -26,7 +26,7 @@ namespace VideoToolbox {
 	[Mac (10,10), iOS (8,0), TV (10,2)]
 #endif
 	public class VTFrameSilo : NativeObject {
-#if !XAMCORE_4_0
+#if !NET
 		protected internal VTFrameSilo (IntPtr handle)
 			: base (handle, false)
 		{

--- a/src/VideoToolbox/VTMultiPassStorage.cs
+++ b/src/VideoToolbox/VTMultiPassStorage.cs
@@ -29,10 +29,12 @@ namespace VideoToolbox {
 		bool closed;
 		VTStatus closedStatus;
 
+#if !NET
 		protected internal VTMultiPassStorage (IntPtr handle)
 			: base (handle, false)
 		{
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal VTMultiPassStorage (IntPtr handle, bool owns)

--- a/src/VideoToolbox/VTSession.cs
+++ b/src/VideoToolbox/VTSession.cs
@@ -27,10 +27,12 @@ namespace VideoToolbox {
 	[iOS (8,0), TV (10,2)]
 #endif
 	public class VTSession : NativeObject {
+#if !NET
 		protected internal VTSession (IntPtr handle)
 			: base (handle, false)
 		{
 		}
+#endif
 
 		[Preserve (Conditional=true)]
 		internal VTSession (IntPtr handle, bool owns)

--- a/tests/monotouch-test/CoreFoundation/PropertyListTests.cs
+++ b/tests/monotouch-test/CoreFoundation/PropertyListTests.cs
@@ -53,7 +53,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			using (var dummy = CreateDummy ()) {
 				var rc = CFGetRetainCount (dummy.Handle);
-				using (var clone = new CFPropertyList (dummy.Handle)) {
+				using (var clone = Runtime.GetINativeObject<CFPropertyList> (dummy.Handle, false)) {
 					Assert.AreEqual (clone.Handle, dummy.Handle, "Handle 1");
 					Assert.AreEqual (rc + 1, CFGetRetainCount (clone.Handle), "RC 1");
 				}
@@ -61,7 +61,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 
 			using (var dummy = CreateDummy ()) {
 				var rc = CFGetRetainCount (dummy.Handle);
-				using (var clone = new CFPropertyList (dummy.Handle, false)) {
+				using (var clone = Runtime.GetINativeObject<CFPropertyList> (dummy.Handle, false)) {
 					Assert.AreEqual (clone.Handle, dummy.Handle, "Handle 2");
 					Assert.AreEqual (rc + 1, CFGetRetainCount (clone.Handle), "RC 2");
 				}
@@ -70,7 +70,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			using (var dummy = CreateDummy ()) {
 				CFRetain (dummy.Handle);
 				var rc = CFGetRetainCount (dummy.Handle);
-				using (var clone = new CFPropertyList (dummy.Handle, true)) {
+				using (var clone = Runtime.GetINativeObject<CFPropertyList> (dummy.Handle, true)) {
 					Assert.AreEqual (clone.Handle, dummy.Handle, "Handle 3");
 					Assert.AreEqual (rc, CFGetRetainCount (clone.Handle), "RC 3");
 				}

--- a/tests/monotouch-test/CoreMedia/CMClockOrTimebaseTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMClockOrTimebaseTest.cs
@@ -19,7 +19,7 @@ namespace MonoTouchFixtures.CoreMedia
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var clock = CMClock.HostTimeClock;
-			var timebase = new CMClockOrTimebase (clock.Handle);
+			var timebase = Runtime.GetINativeObject<CMClockOrTimebase> (clock.Handle, false);
 			// we should be able to dispose the clock and the timebase with no crashes.
 			Assert.AreEqual (clock.Handle, timebase.Handle);
 			clock.Dispose ();

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -196,7 +196,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Assert.That (ptr, Is.EqualTo (IntPtr.Zero), "#e1");
 			ptr = Messaging.IntPtr_objc_msgSend_bool (receiver, new Selector ("INativeObject5:").Handle, true);
 			Assert.That (ptr, Is.Not.EqualTo (IntPtr.Zero), "#e2");
-			path = new CGPath (ptr);
+			path = Runtime.GetINativeObject<CGPath> (ptr, false);
 			path.AddArc (1, 2, 3, 4, 5, false); // this should crash if we get back a bogus ptr
 		}
 


### PR DESCRIPTION
* There should be no public (IntPtr) constructor, at most there should be a
  protected one for NSObject subclasses. There should be no such constructors
  for classes that just implement INativeObject.
* There should be no public (IntPtr, bool) constructor at all, they should all
  be internal.
* If changing the visibility or removing the ctor is a breaking change, then
  make it happen for .NET only.