### PR TITLE
[CoreGraphics] Remove CGColorConversionInfo and CGColorConversionInfoTriple from .NET.

### DIFF
--- a/src/CoreGraphics/CGColorConverter.cs
+++ b/src/CoreGraphics/CGColorConverter.cs
@@ -23,49 +23,32 @@ using Foundation;
 
 namespace CoreGraphics {
 
-#if NET
-	[SupportedOSPlatform ("tvos9.2")]
-	[SupportedOSPlatform ("ios9.3")]
-#if TVOS
-	[Obsolete ("Starting with tvos10.0 replaced by 'CGColorConversionInfoTriple'.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#elif IOS
-	[Obsolete ("Starting with ios10.0 replaced by 'CGColorConversionInfoTriple'.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-#else
+#if !NET
 	[TV (9,2)]
 	[iOS (9,3)]
 	[Obsoleted (PlatformName.TvOS, 10,0, message: "Replaced by 'CGColorConversionInfoTriple'.")]
 	[Obsoleted (PlatformName.iOS, 10,0, message: "Replaced by 'CGColorConversionInfoTriple'.")]
-#endif
 	[StructLayout (LayoutKind.Sequential)]
 	public struct CGColorConverterTriple {
 		public CGColorSpace Space;
 		public CGColorConverterTransformType Transform;
 		public CGColorRenderingIntent Intent;
 	}
+#endif // !NET
 
 	// CGColorConverter.h
-#if NET
-	[SupportedOSPlatform ("tvos9.2")]
-	[SupportedOSPlatform ("ios9.3")]
-#if TVOS
-	[Obsolete ("Starting with tvos10.0 replaced by 'CGColorConversionInfo'.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#elif IOS
-	[Obsolete ("Starting with ios10.0 replaced by 'CGColorConversionInfo'.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-#else
+#if !NET
 	[TV (9,2)]
 	[iOS (9,3)]
 	[Obsoleted (PlatformName.TvOS, 10,0, message: "Replaced by 'CGColorConversionInfo'.")]
 	[Obsoleted (PlatformName.iOS, 10,0, message: "Replaced by 'CGColorConversionInfo'.")]
-#endif
-
 	public class CGColorConverter : NativeObject
 	{
 		public CGColorConverter (NSDictionary options, params CGColorConverterTriple [] triples)
 		{
 		}
 	}
+#endif // !NET
 }
 
 #endif // !MONOMAC && !WATCH


### PR DESCRIPTION
These types aren't used anywhere in the exposed API, nor do they do anything
useful today.