### PR TITLE
[CI] Bootstrap dotnet.

### DIFF
--- a/tools/devops/automation/templates/devices/run-tests.yml
+++ b/tools/devops/automation/templates/devices/run-tests.yml
@@ -65,6 +65,16 @@ steps:
   continueOnError: false
   timeoutInMinutes: 5
 
+- bash: |
+    set -x
+    set -e
+
+    make global6.json
+    make -C builds dotnet
+  workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios
+  displayName: Boostrap dotnet
+  timeoutInMinutes: 30
+
 # Run tests. If we are using xamarin-storage add a periodic command to be executed by xharness, else, since we are using vsdrops do nothing.
 - bash: |
     set -x


### PR DESCRIPTION
This is needed to fix a number of tests that will fail to build on CI with:

```
Task "Exec" (TaskId:108)
[23:06:37.9659920]   Task Parameter:Command=make -j8 -C /Users/xamarinqa/azdo/_work/142/s/xamarin-macios/tests/test-libraries (TaskId:108)
[23:06:37.9719390]   make -j8 -C /Users/xamarinqa/azdo/_work/142/s/xamarin-macios/tests/test-libraries (TaskId:108)
[23:06:38.6389370]   /bin/sh: /Users/xamarinqa/azdo/_work/142/s/xamarin-macios/builds/downloads/dotnet-sdk-6.0.200-preview.22063.5-osx-x64/dotnet: No such file or directory (TaskId:108)
[23:06:38.6394920]   make[3]: *** [.libs/FrameworksInRuntimesNativeDirectory.nupkg] Error 127 (TaskId:108)
[23:06:38.6395440]   make[2]: *** [all-recurse] Error 1 (TaskId:108)
[23:06:38.6395820]   make[1]: *** [all-recurse] Error 1 (TaskId:108)
[23:06:38.6396880]   Making all in custom-type-assembly (TaskId:108)
[23:06:38.6397420]   Making all in frameworks (TaskId:108)
[23:06:38.6397630]   Making all in nugets (TaskId:108)
[23:06:38.6397760]   Making all in FrameworksInRuntimesNativeDirectory (TaskId:108)
[23:06:38.6397860]   GEN      FrameworksInRuntimesNativeDirectory.nupkg (TaskId:108)
```