### PR TITLE
[CI] Check that the mac tests are indeed present.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -432,7 +432,15 @@ steps:
     set -x
     set -e
 
-    make -C $(Build.SourcesDirectory)/xamarin-macios/tests package-tests
+    RC=0
+    make -C $(Build.SourcesDirectory)/xamarin-macios/tests package-tests || RC=$?
+    if [ $RC -eq 0 ]; then
+      echo "##vso[task.setvariable variable=macTestsPresent;isOutput=true]Succeeded"
+    else
+      echo "##vso[task.setvariable variable=macTestsPresent;isOutput=true]Failed"
+    fi
+    
+  name: macTestPkg
   displayName: 'Package Xamarin.mac tests'
   condition: and(succeeded(), contains(variables['configuration.RunMacTests'], 'True'))
   continueOnError: true # not a terrible blocking issue

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -439,6 +439,7 @@ steps:
     else
       echo "##vso[task.setvariable variable=macTestsPresent;isOutput=true]Failed"
     fi
+    exit $RC
     
   name: macTestPkg
   displayName: 'Package Xamarin.mac tests'

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -142,6 +142,15 @@ steps:
   displayName: 'Nuke Provisionator Tool Cache'
   condition: ${{ parameters.clearProvisionatorCache }}
 
+# sometimes the make that creates the pkgs fails.
+- pwsh:
+    if ($Env:macTestsPresent -ne "Succeeded") {
+      Set-GitHubStatus -Status "error" -Description "Mac tests were not packaged." -Context "$Env:CONTEXT"
+      New-GitHubComment -Header "Tests failed catastrophically on $Env:CONTEXT" -Emoji ":fire:" -Description "Mac tests were not packaged.."
+      Stop-Pipeline
+    } 
+  displayName: Validate tests pacakge
+
 - task: DownloadPipelineArtifact@2
   displayName: Download Mac tests
   inputs:

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -144,7 +144,7 @@ steps:
 
 # sometimes the make that creates the pkgs fails.
 - pwsh:
-    if ($Env:macTestsPresent -ne "Succeeded") {
+    if ($Env:MAC_TESTS_PRESENT -ne "Succeeded") {
       Set-GitHubStatus -Status "error" -Description "Mac tests were not packaged." -Context "$Env:CONTEXT"
       New-GitHubComment -Header "Tests failed catastrophically on $Env:CONTEXT" -Emoji ":fire:" -Description "Mac tests were not packaged.."
       Stop-Pipeline

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -32,6 +32,9 @@ stages:
   # we need to have the pkgs built and the device sets to be ran, that is decided via the labels or type of build during the build_packages stage
   condition: and(succeeded(), eq(dependencies.build_packages.outputs['build.configuration.RunDeviceTests'], 'True'))
 
+  variables:
+    MAC_TESTS_PRESENT: $[ dependencies.build_packages.outputs['build.macTestPkg.macTestsPresent'] ]
+
   jobs:
   - job: run_tests
     displayName: 'macOS tests'


### PR DESCRIPTION
Sometimes the make fails which results in errors further in the mac tests pipeline. We now check if we managed to do it and if not, we do not try to run the tests and let the user know.