### PR TITLE
[dotnet/runtime] Fix a few issues with regards to extensions in .NET. Fixes #13742.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -460,6 +460,7 @@
 				IntermediateLinkDir=$(IntermediateLinkDir)
 				InvariantGlobalization=$(InvariantGlobalization)
 				ItemsDirectory=$(_LinkerItemsDirectory)
+				IsAppExtension=$(IsAppExtension)
 				IsSimulatorBuild=$(_SdkIsSimulator)
 				LibMonoLinkMode=$(_LibMonoLinkMode)
 				LibXamarinLinkMode=$(_LibXamarinLinkMode)

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -447,6 +447,7 @@
 				AssemblyName=$(AssemblyName).dll
 				AOTCompiler=$(_AOTCompiler)
 				AOTOutputDirectory=$(_AOTOutputDirectory)
+				AppBundleManifestPath=$(_AppBundleManifestPath)
 				CacheDirectory=$(_LinkerCacheDirectory)
 				@(_BundlerDlsym -> 'Dlsym=%(Identity)')
 				Debug=$(_BundlerDebug)

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -459,7 +459,7 @@
 			"const char *", "base_dir",
 			"const char *", "config_file_name"
 		) {
-			XamarinRuntime = RuntimeMode.MonoVM,
+			Mode = DotNetMode.OnlyLegacy,
 		},
 
 		#endregion

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -476,18 +476,15 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	int rv = 0;
 	switch (launch_mode) {
 	case XamarinLaunchModeExtension:
+#if !DOTNET
+		// It doesn't look like calling mono_domain_set_config is needed in .NET,
+		// it's covered by the call to xamarin_bridge_vm_initialize.
 		char base_dir [1024];
 		char config_file_name [1024];
 
 		snprintf (base_dir, sizeof (base_dir), "%s/" ARCH_SUBDIR, xamarin_get_bundle_path ());
 		snprintf (config_file_name, sizeof (config_file_name), "%s/%s.config", base_dir, xamarin_executable_name); // xamarin_executable_name should never be NULL for extensions.
 
-#if defined (CORECLR_RUNTIME)
-		// Need to figure out how to implement the equivalent of mono_domain_set_config for CoreCLR.
-		// That will need a test case (app extension), which we haven't implemented for CoreCLR yet.
-		// It's likely to require a completely different implementation, probably a property passed to coreclr_initialize.
-		xamarin_assertion_message ("Not implemented for CoreCLR: mono_domain_set_config.");
-#else
 		mono_domain_set_config (mono_domain_get (), base_dir, config_file_name);
 #endif
 

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -583,8 +583,12 @@ namespace Xamarin.Bundler {
 			}
 		}
 
+		string info_plistpath;
 		public string InfoPListPath {
 			get {
+				if (info_plistpath is not null)
+					return info_plistpath;
+
 				switch (Platform) {
 				case ApplePlatform.iOS:
 				case ApplePlatform.TVOS:
@@ -596,6 +600,9 @@ namespace Xamarin.Bundler {
 				default:
 					throw ErrorHelper.CreateError (71, Errors.MX0071, Platform, ProductName);
 				}
+			}
+			set {
+				info_plistpath = value;
 			}
 		}
 

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -121,6 +121,9 @@ namespace Xamarin.Linker {
 				case "CacheDirectory":
 					CacheDirectory = value;
 					break;
+				case "AppBundleManifestPath":
+					Application.InfoPListPath = value;
+					break;
 				case "CustomLinkFlags":
 					Application.ParseCustomLinkFlags (value, "gcc_flags");
 					break;
@@ -367,6 +370,7 @@ namespace Xamarin.Linker {
 				Console.WriteLine ($"LinkerConfiguration:");
 				Console.WriteLine ($"    ABIs: {string.Join (", ", Abis.Select (v => v.AsArchString ()))}");
 				Console.WriteLine ($"    AOTOutputDirectory: {AOTOutputDirectory}");
+				Console.WriteLine ($"    AppBundleManifestPath: {Application.InfoPListPath}");
 				Console.WriteLine ($"    AreAnyAssembliesTrimmed: {Application.AreAnyAssembliesTrimmed}");
 				Console.WriteLine ($"    AssemblyName: {Application.AssemblyName}");
 				Console.WriteLine ($"    CacheDirectory: {CacheDirectory}");

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -155,6 +155,9 @@ namespace Xamarin.Linker {
 					if (!string.IsNullOrEmpty (value))
 						Application.ParseInterpreter (value);
 					break;
+				case "IsAppExtension":
+					Application.IsExtension = string.Equals ("true", value, StringComparison.OrdinalIgnoreCase);
+					break;
 				case "ItemsDirectory":
 					ItemsDirectory = value;
 					break;


### PR DESCRIPTION
* Propagate the IsAppExtension variable correctly.

* Don't try to call mono_domain_set_config for app extensions in .NET.

  It doesn't look like it's needed, and it also immediately aborts anyway, so
  if it turns out to be needed, another solution would have to be implemented.

Fixes https://github.com/xamarin/xamarin-macios/issues/13742.