### PR TITLE
Remove xamarin iOS designtime targets import

### DIFF
--- a/dotnet/Microsoft.iOS.Windows.Sdk/targets/Microsoft.iOS.Windows.Sdk.targets
+++ b/dotnet/Microsoft.iOS.Windows.Sdk/targets/Microsoft.iOS.Windows.Sdk.targets
@@ -15,10 +15,4 @@
 
   -->
 
-  <PropertyGroup Condition="'$(XamarinIOSDesignTimeTargetsPath)' == ''">
-    <XamarinIOSDesignTimeTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Xamarin\iOS\Xamarin.iOS.DesignTime.targets</XamarinIOSDesignTimeTargetsPath>
-  </PropertyGroup>
-
-  <Import Project="$(XamarinIOSDesignTimeTargetsPath)" Condition="Exists('$(XamarinIOSDesignTimeTargetsPath)')" />
-
 </Project>


### PR DESCRIPTION
These files are no longer used by the XamarinVS extension and the import is therefore unnecessary.