### PR TITLE
[AppKit] Don't add NSTextInput.DoCommandBySelector in .NET.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -18694,12 +18694,8 @@ namespace AppKit {
 		[Export ("insertText:")]
 		void InsertText (NSObject insertString);
 
-		// DoCommandBySelector conflicts with NSTextViewDelegate in generated code
-#if XAMCORE_4_0 
-		[Abstract]
-		[Export ("doCommandBySelector:")]
-		void DoCommandBySelector (Selector selector);
-#endif
+		// The doCommandBySelector: conflicts with NSTextViewDelegate in generated code
+		// It's also deprecated in NSTextInput, and why we're not adding it here
 
 		[Abstract]
 		[Export ("setMarkedText:selectedRange:")]


### PR DESCRIPTION
It's deprecated (since macOS 10.6), so just don't add it to avoid any conflicts with other API.