### PR TITLE
[monotouch-test] Ignore a few tests in non-ARM64 simulators.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -154,6 +154,16 @@ partial class TestRuntime
 #endif
 	}
 
+	public static void AssertIfSimulatorThenARM64 ()
+	{
+#if !__MACOS__
+		if (ObjCRuntime.Runtime.Arch != Arch.SIMULATOR)
+			return;
+		if (!IsARM64)
+			NUnit.Framework.Assert.Ignore ("This test does not run simulators that aren't ARM64 simulators.");
+#endif
+	}
+
 	public static void AssertNotSimulator ()
 	{
 #if !__MACOS__
@@ -1247,6 +1257,37 @@ partial class TestRuntime
 		get {
 			return !(Type.GetType ("System.__Canon") is null);
 		}
+	}
+
+
+	enum NXByteOrder /* unspecified in header, means most likely int */ {
+		Unknown,
+		LittleEndian,
+		BigEndian,
+	}
+
+	[StructLayout (LayoutKind.Sequential)]
+	struct NXArchInfo {
+		IntPtr name; // const char *
+		public int CpuType; // cpu_type_t -> integer_t -> int
+		public int CpuSubType; // cpu_subtype_t -> integer_t -> int
+		public NXByteOrder ByteOrder;
+		IntPtr description; // const char *
+
+		public string Name {
+			get { return Marshal.PtrToStringUTF8 (name)!; }
+		}
+
+		public string Description {
+			get { return Marshal.PtrToStringUTF8 (description)!; }
+		}
+	}
+
+	[DllImport (Constants.libSystemLibrary)]
+	static unsafe extern NXArchInfo* NXGetLocalArchInfo ();
+
+	public unsafe static bool IsARM64 {
+		get { return NXGetLocalArchInfo ()->Name.StartsWith ("arm64"); }
 	}
 }
 

--- a/tests/introspection/Mac/introspection-mac.csproj
+++ b/tests/introspection/Mac/introspection-mac.csproj
@@ -16,6 +16,7 @@
     <DefineConstants></DefineConstants>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/introspection/iOS/introspection-ios.csproj
+++ b/tests/introspection/iOS/introspection-ios.csproj
@@ -16,6 +16,7 @@
     <LangVersion>latest</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <RootTestsDirectory>..\..</RootTestsDirectory>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/linker/ios/dont link/dont link.csproj
+++ b/tests/linker/ios/dont link/dont link.csproj
@@ -13,8 +13,10 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants></DefineConstants>
+    <LangVersion>latest</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/linker/ios/link all/link all.csproj
+++ b/tests/linker/ios/link all/link all.csproj
@@ -16,6 +16,7 @@
     <LangVersion>latest</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/linker/ios/link sdk/link sdk.csproj
+++ b/tests/linker/ios/link sdk/link sdk.csproj
@@ -13,8 +13,10 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)-unified</IntermediateOutputPath>
     <DefineConstants></DefineConstants>
+    <LangVersion>latest</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <RootTestsDirectory>..\..\..</RootTestsDirectory>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>

--- a/tests/linker/mac/dont link/dont link-mac.csproj
+++ b/tests/linker/mac/dont link/dont link-mac.csproj
@@ -16,6 +16,7 @@
     <DefineConstants></DefineConstants>
     <LangVersion>latest</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/linker/mac/link all/link all-mac.csproj
+++ b/tests/linker/mac/link all/link all-mac.csproj
@@ -13,6 +13,7 @@
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
     <LangVersion>latest</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/linker/mac/link sdk/link sdk-mac.csproj
+++ b/tests/linker/mac/link sdk/link sdk-mac.csproj
@@ -13,6 +13,7 @@
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
     <LangVersion>latest</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/monotouch-test/Foundation/BundleTest.cs
