### PR TITLE
[src/introspection] Adjust tests and availability attributes to work run on iOS/tvOS 12.4. Fixes #13957.

### DIFF
--- a/src/Network/NWProtocolDefinition.cs
+++ b/src/Network/NWProtocolDefinition.cs
@@ -135,10 +135,11 @@ namespace Network {
 #if NET
 		[SupportedOSPlatform ("tvos13.0")]
 		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios12.0")]
+		[SupportedOSPlatform ("ios13.0")]
 #else
 		[TV (13,0)]
 		[Mac (10,15)]
+		[iOS (13,0)]
 #endif
 		[DllImport (Constants.NetworkLibrary)]
 		static extern unsafe OS_nw_protocol_definition nw_framer_create_definition (string identifier, NWFramerCreateFlags flags, ref BlockLiteral start_handler);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -9908,6 +9908,7 @@ namespace AppKit {
 		[Export ("layerContentsForContentsScale:")]
 		NSObject GetLayerContentsForContentsScale (nfloat layerContentsScale);
 
+		[NoMacCatalyst]
 		[Mac (11,0)]
 		[Static]
 		[Export ("imageWithSystemSymbolName:accessibilityDescription:")]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -3110,6 +3110,7 @@ namespace AVFoundation {
 		string [] AvailableMediaCharacteristicsWithMediaSelectionOptions { get; }
 
 #if !MONOMAC
+		[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
 		[Export ("compatibleWithSavedPhotosAlbum")]
 		bool CompatibleWithSavedPhotosAlbum  { [Bind ("isCompatibleWithSavedPhotosAlbum")] get; }
 #endif

--- a/src/externalaccessory.cs
+++ b/src/externalaccessory.cs
@@ -191,6 +191,7 @@ namespace ExternalAccessory {
 #endif
 	interface EAWiFiUnconfiguredAccessoryBrowser {
 
+		[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
 		[NoTV]
 		[Export ("initWithDelegate:queue:")]
 		[DesignatedInitializer] // according to header comment (but not in attributes)
@@ -208,15 +209,18 @@ namespace ExternalAccessory {
 		[Export ("unconfiguredAccessories", ArgumentSemantic.Copy)]
 		NSSet UnconfiguredAccessories { get; }
 
+		[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
 		[NoTV]
 		[Export ("startSearchingForUnconfiguredAccessoriesMatchingPredicate:")]
 		void StartSearchingForUnconfiguredAccessories ([NullAllowed] NSPredicate predicate);
 
+		[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
 		[NoTV]
 		[Export ("stopSearchingForUnconfiguredAccessories")]
 		void StopSearchingForUnconfiguredAccessories ();
 
 #if !MONOMAC
+		[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
 		[NoTV]
 		[Export ("configureAccessory:withConfigurationUIOnViewController:")]
 		void ConfigureAccessory (EAWiFiUnconfiguredAccessory accessory, UIViewController viewController);

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -1661,6 +1661,7 @@ namespace GameKit {
 		[Async]
 		void LoadAchievementDescriptions ([NullAllowed] GKAchievementDescriptionHandler handler);
 
+		[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
 		[NoWatch]
 		[Export ("loadImageWithCompletionHandler:")]
 		[Async]
@@ -1693,11 +1694,13 @@ namespace GameKit {
 		[NullAllowed]
 		UIImage Image { get; }
 
+		[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
 		[NoWatch]
 		[Static]
 		[Export ("incompleteAchievementImage")]
 		UIImage IncompleteAchievementImage { get; }
 
+		[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
 		[NoWatch]
 		[Static]
 		[Export ("placeholderCompletedAchievementImage")]

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -736,6 +736,7 @@ namespace Metal {
 		nuint GetImageblockMemoryLength (MTLSize imageblockDimensions);
 
 		[TV (13, 0), Mac (11,0), iOS (13, 0)]
+		[MacCatalyst (14, 0)]
 #if NET
 		[Abstract]
 #endif
@@ -2299,6 +2300,7 @@ namespace Metal {
 		nuint GetImageblockMemoryLength (MTLSize imageblockDimensions);
 
 		[Mac (10,14), iOS (12,0), TV (12,0)]
+		[MacCatalyst (14, 0)]
 #if NET
 		[Abstract]
 #endif
@@ -3553,6 +3555,7 @@ namespace Metal {
 
 		[iOS (11, 0), Mac (11,0), NoWatch]
 		[TV (14,5)]
+		[MacCatalyst (14, 0)]
 		[NullAllowed, Export ("tileArguments")]
 		MTLArgument[] TileArguments { get; }
 	}
@@ -3680,21 +3683,25 @@ namespace Metal {
 
 		[iOS (11, 0), NoWatch, Mac (11,0)]
 		[TV (14,5)]
+		[MacCatalyst (14,0)]
 		[Export ("imageblockSampleLength")]
 		nuint ImageblockSampleLength { get; set; }
 
 		[iOS (11, 0), NoWatch, Mac (11,0)]
 		[TV (14,5)]
+		[MacCatalyst (14,0)]
 		[Export ("threadgroupMemoryLength")]
 		nuint ThreadgroupMemoryLength { get; set; }
 
 		[iOS (11, 0), NoWatch, Mac (11,0)]
 		[TV (14,5)]
+		[MacCatalyst (14,0)]
 		[Export ("tileWidth")]
 		nuint TileWidth { get; set; }
 
 		[iOS (11, 0), NoWatch, Mac (11,0)]
 		[TV (14,5)]
+		[MacCatalyst (14,0)]
 		[Export ("tileHeight")]
 		nuint TileHeight { get; set; }
 
@@ -3960,6 +3967,7 @@ namespace Metal {
 		MTLPipelineBufferDescriptorArray Buffers { get; }
 
 		[Mac (11,0), iOS (13, 0), TV (13,0)]
+		[MacCatalyst (14, 0)]
 		[Export ("supportIndirectCommandBuffers")]
 		bool SupportIndirectCommandBuffers { get; set; }
 

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -1026,7 +1026,6 @@ namespace SpriteKit {
 		[Export ("fieldBitMask")]
 		uint FieldBitMask { get; set; } /* uint32_t */
 
-		[iOS (8,0), Mac(10,10)]
 		[Deprecated (PlatformName.iOS, 8, 0)]
 		[Deprecated (PlatformName.TvOS, 8, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -10776,6 +10776,7 @@ namespace UIKit {
 		CGPoint SnapPoint { get; set; }
 	}
 
+	[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
 	[NoTV]
 	[BaseType (typeof (UIViewController))]
 	// iOS6 returns the following (confusing) message with the default .ctor:
@@ -17604,6 +17605,7 @@ namespace UIKit {
 		UIEdgeInsets PerPageContentInsets { get; set; }
 	}
 
+	[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
 	[NoTV]
 	[BaseType (typeof (UIPrintFormatter))]
 	[DisableDefaultCtor] // nonfunctional (and it doesn't show up in the header anyway)

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -471,6 +471,31 @@ namespace Introspection {
 		protected virtual bool SkipUnavailable (Type type, string memberName)
 		{
 			switch (type.FullName) {
+#if __MACOS__
+				case "AppKit.NSDrawer":
+					switch (memberName) {
+					case "AccessibilityChildrenInNavigationOrder":
+					case "get_AccessibilityChildrenInNavigationOrder":
+					case "set_AccessibilityChildrenInNavigationOrder":
+					case "AccessibilityCustomActions":
+					case "get_AccessibilityCustomActions":
+					case "set_AccessibilityCustomActions":
+					case "AccessibilityCustomRotors":
+					case "get_AccessibilityCustomRotors":
+					case "set_AccessibilityCustomRotors":
+						// NSDrawer was deprecated in macOS 10.13, but implements (and inlines) NSAccessibility, which added several new members in macOS 10.13, so ignore those members here.
+						return true;
+					}
+					break;
+				case "GLKit.GLKTextureLoader":
+					switch (memberName) {
+					case "GrayscaleAsAlpha":
+					case "get_GrayscaleAsAlpha":
+						// GLKTextureLoader is deprecated, but the GLKTextureLoaderGrayscaleAsAlpha value, which we've put inside the GLKTextureLoader class, isn't.
+						return true;
+					}
+					break;
+#endif
 #if __MACCATALYST__
 				case "AudioUnit.AudioComponent":
 					switch (memberName) {

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -355,6 +355,14 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			case "SKNode":
+				switch (selectorName) {
+				case "focusItemContainer":
+					if (!TestRuntime.CheckXcodeVersion (12, 0))
+						return true;
+					break;
+				}
+				break;
 			case "INPriceRange":
 				switch (selectorName) {
 				case "initWithMaximumPrice:currencyCode:":
@@ -658,6 +666,16 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			case "NSMenu":
+				switch (selectorName) {
+				case "appearance":
+				case "setAppearance:":
+				case "effectiveAppearance":
+					if (!TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch))
+						return true;
+					break;
+				}
+				break;
 			case "NSQueryGenerationToken": // A test was added in monotouch tests to ensure the selector works
 				switch (selectorName) {
 				case "encodeWithCoder:":
@@ -786,6 +804,12 @@ namespace Introspection {
 					if (!TestRuntime.CheckXcodeVersion (11, 0))
 						return true;
 					break;
+				case "objectWithItemProviderData:typeIdentifier:error:":
+				case "readableTypeIdentifiersForItemProvider":
+					// Conformance added in Xcode 12
+					if (!TestRuntime.CheckXcodeVersion (12, 0))
+						return true;
+					break;
 				}
 				break;
 			case "MPSNNNeuronDescriptor":
@@ -807,7 +831,6 @@ namespace Introspection {
 					break;
 				}
 				break;
-#if __MACOS__ || __MACCATALYST__ || __WATCHOS__
 			case "MLDictionaryFeatureProvider":
 			case "MLMultiArray":
 			case "MLFeatureValue":
@@ -819,7 +842,6 @@ namespace Introspection {
 					break;
 				}
 				break;
-#endif
 			case "BGTaskScheduler":
 				switch (selectorName) {
 				case "sharedScheduler":
@@ -878,6 +900,26 @@ namespace Introspection {
 						return true;
 					break;
 				}
+				break;
+			case "UIControl":
+#if __MACCATALYST__
+				switch (selectorName) {
+				case "contextMenuInteraction:configurationForMenuAtLocation:":
+					if (!TestRuntime.CheckXcodeVersion (12, 0))
+						return true;
+					break;
+				}
+#endif
+				break;
+			case "UISceneConnectionOptions":
+#if __MACCATALYST__
+				switch (selectorName) {
+				case "shortcutItem":
+					if (!TestRuntime.CheckXcodeVersion (12, 0))
+						return true;
+					break;
+				}
+#endif
 				break;
 			}
 

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -392,6 +392,10 @@ namespace Introspection {
 						if (Mac.CheckSystemVersion (10, 13))
 							return true;
 						break;
+					case "progress":
+						if (!TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch))
+							return true;
+						break;
 					}
 					break;
 				case "NSUrlSessionConfiguration":

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -832,10 +832,6 @@ namespace Introspection {
 				case "SKAttributeValue":
 					return !TestRuntime.CheckXcodeVersion (7, 2);
 #endif
-				case "MLDictionaryFeatureProvider":
-				case "MLMultiArray":
-				case "MLFeatureValue":
-					return !TestRuntime.CheckXcodeVersion (10,0);
 				}
 				break;
 			case "mutableCopyWithZone:":


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/13957.