### PR TITLE
[Dotnet] Fix building twice in a row issue

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeBundleResourceOutputPathsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeBundleResourceOutputPathsTaskBase.cs
@@ -39,6 +39,9 @@ namespace Xamarin.MacDev.Tasks
 			if (BundleResources != null) {
 				foreach (var item in BundleResources) {
 					var logicalName = item.GetMetadata ("LogicalName");
+					// if logicalName is null or empty, use the filename
+					if (string.IsNullOrEmpty (logicalName))
+						logicalName = Path.GetFileName (item);
 					var outputPath = item.GetMetadata ("OutputPath");
 					IList<string> tags;
 					string hash;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeBundleResourceOutputPathsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeBundleResourceOutputPathsTaskBase.cs
@@ -41,7 +41,7 @@ namespace Xamarin.MacDev.Tasks
 					var logicalName = item.GetMetadata ("LogicalName");
 					// if logicalName is null or empty, use the filename
 					if (string.IsNullOrEmpty (logicalName))
-						logicalName = Path.GetFileName (item);
+						logicalName = Path.GetFileName (item.GetMetadata ("FullPath"));
 					var outputPath = item.GetMetadata ("OutputPath");
 					IList<string> tags;
 					string hash;

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -718,7 +718,7 @@ namespace Xamarin.Tests {
 			var project = "AppWithResources";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 
-			var projectPath = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			var projectPath = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out _);
 			Clean (projectPath);
 
 			DotNet.AssertBuild (projectPath, GetDefaultProperties (runtimeIdentifiers));

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -706,6 +706,25 @@ namespace Xamarin.Tests {
 			Assert.AreEqual (runtimeIdentifiers.Split (';').Any (v => v.EndsWith ("-x64")), File.Exists (x64txt), "x64.txt");
 		}
 
+		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
+		[TestCase (ApplePlatform.iOS, "ios-arm64;ios-arm")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64")] // https://github.com/xamarin/xamarin-macios/issues/12410
+		public void DoubleBuild (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "AppWithResources";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var projectPath = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (projectPath);
+
+			DotNet.AssertBuild (projectPath, GetDefaultProperties (runtimeIdentifiers));
+			DotNet.AssertBuild (projectPath, GetDefaultProperties (runtimeIdentifiers), FailThisTest: true);
+		}
+
 		void ExecuteWithMagicWordAndAssert (ApplePlatform platform, string runtimeIdentifiers, string executable)
 		{
 			if (!CanExecute (platform, runtimeIdentifiers))

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -722,7 +722,7 @@ namespace Xamarin.Tests {
 			Clean (projectPath);
 
 			DotNet.AssertBuild (projectPath, GetDefaultProperties (runtimeIdentifiers));
-			DotNet.AssertBuild (projectPath, GetDefaultProperties (runtimeIdentifiers), FailThisTest: true);
+			DotNet.AssertBuild (projectPath, GetDefaultProperties (runtimeIdentifiers));
 		}
 
 		void ExecuteWithMagicWordAndAssert (ApplePlatform platform, string runtimeIdentifiers, string executable)


### PR DESCRIPTION
This PR addresses this issue: https://github.com/xamarin/maccore/issues/2530

If you build twice using DotNet.AssertBuild without cleaning in between, the project fails.
From tracing the binlogs, it looks like there is a file "scene.dae" that after the first build, failed to carry over it's metadata: primarily it's 'LogicalName'.
This caused an issue since the output file is composed of a directory + this logical name.
Thus with an empty LogicalName, the output file is a directory and causes the build to fail.
Inside the ComputeBundleResourceOutputPaths, it will now compute a default LogicalName of the filename if LogicalPath is not provided.