### PR TITLE
[MetalPerformanceShaders] Adopt XAMCORE_4_0 changes in .NET.

### DIFF
--- a/src/MetalPerformanceShaders/MPSCompat.cs
+++ b/src/MetalPerformanceShaders/MPSCompat.cs
@@ -1,4 +1,4 @@
-#if !XAMCORE_4_0
+#if !NET
 
 using System;
 using Metal;
@@ -6,9 +6,7 @@ using System.Runtime.Versioning;
 
 using ObjCRuntime;
 
-#if !NET
 using NativeHandle = System.IntPtr;
-#endif
 
 namespace MetalPerformanceShaders {
 
@@ -40,26 +38,14 @@ namespace MetalPerformanceShaders {
 	}
 
 	public partial class MPSCnnConvolution {
-#if !NET
 		[TV (11, 0), iOS (11, 0)]
 		[Obsolete ("Always throws 'NotSupportedException' (not a public API).")]
-#else
-		[SupportedOSPlatform ("ios11.0")]
-		[SupportedOSPlatform ("tvos11.0")]
-		[Obsolete ("Always throws 'NotSupportedException' (not a public API).", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 		public virtual void EncodeToCommandBuffer (IMTLCommandBuffer commandBuffer, MPSImage sourceImage, MPSImage destinationImage, out MPSCnnConvolutionState state)
 			=> throw new NotSupportedException ();
 	}
 
-#if !NET
 	[TV (11,0), Mac (10, 13), iOS (11,0)]
 	[Obsolete ("Empty stub (not a public API).")]
-#else
-	[SupportedOSPlatform ("ios11.0")]
-	[SupportedOSPlatform ("tvos11.0")]
-	[Obsolete ("Empty stub (not a public API).", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
 	public partial class MPSCnnConvolutionState : MPSState, IMPSImageSizeEncodingState {
 
 		[Obsolete ("Always throws 'NotSupportedException' (not a public API).")]
@@ -92,4 +78,4 @@ namespace MetalPerformanceShaders {
 	}
 }
 
-#endif
+#endif // !NET

--- a/src/MetalPerformanceShaders/MPSEnums.cs
+++ b/src/MetalPerformanceShaders/MPSEnums.cs
@@ -23,7 +23,7 @@ namespace MetalPerformanceShaders {
 		InsertDebugGroups = 1 << 3,
 		[iOS (11,0), TV (11,0)]
 		Verbose = 1 << 4,
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'AllowReducedPrecision' instead.")]
 		MPSKernelOptionsAllowReducedPrecision = AllowReducedPrecision,
 #endif
@@ -168,7 +168,7 @@ namespace MetalPerformanceShaders {
 		Logarithm,
 		[TV (13,0), Mac (10,15), iOS (13,0)]
 		GeLU,
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("The value changes when newer versions are released. It will be removed in the future.")]
 		Count, // must always be last
 #endif

--- a/src/MetalPerformanceShaders/MPSImageHistogram.cs
+++ b/src/MetalPerformanceShaders/MPSImageHistogram.cs
@@ -1,4 +1,4 @@
-#if !MONOMAC && !XAMCORE_4_0
+#if !MONOMAC && !NET
 using System;
 using Metal;
 using Foundation;

--- a/src/MetalPerformanceShaders/MPSMatrixDescriptor.cs
+++ b/src/MetalPerformanceShaders/MPSMatrixDescriptor.cs
@@ -1,4 +1,4 @@
-#if !MONOMAC && !XAMCORE_4_0 && !__MACCATALYST__
+#if !MONOMAC && !NET && !__MACCATALYST__
 using System;
 using Metal;
 using Foundation;

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -2829,7 +2829,7 @@ namespace MetalPerformanceShaders {
 		[Export ("secondaryKernelHeight")]
 		nuint SecondaryKernelHeight { get; }
 
-#if !XAMCORE_4_0
+#if !NET
 		// Apple answered to radar://38054031 and said that these were exposed by mistake in an older release
 		// and got removed because they are useless and no developers could have used it before.
 		// Keeping stubs for binary compat.


### PR DESCRIPTION
This means removing obsolete/deprecated API.