### PR TITLE
[release/6.0.2xx-preview13] [bgen] Make sure to render nint/nuint in delegates as nint/nuint for .NET. Fixes #14107.

### DIFF
--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -24,6 +24,7 @@ public class TypeManager {
 	public Type System_UInt16;
 	public Type System_UInt32;
 	public Type System_UInt64;
+	public Type System_UIntPtr;
 	public Type System_Void;
 
 	public Type System_nint;
@@ -187,6 +188,7 @@ public class TypeManager {
 		System_UInt16 = Lookup (corlib_assembly, "System", "UInt16");
 		System_UInt32 = Lookup (corlib_assembly, "System", "UInt32");
 		System_UInt64 = Lookup (corlib_assembly, "System", "UInt64");
+		System_UIntPtr = Lookup (corlib_assembly, "System", "UIntPtr");
 		System_Void = Lookup (corlib_assembly, "System", "Void");
 
 #if NET

--- a/tests/generator/tests/nint-delegates.cs
+++ b/tests/generator/tests/nint-delegates.cs
@@ -1,0 +1,32 @@
+using System;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	[NoMacCatalyst]
+	[BaseType (typeof (NSObject), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTableViewDelegate)})]
+	partial interface NSTableView {
+		[NullAllowed]
+		[Export ("delegate")]
+		NSObject Delegate { get; set; }
+	
+	}
+
+	[BaseType (typeof (NSObject))]
+	[Model][Protocol]
+	partial interface NSTableViewDelegate {
+		[Export ("row:"), DelegateName ("NSTableViewColumnRowPredicate"), DefaultValue (0)]
+		nint ShouldEditTableColumn (nint row);
+	}
+
+	[BaseType (typeof (NSObject))]
+	interface DelegateMethods {
+		[Export ("delegates:b:c:")]
+		void DelegateSomething (D1 a, D2 b, D3 c/*, D4 d*/);
+	}
+
+	delegate nint D1 (nint a);
+	delegate nuint D2 (ref nuint b);
+	delegate nint D3 (out nint c);
+}


### PR DESCRIPTION
This makes us render this:

    public delegate nfloat NSTableViewColumnWidth(NSTableView tableView, nint column);

instead of this:

    public delegate nfloat NSTableViewColumnWidth(NSTableView tableView, IntPtr column);

Fixes https://github.com/xamarin/xamarin-macios/issues/14107.

This is a backport of #14112.