### PR TITLE
[msbuild] Touch all files when copying an app extension into the app.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
@@ -18,6 +18,7 @@ namespace Xamarin.MacDev.Tasks
 		[Output]
 		public ITaskItem? Destination { get; set; }
 
+		public bool TouchDestinationFiles { get; set; }
 		#endregion
 
 		protected override string ToolName {
@@ -42,6 +43,20 @@ namespace Xamarin.MacDev.Tasks
 			args.AddQuoted (Destination!.ItemSpec);
 
 			return args.ToString ();
+		}
+
+		public override bool Execute ()
+		{
+			if (!base.Execute ())
+				return false;
+
+			if (TouchDestinationFiles) {
+				foreach (var file in Directory.EnumerateFiles (Destination!.ItemSpec, "*", SearchOption.AllDirectories)) {
+					File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
+				}
+			}
+
+			return !Log.HasLoggedErrors;
 		}
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2030,6 +2030,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ToolPath="$(DittoPath)"
 			Source="@(_ResolvedAppExtensionReferences)"
 			Destination="$(_AppExtensionRoot)%(_ResolvedAppExtensionReferences.ContainerName)\%(_ResolvedAppExtensionReferences.FileName)%(_ResolvedAppExtensionReferences.Extension)"
+			TouchDestinationFiles="true"
 		/>
 
 		<!-- Delete any code signatures and dSYM dirs since they are now invalid -->


### PR DESCRIPTION
Touch all files when copying an app extension into the app.

This fixes an issue where we'd in some cases run into this scenario:

* Build once (successfully), and sign the app (and app extension), including all dylibs.
* We build again, copy the (unsigned) app extension into the app again, but
  not sign dylibs because the timestamp went back into the past.