### PR TITLE
[dotnet] Remove Runtime.Arch and ObjCRuntime.Arch from Mac Catalyst. Fixes #10312.

### DIFF
--- a/dotnet/BreakingChanges.md
+++ b/dotnet/BreakingChanges.md
@@ -41,3 +41,10 @@ without this type change would be impossible to expose correctly.
 
 There are implicit conversions between `System.IntPtr` and
 `ObjCRuntime.NativeHandle`, so most code should compile without changes.
+
+## The ObjCRuntime.Arch enum and the Runtime.Arch property have been removed.
+
+These APIs are used to determine whether we're executing in the simulator or
+on a device. Neither apply to a Mac Catalyst app, so they've been removed.
+
+Any code that these APIs will have to be ported to not use these APIs.

--- a/src/ObjCRuntime/Runtime.iOS.cs
+++ b/src/ObjCRuntime/Runtime.iOS.cs
@@ -40,13 +40,13 @@ namespace ObjCRuntime {
 		#error Unknown platform
 #endif
 
+#if !__MACCATALYST__
 		public static Arch Arch; // default: = Arch.DEVICE;
+#endif
 
 		unsafe static void InitializePlatform (InitializationOptions* options)
 		{
-#if __MACCATALYST__
-			Arch = Arch.SIMULATOR;
-#else
+#if !__MACCATALYST__
 			if (options->IsSimulator)
 				Arch = Arch.SIMULATOR;
 #endif
@@ -124,10 +124,12 @@ namespace ObjCRuntime {
 #endif // !COREBUILD
 	}
 
+#if !__MACCATALYST__
 	public enum Arch {
 		DEVICE,
 		SIMULATOR
 	}
+#endif
 }
 
 #endif // MONOMAC

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -174,18 +174,14 @@ partial class TestRuntime
 
 	public static void AssertNotSimulator (string message = "This test does not work in the simulator.")
 	{
-#if !__MACOS__ && !__MACCATALYST__
-		if (ObjCRuntime.Runtime.Arch == Arch.SIMULATOR)
+		if (IsSimulator)
 			NUnit.Framework.Assert.Ignore (message);
-#endif
 	}
 
 	public static void AssertSimulator (string message = "This test only works in the simulator.")
 	{
-#if !__MACOS__ && !__MACCATALYST__
-		if (ObjCRuntime.Runtime.Arch != Arch.SIMULATOR)
+		if (!IsSimulator)
 			NUnit.Framework.Assert.Ignore (message);
-#endif
 	}
 
 	public static void AssertSimulatorOrDesktop (string message = "This test only works in the simulator or on the desktop.")

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -146,17 +146,25 @@ partial class TestRuntime
 		NUnit.Framework.Assert.Ignore ("Requires the platform version shipped with Xcode {0}.{1}", major, minor);
 	}
 
-	public static void AssertDevice ()
+	public static void AssertDevice (string message = "This test only runs on device.")
 	{
-#if !MONOMAC
-		if (ObjCRuntime.Runtime.Arch == Arch.SIMULATOR)
-			NUnit.Framework.Assert.Ignore ("This test only runs on device.");
+#if !MONOMAC && !__MACCATALYST__
+		if (ObjCRuntime.Runtime.Arch == Arch.DEVICE)
+			return;
 #endif
+		NUnit.Framework.Assert.Ignore (message);
 	}
 
+	public static void AssertNotDevice (string message = "This test does not run on device.")
+	{
+#if !MONOMAC && !__MACCATALYST__
+		if (ObjCRuntime.Runtime.Arch == Arch.DEVICE)
+			NUnit.Framework.Assert.Ignore (message);
+#endif
+	}
 	public static void AssertIfSimulatorThenARM64 ()
 	{
-#if !__MACOS__
+#if !__MACOS__ && !__MACCATALYST__
 		if (ObjCRuntime.Runtime.Arch != Arch.SIMULATOR)
 			return;
 		if (!IsARM64)
@@ -164,12 +172,26 @@ partial class TestRuntime
 #endif
 	}
 
-	public static void AssertNotSimulator ()
+	public static void AssertNotSimulator (string message = "This test does not work in the simulator.")
 	{
-#if !__MACOS__
+#if !__MACOS__ && !__MACCATALYST__
 		if (ObjCRuntime.Runtime.Arch == Arch.SIMULATOR)
-			NUnit.Framework.Assert.Ignore ("This test does not work in the simulator.");
+			NUnit.Framework.Assert.Ignore (message);
 #endif
+	}
+
+	public static void AssertSimulator (string message = "This test only works in the simulator.")
+	{
+#if !__MACOS__ && !__MACCATALYST__
+		if (ObjCRuntime.Runtime.Arch != Arch.SIMULATOR)
+			NUnit.Framework.Assert.Ignore (message);
+#endif
+	}
+
+	public static void AssertSimulatorOrDesktop (string message = "This test only works in the simulator or on the desktop.")
+	{
+		if (!IsSimulatorOrDesktop)
+			NUnit.Framework.Assert.Ignore (message);
 	}
 
 	public static bool IsVM => 
@@ -954,7 +976,7 @@ partial class TestRuntime
 	{
 #if __WATCHOS__
 		throw new Exception ("Can't get iOS SDK version on WatchOS.");
-#elif !MONOMAC
+#elif !MONOMAC && !__MACCATALYST__
 		if (Runtime.Arch == Arch.SIMULATOR || !UIDevice.CurrentDevice.CheckSystemVersion (6, 0)) {
 			// dyld_get_program_sdk_version was introduced with iOS 6.0, so don't do the SDK check on older deviecs.
 			return true; // dyld_get_program_sdk_version doesn't return what we're looking for on the mac.
@@ -982,6 +1004,36 @@ partial class TestRuntime
 			return true;
 #else
 			return false;
+#endif
+		}
+	}
+
+	public static bool IsDevice {
+		get {
+#if __MACOS__ || __MACCATALYST__
+			return false;
+#else
+			return Runtime.Arch == Arch.DEVICE;
+#endif
+		}
+	}
+
+	public static bool IsSimulator {
+		get {
+#if __MACOS__ || __MACCATALYST__
+			return false;
+#else
+			return Runtime.Arch == Arch.SIMULATOR;
+#endif
+		}
+	}
+
+	public static bool IsSimulatorOrDesktop {
+		get {
+#if __MACOS__ || __MACCATALYST__
+			return true;
+#else
+			return Runtime.Arch == Arch.SIMULATOR;
 #endif
 		}
 	}

--- a/tests/introspection/ApiFrameworkTest.cs
+++ b/tests/introspection/ApiFrameworkTest.cs
@@ -12,11 +12,7 @@ using ObjCRuntime;
 public class Application {
 	public bool IsSimulatorBuild {
 		get {
-#if __IOS__
-			return Runtime.Arch == Arch.SIMULATOR;
-#else
-			return true;
-#endif
+			return TestRuntime.IsSimulator;
 		}
 	}
 }
