### PR TITLE
[CFNetwork] Remove the MessageHandler type from .NET.

### DIFF
--- a/dotnet/BreakingChanges.md
+++ b/dotnet/BreakingChanges.md
@@ -136,3 +136,9 @@ the type `Foundation.ObjCException` (for macOS) have been renamed/moved to
 `ObjCRuntime.ObjCException`. Both types had the exact same functionality: they
 were wrapping a native NSException, and were renamed so that we have identical
 API and behavior on all platforms.
+
+## The type 'CFNetwork.MessageHandler' has been removed.
+
+The type 'CFNetwork.MessageHandler' has been removed. Please use
+'System.Net.Http.CFNetworkHandler' or the more recent
+'Foundation.NSUrlSessionHandler' instead.

--- a/src/CFNetwork/Content.cs
+++ b/src/CFNetwork/Content.cs
@@ -26,6 +26,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#if !NET
+
 using System;
 using System.IO;
 using System.Net;
@@ -140,3 +143,4 @@ namespace CFNetwork {
 		#endregion
 	}
 }
+#endif // !NET

--- a/src/CFNetwork/MessageHandler.cs
+++ b/src/CFNetwork/MessageHandler.cs
@@ -27,6 +27,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#if !NET
+
 using System;
 using System.Net;
 using System.Text.RegularExpressions;
@@ -396,3 +398,4 @@ namespace CFNetwork {
 		}
 	}
 }
+#endif // !NET

--- a/src/CFNetwork/WebRequestStream.cs
+++ b/src/CFNetwork/WebRequestStream.cs
@@ -27,6 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#if !NET
 using System;
 using System.IO;
 using System.Net;
@@ -172,3 +173,4 @@ namespace CFNetwork {
 		}
 	}
 }
+#endif // !NET

--- a/src/CFNetwork/WebResponseStream.cs
+++ b/src/CFNetwork/WebResponseStream.cs
@@ -26,6 +26,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#if !NET
+
 using System;
 using System.IO;
 using System.Net.Http;
@@ -696,3 +699,4 @@ namespace CFNetwork {
 		#endregion
 	}
 }
+#endif // !NET

--- a/src/CFNetwork/WorkerThread.cs
+++ b/src/CFNetwork/WorkerThread.cs
@@ -26,6 +26,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#if !NET
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -234,3 +237,4 @@ namespace CFNetwork {
 		}
 	}
 }
+#endif // !NET


### PR DESCRIPTION
This type has been obsolete for over 3 years, it hasn't been updated in many
more years, and there are multiple newer and better alternatives available.

This meant we could remove a few more other (private/related) types as well.