### PR TITLE
[net][coregraphics] Match native strings representation for structs

### DIFF
--- a/src/CoreGraphics/CGPoint.cs
+++ b/src/CoreGraphics/CGPoint.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.InteropServices;
+
+using CoreFoundation;
+using ObjCRuntime;
+
+namespace CoreGraphics {
+
+	// the remaining of the struct is defined inside src/NativeTypes/Drawing.tt
+	public partial struct CGPoint {
+
+#if NET
+		public override int GetHashCode ()
+		{
+			return HashCode.Combine (x, y);
+		}
+
+#if MONOMAC
+		// <quote>When building for 64 bit systems, or building 32 bit like 64 bit, NSPoint is typedef’d to CGPoint.</quote>
+		// https://developer.apple.com/documentation/foundation/nspoint?language=objc
+		[DllImport (Constants.FoundationLibrary, EntryPoint = "NSStringFromPoint")]
+		extern static /* NSString* */ IntPtr NSStringFromCGPoint (/* NSPoint */ CGPoint point);
+#else
+		[DllImport (Constants.UIKitLibrary)]
+		extern static /* NSString* */ IntPtr NSStringFromCGPoint (CGPoint point);
+#endif // MONOMAC
+
+#if !COREBUILD
+		public override string ToString ()
+		{
+			return CFString.FromHandle (NSStringFromCGPoint (this));
+		}
+#endif
+
+#endif // !NET
+	}
+}

--- a/src/CoreGraphics/CGRect.cs
+++ b/src/CoreGraphics/CGRect.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.InteropServices;
+
+using CoreFoundation;
+using ObjCRuntime;
+
+namespace CoreGraphics {
+
+	// the remaining of the struct is defined inside src/NativeTypes/Drawing.tt
+	public partial struct CGRect {
+
+#if NET
+		public override int GetHashCode ()
+		{
+			return HashCode.Combine (x, y, width, height);
+		}
+
+#if MONOMAC
+		// <quote>When building for 64 bit systems, or building 32 bit like 64 bit, NSRect is typedef’d to CGRect.</quote>
+		// https://developer.apple.com/documentation/foundation/nsrect?language=objc
+		[DllImport (Constants.FoundationLibrary, EntryPoint = "NSStringFromRect")]
+		extern static /* NSString* */ IntPtr NSStringFromCGRect (/* NSRect */ CGRect rect);
+#else
+		[DllImport (Constants.UIKitLibrary)]
+		extern static /* NSString* */ IntPtr NSStringFromCGRect (CGRect rect);
+#endif // MONOMAC
+
+#if !COREBUILD
+		public override string ToString ()
+		{
+			return CFString.FromHandle (NSStringFromCGRect (this));
+		}
+#endif
+
+#endif // !NET
+	}
+}

--- a/src/CoreGraphics/CGSize.cs
+++ b/src/CoreGraphics/CGSize.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.InteropServices;
+
+using CoreFoundation;
+using ObjCRuntime;
+
+namespace CoreGraphics {
+
+	// the remaining of the struct is defined inside src/NativeTypes/Drawing.tt
+	public partial struct CGSize {
+
+#if NET
+		public override int GetHashCode ()
+		{
+			return HashCode.Combine (width, height);
+		}
+
+#if MONOMAC
+		// <quote>When building for 64 bit systems, or building 32 bit like 64 bit, NSSize is typedef’d to CGSize.</quote>
+		// https://developer.apple.com/documentation/foundation/nssize?language=objc
+		[DllImport (Constants.FoundationLibrary, EntryPoint = "NSStringFromSize")]
+		extern static /* NSString* */ IntPtr NSStringFromCGSize (/* NSRect */ CGSize size);
+#else
+		[DllImport (Constants.UIKitLibrary)]
+		extern static /* NSString* */ IntPtr NSStringFromCGSize (CGSize size);
+#endif // MONOMAC
+
+#if !COREBUILD
+		public override string ToString ()
+		{
+			return CFString.FromHandle (NSStringFromCGSize (this));
+		}
+#endif
+
+#endif // !NET
+	}
+}

