### PR TITLE
[net][foundation] Simplify `NSObjectFlag`

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -51,11 +51,18 @@ using NativeHandle = System.IntPtr;
 #endif
 
 namespace Foundation {
+
+#if NET
+	public enum NSObjectFlag {
+		Empty,
+	}
+#else
 	public class NSObjectFlag {
 		public static readonly NSObjectFlag Empty;
 		
 		NSObjectFlag () {}
 	}
+#endif
 
 #if NET && !COREBUILD
 	[ObjectiveCTrackedType]


### PR DESCRIPTION
Use an enum (valuetype) instead of a class.