+++ b/tests/monotouch-test/Foundation/BundleTest.cs
@@ -136,6 +136,9 @@ namespace MonoTouchFixtures.Foundation {
 			if (!TestRuntime.CheckXcodeVersion (5, 0))
 				Assert.Inconclusive ("Requires iOS7 or later");
 
+			// The AppStoreReceiptUrl property may or may not return anything useful on the simulator, so run this only on device.
+			TestRuntime.AssertDevice ();
+
 			// on iOS8 device this now ends with "/StoreKit/sandboxReceipt" 
 			// instead of "/StokeKit/receipt"
 			Assert.That (main.AppStoreReceiptUrl.AbsoluteString, Does.EndWith ("eceipt"), "AppStoreReceiptUrl");

--- a/tests/monotouch-test/MobileCoreServices/UTTypeTest.cs
+++ b/tests/monotouch-test/MobileCoreServices/UTTypeTest.cs
@@ -120,24 +120,40 @@ namespace MonoTouchFixtures.MobileCoreServices {
 		[Test]
 		public void GetPreferredTag ()
 		{
+			// This test may fail in the simulator, if the architecture of the simulator isn't the native one (say running x86_64 on an M1 machine),
+			// so just skip this test for the simulator.
+			TestRuntime.AssertIfSimulatorThenARM64 ();
+
 			Assert.NotNull (UTType.GetPreferredTag (UTType.PDF, UTType.TagClassFilenameExtension), "GetPreferredTag");
 		}
 
 		[Test]
 		public void GetDeclaration ()
 		{
+			// This test may fail in the simulator, if the architecture of the simulator isn't the native one (say running x86_64 on an M1 machine),
+			// so just skip this test for the simulator.
+			TestRuntime.AssertIfSimulatorThenARM64 ();
+
 			Assert.NotNull (UTType.GetDeclaration (UTType.PDF));
 		}
 
 		[Test]
 		public void GetDeclaringBundleURL ()
 		{
+			// This test may fail in the simulator, if the architecture of the simulator isn't the native one (say running x86_64 on an M1 machine),
+			// so just skip this test for the simulator.
+			TestRuntime.AssertIfSimulatorThenARM64 ();
+
 			Assert.NotNull (UTType.GetDeclaringBundleURL (UTType.PDF));
 		}
 
 		[Test]
 		public void CreatePreferredIdentifier ()
 		{
+			// This test may fail in the simulator, if the architecture of the simulator isn't the native one (say running x86_64 on an M1 machine),
+			// so just skip this test for the simulator.
+			TestRuntime.AssertIfSimulatorThenARM64 ();
+
 			string[] extensions = new [] { ".html", ".css", ".jpg", ".js", ".otf" };
 			// random failure reported in #36708 (on some iPad2 only)
 			for (int i=0; i < 100; i++) {

--- a/tests/monotouch-test/UIKit/UIDocumentTest.cs
+++ b/tests/monotouch-test/UIKit/UIDocumentTest.cs
@@ -99,6 +99,10 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void Save ()
 		{
+			// This test may fail in the simulator, if the architecture of the simulator isn't the native one (say running x86_64 on an M1 machine),
+			// so just skip this test for the simulator.
+			TestRuntime.AssertIfSimulatorThenARM64 ();
+
 			using (NSUrl url = NSUrl.FromFilename (GetFileName ())) {
 				doc = new MyDocument (url);
 				doc.Save (url, UIDocumentSaveOperation.ForCreating, OperationHandler);

--- a/tests/monotouch-test/UniformTypeIdentifiers/TypeTest.cs
+++ b/tests/monotouch-test/UniformTypeIdentifiers/TypeTest.cs
@@ -19,6 +19,10 @@ namespace MonoTouchFixtures.UniformTypeIdentifiers {
 		[Test]
 		public void Archive ()
 		{
+			// This test may fail in the simulator, if the architecture of the simulator isn't the native one (say running x86_64 on an M1 machine),
+			// so just skip this test for the simulator.
+			TestRuntime.AssertIfSimulatorThenARM64 ();
+
 			var a = UTTypes.Archive;
 			Assert.False (a.Dynamic, "Dynamic");
 			var z = UTTypes.Zip;


### PR DESCRIPTION
Some tests fail when running on an M1, but in a x64_86 mode, so just ignore
those unless we're running on ARM64 (this will currently exclude them on
x86_64 hardware too, but that'll eventually not be a problem anymore when
there's no more x86_64 hardware, and just checking for ARM64 is easier than
checking for x86_64 mode on an ARM64 CPU).