--- a/src/CoreGraphics/CGVector.cs
+++ b/src/CoreGraphics/CGVector.cs
@@ -58,17 +58,20 @@ namespace CoreGraphics {
 
 		public override int GetHashCode ()
 		{
+#if NET
+			return HashCode.Combine (dx, dy);
+#else
 			unchecked {
 				return ((int)dx) ^ ((int)dy);
 			}
+#endif
 		}
 
 		public override bool Equals (object other)
 		{
-			if (other == null || !(other is CGVector))
-				return false;
-			CGVector o = (CGVector) other;
-			return o.dx == dx && o.dy == dy;
+			if (other is CGVector vector)
+				return dx == vector.dx && dy == vector.dy;
+			return false;
 		}
 
 #if MONOTOUCH
@@ -84,12 +87,7 @@ namespace CoreGraphics {
 #endif
 		public override string ToString ()
 		{
-			using (var ns = new NSString (NSStringFromCGVector (this)))
-				return ns.ToString ();
-#if false
-			return String.Format ("{{dx={0}, dy={1}}}", dx.ToString (CultureInfo.CurrentCulture),
-				dy.ToString (CultureInfo.CurrentCulture));
-#endif
+			return CFString.FromHandle (NSStringFromCGVector (this));
 		}
 
 #if !NET
@@ -104,13 +102,18 @@ namespace CoreGraphics {
 		static public CGVector FromString (string s)
 		{
 			// note: null is allowed
-			var ptr = NSString.CreateNative (s);
+			var ptr = CFString.CreateNative (s);
 			var value = CGVectorFromString (ptr);
-			NSString.ReleaseNative (ptr);
+			CFString.ReleaseNative (ptr);
 			return value;
 		}
 #endif
+#else // MONOMAC
+		public override string ToString ()
+		{
+			return $"{{{dx}, {dy}}}";
+		}
 #endif
-	
+
 	}
 }

--- a/src/NativeTypes/Drawing.tt
+++ b/src/NativeTypes/Drawing.tt
@@ -44,7 +44,7 @@ namespace CoreGraphics
 	}) {
 #>
 	[Serializable]
-	public struct <#= type.Name #> : IEquatable<<#= type.Name #>>
+	public partial struct <#= type.Name #> : IEquatable<<#= type.Name #>>
 	{
 		public static readonly <#= type.Name #> Empty;
 
@@ -204,6 +204,7 @@ namespace CoreGraphics
 		}
 <# } #>
 
+#if !NET
 		public override int GetHashCode ()
 		{
 			var hash = 23;
@@ -211,6 +212,7 @@ namespace CoreGraphics
 			hash = hash * 31 + <#= type.Y_Height #>.GetHashCode ();
 			return hash;
 		}
+#endif
 
 		public void Deconstruct (out nfloat <#= type.X_Width #>, out nfloat <#= type.Y_Height #>)
 		{
@@ -244,6 +246,7 @@ namespace CoreGraphics
 		}
 
 <# } #>
+#if !NET
 		public override string ToString ()
 		{
 			return String.Format ("{{<#= ucfirst (type.X_Width) #>={0}, <#= ucfirst (type.Y_Height) #>={1}}}",
@@ -251,12 +254,13 @@ namespace CoreGraphics
 				<#= type.Y_Height #>.ToString (CultureInfo.CurrentCulture)
 			);
 		}
+#endif
 	}
 
 <# } #>
 
 	[Serializable]
-	public struct CGRect : IEquatable<CGRect>
+	public partial struct CGRect : IEquatable<CGRect>
 	{
 		[Field ("CGRectZero", "CoreGraphics")] // unused but helps xtro
 		public static readonly CGRect Empty;
@@ -558,6 +562,7 @@ namespace CoreGraphics
 				height == rect.height;
 		}
 
+#if !NET
 		public override int GetHashCode ()
 		{
 			var hash = 23;
@@ -573,6 +578,7 @@ namespace CoreGraphics
 			return String.Format ("{{X={0},Y={1},Width={2},Height={3}}}",
 				x, y, width, height);
 		}
+#endif
 
 		public void Deconstruct (out nfloat x, out nfloat y, out nfloat width, out nfloat height)
 		{

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -492,6 +492,9 @@ COREGRAPHICS_CORE_SOURCES = \
 	CoreGraphics/CGImageProperties.cs \
 	CoreGraphics/CGLayer.cs \
 	CoreGraphics/CGPath.cs \
+	CoreGraphics/CGPoint.cs \
+	CoreGraphics/CGRect.cs \
+	CoreGraphics/CGSize.cs \
 	CoreGraphics/CGVector.cs \
 	CoreGraphics/CGPDFDocument.cs \
 	CoreGraphics/CGPDFPage-2.cs \

--- a/tests/monotouch-test/CoreGraphics/AffineTransformTest.cs
+++ b/tests/monotouch-test/CoreGraphics/AffineTransformTest.cs
@@ -530,6 +530,16 @@ namespace MonoTouchFixtures.CoreGraphics {
 			Assert.AreEqual (sizeof (CGAffineTransform), Marshal.SizeOf (typeof (CGAffineTransform)));
 		}
 
+		[Test]
+		public void ToStringTest ()
+		{
+			var transform = new CGAffineTransform ((nfloat)1, (nfloat)2, (nfloat)3, (nfloat)4, (nfloat)5, (nfloat)6);
+#if NET
+			Assert.AreEqual ("[1, 2, 3, 4, 5, 6]", transform.ToString (), "ToString");
+#else
+			Assert.AreEqual ("xx:1.0 yx:2.0 xy:3.0 yy:4.0 x0:5.0 y0:6.0", transform.ToString (), "ToString");
+#endif
+		}
 	}
 
 

--- a/tests/monotouch-test/CoreGraphics/PointTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PointTest.cs
@@ -1,0 +1,31 @@
+//
+// Unit tests for CGPoint
+//
+// Authors:
+//	Sebastien Pouliot < sebastien.pouliot@gmail.com>
+//
+
+using System;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreGraphics {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class PointTest {
+
+		[Test]
+		public void ToStringTest ()
+		{
+			var point = new CGPoint ((nfloat)1, (nfloat)2);
+#if NET
+			Assert.AreEqual ("{1, 2}", point.ToString (), "ToString");
+#else
+			Assert.AreEqual ("{X=1, Y=2}", point.ToString (), "ToString");
+#endif
+		}
+	}
+}

--- a/tests/monotouch-test/CoreGraphics/RectTest.cs
+++ b/tests/monotouch-test/CoreGraphics/RectTest.cs
@@ -7,6 +7,7 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
+using System;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
@@ -72,6 +73,17 @@ namespace MonoTouchFixtures.CoreGraphics
 			} finally {
 				Dlfcn.dlclose (handle);
 			}
