### PR TITLE
Revert "[CI] Use Build artifacts so that they are copied to the release pipeline. (#13501)"

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -18,7 +18,7 @@ stages:
     parameters:
       artifactName: package
       signType: Real
-      usePipelineArtifactTasks: false
+      usePipelineArtifactTasks: true
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
   - template: nuget-msi-convert/job/v2.yml@templates


### PR DESCRIPTION
This reverts commit 3977d7531d5876e6aadcd9eb013cad2c978c885f because it broke the release step because we cannot change the download type.