### PR TITLE
[VTCompressionSession] Fix broken Create overloads for .NET.

### DIFF
--- a/src/VideoToolbox/VTCompressionSession.cs
+++ b/src/VideoToolbox/VTCompressionSession.cs
@@ -86,19 +86,16 @@ namespace VideoToolbox {
 			}
 		}
 
-#if NET
-		[UnmanagedCallersOnly]
-#else
+#if !NET
 #if !MONOMAC
 		[MonoPInvokeCallback (typeof (CompressionOutputCallback))]
-#endif
 #endif
 		static void CompressionCallback (IntPtr outputCallbackClosure, IntPtr sourceFrame, VTStatus status, VTEncodeInfoFlags infoFlags, IntPtr cmSampleBufferPtr)
 		{
 			CompressionCallback (outputCallbackClosure, sourceFrame, status, infoFlags, cmSampleBufferPtr, true);
 		}
+#endif // !NET
 
-		[Obsolete ("This overload requires that the provided compressionOutputCallback manually CFRetain the passed CMSampleBuffer, use Create(int,int,CMVideoCodecType,VTCompressionOutputCallback,VTVideoEncoderSpecification,CVPixelBufferAttributes) variant instead which does not have that requirement.")]
 		public static VTCompressionSession? Create (int width, int height, CMVideoCodecType codecType,
 			VTCompressionOutputCallback compressionOutputCallback,
 			VTVideoEncoderSpecification? encoderSpecification = null, // hardware acceleration is default behavior on iOS. no opt-in required.
@@ -171,9 +168,7 @@ namespace VideoToolbox {
 			CVPixelBufferAttributes? sourceImageBufferAttributes)
 		{
 #if NET
-			unsafe {
-				return Create (width, height, codecType, compressionOutputCallback, encoderSpecification, sourceImageBufferAttributes == null ? null : sourceImageBufferAttributes.Dictionary, &CompressionCallback);
-			}
+			return Create (width, height, codecType, compressionOutputCallback, encoderSpecification, sourceImageBufferAttributes?.Dictionary);
 #else
 			return Create (width, height, codecType, compressionOutputCallback, encoderSpecification, sourceImageBufferAttributes == null ? null : sourceImageBufferAttributes.Dictionary, static_CompressionOutputCallback);
 #endif

--- a/tests/monotouch-test/VideoToolbox/VTCompressionSessionTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTCompressionSessionTests.cs
@@ -11,10 +11,14 @@
 #if !__WATCHOS__
 
 using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
 
 using Foundation;
 using VideoToolbox;
 using CoreMedia;
+using CoreVideo;
 using AVFoundation;
 using CoreFoundation;
 using ObjCRuntime;
@@ -145,6 +149,87 @@ namespace MonoTouchFixtures.VideoToolbox {
 				(sourceFrame, status, flags, buffer) => { });
 			return session;
 		}
+
+#if !NET
+		[DllImport ("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")]
+		static extern IntPtr CFRetain (IntPtr obj);
+#endif
+
+		[TestCase (true)]
+		[TestCase (false)]
+		public void TestCallback (bool stronglyTyped)
+		{
+			Exception ex = null;
+			var thread = new Thread (() => {
+				try {
+					TestCallbackBackground (stronglyTyped);
+				} catch (Exception e) {
+					ex = e;
+				}
+			});
+			thread.IsBackground = true;
+			thread.Start ();
+			Assert.IsTrue (thread.Join (TimeSpan.FromSeconds (30)), "timed out");
+			Assert.IsNull (ex);
+		}
+
+		public void TestCallbackBackground (bool stronglyTyped)
+		{
+			var width = 640;
+			var height = 480;
+			var encoder_specification = new VTVideoEncoderSpecification ();
+			var source_attributes = new CVPixelBufferAttributes (CVPixelFormatType.CV420YpCbCr8BiPlanarFullRange, width, height);
+			var duration = new CMTime (40, 1);
+			VTStatus status;
+			using var frameProperties = new NSDictionary ();
+
+			int callbackCounter = 0;
+			var failures = new List<string> ();
+			var callback = new VTCompressionSession.VTCompressionOutputCallback ((IntPtr sourceFrame, VTStatus status, VTEncodeInfoFlags flags, CMSampleBuffer buffer) =>
+			{
+				Interlocked.Increment (ref callbackCounter);
+				if (status != VTStatus.Ok)
+					failures.Add ($"Callback #{callbackCounter} failed. Expected status = Ok, got status = {status}");
+#if !NET
+				// Work around a crash that occur if the buffer isn't retained
+				if (stronglyTyped) {
+					CFRetain (buffer.Handle);
+				}
+#endif
+			});
+			using var session = stronglyTyped
+				? VTCompressionSession.Create (
+					width, height,
+					CMVideoCodecType.H264,
+					callback,
+					encoder_specification,
+					source_attributes
+					)
+				: VTCompressionSession.Create (
+					width, height,
+					CMVideoCodecType.H264,
+					callback,
+					encoder_specification,
+					source_attributes.Dictionary
+					);
+
+			var frameCount = 20;
+			for (var i = 0; i < frameCount; i++) {
+				using var imageBuffer = new CVPixelBuffer (width, height, CVPixelFormatType.CV420YpCbCr8BiPlanarFullRange);
+				var pts = new CMTime (40 * i, 1);
+				status = session.EncodeFrame (imageBuffer, pts, duration, null, imageBuffer.Handle, out var infoFlags);
+				Assert.AreEqual (status, VTStatus.Ok, $"status #{i}");
+				// This looks weird, but it seems the video encoder can become overwhelmed otherwise, and it
+				// will start failing (and taking a long time to do so, eventually timing out the test).
+				Thread.Sleep (10);
+			};
+			status = session.CompleteFrames (new CMTime (40 * frameCount, 1));
+			Assert.AreEqual (status, VTStatus.Ok, "status finished");
+			Assert.AreEqual (callbackCounter, frameCount, "frame count");
+			Assert.That (failures, Is.Empty, "no callback failures");
+		}
+
+
 	}
 }
 


