### PR TITLE
[Intents] Add missing Xcode13.2 enum value

### DIFF
--- a/src/intents.cs
+++ b/src/intents.cs
@@ -1810,6 +1810,8 @@ namespace Intents {
 		Unknown = 0,
 		NotSubscribed,
 		Subscribed,
+		[Watch (8,3), TV (15,2), NoMac, iOS (15,2), MacCatalyst (15,2)]
+		Voice = 3,
 	}
 
 	[Watch (6,0), TV (14,0), NoMac, iOS (13,0)]


### PR DESCRIPTION
[Intents] Add missing Xcode13.2 enum value

`INMediaUserContextSubscriptionStatusVoice = 3` was added to Intents in Xcode13.2 b1