### PR TITLE
[CI] Add missing import directive.

### DIFF
--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -144,6 +144,8 @@ steps:
 
 # sometimes the make that creates the pkgs fails.
 - pwsh:
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\GitHub.psm1 
+
     if ($Env:MAC_TESTS_PRESENT -ne "Succeeded") {
       Set-GitHubStatus -Status "error" -Description "Mac tests were not packaged." -Context "$Env:CONTEXT"
       New-GitHubComment -Header "Tests failed catastrophically on $Env:CONTEXT" -Emoji ":fire:" -Description "Mac tests were not packaged."


### PR DESCRIPTION
Else the tests fail rather than post a status in github:

```
The term 'Set-GitHubStatus' is not recognized as a name of a
     | cmdlet, function, script file, or executable program. Check
     | the spelling of the name, or if a path was included, verify
     | that the path is correct and try again.

```
