### PR TITLE
[coreimage] Modernize CIFilter

### DIFF
--- a/src/CoreImage/CIFilter.cs
+++ b/src/CoreImage/CIFilter.cs
@@ -143,61 +143,63 @@ namespace CoreImage {
 
 		public NSObject? this [NSString key] {
 			get {
-				return ValueForKey (key);
+				return ValueForKey (key.GetHandle ());
 			}
 			set {
-				SetValueForKey (value, key);
+				SetValueForKey (value, key.GetHandle ());
 			}
 		}
 
 		internal NSObject? ValueForKey (string key)
 		{
-			using (var nskey = new NSString (key))
-				return ValueForKey (nskey);
+			var ptr = CFString.CreateNative (key);
+			var value = ValueForKey (ptr);
+			CFString.ReleaseNative (ptr);
+			return value;
 		}
 
 		internal void SetValue (string key, NSObject? value)
 		{
-			using (var nskey = new NSString (key)){
-				SetValueForKey (value, nskey);
-			}
+			SetHandle (key, value.GetHandle ());
 		}
 		
 		internal static IntPtr CreateFilter (string name)
 		{
-			using (var nsname = new NSString (name))
-				return ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (class_ptr, Selector.GetHandle ("filterWithName:"), nsname.Handle);
+			var ptr = CFString.CreateNative (name);
+			var result = ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (class_ptr, Selector.GetHandle ("filterWithName:"), ptr);
+			CFString.ReleaseNative (ptr);
+			return result;
 		}
 
 		// helper methods
 		internal void SetFloat (string key, float value)
 		{
-			using (var nskey = new NSString (key))
-				SetValueForKey (new NSNumber (value), nskey);
+			using (var n = new NSNumber (value))
+				SetHandle (key, n.Handle);
 		}
 
 		internal void SetInt (string key, int value)
 		{
-			using (var nskey = new NSString (key))
-				SetValueForKey (new NSNumber (value), nskey);
+			using (var n = new NSNumber (value))
+				SetHandle (key, n.Handle);
 		}
 
 		internal void SetNInt (string key, nint value)
 		{
-			using (var nskey = new NSString (key))
-				SetValueForKey (new NSNumber (value), nskey);
+			using (var n = new NSNumber (value))
+				SetHandle (key, n.Handle);
 		}
 
 		internal void SetNUInt (string key, nuint value)
 		{
-			using (var nskey = new NSString (key))
-				SetValueForKey (new NSNumber (value), nskey);
+			using (var n = new NSNumber (value))
+				SetHandle (key, n.Handle);
 		}
 
 		internal void SetBool (string key, bool value)
 		{
-			using (var nskey = new NSString (key))
-				SetValueForKey (new NSNumber (value ? 1 : 0), nskey);
+			using (var n = new NSNumber (value ? 1 : 0))
+				SetHandle (key, n.Handle);
 		}
 
 		internal void SetString (string key, string value)
@@ -209,25 +211,22 @@ namespace CoreImage {
 
 		internal void SetValue (string key, CGPoint value)
 		{
-			using (var nskey = new NSString (key))
-			using (var nsv = new CIVector (value.X, value.Y)) {
-				SetValueForKey (nsv, nskey);
-			}
+			using (var nsv = new CIVector (value.X, value.Y))
+				SetHandle (key, nsv.Handle);
 		}
 
 		internal void SetValue (string key, CGRect value)
 		{
-			using (var nskey = new NSString (key))
-			using (var nsv = new CIVector (value.X, value.Y, value.Width, value.Height)) {
-				SetValueForKey (nsv, nskey);
-			}
+			using (var nsv = new CIVector (value.X, value.Y, value.Width, value.Height))
+				SetHandle (key, nsv.Handle);
 		}
 
 		internal T? Get<T> (string key) where T : class
 		{
-			using (var nskey = new NSString (key)) {
-				return ValueForKey (nskey) as T;
-			}
+			var ptr = CFString.CreateNative (key);
+			var value = ValueForKey (key) as T;
+			CFString.ReleaseNative (ptr);
+			return value;
 		}
 
 		internal float GetFloat (string key)
@@ -271,7 +270,7 @@ namespace CoreImage {
 
 		internal IntPtr GetHandle (string key)
 		{
-			var nsname = NSString.CreateNative (key);
+			var nsname = CFString.CreateNative (key);
 			IntPtr ret;
 			
 			if (IsDirectBinding) 
@@ -279,7 +278,7 @@ namespace CoreImage {
 			else
 				ret = Messaging.IntPtr_objc_msgSendSuper_IntPtr (SuperHandle, Selector.GetHandle ("valueForKey:"), nsname);
 			
-			NSString.ReleaseNative (nsname);
+			CFString.ReleaseNative (nsname);
 			return ret;
 		}
 		
@@ -731,8 +730,8 @@ namespace CoreImage {
 			}
 			set {
 				if (!SupportsInputImage)
-					throw new ArgumentException ("inputImage is not supported by this filter");
-				SetValueForKey (value, CIFilterInputKey.Image);
+					ObjCRuntime.ThrowHelper.ThrowArgumentException ("inputImage is not supported by this filter");
+				SetValueForKey (value, CIFilterInputKey.Image.GetHandle ());
 			}
 		}
 

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -643,11 +643,11 @@ namespace CoreImage {
 #endif
 
 		[Export ("setValue:forKey:"), Internal]
-		void SetValueForKey ([NullAllowed] NSObject value, NSString key);
+		void SetValueForKey ([NullAllowed] NSObject value, IntPtr key);
 
 		[Export ("valueForKey:"), Internal]
 		[return: NullAllowed]
-		NSObject ValueForKey (NSString key);
+		NSObject ValueForKey (IntPtr key);
 
 		// CIRAWFilter (CIFilter)
 


### PR DESCRIPTION
* Use faster `CFString` API (over the slower `NSString` variants)
* Rework internal API to use handles whenever possible
* Better use (and dispose) of `NSNumber`
* Use `ThrowHelper` to throw common exceptions