### PR TITLE
[src] Fix optional/required protocol members in .NET.

### DIFF
--- a/src/AVFoundation/AVAssetDownloadUrlSession.cs
+++ b/src/AVFoundation/AVAssetDownloadUrlSession.cs
@@ -26,7 +26,7 @@ namespace AVFoundation {
 			throw new NotSupportedException ("NS_UNAVAILABLE");
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the overload with a 'INSUrlSessionDelegate' parameter.")]
 		public new static NSUrlSession FromConfiguration (NSUrlSessionConfiguration configuration, NSUrlSessionDelegate sessionDelegate, NSOperationQueue delegateQueue)
 		{

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -472,12 +472,17 @@ namespace AppKit {
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	interface NSAppearanceCustomization {
-
+#if NET
+		[Abstract]
+#endif
 		[Mac (10,9)]
 		[NullAllowed]
 		[Export ("appearance", ArgumentSemantic.Strong)]
 		NSAppearance Appearance { get; set; }
 
+#if NET
+		[Abstract]
+#endif
 		[Mac (10,9)]
 		[Export ("effectiveAppearance", ArgumentSemantic.Strong)]
 		NSAppearance EffectiveAppearance { get; }
@@ -5469,7 +5474,9 @@ namespace AppKit {
 		[Export ("setDockTile:")]
 		void SetDockTile (NSDockTile dockTile);
 
+#if !NET
 		[Abstract]
+#endif
 		[Export ("dockMenu")]
 		NSMenu DockMenu ();
 	}
@@ -6048,100 +6055,102 @@ namespace AppKit {
 #endif
 	[Protocol] // Apple docs say: "you never need to create a class that implements the NSDraggingInfo protocol.", so don't add [Model]
 	interface NSDraggingInfo  {
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("draggingDestinationWindow")]
 		NSWindow DraggingDestinationWindow { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("draggingSourceOperationMask")]
 		NSDragOperation DraggingSourceOperationMask { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("draggingLocation")]
 		CGPoint DraggingLocation { get; }
 	
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("draggedImageLocation")]
 		CGPoint DraggedImageLocation { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("draggedImage")]
 		[Deprecated (PlatformName.MacOSX, 11, 0, message: "Use 'NSDraggingItem' objects instead.")]
 		NSImage DraggedImage { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("draggingPasteboard")]
 		NSPasteboard DraggingPasteboard { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("draggingSource")]
 		NSObject DraggingSource { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("draggingSequenceNumber")]
 		nint DraggingSequenceNumber { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("slideDraggedImageTo:")]
 		void SlideDraggedImageTo (CGPoint screenPoint);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use NSFilePromiseProvider objects instead.")]
 		[Export ("namesOfPromisedFilesDroppedAtDestination:")]
 		string [] PromisedFilesDroppedAtDestination (NSUrl dropDestination);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("animatesToDestination")]
 		bool AnimatesToDestination { get; set; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("numberOfValidItemsForDrop")]
 		nint NumberOfValidItemsForDrop { get; set; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("draggingFormation")]
 		NSDraggingFormation DraggingFormation { get; set; } 
 
-		[Internal]
+#if NET
+		[Abstract]
+#endif
 		[Export ("enumerateDraggingItemsWithOptions:forView:classes:searchOptions:usingBlock:")]
 		void EnumerateDraggingItems (NSDraggingItemEnumerationOptions enumOpts, NSView view, IntPtr classArray,
 					     NSDictionary searchOptions, NSDraggingEnumerator enumerator);
 
 		[Mac (10,11)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("springLoadingHighlight")]
 		NSSpringLoadingHighlight SpringLoadingHighlight { get; }
 
 		[Mac (10,11)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("resetSpringLoading")]
@@ -8327,7 +8336,7 @@ namespace AppKit {
 		[Export ("menuDidClose:")]
 		void MenuDidClose (NSMenu menu);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("menu:willHighlightItem:")]
@@ -11266,12 +11275,18 @@ namespace AppKit {
 	[Model]
 	[Protocol]
 	interface NSPasteboardWriting {
+#if NET
+		[Abstract]
+#endif
 		[Export ("writableTypesForPasteboard:")]
 		string [] GetWritableTypesForPasteboard (NSPasteboard pasteboard);
 
 		[Export ("writingOptionsForType:pasteboard:")]
 		NSPasteboardWritingOptions GetWritingOptionsForType (string type, NSPasteboard pasteboard);
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("pasteboardPropertyListForType:")]
 		NSObject GetPasteboardPropertyListForType (string type);
 	}
@@ -11316,7 +11331,9 @@ namespace AppKit {
 		[Export ("pasteboard:item:provideDataForType:")]
 		void ProvideDataForType (NSPasteboard pasteboard, NSPasteboardItem item, string type);
 
+#if !NET
 		[Abstract]
+#endif
 		[Export ("pasteboardFinishedWithDataProvider:")]
 		void FinishedWithDataProvider (NSPasteboard pasteboard);
 	}
@@ -11333,6 +11350,8 @@ namespace AppKit {
 #endif
 	[Protocol]
 	interface NSPasteboardReading {
+		// This method is required, but we don't generate the correct code for required static methods
+		// [Abstract]
 		[Static]
 		[Export ("readableTypesForPasteboard:")]
 		string [] GetReadableTypesForPasteboard (NSPasteboard pasteboard);
@@ -11559,9 +11578,11 @@ namespace AppKit {
 	[DesignatedDefaultCtor]
 	[BaseType (typeof (NSResponder))]
 	interface NSPopover : NSAppearanceCustomization, NSAccessibilityElementProtocol, NSAccessibility {
+#if !NET
 		[Obsolete ("Use 'GetAppearance' and 'SetAppearance' methods instead.")]
 		[Export ("appearance", ArgumentSemantic.Retain)]
 		new NSPopoverAppearance Appearance { get; set;  }
+#endif
 
 		[Export ("behavior")]
 		NSPopoverBehavior Behavior { get; set;  }
@@ -12169,7 +12190,9 @@ namespace AppKit {
 		[Export ("localizedSummaryItems")]
 		NSDictionary [] LocalizedSummaryItems ();
 
+#if !NET
 		[Abstract]
+#endif
 		[Export ("keyPathsForValuesAffectingPreview")]
 		NSSet KeyPathsForValuesAffectingPreview ();
 	}
@@ -15291,6 +15314,9 @@ namespace AppKit {
 	[NoMacCatalyst]
 	[Protocol]
 	interface NSUserInterfaceItemIdentification {
+#if NET
+		[Abstract]
+#endif
 		[Export ("identifier", ArgumentSemantic.Copy)]
 		string Identifier { get; set; }
 	}
@@ -15302,102 +15328,103 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 #endif
 	partial interface NSTextFinderClient {
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("allowsMultipleSelection")]
 		bool AllowsMultipleSelection { get;  }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("editable")]
 		bool Editable { [Bind ("isEditable")] get;  }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("string", ArgumentSemantic.Copy)]
 		string String { get;  }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("firstSelectedRange")]
 		NSRange FirstSelectedRange { get;  }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("selectedRanges", ArgumentSemantic.Copy)]
 		NSArray SelectedRanges { get; set;  }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("visibleCharacterRanges", ArgumentSemantic.Copy)]
 		NSArray VisibleCharacterRanges { get;  }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("selectable")]
 		bool Selectable { [Bind ("isSelectable")] get;  }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("stringAtIndex:effectiveRange:endsWithSearchBoundary:")]
 		string StringAtIndexeffectiveRangeendsWithSearchBoundary (nuint characterIndex, ref NSRange outRange, bool outFlag);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("stringLength")]
 		nuint StringLength ();
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("scrollRangeToVisible:")]
 		void ScrollRangeToVisible (NSRange range);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("shouldReplaceCharactersInRanges:withStrings:")]
 		bool ShouldReplaceCharactersInRangeswithStrings (NSArray ranges, NSArray strings);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("replaceCharactersInRange:withString:")]
 		void ReplaceCharactersInRangewithString (NSRange range, string str);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("didReplaceCharacters")]
 		void DidReplaceCharacters ();
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("contentViewAtIndex:effectiveCharacterRange:")]
 		NSView ContentViewAtIndexeffectiveCharacterRange (nuint index, ref NSRange outRange);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("rectsForCharacterRange:")]
 		NSArray RectsForCharacterRange (NSRange range);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