### PR DESCRIPTION
Once upon a time there was a single VTCompressionSession.Create method, which
was [driving users insane][1] - they had to manually call CFRetain to avoid
crashes! What an abomination!!

Insane users are clearly not happy users, and we wanted happy users, so time
and effort went into creating a solution: a new Create overload was devised
and [implemented][1], taking extreme care to not break our brave and insane
existing users who had to manually call CFRetain. Because the fix would break
existing users - the now extraneous CFRetain would mean that their apps would
leak memory. *A lot* of it! That's bad, so we decided to make sure that didn't
happen.

Of course, dear old Murhpy wanted a say, so the new Create overload didn't do
as intended. In fact, it had the same insane behavior the old Create overload
had! Ops.

But Murphy decided to have even more fun: the changes were so buggy, that they
in fact fixed the old Create overload! Which from now on wouldn't require the
horrendous manual CFRetain calls... and effectively introducing the leak the
fix was trying so hard to not introduce.

Oh dear Murphy.

Of course he had another trick up his sleeve: in our extreme efforts to help
our users, we added an Obsolete attribute that would tell people to use the
new Create overload.

Let that sink in for a moment: we had an Obsolete attribute on a function that
was (now) perfectly fine, telling users to use a function that was broken.

To get the correct behavior, users would now have to to remove their manual
CFRetain calls, and ignore the obsolete warning on the old (and correct)
Create overload which told users to use the new (and buggy) Create overload.

In other words: still insanity, just a slightly different flavor.

Murphy had a field day!

Time went by, and eventually a sane enough user [reported the insanity to
us][2]. Even better: the user actually provided a fix! Truly, we have some
amazing users.

Unfortunately, the user didn't have access to our code history, and thus was
obviously not able to see the whole picture, and the fix ended up being
incorrect.

Unrelated lesson learned: don't forget your history, otherwise you'll end up
repeating mistakes from the past.

So now came the problem: how to fix all the APIs? In a way that didn't make
our users' existing apps just suddenly start crashing or leaking?

There really was no way, so nothing really happened for quite a while.

Then, an opportunity presented itself: we'd be able to do [widespread breaking
changes][3].

So, hoping that Murphy stays away this sunny winter day, I'm changing both the
new and the old Create overloads to do the right thing. But only in .NET,
where we can do breaking changes! Or at least that's my intention. I've tried
to stave off our dear old friend by adding his arch enemy: unit tests. Which,
of course, Murphy couldn't stay away from, but it seems adding a few
Thread.Sleep calls makes him bored enough to stay away. Hopefully for good...

[1]: https://github.com/xamarin/maccore/commit/66c50b9a176c6edfa8e633bfd9b54831ebddc9e5
[2]: https://github.com/xamarin/xamarin-macios/pull/2070
[3]: https://github.com/xamarin/xamarin-macios/issues/13087