### PR TITLE
[AppKit] Change NSTextViewDelegate.DraggedCell to use the recommended signature for .NET

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19418,9 +19418,9 @@ namespace AppKit {
 		[Export ("textView:didCheckTextInRange:types:options:results:orthography:wordCount:"), DelegateName ("NSTextViewTextChecked"), DefaultValueFromArgument ("results")]
 		NSTextCheckingResult [] DidCheckText (NSTextView view, NSRange range, NSTextCheckingTypes checkingTypes, NSDictionary options, NSTextCheckingResult [] results, NSOrthography orthography, nint wordCount);
 
-#if !XAMCORE_4_0
-		[Export ("textView:draggedCell:inRect:event:"), EventArgs ("NSTextViewDraggedCell")]
-		void DraggedCell (NSTextView view, NSTextAttachmentCell cell, CGRect rect, NSEvent theevent);
+#if NET
+		[Export ("textView:draggedCell:inRect:event:atIndex:"), EventArgs ("NSTextViewDraggedCell")]
+		void DraggedCell (NSTextView view, NSTextAttachmentCell cell, CGRect rect, NSEvent @event, nuint charIndex);
 #else
 		[Export ("textView:draggedCell:inRect:event:"), EventArgs ("NSTextViewDraggedCell")]
 		void DraggedCell (NSTextView view, NSTextAttachmentCell cell, CGRect rect, NSEvent theEvent);

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -7648,7 +7648,7 @@ public partial class Generator : IMemberGatherer {
 				print ("{");
 				indent++;
 				foreach (var p in pars.Skip (minPars).OrderBy (p => p.Name, StringComparer.Ordinal)) {
-					print ("this.{0} = {1};", GetPublicParameterName (p), p.Name);
+					print ("this.{0} = {1};", GetPublicParameterName (p), p.Name.GetSafeParamName ());
 				}
 				indent--;
 				print ("}");

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -55,6 +55,10 @@
 !extra-protocol-member! unexpected selector NSTextFieldDelegate::controlTextDidChange: found
 !extra-protocol-member! unexpected selector NSTextFieldDelegate::controlTextDidEndEditing: found
 
+# Deprecated
+
+!missing-protocol-member! NSTextViewDelegate::textView:draggedCell:inRect:event: not found
+
 ## unsorted
 
 !extra-protocol-member! unexpected selector NSApplicationDelegate::orderFrontStandardAboutPanel: found
@@ -199,7 +203,6 @@
 !missing-protocol-member! NSTextViewDelegate::textView:clickedOnCell:inRect: not found
 !missing-protocol-member! NSTextViewDelegate::textView:clickedOnLink: not found
 !missing-protocol-member! NSTextViewDelegate::textView:doubleClickedOnCell:inRect: not found
-!missing-protocol-member! NSTextViewDelegate::textView:draggedCell:inRect:event:atIndex: not found
 !missing-protocol-member! NSTextViewDelegate::textView:URLForContentsOfTextAttachment:atIndex: not found
 !missing-protocol-member! NSTextViewDelegate::textView:willShowSharingServicePicker:forItems: not found
 !missing-protocol-member! NSWindowDelegate::customWindowsToEnterFullScreenForWindow:onScreen: not found


### PR DESCRIPTION
The 'textView:draggedCell:inRect:event:' selector has been deprecated since
macOS 10.6, so just replace this with the recommended alternative.