### PR TITLE
Bump minimum Visual Studio for Mac version to 17.0 series.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -144,6 +144,13 @@ MACCATALYST_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(MACCATALYST_NUGET_VERSIO
 MACCATALYST_NUGET_VERSION_NO_METADATA=$(MACCATALYST_NUGET_VERSION)-$(NUGET_PRERELEASE_IDENTIFIER)$(MACCATALYST_NUGET_COMMIT_DISTANCE)
 MACCATALYST_NUGET_VERSION_FULL=$(MACCATALYST_NUGET_VERSION_NO_METADATA)+$(NUGET_BUILD_METADATA)
 
+# Compute the architecture for the Visual Studio for Mac dmg
+ifeq ($(shell arch),arm64)
+VSMAC_ARCH=arm64
+else
+VSMAC_ARCH=x64
+endif
+
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
 XCODE_VERSION=13.2
 XCODE_URL=https://dl.internalx.com/internal-files/xcodes/Xcode_13.2.xip
@@ -164,9 +171,9 @@ MIN_XM_MONO_VERSION=6.4.0.94
 MIN_XM_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-06/77/c608cf3eafaea310e11af13cc9380d770112bb83/MonoFramework-MDK-6.4.0.94.macos10.xamarin.universal.pkg
 
 # Minimum Visual Studio version
-MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.blob.core.windows.net/vsmac/3425624/release-8.4/88f89d49594ac101891944e2a6b9a0b607a6fb52/VisualStudioForMac-8.4.4.8.dmg
-MIN_VISUAL_STUDIO_VERSION=8.4.4.8
-MAX_VISUAL_STUDIO_VERSION=8.10.99
+MIN_VISUAL_STUDIO_URL=https://download.visualstudio.microsoft.com/download/pr/6fe2c21c-668d-4922-895c-75504140383f/748e7558885276f5abf4a2e0c8e367c1/visualstudioformac-preview-17.0.0.7303-pre.6-$(VSMAC_ARCH).dmg
+MIN_VISUAL_STUDIO_VERSION=17.0.0.0
+MAX_VISUAL_STUDIO_VERSION=17.0.0.99999
 
 # Minimum CMake version
 MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg
@@ -465,7 +472,7 @@ MAC_PACKAGE_DMG_DIRNAME="$(MAC_PACKAGE_TITLE)"
 MAC_PACKAGE_UTI=com.$(MAC_PACKAGE_NAME_LOWER).pkg
 MAC_PACKAGE_INSTALL_LOCATION=$(MAC_FRAMEWORK_VERSIONED_DIR)
 
-TT = $(SYSTEM_MONO) "/Applications/Visual Studio.app/Contents/Resources/lib/monodevelop/AddIns/MonoDevelop.TextTemplating/TextTransform.exe"
+TT = $(SYSTEM_MONO) "/Applications/Visual Studio.app/Contents/MonoBundle/AddIns/MonoDevelop.TextTemplating/TextTransform.exe"
 
 PRODUCT_KEY_PATH?=$(TOP)/product.snk
 


### PR DESCRIPTION
It currently still uses a preview version, this should be tracked on stable release.
Another option would be to query for the latest version and install that.

The usage of SYSTEM_MONO seems to be needed still.