### PR TITLE
[msbuild] Rework how app manifest detection works

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1205,7 +1205,7 @@
 		<GetMlaunchArguments
 			SessionId="$(BuildSessionId)"
 			AppBundlePath="$(_AppBundlePath)"
-			AppManifestPath="$(_AppBundleManifest)"
+			AppManifestPath="$(_AppBundleManifestPath)"
 			DeviceName="$(_DeviceName)"
 			InstallApp="$(_AppBundlePath)"
 			MlaunchPath="$(_MlaunchPath)"
@@ -1232,7 +1232,7 @@
 		<GetMlaunchArguments
 			SessionId="$(BuildSessionId)"
 			AppBundlePath="$(_AppBundlePath)"
-			AppManifestPath="$(_AppBundleManifest)"
+			AppManifestPath="$(_AppBundleManifestPath)"
 			CaptureOutput="$(_MlaunchCaptureOutput)"
 			DeviceName="$(_DeviceName)"
 			LaunchApp="$(_AppBundlePath)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -132,6 +132,11 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<_RequireProvisioningProfile Condition="'$(_RequireProvisioningProfile)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And ('$(ComputedPlatform)' == 'iPhone' Or '$(CodesignEntitlements)' != '')">true</_RequireProvisioningProfile>
 		<_RequireProvisioningProfile Condition="'$(_RequireProvisioningProfile)' == '' And '$(_PlatformName)' == 'MacCatalyst' And '$(CodesignProvision)' != ''">true</_RequireProvisioningProfile>
 		<_RequireProvisioningProfile Condition="'$(_RequireProvisioningProfile)' == ''">false</_RequireProvisioningProfile>
+
+		<!-- If we should automatically try to detect the app manifest (Info.plist) from any None, BundleResource or Content items -->
+		<!-- It might be desirable to turn off the automatic detection if the current logic detects Info.plist that aren't the app manifest -->
+		<!-- One example would be when including native frameworks in the app bundle - frameworks have an Info.plist that might be picked up -->
+		<AppManifestDetectionEnabled Condition="'$(AppManifestDetectionEnabled)' == ''">true</AppManifestDetectionEnabled>
 	</PropertyGroup>
 
 	<!-- RequireCodeSigning -->

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -460,7 +460,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ApplicationVersion="$(ApplicationVersion)"
 			ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
 			AppBundleName="$(_AppBundleName)"
-			AppManifest="$(_AppManifest)"
+			AppManifest="$(AppBundleManifest)"
 			AssemblyName="$(AssemblyName)"
 			CompiledAppManifest="$(_TemporaryAppManifest)"
 			Debug="$(_BundlerDebug)"
@@ -527,18 +527,18 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</_WriteAppManifestDependsOn>
 	</PropertyGroup>
 
-	<!-- This target will create the $(_AppBundleManifest) file - any task that takes $(_AppBundleManifest) must depend on this target -->
+	<!-- This target will create the $(_AppBundleManifestPath) file - any task that takes $(_AppBundleManifestPath) must depend on this target -->
 	<Target Name="_WriteAppManifest"
 		Condition="'$(_CreateAppManifest)' == 'true'"
 		DependsOnTargets="$(_WriteAppManifestDependsOn)"
 		Inputs="@(_PostCompilePartialAppManifest);$(_TemporaryAppManifest)"
-		Outputs="$(_AppBundleManifest)"
+		Outputs="$(_AppBundleManifestPath)"
 		>
 
 		<WriteAppManifest
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
-			AppBundleManifest="$(_AppBundleManifest)"
+			AppBundleManifest="$(_AppBundleManifestPath)"
 			AppManifests="@(_PostCompilePartialAppManifest);$(_TemporaryAppManifest)"
 			>
 		</WriteAppManifest>
@@ -1297,33 +1297,33 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 			Ref: https://bugzilla.xamarin.com/show_bug.cgi?id=34736
 		-->
-		<FindItemWithLogicalName
+		<FindItemWithLogicalName Condition="'$(AppManifestDetectionEnabled)' != 'false' And '$(AppBundleManifest)' == ''"
 			SessionId="$(BuildSessionId)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(_ResourcePrefix)"
 			LogicalName="Info.plist"
 			Items="@(None)">
-			<Output TaskParameter="Item" PropertyName="_AppManifest" />
+			<Output TaskParameter="Item" PropertyName="AppBundleManifest" />
 		</FindItemWithLogicalName>
-		<FindItemWithLogicalName Condition="'$(_AppManifest)' == '' And '$(_CanOutputAppBundle)' == 'true'"
+		<FindItemWithLogicalName Condition="'$(AppManifestDetectionEnabled)' != 'false' And '$(AppBundleManifest)' == '' And '$(_CanOutputAppBundle)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(_ResourcePrefix)"
 			LogicalName="Info.plist"
 			Items="@(BundleResource)">
