### PR TITLE
[msbuild] Make sure to set 'ResolveAssemblyConflicts=true' before importing Microsoft.CSharp.targets. Fixes #11691.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.AppExtension.CSharp.targets
@@ -24,6 +24,10 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<!-- This must be set before importing Microsoft.CSharp.targets -->
 		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.CSharp.targets
@@ -21,6 +21,10 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<PropertyGroup>
 		<!-- Version/fx properties -->
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkIdentifier)' == '' And '$(TargetFrameworkVersion)' == ''">v4.5</TargetFrameworkVersion>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.FSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.FSharp.targets
@@ -19,6 +19,10 @@
 		     remove this -->
 		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
 		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	    <Import Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -18,9 +18,13 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
 	
-	<!-- This is used to set that we're a binding project. It must be set before including Xamarin.Shared.props -->
 	<PropertyGroup>
+		<!-- This is used to set that we're a binding project. It must be set before including Xamarin.Shared.props -->
 		<IsBindingProject>true</IsBindingProject>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<!-- Due to IDE/template bugs, many bindings projects exist in the wild without correct TFI/TFV tags.

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
@@ -25,6 +25,10 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<!-- This must be set before importing Microsoft.CSharp.targets -->
 		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.Common.targets
@@ -20,6 +20,10 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 
 		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.TVOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
@@ -31,6 +31,10 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		     remove this -->
 		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
 		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<Import Project="Xamarin.TVOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.CSharp.targets
@@ -21,6 +21,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.FSharp.targets
@@ -27,6 +27,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		     remove this -->
 		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
 		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.CSharp.targets
@@ -21,6 +21,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.WatchOS.App.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.FSharp.targets
@@ -27,6 +27,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		     remove this -->
 		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
 		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
@@ -25,6 +25,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- This must be set before importing Microsoft.CSharp.targets -->
 		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.WatchOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
@@ -24,6 +24,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- This must be set before importing Microsoft.CSharp.targets -->
 		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)..\iOS\Xamarin.iOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
@@ -31,6 +31,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		     remove this -->
 		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
 		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.CSharp.targets
@@ -21,6 +21,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.WatchOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.FSharp.targets
@@ -27,6 +27,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		     remove this -->
 		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
 		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 	<Import Project="Xamarin.WatchOS.Common.targets" />
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
@@ -38,6 +38,10 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 			So we need to set the CopyNuGetImplementations variable to 'true' for our library projects.
 		-->
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.iOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
@@ -31,6 +31,10 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		     remove this -->
 		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
 		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.CSharp.targets
@@ -21,6 +21,10 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.iOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.FSharp.targets
@@ -27,6 +27,10 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		     remove this -->
 		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
 		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
 	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.CSharp.targets
@@ -21,6 +21,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(UsingAppleNETSdk)' != 'true'" />
 	<Import Project="Xamarin.iOS.WatchApp.Common.targets" />

--- a/tests/common/TestProjects/SystemMemoryFromNetStandard2_0/Info.plist
+++ b/tests/common/TestProjects/SystemMemoryFromNetStandard2_0/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>Hello iOS</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.microsoft.net6.helloios</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+</dict>
+</plist>

--- a/tests/common/TestProjects/SystemMemoryFromNetStandard2_0/Program.cs
+++ b/tests/common/TestProjects/SystemMemoryFromNetStandard2_0/Program.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace app
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            System.Console.WriteLine (typeof (UIKit.UIWindow));
+            C.DoIt ();
+        }
+    }
+}

--- a/tests/common/TestProjects/SystemMemoryFromNetStandard2_0/SystemMemoryFromNetStandard2_0.csproj
+++ b/tests/common/TestProjects/SystemMemoryFromNetStandard2_0/SystemMemoryFromNetStandard2_0.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{5C7259BF-4253-48A6-9D9E-5036F492D7CE}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>SystemMemoryFromNetStandard2_0</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>SystemMemoryFromNetStandard2_0</AssemblyName>
+    <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <OutputPath>bin\$(Platform)\$(Configuration)</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'iPhoneSimulator' ">
+    <MtouchArch>x86_64</MtouchArch>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'iPhone' ">
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchArch>ARM64</MtouchArch>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Xamarin.iOS" />
+    <ProjectReference Include="../SystemMemoryLibrary/SystemMemoryLibrary.csproj"  />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+</Project>

