### PR TITLE
[objcruntime] Remove `SupportsModernObjectiveC` from the registrar

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -1900,18 +1900,6 @@ namespace Registrar {
 			return objcType;
 		}
 			
-		protected bool SupportsModernObjectiveC {
-			get {
-#if MTOUCH || MONOTOUCH || BUNDLER
-				return true;
-#elif MMP
-				return App.Is64Build;
-#elif MONOMAC
-				return IntPtr.Size == 8;
-#endif
-			}
-		}
-
 		// This method is not thread-safe wrt 'types', and must be called with
 		// a lock held on 'types'.
 		ObjCType RegisterTypeUnsafe (TType type, ref List<Exception> exceptions)
@@ -2104,7 +2092,7 @@ namespace Registrar {
 							DeclaringType = objcType,
 							FieldType = "XamarinObject",// "^v", // void*
 							Name = "__monoObjectGCHandle",
-							IsPrivate = SupportsModernObjectiveC,
+							IsPrivate = true,
 							IsStatic = false,
 						}, ref exceptions);
 					}

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -5020,11 +5020,7 @@ namespace Registrar {
 			}
 
 			header.WriteLine ("#include <stdarg.h>");
-			if (SupportsModernObjectiveC) {
-				methods.WriteLine ("#include <xamarin/xamarin.h>");
-			} else {
-				header.WriteLine ("#include <xamarin/xamarin.h>");
-			}
+			methods.WriteLine ("#include <xamarin/xamarin.h>");
 			header.WriteLine ("#include <objc/objc.h>");
 			header.WriteLine ("#include <objc/runtime.h>");
 			header.WriteLine ("#include <objc/message.h>");


### PR DESCRIPTION
Since 32bits macOS support was dropped this is always `true` so it is not
needed anymore.