### PR TITLE
[msbuild/tests] Add support for xcframeworks with static libraries in them.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ResolveNativeReferencesBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ResolveNativeReferencesBase.cs
@@ -41,6 +41,20 @@ namespace Xamarin.MacDev.Tasks {
 
 		#endregion
 
+		// returns the Mach-O file for the given path:
+		// * for frameworks, returns foo.framework/foo
+		// * for anything else, returns the input path
+		static string? GetActualLibrary (string? path)
+		{
+			if (path is null)
+				return null;
+
+			if (path.EndsWith (".framework", StringComparison.OrdinalIgnoreCase))
+				return Path.Combine (path, Path.GetFileNameWithoutExtension (path));
+
+			return path;
+		}
+
 		public override bool Execute ()
 		{
 			var native_frameworks = new List<ITaskItem> ();
@@ -227,7 +241,7 @@ namespace Xamarin.MacDev.Tasks {
 				}
 				var library_path = (PString) item ["LibraryPath"];
 				var library_identifier = (PString) item ["LibraryIdentifier"];
-				return Path.Combine (library_identifier, library_path, Path.GetFileNameWithoutExtension (library_path));
+				return GetActualLibrary (Path.Combine (library_identifier, library_path));
 			}
 			return String.Empty;
 		}

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -148,8 +148,13 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			>
-			<Output TaskParameter="NativeFrameworks" ItemName="_FrameworkNativeReference" />
+			<Output TaskParameter="NativeFrameworks" ItemName="_ResolvedNativeReference" />
 		</ResolveNativeReferences>
+
+		<ItemGroup>
+			<_FrameworkNativeReference Include="@(_ResolvedNativeReference)" Condition="'%(Kind)' == 'Framework'" />
+			<_FileNativeReference Include="@(_ResolvedNativeReference)" Condition="'%(Kind)' == 'Static' Or '%(Kind)' == 'Dynamic'" />
+		</ItemGroup>
 	</Target>
 	
 	<PropertyGroup>

