### PR TITLE
[AppKit] INSTextInputClient.GetAttributedSubstring can return null. Fixes #14129.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19809,6 +19809,7 @@ namespace AppKit {
 #if NET
 		[Abstract]
 #endif
+		[return: NullAllowed]
 		[Export ("attributedSubstringForProposedRange:actualRange:")]
 		NSAttributedString GetAttributedSubstring (NSRange proposedRange, out NSRange actualRange);
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/14129.