### PR TITLE
Compare the `TestExecutingResult.TimedOut` flag only

### DIFF
--- a/tests/xharness/Jenkins/TestTasks/BuildProject.cs
+++ b/tests/xharness/Jenkins/TestTasks/BuildProject.cs
@@ -115,7 +115,7 @@ namespace Xharness.Jenkins.TestTasks {
 				var references = GetNestedReferenceProjects (TestProject.Path);
 				foreach (var referenceProject in references) {
 					var execResult = await RestoreNugetsAsync (referenceProject, log); // do the replace in case we use win paths
-					if (execResult == TestExecutingResult.TimedOut) {
+					if ((execResult & TestExecutingResult.TimedOut) == TestExecutingResult.TimedOut) {
 						return execResult;
 					}
 				}


### PR DESCRIPTION
This is in reaction to https://github.com/dotnet/xharness/pull/786 which adds a new sub-result to preserve behavior when the bump happens.
This is the only occurrence where we're comparing `TimedOut` via equality.