### PR TITLE
[VideoToolbox] Add a VTCompressionSession.EncodeFrame overload that takes a CVImageBuffer instead of a handle to one.

### DIFF
--- a/src/VideoToolbox/VTCompressionSession.cs
+++ b/src/VideoToolbox/VTCompressionSession.cs
@@ -248,6 +248,15 @@ namespace VideoToolbox {
 			/* VTEncodeInfoFlags */ out VTEncodeInfoFlags flags);
 
 		public VTStatus EncodeFrame (CVImageBuffer imageBuffer, CMTime presentationTimestamp, CMTime duration,
+			NSDictionary frameProperties, CVImageBuffer sourceFrame, out VTEncodeInfoFlags infoFlags)
+		{
+			if (sourceFrame is null)
+				throw new ArgumentNullException (nameof (sourceFrame));
+
+			return EncodeFrame (imageBuffer, presentationTimestamp, duration, frameProperties, sourceFrame.GetCheckedHandle (), out infoFlags);
+		}
+
+		public VTStatus EncodeFrame (CVImageBuffer imageBuffer, CMTime presentationTimestamp, CMTime duration, 
 			NSDictionary frameProperties, IntPtr sourceFrame, out VTEncodeInfoFlags infoFlags)
 		{
 			if (imageBuffer is null)
@@ -284,6 +293,17 @@ namespace VideoToolbox {
 			var del = (VTCompressionOutputHandler)(block->Target);
 			if (del is not null)
 				del (status, infoFlags, new CMSampleBuffer (sampleBuffer));
+		}
+
+		[Mac (10,11), iOS (9,0)]
+		public VTStatus EncodeFrame (CVImageBuffer imageBuffer, CMTime presentationTimestamp, CMTime duration,
+			NSDictionary frameProperties, CVImageBuffer sourceFrame, out VTEncodeInfoFlags infoFlags,
+			VTCompressionOutputHandler outputHandler)
+		{
+			if (sourceFrame is null)
+				throw new ArgumentNullException (nameof (sourceFrame));
+
+			return EncodeFrame (imageBuffer, presentationTimestamp, duration, frameProperties, sourceFrame.GetCheckedHandle (), out infoFlags, outputHandler);
 		}
 
 		[Mac (10,11), iOS (9,0)]

--- a/tests/monotouch-test/VideoToolbox/VTCompressionSessionTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTCompressionSessionTests.cs
@@ -217,7 +217,7 @@ namespace MonoTouchFixtures.VideoToolbox {
 			for (var i = 0; i < frameCount; i++) {
 				using var imageBuffer = new CVPixelBuffer (width, height, CVPixelFormatType.CV420YpCbCr8BiPlanarFullRange);
 				var pts = new CMTime (40 * i, 1);
-				status = session.EncodeFrame (imageBuffer, pts, duration, null, imageBuffer.Handle, out var infoFlags);
+				status = session.EncodeFrame (imageBuffer, pts, duration, null, imageBuffer, out var infoFlags);
 				Assert.AreEqual (status, VTStatus.Ok, $"status #{i}");
 				// This looks weird, but it seems the video encoder can become overwhelmed otherwise, and it
 				// will start failing (and taking a long time to do so, eventually timing out the test).


### PR DESCRIPTION
This makes the API nicer to use.