### PR TITLE
[QuickLookThumbnailing] Adopt XAMCORE_4_0 changes in .NET.

### DIFF
--- a/src/quicklookthumbnailing.cs
+++ b/src/quicklookthumbnailing.cs
@@ -129,7 +129,7 @@ namespace QuickLookThumbnailing {
 	}
 }
 
-#if IOS && !XAMCORE_4_0
+#if IOS && !NET
 namespace QuickLook {
 #else
 namespace QuickLookThumbnailing {


### PR DESCRIPTION
This means using the correct namespace.