### PR TITLE
[tests] Fix checking availability for .NET.

### DIFF
--- a/tests/common/PlatformInfo.cs
+++ b/tests/common/PlatformInfo.cs
@@ -196,11 +196,7 @@ namespace Xamarin.Tests
 			//     [SupportedOSPlatform ("1.0")
 			//     [UnsupportedOSPlatform ("2.0")
 			// if we run into the SupportedOSPlatform attribute first.
-			foreach (var parsedAttr in attributes) {
-				var attr = parsedAttr.Attribute;
-				var platform = parsedAttr.Platform;
-				var version = parsedAttr.Version;
-
+			foreach (var (attr, platform, version) in attributes) {
 				if (platform != attributePlatform)
 					continue;
 
@@ -214,11 +210,7 @@ namespace Xamarin.Tests
 				}
 			}
 
-			foreach (var parsedAttr in attributes) {
-				var attr = parsedAttr.Attribute;
-				var platform = parsedAttr.Platform;
-				var version = parsedAttr.Version;
-
+			foreach (var (attr, platform, version) in attributes) {
 				if (platform != attributePlatform)
 					continue;
 


### PR DESCRIPTION
Change the logic to detect if an API is available to:

* First check if there are any applicable UnavailableOSPlatform attributes,
  and only if an applicable attribute is found, then state that the API is
  unavailable (we can't ascertain that an API is available from an
  UnavailableOSPlatform attribute, only that it's unavailable).
* Once we know there are no applicable UnavailableOSPlatform attributes, we go
  on to check for applicable SupportedOSPlatform attributes, and if one is
  found, then we can say whether the API is available or not.
* If neither attributes were found, and we're building for Mac Catalyst, then
  repeat the two above checks for iOS instead.
* If still nothing, then assume the API is available (while incorrect, it's
  how our attributes are currently implemented).

This fixes introspection showing numerous test failures on older OS versions,
because we were detecting availability wrong - we were assuming that if
there's an UnavailableOSPlatform attribute whose version didn't match the OS
version, that the API was available (test case that proves this logic is
incorrect: OS version = 1.0, API introduced in 2.0, API unavailable in 3.0
- we'd detect that OS version 1.0 < unavailable in 3.0, and say "yay, we're
not unavailable, so we must be available!").