### PR TITLE
[bgen] Make sure to render nint/nuint in delegates as nint/nuint for .NET. Fixes #14107.

### DIFF
--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -24,6 +24,7 @@ public class TypeManager {
 	public Type System_UInt16;
 	public Type System_UInt32;
 	public Type System_UInt64;
+	public Type System_UIntPtr;
 	public Type System_Void;
 
 	public Type System_nint;
@@ -187,6 +188,7 @@ public class TypeManager {
 		System_UInt16 = Lookup (corlib_assembly, "System", "UInt16");
 		System_UInt32 = Lookup (corlib_assembly, "System", "UInt32");
 		System_UInt64 = Lookup (corlib_assembly, "System", "UInt64");
+		System_UIntPtr = Lookup (corlib_assembly, "System", "UIntPtr");
 		System_Void = Lookup (corlib_assembly, "System", "Void");
 
 #if NET

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5727,7 +5727,7 @@ public partial class Generator : IMemberGatherer {
 					print ("[MonoNativeFunctionWrapper]\n");
 
 				print ("public delegate {0} {1} ({2});",
-				       RenderType (mi.ReturnType),
+				       RenderType (mi.ReturnType, mi.ReturnTypeCustomAttributes),
 				       shortName,
 				       RenderParameterDecl (mi.GetParameters ()));
 			}
@@ -8009,9 +8009,9 @@ public partial class Generator : IMemberGatherer {
 		string name;
 		if (pt.IsByRef) {
 			pt = pt.GetElementType ();
-			name = (removeRefTypes ? "" : (p.IsOut ? "out " : "ref ")) + prefix + RenderType (pt);
+			name = (removeRefTypes ? "" : (p.IsOut ? "out " : "ref ")) + prefix + RenderType (pt, p);
 		} else
-			name = prefix + RenderType (pt);
+			name = prefix + RenderType (pt, p);
 		if (!pt.IsValueType && AttributeManager.HasAttribute<NullAllowedAttribute> (p))
 			name += "?";
 		return name;
@@ -8162,8 +8162,16 @@ public partial class Generator : IMemberGatherer {
 
 		return def;
 	}
-	
-	string RenderType (Type t)
+
+	bool HasNativeAttribute (ICustomAttributeProvider provider)
+	{
+		if (provider is null)
+			return false;
+
+		return AttributeManager.HasAttribute (provider, "NativeIntegerAttribute");
+	}
+
+	string RenderType (Type t, ICustomAttributeProvider provider = null)
 	{
 		t = GetCorrectGenericType (t);
 
@@ -8198,6 +8206,12 @@ public partial class Generator : IMemberGatherer {
 		
 		if (t == TypeManager.System_Void)
 			return "void";
+
+		if (t == TypeManager.System_IntPtr) {
+			return HasNativeAttribute (provider) ? "nint" : "IntPtr";
+		} else if (t == TypeManager.System_UIntPtr) {
+			return HasNativeAttribute (provider) ? "nuint" : "UIntPtr";
+		}
 
 		string ns = t.Namespace;
 		if (NamespaceManager.ImplicitNamespaces.Contains (ns) || t.IsGenericType) {

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -843,6 +843,33 @@ namespace GeneratorTests
 #endif
 		}
 
+		[Test]
+#if !NET
+		[Ignore ("This only applies to .NET")]
+#endif
+		public void NativeIntDelegates ()
+		{
+			var bgen = BuildFile (Profile.iOS, "tests/nint-delegates.cs");
+
+			Func<string, bool> verifyDelegate = (typename) => {
+				// Assert that the return type from the delegate is IntPtr
+				var type = bgen.ApiAssembly.MainModule.GetType ("NS", typename);
+				Assert.NotNull (type, typename);
+				var method = type.Methods.First (m => m.Name == "Invoke");
+				Assert.IsNotNull (method.MethodReturnType.CustomAttributes.FirstOrDefault (attr => attr.AttributeType.Name == "NativeIntegerAttribute"), "Return type for delegate " + typename);
+				foreach (var p in method.Parameters) {
+					Assert.IsNotNull (p.CustomAttributes.FirstOrDefault (attr => attr.AttributeType.Name == "NativeIntegerAttribute"), $"Parameter {p.Name}'s type for delegate " + typename);
+				}
+
+				return false;
+			};
+
+			verifyDelegate ("D1");
+			verifyDelegate ("D2");
+			verifyDelegate ("D3");
+			verifyDelegate ("NSTableViewColumnRowPredicate");
+		}
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/tests/nint-delegates.cs
+++ b/tests/generator/tests/nint-delegates.cs
@@ -1,0 +1,32 @@
+using System;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	[NoMacCatalyst]
+	[BaseType (typeof (NSObject), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTableViewDelegate)})]
+	partial interface NSTableView {
+		[NullAllowed]
+		[Export ("delegate")]
+		NSObject Delegate { get; set; }
+	
+	}
+
+	[BaseType (typeof (NSObject))]
+	[Model][Protocol]
+	partial interface NSTableViewDelegate {
+		[Export ("row:"), DelegateName ("NSTableViewColumnRowPredicate"), DefaultValue (0)]
+		nint ShouldEditTableColumn (nint row);
+	}
+
+	[BaseType (typeof (NSObject))]
+	interface DelegateMethods {
+		[Export ("delegates:b:c:")]
+		void DelegateSomething (D1 a, D2 b, D3 c/*, D4 d*/);
+	}
+
+	delegate nint D1 (nint a);
+	delegate nuint D2 (ref nuint b);
+	delegate nint D3 (out nint c);
+}


### PR DESCRIPTION
This makes us render this:

    public delegate nfloat NSTableViewColumnWidth(NSTableView tableView, nint column);

instead of this:

    public delegate nfloat NSTableViewColumnWidth(NSTableView tableView, IntPtr column);

Fixes https://github.com/xamarin/xamarin-macios/issues/14107.