### PR TITLE
Ensure we remotely copy all project pdbs and not only the main app one

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -316,9 +316,11 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 			<_RemoteILLinkPath>$(ILLinkTasksAssembly.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)').Replace('net472', 'net6.0').Replace('$([System.IO.Path]::GetFileName('$(ILLinkTasksAssembly)'))', 'illink.dll'))</_RemoteILLinkPath>
 		</PropertyGroup>
 
+		<!-- Include Debug symbols as input so those are copied to the server -->
 		<ItemGroup>
-			<!-- Include Debug symbols as input so those are copied to the server -->
-			<_ILLinkDebugSymbols Include="@(_DebugSymbolsIntermediatePath)" Condition="'$(_DebugSymbolsProduced)'=='true'" />
+			<!-- @(_PDBToLink) comes from the _ComputeManagedAssemblyToLink target, which is a dependency of this target and is included in Microsoft.NET.ILLink.targets -->
+			<!-- @(_PDBToLink) should contain the current assembly pdb and the project reference pdbs -->
+			<_ILLinkDebugSymbols Include="@(_PDBToLink)" />
 		</ItemGroup>
 		
 		<Delete SessionId="$(BuildSessionId)" Files="@(_LinkedResolvedFileToPublishCandidate)" />


### PR DESCRIPTION
With the previous approach we were only copying the main app pdb to the Mac instead of all the involved pdb files (main app and referenced projects). This was causing the class libraries to not load the symbols and not hit any breakpoints while debugging