### PR TITLE
[Photos] Adopt XAMCORE_4_0 changes in .NET.

### DIFF
--- a/src/Photos/Enums.cs
+++ b/src/Photos/Enums.cs
@@ -383,7 +383,7 @@ namespace Photos
 	[TV (13,0), Mac (10,15), iOS (13,0)]
 	[Native]
 	public enum PHPhotosError : long {
-#if !XAMCORE_4_0
+#if !NET
 		[Deprecated (PlatformName.MacOSX, 12, 0, message: "Use 'InternalError' instead.")]
 		Invalid = -1,
 #endif

--- a/src/Photos/PHCompat.cs
+++ b/src/Photos/PHCompat.cs
@@ -27,7 +27,7 @@ namespace Photos {
 	}
 #endif
 
-#if !XAMCORE_4_0
+#if !NET
 	// incorrect signature, should have been `ref NSError`
 	[Obsolete ("Use 'PHLivePhotoFrameProcessingBlock2' instead.")]
 	public delegate CIImage PHLivePhotoFrameProcessingBlock (IPHLivePhotoFrame frame, NSError error);
@@ -41,25 +41,15 @@ namespace Photos {
 #if MONOMAC
 	public partial class PHAssetCollection {
 
-#if !NET
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX)]
-#else
-		[UnsupportedOSPlatform ("macos")]
-		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 		public static PHFetchResult FetchMoments (PHFetchOptions options)
 		{
 			return null;
 		}
 
-#if !NET
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX)]
-#else
-		[UnsupportedOSPlatform ("macos")]
-		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 		public static PHFetchResult FetchMoments (PHCollectionList momentList, PHFetchOptions options)
 		{
 			return null;
@@ -68,25 +58,15 @@ namespace Photos {
 
 	public partial class PHCollectionList {
 
-#if !NET
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX)]
-#else
-		[UnsupportedOSPlatform ("macos")]
-		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 		public static PHFetchResult FetchMomentLists (PHCollectionListSubtype subType, PHFetchOptions options)
 		{
 			return null;
 		}
 
-#if !NET
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX)]
-#else
-		[UnsupportedOSPlatform ("macos")]
-		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 		public static PHFetchResult FetchMomentLists (PHCollectionListSubtype subType, PHAssetCollection moment, PHFetchOptions options)
 		{
 			return null;
@@ -94,14 +74,8 @@ namespace Photos {
 	}
 
 	public partial class PHContentEditingInput {
-
-#if !NET
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX, message: "Use 'AudiovisualAsset' instead.")]
-#else
-		[UnsupportedOSPlatform ("macos")]
-		[Obsolete ("Use 'AudiovisualAsset' instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 		public virtual AVFoundation.AVAsset AvAsset {
 			get { return AudiovisualAsset; }
 		}
@@ -110,20 +84,14 @@ namespace Photos {
 	public delegate void PHImageDataHandler (NSData data, NSString dataUti, CGImagePropertyOrientation orientation, NSDictionary info);
 
 	public partial class PHImageManager {
-
-#if !NET
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX, message: "Use 'RequestImageDataAndOrientation (PHAsset asset, [NullAllowed] PHImageRequestOptions options, PHImageManagerRequestImageDataHandler resultHandler)' instead.")]
-#else
-		[UnsupportedOSPlatform ("macos")]
-		[Obsolete ("Use 'RequestImageDataAndOrientation (PHAsset asset, [NullAllowed] PHImageRequestOptions options, PHImageManagerRequestImageDataHandler resultHandler)' instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 		public virtual int RequestImageData (PHAsset asset, PHImageRequestOptions options, PHImageDataHandler handler)
 		{
 			return -1;
 		}
 	}
-#endif
+#endif // MONOMAC
 
-#endif
+#endif // !NET
 }

--- a/src/photos.cs
+++ b/src/photos.cs
@@ -514,7 +514,7 @@ namespace Photos
 	[BaseType (typeof (PHObject))]
 	[DisableDefaultCtor] // not user createable (calling description fails, see below) must be fetched by API
 	// NSInternalInconsistencyException Reason: PHCollection has no identifier
-#if TVOS || XAMCORE_4_0
+#if TVOS || NET
 	[Abstract] // Acording to docs: The abstract superclass for Photos asset collections and collection lists.
 #endif
 	interface PHCollection {
@@ -977,7 +977,7 @@ namespace Photos
 
 	delegate void PHImageManagerRequestPlayerHandler (AVPlayerItem playerItem, NSDictionary info);
 	delegate void PHImageManagerRequestExportHandler (AVAssetExportSession exportSession, NSDictionary info);
-#if XAMCORE_4_0
+#if NET
 	delegate void PHImageManagerRequestAVAssetHandler (AVAsset asset, AVAudioMix audioMix, NSDictionary info);
 #else
 	delegate void PHImageManagerRequestAvAssetHandler (AVAsset asset, AVAudioMix audioMix, NSDictionary info);
@@ -1017,7 +1017,7 @@ namespace Photos
 
 		[Mac (10,15)]
 		[Export ("requestAVAssetForVideo:options:resultHandler:")]
-#if XAMCORE_4_0
+#if NET
 		int /* PHImageRequestID = int32_t */ RequestAVAsset (PHAsset asset, [NullAllowed] PHVideoRequestOptions options, PHImageManagerRequestAVAssetHandler resultHandler);
 #else
 		int /* PHImageRequestID = int32_t */ RequestAvAsset (PHAsset asset, [NullAllowed] PHVideoRequestOptions options, PHImageManagerRequestAvAssetHandler resultHandler);
@@ -1067,7 +1067,7 @@ namespace Photos
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // doc -> "abstract base class"
 	// throws "NSInternalInconsistencyException Reason: PHObject has no identifier"
-#if TVOS || XAMCORE_4_0
+#if TVOS || NET
 	[Abstract] // Acording to docs: The abstract base class for Photos model objects (assets and collections).
 #endif
 	interface PHObject : NSCopying {
@@ -1267,7 +1267,7 @@ namespace Photos
 		NSString CancelledKey { get; }
 	}
 
-#if XAMCORE_4_0
+#if NET
 	delegate CIImage PHLivePhotoFrameProcessingBlock (IPHLivePhotoFrame frame, ref NSError error);
 #else
 	delegate CIImage PHLivePhotoFrameProcessingBlock2 (IPHLivePhotoFrame frame, ref NSError error);
@@ -1293,7 +1293,7 @@ namespace Photos
 		CMTime PhotoTime { get; }
 
 		[NullAllowed, Export ("frameProcessor", ArgumentSemantic.Copy)]
-#if XAMCORE_4_0
+#if NET
 		PHLivePhotoFrameProcessingBlock FrameProcessor { get; set; }
 #else
 		PHLivePhotoFrameProcessingBlock2 FrameProcessor2 { get; set; }

--- a/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
+++ b/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
@@ -28,7 +28,11 @@ namespace MonoTouchFixtures.Photos {
 
 		static NSError error_faker;
 
+#if NET
+		static PHLivePhotoFrameProcessingBlock managed = (IPHLivePhotoFrame frame, ref NSError error) => {
+#else
 		static PHLivePhotoFrameProcessingBlock2 managed = (IPHLivePhotoFrame frame, ref NSError error) => {
+#endif
 			error = error_faker;
 			return null;
 		};
@@ -44,7 +48,11 @@ namespace MonoTouchFixtures.Photos {
 			using (var cei = new PHContentEditingInput ())
 			using (var lpec = new PHLivePhotoEditingContext (cei)) {
 				// not much but it means the linker cannot remove it
+#if NET
+				Assert.Null (lpec.FrameProcessor, "FrameProcessor2");
+#else
 				Assert.Null (lpec.FrameProcessor2, "FrameProcessor2");
+#endif
 			}
 		}
 
@@ -54,7 +62,11 @@ namespace MonoTouchFixtures.Photos {
 			if (!Runtime.DynamicRegistrationSupported)
 				Assert.Ignore ("This test requires support for the dynamic registrar to setup the block");
 
+#if NET
+			var t = typeof (NSObject).Assembly.GetType ("ObjCRuntime.Trampolines+SDPHLivePhotoFrameProcessingBlock");
+#else
 			var t = typeof (NSObject).Assembly.GetType ("ObjCRuntime.Trampolines+SDPHLivePhotoFrameProcessingBlock2");
+#endif
 			Assert.NotNull (t, "SDPHLivePhotoFrameProcessingBlock2");
 
 			var m = t.GetMethod ("Invoke", BindingFlags.Static | BindingFlags.NonPublic);

--- a/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
+++ b/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
@@ -49,7 +49,7 @@ namespace MonoTouchFixtures.Photos {
 			using (var lpec = new PHLivePhotoEditingContext (cei)) {
 				// not much but it means the linker cannot remove it
 #if NET
-				Assert.Null (lpec.FrameProcessor, "FrameProcessor2");
+				Assert.Null (lpec.FrameProcessor, "FrameProcessor");
 #else
 				Assert.Null (lpec.FrameProcessor2, "FrameProcessor2");
 #endif


### PR DESCRIPTION
This means removing obsolete/deprecated API.