### PR TITLE
[tools] Remove XAMCORE_4_0 condition in linker source.

### DIFF
--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -356,8 +356,6 @@ namespace Xamarin.Bundler {
 				Console.WriteLine (format);
 		}
 
-		public const bool IsXAMCORE_4_0 = false;
-
 		public static bool IsDotNet {
 			get { return TargetFramework.IsDotNet; }
 		}

--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -168,7 +168,7 @@ namespace Xamarin.Linker {
 					break;
 				}
 
-				if (!Driver.IsXAMCORE_4_0 && tr.Is ("System.Runtime.CompilerServices", "CompilerGeneratedAttribute")) {
+				if (tr.Is ("System.Runtime.CompilerServices", "CompilerGeneratedAttribute")) {
 #if DEBUG
 					Console.WriteLine ("Assembly {0} : processing", assembly);
 #endif
@@ -725,7 +725,7 @@ namespace Xamarin.Linker {
 
 			if (method.IsBindingImplOptimizableCode (LinkContext)) {
 				// We optimize all methods that have the [BindingImpl (BindingImplAttributes.Optimizable)] attribute.
-			} else if (!Driver.IsXAMCORE_4_0 && (method.IsGeneratedCode (LinkContext) && (
+			} else if ((method.IsGeneratedCode (LinkContext) && (
 #if NET
 				GetIsExtensionType (method.DeclaringType)
 #else

--- a/tools/linker/MobileExtensions.cs
+++ b/tools/linker/MobileExtensions.cs
@@ -132,7 +132,7 @@ namespace Xamarin.Linker {
 			if (IsBindingImplOptimizableCode (self, link_context))
 				return true;
 
-			if (!Driver.IsXAMCORE_4_0 && IsGeneratedCode (self, link_context))
+			if (IsGeneratedCode (self, link_context))
 				return true;
 
 			return false;


### PR DESCRIPTION
Thinks are working fine as-is (with this XAMCORE_4_0 variable set to false),
and I see no particular reason in the code to change it, nor does the original
implementation explain much (b2bcad7a947d502db1355f017966a897966c9bb1).

So just remove this XAMCORE_4_0 condition as if it had never existed.