### PR TITLE
[dotnet] Downgrade the linker reference.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,9 +4,9 @@
       <Uri>https://github.com/dotnet/installer</Uri>
       <Sha>e950d071463b02978f13d5324aeadd0eb9a51cfc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.200-1.22069.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-1.21519.4">
       <Uri>https://github.com/dotnet/linker</Uri>
-      <Sha>70dc7f6daaf50e8eb67afb91876b8efc8330103f</Sha>
+      <Sha>d0662ed8db919642177ddfd06a1c33895a69015f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.2-mauipre.1.22074.5">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <!--Package versions-->
   <PropertyGroup>
     <MicrosoftDotnetSdkInternalPackageVersion>6.0.200-rtm.22078.8</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETILLinkTasksPackageVersion>6.0.200-1.22069.1</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>6.0.100-1.21519.4</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETILStripTasksPackageVersion>6.0.0-rc.2.21468.3</MicrosoftNETILStripTasksPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftNETCoreAppRefPackageVersion>


### PR DESCRIPTION
Downgrade the linker reference to use a 6.0.100 version, otherwise we might
end up building dotnet-linker.dll with a reference to illink.dll v6.0.200, and
then (trying to) execute on illink.dll v6.0.100, which fails with the
following unhelpful error:

> error ILLink : error IL1027: Custom step 'Xamarin.SetupStep' could not be found

This occurs because illink.dll v6.0.100 fails to load our custom step assembly
(dotnet-linker.dll) where the 'Xamarin.SetupStep' is, beacuse
dotnet-linker.dll references illink.dll v6.0.200.