### PR TITLE
[dotnet] Don't add FileNativeReferences to the main libraries to link with. Fixes #13503.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1062,8 +1062,6 @@
 			<_XamarinMainLibraries Include="$(_XamarinNativeLibraryDirectory)/$(_LibXamarinName)" />
 			<!-- Link with the libraries shipped with the mono runtime pack -->
 			<_XamarinMainLibraries Include="@(_MonoLibrary)" />
-			<!-- Link with static libraries from NativeReference items ((xc)frameworks are handled in the _ComputeFrameworkFilesToPublish target, and dynamic libraries are handled in the _ComputeDynamicLibrariesToPublish target) -->
-			<_XamarinMainLibraries Include="@(_FileNativeReference)" />
 
 			<!-- The frameworks we need to link with (both weakly and normally) -->
 			<_NativeExecutableFrameworks Include="@(_LinkerFrameworks)" />
@@ -1078,6 +1076,7 @@
 			<!-- Here we must add all the files that should make us (re-)link the executable -->
 			<_LinkNativeExecutableInputs Include="@(_NativeExecutableObjectFiles)" />
 			<_LinkNativeExecutableInputs Include="@(_XamarinMainLibraries)" />
+			<_LinkNativeExecutableInputs Include="@(_FileNativeReference)" />
 		</ItemGroup>
 	</Target>
 

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -955,5 +955,32 @@ namespace Xamarin.Tests
 				throw new ArgumentOutOfRangeException ($"Unknown platform: {platform}");
 			}
 		}
+
+		public static string GetTestLibraryDirectory (ApplePlatform platform, bool? simulator = null)
+		{
+			string dir;
+
+			switch (platform) {
+			case ApplePlatform.iOS:
+				dir = simulator.Value ? "iphonesimulator" : "iphoneos";
+				break;
+			case ApplePlatform.MacOSX:
+				dir = "macos";
+				break;
+			case ApplePlatform.WatchOS:
+				dir = simulator.Value ? "watchsimulator" : "watchos";
+				break;
+			case ApplePlatform.TVOS:
+				dir = simulator.Value ? "tvsimulator" : "tvos";
+				break;
+			case ApplePlatform.MacCatalyst:
+				dir = "maccatalyst";
+				break;
+			default:
+				throw new NotImplementedException ($"Unknown platform: {platform}");
+			}
+
+			return Path.Combine (SourceRoot, "tests", "test-libraries", ".libs", dir);
+		}
 	}
 }

--- a/tests/dotnet/UnitTests/TemplateProjectTest.cs
+++ b/tests/dotnet/UnitTests/TemplateProjectTest.cs
@@ -62,5 +62,37 @@ class MainClass {
 			var errors = BinLog.GetBuildLogErrors (result.BinLogPath);
 			Assert.That (errors, Has.Some.Matches<BuildLogEvent> (v => v.Message.Contains (magic)), "Expected error");
 		}
+
+		// https://github.com/xamarin/xamarin-macios/issues/13503
+		[TestCase (ApplePlatform.MacOSX, null)]
+		public void NativeReferenceStaticLibraryForceLoad (ApplePlatform platform, bool? simulator)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var tmpdir = Cache.CreateTemporaryDirectory ();
+			var magic = Guid.NewGuid ().ToString ();
+			var pathToNativeLibrary = Path.Combine (Configuration.GetTestLibraryDirectory (platform, simulator), "libtest.a");
+			var relativePathToNativeLibrary = Path.GetRelativePath (tmpdir, pathToNativeLibrary);
+			var csproj = $@"<Project Sdk=""Microsoft.NET.Sdk"">
+	<PropertyGroup>
+		<TargetFramework>{platform.ToFramework ()}</TargetFramework>
+		<OutputType>Exe</OutputType>
+	</PropertyGroup>
+	<ItemGroup>
+		<NativeReference Include=""{relativePathToNativeLibrary}"">
+			<Kind>Static</Kind>
+			<ForceLoad>True</ForceLoad>
+		</NativeReference>
+	</ItemGroup>
+</Project>";
+
+			Configuration.CopyDotNetSupportingFiles (tmpdir);
+			var project_path = Path.Combine (tmpdir, "TestProject.csproj");
+			File.WriteAllText (project_path, csproj);
+			File.WriteAllText (Path.Combine (tmpdir, "Info.plist"), EmptyAppManifest);
+			File.WriteAllText (Path.Combine (tmpdir, "Main.cs"), EmptyMainFile);
+
+			DotNet.AssertBuild (project_path, GetDefaultProperties ());
+		}
 	}
 }


### PR DESCRIPTION
Don't add FileNativeReferences to the main libraries to link with, because we
pass that list of main libraries to the LinkNativeCodeTask, and we're already
passing the FileNativeReferences for a different task parameter.

This means that we end up adding the file native reference twice to the linker
arguments, and that's wasteful. It can also cause problems if those linker
arguments aren't always computed in the same way (once as a relative path,
once as an absolute path for instance).

Fixes https://github.com/xamarin/xamarin-macios/issues/13503.