### PR TITLE
Link against the Compression framework.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1095,9 +1095,10 @@
 			<!-- CFNetwork is required by xamarin_start_wwan -->
 			<_NativeExecutableFrameworks Include="CFNetwork" Condition="'$(_PlatformName)' == 'iOS'" />
 
-			<!-- Mono requires zlib and iconv -->
+			<!-- Mono requires zlib, iconv, and the "Compression framework" -->
 			<_MainLinkerFlags Include="-lz" />
 			<_MainLinkerFlags Include="-liconv" />
+			<_MainLinkerFlags Include="-lcompression" />
 
 			<!-- Here we must add all the files that should make us (re-)link the executable -->
 			<_LinkNativeExecutableInputs Include="@(_NativeExecutableObjectFiles)" />


### PR DESCRIPTION
Mono will eventually use functions from the Compression framework to
decompress ICU data files during the runtime's initialization. Prepare
for this by linking against the compression framework.

Also see https://developer.apple.com/documentation/compression?language=objc.