### PR TITLE
[Foundation] Remove the NSDateComponentsWrappingBehavior in .NET.

### DIFF
--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -893,7 +893,7 @@ namespace Foundation  {
 		None, Default, All 
 	}
 
-#if !XAMCORE_4_0
+#if !NET
 	[Flags]
 	[Native]
 	public enum NSDateComponentsWrappingBehavior : ulong {

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -681,7 +681,7 @@ namespace Foundation
 		[Export ("components:fromDate:toDate:options:")]
 		NSDateComponents Components (NSCalendarUnit unitFlags, NSDate fromDate, NSDate toDate, NSCalendarOptions opts);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the overload with a 'NSCalendarOptions' parameter.")]
 		[Wrap ("Components (unitFlags, fromDate, toDate, (NSCalendarOptions) opts)")]
 		NSDateComponents Components (NSCalendarUnit unitFlags, NSDate fromDate, NSDate toDate, NSDateComponentsWrappingBehavior opts);
@@ -690,7 +690,7 @@ namespace Foundation
 		[Export ("dateByAddingComponents:toDate:options:")]
 		NSDate DateByAddingComponents (NSDateComponents comps, NSDate date, NSCalendarOptions opts);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the overload with a 'NSCalendarOptions' parameter.")]
 		[Wrap ("DateByAddingComponents (comps, date, (NSCalendarOptions) opts)")]
 		NSDate DateByAddingComponents (NSDateComponents comps, NSDate date, NSDateComponentsWrappingBehavior opts);

--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -34,8 +34,13 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.AreEqual ((nint) now.Day, comps.Day, "a day");
 
 			var dayCompare = now;
+#if !NET
 			comps = cal.Components (NSCalendarUnit.Hour, (NSDate) dayCompare.AddHours (-1), (NSDate) dayCompare, NSDateComponentsWrappingBehavior.None);
 			Assert.AreEqual ((nint) 1, comps.Hour, "b hour");
+#endif
+
+			comps = cal.Components (NSCalendarUnit.Hour, (NSDate) dayCompare.AddHours (-1), (NSDate) dayCompare, NSCalendarOptions.None);
+			Assert.AreEqual ((nint) 1, comps.Hour, "c hour");
 		}
 
 		[Test]
@@ -49,8 +54,14 @@ namespace MonoTouchFixtures.Foundation {
 			comps.Day = 2;
 			comps.TimeZone = NSTimeZone.FromAbbreviation ("UTC");
 			cal.TimeZone = comps.TimeZone;
+
+#if !NET
 			date = cal.DateByAddingComponents (comps, now, NSDateComponentsWrappingBehavior.None);
 			Assert.AreEqual (now.SecondsSinceReferenceDate + 3600 * 24 * 2, date.SecondsSinceReferenceDate, "a");
+#endif
+
+			date = cal.DateByAddingComponents (comps, now, NSCalendarOptions.None);
+			Assert.AreEqual (now.SecondsSinceReferenceDate + 3600 * 24 * 2, date.SecondsSinceReferenceDate, "b");
 		}
 
 		[Test]

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-Foundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-Foundation.ignore
@@ -44,9 +44,6 @@
 ## should not have been [Native] it's 32bits only values -> XAMCORE_4_0
 !unknown-native-enum! NSBundleExecutableArchitecture bound
 
-## enum was [re]named to NSCalendarOptions - excluding from XAMCORE_4_0
-!unknown-native-enum! NSDateComponentsWrappingBehavior bound
-
 ## collections - many are special
 !missing-type! NSCountedSet not bound
 !missing-selector! NSCountedSet::addObject: not bound


### PR DESCRIPTION
It's our own enum, and all the API using it have been obsoleted/removed.

There doesn't seem to be any other usage of it on GitHub either (only our own
source code and documentation).