### PR TITLE
[msbuild/dotnet] Make codesigning createdump work in universal apps. Fixes #14155.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -238,6 +238,7 @@
 			_CompileNativeExecutable;
 			_LinkNativeExecutable;
 			_ComputePublishLocation;
+			_ComputeCodesignItems;
 			CopyFilesToPublishDirectory;
 			_CopyDirectoriesToBundle;
 			_CopyAppExtensionsToBundle;
@@ -291,11 +292,15 @@
 			<_RuntimeIdentifiersAsItems Update="@(_RuntimeIdentifiersAsItems)">
 				<!-- Platform = "rid-arch".Substring (0, "rid-arch".IndexOf ('-')) -->
 				<Platform>$([System.String]::new('%(Identity)').Substring(0, $([System.String]::new('%(Identity)').IndexOf ('-'))))</Platform>
+				<RidSpecificCodesignItemsPath>$(DeviceSpecificIntermediateOutputPath)codesignitems-%(Identity).items</RidSpecificCodesignItemsPath>
 			</_RuntimeIdentifiersAsItems>
 
 			<!-- Verify that we're not mixing simulator + device RIDs in a single build -->
 			<_RuntimeIdentifierPlatforms Include="@(_RuntimeIdentifiersAsItems -> '%(Platform)')" />
 			<_RuntimeIdentifierDistinctPlatforms Include="@(_RuntimeIdentifierPlatforms->Distinct())" />
+
+			<!-- Create an item group with all the rid-specific CodesignItemsPath -->
+			<_RidSpecificCodesignItemsPath Include="@(_RuntimeIdentifiersAsItems -> '%(RidSpecificCodesignItemsPath)')" />
 		</ItemGroup>
 
 		<!-- Show an error if we're mixing simulator + device RIDs in a single build -->
@@ -320,7 +325,11 @@
 		<MSBuild
 			Projects="$(MSBuildProjectFile)"
 			Targets="_BuildRidSpecificAppBundle"
-			Properties="RuntimeIdentifier=%(_RuntimeIdentifiersAsItems.Identity);$(_RidSpecificProperties)">
+			Properties="
+				RuntimeIdentifier=%(_RuntimeIdentifiersAsItems.Identity);
+				_CodesignItemsPath=%(_RuntimeIdentifiersAsItems.RidSpecificCodesignItemsPath);
+				$(_RidSpecificProperties);
+				">
 			<Output TaskParameter="TargetOutputs" ItemName="_AssemblyPublishDirectories" />
 		</MSBuild>
 
@@ -1237,6 +1246,44 @@
 		</_ComputeLinkModeDependsOn>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<_CodesignAppBundleDependsOn Condition="'$(RuntimeIdentifiers)' != ''">
+			_CollectRidSpecificCodesignItems;
+			$(_CodesignAppBundleDependsOn);
+		</_CodesignAppBundleDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_CollectRidSpecificCodesignItems"
+			DependsOnTargets="_RunRidSpecificBuild;_DetectSigningIdentity;_PrepareResourceRules;_ComputeVariables"
+		>
+
+		<!-- Read the stored list of files to sign if we're an outer build of a multi-rid build -->
+		<ReadItemsFromFile
+			SessionId="$(BuildSessionId)"
+			File="%(_RidSpecificCodesignItemsPath.Identity)"
+			Condition="@(_RidSpecificCodesignItemsPath->Count()) &gt; 0"
+		>
+			<Output TaskParameter="Items" ItemName="_RidSpecificCodesignItems" />
+		</ReadItemsFromFile>
+
+		<ItemGroup>
+			<!-- The rid-specific build might not have set these values -->
+			<_RidSpecificCodesignItems>
+				<CodesignAllocate Condition="'%(_RidSpecificCodesignItem.CodesignAllocate)' == ''">$(_CodesignAllocate)</CodesignAllocate>
+				<CodesignDisableTimestamp Condition="'%(_RidSpecificCodesignItem.CodesignDisableTimestamp)' == '' And '$(_BundlerDebug)' == 'true'">true</CodesignDisableTimestamp>
+				<CodesignExtraArgs Condition="'%(_RidSpecificCodesignItem.CodesignExtraArgs)' == ''">$(CodesignExtraArgs)</CodesignExtraArgs>
+				<CodesignKeychain Condition="'%(_RidSpecificCodesignItem.CodesignKeychain)' == ''">$(CodesignKeychain)</CodesignKeychain>
+				<CodesignResourceRules Condition="'%(_RidSpecificCodesignItem.CodesignResourceRules)' == ''">$(_PreparedResourceRules)</CodesignResourceRules>
+				<CodesignSigningKey Condition="'%(_RidSpecificCodesignItem.CodesignSigningKey)' == ''">$(_CodeSigningKey)</CodesignSigningKey>
+				<CodesignUseHardenedRuntime Condition="'%(_RidSpecificCodesignItem.CodesignUseHardenedRuntime)' == ''">$(UseHardenedRuntime)</CodesignUseHardenedRuntime>
+				<CodesignUseSecureTimestamp Condition="'%(_RidSpecificCodesignItem.CodesignUseSecureTimestamp)' == ''">$(UseHardenedRuntime)</CodesignUseSecureTimestamp>
+			</_RidSpecificCodesignItems>
+
+			<!-- These items are relative to the root of the app bundle, we need to make them relative to the PublishDir property -->
+			<_CodesignItems Include="@(_RidSpecificCodesignItems -> '$(_RelativePublishDir)%(Identity)')" />
+		</ItemGroup>
+	</Target>
+
 	<Target Name="_ComputePublishLocation"
 		DependsOnTargets="_GenerateBundleName;_ParseBundlerArguments;_ComputeMonoLibraries;_DetectSigningIdentity;_PrepareResourceRules"
 		Condition="'$(_CanOutputAppBundle)' == 'true'"
