### PR TITLE
[msbuild] Fix merging of apps with symlinks to directories.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MergeAppBundlesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MergeAppBundlesTaskBase.cs
@@ -282,6 +282,11 @@ namespace Xamarin.MacDev.Tasks {
 					BundlePath = fullInput,
 					SpecificSubdirectory = specificSubdirectory,
 				};
+				// Remove any files inside directories which are symlinks (we only need to process the symlink itself)
+				var symlinkDirectories = files.Where (v => PathUtils.IsSymlink (v) && Directory.Exists (v));
+				if (symlinkDirectories.Any ()) {
+					files = files.Where (file => !symlinkDirectories.Any (dir => file.StartsWith (dir + Path.DirectorySeparatorChar))).ToArray ();
+				}
 				foreach (var file in files) {
 					var relativePath = file.Substring (fullInput.Length + 1);
 					var entry = new Entry {
@@ -442,11 +447,11 @@ namespace Xamarin.MacDev.Tasks {
 
 		FileType GetFileType (string path)
 		{
-			if (Directory.Exists (path))
-				return FileType.Directory;
-
 			if (PathUtils.IsSymlink (path))
 				return FileType.Symlink;
+
+			if (Directory.Exists (path))
+				return FileType.Directory;
 
 			if (path.EndsWith (".exe", StringComparison.Ordinal) || path.EndsWith (".dll", StringComparison.Ordinal))
 				return FileType.PEAssembly;

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MergeAppBundleTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MergeAppBundleTaskTest.cs
@@ -275,5 +275,28 @@ namespace Xamarin.MacDev.Tasks {
 			Assert.That (new FileInfo (fileA).Length, Is.EqualTo (new FileInfo (nonFatBinary).Length), "File length");
 		}
 
+		[Test]
+		public void TestDirectoriesAsSymlinks ()
+		{
+			var bundleA = Path.Combine (Cache.CreateTemporaryDirectory (), "MergeMe.app");
+			var bundleB = Path.Combine (Cache.CreateTemporaryDirectory (), "MergeMe.app");
+			var fileA = Path.Combine (bundleA, "A", "A.txt");
+			var fileB = Path.Combine (bundleB, "A.txt");
+			Directory.CreateDirectory (Path.GetDirectoryName (fileA));
+			File.WriteAllText (fileA, "A");
+			Directory.CreateDirectory (Path.GetDirectoryName (fileB));
+			File.WriteAllText (fileB, "A");
+			var linkA = Path.Combine (bundleA, "B");
+			var linkB = Path.Combine (bundleB, "B");
+			Assert.IsTrue (PathUtils.Symlink ("A", linkA), "Link A");
+			Assert.IsTrue (PathUtils.Symlink ("A", linkB), "Link B");
+
+			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
+			var task = CreateTask (outputBundle, bundleA, bundleB);
+			Assert.IsTrue (task.Execute (), "Task execution");
+			Assert.IsTrue (PathUtils.IsSymlink (Path.Combine (outputBundle, "B")), "IsSymlink");
+			Assert.IsFalse (PathUtils.IsSymlink (Path.Combine (outputBundle, "A", "A.txt")), "IsSymlink");
+			Assert.IsFalse (PathUtils.IsSymlink (Path.Combine (outputBundle, "B", "A.txt")), "IsSymlink");
+		}
 	}
 }


### PR DESCRIPTION
Symlinks to directories are treated the same as other symlinks (as files), not
as directories. This way we don't end up re-creating a directory hierarchy
when we only have to create a symlink.