### PR TITLE
[SceneKit] Make SCNMatrix4 column-major in .NET. Fixes #4652.

### DIFF
--- a/dotnet/BreakingChanges.md
+++ b/dotnet/BreakingChanges.md
@@ -74,3 +74,14 @@ These APIs are used to determine whether we're executing in the simulator or
 on a device. Neither apply to a Mac Catalyst app, so they've been removed.
 
 Any code that these APIs will have to be ported to not use these APIs.
+
+## The SceneKit.SCNMatrix4 matrix is transposed in memory.
+
+The managed SCNMatrix4 struct used to be a row-major matrix, while the native
+SCNMatrix4 struct is a column-major matrix. This difference in the memory
+representation meant that matrices would often have to be transposed when
+interacting with the platform.
+
+In .NET, we've changed the managed SCNMatrix4 to be a column-major matrix, to
+match the native version. This means that any transposing that's currently
+done when accessing Apple APIs has to be undone.

--- a/src/SceneKit/SCNMatrix4.cs
+++ b/src/SceneKit/SCNMatrix4.cs
@@ -26,6 +26,8 @@ SOFTWARE.
 
  */
 
+#if !NET
+
 using System;
 using System.Runtime.InteropServices;
 using Foundation;
@@ -170,6 +172,12 @@ namespace SceneKit
         public SCNVector4 Column0
         {
             get { return new SCNVector4(Row0.X, Row1.X, Row2.X, Row3.X); }
+            set {
+                M11 = value.X;
+                M21 = value.Y;
+                M31 = value.Z;
+                M41 = value.W;
+            }
         }
 
         /// <summary>
@@ -178,6 +186,12 @@ namespace SceneKit
         public SCNVector4 Column1
         {
             get { return new SCNVector4(Row0.Y, Row1.Y, Row2.Y, Row3.Y); }
+            set {
+                M12 = value.X;
+                M22 = value.Y;
+                M32 = value.Z;
+                M42 = value.W;
+            }
         }
 
         /// <summary>
@@ -186,6 +200,12 @@ namespace SceneKit
         public SCNVector4 Column2
         {
             get { return new SCNVector4(Row0.Z, Row1.Z, Row2.Z, Row3.Z); }
+            set {
+                M13 = value.X;
+                M23 = value.Y;
+                M33 = value.Z;
+                M43 = value.W;
+            }
         }
 
         /// <summary>
@@ -194,6 +214,12 @@ namespace SceneKit
         public SCNVector4 Column3
         {
             get { return new SCNVector4(Row0.W, Row1.W, Row2.W, Row3.W); }
+            set {
+                M14 = value.X;
+                M24 = value.Y;
+                M34 = value.Z;
+                M44 = value.W;
+            }
         }
 
         /// <summary>
@@ -307,6 +333,29 @@ namespace SceneKit
         #endregion
 
         #region Static
+
+        #region CreateFromColumns
+
+        public static SCNMatrix4 CreateFromColumns (SCNVector4 column0, SCNVector4 column1, SCNVector4 column2, SCNVector4 column3)
+        {
+            var result = new SCNMatrix4 ();
+            result.Column0 = column0;
+            result.Column1 = column1;
+            result.Column2 = column2;
+            result.Column3 = column3;
+            return result;
+        }
+
+        public static void CreateFromColumns (SCNVector4 column0, SCNVector4 column1, SCNVector4 column2, SCNVector4 column3, out SCNMatrix4 result)
+        {
+            result = new SCNMatrix4 ();
+            result.Column0 = column0;
+            result.Column1 = column1;
+            result.Column2 = column2;
+            result.Column3 = column3;
+        }
+
+        #endregion
         
         #region CreateFromAxisAngle
         
@@ -1176,3 +1225,6 @@ namespace SceneKit
 #endif
     }
 }
+
+#endif // !NET
+

