### PR TITLE
[AVFoundation] Allowing the use of AVMediaTypes and AVCaptureDeviceType

### DIFF
--- a/src/AVFoundation/AVCaptureDeviceDiscoverySession.cs
+++ b/src/AVFoundation/AVCaptureDeviceDiscoverySession.cs
@@ -12,7 +12,7 @@ using Foundation;
 using ObjCRuntime;
 
 namespace AVFoundation {
-#if IOS
+#if IOS && !NET
 	public partial class AVCaptureDeviceDiscoverySession {
 
 		public static AVCaptureDeviceDiscoverySession Create (AVCaptureDeviceType [] deviceTypes, string mediaType, AVCaptureDevicePosition position)

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -10523,10 +10523,16 @@ namespace AVFoundation {
 	[DisableDefaultCtor] // init NS_UNAVAILABLE
 	interface AVCaptureDeviceDiscoverySession {
 
+#if !NET
 		[Internal]
 		[Static]
 		[Export ("discoverySessionWithDeviceTypes:mediaType:position:")]
 		AVCaptureDeviceDiscoverySession _Create (NSArray deviceTypes, [NullAllowed] string mediaType, AVCaptureDevicePosition position);
+#else
+		[Static]
+		[Export ("discoverySessionWithDeviceTypes:mediaType:position:")]
+		AVCaptureDeviceDiscoverySession Create ([BindAs (typeof (AVCaptureDeviceType[]))] NSString[] deviceTypes, [NullAllowed] [BindAs (typeof (AVMediaTypes))] NSString mediaType, AVCaptureDevicePosition position);
+#endif
 
 		[Export ("devices")]
 		AVCaptureDevice [] Devices { get; }


### PR DESCRIPTION
Co-Written by @dalexsoto 

This PR will allow us to use the correct enum types `AVMediaTypes` and `AVCaptureDeviceType`