--- a/tests/bindings-test/StructsAndEnums.cs
+++ b/tests/bindings-test/StructsAndEnums.cs
@@ -9,6 +9,11 @@ using MatrixFloat3x3 = global::OpenTK.NMatrix3;
 using MatrixFloat4x3 = global::OpenTK.NMatrix4x3;
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 
+public static class LibTest {
+	[DllImport ("__Internal")]
+	public static extern int theUltimateAnswer ();
+}
+
 namespace Bindings.Test
 {
 	public static class CFunctions {

--- a/tests/bindings-test/dotnet/shared.csproj
+++ b/tests/bindings-test/dotnet/shared.csproj
@@ -6,6 +6,7 @@
     <AssemblyOriginatorKeyFile>..\..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>
     <IsBindingProject>true</IsBindingProject>
+    <NoBindingEmbedding>true</NoBindingEmbedding>
 
     <RootTestsDirectory>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\..'))</RootTestsDirectory>
     <BindingsTestDirectory>$(RootTestsDirectory)\bindings-test</BindingsTestDirectory>
@@ -30,17 +31,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ObjcBindingNativeLibrary Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\libtest.a">
-      <Link>libtest.a</Link>
-    </ObjcBindingNativeLibrary>
+    <NativeReference Include="$(TestLibrariesDirectory)\.libs\libtest.xcframework">
+      <Kind>Static</Kind>
+    </NativeReference>
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="$(RootTestsDirectory)\common\ConditionalCompilation.cs">
       <Link>ConditionalCompilation.cs</Link>
-    </Compile>
-    <Compile Include="$(BindingsTestDirectory)\libtest.linkwith.cs">
-      <DependentUpon>libtest.a</DependentUpon>
     </Compile>
     <Compile Include="$(BindingsTestDirectory)\ProtocolTest.cs" />
     <Compile Include="$(RootTestsDirectory)\api-shared\ObjCRuntime\Registrar.cs">
@@ -73,18 +71,17 @@
     <None Include="$(TestLibrariesDirectory)\testgenerator.cs">
       <Link>testgenerator.cs</Link>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.m" />
-    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.h" />
-    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.cs" />
-    <GeneratedTestInput Include="$(TestLibrariesDirectory)\Makefile" />
-    <GeneratedTestOutput Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\libtest.a" />
-    <GeneratedTestOutput Include="$(BindingsTestDirectory)\ApiDefinition.generated.cs" />
-    <GeneratedTestOutput Include="$(BindingsTestDirectory)\StructsAndEnums.generated.cs" />
+    <None Include="$(TestLibrariesDirectory)\libframework.m">
+      <Link>libframework.m</Link>
+    </None>
+    <None Include="$(TestLibrariesDirectory)\libframework.h">
+      <Link>libframework.h</Link>
+    </None>
+    <TestLibrariesInput Include="$(TestLibrariesDirectory)\libframework.m" />
+    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\libtest.xcframework" />
   </ItemGroup>
 
-  <Target Name="BuildTestLibraries" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" BeforeTargets="BeforeBuild">
+  <Target Name="BuildTestLibraries" Inputs="@(TestLibrariesInput)" Outputs="@(TestLibrariesOutput)" BeforeTargets="BeforeBuild">
     <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
   </Target>
 </Project>

--- a/tests/bindings-test/dotnet/shared.csproj
+++ b/tests/bindings-test/dotnet/shared.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <NativeReference Include="$(TestLibrariesDirectory)\.libs\libtest.xcframework">
       <Kind>Static</Kind>
+      <Frameworks>CoreLocation Foundation ModelIO</Frameworks>
     </NativeReference>
   </ItemGroup>
 

--- a/tests/bindings-test/libtest.linkwith.cs
+++ b/tests/bindings-test/libtest.linkwith.cs
@@ -1,13 +1,9 @@
+#if !NET
 using System;
 using ObjCRuntime;
 using System.Runtime.InteropServices;
 
 [assembly: LinkWith ("libtest.a", LinkTarget.Simulator | LinkTarget.ArmV6 | LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Arm64 | LinkTarget.Simulator64, SmartLink = true, Frameworks = LinkWithConstants.Frameworks, LinkerFlags = "-lz")]
-
-public static class LibTest {
-	[DllImport ("__Internal")]
-	public static extern int theUltimateAnswer ();
-}
 
 static class LinkWithConstants
 {
@@ -17,3 +13,4 @@ static class LinkWithConstants
 	public const string Frameworks = "Foundation ModelIO CoreLocation";
 #endif
 }
+#endif

--- a/tests/bindings-test2/dotnet/shared.csproj
+++ b/tests/bindings-test2/dotnet/shared.csproj
@@ -6,6 +6,7 @@
     <AssemblyOriginatorKeyFile>..\..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>
     <IsBindingProject>true</IsBindingProject>
+    <NoBindingEmbedding>true</NoBindingEmbedding>
 
     <RootTestsDirectory>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\..'))</RootTestsDirectory>
     <BindingsTest2Directory>$(RootTestsDirectory)\bindings-test2</BindingsTest2Directory>
@@ -23,15 +24,15 @@
     <ObjcBindingApiDefinition Include="$(BindingsTest2Directory)\ApiDefinition.cs" />
     <ObjcBindingApiDefinition Include="$(BindingsTest2Directory)\ApiProtocol.cs" />
     <ObjcBindingCoreSource Include="$(BindingsTest2Directory)\StructsAndEnums.cs" />
-    <ObjcBindingNativeLibrary Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\libtest2.a">
-      <Link>libtest2.a</Link>
-    </ObjcBindingNativeLibrary>
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(BindingsTest2Directory)\libtest2.linkwith.cs">
-      <DependentUpon>libtest2.a</DependentUpon>
-    </Compile>
+    <NativeReference Include="$(TestLibrariesDirectory)\.libs\libtest2.xcframework">
+      <Kind>Static</Kind>
+    </NativeReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(BindingsTest2Directory)\BindingTest.cs" />
   </ItemGroup>
 
@@ -42,16 +43,17 @@
     <None Include="$(TestLibrariesDirectory)\libtest2.h">
       <Link>libtest2.h</Link>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.m" />
-    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.h" />
-    <GeneratedTestInput Include="$(TestLibrariesDirectory)\*.cs" />
-    <GeneratedTestInput Include="$(TestLibrariesDirectory)\Makefile" />
-    <GeneratedTestOutput Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\libtest2.a" />
+    <None Include="$(TestLibrariesDirectory)\libframework.m">
+      <Link>libframework.m</Link>
+    </None>
+    <None Include="$(TestLibrariesDirectory)\libframework.h">
+      <Link>libframework.h</Link>
+    </None>
+    <TestLibrariesInput Include="$(TestLibrariesDirectory)\libframework.m" />
+    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\libtest2.xcframework" />
   </ItemGroup>
 
-  <Target Name="BuildTestLibraries" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" BeforeTargets="BeforeBuild">
+  <Target Name="BuildTestLibraries" Inputs="@(TestLibrariesInput)" Outputs="@(TestLibrariesOutput)" BeforeTargets="BeforeBuild">
     <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
   </Target>
 </Project>

--- a/tests/dotnet/BindingOldStyle/ApiDefinition.cs
+++ b/tests/dotnet/BindingOldStyle/ApiDefinition.cs
@@ -1,0 +1,7 @@
+using Foundation;
+
+namespace MyApiDefinition {
+	[BaseType (typeof (NSObject))]
+	interface MyNativeClass {
+	}
+}

--- a/tests/dotnet/BindingOldStyle/MacCatalyst/BindingOldStyle.csproj
+++ b/tests/dotnet/BindingOldStyle/MacCatalyst/BindingOldStyle.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/BindingOldStyle/MacCatalyst/Makefile
+++ b/tests/dotnet/BindingOldStyle/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/BindingOldStyle/MyClass.cs
+++ b/tests/dotnet/BindingOldStyle/MyClass.cs
@@ -1,0 +1,8 @@
+using System;
+namespace MyClassLibrary {
+	public class MyClass {
+		public MyClass ()
+		{
+		}
+	}
+}

--- a/tests/dotnet/BindingOldStyle/StructsAndEnums.cs
+++ b/tests/dotnet/BindingOldStyle/StructsAndEnums.cs
@@ -1,0 +1,6 @@
+namespace MyClassLibrary {
+	public struct MyStruct {
+		public int A;
+		public int B;
+	}
+}

--- a/tests/dotnet/BindingOldStyle/iOS/BindingOldStyle.csproj
+++ b/tests/dotnet/BindingOldStyle/iOS/BindingOldStyle.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/BindingOldStyle/iOS/Makefile
+++ b/tests/dotnet/BindingOldStyle/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/BindingOldStyle/macOS/BindingOldStyle.csproj
+++ b/tests/dotnet/BindingOldStyle/macOS/BindingOldStyle.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/BindingOldStyle/macOS/Makefile
+++ b/tests/dotnet/BindingOldStyle/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/BindingOldStyle/shared.csproj
+++ b/tests/dotnet/BindingOldStyle/shared.csproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<IsBindingProject>true</IsBindingProject>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ObjcBindingApiDefinition Include="../ApiDefinition.cs" />
+		<ObjcBindingCoreSource Include="../StructsAndEnums.cs" />
+		<!-- doesn't have to be a real native library for this particular test, we're just testing what happens with 'dotnet pack' on a project with an ObjcBindingNativeLibrary item (it's supposed to show an error) -->
+		<ObjcBindingNativeLibrary Include="../shared.mk" />
+	</ItemGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+</Project>

--- a/tests/dotnet/BindingOldStyle/shared.mk
+++ b/tests/dotnet/BindingOldStyle/shared.mk
@@ -1,0 +1,3 @@
+TOP=../../../..
+
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/BindingOldStyle/tvOS/BindingOldStyle.csproj
+++ b/tests/dotnet/BindingOldStyle/tvOS/BindingOldStyle.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-tvos</TargetFramework>
+	</PropertyGroup>
+  <Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/BindingOldStyle/tvOS/Makefile
+++ b/tests/dotnet/BindingOldStyle/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/UnitTests/PackTest.cs
+++ b/tests/dotnet/UnitTests/PackTest.cs
@@ -19,12 +19,12 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacCatalyst)]
 		[TestCase (ApplePlatform.TVOS)]
 		[TestCase (ApplePlatform.MacOSX)]
-		public void BindingProject (ApplePlatform platform)
+		public void BindingOldStyle (ApplePlatform platform)
 		{
-			var project = "bindings-test";
+			var project = "BindingOldStyle";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 
-			var project_path = Path.Combine (Configuration.RootPath, "tests", project, "dotnet", platform.AsString (), $"{project}.csproj");
+			var project_path = GetProjectPath (project, platform: platform);
 			Clean (project_path);
 			Configuration.CopyDotNetSupportingFiles (Path.GetDirectoryName (project_path));
 

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -167,16 +167,16 @@ namespace Xamarin.Tests {
 			Assert.That (ad.MainModule.Resources.Count (), Is.EqualTo (2), "2 resources"); // There are 2 embedded resources by default by the F# compiler.
 		}
 
-		[TestCase ("iOS")]
-		[TestCase ("tvOS")]
-		[TestCase ("macOS")]
-		[TestCase ("MacCatalyst")]
-		public void BuildBindingsTest (string platform)
+		[TestCase (ApplePlatform.iOS)]
+		[TestCase (ApplePlatform.TVOS)]
+		[TestCase (ApplePlatform.MacOSX)]
+		[TestCase (ApplePlatform.MacCatalyst)]
+		public void BuildBindingsTest (ApplePlatform platform)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 			var assemblyName = "bindings-test";
 			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
-			var project_dir = Path.Combine (dotnet_bindings_dir, platform);
+			var project_dir = Path.Combine (dotnet_bindings_dir, platform.AsString ());
 			var project_path = Path.Combine (project_dir, $"{assemblyName}.csproj");
 
 			Clean (project_path);
@@ -194,20 +194,21 @@ namespace Xamarin.Tests {
 
 			// Verify that there's one resource in the binding assembly, and its name
 			var ad = AssemblyDefinition.ReadAssembly (asm, new ReaderParameters { ReadingMode = ReadingMode.Deferred });
-			Assert.That (ad.MainModule.Resources.Count, Is.EqualTo (1), "1 resource");
-			Assert.That (ad.MainModule.Resources [0].Name, Is.EqualTo ("libtest.a"), "libtest.a");
+			Assert.That (ad.MainModule.Resources.Count, Is.EqualTo (0), "no embedded resources");
+			var resourceBundle = Path.Combine (project_dir, "bin", "Debug", platform.ToFramework (), assemblyName + ".resources");
+			Assert.That (resourceBundle, Does.Exist, "Bundle existence");
 		}
 
-		[TestCase ("iOS")]
-		[TestCase ("tvOS")]
-		[TestCase ("macOS")]
-		[TestCase ("MacCatalyst")]
-		public void BuildBindingsTest2 (string platform)
+		[TestCase (ApplePlatform.iOS)]
+		[TestCase (ApplePlatform.TVOS)]
+		[TestCase (ApplePlatform.MacOSX)]
+		[TestCase (ApplePlatform.MacCatalyst)]
+		public void BuildBindingsTest2 (ApplePlatform platform)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 			var assemblyName = "bindings-test2";
 			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
-			var project_dir = Path.Combine (dotnet_bindings_dir, platform);
+			var project_dir = Path.Combine (dotnet_bindings_dir, platform.AsString ());
 			var project_path = Path.Combine (project_dir, $"{assemblyName}.csproj");
 
 			Clean (project_path);
@@ -224,8 +225,9 @@ namespace Xamarin.Tests {
 
 			// Verify that there's one resource in the binding assembly, and its name
 			var ad = AssemblyDefinition.ReadAssembly (asm, new ReaderParameters { ReadingMode = ReadingMode.Deferred });
-			Assert.That (ad.MainModule.Resources.Count, Is.EqualTo (1), "1 resource");
-			Assert.That (ad.MainModule.Resources [0].Name, Is.EqualTo ("libtest2.a"), "libtest2.a");
+			Assert.That (ad.MainModule.Resources.Count, Is.EqualTo (0), "no embedded resources");
+			var resourceBundle = Path.Combine (project_dir, "bin", "Debug", platform.ToFramework (), assemblyName + ".resources");
+			Assert.That (resourceBundle, Does.Exist, "Bundle existence");
 		}
 
 		[TestCase ("iOS", "monotouch")]

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -336,6 +336,22 @@ XTEST_XCTARGETS += \
 
 all-local:: .libs/XTest.xcframework
 
+LIBTEST_XCFRAMEWORKS += $(foreach platform,$(XCPLATFORMS),.libs/$(platform)/libtest.a)
+
+.libs/libtest.xcframework: $(LIBTEST_XCFRAMEWORKS) Makefile
+	$(Q) rm -rf $@
+	$(Q_GEN) $(XCODE_DEVELOPER_ROOT)/usr/bin/xcodebuild -quiet -create-xcframework $(foreach lib,$(LIBTEST_XCFRAMEWORKS),-library $(lib)) -output $@
+
+all-local:: .libs/libtest.xcframework
+
+LIBTEST2_XCFRAMEWORKS += $(foreach platform,$(XCPLATFORMS),.libs/$(platform)/libtest2.a)
+
+.libs/libtest2.xcframework: $(LIBTEST2_XCFRAMEWORKS) Makefile
+	$(Q) rm -rf $@
+	$(Q_GEN) $(XCODE_DEVELOPER_ROOT)/usr/bin/xcodebuild -quiet -create-xcframework $(foreach lib,$(LIBTEST2_XCFRAMEWORKS),-library $(lib)) -output $@
+
+all-local:: .libs/libtest2.xcframework
+
 # Xamarin.Mac
 
 MAC_CLANG = DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT) $(MAC_CC)


### PR DESCRIPTION
* Add support for xcframeworks with static libraries in them.
* Create a libtest.xcframework and a libtest2.xcframework for our tests.
* Make the .NET version of bindings-test and bindings-test2 use an xcframework
  instead of a fat static library.

This is required for supporting ARM64 in the simulator, because then we won't
be able to create a fat static library for all the architectures we support
anymore, because there will be two ARM64 slices, one for device and one for
the simulator. By switching to an xcframework of static libraries, we don't
run into this problem.