### PR TITLE
[CI] Increate timeouts so that we do not have failures.

### DIFF
--- a/tools/devops/automation/templates/build/publish-html.yml
+++ b/tools/devops/automation/templates/build/publish-html.yml
@@ -118,7 +118,7 @@ steps:
       $apiDiffData | ConvertTo-Json | Write-Host
       Write-Host "##vso[task.setvariable variable=APIDIFF_JSON_PATH]$path"
     displayName: 'Create API from stable diff gists'
-    timeoutInMinutes: 1
+    timeoutInMinutes: 10
     env:
       GITHUB_TOKEN: $(GitHub.Token)
 
@@ -160,7 +160,7 @@ steps:
       ACCESSTOKEN: $(System.AccessToken)
     displayName: 'Add summaries'
     condition: always()
-    timeoutInMinutes: 1
+    timeoutInMinutes: 10
 
 - ${{ if ne(parameters.runTests, true) }}:
   - powershell: |
@@ -176,4 +176,4 @@ steps:
       ACCESSTOKEN: $(System.AccessToken)
     displayName: 'Add summaries'
     condition: always()
-    timeoutInMinutes: 1
+    timeoutInMinutes: 5


### PR DESCRIPTION
We have added more files and the API seems to take long sometimes,
increate the timeots to avoid failures like in https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5532523&view=logs&j=704af8c3-a112-593d-cee6-636e1ea22709&t=62b5d5ee-dc4f-530c-7279-a3bef6bd6bc7