### PR TITLE
[xharness] Bump timeout for the .NET tests to 3 hours. Fixes #xamarin/maccore@2538.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -248,7 +248,7 @@ namespace Xharness.Jenkins {
 				TestProject = buildDotNetTestsProject,
 				Platform = TestPlatform.All,
 				TestName = "DotNet tests",
-				Timeout = TimeSpan.FromMinutes (120),
+				Timeout = TimeSpan.FromMinutes (180),
 				Ignored = !IncludeDotNet,
 			};
 			Tasks.Add (runDotNetTests);


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2538.