### PR TITLE
[msbuild] Improve logic to clean up the app bundle for macOS and Mac Catalyst apps before signing.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/GetFileSystemEntriesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/GetFileSystemEntriesTaskBase.cs
@@ -20,6 +20,9 @@ namespace Xamarin.MacDev.Tasks
 
 		[Required]
 		public bool Recursive { get; set; }
+
+		[Required]
+		public bool IncludeDirectories { get; set; }
 		#endregion
 
 		#region Outputs
@@ -32,7 +35,9 @@ namespace Xamarin.MacDev.Tasks
 		public override bool Execute ()
 		{
 			var searchOption = Recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
-			var entriesFullPath = Directory.GetFileSystemEntries (DirectoryPath, Pattern, searchOption);
+			var entriesFullPath = IncludeDirectories ?
+				Directory.GetFileSystemEntries (DirectoryPath, Pattern, searchOption) :
+				Directory.GetFiles (DirectoryPath, Pattern, searchOption);
 
 			Entries = entriesFullPath.Select (v => new TaskItem (v)).ToArray ();
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -109,6 +109,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_CodesignAppExtensions;
 			_PrepareCodesignAppExtension;
 			_CalculateCodesignAppBundleInputs;
+			_CleanAppBundleRootDirectory;
 		</_CodesignAppBundleDependsOn>
 
 		<CoreCodesignDependsOn>
@@ -594,23 +595,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<_CodesignDisableTimestamp Condition="'$(_SdkIsSimulator)' == 'true' Or '$(_BundlerDebug)' == 'true'">True</_CodesignDisableTimestamp>
 		</PropertyGroup>
 
-		<!-- Delete any crash dumps in the app bundle that might exist. Ref: https://github.com/xamarin/xamarin-macios/issues/12320 -->
-		<!-- Use a task to collect the files, so that we get the correct behavior on Windows -->
-		<GetFileSystemEntries
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
-			DirectoryPath="$(AppBundleDir)"
-			Pattern="mono_crash.mem.*"
-			Recursive="false"
-			>
-			<Output TaskParameter="Entries" ItemName="_MonoCrashDumpsInAppBundle" />
-		</GetFileSystemEntries>
-		<Delete
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
-			Files="@(_MonoCrashDumpsInAppBundle)"
-		/>
-
 		<Codesign
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -637,6 +621,41 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true' And Exists ('$(_AppBundlePath)_CodeSignature\CodeResources')"
 			Files="$(_AppBundlePath)_CodeSignature\CodeResources"
 		/>
+	</Target>
+
+	<Target Name="_CleanAppBundleRootDirectory" Condition="'$(_PlatformName)' == 'MacCatalyst' Or '$(_PlatformName)' == 'macOS'">
+		<!-- There shouldn't be any files in the root directory of the app bundle for macOS or Mac Catalyst (signing will fail) -->
+
+		<!-- Delete any crash dumps in the app bundle that might exist. Ref: https://github.com/xamarin/xamarin-macios/issues/12320 -->
+		<!-- Use a task to collect the files, so that we get the correct behavior on Windows -->
+		<GetFileSystemEntries
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true' And ('$(_PlatformName)' == 'MacCatalyst' Or '$(_PlatformName)' == 'macOS')"
+			DirectoryPath="$(AppBundleDir)"
+			Pattern="mono_crash.*"
+			Recursive="false"
+			IncludeDirectories="false"
+			>
+			<Output TaskParameter="Entries" ItemName="_MonoCrashDumpsInAppBundle" />
+		</GetFileSystemEntries>
+		<Delete
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true' And ('$(_PlatformName)' == 'MacCatalyst' Or '$(_PlatformName)' == 'macOS')"
+			Files="@(_MonoCrashDumpsInAppBundle)"
+		/>
+
+		<!-- Warn about any files that are left -->
+		<GetFileSystemEntries
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true' And ('$(_PlatformName)' == 'MacCatalyst' Or '$(_PlatformName)' == 'macOS')"
+			DirectoryPath="$(AppBundleDir)"
+			Pattern="*"
+			Recursive="false"
+			IncludeDirectories="false"
+			>
+			<Output TaskParameter="Entries" ItemName="_FilesInAppBundleRootDirectory" />
+		</GetFileSystemEntries>
+		<Warning Text="Found files in the root directory of the app bundle. This will likely cause codesign to fail. Files:%0a@(_FilesInAppBundleRootDirectory, '%0a')" Condition="@(_FilesInAppBundleRootDirectory->Count()) &gt; 0"/>
 	</Target>
 
 	<Target Name="_CoreCreateIpa" Condition="'$(BuildIpa)' == 'true'" DependsOnTargets="Codesign">

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -60,6 +60,11 @@ namespace Xamarin.Tests {
 			return rv;
 		}
 
+		public static ExecutionResult Build (string project, Dictionary<string, string> properties = null)
+		{
+			return Execute ("build", project, properties, false);
+		}
+
 		public static ExecutionResult AssertNew (string outputDirectory, string template)
 		{
 			Directory.CreateDirectory (outputDirectory);


### PR DESCRIPTION
There can't be any files in the root directory of the app bundle for macOS and
Mac Catalyst, otherwise code signing will fail. The problem is that Mono will
create a crash report in the current directory if the process crashes, and the
current directory is the root directory of the app bundle, which means that if
running an app crashes, the next build will likely fail because of the crash
report.

We had logic to detect this and remove any crash reports, but our crash report
detection pattern wasn't good enough and let some files through. This PR
updates that pattern, and also improves the code to report warnings for any
other files in the app bundle's root directory.