### PR TITLE
[dotnet] Sign the 'createdump' executable. Fixes #13417.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1266,8 +1266,8 @@
 
 			<!-- Put the 'createdump' executable in the expected location in the app bundle when using CoreCLR -->
 			<!-- Ref: https://github.com/xamarin/xamarin-macios/issues/11432 -->
-			<ResolvedFileToPublish
-				Update="@(ResolvedFileToPublish)"
+			<_CreateDumpExecutable
+				Include="@(ResolvedFileToPublish)"
 				Condition=" '$(UseMonoRuntime)' == 'false' And
 				            '%(ResolvedFileToPublish.Filename)' == 'createdump' And
 				            '%(ResolvedFileToPublish.Extension)' == '' And
@@ -1277,6 +1277,14 @@
 				            "
 				PublishFolderType="Assembly"
 			/>
+			<ResolvedFileToPublish
+				Update="@(_CreateDumpExecutable)"
+				RelativePath="$(_DylibPublishDir)\%(Filename)%(Extension)"
+				Condition="@(_CreateDumpExecutable->Count()) &gt; 0"
+			/>
+			<!-- The 'createdump' executable must be signed. -->
+			<!-- Ref: https://github.com/xamarin/xamarin-macios/issues/13417 -->
+			<_CodesignItems Include="@(_CreateDumpExecutable)" Condition="'$(_RequireCodeSigning)' == 'true'" />
 
 			<!-- Remove any dylibs Mono told us not to link with -->
 			<ResolvedFileToPublish

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1177,7 +1177,7 @@
 	</PropertyGroup>
 
 	<Target Name="_ComputePublishLocation"
-		DependsOnTargets="_GenerateBundleName;_ParseBundlerArguments;_ComputeMonoLibraries"
+		DependsOnTargets="_GenerateBundleName;_ParseBundlerArguments;_ComputeMonoLibraries;_DetectSigningIdentity;_PrepareResourceRules"
 		Condition="'$(_CanOutputAppBundle)' == 'true'"
 		>
 		<PropertyGroup>
@@ -1277,14 +1277,18 @@
 				            "
 				PublishFolderType="Assembly"
 			/>
-			<ResolvedFileToPublish
-				Update="@(_CreateDumpExecutable)"
-				RelativePath="$(_DylibPublishDir)\%(Filename)%(Extension)"
-				Condition="@(_CreateDumpExecutable->Count()) &gt; 0"
-			/>
+			<ResolvedFileToPublish Remove="@(_CreateDumpExecutable)" />
+			<ResolvedFileToPublish Include="@(_CreateDumpExecutable)" />
 			<!-- The 'createdump' executable must be signed. -->
 			<!-- Ref: https://github.com/xamarin/xamarin-macios/issues/13417 -->
-			<_CodesignItems Include="@(_CreateDumpExecutable)" Condition="'$(_RequireCodeSigning)' == 'true'" />
+			<_CodesignItems Include="@(_CreateDumpExecutable)" Condition="'$(_RequireCodeSigning)' == 'true'">
+				<CodesignAllocate>$(_CodesignAllocate)</CodesignAllocate>
+				<CodesignDisableTimestamp Condition="'$(_BundlerDebug)' == 'true'">true</CodesignDisableTimestamp>
+				<CodesignExtraArgs>$(CodesignExtraArgs)</CodesignExtraArgs>
+				<CodesignKeychain>$(CodesignKeychain)</CodesignKeychain>
+				<CodesignResourceRules>$(_PreparedResourceRules)</CodesignResourceRules>
+				<CodesignSigningKey>$(_CodeSigningKey)</CodesignSigningKey>
+			</_CodesignItems>
 
 			<!-- Remove any dylibs Mono told us not to link with -->
 			<ResolvedFileToPublish

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2038,6 +2038,16 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 		<!-- Compute some metadata for the items -->
 		<ItemGroup>
+			<!-- Set individual metadata based on global values unless already specified -->
+			<_CodesignItems>
+				<CodesignAllocate Condition="'%(_CodesignItems.CodesignAllocate)' == ''">$(_CodesignAllocate)</CodesignAllocate>
+				<CodesignDisableTimestamp Condition="'%(_CodesignItems.CodesignDisableTimestamp)' == ''">$(_CodesignDisableTimestamp)</CodesignDisableTimestamp>
+				<CodesignEntitlements Condition="'%(_CodesignItems.CodesignEntitlements)' == ''">$(_AppBundleCodesignEntitlements)</CodesignEntitlements>
+				<CodesignExtraArgs Condition="'%(_CodesignItems.CodesignExtraArgs)' == ''">$(CodesignExtraArgs)</CodesignExtraArgs>
+				<CodesignKeychain Condition="'%(_CodesignItems.CodesignKeychain)' == ''">$(CodesignKeychain)</CodesignKeychain>
+				<CodesignResourceRules Condition="'%(_CodesignItems.CodesignResourceRules)' == ''">$(_PreparedResourceRules)</CodesignResourceRules>
+				<CodesignSigningKey Condition="'%(_CodesignItems.CodesignSigningKey)' == ''">$(_CodeSigningKey)</CodesignSigningKey>
+			</_CodesignItems>
 			<!-- Compute the relative path of the item in the app bundle -->
 			<_CodesignItems>
 				<CodesignRelativeAppBundlePath>$([System.String]::new('%(Identity)')).Substring($([System.String]::new('%(Identity)')).LastIndexOf('.app/')+5)</CodesignRelativeAppBundlePath>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2038,16 +2038,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 		<!-- Compute some metadata for the items -->
 		<ItemGroup>
