### PR TITLE
[AppKit] Make NSScrollView.DocumentView be an NSView in .NET. Fixes #8198.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -13320,7 +13320,7 @@ namespace AppKit {
 
 		//Detected properties
 		[Export ("documentView", ArgumentSemantic.Retain), NullAllowed]
-#if XAMCORE_4_0
+#if NET
 		NSView DocumentView { get; set; }
 #else
 		NSObject DocumentView { get; set; }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/8198.