-			<Output TaskParameter="Item" PropertyName="_AppManifest" />
+			<Output TaskParameter="Item" PropertyName="AppBundleManifest" />
 		</FindItemWithLogicalName>
-		<FindItemWithLogicalName Condition="'$(_AppManifest)' == '' And '$(_CanOutputAppBundle)' == 'true'"
+		<FindItemWithLogicalName Condition="'$(AppManifestDetectionEnabled)' != 'false' And '$(AppBundleManifest)' == '' And '$(_CanOutputAppBundle)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(_ResourcePrefix)"
 			LogicalName="Info.plist"
 			Items="@(Content)">
-			<Output TaskParameter="Item" PropertyName="_AppManifest" />
+			<Output TaskParameter="Item" PropertyName="AppBundleManifest" />
 		</FindItemWithLogicalName>
-		<Error Condition="'$(_AppManifest)' == '' And '$(_CanOutputAppBundle)' == 'true' And '$(UsingAppleNETSdk)' != 'true'" Text="Info.plist not found."/>
+		<Error Condition="'$(AppBundleManifest)' == '' And '$(_CanOutputAppBundle)' == 'true' And '$(UsingAppleNETSdk)' != 'true'" Text="Info.plist not found."/>
 		<PropertyGroup>
-			<_AppBundleManifest>$(_AppBundlePath)$(_AppBundleManifestRelativePath)Info.plist</_AppBundleManifest>
+			<_AppBundleManifestPath>$(_AppBundlePath)$(_AppBundleManifestRelativePath)Info.plist</_AppBundleManifestPath>
 			<!-- We should only write out a compiled app manifest if we're creating an app bundle -->
 			<_CreateAppManifest>$(_CanOutputAppBundle)</_CreateAppManifest>
 			<_TemporaryAppManifest>$(DeviceSpecificIntermediateOutputPath)AppManifest.plist</_TemporaryAppManifest>
@@ -2281,7 +2281,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<CompileProductDefinition
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
-			AppManifest="$(_AppBundleManifest)"
+			AppManifest="$(_AppBundleManifestPath)"
 			OutputDirectory="$(IntermediateOutputPath)"
 			ProductDefinition="$(ProductDefinition)"
 			TargetArchitectures="$(TargetArchitectures)"
@@ -2298,7 +2298,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
-			AppManifest="$(_AppBundleManifest)"
+			AppManifest="$(_AppBundleManifestPath)"
 			EnablePackageSigning="$(EnablePackageSigning)"
 			MainAssembly="$(TargetPath)"
 			Name="$(AssemblyName)"

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -21,7 +21,7 @@
 			GenerateApplicationManifest="$(GenerateApplicationManifest)"
 			ApplicationId="$(ApplicationId)"
 			ApplicationTitle="$(ApplicationTitle)"
-			AppManifest="$(_AppManifest)"
+			AppManifest="$(AppBundleManifest)"
 			ProvisioningProfile="$(CodesignProvision)"
 			SigningKey="$(CodesignKey)">
 
@@ -171,12 +171,12 @@
 
 	<Target Name="_CompileHotRestartAppManifest"
 		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsHotRestartBuild)' == 'true'"
-		Inputs="$(_AppManifest);$(HotRestartAppBundlePath)\Extracted"
-		Outputs="$(HotRestartSignedAppDir)$(_AppManifest);$(HotRestartSignedAppDir)Extracted">
+		Inputs="$(AppBundleManifest);$(HotRestartAppBundlePath)\Extracted"
+		Outputs="$(HotRestartSignedAppDir)$(AppBundleManifest);$(HotRestartSignedAppDir)Extracted">
 
 		<HotRestart.Tasks.CompileAppManifest
 			AppBundlePath="$(HotRestartAppBundlePath)"
-			AppManifestPath="$(_AppManifest)" 
+			AppManifestPath="$(AppBundleManifest)" 
 			ApplicationTitle="$(ApplicationTitle)"/>
 	</Target>
 
@@ -288,7 +288,7 @@
 
 	<Target Name="_CollectCodeSignHotRestartInputs">
 		<ItemGroup>
-			<_CodeSignHotRestartInputs Include="$(_AppManifest)" Outputs="$(HotRestartSignedAppDir)$(_AppManifest)" />
+			<_CodeSignHotRestartInputs Include="$(AppBundleManifest)" Outputs="$(HotRestartSignedAppDir)$(AppBundleManifest)" />
 			<_CodeSignHotRestartInputs Include="$(CodesignEntitlements)" Outputs="$(HotRestartSignedAppDir)$(CodesignEntitlements)" />
 			<_CodeSignHotRestartInputs Include="$(_ProvisioningProfilePath)" Outputs="$(HotRestartSignedAppDir)embedded.mobileprovision" />
 			<_CodeSignHotRestartInputs Include="@(_HotRestartFrameworkFiles)" Outputs="$(HotRestartAppBundlePath)\Frameworks\%(_HotRestartFrameworkFiles.FrameworkDir)%(RecursiveDir)%(Filename)%(Extension)" />

