### PR TITLE
[Security] Fix setting the path to the icon for the authorization dialog when creating a new authorization reference.

### DIFF
--- a/src/Security/Authorization.cs
+++ b/src/Security/Authorization.cs
@@ -215,7 +215,7 @@ namespace Security {
 						if (parameters.PathToSystemPrivilegeTool != null)
 							EncodeString (ref pars.ptrToAuthorization [pars.count++], "system.privilege.admin", parameters.PathToSystemPrivilegeTool);
 						if (parameters.IconPath != null)
-							EncodeString (ref pars.ptrToAuthorization [pars.count++], "prompt", parameters.IconPath);
+							EncodeString (ref pars.ptrToAuthorization [pars.count++], "icon", parameters.IconPath);
 					}
 					if (environment != null || (parameters != null && parameters.Prompt != null)){
 						penv = &env;


### PR DESCRIPTION
This looks like a c&p mistake from the initial implementation from 2012:

https://github.com/xamarin/maccore/commit/55d6a7dcb695859bfc4144ee030c45928b5bf711