### PR TITLE
[Metal] Exposing Selectors in iOS. Fixes  #12648

### DIFF
--- a/src/Metal/MTLRenderCommandEncoder.cs
+++ b/src/Metal/MTLRenderCommandEncoder.cs
@@ -1,4 +1,3 @@
-#if MONOMAC
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
@@ -11,6 +10,7 @@ using ObjCRuntime;
 
 namespace Metal {
 	public static class IMTLRenderCommandEncoder_Extensions {
+#if MONOMAC
 #if !NET
 		[Mac (10,13), NoiOS, NoTV, NoWatch]
 #endif
@@ -28,6 +28,7 @@ namespace Metal {
 			fixed (void* handle = scissorRects)
 				This.SetScissorRects ((IntPtr)handle, (nuint)(scissorRects?.Length ?? 0));
 		}
+#endif
 
 #if IOS
 #if !NET
@@ -57,4 +58,3 @@ namespace Metal {
 #endif
 	}
 }
-#endif


### PR DESCRIPTION
As a response to this issue: https://github.com/xamarin/xamarin-macios/issues/12648

`SetTileSamplerStates` and `SetTileBuffers` are methods only for iOS, but this whole file is contained inside an `#if MONOMAC`. Therefore, we should move this Monomac to cover just the Mac portion.