@@ -148,8 +144,7 @@ namespace Introspection {
 		[Test]
 		public void Simlauncher ()
 		{
-			if (Runtime.Arch != Arch.SIMULATOR)
-				Assert.Ignore ("Only needed on simulator");
+			TestRuntime.AssertSimulator ("Only needed on simulator");
 
 			var all = GetFrameworks ();
 

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -556,7 +556,7 @@ namespace Introspection {
 					if (!supports) {
 #if __IOS__
 						// broken in xcode 12 beta 1 simulator (only)
-						if ((Runtime.Arch == Arch.SIMULATOR) && TestRuntime.CheckXcodeVersion (12,0)) {
+						if (TestRuntime.IsSimulatorOrDesktop && TestRuntime.CheckXcodeVersion (12,0)) {
 							switch (type.Name) {
 							case "ARFaceGeometry":
 							case "ARPlaneGeometry":
@@ -658,7 +658,7 @@ namespace Introspection {
 					case "SKRenderer":
 						// was not possible in iOS 11.4 (current minimum) simulator
 						if (!TestRuntime.CheckXcodeVersion (12,0)) {
-							if (Runtime.Arch == Arch.SIMULATOR)
+							if (TestRuntime.IsSimulatorOrDesktop)
 								continue;
 						}
 						break;

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -195,21 +195,21 @@ namespace Introspection {
 			case "NEHotspotEapSettings": // Wireless Accessory Configuration is not supported in the simulator.
 			case "NEHotspotConfigurationManager":
 			case "NEHotspotHS20Settings":
-				if (Runtime.Arch == Arch.SIMULATOR)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 			case "ARBodyTrackingConfiguration":
 			case "ARGeoTrackingConfiguration":
 			switch (selectorName) {
 				case "supportsAppClipCodeTracking": // Only available on device
-					return Runtime.Arch == Arch.SIMULATOR;
+					return TestRuntime.IsSimulatorOrDesktop;
 				}
 				break;
 			case "CSImportExtension":
 				switch (selectorName) {
 				case "beginRequestWithExtensionContext:": 
 				case "updateAttributes:forFileAtURL:error:":
-					if (Runtime.Arch == Arch.SIMULATOR) // not available in the sim
+					if (TestRuntime.IsSimulatorOrDesktop) // not available in the sim
 						return true;
 					break;
 				}
@@ -217,7 +217,7 @@ namespace Introspection {
 			case "HKQuery":
 				switch (selectorName) {
 				case "predicateForVerifiableClinicalRecordsWithRelevantDateWithinDateInterval:": // not available in the sim
-					if (Runtime.Arch == Arch.SIMULATOR) // not available in the sim
+					if (TestRuntime.IsSimulatorOrDesktop) // not available in the sim
 						return true;
 					break;
 				}
@@ -822,7 +822,7 @@ namespace Introspection {
 				case "defaultBody2DSkeletonDefinition":
 				case "defaultBody3DSkeletonDefinition":
 					// This selector does not exist in the simulator
-					if (Runtime.Arch == Arch.SIMULATOR)
+					if (TestRuntime.IsSimulatorOrDesktop)
 						return true;
 					break;
 				}

--- a/tests/introspection/ApiTypeTest.cs
+++ b/tests/introspection/ApiTypeTest.cs
@@ -26,7 +26,7 @@ namespace Introspection {
 			case "DeviceCheck":
 				// we can't call the `NFCNdefReaderSession.ReadingAvailable` API on 32bits (PlatformNotSupportedException)
 				// and if we call it then the .cctor is executed and we get the same failures :()
-				return ((IntPtr.Size == 4) || (Runtime.Arch == Arch.SIMULATOR));
+				return ((IntPtr.Size == 4) || TestRuntime.IsSimulatorOrDesktop);
 #endif
 			default:
 				return false;

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -1083,14 +1083,14 @@ namespace Introspection
 				case "MediaSetupLibrary":
 				case "MLComputeLibrary":
 					// Xcode 12 beta 2 does not ship these framework/headers for the simulators
-					if (Runtime.Arch == Arch.DEVICE)
+					if (TestRuntime.IsDevice)
 						Assert.True (CheckLibrary (s), fi.Name);
 					break;
 #endif
 #if __TVOS__
 				case "MetalPerformanceShadersLibrary":
 					// not supported in tvOS (12.1) simulator so load fails
-					if (Runtime.Arch == Arch.SIMULATOR)
+					if (TestRuntime.IsSimulatorOrDesktop)
 						break;
 					goto default;
 #endif
@@ -1102,7 +1102,7 @@ namespace Introspection
 							if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
 								continue;
 							// Phone works unless Xcode 12 on simulator
-							if ((Runtime.Arch == Arch.SIMULATOR) && TestRuntime.CheckXcodeVersion (12, 0))
+							if (TestRuntime.IsSimulatorOrDesktop && TestRuntime.CheckXcodeVersion (12, 0))
 								continue;
 						}
 #endif

--- a/tests/introspection/iOS/iOSApiClassPtrTest.cs
+++ b/tests/introspection/iOS/iOSApiClassPtrTest.cs
@@ -23,7 +23,7 @@ namespace Introspection {
 			case "Phase": // missing in the sim
 			case "ShazamKit": // missing in the sim
 			case "ThreadNetwork": // missing in the sim
-				if (Runtime.Arch == Arch.SIMULATOR)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 			}

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -50,7 +50,7 @@ namespace Introspection {
 			case "Metal":
 			case "MonoTouch.Metal":
 				// they works with iOS9 beta 4 (but won't work on older simulators)
-				if ((Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (7, 0))
+				if (TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (7, 0))
 					return true;
 				break;
 #if !__WATCHOS__
@@ -58,7 +58,7 @@ namespace Introspection {
 			case "MonoTouch.MetalKit":
 			case "MetalPerformanceShaders":
 			case "MonoTouch.MetalPerformanceShaders":
-				if (Runtime.Arch == Arch.SIMULATOR)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				// some devices don't support metal and that crash some API that does not check that, e.g. #33153
 				if (!TestRuntime.CheckXcodeVersion (7, 0) || (MTLDevice.SystemDefault == null))
@@ -71,7 +71,7 @@ namespace Introspection {
 				break;
 			case "DeviceCheck": // Only available on device
 			case "MLCompute": // Only available on device
-				if (Runtime.Arch == Arch.SIMULATOR)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 			}
@@ -155,7 +155,7 @@ namespace Introspection {
 
 			// Metal is not available on the (iOS8) simulator
 			case "CAMetalLayer":
-				return (Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (11, 0);
+				return TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (11, 0);
 
 			// in 8.2 beta 1 this crash the app (simulator) without giving any details in the logs
 			case "WKUserNotificationInterfaceController":
@@ -175,7 +175,7 @@ namespace Introspection {
 			// these work only on devices, so we skip the simulator
 			case "MTLHeapDescriptor":
 			case "MTLSharedEventListener":
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 #if __WATCHOS__
 			// The following watchOS 3.2 Beta 2 types Fails, but they can be created we verified using an ObjC app, we will revisit before stable
 			case "INRequestPaymentIntent":
@@ -206,7 +206,7 @@ namespace Introspection {
 			case "NEHotspotEapSettings": // Wireless Accessory Configuration is not supported in the simulator.
 			case "NEHotspotConfigurationManager":
 			case "NEHotspotHS20Settings":
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 			// iOS 12
 			case "INGetAvailableRestaurantReservationBookingDefaultsIntentResponse": // Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Unable to initialize 'INGetAvailableRestaurantReservationBookingDefaultsIntentResponse'. Please make sure that your intent definition file is valid.
 			case "INGetAvailableRestaurantReservationBookingsIntentResponse": // Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Unable to initialize 'INGetAvailableRestaurantReservationBookingsIntentResponse'. Please make sure that your intent definition file is valid.
@@ -217,24 +217,24 @@ namespace Introspection {
 				// Doesn't exist in the simulator; aborts on device if the required entitlement isn't available.
 				return true;
 #endif
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 			case "RPSystemBroadcastPickerView": // Symbol not available in simulator
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 			case "ICNotificationManagerConfiguration": // This works on device but not on simulator, and docs explicitly says it is user creatable
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 			case "VNDocumentCameraViewController": // Name: NSGenericException Reason: Document camera is not available on simulator
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 			case "AVAudioRecorder": // Stopped working with Xcode 11.2 beta 2
 				return TestRuntime.CheckXcodeVersion (11, 2);
 			case "UIMenuController": // Stopped working with Xcode 11.3 beta 1
 				return TestRuntime.CheckXcodeVersion (11, 3);
 			case "THClient":
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 #if __TVOS__
 			case "MPSPredicate":
 				// the device .ctor ends up calling `initWithBuffer:offset:` and crash on older (non 4k AppleTV devices)
 				// MPSPredicate.mm:102: failed assertion `[MPSPredicate initWithBuffer:offset:] device: Apple A8 GPU does not support predication.'
-				return ((Runtime.Arch == Arch.DEVICE) && (UIScreen.MainScreen.NativeBounds.Width <= 1920));
+				return (TestRuntime.IsDevice && (UIScreen.MainScreen.NativeBounds.Width <= 1920));
 #endif
 #if __TVOS__ || __WATCHOS__
 			case "NSMetadataQuery":

--- a/tests/introspection/iOS/iOSApiFieldTest.cs
+++ b/tests/introspection/iOS/iOSApiFieldTest.cs
@@ -40,7 +40,7 @@ namespace Introspection {
 			case "Metal":
 			case "MonoTouch.Metal":
 				// they works with iOS9 beta 4 (but won't work on older simulators)
-				if ((Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (7, 0))
+				if (TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (7, 0))
 					return true;
 				break;
 			case "MetalKit":
@@ -53,12 +53,12 @@ namespace Introspection {
 				break;
 			case "Phase":
 			case "DeviceCheck": // Only available on device
-				if (Runtime.Arch == Arch.SIMULATOR)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 			case "IOSurface":
 				// Available in the simulator starting with iOS 11
-				return Runtime.Arch == Arch.SIMULATOR && !TestRuntime.CheckXcodeVersion (9, 0);
+				return TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (9, 0);
 			case "iAd":
 				// largely removed in xcode 13, including ADClient.ErrorDomain
 				// since using this code leads to rejections it's totally removed (so no version check)
@@ -97,10 +97,10 @@ namespace Introspection {
 
 			// Apple does not ship a PushKit for every arch on some devices :(
 			case "Voip":
-				return Runtime.Arch == Arch.DEVICE;
+				return TestRuntime.IsDevice;
 			// Just available on device
 			case "UsageKey":
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 			// Xcode 12.2 Beta 1 does not ship this but it is available in Xcode 12.0...
 			case "BarometricPressure":
 				return true;
@@ -117,7 +117,7 @@ namespace Introspection {
 					return true;
 				break;
 			case "IOSurface":
-				return Runtime.Arch == Arch.SIMULATOR && !TestRuntime.CheckXcodeVersion (9, 0);
+				return TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (9, 0);
 			}
 
 			switch (constantName) {
@@ -135,7 +135,7 @@ namespace Introspection {
 				return true;
 			// Apple does not ship a PushKit for every arch on some devices :(
 			case "PKPushTypeVoIP":
-				return Runtime.Arch == Arch.DEVICE;
+				return TestRuntime.IsDevice;
 			// there's only partial support for metal on the simulator (on iOS9 beta 5) but most other frameworks
 			// that interop with it are not (yet) supported
 			case "kCVMetalTextureCacheMaximumTextureAgeKey":
@@ -150,7 +150,7 @@ namespace Introspection {
 			case "MTKTextureLoaderOptionTextureCPUCacheMode":
 			case "MTKModelErrorDomain":
 			case "MTKModelErrorKey":
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 			// Xcode 12.2 Beta 1 does not ship this but it is available in Xcode 12.0...
 			case "HKMetadataKeyBarometricPressure":
 				return true;

--- a/tests/introspection/iOS/iOSApiPInvokeTest.cs
+++ b/tests/introspection/iOS/iOSApiPInvokeTest.cs
@@ -26,7 +26,7 @@ namespace Introspection {
 
 		protected override bool Skip (string symbolName)
 		{
-			bool simulator = Runtime.Arch == Arch.SIMULATOR;
+			var simulator = TestRuntime.IsSimulatorOrDesktop;
 			switch (symbolName) {
 			// Metal support inside simulator is only available in recent iOS9 SDK
 #if !__WATCHOS__
@@ -86,7 +86,7 @@ namespace Introspection {
 			// 2. on the real target for Xamarin.iOS.dll/monotouch.dll
 			//    as the simulator miss some libraries and symbols
 			//    but the rest of the BCL is fine to test
-			return (a == typeof (NSObject).Assembly && (Runtime.Arch == Arch.SIMULATOR));
+			return (a == typeof (NSObject).Assembly && TestRuntime.IsSimulatorOrDesktop);
 		}
 
 		[Test]

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -41,7 +41,7 @@ namespace Introspection {
 			case "MediaSetup":
 			case "Phase":
 			case "ThreadNetwork":
-				if (Runtime.Arch == Arch.SIMULATOR)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 			case "CoreNFC": // Only available on devices that support NFC, so check if NFCNDEFReaderSession is present.
@@ -55,7 +55,7 @@ namespace Introspection {
 			case "PKPushCredentials":
 			case "PKPushPayload":
 			case "PKPushRegistry":
-				if (Runtime.Arch != Arch.DEVICE)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 
 				// Requires iOS 8.2 or later in 32-bit mode
@@ -70,7 +70,7 @@ namespace Introspection {
 			case "MTLHeap":
 			case "MTLSharedTextureHandle":
 			case "RPSystemBroadcastPickerView": // Symbol not available in simulator
-				if (Runtime.Arch != Arch.DEVICE)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 
 				// Requires iOS 10
@@ -81,7 +81,7 @@ namespace Introspection {
 			case "MTLFunctionConstantValues":
 			case "MTLHeapDescriptor":
 				// Symbol not available in simulator - but works on BigSur (others might too)
-				if (Runtime.Arch != Arch.DEVICE)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 			case "CMMovementDisorderManager":
@@ -133,7 +133,7 @@ namespace Introspection {
 			case "MonoTouch.CoreAudioKit":
 			case "CoreAudioKit":
 				// they works with iOS9 beta 4 (but won't work on older simulators)
-				if ((Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (7, 0))
+				if (TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (7, 0))
 					return true;
 				break;
 
@@ -148,7 +148,7 @@ namespace Introspection {
 
 			switch (type.Name) {
 			case "CAMetalLayer":
-				return (Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (11, 0);
+				return TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (11, 0);
 #if !XAMCORE_3_0
 				// mistake (base type) fixed by a breaking change
 			case "MFMailComposeViewControllerDelegate":

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -38,14 +38,14 @@ namespace Introspection {
 			case "GameController":
 			case "MonoTouch.GameController":
 			case "MLCompute": // xcode 12 beta 3
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 
 			case "CoreAudioKit":
 			case "MonoTouch.CoreAudioKit":
 			case "Metal":
 			case "MonoTouch.Metal":
 				// they works with iOS9 beta 4 (but won't work on older simulators)
-				if ((Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (7, 0))
+				if (TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (7, 0))
 					return true;
 				break;
 			case "Chip":
@@ -55,7 +55,7 @@ namespace Introspection {
 			case "MonoTouch.MetalPerformanceShaders":
 			case "Phase":
 			case "ThreadNetwork":
-				if (Runtime.Arch == Arch.SIMULATOR)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 			// Xcode 9
@@ -64,7 +64,7 @@ namespace Introspection {
 					return true;
 				break;
 			case "DeviceCheck":
-				if (Runtime.Arch == Arch.SIMULATOR)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 
@@ -83,7 +83,7 @@ namespace Introspection {
 #endif // HAS_WATCHCONNECTIVITY
 			case "ShazamKit":
 				// ShazamKit is not fully supported in the simulator
-				if (Runtime.Arch == Arch.SIMULATOR)
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 			}
@@ -99,9 +99,9 @@ namespace Introspection {
 
 			// Metal is not available on the simulator
 			case "CAMetalLayer":
-				return (Runtime.Arch == Arch.SIMULATOR) && !TestRuntime.CheckXcodeVersion (11, 0);
+				return TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (11, 0);
 			case "SKRenderer":
-				return (Runtime.Arch == Arch.SIMULATOR);
+				return TestRuntime.IsSimulatorOrDesktop;
 
 			// iOS 10 - this type can only be instantiated on devices, but the selectors are forwarded
 			//  to a MTLHeapDescriptorInternal and don't respond - so we'll add unit tests for them
@@ -111,7 +111,7 @@ namespace Introspection {
 			case "MTLTileRenderPipelineDescriptor":
 			case "MTLRasterizationRateLayerDescriptor":
 			case "MTLRasterizationRateMapDescriptor":
-				return Runtime.Arch == Arch.SIMULATOR;
+				return TestRuntime.IsSimulatorOrDesktop;
 #if __WATCHOS__
 				// The following watchOS 3.2 Beta 2 types Fails, but they can be created we verified using an ObjC app, we will revisit before stable
 			case "INPersonResolutionResult":
@@ -294,7 +294,7 @@ namespace Introspection {
 			case "CIContext":
 				switch (name) {
 				case "render:toIOSurface:bounds:colorSpace:":
-					if (Runtime.Arch == Arch.SIMULATOR)
+					if (TestRuntime.IsSimulatorOrDesktop)
 						return !TestRuntime.CheckXcodeVersion (11, 0);
 					if (!TestRuntime.CheckXcodeVersion (9, 0))
 						return true;
@@ -309,7 +309,7 @@ namespace Introspection {
 					if (TestRuntime.CheckXcodeVersion (11, 0))
 						break;
 					// did not work on simulator before iOS 13 (shortcut logic)
-					if (Runtime.Arch == Arch.SIMULATOR)
+					if (TestRuntime.IsSimulatorOrDesktop)
 						return true;
 					// was a private framework (on iOS) before Xcode 9.0 (shortcut logic)
 					if (!TestRuntime.CheckXcodeVersion (9, 0))
@@ -320,7 +320,7 @@ namespace Introspection {
 			case "CIRenderDestination":
 				switch (name) {
 				case "initWithIOSurface:":
-					if (Runtime.Arch == Arch.SIMULATOR)
+					if (TestRuntime.IsSimulatorOrDesktop)
 						return !TestRuntime.CheckXcodeVersion (11, 0);
 					if (!TestRuntime.CheckXcodeVersion (9, 0))
 						return true;
@@ -334,7 +334,7 @@ namespace Introspection {
 				case "texImageIOSurface:target:internalFormat:width:height:format:type:plane:":
 				case "setTessellator:":
 				case "tessellator":
-					if (Runtime.Arch == Arch.SIMULATOR)
+					if (TestRuntime.IsSimulatorOrDesktop)
 						return !TestRuntime.CheckXcodeVersion (11, 0);
 					if (!TestRuntime.CheckXcodeVersion (9, 0))
 						return true;
@@ -393,7 +393,7 @@ namespace Introspection {
 				switch (name) {
 				case "isAutoFocusEnabled":
 				case "setAutoFocusEnabled:":
-					if ((Runtime.Arch == Arch.SIMULATOR) && TestRuntime.CheckXcodeVersion (12, 0))
+					if (TestRuntime.IsSimulatorOrDesktop && TestRuntime.CheckXcodeVersion (12, 0))
 						return true;
 					break;
 				}
@@ -401,7 +401,7 @@ namespace Introspection {
 			case "ARReferenceImage":
 				switch (name) {
 				case "copyWithZone:":
-					if ((Runtime.Arch == Arch.SIMULATOR) && TestRuntime.CheckXcodeVersion (12, 0))
+					if (TestRuntime.IsSimulatorOrDesktop && TestRuntime.CheckXcodeVersion (12, 0))
 						return true;
 					break;
 				}
@@ -770,7 +770,7 @@ namespace Introspection {
 
 			// on iOS8.0 this does not work on the simulator (but works on devices)
 			case "language":
-				if (declaredType.Name == "AVSpeechSynthesisVoice" && TestRuntime.CheckXcodeVersion (6, 0) && Runtime.Arch == Arch.SIMULATOR)
+				if (declaredType.Name == "AVSpeechSynthesisVoice" && TestRuntime.CheckXcodeVersion (6, 0) && TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 
@@ -795,7 +795,7 @@ namespace Introspection {
 				switch (declaredType.Name) {
 				case "SCNRenderer":
 				case "SCNView":
-					return Runtime.Arch == Arch.SIMULATOR;
+					return TestRuntime.IsSimulatorOrDesktop;
 				}
 				break;
 
@@ -867,7 +867,7 @@ namespace Introspection {
 					if (TestRuntime.CheckXcodeVersion (11, 0))
 						break;
 					// did not work on simulator before iOS 13 (shortcut logic)
-					if (Runtime.Arch == Arch.SIMULATOR)
+					if (TestRuntime.IsSimulatorOrDesktop)
 						return true;
 					// was a private framework (on iOS) before Xcode 9.0 (shortcut logic)
 					if (!TestRuntime.CheckXcodeVersion (9, 0))

--- a/tests/introspection/iOS/iOSApiTypoTest.cs
+++ b/tests/introspection/iOS/iOSApiTypoTest.cs
@@ -39,8 +39,7 @@ namespace Introspection {
 
 			// that's slow and there's no value to run it on devices as the API names
 			// being verified won't change from the simulator
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("Typos only detected on simulator");
+			TestRuntime.AssertSimulatorOrDesktop ("Typos only detected on simulator");
 
 			base.TypoTest ();
 #endif

--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -411,10 +411,7 @@ namespace LinkAll {
 		[Test]
 		public void SingleEpsilon_Compare ()
 		{
-#if !__MACOS__
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("Known to fail on devices, see bug #15802");
-#endif
+			TestRuntime.AssertNotDevice ("Known to fail on devices, see bug #15802");
 			// works on some ARM CPU (e.g. iPhone5S) but not others (iPad4 or iPodTouch5)
 			Assert.That (Single.Epsilon, Is.Not.EqualTo (0f), "Epsilon");
 			Assert.That (-Single.Epsilon, Is.Not.EqualTo (0f), "-Epsilon");
@@ -423,10 +420,7 @@ namespace LinkAll {
 		[Test]
 		public void SingleEpsilon_ToString ()
 		{
-#if !__MACOS__
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("Known to fail on devices, see bug #15802");
-#endif
+			TestRuntime.AssertNotDevice ("Known to fail on devices, see bug #15802");
 			var ci = CultureInfo.InvariantCulture;
 #if NET
 			Assert.That (Single.Epsilon.ToString (ci), Is.EqualTo ("1E-45"), "Epsilon.ToString()");
@@ -440,10 +434,7 @@ namespace LinkAll {
 		[Test]
 		public void DoubleEpsilon_Compare ()
 		{
-#if !__MACOS__
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("Known to fail on devices, see bug #15802");
-#endif
+			TestRuntime.AssertNotDevice ("Known to fail on devices, see bug #15802");
 			// works on some ARM CPU (e.g. iPhone5S) but not others (iPad4 or iPodTouch5)
 			Assert.That (Double.Epsilon, Is.Not.EqualTo (0f), "Epsilon");
 			Assert.That (-Double.Epsilon, Is.Not.EqualTo (0f), "-Epsilon");
@@ -452,10 +443,7 @@ namespace LinkAll {
 		[Test]
 		public void DoubleEpsilon_ToString ()
 		{
-#if !__MACOS__
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("Known to fail on devices, see bug #15802");
-#endif
+			TestRuntime.AssertNotDevice ("Known to fail on devices, see bug #15802");
 			var ci = CultureInfo.InvariantCulture;
 			// note: unlike Single this works on both my iPhone5S and iPodTouch5
 #if NET

--- a/tests/linker/ios/link all/PreserveTest.cs
+++ b/tests/linker/ios/link all/PreserveTest.cs
@@ -105,7 +105,7 @@ namespace LinkAll.Attributes {
 		public void Runtime_RegisterEntryAssembly ()
 		{
 #if NET
-			TestRuntime.AssertNotDevice ("https://github.com/xamarin/xamarin-macios/issues/10457");
+			TestRuntime.AssertSimulator ("https://github.com/xamarin/xamarin-macios/issues/10457");
 #endif
 
 			var klass = Type.GetType ("ObjCRuntime.Runtime, " + AssemblyName);

--- a/tests/linker/ios/link all/PreserveTest.cs
+++ b/tests/linker/ios/link all/PreserveTest.cs
@@ -105,10 +105,7 @@ namespace LinkAll.Attributes {
 		public void Runtime_RegisterEntryAssembly ()
 		{
 #if NET
-#if !__MACOS__
-			if (Runtime.Arch == Arch.DEVICE)
-#endif
-				Assert.Ignore ("https://github.com/xamarin/xamarin-macios/issues/10457");
+			TestRuntime.AssertNotDevice ("https://github.com/xamarin/xamarin-macios/issues/10457");
 #endif
 
 			var klass = Type.GetType ("ObjCRuntime.Runtime, " + AssemblyName);
@@ -118,7 +115,7 @@ namespace LinkAll.Attributes {
 #if __MACOS__
 			var expectedNull = true;
 #else
-			var expectedNull = Runtime.Arch == Arch.DEVICE;
+			var expectedNull = TestRuntime.IsDevice;
 #endif
 			Assert.That (method == null, Is.EqualTo (expectedNull), "RegisterEntryAssembly");
 		}

--- a/tests/linker/ios/link sdk/Bug1820Test.cs
+++ b/tests/linker/ios/link sdk/Bug1820Test.cs
@@ -155,8 +155,7 @@ namespace LinkSdk.Serialization {
 		public void Bug1820_GenericList ()
 		{
 #if NET && (__IOS__ || __TVOS__)
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("https://github.com/mono/linker/issues/2266");
+			TestRuntime.AssertNotDevice ("https://github.com/mono/linker/issues/2266");
 #endif
 			string input = @"
 				<?xml version=""1.0"" encoding=""UTF-8""?>

--- a/tests/linker/ios/link sdk/Bug2096Test.cs
+++ b/tests/linker/ios/link sdk/Bug2096Test.cs
@@ -47,8 +47,7 @@ namespace LinkSdk.Aot {
 #if !__MACOS__
 			// fails with 5.0.2 (5.1) when running on devices with
 			// Attempting to JIT compile method 'A:InnerMethod<D, long> (D,long)' while running with --aot-only.
-			if (Runtime.Arch == Arch.SIMULATOR)
-				Assert.Inconclusive ("only fails on devices");
+			TestRuntime.AssertNotDevice ("only fails on devices");
 #endif
 		}
 	}

--- a/tests/linker/ios/link sdk/DllImportTest.cs
+++ b/tests/linker/ios/link sdk/DllImportTest.cs
@@ -51,7 +51,7 @@ namespace LinkSdk {
 				// note 2: simulators also got the new libsqlite version with Xcode 9, and since Xcode 9 ships an ever newer sqlite version,
 				// we get even more API as well.
 				var hasNewerSqlite = TestRuntime.CheckXcodeVersion (9, 0);
-#if __MACOS__
+#if __MACOS__ || __MACCATALYST__
 				var hasNewSqlite = hasNewerSqlite || TestRuntime.CheckXcodeVersion (8, 0);
 #else
 				var hasNewSqlite = hasNewerSqlite || TestRuntime.CheckXcodeVersion (8, 0) && Runtime.Arch == Arch.DEVICE;

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -202,7 +202,7 @@ namespace LinkSdk {
 #if !__MACOS__
 			// we want to ensure we can get the constants without authorization (on iOS 6.0+) so this application
 			// needs to be unauthorized (in settings.app). Note: authorization checks only occurs on devices
-			if ((Runtime.Arch == Arch.DEVICE) && UIDevice.CurrentDevice.CheckSystemVersion (6,0)) {
+			if (TestRuntime.IsDevice && UIDevice.CurrentDevice.CheckSystemVersion (6,0)) {
 				Assert.That (ABAddressBook.GetAuthorizationStatus (), Is.Not.EqualTo (ABAuthorizationStatus.Authorized),
 					"Please deny access to contacts for this this application (it's important for this test)");
 			}
@@ -344,11 +344,7 @@ namespace LinkSdk {
 		public void Bug1790_TimeZoneInfo_Local ()
 		{
 			// the simulator has complete file access but the device won't have - i.e. we can't depend on it
-#if __MACOS__
-			var hasFileAccess = true;
-#else
-			var hasFileAccess = Runtime.Arch == Arch.SIMULATOR;
-#endif
+			var hasFileAccess = TestRuntime.IsSimulatorOrDesktop;
 			Assert.That (File.Exists ("/etc/localtime"), Is.EqualTo (hasFileAccess), "/etc/localtime");
 			Assert.NotNull (TimeZoneInfo.Local, "Local");
 			// should not throw a TimeZoneNotFoundException on devices
@@ -372,10 +368,6 @@ namespace LinkSdk {
 				Thread.Sleep (values [number]);
 				//Console.WriteLine (number);
 			});
-#if !__MACOS__
-			if (Runtime.Arch == Arch.SIMULATOR)
-				Assert.Inconclusive ("only fails on devices");
-#endif
 		}
 		
 		[Test]
@@ -883,12 +875,8 @@ namespace LinkSdk {
 			var home = Environment.GetEnvironmentVariable ("HOME");
 #endif
 
-#if __MACOS__
-			bool device = false;
-#else
 			// note: this test is more interesting on devices because of the sandbox they have
-			bool device = Runtime.Arch == Arch.DEVICE;
-#endif
+			var device = TestRuntime.IsDevice;
 
 			// some stuff we do not support (return String.Empty for the path)
 			TestFolder (Environment.SpecialFolder.Programs, supported: false);
@@ -1005,7 +993,7 @@ namespace LinkSdk {
 #if __MACOS__
 			Assert.That (path, Is.EqualTo (home), "UserProfile");
 #else
-			if (Runtime.Arch == Arch.DEVICE) {
+			if (TestRuntime.IsDevice) {
 				if (isExtension)
 					Assert.That (path, Does.StartWith ("/private/var/mobile/Containers/Data/PluginKitPlugin/"), "Containers-ios8");
 #if !__WATCHOS__

--- a/tests/linker/ios/link sdk/OptimizeGeneratedCodeTest.cs
+++ b/tests/linker/ios/link sdk/OptimizeGeneratedCodeTest.cs
@@ -31,7 +31,7 @@ namespace Linker.Shared {
 		{
 			var button = new UIButton ();
 			button.TouchCancel += delegate {
-				if (Runtime.Arch == Arch.SIMULATOR) {
+				if (TestRuntime.IsSimulatorOrDesktop) {
 					// kaboom
 				}
 			};
@@ -45,7 +45,7 @@ namespace Linker.Shared {
 		{
 			var button = new UIButton ();
 			button.TouchCancel += delegate {
-				if (Runtime.Arch == Arch.SIMULATOR) {
+				if (TestRuntime.IsSimulatorOrDesktop) {
 					// kaboom
 				}
 			};

--- a/tests/monotouch-test/AVFoundation/AVAssetDownloadUrlSessionTests.cs
+++ b/tests/monotouch-test/AVFoundation/AVAssetDownloadUrlSessionTests.cs
@@ -39,8 +39,7 @@ namespace monotouchtest {
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				Assert.Ignore ("Ignoring AVAssetDownloadUrlSession tests: Requires iOS9+");
 
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("Ignoring CreateSessionTest tests: Requires com.apple.developer.media-asset-download entitlement");
+			TestRuntime.AssertNotDevice ("Ignoring CreateSessionTest tests: Requires com.apple.developer.media-asset-download entitlement");
 
 			using (var backgroundConfiguration = NSUrlSessionConfiguration.CreateBackgroundSessionConfiguration ("HLS-Identifier")) {
 				Assert.DoesNotThrow (() => AVAssetDownloadUrlSession.CreateSession (backgroundConfiguration, null, NSOperationQueue.MainQueue), "Should not throw InvalidCastException");

--- a/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
@@ -92,10 +92,7 @@ namespace MonoTouchFixtures.AVFoundation {
 		public void MetadataObjectTypesTest ()
 		{
 			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 8, 0, throwIfOtherPlatform: false);
-
-			if (Runtime.Arch != Arch.DEVICE)
-				Assert.Ignore ("This test only runs on device (requires camera access)");
-
+			TestRuntime.AssertDevice ("This test only runs on device (requires camera access)");
 			TestRuntime.RequestCameraPermission (AVMediaTypes.Video.GetConstant (), true);
 
 			using (var captureSession = new AVCaptureSession ()) {
@@ -122,7 +119,7 @@ namespace MonoTouchFixtures.AVFoundation {
 									if (!TestRuntime.CheckXcodeVersion (11, 0))
 										continue;
 									// xcode 12 beta 1 on device
-									if ((Runtime.Arch == Arch.DEVICE) && TestRuntime.CheckXcodeVersion (12, 0))
+									if (TestRuntime.IsDevice && TestRuntime.CheckXcodeVersion (12, 0))
 										continue;
 									break;
 								}

--- a/tests/monotouch-test/AudioToolbox/AudioSessionTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioSessionTest.cs
@@ -33,7 +33,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 					Assert.That (Enum.IsDefined (typeof (AudioSessionOutputRouteKind), output), "Output: " + output.ToString ());
 			}
 			
-			if (Runtime.Arch == Arch.DEVICE) {
+			if (TestRuntime.IsDevice) {
 				Assert.That (outputs != null && outputs.Length > 0, "All known devices have at least speakers #1");
 				Assert.That (outputs [0] != AudioSessionOutputRouteKind.None, "All known devices have at least speakers #2");
 			}

--- a/tests/monotouch-test/AudioToolbox/SoundBankTest.cs
+++ b/tests/monotouch-test/AudioToolbox/SoundBankTest.cs
@@ -41,8 +41,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		public void GetName_DLS_SimOnly ()
 		{
 			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("Use local file system (need a smaller sample)");
+			TestRuntime.AssertNotDevice ("Use local file system (need a smaller sample)");
 
 			using (NSUrl url = new NSUrl (local_dls)) {
 				Assert.That (SoundBank.GetName (url), Is.EqualTo ("QuickTime Music Synthesizer  "), "Name");
@@ -68,8 +67,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		public void GetInstrumentInfo_DLS_SimOnly ()
 		{
 			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("Use local file system (need a smaller sample)");
+			TestRuntime.AssertNotDevice ("Use local file system (need a smaller sample)");
 
 			using (NSUrl url = new NSUrl (local_dls)) {
 				var info = SoundBank.GetInstrumentInfo (url);

--- a/tests/monotouch-test/Contacts/ContactStoreTest.cs
+++ b/tests/monotouch-test/Contacts/ContactStoreTest.cs
@@ -58,8 +58,7 @@ namespace MonoTouchFixtures.Contacts {
 			using (var store = new CNContactStore ()) {
 				var contact = store.GetUnifiedContact (identifier, fetchKeys, out error);
 				// it's in the default simulator build
-#if !MONOMAC
-				if (Runtime.Arch == Arch.SIMULATOR) {
+				if (TestRuntime.IsSimulatorOrDesktop) {
 					// it fails on some bots (watchOS 4.2 on jenkins) so we cannot assume it always work
 					if (error != null)
 						return;
@@ -68,7 +67,6 @@ namespace MonoTouchFixtures.Contacts {
 					Assert.True (contact.AreKeysAvailable (CNContactOptions.None), "AreKeysAvailable-2");
 					Assert.True (contact.AreKeysAvailable (fetchKeys), "AreKeysAvailable-3");
 				}
-#endif
 			}
 		}
 	}

--- a/tests/monotouch-test/Foundation/NSTimeZoneTest.cs
+++ b/tests/monotouch-test/Foundation/NSTimeZoneTest.cs
@@ -44,7 +44,7 @@ namespace MonoTouchFixtures.Foundation {
 			foreach (var name in NSTimeZone.KnownTimeZoneNames) {
 				// simulator uses OSX to get timezones which might have some holes,
 				// e.g. @"Pacific/Bougainville" does not seems to be available in Mavericks
-#if !MONOMAC
+#if !MONOMAC && !__MACCATALYST__
 				if (Runtime.Arch == Arch.SIMULATOR) {
 					if (!File.Exists (Path.Combine ("/usr/share/zoneinfo/", name)))
 						continue;

--- a/tests/monotouch-test/MLCompute/MLEnumsTest.cs
+++ b/tests/monotouch-test/MLCompute/MLEnumsTest.cs
@@ -17,10 +17,7 @@ namespace MonoTouchFixtures.MLCompute {
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
-#if !MONOMAC
-			if (Runtime.Arch == Arch.SIMULATOR)
-				Assert.Ignore ("https://github.com/xamarin/maccore/issues/2271");
-#endif
+			TestRuntime.AssertNotSimulator ("https://github.com/xamarin/maccore/issues/2271");
 		}
 
 		[Test]

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -73,7 +73,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 
 			var temp = String.Empty;
 			using (NSUrl url = new NSUrl (NSBundle.MainBundle.ResourceUrl.AbsoluteString + "basn3p08.png")) {
-#if __MACOS__
+#if __MACOS__ || __MACCATALYST__
 				var read_only = false;
 #else
 				var read_only = Runtime.Arch == Arch.DEVICE;

--- a/tests/monotouch-test/MediaPlayer/MediaItemTest.cs
+++ b/tests/monotouch-test/MediaPlayer/MediaItemTest.cs
@@ -19,8 +19,7 @@ namespace MonoTouchFixtures.MediaPlayer {
 		[Test]
 		public void DefaultValues ()
 		{
-			if (Runtime.Arch != Arch.DEVICE)
-				Assert.Inconclusive ("This test only works on device (the simulator does not have an iPod Music library).");
+			TestRuntime.AssertDevice ();
 
 			TestRuntime.RequestMediaLibraryPermission (true);
 

--- a/tests/monotouch-test/Metal/HeapDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/HeapDescriptorTest.cs
@@ -18,7 +18,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
-#if !MONOMAC
+#if !MONOMAC && !__MACCATALYST__
 			TestRuntime.AssertXcodeVersion (8, 0);
 
 			if (Runtime.Arch == Arch.SIMULATOR)

--- a/tests/monotouch-test/MetalPerformanceShaders/ImageScaleTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/ImageScaleTest.cs
@@ -22,7 +22,7 @@ namespace MonoTouchFixtures.MetalPerformanceShaders {
 		{
 			TestRuntime.AssertXcodeVersion (9,0);
 
-#if !MONOMAC
+#if !MONOMAC && !__MACCATALYST__
 			if (Runtime.Arch == Arch.SIMULATOR)
 				Assert.Inconclusive ("Metal Performance Shaders is not supported in the simulator");
 #endif

--- a/tests/monotouch-test/MetalPerformanceShaders/KernelTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/KernelTest.cs
@@ -22,7 +22,7 @@ namespace MonoTouchFixtures.MetalPerformanceShaders {
 		[OneTimeSetUp]
 		public void Metal ()
 		{
-#if !MONOMAC
+#if !MONOMAC && !__MACCATALYST__
 			TestRuntime.AssertXcodeVersion (7, 0);
 
 			if (Runtime.Arch == Arch.SIMULATOR)

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
@@ -23,7 +23,7 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 		[OneTimeSetUp]
 		public void Metal ()
 		{
-#if !MONOMAC
+#if !MONOMAC && !__MACCATALYST__
 			TestRuntime.AssertXcodeVersion (7, 0);
 
 			if (Runtime.Arch == Arch.SIMULATOR)

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
@@ -23,7 +23,7 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 		[OneTimeSetUp]
 		public void Metal ()
 		{
-#if !MONOMAC
+#if !MONOMAC && !__MACCATALYST__
 			TestRuntime.AssertXcodeVersion (7, 0);
 
 			if (Runtime.Arch == Arch.SIMULATOR)

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
@@ -23,7 +23,7 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 		[OneTimeSetUp]
 		public void Metal ()
 		{
-#if !MONOMAC
+#if !MONOMAC && !__MACCATALYST__
 			TestRuntime.AssertXcodeVersion (7, 0);
 
 			if (Runtime.Arch == Arch.SIMULATOR)

--- a/tests/monotouch-test/ObjCRuntime/DlfcnTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/DlfcnTest.cs
@@ -25,7 +25,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Assert.That (handle, Is.Not.EqualTo (IntPtr.Zero), "dlopen");
 			var err = Dlfcn.dlclose (handle);
 			var expected = 0;
-#if !MONOMAC
+#if !MONOMAC && !__MACCATALYST__
 			if (Runtime.Arch == Arch.DEVICE && TestRuntime.CheckXcodeVersion (7, 0) && !TestRuntime.CheckXcodeVersion (10, 0)) {
 				// Apple is doing some funky stuff with dlopen... this condition is to track if this change during betas
 				expected = -1;

--- a/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
@@ -87,7 +87,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void ObjCException ()
 		{
-#if !__WATCHOS__ && !__MACOS__
+#if !__WATCHOS__ && !__MACOS__ && !__MACCATALYST__
 			if (Runtime.Arch == Arch.DEVICE)
 				Assert.Ignore ("This test requires wrapper functions, which are not enabled for monotouch-test on device.");
 #endif
@@ -136,8 +136,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Exception thrownException = null;
 
 #if !__WATCHOS__ && !__MACOS__
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("This test requires wrapper functions, which are not enabled for monotouch-test on device.");
+			TestRuntime.AssertNotDevice ("This test requires wrapper functions, which are not enabled for monotouch-test on device.");
 #endif
 
 #if !DEBUG && !__WATCHOS__

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -151,7 +151,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		void CallProperty (IntPtr receiver, string selector, ref int called_var, string id, bool expectFailure = false)
 		{
-#if !MONOMAC
+#if !MONOMAC && !__MACCATALYST__
 			if (Runtime.Arch == Arch.DEVICE && expectFailure) {
 				Console.WriteLine ("Skipping '{0}', it's expected to throw a 'Selector not found exception', but on device it seems to crash instead", selector);
 				return;

--- a/tests/monotouch-test/ObjCRuntime/TrampolineTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/TrampolineTest.cs
@@ -24,7 +24,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 	[Preserve (AllMembers = true)]
 	public class TrampolineTest {
 		public static readonly nfloat pi = 3.14159f;
-#if MONOMAC
+#if MONOMAC || __MACCATALYST__
 		public static bool IsX64 { get { return IntPtr.Size == 8 && !IsArm64CallingConvention; } }
 		public static bool IsX86 { get { return IntPtr.Size == 4; } }
 #else
@@ -34,7 +34,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		public static bool IsArm64 { get { return IntPtr.Size == 8 && IsArm64CallingConvention; } }
 		public static bool IsArm32 {
 			get {
-#if __WATCHOS__ || __MACOS__
+#if __WATCHOS__ || __MACOS__ || __MACCATALYST__
 				return false;
 #else
 				return IntPtr.Size == 4 && Runtime.Arch == Arch.DEVICE;

--- a/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/CaptiveNetworkTest.cs
@@ -30,7 +30,7 @@ namespace MonoTouchFixtures.SystemConfiguration {
 		[Test]
 		public void Fields ()
 		{
-			if (Runtime.Arch == Arch.SIMULATOR) {
+			if (TestRuntime.IsSimulatorOrDesktop) {
 				// Fails (NullReferenceException) on iOS6 simulator
 				TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 			}

--- a/tests/monotouch-test/UIKit/ImageTest.cs
+++ b/tests/monotouch-test/UIKit/ImageTest.cs
@@ -57,7 +57,7 @@ namespace MonoTouchFixtures.UIKit {
 				using (var resized = original.Scale (half)) {
 					Assert.That (resized.CGImage.Height, Is.EqualTo (resized.CGImage.Width), "Width-Height-identical");
 					// caching of the backing CGImage occurs on devices (but not always)
-					if (Runtime.Arch == Arch.SIMULATOR) {
+					if (TestRuntime.IsSimulatorOrDesktop) {
 						Assert.That ((nint) 16, Is.EqualTo (resized.CGImage.Width), "half");
 					} else {
 						var h = resized.CGImage.Height;

--- a/tests/monotouch-test/UIKit/PopoverControllerTest.cs
+++ b/tests/monotouch-test/UIKit/PopoverControllerTest.cs
@@ -46,8 +46,7 @@ namespace MonoTouchFixtures.UIKit {
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
 				Assert.Inconclusive ("Requires iPad");
 			
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("ObjectiveC exception crash on devices - bug #3980");
+			TestRuntime.AssertNotDevice ("ObjectiveC exception crash on devices - bug #3980");
 			
 			using (var vc = new UIViewController ())
 			using (var bbi = new UIBarButtonItem (UIBarButtonSystemItem.Action))
@@ -85,8 +84,7 @@ namespace MonoTouchFixtures.UIKit {
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
 				Assert.Inconclusive ("Requires iPad");
 
-			if (Runtime.Arch == Arch.DEVICE)
-				Assert.Ignore ("ObjectiveC exception crash on devices - bug #3980");
+			TestRuntime.AssertNotDevice ("ObjectiveC exception crash on devices - bug #3980");
 			
 			using (var vc = new UIViewController ())
 			using (var bbi = new UIBarButtonItem (UIBarButtonSystemItem.Action))

--- a/tests/monotouch-test/UIKit/ReferenceLibraryViewControllerTest.cs
+++ b/tests/monotouch-test/UIKit/ReferenceLibraryViewControllerTest.cs
@@ -22,8 +22,10 @@ namespace MonoTouchFixtures.UIKit {
 
 		public void InitWithTerm ()
 		{
+#if !__MACCATALYST__
 			if (Runtime.Arch == Arch.DEVICE && TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 9, 0))
 				Assert.Ignore ("crash on iOS9 devices");
+#endif
 			using (UIReferenceLibraryViewController rlvc = new UIReferenceLibraryViewController ("Mono")) {
 			}
 		}

--- a/tests/monotouch-test/mono/Symbols.cs
+++ b/tests/monotouch-test/mono/Symbols.cs
@@ -16,8 +16,7 @@ namespace MonoTouchFixtures {
 		[Test]
 		public void FunctionNames ()
 		{
-			if (Runtime.Arch != Arch.DEVICE)
-				Assert.Ignore ("This is a device-only test.");
+			TestRuntime.AssertDevice ();
 			
 			Collect ();
 			bool aot = symbols [1].Contains ("MonoTouchFixtures_Symbols_Collect");


### PR DESCRIPTION
Remove Runtime.Arch and ObjCRuntime.Arch from Mac Catalyst, because they don't
apply for a Mac Catalyst app (which is neither a simulator environment, nor a
device environment).

This means that code using these APIs will have to be re-evaluated to
determine what's the correct behavior for Mac Catalyst.

Also update our tests accordingly.

Fixes https://github.com/xamarin/xamarin-macios/issues/10312.