### PR TITLE
[generator] Make sure to not have dead code. Fixes a few compiler warnings.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -911,7 +911,7 @@ public partial class Generator : IMemberGatherer {
 		get {
 #if NET
 			return 4;
-#endif
+#else
 			switch (CurrentPlatform) {
 			case PlatformName.MacOSX:
 			case PlatformName.iOS:
@@ -922,6 +922,7 @@ public partial class Generator : IMemberGatherer {
 			default:
 				return 4;
 			}
+#endif
 		}
 	}
 	Type [] types, strong_dictionaries;


### PR DESCRIPTION
Fixes:

    src/generator.cs(915,4): warning CS0162: Unreachable code detected
    src/generator.cs(918,5): warning CS0162: Unreachable code detected
    src/generator.cs(921,5): warning CS0162: Unreachable code detected
    src/generator.cs(923,5): warning CS0162: Unreachable code detected