### PR TITLE
[corefoundation] Skip intermediate call inside `CFArray.DefaultConvert`

### DIFF
--- a/src/CoreFoundation/CFArray.cs
+++ b/src/CoreFoundation/CFArray.cs
@@ -189,7 +189,7 @@ namespace CoreFoundation {
 		static T DefaultConvert<T> (NativeHandle handle) where T: class, INativeObject
 		{
 			if (handle != CFNullHandle)
-				return Runtime.GetINativeObject<T> (handle, false)!;
+				return Runtime.GetINativeObject<T> (handle, forced_type: false, owns: false)!;
 			return null!;
 		}
 


### PR DESCRIPTION
This allow the linker to remove the helper API (code and metadata) from
smaller apps.