### PR TITLE
[release/6.0.1xx-preview11] Use the '.NET 6 MAUI' channel for dotnet/runtime bits.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -552,6 +552,9 @@ DOTNET6_DIR=$(abspath $(TOP)/builds/downloads/$(basename $(basename $(DOTNET6_TA
 DOTNET6=$(DOTNET6_DIR)/dotnet
 DOTNET6_BCL_DIR:=$(abspath $(TOP)/builds/downloads/microsoft.netcore.app.ref/$(DOTNET6_BCL_VERSION)/ref/net6.0)
 
+# The sdk version band has the last two digits set to 0: https://github.com/dotnet/sdk/blob/22c4860dcb2cf6b123dd641cc4a87a50380759d5/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs#L52-L53
+MANIFEST_VERSION_BAND=$(shell echo $(DOTNET6_VERSION_BAND) | sed 's/..$$/00/')
+
 DOTNET6_CSC=$(DOTNET6) exec $(DOTNET6_DIR)/sdk/$(DOTNET6_VERSION_BAND)/Roslyn/bincore/csc.dll
 
 # How are our assemblies named?

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -110,6 +110,10 @@ $(eval $(call FixMacCatalystAssembly,System.Net.Http))
 
 ifdef CUSTOM_DOTNET
 DOWNLOAD_DOTNET_VERSION=$(CUSTOM_DOTNET_VERSION)
+else
+ifneq ($(BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION),)
+DOWNLOAD_DOTNET_VERSION=$(BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION)
+endif
 endif
 
 .stamp-download-dotnet-packages: $(TOP)/Make.config downloads/$(basename $(basename $(DOTNET6_TARBALL_NAME))) package-download/global.json package-download/NuGet.config

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -125,8 +125,10 @@ endif
 		/p:PackageRuntimeIdentifiers="$(DOTNET_RUNTIME_IDENTIFIERS)" \
 		/p:PackageRuntimeIdentifiersCoreCLR="$(DOTNET_CORECLR_RUNTIME_IDENTIFIERS)" \
 		/p:CustomDotNetVersion="$(DOWNLOAD_DOTNET_VERSION)" \
+		/p:DotNetManifestVersionBand="$(MANIFEST_VERSION_BAND)" \
 		/bl \
 		$(DOTNET_BUILD_VERBOSITY)
+	$(Q) $(CP) ./downloads/microsoft.net.workload.mono.toolchain.manifest-$(MANIFEST_VERSION_BAND)/$(DOWNLOAD_DOTNET_VERSION)/data/WorkloadManifest.* ./downloads/dotnet-sdk-$(DOTNET6_VERSION)-osx-x64/sdk-manifests/$(MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain/
 	$(Q) touch $@
 
 BundledNETCorePlatformsPackageVersion.txt: .stamp-download-dotnet-packages

--- a/builds/package-download/download-packages.proj
+++ b/builds/package-download/download-packages.proj
@@ -16,6 +16,9 @@
 
     <!-- download the reference assemblies -->
     <PackageDownload Include="microsoft.netcore.app.ref" Version="[$(ActualPackageVersion)]" />
+
+    <!-- and get the mono workload as well -->
+    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-$(DotNetManifestVersionBand)" Version="[$(ActualPackageVersion)]" />
   </ItemGroup>
 
   <!-- target to write out the BundledNETCorePlatformsPackageVersion to a file -->

--- a/builds/package-download/download-packages.proj
+++ b/builds/package-download/download-packages.proj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ActualPackageVersion Condition="'$(CustomDotNetVersion)' != ''">$(CustomDotNetVersion)</ActualPackageVersion>
+    <ActualPackageVersion Condition="'$(ActualPackageVersion)' == ''">$(BundledNETCorePlatformsPackageVersion)</ActualPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,16 +11,15 @@
     <PackageRuntimeIdentifiersCoreCLR Include="$(PackageRuntimeIdentifiersCoreCLR.Split(' '))" />
 
     <!-- download the runtime packs -->
-    <PackageDownload Include="@(PackageRuntimeIdentifiers -> 'Microsoft.NETCore.App.Runtime.Mono.%(Identity)')" Version="[$(BundledNETCorePlatformsPackageVersion)]" />
-    <PackageDownload Include="@(PackageRuntimeIdentifiersCoreCLR -> 'Microsoft.NETCore.App.Runtime.%(Identity)')" Version="[$(BundledNETCorePlatformsPackageVersion)]" />
+    <PackageDownload Include="@(PackageRuntimeIdentifiers -> 'Microsoft.NETCore.App.Runtime.Mono.%(Identity)')" Version="[$(ActualPackageVersion)]" />
+    <PackageDownload Include="@(PackageRuntimeIdentifiersCoreCLR -> 'Microsoft.NETCore.App.Runtime.%(Identity)')" Version="[$(ActualPackageVersion)]" />
 
     <!-- download the reference assemblies -->
-    <PackageDownload Include="microsoft.netcore.app.ref" Version="[$(BundledNETCorePlatformsPackageVersion)]" Condition="'$(CustomDotNetVersion)' == ''" />
-    <PackageDownload Include="microsoft.netcore.app.ref" Version="[$(CustomDotNetVersion)]" Condition="'$(CustomDotNetVersion)' != ''" />
+    <PackageDownload Include="microsoft.netcore.app.ref" Version="[$(ActualPackageVersion)]" />
   </ItemGroup>
 
   <!-- target to write out the BundledNETCorePlatformsPackageVersion to a file -->
   <Target Name="WriteBundledNETCorePlatformsPackageVersion" Condition="'$(WriteFilePath)' != ''">
-    <WriteLinesToFile File="$(WriteFilePath)" Lines="$(BundledNETCorePlatformsPackageVersion)" Overwrite="true" />
+    <WriteLinesToFile File="$(WriteFilePath)" Lines="$(ActualPackageVersion)" Overwrite="true" />
   </Target>
 </Project>

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -3,8 +3,6 @@ TOP = ..
 include $(TOP)/Make.config
 include $(TOP)/mk/rules.mk
 
-# The sdk version band has the last two digits set to 0: https://github.com/dotnet/sdk/blob/22c4860dcb2cf6b123dd641cc4a87a50380759d5/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs#L52-L53
-MANIFEST_VERSION_BAND=$(shell echo $(DOTNET6_VERSION_BAND) | sed 's/..$$/00/')
 DOTNET_MANIFESTS_PATH=$(DOTNET6_DIR)/sdk-manifests/$(MANIFEST_VERSION_BAND)
 DOTNET_PACKS_PATH=$(DOTNET6_DIR)/packs
 DOTNET_TEMPLATE_PACKS_PATH=$(DOTNET6_DIR)/template-packs

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
       <Uri>https://github.com/dotnet/linker</Uri>
       <Sha>d0662ed8db919642177ddfd06a1c33895a69015f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.1-mauipre.1.21602.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+      <Sha>3992fc3841133e15ad322842d35adb8c249a824f</Sha>
     </Dependency>
     <!-- This is required for our test apps to build; in some cases Microsoft.AspNetCore.App is pulled in, and when building test apps the build needs to be able to resolve that -->
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,6 +5,6 @@
     <MicrosoftNETILLinkTasksPackageVersion>6.0.100-1.21519.4</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETILStripTasksPackageVersion>6.0.0-rc.2.21468.3</MicrosoftNETILStripTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.1-mauipre.1.21602.7</MicrosoftNETCoreAppRefPackageVersion>
   </PropertyGroup>
 </Project>

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -829,13 +829,13 @@ namespace LinkSdk {
 		public void PrivateMemorySize64 ()
 		{
 			// ref: https://bugzilla.xamarin.com/show_bug.cgi?id=21882
+#if NET
+			// It's not entirely clear, but it appears this is not implemented, and won't be, for mobile platforms: https://github.com/dotnet/runtime/issues/28990
+			Assert.Throws<PlatformNotSupportedException> (() => { var mem = System.Diagnostics.Process.GetCurrentProcess ().PrivateMemorySize64; }, "PrivateMemorySize64");
+#else
 			var mem = System.Diagnostics.Process.GetCurrentProcess ().PrivateMemorySize64;
 			// the above used a mach call that iOS samdbox did *not* allow (sandbox) on device
 			// but has been fixed (different call) for the same PID
-#if NET
-			// It's not entirely clear, but it appears this is not implemented, and won't be, for mobile platforms: https://github.com/dotnet/runtime/issues/28990
-			Assert.That (mem, Is.EqualTo (0), "PrivateMemorySize64");
-#else
 			Assert.That (mem, Is.Not.EqualTo (0), "PrivateMemorySize64");
 #endif
 		}

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -830,8 +830,13 @@ namespace LinkSdk {
 		{
 			// ref: https://bugzilla.xamarin.com/show_bug.cgi?id=21882
 #if NET
+#if __MACOS__
+			var mem = System.Diagnostics.Process.GetCurrentProcess ().PrivateMemorySize64;
+			Assert.That (mem, Is.EqualTo (0), "PrivateMemorySize64");
+#else
 			// It's not entirely clear, but it appears this is not implemented, and won't be, for mobile platforms: https://github.com/dotnet/runtime/issues/28990
 			Assert.Throws<PlatformNotSupportedException> (() => { var mem = System.Diagnostics.Process.GetCurrentProcess ().PrivateMemorySize64; }, "PrivateMemorySize64");
+#endif // __MACOS__
 #else
 			var mem = System.Diagnostics.Process.GetCurrentProcess ().PrivateMemorySize64;
 			// the above used a mach call that iOS samdbox did *not* allow (sandbox) on device


### PR DESCRIPTION
We are in a situation where:

1. .NET MAUI is still in preview
2. We need dotnet/runtime fixes for MAUI, but we don't necessarily want all fixes to go into the .NET 6 service release.

The solution is to simplify use different builds/packs from dotnet/runtime.

Ref: https://github.com/xamarin/xamarin-android/pull/6542


Backport of #13504
