### PR TITLE
[Foundation] Remove conditional code that wasn't conditional for NSValueTransformer.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -11041,10 +11041,7 @@ namespace Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-#if !MONOMAC || !XAMCORE_4_0
-	// there were some, partial bindings in foundation-desktop.cs which did not define it as abstract for XM :(
 	[Abstract] // Apple docs: NSValueTransformer is an abstract class...
-#endif
 	interface NSValueTransformer {
 		[Static]
 		[Export ("setValueTransformer:forName:")]


### PR DESCRIPTION
The conditional code was always true pre-NET. There's no reason to change it
for NET, so the condition can just be completely removed.

Clearly this wasn't the intention, and the condition was intended to be false
on macOS, but it's too late now to fix this accidental breaking change when it
occurred over 6 years ago.

Ref: https://github.com/xamarin/maccore/commit/3bc5c33bbc7c0eaf32ba7bb412b76c087b1365c0