### PR TITLE
[Blocks] Constrain the generic type for GetTarget and GetDelegateForBlock to delegates in .NET

### DIFF
--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -226,12 +226,20 @@ namespace ObjCRuntime {
 			}
 		}
 
+#if NET
+		public T GetDelegateForBlock<T> () where T: System.MulticastDelegate
+#else
 		public T GetDelegateForBlock<T> () where T: class
+#endif
 		{
 			return (T) (object) Runtime.GetDelegateForBlock (invoke, typeof (T));
 		}
 
+#if NET
+		public unsafe static T GetTarget<T> (IntPtr block) where T: System.MulticastDelegate
+#else
 		public unsafe static T GetTarget<T> (IntPtr block) where T: class /* /* requires C# 7.3+: System.MulticastDelegate */
+#endif
 		{
 			return (T) ((BlockLiteral *) block)->Target;
 		}


### PR DESCRIPTION
This makes it clearer what kind of types the method can handle.

A delegate constraint requires a newer C# version, which is why we can't do it
for legacy Xamarin.