### PR TITLE
[src] Remove Runtime.GetSurfacedObjects in .NET.

### DIFF
--- a/src/ObjCRuntime/Runtime.iOS.cs
+++ b/src/ObjCRuntime/Runtime.iOS.cs
@@ -54,7 +54,7 @@ namespace ObjCRuntime {
 			UIApplication.Initialize ();
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		// This method is documented to be for diagnostic purposes only,
 		// and should not be considered stable API.
 		[EditorBrowsable (EditorBrowsableState.Never)]


### PR DESCRIPTION
This method exposes internal implementation details, and makes it difficult to
innovate in the runtime. Additionally it's purpose was always for diagnosis,
but I've never seen it used (not even for its intented purpose), so we can
just remove it for .NET.