### PR TITLE
[net] Fix the product/assemblies names in error messages

### DIFF
--- a/src/ObjCRuntime/Runtime.iOS.cs
+++ b/src/ObjCRuntime/Runtime.iOS.cs
@@ -21,6 +21,26 @@ namespace ObjCRuntime {
 
 	public static partial class Runtime {
 #if !COREBUILD
+#if NET
+#if WATCH
+		internal const string ProductName = "Microsoft.watchOS";
+#elif TVOS
+		internal const string ProductName = "Microsoft.tvOS";
+#elif IOS
+		internal const string ProductName = "Microsoft.iOS";
+#else
+		#error Unknown platform
+#endif
+#if WATCH
+		internal const string AssemblyName = "Microsoft.watchOS.dll";
+#elif TVOS
+		internal const string AssemblyName = "Microsoft.tvOS.dll";
+#elif IOS
+		internal const string AssemblyName = "Microsoft.iOS.dll";
+#else
+		#error Unknown platform
+#endif
+#else
 #if WATCH
 		internal const string ProductName = "Xamarin.Watch";
 #elif TVOS
@@ -38,6 +58,7 @@ namespace ObjCRuntime {
 		internal const string AssemblyName = "Xamarin.iOS.dll";
 #else
 		#error Unknown platform
+#endif
 #endif
 
 #if !__MACCATALYST__

--- a/src/ObjCRuntime/Runtime.mac.cs
+++ b/src/ObjCRuntime/Runtime.mac.cs
@@ -39,8 +39,13 @@ namespace ObjCRuntime {
 
 	public static partial class Runtime {
 #if !COREBUILD
+#if NET
+		internal const string ProductName = "Microsoft.macOS";
+		internal const string AssemblyName = "Microsoft.macOS.dll";
+#else
 		internal const string ProductName = "Xamarin.Mac";
 		internal const string AssemblyName = "Xamarin.Mac.dll";
+#endif
 
 		public static string? FrameworksPath {
 			get; set;


### PR DESCRIPTION
Found while looking [1] at the strings inside the assemblies.

The diff for before/after the PR is

```diff
-Version mismatch between the native Xamarin.iOS runtime and Xamarin.iOS.dll. Please reinstall Xamarin.iOS.
+Version mismatch between the native Microsoft.iOS runtime and Microsoft.iOS.dll. Please reinstall Microsoft.iOS.
```

[1] https://github.com/xamarin/xamarin-macios/issues/14188