### PR TITLE
[ObjCRuntime] Improve code to render an exception to avoid a NullReferenceException in case of invalid input.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -517,13 +517,17 @@ namespace ObjCRuntime {
 		{
 			var str = new StringBuilder ();
 			try {
-				var exc = (Exception) GetGCHandleTarget (exception_gchandle)!;
+				var exc = (Exception?) GetGCHandleTarget (exception_gchandle);
 
-				int counter = 0;
-				do {
-					PrintException (exc, counter > 0, str);
-					exc = exc.InnerException;
-				} while (counter < 10 && exc is not null);
+				if (exc is null) {
+					str.Append ($"Unable to print exception handle 0x{exception_gchandle.ToString ("x")}: null exception");
+				} else {
+					int counter = 0;
+					do {
+						PrintException (exc, counter > 0, str);
+						exc = exc.InnerException;
+					} while (counter < 10 && exc is not null);
+				}
 			} catch (Exception exception) {
 				str.Append ("Failed to print exception: ").Append (exception);
 			}


### PR DESCRIPTION
Output before fix:

    Xamarin.Mac: Processing managed exception for exception marshalling (mode: 2):
    Failed to print exception: System.NullReferenceException: Object reference not set to an instance of an object.
       at ObjCRuntime.Runtime.PrintException(Exception exc, Boolean isInnerException, StringBuilder sb)
       at ObjCRuntime.Runtime.PrintAllExceptions(IntPtr exception_gchandle)

Output after fix:

    Xamarin.Mac: Processing managed exception for exception marshalling (mode: 2):
    Unable to print exception handle 0x102ca12b8: null exception

while not much more informative, it's at least not throwing a NullReferenceException that seems unexpected.