### PR TITLE
[msbuild/dotnet] Add a FilterStaticFramework task to filter out frameworks of static libraries from frameworks we copy to the app bundle.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -596,6 +596,20 @@
 				<SourceDirectory>%(RootDir)%(Directory)</SourceDirectory>
 			</_FrameworkToPublish>
 		</ItemGroup>
+
+		<!-- Figure out which frameworks are really dynamic libraries, and only publish those -->
+		<FilterStaticFrameworks
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			FrameworkToPublish="@(_FrameworkToPublish)"
+		>
+			<Output TaskParameter="FrameworkToPublish" ItemName="_FilteredFrameworkToPublish" />
+		</FilterStaticFrameworks>
+
+		<ItemGroup>
+			<_FrameworkToPublish Remove="@(_FrameworkToPublish)" />
+			<_FrameworkToPublish Include="@(_FilteredFrameworkToPublish)" />
+		</ItemGroup>
 	</Target>
 
 	<Target Name="_CopyFrameworksToBundle"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -8,6 +8,7 @@
 	</PropertyGroup>
 
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CompileNativeCode" AssemblyFile="$(_XamarinTaskAssembly)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.FilterStaticFrameworks" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.FindAotCompiler" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.LinkNativeCode" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.SymbolStrip" AssemblyFile="$(_XamarinTaskAssembly)" />

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -1940,6 +1940,15 @@ namespace Xamarin.Localization.MSBuild {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File &apos;{0}&apos; is not a valid framework: {1}.
+        /// </summary>
+        public static string E7092 {
+            get {
+                return ResourceManager.GetString("E7092", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid framework: {0}.
         /// </summary>
         public static string InvalidFramework {
@@ -2553,6 +2562,15 @@ namespace Xamarin.Localization.MSBuild {
         public static string W7087 {
             get {
                 return ResourceManager.GetString("W7087", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The framework {0} is a framework of static libraries, and will not be copied to the app..
+        /// </summary>
+        public static string W7091 {
+            get {
+                return ResourceManager.GetString("W7091", resourceCulture);
             }
         }
     }

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1343,4 +1343,14 @@
         <value>Expected a 'manifest' file in the directory {0}.</value>
         <comment>The following are literal names and should not be translated: manifest</comment>
     </data>
+
+    <data name="W7091" xml:space="preserve">
+        <value>The framework {0} is a framework of static libraries, and will not be copied to the app.</value>
+    </data>
+
+    <!-- This is the same as MT0140 -->
+    <data name="E7092" xml:space="preserve">
+        <value>File '{0}' is not a valid framework: {1}</value>
+    </data>
+
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FilterStaticFrameworksTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FilterStaticFrameworksTaskBase.cs
@@ -22,6 +22,10 @@ namespace Xamarin.MacDev.Tasks {
 					var item = list [i];
 					var frameworkExecutablePath = item.ItemSpec;
 					try {
+						if (frameworkExecutablePath.EndsWith (".framework", StringComparison.OrdinalIgnoreCase) && Directory.Exists (frameworkExecutablePath)) {
+							frameworkExecutablePath = Path.Combine (frameworkExecutablePath, Path.GetFileNameWithoutExtension (frameworkExecutablePath));
+						}
+
 						if (MachO.IsDynamicFramework (frameworkExecutablePath))
 							continue;
 					} catch (Exception e) {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FilterStaticFrameworksTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FilterStaticFrameworksTaskBase.cs
@@ -1,0 +1,44 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+
+using Microsoft.Build.Framework;
+
+using Xamarin.Localization.MSBuild;
+
+namespace Xamarin.MacDev.Tasks {
+	// This task takes an itemgroup of frameworks, and filters out frameworks that aren't dynamic libraries.
+	public abstract class FilterStaticFrameworksTaskBase : XamarinTask {
+		[Output]
+		public ITaskItem []? FrameworkToPublish { get; set; }
+
+		public override bool Execute ()
+		{
+			if (FrameworkToPublish is not null && FrameworkToPublish.Length > 0) {
+				var list = FrameworkToPublish.ToList ();
+				for (var i = list.Count - 1; i >= 0; i--) {
+					var item = list [i];
+					var frameworkExecutablePath = item.ItemSpec;
+					try {
+						if (MachO.IsDynamicFramework (frameworkExecutablePath))
+							continue;
+					} catch (Exception e) {
+						Log.LogError (7091, frameworkExecutablePath, MSBStrings.E7092 /* File '{0}' is not a valid framework: {1} */, frameworkExecutablePath, e.Message);
+						continue;
+					}
+
+					Log.LogWarning (7091, frameworkExecutablePath, MSBStrings.W7091 /* "The framework {0} is a framework of static libraries, and will not be copied to the app." */, Path.GetDirectoryName (frameworkExecutablePath));
+					list.RemoveAt (i);
+				}
+
+				// Copy back the list if anything was removed from it
+				if (FrameworkToPublish.Length != list.Count)
+					FrameworkToPublish = list.ToArray ();
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworks.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworks.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 			return base.Execute ();
 		}
 
-		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+		public bool ShouldCopyToBuildServer (ITaskItem item) => true;
 
 		public bool ShouldCreateOutputFile (ITaskItem item) => false;
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworks.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworks.cs
@@ -1,7 +1,11 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Tasks;
+using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.MacDev.Tasks {
-	public class FilterStaticFrameworks : FilterStaticFrameworksTaskBase {
+	public class FilterStaticFrameworks : FilterStaticFrameworksTaskBase, ITaskCallback {
 		public override bool Execute ()
 		{
 			if (ShouldExecuteRemotely ())
@@ -9,5 +13,11 @@ namespace Xamarin.MacDev.Tasks {
 
 			return base.Execute ();
 		}
+
+		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+
+		public bool ShouldCreateOutputFile (ITaskItem item) => false;
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworks.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworks.cs
@@ -1,0 +1,13 @@
+using Xamarin.Messaging.Build.Client;
+
+namespace Xamarin.MacDev.Tasks {
+	public class FilterStaticFrameworks : FilterStaticFrameworksTaskBase {
+		public override bool Execute ()
+		{
+			if (ShouldExecuteRemotely ())
+				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+
+			return base.Execute ();
+		}
+	}
+}


### PR DESCRIPTION
A later PR will include a test case for this.