--- a/tests/common/TestProjects/SystemMemoryLibrary/SystemMemoryConsumer.cs
+++ b/tests/common/TestProjects/SystemMemoryLibrary/SystemMemoryConsumer.cs
@@ -1,0 +1,6 @@
+public class C {
+	public static void DoIt ()
+	{
+		System.Console.WriteLine (typeof (System.Buffers.MemoryHandle));
+	}
+}

--- a/tests/common/TestProjects/SystemMemoryLibrary/SystemMemoryLibrary.csproj
+++ b/tests/common/TestProjects/SystemMemoryLibrary/SystemMemoryLibrary.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
+</Project>

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectTest.cs
@@ -18,7 +18,7 @@ namespace Xamarin.iOS.Tasks
 		{
 		}
 
-		public ProjectPaths BuildProject (string appName, int expectedErrorCount = 0, bool clean = true, bool nuget_restore = false)
+		public ProjectPaths BuildProject (string appName, int expectedErrorCount = 0, bool clean = true, bool nuget_restore = false, bool is_library = false)
 		{
 			var mtouchPaths = SetupProjectPaths (appName);
 			var csproj = mtouchPaths.ProjectCSProjPath;
@@ -55,7 +55,7 @@ namespace Xamarin.iOS.Tasks
 
 			RunTarget (mtouchPaths, "Build", Mode, expectedErrorCount);
 
-			if (expectedErrorCount > 0)
+			if (expectedErrorCount > 0 || is_library)
 				return mtouchPaths;
 
 			Assert.IsTrue (Directory.Exists (AppBundlePath), "App Bundle does not exist: {0} ", AppBundlePath);

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/SystemMemoryReference.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/SystemMemoryReference.cs
@@ -24,5 +24,19 @@ namespace Xamarin.iOS.Tasks {
 			Assert.IsTrue (File.Exists (Path.Combine (AppBundlePath, "SystemMemoryReference")), "App bundle not created properly");
 			Assert.IsFalse (File.Exists (Path.Combine (AppBundlePath, "System.Memory.dll")), "System.Memory.dll was incorrectly copied from NuGet");
 		}
+
+		[Test]
+		public void NetStandard2_0ReferenceFromLibraryAndDirectNuGetReference ()
+		{
+			BuildProject ("SystemMemoryLibrary", clean: false, nuget_restore: true, is_library: true);
+			BuildProject ("SystemMemoryFromNetStandard2_0", clean: false, nuget_restore: true);
+
+			var primaryReferenceIndex = Engine.MessageEvents.FindIndex ((v) => v.Message.TrimStart ().StartsWith ("Primary reference \"System.Memory, Version") && v.ProjectFile.Contains ("SystemMemoryFromNetStandard2_0.csproj"));
+			Assert.That (primaryReferenceIndex, Is.GreaterThanOrEqualTo (0), "Failure to find primary reference result in build log");
+			var resolvedFilePath = Engine.MessageEvents [primaryReferenceIndex + 1];
+
+			Assert.That (resolvedFilePath.Message, Does.Contain ("Resolved file path is "), "ResolvedFilePath 1");
+			Assert.That (resolvedFilePath.Message, Does.Contain ("/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/Facades/System.Memory.dll"), "ResolvedFilePath 2");
+		}
 	}
 }


### PR DESCRIPTION
We must set `ResolveAssemblyConflicts=true` before loading
Microsoft.Common.targets (which is loaded by Microsoft.CSharp.targets),
because otherwise we won'd do any conflict resolution at all, since the
variable isn't 'true' when it needs to be.

Also add test.

Fixes https://github.com/xamarin/xamarin-macios/issues/11691.
Fixes https://github.com/mono/mono/issues/20805.