### PR TITLE
[CoreMidi] Fix availability for MidiNetworkConnectionPolicy.

### DIFF
--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -73,14 +73,6 @@ namespace CoreMidi {
 		NotPermitted = -10844
 	}
 
-#if !MONOMAC || !XAMCORE_4_0
-	// NSUInteger -> MIDINetworkSession.h
-	[Native]
-	public enum MidiNetworkConnectionPolicy : ulong {
-		NoOne, HostsInContactsList, Anyone
-	}
-#endif
-
 	[Flags]
 	// SInt32 - MIDIServices.h
 	enum MidiObjectType : int {

--- a/src/coremidi.cs
+++ b/src/coremidi.cs
@@ -39,6 +39,18 @@ using NativeHandle = System.IntPtr;
 
 namespace CoreMidi {
 
+
+	[Mac (10,14)]
+	[Watch (8,0)]
+	[TV (15,0)]
+	// NSUInteger -> MIDINetworkSession.h
+	[Native]
+	public enum MidiNetworkConnectionPolicy : ulong {
+		NoOne,
+		HostsInContactsList,
+		Anyone,
+	}
+
 	[Mac (11, 0), iOS (14, 0)]
 	public enum MidiProtocolId {
 		Protocol_1_0 = 1,


### PR DESCRIPTION
This enum isn't deprecated, so no reason for them to not exist in .NET.

Also update the availability attributes according to current headers.

Finally move the entire enum to be processed by the generator to simplify
availability attributes.