### PR TITLE
[dotnet-linker] Touch the build output to avoid make confusion.

### DIFF
--- a/tools/dotnet-linker/Makefile
+++ b/tools/dotnet-linker/Makefile
@@ -21,6 +21,7 @@ dotnet-linker.csproj.inc: global.json
 
 $(BUILD_DIR)/dotnet-linker%dll $(BUILD_DIR)/dotnet-linker%pdb: Makefile global.json $(dotnet_linker_dependencies)
 	$(Q_DOTNET_BUILD) $(DOTNET6) build dotnet-linker.csproj $(DOTNET_BUILD_VERBOSITY)
+	$(Q) touch $(BUILD_DIR)/dotnet-linker.dll $(BUILD_DIR)/dotnet-linker.pdb
 
 define InstallTemplate
 $(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/dotnet-linker/%: $(BUILD_DIR)/% | $(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/dotnet-linker


### PR DESCRIPTION
Make gets confused sometimes if running a rule doesn't update the timestamp of
the target of those rules (and make may in certain cases end up with an
infinite loop).

Avoid this by making sure to always update the timestamp of the
dotnet-linker.dll we build, even if MSBuild decides no re-compilation was
necessary.