### PR TITLE
[dotnet] Add support for the PublishFolderType metadata on Content and BundleResource items.

### DIFF
--- a/dotnet/BundleContents.md
+++ b/dotnet/BundleContents.md
@@ -3,11 +3,13 @@
 There are a few items that are automatically included during the build, and
 that we're supposed to copy to the app bundle somehow:
 
-* `@(None)`, `@(Content)` and `@(EmbeddedResource)` items with the
-  `CopyToOutputDirectory` or the `CopyToPublishDirectory` metadata set (to
-  either `Always` or `PreserveNewest`).
+* `@(None)` and `@(EmbeddedResource)` items with the `CopyToOutputDirectory` or the
+  `CopyToPublishDirectory` metadata set (to either `Always` or
+  `PreserveNewest`).
     * `CopyToOutputDirectory` doesn't work with directories (for frameworks),
       in that case `CopyToPublishDirectory` must be used.
+* `@(Content)` and `@(BundleResource)` items (the `CopyToOutputDirectory` or
+  `CopyToPublishDirectory` metadata has no effect on these items).
 * Runtime packs (our own, or the runtime itself (CoreCLR/MonoVM)). We have
   some logic to detect this.
 * The output from referenced projects (transitively).

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CollectBundleResourcesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CollectBundleResourcesTaskBase.cs
@@ -48,6 +48,11 @@ namespace Xamarin.MacDev.Tasks
 
 			if (BundleResources != null) {
 				foreach (var item in BundleResources) {
+					// Skip anything with the PublishFolderType metadata, these are copied directly to the ResolvedFileToPublish item group instead.
+					var publishFolderType = item.GetMetadata ("PublishFolderType");
+					if (!string.IsNullOrEmpty (publishFolderType))
+						continue;
+
 					var logicalName = BundleResource.GetLogicalName (ProjectDir, prefixes, item, !string.IsNullOrEmpty(SessionId));
 					// We need a physical path here, ignore the Link element
 					var path = item.GetMetadata ("FullPath");

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeBundleLocationTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeBundleLocationTaskBase.cs
@@ -57,6 +57,20 @@ namespace Xamarin.MacDev.Tasks {
 			}
 		}
 
+		void AddResourceFiles (ITaskItem[]? items)
+		{
+			if (items is null || items.Length == 0)
+				return;
+
+			var resources = items.
+				// Remove any items with PublishFolderType set
+				Where (v => string.IsNullOrEmpty (v.GetMetadata ("PublishFolderType"))).
+				// Get the full path
+				Select (v => Path.GetFullPath (v.ItemSpec));
+
+			resourceFilesSet.UnionWith (resources);
+		}
+
 		public override bool Execute ()
 		{
 			if (ResolvedFileToPublish is null || ResolvedFileToPublish.Length == 0)
@@ -69,12 +83,9 @@ namespace Xamarin.MacDev.Tasks {
 			ResourceDirectory = ResourceDirectory.Replace ('\\', Path.DirectorySeparatorChar);
 
 			// Collect all our BundleResource, Content and EmbeddedResource paths into one big dictionary for later lookup.
-			if (BundleResource?.Length > 0)
-				resourceFilesSet.UnionWith (BundleResource.Select (v => Path.GetFullPath (v.ItemSpec)));
-			if (Content?.Length > 0)
-				resourceFilesSet.UnionWith (Content.Select (v => Path.GetFullPath (v.ItemSpec)));
-			if (EmbeddedResource?.Length > 0)
-				resourceFilesSet.UnionWith (EmbeddedResource.Select (v => Path.GetFullPath (v.ItemSpec)));
+			AddResourceFiles (BundleResource);
+			AddResourceFiles (Content);
+			AddResourceFiles (EmbeddedResource);
 
 			var appleFrameworks = new Dictionary<string, List<ITaskItem>> ();
 			var list = ResolvedFileToPublish.ToList ();

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -436,6 +436,12 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<FileWrites Include="$(_ProcessedBundleResourcesPath)" />
 			<FileWrites Include="$(_ProcessedContentPath)" />
 		</ItemGroup>
+
+		<!-- Copy any items with the PublishFolderType metadata directly to the ResolvedFileToPublish item group -->
+		<ItemGroup>
+			<ResolvedFileToPublish Include="@(BundleResource)" Condition="'%(BundleResource.PublishFolderType)' != ''" />
+			<ResolvedFileToPublish Include="@(Content)" Condition="'%(Content.PublishFolderType)' != ''" />
+		</ItemGroup>
 	</Target>
 
 	<!--

--- a/tests/dotnet/BundleStructure/BundleResourceD.txt
+++ b/tests/dotnet/BundleStructure/BundleResourceD.txt
@@ -1,0 +1,1 @@
+BundleResourceD

--- a/tests/dotnet/BundleStructure/BundleResourceE.txt
+++ b/tests/dotnet/BundleStructure/BundleResourceE.txt
@@ -1,0 +1,1 @@
+BundleResourceE

--- a/tests/dotnet/BundleStructure/BundleResourceF.txt
+++ b/tests/dotnet/BundleStructure/BundleResourceF.txt
@@ -1,0 +1,1 @@
+BundleResourceF

--- a/tests/dotnet/BundleStructure/BundleResourceG.txt
+++ b/tests/dotnet/BundleStructure/BundleResourceG.txt
@@ -1,0 +1,1 @@
+BundleResourceG

--- a/tests/dotnet/BundleStructure/BundleResourceH.txt
+++ b/tests/dotnet/BundleStructure/BundleResourceH.txt
@@ -1,0 +1,1 @@
+BundleResourceH

--- a/tests/dotnet/BundleStructure/ContentD.txt
+++ b/tests/dotnet/BundleStructure/ContentD.txt
@@ -1,0 +1,1 @@
+ContentD

--- a/tests/dotnet/BundleStructure/ContentE.txt
+++ b/tests/dotnet/BundleStructure/ContentE.txt
@@ -1,0 +1,1 @@
+ContentE

--- a/tests/dotnet/BundleStructure/ContentF.txt
+++ b/tests/dotnet/BundleStructure/ContentF.txt
@@ -1,0 +1,1 @@
+ContentF

--- a/tests/dotnet/BundleStructure/ContentG.txt
+++ b/tests/dotnet/BundleStructure/ContentG.txt
@@ -1,0 +1,1 @@
+ContentG

--- a/tests/dotnet/BundleStructure/ContentH.txt
+++ b/tests/dotnet/BundleStructure/ContentH.txt
@@ -1,0 +1,1 @@
+ContentH

--- a/tests/dotnet/BundleStructure/EmbeddedResourceD.txt
+++ b/tests/dotnet/BundleStructure/EmbeddedResourceD.txt
@@ -1,0 +1,1 @@
+EmbeddedResourceD

--- a/tests/dotnet/BundleStructure/EmbeddedResourceE.txt
+++ b/tests/dotnet/BundleStructure/EmbeddedResourceE.txt
@@ -1,0 +1,1 @@
+EmbeddedResourceE

--- a/tests/dotnet/BundleStructure/EmbeddedResourceF.txt
+++ b/tests/dotnet/BundleStructure/EmbeddedResourceF.txt
@@ -1,0 +1,1 @@
+EmbeddedResourceF

--- a/tests/dotnet/BundleStructure/EmbeddedResourceG.txt
+++ b/tests/dotnet/BundleStructure/EmbeddedResourceG.txt
@@ -1,0 +1,1 @@
+EmbeddedResourceG

--- a/tests/dotnet/BundleStructure/EmbeddedResourceH.txt
+++ b/tests/dotnet/BundleStructure/EmbeddedResourceH.txt
@@ -1,0 +1,1 @@
+EmbeddedResourceH

--- a/tests/dotnet/BundleStructure/shared.csproj
+++ b/tests/dotnet/BundleStructure/shared.csproj
@@ -139,15 +139,37 @@
 
 		<!-- Content items -->
 
-		<!-- Content without any metadata -->
+		<!-- Content without any metadata: bundled -->
 		<Content Include="../ContentA.txt" />
-		<!-- Content with CopyToOutputDirectory -->
+		<!-- Content with CopyToOutputDirectory: bundled -->
 		<Content Include="../ContentB.txt">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<!-- Content with CopyToPublishDirectory -->
+		<!-- Content with CopyToPublishDirectory: bundled -->
 		<Content Include="../ContentC.txt">
 			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+		<!-- Content with CopyToPublishDirectory=Never: still bundled -->
+		<Content Include="../ContentD.txt">
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</Content>
+		<!-- Content with CopyToOutputDirectory=Never: still bundled -->
+		<Content Include="../ContentE.txt">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</Content>
+		<!-- Content with CopyToOutputDirectory and PublishFolderType=None: not bundled -->
+		<Content Include="../ContentF.txt">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PublishFolderType>None</PublishFolderType>
+		</Content>
+		<!-- Content with CopyToPublishDirectory and PublishFolderType=None: not bundled -->
+		<Content Include="../ContentG.txt">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			<PublishFolderType>None</PublishFolderType>
+		</Content>
+		<!-- Content with just PublishFolderType=None: not bundled -->
+		<Content Include="../ContentH.txt">
+			<PublishFolderType>None</PublishFolderType>
 		</Content>
 
 		<!-- EmbeddedResource items -->
@@ -162,6 +184,28 @@
 		<EmbeddedResource Include="EmbeddedResourceC.txt">
 			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
 		</EmbeddedResource>
+		<!-- EmbeddedResource with CopyToPublishDirectory=Never: not bundled -->
+		<EmbeddedResource Include="../EmbeddedResourceD.txt">
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</EmbeddedResource>
+		<!-- EmbeddedResource with CopyToOutputDirectory=Never: not bundled -->
+		<EmbeddedResource Include="../EmbeddedResourceE.txt">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</EmbeddedResource>
+		<!-- EmbeddedResource with CopyToOutputDirectory and PublishFolderType=None: not bundled -->
+		<EmbeddedResource Include="../EmbeddedResourceF.txt">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PublishFolderType>None</PublishFolderType>
+		</EmbeddedResource>
+		<!-- EmbeddedResource with CopyToPublishDirectory and PublishFolderType=None: not bundled -->
+		<EmbeddedResource Include="../EmbeddedResourceG.txt">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			<PublishFolderType>None</PublishFolderType>
+		</EmbeddedResource>
+		<!-- EmbeddedResource with just PublishFolderType=None: not bundled -->
+		<EmbeddedResource Include="../EmbeddedResourceH.txt">
+			<PublishFolderType>None</PublishFolderType>
+		</EmbeddedResource>
 
 		<!-- BundleResource items -->
 
@@ -174,6 +218,28 @@
 		<!-- Content with CopyToPublishDirectory: bundled -->
 		<BundleResource Include="../BundleResourceC.txt">
 			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</BundleResource>
+		<!-- BundleResource with CopyToPublishDirectory=Never: still bundled -->
+		<BundleResource Include="../BundleResourceD.txt">
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</BundleResource>
+		<!-- BundleResource with CopyToOutputDirectory=Never: still bundled -->
+		<BundleResource Include="../BundleResourceE.txt">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</BundleResource>
+		<!-- BundleResource with CopyToOutputDirectory and PublishFolderType=None: not bundled -->
+		<BundleResource Include="../BundleResourceF.txt">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PublishFolderType>None</PublishFolderType>
+		</BundleResource>
+		<!-- BundleResource with CopyToPublishDirectory and PublishFolderType=None: not bundled -->
+		<BundleResource Include="../BundleResourceG.txt">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			<PublishFolderType>None</PublishFolderType>
+		</BundleResource>
+		<!-- BundleResource with just PublishFolderType=None: not bundled -->
+		<BundleResource Include="../BundleResourceH.txt">
+			<PublishFolderType>None</PublishFolderType>
 		</BundleResource>
 
 		<None Remove="@(Content)" />

--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -187,14 +187,20 @@ namespace Xamarin.Tests {
 			expectedFiles.Add ($"{resourcesDirectory}ContentA.txt");
 			expectedFiles.Add ($"{resourcesDirectory}ContentB.txt");
 			expectedFiles.Add ($"{resourcesDirectory}ContentC.txt");
+			expectedFiles.Add ($"{resourcesDirectory}ContentD.txt");
+			expectedFiles.Add ($"{resourcesDirectory}ContentE.txt");
 
 			// expectedFiles.Add ($"{resourcesDirectory}EmbeddedResourceA.txt");
 			expectedFiles.Add ($"{resourcesDirectory}EmbeddedResourceB.txt");
 			expectedFiles.Add ($"{resourcesDirectory}EmbeddedResourceC.txt");
+			// expectedFiles.Add ($"{resourcesDirectory}EmbeddedResourceD.txt");
+			// expectedFiles.Add ($"{resourcesDirectory}EmbeddedResourceE.txt");
 
 			expectedFiles.Add ($"{resourcesDirectory}BundleResourceA.txt");
 			expectedFiles.Add ($"{resourcesDirectory}BundleResourceB.txt");
 			expectedFiles.Add ($"{resourcesDirectory}BundleResourceC.txt");
+			expectedFiles.Add ($"{resourcesDirectory}BundleResourceD.txt");
+			expectedFiles.Add ($"{resourcesDirectory}BundleResourceE.txt");
 
 			expectedFiles.Add ($"{resourcesDirectory}AutoIncluded.txt");
 			expectedFiles.Add ($"{resourcesDirectory}SubDirectory");


### PR DESCRIPTION
Add support for the PublishFolderType metadata on Content and BundleResource
items, which makes it possible to change the location in the app bundle for
these items (this was possible to do before with the Link metadata), but most
importantly it also makes it possible to choose to *not* bundle these items in
the app bundle (which was not possible before with the Link metadata, nor any
other means).

At first I thought setting CopyToPublishDirectory /
CopyToOutputDirectory=Never would accomplish that, but it turns out we don't
honor those, and since we already have this behavior of ignoring
CopyToPublishDirectory / CopyToOutputDirectory in legacy Xamarin, I didn't
want to change it in .NET.

So I added support for honoring the PublishFolderType metadata instead, which
is new and we already support for other item groups. This is accomplished by
adding all Content and BundleResource items with PublishFolderType set to the
ResolvedFileToPublish item group (where we already handle any
PublishFolderType values), and then we ignore such Content and BundleResource
items in our CollectBundleResources task.

Also update the documentation and add tests.