+#endif
 		[Export ("drawCharactersInRange:forContentView:")]
+#if !XAMCORE_4_0
 		void DrawCharactersInRangeforContentView (NSRange range, NSView view);
 #else
-		[Export ("drawCharactersInRange:forContentView:")]
 		void DrawCharacters (NSRange range, NSView view);
 #endif
 
@@ -19315,33 +19342,63 @@ namespace AppKit {
 	[Protocol, Model]
 	interface NSTextInputClient
 	{
+#if NET
+		[Abstract]
+#endif
 		[Export ("insertText:replacementRange:")]
 		void InsertText (NSObject text, NSRange replacementRange);
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("setMarkedText:selectedRange:replacementRange:")]
 		void SetMarkedText (NSObject text, NSRange selectedRange, NSRange replacementRange);
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("unmarkText")]
 		void UnmarkText ();
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("selectedRange")]
 		NSRange SelectedRange { get; }
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("markedRange")]
 		NSRange MarkedRange { get; }
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("hasMarkedText")]
 		bool HasMarkedText { get; }
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("attributedSubstringForProposedRange:actualRange:")]
 		NSAttributedString GetAttributedSubstring (NSRange proposedRange, out NSRange actualRange);
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("validAttributesForMarkedText")]
 		NSString [] ValidAttributesForMarkedText { get; }
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("firstRectForCharacterRange:actualRange:")]
 		CGRect GetFirstRect (NSRange characterRange, out NSRange actualRange);
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("characterIndexForPoint:")]
 		nuint GetCharacterIndex (CGPoint point);
 
