### PR TITLE
[AudioComponentDescription] Strong-type the ComponentSubType field in .NET.

### DIFF
--- a/src/AudioUnit/AudioComponentDescription.cs
+++ b/src/AudioUnit/AudioComponentDescription.cs
@@ -257,7 +257,11 @@ namespace AudioUnit
 		public AudioComponentType ComponentType;
 		
 		[MarshalAs(UnmanagedType.U4)]
+#if NET && !COREBUILD
+		public AudioUnitSubType ComponentSubType;
+#else
 		public int ComponentSubType;
+#endif
         
 		[MarshalAs(UnmanagedType.U4)] 
 		public AudioComponentManufacturerType ComponentManufacturer;
@@ -268,7 +272,11 @@ namespace AudioUnit
 		internal AudioComponentDescription (AudioComponentType type, int subType)
 		{
 			ComponentType = type;
+#if NET && !COREBUILD
+			ComponentSubType = (AudioUnitSubType) subType;
+#else
 			ComponentSubType = subType;
+#endif
 			ComponentManufacturer = AudioComponentManufacturerType.Apple;
 			ComponentFlags = (AudioComponentFlag) 0;
 			ComponentFlagsMask = 0;

--- a/tests/monotouch-test/AudioUnit/AUAudioUnitFactoryTest.cs
+++ b/tests/monotouch-test/AudioUnit/AUAudioUnitFactoryTest.cs
@@ -29,9 +29,17 @@ namespace MonoTouchFixtures.AudioUnit {
 			var desc = new AudioComponentDescription {
 				ComponentType = AudioComponentType.Output,
 #if MONOMAC
+#if NET
+				ComponentSubType = AudioUnitSubType.VoiceProcessingIO,
+#else
 				ComponentSubType = (int)AudioUnitSubType.VoiceProcessingIO,
+#endif
+#else
+#if NET
+				ComponentSubType = (AudioUnitSubType) AudioTypeOutput.Remote,
 #else
 				ComponentSubType = 0x72696f63, // Remote_IO
+#endif
 #endif
 				ComponentManufacturer = AudioComponentManufacturerType.Apple
 			};

--- a/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs
+++ b/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs
@@ -25,14 +25,22 @@ namespace Xamarin.Mac.Tests
 
 			AudioComponentDescription mixerDescription = new AudioComponentDescription ();
 			mixerDescription.ComponentType = AudioComponentType.Mixer;
+#if NET
+			mixerDescription.ComponentSubType = (AudioUnitSubType)AudioTypeMixer.MultiChannel;
+#else
 			mixerDescription.ComponentSubType = (int)AudioTypeMixer.MultiChannel;
+#endif
 			mixerDescription.ComponentFlags = 0;
 			mixerDescription.ComponentFlagsMask = 0;
 			mixerDescription.ComponentManufacturer = AudioComponentManufacturerType.Apple;
 
 			AudioComponentDescription outputDesciption = new AudioComponentDescription ();
 			outputDesciption.ComponentType = AudioComponentType.Output;
+#if NET
+			outputDesciption.ComponentSubType = (AudioUnitSubType)AudioTypeOutput.System;
+#else
 			outputDesciption.ComponentSubType = (int)AudioTypeOutput.System;
+#endif
 			outputDesciption.ComponentFlags = 0;
 			outputDesciption.ComponentFlagsMask = 0;
 			outputDesciption.ComponentManufacturer = AudioComponentManufacturerType.Apple;

--- a/tests/monotouch-test/AudioUnit/AudioUnit.cs
+++ b/tests/monotouch-test/AudioUnit/AudioUnit.cs
@@ -18,7 +18,11 @@ namespace Xamarin.Mac.Tests
 		{
 			AudioComponentDescription desc = new AudioComponentDescription ();
 			desc.ComponentType = AudioComponentType.Output;
+#if NET
+			desc.ComponentSubType = AudioUnitSubType.HALOutput; // 'ahal'
+#else
 			desc.ComponentSubType = 1634230636; // 'ahal'
+#endif
 			desc.ComponentFlags = 0;
 			desc.ComponentFlagsMask = 0;
 			desc.ComponentManufacturer = AudioComponentManufacturerType.Apple;

--- a/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
+++ b/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
@@ -26,9 +26,17 @@ namespace MonoTouchFixtures.AudioUnit
 			AudioComponentDescription cd = new AudioComponentDescription () {
 				ComponentType = AudioComponentType.Output,
 #if MONOMAC
+#if NET
+				ComponentSubType = AudioUnitSubType.VoiceProcessingIO,
+#else
 				ComponentSubType = (int)AudioUnitSubType.VoiceProcessingIO,
+#endif
+#else
+#if NET
+				ComponentSubType = (AudioUnitSubType) AudioTypeOutput.Remote,
 #else
 				ComponentSubType = 0x72696f63, // Remote_IO
+#endif
 #endif
 				ComponentManufacturer = AudioComponentManufacturerType.Apple
 			};
@@ -55,9 +63,17 @@ namespace MonoTouchFixtures.AudioUnit
 			AudioComponentDescription cd = new AudioComponentDescription () {
 				ComponentType = AudioComponentType.Output,
 #if MONOMAC
+#if NET
+				ComponentSubType = AudioUnitSubType.VoiceProcessingIO,
+#else
 				ComponentSubType = (int)AudioUnitSubType.VoiceProcessingIO,
+#endif
+#else
+#if NET
+				ComponentSubType = (AudioUnitSubType) AudioTypeOutput.Remote,
 #else
 				ComponentSubType = 0x72696f63, // Remote_IO
+#endif
 #endif
 				ComponentManufacturer = AudioComponentManufacturerType.Apple
 			};


### PR DESCRIPTION
Strong names are always better!