### PR TITLE
[UIKit] Make UITextInputTraits members optional in .NET. Fixes #5831.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -6150,41 +6150,59 @@ namespace UIKit {
 		void SetAngleAndMagnitude (nfloat angle, nfloat magnitude);
 	}
 
+#if !NET
 	// HACK: those members are not *required* in ObjC but we made them
 	// abstract to have them inlined in UITextField and UITextView
 	// Even more confusing it that respondToSelecttor return NO on them
 	// even if it works in _real_ life (compare unit and introspection tests)
+#endif
 	[Protocol]
 	interface UITextInputTraits {
+#if !NET
 		[Abstract]
+#endif
 		[Export ("autocapitalizationType")]
 		UITextAutocapitalizationType AutocapitalizationType { get; set; }
 	
+#if !NET
 		[Abstract]
+#endif
 		[Export ("autocorrectionType")]
 		UITextAutocorrectionType AutocorrectionType { get; set;  }
 	
+#if !NET
 		[Abstract]
+#endif
 		[Export ("keyboardType")]
 		UIKeyboardType KeyboardType { get; set;  }
 	
+#if !NET
 		[Abstract]
+#endif
 		[Export ("keyboardAppearance")]
 		UIKeyboardAppearance KeyboardAppearance { get; set;  }
 	
+#if !NET
 		[Abstract]
+#endif
 		[Export ("returnKeyType")]
 		UIReturnKeyType ReturnKeyType { get; set;  }
 	
+#if !NET
 		[Abstract]
+#endif
 		[Export ("enablesReturnKeyAutomatically")]
 		bool EnablesReturnKeyAutomatically { get; set;  }
 	
+#if !NET
 		[Abstract]
+#endif
 		[Export ("secureTextEntry")]
 		bool SecureTextEntry { [Bind ("isSecureTextEntry")] get; set;  }
 
+#if !NET
 		[Abstract]
+#endif
 		[Export ("spellCheckingType")]
 		UITextSpellCheckingType SpellCheckingType { get; set; }
 

--- a/tests/monotouch-test/UIKit/TextFieldTest.cs
+++ b/tests/monotouch-test/UIKit/TextFieldTest.cs
@@ -110,6 +110,16 @@ namespace MonoTouchFixtures.UIKit {
 			// that's even more confusing since they all fails for respondToSelector tests but works in real life
 			using (UITextField tf = new UITextField ()) {
 				// this is just to show we can get and set those values (even if respondToSelector returns NO)
+#if NET
+				tf.SetAutocapitalizationType (tf.GetAutocapitalizationType ());
+				tf.SetAutocorrectionType (tf.GetAutocorrectionType ());
+				tf.SetEnablesReturnKeyAutomatically (tf.GetEnablesReturnKeyAutomatically ());
+				tf.SetKeyboardAppearance (tf.GetKeyboardAppearance ());
+				tf.SetKeyboardType (tf.GetKeyboardType ());
+				tf.SetReturnKeyType (tf.GetReturnKeyType ());
+				tf.SetSecureTextEntry (tf.GetSecureTextEntry ());
+				tf.SetSpellCheckingType (tf.GetSpellCheckingType ());
+#else
 				tf.AutocapitalizationType = tf.AutocapitalizationType;
 				tf.AutocorrectionType = tf.AutocorrectionType;
 				tf.EnablesReturnKeyAutomatically = tf.EnablesReturnKeyAutomatically;
@@ -118,6 +128,7 @@ namespace MonoTouchFixtures.UIKit {
 				tf.ReturnKeyType = tf.ReturnKeyType;
 				tf.SecureTextEntry = tf.SecureTextEntry;
 				tf.SpellCheckingType = tf.SpellCheckingType;
+#endif
 			}
 		}
 	}

--- a/tests/monotouch-test/UIKit/TextViewTest.cs
+++ b/tests/monotouch-test/UIKit/TextViewTest.cs
@@ -87,6 +87,16 @@ namespace MonoTouchFixtures.UIKit {
 			// that's even more confusing since they all fails for respondToSelector tests but works in real life
 			using (UITextView tv = new UITextView ()) {
 				// this is just to show we can get and set those values (even if respondToSelector returns NO)
+#if NET
+				tv.SetAutocapitalizationType (tv.GetAutocapitalizationType ());
+				tv.SetAutocorrectionType (tv.GetAutocorrectionType ());
+				tv.SetEnablesReturnKeyAutomatically (tv.GetEnablesReturnKeyAutomatically ());
+				tv.SetKeyboardAppearance (tv.GetKeyboardAppearance ());
+				tv.SetKeyboardType (tv.GetKeyboardType ());
+				tv.SetReturnKeyType (tv.GetReturnKeyType ());
+				tv.SetSecureTextEntry (tv.GetSecureTextEntry ());
+				tv.SetSpellCheckingType (tv.GetSpellCheckingType ());
+#else
 				tv.AutocapitalizationType = tv.AutocapitalizationType;
 				tv.AutocorrectionType = tv.AutocorrectionType;
 				tv.EnablesReturnKeyAutomatically = tv.EnablesReturnKeyAutomatically;
@@ -95,6 +105,7 @@ namespace MonoTouchFixtures.UIKit {
 				tv.ReturnKeyType = tv.ReturnKeyType;
 				tv.SecureTextEntry = tv.SecureTextEntry;
 				tv.SpellCheckingType = tv.SpellCheckingType;
+#endif
 			}
 		}
 	}

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-UIKit.ignore
@@ -82,25 +82,6 @@
 !missing-pinvoke! NSStringFromUIOffset is not bound
 !missing-pinvoke! UIOffsetFromString is not bound
 
-## HACK: those members are not *required* in ObjC but we made them abstract to have them inlined in UITextField and UITextView
-## Even more confusing it that respondToSelecttor return NO on them even if it works in _real_ life (compare unit and introspection tests)
-!incorrect-protocol-member! UITextInputTraits::autocapitalizationType is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::autocorrectionType is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::enablesReturnKeyAutomatically is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::isSecureTextEntry is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::keyboardAppearance is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::keyboardType is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::returnKeyType is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::setAutocapitalizationType: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::setAutocorrectionType: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::setEnablesReturnKeyAutomatically: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::setKeyboardAppearance: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::setKeyboardType: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::setReturnKeyType: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::setSecureTextEntry: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::setSpellCheckingType: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UITextInputTraits::spellCheckingType is OPTIONAL and should NOT be abstract
-
 ## UIAccessibility
 ## We can't expose them as categories of NSObject so we have custom types instead
 !missing-selector! NSObject::accessibilityActivationPoint not bound


### PR DESCRIPTION
Once upon a long time ago we decided to mark the properties in the
UITextInputTraits protocol as required in our API definition, because that way
we'd inline these properties in any class that implemented the
UITextInputTraits protocol, which made calling these properties much easier.

At a later point, we implemented better support for protocols, and now we
automatically generate extension methods for such properties (a corresponding
Get/Set method for the get/set property accessors), so we don't need these
inlined properties anymore.

However, removing them would be a breaking change, so we were stuck with these
redundant inlined properties, until .NET came along.

Ref: https://github.com/xamarin/maccore/commit/0e8057086362f7f9f22b68b9d174e8568b11bf7b

Fixes https://github.com/xamarin/xamarin-macios/issues/5831.