### PR TITLE
[release/6.0.2xx-preview13] [dotnet] Fix templates to use NativeHandle instead of IntPtr. Fixes #13979.

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/ApiDefinition.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/ApiDefinition.cs
@@ -62,7 +62,7 @@ namespace MacCatalystBinding1
 // Can be bound as:
 //
 //     [Export ("initWithElmo:")]
-//     IntPtr Constructor (ElmoMuppet elmo);
+//     NativeHandle Constructor (ElmoMuppet elmo);
 //
 // For more information, see https://aka.ms/ios-binding
 //

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/ApiDefinition.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/ApiDefinition.cs
@@ -62,7 +62,7 @@ namespace iOSBinding1
 // Can be bound as:
 //
 //     [Export ("initWithElmo:")]
-//     IntPtr Constructor (ElmoMuppet elmo);
+//     NativeHandle Constructor (ElmoMuppet elmo);
 //
 // For more information, see https://aka.ms/ios-binding
 //

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.cs
@@ -1,7 +1,9 @@
+using ObjCRuntime;
+
 namespace macOSApp1;
 
 public partial class ViewController : NSViewController {
-	public ViewController (IntPtr handle) : base (handle)
+	protected ViewController (NativeHandle handle) : base (handle)
 	{
 	}
 

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.cs
@@ -1,7 +1,9 @@
+using ObjCRuntime;
+
 namespace tvOSApp1;
 
 public partial class ViewController : UIViewController {
-	public ViewController (IntPtr handle) : base (handle)
+	protected ViewController (NativeHandle handle) : base (handle)
 	{
 	}
 }

--- a/tests/dotnet/UnitTests/TemplateTest.cs
+++ b/tests/dotnet/UnitTests/TemplateTest.cs
@@ -11,28 +11,30 @@ using Xamarin.Utils;
 
 namespace Xamarin.Tests {
 	[TestFixture]
-	public class TemplateTest {
+	public class TemplateTest : TestBaseClass {
 		public struct TemplateInfo {
-			public readonly string Platform;
+			public readonly ApplePlatform Platform;
 			public readonly string Template;
 			public readonly bool ValidateSuccessfulBuild;
+			public readonly bool Execute;
 
-			public TemplateInfo (string platform, string template, bool validateSuccessfulBuild = true)
+			public TemplateInfo (ApplePlatform platform, string template, bool validateSuccessfulBuild = true, bool execute = false)
 			{
 				Platform = platform;
 				Template = template;
 				ValidateSuccessfulBuild = validateSuccessfulBuild;
+				Execute = execute;
 			}
 		}
 
 		public static TemplateInfo[] Templates = {
-			new TemplateInfo ("iOS", "ios"),
-			new TemplateInfo ("iOS", "ioslib"),
-			new TemplateInfo ("iOS", "iosbinding", false), // Bindings can not build without a native library assigned
-			new TemplateInfo ("tvOS", "tvos"),
-			new TemplateInfo ("MacCatalyst", "maccatalyst"),
-			new TemplateInfo ("MacCatalyst", "maccatalystbinding", false), // Bindings can not build without a native library assigned
-			new TemplateInfo ("macOS", "macos"),
+			new TemplateInfo (ApplePlatform.iOS, "ios"),
+			new TemplateInfo (ApplePlatform.iOS, "ioslib"),
+			new TemplateInfo (ApplePlatform.iOS, "iosbinding", false), // Bindings can not build without a native library assigned
+			new TemplateInfo (ApplePlatform.TVOS, "tvos"),
+			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalyst", execute: true),
+			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalystbinding", false), // Bindings can not build without a native library assigned
+			new TemplateInfo (ApplePlatform.MacOSX, "macos", execute: true),
 		};
 
 		public class TemplateConfig {
@@ -94,6 +96,36 @@ namespace Xamarin.Tests {
 			var rv = DotNet.AssertBuild (csproj);
 			var warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).Select (v => v.Message);
 			Assert.That (warnings, Is.Empty, $"Build warnings:\n\t{string.Join ("\n\t", warnings)}");
+
+			if (info.Execute) {
+				var platform = info.Platform;
+				var runtimeIdentifiers = GetDefaultRuntimeIdentifier (platform);
+
+				Assert.IsTrue (CanExecute (info.Platform, runtimeIdentifiers), "Must be executable to execute!");
+
+				// First add some code to exit the template if it launches successfully.
+				var mainFile = Path.Combine (outputDir, "Main.cs");
+				var mainContents = File.ReadAllText (mainFile);
+				var exitSampleWithSuccess = @"NSTimer.CreateScheduledTimer (1, (v) => {
+	Console.WriteLine (Environment.GetEnvironmentVariable (""MAGIC_WORD""));
+	Environment.Exit (0);
+			});
+			";
+				var modifiedMainContents = mainContents.Replace ("// This is the main entry point of the application.", exitSampleWithSuccess);
+				Assert.AreNotEqual (modifiedMainContents, mainContents, "Failed to modify the main content");
+				File.WriteAllText (mainFile, modifiedMainContents);
+
+				// Build the sample
+				rv = DotNet.AssertBuild (csproj);
+
+				// There should still not be any warnings
+				warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).Select (v => v.Message);
+				Assert.That (warnings, Is.Empty, $"Build warnings (2):\n\t{string.Join ("\n\t", warnings)}");
+
+				var appPath = GetAppPath (csproj, platform, runtimeIdentifiers);
+				var appExecutable = GetNativeExecutable (platform, appPath);
+				ExecuteWithMagicWordAndAssert (appExecutable);
+			}
 		}
 	}
 }

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -51,6 +51,12 @@ namespace Xamarin.Tests {
 			return rv;
 		}
 
+		protected string GetAppPath (string projectPath, ApplePlatform platform, string runtimeIdentifiers, string configuration = "Debug")
+		{
+			var appPathRuntimeIdentifier = runtimeIdentifiers.IndexOf (';') >= 0 ? "" : runtimeIdentifiers;
+			return Path.Combine (Path.GetDirectoryName (projectPath)!, "bin", configuration, platform.ToFramework (), appPathRuntimeIdentifier, Path.GetFileNameWithoutExtension (projectPath) + ".app");
+		}
+
 		protected string GetDefaultRuntimeIdentifier (ApplePlatform platform)
 		{
 			switch (platform) {


### PR DESCRIPTION
Also make the (NativeHandle) constructor protected instead of public, to make
it clearer that it's not for public consumption.

And modify the template tests to execute the template if we can.

Fixes https://github.com/xamarin/xamarin-macios/issues/13979.


Backport of #14001
