### PR TITLE
[tests] Remove a few Assert.Inconclusive calls that won't be executed anymore.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/DispatchTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchTests.cs
@@ -27,17 +27,6 @@ namespace MonoTouchFixtures.CoreFoundation {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class DispatchTests {
-		
-		static bool RunningOnSnowLeopard {
-			get {
-#if !MONOMAC
-				if (Runtime.Arch == Arch.DEVICE)
-					return false;
-#endif
-				return !File.Exists ("/usr/lib/system/libsystem_kernel.dylib");
-			}
-		}
-
 #if !MONOMAC // UIKitThreadAccessException and NSStringDrawing.WeakDrawString don't exist on mac
 		[Test]
 		public void MainQueueDispatch ()
@@ -45,9 +34,6 @@ namespace MonoTouchFixtures.CoreFoundation {
 #if !DEBUG || OPTIMIZEALL
 			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
 #endif
-			if (RunningOnSnowLeopard)
-				Assert.Ignore ("this test crash when executed with the iOS simulator on Snow Leopard");
-
 			bool hit = false;
 			// We need to check the UIKitThreadAccessException, but there are very few API
 			// with that check on WatchOS. NSStringDrawing.WeakDrawString is one example, here we pass
@@ -103,9 +89,6 @@ namespace MonoTouchFixtures.CoreFoundation {
 #if !DEBUG || OPTIMIZEALL
 			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
 #endif
-			if (RunningOnSnowLeopard)
-				Assert.Ignore ("this test crash when executed with the iOS simulator on Snow Leopard");
-
 			bool hit = false;
 			// We need to check the UIKitThreadAccessException, but there are very few API
 			// with that check on WatchOS. NSStringDrawing.WeakDrawString is one example, here we pass
@@ -215,8 +198,6 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void Main ()
 		{
-			if (RunningOnSnowLeopard)
-				Assert.Ignore ("Shows corruption (missing first 4 chars) when executed the iOS simulator on Snow Leopard");
 			Assert.That (DispatchQueue.MainQueue.Label, Is.EqualTo ("com.apple.main-thread"), "Main");
 		}
 
@@ -263,9 +244,6 @@ namespace MonoTouchFixtures.CoreFoundation {
 #if !DEBUG || OPTIMIZEALL
 			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
 #endif
-			if (RunningOnSnowLeopard)
-				Assert.Ignore ("this test crash when executed with the iOS simulator on Snow Leopard");
-
 			bool hit = false;
 			// We need to check the UIKitThreadAccessException, but there are very few API
 			// with that check on WatchOS. NSStringDrawing.WeakDrawString is one example, here we pass
@@ -320,9 +298,6 @@ namespace MonoTouchFixtures.CoreFoundation {
 #if !DEBUG || OPTIMIZEALL
 			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
 #endif
-			if (RunningOnSnowLeopard)
-				Assert.Ignore ("this test crash when executed with the iOS simulator on Snow Leopard");
-
 			bool hit = false;
 			// We need to check the UIKitThreadAccessException, but there are very few API
 			// with that check on WatchOS. NSStringDrawing.WeakDrawString is one example, here we pass

--- a/tests/monotouch-test/Foundation/FileManagerTest.cs
+++ b/tests/monotouch-test/Foundation/FileManagerTest.cs
@@ -25,13 +25,6 @@ namespace MonoTouchFixtures.Foundation {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class NSFileManagerTest {
-		
-		static bool RunningOnSnowLeopard {
-			get {
-				return !File.Exists ("/usr/lib/system/libsystem_kernel.dylib");
-			}
-		}
-
 		// we might believe that Envioment.UserName os the same as NSFileManager.UserName, but it is not. On the simulator for
 		// example, NSFileManager.UserName is an empty string while mono returns 'somebody'
 		[Test]
@@ -52,11 +45,6 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void GetUrlForUbiquityContainer ()
 		{
-#if !MONOMAC
-			if ((Runtime.Arch == Arch.SIMULATOR) && RunningOnSnowLeopard)
-				Assert.Inconclusive ("sometimes crash under the iOS simulator (generally on the SL/iOS5 bots)");
-#endif
-
 			NSFileManager fm = new NSFileManager ();
 			if (TestRuntime.CheckXcodeVersion (4, 5) && fm.UbiquityIdentityToken == null) {
 				// UbiquityIdentityToken is a fast way to check if iCloud is enabled
@@ -105,9 +93,6 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void GetSkipBackupAttribute ()
 		{
-			if ((Runtime.Arch == Arch.SIMULATOR) && RunningOnSnowLeopard)
-				Assert.Inconclusive ("iOS simulator did not get libsystem_kernel.dylib before Lion");
-			
 			Assert.False (NSFileManager.GetSkipBackupAttribute (NSBundle.MainBundle.ExecutableUrl.ToString ()), "MainBundle");
 
 			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), $"DoNotBackupMe-NSFileManager-{Process.GetCurrentProcess ().Id}");


### PR DESCRIPTION
Don't conditionally ignore tests that fail on Snow Leopard (or earlier),
because we're always executing on a later OS now.