### PR TITLE
[CI] Allow to optionally skip API diff.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -42,6 +42,11 @@ parameters:
   type: boolean
   default: true
 
+- name: enableAPIDiff
+  displayName: Enable API diff generation
+  type: boolean
+  default: true
+
 - name: forceInsertion
   displayName: Force Insertion 
   type: boolean
@@ -263,6 +268,7 @@ stages:
         gitHubToken: ${{ variables['GitHub.Token'] }}
         xqaCertPass: $(xqa--certificates--password)
         enableDotnet: ${{ parameters.enableDotnet }}
+        enableAPIDiff: ${{ parameters.enableAPIDiff }}
 
 # .NET 6 Release Prep and VS Insertion Stages, only execute them when the build comes from an official branch and is not a schedule build from OneLoc
 - ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), eq(parameters.forceInsertion, true))) }}:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -23,6 +23,10 @@ parameters:
   type: boolean
   default: false
 
+- name: enableAPIDiff
+  type: boolean
+  default: true
+
 steps:
 - checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
   clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
@@ -358,10 +362,11 @@ steps:
   displayName: 'Build'
   timeoutInMinutes: 180
 
- # run ASAP so that we do not have any files that got generated confusing git 
-- template: api-diff.yml
-  parameters:
-    prID: variables['PrID']
+# run ASAP so that we do not have any files that got generated confusing git 
+- ${{ if eq(parameters.enableAPIDiff, true) }}:
+  - template: api-diff.yml
+    parameters:
+      prID: variables['PrID']
 
 # build not signed .pkgs for the SDK
 - bash: |

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -25,6 +25,10 @@ parameters:
   type: boolean
   default: false
 
+- name: enableAPIDiff
+  type: boolean
+  default: true
+
 jobs:
 - job: configure
   displayName: 'Configure build'
@@ -105,6 +109,7 @@ jobs:
       gitHubToken: ${{ parameters.gitHubToken }}
       xqaCertPass: ${{ parameters.xqaCertPass }}
       enableDotnet: ${{ parameters.enableDotnet }}
+      enableAPIDiff: ${{ parameters.enableAPIDiff }}
 
 - job: upload_azure_blob
   displayName: 'Upload packages to Azure'


### PR DESCRIPTION
Allow to skip it for several reasons:

1. We might want to seepd up a build during a release.
2. We want to make the build.yml template for pflexible, later we will
   have to instances, one for the diff one to run tests and build.
   Running those in parallel should buy us an hour in the total build.