### PR TITLE
[Foundation] Remove the NSObject.[MonoTouchAssembly|MonoMacAssembly] fields in .NET.

### DIFF
--- a/src/Foundation/NSObject.iOS.cs
+++ b/src/Foundation/NSObject.iOS.cs
@@ -18,7 +18,7 @@ namespace Foundation {
 	{
 #if !COREBUILD
 
-#if !XAMCORE_4_0 && !WATCH
+#if !NET && !WATCH
 		[Obsolete ("Use 'PlatformAssembly' for easier code sharing across platforms.")]
 		public readonly static Assembly MonoTouchAssembly = typeof (NSObject).Assembly;
 #endif

--- a/src/Foundation/NSObject.mac.cs
+++ b/src/Foundation/NSObject.mac.cs
@@ -111,7 +111,7 @@ namespace Foundation {
 		static IntPtr un = Dlfcn.dlopen (Constants.UserNotificationsLibrary, 1);
 		static IntPtr il  = Dlfcn.dlopen (Constants.iTunesLibraryLibrary, 1);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use PlatformAssembly for easier code sharing across platforms.")]
 		public static readonly Assembly MonoMacAssembly = typeof (NSObject).Assembly;
 #endif


### PR DESCRIPTION
They're deprecated, because there's a better alternative (NSObject.PlatformAssembly).