### PR TITLE
[dotnet] Show an error if an app developer tries to publish a simulator architecture.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
@@ -15,7 +15,7 @@
 		     identifier when publishing for a mobile platform (iOS, tvOS), because the default runtime identifier is for the simulator. -->
 		<Error
 			Text="A runtime identifier must be specified in order to publish this project."
-			Condition="'$(_UsingDefaultRuntimeIdentifier)' == 'true' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')"
+			Condition="'$(_XamarinUsingDefaultRuntimeIdentifier)' == 'true' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')"
 		/>
 
 		<!-- It's mandatory to specify a runtime identifier for device when publishing for a mobile platform (iOS, tvOS). -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
@@ -15,7 +15,7 @@
 		     identifier when publishing for a mobile platform (iOS, tvOS), because the default runtime identifier is for the simulator. -->
 		<Error
 			Text="A runtime identifier must be specified in order to publish this project."
-			Condition="'$(_SetDefaultRuntimeIdentiifer)' == 'true' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')"
+			Condition="'$(_UsingDefaultRuntimeIdentifier)' == 'true' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')"
 		/>
 
 		<!-- It's mandatory to specify a runtime identifier for device when publishing for a mobile platform (iOS, tvOS). -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
@@ -9,6 +9,24 @@
 			<IpaPackageDir Condition="'$(IpaPackageDir)' == '' And '$(IpaPackagePath)' == ''">$(PublishDir)</IpaPackageDir>
 			<PkgPackageDir Condition="'$(PkgPackageDir)' == '' And '$(PkgPackagePath)' == ''">$(PublishDir)</PkgPackageDir>
 		</PropertyGroup>
+
+		<!-- Unfortunately we can't set a default runtime identifier when publishing, because by the time we know we're publishing,
+		     it's too late to change the runtime identifier. This means that we'll have to make it mandatory to specify a runtime
+		     identifier when publishing for a mobile platform (iOS, tvOS), because the default runtime identifier is for the simulator. -->
+		<Error
+			Text="A runtime identifier must be specified in order to publish this project."
+			Condition="'$(_SetDefaultRuntimeIdentiifer)' == 'true' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')"
+		/>
+
+		<!-- It's mandatory to specify a runtime identifier for device when publishing for a mobile platform (iOS, tvOS). -->
+		<Error
+			Text="A runtime identifier for a device architecture must be specified in order to publish this project. '$(RuntimeIdentifier)' is a simulator architecture."
+			Condition="$(RuntimeIdentifier.StartsWith('iossimulator-')) Or $(RuntimeIdentifier.StartsWith('tvossimulator-'))"
+		/>
+		<Error
+			Text="A runtime identifier for a device architecture must be specified in order to publish this project. '$(RuntimeIdentifiers)' are simulator architectures."
+			Condition="$(RuntimeIdentifiers.Contains('iossimulator-')) Or $(RuntimeIdentifiers.Contains('tvossimulator-'))"
+		/>
 	</Target>
 	<Target Name="Publish" DependsOnTargets="_PrePublish;Build">
 		<Message Importance="high" Text="Created the package: $(IpaPackagePath)" Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS'" />

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -35,6 +35,7 @@
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'tvOS'">tvossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'macOS'">osx-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'MacCatalyst'">maccatalyst-x64</RuntimeIdentifier>
+		<_SetDefaultRuntimeIdentiifer>true</_SetDefaultRuntimeIdentiifer>
 		<!--
 			Workaround/hack:
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -35,7 +35,7 @@
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'tvOS'">tvossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'macOS'">osx-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'MacCatalyst'">maccatalyst-x64</RuntimeIdentifier>
-		<_UsingDefaultRuntimeIdentifier>true</_UsingDefaultRuntimeIdentifier>
+		<_XamarinUsingDefaultRuntimeIdentifier>true</_XamarinUsingDefaultRuntimeIdentifier>
 		<!--
 			Workaround/hack:
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -35,7 +35,7 @@
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'tvOS'">tvossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'macOS'">osx-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'MacCatalyst'">maccatalyst-x64</RuntimeIdentifier>
-		<_SetDefaultRuntimeIdentiifer>true</_SetDefaultRuntimeIdentiifer>
+		<_UsingDefaultRuntimeIdentifier>true</_UsingDefaultRuntimeIdentifier>
 		<!--
 			Workaround/hack:
 

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -41,6 +41,13 @@ namespace Xamarin.Tests {
 			return Execute ("publish", project, properties, true);
 		}
 
