### PR TITLE
[dotnet] Pass -dead_strip to the native linker when we can.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -431,6 +431,7 @@
 				@(_BundlerDlsym -> 'Dlsym=%(Identity)')
 				Debug=$(_BundlerDebug)
 				DeploymentTarget=$(_MinimumOSVersion)
+				@(_CustomLinkFlags -> 'CustomLinkFlags=%(Identity)')
 				EnableSGenConc=$(EnableSGenConc)
 				@(_BundlerEnvironmentVariables -> 'EnvironmentVariable=%(Identity)=%(Value)')
 				@(_XamarinFrameworkAssemblies -> 'FrameworkAssembly=%(Filename)')
@@ -687,6 +688,10 @@
 		<!-- Load _AssemblyLinkerFlags -->
 		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_AssemblyLinkerFlags.items" Condition="Exists('$(_LinkerItemsDirectory)/_AssemblyLinkerFlags.items')">
 			<Output TaskParameter="Items" ItemName="_AssemblyLinkerFlags" />
+		</ReadItemsFromFile>
+		<!-- Load _MainLinkerFlags -->
+		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_MainLinkerFlags.items" Condition="Exists('$(_LinkerItemsDirectory)/_MainLinkerFlags.items')">
+			<Output TaskParameter="Items" ItemName="_MainLinkerFlags" />
 		</ReadItemsFromFile>
 		<!-- Load _BindingLibraryFrameworks -->
 		<ReadItemsFromFile SessionId="$(BuildSessionId)" File="$(_LinkerItemsDirectory)/_BindingLibraryFrameworks.items" Condition="Exists('$(_LinkerItemsDirectory)/_BindingLibraryFrameworks.items')">

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -119,6 +119,9 @@ namespace Xamarin.Linker {
 				case "CacheDirectory":
 					CacheDirectory = value;
 					break;
+				case "CustomLinkFlags":
+					Application.ParseCustomLinkFlags (value, "gcc_flags");
+					break;
 				case "Debug":
 					Application.EnableDebug = string.Equals (value, "true", StringComparison.OrdinalIgnoreCase);
 					break;

--- a/tools/dotnet-linker/Steps/ComputeNativeBuildFlagsStep.cs
+++ b/tools/dotnet-linker/Steps/ComputeNativeBuildFlagsStep.cs
@@ -44,6 +44,16 @@ namespace Xamarin.Linker {
 				}
 			}
 			Configuration.WriteOutputForMSBuild ("_AssemblyLinkerFlags", linkerFlags);
+
+			if (Configuration.Application.CustomLinkFlags?.Count > 0)
+				Configuration.Application.DeadStrip = false;
+
+			var mainLinkerFlags = new List<MSBuildItem> ();
+			if (Configuration.Application.DeadStrip) {
+				mainLinkerFlags.Add (new MSBuildItem { Include = "-dead_strip" });
+			}
+			Configuration.WriteOutputForMSBuild ("_AssemblyLinkerFlags", mainLinkerFlags);
+
 		}
 	}
 }


### PR DESCRIPTION
Pass -dead_strip to the native linker like we do for legacy Xamarin:

* If there are no custom linker arguments.
* If all third-party bindings in the app has SmartLink = true (this doesn't
  show up in the PR, but the logic exists for legacy Xamarin and is already
  executed for .NET, the resulting Application.DeadStrip value just wasn't
  taken into account).

This shrinks the app size a bot for a Hello World app:

* Before:     10.659.731 (https://gist.github.com/rolfbjarne/b5892a5c7fb8663d38e2b69f67bce90c)
* After:       9.940.240 (https://gist.github.com/rolfbjarne/8404394180fb9971bd2f1475b747c70a)
* Difference:   -719.491 (-6.7 %)