### PR TITLE
[AppKit] Make sure NSFunctionKey doesn't come into Mac Catalyst in .NET.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -674,8 +674,9 @@ namespace AppKit {
 		UpArrow        = 0x7E
 	}
 
-#if !XAMCORE_4_0
+	// This is an untyped enum in AppKit's NSEvent.h
 	[NoMacCatalyst]
+#if !NET
 	[Native]
 	public enum NSFunctionKey : ulong {
 #else

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -283,7 +283,6 @@
 !unknown-native-enum! NSComposite bound
 !unknown-native-enum! NSEventModifierMask bound
 !unknown-native-enum! NSFontPanelMode bound
-!unknown-native-enum! NSFunctionKey bound
 !unknown-native-enum! NSImageScale bound
 !unknown-native-enum! NSMenuProperty bound
 !unknown-native-enum! NSPanelButtonType bound


### PR DESCRIPTION
If NSFunctionKey isn't in Mac Catalyst in legacy Xamarin, it shouldn't be in
.NET either, so adjust the conditional logic accordingly.

Also make the NSFunctionKey enum a non-native enum in .NET, like it's in the
headers.