### PR TITLE
[tests] Shutdown build servers when rebuilding.

### DIFF
--- a/tests/common/shared-dotnet.mk
+++ b/tests/common/shared-dotnet.mk
@@ -17,6 +17,7 @@ reload:
 	$(Q) $(MAKE) -C $(TOP) -j8 all
 	$(Q) $(MAKE) -C $(TOP) -j8 install
 	$(Q) git clean -xfdq
+	$(Q) $(DOTNET6) build-server shutdown # make sure msbuild picks up any new task assemblies we built
 
 reload-and-build:
 	$(Q) $(MAKE) reload

--- a/tests/dotnet/Makefile
+++ b/tests/dotnet/Makefile
@@ -37,6 +37,7 @@ all-local:: $(TARGETS)
 reload: $(TARGETS)
 	$(Q) $(MAKE) -C $(TOP) -j8 all
 	$(Q) $(MAKE) -C $(TOP) -j8 install
+	$(Q) $(DOTNET6) build-server shutdown # make sure msbuild picks up any new task assemblies we built
 
 compare compare-size: $(TARGETS)
 	rm -rf packages


### PR DESCRIPTION
This makes sure that MSBuild picks up rebuilt task assemblies.