### PR TITLE
[Foundation] Make NSBundleExecutableArchitecture non-native.

### DIFF
--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -77,7 +77,7 @@ namespace Foundation  {
 
 #if MONOMAC || !XAMCORE_3_0
 
-#if !XAMCORE_4_0
+#if !NET
 	[Native]
 	public enum NSBundleExecutableArchitecture : long {
 #else

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-Foundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-Foundation.ignore
@@ -38,9 +38,6 @@
 !missing-selector! NSNumber::initWithLong: not bound
 !missing-selector! NSNumber::initWithUnsignedLong: not bound
 
-## should not have been [Native] it's 32bits only values -> XAMCORE_4_0
-!unknown-native-enum! NSBundleExecutableArchitecture bound
-
 ## collections - many are special
 !missing-type! NSCountedSet not bound
 !missing-selector! NSCountedSet::addObject: not bound


### PR DESCRIPTION
NSBundleExecutableArchitecture is an enum of our own invention, so there's no
need for it to be a native enum.