### PR TITLE
[src] Fix numerous compiler warnings.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -50,6 +50,7 @@ namespace ObjCRuntime {
 
 		internal const uint INVALID_TOKEN_REF = 0xFFFFFFFF;
 
+#pragma warning disable 649 // Field 'X' is never assigned to, and will always have its default value
 		internal unsafe struct MTRegistrationMap {
 			public IntPtr assembly;
 			public MTClassMap *map;
@@ -64,6 +65,7 @@ namespace ObjCRuntime {
 			public int protocol_wrapper_count;
 			public int protocol_count;
 		}
+#pragma warning restore 649
 
 		[Flags]
 		internal enum MTTypeFlags : uint
@@ -100,6 +102,7 @@ namespace ObjCRuntime {
 		}
 
 		/* Keep Delegates, Trampolines and InitializationOptions in sync with monotouch-glue.m */
+#pragma warning disable 649 // Field 'X' is never assigned to, and will always have its default value
 		internal struct Trampolines {
 			public IntPtr tramp;
 			public IntPtr stret_tramp;
@@ -125,6 +128,7 @@ namespace ObjCRuntime {
 			public IntPtr get_flags_tramp;
 			public IntPtr set_flags_tramp;
 		}
+#pragma warning restore 649
 
 		[Flags]
 		internal enum InitializationFlags : int {


### PR DESCRIPTION
Fixes:

    ObjCRuntime/Runtime.cs(64,15): warning CS0649: Field 'Runtime.MTRegistrationMap.protocol_wrapper_count' is never assigned to, and will always have its default value 0
    ObjCRuntime/Runtime.cs(111,18): warning CS0649: Field 'Runtime.Trampolines.ctor_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(58,33): warning CS0649: Field 'Runtime.MTRegistrationMap.protocol_wrapper_map' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(63,15): warning CS0649: Field 'Runtime.MTRegistrationMap.skipped_map_count' is never assigned to, and will always have its default value 0
    CoreText/CTStringAttributes.cs(104,37): warning CS0649: Field 'CTStringAttributeKey.WritingDirection' is never assigned to, and will always have its default value null
    ObjCRuntime/Runtime.cs(125,18): warning CS0649: Field 'Runtime.Trampolines.get_flags_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(121,18): warning CS0649: Field 'Runtime.Trampolines.copy_with_zone_2' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(61,15): warning CS0649: Field 'Runtime.MTRegistrationMap.map_count' is never assigned to, and will always have its default value 0
    ObjCRuntime/Runtime.cs(117,18): warning CS0649: Field 'Runtime.Trampolines.long_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(56,18): warning CS0649: Field 'Runtime.MTRegistrationMap.full_token_references' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(126,18): warning CS0649: Field 'Runtime.Trampolines.set_flags_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(104,18): warning CS0649: Field 'Runtime.Trampolines.tramp' is never assigned to, and will always have its default value
    CoreText/CTStringAttributes.cs(101,37): warning CS0649: Field 'CTStringAttributeKey.BaselineInfo' is never assigned to, and will always have its default value null
    ObjCRuntime/Runtime.cs(60,15): warning CS0649: Field 'Runtime.MTRegistrationMap.assembly_count' is never assigned to, and will always have its default value 0
    ObjCRuntime/Runtime.cs(116,18): warning CS0649: Field 'Runtime.Trampolines.x86_double_abi_static_stret_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(106,18): warning CS0649: Field 'Runtime.Trampolines.fpret_single_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(105,18): warning CS0649: Field 'Runtime.Trampolines.stret_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(113,18): warning CS0649: Field 'Runtime.Trampolines.static_fpret_single_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(120,18): warning CS0649: Field 'Runtime.Trampolines.copy_with_zone_1' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(62,15): warning CS0649: Field 'Runtime.MTRegistrationMap.full_token_reference_count' is never assigned to, and will always have its default value 0
    ObjCRuntime/Runtime.cs(118,18): warning CS0649: Field 'Runtime.Trampolines.static_long_tramp' is never assigned to, and will always have its default value
    CoreText/CTStringAttributes.cs(102,37): warning CS0649: Field 'CTStringAttributeKey.BaselineReferenceInfo' is never assigned to, and will always have its default value null
    ObjCRuntime/Runtime.cs(59,25): warning CS0649: Field 'Runtime.MTRegistrationMap.protocol_map' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(108,18): warning CS0649: Field 'Runtime.Trampolines.release_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(55,23): warning CS0649: Field 'Runtime.MTRegistrationMap.map' is never assigned to, and will always have its default value
    CoreText/CTStringAttributes.cs(100,37): warning CS0649: Field 'CTStringAttributeKey.BaselineClass' is never assigned to, and will always have its default value null
    ObjCRuntime/Runtime.cs(123,18): warning CS0649: Field 'Runtime.Trampolines.get_gchandle_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(57,30): warning CS0649: Field 'Runtime.MTRegistrationMap.skipped_map' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(65,15): warning CS0649: Field 'Runtime.MTRegistrationMap.protocol_count' is never assigned to, and will always have its default value 0
    ObjCRuntime/Runtime.cs(124,18): warning CS0649: Field 'Runtime.Trampolines.set_gchandle_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(115,18): warning CS0649: Field 'Runtime.Trampolines.static_stret_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(54,18): warning CS0649: Field 'Runtime.MTRegistrationMap.assembly' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(109,18): warning CS0649: Field 'Runtime.Trampolines.retain_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(114,18): warning CS0649: Field 'Runtime.Trampolines.static_fpret_double_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(107,18): warning CS0649: Field 'Runtime.Trampolines.fpret_double_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(110,18): warning CS0649: Field 'Runtime.Trampolines.static_tramp' is never assigned to, and will always have its default value
    ObjCRuntime/Runtime.cs(112,18): warning CS0649: Field 'Runtime.Trampolines.x86_double_abi_stret_tramp' is never assigned to, and will always have its default value