### PR TITLE
[Foundation] Remove a WebKit workaround for NSProxy on tvOS in .NET.

### DIFF
--- a/src/Foundation/NSProxy.cs
+++ b/src/Foundation/NSProxy.cs
@@ -26,7 +26,7 @@ namespace Foundation {
 	}
 }
 
-#if !XAMCORE_4_0 || (__IOS__ || __MACOS__)
+#if !NET || (__IOS__ || __MACOS__)
 namespace WebKit {
 	// We need to keep NSProxy if WKNavigationDelegate or IWKNavigationDelegate are used
 	// This cannot be done on an interface but the protocol won't be used without a WKWebView

--- a/tests/introspection/ApiFrameworkTest.cs
+++ b/tests/introspection/ApiFrameworkTest.cs
@@ -60,12 +60,12 @@ namespace Introspection {
 			case "WatchKit": // Apple removed WatchKit from iOS
 #endif
 				return true;
-#elif __TVOS__ && !XAMCORE_4_0
+#elif __TVOS__ && !NET
 			// mistakes (can't be fixed without breaking binary compatibility)
 			case "CoreSpotlight":
 			case "WebKit":
 				return true;
-#elif __WATCHOS__ && !XAMCORE_4_0
+#elif __WATCHOS__ && !NET
 			// helpers (largely enums) for AVFoundation API - no p/invokes or obj-C API that requires native linking
 			case "AudioToolbox":
 				return true;

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -50,7 +50,9 @@ using UIKit;
 #if !__WATCHOS__ && !__MACCATALYST__ && !__MACOS__
 using OpenGLES;
 #endif
+#if !(__TVOS__ && NET)
 using WebKit;
+#endif
 using NUnit.Framework;
 using MonoTests.System.Net.Http;
 using Xamarin.Utils;

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -45,7 +45,9 @@ using CoreLocation;
 #if !__TVOS__
 using Contacts;
 #endif
+#if !(__TVOS__ && NET)
 using WebKit;
+#endif
 using OpenTK;
 using NUnit.Framework;
 using Bindings.Test;


### PR DESCRIPTION
The WebKit framework doesn't exist on tvOS.