### PR TITLE
[foundation] Fix some `IntPtr` -> `NativeHandle` inside `NSObject`

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -329,8 +329,8 @@ namespace Foundation {
 		}
 
 		private void InitializeObject (bool alloced) {
-			if (alloced && handle == IntPtr.Zero && Class.ThrowOnInitFailure) {
-				if (ClassHandle == IntPtr.Zero)
+			if (alloced && handle == NativeHandle.Zero && Class.ThrowOnInitFailure) {
+				if (ClassHandle == NativeHandle.Zero)
 					throw new Exception (string.Format ("Could not create an native instance of the type '{0}': the native class hasn't been loaded.\n" +
 						"It is possible to ignore this condition by setting ObjCRuntime.Class.ThrowOnInitFailure to false.",
 						GetType ().FullName));
@@ -598,8 +598,8 @@ namespace Foundation {
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		protected void InitializeHandle (NativeHandle handle, string initSelector)
 		{
-			if (this.handle == IntPtr.Zero && Class.ThrowOnInitFailure) {
-				if (ClassHandle == IntPtr.Zero)
+			if (this.handle == NativeHandle.Zero && Class.ThrowOnInitFailure) {
+				if (ClassHandle == NativeHandle.Zero)
 					throw new Exception (string.Format ("Could not create an native instance of the type '{0}': the native class hasn't been loaded.\n" +
 						"It is possible to ignore this condition by setting ObjCRuntime.Class.ThrowOnInitFailure to false.",
 						GetType ().FullName));
@@ -608,8 +608,8 @@ namespace Foundation {
 					new Class (ClassHandle).Name));
 			}
 
-			if (handle == IntPtr.Zero && Class.ThrowOnInitFailure) {
-				Handle = IntPtr.Zero; // We'll crash if we don't do this.
+			if (handle == NativeHandle.Zero && Class.ThrowOnInitFailure) {
+				Handle = NativeHandle.Zero; // We'll crash if we don't do this.
 				throw new Exception (string.Format ("Could not initialize an instance of the type '{0}': the native '{1}' method returned nil.\n" +
 				"It is possible to ignore this condition by setting ObjCRuntime.Class.ThrowOnInitFailure to false.",
 					GetType ().FullName, initSelector));
@@ -619,7 +619,7 @@ namespace Foundation {
 		}
 		
 		private bool AllocIfNeeded () {
-			if (handle == IntPtr.Zero) {
+			if (handle == NativeHandle.Zero) {
 #if MONOMAC
 				handle = Messaging.IntPtr_objc_msgSend (Class.GetHandle (this.GetType ()), Selector.AllocHandle);
 #else
@@ -796,13 +796,8 @@ namespace Foundation {
 			case TypeCode.String:
 				return new NSString ((string) obj);
 			default:
-#if NET
 				if (t == typeof (NativeHandle))
 					return NSValue.ValueFromPointer ((NativeHandle) obj);
-#else
-				if (t == typeof (IntPtr))
-					return NSValue.ValueFromPointer ((IntPtr) obj);
-#endif
 #if !NO_SYSTEM_DRAWING
 				if (t == typeof (SizeF))
 					return NSValue.FromSizeF ((SizeF) obj);
@@ -843,7 +838,7 @@ namespace Foundation {
 			}
 		}
 
-		public void SetValueForKeyPath (IntPtr handle, NSString keyPath)
+		public void SetValueForKeyPath (NativeHandle handle, NSString keyPath)
 		{
 			if (keyPath == null)
 				throw new ArgumentNullException ("keyPath");
@@ -920,7 +915,7 @@ namespace Foundation {
 
 		internal void ClearHandle ()
 		{
-			handle = IntPtr.Zero;
+			handle = NativeHandle.Zero;
 		}
 
 		protected virtual void Dispose (bool disposing) {
@@ -928,7 +923,7 @@ namespace Foundation {
 				return;
 			disposed = true;
 			
-			if (handle != IntPtr.Zero) {
+			if (handle != NativeHandle.Zero) {
 				if (disposing) {
 					ReleaseManagedRef ();
 				} else {
@@ -955,9 +950,9 @@ namespace Foundation {
 
 		unsafe void FreeData ()
 		{
-			if (super != IntPtr.Zero) {
+			if (super != NativeHandle.Zero) {
 				Marshal.FreeHGlobal (super);
-				super = IntPtr.Zero;
+				super = NativeHandle.Zero;
 			}
 		}
 
@@ -989,7 +984,7 @@ namespace Foundation {
 				if (!call_drain)
 					return;
 #if NET
-				Messaging.void_objc_msgSend_NativeHandle_NativeHandle_bool (class_ptr, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), Selector.GetHandle ("drain:"), IntPtr.Zero, false);
+				Messaging.void_objc_msgSend_NativeHandle_NativeHandle_bool (class_ptr, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), Selector.GetHandle ("drain:"), NativeHandle.Zero, false);
 #else
 #if MONOMAC
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (class_ptr, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle, drainHandle, IntPtr.Zero, false);


### PR DESCRIPTION
Using NativeHandle avoids implicit casts [1]

[1] likely not an issue with JIT/AOT optimization, less sure for the
interpreter. No harm in not having those in the product assembly.