### PR TITLE
[CGAffineTransform] Rename public fields in .NET to follow Apple and managed naming conventions. Fixes #13494.

### DIFF
--- a/src/CoreGraphics/CGAffineTransform.cs
+++ b/src/CoreGraphics/CGAffineTransform.cs
@@ -37,17 +37,50 @@ namespace CoreGraphics {
 	// CGAffineTransform.h
 	[StructLayout(LayoutKind.Sequential)]
 	public struct CGAffineTransform {
+#if NET
+		public /* CGFloat */ nfloat A;
+		public /* CGFloat */ nfloat B;
+		public /* CGFloat */ nfloat C;
+		public /* CGFloat */ nfloat D;
+		public /* CGFloat */ nfloat Tx;
+		public /* CGFloat */ nfloat Ty;
+#else
+		[Obsolete ("Use 'A' instead.")]
 		public /* CGFloat */ nfloat xx;   // a
+		[Obsolete ("Use 'B' instead.")]
 		public /* CGFloat */ nfloat yx;   // b 
+		[Obsolete ("Use 'C' instead.")]
 		public /* CGFloat */ nfloat xy;   // c
+		[Obsolete ("Use 'D' instead.")]
 		public /* CGFloat */ nfloat yy;   // d
+		[Obsolete ("Use 'Tx' instead.")]
 		public /* CGFloat */ nfloat x0;   // tx
+		[Obsolete ("Use 'Ty' instead.")]
 		public /* CGFloat */ nfloat y0;   // ty
+
+		public /* CGFloat */ nfloat A { get => xx; set => xx = value; }
+		public /* CGFloat */ nfloat B { get => yx; set => yx = value; }
+		public /* CGFloat */ nfloat C { get => xy; set => xy = value; }
+		public /* CGFloat */ nfloat D { get => yy; set => yy = value; }
+		public /* CGFloat */ nfloat Tx { get => x0; set => x0 = value; }
+		public /* CGFloat */ nfloat Ty { get => y0; set => y0 = value; }
+#endif
 
 #if !COREBUILD
 		//
 		// Constructors
 		//
+#if NET
+		public CGAffineTransform (nfloat a, nfloat b, nfloat c, nfloat d, nfloat tx, nfloat ty)
+		{
+			this.A = a;
+			this.B = b;
+			this.C = c;
+			this.D = d;
+			this.Tx = tx;
+			this.Ty = ty;
+		}
+#else
 		public CGAffineTransform (nfloat xx, nfloat yx, nfloat xy, nfloat yy, nfloat x0, nfloat y0)
 		{
 			this.xx = xx;
@@ -57,6 +90,7 @@ namespace CoreGraphics {
 			this.x0 = x0;
 			this.y0 = y0;
 		}
+#endif
 		
 		// Identity
 		public static CGAffineTransform MakeIdentity ()
@@ -89,23 +123,41 @@ namespace CoreGraphics {
 		//
 		public static CGAffineTransform Multiply (CGAffineTransform a, CGAffineTransform b)
 		{
+#if NET
+			return new CGAffineTransform (a.A * b.A + a.B * b.C,
+						      a.A * b.B + a.B * b.D,
+						      a.C * b.A + a.D * b.C,
+						      a.C * b.B + a.D * b.D,
+						      a.Tx * b.A + a.Ty * b.C + b.Tx,
+						      a.Tx * b.B + a.Ty * b.D + b.Ty);
+#else
 			return new CGAffineTransform (a.xx * b.xx + a.yx * b.xy,
 						      a.xx * b.yx + a.yx * b.yy,
 						      a.xy * b.xx + a.yy * b.xy,
 						      a.xy * b.yx + a.yy * b.yy,
 						      a.x0 * b.xx + a.y0 * b.xy + b.x0,
 						      a.x0 * b.yx + a.y0 * b.yy + b.y0);
+#endif
 		}
 
 		public void Multiply (CGAffineTransform b)
 		{
 			var a = this;
+#if NET
+			A = a.A * b.A + a.B * b.C;
+			B = a.A * b.B + a.B * b.D;
+			C = a.C * b.A + a.D * b.C;
+			D = a.C * b.B + a.D * b.D;
+			Tx = a.Tx * b.A + a.Ty * b.C + b.Tx;
+			Ty = a.Tx * b.B + a.Ty * b.D + b.Ty;
+#else
 			xx = a.xx * b.xx + a.yx * b.xy;
 			yx = a.xx * b.yx + a.yx * b.yy;
 			xy = a.xy * b.xx + a.yy * b.xy;
 			yy = a.xy * b.yx + a.yy * b.yy;
 			x0 = a.x0 * b.xx + a.y0 * b.xy + b.x0;
 			y0 = a.x0 * b.yx + a.y0 * b.yy + b.y0;
+#endif
 		}
 
 		public void Scale (nfloat sx, nfloat sy, MatrixOrder order)
@@ -130,6 +182,15 @@ namespace CoreGraphics {
 
 		public static CGAffineTransform Scale (CGAffineTransform transform, nfloat sx, nfloat sy)
 		{
+#if NET
+			return new CGAffineTransform (
+				sx * transform.A,
+				sx * transform.B,
+				sy * transform.C,
+				sy * transform.D,
+				transform.Tx,
+				transform.Ty);
+#else
 			return new CGAffineTransform (
 				sx * transform.xx,
 				sx * transform.yx,
@@ -137,6 +198,7 @@ namespace CoreGraphics {
 				sy * transform.yy,
 				transform.x0,
 				transform.y0);
+#endif
 		}
 
 		public void Translate (nfloat tx, nfloat ty, MatrixOrder order)
@@ -161,6 +223,15 @@ namespace CoreGraphics {
 
 		public static CGAffineTransform Translate (CGAffineTransform transform, nfloat tx, nfloat ty)
 		{
+#if NET
+			return new CGAffineTransform (
+				transform.A,
+				transform.B,
+				transform.C,
+				transform.D,
+				tx * transform.A + ty * transform.C + transform.Tx,
+				tx * transform.B + ty * transform.D + transform.Ty);
+#else
 			return new CGAffineTransform (
 				transform.xx,
 				transform.yx,
@@ -168,6 +239,7 @@ namespace CoreGraphics {
 				transform.yy,
 				tx * transform.xx + ty * transform.xy + transform.x0,
 				tx * transform.yx + ty * transform.yy + transform.y0);
+#endif
 		}
 
 		public void Rotate (nfloat angle, MatrixOrder order)
@@ -192,6 +264,18 @@ namespace CoreGraphics {
 			
 		public static CGAffineTransform Rotate (CGAffineTransform transform, nfloat angle)
 		{
+#if NET
+			var cos = (nfloat) Math.Cos (angle);
+			var sin = (nfloat) Math.Sin (angle);
+
+			return new CGAffineTransform (
+				cos * transform.A + sin * transform.C,
+				cos * transform.B + sin * transform.D,
+				cos * transform.C - sin * transform.A,
+				cos * transform.D - sin * transform.B,
+				transform.Tx,
+				transform.Ty);
+#else
 			var cos = (nfloat) Math.Cos (angle);
 			var sin = (nfloat) Math.Sin (angle);
 
@@ -202,25 +286,40 @@ namespace CoreGraphics {
 				cos * transform.yy - sin * transform.yx,
 				transform.x0,
 				transform.y0);
+#endif
 		}
 
 		public bool IsIdentity {
 			get {
+#if NET
+				return A == 1 && B == 0 && C == 0 && D == 1 && Tx == 0 && Ty == 0;
+#else
 				return xx == 1 && yx == 0 && xy == 0 && yy == 1 && x0 == 0 && y0 == 0;
+#endif
 			}
 		}
 		
 		public override String ToString ()
 		{
+#if NET
+			String s = String.Format ("A:{0:##0.0#} B:{1:##0.0#} C:{2:##0.0#} D:{3:##0.0#} Tx:{4:##0.0#} Ty:{5:##0.0#}", A, B, C, D, Tx, Ty);
+#else
 			String s = String.Format ("xx:{0:##0.0#} yx:{1:##0.0#} xy:{2:##0.0#} yy:{3:##0.0#} x0:{4:##0.0#} y0:{5:##0.0#}", xx, yx, xy, yy, x0, y0);
+#endif
 			return s;
 		}
 
 		public static bool operator == (CGAffineTransform lhs, CGAffineTransform rhs)
 		{
+#if NET
+			return (lhs.A == rhs.A && lhs.C == rhs.C &&
+				lhs.B == rhs.B && lhs.D == rhs.D &&
+				lhs.Tx == rhs.Tx && lhs.Ty == rhs.Ty);
+#else
 			return (lhs.xx == rhs.xx && lhs.xy == rhs.xy &&
 				lhs.yx == rhs.yx && lhs.yy == rhs.yy &&
 				lhs.x0 == rhs.x0 && lhs.y0 == rhs.y0 );
+#endif
 		}
 
 		public static bool operator != (CGAffineTransform lhs, CGAffineTransform rhs)
@@ -230,35 +329,53 @@ namespace CoreGraphics {
 
 		public static CGAffineTransform operator * (CGAffineTransform a, CGAffineTransform b)
 		{
+#if NET
+			return new CGAffineTransform (a.A * b.A + a.B * b.C,
+						      a.A * b.B + a.B * b.D,
+						      a.C * b.A + a.D * b.C,
+						      a.C * b.B + a.D * b.D,
+						      a.Tx * b.A + a.Ty * b.C + b.Tx,
+						      a.Tx * b.B + a.Ty * b.D + b.Ty);
+#else
 			return new CGAffineTransform (a.xx * b.xx + a.yx * b.xy,
 						      a.xx * b.yx + a.yx * b.yy,
 						      a.xy * b.xx + a.yy * b.xy,
 						      a.xy * b.yx + a.yy * b.yy,
 						      a.x0 * b.xx + a.y0 * b.xy + b.x0,
 						      a.x0 * b.yx + a.y0 * b.yy + b.y0);
+#endif
 		}
 
 		public override bool Equals(object o)
 		{
 			if (o is CGAffineTransform transform) {
-				return (xx == transform.xx && xy == transform.xy &&
-					yx == transform.yx && yy == transform.yy &&
-					x0 == transform.x0 && y0 == transform.y0);
+				return this == transform;
 			} else
 				return false;
 		}
 
 		public override int GetHashCode()
 		{
+#if NET
+			return  (int) this.A ^ (int) this.C ^
+					(int) this.B ^ (int) this.D ^
+					(int) this.Tx ^ (int) this.Ty;
+#else
 			return  (int)this.xx ^ (int)this.xy ^
 					(int)this.yx ^ (int)this.yy ^
 					(int)this.x0 ^ (int)this.y0;
+#endif
 		}
 
 		public CGPoint TransformPoint (CGPoint point)
 		{
+#if NET
+			return new CGPoint (A * point.X + C * point.Y + Tx,
+					    B * point.X + D * point.Y + Ty);
+#else
 			return new CGPoint (xx * point.X + xy * point.Y + x0,
 					    yx * point.X + yy * point.Y + y0);
+#endif
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]

--- a/src/CoreImage/CISampler.cs
+++ b/src/CoreImage/CISampler.cs
@@ -60,7 +60,11 @@ namespace CoreImage {
 
 			if (AffineMatrix.HasValue){
 				var a = AffineMatrix.Value;
+#if NET
+				using (var array = NSArray.FromObjects (a.A, a.B, a.C, a.D, a.Tx, a.Ty))
+#else
 				using (var array = NSArray.FromObjects (a.xx, a.yx, a.xy, a.yy, a.x0, a.y0))
+#endif
 					ret.SetObject (array, CISampler.AffineMatrix);
 			}
 			if (WrapMode.HasValue){

--- a/tests/monotouch-test/CoreGraphics/AffineTransformTest.cs
+++ b/tests/monotouch-test/CoreGraphics/AffineTransformTest.cs
@@ -25,20 +25,38 @@ namespace MonoTouchFixtures.CoreGraphics {
 		public void Ctor ()
 		{
 			var transform = new CGAffineTransform ();
+#if NET
+			Assert.AreEqual ((nfloat) 0, transform.A);
+			Assert.AreEqual ((nfloat) 0, transform.B);
+			Assert.AreEqual ((nfloat) 0, transform.C);
+			Assert.AreEqual ((nfloat) 0, transform.D);
+			Assert.AreEqual ((nfloat) 0, transform.Tx);
+			Assert.AreEqual ((nfloat) 0, transform.Ty);
+#else
 			Assert.AreEqual ((nfloat) 0, transform.xx);
 			Assert.AreEqual ((nfloat) 0, transform.yx);
 			Assert.AreEqual ((nfloat) 0, transform.xy);
 			Assert.AreEqual ((nfloat) 0, transform.yy);
 			Assert.AreEqual ((nfloat) 0, transform.x0);
 			Assert.AreEqual ((nfloat) 0, transform.y0);
+#endif
 
 			transform = new CGAffineTransform (1, 2, 3, 4, 5, 6);
+#if NET
+			Assert.AreEqual ((nfloat) 1, transform.A);
+			Assert.AreEqual ((nfloat) 2, transform.B);
+			Assert.AreEqual ((nfloat) 3, transform.C);
+			Assert.AreEqual ((nfloat) 4, transform.D);
+			Assert.AreEqual ((nfloat) 5, transform.Tx);
+			Assert.AreEqual ((nfloat) 6, transform.Ty);
+#else
 			Assert.AreEqual ((nfloat) 1, transform.xx);
 			Assert.AreEqual ((nfloat) 2, transform.yx);
 			Assert.AreEqual ((nfloat) 3, transform.xy);
 			Assert.AreEqual ((nfloat) 4, transform.yy);
 			Assert.AreEqual ((nfloat) 5, transform.x0);
 			Assert.AreEqual ((nfloat) 6, transform.y0);
+#endif
 		}
 
 		[Test]
@@ -46,12 +64,21 @@ namespace MonoTouchFixtures.CoreGraphics {
 		{
 			var transform = CGAffineTransform.MakeIdentity ();
 
+#if NET
+			Assert.AreEqual ((nfloat) 1, transform.A, "A");
+			Assert.AreEqual ((nfloat) 0, transform.B, "B");
+			Assert.AreEqual ((nfloat) 0, transform.C, "C");
+			Assert.AreEqual ((nfloat) 1, transform.D, "D");
+			Assert.AreEqual ((nfloat) 0, transform.Tx, "Tx");
+			Assert.AreEqual ((nfloat) 0, transform.Ty, "Ty");
+#else
 			Assert.AreEqual ((nfloat) 1, transform.xx, "xx");
 			Assert.AreEqual ((nfloat) 0, transform.yx, "yx");
 			Assert.AreEqual ((nfloat) 0, transform.xy, "xy");
 			Assert.AreEqual ((nfloat) 1, transform.yy, "yy");
 			Assert.AreEqual ((nfloat) 0, transform.x0, "x0");
 			Assert.AreEqual ((nfloat) 0, transform.y0, "y0");
+#endif
 
 			Assert.IsTrue (transform.IsIdentity, "identity");
 		}
@@ -61,24 +88,42 @@ namespace MonoTouchFixtures.CoreGraphics {
 		{
 			var transform = CGAffineTransform.MakeRotation ((nfloat) Math.PI);
 
+#if NET
+			Assert.AreEqual ((nfloat) (-1), transform.A, "A");
+			Assert.That ((double) 0, Is.EqualTo ((double) transform.B).Within (0.0000001), "B");
+			Assert.That ((double) 0, Is.EqualTo ((double) transform.C).Within (0.0000001), "C");
+			Assert.AreEqual ((nfloat) (-1), transform.D, "D");
+			Assert.That ((double) 0, Is.EqualTo ((double) transform.Tx).Within (0.0000001), "Tx");
+			Assert.That ((double) 0, Is.EqualTo ((double) transform.Ty).Within (0.0000001), "Ty");
+#else
 			Assert.AreEqual ((nfloat) (-1), transform.xx, "xx");
 			Assert.That ((double) 0, Is.EqualTo ((double) transform.yx).Within (0.0000001), "yx");
 			Assert.That ((double) 0, Is.EqualTo ((double) transform.xy).Within (0.0000001), "xy");
 			Assert.AreEqual ((nfloat) (-1), transform.yy, "yy");
 			Assert.That ((double) 0, Is.EqualTo ((double) transform.x0).Within (0.0000001), "x0");
 			Assert.That ((double) 0, Is.EqualTo ((double) transform.y0).Within (0.0000001), "y0");
+#endif
 		}
 
 		[Test]
 		public void MakeScale ()
 		{
 			var transform = CGAffineTransform.MakeScale (314, 413);
+#if NET
+			Assert.AreEqual ((nfloat) 314, transform.A);
+			Assert.AreEqual ((nfloat) 0, transform.B);
+			Assert.AreEqual ((nfloat) 0, transform.C);
+			Assert.AreEqual ((nfloat) 413, transform.D);
+			Assert.AreEqual ((nfloat) 0, transform.Tx);
+			Assert.AreEqual ((nfloat) 0, transform.Ty);
+#else
 			Assert.AreEqual ((nfloat) 314, transform.xx);
 			Assert.AreEqual ((nfloat) 0, transform.yx);
 			Assert.AreEqual ((nfloat) 0, transform.xy);
 			Assert.AreEqual ((nfloat) 413, transform.yy);
 			Assert.AreEqual ((nfloat) 0, transform.x0);
 			Assert.AreEqual ((nfloat) 0, transform.y0);
+#endif
 		}
 
 		[Test]
@@ -86,12 +131,21 @@ namespace MonoTouchFixtures.CoreGraphics {
 		{
 			var transform = CGAffineTransform.MakeTranslation (12, 23);
 
+#if NET
+			Assert.AreEqual ((nfloat) 1, transform.A, "A");
+			Assert.AreEqual ((nfloat) 0, transform.B, "B");
+			Assert.AreEqual ((nfloat) 0, transform.C, "C");
+			Assert.AreEqual ((nfloat) 1, transform.D, "D");
+			Assert.AreEqual ((nfloat) 12, transform.Tx, "Tx");
+			Assert.AreEqual ((nfloat) 23, transform.Ty, "Ty");
+#else
 			Assert.AreEqual ((nfloat) 1, transform.xx, "xx");
 			Assert.AreEqual ((nfloat) 0, transform.yx, "yx");
 			Assert.AreEqual ((nfloat) 0, transform.xy, "xy");
 			Assert.AreEqual ((nfloat) 1, transform.yy, "yy");
 			Assert.AreEqual ((nfloat) 12, transform.x0, "x0");
 			Assert.AreEqual ((nfloat) 23, transform.y0, "y0");
+#endif
 		}
 
 		[Test]
@@ -101,12 +155,21 @@ namespace MonoTouchFixtures.CoreGraphics {
 			var transform = new CGAffineTransform (9, 8, 7, 6, 5, 4);
 			transform.Multiply (a);
 
+#if NET
+			Assert.AreEqual ((nfloat) 33, transform.A, "A");
+			Assert.AreEqual ((nfloat) 50, transform.B, "B");
+			Assert.AreEqual ((nfloat) 25, transform.C, "C");
+			Assert.AreEqual ((nfloat) 38, transform.D, "D");
+			Assert.AreEqual ((nfloat) 22, transform.Tx, "Tx");
+			Assert.AreEqual ((nfloat) 32, transform.Ty, "Ty");
+#else
 			Assert.AreEqual ((nfloat) 33, transform.xx, "xx");
 			Assert.AreEqual ((nfloat) 50, transform.yx, "yx");
 			Assert.AreEqual ((nfloat) 25, transform.xy, "xy");
 			Assert.AreEqual ((nfloat) 38, transform.yy, "yy");
 			Assert.AreEqual ((nfloat) 22, transform.x0, "x0");
 			Assert.AreEqual ((nfloat) 32, transform.y0, "y0");
+#endif
 		}
 
 		[Test]
@@ -116,12 +179,21 @@ namespace MonoTouchFixtures.CoreGraphics {
 			var b = new CGAffineTransform (9, 8, 7, 6, 5, 4);
 			var transform = CGAffineTransform.Multiply (a, b);
 
+#if NET
+			Assert.AreEqual ((nfloat) 23, transform.A, "A");
+			Assert.AreEqual ((nfloat) 20, transform.B, "B");
+			Assert.AreEqual ((nfloat) 55, transform.C, "C");
+			Assert.AreEqual ((nfloat) 48, transform.D, "D");
+			Assert.AreEqual ((nfloat) 92, transform.Tx, "Tx");
+			Assert.AreEqual ((nfloat) 80, transform.Ty, "Ty");
+#else
 			Assert.AreEqual ((nfloat) 23, transform.xx, "xx");
 			Assert.AreEqual ((nfloat) 20, transform.yx, "yx");
 			Assert.AreEqual ((nfloat) 55, transform.xy, "xy");
 			Assert.AreEqual ((nfloat) 48, transform.yy, "yy");
 			Assert.AreEqual ((nfloat) 92, transform.x0, "x0");
 			Assert.AreEqual ((nfloat) 80, transform.y0, "y0");
+#endif
 		}
 		[Test]
 		public void Scale ()
@@ -130,23 +202,41 @@ namespace MonoTouchFixtures.CoreGraphics {
 			// t' = t * [ sx 0 0 sy 0 0 ]
 			transform1.Scale (3, 4); // MatrixOrder.Append by default
 
+#if NET
+			Assert.AreEqual ((nfloat) 3, transform1.A);
+			Assert.AreEqual ((nfloat) 0, transform1.B);
+			Assert.AreEqual ((nfloat) 0, transform1.C);
+			Assert.AreEqual ((nfloat) 4, transform1.D);
+			Assert.AreEqual ((nfloat) 3, transform1.Tx);
+			Assert.AreEqual ((nfloat) 8, transform1.Ty);
+#else
 			Assert.AreEqual ((nfloat) 3, transform1.xx);
 			Assert.AreEqual ((nfloat) 0, transform1.yx);
 			Assert.AreEqual ((nfloat) 0, transform1.xy);
 			Assert.AreEqual ((nfloat) 4, transform1.yy);
 			Assert.AreEqual ((nfloat) 3, transform1.x0);
 			Assert.AreEqual ((nfloat) 8, transform1.y0);
+#endif
 
 			var transform2 = CGAffineTransform.MakeTranslation (1, 2);
 			// t' = [ sx 0 0 sy 0 0 ] * t – Swift equivalent
 			transform2.Scale (3, 4, MatrixOrder.Prepend);
 
+#if NET
+			Assert.AreEqual ((nfloat) 3, transform2.A);
+			Assert.AreEqual ((nfloat) 0, transform2.B);
+			Assert.AreEqual ((nfloat) 0, transform2.C);
+			Assert.AreEqual ((nfloat) 4, transform2.D);
+			Assert.AreEqual ((nfloat) 1, transform2.Tx);
+			Assert.AreEqual ((nfloat) 2, transform2.Ty);
+#else
 			Assert.AreEqual ((nfloat)3, transform2.xx);
 			Assert.AreEqual ((nfloat)0, transform2.yx);
 			Assert.AreEqual ((nfloat)0, transform2.xy);
 			Assert.AreEqual ((nfloat)4, transform2.yy);
 			Assert.AreEqual ((nfloat)1, transform2.x0);
 			Assert.AreEqual ((nfloat)2, transform2.y0);
+#endif
 		}
 
 		[Test]
@@ -172,32 +262,59 @@ namespace MonoTouchFixtures.CoreGraphics {
 			var transform = CGAffineTransform.MakeIdentity ();
 			transform.Translate (1, -1); // MatrixOrder.Append by default
 
+#if NET
+			Assert.AreEqual ((nfloat) 1, transform.A, "A");
+			Assert.AreEqual ((nfloat) 0, transform.B, "B");
+			Assert.AreEqual ((nfloat) 0, transform.C, "C");
+			Assert.AreEqual ((nfloat) 1, transform.D, "D");
+			Assert.AreEqual ((nfloat) 1, transform.Tx, "Tx");
+			Assert.AreEqual ((nfloat) (-1), transform.Ty, "Ty");
+#else
 			Assert.AreEqual ((nfloat) 1, transform.xx, "xx");
 			Assert.AreEqual ((nfloat) 0, transform.yx, "yx");
 			Assert.AreEqual ((nfloat) 0, transform.xy, "xy");
 			Assert.AreEqual ((nfloat) 1, transform.yy, "yy");
 			Assert.AreEqual ((nfloat) 1, transform.x0, "x0");
 			Assert.AreEqual ((nfloat) (-1), transform.y0, "y0");
+#endif
 
 			transform = new CGAffineTransform (1, 2, 3, 4, 5, 6);
 			transform.Translate (2, -3);
 
+#if NET
+			Assert.AreEqual ((nfloat) 1, transform.A, "A");
+			Assert.AreEqual ((nfloat) 2, transform.B, "B");
+			Assert.AreEqual ((nfloat) 3, transform.C, "C");
+			Assert.AreEqual ((nfloat) 4, transform.D, "D");
+			Assert.AreEqual ((nfloat) 7, transform.Tx, "Tx");
+			Assert.AreEqual ((nfloat) 3, transform.Ty, "Ty");
+#else
 			Assert.AreEqual ((nfloat)1, transform.xx, "xx");
 			Assert.AreEqual ((nfloat)2, transform.yx, "yx");
 			Assert.AreEqual ((nfloat)3, transform.xy, "xy");
 			Assert.AreEqual ((nfloat)4, transform.yy, "yy");
 			Assert.AreEqual ((nfloat)7, transform.x0, "x0");
 			Assert.AreEqual ((nfloat)3, transform.y0, "y0");
+#endif
 
 			transform = new CGAffineTransform (1, 2, 3, 4, 5, 6);
 			transform.Translate (2, -3, MatrixOrder.Prepend);
 
+#if NET
+			Assert.AreEqual ((nfloat) 1, transform.A, "A");
+			Assert.AreEqual ((nfloat) 2, transform.B, "B");
+			Assert.AreEqual ((nfloat) 3, transform.C, "C");
+			Assert.AreEqual ((nfloat) 4, transform.D, "D");
+			Assert.AreEqual ((nfloat) (-2), transform.Tx, "Tx");
+			Assert.AreEqual ((nfloat) (-2), transform.Ty, "Ty");
+#else
 			Assert.AreEqual ((nfloat)1, transform.xx, "xx");
 			Assert.AreEqual ((nfloat)2, transform.yx, "yx");
 			Assert.AreEqual ((nfloat)3, transform.xy, "xy");
 			Assert.AreEqual ((nfloat)4, transform.yy, "yy");
 			Assert.AreEqual ((nfloat)(-2), transform.x0, "x0");
 			Assert.AreEqual ((nfloat)(-2), transform.y0, "y0");
+#endif
 		}
 
 		[Test]
@@ -207,24 +324,42 @@ namespace MonoTouchFixtures.CoreGraphics {
 			var transformM = CGAffineTransform.Translate (origin, 1, -1);
 			var transformN = CGAffineTransformTranslate (origin, 1, -1);
 
+#if NET
+			Assert.AreEqual ((nfloat) 1, transformM.A, "A");
+			Assert.AreEqual ((nfloat) 0, transformM.B, "B");
+			Assert.AreEqual ((nfloat) 0, transformM.C, "C");
+			Assert.AreEqual ((nfloat) 1, transformM.D, "D");
+			Assert.AreEqual ((nfloat) 1, transformM.Tx, "Tx");
+			Assert.AreEqual ((nfloat) (-1), transformM.Ty, "Ty");
+#else
 			Assert.AreEqual ((nfloat) 1, transformM.xx, "xx");
 			Assert.AreEqual ((nfloat) 0, transformM.yx, "yx");
 			Assert.AreEqual ((nfloat) 0, transformM.xy, "xy");
 			Assert.AreEqual ((nfloat) 1, transformM.yy, "yy");
 			Assert.AreEqual ((nfloat) 1, transformM.x0, "x0");
 			Assert.AreEqual ((nfloat) (-1), transformM.y0, "y0");
+#endif
 			Assert.IsTrue (transformN == transformM);
 
 			origin = new CGAffineTransform (1, 2, 3, 4, 5, 6);
 			transformM = CGAffineTransform.Translate (origin, 2, -3);
 			transformN = CGAffineTransformTranslate (origin, 2, -3);
 
+#if NET
+			Assert.AreEqual ((nfloat) 1, transformM.A, "A");
+			Assert.AreEqual ((nfloat) 2, transformM.B, "B");
+			Assert.AreEqual ((nfloat) 3, transformM.C, "C");
+			Assert.AreEqual ((nfloat) 4, transformM.D, "D");
+			Assert.AreEqual ((nfloat) (-2), transformM.Tx, "Tx");
+			Assert.AreEqual ((nfloat) (-2), transformM.Ty, "Ty");
+#else
 			Assert.AreEqual ((nfloat) 1, transformM.xx, "xx");
 			Assert.AreEqual ((nfloat) 2, transformM.yx, "yx");
 			Assert.AreEqual ((nfloat) 3, transformM.xy, "xy");
 			Assert.AreEqual ((nfloat) 4, transformM.yy, "yy");
 			Assert.AreEqual ((nfloat) (-2), transformM.x0, "x0");
 			Assert.AreEqual ((nfloat) (-2), transformM.y0, "y0");
+#endif
 			Assert.IsTrue (transformN == transformM);
 		}
 
@@ -237,22 +372,40 @@ namespace MonoTouchFixtures.CoreGraphics {
 			var transform = new CGAffineTransform (1, 2, 3, 4, 5, 6);
 			transform.Rotate ((nfloat) Math.PI); // MatrixOrder.Append by default
 
+#if NET
+			Assert.That ((double) (-1), Is.EqualTo ((double) transform.A).Within (0.000001), "A");
+			Assert.That ((double) (-2), Is.EqualTo ((double) transform.B).Within (0.000001), "B");
+			Assert.That ((double) (-3), Is.EqualTo ((double) transform.C).Within (0.000001), "C");
+			Assert.That ((double) (-4), Is.EqualTo ((double) transform.D).Within (0.000001), "D");
+			Assert.That ((double) (-5), Is.EqualTo ((double) transform.Tx).Within (0.000001), "Tx");
+			Assert.That ((double) (-6), Is.EqualTo ((double) transform.Ty).Within (0.000001), "Ty");
+#else
 			Assert.That ((double) (-1), Is.EqualTo ((double) transform.xx).Within (0.000001), "xx");
 			Assert.That ((double) (-2), Is.EqualTo ((double) transform.yx).Within (0.000001), "yx");
 			Assert.That ((double) (-3), Is.EqualTo ((double) transform.xy).Within (0.000001), "xy");
 			Assert.That ((double) (-4), Is.EqualTo ((double) transform.yy).Within (0.000001), "yy");
 			Assert.That ((double) (-5), Is.EqualTo ((double) transform.x0).Within (0.000001), "x0");
 			Assert.That ((double) (-6), Is.EqualTo ((double) transform.y0).Within (0.000001), "y0");
+#endif
 
 			transform = new CGAffineTransform (1, 2, 3, 4, 5, 6);
 			transform.Rotate ((nfloat)Math.PI, MatrixOrder.Prepend);
 
+#if NET
+			Assert.That ((double) (-1), Is.EqualTo ((double)transform.A).Within (0.000001), "A");
+			Assert.That ((double) (-2), Is.EqualTo ((double)transform.B).Within (0.000001), "B");
+			Assert.That ((double) (-3), Is.EqualTo ((double)transform.C).Within (0.000001), "C");
+			Assert.That ((double) (-4), Is.EqualTo ((double)transform.D).Within (0.000001), "D");
+			Assert.That ((double) 5, Is.EqualTo ((double)transform.Tx).Within (0.000001), "Tx");
+			Assert.That ((double) 6, Is.EqualTo ((double)transform.Ty).Within (0.000001), "Ty");
+#else
 			Assert.That ((double)(-1), Is.EqualTo ((double)transform.xx).Within (0.000001), "xx");
 			Assert.That ((double)(-2), Is.EqualTo ((double)transform.yx).Within (0.000001), "yx");
 			Assert.That ((double)(-3), Is.EqualTo ((double)transform.xy).Within (0.000001), "xy");
 			Assert.That ((double)(-4), Is.EqualTo ((double)transform.yy).Within (0.000001), "yy");
 			Assert.That ((double)5, Is.EqualTo ((double)transform.x0).Within (0.000001), "x0");
 			Assert.That ((double)6, Is.EqualTo ((double)transform.y0).Within (0.000001), "y0");
+#endif
 		}
 
 		[Test]
@@ -261,6 +414,21 @@ namespace MonoTouchFixtures.CoreGraphics {
 			var transformM = CGAffineTransform.Rotate (new CGAffineTransform (1, 2, 3, 4, 5, 6), (nfloat) Math.PI);
 			var transformN = CGAffineTransformRotate (new CGAffineTransform (1, 2, 3, 4, 5, 6), (nfloat) Math.PI);
 
+#if NET
+			Assert.That ((double) (-1), Is.EqualTo ((double) transformM.A).Within (0.000001), "A");
+			Assert.That ((double) (-2), Is.EqualTo ((double) transformM.B).Within (0.000001), "B");
+			Assert.That ((double) (-3), Is.EqualTo ((double) transformM.C).Within (0.000001), "C");
+			Assert.That ((double) (-4), Is.EqualTo ((double) transformM.D).Within (0.000001), "D");
+			Assert.That ((double) 5, Is.EqualTo ((double) transformM.Tx).Within (0.000001), "Tx");
+			Assert.That ((double) 6, Is.EqualTo ((double) transformM.Ty).Within (0.000001), "Ty");
+
+			Assert.That ((double) transformN.A, Is.EqualTo ((double) transformM.A).Within (0.000001), "A");
+			Assert.That ((double) transformN.B, Is.EqualTo ((double) transformM.B).Within (0.000001), "B");
+			Assert.That ((double) transformN.C, Is.EqualTo ((double) transformM.C).Within (0.000001), "C");
+			Assert.That ((double) transformN.D, Is.EqualTo ((double) transformM.D).Within (0.000001), "D");
+			Assert.That ((double) 5, Is.EqualTo ((double) transformM.Tx).Within (0.000001), "Tx");
+			Assert.That ((double) 6, Is.EqualTo ((double) transformM.Ty).Within (0.000001), "Ty");
+#else
 			Assert.That ((double) (-1), Is.EqualTo ((double) transformM.xx).Within (0.000001), "xx");
 			Assert.That ((double) (-2), Is.EqualTo ((double) transformM.yx).Within (0.000001), "yx");
 			Assert.That ((double) (-3), Is.EqualTo ((double) transformM.xy).Within (0.000001), "xy");
@@ -274,6 +442,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 			Assert.That ((double) transformN.yy, Is.EqualTo ((double) transformM.yy).Within (0.000001), "yy");
 			Assert.That ((double) 5, Is.EqualTo ((double) transformM.x0).Within (0.000001), "x0");
 			Assert.That ((double) 6, Is.EqualTo ((double) transformM.y0).Within (0.000001), "y0");
+#endif
 		}
 
 		[DllImport (global::ObjCRuntime.Constants.CoreGraphicsLibrary)]
@@ -313,12 +482,21 @@ namespace MonoTouchFixtures.CoreGraphics {
 		{
 			var transform = new CGAffineTransform (1, 2, 3, 4, 5, 6).Invert ();
 
+#if NET
+			Assert.AreEqual ((nfloat) (-2), transform.A, "A");
+			Assert.AreEqual ((nfloat) 1, transform.B, "B");
+			Assert.AreEqual ((nfloat) 1.5, transform.C, "C");
+			Assert.AreEqual ((nfloat) (-0.5), transform.D, "D");
+			Assert.AreEqual ((nfloat) 1.0, transform.Tx, "Tx");
+			Assert.AreEqual ((nfloat) (-2.0), transform.Ty, "Ty");
+#else
 			Assert.AreEqual ((nfloat) (-2), transform.xx, "xx");
 			Assert.AreEqual ((nfloat) 1, transform.yx, "yx");
 			Assert.AreEqual ((nfloat) 1.5, transform.xy, "xy");
 			Assert.AreEqual ((nfloat) (-0.5), transform.yy, "yy");
 			Assert.AreEqual ((nfloat) 1.0, transform.x0, "x0");
 			Assert.AreEqual ((nfloat) (-2.0), transform.y0, "y0");
+#endif
 		}
 
 		[Test]
@@ -328,12 +506,21 @@ namespace MonoTouchFixtures.CoreGraphics {
 			// looks simplistic but that NSValue logic is implemented by "us" on macOS
 			using (var nsv = NSValue.FromCGAffineTransform (transform)) {
 				var tback = nsv.CGAffineTransformValue;
+#if NET
+				Assert.AreEqual ((nfloat) 1, tback.A, "A");
+				Assert.AreEqual ((nfloat) 2, tback.B, "B");
+				Assert.AreEqual ((nfloat) 3, tback.C, "C");
+				Assert.AreEqual ((nfloat) 4, tback.D, "D");
+				Assert.AreEqual ((nfloat) 5, tback.Tx, "Tx");
+				Assert.AreEqual ((nfloat) 6, tback.Ty, "Ty");
+#else
 				Assert.AreEqual ((nfloat)1, tback.xx, "xx");
 				Assert.AreEqual ((nfloat)2, tback.yx, "yx");
 				Assert.AreEqual ((nfloat)3, tback.xy, "xy");
 				Assert.AreEqual ((nfloat)4, tback.yy, "yy");
 				Assert.AreEqual ((nfloat)5, tback.x0, "x0");
 				Assert.AreEqual ((nfloat)6, tback.y0, "y0");
+#endif
 			}
 		}
 


### PR DESCRIPTION
Rename the public fields in CGAffineTransform to:

* Follow our naming convention (public API should always start with an
  upper-case letter).
* Use the same names as Apple's version to ease porting Swift/Objective-C
  code.

Fixes https://github.com/xamarin/xamarin-macios/issues/13494.