### PR TITLE
[foundation] Modernize and simplify NSKeyed[Una|A]rchiver

### DIFF
--- a/src/Foundation/NSKeyedArchiver.cs
+++ b/src/Foundation/NSKeyedArchiver.cs
@@ -32,23 +32,25 @@ namespace Foundation {
 
 		public static void GlobalSetClassName (string name, Class kls)
 		{
-			if (name == null)
-				throw new ArgumentNullException ("name");
-			if (kls == null)
-				throw new ArgumentNullException ("kls");
+			if (name is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
+			if (kls is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (kls));
 
-			var nsname = new NSString (name);
-			ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (class_ptr, Selector.GetHandle ("setClassName:forClass:"), nsname.Handle, kls.Handle);
-			nsname.Dispose ();
+			var ptr = CFString.CreateNative (name);
+			ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (class_ptr, Selector.GetHandle ("setClassName:forClass:"), ptr, kls.Handle);
+			CFString.ReleaseNative (ptr);
 		}
 
 		public static string GlobalGetClassName (Class kls)
 		{
-			if (kls == null)
-				throw new ArgumentNullException ("kls");
+			if (kls is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (kls));
+
 			return CFString.FromHandle (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (class_ptr, Selector.GetHandle ("classNameForClass:"), kls.Handle));
 		}
 
+#if !NET
 		public bool RequiresSecureCoding {
 			get {
 				return GetRequiresSecureCoding ();
@@ -57,5 +59,6 @@ namespace Foundation {
 				SetRequiresSecureCoding (value);
 			}
 		}
+#endif
 	}
 }

--- a/src/Foundation/NSKeyedUnarchiver.cs
+++ b/src/Foundation/NSKeyedUnarchiver.cs
@@ -20,7 +20,6 @@
 //
 // Copyright 2011, 2012 Xamarin Inc
 using System;
-using System.Runtime.InteropServices;
 using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
@@ -31,25 +30,28 @@ namespace Foundation {
 
 		public static void GlobalSetClass (Class kls, string codedName)
 		{
-			if (codedName == null)
-				throw new ArgumentNullException ("codedName");
-			if (kls == null)
-				throw new ArgumentNullException ("kls");
-			
-			using (var nsname = new NSString (codedName))
-				ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (class_ptr, Selector.GetHandle ("setClass:forClassName:"), kls.Handle, nsname.Handle);
+			if (codedName is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (codedName));
+			if (kls is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (kls));
+
+			var ptr = CFString.CreateNative (codedName);
+			ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (class_ptr, Selector.GetHandle ("setClass:forClassName:"), kls.Handle, ptr);
+			CFString.ReleaseNative (ptr);
 		}
 
 		public static Class GlobalGetClass (string codedName)
 		{
-			if (codedName == null)
-				throw new ArgumentNullException ("codedName");
-			using (var nsname = new NSString (codedName))
-				return new Class (
-						ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (
-							class_ptr, Selector.GetHandle ("classForClassName:"), nsname.Handle));
+			if (codedName is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (codedName));
+
+			var ptr = CFString.CreateNative (codedName);
+			var result = new Class (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (class_ptr, Selector.GetHandle ("classForClassName:"), ptr));
+			CFString.ReleaseNative (ptr);
+			return result;
 		}
 
+#if !NET
 		public bool RequiresSecureCoding {
 			get {
 				return GetRequiresSecureCoding ();
@@ -58,6 +60,6 @@ namespace Foundation {
 				SetRequiresSecureCoding (value);
 			}
 		}
-
+#endif
 	}
 }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -2459,11 +2459,16 @@ namespace Foundation
 		[Field ("NSKeyedArchiveRootObjectKey")]
 		NSString RootObjectKey { get; }
 
+#if NET
+		[Export ("requiresSecureCoding")]
+		bool RequiresSecureCoding { get; set; }
+#else
 		[Export ("setRequiresSecureCoding:")]
 		void SetRequiresSecureCoding (bool requireSecureEncoding);
 
 		[Export ("requiresSecureCoding")]
 		bool GetRequiresSecureCoding ();
+#endif
 
 		[Watch (3,0)][TV (10,0)][Mac (10, 12)][iOS (10,0)]
 		[Export ("encodedData", ArgumentSemantic.Strong)]
@@ -2554,12 +2559,16 @@ namespace Foundation
 		[return: NullAllowed]
 		Class GetClass (string codedName);
 
+#if NET
+		[Export ("requiresSecureCoding")]
+		bool RequiresSecureCoding { get; set; }
+#else
 		[Export ("setRequiresSecureCoding:")]
 		void SetRequiresSecureCoding (bool requireSecureEncoding);
 
 		[Export ("requiresSecureCoding")]
 		bool GetRequiresSecureCoding ();
-
+#endif
 
 		[Watch (7,0), TV (14,0), Mac (11,0), iOS (14,0)]
 		[Static]


### PR DESCRIPTION
* Use `is` instead of `==` for null checks
* Use `ThrowHelper` to throw common exceptions
* Use faster `CFString` API (over the slower `NSString` variants)
* Change bindings to generate `RequiresSecureCoding` property without extra manual bindings