### PR TITLE
[AppKit/Foundation] Make the "Color" suffix consistent in NSColor and UIColor properties. Fixes #7945.

### DIFF
--- a/src/AppKit/NSColor.cs
+++ b/src/AppKit/NSColor.cs
@@ -239,14 +239,6 @@ namespace AppKit {
 				return base.ToString ();
 			}
 		}
-
-		[Obsolete ("Use 'UnderPageBackgroundColor' instead.")]
-		public static NSColor UnderPageBackground {
-			get {
-				return UnderPageBackgroundColor;
-			}
-		}
-
 	}
 }
 #endif // !__MACCATALYST__

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -4144,25 +4144,60 @@ namespace AppKit {
 		[Export ("colorWithCIColor:")]
 		NSColor FromCIColor (CIColor color);
 
+#if !NET
+		[Obsolete ("Use 'Label' instead.")]
 		[Mac (10,10)]
 		[Static, Export ("labelColor")]
 		NSColor LabelColor { get; }
+#endif
 
+		[Mac (10,10)]
+		[Static, Export ("labelColor")]
+		NSColor Label { get; }
+
+#if !NET
+		[Obsolete ("Use 'SecondaryLabel' instead.")]
 		[Mac (10,10)]
 		[Static, Export ("secondaryLabelColor")]
 		NSColor SecondaryLabelColor { get; }
+#endif
 
+		[Mac (10,10)]
+		[Static, Export ("secondaryLabelColor")]
+		NSColor SecondaryLabel { get; }
+
+#if !NET
+		[Obsolete ("Use 'TertiaryLabel' instead.")]
 		[Mac (10,10)]
 		[Static, Export ("tertiaryLabelColor")]
 		NSColor TertiaryLabelColor { get; } 
+#endif
 
+		[Mac (10,10)]
+		[Static, Export ("tertiaryLabelColor")]
+		NSColor TertiaryLabel { get; }
+
+#if !NET
+		[Obsolete ("Use 'QuaternaryLabel' instead.")]
 		[Mac (10,10)]
 		[Static, Export ("quaternaryLabelColor")]
 		NSColor QuaternaryLabelColor { get; }
+#endif
 
+		[Mac (10,10)]
+		[Static, Export ("quaternaryLabelColor")]
+		NSColor QuaternaryLabel { get; }
+
+#if !NET
+		[Obsolete ("Use 'Link' instead.")]
 		[Mac (10, 10)]
 		[Static, Export ("linkColor", ArgumentSemantic.Strong)]
 		NSColor LinkColor { get; }
+#endif
+
+		[Mac (10, 10)]
+		[Static, Export ("linkColor", ArgumentSemantic.Strong)]
+		NSColor Link { get; }
 		
 		[Mac (10,12)]
 		[Static]
@@ -4174,10 +4209,18 @@ namespace AppKit {
 		[Export ("colorWithColorSpace:hue:saturation:brightness:alpha:")]
 		NSColor FromColor (NSColorSpace space, nfloat hue, nfloat saturation, nfloat brightness, nfloat alpha);
 
+#if !NET
+		[Obsolete ("Use 'ScrubberTexturedBackground' instead.")]
 		[Mac (10, 12, 2)]
 		[Static]
 		[Export ("scrubberTexturedBackgroundColor", ArgumentSemantic.Strong)]
 		NSColor ScrubberTexturedBackgroundColor { get; }
+#endif
+
+		[Mac (10, 12, 2)]
+		[Static]
+		[Export ("scrubberTexturedBackgroundColor", ArgumentSemantic.Strong)]
+		NSColor ScrubberTexturedBackground { get; }
 
 		[Mac (10,13)]
 		[Static]
@@ -4200,119 +4243,287 @@ namespace AppKit {
 		[return: NullAllowed]
 		NSColor GetColor (NSColorType type);
 
+#if !NET
+		[Obsolete ("Use 'SystemRed' instead.")]
 		[Mac (10, 10)]
 		[Static]
 		[Export ("systemRedColor", ArgumentSemantic.Strong)]
 		NSColor SystemRedColor { get; }
+#endif
 
+		[Mac (10, 10)]
+		[Static]
+		[Export ("systemRedColor", ArgumentSemantic.Strong)]
+		NSColor SystemRed { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemGreen' instead.")]
 		[Mac (10, 10)]
 		[Static]
 		[Export ("systemGreenColor", ArgumentSemantic.Strong)]
 		NSColor SystemGreenColor { get; }
+#endif
 
+		[Mac (10, 10)]
+		[Static]
+		[Export ("systemGreenColor", ArgumentSemantic.Strong)]
+		NSColor SystemGreen { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemBlue' instead.")]
 		[Mac (10, 10)]
 		[Static]
 		[Export ("systemBlueColor", ArgumentSemantic.Strong)]
 		NSColor SystemBlueColor { get; }
+#endif
 
+		[Mac (10, 10)]
+		[Static]
+		[Export ("systemBlueColor", ArgumentSemantic.Strong)]
+		NSColor SystemBlue { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemOrange' instead.")]
 		[Mac (10, 10)]
 		[Static]
 		[Export ("systemOrangeColor", ArgumentSemantic.Strong)]
 		NSColor SystemOrangeColor { get; }
+#endif
 
+		[Mac (10, 10)]
+		[Static]
+		[Export ("systemOrangeColor", ArgumentSemantic.Strong)]
+		NSColor SystemOrange { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemYellow' instead.")]
 		[Mac (10, 10)]
 		[Static]
 		[Export ("systemYellowColor", ArgumentSemantic.Strong)]
 		NSColor SystemYellowColor { get; }
+#endif
 
+		[Mac (10, 10)]
+		[Static]
+		[Export ("systemYellowColor", ArgumentSemantic.Strong)]
+		NSColor SystemYellow { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemBrown' instead.")]
 		[Mac (10, 10)]
 		[Static]
 		[Export ("systemBrownColor", ArgumentSemantic.Strong)]
 		NSColor SystemBrownColor { get; }
+#endif
 
+		[Mac (10, 10)]
+		[Static]
+		[Export ("systemBrownColor", ArgumentSemantic.Strong)]
+		NSColor SystemBrown { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemPink' instead.")]
 		[Mac (10, 10)]
 		[Static]
 		[Export ("systemPinkColor", ArgumentSemantic.Strong)]
 		NSColor SystemPinkColor { get; }
+#endif
 
+		[Mac (10, 10)]
+		[Static]
+		[Export ("systemPinkColor", ArgumentSemantic.Strong)]
+		NSColor SystemPink { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemPurple' instead.")]
 		[Mac (10, 10)]
 		[Static]
 		[Export ("systemPurpleColor", ArgumentSemantic.Strong)]
 		NSColor SystemPurpleColor { get; }
+#endif
 
+		[Mac (10, 10)]
+		[Static]
+		[Export ("systemPurpleColor", ArgumentSemantic.Strong)]
+		NSColor SystemPurple { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemGray' instead.")]
 		[Mac (10, 10)]
 		[Static]
 		[Export ("systemGrayColor", ArgumentSemantic.Strong)]
 		NSColor SystemGrayColor { get; }
+#endif
 
+		[Mac (10, 10)]
+		[Static]
+		[Export ("systemGrayColor", ArgumentSemantic.Strong)]
+		NSColor SystemGray { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemIndigo' instead.")]
 		[Mac (10, 15)]
 		[Static]
 		[Export ("systemIndigoColor", ArgumentSemantic.Strong)]
 		NSColor SystemIndigoColor { get; }
+#endif
 
+		[Mac (10, 15)]
+		[Static]
+		[Export ("systemIndigoColor", ArgumentSemantic.Strong)]
+		NSColor SystemIndigo { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemMint' instead.")]
 		[Mac (10, 12)]
 		[Static]
 		[Export ("systemMintColor", ArgumentSemantic.Strong)]
 		NSColor SystemMintColor { get; }
+#endif
 
+		[Mac (10, 12)]
+		[Static]
+		[Export ("systemMintColor", ArgumentSemantic.Strong)]
+		NSColor SystemMint { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemCyan' instead.")]
 		[Mac (12, 0)]
 		[Static]
 		[Export ("systemCyanColor", ArgumentSemantic.Strong)]
 		NSColor SystemCyanColor { get; }
+#endif
 
+		[Mac (12, 0)]
+		[Static]
+		[Export ("systemCyanColor", ArgumentSemantic.Strong)]
+		NSColor SystemCyan { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemTeal' instead.")]
 		[Mac (10, 12)]
 		[Static]
 		[Export ("systemTealColor", ArgumentSemantic.Strong)]
 		NSColor SystemTealColor { get; }
+#endif
 
+		[Mac (10, 12)]
+		[Static]
+		[Export ("systemTealColor", ArgumentSemantic.Strong)]
+		NSColor SystemTeal { get; }
+
+#if !NET
+		[Obsolete ("Use 'Separator' instead.")]
 		[Mac (10, 14)]
 		[Static]
 		[Export ("separatorColor", ArgumentSemantic.Strong)]
 		NSColor SeparatorColor { get; }
+#endif
 
+		[Mac (10, 14)]
+		[Static]
+		[Export ("separatorColor", ArgumentSemantic.Strong)]
+		NSColor Separator { get; }
+
+#if !NET
+		[Obsolete ("Use 'SelectedContentBackground' instead.")]
 		[Mac (10, 14)]
 		[Static]
 		[Export ("selectedContentBackgroundColor", ArgumentSemantic.Strong)]
 		NSColor SelectedContentBackgroundColor { get; }
+#endif
 
+		[Mac (10, 14)]
+		[Static]
+		[Export ("selectedContentBackgroundColor", ArgumentSemantic.Strong)]
+		NSColor SelectedContentBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'UnemphasizedSelectedContentBackground' instead.")]
 		[Mac (10, 14)]
 		[Static]
 		[Export ("unemphasizedSelectedContentBackgroundColor", ArgumentSemantic.Strong)]
 		NSColor UnemphasizedSelectedContentBackgroundColor { get; }
+#endif
+
+		[Mac (10, 14)]
+		[Static]
+		[Export ("unemphasizedSelectedContentBackgroundColor", ArgumentSemantic.Strong)]
+		NSColor UnemphasizedSelectedContentBackground { get; }
 
 		[Mac (10, 14)]
 		[Static]
 		[Export ("alternatingContentBackgroundColors", ArgumentSemantic.Strong)]
 		NSColor[] AlternatingContentBackgroundColors { get; }
 
+#if !NET
+		[Obsolete ("Use 'UnemphasizedSelectedTextBackground' instead.")]
 		[Mac (10, 14)]
 		[Static]
 		[Export ("unemphasizedSelectedTextBackgroundColor", ArgumentSemantic.Strong)]
 		NSColor UnemphasizedSelectedTextBackgroundColor { get; }
+#endif
 
+		[Mac (10, 14)]
+		[Static]
+		[Export ("unemphasizedSelectedTextBackgroundColor", ArgumentSemantic.Strong)]
+		NSColor UnemphasizedSelectedTextBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'UnemphasizedSelectedText' instead.")]
 		[Mac (10, 14)]
 		[Static]
 		[Export ("unemphasizedSelectedTextColor", ArgumentSemantic.Strong)]
 		NSColor UnemphasizedSelectedTextColor { get; }
+#endif
 
+		[Mac (10, 14)]
+		[Static]
+		[Export ("unemphasizedSelectedTextColor", ArgumentSemantic.Strong)]
+		NSColor UnemphasizedSelectedText { get; }
+
+#if !NET
+		[Obsolete ("Use 'ControlAccent' instead.")]
 		[Mac (10, 14)]
 		[Static]
 		[Export ("controlAccentColor", ArgumentSemantic.Strong)]
 		NSColor ControlAccentColor { get; }
+#endif
+
+		[Mac (10, 14)]
+		[Static]
+		[Export ("controlAccentColor", ArgumentSemantic.Strong)]
+		NSColor ControlAccent { get; }
 
 		[Mac (10,14)]
 		[Export ("colorWithSystemEffect:")]
 		NSColor FromSystemEffect (NSColorSystemEffect systemEffect);
 
+#if !NET
+		[Obsolete ("Use 'FindHighlight' instead.")]
 		[Mac (10, 13)]
 		[Static]
 		[Export ("findHighlightColor", ArgumentSemantic.Strong)]
 		NSColor FindHighlightColor { get; }
+#endif
 
+		[Mac (10, 13)]
+		[Static]
+		[Export ("findHighlightColor", ArgumentSemantic.Strong)]
+		NSColor FindHighlight { get; }
+
+#if !NET
+		[Obsolete ("Use 'PlaceholderText' instead.")]
 		[Mac (10, 10)]
 		[Static]
 		[Export ("placeholderTextColor", ArgumentSemantic.Strong)]
 		NSColor PlaceholderTextColor { get; }
+#endif
+
+		[Mac (10, 10)]
+		[Static]
+		[Export ("placeholderTextColor", ArgumentSemantic.Strong)]
+		NSColor PlaceholderText { get; }
 
 		[Mac (10,15)]
 		[Static]
@@ -23435,8 +23646,14 @@ namespace AppKit {
 	[NoMacCatalyst]
 	partial interface NSColor {
 
+#if !NET
+		[Obsolete ("Use 'UnderPageBackground' instead.")]
 		[Static, Export ("underPageBackgroundColor")]
 		NSColor UnderPageBackgroundColor { get; }
+#endif
+
+		[Static, Export ("underPageBackgroundColor")]
+		NSColor UnderPageBackground { get; }
 
 		[Static, Export ("colorWithCGColor:")]
 		NSColor FromCGColor (CGColor cgColor);

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -4613,35 +4613,82 @@ namespace UIKit {
 		[Export ("CIColor")]
 		CIColor CIColor { get; }
 
+#if !NET
+		[Obsolete ("Use 'LightText' instead.")]
 		[NoWatch][NoTV]
 		[Export ("lightTextColor")]
 		[Static]
 		UIColor LightTextColor { get; }
+#endif
 
+		[NoWatch][NoTV]
+		[Export ("lightTextColor")]
+		[Static]
+		UIColor LightText { get; }
+
+#if !NET
+		[Obsolete ("Use 'DarkText' instead.")]
 		[NoWatch][NoTV]
 		[Export ("darkTextColor")]
 		[Static]
 		UIColor DarkTextColor { get; }
+#endif
 
-		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'SystemGroupedBackgroundColor' instead.")]
+		[NoWatch][NoTV]
+		[Export ("darkTextColor")]
+		[Static]
+		UIColor DarkText { get; }
+
+#if !NET
+		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'SystemGroupedBackground' instead.")]
 		[NoWatch][NoTV]
 		[Export ("groupTableViewBackgroundColor")][Static]
 		UIColor GroupTableViewBackgroundColor { get; }
+#endif
 
+		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'SystemGroupedBackground' instead.")]
+		[NoWatch][NoTV]
+		[Export ("groupTableViewBackgroundColor")][Static]
+		UIColor GroupTableViewBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'ViewFlipsideBackground' instead.")]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[NoWatch][NoTV]
 		[Export ("viewFlipsideBackgroundColor")][Static]
 		UIColor ViewFlipsideBackgroundColor { get; }
+#endif
 
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[NoWatch][NoTV]
+		[Export ("viewFlipsideBackgroundColor")][Static]
+		UIColor ViewFlipsideBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'ScrollViewTexturedBackground' instead.")]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[NoWatch][NoTV]
 		[Export ("scrollViewTexturedBackgroundColor")][Static]
 		UIColor ScrollViewTexturedBackgroundColor { get; }
+#endif
 
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[NoWatch][NoTV]
+		[Export ("scrollViewTexturedBackgroundColor")][Static]
+		UIColor ScrollViewTexturedBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'UnderPageBackground' instead.")]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[NoWatch][NoTV]
 		[Static, Export ("underPageBackgroundColor")]
 		UIColor UnderPageBackgroundColor { get; }
+#endif
+
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[NoWatch][NoTV]
+		[Static, Export ("underPageBackgroundColor")]
+		UIColor UnderPageBackground { get; }
 
 		[NoWatch]
 		[Static, Export ("colorWithCIColor:")]
@@ -4712,190 +4759,486 @@ namespace UIKit {
 		// and adjust accordingly since a lot of those are static properties
 		// that cannot be exposed from a [Category]
 
+#if !NET
+		[Obsolete ("Use 'SystemRed' instead.")]
 		[TV (9,0), NoWatch, iOS (7,0)]
 		[Static]
 		[Export ("systemRedColor")]
 		UIColor SystemRedColor { get; }
+#endif
 
+		[TV (9,0), NoWatch, iOS (7,0)]
+		[Static]
+		[Export ("systemRedColor")]
+		UIColor SystemRed { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemGreen' instead.")]
 		[TV (9,0), NoWatch, iOS (7,0)]
 		[Static]
 		[Export ("systemGreenColor")]
 		UIColor SystemGreenColor { get; }
+#endif
 
+		[TV (9,0), NoWatch, iOS (7,0)]
+		[Static]
+		[Export ("systemGreenColor")]
+		UIColor SystemGreen { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemBlue' instead.")]
 		[TV (9,0), NoWatch, iOS (7,0)]
 		[Static]
 		[Export ("systemBlueColor")]
 		UIColor SystemBlueColor { get; }
+#endif
 
+		[TV (9,0), NoWatch, iOS (7,0)]
+		[Static]
+		[Export ("systemBlueColor")]
+		UIColor SystemBlue { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemOrange' instead.")]
 		[TV (9,0), NoWatch, iOS (7,0)]
 		[Static]
 		[Export ("systemOrangeColor")]
 		UIColor SystemOrangeColor { get; }
+#endif
 
+		[TV (9,0), NoWatch, iOS (7,0)]
+		[Static]
+		[Export ("systemOrangeColor")]
+		UIColor SystemOrange { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemYellow' instead.")]
 		[TV (9,0), NoWatch, iOS (7,0)]
 		[Static]
 		[Export ("systemYellowColor")]
 		UIColor SystemYellowColor { get; }
+#endif
 
+		[TV (9,0), NoWatch, iOS (7,0)]
+		[Static]
+		[Export ("systemYellowColor")]
+		UIColor SystemYellow { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemPink' instead.")]
 		[TV (9,0), NoWatch, iOS (7,0)]
 		[Static]
 		[Export ("systemPinkColor")]
 		UIColor SystemPinkColor { get; }
+#endif
 
+		[TV (9,0), NoWatch, iOS (7,0)]
+		[Static]
+		[Export ("systemPinkColor")]
+		UIColor SystemPink { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemPurple' instead.")]
 		[TV (9,0), NoWatch, iOS (9,0)]
 		[Static]
 		[Export ("systemPurpleColor")]
 		UIColor SystemPurpleColor { get; }
+#endif
 
+		[TV (9,0), NoWatch, iOS (9,0)]
+		[Static]
+		[Export ("systemPurpleColor")]
+		UIColor SystemPurple { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemTeal' instead.")]
 		[TV (9,0), NoWatch, iOS (7,0)]
 		[Static]
 		[Export ("systemTealColor")]
 		UIColor SystemTealColor { get; }
+#endif
 
+		[TV (9,0), NoWatch, iOS (7,0)]
+		[Static]
+		[Export ("systemTealColor")]
+		UIColor SystemTeal { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemIndigo' instead.")]
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Static]
 		[Export ("systemIndigoColor")]
 		UIColor SystemIndigoColor { get; }
+#endif
 
+		[TV (13,0), NoWatch, iOS (13,0)]
+		[Static]
+		[Export ("systemIndigoColor")]
+		UIColor SystemIndigo { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemBrown' instead.")]
 		[TV (15,0), NoWatch, iOS (15,0), MacCatalyst (15,0)]
 		[Static]
 		[Export ("systemBrownColor")]
 		UIColor SystemBrownColor { get; }
+#endif
 
+		[TV (15,0), NoWatch, iOS (15,0), MacCatalyst (15,0)]
+		[Static]
+		[Export ("systemBrownColor")]
+		UIColor SystemBrown { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemMint' instead.")]
 		[TV (15,0), NoWatch, iOS (15,0), MacCatalyst (15,0)]
 		[Static]
 		[Export ("systemMintColor")]
 		UIColor SystemMintColor { get; }
+#endif
 
+		[TV (15,0), NoWatch, iOS (15,0), MacCatalyst (15,0)]
+		[Static]
+		[Export ("systemMintColor")]
+		UIColor SystemMint { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemCyan' instead.")]
 		[TV (15,0), NoWatch, iOS (15,0), MacCatalyst (15,0)]
 		[Static]
 		[Export ("systemCyanColor")]
 		UIColor SystemCyanColor { get; }
+#endif
 
+		[TV (15,0), NoWatch, iOS (15,0), MacCatalyst (15,0)]
+		[Static]
+		[Export ("systemCyanColor")]
+		UIColor SystemCyan { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemGray' instead.")]
 		[TV (9,0), NoWatch, iOS (7,0)]
 		[Static]
 		[Export ("systemGrayColor")]
 		UIColor SystemGrayColor { get; }
+#endif
 
+		[TV (9,0), NoWatch, iOS (7,0)]
+		[Static]
+		[Export ("systemGrayColor")]
+		UIColor SystemGray { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemGray2' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("systemGray2Color")]
 		UIColor SystemGray2Color { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("systemGray2Color")]
+		UIColor SystemGray2 { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemGray3' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("systemGray3Color")]
 		UIColor SystemGray3Color { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("systemGray3Color")]
+		UIColor SystemGray3 { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemGray4' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("systemGray4Color")]
 		UIColor SystemGray4Color { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("systemGray4Color")]
+		UIColor SystemGray4 { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemGray5' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("systemGray5Color")]
 		UIColor SystemGray5Color { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("systemGray5Color")]
+		UIColor SystemGray5 { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemGray6' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("systemGray6Color")]
 		UIColor SystemGray6Color { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("systemGray6Color")]
+		UIColor SystemGray6 { get; }
+
+#if !NET
+		[Obsolete ("Use 'Tint' instead.")]
 		[TV (15,0), NoWatch, iOS (15,0), MacCatalyst (15,0)]
 		[Static]
 		[Export ("tintColor")]
 		UIColor TintColor { get; }
+#endif
 
+		[TV (15,0), NoWatch, iOS (15,0), MacCatalyst (15,0)]
+		[Static]
+		[Export ("tintColor")]
+		UIColor Tint { get; }
+
+#if !NET
+		[Obsolete ("Use 'Label' instead.")]
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Static]
 		[Export ("labelColor")]
 		UIColor LabelColor { get; }
+#endif
 
+		[TV (13,0), NoWatch, iOS (13,0)]
+		[Static]
+		[Export ("labelColor")]
+		UIColor Label { get; }
+
+#if !NET
+		[Obsolete ("Use 'SecondaryLabel' instead.")]
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Static]
 		[Export ("secondaryLabelColor")]
 		UIColor SecondaryLabelColor { get; }
+#endif
 
+		[TV (13,0), NoWatch, iOS (13,0)]
+		[Static]
+		[Export ("secondaryLabelColor")]
+		UIColor SecondaryLabel { get; }
+
+#if !NET
+		[Obsolete ("Use 'TertiaryLabel' instead.")]
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Static]
 		[Export ("tertiaryLabelColor")]
 		UIColor TertiaryLabelColor { get; }
+#endif
 
+		[TV (13,0), NoWatch, iOS (13,0)]
+		[Static]
+		[Export ("tertiaryLabelColor")]
+		UIColor TertiaryLabel { get; }
+
+#if !NET
+		[Obsolete ("Use 'QuaternaryLabel' instead.")]
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Static]
 		[Export ("quaternaryLabelColor")]
 		UIColor QuaternaryLabelColor { get; }
+#endif
 
+		[TV (13,0), NoWatch, iOS (13,0)]
+		[Static]
+		[Export ("quaternaryLabelColor")]
+		UIColor QuaternaryLabel { get; }
+
+#if !NET
+		[Obsolete ("Use 'Link' instead.")]
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Static]
 		[Export ("linkColor")]
 		UIColor LinkColor { get; }
+#endif
 
+		[TV (13,0), NoWatch, iOS (13,0)]
+		[Static]
+		[Export ("linkColor")]
+		UIColor Link { get; }
+
+#if !NET
+		[Obsolete ("Use 'PlaceholderText' instead.")]
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Static]
 		[Export ("placeholderTextColor")]
 		UIColor PlaceholderTextColor { get; }
+#endif
 
+		[TV (13,0), NoWatch, iOS (13,0)]
+		[Static]
+		[Export ("placeholderTextColor")]
+		UIColor PlaceholderText { get; }
+
+#if !NET
+		[Obsolete ("Use 'Separator' instead.")]
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Static]
 		[Export ("separatorColor")]
 		UIColor SeparatorColor { get; }
+#endif
 
+		[TV (13,0), NoWatch, iOS (13,0)]
+		[Static]
+		[Export ("separatorColor")]
+		UIColor Separator { get; }
+
+#if !NET
+		[Obsolete ("Use 'OpaqueSeparator' instead.")]
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Static]
 		[Export ("opaqueSeparatorColor")]
 		UIColor OpaqueSeparatorColor { get; }
+#endif
 
+		[TV (13,0), NoWatch, iOS (13,0)]
+		[Static]
+		[Export ("opaqueSeparatorColor")]
+		UIColor OpaqueSeparator { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemBackground' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("systemBackgroundColor")]
 		UIColor SystemBackgroundColor { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("systemBackgroundColor")]
+		UIColor SystemBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'SecondarySystemBackground' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("secondarySystemBackgroundColor")]
 		UIColor SecondarySystemBackgroundColor { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("secondarySystemBackgroundColor")]
+		UIColor SecondarySystemBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'TertiarySystemBackground' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("tertiarySystemBackgroundColor")]
 		UIColor TertiarySystemBackgroundColor { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("tertiarySystemBackgroundColor")]
+		UIColor TertiarySystemBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemGroupedBackground' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("systemGroupedBackgroundColor")]
 		UIColor SystemGroupedBackgroundColor { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("systemGroupedBackgroundColor")]
+		UIColor SystemGroupedBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'SecondarySystemGroupedBackground' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("secondarySystemGroupedBackgroundColor")]
 		UIColor SecondarySystemGroupedBackgroundColor { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("secondarySystemGroupedBackgroundColor")]
+		UIColor SecondarySystemGroupedBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'TertiarySystemGroupedBackground' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("tertiarySystemGroupedBackgroundColor")]
 		UIColor TertiarySystemGroupedBackgroundColor { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("tertiarySystemGroupedBackgroundColor")]
+		UIColor TertiarySystemGroupedBackground { get; }
+
+#if !NET
+		[Obsolete ("Use 'SystemFill' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("systemFillColor")]
 		UIColor SystemFillColor { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("systemFillColor")]
+		UIColor SystemFill { get; }
+
+#if !NET
+		[Obsolete ("Use 'SecondarySystemFill' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("secondarySystemFillColor")]
 		UIColor SecondarySystemFillColor { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("secondarySystemFillColor")]
+		UIColor SecondarySystemFill { get; }
+
+#if !NET
+		[Obsolete ("Use 'TertiarySystemFill' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("tertiarySystemFillColor")]
 		UIColor TertiarySystemFillColor { get; }
+#endif
 
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("tertiarySystemFillColor")]
+		UIColor TertiarySystemFill { get; }
+
+#if !NET
+		[Obsolete ("Use 'QuaternarySystemFill' instead.")]
 		[NoWatch, NoTV, iOS (13,0)]
 		[Static]
 		[Export ("quaternarySystemFillColor")]
 		UIColor QuaternarySystemFillColor { get; }
+#endif
+
+		[NoWatch, NoTV, iOS (13,0)]
+		[Static]
+		[Export ("quaternarySystemFillColor")]
+		UIColor QuaternarySystemFill { get; }
 
 		// UIColor (UIAccessibility) Category
 

--- a/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
+++ b/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
@@ -76,7 +76,7 @@ namespace MonoTouchFixtures.MapKit {
 				Assert.That (av.PinColor, Is.EqualTo (MKPinAnnotationColor.Red), "PinColor");
 #if MONOMAC
 				if (TestRuntime.CheckSystemVersion (ApplePlatform.MacOSX, 10, 12)) {
-					Assert.That (av.PinTintColor, Is.EqualTo (NSColor.SystemRedColor), "PinTintColor");
+					Assert.That (av.PinTintColor, Is.EqualTo (NSColor.SystemRed), "PinTintColor");
 				} else {
 					Assert.Null (av.PinTintColor, "PinTintColor"); // differs from the other init call
 				}

--- a/tests/monotouch-test/UIKit/ColorTest.cs
+++ b/tests/monotouch-test/UIKit/ColorTest.cs
@@ -98,12 +98,12 @@ namespace MonoTouchFixtures.UIKit {
 			RoundtripHSBA (UIColor.White);
 			RoundtripHSBA (UIColor.Yellow);
 #if !__TVOS__ && !__WATCHOS__
-			RoundtripHSBA (UIColor.DarkTextColor);
-			RoundtripHSBA (UIColor.GroupTableViewBackgroundColor, false);           // unsupported color space
-			RoundtripHSBA (UIColor.LightTextColor);
-			RoundtripHSBA (UIColor.ScrollViewTexturedBackgroundColor, false);       // unsupported color space
-			RoundtripHSBA (UIColor.UnderPageBackgroundColor, false);                        // unsupported color space
-			RoundtripHSBA (UIColor.ViewFlipsideBackgroundColor, false);                     // unsupported color space
+			RoundtripHSBA (UIColor.DarkText);
+			RoundtripHSBA (UIColor.GroupTableViewBackground, false);           // unsupported color space
+			RoundtripHSBA (UIColor.LightText);
+			RoundtripHSBA (UIColor.ScrollViewTexturedBackground, false);       // unsupported color space
+			RoundtripHSBA (UIColor.UnderPageBackground, false);                        // unsupported color space
+			RoundtripHSBA (UIColor.ViewFlipsideBackground, false);                     // unsupported color space
 #endif
 #if false
 			for (int r = 0; r < 256; r++) {
@@ -152,7 +152,7 @@ namespace MonoTouchFixtures.UIKit {
 			RoundtripHSB (UIColor.Cyan);
 			RoundtripHSB (UIColor.DarkGray);
 #if !__TVOS__ && !__WATCHOS__
-			RoundtripHSB (UIColor.DarkTextColor);
+			RoundtripHSB (UIColor.DarkText);
 #endif
 			RoundtripHSB (UIColor.Gray);
 			RoundtripHSB (UIColor.Green);
@@ -188,7 +188,7 @@ namespace MonoTouchFixtures.UIKit {
 			RoundtripRGBA (UIColor.Cyan);
 			RoundtripRGBA (UIColor.DarkGray);
 #if !__TVOS__ && !__WATCHOS__
-			RoundtripRGBA (UIColor.DarkTextColor);
+			RoundtripRGBA (UIColor.DarkText);
 #endif
 			RoundtripRGBA (UIColor.Gray);
 			RoundtripRGBA (UIColor.Green);
@@ -225,7 +225,7 @@ namespace MonoTouchFixtures.UIKit {
 			RoundtripRGB (UIColor.Cyan);
 			RoundtripRGB (UIColor.DarkGray);
 #if !__TVOS__ && !__WATCHOS__
-			RoundtripRGB (UIColor.DarkTextColor);
+			RoundtripRGB (UIColor.DarkText);
 #endif
 			RoundtripRGB (UIColor.Gray);
 			RoundtripRGB (UIColor.Green);
@@ -269,7 +269,7 @@ namespace MonoTouchFixtures.UIKit {
 			RoundtripConstructorRGB (UIColor.Cyan);
 			RoundtripConstructorRGB (UIColor.DarkGray);
 #if !__TVOS__ && !__WATCHOS__
-			RoundtripConstructorRGB (UIColor.DarkTextColor);
+			RoundtripConstructorRGB (UIColor.DarkText);
 #endif
 			RoundtripConstructorRGB (UIColor.Gray);
 			RoundtripConstructorRGB (UIColor.Green);


### PR DESCRIPTION
Make the "Color" suffix consistent in NSColor and UIColor properties (by
removing the "Color" suffix for all such properties).

_We could also add the "Color" suffix everywhere, which matches Apple's Objective-C naming. We could also do what Swift does, which is not being consistent, some colors have "Color" suffix in Swift, some don't_

Fixes https://github.com/xamarin/xamarin-macios/issues/7945.