### PR TITLE
[dotnet-linker] We must store the availability attributes when linking.

### DIFF
--- a/tools/dotnet-linker/Steps/StoreAttributesStep.cs
+++ b/tools/dotnet-linker/Steps/StoreAttributesStep.cs
@@ -21,6 +21,14 @@ namespace Xamarin.Linker.Steps {
 					break;
 				}
 				break;
+			case "System.Runtime.Versioning":
+				switch (attr_type.Name) {
+				case "SupportedOSPlatformAttribute":
+				case "UnsupportedOSPlatformAttribute":
+					LinkContext.StoreCustomAttribute (provider, attribute, "Availability");
+					break;
+				}
+				break;
 			}
 
 			if (store)


### PR DESCRIPTION
We must store the availability attributes when linking, so that the registrar
can access them when the linker is done linking the app.

Fixes this test failure:

* Xamarin.Registrar.MT4162_dotnet(iOS,"iOS",LinkAll)

Ref: https://github.com/xamarin/xamarin-macios/issues/13517