### PR TITLE
[net][objcruntime] Remove `Class (IntPtr)` for .net profile

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -74,17 +74,10 @@ namespace ObjCRuntime {
 			this.handle = GetHandle (type);
 		}
 
-		public Class (IntPtr handle)
-		{
-			this.handle = handle;
-		}
-
-#if NET
 		public Class (NativeHandle handle)
 		{
 			this.handle = handle;
 		}
-#endif
 
 		[Preserve (Conditional = true)]
 #if NET


### PR DESCRIPTION
That was mentioned

> Remove the (IntPtr) constructor for .NET

inside https://github.com/xamarin/xamarin-macios/pull/13281
but not actually done inside that PR