### PR TITLE
[release/6.0.2xx-preview13] [AppKit] Adopt XAMCORE_4_0 changes in .NET.

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -100,7 +100,7 @@ namespace AppKit {
 		Cancelled, Success, Failure, ReplyLater
 	}
 
-#if !XAMCORE_4_0
+#if !NET
 	[NoMacCatalyst]
 	[Native]
 	public enum NSApplicationLayoutDirection : long {
@@ -250,7 +250,7 @@ namespace AppKit {
 	
 #region NSCell Defines 
 
-#if !XAMCORE_4_0
+#if !NET
 	[NoMacCatalyst]
 	[Native]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use formatters instead.")]
@@ -1262,7 +1262,7 @@ namespace AppKit {
 	[NoMacCatalyst]
 	public enum NSStackViewVisibilityPriority : int {
 		MustHold = 1000,
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'MustHold' instead.")]
 		Musthold = MustHold,
 #endif
@@ -1523,7 +1523,7 @@ namespace AppKit {
 	}
 #endif // !NET
 
-#if !XAMCORE_4_0
+#if !NET
 	[NoMacCatalyst]
 	[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use NSTextStorageEditActions instead.")]
 	[Flags]
@@ -1724,7 +1724,7 @@ namespace AppKit {
 	}
 #endif // !NET
 
-#if !XAMCORE_4_0
+#if !NET
 	[NoMacCatalyst]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use NSModalResponse instead.")]
 	[Native]
@@ -1825,7 +1825,7 @@ namespace AppKit {
 	[Native]
 	public enum NSSpeechBoundary : ulong {
 		Immediate =  0,
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'Word' instead.")]
 		hWord,
 #endif
@@ -2121,7 +2121,7 @@ namespace AppKit {
 		AllRenderers       =   1,
 		DoubleBuffer       =   5,
 		TripleBuffer = 3,
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'TripleBuffer' instead.")]
 		TrippleBuffer = TripleBuffer,
 #endif
@@ -2299,7 +2299,7 @@ namespace AppKit {
 		GenericPreferencesIcon        = 0x70726566,   //'pref'
 		GenericQueryDocumentIcon      = 0x71657279,   //'qery'
 		GenericRamDiskIcon            = 0x72616D64,   //'ramd'
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'GenericSharedLibraryIcon' instead.")]
 		GenericSharedLibaryIcon       = 0x73686C62,   //'shlb'
 #endif
@@ -2751,7 +2751,7 @@ namespace AppKit {
 	public enum NSWindowTitleVisibility : long {
 		Visible = 0,
 		Hidden = 1,
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("This API is not available on this platform.")]
 		HiddenWhenActive = 2,
 #endif

--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -38,11 +38,7 @@ namespace AppKit {
 		public static bool CheckForIllegalCrossThreadCalls = true;
 		public static bool CheckForEventAndDelegateMismatches = true;
 
-#if !(XAMCORE_4_0 && NET)
-#if NET
-		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("This field is ignored (treated as if always true).")]
-#endif
+#if !NET
 		public static bool IgnoreMissingAssembliesDuringRegistration = false;
 #endif
 

--- a/src/AppKit/NSBezierPath.cs
+++ b/src/AppKit/NSBezierPath.cs
@@ -102,7 +102,7 @@ namespace AppKit {
 				_AppendPathWithPoints ((IntPtr)ptr, points.Length);
 		}
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'Append (CGPoint[])' instead.")]
 		public unsafe void AppendPathWithPoints (CGPoint[] points)
 		{

--- a/src/AppKit/NSCollectionView.cs
+++ b/src/AppKit/NSCollectionView.cs
@@ -16,19 +16,14 @@ namespace AppKit {
 			_RegisterClassForSupplementaryView (viewClass == null ? IntPtr.Zero : Class.GetHandle (viewClass), kind, identifier);
 		}
 
-#if !XAMCORE_4_0
-#if NET
-		[SupportedOSPlatform ("macos10.11")]
-		[Obsolete ("Use 'GetLayoutAttributes' instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#else
+#if !NET
 		[Mac (10, 11)]
 		[Obsolete ("Use 'GetLayoutAttributes' instead.")]
-#endif
 		public virtual NSCollectionViewLayoutAttributes GetLayoutAttributest (string kind, NSIndexPath indexPath)
 		{
 			return GetLayoutAttributes (kind, indexPath);
 		}
-#endif
+#endif // !NET
 	}
 }
 #endif // !__MACCATALYST__

--- a/src/AppKit/NSCollectionViewDelegate.cs
+++ b/src/AppKit/NSCollectionViewDelegate.cs
@@ -1,4 +1,4 @@
-#if !XAMCORE_4_0 && !__MACCATALYST__
+#if !NET && !__MACCATALYST__
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -8,13 +8,8 @@ namespace AppKit
 {
 	public partial class NSCollectionViewDelegate
 	{
-#if NET
-		[SupportedOSPlatform ("macos10.11")]
-		[Obsolete ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#else
 		[Mac (10, 11)]
 		[Obsolete ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.")]
-#endif
 		public virtual NSDragOperation ValidateDrop (NSCollectionView collectionView, NSDraggingInfo draggingInfo, out NSIndexPath proposedDropIndexPath, out NSCollectionViewDropOperation proposedDropOperation)
 		{
 			proposedDropIndexPath = null;
@@ -25,13 +20,8 @@ namespace AppKit
 
 	public partial class NSCollectionViewDelegateFlowLayout
 	{
-#if NET
-		[SupportedOSPlatform ("macos10.11")]
-		[Obsolete ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#else
 		[Mac (10, 11)]
 		[Obsolete ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.")]
-#endif
 		public virtual NSDragOperation ValidateDrop (NSCollectionView collectionView, NSDraggingInfo draggingInfo, out NSIndexPath proposedDropIndexPath, out NSCollectionViewDropOperation proposedDropOperation)
 		{
 			proposedDropIndexPath = null;
@@ -41,13 +31,8 @@ namespace AppKit
 	}
 
 	public static partial class NSCollectionViewDelegate_Extensions {
-#if NET
-		[SupportedOSPlatform ("macos10.11")]
- 		[Obsolete ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.")]
-#else
 		[Mac (10, 11)]
 		[Obsolete ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.")]
-#endif
 		public static NSDragOperation ValidateDrop (this INSCollectionViewDelegate This, NSCollectionView collectionView, NSDraggingInfo draggingInfo, out NSIndexPath proposedDropIndexPath, out NSCollectionViewDropOperation proposedDropOperation)
 		{
 			proposedDropIndexPath = null;
@@ -56,4 +41,4 @@ namespace AppKit
 		}
 	}
 }
-#endif
+#endif // !NET && !__MACCATALYST__

--- a/src/AppKit/NSDraggingInfo.cs
+++ b/src/AppKit/NSDraggingInfo.cs
@@ -7,6 +7,21 @@ using Foundation;
 using ObjCRuntime;
 
 namespace AppKit {
+#if NET
+	public static partial class INSDraggingInfo_Extensions {
+		public static void EnumerateDraggingItems (this INSDraggingInfo self, NSDraggingItemEnumerationOptions enumOpts, NSView view, INSPasteboardReading [] classArray, NSDictionary searchOptions, NSDraggingEnumerator enumerator)
+		{
+			using var nsa_classArray = NSArray.FromNSObjects (classArray);
+			self.EnumerateDraggingItems (enumOpts, view, nsa_classArray.Handle, searchOptions, enumerator);
+		}
+
+		public static void EnumerateDraggingItems (this INSDraggingInfo self, NSDraggingItemEnumerationOptions enumOpts, NSView view, NSArray classArray, NSDictionary searchOptions, NSDraggingEnumerator enumerator)
+		{
+			self.EnumerateDraggingItems (enumOpts, view, classArray.Handle, searchOptions, enumerator);
+		}
+	}
+
+#else
 	public partial class NSDraggingInfo {
 		public void EnumerateDraggingItems (NSDraggingItemEnumerationOptions enumOpts, NSView view, NSPasteboardReading [] classArray, NSDictionary searchOptions, NSDraggingEnumerator enumerator)
 		{
@@ -20,5 +35,6 @@ namespace AppKit {
 			EnumerateDraggingItems (enumOpts, view, classArray.Handle, searchOptions, enumerator);
 		}
 	}
+#endif
 }
 #endif // !__MACCATALYST__

--- a/src/AppKit/NSDraggingItem.cs
+++ b/src/AppKit/NSDraggingItem.cs
@@ -7,9 +7,11 @@ using Foundation;
 using ObjCRuntime;
 
 namespace AppKit {
+#if !NET
 	public partial class NSDraggingItem {
 		public NSDraggingItem (NSPasteboardWriting pasteboardWriter) : this ((INSPasteboardWriting)pasteboardWriter) {
 		}
 	}
+#endif
 }
 #endif // !__MACCATALYST__

--- a/src/AppKit/NSDraggingSession.cs
+++ b/src/AppKit/NSDraggingSession.cs
@@ -8,7 +8,11 @@ using ObjCRuntime;
 
 namespace AppKit {
 	public partial class NSDraggingSession {
+#if NET
+		public void EnumerateDraggingItems (NSDraggingItemEnumerationOptions enumOpts, NSView view, INSPasteboardReading [] classArray, NSDictionary searchOptions, NSDraggingEnumerator enumerator)
+#else
 		public void EnumerateDraggingItems (NSDraggingItemEnumerationOptions enumOpts, NSView view, NSPasteboardReading [] classArray, NSDictionary searchOptions, NSDraggingEnumerator enumerator)
+#endif
 		{
 			var nsa_classArray = NSArray.FromNSObjects (classArray);
 			EnumerateDraggingItems (enumOpts, view, nsa_classArray.Handle, searchOptions, enumerator);

--- a/src/AppKit/NSLayoutManager.cs
+++ b/src/AppKit/NSLayoutManager.cs
@@ -17,15 +17,8 @@ namespace AppKit {
 namespace UIKit {
 #endif
 	partial class NSLayoutManager {
-#if !XAMCORE_4_0 && MONOMAC
-#if NET
-		[UnsupportedOSPlatform ("macos10.11")]
-#if MONOMAC
-		[Obsolete ("Starting with macos10.11.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-#else
+#if !NET && MONOMAC
 		[Deprecated (PlatformName.MacOSX, 10, 11)]
-#endif
 		public CGRect [] GetRectArray (NSRange glyphRange, NSRange selectedGlyphRange, NSTextContainer textContainer)
 		{
 			if (textContainer == null)
@@ -44,7 +37,7 @@ namespace UIKit {
 			}
 			return returnArray;
 		}
-#endif // MONOMAC
+#endif // !NET && MONOMAC
 
 #if !NET && MONOMAC
 		[Obsolete ("Use 'GetIntAttribute' instead.")]
@@ -52,7 +45,7 @@ namespace UIKit {
 		{
 			return GetIntAttribute (attributeTag, glyphIndex);
 		}
-#endif
+#endif // !NET && MONOMAC
 	}
 }
 

--- a/src/AppKit/NSMutableFontCollection.cs
+++ b/src/AppKit/NSMutableFontCollection.cs
@@ -12,7 +12,7 @@ using System;
 
 namespace AppKit
 {
-#if !XAMCORE_4_0
+#if !NET
 	public partial class NSMutableFontCollection
 	{
 		[Obsolete ("macOS 10.12 does not allow creation via this constructor")]

--- a/src/AppKit/NSPasteboard.cs
+++ b/src/AppKit/NSPasteboard.cs
@@ -16,6 +16,7 @@ namespace AppKit {
 			return result;
 		}
 		
+#if !NET
 		public bool WriteObjects (NSPasteboardWriting [] objects)
 		{
 			var nsa_pasteboardReading = NSArray.FromNSObjects (objects);
@@ -23,6 +24,7 @@ namespace AppKit {
 			nsa_pasteboardReading.Dispose ();
 			return result;
 		}
+#endif
 	}
 }
 #endif // !__MACCATALYST__

--- a/src/AppKit/NSSharingServiceDelegate.cs
+++ b/src/AppKit/NSSharingServiceDelegate.cs
@@ -7,6 +7,7 @@ using Foundation;
 using ObjCRuntime;
 
 namespace AppKit {
+#if !NET
 	public partial class NSSharingServiceDelegate {
 		CGRect SourceFrameOnScreenForShareItem (NSSharingService sharingService, NSPasteboardWriting item)
 		{
@@ -18,5 +19,6 @@ namespace AppKit {
 			return TransitionImageForShareItem (sharingService, (INSPasteboardWriting)item, contentRect);
 		}
 	}
+#endif
 }
 #endif // !__MACCATALYST__

--- a/src/AppKit/NSTextTableBlock.cs
+++ b/src/AppKit/NSTextTableBlock.cs
@@ -12,7 +12,7 @@ using System;
 
 namespace AppKit
 {
-#if !XAMCORE_4_0
+#if !NET
 	public partial class NSTextTableBlock
 	{
 		[Obsolete ("macOS 10.12 does not allow creation via this constructor")]

--- a/src/AppKit/NSTouch.cs
+++ b/src/AppKit/NSTouch.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace AppKit {
 	public partial class NSTouch {
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("This type is not meant to be user-created")]
 		public NSTouch ()
 		{

--- a/src/AppKit/NSWorkspace.cs
+++ b/src/AppKit/NSWorkspace.cs
@@ -65,12 +65,8 @@ namespace AppKit {
 			return NSFileTypeForHFSTypeCode (fourCcTypeCode);
 		}
 
-#if !XAMCORE_4_0
 #if !NET
-		[Obsolete ("Use the overload that takes 'ref NSError' instead.")]
-#else
-		[Obsolete ("Use the overload that takes 'ref NSError' instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif // !NET
+		[Obsolete ("Use the overload that takes 'out NSError' instead.")]
 		public virtual NSRunningApplication LaunchApplication (NSUrl url, NSWorkspaceLaunchOptions options, NSDictionary configuration, NSError error)
 		{
 			return LaunchApplication (url, options, configuration, out error);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -165,11 +165,16 @@ namespace AppKit {
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSAnimationDelegate)})]
 	interface NSAnimation : NSCoding, NSCopying {
+#if NET
+		[DesignatedInitializer]
+#endif
 		[Export ("initWithDuration:animationCurve:")]
+#if !NET
 		[Sealed] // Just to avoid the duplicate selector error
+#endif
 		NativeHandle Constructor (double duration, NSAnimationCurve animationCurve);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the constructor instead.")]
 		[Export ("initWithDuration:animationCurve:")]
 		IntPtr Constant (double duration, NSAnimationCurve animationCurve);
@@ -603,7 +608,7 @@ namespace AppKit {
 		[Export ("nextEventMatchingMask:untilDate:inMode:dequeue:"), Protected]
 		NSEvent NextEvent (NSEventMask mask, [NullAllowed] NSDate expiration, NSString runLoopMode, bool deqFlag);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the 'NextEvent (NSEventMask, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
 		[Wrap ("NextEvent ((NSEventMask) (ulong) mask, expiration, (NSString) mode, deqFlag)", IsVirtual = true), Protected]
 		NSEvent NextEvent (nuint mask, NSDate expiration, string mode, bool deqFlag);
@@ -638,7 +643,7 @@ namespace AppKit {
 		[Deprecated (PlatformName.MacOSX, 10, 12, message: "Use EnumerateWindows instead.")]
 		NSWindow MakeWindowsPerform (Selector aSelector, bool inOrder);
 	
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Remove usage or use 'DangerousWindows' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Wrap ("DangerousWindows", IsVirtual = true)] 
@@ -740,7 +745,7 @@ namespace AppKit {
 		NSObject ServicesProvider { get; set; }
 	
 		[Export ("userInterfaceLayoutDirection")]
-#if !XAMCORE_4_0
+#if !NET
 		NSApplicationLayoutDirection UserInterfaceLayoutDirection { get; }
 #else
 		NSUserInterfaceLayoutDirection UserInterfaceLayoutDirection { get; }
@@ -855,16 +860,7 @@ namespace AppKit {
 		[Export ("completeStateRestoration")]
 		void CompleteStateRestoration ();
 
-#if XAMCORE_4_0
-		[Export ("registerServicesMenuSendTypes:returnTypes:"), EventArgs ("NSApplicationRegister")]
-		void RegisterServicesMenu (string [] sendTypes, string [] returnTypes);
-
-		[Export ("orderFrontStandardAboutPanel:")]
-		void OrderFrontStandardAboutPanel (NSObject sender);
-
-		[Export ("orderFrontStandardAboutPanelWithOptions:")]
-		void OrderFrontStandardAboutPanelWithOptions (NSDictionary optionsDictionary);
-#else
+#if !NET
 		[Export ("registerServicesMenuSendTypes:returnTypes:"), EventArgs ("NSApplicationRegister")]
 		void RegisterServicesMenu2 (string [] sendTypes, string [] returnTypes);
 
@@ -882,6 +878,29 @@ namespace AppKit {
 		[Mac (12,0)]
 		[Export ("protectedDataAvailable")]
 		bool ProtectedDataAvailable { [Bind ("isProtectedDataAvailable")] get; }
+	}
+
+	[NoMacCatalyst]
+	[Category]
+	[BaseType (typeof(NSApplication))]
+	interface NSApplication_NSServicesMenu {
+		[Export ("registerServicesMenuSendTypes:returnTypes:"), EventArgs ("NSApplicationRegister")]
+		void RegisterServicesMenu (string [] sendTypes, string [] returnTypes);
+	}
+
+	[NoMacCatalyst]
+	[Category]
+	[BaseType (typeof(NSApplication))]
+	interface NSApplication_NSStandardAboutPanel {
+		[Export ("orderFrontStandardAboutPanel:")]
+		void OrderFrontStandardAboutPanel ([NullAllowed] NSObject sender);
+
+		[Export ("orderFrontStandardAboutPanelWithOptions:")]
+#if XAMCORE_5_0
+		void OrderFrontStandardAboutPanelWithOptions (NSDictionary<NSAboutPanelOption, NSObject> optionsDictionary);
+#else
+		void OrderFrontStandardAboutPanelWithOptions (NSDictionary optionsDictionary);
+#endif
 	}
 
 	[NoMacCatalyst]
@@ -1002,7 +1021,7 @@ namespace AppKit {
 		[Export ("applicationDidChangeScreenParameters:"), EventArgs ("NSNotification")]
 		void ScreenParametersChanged (NSNotification notification);
 
-#if !XAMCORE_4_0 // Needs to move from delegate in next API break
+#if !NET // Needs to move from delegate in next API break
 		[Obsolete ("Use the 'RegisterServicesMenu2' on NSApplication.")]
 		[Export ("registerServicesMenuSendTypes:returnTypes:"), EventArgs ("NSApplicationRegister")]
 		void RegisterServicesMenu (string [] sendTypes, string [] returnTypes);
@@ -2053,10 +2072,18 @@ namespace AppKit {
 		//NSImage DraggingImageForRowsWithIndexes (NSBrowser browser, NSIndexSet rowIndexes, int column, NSEvent theEvent, NSPointPointer dragImageOffset);
 
 		[Export ("browser:validateDrop:proposedRow:column:dropOperation:")]
+#if NET
+		NSDragOperation ValidateDrop (NSBrowser browser, INSDraggingInfo info, ref nint row, ref nint column, ref NSBrowserDropOperation dropOperation);
+#else
 		NSDragOperation ValidateDrop (NSBrowser browser, [Protocolize (4)] NSDraggingInfo info, ref nint row, ref nint column, ref NSBrowserDropOperation dropOperation);
+#endif
 
 		[Export ("browser:acceptDrop:atRow:column:dropOperation:")]
+#if NET
+		bool AcceptDrop (NSBrowser browser, INSDraggingInfo info, nint row, nint column, NSBrowserDropOperation dropOperation);
+#else
 		bool AcceptDrop (NSBrowser browser, [Protocolize (4)] NSDraggingInfo info, nint row, nint column, NSBrowserDropOperation dropOperation);
+#endif
 
 		[return: NullAllowed]
 		[Export ("browser:typeSelectStringForRow:inColumn:")]
@@ -3163,10 +3190,18 @@ namespace AppKit {
 		//NSImage DraggingImageForItems (NSCollectionView collectionView, NSIndexSet indexes, NSEvent evg, NSPointPointer dragImageOffset);
 
 		[Export ("collectionView:validateDrop:proposedIndex:dropOperation:")]
+#if NET
+		NSDragOperation ValidateDrop (NSCollectionView collectionView, INSDraggingInfo draggingInfo, ref nint dropIndex, ref NSCollectionViewDropOperation dropOperation);
+#else
 		NSDragOperation ValidateDrop (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, ref nint dropIndex, ref NSCollectionViewDropOperation dropOperation);
+#endif
 
 		[Export ("collectionView:acceptDrop:index:dropOperation:")]
+#if NET
+		bool AcceptDrop (NSCollectionView collectionView, INSDraggingInfo draggingInfo, nint index, NSCollectionViewDropOperation dropOperation);
+#else
 		bool AcceptDrop (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, nint index, NSCollectionViewDropOperation dropOperation);
+#endif
 
 		[Mac (10,11)]
 		[Export ("collectionView:canDragItemsAtIndexPaths:withEvent:")]
@@ -3186,7 +3221,7 @@ namespace AppKit {
 		[Export ("collectionView:draggingImageForItemsAtIndexPaths:withEvent:offset:")]
 		NSImage GetDraggingImage (NSCollectionView collectionView, NSSet indexPaths, NSEvent theEvent, ref CGPoint dragImageOffset);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Mac (10,11)]
 		[Export ("collectionView:validateDrop:proposedIndexPath:dropOperation:")]
 		NSDragOperation ValidateDropOperation (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation);
@@ -3198,7 +3233,11 @@ namespace AppKit {
 
 		[Mac (10,11)]
 		[Export ("collectionView:acceptDrop:indexPath:dropOperation:")]
+#if NET
+		bool AcceptDrop (NSCollectionView collectionView, INSDraggingInfo draggingInfo, NSIndexPath indexPath, NSCollectionViewDropOperation dropOperation);
+#else
 		bool AcceptDrop (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, NSIndexPath indexPath, NSCollectionViewDropOperation dropOperation);
+#endif
 
 		[Mac (10,11)]
 		[Export ("collectionView:pasteboardWriterForItemAtIndexPath:")]
@@ -3663,7 +3702,7 @@ namespace AppKit {
 	[BaseType (typeof(NSCollectionViewLayout))]
 	interface NSCollectionViewTransitionLayout
 	{
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the constructor that allows you to set currentLayout and newLayout.")]
 		[Export ("init")]
 		NativeHandle Constructor ();
@@ -4934,7 +4973,7 @@ namespace AppKit {
 		NSFont Font { get; set; }
 
 		[Export ("formatter", ArgumentSemantic.Retain), NullAllowed]
-#if XAMCORE_4_0
+#if NET
 		NSFormatter Formatter { get; set; }
 #else
 		NSObject Formatter { get; set; }
@@ -5062,7 +5101,7 @@ namespace AppKit {
 	[DesignatedDefaultCtor]
 	[BaseType (typeof (NSObject))]
 	interface NSController : NSCoding, NSEditorRegistration 
-#if XAMCORE_4_0
+#if NET
 	, NSEditor // Conflict over if CommitEditing is a property or a method. NSViewController has it right so can't "fix" NSEditor to match existing API
 #endif
 	{
@@ -5070,9 +5109,13 @@ namespace AppKit {
 		void DiscardEditing ();
 
 		[Export ("commitEditingWithDelegate:didCommitSelector:contextInfo:")]
+#if NET
+		void CommitEditing ([NullAllowed] NSObject delegate1, [NullAllowed] Selector didCommitSelector, IntPtr contextInfo);
+#else
 		void CommitEditingWithDelegate ([NullAllowed] NSObject delegate1, [NullAllowed] Selector didCommitSelector, IntPtr contextInfo);
+#endif
 
-#if XAMCORE_4_0
+#if NET
 		[Export ("objectDidBeginEditing:")]
 		void ObjectDidBeginEditing (INSEditor editor);
 
@@ -5087,7 +5130,11 @@ namespace AppKit {
 #endif
 
 		[Export ("commitEditing")]
+#if NET
+		bool CommitEditing ();
+#else
 		bool CommitEditing { get; }
+#endif
 
 		[Export ("isEditing")]
 		bool IsEditing { get; }
@@ -5691,7 +5738,7 @@ namespace AppKit {
 
 		// Found in NSUserInterfaceValidations protocol with INSValidatedUserInterfaceItem param but bound originally with NSObject
 		// Adding protocol gave warning 0108 which is unfixable without API break 
-#if XAMCORE_4_0
+#if NET
 		[Export ("validateUserInterfaceItem:")]
 		bool ValidateUserInterfaceItem (INSValidatedUserInterfaceItem anItem);
 #else
@@ -5977,7 +6024,7 @@ namespace AppKit {
 
 		// Found in NSUserInterfaceValidations protocol with INSValidatedUserInterfaceItem param but bound originally with NSObject
 		// Adding protocol gave warning 0108 which is unfixable without API break 
-#if XAMCORE_4_0
+#if NET
 		[Export ("validateUserInterfaceItem:")]
 		bool ValidateUserInterfaceItem (INSValidatedUserInterfaceItem anItem);
 #else
@@ -6050,7 +6097,7 @@ namespace AppKit {
 	}
 	
 	[NoMacCatalyst]
-#if !XAMCORE_4_0
+#if !NET
 	[BaseType (typeof (NSObject))]
 #endif
 	[Protocol] // Apple docs say: "you never need to create a class that implements the NSDraggingInfo protocol.", so don't add [Model]
@@ -6157,31 +6204,61 @@ namespace AppKit {
 		void ResetSpringLoading ();
 	}
 
+	interface INSDraggingInfo { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
 	interface NSDraggingDestination {
 		[Export ("draggingEntered:"), DefaultValue (NSDragOperation.None)]
+#if NET
+		NSDragOperation DraggingEntered (INSDraggingInfo sender);
+#else
 		NSDragOperation DraggingEntered ([Protocolize (4)] NSDraggingInfo sender);
+#endif
 
 		[Export ("draggingUpdated:"), DefaultValue (NSDragOperation.None)]
+#if NET
+		NSDragOperation DraggingUpdated (INSDraggingInfo sender);
+#else
 		NSDragOperation DraggingUpdated ([Protocolize (4)] NSDraggingInfo sender);
+#endif
 
 		[Export ("draggingExited:")]
+#if NET
+		void DraggingExited ([NullAllowed] INSDraggingInfo sender);
+#else
 		void DraggingExited ([Protocolize (4)] NSDraggingInfo sender);
+#endif
 
 		[Export ("prepareForDragOperation:"), DefaultValue (false)]
+#if NET
+		bool PrepareForDragOperation (INSDraggingInfo sender);
+#else
 		bool PrepareForDragOperation ([Protocolize (4)] NSDraggingInfo sender);
+#endif
 
 		[Export ("performDragOperation:"), DefaultValue (false)]
+#if NET
+		bool PerformDragOperation (INSDraggingInfo sender);
+#else
 		bool PerformDragOperation ([Protocolize (4)] NSDraggingInfo sender);
+#endif
 
 		[Export ("concludeDragOperation:")]
+#if NET
+		void ConcludeDragOperation ([NullAllowed] INSDraggingInfo sender);
+#else
 		void ConcludeDragOperation ([Protocolize (4)] NSDraggingInfo sender);
+#endif
 
 		[Export ("draggingEnded:")]
+#if NET
+		void DraggingEnded (INSDraggingInfo sender);
+#else
 		void DraggingEnded ([Protocolize (4)] NSDraggingInfo sender);
+#endif
 
 		[DebuggerBrowsableAttribute (DebuggerBrowsableState.Never)]
 		[Export ("wantsPeriodicDraggingUpdates"), DefaultValue (true)]
@@ -7406,7 +7483,7 @@ namespace AppKit {
 		[Export ("gridViewWithNumberOfColumns:rows:")]
 		NSGridView Create (nint columnCount, nint rowCount);
 		
-#if !XAMCORE_4_0
+#if !NET
 		[Static]
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Obsolete ("You should use either 'NSGridView.Create(NSView [][] rowsAndColumns)' or 'NSGridView.Create(NSView [,] rowsAndColumns)'.")]
@@ -8185,7 +8262,7 @@ namespace AppKit {
 		[Export ("itemArray", ArgumentSemantic.Copy)]
 		NSMenuItem[] Items { get; [Mac (10, 14)] set; }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'Items' instead.")]
 		[Wrap ("Items", IsVirtual = true)]
 		NSMenuItem [] ItemArray ();
@@ -8988,7 +9065,7 @@ namespace AppKit {
 		nint RunModal (string [] types);
 	}
 
-#if !XAMCORE_4_0 && !__MACCATALYST__
+#if !NET && !__MACCATALYST__
 	// This class doesn't show up in any documentation
 	[BaseType (typeof (NSOpenPanel))]
 	[DisableDefaultCtor] // should not be created by (only returned to) user code
@@ -9291,10 +9368,18 @@ namespace AppKit {
 		bool OutlineViewwriteItemstoPasteboard (NSOutlineView outlineView, NSArray items, NSPasteboard pboard);
 	
 		[Export ("outlineView:validateDrop:proposedItem:proposedChildIndex:")]
+#if NET
+		NSDragOperation ValidateDrop (NSOutlineView outlineView, INSDraggingInfo info, [NullAllowed] NSObject item, nint index);
+#else
 		NSDragOperation ValidateDrop (NSOutlineView outlineView, [Protocolize (4)] NSDraggingInfo info, [NullAllowed] NSObject item, nint index);
+#endif
 	
 		[Export ("outlineView:acceptDrop:item:childIndex:")]
+#if NET
+		bool AcceptDrop (NSOutlineView outlineView, INSDraggingInfo info, [NullAllowed] NSObject item, nint index);
+#else
 		bool AcceptDrop (NSOutlineView outlineView, [Protocolize (4)] NSDraggingInfo info, [NullAllowed] NSObject item, nint index);
+#endif
 	
 		[Export ("outlineView:namesOfPromisedFilesDroppedAtDestination:forDraggedItems:")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'NSFilePromiseReceiver' objects instead.")]
@@ -11271,8 +11356,12 @@ namespace AppKit {
 	}
 	
 	[NoMacCatalyst]
+#if !NET
+	// A class that implements only NSPasteboardWriting does not make sense, it's
+	// used to add pasteboard support to existing classes.
 	[BaseType (typeof (NSObject))]
 	[Model]
+#endif
 	[Protocol]
 	interface NSPasteboardWriting {
 #if NET
@@ -11342,8 +11431,8 @@ namespace AppKit {
 	interface INSPasteboardWriting {}
 
 	[NoMacCatalyst]
+#if !NET
 	[BaseType (typeof (NSObject))]
-#if !XAMCORE_4_0
 	// A class that implements only NSPasteboardReading does not make sense, it's
 	// used to add pasteboard support to existing classes.
 	[Model]
@@ -11540,10 +11629,18 @@ namespace AppKit {
 		bool ShouldDragPathComponentCell (NSPathControl pathControl, NSPathComponentCell pathComponentCell, NSPasteboard pasteboard);
 
 		[Export ("pathControl:validateDrop:")]
+#if NET
+		NSDragOperation ValidateDrop (NSPathControl pathControl, INSDraggingInfo info);
+#else
 		NSDragOperation ValidateDrop (NSPathControl pathControl, [Protocolize (4)] NSDraggingInfo info);
+#endif
 
 		[Export ("pathControl:acceptDrop:")]
+#if NET
+		bool AcceptDrop (NSPathControl pathControl, INSDraggingInfo info);
+#else
 		bool AcceptDrop (NSPathControl pathControl, [Protocolize (4)] NSDraggingInfo info);
+#endif
 
 		[Export ("pathControl:willDisplayOpenPanel:")]
 		void WillDisplayOpenPanel (NSPathControl pathControl, NSOpenPanel openPanel);
@@ -12010,19 +12107,19 @@ namespace AppKit {
 		[Export ("printSettings")]
 		NSMutableDictionary PrintSettings { get; }
 
-#if XAMCORE_4_0
+#if NET
 		[Internal]
 #endif
 		[Export ("PMPrintSession")]
 		IntPtr GetPMPrintSession ();
 
-#if XAMCORE_4_0
+#if NET
 		[Internal]
 #endif
 		[Export ("PMPageFormat")]
 		IntPtr GetPMPageFormat ();
 
-#if XAMCORE_4_0
+#if NET
 		[Internal]
 #endif
 		[Export ("PMPrintSettings")]
@@ -13085,7 +13182,7 @@ namespace AppKit {
 		
 	}
 
-#if !XAMCORE_4_0 && !__MACCATALYST__
+#if !NET && !__MACCATALYST__
 	// This class doesn't show up in any documentation.
 	[BaseType (typeof (NSSavePanel))]
 	[DisableDefaultCtor] // should not be created by (only returned to) user code
@@ -13857,12 +13954,11 @@ namespace AppKit {
 
 		[Export ("vertical")]
 		// Radar 27222357
-#if XAMCORE_4_0
-		bool
+#if NET
+		bool IsVertical { [Bind ("isVertical")] get; [Mac (10, 12)] set; }
 #else
-		nint
+		nint IsVertical { [Bind ("isVertical")] get; [Mac (10, 12)] set; }
 #endif
-		IsVertical { [Bind ("isVertical")] get; [Mac (10, 12)] set; }
 
 		[Export ("acceptsFirstMouse:")]
 		bool AcceptsFirstMouse (NSEvent theEvent);
@@ -13959,12 +14055,11 @@ namespace AppKit {
 
 		[Export ("vertical")]
 		// Radar 27222357
-#if XAMCORE_4_0
-		bool
+#if NET
+		bool IsVertical { [Bind ("isVertical")] get; [Mac (10, 12)] set; }
 #else
-		nint
+		nint IsVertical { [Bind ("isVertical")] get; [Mac (10, 12)] set; }
 #endif
-		IsVertical { [Bind ("isVertical")] get; [Mac (10, 12)] set; }
 
 		[Export ("knobRectFlipped:")]
 		CGRect KnobRectFlipped (bool flipped);
@@ -14414,7 +14509,7 @@ namespace AppKit {
 		bool IsAutomaticTextCompletionEnabled { get; }
 
 		[Mac (10,12,2)]
-#if XAMCORE_4_0
+#if NET
 		[Async (ResultTypeName="NSSpellCheckerCandidates")]
 #else
 		[Async (ResultTypeName="NSSpellCheckerCanidates")]
@@ -14781,23 +14876,47 @@ namespace AppKit {
 	{
 		[Abstract]
 		[Export ("springLoadingActivated:draggingInfo:")]
+#if NET
+		void Activated (bool activated, INSDraggingInfo draggingInfo);
+#else
 		void Activated (bool activated, [Protocolize (4)] NSDraggingInfo draggingInfo);
+#endif
 
 		[Abstract]
 		[Export ("springLoadingHighlightChanged:")]
+#if NET
+		void HighlightChanged (INSDraggingInfo draggingInfo);
+#else
 		void HighlightChanged ([Protocolize (4)] NSDraggingInfo draggingInfo);
+#endif
 
 		[Export ("springLoadingEntered:")]
+#if NET
+		NSSpringLoadingOptions Entered (INSDraggingInfo draggingInfo);
+#else
 		NSSpringLoadingOptions Entered ([Protocolize (4)] NSDraggingInfo draggingInfo);
+#endif
 
 		[Export ("springLoadingUpdated:")]
+#if NET
+		NSSpringLoadingOptions Updated (INSDraggingInfo draggingInfo);
+#else
 		NSSpringLoadingOptions Updated ([Protocolize (4)] NSDraggingInfo draggingInfo);
+#endif
 
 		[Export ("springLoadingExited:")]
+#if NET
+		void Exited (INSDraggingInfo draggingInfo);
+#else
 		void Exited ([Protocolize (4)] NSDraggingInfo draggingInfo);
+#endif
 
 		[Export ("draggingEnded:")]
+#if NET
+		void DraggingEnded (INSDraggingInfo draggingInfo);
+#else
 		void DraggingEnded ([Protocolize (4)] NSDraggingInfo draggingInfo);
+#endif
 	}
 
 	[Mac (10,9)]
@@ -15852,13 +15971,17 @@ namespace AppKit {
 		NSMenu DefaultMenu ();
 
 		[Export ("addToolTipRect:owner:userData:")]
-#if !XAMCORE_4_0
+#if !NET
 		nint AddToolTip (CGRect rect, NSObject owner, IntPtr userData);
 #else
 		nint AddToolTip (CGRect rect, INSToolTipOwner owner, IntPtr userData);
 #endif
 
+#if NET
+		[Wrap ("AddToolTip (rect, owner, IntPtr.Zero)")]
+#else
 		[Wrap ("AddToolTip (rect, (NSObject)owner, IntPtr.Zero)")]
+#endif
 		nint AddToolTip (CGRect rect, INSToolTipOwner owner);
 
 		[Export ("removeToolTip:")]
@@ -17413,10 +17536,18 @@ namespace AppKit {
 		bool WriteRows (NSTableView tableView, NSIndexSet rowIndexes, NSPasteboard pboard );
 	
 		[Export ("tableView:validateDrop:proposedRow:proposedDropOperation:")]
+#if NET
+		NSDragOperation ValidateDrop (NSTableView tableView, INSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+#else
 		NSDragOperation ValidateDrop (NSTableView tableView, [Protocolize (4)] NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+#endif
 	
 		[Export ("tableView:acceptDrop:row:dropOperation:")]
+#if NET
+		bool AcceptDrop (NSTableView tableView, INSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+#else
 		bool AcceptDrop (NSTableView tableView, [Protocolize (4)] NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+#endif
 	
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'NSFilePromiseReceiver' instead.")]
 		[Export ("tableView:namesOfPromisedFilesDroppedAtDestination:forDraggedRowsWithIndexes:")]
@@ -17432,7 +17563,11 @@ namespace AppKit {
 		void DraggingSessionEnded (NSTableView tableView, NSDraggingSession draggingSession, CGPoint endedAtScreenPoint, NSDragOperation operation);
 
 		[Export ("tableView:updateDraggingItemsForDrag:")]
+#if NET
+		void UpdateDraggingItems (NSTableView tableView, INSDraggingInfo draggingInfo);
+#else
 		void UpdateDraggingItems (NSTableView tableView, [Protocolize (4)] NSDraggingInfo draggingInfo);
+#endif
 	}
 
 	//
@@ -17536,10 +17671,18 @@ namespace AppKit {
 		bool WriteRows (NSTableView tableView, NSIndexSet rowIndexes, NSPasteboard pboard );
 	
 		[Export ("tableView:validateDrop:proposedRow:proposedDropOperation:")]
+#if NET
+		NSDragOperation ValidateDrop (NSTableView tableView, INSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+#else
 		NSDragOperation ValidateDrop (NSTableView tableView, [Protocolize (4)] NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+#endif
 	
 		[Export ("tableView:acceptDrop:row:dropOperation:")]
+#if NET
+		bool AcceptDrop (NSTableView tableView, INSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+#else
 		bool AcceptDrop (NSTableView tableView, [Protocolize (4)] NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+#endif
 	
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'NSFilePromiseReceiver' objects instead.")]
 		[Export ("tableView:namesOfPromisedFilesDroppedAtDestination:forDraggedRowsWithIndexes:")]
@@ -17567,7 +17710,11 @@ namespace AppKit {
 		void DraggingSessionEnded (NSTableView tableView, NSDraggingSession draggingSession, CGPoint endedAtScreenPoint, NSDragOperation operation);
 
 		[Export ("tableView:updateDraggingItemsForDrag:")]
+#if NET
+		void UpdateDraggingItems (NSTableView tableView, INSDraggingInfo draggingInfo);
+#else
 		void UpdateDraggingItems (NSTableView tableView, [Protocolize (4)] NSDraggingInfo draggingInfo);
+#endif
 	}
 	
 	[NoMacCatalyst]
@@ -17672,7 +17819,7 @@ namespace AppKit {
 		[Export ("tabViewType")]
 		NSTabViewType TabViewType { get; set; }
 
-#if XAMCORE_4_0
+#if NET
 		[Export ("tabViewItems")]
 		NSTabViewItem [] Items { get; [Mac (10, 14)] set; }
 #else
@@ -17756,7 +17903,7 @@ namespace AppKit {
 		[Export ("tabView", ArgumentSemantic.Strong)]
 		NSTabView TabView { get; set; }
 
-#if !XAMCORE_4_0 && MONOMAC
+#if !NET && MONOMAC
 		// This property does not exist in any stable header - it was probably added in a beta and then removed.
 		[Obsoleted (PlatformName.MacOSX, 10, 10, message: "Do not use; this API was removed.")]
 		[Export ("segmentedControl", ArgumentSemantic.Strong)]
@@ -18589,20 +18736,26 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	interface NSTextList : NSCoding, NSCopying, NSSecureCoding {
 		[Export ("initWithMarkerFormat:options:")]
-		NativeHandle Constructor (
-#if XAMCORE_4_0
-		[BindAs (typeof (NSTextListMarkerFormats))] 
+#if NET
+		NativeHandle Constructor ([BindAs (typeof (NSTextListMarkerFormats))] NSString format, NSTextListOptions mask);
+#else
+		NativeHandle Constructor (string format, NSTextListOptions mask);
 #endif
-		string format, NSTextListOptions mask);
 
+#if !NET
 		[Wrap ("this (format.GetConstant(), mask)")]
 		NativeHandle Constructor (NSTextListMarkerFormats format, NSTextListOptions mask);
+#endif
 
-#if XAMCORE_4_0
+#if NET
 		[BindAs (typeof (NSTextListMarkerFormats))] 
 #endif
 		[Export ("markerFormat")]
+#if NET
+		NSString MarkerFormat { get; }
+#else
 		string MarkerFormat { get; }
+#endif
 
 		[Export ("listOptions")]
 		NSTextListOptions ListOptions { get; }
@@ -19032,7 +19185,11 @@ namespace AppKit {
 		string [] AcceptableDragTypes ();
 
 		[Export ("dragOperationForDraggingInfo:type:")]
+#if NET
+		NSDragOperation DragOperationForDraggingInfo (INSDraggingInfo dragInfo, string type);
+#else
 		NSDragOperation DragOperationForDraggingInfo ([Protocolize (4)] NSDraggingInfo dragInfo, string type);
+#endif
 
 		[Export ("cleanUpAfterDragOperation")]
 		void CleanUpAfterDragOperation ();
@@ -19213,7 +19370,7 @@ namespace AppKit {
 		[Export ("toggleSmartInsertDelete:")]
 		void ToggleSmartInsertDelete (NSObject sender);
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'SmartInsert(string, NSRange, out string, out string)' overload instead.")]
 		[Wrap ("throw new NotSupportedException ()", IsVirtual = true)]
 		void SmartInsert (string pasteString, NSRange charRangeToReplace, string beforeString, string afterString);
@@ -20158,7 +20315,7 @@ namespace AppKit {
 		void RearrangeObjects ();
 
 		[Export ("arrangedObjects")]
-#if XAMCORE_4_0
+#if NET
 		NSTreeNode ArrangedObjects { get; }
 #else
 		NSObject ArrangedObjects { get; }
@@ -21144,7 +21301,7 @@ namespace AppKit {
 		[Mac (10,9)]
 		[Export ("endSheet:returnCode:")]
 		void EndSheet (NSWindow sheetWindow, NSModalResponse returnCode);
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use the EndSheet(NSWindow,NSModalResponse) overload.")]
 		[Mac (10,9)]
 		[Wrap ("EndSheet (sheetWindow, (NSModalResponse)(long)returnCode)", IsVirtual = true)]
@@ -22731,7 +22888,11 @@ namespace AppKit {
 		INSPasteboardWriting PasteboardWriterForItem (NSCollectionView collectionView, nuint index);
 
 		[Export ("collectionView:updateDraggingItemsForDrag:")]
+#if NET
+		void UpdateDraggingItemsForDrag (NSCollectionView collectionView, INSDraggingInfo draggingInfo);
+#else
 		void UpdateDraggingItemsForDrag (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo);
+#endif
 
 		[Export ("collectionView:draggingSession:willBeginAtPoint:forItemsAtIndexes:")]
 		void DraggingSessionWillBegin (NSCollectionView collectionView, NSDraggingSession draggingSession,
@@ -22868,7 +23029,11 @@ namespace AppKit {
 
 		// - (void)outlineView:(NSOutlineView *)outlineView updateDraggingItemsForDrag:(id <NSDraggingInfo>)draggingInfo NS_AVAILABLE_MAC(10_7);
 		[Export ("outlineView:updateDraggingItemsForDrag:")]
+#if NET
+		void UpdateDraggingItemsForDrag (NSOutlineView outlineView, INSDraggingInfo draggingInfo);
+#else
 		void UpdateDraggingItemsForDrag (NSOutlineView outlineView, [Protocolize (4)] NSDraggingInfo draggingInfo);
+#endif
 	}
 
 	interface NSWindowExposeEventArgs {
@@ -22955,7 +23120,9 @@ namespace AppKit {
 		NSPrintRenderingQuality PreferredRenderingQuality { get; }
 	}
 
-#if !XAMCORE_4_0
+#if !NET
+	// This category is implemented directly on the NSResponder class instead.
+	// Ref: https://github.com/xamarin/xamarin-macios/issues/4837
 	[NoMacCatalyst]
 	[Category, BaseType (typeof (NSResponder))]
  	partial interface NSControlEditingSupport {
@@ -22978,7 +23145,8 @@ namespace AppKit {
 		[Export ("quickLookWithEvent:")]
 		void QuickLook (NSEvent withEvent);
 
-		// From  NSControlEditingSupport category. Needs to be here to make the API easier to be used. issue 4837
+		// Inlined the NSControlEditingSupport category. Needs to be here to make the API easier to be used.
+		// Ref: https://github.com/xamarin/xamarin-macios/issues/4837
 		[Export ("validateProposedFirstResponder:forEvent:")]
 		bool ValidateProposedFirstResponder (NSResponder responder, [NullAllowed] NSEvent forEvent);
 
@@ -24723,7 +24891,7 @@ namespace AppKit {
 		[Field ("NSAccessibilityWindowAttribute")]
 		NSString WindowAttribute { get; }
 
-#if !XAMCORE_4_0
+#if !NET
 		[Obsolete ("Use 'TopLevelUIElementAttribute' instead.")]
 		[Field ("NSAccessibilityTopLevelUIElementAttribute")]
 		NSString ToplevelUIElementAttribute { get; }

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -16558,6 +16558,10 @@ namespace AppKit {
 		[Export ("initWithViewAnimations:")]
 		NativeHandle Constructor (NSDictionary [] viewAnimations);
 	
+		[DesignatedInitializer]
+		[Export ("initWithDuration:animationCurve:")]
+		NativeHandle Constructor (double duration, NSAnimationCurve animationCurve);
+
 		[Export ("viewAnimations", ArgumentSemantic.Copy)]
 		NSDictionary [] ViewAnimations { get; set; }
 	

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8881,7 +8881,6 @@ namespace Foundation
 
 		[Deprecated (PlatformName.MacOSX, message: "Now on 'NSEditor' protocol.")]
 		[Export ("commitEditingWithDelegate:didCommitSelector:contextInfo:")]
-		//void CommitEditingWithDelegateDidCommitSelectorContextInfo (NSObject objDelegate, Selector didCommitSelector, IntPtr contextInfo);
 		void CommitEditing (NSObject objDelegate, Selector didCommitSelector, IntPtr contextInfo);
 #endif
 		[Export ("methodForSelector:")]

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -2412,13 +2412,17 @@ namespace WebKit {
 
 		[Export ("webView:dragDestinationActionMaskForDraggingInfo:"), DelegateName ("DragDestinationGetActionMask"), DefaultValue (0)]
 #if NET
-		WebDragDestinationAction UIGetDragDestinationActionMask (WebView webView, NSDraggingInfo draggingInfo);
+		WebDragDestinationAction UIGetDragDestinationActionMask (WebView webView, INSDraggingInfo draggingInfo);
 #else
 		NSEventModifierMask UIGetDragDestinationActionMask (WebView webView, NSDraggingInfo draggingInfo);
 #endif
 
 		[Export ("webView:willPerformDragDestinationAction:forDraggingInfo:"), EventArgs ("WebViewDrag")]
+#if NET
+		void UIWillPerformDragDestination (WebView webView, WebDragDestinationAction action, INSDraggingInfo draggingInfo);
+#else
 		void UIWillPerformDragDestination (WebView webView, WebDragDestinationAction action, NSDraggingInfo draggingInfo);
+#endif
 
 		[Export ("webView:dragSourceActionMaskForPoint:"), DelegateName ("DragSourceGetActionMask"), DefaultValue (0)]
 #if NET

--- a/tests/introspection/Mac/MacApiTypoTest.cs
+++ b/tests/introspection/Mac/MacApiTypoTest.cs
@@ -31,6 +31,7 @@ namespace Introspection
 			return txt.Substring ((int)typoRange.Location, (int)typoRange.Length);
 		}
 
+#if !NET
 		public override bool Skip (Type baseType, string typo)
 		{
 			if (baseType == typeof (NSSpellCheckerCanidates))
@@ -38,5 +39,6 @@ namespace Introspection
 
 			return base.Skip (baseType, typo);
 		}
+#endif
 	}
 }

--- a/tests/monotouch-test/AppKit/NSDraggingItem.cs
+++ b/tests/monotouch-test/AppKit/NSDraggingItem.cs
@@ -21,19 +21,37 @@ namespace Xamarin.Mac.Tests
 #pragma warning restore 0219
 		}
 		
+#if NET
+		class MyPasteboard : NSObject, INSPasteboardWriting
+#else
 		class MyPasteboard : NSPasteboardWriting
+#endif
 		{
+#if NET
+			NSObject INSPasteboardWriting.GetPasteboardPropertyListForType (string type)
+#else
 			public override NSObject GetPasteboardPropertyListForType (string type)
+#endif
 			{
 				return new NSObject ();
 			}
 
+#if NET
+			string[] INSPasteboardWriting.GetWritableTypesForPasteboard (NSPasteboard pasteboard)
+#else
 			public override string[] GetWritableTypesForPasteboard (NSPasteboard pasteboard)
+#endif
 			{
 				return new string [] {};
 			}
 
+#if NET
+			[Export ("writingOptionsForType:pasteboard:")]
+			public NSPasteboardWritingOptions GetWritingOptionsForType (string type, NSPasteboard pasteboard)
+#else
+		
 			public override NSPasteboardWritingOptions GetWritingOptionsForType (string type, NSPasteboard pasteboard)
+#endif
 			{
 				return NSPasteboardWritingOptions.WritingPromised;
 			}

--- a/tests/monotouch-test/AppKit/NSPasteboard.cs
+++ b/tests/monotouch-test/AppKit/NSPasteboard.cs
@@ -19,33 +19,62 @@ namespace Xamarin.Mac.Tests
 			if (b == null)
 				Assert.Inconclusive ("NSPasteboard could not be provided by the OS.");
 			b.WriteObjects (new INSPasteboardWriting [] { (NSString)"asfd" });
+#if NET
+			b.WriteObjects (new INSPasteboardWriting [] { new MyPasteboard () });
+#else
 			b.WriteObjects (new NSPasteboardWriting [] { new MyPasteboard () });
+#endif
 			// from the docs: the lifetime of a unique pasteboard is not related to the lifetime of the creating app,
 			// you must release a unique pasteboard by calling releaseGlobally to avoid possible leaks. 
 			b.ReleaseGlobally (); 
 		}
 		
+#if NET
+		class MyPasteboard2 : NSObject, INSPasteboardReading
+#else
 		class MyPasteboard2 : NSPasteboardReading
+#endif
 		{
+#if NET
+			NSObject INSPasteboardReading.InitWithPasteboardPropertyList (NSObject propertyList, string type)
+#else
 			public override NSObject InitWithPasteboardPropertyList (NSObject propertyList, string type)
+#endif
 			{
 				return new NSObject ();
 			}
 		}
 		
+#if NET
+		class MyPasteboard : NSObject, INSPasteboardWriting
+#else
 		class MyPasteboard : NSPasteboardWriting
+#endif
 		{
+#if NET
+			NSObject INSPasteboardWriting.GetPasteboardPropertyListForType (string type)
+#else
 			public override NSObject GetPasteboardPropertyListForType (string type)
+#endif
 			{
 				return new NSObject ();
 			}
 
+#if NET
+			string[] INSPasteboardWriting.GetWritableTypesForPasteboard (NSPasteboard pasteboard)
+#else
 			public override string[] GetWritableTypesForPasteboard (NSPasteboard pasteboard)
+#endif
 			{
 				return new string [] {};
 			}
 
+#if NET
+			[Export ("writingOptionsForType:pasteboard:")]
+			public NSPasteboardWritingOptions GetWritingOptionsForType (string type, NSPasteboard pasteboard)
+#else
 			public override NSPasteboardWritingOptions GetWritingOptionsForType (string type, NSPasteboard pasteboard)
+#endif
 			{
 				return NSPasteboardWritingOptions.WritingPromised;
 			}

--- a/tests/monotouch-test/AppKit/NSSlider.cs
+++ b/tests/monotouch-test/AppKit/NSSlider.cs
@@ -20,12 +20,13 @@ namespace Xamarin.Mac.Tests
 
 			NSSlider slider = new NSSlider ();
 			var isVert = slider.IsVertical;
-#if XAMCORE_4_0
+#if NET
 			slider.IsVertical = true;
+			Assert.IsTrue (slider.IsVertical);
 #else
 			slider.IsVertical = 1;
-#endif
 			Assert.AreEqual ((nint) 1, slider.IsVertical);
+#endif
 		}
 	}
 }

--- a/tests/monotouch-test/AppKit/NSTabViewController.cs
+++ b/tests/monotouch-test/AppKit/NSTabViewController.cs
@@ -41,6 +41,7 @@ namespace Xamarin.Mac.Tests
 //			Assert.IsFalse (controller.TabView == tabView, "NSTabViewControllerShouldChangeTabView - Failed to set the TabView property");
 //		}
 
+#if !NET
 		[Test]
 		public void NSTabViewControllerShouldChangeSegmentedControl ()
 		{
@@ -53,6 +54,7 @@ namespace Xamarin.Mac.Tests
 
 			Assert.IsFalse (controller.SegmentedControl == segmentedControl, "NSTabViewControllerShouldChangeSegmentedControl - Failed to set the SegmentedControl property");
 		}
+#endif
 
 		[Test]
 		public void NSTabViewControllerShouldChangeTransitionOptions ()

--- a/tests/monotouch-test/AppKit/NSWorkspace.cs
+++ b/tests/monotouch-test/AppKit/NSWorkspace.cs
@@ -56,7 +56,11 @@ namespace Xamarin.Mac.Tests
 			Assert.That (FourCC ((int) HfsTypeCode.GenericPreferencesIcon), Is.EqualTo ("pref"), "pref");
 			Assert.That (FourCC ((int) HfsTypeCode.GenericQueryDocumentIcon), Is.EqualTo ("qery"), "qery");
 			Assert.That (FourCC ((int) HfsTypeCode.GenericRamDiskIcon), Is.EqualTo ("ramd"), "ramd");
+#if NET
+			Assert.That (FourCC ((int) HfsTypeCode.GenericSharedLibraryIcon), Is.EqualTo ("shlb"), "shlb");
+#else
 			Assert.That (FourCC ((int) HfsTypeCode.GenericSharedLibaryIcon), Is.EqualTo ("shlb"), "shlb");
+#endif
 			Assert.That (FourCC ((int) HfsTypeCode.GenericStationeryIcon), Is.EqualTo ("sdoc"), "sdoc");
 			Assert.That (FourCC ((int) HfsTypeCode.GenericSuitcaseIcon), Is.EqualTo ("suit"), "suit");
 			Assert.That (FourCC ((int) HfsTypeCode.GenericUrlIcon), Is.EqualTo ("gurl"), "gurl");

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -32,10 +32,6 @@
 ## Defined in NSLayoutManager (NSLayoutManagerDeprecated)
 !missing-selector! NSLayoutManager::rectArrayForCharacterRange:withinSelectedCharacterRange:inTextContainer:rectCount: not bound
 
-## Used in sandbox for NSOpen/Save panel but never should have been bound. #if !XAMCORE_3_0'ed
-!unknown-type! NSRemoteOpenPanel bound
-!unknown-type! NSRemoteSavePanel bound
-
 ## Defined in NSControlTextEditingDelegate - NSTextFieldDelegate <NSControlTextEditingDelegate>
 !extra-protocol-member! unexpected selector NSTextFieldDelegate::control:didFailToFormatString:errorDescription: found
 !extra-protocol-member! unexpected selector NSTextFieldDelegate::control:didFailToValidatePartialString:errorDescription: found
@@ -65,11 +61,6 @@
 
 ## unsorted
 
-!extra-protocol-member! unexpected selector NSApplicationDelegate::orderFrontStandardAboutPanel: found
-!extra-protocol-member! unexpected selector NSApplicationDelegate::orderFrontStandardAboutPanelWithOptions: found
-!extra-protocol-member! unexpected selector NSApplicationDelegate::readSelectionFromPasteboard: found
-!extra-protocol-member! unexpected selector NSApplicationDelegate::registerServicesMenuSendTypes:returnTypes: found
-!extra-protocol-member! unexpected selector NSApplicationDelegate::writeSelectionToPasteboard:types: found
 !extra-protocol-member! unexpected selector NSGestureRecognizerDelegate::xamarinselector:removed: found
 !extra-protocol-member! unexpected selector NSPasteboardReading::xamarinselector:removed: found
 !missing-enum! NSWritingDirectionFormatType not bound
@@ -208,7 +199,6 @@
 !unknown-field! NSTableColumn bound
 !unknown-field! NSTextMovement bound
 !unknown-native-enum! NSAlertButtonReturn bound
-!unknown-native-enum! NSApplicationLayoutDirection bound
 !unknown-native-enum! NSBackingStore bound
 !unknown-native-enum! NSCellHit bound
 !unknown-native-enum! NSCellStateValue bound
@@ -218,20 +208,16 @@
 !unknown-native-enum! NSFontPanelMode bound
 !unknown-native-enum! NSImageScale bound
 !unknown-native-enum! NSMenuProperty bound
-!unknown-native-enum! NSPanelButtonType bound
 !unknown-native-enum! NSRunResponse bound
 !unknown-native-enum! NSTableColumnResizing bound
 !unknown-native-enum! NSTableViewAnimation bound
 !unknown-native-enum! NSTableViewGridStyle bound
-!unknown-native-enum! NSTextStorageEditedFlags bound
-!unknown-native-enum! NSType bound
 !unknown-native-enum! NSViewResizingMask bound
 
 ## NSGlyphStorage protocol not bound
 !missing-protocol-conformance! NSLayoutManager should conform to NSGlyphStorage (defined in 'NSGlyphGeneration' category)
 
 ## Fixed in XAMCORE_4_0
-!missing-protocol-conformance! NSController should conform to NSEditor
 !missing-protocol-conformance! NSDocument should conform to NSUserInterfaceValidations
 !missing-protocol-conformance! NSDocumentController should conform to NSUserInterfaceValidations
 !missing-protocol-conformance! NSTextView should conform to NSColorChanging
@@ -253,13 +239,13 @@
 !missing-release-attribute-on-return-value! Foundation.NSObject AppKit.NSObjectController::get_NewObject()'s selector's ('newObject') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 
 # Initial result from new rule extra-null-allowed
-!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSBrowserDelegate::ValidateDrop(AppKit.NSBrowser,AppKit.NSDraggingInfo,System.IntPtr&,System.IntPtr&,AppKit.NSBrowserDropOperation&)' has a extraneous [NullAllowed] on parameter #2
-!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSBrowserDelegate::ValidateDrop(AppKit.NSBrowser,AppKit.NSDraggingInfo,System.IntPtr&,System.IntPtr&,AppKit.NSBrowserDropOperation&)' has a extraneous [NullAllowed] on parameter #3
-!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSBrowserDelegate::ValidateDrop(AppKit.NSBrowser,AppKit.NSDraggingInfo,System.IntPtr&,System.IntPtr&,AppKit.NSBrowserDropOperation&)' has a extraneous [NullAllowed] on parameter #4
-!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSCollectionViewDelegate::ValidateDrop(AppKit.NSCollectionView,AppKit.NSDraggingInfo,System.IntPtr&,AppKit.NSCollectionViewDropOperation&)' has a extraneous [NullAllowed] on parameter #2
-!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSCollectionViewDelegate::ValidateDrop(AppKit.NSCollectionView,AppKit.NSDraggingInfo,System.IntPtr&,AppKit.NSCollectionViewDropOperation&)' has a extraneous [NullAllowed] on parameter #3
-!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSCollectionViewDelegate::ValidateDropOperation(AppKit.NSCollectionView,AppKit.NSDraggingInfo,Foundation.NSIndexPath&,AppKit.NSCollectionViewDropOperation&)' has a extraneous [NullAllowed] on parameter #2
-!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSCollectionViewDelegate::ValidateDropOperation(AppKit.NSCollectionView,AppKit.NSDraggingInfo,Foundation.NSIndexPath&,AppKit.NSCollectionViewDropOperation&)' has a extraneous [NullAllowed] on parameter #3
+!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSBrowserDelegate::ValidateDrop(AppKit.NSBrowser,AppKit.INSDraggingInfo,System.IntPtr&,System.IntPtr&,AppKit.NSBrowserDropOperation&)' has a extraneous [NullAllowed] on parameter #2
+!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSBrowserDelegate::ValidateDrop(AppKit.NSBrowser,AppKit.INSDraggingInfo,System.IntPtr&,System.IntPtr&,AppKit.NSBrowserDropOperation&)' has a extraneous [NullAllowed] on parameter #3
+!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSBrowserDelegate::ValidateDrop(AppKit.NSBrowser,AppKit.INSDraggingInfo,System.IntPtr&,System.IntPtr&,AppKit.NSBrowserDropOperation&)' has a extraneous [NullAllowed] on parameter #4
+!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSCollectionViewDelegate::ValidateDrop(AppKit.NSCollectionView,AppKit.INSDraggingInfo,System.IntPtr&,AppKit.NSCollectionViewDropOperation&)' has a extraneous [NullAllowed] on parameter #2
+!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSCollectionViewDelegate::ValidateDrop(AppKit.NSCollectionView,AppKit.INSDraggingInfo,System.IntPtr&,AppKit.NSCollectionViewDropOperation&)' has a extraneous [NullAllowed] on parameter #3
+!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSCollectionViewDelegate::ValidateDrop(AppKit.NSCollectionView,AppKit.INSDraggingInfo,Foundation.NSIndexPath&,AppKit.NSCollectionViewDropOperation&)' has a extraneous [NullAllowed] on parameter #2
+!extra-null-allowed! 'AppKit.NSDragOperation AppKit.NSCollectionViewDelegate::ValidateDrop(AppKit.NSCollectionView,AppKit.INSDraggingInfo,Foundation.NSIndexPath&,AppKit.NSCollectionViewDropOperation&)' has a extraneous [NullAllowed] on parameter #3
 !extra-null-allowed! 'AppKit.NSImage AppKit.NSCollectionView::GetDraggingImage(Foundation.NSSet`1<Foundation.NSIndexPath>,AppKit.NSEvent,CoreGraphics.CGPoint&)' has a extraneous [NullAllowed] on parameter #2
 !extra-null-allowed! 'AppKit.NSImage AppKit.NSCollectionViewDelegate::GetDraggingImage(AppKit.NSCollectionView,Foundation.NSSet,AppKit.NSEvent,CoreGraphics.CGPoint&)' has a extraneous [NullAllowed] on parameter #3
 !extra-null-allowed! 'AppKit.NSImage AppKit.NSTableView::DragImageForRows(Foundation.NSIndexSet,AppKit.NSTableColumn[],AppKit.NSEvent,CoreGraphics.CGPoint&)' has a extraneous [NullAllowed] on parameter #3
@@ -504,7 +490,6 @@
 !missing-null-allowed! 'AppKit.NSWindow AppKit.NSApplication::get_ModalWindow()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'AppKit.NSWindow AppKit.NSApplication::WindowWithWindowNumber(System.IntPtr)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'AppKit.NSWindow AppKit.NSDocument::get_WindowForSheet()' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'AppKit.NSWindow AppKit.NSDraggingInfo::get_DraggingDestinationWindow()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'AppKit.NSWindow AppKit.NSEvent::get_Window()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'AppKit.NSWindow AppKit.NSPopoverDelegate::GetDetachableWindowForPopover(AppKit.NSPopover)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'AppKit.NSWindow AppKit.NSSharingServiceDelegate::SourceWindowForShareItems(AppKit.NSSharingService,Foundation.NSObject[],AppKit.NSSharingContentScope)' is missing an [NullAllowed] on return type
@@ -587,7 +572,6 @@
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSDocumentController::MakeDocument(Foundation.NSUrl,System.String,Foundation.NSError&)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSDocumentController::MakeUntitledDocument(System.String,Foundation.NSError&)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSDocumentController::OpenUntitledDocument(System.Boolean,Foundation.NSError&)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSObject AppKit.NSDraggingInfo::get_DraggingSource()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSEPSImageRep::FromData(Foundation.NSData)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSEvent::AddGlobalMonitorForEventsMatchingMask(AppKit.NSEventMask,AppKit.GlobalEventHandler)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSEvent::AddLocalMonitorForEventsMatchingMask(AppKit.NSEventMask,AppKit.LocalEventHandler)' is missing an [NullAllowed] on return type
@@ -604,7 +588,6 @@
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSOutlineViewDelegate::GetNextTypeSelectMatch(AppKit.NSOutlineView,Foundation.NSObject,Foundation.NSObject,System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSPasteboard::GetPropertyListForType(System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSPasteboardItem::GetPropertyListForType(System.String)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSObject AppKit.NSPasteboardWriting::GetPasteboardPropertyListForType(System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSResponder::SupplementalTargetForAction(ObjCRuntime.Selector,Foundation.NSObject)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSResponder::ValidRequestorForSendType(System.String,System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject AppKit.NSSpeechSynthesizer::ObjectForProperty(System.String,Foundation.NSError&)' is missing an [NullAllowed] on return type
@@ -773,7 +756,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSApplication::MiniaturizeAll(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSApplication::OrderFrontCharacterPalette(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSApplication::OrderFrontColorPanel(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSApplication::OrderFrontStandardAboutPanel2(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSApplication::set_ApplicationIconImage(AppKit.NSImage)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSApplication::set_MainMenu(AppKit.NSMenu)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSApplication::set_ServicesMenu(AppKit.NSMenu)' is missing an [NullAllowed] on parameter #0
@@ -874,8 +856,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSDocumentController::CloseAllDocuments(Foundation.NSObject,ObjCRuntime.Selector,System.IntPtr)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSDocumentController::CloseAllDocuments(Foundation.NSObject,ObjCRuntime.Selector,System.IntPtr)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void AppKit.NSDocumentController::ReviewUnsavedDocuments(System.String,System.Boolean,Foundation.NSObject,ObjCRuntime.Selector,System.IntPtr)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSDraggingDestination::ConcludeDragOperation(AppKit.NSDraggingInfo)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void AppKit.NSDraggingDestination::DraggingExited(AppKit.NSDraggingInfo)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSDraggingImageComponent::set_Contents(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSFontManager::AddFontTrait(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSFontManager::ModifyFont(Foundation.NSObject)' is missing an [NullAllowed] on parameter #0
@@ -1205,7 +1185,6 @@
 !missing-null-allowed! 'System.Void AppKit.NSCell::EditWithFrame(CoreGraphics.CGRect,AppKit.NSView,AppKit.NSText,Foundation.NSObject,AppKit.NSEvent)' is missing an [NullAllowed] on parameter #4
 !missing-null-allowed! 'System.Void AppKit.NSDocumentController::ReviewUnsavedDocuments(System.String,System.Boolean,Foundation.NSObject,ObjCRuntime.Selector,System.IntPtr)' is missing an [NullAllowed] on parameter #2
 !missing-null-allowed! 'System.Void AppKit.NSDocumentController::ReviewUnsavedDocuments(System.String,System.Boolean,Foundation.NSObject,ObjCRuntime.Selector,System.IntPtr)' is missing an [NullAllowed] on parameter #3
-!missing-null-allowed! 'System.Void AppKit.NSDraggingInfo::EnumerateDraggingItems(AppKit.NSDraggingItemEnumerationOptions,AppKit.NSView,System.IntPtr,Foundation.NSDictionary,AppKit.NSDraggingEnumerator)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void AppKit.NSDraggingItem::SetDraggingFrame(CoreGraphics.CGRect,Foundation.NSObject)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void AppKit.NSDraggingSession::EnumerateDraggingItems(AppKit.NSDraggingItemEnumerationOptions,AppKit.NSView,System.IntPtr,Foundation.NSDictionary,AppKit.NSDraggingEnumerator)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void AppKit.NSMatrix::.ctor(CoreGraphics.CGRect,AppKit.NSMatrixMode,ObjCRuntime.Class,System.IntPtr,System.IntPtr)' is missing an [NullAllowed] on parameter #2


### PR DESCRIPTION
* A lot of obsolete/deprecated removal.
* Remove the NSDraggingInfo model, which required numerous other changes.
* Remove the NSPasteboardReading/NSPasteboardWriting models, which required more
  numerous changes.
* Update the tests accordingly.


Backport of #13987
