### PR TITLE
Default VerifyDependencyInjectionOpenGenericServiceTrimmability

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -138,6 +138,9 @@
 		<_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>		
 		<NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
 		<BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
+		<!-- Verify DI trimmability at development-time, but turn the validation off for production/trimmed builds. -->
+		<VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == '' And '$(_BundlerDebug)' != 'true'">false</VerifyDependencyInjectionOpenGenericServiceTrimmability>
+		<VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == ''">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
 
 		<!-- We don't need to generate reference assemblies for apps or app extensions -->
 		<ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' And ('$(OutputType)' == 'Exe' Or '$(IsAppExtension)' == 'true')">false</ProduceReferenceAssembly>


### PR DESCRIPTION
We need to use better default values for `$(VerifyDependencyInjectionOpenGenericServiceTrimmability)`.

This feature switch ensures that DynamicallyAccessedMembers are applied correctly to open generic types used in Dependency Injection.

In the base SDK, this switch is enabled when `PublishTrimmed=true`. However, iOS apps don't set `PublishTrimmed=true` until a Target. So devs are missing out on this validation.

Conversely, in published apps, we don't want to pay the cost of doing this validation. It was showing up in startup profiles on Android. So turning the feature switch off in Release builds (builds without debugging enabled).

Port of https://github.com/xamarin/xamarin-android/commit/90f546cacc15ca6693020ac2e92aa737315ea0a4

cc @rolfbjarne @jonathanpeppers 

Note, in Android we used `PublishTrimmed` to set this property, but in iOS `PublishTrimmed` isn't set yet. So I followed the same pattern as `UseSystemResourceKeys`, which is the same scenario - when a dev is developing the app vs. a production build.