### PR TITLE
[SpriteKit] Adopt XAMCORE_4_0 changes in .NET.

### DIFF
--- a/src/SpriteKit/SKAction.cs
+++ b/src/SpriteKit/SKAction.cs
@@ -15,7 +15,7 @@ using CoreFoundation;
 
 namespace SpriteKit {
 
-#if !XAMCORE_4_0
+#if !NET
 	[Obsolete ("Use 'SKActionTimingFunction2' instead.")]
 	public delegate void SKActionTimingFunction (float /* float, not CGFloat */ time);
 #endif
@@ -27,7 +27,7 @@ namespace SpriteKit {
 			return SKAction.ResizeTo (size.Width, size.Height, duration);
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'TimingFunction2' instead.")]
 		public virtual SKActionTimingFunction? TimingFunction { get; set; }
 #endif

--- a/src/SpriteKit/SKUniform.cs
+++ b/src/SpriteKit/SKUniform.cs
@@ -76,7 +76,7 @@ namespace SpriteKit {
 				InitializeHandle (InitWithNameFloatVector4 (name, value), "initWithName:floatVector4:");
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		// Apple deprecated initWithName:floatMatrix2: in macOS10.12/iOS10.0
 		// and made available initWithName:matrixFloat2x2: so we invoke
 		// the right one at runtime depending on which OS version we are running
@@ -133,7 +133,7 @@ namespace SpriteKit {
 			else
 				InitializeHandle (InitWithNameFloatMatrix4 (name, value), "initWithName:floatMatrix4:");
 		}
-#endif // !XAMCORE_4_0
+#endif // !NET
 
 		// Apple deprecated floatVector2Value in macOS10.12/iOS10.0
 		// and made available vectorFloat2Value so we invoke
@@ -192,7 +192,7 @@ namespace SpriteKit {
 			}
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		// Apple deprecated floatMatrix2Value in macOS10.12/iOS10.0
 		// and made available matrixFloat2x2Value so we invoke
 		// the right one at runtime depending on which OS version we are running
@@ -273,7 +273,7 @@ namespace SpriteKit {
 					_FloatMatrix4Value = value;
 			}
 		}
-#endif // !XAMCORE_4_0
+#endif // !NET
 	}
 }
 #endif // !WATCH

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -350,7 +350,7 @@ namespace SpriteKit {
 		[Export ("obstaclesFromSpriteTextures:accuracy:")]
 		GKPolygonObstacle[] ObstaclesFromSpriteTextures (SKNode[] sprites, float accuracy);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Deprecated (PlatformName.iOS, 10,0, message: "Attributes are only available for node classes supporting SKShader (see SKSpriteNode etc.).")]
 		[Deprecated (PlatformName.MacOSX, 10,12, message: "Attributes are only available for node classes supporting SKShader (see SKSpriteNode etc.).")]
 		[iOS (9,0),Mac(10,11)]
