### PR TITLE
[VTCompressionSession] Enable nullability + a few other code updates

### DIFF
--- a/src/VideoToolbox/VTCompressionSession.cs
+++ b/src/VideoToolbox/VTCompressionSession.cs
@@ -21,6 +21,8 @@ using CoreVideo;
 using NativeHandle = System.IntPtr;
 #endif
 
+#nullable enable
+
 namespace VideoToolbox {
 
 #if NET
@@ -43,17 +45,6 @@ namespace VideoToolbox {
 		{
 		}
 
-		~VTCompressionSession ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-		
 		protected override void Dispose (bool disposing)
 		{
 			if (Handle != IntPtr.Zero)
@@ -66,17 +57,17 @@ namespace VideoToolbox {
 		}
 
 		// sourceFrame: It seems it's only used as a parameter to be passed into EncodeFrame so no need to strong type it
-		public delegate void VTCompressionOutputCallback (/* void* */ IntPtr sourceFrame, /* OSStatus */ VTStatus status, VTEncodeInfoFlags flags, CMSampleBuffer buffer);
+		public delegate void VTCompressionOutputCallback (/* void* */ IntPtr sourceFrame, /* OSStatus */ VTStatus status, VTEncodeInfoFlags flags, CMSampleBuffer? buffer);
 #if !NET
 		delegate void CompressionOutputCallback (/* void* CM_NULLABLE */ IntPtr outputCallbackClosure, /* void* CM_NULLABLE */ IntPtr sourceFrame, /* OSStatus */ VTStatus status, VTEncodeInfoFlags infoFlags, /* CMSampleBufferRef CM_NULLABLE */ IntPtr cmSampleBufferPtr);
 
 		//
 		// Here for legacy code, which would only work under duress (user had to manually ref the CMSampleBuffer on the callback)
 		//
-		static CompressionOutputCallback _static_CompressionOutputCallback;
+		static CompressionOutputCallback? _static_CompressionOutputCallback;
 		static CompressionOutputCallback static_CompressionOutputCallback {
 			get {
-				if (_static_CompressionOutputCallback == null)
+				if (_static_CompressionOutputCallback is null)
 					_static_CompressionOutputCallback = new CompressionOutputCallback (CompressionCallback);
 				return _static_CompressionOutputCallback;
 			}
@@ -86,7 +77,7 @@ namespace VideoToolbox {
 		static void CompressionCallback (IntPtr outputCallbackClosure, IntPtr sourceFrame, VTStatus status, VTEncodeInfoFlags infoFlags, IntPtr cmSampleBufferPtr, bool owns)
 		{
 			var gch = GCHandle.FromIntPtr (outputCallbackClosure);
-			var func = (VTCompressionOutputCallback) gch.Target;
+			var func = (VTCompressionOutputCallback) gch.Target!;
 			if (cmSampleBufferPtr == IntPtr.Zero) {
 				func (sourceFrame, status, infoFlags, null);
 			} else {
@@ -108,10 +99,10 @@ namespace VideoToolbox {
 		}
 
 		[Obsolete ("This overload requires that the provided compressionOutputCallback manually CFRetain the passed CMSampleBuffer, use Create(int,int,CMVideoCodecType,VTCompressionOutputCallback,VTVideoEncoderSpecification,CVPixelBufferAttributes) variant instead which does not have that requirement.")]
-		public static VTCompressionSession Create (int width, int height, CMVideoCodecType codecType,
+		public static VTCompressionSession? Create (int width, int height, CMVideoCodecType codecType,
 			VTCompressionOutputCallback compressionOutputCallback,
-			VTVideoEncoderSpecification encoderSpecification = null, // hardware acceleration is default behavior on iOS. no opt-in required.
-			NSDictionary sourceImageBufferAttributes = null)
+			VTVideoEncoderSpecification? encoderSpecification = null, // hardware acceleration is default behavior on iOS. no opt-in required.
+			NSDictionary? sourceImageBufferAttributes = null)
 		{
 #if NET
 			unsafe {
@@ -125,10 +116,10 @@ namespace VideoToolbox {
 #if !NET
 		// End region of legacy code
 
-		static CompressionOutputCallback _static_newCompressionOutputCallback;
+		static CompressionOutputCallback? _static_newCompressionOutputCallback;
 		static CompressionOutputCallback static_newCompressionOutputCallback {
 			get {
-				if (_static_newCompressionOutputCallback == null)
+				if (_static_newCompressionOutputCallback is null)
 					_static_newCompressionOutputCallback = new CompressionOutputCallback (NewCompressionCallback);
 				return _static_newCompressionOutputCallback;
 			}
@@ -159,25 +150,25 @@ namespace VideoToolbox {
 #if NET
 			/* VTCompressionOutputCallback */ delegate* unmanaged</* void* CM_NULLABLE */ IntPtr, /* void* CM_NULLABLE */ IntPtr, /* OSStatus */ VTStatus, VTEncodeInfoFlags, /* CMSampleBufferRef CM_NULLABLE */ IntPtr, void> outputCallback,
 #else
-			/* VTCompressionOutputCallback */ CompressionOutputCallback outputCallback,
+			/* VTCompressionOutputCallback */ CompressionOutputCallback? outputCallback,
 #endif
 			/* void* */ IntPtr outputCallbackClosure,
 			/* VTCompressionSessionRef* */ out IntPtr compressionSessionOut);
 
 #if false // Disabling for now until we have some tests on this
 		[Mac (10,11), iOS (9,0)]
-		public static VTCompressionSession Create (int width, int height, CMVideoCodecType codecType,
-			VTVideoEncoderSpecification encoderSpecification = null,
-			NSDictionary sourceImageBufferAttributes = null)
+		public static VTCompressionSession? Create (int width, int height, CMVideoCodecType codecType,
+			VTVideoEncoderSpecification? encoderSpecification = null,
+			NSDictionary? sourceImageBufferAttributes = null)
 		{
 			return Create (width, height, codecType, null,
 				encoderSpecification, sourceImageBufferAttributes);
 		}
 #endif
-		public static VTCompressionSession Create (int width, int height, CMVideoCodecType codecType,
+		public static VTCompressionSession? Create (int width, int height, CMVideoCodecType codecType,
 			VTCompressionOutputCallback compressionOutputCallback,
-			VTVideoEncoderSpecification encoderSpecification, // hardware acceleration is default behavior on iOS. no opt-in required.
-			CVPixelBufferAttributes sourceImageBufferAttributes)
+			VTVideoEncoderSpecification? encoderSpecification, // hardware acceleration is default behavior on iOS. no opt-in required.
+			CVPixelBufferAttributes? sourceImageBufferAttributes)
 		{
 #if NET
 			unsafe {
@@ -188,10 +179,10 @@ namespace VideoToolbox {
 #endif
 		}
 
-		unsafe static VTCompressionSession Create (int width, int height, CMVideoCodecType codecType,
+		unsafe static VTCompressionSession? Create (int width, int height, CMVideoCodecType codecType,
 			VTCompressionOutputCallback compressionOutputCallback,
-			VTVideoEncoderSpecification encoderSpecification, // hardware acceleration is default behavior on iOS. no opt-in required.
-		        NSDictionary sourceImageBufferAttributes, // Undocumented options, probably always null
+			VTVideoEncoderSpecification? encoderSpecification, // hardware acceleration is default behavior on iOS. no opt-in required.
+		        NSDictionary? sourceImageBufferAttributes, // Undocumented options, probably always null
 #if NET
 		        delegate* unmanaged</* void* CM_NULLABLE */ IntPtr, /* void* CM_NULLABLE */ IntPtr, /* OSStatus */ VTStatus, VTEncodeInfoFlags, /* CMSampleBufferRef CM_NULLABLE */ IntPtr, void> staticCback)
 #else
@@ -199,18 +190,16 @@ namespace VideoToolbox {
 #endif
 		{
 			var callbackHandle = default (GCHandle);
-			if (compressionOutputCallback != null)
+			if (compressionOutputCallback is not null)
 				callbackHandle = GCHandle.Alloc (compressionOutputCallback);
 
-			IntPtr ret;
-
 			var result = VTCompressionSessionCreate (IntPtr.Zero, width, height, codecType,
-				encoderSpecification != null ? encoderSpecification.Dictionary.Handle : IntPtr.Zero,
-				sourceImageBufferAttributes != null ? sourceImageBufferAttributes.Handle : IntPtr.Zero,
+				encoderSpecification.GetHandle (),
+				sourceImageBufferAttributes.GetHandle (),
 				IntPtr.Zero,
 				callbackHandle.IsAllocated ? (staticCback) : null,
 				GCHandle.ToIntPtr (callbackHandle),
-	            out ret);
+	            out var ret);
 
 			if (result == VTStatus.Ok && ret != IntPtr.Zero)
 				return new VTCompressionSession (ret, true) {
@@ -229,12 +218,9 @@ namespace VideoToolbox {
 		[DllImport (Constants.VideoToolboxLibrary)]
 		extern static IntPtr /* cvpixelbufferpoolref */ VTCompressionSessionGetPixelBufferPool (IntPtr handle);
 
-		public CVPixelBufferPool GetPixelBufferPool ()
+		public CVPixelBufferPool? GetPixelBufferPool ()
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("CompressionSession");
-
-			var ret = VTCompressionSessionGetPixelBufferPool (Handle);
+			var ret = VTCompressionSessionGetPixelBufferPool (GetCheckedHandle ());
 
 			if (ret != IntPtr.Zero) 
 				return new CVPixelBufferPool (ret, false);
@@ -253,10 +239,7 @@ namespace VideoToolbox {
 #endif
 		public VTStatus PrepareToEncodeFrames ()
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("CompressionSession");
-			
-			return VTCompressionSessionPrepareToEncodeFrames (Handle);
+			return VTCompressionSessionPrepareToEncodeFrames (GetCheckedHandle ());
 		}
 		
 		[DllImport (Constants.VideoToolboxLibrary)]
@@ -272,27 +255,25 @@ namespace VideoToolbox {
 		public VTStatus EncodeFrame (CVImageBuffer imageBuffer, CMTime presentationTimestampe, CMTime duration, 
 			NSDictionary frameProperties, IntPtr sourceFrame, out VTEncodeInfoFlags infoFlags)
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("CompressionSession");
-			if (imageBuffer == null)
-				throw new ArgumentNullException ("imageBuffer");
+			if (imageBuffer is null)
+				throw new ArgumentNullException (nameof (imageBuffer));
 			
-			return VTCompressionSessionEncodeFrame (Handle, imageBuffer.Handle, presentationTimestampe, duration,
-				frameProperties == null ? IntPtr.Zero : frameProperties.Handle,
+			return VTCompressionSessionEncodeFrame (GetCheckedHandle (), imageBuffer.Handle, presentationTimestampe, duration,
+				frameProperties.GetHandle (),
 				sourceFrame, out infoFlags);
 		}		
 
 #if false // Disabling for now until we have some tests on this
 		[Mac (10,11), iOS (9,0)]
 		[DllImport (Constants.VideoToolboxLibrary)]
-		extern static unsafe VTStatus VTCompressionSessionEncodeFrameWithOutputHandler (
+		extern static VTStatus VTCompressionSessionEncodeFrameWithOutputHandler (
 			/* VTCompressionSessionRef */ IntPtr session,
 			/* CVImageBufferRef */ IntPtr imageBuffer,
 			/* CMTime */ CMTime presentation,
 			/* CMTime */ CMTime duration, // can ve CMTime.Invalid
 			/* CFDictionaryRef */ IntPtr dict, // can be null, undocumented options
 			/* VTEncodeInfoFlags */ out VTEncodeInfoFlags flags,
-			/* VTCompressionOutputHandler */ BlockLiteral *outputHandler);
+			/* VTCompressionOutputHandler */ ref BlockLiteral outputHandler);
 
 		public delegate void VTCompressionOutputHandler (VTStatus status, VTEncodeInfoFlags infoFlags, CMSampleBuffer sampleBuffer);
 
@@ -306,7 +287,7 @@ namespace VideoToolbox {
 			VTStatus status, VTEncodeInfoFlags infoFlags, IntPtr sampleBuffer)
 		{
 			var del = (VTCompressionOutputHandler)(block->Target);
-			if (del != null)
+			if (del is not null)
 				del (status, infoFlags, new CMSampleBuffer (sampleBuffer));
 		}
 
@@ -315,26 +296,21 @@ namespace VideoToolbox {
 			NSDictionary frameProperties, IntPtr sourceFrame, out VTEncodeInfoFlags infoFlags,
 			VTCompressionOutputHandler outputHandler)
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("CompressionSession");
-			if (imageBuffer == null)
-				throw new ArgumentNullException ("imageBuffer");
-			if (outputHandler == null)
-				throw new ArgumentNullException ("outputHandler");
+			if (imageBuffer is null)
+				throw new ArgumentNullException ((imageBuffer));
+			if (outputHandler is null)
+				throw new ArgumentNullException (nameof (outputHandler));
 
-			unsafe {
-				var block = new BlockLiteral ();
-				var blockPtr = &block;
-				block.SetupBlockUnsafe (compressionOutputHandlerTrampoline, outputHandler);
+			var block = new BlockLiteral ();
+			block.SetupBlockUnsafe (compressionOutputHandlerTrampoline, outputHandler);
 
-				try {
-					return VTCompressionSessionEncodeFrameWithOutputHandler (Handle,
-						imageBuffer.Handle, presentationTimestamp, duration,
-						frameProperties == null ? IntPtr.Zero : frameProperties.Handle,
-						out infoFlags, blockPtr);
-				} finally {
-					blockPtr->CleanupBlock ();
-				}
+			try {
+				return VTCompressionSessionEncodeFrameWithOutputHandler (GetCheckedHandle (),
+					imageBuffer.Handle, presentationTimestamp, duration,
+					frameProperties.GetHandle (),
+					out infoFlags, ref block);
+			} finally {
+				block.CleanupBlock ();
 			}
 		}
 #endif
@@ -343,9 +319,7 @@ namespace VideoToolbox {
 
 		public VTStatus CompleteFrames (CMTime completeUntilPresentationTimeStamp)
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("CompressionSession");
-			return VTCompressionSessionCompleteFrames (Handle, completeUntilPresentationTimeStamp);
+			return VTCompressionSessionCompleteFrames (GetCheckedHandle (), completeUntilPresentationTimeStamp);
 		}
 
 #if !NET
@@ -359,9 +333,7 @@ namespace VideoToolbox {
 #endif
 		public VTStatus BeginPass (VTCompressionSessionOptionFlags flags)
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("CompressionSession");
-			return VTCompressionSessionBeginPass (Handle, flags, IntPtr.Zero);
+			return VTCompressionSessionBeginPass (GetCheckedHandle (), flags, IntPtr.Zero);
 		}
 
 #if !NET
@@ -381,11 +353,7 @@ namespace VideoToolbox {
 #endif
 		public VTStatus EndPass (out bool furtherPassesRequested)
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("CompressionSession");
-
-			byte b;
-			var result = VTCompressionSessionEndPass (Handle, out b, IntPtr.Zero);
+			var result = VTCompressionSessionEndPass (GetCheckedHandle (), out var b, IntPtr.Zero);
 			furtherPassesRequested = b != 0;
 			return result;
 		}
@@ -393,10 +361,7 @@ namespace VideoToolbox {
 		// Like EndPass, but this will be the final pass, so the encoder will skip the evaluation.
 		public VTStatus EndPassAsFinal ()
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("CompressionSession");
-
-			return VTCompressionSessionEndPass (Handle, IntPtr.Zero, IntPtr.Zero);
+			return VTCompressionSessionEndPass (GetCheckedHandle (), IntPtr.Zero, IntPtr.Zero);
 		}
 
 #if !NET
@@ -411,13 +376,9 @@ namespace VideoToolbox {
 #if !NET
 		[Mac (10,10)]
 #endif
-		public VTStatus GetTimeRangesForNextPass (out CMTimeRange [] timeRanges)
+		public VTStatus GetTimeRangesForNextPass (out CMTimeRange []? timeRanges)
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("CompressionSession");
-			IntPtr target;
-			int count;
-			var v = VTCompressionSessionGetTimeRangesForNextPass (Handle, out count, out target);
+			var v = VTCompressionSessionGetTimeRangesForNextPass (GetCheckedHandle (), out var count, out var target);
 			if (v != VTStatus.Ok) {
 				timeRanges = null;
 				return v;
@@ -433,12 +394,10 @@ namespace VideoToolbox {
 
 		public VTStatus SetCompressionProperties (VTCompressionProperties options)
 		{
-			if (Handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("CompressionSession");
-			if (options == null)
-				throw new ArgumentNullException ("options");
+			if (options is null)
+				throw new ArgumentNullException (nameof (options));
 
-			return VTSessionSetProperties (Handle, options.Dictionary.Handle);
+			return VTSessionSetProperties (GetCheckedHandle (), options.Dictionary.Handle);
 		}
 	}	
 }


### PR DESCRIPTION
* Remove unnecessary destructor and Dispose method.
* Enable nullability and fix code accordingly.
* Use 'is' and 'is not' instead of '==' and '!=' for object identity.
* Use 'nameof (parameter)' instead of string constants.
* Use the null-safe NativeObjectExtensions.GetHandle extension method to get
  the handle instead of checking for null (avoids some code duplication).
* Call 'GetCheckedHandle ()' (which will throw an ObjectDisposedException if
  Handle == IntPtr.Zero) instead of manually checking for IntPtr.Zero and
  throwing ObjectDisposedException.
* Simplify some block code.