### PR TITLE
[AppKit] Use the correct interface for inlining protocols in our api definitions in .NET.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -27176,7 +27176,11 @@ namespace AppKit {
 	[NoMacCatalyst]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
+#if NET
+	interface NSFontAssetRequest : NSProgressReporting
+#else
 	interface NSFontAssetRequest : INSProgressReporting
+#endif
 	{
 		[Export ("initWithFontDescriptors:options:")]
 		[DesignatedInitializer]

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -101,7 +101,6 @@
 !missing-protocol! NSGlyphStorage not bound
 !missing-protocol-conformance! NSCollectionViewItem should conform to NSCollectionViewElement
 !missing-protocol-conformance! NSColorPicker should conform to NSColorPickingDefault
-!missing-protocol-conformance! NSFontAssetRequest should conform to NSProgressReporting
 !missing-protocol-conformance! NSMenu should conform to NSAccessibilityElement
 !missing-protocol-conformance! NSMenuItem should conform to NSAccessibilityElement
 !missing-protocol-conformance! NSPageController should conform to NSAnimatablePropertyContainer


### PR DESCRIPTION
Also update/fix code to show the corresponding warning in the generator, and
make a note of why MKUserLocation/MKAnnotation is special.