### PR TITLE
[CFNetwork] Move the CFHost and CFHTTP* types to the CFNetwork namespace in .NET.

### DIFF
--- a/dotnet/BreakingChanges.md
+++ b/dotnet/BreakingChanges.md
@@ -85,3 +85,15 @@ interacting with the platform.
 In .NET, we've changed the managed SCNMatrix4 to be a column-major matrix, to
 match the native version. This means that any transposing that's currently
 done when accessing Apple APIs has to be undone.
+
+## Some types were moved from the CoreServices namespace to the CFNetwork namespace.
+
+The following types:
+
+* CFHTTPStream
+* CFHTTPMessage
+* CFHTTPAuthentication
+
+were moved from the CoreServices namespace to the CFNetwork namespace.
+
+This requires adding a `using CFNetwork;` statement to any files that uses these types.

--- a/src/CFNetwork/CFHTTPAuthentication.cs
+++ b/src/CFNetwork/CFHTTPAuthentication.cs
@@ -21,7 +21,7 @@ using NativeHandle = System.IntPtr;
 #endif
 
 // CFHTTPAuthentication is in CFNetwork.framework, no idea why it ended up in CoreServices when it was bound.
-#if XAMCORE_4_0
+#if NET
 namespace CFNetwork {
 #else
 namespace CoreServices {

--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -24,7 +24,7 @@ using NativeHandle = System.IntPtr;
 #endif
 
 // CFHTTPMessage is in CFNetwork.framework, no idea why it ended up in CoreServices when it was bound.
-#if XAMCORE_4_0
+#if NET
 namespace CFNetwork {
 #else
 namespace CoreServices {

--- a/src/CFNetwork/CFHTTPStream.cs
+++ b/src/CFNetwork/CFHTTPStream.cs
@@ -20,7 +20,7 @@ using NativeHandle = System.IntPtr;
 #endif
 
 // CFHttpStream is in CFNetwork.framework, no idea why it ended up in CoreServices when it was bound.
-#if XAMCORE_4_0
+#if NET
 namespace CFNetwork {
 #else
 namespace CoreServices {

--- a/src/CFNetwork/CFHost.cs
+++ b/src/CFNetwork/CFHost.cs
@@ -22,7 +22,7 @@ using NativeHandle = System.IntPtr;
 #endif
 
 // CFHost is in CFNetwork.framework, no idea why it ended up in CoreServices when it was bound.
-#if XAMCORE_4_0
+#if NET
 namespace CFNetwork {
 #else
 namespace CoreServices {

--- a/src/CoreFoundation/CFProxySupport.cs
+++ b/src/CoreFoundation/CFProxySupport.cs
@@ -34,6 +34,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using ObjCRuntime;
 using Foundation;
+#if NET
+using CFNetwork;
+#endif
 
 namespace CoreFoundation {
 	// Utility enum for string constants in ObjC

--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -37,7 +37,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-#if XAMCORE_4_0
+#if NET
 using CFNetwork;
 #elif !WATCH
 using CoreServices;

--- a/src/Foundation/NSStream.cs
+++ b/src/Foundation/NSStream.cs
@@ -34,7 +34,7 @@ using System.Net;
 using System.Net.Sockets;
 using ObjCRuntime;
 #if !WATCH
-#if XAMCORE_4_0
+#if NET
 using CFNetwork;
 #else
 using CoreServices;

--- a/src/System.Net.Http/CFContentStream.cs
+++ b/src/System.Net.Http/CFContentStream.cs
@@ -32,7 +32,7 @@ using System.IO;
 using System.Net;
 using System.Runtime.ExceptionServices;
 
-#if XAMCORE_4_0
+#if NET
 using CFNetwork;
 using CoreFoundation;
 #else

--- a/src/System.Net.Http/CFNetworkHandler.cs
+++ b/src/System.Net.Http/CFNetworkHandler.cs
@@ -33,7 +33,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Net;
 
-#if XAMCORE_4_0
+#if NET
 using CFNetwork;
 using CoreFoundation;
 using CF=CoreFoundation;

--- a/src/cfnetwork.cs
+++ b/src/cfnetwork.cs
@@ -9,7 +9,7 @@ using Foundation;
 using ObjCRuntime;
 
 // Both CFHttpStream and CFHTTPMessage are in CFNetwork.framework, no idea why they ended up in CoreServices when they were bound.
-#if XAMCORE_4_0
+#if NET
 namespace CFNetwork {
 #else
 namespace CoreServices {

--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -15,7 +15,11 @@ using CoreMedia;
 using CoreFoundation;
 using CoreGraphics;
 using CoreText;
+#if NET
+using CFNetwork;
+#else
 using CoreServices;
+#endif
 using CoreVideo;
 using Foundation;
 using ImageIO;

--- a/tests/introspection/ApiFrameworkTest.cs
+++ b/tests/introspection/ApiFrameworkTest.cs
@@ -51,9 +51,11 @@ namespace Introspection {
 			case "System.Drawing":
 				return true;
 #if __IOS__
+#if !NET
 			// Some CF* types that requires CFNetwork which we always link with
 			// ref: tools/common/CompilerFlags.cs
 			case "CoreServices":
+#endif
 #if !NET
 			case "WatchKit": // Apple removed WatchKit from iOS
 #endif

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -676,7 +676,11 @@ namespace LinkSdk {
 		public void WebProxy_Leak ()
 		{
 			// note: needs to be executed under Instrument to verify it does not leak
+#if NET
+			Assert.NotNull (global::CoreFoundation.CFNetwork.GetSystemProxySettings (), "should not leak");
+#else
 			Assert.NotNull (CFNetwork.GetSystemProxySettings (), "should not leak");
+#endif
 		}
 #endif // !__TVOS__ && !__WATCHOS__
 		

--- a/tests/monotouch-test/CoreFoundation/ProxyTest.cs
+++ b/tests/monotouch-test/CoreFoundation/ProxyTest.cs
@@ -119,7 +119,11 @@ namespace MonoTouchFixtures.CoreFoundation {
 			NSError error = null;
 			var script = File.ReadAllText (pacPath);
 			var targetUri = NetworkResources.XamarinUri;
+#if NET
+			var proxies = global::CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationScript (script, targetUri, out error);
+#else
 			var proxies = CFNetwork.ExecuteProxyAutoConfigurationScript (script, targetUri, out error);
+#endif
 			Assert.IsNull (error, "Null error");
 			Assert.AreEqual (1, proxies.Length, "Length");
 			// assert the data of the proxy, although we are really testing the js used
@@ -133,7 +137,11 @@ namespace MonoTouchFixtures.CoreFoundation {
 			NSError error = null;
 			var script = File.ReadAllText (pacPath);
 			var targetUri = NetworkResources.MicrosoftUri;
+#if NET
+			var proxies = global::CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationScript (script, targetUri, out error);
+#else
 			var proxies = CFNetwork.ExecuteProxyAutoConfigurationScript (script, targetUri, out error);
+#endif
 			Assert.IsNull (error, "Null error");
 			Assert.IsNotNull (proxies, "Not null proxies");
 			Assert.AreEqual (1, proxies.Length, "Proxies length");
@@ -146,7 +154,11 @@ namespace MonoTouchFixtures.CoreFoundation {
 			NSError error = null;
 			var script = "Not VALID js";
 			var targetUri = NetworkResources.MicrosoftUri;
+#if NET
+			var proxies = global::CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationScript (script, targetUri, out error);
+#else
 			var proxies = CFNetwork.ExecuteProxyAutoConfigurationScript (script, targetUri, out error);
+#endif
 			Assert.IsNotNull (error, "Not null error");
 			Assert.IsNull (proxies, "Null proxies");
 		}
@@ -170,7 +182,11 @@ namespace MonoTouchFixtures.CoreFoundation {
 				try {
 					CancellationTokenSource cancelSource = new CancellationTokenSource ();
 					CancellationToken cancelToken = cancelSource.Token;
+#if NET
+					var result = await global::CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationScriptAsync (script, targetUri, cancelToken);
+#else
 					var result = await CFNetwork.ExecuteProxyAutoConfigurationScriptAsync (script, targetUri, cancelToken);
+#endif
 					proxies = result.proxies;
 					error = result.error;
 				} catch (Exception e) {
@@ -208,7 +224,11 @@ namespace MonoTouchFixtures.CoreFoundation {
 				try {
 					CancellationTokenSource cancelSource = new CancellationTokenSource ();
 					CancellationToken cancelToken = cancelSource.Token;
+#if NET
+					var result = await global::CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationScriptAsync (script, targetUri, cancelToken);
+#else
 					var result = await CFNetwork.ExecuteProxyAutoConfigurationScriptAsync (script, targetUri, cancelToken);
+#endif
 					proxies = result.proxies;
 					error = result.error;
 				} catch (Exception e) {
@@ -230,7 +250,11 @@ namespace MonoTouchFixtures.CoreFoundation {
 			NSError error;
 			var pacUri = new Uri ($"http://localhost:{port}/example.pac");
 			var targetUri = NetworkResources.XamarinUri;
+#if NET
+			var proxies = global::CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationUrl (pacUri, targetUri, out error);
+#else
 			var proxies = CFNetwork.ExecuteProxyAutoConfigurationUrl (pacUri, targetUri, out error);
+#endif
 			Assert.IsNull (error, "Null error");
 			Assert.AreEqual (1, proxies.Length, "Length");
 			// assert the data of the proxy, although we are really testing the js used
@@ -243,7 +267,11 @@ namespace MonoTouchFixtures.CoreFoundation {
 			NSError error;
 			var pacUri = new Uri ($"http://localhost:{port}/example.pac");
 			var targetUri = NetworkResources.MicrosoftUri;
+#if NET
+			var proxies = global::CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationUrl (pacUri, targetUri, out error);
+#else
 			var proxies = CFNetwork.ExecuteProxyAutoConfigurationUrl (pacUri, targetUri, out error);
+#endif
 			Assert.IsNull (error, "Null error");
 			Assert.IsNotNull (proxies, "Not null proxies");
 			Assert.AreEqual (1, proxies.Length, "Proxies length");
@@ -267,7 +295,11 @@ namespace MonoTouchFixtures.CoreFoundation {
 				try {
 					CancellationTokenSource cancelSource = new CancellationTokenSource ();
 					CancellationToken cancelToken = cancelSource.Token;
+#if NET
+					var result = await global::CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationUrlAsync (pacUri, targetUri, cancelToken);
+#else
 					var result = await CFNetwork.ExecuteProxyAutoConfigurationUrlAsync (pacUri, targetUri, cancelToken);
+#endif
 					proxies = result.proxies;
 					error = result.error;
 				} catch (Exception e) {
@@ -302,7 +334,11 @@ namespace MonoTouchFixtures.CoreFoundation {
 				try {
 					CancellationTokenSource cancelSource = new CancellationTokenSource ();
 					CancellationToken cancelToken = cancelSource.Token;
+#if NET
+					var result = await global::CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationUrlAsync (pacUri, targetUri, cancelToken);
+#else
 					var result = await CFNetwork.ExecuteProxyAutoConfigurationUrlAsync (pacUri, targetUri, cancelToken);
+#endif
 					proxies = result.proxies;
 					error = result.error;
 				} catch (Exception e) {

--- a/tests/monotouch-test/CoreServices/HttpMessageTest.cs
+++ b/tests/monotouch-test/CoreServices/HttpMessageTest.cs
@@ -11,7 +11,7 @@
 
 using System;
 using System.Net;
-#if XAMCORE_4_0
+#if NET
 using CFNetwork;
 #else
 using CoreServices;

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-CFNetwork.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-CFNetwork.ignore
@@ -1,6 +1,9 @@
 ## sharpie maps it to CFNetServicesError, but current location match other values
 !extra-enum-value! Managed value -72008 for CFNetworkErrors.NetServiceMissingRequiredConfiguration not found in native headers
 
+## removed in Xcode 10 (both headers and libs) but would work on older OS
+!unknown-field! kCFHTTPAuthenticationSchemeOAuth1 bound
+
 ## unsorted
 !missing-enum! CFHostInfoType not bound
 !missing-enum! CFNetServiceBrowserFlags not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-CoreServices.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-CoreServices.ignore
@@ -1,2 +1,0 @@
-## removed in Xcode 10 (both headers and libs) but would work on older OS
-!unknown-field! kCFHTTPAuthenticationSchemeOAuth1 bound


### PR DESCRIPTION
These types come from the CFNetwork.framework, but for some reason they were bound inside CoreServices many years ago.

This resolves a potential issue where we might end up linking with the
CoreServices framework instead of CFNetwork framework (because we use the
namespace of types to determine which framework they belong to).