### PR TITLE
[tests] Disable attribute duplication check

### DIFF
--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -553,8 +553,10 @@ namespace Introspection {
 					s = aa.ToString ();
 #endif
 				if (s.Length > 0) {
+#if !NET
 					if (type_level.Contains (s))
 						AddErrorLine ($"[FAIL] Both '{t}' and '{m}' are marked with `{s}`.");
+#endif
 					if (member_level.Contains (s))
 						AddErrorLine ($"[FAIL] '{m}' is decorated more than once with `{s}`.");
 					else


### PR DESCRIPTION
- Disable check "[FAIL] Both '{t}' and '{m}' are marked with `{s}`." type and member on that type in NET
- Due to the behavior of NET6 style attributes, we are forced to duplicate availability attributes in many cases
- See https://github.com/xamarin/xamarin-macios/issues/10170 for details