### PR TITLE
[NET6] Add binding project template for iOS and MacCatalyst

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/template.json
@@ -1,0 +1,19 @@
+﻿{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS", "Mac Catalyst" ],
+  "identity": "Microsoft.MacCatalyst.MacCatalystBinding",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library",
+  "shortName": "maccatalystbinding",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "MacCatalystBinding1",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "MacCatalystBinding1.csproj" }
+  ],
+  "defaultName": "MacCatalystBinding1"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/ApiDefinition.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/ApiDefinition.cs
@@ -1,0 +1,70 @@
+namespace MacCatalystBinding1
+{
+
+// The first step to creating a binding is to add your native library ("libNativeLibrary.a")
+// to the project.
+// Open your binding csproj and add a section like this
+// <ItemGroup>
+//   <NativeReference Include="MyLibrary.xcframework">
+//     <Kind>Framework</Kind>
+//     <Frameworks></Frameworks>
+//   </NativeReference>
+// </ItemGroup>
+//
+// Once you've added it, you will need to customize it for your specific library:
+//  - Change the Include to the correct path/name of your library
+//  - Change Kind to Static (.a) or Framework (.framework/.xcframework) based upon the library kind and extension.
+//    - Dynamic (.dylib) is a third option but rarely if ever valid
+//  - If your library depends on other frameworks, add them inside <Frameworks></Frameworks>
+// Example:
+// <NativeReference Include="libs\MyTestFramework.xcframework">
+//   <Kind>Framework</Kind>
+//   <Frameworks>CoreLocation ModelIO</Frameworks>
+// </NativeReference>
+// 
+// Once you've done that, you're ready to move on to binding the API...
+//
+// Here is where you'd define your API definition for the native Objective-C library.
+//
+// For example, to bind the following Objective-C class:
+//
+//     @interface Widget : NSObject {
+//     }
+//
+// The C# binding would look like this:
+//
+//     [BaseType (typeof (NSObject))]
+//     interface Widget {
+//     }
+//
+// To bind Objective-C properties, such as:
+//
+//     @property (nonatomic, readwrite, assign) CGPoint center;
+//
+// You would add a property definition in the C# interface like so:
+//
+//     [Export ("center")]
+//     CGPoint Center { get; set; }
+//
+// To bind an Objective-C method, such as:
+//
+//     -(void) doSomething:(NSObject *)object atIndex:(NSInteger)index;
+//
+// You would add a method definition to the C# interface like so:
+//
+//     [Export ("doSomething:atIndex:")]
+//     void DoSomething (NSObject object, int index);
+//
+// Objective-C "constructors" such as:
+//
+//     -(id)initWithElmo:(ElmoMuppet *)elmo;
+//
+// Can be bound as:
+//
+//     [Export ("initWithElmo:")]
+//     IntPtr Constructor (ElmoMuppet elmo);
+//
+// For more information, see https://aka.ms/ios-binding
+//
+
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/MacCatalystBinding1.csproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/MacCatalystBinding1.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MacCatalystBinding1</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+    <NoBindingEmbedding>true</NoBindingEmbedding>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+    <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/StructsAndEnums.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/StructsAndEnums.cs
@@ -1,0 +1,4 @@
+namespace MacCatalystBinding1
+{
+
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/template.json
@@ -1,0 +1,19 @@
+﻿{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "iOS", "Mobile" ],
+  "identity": "Microsoft.iOS.iOSBinding",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library",
+  "shortName": "iosbinding",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "iOSBinding1",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "iOSBinding1.csproj" }
+  ],
+  "defaultName": "iOSBinding1"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/ApiDefinition.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/ApiDefinition.cs
@@ -1,0 +1,70 @@
+namespace iOSBinding1
+{
+
+// The first step to creating a binding is to add your native library ("libNativeLibrary.a")
+// to the project.
+// Open your binding csproj and add a section like this
+// <ItemGroup>
+//   <NativeReference Include="MyLibrary.xcframework">
+//     <Kind>Framework</Kind>
+//     <Frameworks></Frameworks>
+//   </NativeReference>
+// </ItemGroup>
+//
+// Once you've added it, you will need to customize it for your specific library:
+//  - Change the Include to the correct path/name of your library
+//  - Change Kind to Static (.a) or Framework (.framework/.xcframework) based upon the library kind and extension.
+//    - Dynamic (.dylib) is a third option but rarely if ever valid
+//  - If your library depends on other frameworks, add them inside <Frameworks></Frameworks>
+// Example:
+// <NativeReference Include="libs\MyTestFramework.xcframework">
+//   <Kind>Framework</Kind>
+//   <Frameworks>CoreLocation ModelIO</Frameworks>
+// </NativeReference>
+// 
+// Once you've done that, you're ready to move on to binding the API...
+//
+// Here is where you'd define your API definition for the native Objective-C library.
+//
+// For example, to bind the following Objective-C class:
+//
+//     @interface Widget : NSObject {
+//     }
+//
+// The C# binding would look like this:
+//
+//     [BaseType (typeof (NSObject))]
+//     interface Widget {
+//     }
+//
+// To bind Objective-C properties, such as:
+//
+//     @property (nonatomic, readwrite, assign) CGPoint center;
+//
+// You would add a property definition in the C# interface like so:
+//
+//     [Export ("center")]
+//     CGPoint Center { get; set; }
+//
+// To bind an Objective-C method, such as:
+//
+//     -(void) doSomething:(NSObject *)object atIndex:(NSInteger)index;
+//
+// You would add a method definition to the C# interface like so:
+//
+//     [Export ("doSomething:atIndex:")]
+//     void DoSomething (NSObject object, int index);
+//
+// Objective-C "constructors" such as:
+//
+//     -(id)initWithElmo:(ElmoMuppet *)elmo;
+//
+// Can be bound as:
+//
+//     [Export ("initWithElmo:")]
+//     IntPtr Constructor (ElmoMuppet elmo);
+//
+// For more information, see https://aka.ms/ios-binding
+//
+
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/StructsAndEnums.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/StructsAndEnums.cs
@@ -1,0 +1,4 @@
+namespace iOSBinding1
+{
+
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/iOSBinding1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/iOSBinding1.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-ios</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSBinding1</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+    <NoBindingEmbedding>true</NoBindingEmbedding>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+    <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet/UnitTests/TemplateTest.cs
+++ b/tests/dotnet/UnitTests/TemplateTest.cs
@@ -17,8 +17,10 @@ namespace Xamarin.Tests {
 			// { platform, template_name }
 			new [] { "iOS", "ios" },
 			new [] { "iOS", "ioslib" },
+			//new [] { "iOS", "iosbinding" },
 			new [] { "tvOS", "tvos" },
 			new [] { "MacCatalyst", "maccatalyst" },
+			//new [] { "MacCatalyst", "maccatalystbinding" },
 			new [] { "macOS", "macos" },
 		};
 


### PR DESCRIPTION
- Fixes https://github.com/xamarin/xamarin-macios/issues/13578
- Uses older-style namespace with {} instead of top level due to https://github.com/xamarin/xamarin-macios/issues/13837
- Tests are commented out as they fail with:

```MSBuild : error MT7068: Can't create a binding resource package unless there are native references in the binding project. [/Users/donblas/Programming/xamarin-macios/tests/dotnet/UnitTests/bin/Debug/net6.0/tmp-test-dir/Xamarin.Tests.TemplateTest.CreateAndBuildTemplate1/iosbinding/iosbinding.csproj]```

Not sure how I should handle ^