### PR TITLE
Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 037cc660587eda859b2d735f571e8fc632e83d3b
+NEEDED_MACCORE_VERSION := 6e6b84249bf9cac6d4d7ddc25326784c4f641092
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@6e6b84249b [release] Don't try to remove the prebuilt app, it's not there anymore.

Diff: https://github.com/xamarin/maccore/compare/037cc660587eda859b2d735f571e8fc632e83d3b..6e6b84249bf9cac6d4d7ddc25326784c4f641092