### PR TITLE
[runtime] Don't try to log an exception for GCHandle that has been freed.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2174,12 +2174,14 @@ xamarin_log_marshalled_exceptions ()
 }
 
 void
-xamarin_log_managed_exception (GCHandle handle, MarshalManagedExceptionMode mode)
+xamarin_log_managed_exception (MonoObject *exception, MarshalManagedExceptionMode mode)
 {
 	if (!xamarin_log_marshalled_exceptions ())
 		return;
 
+	GCHandle handle = xamarin_gchandle_new (exception, false);
 	NSLog (@PRODUCT ": Processing managed exception for exception marshalling (mode: %i):\n%@", mode, xamarin_print_all_exceptions (handle));
+	xamarin_gchandle_free (handle);
 }
 
 void
@@ -2291,7 +2293,7 @@ xamarin_process_managed_exception (MonoObject *exception)
 #endif
 	}
 
-	xamarin_log_managed_exception (handle, mode);
+	xamarin_log_managed_exception (exception, mode);
 
 	switch (mode) {
 #if !defined (CORECLR_RUNTIME) // CoreCLR won't unwind through native frames, so we'll have to abort (in the default case statement)

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -260,7 +260,7 @@ MonoException *	xamarin_create_system_invalid_cast_exception (const char *messag
 MonoException *	xamarin_create_system_entry_point_not_found_exception (const char *entrypoint);
 NSString *		xamarin_print_all_exceptions (GCHandle handle);
 bool			xamarin_log_marshalled_exceptions ();
-void			xamarin_log_managed_exception (GCHandle handle, MarshalManagedExceptionMode mode);
+void			xamarin_log_managed_exception (MonoObject *exception, MarshalManagedExceptionMode mode);
 void			xamarin_log_objectivec_exception (NSException *exception, MarshalObjectiveCExceptionMode mode);
 
 id				xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl);


### PR DESCRIPTION
It does exactly what you'd think it does: nothing helpful at all.

Make sure to use a GCHandle that's alive instead.

Output before fix:

    Xamarin.Mac: Processing managed exception for exception marshalling (mode: 2):
    Failed to print exception: System.NullReferenceException: Object reference not set to an instance of an object.
       at ObjCRuntime.Runtime.PrintException(Exception exc, Boolean isInnerException, StringBuilder sb)
       at ObjCRuntime.Runtime.PrintAllExceptions(IntPtr exception_gchandle)

Output after fix:

    Xamarin.Mac: Processing managed exception for exception marshalling (mode: 2):
    Failed to lookup the required marshalling information.
    Additional information:
       Selector: conformsToProtocol:
       Type: ViewController
     (ObjCRuntime.RuntimeException)
    Failed to get the 'this' instance in a method call to templ.ViewController.InvokeConformsToProtocol. (ObjCRuntime.RuntimeException)
       at Registrar.DynamicRegistrar.GetMethodDescriptionAndObject(Type type, IntPtr selector, Boolean is_static, IntPtr obj, IntPtr& mthis, IntPtr desc)
       at ObjCRuntime.Runtime.GetMethodAndObjectForSelector(IntPtr klass, IntPtr sel, Boolean is_static, IntPtr obj, IntPtr& mthis, IntPtr desc)
       at ObjCRuntime.Runtime.get_method_and_object_for_selector(IntPtr cls, IntPtr sel, Boolean is_static, IntPtr obj, IntPtr& mthis, IntPtr desc, IntPtr& exception_gchandle)
    Failed to marshal the Objective-C object 0x7f89e6c2a2a0 (type: ViewController). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'templ.ViewController' does not have a constructor that takes one NativeHandle argument). (ObjCRuntime.RuntimeException)
       at ObjCRuntime.Runtime.MissingCtor(IntPtr ptr, IntPtr klass, Type type, MissingCtorResolution resolution)
       at ObjCRuntime.Runtime.ConstructNSObject[T](IntPtr ptr, Type type, MissingCtorResolution missingCtorResolution)
       at ObjCRuntime.Runtime.ConstructNSObject(IntPtr ptr, IntPtr klass, MissingCtorResolution missingCtorResolution)
       at ObjCRuntime.Runtime.GetNSObject(IntPtr ptr, MissingCtorResolution missingCtorResolution, Boolean evenInFinalizerQueue)
       at Registrar.DynamicRegistrar.GetMethodDescriptionAndObject(Type type, IntPtr selector, Boolean is_static, IntPtr obj, IntPtr& mthis, IntPtr desc)