### PR TITLE
[Foundation/ObjCRuntime] Use 'ObjCException' as the native exception type name for all platforms in .NET. Fixes #13855.

### DIFF
--- a/runtime/product.h
+++ b/runtime/product.h
@@ -31,7 +31,11 @@
   #else
     #error Unknown MONOTOUCH product for dual assembly
   #endif
-	#define PRODUCT_EXCEPTION_TYPE   "MonoTouchException"
+  #if DOTNET
+    #define PRODUCT_EXCEPTION_TYPE   "ObjCException"
+  #else
+    #define PRODUCT_EXCEPTION_TYPE   "MonoTouchException"
+  #endif
 	#ifdef __LP64__
 		#define ARCH_SUBDIR ".monotouch-64"
 	#else

--- a/src/Foundation/MonoTouchException.cs
+++ b/src/Foundation/MonoTouchException.cs
@@ -1,4 +1,4 @@
-#if !MONOMAC
+#if !MONOMAC && !NET
 
 using System;
 using System.Text;
@@ -66,4 +66,4 @@ namespace Foundation {
 	}
 }
 
-#endif // !MONOMAC
+#endif // !MONOMAC && !NET

--- a/src/Foundation/ObjCException.cs
+++ b/src/Foundation/ObjCException.cs
@@ -21,11 +21,20 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if MONOMAC
+#if MONOMAC || NET
 
 using System;
+using System.Text;
 
