### PR TITLE
[AudioUnit] Improve a few AudioUnit methods to return the error code.

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -109,6 +109,11 @@ namespace AudioUnit
 			return String.Format ("Unknown error code: 0x{0:x}", k);
 		}
 		
+		internal AudioUnitException (AudioUnitStatus status)
+			: this ((int) status)
+		{
+		}
+
 		internal AudioUnitException (int k) : base (Lookup (k))
 		{
 		}
@@ -323,7 +328,7 @@ namespace AudioUnit
 			if (component is null)
 				throw new ArgumentNullException (nameof (component));
 
-			int err = AudioComponentInstanceNew (component.GetCheckedHandle (), out var handle);
+			var err = AudioComponentInstanceNew (component.GetCheckedHandle (), out var handle);
 			if (err != 0)
 				throw new AudioUnitException (err);
 
@@ -758,32 +763,60 @@ namespace AudioUnit
 		}
 #endif
 
-		// TODO: return AudioUnitStatus
-		public int Initialize ()
+#if NET
+		public AudioUnitStatus Initialize ()
 		{
 			return AudioUnitInitialize (Handle);
 		}
+#else
+		public int Initialize ()
+		{
+			return (int) AudioUnitInitialize (Handle);
+		}
+#endif
 
-		// TODO: return AudioUnitStatus
-		public int Uninitialize ()
+#if NET
+		public AudioUnitStatus Uninitialize ()
 		{
 			return AudioUnitUninitialize (Handle);
 		}
-
-		public void Start()
+#else
+		public int Uninitialize ()
 		{
+			return (int) AudioUnitUninitialize (Handle);
+		}
+#endif
+
+#if NET
+		public AudioUnitStatus Start ()
+#else
+		public void Start()
+#endif
+		{
+			AudioUnitStatus rv = 0;
 			if (! _isPlaying) {
-				AudioOutputUnitStart (Handle);
+				rv = AudioOutputUnitStart (Handle);
 				_isPlaying = true;
 			}
+#if NET
+			return rv;
+#endif
 		}
 		
+#if NET
+		public AudioUnitStatus Stop ()
+#else
 		public void Stop()
+#endif
 		{
+			AudioUnitStatus rv = 0;
 			if (_isPlaying) {
-				AudioOutputUnitStop (Handle);
+				rv = AudioOutputUnitStop (Handle);
 				_isPlaying = false;
 			}
+#if NET
+			return rv;
+#endif
 		}
 
 		#region Render
@@ -823,22 +856,22 @@ namespace AudioUnit
 		}
 
 		[DllImport(Constants.AudioUnitLibrary, EntryPoint = "AudioComponentInstanceNew")]
-		static extern int AudioComponentInstanceNew(IntPtr inComponent, out IntPtr inDesc);
+		static extern AudioUnitStatus AudioComponentInstanceNew(IntPtr inComponent, out IntPtr inDesc);
 
 		[DllImport(Constants.AudioUnitLibrary)]
 		static extern IntPtr AudioComponentInstanceGetComponent (IntPtr inComponent);
 		
 		[DllImport(Constants.AudioUnitLibrary)]
-		static extern int AudioUnitInitialize(IntPtr inUnit);
+		static extern AudioUnitStatus AudioUnitInitialize (IntPtr inUnit);
 		
 		[DllImport(Constants.AudioUnitLibrary)]
-		static extern int AudioUnitUninitialize(IntPtr inUnit);
+		static extern AudioUnitStatus AudioUnitUninitialize (IntPtr inUnit);
 
 		[DllImport(Constants.AudioUnitLibrary)]
-		static extern int AudioOutputUnitStart(IntPtr ci);
+		static extern AudioUnitStatus AudioOutputUnitStart (IntPtr ci);
 
 		[DllImport(Constants.AudioUnitLibrary)]
-		static extern int AudioOutputUnitStop(IntPtr ci);
+		static extern AudioUnitStatus AudioOutputUnitStop (IntPtr ci);
 
 		[DllImport(Constants.AudioUnitLibrary)]
 		static extern AudioUnitStatus AudioUnitRender(IntPtr inUnit, ref AudioUnitRenderActionFlags ioActionFlags, ref AudioTimeStamp inTimeStamp,

--- a/tests/monotouch-test/AudioToolbox/AudioUnitTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioUnitTest.cs
@@ -32,7 +32,10 @@ namespace MonoTouchFixtures.AudioToolbox {
 			var audioComponent = AudioComponent.FindComponent (AudioTypeOutput.VoiceProcessingIO);
 			using var audioUnit = new global::AudioUnit.AudioUnit (audioComponent);
 
-			Assert.AreEqual (AudioUnitStatus.OK, audioUnit.SetInputCallback (InputCallback, AudioUnitScopeType.Input, 1), "SetInputCallback");
+			var rv = audioUnit.SetInputCallback (InputCallback, AudioUnitScopeType.Input, 1);
+			if (rv == AudioUnitStatus.CannotDoInCurrentContext)
+				Assert.Ignore ("Can't set input callback"); // No microphone? In a VM? This seems to happen often on bots.
+			Assert.AreEqual (AudioUnitStatus.OK, rv, "SetInputCallback");
 			Assert.AreEqual (AudioUnitStatus.OK, audioUnit.Initialize (), "Initialize");
 			try {
 				Assert.AreEqual (AudioUnitStatus.OK, audioUnit.Start (), "Start");

--- a/tests/monotouch-test/AudioToolbox/AudioUnitTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioUnitTest.cs
@@ -32,13 +32,13 @@ namespace MonoTouchFixtures.AudioToolbox {
 			var audioComponent = AudioComponent.FindComponent (AudioTypeOutput.VoiceProcessingIO);
 			using var audioUnit = new global::AudioUnit.AudioUnit (audioComponent);
 
-			audioUnit.SetInputCallback (InputCallback, AudioUnitScopeType.Input, 1);
-			audioUnit.Initialize ();
+			Assert.AreEqual (AudioUnitStatus.OK, audioUnit.SetInputCallback (InputCallback, AudioUnitScopeType.Input, 1), "SetInputCallback");
+			Assert.AreEqual (AudioUnitStatus.OK, audioUnit.Initialize (), "Initialize");
 			try {
-				audioUnit.Start ();
+				Assert.AreEqual (AudioUnitStatus.OK, audioUnit.Start (), "Start");
 				Assert.IsTrue (inputCallbackEvent.WaitOne (TimeSpan.FromSeconds (1)), "No input callback for 1 second");
 			} finally {
-				audioUnit.Stop ();
+				Assert.AreEqual (AudioUnitStatus.OK, audioUnit.Stop (), "Stop");
 			}
 		}
 


### PR DESCRIPTION
This makes it easier to figure out problems in consuming code, since it makes
it easier to identify where things start to go wrong.

Fixes https://github.com/xamarin/maccore/issues/2539.