### PR TITLE
[generator] Generate the same invoke code for Mac Catalyst like we already do for macOS.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4052,7 +4052,7 @@ public partial class Generator : IMemberGatherer {
 		bool x64_stret = Stret.X86_64NeedStret (returnType, this);
 		bool aligned = AttributeManager.HasAttribute<AlignAttribute> (mi);
 
-		if (CurrentPlatform == PlatformName.MacOSX) {
+		if (CurrentPlatform == PlatformName.MacOSX || CurrentPlatform == PlatformName.MacCatalyst) {
 			print ("if (global::ObjCRuntime.Runtime.IsARM64CallingConvention) {");
 			indent++;
 			GenerateInvoke (false, supercall, mi, minfo, selector, args, assign_to_temp, category_type, false);

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4053,15 +4053,19 @@ public partial class Generator : IMemberGatherer {
 		bool aligned = AttributeManager.HasAttribute<AlignAttribute> (mi);
 
 		if (CurrentPlatform == PlatformName.MacOSX || CurrentPlatform == PlatformName.MacCatalyst) {
-			print ("if (global::ObjCRuntime.Runtime.IsARM64CallingConvention) {");
-			indent++;
-			GenerateInvoke (false, supercall, mi, minfo, selector, args, assign_to_temp, category_type, false);
-			indent--;
-			print ("} else {");
-			indent++;
-			GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args, assign_to_temp, category_type, aligned && x64_stret);
-			indent--;
-			print ("}");
+			if (x64_stret) {
+				print ("if (global::ObjCRuntime.Runtime.IsARM64CallingConvention) {");
+				indent++;
+				GenerateInvoke (false, supercall, mi, minfo, selector, args, assign_to_temp, category_type, false);
+				indent--;
+				print ("} else {");
+				indent++;
+				GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args, assign_to_temp, category_type, aligned && x64_stret);
+				indent--;
+				print ("}");
+			} else {
+				GenerateInvoke (false, supercall, mi, minfo, selector, args, assign_to_temp, category_type, false);
+			}
 			return;
 		}
 


### PR DESCRIPTION
This makes the generated code much smaller, and also avoids calling
Runtime.Arch for Mac Catalyst.