### PR TITLE
[StoreKit] Adopt XAMCORE_4_0 changes in .NET.

### DIFF
--- a/src/StoreKit/Enums.cs
+++ b/src/StoreKit/Enums.cs
@@ -33,7 +33,7 @@ namespace StoreKit {
 		CloudServiceNetworkConnectionFailed,
 		// iOS 10.3
 		CloudServiceRevoked,
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'SKError.CloudServiceRevoked' instead.")]
 		Revoked = CloudServiceRevoked,
 #endif

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -106,7 +106,7 @@ namespace StoreKit {
 
 	[Watch (6, 2)]
 	[BaseType (typeof (NSObject))]
-#if XAMCORE_4_0
+#if NET
 	[DisableDefaultCtor]
 #endif
 	partial interface SKPayment : NSMutableCopying {
@@ -149,7 +149,7 @@ namespace StoreKit {
 
 	[Watch (6, 2)]
 	[BaseType (typeof (SKPayment))]
-#if XAMCORE_4_0
+#if NET
 	[DisableDefaultCtor]
 #endif
 	interface SKMutablePayment {
@@ -289,7 +289,7 @@ namespace StoreKit {
 		[Deprecated (PlatformName.MacOSX, 10,15, message: "Use 'IsDownloadable' instead.")]
 		[Export ("downloadable")]
 		bool Downloadable { get; }
-#elif !XAMCORE_4_0
+#elif !NET
 		[Obsolete ("Use 'IsDownloadable' instead.")]
 		bool Downloadable {
 			[Wrap ("IsDownloadable")]
@@ -303,7 +303,7 @@ namespace StoreKit {
 
 		[NoiOS]
 		[NoWatch]
-#if XAMCORE_4_0
+#if NET
 		[NoTV]
 #else
 		[Deprecated (PlatformName.TvOS, 9, 0, message: "Use 'DownloadContentLengths' instead.")]
@@ -316,12 +316,8 @@ namespace StoreKit {
 		[Export ("downloadContentLengths")]
 		NSNumber [] DownloadContentLengths { get;  }
 
-		[NoiOS]
-#if XAMCORE_4_0
-		[NoTV]
-#else
-		[Deprecated (PlatformName.TvOS, 9, 0, message: "Use 'DownloadContentVersion' instead.")]
-#endif
+		[iOS (13,0)]
+		[TV (13,0)]
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'DownloadContentVersion' instead.")]
 		[Export ("contentVersion")]
 		string ContentVersion { get; }
@@ -531,7 +527,7 @@ namespace StoreKit {
 		   Delegates=new string [] { "WeakDelegate" },
 		   Events   =new Type   [] { typeof (SKStoreProductViewControllerDelegate) })]
 	interface SKStoreProductViewController {
-#if !XAMCORE_4_0
+#if !NET
 		// SKStoreProductViewController is an OS View Controller which can't be customized
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-StoreKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-StoreKit.ignore
@@ -3,6 +3,3 @@
 
 ## web docs <quote>In Mac apps built with Mac Catalyst, this function has no effect.</quote>
 !missing-selector! SKPaymentQueue::showPriceConsentIfNeeded not bound
-
-## deprecated or not used on catalyst
-!missing-selector! SKProduct::contentVersion not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-StoreKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-StoreKit.ignore
@@ -1,2 +1,0 @@
-## deprecated w/replacement in iOS 6, not version information specific to iOS
-!missing-selector! SKProduct::contentVersion not bound

--- a/tests/xtro-sharpie/iOS-StoreKit.ignore
+++ b/tests/xtro-sharpie/iOS-StoreKit.ignore
@@ -1,2 +1,0 @@
-## deprecated w/replacement in iOS 6, not version information specific to iOS
-!missing-selector! SKProduct::contentVersion not bound


### PR DESCRIPTION
This is mostly removing obsolete/removed API, except for
SKProduct.ContentVersion, where the XAMCORE_4_0 annotations were wrong and the
property is still alive and kicking.