### PR TITLE
[CI] Use Build artifacts so that they are copied to the release pipeline.

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -18,7 +18,7 @@ stages:
     parameters:
       artifactName: package
       signType: Real
-      usePipelineArtifactTasks: true
+      usePipelineArtifactTasks: false
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
   - template: nuget-msi-convert/job/v2.yml@templates


### PR DESCRIPTION
We need to allow the release pipeline to access the artefacts.