### PR TITLE
[AppKit] Update NSWindowStyle deprecations according to headers.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -868,6 +868,7 @@ namespace AppKit {
 #endregion
 	
 #region NSWindow
+	// This enum is called NSWindowStyleMask in the headers.
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
@@ -880,10 +881,12 @@ namespace AppKit {
 		Utility		       					= 1 << 4,
 		DocModal	       					= 1 << 6,
 		NonactivatingPanel     				= 1 << 7,
-		[Advice ("'TexturedBackground' should no longer be used.")]
+		[Deprecated (PlatformName.MacOSX, 11, 0, message: "Don't use 'TexturedBackground' anymore.")]
 		TexturedBackground     				= 1 << 8,
-		[Deprecated (PlatformName.MacOSX, 10, 14)]
+#if !NET
+		[Deprecated (PlatformName.MacOSX, 10, 9, message: "Don't use, this value has no effect.")]
 		Unscaled	       					= 1 << 11,
+#endif
 		UnifiedTitleAndToolbar 				= 1 << 12,
 		Hud		       						= 1 << 13,
 		FullScreenWindow       				= 1 << 14,

--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -70,6 +70,7 @@ namespace Extrospection {
 			{ "NFCVASErrorCode", "VasErrorCode" },
 			{ "NFCVASMode", "VasMode" },
 			{ "NFCISO15693RequestFlag", "RequestFlag" },
+			{ "NSWindowStyleMask", "NSWindowStyle" },
 			// not enums
 		};
 
@@ -114,6 +115,7 @@ namespace Extrospection {
 			{ "MIDIMessageType", "MidiMessageType" },
 			{ "MIDISysExStatus", "MidiSysExStatus" },
 			{ "MIDISystemStatus", "MidiSystemStatus" },
+			{ "NSWindowStyleMask", "NSWindowStyle" },
 			// not enums
 		};
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-AppKit.ignore
@@ -43,7 +43,6 @@
 !missing-enum! NSSplitViewItemCollapseBehavior not bound
 !missing-enum! NSTableColumnResizingOptions not bound
 !missing-enum! NSTableViewGridLineStyle not bound
-!missing-enum! NSWindowStyleMask not bound
 !missing-field! NSAbortModalException not bound
 !missing-field! NSAbortPrintingException not bound
 !missing-field! NSAccessibilityAscendingSortDirectionValue not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -293,7 +293,6 @@
 !unknown-native-enum! NSTextStorageEditedFlags bound
 !unknown-native-enum! NSType bound
 !unknown-native-enum! NSViewResizingMask bound
-!unknown-native-enum! NSWindowStyle bound
 !wrong-enum-size! NSSpellingState managed 4 vs native 8
 
 ## NSGlyphStorage protocol not bound

--- a/tests/xtro-sharpie/common-AppKit.ignore
+++ b/tests/xtro-sharpie/common-AppKit.ignore
@@ -43,7 +43,6 @@
 !missing-enum! NSSplitViewItemCollapseBehavior not bound
 !missing-enum! NSTableColumnResizingOptions not bound
 !missing-enum! NSTableViewGridLineStyle not bound
-!missing-enum! NSWindowStyleMask not bound
 !missing-field! NSAbortModalException not bound
 !missing-field! NSAbortPrintingException not bound
 !missing-field! NSAccessibilityAscendingSortDirectionValue not bound

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -302,7 +302,6 @@
 !unknown-native-enum! NSTextStorageEditedFlags bound
 !unknown-native-enum! NSType bound
 !unknown-native-enum! NSViewResizingMask bound
-!unknown-native-enum! NSWindowStyle bound
 !wrong-enum-size! NSEventSubtype managed 8 vs native 2
 !wrong-enum-size! NSSpellingState managed 4 vs native 8
 
@@ -1335,3 +1334,7 @@
 
 # deprecated in 10.12, now removed
 !extra-enum-value! Managed value 7 for NSWindowButton.FullScreenButton not found in native headers
+
+# deprecated
+!extra-enum-value! Managed value 2048 for NSWindowStyle.Unscaled not found in native headers
+


### PR DESCRIPTION
Also remove the Unscaled field, it's removed from the headers, and it was
deprecated before the earliest macOS version we support.

Also also fix a few xtro issues.