--- a/src/SceneKit/SCNMatrix4_dotnet.cs
+++ b/src/SceneKit/SCNMatrix4_dotnet.cs
@@ -1,0 +1,1201 @@
+/*
+ * This keeps the code of OpenTK's Matrix4 almost intact, except we replace the
+ * Vector4 with a SCNVector4
+ 
+Copyright (c) 2006 - 2008 The Open Toolkit library.
+Copyright (c) 2014 Xamarin Inc.  All rights reserved
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+ */
+
+#if NET
+
+#if !MONOMAC
+#define PFLOAT_SINGLE
+#endif
+
+using System;
+using System.Runtime.InteropServices;
+using Foundation;
+
+using Vector3 = global::OpenTK.Vector3;
+using Vector3d = global::OpenTK.Vector3d;
+using Vector4 = global::OpenTK.Vector4;
+using Quaternion = global::OpenTK.Quaternion;
+using Quaterniond = global::OpenTK.Quaterniond;
+
+#if PFLOAT_SINGLE
+using pfloat = System.Single;
+#else
+using pfloat = ObjCRuntime.nfloat;
+#endif
+
+#nullable enable
+
+namespace SceneKit {
+	/// <summary>
+	/// Represents a 4x4 Matrix
+	/// </summary>
+	[Serializable]
+	public struct SCNMatrix4 : IEquatable<SCNMatrix4> {
+		#region Fields
+
+		/// <summary>
+		/// Left-most column of the matrix
+		/// </summary>
+		public SCNVector4 Column0;
+		/// <summary>
+		/// 2nd column of the matrix
+		/// </summary>
+		public SCNVector4 Column1;
+		/// <summary>
+		/// 3rd column of the matrix
+		/// </summary>
+		public SCNVector4 Column2;
+		/// <summary>
+		/// Right-most column of the matrix
+		/// </summary>
+		public SCNVector4 Column3;
+
+		/// <summary>
+		/// The identity matrix
+		/// </summary>
+		public readonly static SCNMatrix4 Identity = new SCNMatrix4 (SCNVector4.UnitX, SCNVector4.UnitY, SCNVector4.UnitZ, SCNVector4.UnitW);
+
+		#endregion
+
+		#region Constructors
+
+		/// <summary>
+		/// Constructs a new instance.
+		/// </summary>
+		/// <param name="row0">Top row of the matrix</param>
+		/// <param name="row1">Second row of the matrix</param>
+		/// <param name="row2">Third row of the matrix</param>
+		/// <param name="row3">Bottom row of the matrix</param>
+		public SCNMatrix4 (SCNVector4 row0, SCNVector4 row1, SCNVector4 row2, SCNVector4 row3)
+		{
+			Column0 = new SCNVector4 (row0.X, row1.X, row2.X, row3.X);
+			Column1 = new SCNVector4 (row0.Y, row1.Y, row2.Y, row3.Y);
+			Column2 = new SCNVector4 (row0.Z, row1.Z, row2.Z, row3.Z);
+			Column3 = new SCNVector4 (row0.W, row1.W, row2.W, row3.W);
+		}
+
+		/// <summary>
+		/// Constructs a new instance.
+		/// </summary>
+		/// <param name="m00">First item of the first row of the matrix.</param>
+		/// <param name="m01">Second item of the first row of the matrix.</param>
+		/// <param name="m02">Third item of the first row of the matrix.</param>
+		/// <param name="m03">Fourth item of the first row of the matrix.</param>
+		/// <param name="m10">First item of the second row of the matrix.</param>
+		/// <param name="m11">Second item of the second row of the matrix.</param>
+		/// <param name="m12">Third item of the second row of the matrix.</param>
+		/// <param name="m13">Fourth item of the second row of the matrix.</param>
+		/// <param name="m20">First item of the third row of the matrix.</param>
+		/// <param name="m21">Second item of the third row of the matrix.</param>
+		/// <param name="m22">Third item of the third row of the matrix.</param>
+		/// <param name="m23">First item of the third row of the matrix.</param>
+		/// <param name="m30">Fourth item of the fourth row of the matrix.</param>
+		/// <param name="m31">Second item of the fourth row of the matrix.</param>
+		/// <param name="m32">Third item of the fourth row of the matrix.</param>
+		/// <param name="m33">Fourth item of the fourth row of the matrix.</param>
+		public SCNMatrix4 (
+			pfloat m00, pfloat m01, pfloat m02, pfloat m03,
+			pfloat m10, pfloat m11, pfloat m12, pfloat m13,
+			pfloat m20, pfloat m21, pfloat m22, pfloat m23,
+			pfloat m30, pfloat m31, pfloat m32, pfloat m33)
+		{
+			Column0 = new SCNVector4 (m00, m10, m20, m30);
+			Column1 = new SCNVector4 (m01, m11, m21, m31);
+			Column2 = new SCNVector4 (m02, m12, m22, m32);
+			Column3 = new SCNVector4 (m03, m13, m23, m33);
+		}
+
+#if !WATCH
+		public SCNMatrix4 (CoreAnimation.CATransform3D transform)
+		{
+			Column0 = new SCNVector4 ((pfloat) transform.M11, (pfloat) transform.M21, (pfloat) transform.M31, (pfloat) transform.M41);
+			Column1 = new SCNVector4 ((pfloat) transform.M12, (pfloat) transform.M22, (pfloat) transform.M32, (pfloat) transform.M42);
+			Column2 = new SCNVector4 ((pfloat) transform.M13, (pfloat) transform.M23, (pfloat) transform.M33, (pfloat) transform.M43);
+			Column3 = new SCNVector4 ((pfloat) transform.M14, (pfloat) transform.M24, (pfloat) transform.M34, (pfloat) transform.M44);
+		}
+#endif
+
+		#endregion
+
+		#region Public Members
+
+		#region Properties
+
+		/// <summary>
+		/// The determinant of this matrix
+		/// </summary>
+		public pfloat Determinant {
+			get {
+				return
+					Column0.X * Column1.Y * Column2.Z * Column3.W - Column0.X * Column1.Y * Column2.W * Column3.Z + Column0.X * Column1.Z * Column2.W * Column3.Y - Column0.X * Column1.Z * Column2.Y * Column3.W
+				  + Column0.X * Column1.W * Column2.Y * Column3.Z - Column0.X * Column1.W * Column2.Z * Column3.Y - Column0.Y * Column1.Z * Column2.W * Column3.X + Column0.Y * Column1.Z * Column2.X * Column3.W
+				  - Column0.Y * Column1.W * Column2.X * Column3.Z + Column0.Y * Column1.W * Column2.Z * Column3.X - Column0.Y * Column1.X * Column2.Z * Column3.W + Column0.Y * Column1.X * Column2.W * Column3.Z
+				  + Column0.Z * Column1.W * Column2.X * Column3.Y - Column0.Z * Column1.W * Column2.Y * Column3.X + Column0.Z * Column1.X * Column2.Y * Column3.W - Column0.Z * Column1.X * Column2.W * Column3.Y
+				  + Column0.Z * Column1.Y * Column2.W * Column3.X - Column0.Z * Column1.Y * Column2.X * Column3.W - Column0.W * Column1.X * Column2.Y * Column3.Z + Column0.W * Column1.X * Column2.Z * Column3.Y
+				  - Column0.W * Column1.Y * Column2.Z * Column3.X + Column0.W * Column1.Y * Column2.X * Column3.Z - Column0.W * Column1.Z * Column2.X * Column3.Y + Column0.W * Column1.Z * Column2.Y * Column3.X;
+			}
+		}
+
+		/// <summary>
+		/// The top row of this matrix
+		/// </summary>
+		public SCNVector4 Row0 {
+			get { return new SCNVector4 (Column0.X, Column1.X, Column2.X, Column3.X); }
+			set {
+				M11 = value.X;
+				M12 = value.Y;
+				M13 = value.Z;
+				M14 = value.W;
+			}
+		}
+
+		/// <summary>
+		/// The second row of this matrix
+		/// </summary>
+		public SCNVector4 Row1 {
+			get { return new SCNVector4 (Column0.Y, Column1.Y, Column2.Y, Column3.Y); }
+			set {
+				M21 = value.X;
+				M22 = value.Y;
+				M23 = value.Z;
+				M24 = value.W;
+			}
+		}
+
+		/// <summary>
+		/// The third row of this matrix
+		/// </summary>
+		public SCNVector4 Row2 {
+			get { return new SCNVector4 (Column0.Z, Column1.Z, Column2.Z, Column3.Z); }
+			set {
+				M31 = value.X;
+				M32 = value.Y;
+				M33 = value.Z;
+				M34 = value.W;
+			}
+		}
+
+		/// <summary>
+		/// The last row of this matrix
+		/// </summary>
+		public SCNVector4 Row3 {
+			get { return new SCNVector4 (Column0.W, Column1.W, Column2.W, Column3.W); }
+			set {
+				M41 = value.X;
+				M42 = value.Y;
+				M43 = value.Z;
+				M44 = value.W;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value at row 1, column 1 of this instance.
+		/// </summary>
+		public pfloat M11 { get { return Column0.X; } set { Column0.X = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 1, column 2 of this instance.
+		/// </summary>
+		public pfloat M12 { get { return Column1.X; } set { Column1.X = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 1, column 3 of this instance.
+		/// </summary>
+		public pfloat M13 { get { return Column2.X; } set { Column2.X = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 1, column 4 of this instance.
+		/// </summary>
+		public pfloat M14 { get { return Column3.X; } set { Column3.X = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 2, column 1 of this instance.
+		/// </summary>
+		public pfloat M21 { get { return Column0.Y; } set { Column0.Y = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 2, column 2 of this instance.
+		/// </summary>
+		public pfloat M22 { get { return Column1.Y; } set { Column1.Y = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 2, column 3 of this instance.
+		/// </summary>
+		public pfloat M23 { get { return Column2.Y; } set { Column2.Y = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 2, column 4 of this instance.
+		/// </summary>
+		public pfloat M24 { get { return Column3.Y; } set { Column3.Y = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 3, column 1 of this instance.
+		/// </summary>
+		public pfloat M31 { get { return Column0.Z; } set { Column0.Z = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 3, column 2 of this instance.
+		/// </summary>
+		public pfloat M32 { get { return Column1.Z; } set { Column1.Z = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 3, column 3 of this instance.
+		/// </summary>
+		public pfloat M33 { get { return Column2.Z; } set { Column2.Z = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 3, column 4 of this instance.
+		/// </summary>
+		public pfloat M34 { get { return Column3.Z; } set { Column3.Z = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 4, column 1 of this instance.
+		/// </summary>
+		public pfloat M41 { get { return Column0.W; } set { Column0.W = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 4, column 2 of this instance.
+		/// </summary>
+		public pfloat M42 { get { return Column1.W; } set { Column1.W = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 4, column 3 of this instance.
+		/// </summary>
+		public pfloat M43 { get { return Column2.W; } set { Column2.W = value; } }
+
+		/// <summary>
+		/// Gets or sets the value at row 4, column 4 of this instance.
+		/// </summary>
+		public pfloat M44 { get { return Column3.W; } set { Column3.W = value; } }
+
+		#endregion
+
+		#region Instance
+
+		#region public void Invert()
+
+		/// <summary>
+		/// Converts this instance into its inverse.
+		/// </summary>
+		public void Invert ()
+		{
+			this = SCNMatrix4.Invert (this);
+		}
+
+		#endregion
+
+		#region public void Transpose()
+
+		/// <summary>
+		/// Converts this instance into its transpose.
+		/// </summary>
+		public void Transpose ()
+		{
+			this = SCNMatrix4.Transpose (this);
+		}
+
+		#endregion
+
+		#endregion
+
+		#region Static
+
+		#region CreateFromColumns
+
+		public static SCNMatrix4 CreateFromColumns (SCNVector4 column0, SCNVector4 column1, SCNVector4 column2, SCNVector4 column3)
+		{
+			var result = new SCNMatrix4 ();
+			result.Column0 = column0;
+			result.Column1 = column1;
+			result.Column2 = column2;
+			result.Column3 = column3;
+			return result;
+		}
+
+		public static void CreateFromColumns (SCNVector4 column0, SCNVector4 column1, SCNVector4 column2, SCNVector4 column3, out SCNMatrix4 result)
+		{
+			result = new SCNMatrix4 ();
+			result.Column0 = column0;
+			result.Column1 = column1;
+			result.Column2 = column2;
+			result.Column3 = column3;
+		}
+
+		#endregion
+
+		#region CreateFromAxisAngle
+
+		/// <summary>
+		/// Build a rotation matrix from the specified axis/angle rotation.
+		/// </summary>
+		/// <param name="axis">The axis to rotate about.</param>
+		/// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
+		/// <param name="result">A matrix instance.</param>
+		public static void CreateFromAxisAngle (SCNVector3 axis, pfloat angle, out SCNMatrix4 result)
+		{
+			pfloat cos = (float) System.Math.Cos (-angle);
+			pfloat sin = (float) System.Math.Sin (-angle);
+			pfloat t = 1.0f - cos;
+
+			axis.Normalize ();
+
+			result = new SCNMatrix4 (t * axis.X * axis.X + cos, t * axis.X * axis.Y - sin * axis.Z, t * axis.X * axis.Z + sin * axis.Y, 0.0f,
+								 t * axis.X * axis.Y + sin * axis.Z, t * axis.Y * axis.Y + cos, t * axis.Y * axis.Z - sin * axis.X, 0.0f,
+								 t * axis.X * axis.Z - sin * axis.Y, t * axis.Y * axis.Z + sin * axis.X, t * axis.Z * axis.Z + cos, 0.0f,
+								 0, 0, 0, 1);
+		}
+
+		public static void CreateFromAxisAngle (Vector3 axis, float angle, out SCNMatrix4 result)
+		{
+			pfloat cos = (float) System.Math.Cos (-angle);
+			pfloat sin = (float) System.Math.Sin (-angle);
+			pfloat t = 1.0f - cos;
+
+			axis.Normalize ();
+
+			result = new SCNMatrix4 (t * axis.X * axis.X + cos, t * axis.X * axis.Y - sin * axis.Z, t * axis.X * axis.Z + sin * axis.Y, 0.0f,
+								 t * axis.X * axis.Y + sin * axis.Z, t * axis.Y * axis.Y + cos, t * axis.Y * axis.Z - sin * axis.X, 0.0f,
+								 t * axis.X * axis.Z - sin * axis.Y, t * axis.Y * axis.Z + sin * axis.X, t * axis.Z * axis.Z + cos, 0.0f,
+								 0, 0, 0, 1);
+		}
+
+		public static void CreateFromAxisAngle (Vector3d axis, double angle, out SCNMatrix4 result)
+		{
+			double cos = System.Math.Cos (-angle);
+			double sin = System.Math.Sin (-angle);
+			double t = 1.0f - cos;
+
+			axis.Normalize ();
+
+			result = new SCNMatrix4 ((pfloat) (t * axis.X * axis.X + cos), (pfloat) (t * axis.X * axis.Y - sin * axis.Z), (pfloat) (t * axis.X * axis.Z + sin * axis.Y), (pfloat) (0.0f),
+					(pfloat) ( t * axis.X * axis.Y + sin * axis.Z), (pfloat) (t * axis.Y * axis.Y + cos), (pfloat) (t * axis.Y * axis.Z - sin * axis.X), (pfloat) 0.0f,
+					(pfloat) (t * axis.X * axis.Z - sin * axis.Y), (pfloat) (t * axis.Y * axis.Z + sin * axis.X), (pfloat) (t * axis.Z * axis.Z + cos), (pfloat) 0.0f,
+					0, 0, 0, 1);
+		}
+
+		/// <summary>
+		/// Build a rotation matrix from the specified axis/angle rotation.
+		/// </summary>
+		/// <param name="axis">The axis to rotate about.</param>
+		/// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
+		/// <returns>A matrix instance.</returns>
+		public static SCNMatrix4 CreateFromAxisAngle (SCNVector3 axis, pfloat angle)
+		{
+			SCNMatrix4 result;
+			CreateFromAxisAngle (axis, angle, out result);
+			return result;
+		}
+
+		#endregion
+
+		#region CreateRotation[XYZ]
+
+		/// <summary>
+		/// Builds a rotation matrix for a rotation around the x-axis.
+		/// </summary>
+		/// <param name="angle">The counter-clockwise angle in radians.</param>
+		/// <param name="result">The resulting SCNMatrix4 instance.</param>
+		public static void CreateRotationX (pfloat angle, out SCNMatrix4 result)
+		{
+			pfloat cos = (pfloat) System.Math.Cos (angle);
+			pfloat sin = (pfloat) System.Math.Sin (angle);
+
+			result = new SCNMatrix4 ();
+			result.Row0 = SCNVector4.UnitX;
+			result.Row1 = new SCNVector4 (0.0f, cos, sin, 0.0f);
+			result.Row2 = new SCNVector4 (0.0f, -sin, cos, 0.0f);
+			result.Row3 = SCNVector4.UnitW;
+		}
+
+		/// <summary>
+		/// Builds a rotation matrix for a rotation around the x-axis.
+		/// </summary>
+		/// <param name="angle">The counter-clockwise angle in radians.</param>
+		/// <returns>The resulting SCNMatrix4 instance.</returns>
+		public static SCNMatrix4 CreateRotationX (pfloat angle)
+		{
+			SCNMatrix4 result;
+			CreateRotationX (angle, out result);
+			return result;
+		}
+
+		/// <summary>
+		/// Builds a rotation matrix for a rotation around the y-axis.
+		/// </summary>
+		/// <param name="angle">The counter-clockwise angle in radians.</param>
+		/// <param name="result">The resulting SCNMatrix4 instance.</param>
+		public static void CreateRotationY (pfloat angle, out SCNMatrix4 result)
+		{
+			pfloat cos = (pfloat) System.Math.Cos (angle);
+			pfloat sin = (pfloat) System.Math.Sin (angle);
+
+			result = new SCNMatrix4 ();
+			result.Row0 = new SCNVector4 (cos, 0.0f, -sin, 0.0f);
+			result.Row1 = SCNVector4.UnitY;
+			result.Row2 = new SCNVector4 (sin, 0.0f, cos, 0.0f);
+			result.Row3 = SCNVector4.UnitW;
+		}
+
+		/// <summary>
+		/// Builds a rotation matrix for a rotation around the y-axis.
+		/// </summary>
+		/// <param name="angle">The counter-clockwise angle in radians.</param>
+		/// <returns>The resulting SCNMatrix4 instance.</returns>
+		public static SCNMatrix4 CreateRotationY (pfloat angle)
+		{
+			SCNMatrix4 result;
+			CreateRotationY (angle, out result);
+			return result;
+		}
+
+		/// <summary>
+		/// Builds a rotation matrix for a rotation around the z-axis.
+		/// </summary>
+		/// <param name="angle">The counter-clockwise angle in radians.</param>
+		/// <param name="result">The resulting SCNMatrix4 instance.</param>
+		public static void CreateRotationZ (pfloat angle, out SCNMatrix4 result)
+		{
+			pfloat cos = (pfloat) System.Math.Cos (angle);
+			pfloat sin = (pfloat) System.Math.Sin (angle);
+
+			result = new SCNMatrix4 ();
+			result.Row0 = new SCNVector4 (cos, sin, 0.0f, 0.0f);
+			result.Row1 = new SCNVector4 (-sin, cos, 0.0f, 0.0f);
+			result.Row2 = SCNVector4.UnitZ;
+			result.Row3 = SCNVector4.UnitW;
+		}
+
+		/// <summary>
+		/// Builds a rotation matrix for a rotation around the z-axis.
+		/// </summary>
+		/// <param name="angle">The counter-clockwise angle in radians.</param>
+		/// <returns>The resulting SCNMatrix4 instance.</returns>
+		public static SCNMatrix4 CreateRotationZ (pfloat angle)
+		{
+			SCNMatrix4 result;
+			CreateRotationZ (angle, out result);
+			return result;
+		}
+
+		#endregion
+
+		#region CreateTranslation
+
+		/// <summary>
+		/// Creates a translation matrix.
+		/// </summary>
+		/// <param name="x">X translation.</param>
+		/// <param name="y">Y translation.</param>
+		/// <param name="z">Z translation.</param>
+		/// <param name="result">The resulting SCNMatrix4 instance.</param>
+		public static void CreateTranslation (pfloat x, pfloat y, pfloat z, out SCNMatrix4 result)
+		{
+			result = Identity;
+			result.Row3 = new SCNVector4 (x, y, z, 1);
+		}
+
+		/// <summary>
+		/// Creates a translation matrix.
+		/// </summary>
+		/// <param name="vector">The translation vector.</param>
+		/// <param name="result">The resulting SCNMatrix4 instance.</param>
+		public static void CreateTranslation (ref SCNVector3 vector, out SCNMatrix4 result)
+		{
+			result = Identity;
+			result.Row3 = new SCNVector4 (vector.X, vector.Y, vector.Z, 1);
+		}
+
+		/// <summary>
+		/// Creates a translation matrix.
+		/// </summary>
+		/// <param name="x">X translation.</param>
+		/// <param name="y">Y translation.</param>
+		/// <param name="z">Z translation.</param>
+		/// <returns>The resulting SCNMatrix4 instance.</returns>
+		public static SCNMatrix4 CreateTranslation (pfloat x, pfloat y, pfloat z)
+		{
+			SCNMatrix4 result;
+			CreateTranslation (x, y, z, out result);
+			return result;
+		}
+
+		/// <summary>
+		/// Creates a translation matrix.
+		/// </summary>
+		/// <param name="vector">The translation vector.</param>
+		/// <returns>The resulting SCNMatrix4 instance.</returns>
+		public static SCNMatrix4 CreateTranslation (SCNVector3 vector)
+		{
+			SCNMatrix4 result;
+			CreateTranslation (vector.X, vector.Y, vector.Z, out result);
+			return result;
+		}
+
+		#endregion
+
+		#region CreateOrthographic
+
+		/// <summary>
+		/// Creates an orthographic projection matrix.
+		/// </summary>
+		/// <param name="width">The width of the projection volume.</param>
+		/// <param name="height">The height of the projection volume.</param>
+		/// <param name="zNear">The near edge of the projection volume.</param>
+		/// <param name="zFar">The far edge of the projection volume.</param>
+		/// <param name="result">The resulting SCNMatrix4 instance.</param>
+		public static void CreateOrthographic (pfloat width, pfloat height, pfloat zNear, pfloat zFar, out SCNMatrix4 result)
+		{
+			CreateOrthographicOffCenter (-width / 2, width / 2, -height / 2, height / 2, zNear, zFar, out result);
+		}
+
+		/// <summary>
+		/// Creates an orthographic projection matrix.
+		/// </summary>
+		/// <param name="width">The width of the projection volume.</param>
+		/// <param name="height">The height of the projection volume.</param>
+		/// <param name="zNear">The near edge of the projection volume.</param>
+		/// <param name="zFar">The far edge of the projection volume.</param>
+		/// <rereturns>The resulting SCNMatrix4 instance.</rereturns>
+		public static SCNMatrix4 CreateOrthographic (pfloat width, pfloat height, pfloat zNear, pfloat zFar)
+		{
+			SCNMatrix4 result;
+			CreateOrthographicOffCenter (-width / 2, width / 2, -height / 2, height / 2, zNear, zFar, out result);
+			return result;
+		}
+
+		#endregion
+
+		#region CreateOrthographicOffCenter
+
+		/// <summary>
+		/// Creates an orthographic projection matrix.
+		/// </summary>
+		/// <param name="left">The left edge of the projection volume.</param>
+		/// <param name="right">The right edge of the projection volume.</param>
+		/// <param name="bottom">The bottom edge of the projection volume.</param>
+		/// <param name="top">The top edge of the projection volume.</param>
+		/// <param name="zNear">The near edge of the projection volume.</param>
+		/// <param name="zFar">The far edge of the projection volume.</param>
+		/// <param name="result">The resulting SCNMatrix4 instance.</param>
+		public static void CreateOrthographicOffCenter (pfloat left, pfloat right, pfloat bottom, pfloat top, pfloat zNear, pfloat zFar, out SCNMatrix4 result)
+		{
+			result = new SCNMatrix4 ();
+
+			pfloat invRL = 1 / (right - left);
+			pfloat invTB = 1 / (top - bottom);
+			pfloat invFN = 1 / (zFar - zNear);
+
+			result.M11 = 2 * invRL;
+			result.M22 = 2 * invTB;
+			result.M33 = -2 * invFN;
+
+			result.M41 = -(right + left) * invRL;
+			result.M42 = -(top + bottom) * invTB;
+			result.M43 = -(zFar + zNear) * invFN;
+			result.M44 = 1;
+		}
+
+		/// <summary>
+		/// Creates an orthographic projection matrix.
+		/// </summary>
+		/// <param name="left">The left edge of the projection volume.</param>
+		/// <param name="right">The right edge of the projection volume.</param>
+		/// <param name="bottom">The bottom edge of the projection volume.</param>
+		/// <param name="top">The top edge of the projection volume.</param>
+		/// <param name="zNear">The near edge of the projection volume.</param>
+		/// <param name="zFar">The far edge of the projection volume.</param>
+		/// <returns>The resulting SCNMatrix4 instance.</returns>
+		public static SCNMatrix4 CreateOrthographicOffCenter (pfloat left, pfloat right, pfloat bottom, pfloat top, pfloat zNear, pfloat zFar)
+		{
+			SCNMatrix4 result;
+			CreateOrthographicOffCenter (left, right, bottom, top, zNear, zFar, out result);
+			return result;
+		}
+
+		#endregion
+
+		#region CreatePerspectiveFieldOfView
+
+		/// <summary>
+		/// Creates a perspective projection matrix.
+		/// </summary>
+		/// <param name="fovy">Angle of the field of view in the y direction (in radians)</param>
+		/// <param name="aspect">Aspect ratio of the view (width / height)</param>
+		/// <param name="zNear">Distance to the near clip plane</param>
+		/// <param name="zFar">Distance to the far clip plane</param>
+		/// <param name="result">A projection matrix that transforms camera space to raster space</param>
+		/// <exception cref="System.ArgumentOutOfRangeException">
+		/// Thrown under the following conditions:
+		/// <list type="bullet">
+		/// <item>fovy is zero, less than zero or larger than Math.PI</item>
+		/// <item>aspect is negative or zero</item>
+		/// <item>zNear is negative or zero</item>
+		/// <item>zFar is negative or zero</item>
+		/// <item>zNear is larger than zFar</item>
+		/// </list>
+		/// </exception>
+		public static void CreatePerspectiveFieldOfView (pfloat fovy, pfloat aspect, pfloat zNear, pfloat zFar, out SCNMatrix4 result)
+		{
+			if (fovy <= 0 || fovy > Math.PI)
+				throw new ArgumentOutOfRangeException ("fovy");
+			if (aspect <= 0)
+				throw new ArgumentOutOfRangeException ("aspect");
+			if (zNear <= 0)
+				throw new ArgumentOutOfRangeException ("zNear");
+			if (zFar <= 0)
+				throw new ArgumentOutOfRangeException ("zFar");
+			if (zNear >= zFar)
+				throw new ArgumentOutOfRangeException ("zNear");
+
+			pfloat yMax = zNear * (float) System.Math.Tan (0.5f * fovy);
+			pfloat yMin = -yMax;
+			pfloat xMin = yMin * aspect;
+			pfloat xMax = yMax * aspect;
+
+			CreatePerspectiveOffCenter (xMin, xMax, yMin, yMax, zNear, zFar, out result);
+		}
+
+		/// <summary>
+		/// Creates a perspective projection matrix.
+		/// </summary>
+		/// <param name="fovy">Angle of the field of view in the y direction (in radians)</param>
+		/// <param name="aspect">Aspect ratio of the view (width / height)</param>
+		/// <param name="zNear">Distance to the near clip plane</param>
+		/// <param name="zFar">Distance to the far clip plane</param>
+		/// <returns>A projection matrix that transforms camera space to raster space</returns>
+		/// <exception cref="System.ArgumentOutOfRangeException">
+		/// Thrown under the following conditions:
+		/// <list type="bullet">
+		/// <item>fovy is zero, less than zero or larger than Math.PI</item>
+		/// <item>aspect is negative or zero</item>
+		/// <item>zNear is negative or zero</item>
+		/// <item>zFar is negative or zero</item>
+		/// <item>zNear is larger than zFar</item>
+		/// </list>
+		/// </exception>
+		public static SCNMatrix4 CreatePerspectiveFieldOfView (pfloat fovy, pfloat aspect, pfloat zNear, pfloat zFar)
+		{
+			SCNMatrix4 result;
+			CreatePerspectiveFieldOfView (fovy, aspect, zNear, zFar, out result);
+			return result;
+		}
+
+		#endregion
+
+		#region CreatePerspectiveOffCenter
+
+		/// <summary>
+		/// Creates an perspective projection matrix.
+		/// </summary>
+		/// <param name="left">Left edge of the view frustum</param>
+		/// <param name="right">Right edge of the view frustum</param>
+		/// <param name="bottom">Bottom edge of the view frustum</param>
+		/// <param name="top">Top edge of the view frustum</param>
+		/// <param name="zNear">Distance to the near clip plane</param>
+		/// <param name="zFar">Distance to the far clip plane</param>
+		/// <param name="result">A projection matrix that transforms camera space to raster space</param>
+		/// <exception cref="System.ArgumentOutOfRangeException">
+		/// Thrown under the following conditions:
+		/// <list type="bullet">
+		/// <item>zNear is negative or zero</item>
+		/// <item>zFar is negative or zero</item>
+		/// <item>zNear is larger than zFar</item>
+		/// </list>
+		/// </exception>
+		public static void CreatePerspectiveOffCenter (pfloat left, pfloat right, pfloat bottom, pfloat top, pfloat zNear, pfloat zFar, out SCNMatrix4 result)
+		{
+			if (zNear <= 0)
+				throw new ArgumentOutOfRangeException ("zNear");
+			if (zFar <= 0)
+				throw new ArgumentOutOfRangeException ("zFar");
+			if (zNear >= zFar)
+				throw new ArgumentOutOfRangeException ("zNear");
+
+			pfloat x = (2.0f * zNear) / (right - left);
+			pfloat y = (2.0f * zNear) / (top - bottom);
+			pfloat a = (right + left) / (right - left);
+			pfloat b = (top + bottom) / (top - bottom);
+			pfloat c = -(zFar + zNear) / (zFar - zNear);
+			pfloat d = -(2.0f * zFar * zNear) / (zFar - zNear);
+
+			result = new SCNMatrix4 (x, 0, 0, 0,
+								 0, y, 0, 0,
+								 a, b, c, -1,
+								 0, 0, d, 0);
+		}
+
+		/// <summary>
+		/// Creates an perspective projection matrix.
+		/// </summary>
+		/// <param name="left">Left edge of the view frustum</param>
+		/// <param name="right">Right edge of the view frustum</param>
+		/// <param name="bottom">Bottom edge of the view frustum</param>
+		/// <param name="top">Top edge of the view frustum</param>
+		/// <param name="zNear">Distance to the near clip plane</param>
+		/// <param name="zFar">Distance to the far clip plane</param>
+		/// <returns>A projection matrix that transforms camera space to raster space</returns>
+		/// <exception cref="System.ArgumentOutOfRangeException">
+		/// Thrown under the following conditions:
+		/// <list type="bullet">
+		/// <item>zNear is negative or zero</item>
+		/// <item>zFar is negative or zero</item>
+		/// <item>zNear is larger than zFar</item>
+		/// </list>
+		/// </exception>
+		public static SCNMatrix4 CreatePerspectiveOffCenter (pfloat left, pfloat right, pfloat bottom, pfloat top, pfloat zNear, pfloat zFar)
+		{
+			SCNMatrix4 result;
+			CreatePerspectiveOffCenter (left, right, bottom, top, zNear, zFar, out result);
+			return result;
+		}
+
+		#endregion
+
+		#region Scale Functions
+
+		/// <summary>
+		/// Build a scaling matrix
+		/// </summary>
+		/// <param name="scale">Single scale factor for x,y and z axes</param>
+		/// <returns>A scaling matrix</returns>
+		public static SCNMatrix4 Scale (pfloat scale)
+		{
+			return Scale (scale, scale, scale);
+		}
+
+		/// <summary>
+		/// Build a scaling matrix
+		/// </summary>
+		/// <param name="scale">Scale factors for x,y and z axes</param>
+		/// <returns>A scaling matrix</returns>
+		public static SCNMatrix4 Scale (SCNVector3 scale)
+		{
+			return Scale (scale.X, scale.Y, scale.Z);
+		}
+
+		/// <summary>
+		/// Build a scaling matrix
+		/// </summary>
+		/// <param name="x">Scale factor for x-axis</param>
+		/// <param name="y">Scale factor for y-axis</param>
+		/// <param name="z">Scale factor for z-axis</param>
+		/// <returns>A scaling matrix</returns>
+		public static SCNMatrix4 Scale (pfloat x, pfloat y, pfloat z)
+		{
+			var result = new SCNMatrix4 ();
+			result.Row0 = SCNVector4.UnitX * x;
+			result.Row1 = SCNVector4.UnitY * y;
+			result.Row2 = SCNVector4.UnitZ * z;
+			result.Row3 = SCNVector4.UnitW;
+			return result;
+		}
+
+		#endregion
+
+		#region Rotation Functions
+
+		/// <summary>
+		/// Build a rotation matrix from a quaternion
+		/// </summary>
+		/// <param name="q">the quaternion</param>
+		/// <returns>A rotation matrix</returns>
+		public static SCNMatrix4 Rotate (Quaternion q)
+		{
+			SCNMatrix4 result;
+			Vector3 axis;
+			float angle;
+			q.ToAxisAngle (out axis, out angle);
+			CreateFromAxisAngle (axis, angle, out result);
+			return result;
+		}
+
+		/// <summary>
+		/// Build a rotation matrix from a quaternion
+		/// </summary>
+		/// <param name="q">the quaternion</param>
+		/// <returns>A rotation matrix</returns>
+		public static SCNMatrix4 Rotate (Quaterniond q)
+		{
+			Vector3d axis;
+			double angle;
+			SCNMatrix4 result;
+			q.ToAxisAngle (out axis, out angle);
+			CreateFromAxisAngle (axis, angle, out result);
+			return result;
+		}
+		#endregion
+
+		#region Camera Helper Functions
+
+		/// <summary>
+		/// Build a world space to camera space matrix
+		/// </summary>
+		/// <param name="eye">Eye (camera) position in world space</param>
+		/// <param name="target">Target position in world space</param>
+		/// <param name="up">Up vector in world space (should not be parallel to the camera direction, that is target - eye)</param>
+		/// <returns>A SCNMatrix4 that transforms world space to camera space</returns>
+		public static SCNMatrix4 LookAt (SCNVector3 eye, SCNVector3 target, SCNVector3 up)
+		{
+			SCNVector3 z = SCNVector3.Normalize (eye - target);
+			SCNVector3 x = SCNVector3.Normalize (SCNVector3.Cross (up, z));
+			SCNVector3 y = SCNVector3.Normalize (SCNVector3.Cross (z, x));
+
+			SCNMatrix4 rot = new SCNMatrix4 (new SCNVector4 (x.X, y.X, z.X, 0.0f),
+										new SCNVector4 (x.Y, y.Y, z.Y, 0.0f),
+										new SCNVector4 (x.Z, y.Z, z.Z, 0.0f),
+										SCNVector4.UnitW);
+
+			SCNMatrix4 trans = SCNMatrix4.CreateTranslation (-eye);
+
+			return trans * rot;
+		}
+
+		/// <summary>
+		/// Build a world space to camera space matrix
+		/// </summary>
+		/// <param name="eyeX">Eye (camera) position in world space</param>
+		/// <param name="eyeY">Eye (camera) position in world space</param>
+		/// <param name="eyeZ">Eye (camera) position in world space</param>
+		/// <param name="targetX">Target position in world space</param>
+		/// <param name="targetY">Target position in world space</param>
+		/// <param name="targetZ">Target position in world space</param>
+		/// <param name="upX">Up vector in world space (should not be parallel to the camera direction, that is target - eye)</param>
+		/// <param name="upY">Up vector in world space (should not be parallel to the camera direction, that is target - eye)</param>
+		/// <param name="upZ">Up vector in world space (should not be parallel to the camera direction, that is target - eye)</param>
+		/// <returns>A SCNMatrix4 that transforms world space to camera space</returns>
+		public static SCNMatrix4 LookAt (pfloat eyeX, pfloat eyeY, pfloat eyeZ, pfloat targetX, pfloat targetY, pfloat targetZ, pfloat upX, pfloat upY, pfloat upZ)
+		{
+			return LookAt (new SCNVector3 (eyeX, eyeY, eyeZ), new SCNVector3 (targetX, targetY, targetZ), new SCNVector3 (upX, upY, upZ));
+		}
+
+		#endregion
+
+		#region Multiply Functions
+
+		/// <summary>
+		/// Multiplies two instances.
+		/// </summary>
+		/// <param name="left">The left operand of the multiplication.</param>
+		/// <param name="right">The right operand of the multiplication.</param>
+		/// <returns>A new instance that is the result of the multiplication</returns>
+		public static SCNMatrix4 Mult (SCNMatrix4 left, SCNMatrix4 right)
+		{
+			SCNMatrix4 result;
+			Mult (ref left, ref right, out result);
+			return result;
+		}
+
+		/// <summary>
+		/// Multiplies two instances.
+		/// </summary>
+		/// <param name="left">The left operand of the multiplication.</param>
+		/// <param name="right">The right operand of the multiplication.</param>
+		/// <param name="result">A new instance that is the result of the multiplication</param>
+		public static void Mult (ref SCNMatrix4 left, ref SCNMatrix4 right, out SCNMatrix4 result)
+		{
+			result = new SCNMatrix4 (
+				left.M11 * right.M11 + left.M12 * right.M21 + left.M13 * right.M31 + left.M14 * right.M41,
+				left.M11 * right.M12 + left.M12 * right.M22 + left.M13 * right.M32 + left.M14 * right.M42,
+				left.M11 * right.M13 + left.M12 * right.M23 + left.M13 * right.M33 + left.M14 * right.M43,
+				left.M11 * right.M14 + left.M12 * right.M24 + left.M13 * right.M34 + left.M14 * right.M44,
+				left.M21 * right.M11 + left.M22 * right.M21 + left.M23 * right.M31 + left.M24 * right.M41,
+				left.M21 * right.M12 + left.M22 * right.M22 + left.M23 * right.M32 + left.M24 * right.M42,
+				left.M21 * right.M13 + left.M22 * right.M23 + left.M23 * right.M33 + left.M24 * right.M43,
+				left.M21 * right.M14 + left.M22 * right.M24 + left.M23 * right.M34 + left.M24 * right.M44,
+				left.M31 * right.M11 + left.M32 * right.M21 + left.M33 * right.M31 + left.M34 * right.M41,
+				left.M31 * right.M12 + left.M32 * right.M22 + left.M33 * right.M32 + left.M34 * right.M42,
+				left.M31 * right.M13 + left.M32 * right.M23 + left.M33 * right.M33 + left.M34 * right.M43,
+				left.M31 * right.M14 + left.M32 * right.M24 + left.M33 * right.M34 + left.M34 * right.M44,
+				left.M41 * right.M11 + left.M42 * right.M21 + left.M43 * right.M31 + left.M44 * right.M41,
+				left.M41 * right.M12 + left.M42 * right.M22 + left.M43 * right.M32 + left.M44 * right.M42,
+				left.M41 * right.M13 + left.M42 * right.M23 + left.M43 * right.M33 + left.M44 * right.M43,
+				left.M41 * right.M14 + left.M42 * right.M24 + left.M43 * right.M34 + left.M44 * right.M44);
+		}
+
+		#endregion
+
+		#region Invert Functions
+
+		static bool InvertSoftware (SCNMatrix4 matrix, out SCNMatrix4 result)
+		{
+			// https://github.com/dotnet/runtime/blob/79ae74f5ca5c8a6fe3a48935e85bd7374959c570/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs#L1556
+
+			pfloat a = matrix.M11, b = matrix.M12, c = matrix.M13, d = matrix.M14;
+			pfloat e = matrix.M21, f = matrix.M22, g = matrix.M23, h = matrix.M24;
+			pfloat i = matrix.M31, j = matrix.M32, k = matrix.M33, l = matrix.M34;
+			pfloat m = matrix.M41, n = matrix.M42, o = matrix.M43, p = matrix.M44;
+
+			pfloat kp_lo = k * p - l * o;
+			pfloat jp_ln = j * p - l * n;
+			pfloat jo_kn = j * o - k * n;
+			pfloat ip_lm = i * p - l * m;
+			pfloat io_km = i * o - k * m;
+			pfloat in_jm = i * n - j * m;
+
+			pfloat a11 = +(f * kp_lo - g * jp_ln + h * jo_kn);
+			pfloat a12 = -(e * kp_lo - g * ip_lm + h * io_km);
+			pfloat a13 = +(e * jp_ln - f * ip_lm + h * in_jm);
+			pfloat a14 = -(e * jo_kn - f * io_km + g * in_jm);
+
+			pfloat det = a * a11 + b * a12 + c * a13 + d * a14;
+
+#if PFLOAT_SINGLE
+			if (MathF.Abs (det) < pfloat.Epsilon)
+#else
+			if (Math.Abs (det) < pfloat.Epsilon)
+#endif
+			{
+				result = new SCNMatrix4 (pfloat.NaN, pfloat.NaN, pfloat.NaN, pfloat.NaN,
+				                         pfloat.NaN, pfloat.NaN, pfloat.NaN, pfloat.NaN,
+				                         pfloat.NaN, pfloat.NaN, pfloat.NaN, pfloat.NaN,
+				                         pfloat.NaN, pfloat.NaN, pfloat.NaN, pfloat.NaN);
+				return false;
+			}
+
+			result = default (SCNMatrix4);
+
+			pfloat invDet = 1.0f / det;
+
+			result.M11 = a11 * invDet;
+			result.M21 = a12 * invDet;
+			result.M31 = a13 * invDet;
+			result.M41 = a14 * invDet;
+
+			result.M12 = -(b * kp_lo - c * jp_ln + d * jo_kn) * invDet;
+			result.M22 = +(a * kp_lo - c * ip_lm + d * io_km) * invDet;
+			result.M32 = -(a * jp_ln - b * ip_lm + d * in_jm) * invDet;
+			result.M42 = +(a * jo_kn - b * io_km + c * in_jm) * invDet;
+
+			pfloat gp_ho = g * p - h * o;
+			pfloat fp_hn = f * p - h * n;
+			pfloat fo_gn = f * o - g * n;
+			pfloat ep_hm = e * p - h * m;
+			pfloat eo_gm = e * o - g * m;
+			pfloat en_fm = e * n - f * m;
+
+			result.M13 = +(b * gp_ho - c * fp_hn + d * fo_gn) * invDet;
+			result.M23 = -(a * gp_ho - c * ep_hm + d * eo_gm) * invDet;
+			result.M33 = +(a * fp_hn - b * ep_hm + d * en_fm) * invDet;
+			result.M43 = -(a * fo_gn - b * eo_gm + c * en_fm) * invDet;
+
+			pfloat gl_hk = g * l - h * k;
+			pfloat fl_hj = f * l - h * j;
+			pfloat fk_gj = f * k - g * j;
+			pfloat el_hi = e * l - h * i;
+			pfloat ek_gi = e * k - g * i;
+			pfloat ej_fi = e * j - f * i;
+
+			result.M14 = -(b * gl_hk - c * fl_hj + d * fk_gj) * invDet;
+			result.M24 = +(a * gl_hk - c * el_hi + d * ek_gi) * invDet;
+			result.M34 = -(a * fl_hj - b * el_hi + d * ej_fi) * invDet;
+			result.M44 = +(a * fk_gj - b * ek_gi + c * ej_fi) * invDet;
+
+			return true;
+		}
+
+		/// <summary>
+		/// Calculate the inverse of the given matrix
+		/// </summary>
+		/// <param name="mat">The matrix to invert</param>
+		/// <returns>The inverse of the given matrix if it has one, or the input if it is singular</returns>
+		/// <exception cref="InvalidOperationException">Thrown if the SCNMatrix4 is singular.</exception>
+		public static SCNMatrix4 Invert (SCNMatrix4 matrix)
+		{
+			if (!InvertSoftware (matrix, out var inverse))
+				throw new InvalidOperationException ("Matrix is singular and cannot be inverted.");
+			return inverse;
+		}
+
+		#endregion
+
+		#region Transpose
+
+		/// <summary>
+		/// Calculate the transpose of the given matrix
+		/// </summary>
+		/// <param name="mat">The matrix to transpose</param>
+		/// <returns>The transpose of the given matrix</returns>
+		public static SCNMatrix4 Transpose (SCNMatrix4 mat)
+		{
+			return new SCNMatrix4 (mat.Column0, mat.Column1, mat.Column2, mat.Column3);
+		}
+
+
+		/// <summary>
+		/// Calculate the transpose of the given matrix
+		/// </summary>
+		/// <param name="mat">The matrix to transpose</param>
+		/// <param name="result">The result of the calculation</param>
+		public static void Transpose (ref SCNMatrix4 mat, out SCNMatrix4 result)
+		{
+			result = new SCNMatrix4 (mat.Column0, mat.Column1, mat.Column2, mat.Column3);
+		}
+
+		#endregion
+
+		#endregion
+
+		#region Operators
+
+		/// <summary>
+		/// Matrix multiplication
+		/// </summary>
+		/// <param name="left">left-hand operand</param>
+		/// <param name="right">right-hand operand</param>
+		/// <returns>A new SCNMatrix44 which holds the result of the multiplication</returns>
+		public static SCNMatrix4 operator * (SCNMatrix4 left, SCNMatrix4 right)
+		{
+			return SCNMatrix4.Mult (left, right);
+		}
+
+		/// <summary>
+		/// Compares two instances for equality.
+		/// </summary>
+		/// <param name="left">The first instance.</param>
+		/// <param name="right">The second instance.</param>
+		/// <returns>True, if left equals right; false otherwise.</returns>
+		public static bool operator == (SCNMatrix4 left, SCNMatrix4 right)
+		{
+			return left.Equals (right);
+		}
+
+		/// <summary>
+		/// Compares two instances for inequality.
+		/// </summary>
+		/// <param name="left">The first instance.</param>
+		/// <param name="right">The second instance.</param>
+		/// <returns>True, if left does not equal right; false otherwise.</returns>
+		public static bool operator != (SCNMatrix4 left, SCNMatrix4 right)
+		{
+			return !left.Equals (right);
+		}
+
+		#endregion
+
+		#region Overrides
+
+		#region public override string ToString()
+
+		/// <summary>
+		/// Returns a System.String that represents the current SCNMatrix44.
+		/// </summary>
+		/// <returns></returns>
+		public override string ToString ()
+		{
+			return String.Format ("{0}\n{1}\n{2}\n{3}", Row0, Row1, Row2, Row3);
+		}
+
+		#endregion
+
+		#region public override int GetHashCode()
+
+		/// <summary>
+		/// Returns the hashcode for this instance.
+		/// </summary>
+		/// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
+		public override int GetHashCode ()
+		{
+			return Column0.GetHashCode () ^ Column1.GetHashCode () ^ Column2.GetHashCode () ^ Column3.GetHashCode ();
+		}
+
+		#endregion
+
+		#region public override bool Equals(object obj)
+
+		/// <summary>
+		/// Indicates whether this instance and a specified object are equal.
+		/// </summary>
+		/// <param name="obj">The object to compare tresult.</param>
+		/// <returns>True if the instances are equal; false otherwise.</returns>
+		public override bool Equals (object? obj)
+		{
+			if (!(obj is SCNMatrix4))
+				return false;
+
+			return this.Equals ((SCNMatrix4) obj);
+		}
+
+		#endregion
+
+		#endregion
+
+		#endregion
+
+		#region IEquatable<SCNMatrix4> Members
+
+		/// <summary>Indicates whether the current matrix is equal to another matrix.</summary>
+		/// <param name="other">An matrix to compare with this matrix.</param>
+		/// <returns>true if the current matrix is equal to the matrix parameter; otherwise, false.</returns>
+		public bool Equals (SCNMatrix4 other)
+		{
+			return
+				Column0 == other.Column0 &&
+				Column1 == other.Column1 &&
+				Column2 == other.Column2 &&
+				Column3 == other.Column3;
+		}
+
+		#endregion
+
+#if false
+
+	// The following code compiles, btu I want to think about
+	// making this so easily accessible with an implicit operator,
+	// after all, this can be up to 1k of data being moved.
+	
+	// We can do implicit, because our storage is always >= CATransform3D which uses nfloats
+	public static implicit operator CoreAnimation.CATransform3D (SCNMatrix4 source)
+	{
+		return new CoreAnimation.CATransform3D (){
+			m11 = source.Row0.X,
+			m12 = source.Row0.Y,
+			m13 = source.Row0.Z,
+			m14 = source.Row0.W,
+
+			m21 = source.Row1.X,
+			m22 = source.Row1.Y,
+			m23 = source.Row1.Z,
+			m24 = source.Row1.W,
+
+			m31 = source.Row2.X,
+			m32 = source.Row2.Y,
+			m33 = source.Row2.Z,
+			m34 = source.Row2.W,
+
+			m41 = source.Row3.X,
+			m42 = source.Row3.Y,
+			m43 = source.Row3.Z,
+			m44 = source.Row3.W,
+		};
+	}
+#endif
+	}
+}
+
+#endif // NET
+

--- a/src/SceneKit/SCNMatrix4_dotnet.cs
+++ b/src/SceneKit/SCNMatrix4_dotnet.cs
@@ -365,9 +365,9 @@ namespace SceneKit {
 			axis.Normalize ();
 
 			result = new SCNMatrix4 (t * axis.X * axis.X + cos, t * axis.X * axis.Y - sin * axis.Z, t * axis.X * axis.Z + sin * axis.Y, 0.0f,
-								 t * axis.X * axis.Y + sin * axis.Z, t * axis.Y * axis.Y + cos, t * axis.Y * axis.Z - sin * axis.X, 0.0f,
-								 t * axis.X * axis.Z - sin * axis.Y, t * axis.Y * axis.Z + sin * axis.X, t * axis.Z * axis.Z + cos, 0.0f,
-								 0, 0, 0, 1);
+			                     t * axis.X * axis.Y + sin * axis.Z, t * axis.Y * axis.Y + cos, t * axis.Y * axis.Z - sin * axis.X, 0.0f,
+			                     t * axis.X * axis.Z - sin * axis.Y, t * axis.Y * axis.Z + sin * axis.X, t * axis.Z * axis.Z + cos, 0.0f,
+			                     0, 0, 0, 1);
 		}
 
 		public static void CreateFromAxisAngle (Vector3 axis, float angle, out SCNMatrix4 result)
@@ -379,9 +379,9 @@ namespace SceneKit {
 			axis.Normalize ();
 
 			result = new SCNMatrix4 (t * axis.X * axis.X + cos, t * axis.X * axis.Y - sin * axis.Z, t * axis.X * axis.Z + sin * axis.Y, 0.0f,
-								 t * axis.X * axis.Y + sin * axis.Z, t * axis.Y * axis.Y + cos, t * axis.Y * axis.Z - sin * axis.X, 0.0f,
-								 t * axis.X * axis.Z - sin * axis.Y, t * axis.Y * axis.Z + sin * axis.X, t * axis.Z * axis.Z + cos, 0.0f,
-								 0, 0, 0, 1);
+			                     t * axis.X * axis.Y + sin * axis.Z, t * axis.Y * axis.Y + cos, t * axis.Y * axis.Z - sin * axis.X, 0.0f,
+			                     t * axis.X * axis.Z - sin * axis.Y, t * axis.Y * axis.Z + sin * axis.X, t * axis.Z * axis.Z + cos, 0.0f,
+			                     0, 0, 0, 1);
 		}
 
 		public static void CreateFromAxisAngle (Vector3d axis, double angle, out SCNMatrix4 result)
@@ -393,9 +393,9 @@ namespace SceneKit {
 			axis.Normalize ();
 
 			result = new SCNMatrix4 ((pfloat) (t * axis.X * axis.X + cos), (pfloat) (t * axis.X * axis.Y - sin * axis.Z), (pfloat) (t * axis.X * axis.Z + sin * axis.Y), (pfloat) (0.0f),
-					(pfloat) ( t * axis.X * axis.Y + sin * axis.Z), (pfloat) (t * axis.Y * axis.Y + cos), (pfloat) (t * axis.Y * axis.Z - sin * axis.X), (pfloat) 0.0f,
-					(pfloat) (t * axis.X * axis.Z - sin * axis.Y), (pfloat) (t * axis.Y * axis.Z + sin * axis.X), (pfloat) (t * axis.Z * axis.Z + cos), (pfloat) 0.0f,
-					0, 0, 0, 1);
+			         (pfloat) ( t * axis.X * axis.Y + sin * axis.Z), (pfloat) (t * axis.Y * axis.Y + cos), (pfloat) (t * axis.Y * axis.Z - sin * axis.X), (pfloat) 0.0f,
+			         (pfloat) (t * axis.X * axis.Z - sin * axis.Y), (pfloat) (t * axis.Y * axis.Z + sin * axis.X), (pfloat) (t * axis.Z * axis.Z + cos), (pfloat) 0.0f,
+			         0, 0, 0, 1);
 		}
 
 		/// <summary>
@@ -744,9 +744,9 @@ namespace SceneKit {
 			pfloat d = -(2.0f * zFar * zNear) / (zFar - zNear);
 
 			result = new SCNMatrix4 (x, 0, 0, 0,
-								 0, y, 0, 0,
-								 a, b, c, -1,
-								 0, 0, d, 0);
+			                     0, y, 0, 0,
+			                     a, b, c, -1,
+			                     0, 0, d, 0);
 		}
 
 		/// <summary>
@@ -866,9 +866,9 @@ namespace SceneKit {
 			SCNVector3 y = SCNVector3.Normalize (SCNVector3.Cross (z, x));
 
 			SCNMatrix4 rot = new SCNMatrix4 (new SCNVector4 (x.X, y.X, z.X, 0.0f),
-										new SCNVector4 (x.Y, y.Y, z.Y, 0.0f),
-										new SCNVector4 (x.Z, y.Z, z.Z, 0.0f),
-										SCNVector4.UnitW);
+			                             new SCNVector4 (x.Y, y.Y, z.Y, 0.0f),
+			                             new SCNVector4 (x.Z, y.Z, z.Z, 0.0f),
+			                             SCNVector4.UnitW);
 
 			SCNMatrix4 trans = SCNMatrix4.CreateTranslation (-eye);
 

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1469,6 +1469,7 @@ SCENEKIT_API_SOURCES = \
 
 SCENEKIT_CORE_SOURCES = \
 	SceneKit/SCNMatrix4.cs \
+	SceneKit/SCNMatrix4_dotnet.cs \
 	SceneKit/SCNQuaternion.cs \
 	SceneKit/SCNVector3.cs \
 	SceneKit/SCNVector4.cs \

--- a/tests/monotouch-test/SceneKit/SCNMatrixTest.cs
+++ b/tests/monotouch-test/SceneKit/SCNMatrixTest.cs
@@ -1,0 +1,817 @@
+//
+// Unit tests for SCNMatrix4
+//
+// Authors:
+//	Sebastien Pouliot <sebastien@xamarin.com>
+//
+// Copyright 2014 Xamarin Inc. All rights reserved.
+//
+
+#nullable enable
+
+using System;
+using CoreAnimation;
+using Foundation;
+using SceneKit;
+using OpenTK;
+
+using NUnit.Framework;
+
+#if __MACOS__
+#if NET
+using pfloat = ObjCRuntime.nfloat;
+#else
+using pfloat = System.nfloat;
+#endif
+#else
+using pfloat = System.Single;
+#endif
+
+namespace MonoTouchFixtures.SceneKit {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class SCNMatrix4Test {
+		static pfloat OneThird = (pfloat) (1.0 / 3.0);
+		static pfloat OneFifteenth = (pfloat) (1.0 / 15.0);
+		static pfloat TwoThirds = (pfloat) (2.0 / 3.0);
+		static pfloat TwoFifteenths = (pfloat) (2.0 / 15.0); // 0.1333333333..
+		static pfloat SqrtTwo = (pfloat) (Math.Sqrt (2));
+		static pfloat SqrtTwoHalved = (pfloat) (Math.Sqrt (2) / 2);
+		static pfloat SqrtThree = (pfloat) (Math.Sqrt (3));
+		static pfloat SqrtThreeHalved = (pfloat) (Math.Sqrt (3) / 2);
+		static pfloat SqrtThreeInverted = (pfloat) (1 / Math.Sqrt (3));
+		static pfloat SqrtSix = (pfloat) (Math.Sqrt (6));
+		static pfloat SqrtSixInverted = (pfloat)  (1 / Math.Sqrt (6));
+		static pfloat SqrtTwelve = (pfloat) (Math.Sqrt (12)); // 3.464102
+		static pfloat OhPointFive = (pfloat) 0.5;
+
+		public static bool CloseEnough (double a, double b, double epsilon = 0.00001)
+		{
+			const double MinNormal = 2.2250738585072014E-308d;
+			var absA = Math.Abs (a);
+			var absB = Math.Abs (b);
+			var diff = Math.Abs (a - b);
+
+			if (a == b) {
+				return true;
+			} else if (a == 0 || b == 0 || absA + absB < MinNormal) {
+				// a or b is zero or both are extremely close to it
+				// relative error is less meaningful here
+				return diff < (epsilon * MinNormal);
+			} else { // use relative error
+				return diff / (absA + absB) < epsilon;
+			}
+		}
+
+		void AssertEqual (SCNMatrix4 matrix, string message,
+			pfloat m11, pfloat m12, pfloat m13, pfloat m14,
+			pfloat m21, pfloat m22, pfloat m23, pfloat m24,
+			pfloat m31, pfloat m32, pfloat m33, pfloat m34,
+			pfloat m41, pfloat m42, pfloat m43, pfloat m44
+		)
+		{
+			if (CloseEnough (m11, matrix.M11) && CloseEnough (m12, matrix.M12) && CloseEnough (m13, matrix.M13) && CloseEnough (m14, matrix.M14) &&
+				CloseEnough (m21, matrix.M21) && CloseEnough (m22, matrix.M22) && CloseEnough (m23, matrix.M23) && CloseEnough (m24, matrix.M24) &&
+				CloseEnough (m31, matrix.M31) && CloseEnough (m32, matrix.M32) && CloseEnough (m33, matrix.M33) && CloseEnough (m34, matrix.M34) &&
+				CloseEnough (m41, matrix.M41) && CloseEnough (m42, matrix.M42) && CloseEnough (m43, matrix.M43) && CloseEnough (m44, matrix.M44))
+				return;
+
+			var actualString = matrix.ToString ();
+
+			var row1 = $"({m11}, {m12}, {m13}, {m14})";
+			var row2 = $"({m21}, {m22}, {m23}, {m24})";
+			var row3 = $"({m31}, {m32}, {m33}, {m34})";
+			var row4 = $"({m41}, {m42}, {m43}, {m44})";
+			var expectedString = $"{row1}\n{row2}\n{row3}\n{row4}";
+			Assert.Fail ($"Expected matrix:\n{expectedString}\nActual matrix:\n{actualString}\n{message}");
+		}
+
+		void AssertEqual (SCNVector4 vector, string message, pfloat m1, pfloat m2, pfloat m3, pfloat m4)
+		{
+			if (m1 == vector.X && m2 == vector.Y && m3 == vector.Z && m4 == vector.W)
+				return;
+
+			var expectedString = vector.ToString ();
+			var actualString = $"({m1}, {m2}, {m3}, {m4})";
+
+			Assert.Fail ($"Expected vector:\n{expectedString}\nActual vector:\n{actualString}\n{message}");
+		}
+
+		[Test]
+		public void Identity ()
+		{
+			var matrix = SCNMatrix4.Identity;
+			AssertEqual (matrix, "Identity",
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void Constructor_RowVectors ()
+		{
+			var matrix = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			AssertEqual (matrix, "Constructor",
+				11, 12, 13, 14,
+				21, 22, 23, 24,
+				31, 32, 33, 34,
+				41, 42, 43, 44);
+		}
+
+		[Test]
+		public void Constructor_Elements ()
+		{
+			var matrix = new SCNMatrix4 (
+				11, 12, 13, 14,
+				21, 22, 23, 24,
+				31, 32, 33, 34,
+				41, 42, 43, 44);
+			AssertEqual (matrix, "Constructor",
+				11, 12, 13, 14,
+				21, 22, 23, 24,
+				31, 32, 33, 34,
+				41, 42, 43, 44);
+		}
+
+#if !WATCH
+		[Test]
+		public void Constructor_CATransform3d ()
+		{
+			var transform = new CATransform3D () {
+				M11 = 11,
+				M12 = 12,
+				M13 = 13,
+				M14 = 14,
+				M21 = 21,
+				M22 = 22,
+				M23 = 23,
+				M24 = 24,
+				M31 = 31,
+				M32 = 32,
+				M33 = 33,
+				M34 = 34,
+				M41 = 41,
+				M42 = 42,
+				M43 = 43,
+				M44 = 44,
+			};
+			var matrix = new SCNMatrix4 (transform);
+			AssertEqual (matrix, "Constructor",
+				11, 12, 13, 14,
+				21, 22, 23, 24,
+				31, 32, 33, 34,
+				41, 42, 43, 44);
+		}
+#endif
+
+		[Test]
+		public void Determinant ()
+		{
+			var matrix = new SCNMatrix4 (
+				3, 5, 8, 9,
+				5, 3, 5, 8,
+				9, 6, 4, 2,
+				4, 6, 9, 8);
+			Assert.AreEqual ((pfloat) (-165), matrix.Determinant, "Determinant");
+		}
+
+
+		[Test]
+		public void Rows ()
+		{
+			var matrix = new SCNMatrix4 (
+				11, 12, 13, 14,
+				21, 22, 23, 24,
+				31, 32, 33, 34,
+				41, 42, 43, 44);
+			AssertEqual (matrix.Row0, "Row0", 11, 12, 13, 14);
+			AssertEqual (matrix.Row1, "Row1", 21, 22, 23, 24);
+			AssertEqual (matrix.Row2, "Row2", 31, 32, 33, 34);
+			AssertEqual (matrix.Row3, "Row3", 41, 42, 43, 44);
+		}
+
+		[Test]
+		public void Elements ()
+		{
+			var matrix = new SCNMatrix4 (
+				11, 12, 13, 14,
+				21, 22, 23, 24,
+				31, 32, 33, 34,
+				41, 42, 43, 44);
+			Assert.AreEqual ((pfloat) 11, matrix.M11, "M11");
+			Assert.AreEqual ((pfloat) 12, matrix.M12, "M12");
+			Assert.AreEqual ((pfloat) 13, matrix.M13, "M13");
+			Assert.AreEqual ((pfloat) 14, matrix.M14, "M14");
+			Assert.AreEqual ((pfloat) 21, matrix.M21, "M21");
+			Assert.AreEqual ((pfloat) 22, matrix.M22, "M22");
+			Assert.AreEqual ((pfloat) 23, matrix.M23, "M23");
+			Assert.AreEqual ((pfloat) 24, matrix.M24, "M24");
+			Assert.AreEqual ((pfloat) 31, matrix.M31, "M31");
+			Assert.AreEqual ((pfloat) 32, matrix.M32, "M32");
+			Assert.AreEqual ((pfloat) 33, matrix.M33, "M33");
+			Assert.AreEqual ((pfloat) 34, matrix.M34, "M34");
+			Assert.AreEqual ((pfloat) 41, matrix.M41, "M41");
+			Assert.AreEqual ((pfloat) 42, matrix.M42, "M42");
+			Assert.AreEqual ((pfloat) 43, matrix.M43, "M43");
+			Assert.AreEqual ((pfloat) 44, matrix.M44, "M44");
+		}
+
+		[Test]
+		public void Invert ()
+		{
+			var matrix = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			var ex = Assert.Throws<InvalidOperationException> (() => matrix.Invert (), "Singular matrix");
+			Assert.That (ex.Message, Does.Contain ("Matrix is singular and cannot be inverted"), "Singular matrix message");
+
+			matrix = new SCNMatrix4 (
+				3, 5, 8, 9,
+				5, 3, 5, 8,
+				9, 6, 4, 2,
+				4, 6, 9, 8);
+			matrix.Invert ();
+
+			AssertEqual (matrix, "Invert",
+				(pfloat) (-0.6181818181818182), (pfloat) (0.3151515151515151), (pfloat) (-0.030303030303030304), (pfloat) (0.3878787878787879),
+				(pfloat) (1.6363636363636365), (pfloat) (-0.696969696969697), (pfloat) (0.3939393939393939), (pfloat) (-1.2424242424242424),
+				(pfloat) (-1.3818181818181818), (pfloat) (0.3515151515151515), (pfloat) (-0.30303030303030304), (pfloat) (1.2787878787878788),
+				(pfloat) (0.6363636363636364), (pfloat) (-0.030303030303030304), (pfloat) (0.06060606060606061), (pfloat) (-0.5757575757575758));
+		}
+
+		[Test]
+		public void Transpose ()
+		{
+			var matrix = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			matrix.Transpose ();
+			AssertEqual (matrix, "Transpose",
+				11, 21, 31, 41,
+				12, 22, 32, 42,
+				13, 23, 33, 43,
+				14, 24, 34, 44);
+		}
+
+		[Test]
+		public void CreateFromColumns ()
+		{
+			var matrix = SCNMatrix4.CreateFromColumns (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			AssertEqual (matrix, "CreateFromColumns",
+				11, 21, 31, 41,
+				12, 22, 32, 42,
+				13, 23, 33, 43,
+				14, 24, 34, 44);
+		}
+
+		[Test]
+		public void CreateFromColumns_Out ()
+		{
+			SCNMatrix4.CreateFromColumns (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44),
+			out var matrix);
+			AssertEqual (matrix, "CreateFromColumns",
+				11, 21, 31, 41,
+				12, 22, 32, 42,
+				13, 23, 33, 43,
+				14, 24, 34, 44);
+		}
+
+		[Test]
+		public void CreateFromAxisAngle_pfloat_Out ()
+		{
+			SCNMatrix4.CreateFromAxisAngle (new SCNVector3 (2, 2, 2), (pfloat) (Math.PI / 3), out var matrix);
+			AssertEqual (matrix, "CreateFromAxisAngle",
+				TwoThirds, TwoThirds, -OneThird, 0,
+				-OneThird, TwoThirds, TwoThirds, 0,
+				TwoThirds, -OneThird, TwoThirds, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void CreateFromAxisAngle_float_Out ()
+		{
+			SCNMatrix4.CreateFromAxisAngle (new Vector3 (2, 2, 2), (float) (Math.PI / 3), out var matrix);
+			AssertEqual (matrix, "CreateFromAxisAngle",
+				TwoThirds, TwoThirds, -OneThird, 0,
+				-OneThird, TwoThirds, TwoThirds, 0,
+				TwoThirds, -OneThird, TwoThirds, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void CreateFromAxisAngle_double_Out ()
+		{
+			SCNMatrix4.CreateFromAxisAngle (new Vector3d (2, 2, 2), (double) (Math.PI / 3), out var matrix);
+			AssertEqual (matrix, "CreateFromAxisAngle",
+				TwoThirds, TwoThirds, -OneThird, 0,
+				-OneThird, TwoThirds, TwoThirds, 0,
+				TwoThirds, -OneThird, TwoThirds, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void CreateFromAxisAngle ()
+		{
+			var matrix = SCNMatrix4.CreateFromAxisAngle (new SCNVector3 (2, 2, 2), (pfloat) (Math.PI / 3));
+			AssertEqual (matrix, "CreateFromAxisAngle",
+				TwoThirds, TwoThirds, -OneThird, 0,
+				-OneThird, TwoThirds, TwoThirds, 0,
+				TwoThirds, -OneThird, TwoThirds, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void CreateRotationX_Out ()
+		{
+			SCNMatrix4.CreateRotationX ((pfloat) (Math.PI / 3), out var matrix);
+			AssertEqual (matrix, "CreateRotationX",
+				1, 0, 0, 0,
+				0, OhPointFive, SqrtThreeHalved, 0,
+				0, -SqrtThreeHalved, OhPointFive, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void CreateRotationX ()
+		{
+			var matrix = SCNMatrix4.CreateRotationX ((pfloat) (Math.PI / 3));
+			AssertEqual (matrix, "CreateRotationX",
+				1, 0, 0, 0,
+				0, OhPointFive, SqrtThreeHalved, 0,
+				0, -SqrtThreeHalved, OhPointFive, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void CreateRotationY_Out ()
+		{
+			SCNMatrix4.CreateRotationY ((pfloat) (Math.PI / 3), out var matrix);
+			AssertEqual (matrix, "CreateRotationY",
+				OhPointFive, 0, -SqrtThreeHalved, 0,
+				0, 1, 0, 0,
+				SqrtThreeHalved, 0, OhPointFive, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void CreateRotationY ()
+		{
+			var matrix = SCNMatrix4.CreateRotationY ((pfloat) (Math.PI / 3));
+			AssertEqual (matrix, "CreateRotationY",
+				OhPointFive, 0, -SqrtThreeHalved, 0,
+				0, 1, 0, 0,
+				SqrtThreeHalved, 0, OhPointFive, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void CreateRotationZ_Out ()
+		{
+			SCNMatrix4.CreateRotationZ ((pfloat) (Math.PI / 3), out var matrix);
+			AssertEqual (matrix, "CreateRotationZ",
+				OhPointFive, SqrtThreeHalved, 0, 0,
+				-SqrtThreeHalved, OhPointFive, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void CreateRotationZ ()
+		{
+			var matrix = SCNMatrix4.CreateRotationZ ((pfloat) (Math.PI / 3));
+			AssertEqual (matrix, "CreateRotationZ",
+				OhPointFive, SqrtThreeHalved, 0, 0,
+				-SqrtThreeHalved, OhPointFive, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void CreateTranslation_Out ()
+		{
+			SCNMatrix4.CreateTranslation (1, 2, 3, out var matrix);
+			AssertEqual (matrix, "CreateTranslation",
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				1, 2, 3, 1);
+		}
+
+		[Test]
+		public void CreateTranslation_Vector_Out ()
+		{
+			var translation = new SCNVector3 (1, 2, 3);
+			SCNMatrix4.CreateTranslation (ref translation, out var matrix);
+			AssertEqual (matrix, "CreateTranslation",
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				1, 2, 3, 1);
+		}
+
+		[Test]
+		public void CreateTranslation ()
+		{
+			var matrix = SCNMatrix4.CreateTranslation (1, 2, 3);
+			AssertEqual (matrix, "CreateTranslation",
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				1, 2, 3, 1);
+		}
+
+		[Test]
+		public void CreateTranslation_Vector ()
+		{
+			var translation = new SCNVector3 (1, 2, 3);
+			var matrix = SCNMatrix4.CreateTranslation (translation);
+			AssertEqual (matrix, "CreateTranslation",
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				1, 2, 3, 1);
+		}
+
+		[Test]
+		public void CreateOrthographic_Out ()
+		{
+			SCNMatrix4.CreateOrthographic (1, 2, 3, 4, out var matrix);
+			AssertEqual (matrix, "CreateOrthographic",
+				2, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, -2, 0,
+				0, 0, -7, 1);
+		}
+
+		[Test]
+		public void CreateOrthographic ()
+		{
+			var matrix = SCNMatrix4.CreateOrthographic (1, 2, 3, 4);
+			AssertEqual (matrix, "CreateOrthographic",
+				2, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, -2, 0,
+				0, 0, -7, 1);
+		}
+
+		[Test]
+		public void CreateOrthographicOffCenter_Out ()
+		{
+			SCNMatrix4.CreateOrthographicOffCenter (1, 2, 3, 4, 5, 6, out var matrix);
+			AssertEqual (matrix, "CreateOrthographicOffCenter",
+				2, 0, 0, 0,
+				0, 2, 0, 0,
+				0, 0, -2, 0,
+				-3, -7, -11, 1);
+		}
+
+		[Test]
+		public void CreateOrthographicOffCenter ()
+		{
+			var matrix = SCNMatrix4.CreateOrthographicOffCenter (1, 2, 3, 4, 5, 6);
+			AssertEqual (matrix, "CreateOrthographicOffCenter",
+				2, 0, 0, 0,
+				0, 2, 0, 0,
+				0, 0, -2, 0,
+				-3, -7, -11, 1);
+		}
+
+		[Test]
+		public void CreatePerspectiveFieldOfView_Out ()
+		{
+			SCNMatrix4.CreatePerspectiveFieldOfView ((pfloat) (Math.PI / 3), 2, 3, 4, out var matrix);
+			AssertEqual (matrix, "CreatePerspectiveFieldOfView",
+				SqrtThreeHalved, 0, 0, 0,
+				0, SqrtThree, 0, 0,
+				0, 0, -7, -1,
+				0, 0, -24, 0);
+		}
+
+		[Test]
+		public void CreatePerspectiveFieldOfView ()
+		{
+			var matrix = SCNMatrix4.CreatePerspectiveFieldOfView ((pfloat) (Math.PI / 3), 2, 3, 4);
+			AssertEqual (matrix, "CreatePerspectiveFieldOfView",
+				SqrtThreeHalved, 0, 0, 0,
+				0, SqrtThree, 0, 0,
+				0, 0, -7, -1,
+				0, 0, -24, 0);
+		}
+
+		[Test]
+		public void CreatePerspectiveOffCenter_Out ()
+		{
+			SCNMatrix4.CreatePerspectiveOffCenter (1, 2, 3, 4, 5, 6, out var matrix);
+			AssertEqual (matrix, "CreatePerspectiveOffCenter",
+				10, 0, 0, 0,
+				0, 10, 0, 0,
+				3, 7, -11, -1,
+				0, 0, -60, 0);
+		}
+
+		[Test]
+		public void CreatePerspectiveOffCenter ()
+		{
+			var matrix = SCNMatrix4.CreatePerspectiveOffCenter (1, 2, 3, 4, 5, 6);
+			AssertEqual (matrix, "CreatePerspectiveOffCenter",
+				10, 0, 0, 0,
+				0, 10, 0, 0,
+				3, 7, -11, -1,
+				0, 0, -60, 0);
+		}
+
+		[Test]
+		public void Scale ()
+		{
+			var matrix = SCNMatrix4.Scale (2);
+			AssertEqual (matrix, "CreateScale",
+				2, 0, 0, 0,
+				0, 2, 0, 0,
+				0, 0, 2, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void Scale_Vector ()
+		{
+			var matrix = SCNMatrix4.Scale (new SCNVector3 (1, 2, 3));
+			AssertEqual (matrix, "CreateScale",
+				1, 0, 0, 0,
+				0, 2, 0, 0,
+				0, 0, 3, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void Scale_3 ()
+		{
+			var matrix = SCNMatrix4.Scale (1, 2, 3);
+			AssertEqual (matrix, "CreateScale",
+				1, 0, 0, 0,
+				0, 2, 0, 0,
+				0, 0, 3, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void Rotate ()
+		{
+			var quaternion = new Quaternion (1, 2, 3, 4);
+			var matrix = SCNMatrix4.Rotate (quaternion);
+			AssertEqual (matrix, "Rotate",
+				TwoFifteenths, 7 * TwoFifteenths, -OneThird, 0,
+				-TwoThirds, OneThird, TwoThirds, 0,
+				11 * OneFifteenth, TwoFifteenths, TwoThirds, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void Rotate_d ()
+		{
+			var quaternion = new Quaterniond (1, 2, 3, 4);
+			var matrix = SCNMatrix4.Rotate (quaternion);
+			AssertEqual (matrix, "Rotate",
+				TwoFifteenths, 7 * TwoFifteenths, -OneThird, 0,
+				-TwoThirds, OneThird, TwoThirds, 0,
+				11 * OneFifteenth, TwoFifteenths, TwoThirds, 0,
+				0, 0, 0, 1);
+		}
+
+		[Test]
+		public void LookAt_Vectors ()
+		{
+			var matrix = SCNMatrix4.LookAt (new SCNVector3 (1, 2, 3), new SCNVector3 (4, 5, 6), new SCNVector3 (7, 8, 9));
+			AssertEqual (matrix, "LookAt",
+				SqrtSixInverted, -SqrtTwoHalved, -SqrtThreeInverted, 0,
+				-2 * SqrtSixInverted, 0, -SqrtThreeInverted, 0,
+				SqrtSixInverted, SqrtTwoHalved, -SqrtThreeInverted, 0,
+				0, -SqrtTwo, SqrtTwelve, 1);
+		}
+
+		[Test]
+		public void LookAt_Elements ()
+		{
+			var matrix = SCNMatrix4.LookAt (1, 2, 3, 4, 5, 6, 7, 8, 9);
+			AssertEqual (matrix, "LookAt",
+				SqrtSixInverted, -SqrtTwoHalved, -SqrtThreeInverted, 0,
+				-2 * SqrtSixInverted, 0, -SqrtThreeInverted, 0,
+				SqrtSixInverted, SqrtTwoHalved, -SqrtThreeInverted, 0,
+				0, -SqrtTwo, SqrtTwelve, 1);
+		}
+
+		[Test]
+		public void Mult ()
+		{
+			var a = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			var b = new SCNMatrix4 (
+				new SCNVector4 (911, 912, 913, 914),
+				new SCNVector4 (921, 922, 923, 924),
+				new SCNVector4 (931, 932, 933, 934),
+				new SCNVector4 (941, 942, 943, 944));
+			var matrix = SCNMatrix4.Mult (a, b);
+			AssertEqual (matrix, "Mult",
+				46350, 46400, 46450, 46500,
+				83390, 83480, 83570, 83660,
+				120430, 120560, 120690, 120820,
+				157470, 157640, 157810, 157980);
+		}
+
+		[Test]
+		public void Mult_ByRef ()
+		{
+			var a = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			var b = new SCNMatrix4 (
+				new SCNVector4 (911, 912, 913, 914),
+				new SCNVector4 (921, 922, 923, 924),
+				new SCNVector4 (931, 932, 933, 934),
+				new SCNVector4 (941, 942, 943, 944));
+			SCNMatrix4.Mult (ref a, ref b, out var matrix);
+			AssertEqual (matrix, "Mult",
+				46350, 46400, 46450, 46500,
+				83390, 83480, 83570, 83660,
+				120430, 120560, 120690, 120820,
+				157470, 157640, 157810, 157980);
+		}
+
+		[Test]
+		public void Static_Invert ()
+		{
+			var a = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			var ex = Assert.Throws<InvalidOperationException> (() => SCNMatrix4.Invert (a), "Singular matrix");
+			Assert.That (ex.Message, Does.Contain ("Matrix is singular and cannot be inverted"), "Singular matrix message");
+
+			a = new SCNMatrix4 (
+				3, 5, 8, 9,
+				5, 3, 5, 8,
+				9, 6, 4, 2,
+				4, 6, 9, 8);
+
+			var matrix = SCNMatrix4.Invert (a);
+
+			AssertEqual (matrix, "Invert",
+				(pfloat) (-0.6181818181818182), (pfloat) (0.3151515151515151), (pfloat) (-0.030303030303030304), (pfloat) (0.3878787878787879),
+				(pfloat) (1.6363636363636365), (pfloat) (-0.696969696969697), (pfloat) (0.3939393939393939), (pfloat) (-1.2424242424242424),
+				(pfloat) (-1.3818181818181818), (pfloat) (0.3515151515151515), (pfloat) (-0.30303030303030304), (pfloat) (1.2787878787878788),
+				(pfloat) (0.6363636363636364), (pfloat) (-0.030303030303030304), (pfloat) (0.06060606060606061), (pfloat) (-0.5757575757575758));
+		}
+
+		[Test]
+		public void Static_Transpose ()
+		{
+			var a = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			var matrix = SCNMatrix4.Transpose (a);
+			AssertEqual (matrix, "Transpose",
+				11, 21, 31, 41,
+				12, 22, 32, 42,
+				13, 23, 33, 43,
+				14, 24, 34, 44);
+		}
+
+		[Test]
+		public void Static_Transpose_ByRef ()
+		{
+			var a = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			SCNMatrix4.Transpose (ref a, out var matrix);
+			AssertEqual (matrix, "Transpose",
+				11, 21, 31, 41,
+				12, 22, 32, 42,
+				13, 23, 33, 43,
+				14, 24, 34, 44);
+		}
+
+		[Test]
+		public void Operator_Multiply ()
+		{
+			var a = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			var b = new SCNMatrix4 (
+				new SCNVector4 (911, 912, 913, 914),
+				new SCNVector4 (921, 922, 923, 924),
+				new SCNVector4 (931, 932, 933, 934),
+				new SCNVector4 (941, 942, 943, 944));
+			var matrix = a * b;
+			AssertEqual (matrix, "*",
+				46350, 46400, 46450, 46500,
+				83390, 83480, 83570, 83660,
+				120430, 120560, 120690, 120820,
+				157470, 157640, 157810, 157980);
+		}
+
+		[Test]
+		public void Operator_Equals ()
+		{
+			var a = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			var b = new SCNMatrix4 (
+				new SCNVector4 (911, 912, 913, 914),
+				new SCNVector4 (921, 922, 923, 924),
+				new SCNVector4 (931, 932, 933, 934),
+				new SCNVector4 (941, 942, 943, 944));
+			Assert.IsFalse (a == b, "Equals");
+		}
+
+		[Test]
+		public void Operator_NotEquals ()
+		{
+			var a = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			var b = new SCNMatrix4 (
+				new SCNVector4 (911, 912, 913, 914),
+				new SCNVector4 (921, 922, 923, 924),
+				new SCNVector4 (931, 932, 933, 934),
+				new SCNVector4 (941, 942, 943, 944));
+			Assert.IsTrue (a != b, "NotEquals");
+		}
+
+		[Test]
+		public void ToString ()
+		{
+			var matrix = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			Assert.AreEqual ("(11, 12, 13, 14)\n(21, 22, 23, 24)\n(31, 32, 33, 34)\n(41, 42, 43, 44)", matrix.ToString (), "ToString");
+		}
+
+		[Test]
+		public void Object_Equals ()
+		{
+			var a = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			var b = new SCNMatrix4 (
+				new SCNVector4 (911, 912, 913, 914),
+				new SCNVector4 (921, 922, 923, 924),
+				new SCNVector4 (931, 932, 933, 934),
+				new SCNVector4 (941, 942, 943, 944));
+			Assert.IsFalse (((object) a).Equals (b), "object.Equals");
+		}
+
+		[Test]
+		public void IEquatable_Equals ()
+		{
+			var a = new SCNMatrix4 (
+				new SCNVector4 (11, 12, 13, 14),
+				new SCNVector4 (21, 22, 23, 24),
+				new SCNVector4 (31, 32, 33, 34),
+				new SCNVector4 (41, 42, 43, 44));
+			var b = new SCNMatrix4 (
+				new SCNVector4 (911, 912, 913, 914),
+				new SCNVector4 (921, 922, 923, 924),
+				new SCNVector4 (931, 932, 933, 934),
+				new SCNVector4 (941, 942, 943, 944));
+			Assert.IsFalse (((IEquatable<SCNMatrix4>) a).Equals (b), "object.Equals");
+		}
+	}
+}
+

--- a/tests/monotouch-test/SceneKit/SCNMatrixTest.cs
+++ b/tests/monotouch-test/SceneKit/SCNMatrixTest.cs
@@ -7,6 +7,8 @@
 // Copyright 2014 Xamarin Inc. All rights reserved.
 //
 
+#if !__WATCHOS__
+
 #nullable enable
 
 using System;
@@ -222,6 +224,7 @@ namespace MonoTouchFixtures.SceneKit {
 			Assert.AreEqual ((pfloat) 44, matrix.M44, "M44");
 		}
 
+#if NET // The legacy Invert implementation seems very wrong, so only verify .NET behavior
 		[Test]
 		public void Invert ()
 		{
@@ -246,6 +249,7 @@ namespace MonoTouchFixtures.SceneKit {
 				(pfloat) (-1.3818181818181818), (pfloat) (0.3515151515151515), (pfloat) (-0.30303030303030304), (pfloat) (1.2787878787878788),
 				(pfloat) (0.6363636363636364), (pfloat) (-0.030303030303030304), (pfloat) (0.06060606060606061), (pfloat) (-0.5757575757575758));
 		}
+#endif
 
 		[Test]
 		public void Transpose ()
@@ -659,6 +663,7 @@ namespace MonoTouchFixtures.SceneKit {
 				157470, 157640, 157810, 157980);
 		}
 
+#if NET // The legacy Invert implementation seems very wrong, so only verify .NET behavior
 		[Test]
 		public void Static_Invert ()
 		{
@@ -684,6 +689,7 @@ namespace MonoTouchFixtures.SceneKit {
 				(pfloat) (-1.3818181818181818), (pfloat) (0.3515151515151515), (pfloat) (-0.30303030303030304), (pfloat) (1.2787878787878788),
 				(pfloat) (0.6363636363636364), (pfloat) (-0.030303030303030304), (pfloat) (0.06060606060606061), (pfloat) (-0.5757575757575758));
 		}
+#endif
 
 		[Test]
 		public void Static_Transpose ()
@@ -814,4 +820,4 @@ namespace MonoTouchFixtures.SceneKit {
 		}
 	}
 }
-
+#endif // !__WATCHOS__


### PR DESCRIPTION
* Implement a column-major version of SCNMatrix4 in .NET to match native code.
* This was done by copying the existing SCMatrix4 implementation, and modify it
  as required (doing it with conditional compilation in the same file turned out
  to be quite messy, so I opted for using different files for legacy Xamarin and
  .NET).
* There was one major change: the matrix inversion algorithm is new (copied from
   .NET instead), because the legacy Xamarin version showed strange results with
  some test values.
* Add setters for SCNMatrix4.Column[0-3] for legacy Xamarin to match the .NET API.
* Add CreateFromColumns methods for legacy Xamarin to match the .NET API.
* Add tests for all the new API.

Fixes https://github.com/xamarin/xamarin-macios/issues/4652.