### PR TITLE
[dotnet] Check for the x64 version of .NET.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -523,7 +523,15 @@ $(TOP)/dotnet.config: $(TOP)/eng/Versions.props
 	$(Q) grep MicrosoftNETCoreAppRefPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftNETCoreAppRefPackageVersion>//g' -e 's/[ \t]*/BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION=/' >> $@.tmp
 	$(Q) mv $@.tmp $@
 
+ifneq ("$(wildcard /usr/local/share/dotnet/dotnet)","")
 DOTNET=/usr/local/share/dotnet/dotnet
+else
+ifneq ("$(wildcard /usr/local/share/dotnet/x64/dotnet)","")
+DOTNET=/usr/local/share/dotnet/x64/dotnet
+else
+DOTNET=/must/install/dotnet
+endif
+endif
 
 DOTNET_DESTDIR ?= $(TOP)/_build
 DOTNET_NUPKG_DIR ?= $(DOTNET_DESTDIR)/nupkgs

--- a/tests/dotnet/UnitTests/global.json
+++ b/tests/dotnet/UnitTests/global.json
@@ -1,3 +1,6 @@
 {
-	"sdk": { "version": "5.0.200" }
+	"sdk": {
+		"version": "5.0.200",
+		"rollForward": "latestMajor"
+	}
 }


### PR DESCRIPTION
Check for the x64 version of .NET to see if it's installed if the default
dotnet location doesn't exist (the x64 version will exist on an ARM64 mac when
installing the x64 version of .NET).

Also allow the .NET unit tests to be executed using any recentish version of
.NET.