### PR TITLE
[CoreAnimation] Rename CATransform3D's fields to follow standard naming conventions for .NET.

### DIFF
--- a/src/CoreAnimation/CATransform3D.cs
+++ b/src/CoreAnimation/CATransform3D.cs
@@ -20,17 +20,73 @@ namespace CoreAnimation {
 	// CATransform3D.h
 	[StructLayout(LayoutKind.Sequential)]
 	public struct CATransform3D {
-		public nfloat m11, m12, m13, m14;
-		public nfloat m21, m22, m23, m24;
-		public nfloat m31, m32, m33, m34;
-		public nfloat m41, m42, m43, m44;
+#if NET
+		public nfloat M11, M12, M13, M14;
+		public nfloat M21, M22, M23, M24;
+		public nfloat M31, M32, M33, M34;
+		public nfloat M41, M42, M43, M44;
+#else
+		[Obsolete ("Use 'M11' instead.")]
+		public nfloat m11;
+		[Obsolete ("Use 'M12' instead.")]
+		public nfloat m12;
+		[Obsolete ("Use 'M13' instead.")]
+		public nfloat m13;
+		[Obsolete ("Use 'M14' instead.")]
+		public nfloat m14;
+		[Obsolete ("Use 'M21' instead.")]
+		public nfloat m21;
+		[Obsolete ("Use 'M22' instead.")]
+		public nfloat m22;
+		[Obsolete ("Use 'M23' instead.")]
+		public nfloat m23;
+		[Obsolete ("Use 'M24' instead.")]
+		public nfloat m24;
+		[Obsolete ("Use 'M31' instead.")]
+		public nfloat m31;
+		[Obsolete ("Use 'M32' instead.")]
+		public nfloat m32;
+		[Obsolete ("Use 'M33' instead.")]
+		public nfloat m33;
+		[Obsolete ("Use 'M34' instead.")]
+		public nfloat m34;
+		[Obsolete ("Use 'M41' instead.")]
+		public nfloat m41;
+		[Obsolete ("Use 'M42' instead.")]
+		public nfloat m42;
+		[Obsolete ("Use 'M43' instead.")]
+		public nfloat m43;
+		[Obsolete ("Use 'M44' instead.")]
+		public nfloat m44;
+
+		public nfloat M11 { get => m11; set => m11 = value; }
+		public nfloat M12 { get => m12; set => m12 = value; }
+		public nfloat M13 { get => m13; set => m13 = value; }
+		public nfloat M14 { get => m14; set => m14 = value; }
+		public nfloat M21 { get => m21; set => m21 = value; }
+		public nfloat M22 { get => m22; set => m22 = value; }
+		public nfloat M23 { get => m23; set => m23 = value; }
+		public nfloat M24 { get => m24; set => m24 = value; }
+		public nfloat M31 { get => m31; set => m31 = value; }
+		public nfloat M32 { get => m32; set => m32 = value; }
+		public nfloat M33 { get => m33; set => m33 = value; }
+		public nfloat M34 { get => m34; set => m34 = value; }
+		public nfloat M41 { get => m41; set => m41 = value; }
+		public nfloat M42 { get => m42; set => m42 = value; }
+		public nfloat M43 { get => m43; set => m43 = value; }
+		public nfloat M44 { get => m44; set => m44 = value; }
+#endif
 
 		static public readonly CATransform3D Identity;
 
 		static CATransform3D ()
 		{
 			Identity = new CATransform3D ();
+#if NET
+			Identity.M11 = Identity.M22 = Identity.M33 = Identity.M44 = 1f;
+#else
 			Identity.m11 = Identity.m22 = Identity.m33 = Identity.m44 = 1f;
+#endif
 		}
 		
 		[DllImport(Constants.QuartzLibrary)]
@@ -62,8 +118,13 @@ namespace CoreAnimation {
 		public override int GetHashCode ()
 		{
 			unsafe {
+#if NET
+				int code = (int) M11;
+				fixed (nfloat *fp = &M11){
+#else
 				int code = (int) m11;
 				fixed (nfloat *fp = &m11){
+#endif
 					int *ip = (int *) fp;
 					for (int i = 1; i < 4 * IntPtr.Size; i++){
 						code = code ^ ip [i];
@@ -80,9 +141,15 @@ namespace CoreAnimation {
 		{
 			//return CATransform3DMakeTranslation (tx, ty, tz);
 			CATransform3D r = Identity;
+#if NET
+			r.M41 = tx;
+			r.M42 = ty;
+			r.M43 = tz;
+#else
 			r.m41 = tx;
 			r.m42 = ty;
 			r.m43 = tz;
+#endif
 
 			return r;
 		}
@@ -93,9 +160,15 @@ namespace CoreAnimation {
 		public static CATransform3D MakeScale (nfloat sx, nfloat sy, nfloat sz)
 		{
 			CATransform3D r = Identity;
+#if NET
+			r.M11 = sx;
+			r.M22 = sy;
+			r.M33 = sz;
+#else
 			r.m11 = sx;
 			r.m22 = sy;
 			r.m33 = sz;
+#endif
 
 			return r;
 		}
@@ -174,10 +247,17 @@ namespace CoreAnimation {
 		public override string ToString ()
 		{
 			return String.Format ("[{0} {1} {2} {3}; {4} {5} {6} {7}; {8} {9} {10} {11}; {12} {13} {14} {15}]",
+#if NET
+					      M11, M12, M13, M14,
+					      M21, M22, M23, M24,
+					      M31, M32, M33, M34,
+					      M41, M42, M43, M44);
+#else
 					      m11, m12, m13, m14,
 					      m21, m22, m23, m24,
 					      m31, m32, m33, m34,
 					      m41, m42, m43, m44);
+#endif
 		}
 	}
 }

--- a/src/SceneKit/SCNMatrix4.cs
+++ b/src/SceneKit/SCNMatrix4.cs
@@ -134,10 +134,10 @@ namespace SceneKit
 #if !WATCH
 		public SCNMatrix4 (CoreAnimation.CATransform3D transform)
 		{
-			Row0 = new SCNVector4 ((pfloat)transform.m11, (pfloat)transform.m12, (pfloat)transform.m13, (pfloat)transform.m14);
-			Row1 = new SCNVector4 ((pfloat)transform.m21, (pfloat)transform.m22, (pfloat)transform.m23, (pfloat)transform.m24);
-			Row2 = new SCNVector4 ((pfloat)transform.m31, (pfloat)transform.m32, (pfloat)transform.m33, (pfloat)transform.m34);
-			Row3 = new SCNVector4 ((pfloat)transform.m41, (pfloat)transform.m42, (pfloat)transform.m43, (pfloat)transform.m44);
+			Row0 = new SCNVector4 ((pfloat) transform.M11, (pfloat) transform.M12, (pfloat) transform.M13, (pfloat) transform.M14);
+			Row1 = new SCNVector4 ((pfloat) transform.M21, (pfloat) transform.M22, (pfloat) transform.M23, (pfloat) transform.M24);
+			Row2 = new SCNVector4 ((pfloat) transform.M31, (pfloat) transform.M32, (pfloat) transform.M33, (pfloat) transform.M34);
+			Row3 = new SCNVector4 ((pfloat) transform.M41, (pfloat) transform.M42, (pfloat) transform.M43, (pfloat) transform.M44);
 		}
 #endif
 	

--- a/tests/monotouch-test/ObjCRuntime/TrampolineTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/TrampolineTest.cs
@@ -326,10 +326,10 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Messaging.CATransform3D_objc_msgSend_stret (out catransform3d, obj.Handle, new Selector ("testCATransform3D").Handle);
 			}
 			CATransform3D res = new CATransform3D ();
-			res.m11 = 11.1f;
-			res.m22 = 22.2f;
-			res.m33 = 33.3f;
-			res.m44 = 44.4f;
+			res.M11 = 11.1f;
+			res.M22 = 22.2f;
+			res.M33 = 33.3f;
+			res.M44 = 44.4f;
 			Assert.That (catransform3d.Equals (res), "#testCATransform3D");
 #endif // !__WATCHOS__
 			
@@ -743,10 +743,10 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		public CATransform3D Test_CATransform3D ()
 		{
 			CATransform3D res = new CATransform3D ();
-			res.m11 = 11.1f;
-			res.m22 = 22.2f;
-			res.m33 = 33.3f;
-			res.m44 = 44.4f;
+			res.M11 = 11.1f;
+			res.M22 = 22.2f;
+			res.M33 = 33.3f;
+			res.M44 = 44.4f;
 			return res;
 		}
 #endif // !__WATCHOS__

--- a/tests/test-libraries/testgenerator.cs
+++ b/tests/test-libraries/testgenerator.cs
@@ -98,7 +98,7 @@ static class C {
 		new BindAsData { Managed = "CMTimeRange", Native = "CMTimeRange", ManagedCondition = "HAVE_COREMEDIA", ManagedNewExpression = "new CMTimeRange { Duration = new CMTime (37, 38), Start = new CMTime (39, 40) }", Map = ".CMTimeRangeValue", MapFrom = "FromCMTimeRange"  },
 		new BindAsData { Managed = "CMTime", Native = "CMTime", ManagedCondition = "HAVE_COREMEDIA",  ManagedNewExpression = "new CMTime (35, 36)", Map = ".CMTimeValue", MapFrom = "FromCMTime"  },
 		new BindAsData { Managed = "CMTimeMapping", Native = "CMTimeMapping", ManagedCondition = "HAVE_COREMEDIA", ManagedNewExpression = "new CMTimeMapping { Source = new CMTimeRange { Duration = new CMTime (42, 43), Start = new CMTime (44, 45) } }", Map = ".CMTimeMappingValue", MapFrom = "FromCMTimeMapping"  },
-		new BindAsData { Managed = "CATransform3D", Native = "CATransform3D", ManagedCondition = "HAVE_COREANIMATION", ManagedNewExpression = "new CATransform3D { m11 = 41 }", Map = ".CATransform3DValue", MapFrom = "FromCATransform3D"  },
+		new BindAsData { Managed = "CATransform3D", Native = "CATransform3D", ManagedCondition = "HAVE_COREANIMATION", ManagedNewExpression = "new CATransform3D { M11 = 41 }", Map = ".CATransform3DValue", MapFrom = "FromCATransform3D"  },
 		new BindAsData { Managed = "NSDirectionalEdgeInsets", Native = "NSDirectionalEdgeInsets", ManagedCondition = "HAVE_UIKIT", ManagedNewExpression = "new NSDirectionalEdgeInsets (42, 43, 44, 45)", Map = ".DirectionalEdgeInsetsValue", MapFrom = "FromDirectionalEdgeInsets", MinXcodeVersion = new Version (9, 0) },
 	};
 


### PR DESCRIPTION
Public fields shouldn't start with a lower-cased letter.

Also provide public properties in legacy Xamarin so that we can write
identical code for both, and obsolete the lower-cased fields.