### PR TITLE
[objcruntime] Inline the use of the `Class.LookupFullName` method

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -188,12 +188,6 @@ namespace ObjCRuntime {
 			return Messaging.IntPtr_objc_msgSend (obj, Selector.GetHandle (Selector.Class));
 		}
 
-		internal static string? LookupFullName (IntPtr klass)
-		{
-			var type = Lookup (klass);
-			return type?.FullName;
-		}
-
 		public static Type? Lookup (Class? @class)
 		{
 			if (@class is null)

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -845,7 +845,7 @@ namespace ObjCRuntime {
 
 		static IntPtr LookupManagedTypeName (IntPtr klass)
 		{
-			return Marshal.StringToHGlobalAuto (Class.LookupFullName (klass));
+			return Marshal.StringToHGlobalAuto (Class.Lookup (klass)?.FullName);
 		}
 #endregion
 

--- a/tests/linker/ios/link all/PreserveTest.cs
+++ b/tests/linker/ios/link all/PreserveTest.cs
@@ -90,18 +90,6 @@ namespace LinkAll.Attributes {
 		}
 
 		[Test]
-		public void Class_LookupFullName ()
-		{
-			var klass = Type.GetType ("ObjCRuntime.Class, " + AssemblyName);
-			Assert.NotNull (klass, "Class");
-			// only required (and preserved) for debug builds
-			var method = klass.GetMethod ("LookupFullName", BindingFlags.NonPublic | BindingFlags.Static);
-			// note: since iOS/runtime unification this is being called by ObjCRuntime.Runtime.LookupManagedTypeName
-			// and will never be removed (even on Release builds)
-			Assert.NotNull (method, "LookupFullName");
-		}
-
-		[Test]
 		public void Runtime_RegisterEntryAssembly ()
 		{
 #if NET


### PR DESCRIPTION
inside it's _only_ caller and remove the API.

Remove old test that was already not useful (since the method could not
be removed anyway for quite a while).