+		}
+
+		[Test]
+		public void ToStringTest ()
+		{
+			var rect = new CGRect ((nfloat)1, (nfloat)2, (nfloat)3, (nfloat)4);
+#if NET
+			Assert.AreEqual ("{{1, 2}, {3, 4}}", rect.ToString (), "ToString");
+#else
+			Assert.AreEqual ("{X=1,Y=2,Width=3,Height=4}", rect.ToString (), "ToString");
+#endif
 		}
 	}
 }

--- a/tests/monotouch-test/CoreGraphics/SizeTest.cs
+++ b/tests/monotouch-test/CoreGraphics/SizeTest.cs
@@ -1,0 +1,31 @@
+//
+// Unit tests for CGSize
+//
+// Authors:
+//	Sebastien Pouliot < sebastien.pouliot@gmail.com>
+//
+
+using System;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreGraphics {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class SizeTest {
+
+		[Test]
+		public void ToStringTest ()
+		{
+			var size = new CGSize ((nfloat)1, (nfloat)2);
+#if NET
+			Assert.AreEqual ("{1, 2}", size.ToString (), "ToString");
+#else
+			Assert.AreEqual ("{Width=1, Height=2}", size.ToString (), "ToString");
+#endif
+		}
+	}
+}

--- a/tests/monotouch-test/CoreGraphics/VectorTest.cs
+++ b/tests/monotouch-test/CoreGraphics/VectorTest.cs
@@ -1,0 +1,27 @@
+//
+// Unit tests for CGVector
+//
+// Authors:
+//	Sebastien Pouliot < sebastien.pouliot@gmail.com>
+//
+
+using System;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreGraphics {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class VectorTest {
+
+		[Test]
+		public void ToStringTest ()
+		{
+			var vector = new CGVector ((nfloat)1, (nfloat)2);
+			Assert.AreEqual ("{1, 2}", vector.ToString (), "ToString");
+		}
+	}
+}

