### PR TITLE
[JavaScriptCore] Bind JSValue.ToArray as NSArray in .NET. Fixes #12549.

### DIFF
--- a/src/javascriptcore.cs
+++ b/src/javascriptcore.cs
@@ -177,7 +177,11 @@ namespace JavaScriptCore {
 		NSDate ToDate ();
 
 		[Export ("toArray")]
+#if NET
+		NSArray ToArray ();
+#else
 		JSValue [] ToArray ();
+#endif
 
 		[Export ("toDictionary")]
 		NSDictionary ToDictionary ();

--- a/tests/monotouch-test/JavascriptCore/ValueTest.cs
+++ b/tests/monotouch-test/JavascriptCore/ValueTest.cs
@@ -92,6 +92,21 @@ namespace MonoTouchFixtures.JavascriptCore {
 			}
 
 		}
+
+#if NET
+		[Test]
+		public void ToArray ()
+		{
+			TestRuntime.AssertXcodeVersion (11,0);
+
+			using var context = new JSContext ();
+			using var array = NSArray.FromStrings ("a", "b");
+			using var value = JSValue.From (array, context);
+			using var arr2 = value.ToArray ();
+			Assert.AreEqual ("a", arr2.GetItem<NSString> (0).ToString (), "a");
+			Assert.AreEqual ("b", arr2.GetItem<NSString> (1).ToString (), "a");
+		}
+#endif
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/12549.