### PR TITLE
[tests/msbuild] Use full path to binlogs and executables.

### DIFF
--- a/msbuild/Xamarin.HotRestart.PreBuilt/Makefile
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Makefile
@@ -21,7 +21,7 @@ $(TOP)/tests/dotnet/%:
 	$(Q) $(MAKE) -C $(dir $@) $*
 
 .build-stamp: $(wildcard Xamarin.PreBuilt.iOS/*) Makefile NuGet.config global.json
-	$(Q_GEN) $(DOTNET6) build Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj /bl $(MSBUILD_VERBOSITY)
+	$(Q_GEN) $(DOTNET6) build Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj "/bl:$(abspath ./msbuild.binlog)" $(MSBUILD_VERBOSITY)
 	$(Q) touch $@
 
 $(DOTNET_DESTDIR)/$(IOS_WINDOWS_NUGET).Sdk/tools/msbuild/iOS/Xamarin.PreBuilt.iOS.app.zip: Xamarin.PreBuilt.iOS.app.zip

--- a/tests/common/shared-dotnet.mk
+++ b/tests/common/shared-dotnet.mk
@@ -28,13 +28,13 @@ reload-and-run:
 	$(Q) $(MAKE) run
 
 build: prepare
-	$(Q) $(DOTNET6) build "/bl:$@-$(BINLOG_TIMESTAMP).binlog" *.?sproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS)
+	$(Q) $(DOTNET6) build "/bl:$(abspath $@-$(BINLOG_TIMESTAMP).binlog)" *.?sproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS)
 
 run: prepare
-	$(Q) $(DOTNET6) build "/bl:$@-$(BINLOG_TIMESTAMP).binlog" *.?sproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS) -t:Run
+	$(Q) $(DOTNET6) build "/bl:$(abspath $@-$(BINLOG_TIMESTAMP).binlog)" *.?sproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS) -t:Run
 
 run-bare:
-	$(Q) ./bin/Debug/net6.0-*/*/"$(TESTNAME)".app/Contents/MacOS/"$(TESTNAME)" --autostart --autoexit
+	$(Q) "$(abspath .)"/bin/Debug/net6.0-*/*/"$(TESTNAME)".app/Contents/MacOS/"$(TESTNAME)" --autostart --autoexit
 
 run-remote:
 	$(Q) test -n "$(REMOTE_HOST)" || ( echo "Must specify the remote machine by setting the REMOTE_HOST environment variable"; exit 1 )


### PR DESCRIPTION
This way it's easier to copy-paste the path to the these files from terminal output
and open/run it (with a relative/partial path you'll need to know the current directory,
which is just an annoying thing to figure out sometimes).