### PR TITLE
[CoreData] Move CoreData into the .NET age.

### DIFF
--- a/src/CoreData/Obsolete.cs
+++ b/src/CoreData/Obsolete.cs
@@ -30,7 +30,7 @@ namespace CoreData {
 		}
 	}
 #endif
-#if !XAMCORE_4_0
+#if !NET
 	public partial class NSCoreDataCoreSpotlightDelegate {
 
 		[Obsolete ("Default constructor is not available")]

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -103,7 +103,7 @@ namespace CoreData
 		void UpdateCacheNode (NSAtomicStoreCacheNode node, NSManagedObject managedObject);
 
 		[Export ("cacheNodes")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSSet<NSAtomicStoreCacheNode> CacheNodes { get; }
 #else
 		NSSet CacheNodes { get; }
@@ -111,14 +111,14 @@ namespace CoreData
 
 		[Export ("addCacheNodes:")]
 		
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		void AddCacheNodes (NSSet<NSAtomicStoreCacheNode> cacheNodes);
 #else
 		void AddCacheNodes (NSSet cacheNodes);
 #endif
 
 		[Export ("willRemoveCacheNodes:")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		void WillRemoveCacheNodes (NSSet<NSAtomicStoreCacheNode> cacheNodes);
 #else
 		void WillRemoveCacheNodes (NSSet cacheNodes);
@@ -193,7 +193,7 @@ namespace CoreData
 		NSManagedObjectID ObjectID { get; }
 
 		[NullAllowed, Export ("propertyCache", ArgumentSemantic.Retain)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSMutableDictionary<NSString, NSObject> PropertyCache { get; set; }
 #else
 		NSDictionary PropertyCache { get; set; }
@@ -250,7 +250,7 @@ namespace CoreData
 		NSEntityDescription EntityForName (string entityName, NSManagedObjectContext context);
 
 		[Static, Export ("insertNewObjectForEntityForName:inManagedObjectContext:")]
-#if !XAMCORE_4_0
+#if !NET
 		NSObject InsertNewObjectForEntityForName (string entityName, NSManagedObjectContext context);
 #else
 		NSManagedObject InsertNewObject (string entityName, NSManagedObjectContext context);
@@ -274,7 +274,7 @@ namespace CoreData
 		bool Abstract { [Bind("isAbstract")] get; set; }
 
 		[Export ("subentitiesByName")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSEntityDescription> SubentitiesByName { get; }
 #else
 		NSDictionary SubentitiesByName { get; }
@@ -287,7 +287,7 @@ namespace CoreData
 		NSEntityDescription Superentity { get; }
 
 		[Export ("propertiesByName")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSPropertyDescription> PropertiesByName { get; }
 #else
 		NSDictionary PropertiesByName { get; }
@@ -300,14 +300,14 @@ namespace CoreData
 		NSDictionary UserInfo { get; set; }
 
 		[Export ("attributesByName")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSAttributeDescription> AttributesByName { get; }
 #else
 		NSDictionary AttributesByName { get; }
 #endif
 
 		[Export ("relationshipsByName")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSRelationshipDescription> RelationshipsByName { get; }
 #else
 		NSDictionary RelationshipsByName { get; }
@@ -598,7 +598,7 @@ namespace CoreData
 		// name like UITableViewSource's similar (and linked) selector
 		nint SectionFor (string title, nint atIndex);
 
-#if !XAMCORE_4_0
+#if !NET
 		// badly named and conflict with the property
 		[Export ("sectionIndexTitleForSectionName:")]
 		[return: NullAllowed]
@@ -667,12 +667,13 @@ namespace CoreData
 #endif
 	// 	NSInvalidArgumentException *** -loadMetadata: cannot be sent to an abstract object of class NSIncrementalStore: Create a concrete instance!
 	//	Apple doc quote: "NSIncrementalStore is an abstract superclass..."
-#if XAMCORE_4_0 // bad API -> should be an abstract type (breaking change)
-	[Abstract]
+#if NET
+	// Making a class abstract has problems: https://github.com/xamarin/xamarin-macios/issues/4969, so we're not doing this yet
+	// [Abstract] // Abstract superclass.
 #endif
 	[BaseType (typeof (NSPersistentStore))]
 	interface NSIncrementalStore {
-#if XAMCORE_4_0
+#if NET
 		[Protected]
 #endif
 		[Export ("initWithPersistentStoreCoordinator:configurationName:URL:options:")]
@@ -695,8 +696,8 @@ namespace CoreData
 
 		[Static]
 		[Export ("identifierForNewStoreAtURL:")]
-#if XAMCORE_4_0
-		NSObject IdentifierForNewStore (NSUrl storeUrl);
+#if NET
+		NSObject GetIdentifierForNewStore (NSUrl storeUrl);
 #else
 		NSObject IdentifierForNewStoreAtURL (NSUrl storeUrl);
 #endif
@@ -722,14 +723,14 @@ namespace CoreData
 	[BaseType (typeof (NSObject))]
 	interface NSIncrementalStoreNode {
 		[Export ("initWithObjectID:withValues:version:")]
-#if XAMCORE_4_0
-		NativeHandle Constructor (NSManagedObjectID objectID, NSDictionary<NSString, NSObject> values, ulong version);
+#if XAMCORE_5_0
+		NativeHandle Constructor (NSManagedObjectID objectId, NSDictionary<NSString, NSObject> values, ulong version);
 #else 
 		NativeHandle Constructor (NSManagedObjectID objectId, NSDictionary values, ulong version);
 #endif
 
 		[Export ("updateWithValues:version:")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		void Update (NSDictionary<NSString, NSObject> values, ulong version);
 #else
 		void Update (NSDictionary values, ulong version);
@@ -844,14 +845,14 @@ namespace CoreData
 
 		[Export ("valueForKey:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
+#if NET
 		NSObject GetValue (string key);
 #else
 		IntPtr ValueForKey (string key);
 #endif
 
 		[Export ("setValue:forKey:")]
-#if XAMCORE_4_0
+#if NET
 		void SetValue ([NullAllowed] NSObject value, string key);
 #else
 		void SetValue (IntPtr value, string key);
@@ -859,28 +860,30 @@ namespace CoreData
 
 		[Export ("primitiveValueForKey:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
+#if NET
 		NSObject GetPrimitiveValue (string key);
 #else
 		IntPtr PrimitiveValueForKey (string key);
 #endif
 
 		[Export ("setPrimitiveValue:forKey:")]
-#if XAMCORE_4_0
+#if NET
 		void SetPrimitiveValue ([NullAllowed] NSObject value, string key);
 #else
 		void SetPrimitiveValue (IntPtr value, string key);
 #endif
 
 		[Export ("committedValuesForKeys:")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSObject> GetCommittedValues ([NullAllowed] string[] keys);
+#elif NET
+		NSDictionary GetCommittedValues ([NullAllowed] string[] keys);
 #else
 		NSDictionary CommittedValuesForKeys ([NullAllowed] string[] keys);
 #endif
 
 		[Export ("changedValues")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSObject> ChangedValues { get; }
 #else
 		NSDictionary ChangedValues { get; }
@@ -979,8 +982,10 @@ namespace CoreData
 		void DetectConflictsForObject (NSManagedObject object1);
 
 		[Export ("observeValueForKeyPath:ofObject:change:context:")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		void ObserveValue ([NullAllowed] string keyPath, [NullAllowed] NSObject object1, [NullAllowed] NSDictionary<NSString, NSObject> change, IntPtr context);
+#elif NET
+		void ObserveValue ([NullAllowed] string keyPath, [NullAllowed] NSObject object1, [NullAllowed] NSDictionary change, IntPtr context);
 #else
 		void ObserveValueForKeyPath ([NullAllowed] string keyPath, IntPtr object1, [NullAllowed] NSDictionary change, IntPtr context);
 #endif
@@ -989,35 +994,35 @@ namespace CoreData
 		void ProcessPendingChanges ();
 
 		[Export ("assignObject:toPersistentStore:")]
-#if XAMCORE_4_0
+#if NET
 		void AssignObject (NSObject object1, NSPersistentStore store);
 #else
 		void AssignObject (IntPtr object1, NSPersistentStore store);
 #endif
 
 		[Export ("insertedObjects", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSSet<NSManagedObject> InsertedObjects { get; }
 #else
 		NSSet InsertedObjects { get; }
 #endif
 
 		[Export ("updatedObjects", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSSet<NSManagedObject> UpdatedObjects { get; }
 #else
 		NSSet UpdatedObjects { get; }
 #endif
 
 		[Export ("deletedObjects", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSSet<NSManagedObject> DeletedObjects { get; }
 #else
 		NSSet DeletedObjects { get; }
 #endif
 
 		[Export ("registeredObjects", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSSet<NSManagedObject> RegisteredObjects { get; }
 #else
 		NSSet RegisteredObjects { get; }
@@ -1233,7 +1238,11 @@ namespace CoreData
 
 		[Static, Export ("mergedModelFromBundles:")]
 		[return: NullAllowed]
+#if NET
+		NSManagedObjectModel GetMergedModel ([NullAllowed] NSBundle[] bundles);
+#else
 		NSManagedObjectModel MergedModelFromBundles ([NullAllowed] NSBundle[] bundles);
+#endif
 
 		[Static, Export ("modelByMergingModels:")]
 		[return: NullAllowed]
@@ -1243,7 +1252,7 @@ namespace CoreData
 		NativeHandle Constructor (NSUrl url);
 
 		[Export ("entitiesByName", ArgumentSemantic.Copy)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSEntityDescription> EntitiesByName { get; }
 #else
 		NSDictionary EntitiesByName { get; }
@@ -1267,7 +1276,7 @@ namespace CoreData
 
 		[Export ("fetchRequestTemplateForName:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
+#if NET
 		NSFetchRequest GetFetchRequestTemplate (string name);
 #else
 		NSFetchRequest FetchRequestTemplateForName (string name);
@@ -1275,15 +1284,17 @@ namespace CoreData
 
 		[Export ("fetchRequestFromTemplateWithName:substitutionVariables:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
-		NSFetchRequest GetFetchRequestFromTemplate (string name, NSDictionary<NSString, NSObject> variables); 
+#if XAMCORE_5_0
+		NSFetchRequest GetFetchRequestFromTemplate (string name, NSDictionary<NSString, NSObject> variables);
+#elif NET
+		NSFetchRequest GetFetchRequestFromTemplate (string name, NSDictionary variables);
 #else
 		NSFetchRequest FetchRequestFromTemplateWithName (string name, NSDictionary variables);
 #endif
 
 		[NullAllowed] // by default this property is null
 		[Export ("localizationDictionary", ArgumentSemantic.Retain)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSString> LocalizationDictionary { get; set; }
 #else
 		NSDictionary LocalizationDictionary { get; set; }
@@ -1291,22 +1302,26 @@ namespace CoreData
 
 		[Static, Export ("mergedModelFromBundles:forStoreMetadata:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSManagedObjectModel GetMergedModel ([NullAllowed] NSBundle[] bundles, NSDictionary<NSString, NSObject> metadata);
+#elif NET
+		NSManagedObjectModel GetMergedModel ([NullAllowed] NSBundle[] bundles, NSDictionary metadata);
 #else
 		NSManagedObjectModel MergedModelFromBundles ([NullAllowed] NSBundle[] bundles, NSDictionary metadata);
 #endif
 
 		[Static, Export ("modelByMergingModels:forStoreMetadata:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSManagedObjectModel GetModelByMerging (NSManagedObjectModel[] models, NSDictionary<NSString, NSObject> metadata);
+#elif NET
+		NSManagedObjectModel GetModelByMerging (NSManagedObjectModel[] models, NSDictionary metadata);
 #else
 		NSManagedObjectModel ModelByMergingModels (NSManagedObjectModel[] models, NSDictionary metadata);
 #endif
 
 		[Export ("fetchRequestTemplatesByName", ArgumentSemantic.Copy)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSFetchRequest> FetchRequestTemplatesByName { get; }
 #else
 		NSDictionary FetchRequestTemplatesByName { get; }
@@ -1316,14 +1331,16 @@ namespace CoreData
 		NSSet VersionIdentifiers { get; set; }
 
 		[Export ("isConfiguration:compatibleWithStoreMetadata:")]
-#if XAMCORE_4_0
-		bool IsConfiguration ([NullAllowed] string configuration, NSDictionary<NSString, NSObject> metadata);
+#if XAMCORE_5_0
+		bool IsConfigurationCompatibleWithStoreMetadata ([NullAllowed] string configuration, NSDictionary<NSString, NSObject> metadata);
+#elif NET
+		bool IsConfigurationCompatibleWithStoreMetadata ([NullAllowed] string configuration, NSDictionary metadata);
 #else
 		bool IsConfiguration ([NullAllowed] string configuration, NSDictionary metadata);
 #endif
 
 		[Export ("entityVersionHashesByName", ArgumentSemantic.Copy)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSData> EntityVersionHashesByName { get; }
 #else
 		NSDictionary EntityVersionHashesByName { get; }
@@ -1335,8 +1352,8 @@ namespace CoreData
 
 		[Static, Export ("mappingModelFromBundles:forSourceModel:destinationModel:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
-		NSMappingModel FromBundles ([NullAllowed] NSBundle[] bundles, [NullAllowed] NSManagedObjectModel sourceModel, [NullAllowed] NSManagedObjectModel destinationModel);
+#if NET
+		NSMappingModel GetMappingModel ([NullAllowed] NSBundle[] bundles, [NullAllowed] NSManagedObjectModel sourceModel, [NullAllowed] NSManagedObjectModel destinationModel);
 #else
 		NSMappingModel MappingModelFromBundles ([NullAllowed] NSBundle[] bundles, [NullAllowed] NSManagedObjectModel sourceModel, [NullAllowed] NSManagedObjectModel destinationModel);
 #endif
@@ -1353,7 +1370,7 @@ namespace CoreData
 		NSEntityMapping[] EntityMappings { get; set; }
 
 		[Export ("entityMappingsByName", ArgumentSemantic.Copy)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSEntityMapping> EntityMappingsByName { get; }
 #else
 		NSDictionary EntityMappingsByName { get; }
@@ -1369,7 +1386,7 @@ namespace CoreData
 
 		[Export ("objectSnapshot", ArgumentSemantic.Retain)]
 		[NullAllowed]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSObject> ObjectSnapshot { get; }
 #else
 		NSDictionary ObjectSnapshot { get;  }
@@ -1377,7 +1394,7 @@ namespace CoreData
 
 		[Export ("cachedSnapshot", ArgumentSemantic.Retain)]
 		[NullAllowed]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSObject> CachedSnapshot { get; }
 #else
 		NSDictionary CachedSnapshot { get;  }
@@ -1385,7 +1402,7 @@ namespace CoreData
 
 		[Export ("persistedSnapshot", ArgumentSemantic.Retain)]
 		[NullAllowed]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSObject> PersistedSnapshot { get; }
 #else
 		NSDictionary PersistedSnapshot { get;  }
@@ -1399,8 +1416,10 @@ namespace CoreData
 
 		[DesignatedInitializer]
 		[Export ("initWithSource:newVersion:oldVersion:cachedSnapshot:persistedSnapshot:")]
-#if XAMCORE_4_0
-		NativeHandle Constructor (NSManagedObject srcObject, nuint newvers, nuint oldvers, [NullAllowed] NSDictionary<NSString, NSObject> cachesnap, [NullAllowed] NSDictionary<NSString, NSObject> persnap);
+#if XAMCORE_5_0
+		NativeHandle Constructor (NSManagedObject sourceObject, nuint newVersion, nuint oldVersion, [NullAllowed] NSDictionary<NSString, NSObject> cachedSnapshot, [NullAllowed] NSDictionary<NSString, NSObject> persistedSnapshot);
+#elif NET
+		NativeHandle Constructor (NSManagedObject sourceObject, nuint newVersion, nuint oldVersion, [NullAllowed] NSDictionary cachedSnapshot, [NullAllowed] NSDictionary persistedSnapshot);
 #else
 		NativeHandle Constructor (NSManagedObject srcObject, nuint newvers, nuint oldvers, [NullAllowed] NSDictionary cachesnap, [NullAllowed] NSDictionary persnap);
 #endif
@@ -1417,7 +1436,7 @@ namespace CoreData
 		NativeHandle Constructor (NSMergePolicyType ty);
 
 		[Export ("resolveConflicts:error:")]
-#if XAMCORE_4_0
+#if NET
 		bool ResolveConflicts (NSMergeConflict [] list, out NSError error);
 #else
 		bool ResolveConflictserror (NSMergeConflict [] list, out NSError error);
@@ -1741,20 +1760,20 @@ namespace CoreData
 
 		[Static, Export ("metadataForPersistentStoreWithURL:error:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSObject> GetMetadataForPersistentStore (NSUrl url, out NSError error);
 #else
 		NSDictionary MetadataForPersistentStoreWithUrl (NSUrl url, out NSError error);
 #endif
 
 		[Static, Export ("setMetadata:forPersistentStoreWithURL:error:")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		bool SetMetadata ([NullAllowed] NSDictionary<NSString, NSObject> metadata, NSUrl url, out NSError error);
 #else
 		bool SetMetadata ([NullAllowed] NSDictionary metadata, NSUrl url, out NSError error);
 #endif
 
-#if XAMCORE_4_0
+#if NET
 		[Protected]
 #endif
 		[DesignatedInitializer]
@@ -1789,7 +1808,7 @@ namespace CoreData
 
 		[Export ("metadata", ArgumentSemantic.Retain)]
 		[NullAllowed]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSObject> Metadata { get; set; }
 #else
 		NSDictionary Metadata { get; set; }
@@ -1946,7 +1965,7 @@ namespace CoreData
 	{
 
 		[Static, Export ("registeredStoreTypes", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSValue> RegisteredStoreTypes { get; }
 #else
 		NSDictionary RegisteredStoreTypes { get; }
@@ -1978,15 +1997,17 @@ namespace CoreData
 		bool SetMetadata ([NullAllowed] NSDictionary<NSString, NSObject> metadata, string storeType, NSUrl url, [NullAllowed] NSDictionary options, out NSError error);
 
 		[Export ("setMetadata:forPersistentStore:")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		void SetMetadata ([NullAllowed] NSDictionary<NSString, NSObject> metadata, NSPersistentStore store);
 #else
 		void SetMetadata ([NullAllowed] NSDictionary metadata, NSPersistentStore store);
 #endif
 
 		[Export ("metadataForPersistentStore:")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSDictionary<NSString, NSObject> GetMetadata (NSPersistentStore store);
+#elif NET
+		NSDictionary GetMetadata (NSPersistentStore store);
 #else
 		NSDictionary MetadataForPersistentStore (NSPersistentStore store);
 #endif
@@ -2013,7 +2034,7 @@ namespace CoreData
 
 		[Export ("addPersistentStoreWithType:configuration:URL:options:error:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
+#if NET
 		NSPersistentStore AddPersistentStore (NSString storeType, [NullAllowed] string configuration, [NullAllowed] NSUrl storeUrl, [NullAllowed] NSDictionary options, out NSError error);
 #else
 		NSPersistentStore AddPersistentStoreWithType (NSString storeType, [NullAllowed] string configuration, [NullAllowed] NSUrl storeUrl, [NullAllowed] NSDictionary options, out NSError error);
@@ -2141,7 +2162,7 @@ namespace CoreData
 		// 5.0
 		[Export ("executeRequest:withContext:error:")]
 		[return: NullAllowed]
-#if XAMCORE_4_0
+#if NET
 		NSObject Execute (NSPersistentStoreRequest request, NSManagedObjectContext context, out NSError error);
 #else
 		NSObject ExecuteRequestwithContexterror (NSPersistentStoreRequest request, NSManagedObjectContext context, out NSError error);
@@ -2161,7 +2182,7 @@ namespace CoreData
 		[NoWatch][NoTV]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Please see the release notes and Core Data documentation.")]
 		[Field ("NSPersistentStoreUbiquitousContentURLKey")]
-#if XAMCORE_4_0
+#if NET
 		NSString PersistentStoreUbiquitousContentUrlKey { get; }
 #else
 		NSString PersistentStoreUbiquitousContentUrlLKey { get; }
@@ -2277,7 +2298,7 @@ namespace CoreData
 
 		[Export ("finalResult", ArgumentSemantic.Retain)]
 		[NullAllowed]
-#if XAMCORE_4_0
+#if NET
 		INSFetchRequestResult[] FinalResult { get; }
 #else
 		NSObject [] FinalResult { get; }
@@ -2439,35 +2460,35 @@ namespace CoreData
 	[BaseType (typeof (NSPersistentStoreRequest))]
 	interface NSSaveChangesRequest {
 		[Export ("initWithInsertedObjects:updatedObjects:deletedObjects:lockedObjects:")]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NativeHandle Constructor ([NullAllowed] NSSet<NSManagedObject> insertedObjects, [NullAllowed] NSSet<NSManagedObject> updatedObjects, [NullAllowed] NSSet<NSManagedObject> deletedObjects, [NullAllowed] NSSet<NSManagedObject> lockedObjects);
 #else
 		NativeHandle Constructor ([NullAllowed] NSSet insertedObjects, [NullAllowed] NSSet updatedObjects, [NullAllowed] NSSet deletedObjects, [NullAllowed] NSSet lockedObjects);
 #endif
 
 		[NullAllowed, Export ("insertedObjects", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSSet<NSManagedObject> InsertedObjects { get; }
 #else
 		NSSet InsertedObjects { get; }
 #endif
 
 		[NullAllowed, Export ("updatedObjects", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSSet<NSManagedObject> UpdatedObjects { get; }
 #else
 		NSSet UpdatedObjects { get; }
 #endif
 
 		[NullAllowed, Export ("deletedObjects", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSSet<NSManagedObject> DeletedObjects { get; }
 #else
 		NSSet DeletedObjects { get; }
 #endif
 
 		[NullAllowed, Export ("lockedObjects", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 		NSSet<NSManagedObject> LockedObjects { get; }
 #else
 		NSSet LockedObjects { get; }
@@ -2582,7 +2603,7 @@ namespace CoreData
 		NSDictionary[] ConflictingSnapshots { get; }
 	}
 
-#if XAMCORE_4_0
+#if XAMCORE_5_0
 	delegate bool NSBatchInsertRequestDictionaryHandler (NSMutableDictionary<NSString, NSObject> dictionary);
 #else
 	delegate bool NSBatchInsertRequestDictionaryHandler (NSMutableDictionary dictionary);

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -7992,6 +7992,8 @@ namespace Foundation
 		void AddEntries (NSDictionary other);
 	}
 
+	interface NSMutableDictionary<K,V> : NSDictionary {}
+
 	[BaseType (typeof (NSSet))]
 	[DesignatedDefaultCtor]
 	interface NSMutableSet {

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -397,7 +397,11 @@ namespace LinkSdk {
 				// from http://bugzilla.xamarin.com/show_bug.cgi?id=2000
 				NSError error;
 				var c = new NSPersistentStoreCoordinator (model);
+#if NET
+				c.AddPersistentStore (NSPersistentStoreCoordinator.SQLiteStoreType, null, url, null, out error);
+#else
 				c.AddPersistentStoreWithType (NSPersistentStoreCoordinator.SQLiteStoreType, null, url, null, out error);
+#endif
 				Assert.IsNull (error, "error");
 			} finally {
 				File.Delete (sqlitePath);

--- a/tests/monotouch-test/CoreData/FetchedResultsControllerTest.cs
+++ b/tests/monotouch-test/CoreData/FetchedResultsControllerTest.cs
@@ -120,7 +120,11 @@ namespace MonoTouchFixtures.CoreData {
 						var storeUrl = new NSUrl (storePath, false);
 						NSError error;
 
+#if NET
+						if (PersistentStoreCoordinator.AddPersistentStore (NSPersistentStoreCoordinator.SQLiteStoreType, null, storeUrl, null, out error) is null) {
+#else
 						if (PersistentStoreCoordinator.AddPersistentStoreWithType (NSPersistentStoreCoordinator.SQLiteStoreType, null, storeUrl, null, out error) == null) {
+#endif
 							Assert.Fail ("Unresolved error " + error + ", " + error.UserInfo);
 						}
 					}

--- a/tests/monotouch-test/CoreData/ManagedObjectModelTest.cs
+++ b/tests/monotouch-test/CoreData/ManagedObjectModelTest.cs
@@ -32,7 +32,11 @@ namespace MonoTouchFixtures.CoreData {
 		public void IsConfiguration_Null ()
 		{
 			using (var moc = new NSManagedObjectModel()) {
+#if NET
+				Assert.IsFalse (moc.IsConfigurationCompatibleWithStoreMetadata (null, new NSDictionary ()), "IsConfiguration");
+#else
 				Assert.IsFalse (moc.IsConfiguration (null, new NSDictionary ()), "IsConfiguration");
+#endif
 				Default (moc);
 			}
 		}


### PR DESCRIPTION
* Remove obsolete API from .NET.
* Change API marked with XAMCORE_4_0 due to naming problems to be in .NET.
* Change API marked with XAMCORE_4_0 due to using non-generic NSDictionary to be
  in XAMCORE_5_0 instead (yay!). This is because of #13704, which can make using
  generic NSDictionary in API buggy, and I feel it's a bit too risky to change this
  for .NET with the time we have available (no time to fix #13704). Additionally,
  moving this to XAMCORE_5_0 makes it possible to keep grepping for XAMCORE_4_0 to
  see what's left. Update all the CoreData API to be better as defined by our XAMCORE_4_0
  define. Mostly using generic NSSet/NSDictionary types instead of the non-generic
  ones, and other misc naming improvements.
* Change API marked with XAMCORE_4_0 due to both of the above to do both of the
  above - add a version of the naming issue fixed for .NET + a version with the generic
  dictionary for XAMCORE_5_0.