+using Foundation;
+
+#nullable enable
+
+#if NET
+namespace ObjCRuntime {
+#else
 namespace Foundation {
+#endif
 	public class ObjCException : Exception {
 		NSException native_exc;
 
@@ -39,30 +48,53 @@ namespace Foundation {
 			native_exc = exc;
 		}
 
-		public NSException NSException {
+		public NSException? NSException {
 			get {
 				return native_exc;
 			}
 		}
 
-		public string Reason {
+		public string? Reason {
 			get {
-				return native_exc.Reason;
+				return native_exc?.Reason;
 			}
 		}
 
-		public string Name {
+		public string? Name {
 			get {
-				return native_exc.Name;
+				return native_exc?.Name;
 			}
 		}
 
 		public override string Message {
 			get {
-				return string.Format ("{0}: {1}", Name, Reason);
+				var sb = new StringBuilder ("Objective-C exception thrown.  Name: ").Append (Name);
+				sb.Append (" Reason: ").AppendLine (Reason);
+				sb.AppendLine ("Native stack trace:");
+				AppendNativeStackTrace (sb);
+				return sb.ToString ();
 			}
+		}
+
+		void AppendNativeStackTrace (StringBuilder sb)
+		{
+			if (native_exc is not null) {
+				foreach (var symbol in native_exc.CallStackSymbols)
+					sb.Append ('\t').AppendLine (symbol);
+			}
+		}
+
+		public override string ToString ()
+		{
+			var msg = base.ToString ();
+			if (native_exc is null)
+				return msg;
+
+			var sb = new StringBuilder (msg);
+			AppendNativeStackTrace (sb);
+			return sb.ToString ();
 		}
 	}
 }
 
-#endif // MONOMAC
+#endif // MONOMAC || NET

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -443,7 +443,7 @@ namespace ObjCRuntime {
 
 		static void ThrowNSException (IntPtr ns_exception)
 		{
-#if MONOMAC
+#if MONOMAC || NET
 			throw new ObjCException (new NSException (ns_exception));
 #else
 			throw new MonoTouchException (new NSException (ns_exception));
@@ -459,7 +459,7 @@ namespace ObjCRuntime {
 		static IntPtr CreateNSException (IntPtr ns_exception)
 		{
 			Exception ex;
-#if MONOMAC
+#if MONOMAC || NET
 			ex = new ObjCException (Runtime.GetNSObject<NSException> (ns_exception)!);
 #else
 			ex = new MonoTouchException (Runtime.GetNSObject<NSException> (ns_exception)!);
@@ -476,7 +476,7 @@ namespace ObjCRuntime {
 		static IntPtr UnwrapNSException (IntPtr exc_handle)
 		{
 			var obj = GCHandle.FromIntPtr (exc_handle).Target;
-#if MONOMAC
+#if MONOMAC || NET
 			var exc = obj as ObjCException;
 #else
 			var exc = obj as MonoTouchException;

--- a/tests/monotouch-test/Foundation/BundleTest.cs
+++ b/tests/monotouch-test/Foundation/BundleTest.cs
@@ -107,19 +107,31 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void PathForImageResource ()
 		{
+#if NET
+			Assert.Throws<ObjCException> (() => main.PathForImageResource ("basn3p08.png"));
+#else
 			Assert.Throws<MonoTouchException> (() => main.PathForImageResource ("basn3p08.png"));
+#endif
 		}
 
 		[Test]
 		public void PathForSoundResource ()
 		{
+#if NET
+			Assert.Throws<ObjCException> (() => main.PathForSoundResource ("basn3p08.png"));
+#else
 			Assert.Throws<MonoTouchException> (() => main.PathForSoundResource ("basn3p08.png"));
+#endif
 		}
 
 		[Test]
 		public void LoadNib ()
 		{
+#if NET
+			Assert.Throws<ObjCException> (() => NSBundle.LoadNib (String.Empty, main));
+#else
 			Assert.Throws<MonoTouchException> (() => NSBundle.LoadNib (String.Empty, main));
+#endif
 		}
 #endif
 		[Test]

--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -8,10 +8,14 @@ using RectangleF=CoreGraphics.CGRect;
 using SizeF=CoreGraphics.CGSize;
 using PointF=CoreGraphics.CGPoint;
 
+#if NET
+using PlatformException=ObjCRuntime.ObjCException;
+#else
 #if MONOMAC
 using PlatformException = Foundation.ObjCException;
 #else
 using PlatformException = Foundation.MonoTouchException;
+#endif
 #endif
 
 namespace MonoTouchFixtures.Foundation {

--- a/tests/monotouch-test/Foundation/KeyedUnarchiverTest.cs
+++ b/tests/monotouch-test/Foundation/KeyedUnarchiverTest.cs
@@ -15,10 +15,18 @@ using Foundation;
 using ObjCRuntime;
 #if MONOMAC
 using AppKit;
+#if NET
+using PlatformException=ObjCRuntime.ObjCException;
+#else
 using PlatformException=Foundation.ObjCException;
+#endif
 #else
 using UIKit;
+#if NET
+using PlatformException=ObjCRuntime.ObjCException;
+#else
 using PlatformException=Foundation.MonoTouchException;
+#endif
 #endif
 
 using NUnit.Framework;

--- a/tests/monotouch-test/Foundation/ObjectTest.cs
+++ b/tests/monotouch-test/Foundation/ObjectTest.cs
@@ -18,11 +18,19 @@ using ObjCRuntime;
 using Security;
 #if MONOMAC
 using AppKit;
+#if NET
+using PlatformException=ObjCRuntime.ObjCException;
+#else
 using PlatformException = Foundation.ObjCException;
+#endif
 using UIView = AppKit.NSView;
 #else
 using UIKit;
+#if NET
+using PlatformException=ObjCRuntime.ObjCException;
+#else
 using PlatformException=Foundation.MonoTouchException;
+#endif
 #endif
 using NUnit.Framework;
 using Xamarin.Utils;

--- a/tests/monotouch-test/Foundation/UrlRequestTest.cs
+++ b/tests/monotouch-test/Foundation/UrlRequestTest.cs
@@ -42,7 +42,7 @@ namespace MonoTouchFixtures.Foundation {
 					// In older OSes, the Headers is an instance of a class that's somehow immutable,
 					// even though it's an NSMutableDictionary subclass (specifically __NSCFDictionary).
 					// This feels like a bug that Apple fixed at some point.
-#if __MACOS__
+#if __MACOS__ || NET
 					Assert.Throws<ObjCException> (() => mur.Headers.SetValueForKey (s3, s1));
 #else
 					Assert.Throws<MonoTouchException> (() => mur.Headers.SetValueForKey (s3, s1));

--- a/tests/monotouch-test/HealthKit/CdaDocumentSampleTest.cs
+++ b/tests/monotouch-test/HealthKit/CdaDocumentSampleTest.cs
@@ -11,6 +11,8 @@
 using System;
 
 using Foundation;
+using ObjCRuntime;
+
 using HealthKit;
 using UIKit;
 using NUnit.Framework;
@@ -42,7 +44,11 @@ namespace MonoTouchFixtures.HealthKit {
 #endif
 
 				if (throwsException) {
+#if NET
+					var ex = Assert.Throws<ObjCException> (action, "Exception");
+#else
 					var ex = Assert.Throws<MonoTouchException> (action, "Exception");
+#endif
 					Assert.That (ex.Message, Does.Match ("startDate.*and endDate.*exceed the maximum allowed duration for this sample type"), "Exception Message");
 				} else {
 					action ();

--- a/tests/monotouch-test/MapKit/PolygonTest.cs
+++ b/tests/monotouch-test/MapKit/PolygonTest.cs
@@ -106,7 +106,11 @@ namespace MonoTouchFixtures.MapKit {
 			try {
 				pg.Coordinate = new CLLocationCoordinate2D (10, 20);
 			}
+#if NET
+			catch (ObjCException mte) {
+#else
 			catch (MonoTouchException mte) {
+#endif
 				Assert.True (mte.Message.Contains ("unrecognized selector sent to instance"));
 			}
 			catch {

--- a/tests/monotouch-test/MapKit/PolylineTest.cs
+++ b/tests/monotouch-test/MapKit/PolylineTest.cs
@@ -86,7 +86,11 @@ namespace MonoTouchFixtures.MapKit {
 			try {
 				pl.Coordinate = new CLLocationCoordinate2D (10, 20);
 			}
+#if NET
+			catch (ObjCException mte) {
+#else
 			catch (MonoTouchException mte) {
+#endif
 				Assert.True (mte.Message.Contains ("unrecognized selector sent to instance"));
 			}
 			catch {

--- a/tests/monotouch-test/ObjCRuntime/CategoryTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/CategoryTest.cs
@@ -8,7 +8,11 @@ using System.Threading;
 using Foundation;
 #if !MONOMAC
 using UIKit;
+#if NET
+using NativeException = ObjCRuntime.ObjCException;
+#else
 using NativeException = Foundation.MonoTouchException;
+#endif
 #endif
 using Bindings.Test;
 using ObjCRuntime;

--- a/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
@@ -13,10 +13,14 @@ using Bindings.Test;
 
 using NUnit.Framework;
 
+#if NET
+using ObjCException = ObjCRuntime.ObjCException;
+#else
 #if __MACOS__
 using ObjCException = Foundation.ObjCException;
 #else
 using ObjCException = Foundation.MonoTouchException;
+#endif
 #endif
 
 namespace MonoTouchFixtures.ObjCRuntime {

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -19,11 +19,19 @@ using Foundation;
 using AppKit;
 using UIColor = AppKit.NSColor;
 using PlatformException = ObjCRuntime.RuntimeException;
+#if NET
+using NativeException = ObjCRuntime.ObjCException;
+#else
 using NativeException = Foundation.ObjCException;
+#endif
 #else
 using UIKit;
 using PlatformException = ObjCRuntime.RuntimeException;
+#if NET
+using NativeException = ObjCRuntime.ObjCException;
+#else
 using NativeException = Foundation.MonoTouchException;
+#endif
 #endif
 using ObjCRuntime;
 #if !__TVOS__

--- a/tests/monotouch-test/UIKit/PopoverControllerTest.cs
+++ b/tests/monotouch-test/UIKit/PopoverControllerTest.cs
@@ -55,7 +55,11 @@ namespace MonoTouchFixtures.UIKit {
 				pc.PresentFromBarButtonItem (bbi, UIPopoverArrowDirection.Down, true);
 #else
 				// UIBarButtonItem is itself 'ok' but it's not assigned to a view
+#if NET
+				Assert.Throws<ObjCException> (() => pc.PresentFromBarButtonItem (bbi, UIPopoverArrowDirection.Down, true));
+#else
 				Assert.Throws<MonoTouchException> (() => pc.PresentFromBarButtonItem (bbi, UIPopoverArrowDirection.Down, true));
+#endif
 #endif
 				// fails with:
 				// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -[UIPopoverController presentPopoverFromBarButtonItem:permittedArrowDirections:animated:]: Popovers cannot be presented from a view which does not have a window.
@@ -90,7 +94,11 @@ namespace MonoTouchFixtures.UIKit {
 			using (var bbi = new UIBarButtonItem (UIBarButtonSystemItem.Action))
 			using (var pc = new UIPopoverController (vc)) {
 				// 'vc' has never been shown
+#if NET
+				Assert.Throws<ObjCException> (() => pc.PresentFromRect (new CGRect (10, 10, 100, 100), vc.View, UIPopoverArrowDirection.Down, true));
+#else
 				Assert.Throws<MonoTouchException> (() => pc.PresentFromRect (new CGRect (10, 10, 100, 100), vc.View, UIPopoverArrowDirection.Down, true));
+#endif
 				// fails with:
 				// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -[UIPopoverController presentPopoverFromRect:inView:permittedArrowDirections:animated:]: Popovers cannot be presented from a view which does not have a window.
 			}

--- a/tests/monotouch-test/UIKit/UIDocumentTest.cs
+++ b/tests/monotouch-test/UIKit/UIDocumentTest.cs
@@ -155,7 +155,11 @@ namespace MonoTouchFixtures.UIKit {
 			// interesting limitation
 			using (MyUrl url2 = new MyUrl (file, "my document")) {
 				// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: must pass a valid file URL to -[UIDocument initWithFileURL:]
+#if NET
+				Assert.Throws<ObjCException> (delegate { 
+#else
 				Assert.Throws<MonoTouchException> (delegate { 
+#endif
 					new DocumentPoker (url2);
 				});
 			}

--- a/tests/test-libraries/testgenerator.cs
+++ b/tests/test-libraries/testgenerator.cs
@@ -791,10 +791,14 @@ using Security;
 using UIKit;
 #endif
 using MonoTouchException=ObjCRuntime.RuntimeException;
+#if NET
+using NativeException=ObjCRuntime.ObjCException;
+#else
 #if __MACOS__
 using NativeException=Foundation.ObjCException;
 #else
 using NativeException=Foundation.MonoTouchException;
+#endif
 #endif
 using NUnit.Framework;
 using Bindings.Test;


### PR DESCRIPTION
* Use 'ObjCException' instead of 'MonoTouchException' as the managed exception
  type wrapping an NSException for all platforms in .NET (that was already the
  case for macOS, so no change there).
* Make the ObjCException class behave like the MonoTouchException class does.
* Move the ObjCException type to the ObjCRuntime namespace in .NET.

Fixes https://github.com/xamarin/xamarin-macios/issues/13855.