### PR TITLE
[AppKit] Remove NSKey from .NET, it's not used anywhere in our API, nor can I find it in headers.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -546,13 +546,10 @@ namespace AppKit {
 		Pen = 1, PenLower = 2, PenUpper = 4
 	}
 
-#if !XAMCORE_4_0
+#if !NET
 	[NoMacCatalyst]
 	[Native]
 	public enum NSKey : ulong {
-#else
-	public enum NSKey : int
-#endif
 		A              = 0x00,
 		S              = 0x01,
 		D              = 0x02,
@@ -671,6 +668,7 @@ namespace AppKit {
 		DownArrow      = 0x7D,
 		UpArrow        = 0x7E
 	}
+#endif // !NET
 
 #if !XAMCORE_4_0
 	[NoMacCatalyst]

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -284,7 +284,6 @@
 !unknown-native-enum! NSFunctionKey bound
 !unknown-native-enum! NSGlyphStorageOptions bound
 !unknown-native-enum! NSImageScale bound
-!unknown-native-enum! NSKey bound
 !unknown-native-enum! NSMenuProperty bound
 !unknown-native-enum! NSPanelButtonType bound
 !unknown-native-enum! NSRunResponse bound


### PR DESCRIPTION
xtro also agrees that it shouldn't exist.