### PR TITLE
[Foundation] Fix signature for NSAttributedString.LowLevelGetAttributes to support no effectiveRange output. Fixes #13569.

### DIFF
--- a/src/Foundation/NSAttributedString.cs
+++ b/src/Foundation/NSAttributedString.cs
@@ -47,6 +47,17 @@ namespace Foundation {
 			return Runtime.GetNSObject<NSDictionary> (LowLevelGetAttributes (location, out effectiveRange));
 		}
 		
+#if NET
+		public IntPtr LowLevelGetAttributes (nint location, out NSRange effectiveRange)
+		{
+			unsafe {
+				fixed (NSRange *effectiveRangePtr = &effectiveRange) {
+					return LowLevelGetAttributes (location, (IntPtr) effectiveRangePtr);
+				}
+			}
+		}
+#endif
+
 		public NSAttributedString (string str, CTStringAttributes attributes)
 			: this (str, attributes != null ? attributes.Dictionary : null)
 		{

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -258,7 +258,11 @@ namespace Foundation
 		IntPtr LowLevelValue { get; }
 
 		[Export ("attributesAtIndex:effectiveRange:")]
+#if NET
+		IntPtr LowLevelGetAttributes (nint location, IntPtr effectiveRange);
+#else
 		IntPtr LowLevelGetAttributes (nint location, out NSRange effectiveRange);
+#endif
 
 		[Export ("length")]
 		nint Length { get; }


### PR DESCRIPTION
This makes it possible to override LowLevelGetAttributes to provide an
implementation, and be called with a NULL effectiveRange pointer.

Fixes https://github.com/xamarin/xamarin-macios/issues/13569.