### PR TITLE
[objcruntime] Reduce duplication for `GetCheckedHandle` and fix it/them

### DIFF
--- a/src/ObjCRuntime/DisposableObject.cs
+++ b/src/ObjCRuntime/DisposableObject.cs
@@ -91,9 +91,10 @@ namespace ObjCRuntime {
 
 		public NativeHandle GetCheckedHandle ()
 		{
-			if (handle == NativeHandle.Zero)
+			var h = handle;
+			if (h == NativeHandle.Zero)
 				ObjCRuntime.ThrowHelper.ThrowObjectDisposedException (this);
-			return handle;
+			return h;
 		}
 
 #if NET

--- a/src/ObjCRuntime/INativeObject.cs
+++ b/src/ObjCRuntime/INativeObject.cs
@@ -31,18 +31,21 @@ namespace ObjCRuntime {
 		{
 			if (self is null)
 				ThrowHelper.ThrowArgumentNullException (argumentName);
-			if (self.Handle == IntPtr.Zero)
+			if (self.Handle == NativeHandle.Zero)
 				ThrowHelper.ThrowObjectDisposedException (self);
 			return self.Handle;
 		}
 
-		public static IntPtr GetCheckedHandle (this INativeObject self)
+#if !NET
+		public static NativeHandle GetCheckedHandle (this INativeObject self)
 		{
-			if (self.Handle == IntPtr.Zero)
+			var h = self.Handle;
+			if (h == NativeHandle.Zero)
 				ObjCRuntime.ThrowHelper.ThrowObjectDisposedException (self);
 
-			return self.Handle;
+			return h;
 		}
+#endif
 	}
 #endif
 }


### PR DESCRIPTION
Not sure why it was added to `DisposableObject` but it seems the compiler
is not happy to use the extension method for the `NativeObject` subclass
even if it implement `INativeObject` (that might be the reason why?)

So remove it from `NativeObjectExtensions` for .net - as I guess it's too
late to remove from the recent `DisposableObject` in legacy.

The platform assemblies only use it for `NativeObject` subclass so it's
not an big issue... as I assume there's not many `INativeObject` user
code that does not use (or should be using) `NativeObject`.

Fix 1: avoid using `IntPtr` when `NativeHandle` is defined since the
compiler will add (not really needed) implicit conversions everywhere.

Fix 2: ensure the spirit/contract of `GetCheckedHandle` always work.

IOW the goal of `GetCheckedHandle` is to ensure you never get a `nil`
handle, since some native API will crash if they given `nil`

However it's still currently possible, with multithreaded code, to get
a `Zero` value from `GetCheckedHandle`.

From a quick look at the C# code it seems fine. It's easier to see the
problem looking at the IL.

```il
.method public hidebysig
	instance valuetype ObjCRuntime.NativeHandle GetCheckedHandle () cil managed
{
	// Method begins at RVA 0x6c8c
	// Header size: 1
	// Code size: 31 (0x1f)
	.maxstack 8

	IL_0000: ldarg.0
	IL_0001: ldfld valuetype ObjCRuntime.NativeHandle ObjCRuntime.DisposableObject::handle
	IL_0006: ldsfld valuetype ObjCRuntime.NativeHandle ObjCRuntime.NativeHandle::Zero
	IL_000b: call bool ObjCRuntime.NativeHandle::op_Equality(valuetype ObjCRuntime.NativeHandle, valuetype ObjCRuntime.NativeHandle)
	IL_0010: brfalse.s IL_0018

	IL_0012: ldarg.0
	IL_0013: call void ObjCRuntime.ThrowHelper::ThrowObjectDisposedException(object)

	IL_0018: ldarg.0
	IL_0019: ldfld valuetype ObjCRuntime.NativeHandle ObjCRuntime.DisposableObject::handle
	IL_001e: ret
} // end of method DisposableObject::GetCheckedHandle
```

`IL_0001` loads the field and then `IL_006` compares it to `Zero`.

If it's not `Zero` then `IL_0019` loads the field **again** before
returning it `IL_0001e` to the caller.

So if another thread sets the `handle` of this instance to `Zero` between
the two `ldfld` instructions then the caller will get `Zero` and this can
crash the application. Of course what will happen if you use the _old_
handle is _somewhat_ undefined and depends if the native object still
exists. There's a **very** good chance it does it the managed object i
running (so it has not been collected).