### PR TITLE
[introspection] Fix the ApiFrameworkTest.Simlauncher test to fail in case of errors.

### DIFF
--- a/tests/introspection/ApiFrameworkTest.cs
+++ b/tests/introspection/ApiFrameworkTest.cs
@@ -144,7 +144,7 @@ namespace Introspection {
 			AssertIfErrors ($"{Errors} unknown frameworks found:\n{ErrorData}");
 		}
 
-#if __IOS__ && !__MACCATALYST__
+#if __IOS__ && !__MACCATALYST__ && !NET
 		[Test]
 		public void Simlauncher ()
 		{
@@ -202,6 +202,8 @@ namespace Introspection {
 				}
 
 			}
+
+			AssertIfErrors ($"{Errors} unknown frameworks found:\n{ErrorData}");
 		}
 #endif
 	}


### PR DESCRIPTION
* Assert at the end of the test if there were any errors.
* Don't run this test for .NET, since we don't use a simlauncher in .NET.