### PR TITLE
[MetalPerformanceShaders] Make MPSCnnConvolutionDataSource.Load a method in .NET. Fixes #6530.

### DIFF
--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -5541,7 +5541,11 @@ namespace MetalPerformanceShaders {
 
 		[Abstract]
 		[Export ("load")]
+#if NET
+		bool Load ();
+#else
 		bool Load { get; }
+#endif
 
 		[Abstract]
 		[Export ("purge")]


### PR DESCRIPTION
That's also how Swift defines it.

Fixes https://github.com/xamarin/xamarin-macios/issues/6530.