### PR TITLE
[msbuild] Generate Versions.*.g.cs before running msbuild to build the solution.

### DIFF
--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -20,7 +20,13 @@ MSBUILD_DIRECTORIES          =
 MSBUILD_SYMLINKS             =
 MSBUILD_TASK_ASSEMBLIES      =
 
-ALL_SOURCES:= $(shell git ls-files | sed 's/ /\\ /g') $(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.cs) $(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.csproj)
+ALL_SOURCES:= \
+	$(shell git ls-files | sed 's/ /\\ /g') \
+	$(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.cs) \
+	$(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.csproj) \
+	Versions.ios.g.cs \
+	Versions.mac.g.cs \
+
 CONFIG      = Debug
 TARGETFRAMEWORK = netstandard2.0
 WINDOWSRUNTIMEIDENTIFIER = win


### PR DESCRIPTION
Hopefully fixes random build failures like this:

> xamarin-macios/msbuild/Versions.ios.g.cs(3,1): error CS1022: Type or namespace definition, or end-of-file expected