### PR TITLE
*do-not-merge* [release/6.0.2xx-preview13] [main] Update dependencies from dotnet/runtime

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
       <Uri>https://github.com/dotnet/linker</Uri>
       <Sha>d0662ed8db919642177ddfd06a1c33895a69015f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.2-mauipre.1.22074.5">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.2-mauipre.1.22102.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+      <Sha>3da69c23c1f8f502ec2eb1d44ff2fe7522210282</Sha>
     </Dependency>
     <!-- This is required for our test apps to build; in some cases Microsoft.AspNetCore.App is pulled in, and when building test apps the build needs to be able to resolve that -->
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,6 +5,6 @@
     <MicrosoftNETILLinkTasksPackageVersion>6.0.100-1.21519.4</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETILStripTasksPackageVersion>6.0.0-rc.2.21468.3</MicrosoftNETILStripTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.2-mauipre.1.22102.15</MicrosoftNETCoreAppRefPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request updates the following dependencies

[marker]: <> (Begin:c8cd8fc8-4100-422e-9204-08d9bbaa7538)
## From https://github.com/dotnet/runtime
- **Subscription**: c8cd8fc8-4100-422e-9204-08d9bbaa7538
- **Build**: 20220202.15
- **Date Produced**: February 3, 2022 5:48:37 AM UTC
- **Commit**: 3da69c23c1f8f502ec2eb1d44ff2fe7522210282
- **Branch**: refs/heads/release/6.0-maui

[DependencyUpdate]: <> (Begin)

- **Updates**:
  - **Microsoft.NETCore.App.Ref**: [from 6.0.2-mauipre.1.22074.5 to 6.0.2-mauipre.1.22102.15][7]

[7]: https://github.com/dotnet/runtime/compare/6371525...3da69c2

[DependencyUpdate]: <> (End)


[marker]: <> (End:c8cd8fc8-4100-422e-9204-08d9bbaa7538)
















Backport of #14061
