### PR TITLE
[HomeKit] Add missing availability attributes for a few HomeKit types for Mac Catalyst.

### DIFF
--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -271,6 +271,7 @@ namespace HomeKit {
 #endif // !WATCH
 
 	[Watch (3,0), TV (10,0), iOS (10,0)]
+	[MacCatalyst(14,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
 	interface HMAccessoryProfile
@@ -438,6 +439,7 @@ namespace HomeKit {
 
 	[TV (10,0)]
 	[iOS(8,0)]
+	[MacCatalyst(14,0)]
 	[Static]
 	[Internal]
 	interface HMCharacteristicPropertyInternal {
@@ -459,6 +461,7 @@ namespace HomeKit {
 
 	[TV (10,0)]
 	[iOS (8,0)]
+	[MacCatalyst(14,0)]
 	[Static]
 	[Internal]
 	interface HMCharacteristicMetadataUnitsInternal {
@@ -1136,6 +1139,7 @@ namespace HomeKit {
 	[Static, Internal]
 	[iOS (8,0)]
 	[TV (10,0)]
+	[MacCatalyst (14,0)]
 	interface HMCharacteristicMetadataFormatKeys {
 		[Field ("HMCharacteristicMetadataFormatBool")]
 		NSString _Bool { get; }


### PR DESCRIPTION
Ought to fix these introspection failures on macOS 10.15 with Mac Catalyst:

    Introspection.iOSApiFieldTest
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatArray':
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatBool': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatData': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatDictionary': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatFloat': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatInt': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatString': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatTLV8': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatUInt16': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatUInt32': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatUInt64': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataFormatUInt8': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataUnitsArcDegree': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataUnitsCelsius': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataUnitsFahrenheit': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataUnitsLux': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataUnitsMicrogramsPerCubicMeter': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataUnitsPartsPerMillion': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataUnitsPercentage': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicMetadataUnitsSeconds': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicPropertyHidden': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicPropertyReadable': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicPropertySupportsEventNotification': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] Could not open the library '/System/Library/Frameworks/HomeKit.framework/HomeKit' to find the field 'HMCharacteristicPropertyWritable': dlopen(/System/Library/Frameworks/HomeKit.framework/HomeKit, 0): image not found
        [FAIL] FieldExists :   24 errors found in 3916 fields validated: HMCharacteristicMetadataFormatArray, HMCharacteristicMetadataFormatBool, HMCharacteristicMetadataFormatData, HMCharacteristicMetadataFormatDictionary, HMCharacteristicMetadataFormatFloat, HMCharacteristicMetadataFormatInt, HMCharacteristicMetadataFormatString, HMCharacteristicMetadataFormatTLV8, HMCharacteristicMetadataFormatUInt16, HMCharacteristicMetadataFormatUInt32, HMCharacteristicMetadataFormatUInt64, HMCharacteristicMetadataFormatUInt8, HMCharacteristicMetadataUnitsArcDegree, HMCharacteristicMetadataUnitsCelsius, HMCharacteristicMetadataUnitsFahrenheit, HMCharacteristicMetadataUnitsLux, HMCharacteristicMetadataUnitsMicrogramsPerCubicMeter, HMCharacteristicMetadataUnitsPartsPerMillion, HMCharacteristicMetadataUnitsPercentage, HMCharacteristicMetadataUnitsSeconds, HMCharacteristicPropertyHidden, HMCharacteristicPropertyReadable, HMCharacteristicPropertySupportsEventNotification, HMCharacteristicPropertyWritable
            Expected: 0
            But was:  24