### PR TITLE
[release/6.0.2xx-preview13] [CI] Bump the min version of the simulators since Apple remove the old ones.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -215,13 +215,13 @@ DOTNET_MIN_MACCATALYST_SDK_VERSION=13.1
 DOTNET_MIN_MACOS_SDK_VERSION=10.14
 
 # The min simulator version available in the Xcode we're using
-MIN_IOS_SIMULATOR_VERSION=11.4
+MIN_IOS_SIMULATOR_VERSION=12.4
 MIN_WATCHOS_SIMULATOR_VERSION=6.0
 # This is the iOS version that matches the watchOS version (i.e same Xcode)
-MIN_WATCHOS_COMPANION_SIMULATOR_VERSION=12.0
-MIN_TVOS_SIMULATOR_VERSION=11.4
+MIN_WATCHOS_COMPANION_SIMULATOR_VERSION=12.4
+MIN_TVOS_SIMULATOR_VERSION=12.4
 # These are the simulator package ids for the versions above
-EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK11_4 com.apple.pkg.iPhoneSimulatorSDK12_0 com.apple.pkg.AppleTVSimulatorSDK11_4 com.apple.pkg.WatchSimulatorSDK6_0
+EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK12_4 com.apple.pkg.AppleTVSimulatorSDK12_4 com.apple.pkg.WatchSimulatorSDK6_0
 
 INCLUDE_IOS=1
 INCLUDE_MAC=1


### PR DESCRIPTION



Backport of #13906
