### PR TITLE
[objcruntime] Simplified earlier split of internal `Lookup` method

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -211,16 +211,11 @@ namespace ObjCRuntime {
 
 		internal static Type Lookup (IntPtr klass)
 		{
-			return LookupClass (klass, true)!;
-		}
-
-		internal static Type? Lookup (IntPtr klass, bool throw_on_error)
-		{
-			return LookupClass (klass, throw_on_error);
+			return Lookup (klass, true)!;
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)] // To inline the Runtime.DynamicRegistrationSupported code if possible.
-		static Type? LookupClass (IntPtr klass, bool throw_on_error)
+		internal static Type? Lookup (IntPtr klass, bool throw_on_error)
 		{
 			bool is_custom_type;
 			var find_class = klass;


### PR DESCRIPTION
The split [1] was done to ease nullability annotations since there's no
syntax to cover this specific case with custom attributes.

However we don't need three methods for the split. Two are enough :)

[1] https://github.com/xamarin/xamarin-macios/pull/13281