### PR TITLE
[ObjCRuntime] There's no need to look up our own functions dynamically for Xamarin.Mac in .NET. Fixes #13398.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1846,7 +1846,7 @@ namespace ObjCRuntime {
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
-#if MONOMAC
+#if MONOMAC && !NET
 		public static void ReleaseBlockOnMainThread (IntPtr block)
 		{
 			if (release_block_on_main_thread is null)

--- a/src/ObjCRuntime/Runtime.mac.cs
+++ b/src/ObjCRuntime/Runtime.mac.cs
@@ -79,6 +79,10 @@ namespace ObjCRuntime {
 		}
 #endif // !NET
 
+#if NET
+		[DllImport ("__Internal")]
+		extern static void xamarin_initialize ();
+#else
 		static IntPtr runtime_library;
 
 		internal static T LookupInternalFunction<T> (string name) where T: class
@@ -106,6 +110,7 @@ namespace ObjCRuntime {
 				throw new EntryPointNotFoundException (string.Format ("Could not find the runtime method '{0}'", name));
 			return (T) (object) Marshal.GetDelegateForFunctionPointer (rv, typeof (T));
 		}
+#endif
 
 		internal static void EnsureInitialized ()
 		{
@@ -119,7 +124,11 @@ namespace ObjCRuntime {
 			VerifyMonoVersion ();
 #endif
 
+#if NET
+			xamarin_initialize ();
+#else
 			LookupInternalFunction<initialize_func> ("xamarin_initialize") ();
+#endif
 		}
 
 #if !NET


### PR DESCRIPTION
We'll always be a self-contained app, with our libxamarin code linked
statically into the executable, so we can use plain P/Invokes.

Fixes https://github.com/xamarin/xamarin-macios/issues/13398.