### PR TITLE
[Foundation] Fix return type for NSUrlSessionHandler.AutomaticDecompression. Fixes #13576.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -532,7 +532,7 @@ namespace Foundation {
 
 #if NET
 		// Properties that will be called by the default HttpClientHandler
-		public bool AutomaticDecompression {
+		public DecompressionMethods AutomaticDecompression {
 			get => throw new PlatformNotSupportedException ();
 			set => throw new PlatformNotSupportedException ();
 		}


### PR DESCRIPTION
This was probably a c&p error.

Fixes https://github.com/xamarin/xamarin-macios/issues/13576.