### PR TITLE
[AppKit] Add NSKey back to the .NET profile.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -546,10 +546,15 @@ namespace AppKit {
 		Pen = 1, PenLower = 2, PenUpper = 4
 	}
 
-#if !NET
+	// This enum is defined as an untyped enum in MacOSX.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h
+	// It represents values that may be returned by NSEvent.KeyCode (which isn't typed as 'NSKey' because it may be many other values as well).
 	[NoMacCatalyst]
+#if NET
+	public enum NSKey {
+#else
 	[Native]
 	public enum NSKey : ulong {
+#endif
 		A              = 0x00,
 		S              = 0x01,
 		D              = 0x02,
@@ -668,7 +673,6 @@ namespace AppKit {
 		DownArrow      = 0x7D,
 		UpArrow        = 0x7E
 	}
-#endif // !NET
 
 #if !XAMCORE_4_0
 	[NoMacCatalyst]

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -58,6 +58,9 @@
 !extra-protocol-member! unexpected selector NSTextFieldDelegate::controlTextDidChange: found
 !extra-protocol-member! unexpected selector NSTextFieldDelegate::controlTextDidEndEditing: found
 
+# NSKey comes from the Carbon framework
+!unknown-native-enum! NSKey bound
+
 ## unsorted
 
 !extra-enum-native! NSEventSubtype
@@ -289,7 +292,6 @@
 !unknown-native-enum! NSFunctionKey bound
 !unknown-native-enum! NSGlyphStorageOptions bound
 !unknown-native-enum! NSImageScale bound
-!unknown-native-enum! NSKey bound
 !unknown-native-enum! NSMenuProperty bound
 !unknown-native-enum! NSPanelButtonType bound
 !unknown-native-enum! NSRunResponse bound


### PR DESCRIPTION
It turns out the enum is used a bit more than I thought.

Ref: https://discord.com/channels/732297728826277939/732297808148824115/913810268939759626