### PR TITLE
[.NET/AppKit] Use [UnmanagedCallersOnly] instead of [MonoPInvokeCallback] for the managed callbacks called from native code.

### DIFF
--- a/src/AppKit/NSView.cs
+++ b/src/AppKit/NSView.cs
@@ -14,8 +14,10 @@ namespace AppKit {
 
 	public partial class NSView {
 
+#if !NET
 		delegate nint view_compare_func (IntPtr view1, IntPtr view2, IntPtr context);
 		static view_compare_func view_comparer = view_compare;
+#endif
 
 		sealed class SortData
 		{
@@ -23,7 +25,11 @@ namespace AppKit {
 			public Func<NSView, NSView, NSComparisonResult> Comparer;
 		}
 
+#if NET
+		[UnmanagedCallersOnly]
+#else
 		[MonoPInvokeCallback (typeof (view_compare_func))]
+#endif
 		static nint view_compare (IntPtr view1, IntPtr view2, IntPtr context)
 		{
 			var data = (SortData) GCHandle.FromIntPtr (context).Target;
@@ -37,12 +43,17 @@ namespace AppKit {
 			}
 		}
 
-		public void SortSubviews (Func<NSView, NSView, NSComparisonResult> comparer)
+		public unsafe void SortSubviews (Func<NSView, NSView, NSComparisonResult> comparer)
 		{
 			if (comparer == null)
 				throw new ArgumentNullException (nameof (comparer));
 
+#if NET
+			delegate* unmanaged<IntPtr, IntPtr, IntPtr, nint> fptr = &view_compare;
+			var func = (IntPtr) fptr;
+#else
 			var func = Marshal.GetFunctionPointerForDelegate (view_comparer);
+#endif
 			var context = new SortData () { Comparer = comparer };
 			var handle = GCHandle.Alloc (context);
 			try {


### PR DESCRIPTION
Ref https://github.com/xamarin/xamarin-macios/issues/10470.