### PR TITLE
[Foundation] Make NSSecureCoding a static class in .NET.

### DIFF
--- a/src/Foundation/NSSecureCoding.cs
+++ b/src/Foundation/NSSecureCoding.cs
@@ -7,10 +7,11 @@ using ObjCRuntime;
 
 namespace Foundation {
 
-#if XAMCORE_4_0
-	static
-#endif
+#if NET
+	public static partial class NSSecureCoding {
+#else
 	public partial class NSSecureCoding {
+#endif
 
 		const string selConformsToProtocol = "conformsToProtocol:";
 		const string selSupportsSecureCoding = "supportsSecureCoding";


### PR DESCRIPTION
It represents a protocol, so it doesn't need to be instantiated.