### PR TITLE
[net][objcruntime] Remove `DisposableObject.ClearHandle`

### DIFF
--- a/src/ObjCRuntime/DisposableObject.cs
+++ b/src/ObjCRuntime/DisposableObject.cs
@@ -65,14 +65,15 @@ namespace ObjCRuntime {
 
 		protected virtual void Dispose (bool disposing)
 		{
-			ClearHandle ();
+			handle = NativeHandle.Zero;
 		}
 
+#if !NET
 		protected void ClearHandle ()
 		{
 			handle = NativeHandle.Zero;
 		}
-
+#endif
 		void InitializeHandle (NativeHandle handle, bool verify)
 		{
 #if !COREBUILD

--- a/src/SearchKit/SearchKit.cs
+++ b/src/SearchKit/SearchKit.cs
@@ -305,9 +305,8 @@ namespace SearchKit
 
 		protected override void Dispose (bool disposing)
 		{
-			if (Handle != IntPtr.Zero) {
+			if (Handle != NativeHandle.Zero) {
 				SKIndexClose (Handle);
-				ClearHandle ();
 			}
 			base.Dispose (disposing);
 		}

--- a/src/SearchKit/SearchKit.cs
+++ b/src/SearchKit/SearchKit.cs
@@ -295,12 +295,10 @@ namespace SearchKit
 
 		protected override void Retain ()
 		{
-			throw new InvalidOperationException ();
 		}
 
 		protected override void Release ()
 		{
-			throw new InvalidOperationException ();
 		}
 
 		protected override void Dispose (bool disposing)

--- a/src/SearchKit/SearchKit.cs
+++ b/src/SearchKit/SearchKit.cs
@@ -183,7 +183,11 @@ namespace SearchKit
 		}
 	}
 
+#if NET
+	public class SKIndex : DisposableObject
+#else
 	public class SKIndex : NativeObject
+#endif
 	{
 		[DllImport (Constants.SearchKitLibrary)]
 		extern static IntPtr SKIndexCreateWithURL (IntPtr url, IntPtr str, SKIndexType type, IntPtr dict);
@@ -293,6 +297,7 @@ namespace SearchKit
 			Dispose ();
 		}
 
+#if !NET
 		protected override void Retain ()
 		{
 		}
@@ -300,6 +305,7 @@ namespace SearchKit
 		protected override void Release ()
 		{
 		}
+#endif
 
 		protected override void Dispose (bool disposing)
 		{


### PR DESCRIPTION
It is not really needed. The only caller `SKIndex` was already clearing
the handle by calling `Dispose(bool)` which called `ClearHandle`.

If it really becomes needed then it can be reintroduced in the future.