### PR TITLE
[foundation] add `NSMutableDictionary` helper to avoid creating extra `NSString` instances

### DIFF
--- a/src/CoreGraphics/CGContextPDF.cs
+++ b/src/CoreGraphics/CGContextPDF.cs
@@ -113,23 +113,23 @@ namespace CoreGraphics {
 			var ret = base.ToDictionary ();
 
 			if (Title is not null)
-				ret.LowlevelSetObject ((NSString) Title, kCGPDFContextTitle);
+				ret.LowlevelSetObject (Title, kCGPDFContextTitle);
 			if (Author is not null)
-				ret.LowlevelSetObject ((NSString) Author, kCGPDFContextAuthor);
+				ret.LowlevelSetObject (Author, kCGPDFContextAuthor);
 			if (Subject is not null)
-				ret.LowlevelSetObject ((NSString) Subject, kCGPDFContextSubject);
+				ret.LowlevelSetObject (Subject, kCGPDFContextSubject);
 			if (Keywords is not null && Keywords.Length > 0){
 				if (Keywords.Length == 1)
-					ret.LowlevelSetObject ((NSString) Keywords [0], kCGPDFContextKeywords);
+					ret.LowlevelSetObject (Keywords [0], kCGPDFContextKeywords);
 				else
 					ret.LowlevelSetObject (NSArray.FromStrings (Keywords), kCGPDFContextKeywords);
 			}
 			if (Creator is not null)
-				ret.LowlevelSetObject ((NSString) Creator, kCGPDFContextCreator);
+				ret.LowlevelSetObject (Creator, kCGPDFContextCreator);
 			if (OwnerPassword is not null)
-				ret.LowlevelSetObject ((NSString) OwnerPassword, kCGPDFContextOwnerPassword);
+				ret.LowlevelSetObject (OwnerPassword, kCGPDFContextOwnerPassword);
 			if (UserPassword is not null)
-				ret.LowlevelSetObject ((NSString) UserPassword, kCGPDFContextUserPassword);
+				ret.LowlevelSetObject (UserPassword, kCGPDFContextUserPassword);
 			if (EncryptionKeyLength.HasValue)
 				ret.LowlevelSetObject (NSNumber.FromInt32 (EncryptionKeyLength.Value), kCGPDFContextEncryptionKeyLength);
 			if (AllowsPrinting.HasValue && AllowsPrinting.Value == false)

--- a/src/Foundation/NSMutableDictionary.cs
+++ b/src/Foundation/NSMutableDictionary.cs
@@ -25,6 +25,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 
+using CoreFoundation;
 using ObjCRuntime;
 
 #if !NET
@@ -335,13 +336,20 @@ namespace Foundation {
 
 		public void LowlevelSetObject (NSObject obj, IntPtr key)
 		{
-			if (obj == null)
-				throw new ArgumentNullException (nameof (obj));
-#if MONOMAC
-			ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, selSetObject_ForKey_Handle, obj.Handle, key);
-#else
-			ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle ("setObject:forKey:"), obj.Handle, key);
-#endif
+			if (obj is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (obj));
+
+			LowlevelSetObject (obj.Handle, key);
+		}
+
+		public void LowlevelSetObject (string obj, IntPtr key)
+		{
+			if (obj is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (obj));
+
+			var ptr = CFString.CreateNative (obj);
+			LowlevelSetObject (ptr, key);
+			CFString.ReleaseNative (ptr);
 		}
 	}
 }

--- a/src/Foundation/NSMutableDictionary.cs
+++ b/src/Foundation/NSMutableDictionary.cs
@@ -342,12 +342,12 @@ namespace Foundation {
 			LowlevelSetObject (obj.Handle, key);
 		}
 
-		public void LowlevelSetObject (string obj, IntPtr key)
+		public void LowlevelSetObject (string str, IntPtr key)
 		{
-			if (obj is null)
-				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (obj));
+			if (str is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (str));
 
-			var ptr = CFString.CreateNative (obj);
+			var ptr = CFString.CreateNative (str);
 			LowlevelSetObject (ptr, key);
 			CFString.ReleaseNative (ptr);
 		}

--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -78,7 +78,7 @@ namespace ImageIO {
 			var dict = new NSMutableDictionary ();
 			
 			if (BestGuessTypeIdentifier is not null)
-				dict.LowlevelSetObject (new NSString (BestGuessTypeIdentifier), kTypeIdentifierHint);
+				dict.LowlevelSetObject (BestGuessTypeIdentifier, kTypeIdentifierHint);
 			if (!ShouldCache)
 				dict.LowlevelSetObject (CFBoolean.FalseHandle, kShouldCache);
 			if (ShouldAllowFloat)

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -696,7 +696,7 @@ namespace Security {
 				dic = new NSMutableDictionary (publicAndPrivateKeyAttrs.GetDictionary ()!);
 			else
 				dic = new NSMutableDictionary ();
-			dic.LowlevelSetObject (type.GetConstant (), SecAttributeKey.Type);
+			dic.LowlevelSetObject ((NSObject) type.GetConstant ()!, SecAttributeKey.Type);
 			dic.LowlevelSetObject (new NSNumber (keySizeInBits), SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 			return GenerateKeyPair (dic, out publicKey, out privateKey);
 #endif
@@ -708,7 +708,7 @@ namespace Security {
 				throw new ArgumentException ("invalid 'SecKeyType'", nameof (type));
 
 			using (var dic = new NSMutableDictionary ()) {
-				dic.LowlevelSetObject (type.GetConstant (), SecAttributeKey.Type);
+				dic.LowlevelSetObject ((NSObject) type.GetConstant ()!, SecAttributeKey.Type);
 				using (var ksib = new NSNumber (keySizeInBits)) {
 					dic.LowlevelSetObject (ksib, SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 					if (publicKeyAttrs is not null)
@@ -1015,7 +1015,7 @@ namespace Security {
 		{
 			using (var ks = new NSNumber (keySizeInBits))
 			using (var md = parameters is null ? new NSMutableDictionary () : new NSMutableDictionary (parameters)) {
-				md.LowlevelSetObject (keyType.GetConstant (), SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
+				md.LowlevelSetObject ((NSObject) keyType.GetConstant ()!, SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
 				md.LowlevelSetObject (ks, SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 				return CreateRandomKey (md, out error);
 			}
@@ -1065,8 +1065,8 @@ namespace Security {
 		{
 			using (var ks = new NSNumber (keySizeInBits))
 			using (var md = parameters is null ? new NSMutableDictionary () : new NSMutableDictionary (parameters)) {
-				md.LowlevelSetObject (keyType.GetConstant (), SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
-				md.LowlevelSetObject (keyClass.GetConstant (), SecAttributeKey.KeyClass);
+				md.LowlevelSetObject ((NSObject) keyType.GetConstant ()!, SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
+				md.LowlevelSetObject ((NSObject) keyClass.GetConstant ()!, SecAttributeKey.KeyClass);
 				md.LowlevelSetObject (ks, SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 				return Create (keyData, md, out error);
 			}


### PR DESCRIPTION
That makes it easier on the caller, e.g. `CGContextPDF`, to avoid
creating short-lived `NSString` instance without requiring a lot
of code.

Downside: it becomes ambiguious if `NSString` is used, e.g.
`SecCertificate` for the compiler to decide between `NSObject` and
`string` overloads (but it's easy to fix and has no other impact).