### PR TITLE
Prepare for NET6 attribute conversion with hand fixes

### DIFF
--- a/src/AVKit/Enums.cs
+++ b/src/AVKit/Enums.cs
@@ -17,24 +17,6 @@ namespace AVKit {
 	}
 #endif
 
-#if MONOMAC
-	[Mac (10,10)]
-	[Native]
-	public enum AVCaptureViewControlsStyle : long {
-		Inline,
-		Floating,
-		InlineDeviceSelection,
-		Default = Inline,
-	}
-
-	[Mac (10,9)]
-	[Native]
-	public enum AVPlayerViewTrimResult : long {
-		OKButton,
-		CancelButton
-	}
-#endif
-
 #if !MONOMAC || !XAMCORE_4_0
 	[iOS (9,0)]
 	[TV (13,0)]

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -498,25 +498,6 @@ namespace Foundation  {
 		Reverse = 2
 	}
 	
-#if MONOMAC || __MACCATALYST__
-	[MacCatalyst(15, 0)]
-	[Native]
-	public enum NSNotificationSuspensionBehavior : ulong {
-		Drop = 1,
-		Coalesce = 2,
-		Hold = 3,
-		DeliverImmediately = 4,
-	}
-
-	[MacCatalyst(15, 0)]
-	[Flags]
-	[Native]
-	public enum NSNotificationFlags : ulong {
-		DeliverImmediately = (1 << 0),
-		PostToAllSessions = (1 << 1),
-	}
-#endif
-
 	[Flags]
 	[Native]
 	public enum NSStreamEvent : ulong {
@@ -1268,17 +1249,6 @@ namespace Foundation  {
 		Long,
 		Abbreviated
 	}
-
-#if MONOMAC
-	[Mac (10,11)][NoWatch][NoTV][NoiOS]
-	[Native]
-	[Flags]
-	public enum NSFileManagerUnmountOptions : ulong
-	{
-		AllPartitionsAndEjectDisk = 1 << 0,
-		WithoutUI = 1 << 1
-	}
-#endif
 
 	[iOS (9,0)][Mac (10,11)]
 	[Native]

--- a/src/avkit.cs
+++ b/src/avkit.cs
@@ -953,7 +953,7 @@ namespace AVKit {
 	[Native]
 	public enum AVPlayerViewTrimResult : long {
 		OKButton,
-		CancelButton
+		CancelButton,
 	}
 
 }

--- a/src/avkit.cs
+++ b/src/avkit.cs
@@ -14,9 +14,7 @@ using AVFoundation;
 using OpenGLES;
 #endif
 #if !MONOMAC
-using AVCaptureViewControlsStyle = Foundation.NSObject;
 using AVPlayerViewControlsStyle = Foundation.NSObject;
-using AVPlayerViewTrimResult = Foundation.NSObject;
 using NSColor = UIKit.UIColor;
 using NSMenu = Foundation.NSObject;
 using NSView = UIKit.UIView;
@@ -938,6 +936,24 @@ namespace AVKit {
 
 		[Export ("playerView:restoreUserInterfaceForFullScreenExitWithCompletionHandler:")]
 		void RestoreUserInterfaceForFullScreenExit (AVPlayerView playerView, Action<bool> completionHandler);
+	}
+
+	[Mac (10,10)]
+	[NoiOS][NoTV][NoWatch][NoMacCatalyst]
+	[Native]
+	public enum AVCaptureViewControlsStyle : long {
+		Inline,
+		Floating,
+		InlineDeviceSelection,
+		Default = Inline,
+	}
+
+	[Mac (10,9)]
+	[NoiOS][NoTV][NoWatch][NoMacCatalyst]
+	[Native]
+	public enum AVPlayerViewTrimResult : long {
+		OKButton,
+		CancelButton
 	}
 
 }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -16499,6 +16499,6 @@ namespace Foundation
 	public enum NSFileManagerUnmountOptions : ulong
 	{
 		AllPartitionsAndEjectDisk = 1 << 0,
-		WithoutUI = 1 << 1
+		WithoutUI = 1 << 1,
 	}
 }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -16473,4 +16473,32 @@ namespace Foundation
 		Tls,
 		Https,
 	}
+
+	[NoiOS][NoTV][NoWatch]
+	[MacCatalyst(15, 0)]
+	[Native]
+	public enum NSNotificationSuspensionBehavior : ulong {
+		Drop = 1,
+		Coalesce = 2,
+		Hold = 3,
+		DeliverImmediately = 4,
+	}
+
+	[NoiOS][NoTV][NoWatch]
+	[MacCatalyst(15, 0)]
+	[Flags]
+	[Native]
+	public enum NSNotificationFlags : ulong {
+		DeliverImmediately = (1 << 0),
+		PostToAllSessions = (1 << 1),
+	}
+
+	[Mac (10,11)][NoWatch][NoTV][NoiOS][NoMacCatalyst]
+	[Native]
+	[Flags]
+	public enum NSFileManagerUnmountOptions : ulong
+	{
+		AllPartitionsAndEjectDisk = 1 << 0,
+		WithoutUI = 1 << 1
+	}
 }


### PR DESCRIPTION
- The tool I wrote to convert attributes [mellite](https://github.com/chamons/mellite) does single pass through each file
- This means files that define Foo and !Foo, each with availability attributes inside can not be proccessed
- These 2 locations were easy to fix by moving defines inside binding definations, so I did that
- About 10 other locations were not so easy, so those will be worked around by hand in the conversion process.

Part of https://github.com/xamarin/xamarin-macios/issues/10170