### PR TITLE
[CoreGraphics] Add back CGPDFScanner's custom retain/release functions.

### DIFF
--- a/src/CoreGraphics/CGPDFScanner.cs
+++ b/src/CoreGraphics/CGPDFScanner.cs
@@ -61,6 +61,16 @@ namespace CoreGraphics {
 			get { return info; }
 		}
 
+		protected override void Retain ()
+		{
+			CGPDFScannerRetain (GetCheckedHandle ());
+		}
+
+		protected override void Release ()
+		{
+			CGPDFScannerRelease (GetCheckedHandle ());
+		}
+
 		protected override void Dispose (bool disposing)
 		{
 			if (gch.IsAllocated)


### PR DESCRIPTION
This got dropped by mistake at some point.