### PR TITLE
[AVFoundation] Fix availability for a few enums

### DIFF
--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -323,7 +323,10 @@ namespace AVFoundation {
 	}
 #endif // !XAMCORE_3_0 || MONOMAC 
 
-#if !MONOMAC || !XAMCORE_4_0
+	[Mac (10,15)]
+	[iOS (8,0)]
+	[TV (12,0)]
+	[Watch (7,0)]
 	[Flags]
 	[Native]
 	// NSUInteger - AVAudioSession.h
@@ -331,6 +334,8 @@ namespace AVFoundation {
 		ShouldResume = 1
 	}
 
+	[Mac (10,15)]
+	[Watch (7,0)]
 	[Flags]
 	[Native]
 	// NSUInteger - AVAudioSession.h
@@ -338,6 +343,8 @@ namespace AVFoundation {
 		NotifyOthersOnDeactivation = 1
 	}
 
+	[Mac (10,15)]
+	[Watch (7,0)]
 	[Native]
 	// NSUInteger - AVAudioSession.h
 	public enum AVAudioSessionPortOverride : ulong {
@@ -352,6 +359,8 @@ namespace AVFoundation {
 		Speaker = 0x73706b72 // 'spkr'
 	}
 
+	[Mac (10,15)]
+	[Watch (7,0)]
 	[Native]
 	// NSUInteger - AVAudioSession.h
 	public enum AVAudioSessionRouteChangeReason : ulong {
@@ -400,7 +409,7 @@ namespace AVFoundation {
 #else
 		[Obsoleted (PlatformName.MacOSX, 10,7, message : "Unavailable and will be removed in the future.")]
 #endif
-		[NoWatch, iOS (10,0), TV (10,0)]
+		[Watch (3,0), iOS (10,0), TV (10,0)]
 		AllowBluetoothA2DP = 32,
 #if XAMCORE_4_0 // Removed in Xcode 12 GM
 		[NoMac]
@@ -415,12 +424,15 @@ namespace AVFoundation {
 		OverrideMutedMicrophoneInterruption = 128,
 	}
 
+	[Mac (10,15)]
+	[Watch (7,0)]
 	[Native]
 	// NSUInteger - AVAudioSession.h
 	public enum AVAudioSessionInterruptionType : ulong  {
 		Ended, Began
 	}
 
+	[Mac (10,15)]
 	[Native]
 	// NSInteger - AVAudioSession.h
 	// typedef CF_ENUM(NSInteger, AVAudioSessionErrorCode) -> CoreAudioTypes.framework/Headers/AudioSessionTypes.h
@@ -445,7 +457,6 @@ namespace AVFoundation {
 		ExpiredSession = 0x21736573, // '!ses'
 		SessionNotActive = 0x696e6163, // 'inac'
 	}
-#endif
 
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
@@ -482,15 +493,14 @@ namespace AVFoundation {
 		NotDetermined, Restricted, Denied, Authorized
 	}
 
-#if !MONOMAC || !XAMCORE_4_0
 	[iOS (7,0)]
+	[Mac (10,14)]
 	[Native]
 	// NSInteger - AVSpeechSynthesis.h
 	public enum AVSpeechBoundary : long {
 		Immediate,
 		Word
 	}
-#endif
 
 	[iOS (8,0)]
 	[Native]

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -515,8 +515,10 @@ namespace AVFoundation {
 		Auto = 7,
 	}
 
-#if !MONOMAC || !XAMCORE_4_0
-	[NoTV, Watch (5,0)]
+	[iOS (8,0)]
+	[Mac (10,15)]
+	[TV (12,0)]
+	[Watch (7,0)]
 	[Native]
 	public enum AVAudioSessionRecordPermission : ulong {
 		Undetermined = 1970168948 /*'undt'*/,
@@ -524,12 +526,14 @@ namespace AVFoundation {
 		Granted = 1735552628 /*'grnt'*/
 	}
 
+	[iOS (8,0)]
+	[Mac (10,15)]
+	[Watch (7,0)]
 	[Native]
 	public enum AVAudioSessionSilenceSecondaryAudioHintType : ulong {
 		Begin = 1,
 		End = 0
 	}
-#endif
 
 	[Flags]
 	[Native]

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-AVFoundation.ignore
@@ -1,9 +1,8 @@
 ## https://github.com/xamarin/xamarin-macios/issues/3213 should be fixed before conformance to 'AVQueuedSampleBufferRendering' is restored.
 !missing-protocol-conformance! AVSampleBufferDisplayLayer should conform to AVQueuedSampleBufferRendering (defined in 'AVSampleBufferDisplayLayerQueueManagement' category)
 
-# as per the header comments, the following two enums have to be ignored on tvOS
+# as per the header comments, the following enum has to be ignored on tvOS
 !missing-enum! AVAudioSessionIOType not bound
-!missing-enum! AVAudioSessionRecordPermission not bound
 
 # removed in TV 12,0, API that used them was removed in TV 10, added obsolete attr.
 !unknown-field! AVAssetDownloadTaskMediaSelectionKey bound

--- a/tests/xtro-sharpie/tvOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/tvOS-AVFoundation.ignore
@@ -1,9 +1,8 @@
 ## https://github.com/xamarin/xamarin-macios/issues/3213 should be fixed before conformance to 'AVQueuedSampleBufferRendering' is restored.
 !missing-protocol-conformance! AVSampleBufferDisplayLayer should conform to AVQueuedSampleBufferRendering (defined in 'AVSampleBufferDisplayLayerQueueManagement' category)
 
-# as per the header comments, the following two enums have to be ignored on tvOS
+# as per the header comments, the following enum has to be ignored on tvOS
 !missing-enum! AVAudioSessionIOType not bound
-!missing-enum! AVAudioSessionRecordPermission not bound
 
 # removed in TV 12,0, API that used them was removed in TV 10, added obsolete attr.
 !unknown-field! AVAssetDownloadTaskMediaSelectionKey bound


### PR DESCRIPTION
None of these are deprecated, so no reason for them to not exist in .NET.

Also update the availability attributes according to current headers.