### PR TITLE
[runtime] Make Runtime.Arch a readonly field in .NET. Fixes #5518.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -521,6 +521,10 @@
 			<!-- If a release build and the app is not extensible (no interpreter or JIT/code-loading for macOS) then the sealer optimization can be used -->
 			<_ExtraTrimmerArgs Condition="'$(_BundlerDebug)' != 'true' And '$(MtouchInterpreter)' == '' And '$(_RunAotCompiler)' == 'true' And '$(_PlatformName)' != 'macOS'">$(_ExtraTrimmerArgs) --enable-opt sealer</_ExtraTrimmerArgs>
 
+			<!-- Set linker feature flags for device/simulator builds -->
+			<_ExtraTrimmerArgs Condition="('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS') And '$(_SdkIsSimulator)' == 'true'">$(_ExtraTrimmerArgs) --feature ObjCRuntime.Runtime.Arch.IsSimulator true</_ExtraTrimmerArgs>
+			<_ExtraTrimmerArgs Condition="('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS') And '$(_SdkIsSimulator)' != 'true'">$(_ExtraTrimmerArgs) --feature ObjCRuntime.Runtime.Arch.IsSimulator false</_ExtraTrimmerArgs>
+
 			<!-- We always want the linker to process debug symbols, even when building in Release mode, because the AOT compiler uses the managed debug symbols to output DWARF debugging symbols -->
 			<TrimmerRemoveSymbols Condition="'$(TrimmerRemoveSymbols)' == ''">false</TrimmerRemoveSymbols>
 

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -3170,6 +3170,18 @@ xamarin_is_managed_exception_marshaling_disabled ()
 #endif
 }
 
+#if DOTNET && (TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH)
+int
+xamarin_get_runtime_arch ()
+{
+	#if TARGET_OS_SIMULATOR
+		return 1;
+	#else
+		return 0;
+	#endif
+}
+#endif // DOTNET && (TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH)
+
 /*
  * XamarinGCHandle
  */

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -220,6 +220,7 @@ bool			xamarin_register_monoassembly (MonoAssembly *assembly, GCHandle *exceptio
 void			xamarin_install_nsautoreleasepool_hooks ();
 void			xamarin_enable_new_refcount ();
 const char * const	xamarin_get_original_working_directory_path ();
+int				xamarin_get_runtime_arch ();
 
 MonoObject *	xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle);
 bool			xamarin_has_managed_ref (id self);

--- a/src/ILLink.Substitutions.ios.xml
+++ b/src/ILLink.Substitutions.ios.xml
@@ -5,6 +5,8 @@
     </type>
     <type fullname="ObjCRuntime.Runtime">
       <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" />
+      <method signature="System.Int32 GetRuntimeArch()" body="stub" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="false" value="0" />
+      <method signature="System.Int32 GetRuntimeArch()" body="stub" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="true" value="1" />
     </type>
     <type fullname="UIKit.UIApplication">
       <method signature="System.Void EnsureEventAndDelegateAreNotMismatched(System.Object,System.Type)" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />

--- a/src/ILLink.Substitutions.tvos.xml
+++ b/src/ILLink.Substitutions.tvos.xml
@@ -5,6 +5,8 @@
     </type>
     <type fullname="ObjCRuntime.Runtime">
       <method signature="System.Boolean get_IsCoreCLR()" body="stub" value="false" />
+      <method signature="System.Int32 GetRuntimeArch()" body="stub" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="false" value="0" />
+      <method signature="System.Int32 GetRuntimeArch()" body="stub" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="true" value="1" />
     </type>
     <type fullname="UIKit.UIApplication">
       <method signature="System.Void EnsureEventAndDelegateAreNotMismatched(System.Object,System.Type)" body="stub" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false" />

--- a/src/ObjCRuntime/Runtime.iOS.cs
+++ b/src/ObjCRuntime/Runtime.iOS.cs
@@ -41,18 +41,37 @@ namespace ObjCRuntime {
 #endif
 
 #if !__MACCATALYST__
+#if NET
+		public readonly static Arch Arch = (Arch) GetRuntimeArch ();
+#else
 		public static Arch Arch; // default: = Arch.DEVICE;
+#endif
 #endif
 
 		unsafe static void InitializePlatform (InitializationOptions* options)
 		{
-#if !__MACCATALYST__
+#if !__MACCATALYST__ && !NET
 			if (options->IsSimulator)
 				Arch = Arch.SIMULATOR;
 #endif
 
 			UIApplication.Initialize ();
 		}
+
+#if NET && !__MACCATALYST__
+		[SuppressGCTransition] // The native function is a single "return <constant>;" so this should be safe.
+		[DllImport ("__Internal")]
+		static extern int xamarin_get_runtime_arch ();
+
+		// The linker will replace the contents of this method with constant return value depending on the circumstances.
+		// The linker will not do that with P/Invokes (https://github.com/dotnet/linker/issues/2586), so
+		// we need an indirection here. The P/Invoke itself will be removed by the linker once the contents
+		// of this method have been replaced with a constant value.
+		static int GetRuntimeArch ()
+		{
+			return xamarin_get_runtime_arch ();
+		}
+#endif
 
 #if !NET
 		// This method is documented to be for diagnostic purposes only,

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -1547,6 +1547,12 @@ namespace Xamarin.Bundler {
 			} else
 				aotArguments.Add ("full");
 
+			if (IsDeviceBuild) {
+				aotArguments.Add ("readonly-value=ObjCRuntime.Runtime.Arch=i4/0");
+			} else if (IsSimulatorBuild) {
+				aotArguments.Add ("readonly-value=ObjCRuntime.Runtime.Arch=i4/1");
+			}
+
 			var aname = Path.GetFileNameWithoutExtension (fname);
 			var sdk_or_product = Profile.IsSdkAssembly (aname) || Profile.IsProductAssembly (aname);
 


### PR DESCRIPTION
* Make Runtime.Arch a readonly field.
* Tell the AOT compiler Runtime.Arch is a constant value.
* Tell the linker to stub out the method we use to fetch the current
  architecture from native code (it turned out a bit complicated to set the
  Arch field when it's readonly - the solution I came up with was to call a
  P/Invoke).

Test case (size of the main executable): link all (debug)

* Before:  33.522.704 bytes
* After:   33.506.112 bytes
* Difference: -16.592 bytes (-0.05 %)

There were no size differences in release mode, nor were there any size
differences in the "don't link" test, neither for debug nor release mode.

Fixes https://github.com/xamarin/xamarin-macios/issues/5518.