### PR TITLE
[nfloat] Obsolete nfloat.CopyArray in legacy Xamarin and stop using it.

### DIFF
--- a/src/AppKit/NSColor.cs
+++ b/src/AppKit/NSColor.cs
@@ -188,30 +188,19 @@ namespace AppKit {
 			if (components == null)
 				throw new ArgumentNullException ("components");
 
-			var pNativeFloatArray = IntPtr.Zero;
-			
-			try {
-				pNativeFloatArray = Marshal.AllocHGlobal (components.Length * IntPtr.Size);
-				nfloat.CopyArray (components, 0, pNativeFloatArray, components.Length);
-				return _FromColorSpace (space, pNativeFloatArray, components.Length);
-			} finally {
-				Marshal.FreeHGlobal (pNativeFloatArray);
+			unsafe {
+				fixed (nfloat* componentsptr = &components [0]) {
+					return _FromColorSpace (space, (IntPtr) componentsptr, components.Length);
+				}
 			}
 		}
 
 		public void GetComponents (out nfloat [] components)
 		{
-			var pNativeFloatArray = IntPtr.Zero;
-
-			try {
-				var count = (int)ComponentCount;
-			 	components = new nfloat [count];
-				pNativeFloatArray = Marshal.AllocHGlobal (count * IntPtr.Size);
-				_GetComponents (pNativeFloatArray);
-
-				nfloat.CopyArray (pNativeFloatArray, components, 0, count);
-			} finally {
-				Marshal.FreeHGlobal (pNativeFloatArray);
+			components = new nfloat [(int) ComponentCount];
+			unsafe {
+				fixed (nfloat* componentsptr = &components [0])
+					_GetComponents ((IntPtr) componentsptr);
 			}
 		}
 

--- a/src/NativeTypes/Primitives.tt
+++ b/src/NativeTypes/Primitives.tt
@@ -38,6 +38,7 @@
 #endif
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -408,6 +409,8 @@ namespace System
 			return ((IConvertible)v).ToType (targetType, provider);
 		}
 
+		[Obsolete ("This API is not available in .NET, use Buffer.MemoryCopy instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		public static void CopyArray (IntPtr source, <#= type.NSName #> [] destination, int startIndex, int length)
 		{
 			if (source == IntPtr.Zero)
@@ -427,6 +430,8 @@ namespace System
 				destination [i + startIndex] = (<#= type.NSName #>)Marshal.ReadIntPtr (source, i * <#= type.NSName #>.Size);
 		}
 
+		[Obsolete ("This API is not available in .NET, use Buffer.MemoryCopy instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		public static void CopyArray (<#= type.NSName #> [] source, int startIndex, IntPtr destination, int length)
 		{
 			if (source is null)

--- a/tests/monotouch-test/AppKit/NSColor.cs
+++ b/tests/monotouch-test/AppKit/NSColor.cs
@@ -34,6 +34,19 @@ namespace Xamarin.Mac.Tests
 			Assert.AreEqual (c.GreenComponent, components [1], "Green");
 			Assert.AreEqual (c.BlueComponent, components [2], "Blue");
 		}
+
+		[Test]
+		public void FromColorSpace ()
+		{
+			var components = new nfloat [] { 0, 0.33f, 0.66f, 1 };
+			using var color = NSColor.FromColorSpace (NSColorSpace.GenericRGBColorSpace, components);
+
+			color.GetComponents (out var actualComponents);
+			Assert.AreEqual (components [0], actualComponents [0], "Red");
+			Assert.AreEqual (components [1], actualComponents [1], "Green");
+			Assert.AreEqual (components [2], actualComponents [2], "Blue");
+			Assert.AreEqual (components [3], actualComponents [3], "Alpha");
+		}
 	}
 }
 


### PR DESCRIPTION
There's no corresponding System.Runtime.InteropServices.NFloat.CopyArray method in .NET.

It turned out that the API where we used CopyArray don't need to use CopyArray at all, the same can be accomplished faster and simpler by using unsafe code.