@@ -1340,16 +1387,6 @@
 			/>
 			<ResolvedFileToPublish Remove="@(_CreateDumpExecutable)" />
 			<ResolvedFileToPublish Include="@(_CreateDumpExecutable)" />
-			<!-- The 'createdump' executable must be signed. -->
-			<!-- Ref: https://github.com/xamarin/xamarin-macios/issues/13417 -->
-			<_CodesignItems Include="@(_CreateDumpExecutable)" Condition="'$(_RequireCodeSigning)' == 'true'">
-				<CodesignAllocate>$(_CodesignAllocate)</CodesignAllocate>
-				<CodesignDisableTimestamp Condition="'$(_BundlerDebug)' == 'true'">true</CodesignDisableTimestamp>
-				<CodesignExtraArgs>$(CodesignExtraArgs)</CodesignExtraArgs>
-				<CodesignKeychain>$(CodesignKeychain)</CodesignKeychain>
-				<CodesignResourceRules>$(_PreparedResourceRules)</CodesignResourceRules>
-				<CodesignSigningKey>$(_CodeSigningKey)</CodesignSigningKey>
-			</_CodesignItems>
 
 			<!-- Remove any dylibs Mono told us not to link with -->
 			<ResolvedFileToPublish
@@ -1450,6 +1487,43 @@
 			>
 			<Output TaskParameter="NativeFrameworks" ItemName="_FrameworkNativeReference" />
 		</ResolveNativeReferences>
+	</Target>
+
+	<Target Name="_ComputeCodesignItems"
+		Outputs="$(_CodesignItemsPath)"
+		>
+		<ItemGroup Condition="'$(_RequireCodeSigning)' == 'true'">
+			<!-- The 'createdump' executable must be signed. -->
+			<!-- Ref: https://github.com/xamarin/xamarin-macios/issues/13417 -->
+			<_CreateDumpExecutableToSign Include="@(_CreateDumpExecutable -> '$(_DylibPublishDir)%(RelativePath)')" KeepMetadata="false">
+				<CodesignAllocate>$(_CodesignAllocate)</CodesignAllocate>
+				<CodesignDisableTimestamp Condition="'$(_BundlerDebug)' == 'true'">true</CodesignDisableTimestamp>
+				<CodesignEntitlements>$(IntermediateOutputPath)Entitlements.xcent</CodesignEntitlements>
+				<CodesignExtraArgs>$(CodesignExtraArgs)</CodesignExtraArgs>
+				<CodesignKeychain>$(CodesignKeychain)</CodesignKeychain>
+				<CodesignResourceRules>$(_PreparedResourceRules)</CodesignResourceRules>
+				<CodesignSigningKey>$(_CodeSigningKey)</CodesignSigningKey>
+				<CodesignUseHardenedRuntime>$(UseHardenedRuntime)</CodesignUseHardenedRuntime>
+				<CodesignUseSecureTimestamp>$(UseHardenedRuntime)</CodesignUseSecureTimestamp>
+			</_CreateDumpExecutableToSign>
+
+			<_CodesignItems Include="@(_CreateDumpExecutableToSign -> '$(_RelativePublishDir)%(Identity)')" />
+		</ItemGroup>
+
+		<!-- Write a list of files to sign if we're not an outer build of a multi-rid build -->
+		<WriteItemsToFile
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true' And '$(_CodesignItemsPath)' != ''"
+			Items="@(_CreateDumpExecutableToSign)"
+			ItemName="_CodesignItems"
+			File="$(_CodesignItemsPath)"
+			Overwrite="true"
+			IncludeMetadata="true"
+		/>
+		<ItemGroup>
+			<FileWrites Include="$(_CodesignItemsPath)" />
+		</ItemGroup>
+
 	</Target>
 
 	<Target Name="_DecompressAppleBindingResourcePackages"


### PR DESCRIPTION
We don't sign each rid-specific bundle, but we sign the final merged app bundle instead.
This means that we must store the list of files to codesign from the rid-specific
build and load those lists before running codesign on the merged app bundle.

Fixes https://github.com/xamarin/xamarin-macios/issues/14155.