--- a/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
@@ -565,7 +565,7 @@ namespace Xamarin.iOS.Tasks
 		public void DetectAppManifest_ExecutableProject ()
 		{
 			RunTarget (MonoTouchProject, TargetName.DetectAppManifest);
-			Assert.That (MonoTouchProjectInstance.GetPropertyValue ("_AppManifest"), Is.Not.Null.And.Not.Empty, "#1");
+			Assert.That (MonoTouchProjectInstance.GetPropertyValue ("AppBundleManifest"), Is.Not.Null.And.Not.Empty, "#1");
 		}
 
 		[Test]
@@ -574,7 +574,7 @@ namespace Xamarin.iOS.Tasks
 			MonoTouchProjectInstance.RemoveItems ("None");
 
 			RunTarget (MonoTouchProject, TargetName.DetectAppManifest, expectedErrorCount: 1);
-			Assert.That (MonoTouchProjectInstance.GetPropertyValue ("_AppManifest"), Is.Null.Or.Empty, "#1");
+			Assert.That (MonoTouchProjectInstance.GetPropertyValue ("AppBundleManifest"), Is.Null.Or.Empty, "#1");
 		}
 
 		[Test]
@@ -586,7 +586,7 @@ namespace Xamarin.iOS.Tasks
 			MonoTouchProjectInstance.AddItem ("None", "Info.plist");
 
 			RunTarget (MonoTouchProject, TargetName.DetectAppManifest);
-			Assert.AreEqual ("Info.plist", MonoTouchProjectInstance.GetPropertyValue ("_AppManifest"), "#1");
+			Assert.AreEqual ("Info.plist", MonoTouchProjectInstance.GetPropertyValue ("AppBundleManifest"), "#1");
 		}
 
 		[Test]
@@ -599,7 +599,7 @@ namespace Xamarin.iOS.Tasks
 			MonoTouchProjectInstance.AddItem ("None", linkedPlist, new Dictionary<string, string> { { "Link", "Info.plist" } });
 
 			RunTarget (MonoTouchProject, TargetName.DetectAppManifest);
-			Assert.AreEqual (linkedPlist, MonoTouchProjectInstance.GetPropertyValue ("_AppManifest"), "#1");
+			Assert.AreEqual (linkedPlist, MonoTouchProjectInstance.GetPropertyValue ("AppBundleManifest"), "#1");
 		}
 
 		[Test]
@@ -612,14 +612,14 @@ namespace Xamarin.iOS.Tasks
 			MonoTouchProjectInstance.AddItem ("None", logicalPlist, new Dictionary<string, string> { { "LogicalName", "Info.plist" } });
 
 			RunTarget (MonoTouchProject, TargetName.DetectAppManifest);
-			Assert.AreEqual (logicalPlist, MonoTouchProjectInstance.GetPropertyValue ("_AppManifest"), "#1");
+			Assert.AreEqual (logicalPlist, MonoTouchProjectInstance.GetPropertyValue ("AppBundleManifest"), "#1");
 		}
 
 		[Test]
 		public void DetectAppManifest_LibraryProject ()
 		{
 			RunTarget (LibraryProject, TargetName.DetectAppManifest);
-			Assert.That (LibraryProjectInstance.GetPropertyValue ("_AppManifest"), Is.Null.Or.Empty, "#1");
+			Assert.That (LibraryProjectInstance.GetPropertyValue ("AppBundleManifest"), Is.Null.Or.Empty, "#1");
 		}
 	}
 }


### PR DESCRIPTION
Our current behavior is to detect any None, BundleResource or Content item
that's named 'Info.plist', and assume that's the app manifest.

That doesn't quite work when we end up with multiple 'Info.plist' entries in any
of those item groups (one example being a framework as a BundleResource - all frameworks
have an Info.plist, and there's no good way to distinguish what the developer's intention
was).

So:

1. Implement a 'AppManifestDetectionEnabled' property to disable automatic app manifest
   detection.

2. Add a public 'AppBundleManifest' property that specifies the app manifest
   (this is just a renamed version of our previously private '_AppManifest' property).

This makes it possible for app developers to:

* Disable automatic app manifest detection.
* Still have an app manifest by specifying it manually.
* Disable automatic app manifest detection, but also not specify an app manifest
  manually (so no custom app manifest at all).

Also:

* Rename '_AppBundleManifest' to '_AppBundleManifestPath' to make it less confusing
  with the new 'AppBundleManifest' property.