### PR TITLE
[xharness] Improve how we execute external processes in certain cases

### DIFF
--- a/tests/xharness/AppBundleLocator.cs
+++ b/tests/xharness/AppBundleLocator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.DotNet.XHarness.Common.Execution;
@@ -104,9 +105,24 @@ namespace Xharness {
 					proc.StartInfo.Arguments = StringUtils.FormatArguments (args);
 					proc.StartInfo.WorkingDirectory = dir;
 
-					var rv = await processManager.RunAsync (proc, getLog() ?? new ConsoleLog(), environmentVariables: env, timeout: TimeSpan.FromSeconds (120));
-					if (!rv.Succeeded)
-						throw new Exception ($"Unable to evaluate the property {evaluateProperty}, build failed with exit code {rv.ExitCode}. Timed out: {rv.TimedOut}");
+					// Don't evaluate in parallel on multiple threads to avoid overloading the mac.
+					var acquired = await evaluate_semaphore.WaitAsync (TimeSpan.FromMinutes (5));
+					try {
+						var log = getLog () ?? new ConsoleLog ();
+						var memoryLog = new MemoryLog ();
+						var aggregated = Log.CreateAggregatedLog (memoryLog, log);
+						if (!acquired)
+							aggregated.WriteLine ("Unable to acquire lock to evaluate MSBuild property in 5 minutes; will try to evaluate anyway.");
+						var rv = await processManager.RunAsync (proc, aggregated, environmentVariables: env, timeout: TimeSpan.FromMinutes (5));
+						if (!rv.Succeeded) {
+							var msg = $"Unable to evaluate the property {evaluateProperty} in {projectPath}, build failed with exit code {rv.ExitCode}. Timed out: {rv.TimedOut}";
+							Console.WriteLine (msg + " Output: \n" + memoryLog.ToString ());
+							throw new Exception (msg);
+						}
+					} finally {
+						if (acquired)
+							evaluate_semaphore.Release ();
+					}
 					
 					return File.ReadAllText (output).Trim ();
 				}
@@ -115,6 +131,8 @@ namespace Xharness {
 				File.Delete (output);
 			}
 		}
+
+		SemaphoreSlim evaluate_semaphore = new SemaphoreSlim (1);
 
 		public string GetDotNetExecutable (string directory)
 		{

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.DotNet.XHarness.Common.Execution;
@@ -81,6 +82,29 @@ namespace Xharness {
 			return CreateCopyAsync (log, processManager, test, rootDirectory, pr);
 		}
 
+		static SemaphoreSlim ls_files_semaphore = new SemaphoreSlim (1);
+
+		async Task<string[]> ListFilesAsync (ILog log, string test_dir, IProcessManager processManager)
+		{
+			var acquired = await ls_files_semaphore.WaitAsync (TimeSpan.FromMinutes (5));
+			try {
+				if (!acquired)
+					log.WriteLine ($"Unable to acquire lock to run 'git ls-files {test_dir}' in 5 minutes; will try to run anyway.");
+				using var process = new Process ();
+				process.StartInfo.FileName = "git";
+				process.StartInfo.Arguments = "ls-files";
+				process.StartInfo.WorkingDirectory = test_dir;
+				var stdout = new MemoryLog () { Timestamp = false };
+				var result = await processManager.RunAsync (process, stdout, stdout, stdout, timeout: TimeSpan.FromSeconds (60));
+				if (!result.Succeeded)
+					throw new Exception ($"Failed to list the files in the directory {test_dir} (TimedOut: {result.TimedOut} ExitCode: {result.ExitCode}):\n{stdout}");
+				return stdout.ToString ().Split ('\n');
+			} finally {
+				if (acquired)
+					ls_files_semaphore.Release ();
+			}
+		}
+
 		async Task CreateCopyAsync (ILog log, IProcessManager processManager, ITestTask test, string rootDirectory, Dictionary<string, TestProject> allProjectReferences)
 		{
 			var directory = Cache.CreateTemporaryDirectory (test.TestName ?? System.IO.Path.GetFileNameWithoutExtension (Path));
@@ -137,17 +161,7 @@ namespace Xharness {
 					// because the cloned project is stored in a very different directory.
 					var test_dir = System.IO.Path.GetDirectoryName (original_path);
 
-					// Get all the files in the project directory from git
-					using var process = new Process ();
-					process.StartInfo.FileName = "git";
-					process.StartInfo.Arguments = "ls-files";
-					process.StartInfo.WorkingDirectory = test_dir;
-					var stdout = new MemoryLog () { Timestamp = false };
-					var result = await processManager.RunAsync (process, stdout, stdout, stdout, timeout: TimeSpan.FromSeconds (60));
-					if (!result.Succeeded)
-						throw new Exception ($"Failed to list the files in the directory {test_dir} (TimedOut: {result.TimedOut} ExitCode: {result.ExitCode}):\n{stdout}");
-
-					var files = stdout.ToString ().Split ('\n');
+					var files = await ListFilesAsync (log, test_dir, processManager);
 					foreach (var file in files) {
 						var ext = System.IO.Path.GetExtension (file);
 						var full_path = System.IO.Path.Combine (test_dir, file);

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -143,7 +143,7 @@ namespace Xharness {
 					process.StartInfo.Arguments = "ls-files";
 					process.StartInfo.WorkingDirectory = test_dir;
 					var stdout = new MemoryLog () { Timestamp = false };
-					var result = await processManager.RunAsync (process, stdout, stdout, stdout, timeout: TimeSpan.FromSeconds (15));
+					var result = await processManager.RunAsync (process, stdout, stdout, stdout, timeout: TimeSpan.FromSeconds (60));
 					if (!result.Succeeded)
 						throw new Exception ($"Failed to list the files in the directory {test_dir} (TimedOut: {result.TimedOut} ExitCode: {result.ExitCode}):\n{stdout}");
 


### PR DESCRIPTION
* Capture evaluation output, and write it all to the terminal when something
  goes wrong. This way we can see the entire output next to the failure (often
  there's a lot of stuff written to the terminal from different threads, and
  this way we get all that matters written together).
* Only evaluate one project at a time, to avoid overloading the machine.
* Only execute `git ls-files` once at a time, to avoid overloading the machine.
* Bump evaluation timeout to 5 minutes.
* Also increase the time for git to list files in a directory to 60 seconds.

Hopefully this will fix errors like this:

* `Unable to evaluate the property OutputPath, build failed with exit code 0. Timed out: True`
* `System.Exception: Failed to list the files in the directory /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/tmp-test-dir/monotouch-test3403 (TimedOut: True ExitCode: 0)`