### PR TITLE
[AVFoundation] Address all the XAMCORE_4_0 notes in AVFoundation for .NET.

### DIFF
--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -1,5 +1,7 @@
 // Copyright 2014-2016 Xamarin Inc. All rights reserved.
 
+#if !NET
+
 using System;
 using System.ComponentModel;
 using OpenTK;
@@ -13,7 +15,6 @@ using NativeHandle = System.IntPtr;
 #endif
 
 namespace AVFoundation {
-#if !XAMCORE_4_0
 	public delegate int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioToolbox.AudioBuffers outputData);
 
 	partial class AVAudioNode {
@@ -33,9 +34,8 @@ namespace AVFoundation {
 			throw new InvalidOperationException ("Do not use this constructor. Use the 'AVAudioSourceNode (AVAudioFormat, AVAudioSourceNodeRenderHandler2)' constructor instead.");
 		}
 	}
-#endif // !XAMCORE_4_0
 #if !WATCH
-#if MONOMAC && !XAMCORE_4_0
+#if MONOMAC
 	[Obsolete ("This API is not available on this platform.")]
 	public partial class AVCaptureDataOutputSynchronizer : NSObject
 	{
@@ -113,7 +113,7 @@ namespace AVFoundation {
 
 		public abstract void DidOutputSynchronizedDataCollection (AVCaptureDataOutputSynchronizer synchronizer, AVCaptureSynchronizedDataCollection synchronizedDataCollection);
 	}
-#endif // MONOMAC && !XAMCORE_4_0
+#endif // MONOMAC
 
 #if !XAMCORE_3_0
 	partial class AVAsset {
@@ -161,7 +161,6 @@ namespace AVFoundation {
 	}
 #endif
 
-#if !XAMCORE_4_0
 	partial class AVCaptureInputPort {
 
 		[Obsolete ("Valid instance of this type cannot be directly created.")]
@@ -218,13 +217,8 @@ namespace AVFoundation {
 
 #if TVOS
 	// tvOS removed some types - we need to keep stubs of them for binary compatibility
-#if !NET
 	[Obsolete ("Removed in tvOS 10.")]
 	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None)]
-#else
-	[UnsupportedOSPlatform ("tvos10.0")]
-	[Obsolete ("Removed in tvOS 10.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 	public class AVAssetDownloadDelegate : NSObject, IAVAssetDownloadDelegate {
 		public AVAssetDownloadDelegate ()
 		{
@@ -290,23 +284,13 @@ namespace AVFoundation {
 		}
 	}
 
-#if !NET
 	[Obsolete ("Removed in tvOS 10.")]
 	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None)]
-#else
-	[UnsupportedOSPlatform ("tvos10.0")]
-	[Obsolete ("Removed in tvOS 10.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 	public interface IAVAssetDownloadDelegate : INativeObject, IDisposable, INSUrlSessionTaskDelegate, INSUrlSessionDelegate {
 	}
 
-#if !NET
 	[Obsolete ("Removed in tvOS 10.")]
 	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None)]
-#else
-	[UnsupportedOSPlatform ("tvos10.0")]
-	[Obsolete ("Removed in tvOS 10.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 	public static class AVAssetDownloadDelegate_Extensions {
 
 		public static void DidFinishDownloadingToUrl (this IAVAssetDownloadDelegate This, NSUrlSession session, AVAssetDownloadTask assetDownloadTask, NSUrl location)
@@ -325,13 +309,8 @@ namespace AVFoundation {
 		}
 	}
 
-#if !NET
 	[Obsolete ("Removed in tvOS 10.")]
 	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None)]
-#else
-	[UnsupportedOSPlatform ("tvos10.0")]
-	[Obsolete ("Removed in tvOS 10.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 	public class AVAssetDownloadTask : NSUrlSessionTask {
 
 		public override NativeHandle ClassHandle {
@@ -395,13 +374,8 @@ namespace AVFoundation {
 		}
 	}
 
-#if !NET
 	[Obsolete ("Removed in tvOS 10.")]
 	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None)]
