### PR TITLE
[CI] Fix comment aligment and add a warning sign.

### DIFF
--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -447,12 +447,12 @@ function New-GitHubSummaryComment {
     $diffHeader = "API diff"
     $currentPRHeader = "API Current PR diff"
     if ([string]::IsNullOrEmpty($APIDiff)) {
-        $sb.AppendLine("API diff urls have not been provided.")
+        $sb.AppendLine("* :warning: API diff urls have not been provided.")
     } else {
         WriteDiffs $sb $diffHeader $APIDiff
     }
     if ([string]::IsNullOrEmpty($APIGeneratorDiffJson)) {
-        $sb.AppendLine("API Current PR diff urls have not been provided.")
+        $sb.AppendLine("* :warning: API Current PR diff urls have not been provided.")
     } else {
         WriteDiffs $sb $currentPRHeader $APIGeneratorDiffJson
     }
@@ -471,7 +471,7 @@ function New-GitHubSummaryComment {
             $sb.AppendLine($apidiffcomments)
         }
     } else {
-        $sb.AppendLine("Generator diff comments have not been provided.")
+        $sb.AppendLine("* :warning: Generator diff comments have not been provided.")
     }
     if (-not [string]::IsNullOrEmpty($Artifacts)) {
         Write-Host "Parsing artifacts"


### PR DESCRIPTION
Fix the comment so that it does not look like
https://github.com/xamarin/xamarin-macios/commit/94863148dc43454779f639efca2c06780691bce7#commitcomment-63453915