### PR TITLE
[generator] Fix the selector in extension methods for protocol properties with Bind attributes. Fixes #12727.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -6051,12 +6051,14 @@ public partial class Generator : IMemberGatherer {
 				var getter = pi.GetGetMethod ();
 				if (getter != null) {
 					PrintAttributes (pi, preserve:true, advice:true);
-					GenerateMethod (type, getter, false, null, false, false, true, attrib.ToGetter(pi).Selector);
+					var ba = GetBindAttribute (getter);
+					GenerateMethod (type, getter, false, null, false, false, true, ba?.Selector ?? attrib.ToGetter (pi).Selector);
 				}
 				var setter = pi.GetSetMethod ();
 				if (setter != null) {
 					PrintAttributes (pi, preserve:true, advice:true);
-					GenerateMethod (type, setter, false, null, false, false, true, attrib.ToSetter(pi).Selector);
+					var ba = GetBindAttribute (setter);
+					GenerateMethod (type, setter, false, null, false, false, true, ba?.Selector ?? attrib.ToSetter (pi).Selector);
 				}
 			}
 			indent--;

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -773,6 +773,37 @@ namespace GeneratorTests
 #endif
 		}
 
+		[Test]
+		public void ProtocolBindProperty ()
+		{
+			var bgen = BuildFile (Profile.iOS, "tests/protocol-bind-property.cs");
+			bgen.AssertExecute ("build");
+
+			// Assert that the return type from the delegate is IntPtr
+			var type = bgen.ApiAssembly.MainModule.GetType ("NS", "MyProtocol_Extensions");
+			Assert.NotNull (type, "MyProtocol_Extensions");
+
+			var method = type.Methods.First (v => v.Name == "GetOptionalProperty");
+			var ldstr = method.Body.Instructions.Single (v => v.OpCode == OpCodes.Ldstr);
+			Assert.AreEqual ("isOptionalProperty", (string) ldstr.Operand, "isOptionalProperty");
+
+
+			method = type.Methods.First (v => v.Name == "SetOptionalProperty");
+			ldstr = method.Body.Instructions.Single (v => v.OpCode == OpCodes.Ldstr);
+			Assert.AreEqual ("setOptionalProperty:", (string) ldstr.Operand, "setOptionalProperty");
+
+			type = bgen.ApiAssembly.MainModule.GetType ("NS", "MyProtocolWrapper");
+			Assert.NotNull (type, "MyProtocolWrapper");
+
+			method = type.Methods.First (v => v.Name == "get_AbstractProperty");
+			ldstr = method.Body.Instructions.Single (v => v.OpCode == OpCodes.Ldstr);
+			Assert.AreEqual ("isAbstractProperty", (string) ldstr.Operand, "isAbstractProperty");
+
+			method = type.Methods.First (v => v.Name == "set_AbstractProperty");
+			ldstr = method.Body.Instructions.Single (v => v.OpCode == OpCodes.Ldstr);
+			Assert.AreEqual ("setAbstractProperty:", (string) ldstr.Operand, "setAbstractProperty");
+		}
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/tests/protocol-bind-property.cs
+++ b/tests/generator/tests/protocol-bind-property.cs
@@ -1,0 +1,15 @@
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	[Protocol]
+	interface MyProtocol {
+		[Abstract]
+		[Export ("abstractProperty")]
+		bool AbstractProperty { [Bind ("isAbstractProperty")] get; set;  }
+
+		[Export ("optionalProperty")]
+		bool OptionalProperty { [Bind ("isOptionalProperty")] get; set;  }
+	}
+}


### PR DESCRIPTION
Take into account any Bind attributes on optional property getters and setters
on protocols when generating the Get* and Set* extension methods, so that we
use the right selector.

Fixes https://github.com/xamarin/xamarin-macios/issues/12727.