### PR TITLE
[msbuild] Make sure to update global.json/NuGet.config for the Xamarin.HotRestart.PreBuilt build whenever needed.

### DIFF
--- a/msbuild/Xamarin.HotRestart.PreBuilt/Makefile
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Makefile
@@ -9,10 +9,12 @@ Xamarin.PreBuilt.iOS.app.zip: .build-stamp
 	$(Q) rm -rf $@
 	$(Q_GEN) cd $(APP_DIR) && zip -9r $(abspath $@) .
 
-NuGet.config: $(TOP)/tests/dotnet/NuGet.config
+NuGet.config: $(TOP)/tests/dotnet/NuGet.config $(TOP)/NuGet.config
+	$(Q) $(MAKE) $@ -C $(dir $<)
 	$(Q) $(CP) $< $@
 
-global.json: $(TOP)/tests/dotnet/global.json
+global.json: $(TOP)/tests/dotnet/global.json $(TOP)/global6.json
+	$(Q) $(MAKE) $@ -C $(dir $<)
 	$(Q) $(CP) $< $@
 
 $(TOP)/tests/dotnet/%:


### PR DESCRIPTION
This fixes an issue where rebuilding in an already build working copy after a
.NET bump would fail.