+		public static ExecutionResult AssertPublishFailure (string project, Dictionary<string, string> properties = null)
+		{
+			var rv = Execute ("publish", project, properties, false);
+			Assert.AreNotEqual (0, rv.ExitCode, "Unexpected success");
+			return rv;
+		}
+
 		public static ExecutionResult AssertBuild (string project, Dictionary<string, string> properties = null)
 		{
 			return Execute ("build", project, properties, true);

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -150,5 +150,58 @@ namespace Xamarin.Tests {
 
 			Assert.That (pkgPath, Does.Exist, "ipa/pkg creation");
 		}
+
+
+		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
+		[TestCase (ApplePlatform.iOS, "iossimulator-x86")]
+		[TestCase (ApplePlatform.iOS, "iossimulator-x64;iossimulator-x64")]
+		[TestCase (ApplePlatform.iOS, "")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64")]
+		[TestCase (ApplePlatform.TVOS, "")]
+		public void PublishFailureTest (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+
+			string packageExtension;
+			string pathVariable;
+			switch (platform) {
+			case ApplePlatform.iOS:
+			case ApplePlatform.TVOS:
+				packageExtension = "ipa";
+				pathVariable = "IpaPackagePath";
+				break;
+			case ApplePlatform.MacCatalyst:
+			case ApplePlatform.MacOSX:
+				packageExtension = "pkg";
+				pathVariable = "PkgPackagePath";
+				break;
+			default:
+				throw new ArgumentOutOfRangeException ($"Unknown platform: {platform}");
+			}
+			var tmpdir = Cache.CreateTemporaryDirectory ();
+			var pkgPath = Path.Combine (tmpdir, $"MyPackage.{packageExtension}");
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties [pathVariable] = pkgPath;
+
+			var rv = DotNet.AssertPublishFailure (project_path, properties);
+			var errors = BinLog.GetBuildLogErrors (rv.BinLogPath).ToArray ();
+			Assert.AreEqual (1, errors.Length, "Error Count");
+			string expectedErrorMessage;
+			if (string.IsNullOrEmpty (runtimeIdentifiers)) {
+				expectedErrorMessage = $"A runtime identifier must be specified in order to publish this project.";
+			} else if (runtimeIdentifiers.IndexOf (';') >= 0) {
+				expectedErrorMessage = $"A runtime identifier for a device architecture must be specified in order to publish this project. '{runtimeIdentifiers}' are simulator architectures.";
+			} else {
+				expectedErrorMessage = $"A runtime identifier for a device architecture must be specified in order to publish this project. '{runtimeIdentifiers}' is a simulator architecture.";
+			}
+			Assert.AreEqual (expectedErrorMessage, errors [0].Message, "Error Message");
+
+			Assert.That (pkgPath, Does.Not.Exist, "ipa/pkg creation");
+		}
 	}
 }


### PR DESCRIPTION
* We can't publish a simulator build, so show an error in that case.
* We can't change the default runtime identifier when publishing (to a
  publishable runtime identifier), because by the time we know we're
  publishing, it's too late to change the runtime identifier. This means that
  it'll be required for app developers to specify a runtime identifier when
  publishing to a mobile platform, since the current default runtime
  identifier is for a simulator build.

Partial fix for https://github.com/xamarin/xamarin-macios/issues/12997.