### PR TITLE
[CI] Allow to force a build to be usable for insertions.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -35,6 +35,11 @@ parameters:
   type: boolean
   default: true
 
+- name: forceInsertion
+  displayName: Force Insertion 
+  type: boolean
+  default: false 
+
 # We are doing some black magic. We have several templates that 
 # are executed with different parameters. 
 #
@@ -253,7 +258,7 @@ stages:
         enableDotnet: ${{ parameters.enableDotnet }}
 
 # .NET 6 Release Prep and VS Insertion Stages, only execute them when the build comes from an official branch and is not a schedule build from OneLoc
-- ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
+- ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), eq(parameters.forceInsertion, true))) }}:
   - template: templates/release/vs-insertion-prep.yml
 
 # Test stages


### PR DESCRIPTION
This change allows to have a parameter (false by default) that allows to
get a build to be able to do an insertion even when it is comming from a
not predefined branch.

Uses cases:

1. Trigger a buiild with no tests from a special branch to insert.
2. Work with the CI to test the deployment.