### PR TITLE
Remove the type forwarders for System.Drawing types in .NET.

### DIFF
--- a/src/System.Drawing/ColorKnownColorTypeForwarders.cs
+++ b/src/System.Drawing/ColorKnownColorTypeForwarders.cs
@@ -1,2 +1,4 @@
+#if !NET
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Drawing.Color))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Drawing.KnownColor))]
+#endif

--- a/src/System.Drawing/PointSizeRectangleTypeForwarders.cs
+++ b/src/System.Drawing/PointSizeRectangleTypeForwarders.cs
@@ -1,6 +1,8 @@
+#if !NET
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Drawing.Point))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Drawing.PointF))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Drawing.Rectangle))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Drawing.RectangleF))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Drawing.Size))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Drawing.SizeF))]
+#endif


### PR DESCRIPTION
Type forwarders are used to move types and be backwards compatible, but we're
not backwards compatible with anything in our first .NET release, so there's
no need for these type forwarders.