### PR TITLE
ensure PackageType = Template for template packages

### DIFF
--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -49,8 +49,10 @@
     <PackageReference Include="Microsoft.DotNet.Arcade.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
-  <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetSharedFrameworkTaskFile)"/>
+  <!-- do not load this Sdk for template packages -->
+  <!-- it overwrites packageType -->
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" Condition="'$(PackageType)' != 'Template'" />
+  <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetSharedFrameworkTaskFile)" Condition="'$(PackageType)' != 'Template'" />
   <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
 
   <Target Name="_GenerateFrameworkListFile" Condition=" '$(_CreateFrameworkList)' == 'true' Or '$(_CreateRuntimeList)' == 'true' ">


### PR DESCRIPTION
## Problem
Template package does not appear on nuget.org correctly, as `packageType` in nupkg is set to `DotnetPlatform`.

## Solution
Disabled loading Microsoft.DotNet.SharedFramework.Sdk for template package build.
it doesn't seems to be needed and overwrites PackageType to DotnetPlatform, even though initially it is correctly set to 'PackageType'

I would recommend to consider disabling other targets from `common.csproj` that are not needed for template package build.

