### PR TITLE
[UIKit] Use the correct protocol hierarchy for UICollectionViewDelegate for .NET.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -3828,7 +3828,7 @@ namespace UIKit {
 
 	[Model]
 	[Protocol]
-#if XAMCORE_3_0
+#if XAMCORE_3_0 && !NET
 	// bind like UITableViewDelegate to avoid generating duplicate code
 	// it's an API break (binary, source should be fine)
 	[BaseType (typeof (UIScrollViewDelegate))]


### PR DESCRIPTION
The source code claims that having the different protocol hierarchy reduces
duplicate code, but I can't see what kind of code duplication this would
remove. The incorrect hierarchy causes all the UIScrollViewDelegate members to
not be inlined in UICollectionViewController, UICollectionViewDelegate and
UICollectionViewSource, effectively breaking API / source code, because this
might happen in UICollectionViewController subclasses now:

    MyUICollectionViewController.cs(105,24): error CS0115: 'MyUICollectionViewController.DraggingStarted(UIScrollView)': no suitable method found to override
    MyUICollectionViewController.cs(111,24): error CS0115: 'MyUICollectionViewController.DraggingEnded(UIScrollView, bool)': no suitable method found to override

This also debunks the claim from the comment in the api definition that
changing the protocol hierarchy would not be a breaking source change.

So go back to the correct protocol hierarchy for .NET, for all platforms.