### PR TITLE
[AppKit] Remove the NSLayoutManager.LayoutOptions property and the NSGlyphStorageOptions enum in .NET.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1505,19 +1505,17 @@ namespace AppKit {
 		Auto, Fit, Clip
 	}
 
+#if !NET
 	[NoMacCatalyst]
 	[Flags]
-#if !XAMCORE_4_0
 	[Native]
 	[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'NSGlyphProperty' instead.")]
 	public enum NSGlyphStorageOptions : ulong {
-#else
-	public enum NSGlyphStorageOptions : int
-#endif
 		ShowControlGlyphs = 1,
 		ShowInvisibleGlyphs = 2,
 		WantsBidiLevels = 4
 	}
+#endif // !NET
 
 #if !XAMCORE_4_0
 	[NoMacCatalyst]

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -331,7 +331,7 @@ namespace UIKit {
 		[Export ("textContainerChangedTextView:")]
 		void TextContainerChangedTextView (NSTextContainer container);
 
-#if !XAMCORE_4_0
+#if !NET
 		// This was removed in the headers in the macOS 10.11 SDK
 		[NoiOS][NoTV]
 		[NoMacCatalyst]

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -282,7 +282,6 @@
 !unknown-native-enum! NSEventModifierMask bound
 !unknown-native-enum! NSFontPanelMode bound
 !unknown-native-enum! NSFunctionKey bound
-!unknown-native-enum! NSGlyphStorageOptions bound
 !unknown-native-enum! NSImageScale bound
 !unknown-native-enum! NSKey bound
 !unknown-native-enum! NSMenuProperty bound


### PR DESCRIPTION
The former has been removed from the headers, so it's thoroughly deprecated,
and the latter is no longer needed anymore since it was only used by the
former.