### PR TITLE
Implement IEquatable<T> on NSRange

### DIFF
--- a/src/Foundation/NSRange.cs
+++ b/src/Foundation/NSRange.cs
@@ -53,7 +53,7 @@ namespace Foundation {
 
 		public override string ToString ()
 		{
-			return String.Format ("[Location={0},Length={1}]", Location, Length);
+			return string.Format ("[Location={0},Length={1}]", Location, Length);
 		}
 	}
 }

--- a/src/Foundation/NSRange.cs
+++ b/src/Foundation/NSRange.cs
@@ -36,17 +36,17 @@ namespace Foundation {
 			Length = len;
 		}
 
-		public override int GetHashCode()
+		public override int GetHashCode ()
 		{
-			return HashCode.Combine(Location, Length);
+			return HashCode.Combine (Location, Length);
 		}
 		
-		public override bool Equals(object obj)
+		public override bool Equals (object obj)
 		{
-			return obj is NSRange other && Equals(other);
+			return obj is NSRange other && Equals (other);
 		}
 		
-		public bool Equals(NSRange other)
+		public bool Equals (NSRange other)
 		{
 			return Location == other.Location && Length == other.Length;
 		}

--- a/src/Foundation/NSRange.cs
+++ b/src/Foundation/NSRange.cs
@@ -46,7 +46,7 @@ namespace Foundation {
 			return obj is NSRange other && Equals(other);
 		}
 		
-		public override bool Equals(NSRange other)
+		public bool Equals(NSRange other)
 		{
 			return Location == other.Location && Length == other.Length;
 		}

--- a/src/Foundation/NSRange.cs
+++ b/src/Foundation/NSRange.cs
@@ -24,7 +24,7 @@
 using System;
 
 namespace Foundation {
-	public struct NSRange {
+	public struct NSRange : IEquatable<NSRange> {
 		public nint Location;
 		public nint Length;
 
@@ -34,6 +34,21 @@ namespace Foundation {
 		{
 			Location = start;
 			Length = len;
+		}
+
+		public override int GetHashCode()
+		{
+			return HashCode.Combine(Location, Length);
+		}
+		
+		public override bool Equals(object obj)
+		{
+			return obj is NSRange other && Equals(other);
+		}
+		
+		public override bool Equals(NSRange other)
+		{
+			return Location == other.Location && Length == other.Length;
 		}
 
 		public override string ToString ()

--- a/tests/monotouch-test/Foundation/NSRangeTest.cs
+++ b/tests/monotouch-test/Foundation/NSRangeTest.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Runtime.InteropServices;
+
+using NUnit.Framework;
+
+using Foundation;
+using ObjCRuntime;
+using Xamarin.Utils;
+
+namespace MonoTouchFixtures.Foundation {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NSRangeTest {
+
+		// Validates the NSRange IEquatable implementation
+		[TestCase (1, 1, 1, 1, true)]
+		[TestCase (2, 1, 1, 1, false)]
+		[TestCase (1, 2, 1, 1, false)]
+		[TestCase (1, 1, 2, 1, false)]
+		[TestCase (1, 1, 1, 2, false)]
+		public void IEquatableImplementation (int start1, int len1, int start2, int len2, bool expected)
+		{
+			var left = new NSRange (start1, len1);
+			var right = new NSRange (start2, len2);
+
+			Assert.AreEqual (expected, left.Equals (right));
+
+			if (expected) {
+				Assert.AreEqual (left.GetHashCode (), right.GetHashCode ());
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
Where should tests for this live?

This avoids poor performance of GetHashCode and Equals that are used for the struct using reflection on the first field.