### PR TITLE
[QuickLookUI] Adopt XAMCORE_4_0 change in .NET.

### DIFF
--- a/src/quicklookUI.cs
+++ b/src/quicklookUI.cs
@@ -54,7 +54,7 @@ namespace QuickLookUI {
 		[Abstract]
 #endif
 		[Export ("previewItemURL")]
-#if XAMCORE_4_0
+#if NET
 		NSUrl PreviewItemUrl { get; }
 #else
 		NSUrl PreviewItemURL { get; }


### PR DESCRIPTION
This means fixing a property name to follow our naming guidelines.