### PR TITLE
[ObjCRuntime] Add explicit conversion operators between NativeHandle and void*. Fixes #13867.

### DIFF
--- a/src/ObjCRuntime/NativeHandle.cs
+++ b/src/ObjCRuntime/NativeHandle.cs
@@ -66,6 +66,16 @@ namespace ObjCRuntime {
 			return new NativeHandle (value);
 		}
 
+		public unsafe static explicit operator void* (NativeHandle value)
+		{
+			return (void *) (IntPtr) value;
+		}
+
+		public unsafe static explicit operator NativeHandle (void * value)
+		{
+			return new NativeHandle ((IntPtr) value);
+		}
+
 		public override bool Equals (object? o)
 		{
 			if (o is NativeHandle nh)

--- a/tests/monotouch-test/ObjCRuntime/NativeHandleTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/NativeHandleTest.cs
@@ -1,0 +1,26 @@
+using System;
+
+using Foundation;
+using ObjCRuntime;
+
+using NUnit.Framework;
+
+#if NET
+
+namespace MonoTouchFixtures.ObjCRuntime {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NativeHandleTest {
+		[Test]
+		public unsafe void Operators ()
+		{
+			IntPtr value = new IntPtr (0xdadf00d);
+
+			Assert.AreEqual (value, ((NativeHandle) value).Handle, "IntPtr -> NativeHandle");
+			Assert.AreEqual (value, (IntPtr) new NativeHandle (value), "NativeHandle -> IntPtr");
+			Assert.AreEqual (value, ((NativeHandle) ((void *) value)).Handle, "void* -> NativeHandle");
+			Assert.AreEqual (value, (IntPtr) (void *) new NativeHandle (value), "NativeHandle -> void*");
+		}
+	}
+}
+#endif


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/13867.