### PR TITLE
[msbuild] Add helpful comment about unused property

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -60,6 +60,8 @@ namespace Xamarin.MacDev.Tasks
 
 		#region Outputs
 
+		// This output value is not observed anywhere in our targets, but it's required for building on Windows
+		// to make sure any codesigned files other tasks depend on are copied back to the windows machine.
 		[Output]
 		public ITaskItem[] CodesignedFiles { get; set; }
 


### PR DESCRIPTION
This way I don't keep having to figure out why the property must not be
removed, even though it's not (visibly) used.