### PR TITLE
[CoreAnimation] Adopt XAMCORE_4_0 changes in .NET.

### DIFF
--- a/src/CoreAnimation/CACompat.cs
+++ b/src/CoreAnimation/CACompat.cs
@@ -1,4 +1,4 @@
-#if !XAMCORE_4_0
+#if !NET
 
 using System;
 

--- a/src/CoreAnimation/CAScrollLayer.cs
+++ b/src/CoreAnimation/CAScrollLayer.cs
@@ -1,3 +1,4 @@
+#if !NET
 using System;
 
 using Foundation;
@@ -16,3 +17,4 @@ namespace CoreAnimation {
 		}
 	}
 }
+#endif

--- a/src/CoreAnimation/CATextLayer.cs
+++ b/src/CoreAnimation/CATextLayer.cs
@@ -133,7 +133,7 @@ namespace CoreAnimation {
 				}
 			}
 		}
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'TextTruncationMode' instead.")]
 		public virtual string TruncationMode {
 			get { return (string) WeakTruncationMode; }
@@ -145,7 +145,7 @@ namespace CoreAnimation {
 			get { return (string) WeakAlignmentMode; }
 			set { WeakAlignmentMode = (NSString) value; }
 		}
-#endif // !XAMCORE_4_0
+#endif // !NET
 		public CATextLayerTruncationMode TextTruncationMode {
 			get { return CATextLayerTruncationModeExtensions.GetValue (WeakTruncationMode); }
 			set { WeakTruncationMode = value.GetConstant ()!; }

--- a/src/CoreAnimation/CATransform3D.cs
+++ b/src/CoreAnimation/CATransform3D.cs
@@ -215,7 +215,7 @@ namespace CoreAnimation {
 		[DllImport (Constants.QuartzLibrary)]
 		extern static CATransform3D CATransform3DInvert (CATransform3D t);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use Invert() as the argument to this method is unused.")]
 		public CATransform3D Invert (CATransform3D t)
 		{

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -745,11 +745,21 @@ namespace CoreAnimation {
 		[Export ("layer"), New, Static]
 		CALayer Create ();
 
-#if XAMCORE_4_0
+#if NET
 		[Protected]
-#endif
+		[Export ("scrollMode", ArgumentSemantic.Copy)]
+		NSString WeakScrollMode { get; set; }
+
+		CAScroll ScrollMode {
+			[Wrap ("CAScrollExtensions.GetValue (WeakScrollMode)")]
+			get;
+			[Wrap ("WeakScrollMode = value.GetConstant ()!")]
+			set;
+		}
+#else
 		[Export ("scrollMode", ArgumentSemantic.Copy)]
 		NSString ScrollMode { get; set;  }
+#endif
 
 		[Export ("scrollToPoint:")]
 		void ScrollToPoint (CGPoint p);
@@ -914,7 +924,7 @@ namespace CoreAnimation {
 		[Export ("alignmentMode", ArgumentSemantic.Copy)]
 		NSString WeakAlignmentMode { get; set; }
 
-#if !XAMCORE_4_0 // Use smart enums instead, CATruncationMode and CATextLayerAlignmentMode.
+#if !NET // Use smart enums instead, CATruncationMode and CATextLayerAlignmentMode.
 		[Obsolete ("Use 'CATextLayerTruncationMode.None.GetConstant ()' instead.")]
 		[Static]
 		[Wrap ("CATextLayerTruncationMode.None.GetConstant ()")]
@@ -959,7 +969,7 @@ namespace CoreAnimation {
 		[Static]
 		[Wrap ("CATextLayerAlignmentMode.Justified.GetConstant ()")]
 		NSString AlignmentJustified { get; }
-#endif // !XAMCORE_4_0
+#endif // !NET
 
 		[iOS(9,0)]
 		[Export ("allowsFontSubpixelQuantization")]
@@ -1022,7 +1032,7 @@ namespace CoreAnimation {
 	}
 	
 	[BaseType (typeof (NSObject)
-#if XAMCORE_4_0
+#if NET
 		, Delegates = new string [] {"WeakDelegate"}, Events = new Type [] { typeof (CAAnimationDelegate) }
 #endif
 	)]
@@ -1039,7 +1049,7 @@ namespace CoreAnimation {
 		[Export ("timingFunction", ArgumentSemantic.Strong)]
 		CAMediaTimingFunction TimingFunction { get; set; }
 	
-#if XAMCORE_4_0
+#if NET
 		// before that we need to be wrap this manually to avoid the BI1110 error
 		[Wrap ("WeakDelegate")]
 		ICAAnimationDelegate Delegate { get; set; }
@@ -1088,7 +1098,7 @@ namespace CoreAnimation {
 		[Field ("kCAAnimationLinear")]
 		NSString AnimationLinear { get; }
 				
-#if !XAMCORE_4_0
+#if !NET
 		[Field ("kCAAnimationDiscrete")]
 		[Obsolete ("The name has been fixed, use 'AnimationDiscrete' instead.")]
 		NSString AnimationDescrete { get; }
@@ -1400,11 +1410,11 @@ namespace CoreAnimation {
 		[Export ("endPoint")]
 		CGPoint EndPoint { get; set;  }
 
-#if XAMCORE_4_0
+#if NET
 		CAGradientLayerType LayerType {
 			[Wrap ("CAGradientLayerTypeExtensions.GetValue (WeakLayerType)")]
 			get;
-			[Wrap ("WeakLayerType = value.GetConstant ()")]
+			[Wrap ("WeakLayerType = value.GetConstant ()!")]
 			set;
 		}
 
@@ -1785,7 +1795,7 @@ namespace CoreAnimation {
 // rdar #33590997 was filled - no news
 // 'initWithType:', 'behaviorWithType:' and 'behaviorTypes' API now cause rejection
 // https://trello.com/c/J8BDDUV9/86-33590997-coreanimation-quartzcore-api-removals
-#if !XAMCORE_4_0
+#if !NET
 	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface CAEmitterBehavior : NSSecureCoding {

--- a/tests/monotouch-test/CoreAnimation/CATextLayerTests.cs
+++ b/tests/monotouch-test/CoreAnimation/CATextLayerTests.cs
@@ -30,12 +30,20 @@ namespace MonoTouchFixtures.CoreAnimation {
 			};
 
 			Assert.AreEqual (CATextLayerTruncationMode.Middle, textLayer.TextTruncationMode, "TextTruncationMode");
+#if !NET
 			Assert.AreEqual (textLayer.TruncationMode, (string) textLayer.TextTruncationMode.GetConstant (), "TruncationMode");
+#endif
 
+#if NET
+			textLayer.TextTruncationMode = CATextLayerTruncationMode.End;
+#else
 			textLayer.TruncationMode = CATextLayer.TruncantionEnd;
+#endif
 			Assert.AreEqual (CATextLayerTruncationMode.End, textLayer.TextTruncationMode, "TextTruncationMode 2");
 
+#if !NET
 			Assert.Throws<ArgumentNullException> (() => textLayer.TruncationMode = null);
+#endif
 		}
 
 		[Test]
@@ -47,12 +55,20 @@ namespace MonoTouchFixtures.CoreAnimation {
 			};
 
 			Assert.AreEqual (CATextLayerAlignmentMode.Justified, textLayer.TextAlignmentMode, "TextAlignmentMode");
+#if !NET
 			Assert.AreEqual (textLayer.AlignmentMode, (string) textLayer.TextAlignmentMode.GetConstant (), "AlignmentMode");
+#endif
 
+#if NET
+			textLayer.TextAlignmentMode = CATextLayerAlignmentMode.Natural;
+#else
 			textLayer.AlignmentMode = CATextLayer.AlignmentNatural;
+#endif
 			Assert.AreEqual (CATextLayerAlignmentMode.Natural, textLayer.TextAlignmentMode, "TextAlignmentMode 2");
 
+#if !NET
 			Assert.Throws<ArgumentNullException> (() => textLayer.AlignmentMode = null);
+#endif
 		}
 	}
 }

--- a/tests/monotouch-test/CoreAnimation/EmitterBehaviorTest.cs
+++ b/tests/monotouch-test/CoreAnimation/EmitterBehaviorTest.cs
@@ -7,7 +7,7 @@
 // Copyright 2013 Xamarin Inc. All rights reserved.
 //
 
-#if !__WATCHOS__
+#if !__WATCHOS__ && !NET
 
 using Foundation;
 using CoreAnimation;
@@ -82,4 +82,4 @@ namespace MonoTouchFixtures.CoreAnimation {
 	}
 }
 
-#endif // !__WATCHOS__
+#endif // !__WATCHOS__ && !NET

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-CoreAnimation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-CoreAnimation.ignore
@@ -1,14 +1,3 @@
-## header file removed from the framework umbrella in xcode9
-!unknown-type! CAEmitterBehavior bound
-!unknown-field! kCAEmitterBehaviorAlignToMotion bound
-!unknown-field! kCAEmitterBehaviorAttractor bound
-!unknown-field! kCAEmitterBehaviorColorOverLife bound
-!unknown-field! kCAEmitterBehaviorDrag bound
-!unknown-field! kCAEmitterBehaviorLight bound
-!unknown-field! kCAEmitterBehaviorSimpleAttractor bound
-!unknown-field! kCAEmitterBehaviorValueOverLife bound
-!unknown-field! kCAEmitterBehaviorWave bound
-
 ## helpers built from existing (native) values
 !extra-enum-value! Managed value 12 for CAEdgeAntialiasingMask.TopBottomEdges not found in native headers
 !extra-enum-value! Managed value 15 for CAEdgeAntialiasingMask.All not found in native headers


### PR DESCRIPTION
* Mostly just removal of obsolete/deprecated API.
* Modified CAScrollLayer.ScrollMode to use the good name
  (CAScrollLayer.ScrollMode) for the strongly typed enum, and then have a
  WeakScrollMode property for the NSString version (like we do elsewhere).