### PR TITLE
[d17-1] [AudioUnit] Create a GCHandle when AudioUnit.SetInputCallback is called. Fixes #13637.

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -642,6 +642,9 @@ namespace AudioUnit
 
 			inputs [audioUnitElement] = inputDelegate;
 
+			if (!gcHandle.IsAllocated)
+				gcHandle = GCHandle.Alloc (this);
+
 			var cb = new AURenderCallbackStruct ();
 			cb.Proc = CreateInputCallback;
 			cb.ProcRefCon = GCHandle.ToIntPtr (gcHandle);

--- a/tests/monotouch-test/AudioToolbox/AudioUnitTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioUnitTest.cs
@@ -1,0 +1,52 @@
+//
+// Unit tests for AudioUnit
+//
+// Authors:
+//	Rolf Bjarne Kvinge (rolf@xamarin.com)
+//
+// Copyright 2022 Microsoft Corp. All rights reserved.
+//
+
+#if (__MACOS__ || __MACCATALYST__) && NET
+
+using System;
+using System.Threading;
+
+using Foundation;
+using AudioToolbox;
+using AudioUnit;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.AudioToolbox {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class AudioUnitTest
+	{
+		ManualResetEvent inputCallbackEvent = new ManualResetEvent (false);
+
+		[Test]
+		public void Callbacks ()
+		{
+			var audioComponent = AudioComponent.FindComponent (AudioTypeOutput.VoiceProcessingIO);
+			using var audioUnit = new global::AudioUnit.AudioUnit (audioComponent);
+
+			audioUnit.SetInputCallback (InputCallback, AudioUnitScopeType.Input, 1);
+			audioUnit.Initialize ();
+			try {
+				audioUnit.Start ();
+				Assert.IsTrue (inputCallbackEvent.WaitOne (TimeSpan.FromSeconds (1)), "No input callback for 1 second");
+			} finally {
+				audioUnit.Stop ();
+			}
+		}
+
+		AudioUnitStatus InputCallback (AudioUnitRenderActionFlags actionFlags, AudioTimeStamp timeStamp, uint busNumber, uint numberFrames, global::AudioUnit.AudioUnit audioUnit)
+		{
+			inputCallbackEvent.Set ();
+			return AudioUnitStatus.NoError;
+		}
+	}
+}
+
+#endif // (__MACOS__ || __MACCATALYST__) && NET

--- a/tests/monotouch-test/AudioToolbox/AudioUnitTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioUnitTest.cs
@@ -7,7 +7,7 @@
 // Copyright 2022 Microsoft Corp. All rights reserved.
 //
 
-#if (__MACOS__ || __MACCATALYST__) && NET
+#if __MACOS__ && NET
 
 using System;
 using System.Threading;
@@ -25,6 +25,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 	{
 		ManualResetEvent inputCallbackEvent = new ManualResetEvent (false);
 
+		// This test currently only works on macOS, probably due to missing microphone entitlements/permissions for mobile platforms.
 		[Test]
 		public void Callbacks ()
 		{
@@ -49,4 +50,4 @@ namespace MonoTouchFixtures.AudioToolbox {
 	}
 }
 
-#endif // (__MACOS__ || __MACCATALYST__) && NET
+#endif // __MACOS__ && NET


### PR DESCRIPTION
AudioUnit needs a GCHandle in the input callback, which means we have to create it
when SetInputCallback is called (like we already do for SetRenderCallback).

Fixes https://github.com/xamarin/xamarin-macios/issues/13637.


Backport of #13673
