### PR TITLE
[objcruntime] Remove private `GetClassHandle`

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -71,7 +71,7 @@ namespace ObjCRuntime {
 
 		public Class (Type type)
 		{
-			this.handle = GetClassHandle (type);
+			this.handle = GetHandle (type);
 		}
 
 		public Class (IntPtr handle)
@@ -145,7 +145,7 @@ namespace ObjCRuntime {
 		}
 
 		public static NativeHandle GetHandle (Type type) {
-			return GetClassHandle (type);
+			return GetClassHandle (type, true, out _);
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)] // To inline the Runtime.DynamicRegistrationSupported code if possible.
@@ -188,11 +188,6 @@ namespace ObjCRuntime {
 			}
 
 			return @class;
-		}
-
-		static IntPtr GetClassHandle (Type type)
-		{
-			return GetClassHandle (type, true, out var is_custom_type);
 		}
 
 		internal static IntPtr GetClassForObject (IntPtr obj)


### PR DESCRIPTION
It's already exposed publicly, by `GetHandle`, so it's an unneeded
extra call (and associated metadata)