-#else
-	[UnsupportedOSPlatform ("tvos10.0")]
-	[Obsolete ("Removed in tvOS 10.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 	public class AVAssetDownloadUrlSession : NSUrlSession {
 
 		public new static NSUrlSession SharedSession {
@@ -546,10 +520,9 @@ namespace AVFoundation {
 	}
 
 #endif // TVOS
-#endif // !XAMCORE_4_0
 #endif // !WATCH
 
-#if !XAMCORE_4_0 && IOS // includes __MACCATALYST__
+#if IOS // includes __MACCATALYST__
 	public partial class AVCaptureManualExposureBracketedStillImageSettings {
 		[Obsolete ("Use the static 'Create' method to create a working instance of this type.")]
 		public AVCaptureManualExposureBracketedStillImageSettings () : base (NSObjectFlag.Empty)
@@ -567,7 +540,6 @@ namespace AVFoundation {
 	}
 #endif
 
-#if !XAMCORE_4_0
 	// "compatibility shim" in xcode 12.5 were removed in xcode 13
 	public partial class AVPlayerInterstitialEventController {
 
@@ -593,20 +565,12 @@ namespace AVFoundation {
 	}
 
 	#nullable enable
-#if !NET
 	[Obsolete ("Removed in Xcode 13.")]
 	[Deprecated (PlatformName.TvOS, 15,0, PlatformArchitecture.All)]
 	[Deprecated (PlatformName.MacOSX, 12,0, PlatformArchitecture.All)]
 	[Deprecated (PlatformName.iOS, 15,0, PlatformArchitecture.All)]
 	[Deprecated (PlatformName.MacCatalyst, 15,0, PlatformArchitecture.All)]
 	[Deprecated (PlatformName.WatchOS, 8,0, PlatformArchitecture.All)]
-#else
-		[UnsupportedOSPlatform ("ios15.0")]
-		[UnsupportedOSPlatform ("tvos15.0")]
-		[UnsupportedOSPlatform ("maccatalyst15.0")]
-		[UnsupportedOSPlatform ("macos12.0")]
-		[Obsolete ("Removed in Xcode 13.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 	public partial class AVPlayerInterstitialEventObserver : NSObject {
 		
 		public virtual AVPlayerInterstitialEvent[] InterstitialEvents => throw new NotImplementedException ();
@@ -651,5 +615,6 @@ namespace AVFoundation {
 		}
 	} /* class AVPlayerInterstitialEventObserver */
 	#nullable disable
-#endif
 }
+
+#endif // !NET

--- a/src/AVFoundation/AVMetadataItemFilter.cs
+++ b/src/AVFoundation/AVMetadataItemFilter.cs
@@ -23,7 +23,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !XAMCORE_4_0 && WATCH // This empty partial class was accidentally included in our watchOS bindings.
+#if !NET && WATCH // This empty partial class was accidentally included in our watchOS bindings.
 namespace AVFoundation {
 	public partial class AVMetadataItemFilter {
 	}

--- a/src/AVFoundation/AVPlayerLooper.cs
+++ b/src/AVFoundation/AVPlayerLooper.cs
@@ -30,7 +30,7 @@ namespace AVFoundation {
 
 	public partial class AVPlayerLooper {
 
-#if !XAMCORE_4_0 // This API got introduced in Xcode 8.0 binding but is not currently present nor in Xcode 8.3 or Xcode 9.0 needs research
+#if !NET // This API got introduced in Xcode 8.0 binding but is not currently present nor in Xcode 8.3 or Xcode 9.0 needs research
 
 		bool loopingEnabled = true;
 

--- a/src/AVFoundation/AVPlayerViewController.cs
+++ b/src/AVFoundation/AVPlayerViewController.cs
@@ -5,27 +5,21 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Foundation;
 using ObjCRuntime;
-#if HAS_IAD && !XAMCORE_4_0
+#if HAS_IAD && !NET
 using iAd;
 #endif
 
 #nullable enable
 
 namespace AVKit {
-#if HAS_IAD && !XAMCORE_4_0
+#if HAS_IAD && !NET
 	public partial class AVPlayerViewController {
 
 		// This is a [Category] -> C# extension method (see adlib.cs) but it targets on static selector
 		// the resulting syntax does not look good in user code so we provide a better looking API
 		// https://trello.com/c/iQpXOxCd/227-category-and-static-methods-selectors
 		// note: we cannot reuse the same method name - as it would break compilation of existing apps
-#if !NET
 		[Obsoleted (PlatformName.iOS, 15,0, PlatformArchitecture.None, Constants.iAdRemoved)]
-#else
-#if IOS
-		[Obsolete ("Starting with ios15.0 the iAd framework has been removed from iOS.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-#endif
 		static public void PrepareForPrerollAds ()
 		{
 		}

--- a/src/AVFoundation/AVTypes.cs
+++ b/src/AVFoundation/AVTypes.cs
@@ -256,7 +256,7 @@ namespace AVFoundation {
 	}
 #endif
 
-#if MONOMAC || !XAMCORE_4_0
+#if MONOMAC || !NET
 
 #if !NET
 	[Mac (10, 10), NoiOS, NoWatch, NoTV]

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -638,9 +638,7 @@ namespace AVFoundation {
 		Auto = -1
 	}
 
-#if XAMCORE_4_0
-	[NoMac]
-#endif
+	[Mac (10,15)]
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoTV, NoWatch, iOS (8,0)]
 	[Native]

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -964,9 +964,7 @@ namespace AVFoundation {
 		Unavailable = 4
 	}
 
-#if XAMCORE_4_0
-	[NoMac]
-#endif
+	[Mac (10, 15)]
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch, NoTV, iOS (11,0)]
 	[Native]

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -426,7 +426,7 @@ namespace AVFoundation {
 		CannotStartRecording = 0x21726563, // '!rec'
 		BadParam = -50,
 		InsufficientPriority = 0x21707269, // '!pri'
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'ResourceNotAvailable' instead.")]
 		CodeResourceNotAvailable = 0x21726573,
 #endif

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -145,7 +145,7 @@ namespace AVFoundation {
 		Locked, AutoWhiteBalance, ContinuousAutoWhiteBalance
 	}
 
-#if !MONOMAC || !XAMCORE_4_0
+#if !NET
 	[Flags]
 	[Native]
 	[Deprecated (PlatformName.iOS, 6, 0)]

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -258,7 +258,7 @@ namespace AVFoundation {
 		Unknown, ReadyToPlay, Failed
 	}
 
-#if !MONOMAC || !XAMCORE_4_0
+#if !NET
 	[NoTV]
 	[Flags]
 	[Native]

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -350,12 +350,7 @@ namespace AVFoundation {
 	public enum AVAudioSessionPortOverride : ulong {
 		None = 0,
 		[NoTV]
-#if XAMCORE_4_0 // Removed in Xcode 12 GM
-		[NoMac, NoWatch]
-#else
-		[Obsoleted (PlatformName.WatchOS, 2,0, message : "Unavailable and will be removed in the future.")]
-		[Obsoleted (PlatformName.MacOSX, 10,7, message : "Unavailable and will be removed in the future.")]
-#endif
+		[NoMac, NoWatch] // Removed in Xcode 12 GM
 		Speaker = 0x73706b72 // 'spkr'
 	}
 
@@ -380,42 +375,20 @@ namespace AVFoundation {
 	public enum AVAudioSessionCategoryOptions : ulong {
 		MixWithOthers = 1,
 		DuckOthers = 2,
-#if XAMCORE_4_0 // Removed in Xcode 12 GM
-		[NoMac, NoWatch]
-#else
-		[Obsoleted (PlatformName.WatchOS, 2,0, message : "Unavailable and will be removed in the future.")]
-		[Obsoleted (PlatformName.MacOSX, 10,7, message : "Unavailable and will be removed in the future.")]
-#endif
+		[NoMac, NoWatch] // Removed in Xcode 12 GM
 		[NoTV]
 		AllowBluetooth = 4,
-#if XAMCORE_4_0 // Removed in Xcode 12 GM
-		[NoMac, NoWatch]
-#else
-		[Obsoleted (PlatformName.WatchOS, 2,0, message : "Unavailable and will be removed in the future.")]
-		[Obsoleted (PlatformName.MacOSX, 10,7, message : "Unavailable and will be removed in the future.")]
-#endif
+		[NoMac, NoWatch] // Removed in Xcode 12 GM
 		[NoTV]
 		DefaultToSpeaker = 8,
 
-#if XAMCORE_4_0 // Removed in Xcode 12 GM
-		[NoMac]
-#else
-		[Obsoleted (PlatformName.MacOSX, 10,7, message : "Unavailable and will be removed in the future.")]
-#endif
+		[NoMac] // Removed in Xcode 12 GM
 		[iOS (9,0)]
 		InterruptSpokenAudioAndMixWithOthers = 17,
-#if XAMCORE_4_0 // Removed in Xcode 12 GM
-		[NoMac]
-#else
-		[Obsoleted (PlatformName.MacOSX, 10,7, message : "Unavailable and will be removed in the future.")]
-#endif
+		[NoMac] // Removed in Xcode 12 GM
 		[Watch (3,0), iOS (10,0), TV (10,0)]
 		AllowBluetoothA2DP = 32,
-#if XAMCORE_4_0 // Removed in Xcode 12 GM
-		[NoMac]
-#else
-		[Obsoleted (PlatformName.MacOSX, 10,7, message : "Unavailable and will be removed in the future.")]
-#endif
+		[NoMac] // Removed in Xcode 12 GM
 		[NoWatch, iOS (10,0), TV (10,0)]
 		AllowAirPlay = 64,
 		[NoMac]

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -305,7 +305,10 @@ namespace AVFoundation {
 		Succeeded, Failed, Cancelled
 	}
 
-#if !XAMCORE_3_0 || MONOMAC
+#if XAMCORE_3_0
+	[NoiOS]
+	[NoWatch]
+#endif
 	[Unavailable (PlatformName.MacCatalyst)]
 	[NoTV]
 	[Native]
@@ -314,6 +317,9 @@ namespace AVFoundation {
 		NotPlaying, Playing
 	}
 
+#if XAMCORE_3_0
+	[NoiOS]
+#endif
 	[Unavailable (PlatformName.MacCatalyst)]
 	[NoTV, NoWatch]
 	[Native]
@@ -321,7 +327,6 @@ namespace AVFoundation {
 	public enum AVVideoFieldMode : long {
 		Both, TopOnly, BottomOnly, Deinterlace
 	}
-#endif // !XAMCORE_3_0 || MONOMAC 
 
 	[Mac (10,15)]
 	[iOS (8,0)]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -9490,17 +9490,12 @@ namespace AVFoundation {
 		[Export ("alwaysDiscardsLateVideoFrames")]
 		bool AlwaysDiscardsLateVideoFrames { get; set;  }
 
-#if !XAMARIN_4_0
-		[Obsolete ("Use overload accepting a 'IAVCaptureVideoDataOutputSampleBufferDelegate'.")]
 		[Export ("setSampleBufferDelegate:queue:")]
-		[PostGet ("SampleBufferDelegate")]
-		[PostGet ("SampleBufferCallbackQueue")]
-		void SetSampleBufferDelegate ([NullAllowed] AVCaptureVideoDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackQueue);
-
-		[Sealed]
-#endif
-		[Export ("setSampleBufferDelegate:queue:")]
+#if !NET
+		void SetSampleBufferDelegate ([NullAllowed] IAVCaptureVideoDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackQueue);
+#else
 		void SetSampleBufferDelegateQueue ([NullAllowed] IAVCaptureVideoDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackQueue);
+#endif
 
 		// 5.0 APIs
 #if NET
@@ -9572,14 +9567,15 @@ namespace AVFoundation {
 		[NullAllowed, Export ("sampleBufferCallbackQueue")]
 		DispatchQueue SampleBufferCallbackQueue { get;  }
 
-#if XAMCORE_4_0
 		[Export ("setSampleBufferDelegate:queue:")]
+#if NET
 		void SetSampleBufferDelegate ([NullAllowed] IAVCaptureAudioDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackDispatchQueue);
 #else
-		[Export ("setSampleBufferDelegate:queue:")]
 		[Sealed]
 		void SetSampleBufferDelegateQueue ([NullAllowed] IAVCaptureAudioDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackDispatchQueue);
+#endif
 
+#if !NET
 		[Obsolete ("Use overload accepting a 'IAVCaptureVideoDataOutputSampleBufferDelegate'.")]
 		[Export ("setSampleBufferDelegate:queue:")]
 		void SetSampleBufferDelegateQueue ([NullAllowed] AVCaptureAudioDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackDispatchQueue);

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -13138,8 +13138,8 @@ namespace AVFoundation {
 	interface AVAsynchronousKeyValueLoading {
 		[Abstract]
 		[Export ("statusOfValueForKey:error:")]
-#if XAMCORE_4_0
-		AVKeyValueStatus StatusOfValueForKeyerror (string key, out NSError error);
+#if NET
+		AVKeyValueStatus GetStatusOfValue (string forKey, out NSError error);
 #else
 		AVKeyValueStatus StatusOfValueForKeyerror (string key, [NullAllowed] IntPtr outError);
 #endif

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -10185,7 +10185,7 @@ namespace AVFoundation {
 		bool IsStillImageStabilizationScene { get; }
 
 		[NoMac]
-#if XAMCORE_4_0
+#if NET
 		[BindAs (typeof (AVCaptureFlashMode []))]
 #endif		
 		[Export ("supportedFlashModes")]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1929,10 +1929,12 @@ namespace AVFoundation {
 		[Export ("setActive:error:")]
 		bool SetActive (bool beActive, out NSError outError);
 
+#if !NET
 		[NoTV, NoMac]
 		[Export ("setActive:withFlags:error:")]
 		[Deprecated (PlatformName.iOS, 6, 0, message: "Use 'SetActive (bool, AVAudioSessionSetActiveOptions, out NSError)' instead.")]
 		bool SetActive (bool beActive, AVAudioSessionFlags flags, out NSError outError);
+#endif // !NET
 
 		[NoMac]
 		[Export ("setCategory:error:")]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -12949,9 +12949,6 @@ namespace AVFoundation {
 		[DesignatedInitializer]
 		NativeHandle Constructor (AVQueuePlayer player, AVPlayerItem itemToLoop, CMTimeRange loopRange);
 
-#if !XAMCORE_4_0 // This API got introduced in Xcode 8.0 binding but is not currently present nor in Xcode 8.3 or Xcode 9.0 needs research
-		[PostSnippet ("loopingEnabled = false;", Optimizable = true)]
-#endif
 		[Export ("disableLooping")]
 		void DisableLooping ();
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1679,7 +1679,11 @@ namespace AVFoundation {
 
 		[Deprecated (PlatformName.iOS, 8, 0)]
 		[Export ("audioPlayerEndInterruption:withOptions:")]
+#if NET
+		void EndInterruption (AVAudioPlayer player, AVAudioSessionInterruptionOptions flags);
+#else
 		void EndInterruption (AVAudioPlayer player, AVAudioSessionInterruptionFlags flags);
+#endif
 #endif
 	}
 
@@ -1863,12 +1867,13 @@ namespace AVFoundation {
 
 		// Deprecated in iOS 6.0 but we have same C# signature as a method that was deprecated in iOS 8.0
 		[Deprecated (PlatformName.iOS, 8, 0)]
+#if !NET
 		[Export ("audioRecorderEndInterruption:withFlags:")]
 		void EndInterruption (AVAudioRecorder recorder, AVAudioSessionInterruptionFlags flags);
-
-		//[Deprecated (PlatformName.iOS, 8, 0)]
-		//[Export ("audioRecorderEndInterruption:withOptions:")]
-		//void EndInterruption (AVAudioRecorder recorder, AVAudioSessionInterruptionFlags flags);
+#else
+		[Export ("audioRecorderEndInterruption:withOptions:")]
+		void EndInterruption (AVAudioRecorder recorder, AVAudioSessionInterruptionOptions flags);
+#endif // !NET
 #endif
 	}
 
@@ -2531,7 +2536,11 @@ namespace AVFoundation {
 		void InputIsAvailableChanged (bool isInputAvailable);
 	
 		[Export ("endInterruptionWithFlags:")]
+#if NET
+		void EndInterruption (AVAudioSessionInterruptionOptions flags);
+#else
 		void EndInterruption (AVAudioSessionInterruptionFlags flags);
+#endif
 	}
 
 	[NoMac]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -9503,7 +9503,7 @@ namespace AVFoundation {
 		void SetSampleBufferDelegateQueue ([NullAllowed] IAVCaptureVideoDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackQueue);
 
 		// 5.0 APIs
-#if XAMCORE_4_0
+#if NET
 		[BindAs (typeof (CoreVideo.CVPixelFormatType []))]
 #endif
 		[Export ("availableVideoCVPixelFormatTypes")]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -9490,10 +9490,19 @@ namespace AVFoundation {
 		[Export ("alwaysDiscardsLateVideoFrames")]
 		bool AlwaysDiscardsLateVideoFrames { get; set;  }
 
-		[Export ("setSampleBufferDelegate:queue:")]
 #if !NET
+		[Obsolete ("Use overload accepting a 'IAVCaptureVideoDataOutputSampleBufferDelegate'.")]
+		[Export ("setSampleBufferDelegate:queue:")]
+		[PostGet ("SampleBufferDelegate")]
+		[PostGet ("SampleBufferCallbackQueue")]
+		void SetSampleBufferDelegate ([NullAllowed] AVCaptureVideoDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackQueue);
+#endif
+
+		[Export ("setSampleBufferDelegate:queue:")]
+#if NET
 		void SetSampleBufferDelegate ([NullAllowed] IAVCaptureVideoDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackQueue);
 #else
+		[Sealed]
 		void SetSampleBufferDelegateQueue ([NullAllowed] IAVCaptureVideoDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackQueue);
 #endif
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -58,6 +58,9 @@ using AppKit;
 using UIImage = AppKit.NSImage;
 #else
 using UIKit;
+using AVSampleCursorChunkInfo = Foundation.NSObject;
+using AVSampleCursorStorageRange = Foundation.NSObject;
+using AVSampleCursorSyncInfo = Foundation.NSObject;
 #endif
 
 #if !NET

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -7734,7 +7734,7 @@ namespace AVFoundation {
 	[DisableDefaultCtor]
 	interface AVFragmentedMovieTrack
 	{
-#if !XAMCORE_4_0
+#if !NET
 		[NoiOS, NoWatch]
 		[Field ("AVFragmentedMovieTrackTimeRangeDidChangeNotification")]
 		NSString ATimeRangeDidChangeNotification { get; }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -14760,7 +14760,7 @@ namespace AVFoundation {
 		[Export ("replacementFormatDescription")]
 		CMFormatDescription ReplacementFormatDescription { get; }
 	}
-#if XAMCORE_4_0
+#if NET
 	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
 #else
 	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1357,7 +1357,7 @@ namespace AVFoundation {
 	{
 
 		[iOS (9,0), Mac (10,11)]
-#if XAMCORE_4_0
+#if NET
 		// Apple added a new required member in iOS 9, but that breaks our binary compat, so we can't do that in our existing code.
 		[Abstract]
 #endif
@@ -3255,7 +3255,7 @@ namespace AVFoundation {
 	[iOS (12, 0), TV (12,0), Watch (6,0)]
 	interface AVFragmentMinding {
 
-#if !MONOMAC || XAMCORE_4_0
+#if !MONOMAC || NET
 		[Abstract] // not kept in Mac OS because is a breaking change, in other paltforms we are ok
 #endif
 		[Export ("isAssociatedWithFragmentMinder")]
@@ -4013,7 +4013,7 @@ namespace AVFoundation {
 	[Model]
 	[Protocol]
 	interface AVAssetResourceLoaderDelegate {
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[NoWatch]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -6992,7 +6992,7 @@ namespace AVFoundation {
 		[Export ("time")]
 		CMTime Time{ get;}
 
-#if !XAMCORE_4_0
+#if !NET
 		[Field ("AVMetadataObjectTypeFace")]
 		NSString TypeFace { get; }
 
@@ -7066,9 +7066,8 @@ namespace AVFoundation {
 #endif
 	}
 
-#if XAMCORE_4_0
+#if NET
 	[NoWatch]
-	[NoTV]
 #endif
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[Mac (10,10)]
@@ -12038,7 +12037,7 @@ namespace AVFoundation {
 		bool CanPlayFastForward { get; }
 
 		[Field ("AVPlayerItemTimeJumpedNotification")]
-#if !XAMCORE_4_0 
+#if !NET
 		[Notification]
 #else
 		[Notification (typeof (AVPlayerItemTimeJumpedEventArgs))]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -3363,8 +3363,9 @@ namespace AVFoundation {
 
 #endif // MONOMAC
 
-#if XAMCORE_4_0
-	[Abstract] // Abstract superclass.
+#if NET
+	// Making a class abstract has problems: https://github.com/xamarin/xamarin-macios/issues/4969, so we're not doing this yet
+	// [Abstract] // Abstract superclass.
 #endif
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch, NoTV, iOS (11,0)]
@@ -9317,8 +9318,9 @@ namespace AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-#if XAMCORE_4_0
-	[Abstract] // as per docs
+#if NET
+	// Making a class abstract has problems (see https://github.com/xamarin/xamarin-macios/issues/4969), so not doing this (yet).
+	// [Abstract] // as per docs
 #endif
 	// Objective-C exception thrown.  Name: NSGenericException Reason: Cannot instantiate AVCaptureOutput because it is an abstract superclass.
 	[DisableDefaultCtor]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1121,7 +1121,7 @@ namespace AVFoundation {
 		AVAudioEnvironmentReverbParameters ReverbParameters { get; }
 
 		[Export ("applicableRenderingAlgorithms")]
-#if XAMCORE_4_0
+#if NET
 		NSNumber [] ApplicableRenderingAlgorithms { get; }
 #else
 		NSObject [] ApplicableRenderingAlgorithms ();

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -11282,8 +11282,8 @@ namespace AVFoundation {
 
 		[iOS (10,0), Mac (10,15)]
 		[Export ("supportedColorSpaces")]
-#if XAMCORE_4_0
-		[BindAs (typeof (CGColorSpace []))]
+#if NET
+		[BindAs (typeof (AVCaptureColorSpace []))]
 #endif
 		NSNumber[] SupportedColorSpaces { get; }
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1317,7 +1317,7 @@ namespace AVFoundation {
 		[Export ("position")]
 		Vector3 Position { get; set; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 		[TV (13,0), NoWatch, Mac (10,15), iOS (13,0)]
 		[Export ("sourceMode", ArgumentSemantic.Assign)]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -383,7 +383,7 @@ namespace AVFoundation {
 
 	}
 
-#if !XAMCORE_4_0
+#if !NET
 	[NoWatch]
 	[Obsolete ("Use AVMediaCharacteristics enum values")]
 	[BaseType (typeof (NSObject))][Static]
@@ -564,7 +564,7 @@ namespace AVFoundation {
 		Scc = 22,
 	}
 
-#if !XAMCORE_4_0
+#if !NET
 	[NoWatch]
 	[BaseType (typeof (NSObject))][Static]
 	[Obsolete ("Use AVFileTypes enum values")]
@@ -3064,7 +3064,7 @@ namespace AVFoundation {
 		[Export ("availableMetadataFormats")]
 		string [] AvailableMetadataFormats { get;  }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'GetMetadataForFormat' with enum values AVMetadataFormat.")]
 		[Wrap ("GetMetadataForFormat (new NSString (format))", IsVirtual = true)]
 		AVMetadataItem [] MetadataForFormat (string format);
@@ -3383,7 +3383,7 @@ namespace AVFoundation {
 	[DisableDefaultCtor]
 	interface AVCaptureSynchronizedDataCollection : INSFastEnumeration
 	{
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'GetSynchronizedData' instead.")]
 		[Wrap ("GetSynchronizedData (captureOutput)", isVirtual: true)]
 		[return: NullAllowed]
@@ -5101,7 +5101,7 @@ namespace AVFoundation {
 		[Field ("AVMetadataCommonKeyAccessibilityDescription")]
 		NSString CommonKeyAccessibilityDescription { get; }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Field ("AVMetadataFormatQuickTimeUserData")]
 		[Obsolete ("Use 'AVMetadataFormat' enum values")]
 		NSString FormatQuickTimeUserData { get; }
@@ -5283,7 +5283,7 @@ namespace AVFoundation {
 		[Field ("AVMetadata3GPUserDataKeyMediaRating")]
 		NSString K3GPUserDataKeyMediaRating { get; }
 
-#if !XAMCORE_4_0
+#if !NET
 		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadataFormatISOUserData")]
 		[Obsolete ("Use 'AVMetadataFormat' enum values")]
@@ -5432,7 +5432,7 @@ namespace AVFoundation {
 		[Field ("AVMetadataQuickTimeMetadataKeyIsMontage")]
 		NSString QuickTimeMetadataKeyIsMontage { get; }
 		
-#if !XAMCORE_4_0
+#if !NET
 		[Field ("AVMetadataFormatiTunesMetadata")]
 		[Obsolete ("Use 'AVMetadataFormat' enum values")]
 		NSString FormatiTunesMetadata { get; }
@@ -5586,7 +5586,7 @@ namespace AVFoundation {
 		[Field ("AVMetadataiTunesMetadataKeyExecProducer")]
 		NSString iTunesMetadataKeyExecProducer { get; }
 		
-#if !XAMCORE_4_0
+#if !NET
 		[Field ("AVMetadataFormatID3Metadata")]
 		[Obsolete ("Use 'AVMetadataFormat' enum values")]
 		NSString FormatID3Metadata { get; }
@@ -5906,7 +5906,7 @@ namespace AVFoundation {
 		[Field ("AVMetadataIcyMetadataKeyStreamURL")]
 		NSString IcyMetadataKeyStreamUrl { get; }
 		
-#if !XAMCORE_4_0
+#if !NET
 		[iOS (8,0)][Mac (10,10)]
 		[Field ("AVMetadataFormatHLSMetadata")]
 		[Obsolete ("Use 'AVMetadataFormat' enum values")]
@@ -9907,7 +9907,7 @@ namespace AVFoundation {
 		[Export ("availableEmbeddedThumbnailPhotoCodecTypes")]
 		NSString[] _GetAvailableEmbeddedThumbnailPhotoCodecTypes { get; }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'AvailableEmbeddedThumbnailPhotoCodecTypes' instead.")]
 		[iOS (11, 0)]
 		[Wrap ("Array.ConvertAll (_GetAvailableEmbeddedThumbnailPhotoCodecTypes, s => AVVideoCodecTypeExtensions.GetValue (s))", IsVirtual = false)]
@@ -10615,7 +10615,7 @@ namespace AVFoundation {
 		[return: NullAllowed]
 		AVCaptureDevice GetDefaultDevice (AVMediaTypes mediaType);
 
-#if !XAMCORE_4_0
+#if !NET
 		[NoWatch]
 		[Obsolete ("Use 'GetDefaultDevice (AVMediaTypes)'.")]
 		[Static]
@@ -13284,7 +13284,7 @@ namespace AVFoundation {
 		[Export ("enqueueSampleBuffer:")]
 		void Enqueue (CMSampleBuffer sampleBuffer);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Wrap ("Enqueue (sampleBuffer)", IsVirtual = true)]
 		[Obsolete ("Use the 'Enqueue' method instead.")]
 		void EnqueueSampleBuffer (CMSampleBuffer sampleBuffer);
@@ -13299,7 +13299,7 @@ namespace AVFoundation {
 		[Export ("requestMediaDataWhenReadyOnQueue:usingBlock:")]
 		void RequestMediaData (DispatchQueue queue, Action handler);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Wrap ("RequestMediaData (queue, enqueuer)", IsVirtual = true)]
 		[Obsolete ("Use the 'RequestMediaData' method instead.")]
 		void RequestMediaDataWhenReadyOnQueue (DispatchQueue queue, Action enqueuer);
@@ -14769,7 +14769,7 @@ namespace AVFoundation {
 	interface AVAudioSourceNode : AVAudioMixing {
 		[Export ("initWithRenderBlock:")]
 		[DesignatedInitializer]
-#if XAMCORE_4_0
+#if NET
 		NativeHandle Constructor (AVAudioSourceNodeRenderHandler renderHandler);
 #else
 		NativeHandle Constructor (AVAudioSourceNodeRenderHandler2 renderHandler);
@@ -14777,7 +14777,7 @@ namespace AVFoundation {
 
 		[Export ("initWithFormat:renderBlock:")]
 		[DesignatedInitializer]
-#if XAMCORE_4_0
+#if NET
 		NativeHandle Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler);
 #else
 		NativeHandle Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 renderHandler);

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -8121,7 +8121,7 @@ namespace AVFoundation {
 		string PresetName { get;  }
 
 		[Export ("supportedFileTypes")]
-#if XAMCORE_4_0
+#if NET
 		string [] SupportedFileTypes { get;  }
 #else
 		NSObject [] SupportedFileTypes { get;  }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -2589,7 +2589,7 @@ namespace AVFoundation {
 
 		[iOS (7,0)]
 		[Export ("dataSources"), NullAllowed]
-#if XAMCORE_4_0
+#if NET
 		AVAudioSessionDataSourceDescription [] DataSources { get; }
 #else
 		AVAudioSessionDataSourceDescription [] DataSourceDescriptions { get; }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -381,6 +381,10 @@ namespace AVFoundation {
 		[Field ("AVMediaCharacteristicContainsHDRVideo")]
 		ContainsHdrVideo = 16,
 
+		[TV (13,0), NoWatch, Mac (10,15), iOS (13,0)]
+		[Field ("AVMediaCharacteristicContainsAlphaChannel")]
+		ContainsAlphaChannel = 17,
+
 	}
 
 #if !NET
@@ -445,6 +449,8 @@ namespace AVFoundation {
 		[TV (13,0), NoWatch, Mac (10,15), iOS (13,0)]
 		[Field ("AVMediaCharacteristicContainsAlphaChannel")]
 		NSString ContainsAlphaChannel { get; }
+
+		// Do not add more fields here, add them to the AVMediaCharacteristics enum instead.
 	}
 #endif
 

--- a/tests/monotouch-test/AVFoundation/AVPlayerLooperTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVPlayerLooperTest.cs
@@ -9,7 +9,7 @@ namespace monotouchtest.AVFoundation
 	[Preserve (AllMembers = true)]
 	public class AVPlayerLooperTest
 	{
-#if !XAMCORE_4_0
+#if !NET
 		public void TestLoopingEnabled ()
 		{
 			string file = Path.Combine (NSBundle.MainBundle.ResourcePath, "Hand.wav");

--- a/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
@@ -96,7 +96,7 @@ namespace MonoTouchFixtures.AVFoundation {
 			TestRuntime.RequestCameraPermission (AVMediaTypes.Video.GetConstant (), true);
 
 			using (var captureSession = new AVCaptureSession ()) {
-				using (var videoDevice = AVCaptureDevice.DefaultDeviceWithMediaType (AVMediaTypes.Video.GetConstant ())) {
+				using (var videoDevice = AVCaptureDevice.GetDefaultDevice (AVMediaTypes.Video.GetConstant ())) {
 
 					NSError error;
 					using (var videoInput = new AVCaptureDeviceInput (videoDevice, out error)) {

--- a/tests/monotouch-test/AVFoundation/MetadataObjectTest.cs
+++ b/tests/monotouch-test/AVFoundation/MetadataObjectTest.cs
@@ -35,7 +35,9 @@ namespace MonoTouchFixtures.AVFoundation {
 #if !MONOMAC // No Type property for Mac
 				Assert.AreEqual (AVMetadataObjectType.Face, obj.Type, "Type");
 #endif
+#if !NET
 				Assert.AreEqual (AVMetadataObject.TypeFace, obj.WeakType, "WeakType");
+#endif
 			}
 
 #if !MONOMAC // iOS only

--- a/tests/monotouch-test/AVFoundation/UtilitiesTest.cs
+++ b/tests/monotouch-test/AVFoundation/UtilitiesTest.cs
@@ -40,6 +40,7 @@ namespace MonoTouchFixtures.AVFoundation {
 		}
 	}
 
+#if __MACOS__ || !NET
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class AVStructTest {
@@ -56,6 +57,7 @@ namespace MonoTouchFixtures.AVFoundation {
 			Assert.That (Marshal.SizeOf (typeof (AVSampleCursorChunkInfo)), Is.EqualTo (IntPtr.Size == 8 ? 16 : 12), "AVSampleCursorChunkInfo Size");
 		}
 	}
+#endif // __MACOS__ || !NET
 }
 	
 #endif // !__WATCHOS__

--- a/tests/monotouch-test/CoreMedia/CMFormatDescriptionTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMFormatDescriptionTest.cs
@@ -63,7 +63,7 @@ namespace MonoTouchFixtures.CoreMedia {
 //				Assert.That (fde, Is.EqualTo (CMFormatDescriptionError.InvalidParameter), "CMFormatDescriptionError (authorized)");
 
 				using (var captureSession = new AVCaptureSession ()) {
-					using (var videoDevice = AVCaptureDevice.DefaultDeviceWithMediaType (AVMediaTypes.Video.GetConstant ())) {
+					using (var videoDevice = AVCaptureDevice.GetDefaultDevice (AVMediaTypes.Video.GetConstant ())) {
 						if (videoDevice == null)
 							Assert.Inconclusive ("Failed to create a video device for testing");
 						NSError error;
@@ -96,7 +96,7 @@ namespace MonoTouchFixtures.CoreMedia {
 			}
 
 			using (var captureSession = new AVCaptureSession ()) {
-				using (var videoDevice = AVCaptureDevice.DefaultDeviceWithMediaType (AVMediaTypes.Video.GetConstant ())) {
+				using (var videoDevice = AVCaptureDevice.GetDefaultDevice (AVMediaTypes.Video.GetConstant ())) {
 					if (videoDevice == null)
 						Assert.Inconclusive ("Failed to create a video device for testing");
 					foreach (var format in videoDevice.Formats) {

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AVFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AVFoundation.ignore
@@ -32,5 +32,5 @@
 ## deprecated in all Mac Catalyst versions we support, and there's a viable alternative to use instead.
 !missing-protocol-member! AVAudioRecorderDelegate::audioRecorderEndInterruption:withFlags: not found
 
-## this API is to have cute Objective-C syntax for something that's (according to the docs) identical to what another method do (which we've bound).
+## this API is to have cute Objective-C syntax for something that's (according to the docs) identical to what another method does (which we've bound).
 !missing-selector! AVCaptureSynchronizedDataCollection::objectForKeyedSubscript: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AVFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AVFoundation.ignore
@@ -28,3 +28,9 @@
 !missing-selector! AVSampleCursor::presentationTimeStamp not bound
 !missing-selector! AVSampleCursor::samplesWithEarlierDecodeTimeStampsMayHaveLaterPresentationTimeStampsThanCursor: not bound
 !missing-selector! AVSampleCursor::samplesWithLaterDecodeTimeStampsMayHaveEarlierPresentationTimeStampsThanCursor: not bound
+
+## deprecated in all Mac Catalyst versions we support, and there's a viable alternative to use instead.
+!missing-protocol-member! AVAudioRecorderDelegate::audioRecorderEndInterruption:withFlags: not found
+
+## this API is to have cute Objective-C syntax for something that's (according to the docs) identical to what another method do (which we've bound).
+!missing-selector! AVCaptureSynchronizedDataCollection::objectForKeyedSubscript: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-AVFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-AVFoundation.ignore
@@ -1,28 +1,14 @@
 ## there's a type of the same name (like NSObject, check what Swift did)
 !missing-protocol! AVVideoCompositionInstruction not bound
 
-## fixed in XAMCORE_3_0 - API break
-!incorrect-protocol-member! AVAssetResourceLoaderDelegate::resourceLoader:shouldWaitForLoadingOfRequestedResource: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! AVAudioMixing::destinationForMixer:bus: is REQUIRED and should be abstract
-
-## Used only once in a deprecated API, native use `NSInteger` not a real enum - that's why there's a `[Native]`
-!unknown-native-enum! AVAudioSessionFlags bound
-
-## native use `NSUInteger` not a real enum - that's why there's a `[Native]`
-!unknown-native-enum! AVAudioSessionInterruptionFlags bound
-
 ## it's already defined in the base class, it's fine even if it returns mutable tracks in this case 
 !missing-selector! AVMutableComposition::tracks not bound
 
 ## type and protocol are named identically (check the swift name, it's a similar situation to NSObject)
 !missing-protocol-conformance! AVVideoCompositionInstruction should conform to AVVideoCompositionInstruction
 
-## AVAudioPlayer INTERRUPTION NOTIFICATIONS ARE DEPRECATED - Use AVAudioSession instead. 
-
 ### deprecated in iOS8
 !missing-protocol-member! AVAudioPlayerDelegate::audioPlayerEndInterruption:withFlags: not found
-### deprecated in iOS8
-!missing-protocol-member! AVAudioRecorderDelegate::audioRecorderEndInterruption:withOptions: not found
 
 ## unsorted
 
@@ -42,12 +28,6 @@
 !missing-selector! NSCoder::encodeCMTime:forKey: not bound
 !missing-selector! NSCoder::encodeCMTimeMapping:forKey: not bound
 !missing-selector! NSCoder::encodeCMTimeRange:forKey: not bound
-
-# cannot be done because it will break the API, we have a #if define with the correct implementation
-!incorrect-protocol-member! AVAudio3DMixing::pointSourceInHeadMode is REQUIRED and should be abstract
-!incorrect-protocol-member! AVAudio3DMixing::setPointSourceInHeadMode: is REQUIRED and should be abstract
-!incorrect-protocol-member! AVAudio3DMixing::setSourceMode: is REQUIRED and should be abstract
-!incorrect-protocol-member! AVAudio3DMixing::sourceMode is REQUIRED and should be abstract
 
 !missing-release-attribute-on-return-value! CoreMedia.CMFormatDescription AVFoundation.AVTimedMetadataGroup::CopyFormatDescription()'s selector's ('copyFormatDescription') Objective-C method family ('copy') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 
@@ -78,6 +58,3 @@
 
 # adding abstract member to an existing type would be a breaking change
 !incorrect-protocol-member! AVQueuedSampleBufferRendering::hasSufficientMediaDataForReliablePlaybackStart is REQUIRED and should be abstract
-
-# added for XAMCORE_4_0 since it is part of a new breaking change in a notification
-!missing-field! AVPlayerItemTimeJumpedOriginatingParticipantKey not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-AVFoundation.ignore
@@ -7,5 +7,5 @@
 ## deprecated in all iOS versions we support, and there's a viable alternative to use instead.
 !missing-protocol-member! AVAudioRecorderDelegate::audioRecorderEndInterruption:withFlags: not found
 
-## this API is to have cute Objective-C syntax for something that's (according to the docs) identical to what another method do (which we've bound).
+## this API is to have cute Objective-C syntax for something that's (according to the docs) identical to what another method does (which we've bound).
 !missing-selector! AVCaptureSynchronizedDataCollection::objectForKeyedSubscript: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-AVFoundation.ignore
@@ -3,3 +3,9 @@
 
 ## https://github.com/xamarin/xamarin-macios/issues/3213 should be fixed before conformance to 'AVQueuedSampleBufferRendering' is restored.
 !missing-protocol-conformance! AVSampleBufferDisplayLayer should conform to AVQueuedSampleBufferRendering (defined in 'AVSampleBufferDisplayLayerQueueManagement' category)
+
+## deprecated in all iOS versions we support, and there's a viable alternative to use instead.
+!missing-protocol-member! AVAudioRecorderDelegate::audioRecorderEndInterruption:withFlags: not found
+
+## this API is to have cute Objective-C syntax for something that's (according to the docs) identical to what another method do (which we've bound).
+!missing-selector! AVCaptureSynchronizedDataCollection::objectForKeyedSubscript: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AVFoundation.ignore
@@ -1,9 +1,6 @@
 
 ## from iOS 4.0 to 5.1
 
-## Won't be used as a Delegate protocol so no need to mark this one as abstract
-!incorrect-protocol-member! AVFragmentMinding::isAssociatedWithFragmentMinder is REQUIRED and should be abstract
-
 ## iOS Only. Available on OSX but probably private selector mostly decorated with NS_AVAILABLE_IOS
 !missing-field! AVMediaCharacteristicEasyToRead not bound
 !missing-field! AVVideoDecompressionPropertiesKey not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AVFoundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AVFoundation.todo
@@ -1,7 +1,1 @@
 !extra-enum-value! Managed value 1 for AVAudioSessionRouteSharingPolicy.LongForm is available for the current platform while the value in the native header is not
-!missing-enum-value! AVAudioSessionCategoryOptions native value AVAudioSessionCategoryOptionAllowAirPlay = 64 not bound
-!missing-enum-value! AVAudioSessionCategoryOptions native value AVAudioSessionCategoryOptionAllowBluetooth = 4 not bound
-!missing-enum-value! AVAudioSessionCategoryOptions native value AVAudioSessionCategoryOptionAllowBluetoothA2DP = 32 not bound
-!missing-enum-value! AVAudioSessionCategoryOptions native value AVAudioSessionCategoryOptionDefaultToSpeaker = 8 not bound
-!missing-enum-value! AVAudioSessionCategoryOptions native value AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers = 17 not bound
-!missing-enum-value! AVAudioSessionPortOverride native value AVAudioSessionPortOverrideSpeaker = 1936747378 not bound

--- a/tests/xtro-sharpie/macOS-AVFoundation.todo
+++ b/tests/xtro-sharpie/macOS-AVFoundation.todo
@@ -1,7 +1,1 @@
 !extra-enum-value! Managed value 1 for AVAudioSessionRouteSharingPolicy.LongForm is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 17 for AVAudioSessionCategoryOptions.InterruptSpokenAudioAndMixWithOthers is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 1936747378 for AVAudioSessionPortOverride.Speaker is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 32 for AVAudioSessionCategoryOptions.AllowBluetoothA2DP is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 4 for AVAudioSessionCategoryOptions.AllowBluetooth is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 64 for AVAudioSessionCategoryOptions.AllowAirPlay is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 8 for AVAudioSessionCategoryOptions.DefaultToSpeaker is available for the current platform while the value in the native header is not

--- a/tests/xtro-sharpie/watchOS-AVFoundation.todo
+++ b/tests/xtro-sharpie/watchOS-AVFoundation.todo
@@ -1,3 +1,0 @@
-!extra-enum-value! Managed value 1936747378 for AVAudioSessionPortOverride.Speaker is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 4 for AVAudioSessionCategoryOptions.AllowBluetooth is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 8 for AVAudioSessionCategoryOptions.DefaultToSpeaker is available for the current platform while the value in the native header is not


### PR DESCRIPTION
This PR is probably best reviewed commit-by-commit, since it contains many small and discrete commits.