### PR TITLE
[Foundation] Rename parameter to NSItemProviderCompletionHandler to be more descriptive.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -141,7 +141,7 @@ namespace Foundation
 	delegate bool NSEnumerateErrorHandler (NSUrl url, NSError error);
 	delegate void NSMetadataQueryEnumerationCallback (NSObject result, nuint idx, ref bool stop);
 #if NET
-	delegate void NSItemProviderCompletionHandler (INSSecureCoding item, NSError error);
+	delegate void NSItemProviderCompletionHandler (INSSecureCoding itemBeingLoaded, NSError error);
 #else
 	delegate void NSItemProviderCompletionHandler (NSObject itemBeingLoaded, NSError error);
 #endif


### PR DESCRIPTION
Ref: https://github.com/xamarin/xamarin-macios/pull/13756/files#r786311588