@@ -21199,6 +21256,8 @@ namespace AppKit {
 	[Model]
 	[Protocol]
 	partial interface NSWindowRestoration {
+		// This method is required, but we don't generate the correct code for required static methods.
+		// [Abstract]
 		[Static]
 		[Export ("restoreWindowWithIdentifier:state:completionHandler:")]
 		void RestoreWindow (string identifier, NSCoder state, NSWindowCompletionHandler onCompletion);
@@ -22166,11 +22225,15 @@ namespace AppKit {
 		[Export ("ruleEditor:displayValueForCriterion:inRow:"), DelegateName ("NSRulerEditorDisplayValue"), DefaultValue(null)]
 		NSObject DisplayValue (NSRuleEditor editor, NSObject criterion, nint row);
 
+#if !NET
 		[Abstract]
+#endif
 		[Export ("ruleEditor:predicatePartsForCriterion:withDisplayValue:inRow:"), DelegateName ("NSRulerEditorPredicateParts"), DefaultValue(null)]
 		NSDictionary PredicateParts (NSRuleEditor editor, NSObject criterion, NSObject value, nint row);
 
+#if !NET
 		[Abstract]
+#endif
 		[Export ("ruleEditorRowsDidChange:"), EventArgs ("NSNotification")]
 		void RowsDidChange (NSNotification notification);
 		
@@ -24390,7 +24453,7 @@ namespace AppKit {
 		bool IsAccessibilitySelectorAllowed (Selector selector);
 
 		[Mac (10, 12)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("accessibilityRequired")]
@@ -24529,21 +24592,21 @@ namespace AppKit {
 		NSString AnnouncementRequestedNotification { get; }
 
 		[Mac (10, 13)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[NullAllowed, Export ("accessibilityChildrenInNavigationOrder", ArgumentSemantic.Copy)]
 		NSAccessibilityElement[] AccessibilityChildrenInNavigationOrder { get; set; }
 
 		[Mac (10, 13)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("accessibilityCustomRotors", ArgumentSemantic.Copy)]
 		NSAccessibilityCustomRotor[] AccessibilityCustomRotors { get; set; }
 
 		[Mac (10, 13)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[NullAllowed, Export ("accessibilityCustomActions", ArgumentSemantic.Copy)]
@@ -25945,6 +26008,9 @@ namespace AppKit {
 		[Export ("filePromiseProvider:fileNameForType:")]
 		string GetFileNameForDestination (NSFilePromiseProvider filePromiseProvider, string fileType);
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("filePromiseProvider:writePromiseToURL:completionHandler:")]
 		void WritePromiseToUrl (NSFilePromiseProvider filePromiseProvider, NSUrl url, [NullAllowed] Action<NSError> completionHandler);
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -3520,6 +3520,9 @@ namespace AVFoundation {
 		[Export ("stopRequestingMediaData")]
 		void StopRequestingMediaData ();
 
+#if NET
+		[Abstract]
+#endif
 		[TV (14,5), Watch (7,4), Mac (11,3), iOS (14,5)]
 		[MacCatalyst (14,5)]
 		[Export ("hasSufficientMediaDataForReliablePlaybackStart")]

--- a/src/carplay.cs
+++ b/src/carplay.cs
@@ -263,7 +263,7 @@ namespace CarPlay {
 		[Export ("trailingNavigationBarButtons", ArgumentSemantic.Strong)]
 		CPBarButton [] TrailingNavigationBarButtons { get; set; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (12,2)]
@@ -1054,8 +1054,9 @@ namespace CarPlay {
 	[BaseType (typeof (NSObject))]
 	interface CPSessionConfigurationDelegate {
 
-		// This is not @required since Xcode 11 but kept for API compatibility.
+#if !NET
 		[Abstract]
+#endif
 		[Export ("sessionConfiguration:limitedUserInterfacesChanged:")]
 		void LimitedUserInterfacesChanged (CPSessionConfiguration sessionConfiguration, CPLimitableUserInterface limitedUserInterfaces);
 
@@ -1933,7 +1934,7 @@ namespace CarPlay {
 		[NullAllowed, Export ("userInfo", ArgumentSemantic.Strong)]
 		NSObject UserInfo { get; set; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (15, 0), MacCatalyst (15,0)]

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -2388,7 +2388,7 @@ namespace CoreImage {
 		[NullAllowed, Export ("metalTexture")]
 		IMTLTexture MetalTexture { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // @required but it was added in Xcode9
 #endif
 		[iOS (11,0)]
@@ -2431,7 +2431,7 @@ namespace CoreImage {
 		[NullAllowed, Export ("metalCommandBuffer")]
 		IMTLCommandBuffer MetalCommandBuffer { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // @required but it was added in Xcode9
 #endif
 		[iOS (11,0)]

--- a/src/corenfc.cs
+++ b/src/corenfc.cs
@@ -570,7 +570,9 @@ namespace CoreNFC {
 		[Export ("readerSessionDidBecomeActive:")]
 		void DidBecomeActive (NFCReaderSession session);
 
+#if !NET
 		[Abstract]
+#endif
 		[Export ("readerSession:didDetectTags:")]
 		void DidDetectTags (NFCReaderSession session, INFCTag [] tags);
 
@@ -953,7 +955,9 @@ namespace CoreNFC {
 	[iOS (13,0)]
 	[Protocol]
 	interface NFCMiFareTag : NFCTag, NFCNdefTag {
-
+#if NET
+		[Abstract]
+#endif
 		[Export ("mifareFamily", ArgumentSemantic.Assign)]
 		NFCMiFareFamily MifareFamily { get; }
 
@@ -992,9 +996,6 @@ namespace CoreNFC {
 		[Export ("tagReaderSessionDidBecomeActive:")]
 		void DidBecomeActive (NFCTagReaderSession session);
 
-#if NET
-		[Abstract]
-#endif
 		[Export ("tagReaderSession:didDetectTags:")]
 		void DidDetectTags (NFCTagReaderSession session, INFCTag[] tags);
 	}

--- a/src/fileprovider.cs
+++ b/src/fileprovider.cs
@@ -446,7 +446,7 @@ namespace FileProvider {
 		[Export ("filename")]
 		string Filename { get; }
 
-#if !XAMCORE_4_0
+#if !NET
 		// became optional when deprecated
 		[Abstract]
 #endif

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -1466,13 +1466,13 @@ namespace GameKit {
 		[Export ("matchmakerViewController:didFailWithError:"), EventArgs ("GKError")]
 		void DidFailWithError (GKMatchmakerViewController viewController, NSError error);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("matchmakerViewController:didFindMatch:"), EventArgs ("GKMatch")]
 		void DidFindMatch (GKMatchmakerViewController viewController, GKMatch match);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[NoTV]
@@ -1481,7 +1481,7 @@ namespace GameKit {
 		[Export ("matchmakerViewController:didFindPlayers:"), EventArgs ("GKPlayers")]
 		void DidFindPlayers (GKMatchmakerViewController viewController, string [] playerIDs);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[iOS (8,0), Mac (10,10)]
@@ -1885,7 +1885,7 @@ namespace GameKit {
 		[Export ("handleMatchEnded:")]
 		void HandleMatchEnded (GKTurnBasedMatch match);
 
-#if !MONOMAC || XAMCORE_4_0
+#if !MONOMAC || NET
 		[Abstract]
 #endif
 		[Export ("handleTurnEventForMatch:didBecomeActive:")]
@@ -2132,7 +2132,7 @@ namespace GameKit {
 		[Export ("turnBasedMatchmakerViewController:didFailWithError:")]
 		void FailedWithError (GKTurnBasedMatchmakerViewController viewController, NSError error);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[NoTV]
@@ -2141,7 +2141,7 @@ namespace GameKit {
 		[Export ("turnBasedMatchmakerViewController:didFindMatch:")]
 		void FoundMatch (GKTurnBasedMatchmakerViewController viewController, GKTurnBasedMatch match);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[NoTV]

--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -423,7 +423,7 @@ namespace GameplayKit {
 	[Protocol]
 	interface GKGameModelPlayer {
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 		[Export ("playerId")]
 		nint PlayerId { get; }

--- a/src/intentsui.cs
+++ b/src/intentsui.cs
@@ -67,7 +67,7 @@ namespace IntentsUI {
 	[Protocol]
 	interface INUIHostedViewControlling {
 
-#if !XAMCORE_4_0 && !__MACCATALYST__ // Apple made this member optional in iOS 11
+#if !NET && !__MACCATALYST__ // Apple made this member optional in iOS 11
 		[Abstract]
 #endif
 		[Export ("configureWithInteraction:context:completion:")]

--- a/src/metrickit.cs
+++ b/src/metrickit.cs
@@ -429,7 +429,7 @@ namespace MetricKit {
 	[NoWatch, NoTV, Mac (12,0), iOS (13,0)]
 	[Protocol]
 	interface MXMetricManagerSubscriber {
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[NoMac]

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -1043,16 +1043,28 @@ namespace ModelIO {
 		[Export ("map")]
 		MDLMeshBufferMap Map { get; }
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("length")]
 		nuint Length { get; }
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("allocator", ArgumentSemantic.Retain)]
 		IMDLMeshBufferAllocator Allocator { get; }
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("zone", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		IMDLMeshBufferZone Zone { get; }
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("type")]
 		MDLMeshBufferType Type { get; }
 	}
@@ -1127,9 +1139,15 @@ namespace ModelIO {
 	[Protocol]
 	interface MDLMeshBufferZone
 	{
+#if NET
+		[Abstract]
+#endif
 		[Export ("capacity")]
 		nuint Capacity { get; }
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("allocator")]
 		IMDLMeshBufferAllocator Allocator { get; }
 	}
@@ -1285,14 +1303,14 @@ namespace ModelIO {
 		[Export ("removeObject:")]
 		void RemoveObject (MDLObject @object);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (10,3), TV (10,2), Mac (10,12,4)]
 		[Export ("objectAtIndexedSubscript:")]
 		MDLObject GetObject (nuint index);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (10,3), TV (10,2), Mac (10,12,4)]
@@ -1972,7 +1990,7 @@ namespace ModelIO {
 		[iOS (10,0)]
 		[Mac (10,12)]
 		[TV (10,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("resetsTransform")]
@@ -1988,7 +2006,7 @@ namespace ModelIO {
 
 		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
 		[Mac (10,12)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("keyTimes", ArgumentSemantic.Copy)]

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -290,7 +290,7 @@ namespace PassKit {
 		[Deprecated (PlatformName.iOS, 11,0, message: "Use 'DidAuthorizePayment2' instead.")]
 		[Export ("paymentAuthorizationViewController:didAuthorizePayment:completion:")]
 		[EventArgs ("PKPaymentAuthorization")]
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		void DidAuthorizePayment (PKPaymentAuthorizationViewController controller, PKPayment payment, Action<PKPaymentAuthorizationStatus> completion);
@@ -324,7 +324,7 @@ namespace PassKit {
 
 		[iOS (8,3)]
 		[Export ("paymentAuthorizationViewControllerWillAuthorizePayment:")]
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		void WillAuthorizePayment (PKPaymentAuthorizationViewController controller);
@@ -1144,7 +1144,7 @@ namespace PassKit {
 		[NoMac]
 		[Deprecated (PlatformName.WatchOS, 4,0, message: "Use 'DidAuthorizePayment' overload with the 'Action<PKPaymentAuthorizationResult>' parameter instead.")]
 		[Deprecated (PlatformName.iOS, 11,0, message: "Use 'DidAuthorizePayment' overload with the 'Action<PKPaymentAuthorizationResult>' parameter instead.")]
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("paymentAuthorizationController:didAuthorizePayment:completion:")]
@@ -1204,7 +1204,7 @@ namespace PassKit {
 		[MacCatalyst (14,0)]
 		[Export ("presentationWindowForPaymentAuthorizationController:")]
 		[return: NullAllowed]
-#if MONOMAC
+#if MONOMAC || __MACCATALYST__
 		[Abstract]
 #endif
 		UIWindow GetPresentationWindow (PKPaymentAuthorizationController controller);

--- a/src/pushkit.cs
+++ b/src/pushkit.cs
@@ -98,7 +98,9 @@ namespace PushKit
 
 		[NoWatch]
 		[NoMac]
+#if !NET
 		[Abstract] // now optional in iOS 11
+#endif
 		[Deprecated (PlatformName.iOS, 11,0, message: "Use the 'DidReceiveIncomingPushWithPayload' overload accepting an 'Action' argument instead.")]
 		[NoMacCatalyst]
 		[Export ("pushRegistry:didReceiveIncomingPushWithPayload:forType:"), EventArgs ("PKPushRegistryRecieved"), EventName ("IncomingPushReceived")]

--- a/src/quicklookUI.cs
+++ b/src/quicklookUI.cs
@@ -50,7 +50,7 @@ namespace QuickLookUI {
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	interface QLPreviewItem {
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("previewItemURL")]
@@ -168,7 +168,7 @@ namespace QuickLookUI {
 	[Mac (10,13)]
 	[Protocol]
 	interface QLPreviewingController {
-#if !XAMCORE_4_0 // This is optional in headers
+#if !NET
 		[Abstract]
 #endif
 		[Export ("preparePreviewOfSearchableItemWithIdentifier:queryString:completionHandler:")]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -153,7 +153,7 @@ namespace SceneKit {
 		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
 #endif
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (11,0), TV (11,0), Watch (4,0), Mac (10,13)]
@@ -164,7 +164,7 @@ namespace SceneKit {
 		[Export ("removeAllAnimations")]
 		void RemoveAllAnimations ();
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Watch (8,0), TV (15,0), Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
@@ -179,7 +179,7 @@ namespace SceneKit {
 		[Export ("animationKeys")]
 		NSString [] GetAnimationKeys ();
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[return: NullAllowed]
@@ -233,13 +233,16 @@ namespace SceneKit {
 		[Export ("removeAnimationForKey:fadeOutDuration:")]
 		void RemoveAnimation (NSString key, nfloat duration);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (11,0), TV (11,0), Watch (4,0), Mac (10,13)]
 		[Export ("removeAnimationForKey:blendOutDuration:")]
 		void RemoveAnimationUsingBlendOutDuration (NSString key, nfloat blendOutDuration);
 
+#if NET
+		[Abstract]
+#endif
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'SCNAnimationPlayer.Speed' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0,   message: "Use 'SCNAnimationPlayer.Speed' instead.")]
 		[Deprecated (PlatformName.iOS, 11, 0,    message: "Use 'SCNAnimationPlayer.Speed' instead.")]
@@ -3051,6 +3054,9 @@ namespace SceneKit {
 		IntPtr Context { get;  }
 
 #if MONOMAC
+#if NET
+		[Abstract]
+#endif
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[NoiOS]
 		[Export ("currentTime")]
@@ -3116,7 +3122,7 @@ namespace SceneKit {
 		[Export ("prepareObjects:withCompletionHandler:")]
 		void Prepare (NSObject [] objects, [NullAllowed] Action<bool> completionHandler);
 
-	#if XAMCORE_4_0
+	#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
 		[iOS (9,0)][Mac (10,11)] // SKTransition -> SpriteKit -> only on 64 bits
@@ -3124,28 +3130,28 @@ namespace SceneKit {
 		[Export ("presentScene:withTransition:incomingPointOfView:completionHandler:")]
 		void PresentScene (SCNScene scene, SKTransition transition, [NullAllowed] SCNNode pointOfView, [NullAllowed] Action completionHandler);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 #endif
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("nodesInsideFrustumWithPointOfView:")]
 		SCNNode[] GetNodesInsideFrustum (SCNNode pointOfView);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 #endif
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("debugOptions", ArgumentSemantic.Assign)]
 		SCNDebugOptions DebugOptions { get; set; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 #endif
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("renderingAPI")]
 		SCNRenderingApi RenderingApi { get; }
 
-	#if XAMCORE_4_0
+	#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
 		[NoWatch]
@@ -3153,7 +3159,7 @@ namespace SceneKit {
 		[NullAllowed, Export ("currentRenderCommandEncoder")]
 		IMTLRenderCommandEncoder CurrentRenderCommandEncoder { get; }
 
-	#if XAMCORE_4_0
+	#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
 		[NoWatch]
@@ -3161,7 +3167,7 @@ namespace SceneKit {
 		[NullAllowed, Export ("device")]
 		IMTLDevice Device { get; }
 
-	#if XAMCORE_4_0
+	#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
 		[NoWatch]
@@ -3169,7 +3175,7 @@ namespace SceneKit {
 		[Export ("colorPixelFormat")]
 		MTLPixelFormat ColorPixelFormat { get; }
 
-	#if XAMCORE_4_0
+	#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
 		[NoWatch]
@@ -3177,7 +3183,7 @@ namespace SceneKit {
 		[Export ("depthPixelFormat")]
 		MTLPixelFormat DepthPixelFormat { get; }
 
-	#if XAMCORE_4_0
+	#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
 		[NoWatch]
@@ -3185,7 +3191,7 @@ namespace SceneKit {
 		[Export ("stencilPixelFormat")]
 		MTLPixelFormat StencilPixelFormat { get; }
 
-	#if XAMCORE_4_0
+	#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
 		[NoWatch]
@@ -3193,14 +3199,14 @@ namespace SceneKit {
 		[NullAllowed, Export ("commandQueue")]
 		IMTLCommandQueue CommandQueue { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 #endif
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("audioEngine")]
 		AVAudioEngine AudioEngine { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 #endif
 		[NoWatch]
@@ -3209,7 +3215,7 @@ namespace SceneKit {
 		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		AVAudioEnvironmentNode AudioEnvironmentNode { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 #endif
 		[iOS (9,0)][Mac (10,11)]
@@ -3217,21 +3223,21 @@ namespace SceneKit {
 		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		SCNNode AudioListener { get; set; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 #endif
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("temporalAntialiasingEnabled")]
 		bool TemporalAntialiasingEnabled { [Bind ("isTemporalAntialiasingEnabled")] get; set; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 #endif
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 		[Export ("currentViewport")]
 		CGRect CurrentViewport { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 #endif
 		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
@@ -3240,7 +3246,7 @@ namespace SceneKit {
 
 		[NoWatch]
 		[TV (14,0)][Mac (10,11)][iOS (14,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[Export ("currentRenderPassDescriptor")]
@@ -3850,7 +3856,7 @@ namespace SceneKit {
 		[Export ("removeAllActions")]
 		void RemoveAllActions ();
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (8,0), Mac(10,10)]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -1502,7 +1502,9 @@ namespace UIKit {
 	[Protocol]
 	interface UIInputViewAudioFeedback {
 		[Export ("enableInputClicksWhenVisible")]
-		[Abstract] // it's technically optional but there's no point in adopting the protocol if you do not provide the implemenation
+#if !NET
+		[Abstract]
+#endif
 		bool EnableInputClicksWhenVisible { get; }
 	}
 
@@ -5102,13 +5104,13 @@ namespace UIKit {
 	[Protocol]
 	[Model]
 	interface UIDynamicAnimatorDelegate {
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("dynamicAnimatorWillResume:")]
 		void WillResume (UIDynamicAnimator animator);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("dynamicAnimatorDidPause:")]
@@ -15489,7 +15491,7 @@ namespace UIKit {
 		CGAffineTransform TargetTransform { get; }
 
 
-#if XAMCORE_4_0 // Can't break the world right now
+#if NET // Can't break the world right now
 		[Abstract]
 #endif
 		[iOS (10,0), TV (10,0)]
@@ -15837,7 +15839,7 @@ namespace UIKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 		UIView GetTransitionViewControllerForKey (NSString key);
 
-#if XAMCORE_4_0 // This is abstract in headers but is a breaking change
+#if NET // This is abstract in headers but is a breaking change
 		[Abstract]
 #endif
 		[iOS (10, 0)]
@@ -15867,7 +15869,7 @@ namespace UIKit {
 		[Export ("notifyWhenInteractionEndsUsingBlock:")]
 		void NotifyWhenInteractionEndsUsingBlock (Action<IUIViewControllerTransitionCoordinatorContext> handler);
 
-#if XAMCORE_4_0 // This is abstract in headers but is a breaking change
+#if NET // This is abstract in headers but is a breaking change
 		[Abstract]
 #endif
 		[iOS (10,0)]
@@ -16544,16 +16546,18 @@ namespace UIKit {
 	[iOS (8,0)]
 	[Protocol]
 	interface UIPopoverBackgroundViewMethods {
-		//
-		// These must be overwritten by users, using the [Export ("...")] on the
-		// static method
-		//
+		// This method is required, but we don't generate the correct code for required static methods.
+		// [Abstract]
 		[Static, Export ("arrowHeight")]
 		nfloat GetArrowHeight ();
 
+		// This method is required, but we don't generate the correct code for required static methods.
+		// [Abstract]
 		[Static, Export ("arrowBase")]
 		nfloat GetArrowBase ();
 
+		// This method is required, but we don't generate the correct code for required static methods.
+		// [Abstract]
 		[Static, Export ("contentViewInsets")]
 		UIEdgeInsets GetContentViewInsets ();
 	}
@@ -17525,14 +17529,14 @@ namespace UIKit {
 		void AdjustTextPositionByCharacterOffset (nint offset);		
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // Adding required members is a breaking change
 #endif
 		[Export ("setMarkedText:selectedRange:")]
 		void SetMarkedText (string markedText, NSRange selectedRange);
 
 		[iOS (13,0)]
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // Adding required members is a breaking change
 #endif
 		[Export ("unmarkText")]
@@ -17540,7 +17544,7 @@ namespace UIKit {
 
 		// Another abstract that was introduced on this released, breaking ABI
 		// Radar: 26867207
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (10, 0)]
@@ -17549,7 +17553,7 @@ namespace UIKit {
 
 		// New abstract, breaks ABI
 		// Radar: 33685383
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (11,0)]
@@ -17558,7 +17562,7 @@ namespace UIKit {
 
 		// New abstract, breaks ABI
 		// Radar: 33685383
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (11,0)]
@@ -17623,7 +17627,7 @@ namespace UIKit {
 
 		[iOS (9,0)]
 		[Export ("topAnchor", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if NET
 		// Apple added a new required member in iOS 9, but that breaks our binary compat, so we can't do that in our existing code.
 		[Abstract]
 #endif
@@ -17631,7 +17635,7 @@ namespace UIKit {
 
 		[iOS (9,0)]
 		[Export ("bottomAnchor", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if NET
 		// Apple added a new required member in iOS 9, but that breaks our binary compat, so we can't do that in our existing code.
 		[Abstract]
 #endif
@@ -17639,7 +17643,7 @@ namespace UIKit {
 
 		[iOS (9,0)]
 		[Export ("heightAnchor", ArgumentSemantic.Strong)]
-#if XAMCORE_4_0
+#if NET
 		// Apple added a new required member in iOS 9, but that breaks our binary compat, so we can't do that in our existing code.
 		[Abstract]
 #endif
@@ -17837,7 +17841,7 @@ namespace UIKit {
 		[Export ("documentMenu:didPickDocumentPicker:"), EventArgs ("UIDocumentMenuDocumentPicked")]
 		void DidPickDocumentPicker (UIDocumentMenuViewController documentMenu, UIDocumentPickerViewController documentPicker);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("documentMenuWasCancelled:")]
@@ -17917,7 +17921,7 @@ namespace UIKit {
 	[BaseType (typeof (NSObject))]
 	partial interface UIDocumentPickerDelegate {
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Implement 'DidPickDocument (UIDocumentPickerViewController, NSUrl[])' instead.")]
-#if !XAMCORE_4_0
+#if !NET
 		[Abstract]
 #endif
 		[Export ("documentPicker:didPickDocumentAtURL:"), EventArgs ("UIDocumentPicked")]
@@ -18144,7 +18148,7 @@ namespace UIKit {
 		// FIXME: declared as a @required, but this breaks compatibility
 		// Radar: 41121416
 		[TV (12, 0), iOS (12, 0), NoWatch]
-#if XAMCORE_4_0 
+#if NET
 		[Abstract]
 #endif
 		[Export ("frame")]
@@ -18395,10 +18399,9 @@ namespace UIKit {
 	[iOS (9,0)]
 	[Protocol]
 	interface UIFocusEnvironment {
-		// Apple moved this member to @optional since they deprecated it
-		// but that's a breaking change for us, so it remains [Abstract]
-		// and we need to teach the intro and xtro tests about it
+#if !NET
 		[Abstract]
+#endif
 		[NullAllowed, Export ("preferredFocusedView", ArgumentSemantic.Weak)]
 		[iOS (9,0)] // duplicated so it's inlined properly
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'PreferredFocusEnvironments' instead.")]
@@ -18424,7 +18427,7 @@ namespace UIKit {
 		// FIXME: declared as a @required, but this breaks compatibility
 		// Radar: 26825293
 		//
-#if XAMCORE_4_0
+#if NET
 		[Abstract]
 #endif
 		[iOS (10, 0)]
@@ -18440,14 +18443,14 @@ namespace UIKit {
 		// FIXME: declared as a @required, but this breaks compatibility
 		// Radar: 41121293
 		[TV (12, 0), iOS (12, 0)]
-#if XAMCORE_4_0 
+#if NET
 		[Abstract]
 #endif
 		[NullAllowed, Export ("parentFocusEnvironment", ArgumentSemantic.Weak)]
 		IUIFocusEnvironment ParentFocusEnvironment { get; }
 
 		[TV (12, 0), iOS (12, 0)]
-#if XAMCORE_4_0 
+#if NET
 		[Abstract]
 #endif
 		[NullAllowed, Export ("focusItemContainer")]

--- a/src/watchconnectivity.cs
+++ b/src/watchconnectivity.cs
@@ -153,21 +153,21 @@ namespace WatchConnectivity {
 		[Export ("session:didReceiveFile:")]
 		void DidReceiveFile (WCSession session, WCSessionFile file);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // OS 10 beta 1 SDK made this required
 #endif
 		[Watch (2,2)][iOS (9,3)]
 		[Export ("session:activationDidCompleteWithState:error:")]
 		void ActivationDidComplete (WCSession session, WCSessionActivationState activationState, [NullAllowed] NSError error);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // OS 10 beta 1 SDK made this required
 #endif
 		[NoWatch][iOS (9,3)]
 		[Export ("sessionDidBecomeInactive:")]
 		void DidBecomeInactive (WCSession session);
 
-#if XAMCORE_4_0
+#if NET
 		[Abstract] // OS 10 beta 1 SDK made this required
 #endif
 		[NoWatch][iOS (9,3)]

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -2102,12 +2102,21 @@ namespace WebKit {
 	[Protocol]
 #endif
 	partial interface WebOpenPanelResultListener {
+#if NET
+		[Abstract]
+#endif
 		[Export ("chooseFilename:")]
 		void ChooseFilename (string filename);
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("chooseFilenames:")]
 		void ChooseFilenames (string [] filenames);
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("cancel")]
 		void Cancel ();
 	}
@@ -2141,12 +2150,21 @@ namespace WebKit {
 	[Protocol]
 #endif
 	partial interface WebPolicyDecisionListener {
+#if NET
+		[Abstract]
+#endif
 		[Export ("use")]
 		void Use ();
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("download")]
 		void Download ();
 
+#if NET
+		[Abstract]
+#endif
 		[Export ("ignore")]
 		void Ignore ();
 	}

--- a/tests/monotouch-test/AppKit/NSAppearance.cs
+++ b/tests/monotouch-test/AppKit/NSAppearance.cs
@@ -55,8 +55,13 @@ namespace Xamarin.Mac.Tests
 		{
 			Asserts.EnsureYosemite ();
 
-			using (NSButton b = new NSButton ())
+			using (NSButton b = new NSButton ()) {
+#if NET
+				b.Appearance = null;
+#else
 				b.SetAppearance (null);
+#endif
+			}
 		}
 	}
 }

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-GameKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-GameKit.ignore
@@ -9,11 +9,6 @@
 # This selector does not exist (respond?) in macOS either
 !missing-selector! GKLeaderboardSet::loadImageWithCompletionHandler: not bound
 
-# Deprecated
-!incorrect-protocol-member! GKMatchmakerViewControllerDelegate::matchmakerViewController:didFindPlayers: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! GKTurnBasedMatchmakerViewControllerDelegate::turnBasedMatchmakerViewController:didFindMatch: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! GKTurnBasedMatchmakerViewControllerDelegate::turnBasedMatchmakerViewController:playerQuitForMatch: is OPTIONAL and should NOT be abstract
-
 # Are only available for TvOS
 
 ## not annotated by itself but it maps to presentFriendRequestCreatorFromViewController which is not available on Catalyst

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-MetricKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-MetricKit.ignore
@@ -1,2 +1,0 @@
-# Added for xamcore 4.0
-!incorrect-protocol-member! MXMetricManagerSubscriber::didReceiveMetricPayloads: is OPTIONAL and should NOT be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-PassKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-PassKit.ignore
@@ -1,9 +1,6 @@
 ## fails in introspection tests
 !missing-selector! PKPass::icon not bound
 
-## keep @optional like iOS to ease code sharing
-!incorrect-protocol-member! PKPaymentAuthorizationControllerDelegate::presentationWindowForPaymentAuthorizationController: is REQUIRED and should be abstract
-
 ## type won't load, no documentation about its usage
 !missing-selector! PKIssuerProvisioningExtensionHandler::generateAddPaymentPassRequestForPassEntryWithIdentifier:configuration:certificateChain:nonce:nonceSignature:completionHandler: not bound
 !missing-selector! PKIssuerProvisioningExtensionHandler::passEntriesWithCompletion: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-UIKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-UIKit.todo
@@ -35,13 +35,6 @@
 !extra-null-allowed! 'System.Void UIKit.UIView::set_MotionEffects(UIKit.UIMotionEffect[])' has a extraneous [NullAllowed] on parameter #0
 !extra-null-allowed! 'UIKit.IUITextDocumentProxy UIKit.UIInputViewController::get_TextDocumentProxy()' has a extraneous [NullAllowed] on return type
 !extra-null-allowed! 'UIKit.UIView UIKit.UIScreen::SnapshotView(System.Boolean)' has a extraneous [NullAllowed] on return type
-!incorrect-protocol-member! UIDocumentMenuDelegate::documentMenuWasCancelled: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UIDocumentPickerDelegate::documentPicker:didPickDocumentAtURL: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UIFocusEnvironment::focusItemContainer is REQUIRED and should be abstract
-!incorrect-protocol-member! UIFocusEnvironment::parentFocusEnvironment is REQUIRED and should be abstract
-!incorrect-protocol-member! UIFocusItem::frame is REQUIRED and should be abstract
-!incorrect-protocol-member! UITextDocumentProxy::setMarkedText:selectedRange: is REQUIRED and should be abstract
-!incorrect-protocol-member! UITextDocumentProxy::unmarkText is REQUIRED and should be abstract
 !missing-field! UIApplicationInvalidInterfaceOrientationException not bound
 !missing-field! UIKeyInputF1 not bound
 !missing-null-allowed! 'CoreAnimation.CADisplayLink UIKit.UIScreen::CreateDisplayLink(Foundation.NSObject,ObjCRuntime.Selector)' is missing an [NullAllowed] on return type

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-AVFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-AVFoundation.ignore
@@ -55,6 +55,3 @@
 
 # no tests/samples
 !missing-pinvoke! AVSampleBufferAttachContentKey is not bound
-
-# adding abstract member to an existing type would be a breaking change
-!incorrect-protocol-member! AVQueuedSampleBufferRendering::hasSufficientMediaDataForReliablePlaybackStart is REQUIRED and should be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-CoreImage.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-CoreImage.ignore
@@ -1,8 +1,3 @@
-## new @required on existing protocols are breaking changes
-!incorrect-protocol-member! CIImageProcessorInput::surface is REQUIRED and should be abstract
-!incorrect-protocol-member! CIImageProcessorOutput::surface is REQUIRED and should be abstract
-
-
 ## requires varargs support
 !missing-selector! +CIFilter::filterWithName:keysAndValues: not bound
 !missing-selector! CISampler::initWithImage:keysAndValues: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-GameKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-GameKit.ignore
@@ -14,6 +14,4 @@
 
 ## unsorted
 
-!incorrect-protocol-member! GKMatchmakerViewControllerDelegate::matchmakerViewController:didFindHostedPlayers: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! GKMatchmakerViewControllerDelegate::matchmakerViewController:didFindMatch: is OPTIONAL and should NOT be abstract
 !missing-selector! GKVoiceChat::playerVoiceChatStateDidChangeHandler not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-GameplayKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-GameplayKit.ignore
@@ -1,10 +1,6 @@
-## Fixed in XAMCORE_4_0
-!incorrect-protocol-member! GKGameModelPlayer::playerId is REQUIRED and should be abstract
-
 ## no generator support for FastEnumeration - https://bugzilla.xamarin.com/show_bug.cgi?id=4391
 !missing-protocol-conformance! GKBehavior should conform to NSFastEnumeration
 !missing-protocol-conformance! GKComponentSystem should conform to NSFastEnumeration
-
 
 ## unsorted
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-ModelIO.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-ModelIO.ignore
@@ -1,18 +1,3 @@
-# fixed in XAMCORE_4_0 - API break
-!incorrect-protocol-member! MDLObjectContainerComponent::count is REQUIRED and should be abstract
-!incorrect-protocol-member! MDLObjectContainerComponent::objectAtIndexedSubscript: is REQUIRED and should be abstract
-!incorrect-protocol-member! MDLTransformComponent::keyTimes is REQUIRED and should be abstract
-!incorrect-protocol-member! MDLTransformComponent::resetsTransform is REQUIRED and should be abstract
-!incorrect-protocol-member! MDLTransformComponent::setResetsTransform: is REQUIRED and should be abstract
-
-## old @optional methods that became @required (abstract) in existing types (breaking changes)
-!incorrect-protocol-member! MDLMeshBuffer::allocator is REQUIRED and should be abstract
-!incorrect-protocol-member! MDLMeshBuffer::length is REQUIRED and should be abstract
-!incorrect-protocol-member! MDLMeshBuffer::type is REQUIRED and should be abstract
-!incorrect-protocol-member! MDLMeshBuffer::zone is REQUIRED and should be abstract
-!incorrect-protocol-member! MDLMeshBufferZone::allocator is REQUIRED and should be abstract
-!incorrect-protocol-member! MDLMeshBufferZone::capacity is REQUIRED and should be abstract
-
 ## we only export the overload that expose an NSError
 !missing-selector! MDLAsset::exportAssetToURL: not bound
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-PassKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-PassKit.ignore
@@ -1,10 +1,3 @@
-## made optional in xcode9 beta 3 since it was replaced with newer API
-!incorrect-protocol-member! PKPaymentAuthorizationViewControllerDelegate::paymentAuthorizationViewController:didAuthorizePayment:completion: is OPTIONAL and should NOT be abstract
-
-## made optional in xcode12 beta 3 since it was replaced with newer API
-!incorrect-protocol-member! PKPaymentAuthorizationControllerDelegate::paymentAuthorizationController:didAuthorizePayment:completion: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! PKPaymentAuthorizationViewControllerDelegate::paymentAuthorizationViewControllerWillAuthorizePayment: is OPTIONAL and should NOT be abstract
-
 # Initial result from new rule extra-null-allowed
 !extra-null-allowed! 'System.Void PassKit.PKPaymentRequest::set_CountryCode(System.String)' has a extraneous [NullAllowed] on parameter #0
 !extra-null-allowed! 'System.Void PassKit.PKPaymentRequest::set_CurrencyCode(System.String)' has a extraneous [NullAllowed] on parameter #0

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-SceneKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-SceneKit.ignore
@@ -1,35 +1,3 @@
-## Breaking changes fixed in XAMCORE_4_0
-## we cannot add abstract members to existing SCNSceneRenderer or SCNAnimatable protocols (breaking changes)
-!incorrect-protocol-member! SCNAnimatable::addAnimationPlayer:forKey: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNAnimatable::animationPlayerForKey: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNAnimatable::removeAllAnimationsWithBlendOutDuration: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNAnimatable::removeAnimationForKey:blendOutDuration: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNAnimatable::setSpeed:forAnimationKey: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::audioEngine is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::audioListener is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::debugOptions is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::nodesInsideFrustumWithPointOfView: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::presentScene:withTransition:incomingPointOfView:completionHandler: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::renderingAPI is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::setAudioListener: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::setDebugOptions: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::audioEnvironmentNode is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::colorPixelFormat is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::commandQueue is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::currentRenderCommandEncoder is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::depthPixelFormat is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::device is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::stencilPixelFormat is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::currentViewport is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::isTemporalAntialiasingEnabled is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::setTemporalAntialiasingEnabled: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::setUsesReverseZ: is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::usesReverseZ is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::currentRenderPassDescriptor is REQUIRED and should be abstract
-
-## same for SCNActionable, it is required member of a protocol added to XAMCORE_4_0
-!incorrect-protocol-member! SCNActionable::actionKeys is REQUIRED and should be abstract
-
 ## We have managed counterparts that comes from OpenTK code
 !missing-field! SCNMatrix4Identity not bound
 !missing-field! SCNVector3Zero not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-UIKit.ignore
@@ -14,9 +14,6 @@
 !missing-pinvoke! NSTextAlignmentFromCTTextAlignment is not bound
 !missing-pinvoke! NSTextAlignmentToCTTextAlignment is not bound
 
-## this was (pre iOS10) a required member that was deprecated and made optional
-!incorrect-protocol-member! UIFocusEnvironment::preferredFocusedView is OPTIONAL and should NOT be abstract
-
 ## https://bugzilla.xamarin.com/show_bug.cgi?id=43788
 !missing-selector! +UIView::layerClass not bound
 
@@ -49,16 +46,6 @@
 !missing-selector! UIImageView::setUserInteractionEnabled: not bound
 !missing-selector! UILabel::isUserInteractionEnabled not bound
 !missing-selector! UILabel::setUserInteractionEnabled: not bound
-
-## it's technically optional but there's no point in adopting the protocol if you do not provide the implemenation
-!incorrect-protocol-member! UIInputViewAudioFeedback::enableInputClicksWhenVisible is OPTIONAL and should NOT be abstract
-
-## fixed in XAMCORE_4_0 - API break
-!incorrect-protocol-member! UIDynamicAnimatorDelegate::dynamicAnimatorDidPause: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UIDynamicAnimatorDelegate::dynamicAnimatorWillResume: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UILayoutSupport::bottomAnchor is REQUIRED and should be abstract
-!incorrect-protocol-member! UILayoutSupport::heightAnchor is REQUIRED and should be abstract
-!incorrect-protocol-member! UILayoutSupport::topAnchor is REQUIRED and should be abstract
 
 ## the [Sealed] attributes removes the [Export] one so it seems missing (but it's not)
 !missing-selector! UIGestureRecognizer::ignorePress:forEvent: not bound
@@ -131,15 +118,6 @@
 !missing-selector! NSObject::setIsAccessibilityElement: not bound
 !missing-selector! NSObject::setShouldGroupAccessibilityChildren: not bound
 !missing-selector! NSObject::shouldGroupAccessibilityChildren not bound
-
-## @required members added to exixting interfaces (breaking change), fixed on XAMCORE_4_0
-!incorrect-protocol-member! UIFocusEnvironment::preferredFocusEnvironments is REQUIRED and should be abstract
-!incorrect-protocol-member! UITextDocumentProxy::documentInputMode is REQUIRED and should be abstract
-!incorrect-protocol-member! UITextDocumentProxy::documentIdentifier is REQUIRED and should be abstract
-!incorrect-protocol-member! UITextDocumentProxy::selectedText is REQUIRED and should be abstract
-!incorrect-protocol-member! UIViewControllerContextTransitioning::pauseInteractiveTransition is REQUIRED and should be abstract
-!incorrect-protocol-member! UIViewControllerTransitionCoordinator::notifyWhenInteractionChangesUsingBlock: is REQUIRED and should be abstract
-!incorrect-protocol-member! UIViewControllerTransitionCoordinatorContext::isInterruptible is REQUIRED and should be abstract
 
 # Apple renamed it from UILineBreakMode and we kept the old name for API compatibility
 !missing-enum! NSLineBreakMode not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CarPlay.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CarPlay.ignore
@@ -1,9 +1,3 @@
-!incorrect-protocol-member! CPBarButtonProviding::backButton is REQUIRED and should be abstract
-!incorrect-protocol-member! CPBarButtonProviding::setBackButton: is REQUIRED and should be abstract
-!incorrect-protocol-member! CPSessionConfigurationDelegate::sessionConfiguration:limitedUserInterfacesChanged: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! CPListTemplateItem::isEnabled is REQUIRED and should be abstract
-!incorrect-protocol-member! CPListTemplateItem::setEnabled: is REQUIRED and should be abstract
-
 # Removed in iOS 14
 !unknown-field! CPMaximumListItemImageSize bound
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreNFC.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreNFC.ignore
@@ -1,3 +1,0 @@
-## breaking change -> XAMCORE_4_0
-!incorrect-protocol-member! NFCReaderSessionDelegate::readerSession:didDetectTags: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NFCMiFareTag::mifareFamily is REQUIRED and should be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreNFC.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreNFC.todo
@@ -1,1 +1,0 @@
-!incorrect-protocol-member! NFCTagReaderSessionDelegate::tagReaderSession:didDetectTags: is OPTIONAL and should NOT be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-FileProvider.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-FileProvider.ignore
@@ -1,2 +1,0 @@
-## this was _demoted_ to `@optional` when the property was deprecated in iOS 14 SDK
-!incorrect-protocol-member! NSFileProviderItem::typeIdentifier is OPTIONAL and should NOT be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-GameKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-GameKit.ignore
@@ -1,8 +1,2 @@
-# fixed in XAMCORE_3_0 - API break
-
-!incorrect-protocol-member! GKMatchmakerViewControllerDelegate::matchmakerViewController:didFindPlayers: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! GKTurnBasedMatchmakerViewControllerDelegate::turnBasedMatchmakerViewController:didFindMatch: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! GKTurnBasedMatchmakerViewControllerDelegate::turnBasedMatchmakerViewController:playerQuitForMatch: is OPTIONAL and should NOT be abstract
-
 # API removed by Apple, marked as deprecated
 !unknown-native-enum! GKAuthenticationType bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-IntentsUI.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-IntentsUI.ignore
@@ -1,2 +1,0 @@
-## Apple made this protocol member optional in iOS 11 but it is a breaking change for us. Added to XAMCORE_4_0.
-!incorrect-protocol-member! INUIHostedViewControlling::configureWithInteraction:context:completion: is OPTIONAL and should NOT be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-MetricKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-MetricKit.ignore
@@ -1,2 +1,0 @@
-# Added for xamcore 4.0
-!incorrect-protocol-member! MXMetricManagerSubscriber::didReceiveMetricPayloads: is OPTIONAL and should NOT be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-PushKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-PushKit.ignore
@@ -1,2 +1,0 @@
-## was @required but now @optional (a replacement was added in Xcode9) - still a breaking change to remove the abstract
-!incorrect-protocol-member! PKPushRegistryDelegate::pushRegistry:didReceiveIncomingPushWithPayload:forType: is OPTIONAL and should NOT be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
@@ -10,18 +10,9 @@
 ## exception name, not clear if useful
 !missing-field! UIApplicationInvalidInterfaceOrientationException not bound
 
-## fixed for XAMCORE_4_0
-!incorrect-protocol-member! UIDocumentPickerDelegate::documentPicker:didPickDocumentAtURL: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! UIFocusItem::frame is REQUIRED and should be abstract
-!incorrect-protocol-member! UIFocusEnvironment::focusItemContainer is REQUIRED and should be abstract
-!incorrect-protocol-member! UIFocusEnvironment::parentFocusEnvironment is REQUIRED and should be abstract
-
 ## Special case from UIAccessibilityAction. We added it (completly) on UIResponser but magic tap is also available on app delegate according to docs
 ## See comments is uikit.cs for more info
 !extra-protocol-member! unexpected selector UIApplicationDelegate::accessibilityPerformMagicTap found
-
-# fixed in XAMCORE_4_0 - API break
-!incorrect-protocol-member! UIDocumentMenuDelegate::documentMenuWasCancelled: is OPTIONAL and should NOT be abstract
 
 ## the category name is clear enough: UIPrintPaper_Deprecated_Nonfunctional
 !missing-selector! UIPrintPaper::printRect not bound
@@ -44,10 +35,6 @@
 !missing-protocol-member! NSCollectionLayoutVisibleItem::setCenter: not found
 !missing-protocol-member! NSCollectionLayoutVisibleItem::setTransform: not found
 !missing-protocol-member! NSCollectionLayoutVisibleItem::transform not found
-
-## This is a breaking change
-!incorrect-protocol-member! UITextDocumentProxy::setMarkedText:selectedRange: is REQUIRED and should be abstract
-!incorrect-protocol-member! UITextDocumentProxy::unmarkText is REQUIRED and should be abstract
 
 ## Not really useful to have them exposed
 !missing-pinvoke! UIFontWeightForImageSymbolWeight is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-WatchConnectivity.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-WatchConnectivity.ignore
@@ -1,4 +1,0 @@
-## They were _upgraded_ to required in iOS 10 beta 1
-!incorrect-protocol-member! WCSessionDelegate::session:activationDidCompleteWithState:error: is REQUIRED and should be abstract
-!incorrect-protocol-member! WCSessionDelegate::sessionDidBecomeInactive: is REQUIRED and should be abstract
-!incorrect-protocol-member! WCSessionDelegate::sessionDidDeactivate: is REQUIRED and should be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -59,6 +59,10 @@
 
 !missing-protocol-member! NSTextViewDelegate::textView:draggedCell:inRect:event: not found
 
+# These members are required and static, and the generator doesn't create the correct code for that case
+!incorrect-protocol-member! +NSPasteboardReading::readableTypesForPasteboard: is REQUIRED and should be abstract
+!incorrect-protocol-member! +NSWindowRestoration::restoreWindowWithIdentifier:state:completionHandler: is REQUIRED and should be abstract
+
 ## unsorted
 
 !extra-protocol-member! unexpected selector NSApplicationDelegate::orderFrontStandardAboutPanel: found
@@ -68,76 +72,6 @@
 !extra-protocol-member! unexpected selector NSApplicationDelegate::writeSelectionToPasteboard:types: found
 !extra-protocol-member! unexpected selector NSGestureRecognizerDelegate::xamarinselector:removed: found
 !extra-protocol-member! unexpected selector NSPasteboardReading::xamarinselector:removed: found
-!incorrect-protocol-member! +NSPasteboardReading::readableTypesForPasteboard: is REQUIRED and should be abstract
-!incorrect-protocol-member! +NSWindowRestoration::restoreWindowWithIdentifier:state:completionHandler: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAccessibility::accessibilityChildrenInNavigationOrder is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAccessibility::accessibilityCustomActions is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAccessibility::accessibilityCustomRotors is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAccessibility::isAccessibilityRequired is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAccessibility::setAccessibilityChildrenInNavigationOrder: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAccessibility::setAccessibilityCustomActions: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAccessibility::setAccessibilityCustomRotors: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAccessibility::setAccessibilityRequired: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAppearanceCustomization::appearance is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAppearanceCustomization::effectiveAppearance is REQUIRED and should be abstract
-!incorrect-protocol-member! NSAppearanceCustomization::setAppearance: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDockTilePlugIn::dockMenu is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSDraggingInfo::animatesToDestination is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::draggedImage is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::draggedImageLocation is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::draggingDestinationWindow is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::draggingFormation is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::draggingLocation is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::draggingPasteboard is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::draggingSequenceNumber is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::draggingSource is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::draggingSourceOperationMask is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::enumerateDraggingItemsWithOptions:forView:classes:searchOptions:usingBlock: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::namesOfPromisedFilesDroppedAtDestination: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::numberOfValidItemsForDrop is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::resetSpringLoading is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::setAnimatesToDestination: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::setDraggingFormation: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::setNumberOfValidItemsForDrop: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::slideDraggedImageTo: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSDraggingInfo::springLoadingHighlight is REQUIRED and should be abstract
-!incorrect-protocol-member! NSFilePromiseProviderDelegate::filePromiseProvider:writePromiseToURL:completionHandler: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSMenuDelegate::menu:willHighlightItem: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSPasteboardItemDataProvider::pasteboardFinishedWithDataProvider: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSPasteboardWriting::pasteboardPropertyListForType: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSPasteboardWriting::writableTypesForPasteboard: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSPrintPanelAccessorizing::keyPathsForValuesAffectingPreview is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSRuleEditorDelegate::ruleEditor:predicatePartsForCriterion:withDisplayValue:inRow: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSRuleEditorDelegate::ruleEditorRowsDidChange: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::allowsMultipleSelection is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::contentViewAtIndex:effectiveCharacterRange: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::didReplaceCharacters is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::drawCharactersInRange:forContentView: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::firstSelectedRange is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::isEditable is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::isSelectable is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::rectsForCharacterRange: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::replaceCharactersInRange:withString: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::scrollRangeToVisible: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::selectedRanges is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::setSelectedRanges: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::shouldReplaceCharactersInRanges:withStrings: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::string is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::stringAtIndex:effectiveRange:endsWithSearchBoundary: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::stringLength is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextFinderClient::visibleCharacterRanges is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! NSTextInputClient::attributedSubstringForProposedRange:actualRange: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSTextInputClient::characterIndexForPoint: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSTextInputClient::firstRectForCharacterRange:actualRange: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSTextInputClient::hasMarkedText is REQUIRED and should be abstract
-!incorrect-protocol-member! NSTextInputClient::insertText:replacementRange: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSTextInputClient::markedRange is REQUIRED and should be abstract
-!incorrect-protocol-member! NSTextInputClient::selectedRange is REQUIRED and should be abstract
-!incorrect-protocol-member! NSTextInputClient::setMarkedText:selectedRange:replacementRange: is REQUIRED and should be abstract
-!incorrect-protocol-member! NSTextInputClient::unmarkText is REQUIRED and should be abstract
-!incorrect-protocol-member! NSTextInputClient::validAttributesForMarkedText is REQUIRED and should be abstract
-!incorrect-protocol-member! NSUserInterfaceItemIdentification::identifier is REQUIRED and should be abstract
-!incorrect-protocol-member! NSUserInterfaceItemIdentification::setIdentifier: is REQUIRED and should be abstract
 !missing-enum! NSWritingDirectionFormatType not bound
 !missing-enum-native! NSSpellingState
 !missing-field! NSAuthorDocumentAttribute not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-GameKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-GameKit.ignore
@@ -1,10 +1,3 @@
-## fixed in XAMCORE_3_0 - API break
-
-!incorrect-protocol-member! GKMatchmakerViewControllerDelegate::matchmakerViewController:didFindPlayers: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! GKTurnBasedEventHandlerDelegate::handleTurnEventForMatch:didBecomeActive: is REQUIRED and should be abstract
-!incorrect-protocol-member! GKTurnBasedMatchmakerViewControllerDelegate::turnBasedMatchmakerViewController:didFindMatch: is OPTIONAL and should NOT be abstract
-!incorrect-protocol-member! GKTurnBasedMatchmakerViewControllerDelegate::turnBasedMatchmakerViewController:playerQuitForMatch: is OPTIONAL and should NOT be abstract
-
 # Used to remove hard to kill delegate API until XAMCORE_4_0
 !extra-protocol-member! unexpected selector GKMatchDelegate::xamarin:selector:removed: found
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-QuickLookUI.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-QuickLookUI.ignore
@@ -1,3 +1,0 @@
-# Fixed in XAMCORE_4_0
-!incorrect-protocol-member! QLPreviewItem::previewItemURL is REQUIRED and should be abstract
-!incorrect-protocol-member! QLPreviewingController::preparePreviewOfSearchableItemWithIdentifier:queryString:completionHandler: is OPTIONAL and should NOT be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-SceneKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-SceneKit.ignore
@@ -1,5 +1,3 @@
-!incorrect-protocol-member! SCNSceneRenderer::currentTime is REQUIRED and should be abstract
-!incorrect-protocol-member! SCNSceneRenderer::setCurrentTime: is REQUIRED and should be abstract
 !missing-selector! SCNProgram::geometryShader not bound
 !missing-selector! SCNProgram::setGeometryShader: not bound
 !missing-selector! SCNProgram::setTessellationControlShader: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-WebKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-WebKit.ignore
@@ -1,11 +1,5 @@
 ## only a subset of the old, pre WKWebKit, is bound for macOS
 
-!incorrect-protocol-member! WebOpenPanelResultListener::cancel is REQUIRED and should be abstract
-!incorrect-protocol-member! WebOpenPanelResultListener::chooseFilename: is REQUIRED and should be abstract
-!incorrect-protocol-member! WebOpenPanelResultListener::chooseFilenames: is REQUIRED and should be abstract
-!incorrect-protocol-member! WebPolicyDecisionListener::download is REQUIRED and should be abstract
-!incorrect-protocol-member! WebPolicyDecisionListener::ignore is REQUIRED and should be abstract
-!incorrect-protocol-member! WebPolicyDecisionListener::use is REQUIRED and should be abstract
 !missing-enum! WKUserInterfaceDirectionPolicy not bound
 !missing-field! WebViewDidBeginEditingNotification not bound
 !missing-field! WebViewDidChangeNotification not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
@@ -58,11 +58,6 @@
 ## https://github.com/xamarin/xamarin-macios/issues/3213 should be fixed before conformance to 'UIStateRestoring' is restored.
 !missing-protocol-conformance! UIViewController should conform to UIStateRestoring (defined in 'UIStateRestoration' category)
 
-## fixed for XAMCORE_4_0
-!incorrect-protocol-member! UIFocusItem::frame is REQUIRED and should be abstract
-!incorrect-protocol-member! UIFocusEnvironment::focusItemContainer is REQUIRED and should be abstract
-!incorrect-protocol-member! UIFocusEnvironment::parentFocusEnvironment is REQUIRED and should be abstract
-
 ## not supported as per introspection, rdar filled: 42851110
 !missing-protocol-conformance! NSAttributedString should conform to NSItemProviderReading (defined in 'NSAttributedString_ItemProvider' category)
 !missing-protocol-conformance! NSAttributedString should conform to NSItemProviderWriting (defined in 'NSAttributedString_ItemProvider' category)
@@ -81,10 +76,6 @@
 !missing-protocol-member! NSCollectionLayoutVisibleItem::setCenter: not found
 !missing-protocol-member! NSCollectionLayoutVisibleItem::setTransform: not found
 !missing-protocol-member! NSCollectionLayoutVisibleItem::transform not found
-
-## This is a breaking change
-!incorrect-protocol-member! UITextDocumentProxy::setMarkedText:selectedRange: is REQUIRED and should be abstract
-!incorrect-protocol-member! UITextDocumentProxy::unmarkText is REQUIRED and should be abstract
 
 ## Not really useful to have them exposed
 !missing-pinvoke! UIFontWeightForImageSymbolWeight is not bound


### PR DESCRIPTION
Make required protocol members [Abstract] and optional protocol members not in
.NET. This way we're matching Apple's API (for now at least).