@@ -1835,7 +1835,7 @@ namespace SpriteKit {
 		IntPtr InitWithNameVectorFloat4 (string name, Vector4 value);
 #endif
 
-#if !XAMCORE_4_0
+#if !NET
 		[Internal]
 		[NoWatch]
 		[Deprecated (PlatformName.iOS, 10, 0)]
@@ -1844,7 +1844,7 @@ namespace SpriteKit {
 		IntPtr InitWithNameFloatMatrix2 (string name, Matrix2 value);
 #endif
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the '(string, MatrixFloat2x2)' overload instead.")]
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
@@ -1857,7 +1857,7 @@ namespace SpriteKit {
 		[Internal]
 		IntPtr InitWithNameMatrixFloat2x2 (string name, Matrix2 value);
 #endif
-#endif // !XAMCORE_4_0
+#endif // !NET
 
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
@@ -1865,7 +1865,7 @@ namespace SpriteKit {
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		NativeHandle Constructor (string name, MatrixFloat2x2 value);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Internal]
 		[NoWatch]
 		[Deprecated (PlatformName.iOS, 10, 0)]
@@ -1893,7 +1893,7 @@ namespace SpriteKit {
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		NativeHandle Constructor (string name, MatrixFloat3x3 value);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Internal]
 		[NoWatch]
 		[Deprecated (PlatformName.iOS, 10, 0)]
@@ -1902,7 +1902,7 @@ namespace SpriteKit {
 		IntPtr InitWithNameFloatMatrix4 (string name, Matrix4 value);
 #endif
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the '(string, MatrixFloat4x4)' overload instead.")]
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
@@ -1996,7 +1996,7 @@ namespace SpriteKit {
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] set;
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		[Internal]
 		[Deprecated (PlatformName.iOS, 10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 12)]
@@ -2005,7 +2005,7 @@ namespace SpriteKit {
 		Matrix2 _FloatMatrix2Value { get; set; }
 #endif
 
-#if !XAMCORE_4_0 && WATCH
+#if !NET && WATCH
 		[Obsolete ("Use 'MatrixFloat2x2Value' instead.")]
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
@@ -2016,7 +2016,7 @@ namespace SpriteKit {
 		}
 #endif
 
-#if !XAMCORE_4_0 && WATCH
+#if !NET && WATCH
 		[Sealed] // The selector is already used in the 'FloatMatrix2x2Value' property.
 #endif
 		[iOS (10,0)][Mac (10,12)]
@@ -2027,7 +2027,7 @@ namespace SpriteKit {
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] set;
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		[Internal]
 		[NoWatch]
 		[Deprecated (PlatformName.iOS, 10, 0)]
@@ -2036,7 +2036,7 @@ namespace SpriteKit {
 		Matrix3 _FloatMatrix3Value { get; set; }
 #endif
 
-#if !XAMCORE_4_0 && WATCH
+#if !NET && WATCH
 		[Obsolete ("Use 'MatrixFloat3x3Value' instead.")]
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
@@ -2047,7 +2047,7 @@ namespace SpriteKit {
 		}
 #endif
 
-#if !XAMCORE_4_0 && WATCH
+#if !NET && WATCH
 		[Sealed] // The selector is already used in the 'FloatMatrix3x3Value' property.
 #endif
 		[iOS (10,0)][Mac (10,12)]
@@ -2058,7 +2058,7 @@ namespace SpriteKit {
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] set;
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		[Internal]
 		[NoWatch]
 		[Deprecated (PlatformName.iOS, 10, 0)]
@@ -2067,8 +2067,8 @@ namespace SpriteKit {
 		Matrix4 _FloatMatrix4Value { get; set; }
 #endif
 
-#if !XAMCORE_4_0 && WATCH
-		[Obsolete ("Use 'FloatMatrix4x4Value' instead.")]
+#if !NET && WATCH
+		[Obsolete ("Use 'MatrixFloat4x4Value' instead.")]
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10,0)]
 		[Export ("matrixFloat4x4Value", ArgumentSemantic.Assign)]
@@ -2078,7 +2078,7 @@ namespace SpriteKit {
 		}
 #endif
 
-#if !XAMCORE_4_0 && WATCH
+#if !NET && WATCH
 		[Sealed] // The selector is already used in the 'FloatMatrix4x4Value' property.
 #endif
 		[iOS (10,0)][Mac (10,12)]
@@ -2120,7 +2120,7 @@ namespace SpriteKit {
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		SKUniform Create (string name, Vector4 value);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the '(string, MatrixFloat2x2)' overload instead.")]
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10, 0)]
@@ -2137,7 +2137,7 @@ namespace SpriteKit {
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		SKUniform Create (string name, MatrixFloat2x2 value);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the '(string, MatrixFloat3x3)' overload instead.")]
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10, 0)]
@@ -2154,7 +2154,7 @@ namespace SpriteKit {
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		SKUniform Create (string name, MatrixFloat3x3 value);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'the '(string, MatrixFloat4x4)' overload instead.")]
 		[iOS (10,0)][Mac (10,12)]
 		[TV (10, 0)]

--- a/tests/monotouch-test/SpriteKit/UniformTest.cs
+++ b/tests/monotouch-test/SpriteKit/UniformTest.cs
@@ -45,6 +45,9 @@ namespace MonoTouchFixtures.SpriteKit
 
 			using (var obj = new SKUniform ("name")) {
 				var M4Zero = new Matrix4 (Vector4.Zero, Vector4.Zero, Vector4.Zero, Vector4.Zero);
+				var N4Zero = default (NMatrix4);
+				var N3Zero = default (NMatrix3);
+				var N2Zero = default (NMatrix2);
 				Assert.AreEqual ("name", obj.Name, "1 Name");
 				Assert.AreEqual (SKUniformType.None, obj.UniformType, "1 UniformType");
 				Assert.IsNull (obj.TextureValue, "1 TextureValue");
@@ -52,9 +55,18 @@ namespace MonoTouchFixtures.SpriteKit
 				Asserts.AreEqual (Vector2.Zero, obj.FloatVector2Value, "1 FloatVector2Value");
 				Asserts.AreEqual (Vector3.Zero, obj.FloatVector3Value, "1 FloatVector3Value");
 				Asserts.AreEqual (Vector4.Zero, obj.FloatVector4Value, "1 FloatVector4Value");
+#if !NET
 				Asserts.AreEqual (Matrix2.Zero, obj.FloatMatrix2Value, "1 FloatMatrix2Value");
+#endif
+				Asserts.AreEqual (N2Zero, obj.MatrixFloat2x2Value, "1 MatrixFloat2x2Value");
+#if !NET
 				Asserts.AreEqual (Matrix3.Zero, obj.FloatMatrix3Value, "1 FloatMatrix3Value");
+#endif
+				Asserts.AreEqual (N3Zero, obj.MatrixFloat3x3Value, "1 MatrixFloat3x3Value");
+#if !NET
 				Asserts.AreEqual (M4Zero, obj.FloatMatrix4Value, "1 FloatMatrix4Value");
+#endif
+				Asserts.AreEqual (N4Zero, obj.MatrixFloat4x4Value, "1 MatrixFloat4x4Value");
 
 				texture = SKTexture.FromImageNamed ("basn3p08.png");
 				V2 = new Vector2 (1, 2);
@@ -82,14 +94,26 @@ namespace MonoTouchFixtures.SpriteKit
 				obj.FloatVector4Value = V4;
 				Asserts.AreEqual (V4, obj.FloatVector4Value, "2 FloatVector4Value");
 
+#if !NET
 				obj.FloatMatrix2Value = M2;
 				Asserts.AreEqual (M2, obj.FloatMatrix2Value, "2 FloatMatrix2Value");
+#endif
+				obj.MatrixFloat2x2Value = M2x2;
+				Asserts.AreEqual (M2x2, obj.MatrixFloat2x2Value, "2 MatrixFloat2x2Value");
 
+#if !NET
 				obj.FloatMatrix3Value = M3;
 				Asserts.AreEqual (M3, obj.FloatMatrix3Value, "2 FloatMatrix3Value");
+#endif
+				obj.MatrixFloat3x3Value = M3x3;
+				Asserts.AreEqual (M3x3, obj.MatrixFloat3x3Value, "2 MatrixFloat3x3Value");
 
+#if !NET
 				obj.FloatMatrix4Value = M4;
 				Asserts.AreEqual (M4, obj.FloatMatrix4Value, "2 FloatMatrix4Value");
+#endif
+				obj.MatrixFloat4x4Value = M4x4;
+				Asserts.AreEqual (M4x4, obj.MatrixFloat4x4Value, "2 MatrixFloat4x4Value");
 			}
 
 			bool hasSimdConstructors = TestRuntime.CheckXcodeVersion (8, 0);
@@ -113,6 +137,7 @@ namespace MonoTouchFixtures.SpriteKit
 				Asserts.AreEqual (V4, obj.FloatVector4Value, "7 FloatVector4Value");
 			}
 
+#if !NET
 			using (var obj = new SKUniform ("name", M2)) {
 				Asserts.AreEqual (M2, obj.FloatMatrix2Value, "8 FloatMatrix2Value");
 				Asserts.AreEqual (M2, MatrixFloat2x2.Transpose (CFunctions.GetMatrixFloat2x2 (obj, "matrixFloat2x2Value")), "8b FloatMatrix2Value");
@@ -127,6 +152,7 @@ namespace MonoTouchFixtures.SpriteKit
 				Asserts.AreEqual (M4, obj.FloatMatrix4Value, "10 FloatMatrix4Value");
 				Asserts.AreEqual (M4, MatrixFloat4x4.Transpose (CFunctions.GetMatrixFloat4x4 (obj, "matrixFloat4x4Value")), "10b FloatMatrix4Value");
 			}
+#endif
 
 			using (var obj = new SKUniform ("name", M2x2)) {
 				Asserts.AreEqual (M2x2, obj.MatrixFloat2x2Value, "11 MatrixFloat2x2Value");

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-SpriteKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-SpriteKit.todo
@@ -1,4 +1,0 @@
-!deprecated-attribute-missing! SKNode::attributeValues missing a [Deprecated] attribute
-!deprecated-attribute-missing! SKNode::setAttributeValues: missing a [Deprecated] attribute
-!deprecated-attribute-missing! SKNode::setValue:forAttributeNamed: missing a [Deprecated] attribute
-!deprecated-attribute-missing! SKNode::valueForAttributeNamed: missing a [Deprecated] attribute


### PR DESCRIPTION
This means removing numerous obsolete/deprecated methods where better/more
correct alternatives already exist.

Also fix one obsolete message and adjust the tests.