### PR TITLE
[CFNetworkHandler] Only use public API to set cookies in CookieContainers. Fixes #8072.

### DIFF
--- a/src/System.Net.Http/CFNetworkHandler.cs
+++ b/src/System.Net.Http/CFNetworkHandler.cs
@@ -376,10 +376,16 @@ namespace System.Net.Http
 
 		void AddCookie (string value, Uri uri, string header)
 		{
-#if !NET_TODO
-			// NET_TODO: CookieCollection.CookieCutter is internal to mscorlib:
+#if NET
+			// .NET: CookieCollection.CookieCutter is internal to mscorlib:
 			// https://github.com/microsoft/referencesource/blob/a7bd3242bd7732dec4aebb21fbc0f6de61c2545e/System/net/System/Net/cookiecontainer.cs#L632
 			// https://github.com/xamarin/xamarin-macios/issues/8072
+			// so use the public CookieContainer.SetCookies instead.
+			try {
+				cookies.SetCookies (uri, value);
+			} catch {
+			}
+#else
 			CookieCollection cookies1 = null;
 			try {
 				cookies1 = cookies.CookieCutter (uri, header, value, false);


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/8072.