### PR TITLE
[uikit] Use a code-first approach to app-level debugging options

### DIFF
--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/Main.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/Main.cs
@@ -1,5 +1,12 @@
 using iOSApp1;
 
+#if DEBUG
+// Enable runtime checks to ensure some types are only used from the main (UI) thread
+UIApplication.CheckForIllegalCrossThreadCalls = true;
+// Enable runtime checks to ensure ObjC delegates and events (using their own delegates) are not mixed
+UIApplication.CheckForEventAndDelegateMismatches = true;
+#endif
+
 // This is the main entry point of the application.
 // If you want to use a different Application Delegate class from "AppDelegate"
 // you can specify it here.

--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -35,8 +35,14 @@ using ObjCRuntime;
 
 namespace AppKit {
 	public partial class NSApplication : NSResponder {
+
+#if NET
+		public static bool CheckForIllegalCrossThreadCalls { get; set; }
+		public static bool CheckForEventAndDelegateMismatches { get; set; }
+#else
 		public static bool CheckForIllegalCrossThreadCalls = true;
 		public static bool CheckForEventAndDelegateMismatches = true;
+#endif
 
 #if !(XAMCORE_4_0 && NET)
 #if NET

--- a/src/UIKit/UIApplication.cs
+++ b/src/UIKit/UIApplication.cs
@@ -42,8 +42,13 @@ namespace UIKit {
 #endif
 	{
 		static Thread? mainThread;
+#if NET
+		public static bool CheckForIllegalCrossThreadCalls { get; set; }
+		public static bool CheckForEventAndDelegateMismatches { get; set; }
+#else
 		public static bool CheckForIllegalCrossThreadCalls = true;
 		public static bool CheckForEventAndDelegateMismatches = true;
+#endif
 
 #if !WATCH
 		// We link with __Internal here so that this function is interposable from third-party native libraries.


### PR DESCRIPTION
Change `CheckForIllegalCrossThreadCalls` and `CheckForEventAndDelegateMismatches`
from fields to properties.

This has two main benefits:

1. Setting them inside code (and part of the templates) makes the
features easier to discover and easier to tweak the conditions to enable
or disable them. No extra arguments hidden in project files :)

2. This allows the linker to remove the properties (when disabled) since
they are not set from the static constructor (like the current fields)

Note: this is a draft, what's missing are

1. update all templates (ideally including MAUI ones in a different PR)

2. update the linker code to detect the properties (if never set) to
remove the feature. No more settings would be needed