-			<!-- Set individual metadata based on global values unless already specified -->
-			<_CodesignItems>
-				<CodesignAllocate Condition="'%(_CodesignItems.CodesignAllocate)' == ''">$(_CodesignAllocate)</CodesignAllocate>
-				<CodesignDisableTimestamp Condition="'%(_CodesignItems.CodesignDisableTimestamp)' == ''">$(_CodesignDisableTimestamp)</CodesignDisableTimestamp>
-				<CodesignEntitlements Condition="'%(_CodesignItems.CodesignEntitlements)' == ''">$(_AppBundleCodesignEntitlements)</CodesignEntitlements>
-				<CodesignExtraArgs Condition="'%(_CodesignItems.CodesignExtraArgs)' == ''">$(CodesignExtraArgs)</CodesignExtraArgs>
-				<CodesignKeychain Condition="'%(_CodesignItems.CodesignKeychain)' == ''">$(CodesignKeychain)</CodesignKeychain>
-				<CodesignResourceRules Condition="'%(_CodesignItems.CodesignResourceRules)' == ''">$(_PreparedResourceRules)</CodesignResourceRules>
-				<CodesignSigningKey Condition="'%(_CodesignItems.CodesignSigningKey)' == ''">$(_CodeSigningKey)</CodesignSigningKey>
-			</_CodesignItems>
 			<!-- Compute the relative path of the item in the app bundle -->
 			<_CodesignItems>
 				<CodesignRelativeAppBundlePath>$([System.String]::new('%(Identity)')).Substring($([System.String]::new('%(Identity)')).LastIndexOf('.app/')+5)</CodesignRelativeAppBundlePath>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2043,12 +2043,21 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<CodesignRelativeAppBundlePath>$([System.String]::new('%(Identity)').Substring($([MSBuild]::Add($([System.String]::new('%(Identity)').LastIndexOf('.app/')),5))))</CodesignRelativeAppBundlePath>
 			</_CodesignItems>
 			<!-- Set CodesignStampPath if it's not set already -->
-			<_CodesignItems>
-				<CodesignStampPath Condition="'%(_CodesignItems.CodesignStampPath)' == ''">$(DeviceSpecificIntermediateOutputPath)codesign\</CodesignStampPath>
+			<_CodesignItems Condition="'%(_CodesignItems.CodesignStampPath)' == ''">
+				<CodesignStampPath>$(DeviceSpecificIntermediateOutputPath)codesign\</CodesignStampPath>
+				<IsInputDirectory Condition="Exists('%(_CodesignItems.Identity)') And !$([System.IO.File]::Exists('%(_CodesignItems.Identity)'))">true</IsInputDirectory>
 			</_CodesignItems>
 			<!-- Set CodesignStampFile if it's not set already -->
-			<_CodesignItems>
-				<CodesignStampFile Condition="'%(_CodesignItems.CodesignStampFile)' == ''">%(_CodesignItems.CodesignStampPath)\%(_CodesignItems.CodesignRelativeAppBundlePath)</CodesignStampFile>
+			<!-- Don't use a directory as a stamp file, instead use a file inside that directory -->
+			<!-- This checks if the input is a directory, because we can't check if the stamp location might be (it might not exist yet) -->
+			<!-- Unfortunately System.IO.Directory.Exists can't be called from MSBuild, so we combine two other methods:
+				1. The built-in 'Exists' condition returns true if the input is either a file or a directory (and it exists)
+				2. We can call System.IO.File.Exists, which only returns true if the input is a file (and it exists).
+				3. So we can determine that the input is a directory, if the built-in 'Exists' return true, but System.IO.File.Exists return false
+			-->
+			<_CodesignItems Condition="'%(_CodesignItems.CodesignStampFile)' == ''">
+				<CodesignStampFile Condition="'%(_CodesignItems.IsInputDirectory)' != 'true'">%(_CodesignItems.CodesignStampPath)\%(_CodesignItems.CodesignRelativeAppBundlePath)</CodesignStampFile>
+				<CodesignStampFile Condition="'%(_CodesignItems.IsInputDirectory)' == 'true'">%(_CodesignItems.CodesignStampPath)\%(_CodesignItems.CodesignRelativeAppBundlePath)\.directory-stamp</CodesignStampFile>
 			</_CodesignItems>
 		</ItemGroup>
 	</Target>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2040,7 +2040,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<ItemGroup>
 			<!-- Compute the relative path of the item in the app bundle -->
 			<_CodesignItems>
-				<CodesignRelativeAppBundlePath>$([System.String]::new('%(Identity)')).Substring($([System.String]::new('%(Identity)')).LastIndexOf('.app/')+5)</CodesignRelativeAppBundlePath>
+				<CodesignRelativeAppBundlePath>$([System.String]::new('%(Identity)').Substring($([MSBuild]::Add($([System.String]::new('%(Identity)').LastIndexOf('.app/')),5))))</CodesignRelativeAppBundlePath>
 			</_CodesignItems>
 			<!-- Set CodesignStampPath if it's not set already -->
 			<_CodesignItems>


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/13417.