### PR TITLE
[AppKit] Remove NSImage.DrawInRect in .NET, because it's already implemented as NSImage.Draw.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -9669,10 +9669,13 @@ namespace AppKit {
 		[Export ("template")]
 		bool Template { [Bind ("isTemplate")]get; set; }
 
+#if !NET
+		[Obsolete ("Use 'Draw' instead.")]
 		[NoMacCatalyst]
 		[Export ("drawInRect:fromRect:operation:fraction:")]
 		[Sealed]
 		void DrawInRect (CGRect dstRect, CGRect srcRect, NSCompositingOperation operation, nfloat delta);
+#endif
 
 		[Deprecated (PlatformName.MacOSX, 10, 6, message: "Use DrawInRect with respectContextIsFlipped instead.")]
 		[Export ("flipped")]


### PR DESCRIPTION
There's no need to have two methods doing the exact same thing.