### PR TITLE
[Intents] The INPersonRelationship enum was added to macOS 12.1 according to the documentation.

### DIFF
--- a/src/intents.cs
+++ b/src/intents.cs
@@ -2225,11 +2225,7 @@ namespace Intents {
 		School,
 	}
 
-#if XAMCORE_4_0
-	[NoMac]
-#elif MONOMAC
-	[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
-#endif
+	[Mac (12, 1)]
 	[iOS (10, 2)]
 	[Watch (3, 2)]
 	[NoTV]
@@ -2237,36 +2233,91 @@ namespace Intents {
 		[Field (null)]
 		None,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipFather")]
 		Father,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipMother")]
 		Mother,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipParent")]
 		Parent,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipBrother")]
 		Brother,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipSister")]
 		Sister,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipChild")]
 		Child,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipFriend")]
 		Friend,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipSpouse")]
 		Spouse,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipPartner")]
 		Partner,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipAssistant")]
 		Assistant,
 
+#if NET
+		[NoMac]
+#else
+		[Obsoleted (PlatformName.MacOSX, 10,0, message: "Unavailable on macOS, will be removed in the future.")]
+#endif
 		[Field ("INPersonRelationshipManager")]
 		Manager,
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-Intents.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-Intents.ignore
@@ -30,19 +30,6 @@
 !missing-type! INTicketedEvent not bound
 !missing-type! INTicketedEventReservation not bound
 
-## Apple fixed API availability fixed in XAMCORE_4_0
-!unknown-field! INPersonRelationshipAssistant bound
-!unknown-field! INPersonRelationshipBrother bound
-!unknown-field! INPersonRelationshipChild bound
-!unknown-field! INPersonRelationshipFather bound
-!unknown-field! INPersonRelationshipFriend bound
-!unknown-field! INPersonRelationshipManager bound
-!unknown-field! INPersonRelationshipMother bound
-!unknown-field! INPersonRelationshipParent bound
-!unknown-field! INPersonRelationshipPartner bound
-!unknown-field! INPersonRelationshipSister bound
-!unknown-field! INPersonRelationshipSpouse bound
-
 ## Headers say Mac (12,0) but types used in properties are still NoMac
 !missing-protocol! INStartCallIntentHandling not bound
 


### PR DESCRIPTION
But only some values, the rest aren't available, so remove those from .NET.