### PR TITLE
[AppKit] Fix NSWindow.WindowController's return type in .NET.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -20712,7 +20712,11 @@ namespace AppKit {
 	
 		[Export ("windowController")]
 		[NullAllowed]
+#if NET
+		NSWindowController WindowController { get; set; }
+#else
 		NSObject WindowController { get; set; }
+#endif
 	
 		[Export ("isSheet")]
 		bool IsSheet { get; }


### PR DESCRIPTION
NSWindow.WindowController's type is supposed to be 'NSWindowController', not
'NSObject'. Fix this in .NET, since it's a breaking change.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=40095.