### PR TITLE
[Security] Fix call to AuthorizationExecuteWithPrivileges to pass a null-terminated array for the arguments. Fixes #13465.

### DIFF
--- a/src/Security/Authorization.cs
+++ b/src/Security/Authorization.cs
@@ -147,7 +147,7 @@ namespace Security {
 #endif
 #endif
 		[DllImport (Constants.SecurityLibrary)]
-		extern static int /* OSStatus = int */ AuthorizationExecuteWithPrivileges (IntPtr handle, string pathToTool, AuthorizationFlags flags, string [] args, IntPtr FILEPtr);
+		extern static int /* OSStatus = int */ AuthorizationExecuteWithPrivileges (IntPtr handle, string pathToTool, AuthorizationFlags flags, string? []? args, IntPtr FILEPtr);
 
 		[DllImport (Constants.SecurityLibrary)]
 		extern static int /* OSStatus = int */ AuthorizationFree (IntPtr handle, AuthorizationFlags flags);
@@ -165,9 +165,22 @@ namespace Security {
 		[Obsolete ("Starting with macos10.7 use the Service Management framework or the launchd-launched helper tool instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
 #endif
 #endif
-		public int ExecuteWithPrivileges (string pathToTool, AuthorizationFlags flags, string [] args)
+		public int ExecuteWithPrivileges (string pathToTool, AuthorizationFlags flags, string []? args)
 		{
-			return AuthorizationExecuteWithPrivileges (Handle, pathToTool, flags, args, IntPtr.Zero);
+			string?[]? arguments = args!;
+
+			if (arguments is not null) {
+				// The arguments array must be null-terminated, so make sure that's the case
+				if (arguments.Length == 0) {
+					arguments = new string? [] { null };
+				} else if (arguments [arguments.Length - 1] is not null) {
+					var array = new string? [arguments.Length + 1];
+					arguments.CopyTo (array, 0);
+					arguments = array;
+				}
+			}
+
+			return AuthorizationExecuteWithPrivileges (Handle, pathToTool, flags, arguments, IntPtr.Zero);
 		}
 
 		protected override void Dispose (bool disposing)


### PR DESCRIPTION
It looks like this was a latent bug that was uncovered due to unrelated code
changes. The problem is that the 'AuthorizationExecuteWithPrivileges' function
takes a null-terminated array as the arguments, and we were not
null-terminating the array we were passing (on purpose at least - it probably
have happened in the past by accident).

Fixes https://github.com/xamarin/xamarin-macios/issues/13465.