### PR TITLE
[dotnet] Convert windows dir separators to mac dir separators for relative paths in the _StripAssemblyIL target. Fixes #13838.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -699,6 +699,14 @@
 				<OutputPath Condition="'%(ResolvedFileToPublish.DestinationSubPath)' != ''">$(_StrippedAssemblyDirectory)\%(ResolvedFileToPublish.DestinationSubPath)</OutputPath>
 				<OutputPath Condition="'%(ResolvedFileToPublish.DestinationSubPath)' == ''">$(_StrippedAssemblyDirectory)\%(Filename)%(Extension)</OutputPath>
 			</_AssembliesToBeStripped>
+
+			<!-- Use forward slashes in OutputPath, otherwise ILStrip will create filenames that resemble the part of
+				 the relative path of the item that uses backslashes, instead of writing the file to the location of the
+				 relative path. -->
+			<_AssembliesToBeStripped>
+				<OutputPath>$([System.String]::Copy('%(OutputPath)').Replace('\', '/'))</OutputPath>
+			</_AssembliesToBeStripped>
+
 			<_AssemblyDirsToCreate Include="@(_AssembliesToBeStripped->'%(OutputPath)%(Directory)'->Distinct())"/>
 		</ItemGroup>
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="@(_AssemblyDirsToCreate)" />


### PR DESCRIPTION
It seems that MSBuild doesn't always automatically convert directory
separators for relative paths, so we have to do it ourselves.

Thanks to @lauxjpn for diagnosing this and coming up with a fix.

Fixes https://github.com/xamarin/xamarin-macios/issues/13838.