### PR TITLE
[msbuild] Don't report 'unable to open object file:' from dsymutil as warnings.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
@@ -73,7 +73,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
-			if (singleLine.StartsWith ("warning:", StringComparison.Ordinal))
+			if (singleLine.StartsWith ("warning:", StringComparison.Ordinal) && !singleLine.Contains ("unable to open object file: No such file or directory"))
 				Log.LogWarning (singleLine);
 			else
 				Log.LogMessage (messageImportance, singleLine);


### PR DESCRIPTION
Just log these messages as normal messages, because they're not very actionable.

Ref: #13652.