### PR TITLE
[ApiDiff] Add Current PR Diffs in a similar style as API Diffs

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19422,12 +19422,12 @@ namespace AppKit {
 		[Export ("textView:didCheckTextInRange:types:options:results:orthography:wordCount:"), DelegateName ("NSTextViewTextChecked"), DefaultValueFromArgument ("results")]
 		NSTextCheckingResult [] DidCheckText (NSTextView view, NSRange range, NSTextCheckingTypes checkingTypes, NSDictionary options, NSTextCheckingResult [] results, NSOrthography orthography, nint wordCount);
 
-#if NET
-		[Export ("textView:draggedCell:inRect:event:atIndex:"), EventArgs ("NSTextViewDraggedCell")]
-		void DraggedCell (NSTextView view, NSTextAttachmentCell cell, CGRect rect, NSEvent @event, nuint charIndex);
-#else
+#if !NET
 		[Export ("textView:draggedCell:inRect:event:"), EventArgs ("NSTextViewDraggedCell")]
-		void DraggedCell (NSTextView view, NSTextAttachmentCell cell, CGRect rect, NSEvent theEvent);
+		void DraggedCell (NSTextView view, NSTextAttachmentCell cell, CGRect rect, NSEvent theevent);
+#else
+		[Export ("textView:draggedCell:inRect:event:atIndex:"), EventArgs ("NSTextViewDraggedCell")]
+		void DraggedCell (NSTextView view, NSTextAttachmentCell cell, CGRect rect, NSEvent theEvent, nuint charIndex);
 #endif
 
 		[Export ("undoManagerForTextView:"), DelegateName ("NSTextViewGetUndoManager"), DefaultValue (null)]

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -99,6 +99,26 @@ $(APIDIFF_DIR)/diff/%.html: $(APIDIFF_DIR)/temp/%.xml $(APIDIFF_DIR)/references/
 	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $(APIDIFF_DIR)/references/$*.xml $(APIDIFF_DIR)/temp/$*.xml $(APIDIFF_IGNORE) $@
 	$(Q) touch $@
 
+$(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.html: $(APIDIFF_DIR)/temp/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml $(APIDIFF_DIR)/references/xi/Xamarin.iOS/Xamarin.iOS.xml $(MONO_API_HTML)
+	$(Q) mkdir -p $(dir $@)
+	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $(APIDIFF_DIR)/references/xi/Xamarin.iOS/Xamarin.iOS.xml $< $(APIDIFF_IGNORE) $@
+	$(Q) touch $@
+
+$(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.html: $(APIDIFF_DIR)/temp/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.xml $(APIDIFF_DIR)/references/xm/Xamarin.Mac/Xamarin.Mac.xml $(MONO_API_HTML)
+	$(Q) mkdir -p $(dir $@)
+	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $(APIDIFF_DIR)/references/xm/Xamarin.Mac/Xamarin.Mac.xml $< $(APIDIFF_IGNORE) $@
+	$(Q) touch $@
+
+$(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.html: $(APIDIFF_DIR)/temp/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.xml $(APIDIFF_DIR)/references/xi/Xamarin.TVOS/Xamarin.TVOS.xml $(MONO_API_HTML)
+	$(Q) mkdir -p $(dir $@)
+	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $(APIDIFF_DIR)/references/xi/Xamarin.TVOS/Xamarin.TVOS.xml $< $(APIDIFF_IGNORE) $@
+	$(Q) touch $@
+
+$(APIDIFF_DIR)/diff/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.MacCatalyst.html: $(APIDIFF_DIR)/temp/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml $(APIDIFF_DIR)/temp/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.xml $(MONO_API_HTML)
+	$(Q) mkdir -p $(dir $@)
+	$(Q) sed -e 's_<assembly name="Xamarin.MacCatalyst" version="0.0.0.0">_<assembly name="Xamarin.iOS" version="0.0.0.0">_' $(APIDIFF_DIR)/temp/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.xml > $(APIDIFF_DIR)/temp/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.MacCatalyst-as-iOS.xml
+	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $< $(APIDIFF_DIR)/temp/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.MacCatalyst-as-iOS.xml $(APIDIFF_IGNORE) $@
+
 # this is a hack to show the difference between iOS and tvOS
 $(APIDIFF_DIR)/diff/ios-to-tvos.html: $(APIDIFF_DIR)/temp/xi/Xamarin.iOS/Xamarin.iOS.xml $(APIDIFF_DIR)/temp/xi/Xamarin.TVOS/Xamarin.TVOS.xml $(MONO_API_HTML)
 	$(Q) mkdir -p $(dir $@)
@@ -119,26 +139,12 @@ $(APIDIFF_DIR)/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html: 
 $(APIDIFF_DIR)/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst-api-diff.html: $(APIDIFF_DIR)/diff/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.html
 
 # Compare new dotnet vs. stable legacy
-$(APIDIFF_DIR)/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html: $(APIDIFF_DIR)/temp/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml $(APIDIFF_DIR)/references/xi/Xamarin.iOS/Xamarin.iOS.xml $(MONO_API_HTML)
-	$(Q) mkdir -p $(dir $@)
-	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $(APIDIFF_DIR)/references/xi/Xamarin.iOS/Xamarin.iOS.xml $< $(APIDIFF_IGNORE) $@
-	$(Q) touch $@
-
-$(APIDIFF_DIR)/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html: $(APIDIFF_DIR)/temp/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.xml $(APIDIFF_DIR)/references/xm/Xamarin.Mac/Xamarin.Mac.xml $(MONO_API_HTML)
-	$(Q) mkdir -p $(dir $@)
-	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $(APIDIFF_DIR)/references/xm/Xamarin.Mac/Xamarin.Mac.xml $< $(APIDIFF_IGNORE) $@
-	$(Q) touch $@
-
-$(APIDIFF_DIR)/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html: $(APIDIFF_DIR)/temp/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.xml $(APIDIFF_DIR)/references/xi/Xamarin.TVOS/Xamarin.TVOS.xml $(MONO_API_HTML)
-	$(Q) mkdir -p $(dir $@)
-	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $(APIDIFF_DIR)/references/xi/Xamarin.TVOS/Xamarin.TVOS.xml $< $(APIDIFF_IGNORE) $@
-	$(Q) touch $@
+$(APIDIFF_DIR)/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html:     $(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.html
+$(APIDIFF_DIR)/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html:   $(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.html
+$(APIDIFF_DIR)/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html:   $(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.html
 
 # Compare Dotnet iOS vs. Dotnet MacCatalyst
-$(APIDIFF_DIR)/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.MacCatalyst-api-diff.html: $(APIDIFF_DIR)/temp/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml $(APIDIFF_DIR)/temp/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.xml $(MONO_API_HTML)
-	$(Q) mkdir -p $(dir $@)
-	$(Q) sed -e 's_<assembly name="Xamarin.MacCatalyst" version="0.0.0.0">_<assembly name="Xamarin.iOS" version="0.0.0.0">_' $(APIDIFF_DIR)/temp/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.xml > $(APIDIFF_DIR)/temp/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.MacCatalyst-as-iOS.xml
-	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $< $(APIDIFF_DIR)/temp/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.MacCatalyst-as-iOS.xml $(APIDIFF_IGNORE) $@
+$(APIDIFF_DIR)/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.MacCatalyst-api-diff.html: $(APIDIFF_DIR)/diff/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.MacCatalyst.html
 
 $(APIDIFF_DIR)/%-api-diff.html:
 	$(Q) rm -f $@
@@ -146,9 +152,9 @@ $(APIDIFF_DIR)/%-api-diff.html:
 	$(Q) touch $@-toc
 	$(Q_GEN) for file in $?; do \
 		if [[ "x0" != "x`stat -L -f %z $$file`" ]]; then  \
-			cat $$file | sed "s_<h1>_<h1 id='$$file'>_" >> $@;	\
+			cat $$file | sed "s*<h1>*<h1 id='$$file'>*" >> $@;	\
 			echo "<br><hr>" >> $@;	\
-			echo "<a href='#$$file'>`echo $$file | sed -e 's_html_dll_' -e 's_diff/xi/Xamarin.iOS/__' -e 's_diff/xi/Xamarin.WatchOS/__' -e 's_diff/xi/Xamarin.TVOS/__' -e 's_diff/xm/4.5/_\(Full profile\) _' -e 's_diff/xm/Xamarin.Mac/_\(Mobile profile\) _' -e 's_diff/xm/_\(Classic profile\) _' `</a><br/>" >> $@-toc; \
+			echo "<a href='#$$file'>`echo $$file | sed -e 's_html_dll_' -e 's_diff/xi/Xamarin.iOS/__' -e 's_diff/xi/Xamarin.WatchOS/__' -e 's_diff/xi/Xamarin.TVOS/__' -e 's_diff/xm/4.5/_\(Full profile\) _' -e 's_diff/xm/Xamarin.Mac/_\(Mobile profile\) _' -e 's_diff/xm/_\(Classic profile\) _' -e 's_diff/dotnet/Microsoft.iOS.Ref/ref/net6.0/__' -e 's_diff/dotnet/Microsoft.tvOS.Ref/ref/net6.0/__' -e 's_diff/dotnet/Microsoft.macOS.Ref/ref/net6.0/__' -e 's_diff/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/__' -e 's_diff/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/__' -e 's_diff/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/__' -e 's_diff/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/__' -e 's_diff/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/__' -e 's#/Users/.*apidiff/##' `</a><br/>" >> $@-toc; \
 		fi; \
 	done
 	$(Q) if [ ! -f $@ ]; then \
@@ -360,7 +366,8 @@ IOS_REFS     = $(foreach file,$(IOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-reference
 MAC_REFS     = $(foreach file,$(MAC_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xm/$(file).xml)
 WATCHOS_REFS = $(foreach file,$(WATCHOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xi/$(file).xml)
 TVOS_REFS    = $(foreach file,$(TVOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xi/$(file).xml)
-DOTNET_REFS = $(foreach file,$(DOTNET_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/dotnet/$(file).xml)
+DOTNET_REFS = $(foreach file,$(DOTNET_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/dotnet/$(file).xml) \
+	$(foreach file,$(DOTNET_LEGACY_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/dotnet/legacy-diff/$(file).xml)
 
 $(APIDIFF_DIR)/references/xi/%.xml: $(UNZIP_DIR_iOS)/%.dll $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/xi/$*)
@@ -380,36 +387,40 @@ $(APIDIFF_DIR)/updated-references/xm/%.xml: $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURREN
 
 # The dotnet references xmls may come from different hashes, so we need to have separate rules for all of them
 $(APIDIFF_DIR)/references/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml: $(UNZIP_DIR_DOTNET_iOS)/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@)
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
 $(APIDIFF_DIR)/references/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.xml: $(UNZIP_DIR_DOTNET_macOS)/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@)
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
 $(APIDIFF_DIR)/references/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.xml: $(UNZIP_DIR_DOTNET_tvOS)/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@)
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
 $(APIDIFF_DIR)/references/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml: $(UNZIP_DIR_DOTNET_iOS)/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@)
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
 $(APIDIFF_DIR)/references/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.xml: $(UNZIP_DIR_DOTNET_macOS)/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@)
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
 $(APIDIFF_DIR)/references/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.xml: $(UNZIP_DIR_DOTNET_MacCatalyst)/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@)
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
 $(APIDIFF_DIR)/references/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.xml: $(UNZIP_DIR_DOTNET_tvOS)/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@)
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
+$(APIDIFF_DIR)/updated-references/dotnet/legacy-diff/%.xml: $(DOTNET_DESTDIR)/%.dll $(MONO_API_INFO)
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/legacy-diff/$*)
+	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $(APIDIFF_DIR)/references/dotnet/legacy-diff/$*.xml
+
 $(APIDIFF_DIR)/updated-references/dotnet/%.xml: $(DOTNET_DESTDIR)/%.dll $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@)
-	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/$*)
+	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $(APIDIFF_DIR)/references/dotnet/$*.xml
 
 update-tvos-refs: $(TVOS_REFS)
 update-watchos-refs: $(WATCHOS_REFS)
@@ -450,11 +461,11 @@ merger.exe: merger.cs
 
 ifdef INCLUDE_IOS
 ios-markdown: merger.exe $(foreach file,$(IOS_ASSEMBLIES),$(APIDIFF_DIR)/diff/xi/$(file).md)
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.iOS $(CURDIR)/diff/xi/Xamarin.iOS/ ios
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.iOS $(APIDIFF_DIR)/diff/xi/Xamarin.iOS/ ios $(APIDIFF_DIR)
 dotnet-ios-markdown: merger.exe $(APIDIFF_DIR)/diff/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.md
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.iOS.Dotnet $(CURDIR)/diff/dotnet/Microsoft.iOS.Ref/ref/net6.0/ dotnet-ios
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.iOS.Dotnet $(APIDIFF_DIR)/diff/dotnet/Microsoft.iOS.Ref/ref/net6.0/ dotnet-ios $(APIDIFF_DIR)
 dotnet-legacy-ios-markdown: merger.exe $(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.md
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.iOS.Stable.Legacy $(CURDIR)/diff/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/ dotnet-legacy-ios
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.iOS.Stable.Legacy $(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/ dotnet-legacy-ios $(APIDIFF_DIR)
 else
 ios-markdown: ; @true
 dotnet-ios-markdown: ; @true
@@ -463,11 +474,11 @@ endif
 
 ifdef INCLUDE_TVOS
 tvos-markdown: merger.exe $(foreach file,$(TVOS_ASSEMBLIES),$(APIDIFF_DIR)/diff/xi/$(file).md)
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.TVOS $(CURDIR)/diff/xi/Xamarin.TVOS/ tvos
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.TVOS $(APIDIFF_DIR)/diff/xi/Xamarin.TVOS/ tvos $(APIDIFF_DIR)
 dotnet-tv-markdown: merger.exe $(APIDIFF_DIR)/diff/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.md
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.TVOS.Dotnet $(CURDIR)/diff/dotnet/Microsoft.tvOS.Ref/ref/net6.0/ dotnet-tvos
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.TVOS.Dotnet $(APIDIFF_DIR)/diff/dotnet/Microsoft.tvOS.Ref/ref/net6.0/ dotnet-tvos $(APIDIFF_DIR)
 dotnet-legacy-tv-markdown: merger.exe $(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.md
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.TVOS.Stable.Legacy $(CURDIR)/diff/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/ dotnet-legacy-tvos
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.TVOS.Stable.Legacy $(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/ dotnet-legacy-tvos $(APIDIFF_DIR)
 else
 tvos-markdown: ; @true
 dotnet-tv-markdown: ; @true
@@ -476,17 +487,17 @@ endif
 
 ifdef INCLUDE_WATCH
 watchos-markdown: merger.exe $(foreach file,$(WATCHOS_ASSEMBLIES),$(APIDIFF_DIR)/diff/xi/$(file).md)
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.WatchOS $(CURDIR)/diff/xi/Xamarin.WatchOS/ watchos
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.WatchOS $(APIDIFF_DIR)/diff/xi/Xamarin.WatchOS/ watchos $(APIDIFF_DIR)
 else
 watchos-markdown: ; @true
 endif
 
 ifdef INCLUDE_MACCATALYST
 dotnet-maccatalyst-markdown: merger.exe $(APIDIFF_DIR)/diff/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.md
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.MacCatalyst.Dotnet $(CURDIR)/diff/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/ dotnet-maccatalyst
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.MacCatalyst.Dotnet $(APIDIFF_DIR)/diff/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/ dotnet-maccatalyst $(APIDIFF_DIR) $(APIDIFF_DIR)
 ifdef ENABLE_DOTNET
 dotnet-iOS-MacCatalyst-markdown: merger.exe $(APIDIFF_DIR)/diff/dotnet/iOS-MacCatalyst-diff/Xamarin.iOS-MacCatalyst.md
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.Dotnet.iOS-MacCatalyst $(CURDIR)/diff/dotnet/iOS-MacCatalyst-diff/ dotnet-maccatios
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.Dotnet.iOS-MacCatalyst $(APIDIFF_DIR)/diff/dotnet/iOS-MacCatalyst-diff/ dotnet-maccatios $(APIDIFF_DIR)
 else
 dotnet-iOS-MacCatalyst-markdown: ; @true
 endif # ENABLE_DOTNET
@@ -497,11 +508,11 @@ endif
 
 ifdef INCLUDE_MAC
 macos-markdown: merger.exe $(foreach file,$(MAC_ASSEMBLIES),$(APIDIFF_DIR)/diff/xm/$(file).md)
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.Mac $(CURDIR)/diff/xm/Xamarin.Mac/ macos
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.Mac $(APIDIFF_DIR)/diff/xm/Xamarin.Mac/ macos $(APIDIFF_DIR)
 dotnet-macos-markdown: merger.exe $(APIDIFF_DIR)/diff/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.md
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.Mac.Dotnet $(CURDIR)/diff/dotnet/Microsoft.macOS.Ref/ref/net6.0/ dotnet-macos
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.Mac.Dotnet $(APIDIFF_DIR)/diff/dotnet/Microsoft.macOS.Ref/ref/net6.0/ dotnet-macos $(APIDIFF_DIR)
 dotnet-legacy-macos-markdown: merger.exe $(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.md
-	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.Mac.Stable.Legacy $(CURDIR)/diff/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/ dotnet-legacy-macos
+	$(Q) $(SYSTEM_MONO) --debug merger.exe Xamarin.Mac.Stable.Legacy $(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/ dotnet-legacy-macos $(APIDIFF_DIR)
 else
 macos-markdown: ; @true
 dotnet-macos-markdown: ; @true
@@ -516,9 +527,24 @@ dotnet-markdown: ; @true
 dotnet-legacy-markdown: ; @true
 endif
 
+all-markdowns: ios-markdown tvos-markdown watchos-markdown macos-markdown dotnet-markdown dotnet-legacy-markdown dotnet-iOS-MacCatalyst-markdown
+
 $(APIDIFF_DIR)/diff/%.md: $(APIDIFF_DIR)/temp/%.xml $(APIDIFF_DIR)/references/%.xml $(MONO_API_HTML)
 	$(Q) mkdir -p $(dir $@)
 	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $(APIDIFF_DIR)/references/$*.xml $(APIDIFF_DIR)/temp/$*.xml $(APIDIFF_IGNORE) --md $@
+
+# Dotnet Legacy markdowns need to compare against legacy xmls
+$(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.md: $(APIDIFF_DIR)/temp/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml $(APIDIFF_DIR)/references/xi/Xamarin.iOS/Xamarin.iOS.xml $(MONO_API_HTML)
+	$(Q) mkdir -p $(dir $@)
+	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $< $(APIDIFF_DIR)/references/xi/Xamarin.iOS/Xamarin.iOS.xml $(APIDIFF_IGNORE) --md $@
+
+$(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.md: $(APIDIFF_DIR)/temp/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.xml $(APIDIFF_DIR)/references/xm/Xamarin.Mac/Xamarin.Mac.xml $(MONO_API_HTML)
+	$(Q) mkdir -p $(dir $@)
+	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $< $(APIDIFF_DIR)/references/xm/Xamarin.Mac/Xamarin.Mac.xml $(APIDIFF_IGNORE) --md $@
+
+$(APIDIFF_DIR)/diff/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.md: $(APIDIFF_DIR)/temp/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.xml $(APIDIFF_DIR)/references/xi/Xamarin.TVOS/Xamarin.TVOS.xml $(MONO_API_HTML)
+	$(Q) mkdir -p $(dir $@)
+	$(QF_GEN) $(MONO_BUILD) --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $< $(APIDIFF_DIR)/references/xi/Xamarin.TVOS/Xamarin.TVOS.xml $(APIDIFF_IGNORE) --md $@
 
 # Dotnet iOS vs Dotnet MacCatalyst
 $(APIDIFF_DIR)/diff/dotnet/iOS-MacCatalyst-diff/Xamarin.iOS-MacCatalyst.md: $(APIDIFF_DIR)/temp/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml $(APIDIFF_DIR)/temp/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.xml $(MONO_API_HTML)
@@ -550,7 +576,7 @@ endif
 endif
 	$(Q) $(MAKE) $(UNZIP_STAMPS)
 	$(Q) $(MAKE) all -j8
-	$(Q) $(MAKE) ios-markdown tvos-markdown watchos-markdown macos-markdown dotnet-markdown dotnet-legacy-markdown dotnet-iOS-MacCatalyst-markdown
+	$(Q) $(MAKE) all-markdowns
 	$(Q) $(CP) api-diff.html index.html
 	@echo "@MonkeyWrench: AddFile: $(CURDIR)/index.html"
 	@echo "@MonkeyWrench: AddFile: $(CURDIR)/api-diff.html"

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -386,19 +386,19 @@ $(APIDIFF_DIR)/updated-references/xm/%.xml: $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURREN
 
 # The dotnet references xmls may come from different hashes, so we need to have separate rules for all of them
 $(APIDIFF_DIR)/references/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml: $(UNZIP_DIR_DOTNET_iOS)/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS)
+	$(Q) mkdir -p $(dir $@)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
 $(APIDIFF_DIR)/references/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.xml: $(UNZIP_DIR_DOTNET_macOS)/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac)
+	$(Q) mkdir -p $(dir $@)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
 $(APIDIFF_DIR)/references/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.xml: $(UNZIP_DIR_DOTNET_MacCatalyst)/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst)
+	$(Q) mkdir -p $(dir $@)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
 $(APIDIFF_DIR)/references/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.xml: $(UNZIP_DIR_DOTNET_tvOS)/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS)
+	$(Q) mkdir -p $(dir $@)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
 $(APIDIFF_DIR)/updated-references/dotnet/%.xml: $(DOTNET_DESTDIR)/%.dll $(MONO_API_INFO)

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -366,8 +366,7 @@ IOS_REFS     = $(foreach file,$(IOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-reference
 MAC_REFS     = $(foreach file,$(MAC_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xm/$(file).xml)
 WATCHOS_REFS = $(foreach file,$(WATCHOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xi/$(file).xml)
 TVOS_REFS    = $(foreach file,$(TVOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xi/$(file).xml)
-DOTNET_REFS = $(foreach file,$(DOTNET_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/dotnet/$(file).xml) \
-	$(foreach file,$(DOTNET_LEGACY_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/dotnet/legacy-diff/$(file).xml)
+DOTNET_REFS = $(foreach file,$(DOTNET_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/dotnet/$(file).xml)
 
 $(APIDIFF_DIR)/references/xi/%.xml: $(UNZIP_DIR_iOS)/%.dll $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/xi/$*)
@@ -386,18 +385,6 @@ $(APIDIFF_DIR)/updated-references/xm/%.xml: $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURREN
 	$(QF_GEN) mono --debug $(MONO_API_INFO) -d $(dir $<) $< -o $(APIDIFF_DIR)/references/xm/$*.xml
 
 # The dotnet references xmls may come from different hashes, so we need to have separate rules for all of them
-$(APIDIFF_DIR)/references/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml: $(UNZIP_DIR_DOTNET_iOS)/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS)
-	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
-
-$(APIDIFF_DIR)/references/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.xml: $(UNZIP_DIR_DOTNET_macOS)/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac)
-	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
-
-$(APIDIFF_DIR)/references/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.xml: $(UNZIP_DIR_DOTNET_tvOS)/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.dll  $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS)
-	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
-
 $(APIDIFF_DIR)/references/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.xml: $(UNZIP_DIR_DOTNET_iOS)/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.dll  $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
@@ -413,10 +400,6 @@ $(APIDIFF_DIR)/references/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.Ma
 $(APIDIFF_DIR)/references/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.xml: $(UNZIP_DIR_DOTNET_tvOS)/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS.dll  $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
-
-$(APIDIFF_DIR)/updated-references/dotnet/legacy-diff/%.xml: $(DOTNET_DESTDIR)/%.dll $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/legacy-diff/$*)
-	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $(APIDIFF_DIR)/references/dotnet/legacy-diff/$*.xml
 
 $(APIDIFF_DIR)/updated-references/dotnet/%.xml: $(DOTNET_DESTDIR)/%.dll $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/$*)

--- a/tools/apidiff/merger.cs
+++ b/tools/apidiff/merger.cs
@@ -94,7 +94,6 @@ class Merger {
 		Console.WriteLine ($"@MonkeyWrench: AddFile: {Path.GetFullPath (filePath)}");
 
 		if (File.Exists ("api-diff.html")){
-			// TODO changing filename to filePath may cause trouble here...
 			File.AppendAllText ("api-diff.html", $"\n<h2><a href=\"{filePath}\">{platform} API diff (markdown)</a></h2>");
 		}
 	}

--- a/tools/apidiff/merger.cs
+++ b/tools/apidiff/merger.cs
@@ -13,6 +13,14 @@ class Merger {
 		return line.Substring (start, end - start);
 	}
 
+	static string DestinationPath = null;
+
+	public static void Process (string platform, string path, string os, string destinationPath)
+	{
+		DestinationPath = destinationPath;
+		Process (platform, path, os);
+	}
+
 	public static void Process (string platform, string path, string os)
 	{
 		if (!Directory.Exists (path))
@@ -76,22 +84,30 @@ class Merger {
 		headers.WriteLine ($"# {title}");
 		headers.WriteLine ();
 
-		File.WriteAllText (filename, headers.ToString ());
+		var filePath = DestinationPath is not null ? Path.Combine (DestinationPath, filename) : filename;
+		File.WriteAllText (filePath, headers.ToString ());
 
 		var alldiffs = content.ToString ();
 		if (alldiffs.Length == 0)
 			alldiffs = "No changes were found between both versions."; // should not happen for releases (versions change)
-		File.AppendAllText (filename, alldiffs);
-		Console.WriteLine ($"@MonkeyWrench: AddFile: {Path.GetFullPath (filename)}");
+		File.AppendAllText (filePath, alldiffs);
+		Console.WriteLine ($"@MonkeyWrench: AddFile: {Path.GetFullPath (filePath)}");
 
-		if (File.Exists ("api-diff.html"))
-			File.AppendAllText ("api-diff.html", $"\n<h2><a href=\"{filename}\">{platform} API diff (markdown)</a></h2>");
+		if (File.Exists ("api-diff.html")){
+			// TODO changing filename to filePath may cause trouble here...
+			File.AppendAllText ("api-diff.html", $"\n<h2><a href=\"{filePath}\">{platform} API diff (markdown)</a></h2>");
+		}
 	}
 
 	public static int Main (string [] args)
 	{
 		try {
-			Process (args [0], args [1], args [2]);
+			// if calling merger.cs form tools/apidiff/Makefile, we want to pass in the destinationPath 'arg [3]'
+			// to make sure diffs go to the correct location
+			if (args.Length < 4)
+				Process (args [0], args [1], args [2]);
+			else
+				Process (args [0], args [1], args [2], args [3]);
 			return 0;
 		} catch (Exception e) {
 			Console.WriteLine (e);

--- a/tools/apidiff/merger.cs
+++ b/tools/apidiff/merger.cs
@@ -20,7 +20,7 @@ class Merger {
 		if (!Directory.Exists (path))
 			throw new DirectoryNotFoundException (path);
 
-		if (!Directory.Exists (destinationPath))
+		if (destinationPath is not null && !Directory.Exists (destinationPath))
 			throw new DirectoryNotFoundException (destinationPath);
 
 		var content = new StringWriter ();

--- a/tools/apidiff/merger.cs
+++ b/tools/apidiff/merger.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 
+#nullable enable
+
 class Merger {
 
 	static string GetVersion (string line)
@@ -29,7 +31,7 @@ class Merger {
 		bool lookForVersion = false;
 		foreach (var file in files) {
 			// skip everything before and including title (single #) from each file, we already have one
-			string foundTitle = null;
+			string? foundTitle = null;
 			foreach (var line in File.ReadAllLines (file)) {
 				if (foundTitle != null) {
 					content.WriteLine (line);
@@ -56,7 +58,7 @@ class Merger {
 
 		// https://github.com/MicrosoftDocs/xamarin-docs/blob/live/contributing-guidelines/template.md#file-name
 		var filename = $"{os}-{from}-{to}".Replace ('.', '-').ToLowerInvariant () + ".md";
-		byte[] digest = null;
+		byte[]? digest = null;
 		using (var md = SHA256.Create ())
 			digest = md.ComputeHash (Encoding.UTF8.GetBytes (filename));
 		// (not cryptographically) unique (but good enough) for each filename - so document remains with the same id when it's updated/regenerated
@@ -79,7 +81,7 @@ class Merger {
 		headers.WriteLine ($"# {title}");
 		headers.WriteLine ();
 
-		var filePath = DestinationPath is not null ? Path.Combine (DestinationPath, filename) : filename;
+		var filePath = destinationPath is not null ? Path.Combine (destinationPath, filename) : filename;
 		File.WriteAllText (filePath, headers.ToString ());
 
 		var alldiffs = content.ToString ();

--- a/tools/apidiff/merger.cs
+++ b/tools/apidiff/merger.cs
@@ -13,18 +13,13 @@ class Merger {
 		return line.Substring (start, end - start);
 	}
 
-	static string DestinationPath = null;
-
-	public static void Process (string platform, string path, string os, string destinationPath)
-	{
-		DestinationPath = destinationPath;
-		Process (platform, path, os);
-	}
-
-	public static void Process (string platform, string path, string os)
+	public static void Process (string platform, string path, string os, string? destinationPath = null)
 	{
 		if (!Directory.Exists (path))
 			throw new DirectoryNotFoundException (path);
+
+		if (destinationPath is not null && !Directory.Exists (destinationPath))
+			throw new DirectoryNotFoundException (destinationPath);
 
 		var content = new StringWriter ();
 		var files = Directory.GetFileSystemEntries (path, "*.md");
@@ -93,9 +88,8 @@ class Merger {
 		File.AppendAllText (filePath, alldiffs);
 		Console.WriteLine ($"@MonkeyWrench: AddFile: {Path.GetFullPath (filePath)}");
 
-		if (File.Exists ("api-diff.html")){
+		if (File.Exists ("api-diff.html"))
 			File.AppendAllText ("api-diff.html", $"\n<h2><a href=\"{filePath}\">{platform} API diff (markdown)</a></h2>");
-		}
 	}
 
 	public static int Main (string [] args)
@@ -103,10 +97,7 @@ class Merger {
 		try {
 			// if calling merger.cs form tools/apidiff/Makefile, we want to pass in the destinationPath 'arg [3]'
 			// to make sure diffs go to the correct location
-			if (args.Length < 4)
-				Process (args [0], args [1], args [2]);
-			else
-				Process (args [0], args [1], args [2], args [3]);
+			Process (args [0], args [1], args [2], args.Length > 3 ? args [3] : null);
 			return 0;
 		} catch (Exception e) {
 			Console.WriteLine (e);

--- a/tools/apidiff/merger.cs
+++ b/tools/apidiff/merger.cs
@@ -13,12 +13,12 @@ class Merger {
 		return line.Substring (start, end - start);
 	}
 
-	public static void Process (string platform, string path, string os, string? destinationPath = null)
+	public static void Process (string platform, string path, string os, string? destinationPath)
 	{
 		if (!Directory.Exists (path))
 			throw new DirectoryNotFoundException (path);
 
-		if (destinationPath is not null && !Directory.Exists (destinationPath))
+		if (!Directory.Exists (destinationPath))
 			throw new DirectoryNotFoundException (destinationPath);
 
 		var content = new StringWriter ();
@@ -95,7 +95,7 @@ class Merger {
 	public static int Main (string [] args)
 	{
 		try {
-			// if calling merger.cs form tools/apidiff/Makefile, we want to pass in the destinationPath 'arg [3]'
+			// if calling merger.cs from tools/apidiff/Makefile, we want to pass in the destinationPath 'arg [3]'
 			// to make sure diffs go to the correct location
 			Process (args [0], args [1], args [2], args.Length > 3 ? args [3] : null);
 			return 0;

--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -192,7 +192,7 @@ mv "$ROOT_DIR/NuGet.config.disabled" "$ROOT_DIR/NuGet.config"
 
 # Calculate apidiff references according to the temporary build
 echo "${BLUE}Updating apidiff references...${CLEAR}"
-if ! make update-refs -C "$ROOT_DIR/tools/apidiff" -j8 APIDIFF_DIR="$OUTPUT_DIR/apidiff" IOS_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_ios-build" MAC_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_mac-build" DOTNET_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_build" V=1; then
+if ! make update-refs -C "$ROOT_DIR/tools/apidiff" -j8 APIDIFF_DIR="$OUTPUT_DIR/apidiff" IOS_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_ios-build" MAC_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_mac-build" DOTNET_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_build"; then
 	EC=$?
 	report_error_line "${RED}Failed to update apidiff references${CLEAR}"
 	exit "$EC"

--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -192,7 +192,7 @@ mv "$ROOT_DIR/NuGet.config.disabled" "$ROOT_DIR/NuGet.config"
 
 # Calculate apidiff references according to the temporary build
 echo "${BLUE}Updating apidiff references...${CLEAR}"
-if ! make update-refs -C "$ROOT_DIR/tools/apidiff" -j8 APIDIFF_DIR="$OUTPUT_DIR/apidiff" IOS_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_ios-build" MAC_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_mac-build"; then
+if ! make update-refs -C "$ROOT_DIR/tools/apidiff" -j8 APIDIFF_DIR="$OUTPUT_DIR/apidiff" IOS_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_ios-build" MAC_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_mac-build" DOTNET_DESTDIR="$OUTPUT_SRC_DIR/xamarin-macios/_build" V=1; then
 	EC=$?
 	report_error_line "${RED}Failed to update apidiff references${CLEAR}"
 	exit "$EC"
@@ -240,5 +240,13 @@ APIDIFF_FILE=$OUTPUT_DIR/apidiff/api-diff.html
 if ! make all-local -C "$ROOT_DIR/tools/apidiff" -j8 APIDIFF_DIR="$OUTPUT_DIR/apidiff"; then
 	EC=$?
 	report_error_line "${RED}Failed to run apidiff${CLEAR}"
+	exit "$EC"
+fi
+
+# Now create the markdowns with these references
+echo "${BLUE}Creating markdowns...${CLEAR}"
+if ! make all-markdowns -C "$ROOT_DIR/tools/apidiff" -j8 APIDIFF_DIR="$OUTPUT_DIR/apidiff"; then
+	EC=$?
+	report_error_line "${RED}Failed to create markdowns${CLEAR}"
 	exit "$EC"
 fi

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -412,6 +412,9 @@ function New-GitHubSummaryComment {
         $APIDiff="",
 
         [string]
+        $APIGeneratorDiffJson="",
+
+        [string]
         $APIGeneratorDiff=""
     )
 
@@ -442,16 +445,21 @@ function New-GitHubSummaryComment {
         $sb.AppendLine("* [Html Report (VSDrops)]($Env:VSDROPS_INDEX) [Download]($Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$Env:SYSTEM_TEAMPROJECT/_apis/build/builds/$Env:BUILD_BUILDID/artifacts?artifactName=HtmlReport-sim&api-version=6.0&`$format=zip)")
     }
     if (-not [string]::IsNullOrEmpty($APIDiff)) {
-        WriteDiffs $sb $APIDiff
+        WriteDiffs $sb "API diff" $APIDiff
     } else {
         Write-Host "API diff urls have not been provided."
     }
+    if (-not [string]::IsNullOrEmpty($APIGeneratorDiffJson)) {
+        WriteDiffs $sb "API Current PR diff" $APIGeneratorDiffJson
+    } else {
+        Write-Host "API Current PR diff urls have not been provided."
+    }
     if (-not [string]::IsNullOrEmpty($APIGeneratorDiff)) {
-        Write-Host "Parsing API diff in path $APIGeneratorDiff"
+        Write-Host "Parsing Generator diff in path $APIGeneratorDiff"
         if (-not (Test-Path $APIGeneratorDiff -PathType Leaf)) {
             $sb.AppendLine("Path $APIGeneratorDiff was not found!")
         } else {
-            $sb.AppendLine("# API & Generator diff")
+            $sb.AppendLine("# Generator diff")
             $sb.AppendLine("")
             # ugly workaround to get decent new lines
             foreach ($line in Get-Content -Path $APIGeneratorDiff)
@@ -461,7 +469,7 @@ function New-GitHubSummaryComment {
             $sb.AppendLine($apidiffcomments)
         }
     } else {
-        Write-Host "API & Generator diff comments have not been provided."
+        Write-Host "Generator diff comments have not been provided."
     }
     if (-not [string]::IsNullOrEmpty($Artifacts)) {
         Write-Host "Parsing artifacts"
@@ -557,6 +565,10 @@ function WriteDiffs {
         [System.Text.StringBuilder]
         $sb,
 
+        [Parameter(Mandatory)]
+        [String]
+        $header,
+
         [String]
         $APIDiff
     )
@@ -571,7 +583,7 @@ function WriteDiffs {
         $hasHtmlLinks = "html" -in $json.PSobject.Properties.Name
         $hasMDlinks = "gist" -in $json.PSobject.Properties.Name
         if ($hasHtmlLinks -or $hasMDlinks) {
-            $sb.AppendLine("# API diff")
+            $sb.AppendLine("# $header")
             Write-Host "Message is '$($json.message)'"
             $sb.AppendLine($json.message)
 

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -444,15 +444,17 @@ function New-GitHubSummaryComment {
         # we did generate an index with the files in vsdrops
         $sb.AppendLine("* [Html Report (VSDrops)]($Env:VSDROPS_INDEX) [Download]($Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$Env:SYSTEM_TEAMPROJECT/_apis/build/builds/$Env:BUILD_BUILDID/artifacts?artifactName=HtmlReport-sim&api-version=6.0&`$format=zip)")
     }
-    if (-not [string]::IsNullOrEmpty($APIDiff)) {
-        WriteDiffs $sb "API diff" $APIDiff
+    $diffHeader = "API diff"
+    $currentPRHeader = "API Current PR diff"
+    if ([string]::IsNullOrEmpty($APIDiff)) {
+        $sb.AppendLine("API diff urls have not been provided.")
     } else {
-        Write-Host "API diff urls have not been provided."
+        WriteDiffs $sb $diffHeader $APIDiff
     }
-    if (-not [string]::IsNullOrEmpty($APIGeneratorDiffJson)) {
-        WriteDiffs $sb "API Current PR diff" $APIGeneratorDiffJson
+    if ([string]::IsNullOrEmpty($APIGeneratorDiffJson)) {
+        $sb.AppendLine("API Current PR diff urls have not been provided.")
     } else {
-        Write-Host "API Current PR diff urls have not been provided."
+        WriteDiffs $sb $currentPRHeader $APIGeneratorDiffJson
     }
     if (-not [string]::IsNullOrEmpty($APIGeneratorDiff)) {
         Write-Host "Parsing Generator diff in path $APIGeneratorDiff"
@@ -469,7 +471,7 @@ function New-GitHubSummaryComment {
             $sb.AppendLine($apidiffcomments)
         }
     } else {
-        Write-Host "Generator diff comments have not been provided."
+        $sb.AppendLine("Generator diff comments have not been provided.")
     }
     if (-not [string]::IsNullOrEmpty($Artifacts)) {
         Write-Host "Parsing artifacts"

--- a/tools/devops/automation/scripts/bash/compare.sh
+++ b/tools/devops/automation/scripts/bash/compare.sh
@@ -68,19 +68,22 @@ fi
 
 mkdir -p "$API_COMPARISON"
 
-
 cp -R ./tools/comparison/apidiff/diff "$API_COMPARISON"
+cp -R ./tools/comparison/apidiff/dotnet "$API_COMPARISON"
 cp    ./tools/comparison/apidiff/*.html "$API_COMPARISON"
+cp    ./tools/comparison/apidiff/*.md "$API_COMPARISON"
 cp -R ./tools/comparison/generator-diff "$API_COMPARISON"
 
 if ! grep "href=" "$API_COMPARISON/api-diff.html" >/dev/null 2>&1; then
-	printf ":white_check_mark: [API Diff (from PR only)](%s) (no change)" "$API_URL" >> "$WORKSPACE/api-diff-comments.md"
+	STATUS_MESSAGE=":white_check_mark: API Diff (from PR only) (no change)"
+	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS_MESSAGE;isOutput=true]$STATUS_MESSAGE"
 elif perl -0777 -pe 's/<script type="text\/javascript">.*?<.script>/script removed/gs' "$API_COMPARISON"/*.html | grep data-is-breaking; then
-	printf ":warning: [API Diff (from PR only)](%s) (:fire: breaking changes :fire:)" "$API_URL" >> "$WORKSPACE/api-diff-comments.md"
+	STATUS_MESSAGE=":warning: API Diff (from PR only) (:fire: breaking changes :fire:)"
+	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS_MESSAGE;isOutput=true]$STATUS_MESSAGE"
 else
-	printf ":information_source: [API Diff (from PR only)](%s) (please review changes)" "$API_URL" >> "$WORKSPACE/api-diff-comments.md"
+	STATUS_MESSAGE=":information_source: API Diff (from PR only) (please review changes)"
+	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS_MESSAGE;isOutput=true]$STATUS_MESSAGE"
 fi
-printf "\\n" >> "$WORKSPACE/api-diff-comments.md"
 
 if ! test -s $API_COMPARISON/generator-diff/generator.diff; then
 	printf ":white_check_mark: [Generator Diff](%s) (no change)" "$GENERATOR_URL" >> "$WORKSPACE/api-diff-comments.md"

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -118,7 +118,7 @@ steps:
       $apiDiffData | ConvertTo-Json | Write-Host
       Write-Host "##vso[task.setvariable variable=APIDIFF_JSON_PATH]$path"
     displayName: 'Create API from stable diff gists'
-    timeoutInMinutes: 1
+    timeoutInMinutes: 5
     env:
       GITHUB_TOKEN: $(GitHub.Token)
 
@@ -193,7 +193,7 @@ steps:
       $apiGeneratorDiffData | ConvertTo-Json | Write-Host
       Write-Host "##vso[task.setvariable variable=APIGENERATORDIFF_JSON_PATH]$path"
     displayName: 'Create API from current diff gists'
-    timeoutInMinutes: 1
+    timeoutInMinutes: 5
     env:
       GITHUB_TOKEN: $(GitHub.Token)
 

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -122,6 +122,81 @@ steps:
     env:
       GITHUB_TOKEN: $(GitHub.Token)
 
+- ${{ if eq(parameters.runTests, true) }}:
+  - pwsh: |
+      Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\GitHub.psm1
+
+      $apiDiffRoot = "$Env:STABLE_APID_GENERATOR_DIFF_PATH"
+      $filePatterns = @{
+        "iOS" = "^ios-[a-zA-Z0-9\-]*\.md$";
+        "macOS" = "^macos-[a-zA-Z0-9\-]*\.md$";
+        "tvOS" = "^tvos-[a-zA-Z0-9\-]*\.md$";
+        "watchOS" = "^watchos-[a-zA-Z0-9\-]*\.md$";
+        "dotnet-iOS" = "^dotnet-ios-[a-zA-Z0-9\-]*\.md$";
+        "dotnet-tvOS" = "^dotnet-tvos-[a-zA-Z0-9\-]*\.md$";
+        "dotnet-MacCatalyst" = "^dotnet-maccatalyst-[a-zA-Z0-9\-]*\.md$";
+        "dotnet-macOS" = "^dotnet-macos-[a-zA-Z0-9\-]*\.md$";
+        "dotnet-legacy-iOS" = "^dotnet-legacy-ios-[a-zA-Z0-9\-]*\.md$";
+        "dotnet-legacy-tvOS" = "^dotnet-legacy-tvos-[a-zA-Z0-9\-]*\.md$";
+        "dotnet-legacy-macOS" = "^dotnet-legacy-macos-[a-zA-Z0-9\-]*\.md$";
+        "dotnet-macCatiOS" = "^dotnet-maccatios-[a-zA-Z0-9\-]*\.md$";
+      }
+
+      [System.Collections.Generic.List[System.Object]]$gistsObj = @()
+      $gists = @{}
+
+      foreach ($key in $filePatterns.Keys) {
+        $filter = $filePatterns[$key]
+        $fileName = Get-ChildItem $apiDiffRoot -Name | Where-Object{$_ -match $filter}
+        if ($fileName) {
+          $obj = New-GistObjectDefinition -Name $fileName -Path "$apiDiffRoot\$fileName" -Type "markdown"
+          $gistsObj.Add($obj)
+          # create a gist just for this file
+          $url = New-GistWithFiles -Description "$key API Generator diffs" -Files @($obj)
+          Write-Host "New gist created at $url"
+          $gists[$key] = $url
+        }
+      }
+
+      # create a gist with all diffs
+      $url = New-GistWithFiles -Description "API Generator diffs" -Files $gistsObj
+      $gists["index"] = $url
+
+      # similar dict but for the html links from vsdrops
+      $apiDiffRoot="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID/apigeneratordiff/;/"
+      $html =  @{
+        "iOS" = $apiDiffRoot + "ios-api-diff.html";
+        "macOS" = $apiDiffRoot + "mac-api-diff.html";
+        "tvOS" = $apiDiffRoot + "tvos-api-diff.html";
+        "watchOS" =$apiDiffRoot + "watchos-api-diff.html";
+        "index"= $apiDiffRoot + "api-diff.html";
+        "dotnet-iOS" = $apiDiffRoot + "dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html";
+        "dotnet-tvOS" = $apiDiffRoot + "dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html";
+        "dotnet-MacCatalyst" = $apiDiffRoot + "dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst-api-diff.html";
+        "dotnet-macOS" = $apiDiffRoot + "dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html";
+        "dotnet-legacy-iOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html";
+        "dotnet-legacy-tvOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html";
+        "dotnet-legacy-macOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html";
+        "dotnet-macCatiOS" = $apiDiffRoot + "dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.MacCatalyst-api-diff.html";
+      }
+
+      # build a json object that will be used by the comment to write the data for users
+      $apiGeneratorDiffData = @{
+        "gist" = $gists;
+        "html" = $html;
+        "result" = $Env:API_GENERATOR_DIFF_BUILT;
+        "message" = $Env:API_GENERATOR_DIFF_STATUS_MESSAGE;
+      }
+      # write to a file to be used by the comment to parse
+      $path = "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\apiGeneratorDiff.json"
+      $apiGeneratorDiffData | ConvertTo-Json | Out-File $path
+      $apiGeneratorDiffData | ConvertTo-Json | Write-Host
+      Write-Host "##vso[task.setvariable variable=APIGENERATORDIFF_JSON_PATH]$path"
+    displayName: 'Create API from current diff gists'
+    timeoutInMinutes: 1
+    env:
+      GITHUB_TOKEN: $(GitHub.Token)
+
   - powershell: |
       $env:VSDROPS_INDEX="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID/$Env:DEVICE_PREFIX/;/tests/vsdrops_index.html"
       Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\GitHub.psm1 
@@ -143,11 +218,11 @@ steps:
 
       if ($buildReason -ne "PullRequest" -or $Env:BUILD_PACKAGE -eq "True") {
         Write-Host "Json path is $Env:ARTIFACTS_JSON_PATH"
-        $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -TestSummaryPath "$Env:TESTS_SUMMARY" -Artifacts "$Env:ARTIFACTS_JSON_PATH" -APIDiff "$Env:APIDIFF_JSON_PATH" -APIGeneratorDiff $apiGeneratorComment
+        $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -TestSummaryPath "$Env:TESTS_SUMMARY" -Artifacts "$Env:ARTIFACTS_JSON_PATH" -APIDiff "$Env:APIDIFF_JSON_PATH" -APIGeneratorDiffJson "$Env:APIGENERATORDIFF_JSON_PATH" -APIGeneratorDiff $apiGeneratorComment
         Write-Host $response
       } else {
         Write-Host "Json path is $Env:ARTIFACTS_JSON_PATH"
-        $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -TestSummaryPath "$Env:TESTS_SUMMARY" -APIDiff "$Env:APIDIFF_JSON_PATH" -APIGeneratorDiff $apiGeneratorComment
+        $response = New-GitHubSummaryComment -Context "$Env:CONTEXT" -TestSummaryPath "$Env:TESTS_SUMMARY" -APIDiff "$Env:APIDIFF_JSON_PATH" -APIGeneratorDiffJson "$Env:APIGENERATORDIFF_JSON_PATH" -APIGeneratorDiff $apiGeneratorComment
         Write-Host $response
       }
     env:

--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -122,7 +122,6 @@ steps:
     env:
       GITHUB_TOKEN: $(GitHub.Token)
 
-- ${{ if eq(parameters.runTests, true) }}:
   - pwsh: |
       Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\GitHub.psm1
 
@@ -151,16 +150,23 @@ steps:
         if ($fileName) {
           $obj = New-GistObjectDefinition -Name $fileName -Path "$apiDiffRoot\$fileName" -Type "markdown"
           $gistsObj.Add($obj)
-          # create a gist just for this file
-          $url = New-GistWithFiles -Description "$key API Generator diffs" -Files @($obj)
-          Write-Host "New gist created at $url"
-          $gists[$key] = $url
+          $files = @($obj)
+          if ($files.Length -gt 0) {
+            # create a gist just for this file
+            $url = New-GistWithFiles -Description "$key API Generator diffs" -Files $files
+            Write-Host "New gist created at $url"
+            $gists[$key] = $url
+          } else {
+            Write-Host "Could not create gist for $obj"
+          }
         }
       }
 
-      # create a gist with all diffs
-      $url = New-GistWithFiles -Description "API Generator diffs" -Files $gistsObj
-      $gists["index"] = $url
+      if ($gistsObj.Length -gt 0) {
+        # create a gist with all diffs
+        $url = New-GistWithFiles -Description "API Generator diffs" -Files $gistsObj
+        $gists["index"] = $url
+      }
 
       # similar dict but for the html links from vsdrops
       $apiDiffRoot="$Env:VSDROPSPREFIX/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID/apigeneratordiff/;/"

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -181,6 +181,7 @@ jobs:
     APIDIFF_MESSAGE: $[ dependencies.build.outputs['apidiff.APIDIFF_MESSAGE'] ]
     APIDIFF_BUILT: $[ dependencies.build.outputs['apidiff.APIDIFF_BUILT'] ]
     API_GENERATOR_DIFF_BUILT: $[ dependencies.build.outputs['apiGeneratorDiff.API_GENERATOR_BUILT'] ]
+    API_GENERATOR_DIFF_STATUS_MESSAGE: $[ dependencies.build.outputs['apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE'] ]
     PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
   pool:
     vmImage: 'windows-latest'


### PR DESCRIPTION
This PR gives us easy to inspect API Diffs from the current PR in Github!

Before, we would receive a link inside the "API & Generator Diff" which would download an html file 
with links that were not able to be opened. This was because the links lived inside Azure Devops
but the links were using relative paths.

Now, we will see a new section named "API Current PR diff" with the status message below it.
Then we will be able to download/open each html in devops or the appropriate gist. 

Here is an example of what will show when removing two selectors in foundation: https://github.com/xamarin/xamarin-macios/pull/13401#issuecomment-989538316

This PR also fixes a few issues with the Current API diff generation and fixes an issue with the html and md files inside
the apicomparison zip artifact as well!

~ I tried squashing many commits from my Draft PR so hopefully I didn't miss any commits \fingers_crossed

Changes this:
<img src="https://user-images.githubusercontent.com/50846373/145437228-14a021c7-e710-418e-92e6-3098ebfb789c.png" width="400" />


To this: 
<img src="https://user-images.githubusercontent.com/50846373/145437131-82d512c9-be2a-4f4a-b23f-3f88a649b939.png" width="400" />
