### PR TITLE
[tests] Make the Bug2000_NSPersistentStoreCoordinator test use a process-unique test file name. Fixes #xamarin/maccore@2515.

### DIFF
--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -392,7 +392,7 @@ namespace LinkSdk {
 			model.Entities = new NSEntityDescription[1] { entity };
 			model.SetEntities (model.Entities, String.Empty);
 
-			var sqlitePath = Path.Combine (NSFileManager.TemporaryDirectory, "test.sqlite");
+			var sqlitePath = Path.Combine (NSFileManager.TemporaryDirectory, $"test-{System.Diagnostics.Process.GetCurrentProcess ().Id}.sqlite");
 			NSUrl url =  NSUrl.FromFilename (sqlitePath);
 
 			try {


### PR DESCRIPTION
Make the Bug2000_NSPersistentStoreCoordinator test use a test file name that
contains the process id, so that multiple test processes at the same time
don't stomp on eachother.

Fixes https://github.com/xamarin/maccore/issues/2515.