### PR TITLE
[maccore] Bump maccore to ease submission tests

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 0be9399a534a1b7d28275a1629d95ed092fbfaa8
+NEEDED_MACCORE_VERSION := 037cc660587eda859b2d735f571e8fc632e83d3b
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@037cc66058 Setup MacCoolApp (NET6) to be duel x86_64/arm64 as required by submission tests now
* xamarin/maccore@3332ba19a0 [submission tests] Always build with /bl, even Legacy
* xamarin/maccore@6bb8bf46dd Fix a few submission test issues and document filters
* xamarin/maccore@b63ef4428c [devops] Add pipeline to test provisioning.

Diff: https://github.com/xamarin/maccore/compare/0be9399a534a1b7d28275a1629d95ed092fbfaa8..037cc660587eda859b2d735f571e8fc632e83d3b