### PR TITLE
[Intents] Remove INSetMessageAttributeIntentResponseCode from macOS in .NET.

### DIFF
--- a/src/intents.cs
+++ b/src/intents.cs
@@ -794,7 +794,11 @@ namespace Intents {
 	}
 
 	[iOS (10, 0)]
+#if NET
+	[NoMac]
+#else
 	[Mac (10, 12, 0)]
+#endif
 	[Unavailable (PlatformName.WatchOS)]
 	[NoTV]
 	[Native]

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-Intents.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-Intents.ignore
@@ -1,7 +1,5 @@
 ## unsorted
 
-!unknown-native-enum! INSetMessageAttributeIntentResponseCode bound
-
 ## The API that uses the following is unavailable / API_UNAVAILABLE(macosx)
 !missing-enum! INBookRestaurantReservationIntentCode not bound
 !missing-enum! INGetAvailableRestaurantReservationBookingDefaultsIntentResponseCode not bound


### PR DESCRIPTION
According to the headers it's not available in macOS.