### PR TITLE
[AudioToolbox] Use unsafe code to marshal in/out arrays. Fixes #xamarin/maccore@2537.

### DIFF
--- a/src/AudioToolbox/AudioFile.cs
+++ b/src/AudioToolbox/AudioFile.cs
@@ -794,7 +794,7 @@ namespace AudioToolbox {
 		[DllImport (Constants.AudioToolboxLibrary)]
 		unsafe extern static OSStatus AudioFileReadPacketData (
 			AudioFileID audioFile, [MarshalAs (UnmanagedType.I1)] bool useCache, ref int numBytes, 
-			AudioStreamPacketDescription [] packetDescriptions, long inStartingPacket, ref int numPackets, IntPtr outBuffer);
+			AudioStreamPacketDescription* packetDescriptions, long inStartingPacket, ref int numPackets, IntPtr outBuffer);
 
 		public AudioStreamPacketDescription []? ReadPacketData (long inStartingPacket, int nPackets, byte [] buffer)
 		{
@@ -898,7 +898,10 @@ namespace AudioToolbox {
 		
 		unsafe AudioStreamPacketDescription []? RealReadPacketData (bool useCache, long inStartingPacket, ref int nPackets, IntPtr buffer, ref int count, out AudioFileError error, AudioStreamPacketDescription[] descriptions)
 		{
-			var r = AudioFileReadPacketData (Handle, useCache, ref count, descriptions, inStartingPacket, ref nPackets, buffer);
+			OSStatus r;
+			fixed (AudioStreamPacketDescription* pdesc = &descriptions [0]) {
+				r = AudioFileReadPacketData (Handle, useCache, ref count, pdesc, inStartingPacket, ref nPackets, buffer);
+			}
 
 			error = (AudioFileError)r;
 
@@ -957,7 +960,10 @@ namespace AudioToolbox {
 		{
 			var descriptions = new AudioStreamPacketDescription [nPackets];
 			fixed (byte *bop = &buffer [offset]){
-				var r = AudioFileReadPacketData (Handle, useCache, ref count, descriptions, inStartingPacket, ref nPackets, (IntPtr) bop);
+				OSStatus r;
+				fixed (AudioStreamPacketDescription* pdesc = &descriptions [0]) {
+					r = AudioFileReadPacketData (Handle, useCache, ref count, pdesc, inStartingPacket, ref nPackets, (IntPtr) bop);
+				}
 				error = (AudioFileError)r;
 				if (r == (int) AudioFileError.EndOfFile) {
 					if (count == 0)


### PR DESCRIPTION
Arrays are by default only marshaled to P/Invokes, any changes done to the array
in native code are not copied back to managed memory.

Ref: https://docs.microsoft.com/en-us/dotnet/framework/interop/marshaling-different-types-of-arrays

However, broken code tend to work just fine, because the runtime usually just passes
a pointer to the managed memory to the P/Invoke. This is fast (no need to copy memory
around), but it also has the side effect that any changes to the memory during execution
of the P/Invoke is observed in managed code as well.

For some reason the MonoTouchFixtures.AudioToolbox.AudioConverterTest test runs into
a scenario where this isn't the case, and the test ends up hanging.

So fix it by making the P/Invoke take a pointer to the AudioStreamPacketDescription
array instead of the array itself, and we explicitly pass it a pointer to the managed
memory of the array. This way we'll see any changes to the array in managed code.

Fixes https://github.com/xamarin/maccore/issues/2537.