### PR TITLE
[dotnet] Ask the linker to not mark copied assemblies if we're in a 'don't link' scenario.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -484,6 +484,7 @@
 				XamarinRuntime=$(_XamarinRuntime)
 			</_CustomLinkerOptions>
 			<_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --custom-data "LinkerOptionsFile=$(_CustomLinkerOptionsFile)"</_ExtraTrimmerArgs>
+			<_ExtraTrimmerArgs Condition="'$(TrimMode)' == 'copy' And '$(MarkCopiedAssemblies)' != 'true'">$(_ExtraTrimmerArgs) --custom-data DisableMarkingOfCopyAssemblies=true</_ExtraTrimmerArgs>
 
 			<!-- Verbose output, so that we get something to stdout when something goes wrong -->
 			<_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --verbose</_ExtraTrimmerArgs>


### PR DESCRIPTION
This speeds up builds significantly when the linker is disabled.

Test case: building tests/dotnet/MySimpleApp for macOS.

* Before: 37s
* After: 9s
* Difference: 26s (4x faster)

Test case: run the .NET tests

* Before: 2h55
* After: 1h43
* Difference: 1h12 (1.7x faster)

Contributes towards https://github.com/xamarin/xamarin-macios/issues/10251.
Ref: https://github.com/dotnet/linker/issues/2089