--- a/tests/monotouch-test/Foundation/ObjectTest.cs
+++ b/tests/monotouch-test/Foundation/ObjectTest.cs
@@ -269,8 +269,13 @@ namespace MonoTouchFixtures.Foundation {
 				using (var observer = o.AddObserver ("frame", NSKeyValueObservingOptions.OldNew, change => {
 					var old = ((NSValue) change.OldValue).CGRectValue;
 					var @new = ((NSValue) change.NewValue).CGRectValue;
+#if NET
+					Assert.AreEqual ("{{0, 0}, {0, 0}}", old.ToString (), "#old");
+					Assert.AreEqual ("{{0, 0}, {123, 234}}", @new.ToString (), "#new");
+#else
 					Assert.AreEqual ("{X=0,Y=0,Width=0,Height=0}", old.ToString (), "#old");
 					Assert.AreEqual ("{X=0,Y=0,Width=123,Height=234}", @new.ToString (), "#new");
+#endif
 					observed = true;
 				})) {
 					o.Frame = new CGRect (0, 0, 123, 234);

--- a/tests/monotouch-test/MediaPlayer/MediaItemArtworkTest.cs
+++ b/tests/monotouch-test/MediaPlayer/MediaItemArtworkTest.cs
@@ -24,11 +24,16 @@ namespace MonoTouchFixtures.MediaPlayer {
 			string file = Path.Combine (NSBundle.MainBundle.ResourcePath, "basn3p08.png");
 			using (var img = UIImage.FromFile (file))
 			using (var mia = new MPMediaItemArtwork (img)) {
-				Assert.That (img.Size.ToString (), Is.EqualTo ("{Width=32, Height=32}"), "original");
+#if NET
+				const string expected = "{32, 32}";
+#else
+				const string expected = "{Width=32, Height=32}";
+#endif
+				Assert.That (img.Size.ToString (), Is.EqualTo (expected), "original");
 				var upscale = mia.ImageWithSize (new CGSize (100, 100));
-				Assert.That (upscale.Size.ToString (), Is.EqualTo ("{Width=32, Height=32}"), "upscale");
+				Assert.That (upscale.Size.ToString (), Is.EqualTo (expected), "upscale");
 				var downscale = mia.ImageWithSize (new CGSize (16, 16));
-				Assert.That (downscale.Size.ToString (), Is.EqualTo ("{Width=32, Height=32}"), "downscale");
+				Assert.That (downscale.Size.ToString (), Is.EqualTo (expected), "downscale");
 			}
 		}
 	}

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2288,7 +2288,11 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				var targetContentOffset = new CGPoint (3, 4);
 				Messaging.void_objc_msgSend_IntPtr_CGPoint_ref_CGPoint (obj.Handle, Selector.GetHandle ("scrollViewWillEndDragging:withVelocity:targetContentOffset:"), IntPtr.Zero, velocity, ref targetContentOffset);
 				Console.WriteLine (targetContentOffset);
+#if NET
+				Assert.AreEqual ("{123, 345}", targetContentOffset.ToString (), "ref output");
+#else
 				Assert.AreEqual ("{X=123, Y=345}", targetContentOffset.ToString (), "ref output");
+#endif
 			}
 		}
 #endif // !__WATCHOS
@@ -2299,8 +2303,13 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			[Export ("scrollViewWillEndDragging:withVelocity:targetContentOffset:")]
 			public void WillEndDragging (UIScrollView scrollView, PointF velocity, ref PointF targetContentOffset)
 			{
+#if NET
+				Assert.AreEqual ("{1, 2}", velocity.ToString (), "velocity");
+				Assert.AreEqual ("{3, 4}", targetContentOffset.ToString (), "targetContentOffset");
+#else
 				Assert.AreEqual ("{X=1, Y=2}", velocity.ToString (), "velocity");
 				Assert.AreEqual ("{X=3, Y=4}", targetContentOffset.ToString (), "targetContentOffset");
+#endif
 				targetContentOffset = new CGPoint (123, 345);
 			}
 		}

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-UIKit.ignore
@@ -62,10 +62,6 @@
 !missing-pinvoke! CGPointFromString is not bound
 !missing-pinvoke! CGRectFromString is not bound
 !missing-pinvoke! CGSizeFromString is not bound
-!missing-pinvoke! NSStringFromCGAffineTransform is not bound
-!missing-pinvoke! NSStringFromCGPoint is not bound
-!missing-pinvoke! NSStringFromCGRect is not bound
-!missing-pinvoke! NSStringFromCGSize is not bound
 !missing-pinvoke! NSStringFromUIOffset is not bound
 !missing-pinvoke! UIOffsetFromString is not bound
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-Foundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-Foundation.ignore
@@ -82,9 +82,6 @@
 !missing-pinvoke! NSRectFromString is not bound
 !missing-pinvoke! NSReturnAddress is not bound
 !missing-pinvoke! NSSizeFromString is not bound
-!missing-pinvoke! NSStringFromPoint is not bound
-!missing-pinvoke! NSStringFromRect is not bound
-!missing-pinvoke! NSStringFromSize is not bound
 !missing-pinvoke! NSUnionRect is not bound
 !missing-protocol! NSSpellServerDelegate not bound
 !missing-protocol-member! NSFileManagerDelegate::fileManager:shouldCopyItemAtURL:toURL: not found


### PR DESCRIPTION
* Use the native `NSStringFrom*` API so we can, eventually, use the
native code to parse them from `NSString` and also ensure increased
compatibility with any code that expects the native string representation

* Add unit tests for `ToString` methods

Also use [`System.HashCode`](https://docs.microsoft.com/en-us/dotnet/api/system.hashcode?view=net-6.0) to generate the hash code