### PR TITLE
[CoreGraphics] Improve matrix types for .NET. Fixes #14125.

### DIFF
--- a/src/CoreGraphics/CGAffineTransform.cs
+++ b/src/CoreGraphics/CGAffineTransform.cs
@@ -27,6 +27,7 @@
 //
 
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 using CoreFoundation;
@@ -45,6 +46,27 @@ namespace CoreGraphics {
 		public /* CGFloat */ nfloat D;
 		public /* CGFloat */ nfloat Tx;
 		public /* CGFloat */ nfloat Ty;
+
+#if !XAMCORE_5_0
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use 'A' instead.")]
+		public nfloat xx { get => A; set => A = value; }
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use 'B' instead.")]
+		public nfloat yx { get => B; set => B = value; }
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use 'C' instead.")]
+		public nfloat xy { get => C; set => C = value; }
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use 'D' instead.")]
+		public nfloat yy { get => D; set => D = value; }
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use 'Tx' instead.")]
+		public nfloat x0 { get => Tx; set => Tx = value; }
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use 'Ty' instead.")]
+		public nfloat y0 { get => Ty; set => Ty = value; }
+#endif // !XAMCORE_5_0
 #else
 		[Obsolete ("Use 'A' instead.")]
 		public /* CGFloat */ nfloat xx;   // a

--- a/src/SceneKit/SCNQuaternion.cs
+++ b/src/SceneKit/SCNQuaternion.cs
@@ -96,7 +96,11 @@ namespace SceneKit
 
         public SCNQuaternion (ref Matrix3 matrix)
         {
+#if NET
+            double scale = System.Math.Pow (matrix.GetDeterminant (), 1.0d / 3.0d);
+#else
             double scale = System.Math.Pow(matrix.Determinant, 1.0d / 3.0d);
+#endif
 	    float x, y, z;
 	    
             w = (float) (System.Math.Sqrt(System.Math.Max(0, scale + matrix.R0C0 + matrix.R1C1 + matrix.R2C2)) / 2);

--- a/src/Simd/MatrixFloat2x2.cs
+++ b/src/Simd/MatrixFloat2x2.cs
@@ -56,10 +56,10 @@ namespace OpenTK
 		[Obsolete ("Use 'M22' instead.")]
 		public float R1C1;
 
-		public float M11 { get => R0C0; set => value = R0C0; }
-		public float M21 { get => R1C0; set => value = R1C0; }
-		public float M12 { get => R0C1; set => value = R0C1; }
-		public float M22 { get => R1C1; set => value = R1C1; }
+		public float M11 { get => R0C0; set => R0C0 = value; }
+		public float M21 { get => R1C0; set => R1C0 = value; }
+		public float M12 { get => R0C1; set => R0C1 = value; }
+		public float M22 { get => R1C1; set => R1C1 = value; }
 #endif
 
 #if NET

--- a/src/Simd/MatrixFloat2x2.cs
+++ b/src/Simd/MatrixFloat2x2.cs
@@ -13,6 +13,7 @@
 #nullable enable
 
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 // This type does not come from the CoreGraphics framework; it's defined in /usr/include/simd/matrix_types.h
@@ -25,28 +26,84 @@ namespace OpenTK
 	[StructLayout (LayoutKind.Sequential)]
 	public struct NMatrix2 : IEquatable<NMatrix2>
 	{
+#if NET
+		public float M11;
+		public float M21;
+		public float M12;
+		public float M22;
+
+#if !XAMCORE_5_0
+		[Obsolete ("Use 'M11' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R0C0 { get => M11; set => M11 = value; }
+		[Obsolete ("Use 'M21' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R1C0 { get => M21; set => M21 = value; }
+		[Obsolete ("Use 'M12' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R0C1 { get => M12; set => M12 = value; }
+		[Obsolete ("Use 'M22' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R1C1 { get => M22; set => M22 = value; }
+#endif // !XAMCORE_5_0
+#else
+		[Obsolete ("Use 'M11' instead.")]
 		public float R0C0;
+		[Obsolete ("Use 'M21' instead.")]
 		public float R1C0;
+		[Obsolete ("Use 'M12' instead.")]
 		public float R0C1;
+		[Obsolete ("Use 'M22' instead.")]
 		public float R1C1;
 
-		public readonly static NMatrix2 Identity = new NMatrix2 (
+		public float M11 { get => R0C0; set => value = R0C0; }
+		public float M21 { get => R1C0; set => value = R1C0; }
+		public float M12 { get => R0C1; set => value = R0C1; }
+		public float M22 { get => R1C1; set => value = R1C1; }
+#endif
+
+#if NET
+		static readonly NMatrix2 _identity = new NMatrix2
+		(
 			1, 0,
 			0, 1);
 
+		public static NMatrix2 Identity { get => _identity; }
+#else
+		public readonly static NMatrix2 Identity = new NMatrix2 (
+			1, 0,
+			0, 1);
+#endif
+
 		public NMatrix2 (
-			float r0c0, float r0c1,
-			float r1c0, float r1c1)
+			float m11, float m12,
+			float m21, float m22)
 		{
-			R0C0 = r0c0;
-			R1C0 = r1c0;
-			R0C1 = r0c1;
-			R1C1 = r1c1;
+#if NET
+			M11 = m11;
+			M21 = m21;
+			M12 = m12;
+			M22 = m22;
+#else
+			R0C0 = m11;
+			R1C0 = m21;
+			R0C1 = m12;
+			R1C1 = m22;
+#endif
+		}
+
+		public readonly float GetDeterminant ()
+		{
+#if NET
+			return M11 * M22 - M21 * M12;
+#else
+			return R0C0 * R1C1 - R1C0 * R0C1;
+#endif
 		}
 
 		public float Determinant {
 			get {
-				return R0C0 * R1C1 - R1C0 * R0C1;
+				return M11 * M22 - M21 * M12;
 			}
 		}
 
@@ -57,15 +114,18 @@ namespace OpenTK
 
 		public static NMatrix2 Transpose (NMatrix2 mat)
 		{
-			return new NMatrix2 (mat.R0C0, mat.R1C0, mat.R0C1, mat.R1C1);
+			return new NMatrix2 (mat.M11, mat.M21, mat.M12, mat.M22);
 		}
 
 		public static void Transpose (ref NMatrix2 mat, out NMatrix2 result)
 		{
-			result.R0C0 = mat.R0C0;
-			result.R0C1 = mat.R1C0;
-			result.R1C0 = mat.R0C1;
-			result.R1C1 = mat.R1C1;
+#if !NET
+			result = new NMatrix2 ();
+#endif
+			result.M11 = mat.M11;
+			result.M12 = mat.M21;
+			result.M21 = mat.M12;
+			result.M22 = mat.M22;
 		}
 
 		public static NMatrix2 Multiply (NMatrix2 left, NMatrix2 right)
@@ -77,11 +137,14 @@ namespace OpenTK
 
 		public static void Multiply (ref NMatrix2 left, ref NMatrix2 right, out NMatrix2 result)
 		{
-			result.R0C0 = left.R0C0 * right.R0C0 + left.R0C1 * right.R1C0;
-			result.R0C1 = left.R0C0 * right.R0C1 + left.R0C1 * right.R1C1;
+#if !NET
+			result = new NMatrix2 ();
+#endif
+			result.M11 = left.M11 * right.M11 + left.M12 * right.M21;
+			result.M12 = left.M11 * right.M12 + left.M12 * right.M22;
 
-			result.R1C0 = left.R1C0 * right.R0C0 + left.R1C1 * right.R1C0;
-			result.R1C1 = left.R1C0 * right.R0C1 + left.R1C1 * right.R1C1;
+			result.M21 = left.M21 * right.M11 + left.M22 * right.M21;
+			result.M22 = left.M21 * right.M12 + left.M22 * right.M22;
 		}
 
 		public static NMatrix2 operator * (NMatrix2 left, NMatrix2 right)
@@ -103,8 +166,8 @@ namespace OpenTK
 		public static explicit operator global::OpenTK.Matrix2 (NMatrix2 value)
 		{
 			return new global::OpenTK.Matrix2 (
-				value.R0C0, value.R0C1,
-				value.R1C0, value.R1C1);
+				value.M11, value.M12,
+				value.M21, value.M22);
 		}
 
 		public static explicit operator NMatrix2 (global::OpenTK.Matrix2 value)
@@ -117,12 +180,12 @@ namespace OpenTK
 
 		public override string ToString ()
 		{
-			return $"({R0C0}, {R0C1})\n({R1C0}, {R1C1})";
+			return $"({M11}, {M12})\n({M21}, {M22})";
 		}
 
 		public override int GetHashCode ()
 		{
-			return R0C0.GetHashCode () ^ R0C1.GetHashCode () ^ R1C0.GetHashCode () ^ R1C1.GetHashCode ();
+			return M11.GetHashCode () ^ M12.GetHashCode () ^ M21.GetHashCode () ^ M22.GetHashCode ();
 		}
 
 		public override bool Equals (object? obj)
@@ -136,10 +199,10 @@ namespace OpenTK
 		public bool Equals (NMatrix2 other)
 		{
 			return
-				R0C0 == other.R0C0 &&
-				R0C1 == other.R0C1 &&
-				R1C0 == other.R1C0 &&
-				R1C1 == other.R1C1;
+				M11 == other.M11 &&
+				M12 == other.M12 &&
+				M21 == other.M21 &&
+				M22 == other.M22;
 		}
 	}
 }

--- a/src/Simd/MatrixFloat3x3.cs
+++ b/src/Simd/MatrixFloat3x3.cs
@@ -13,6 +13,7 @@
 #nullable enable
 
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 // This type does not come from the CoreGraphics framework; it's defined in /usr/include/simd/matrix_types.h
@@ -29,77 +30,186 @@ namespace OpenTK
 		 * represented as vectors of length 4, so we pad here
 		 * with dummy fields.
 		 * See top of /usr/include/simd/matrix_types.h for more information. */
+#if NET
+		public float M11;
+		public float M21;
+		public float M31;
+		float dummy0;
+		public float M12;
+		public float M22;
+		public float M32;
+		float dummy1;
+		public float M13;
+		public float M23;
+		public float M33;
+		float dummy2;
+
+#if !XAMCORE_5_0
+		// Add hidden obsolete members for names used in OpenTK's Matrix3 type to ease migration to .NET.
+		[Obsolete ("Use 'M11' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R0C0 { get => M11; set => M11 = value; }
+		[Obsolete ("Use 'M21' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R1C0 { get => M21; set => M21 = value; }
+		[Obsolete ("Use 'M31' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R2C0 { get => M31; set => M31 = value; }
+		[Obsolete ("Use 'M12' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R0C1 { get => M12; set => M12 = value; }
+		[Obsolete ("Use 'M22' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R1C1 { get => M22; set => M22 = value; }
+		[Obsolete ("Use 'M32' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R2C1 { get => M32; set => M32 = value; }
+		[Obsolete ("Use 'M13' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R0C2 { get => M13; set => M13 = value; }
+		[Obsolete ("Use 'M23' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R1C2 { get => M23; set => M23 = value; }
+		[Obsolete ("Use 'M33' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R2C2 { get => M33; set => M33 = value; }
+#endif // !XAMCORE_5_0
+#else
+		[Obsolete ("Use 'M11' instead.")]
 		public float R0C0;
+		[Obsolete ("Use 'M21' instead.")]
 		public float R1C0;
+		[Obsolete ("Use 'M31' instead.")]
 		public float R2C0;
 		float dummy0;
+
+		[Obsolete ("Use 'M12' instead.")]
 		public float R0C1;
+		[Obsolete ("Use 'M22' instead.")]
 		public float R1C1;
+		[Obsolete ("Use 'M32' instead.")]
 		public float R2C1;
 		float dummy1;
+
+		[Obsolete ("Use 'M13' instead.")]
 		public float R0C2;
+		[Obsolete ("Use 'M23' instead.")]
 		public float R1C2;
+		[Obsolete ("Use 'M33' instead.")]
 		public float R2C2;
 		float dummy2;
 
+		public float M11 { get => R0C0; set => R0C0 = value; }
+		public float M21 { get => R1C0; set => R1C0 = value; }
+		public float M31 { get => R2C0; set => R2C0 = value; }
+		public float M12 { get => R0C1; set => R0C1 = value; }
+		public float M22 { get => R1C1; set => R1C1 = value; }
+		public float M32 { get => R2C1; set => R2C1 = value; }
+		public float M13 { get => R0C2; set => R0C2 = value; }
+		public float M23 { get => R1C2; set => R1C2 = value; }
+		public float M33 { get => R2C2; set => R2C2 = value; }
+#endif
+
+#if NET
+		static readonly NMatrix3 _identity = new NMatrix3
+		(
+			1, 0, 0,
+			0, 1, 0,
+			0, 0, 1
+		);
+
+		public static NMatrix3 Identity { get => _identity; }
+#else
 		public readonly static NMatrix3 Identity = new NMatrix3 
 		{
-			R0C0 = 1f,
-			R1C1 = 1f,
-			R2C2 = 1f,
+			M11 = 1f,
+			M22 = 1f,
+			M33 = 1f,
 		};
+#endif
 
 		public NMatrix3 (
-			float r0c0, float r0c1, float r0c2,
-			float r1c0, float r1c1, float r1c2,
-			float r2c0, float r2c1, float r2c2)
+			float m11, float m12, float m13,
+			float m21, float m22, float m23,
+			float m31, float m32, float m33)
 		{
-			R0C0 = r0c0;
-			R1C0 = r1c0;
-			R2C0 = r2c0;
-			R0C1 = r0c1;
-			R1C1 = r1c1;
-			R2C1 = r2c1;
-			R0C2 = r0c2;
-			R1C2 = r1c2;
-			R2C2 = r2c2;
+#if NET
+			M11 = m11;
+			M21 = m21;
+			M31 = m31;
+			M12 = m12;
+			M22 = m22;
+			M32 = m32;
+			M13 = m13;
+			M23 = m23;
+			M33 = m33;
+#else
+			R0C0 = m11;
+			R1C0 = m21;
+			R2C0 = m31;
+			R0C1 = m12;
+			R1C1 = m22;
+			R2C1 = m32;
+			R0C2 = m13;
+			R1C2 = m23;
+			R2C2 = m33;
+#endif
 			dummy0 = 0;
 			dummy1 = 0;
 			dummy2 = 0;
 		}
 
+		public readonly float GetDeterminant ()
+		{
+			return
+#if NET
+				M11 * (M22 * M33 - M23 * M32) -
+				M12 * (M21 * M33 - M23 * M31) +
+				M13 * (M21 * M32 - M22 * M31);
+#else
+				R0C0 * (R1C1 * R2C2 - R1C2 * R2C1) -
+				R0C1 * (R1C0 * R2C2 - R1C2 * R2C0) +
+				R0C2 * (R1C0 * R2C1 - R1C1 * R2C0);
+#endif
+		}
+
+#if !XAMCORE_5_0
 		public float Determinant {
 			get {
 				return
-					R0C0 * (R1C1 * R2C2 - R1C2 * R2C1) -
-					R0C1 * (R1C0 * R2C2 - R1C2 * R2C0) +
-					R0C2 * (R1C0 * R2C1 - R1C1 * R2C0);
+					M11 * (M22 * M33 - M23 * M32) -
+					M12 * (M21 * M33 - M23 * M31) +
+					M13 * (M21 * M32 - M22 * M31);
 			}
 		}
+#endif
 
 		public void Transpose ()
 		{
 			this = Transpose (this);
 		}
 
-		public static NMatrix3 Transpose (NMatrix3 mat)
+		public static NMatrix3 Transpose (NMatrix3 matrix)
 		{
 			NMatrix3 result = new NMatrix3 ();
-			Transpose (ref mat, out result);
+			Transpose (ref matrix, out result);
 			return result;
 		}
 
 		public static void Transpose (ref NMatrix3 mat, out NMatrix3 result)
 		{
-			result.R0C0 = mat.R0C0;
-			result.R1C0 = mat.R0C1;
-			result.R2C0 = mat.R0C2;
-			result.R0C1 = mat.R1C0;
-			result.R1C1 = mat.R1C1;
-			result.R2C1 = mat.R1C2;
-			result.R0C2 = mat.R2C0;
-			result.R1C2 = mat.R2C1;
-			result.R2C2 = mat.R2C2;
+#if !NET
+			result = new NMatrix3 ();
+#endif
+			result.M11 = mat.M11;
+			result.M21 = mat.M12;
+			result.M31 = mat.M13;
+			result.M12 = mat.M21;
+			result.M22 = mat.M22;
+			result.M32 = mat.M23;
+			result.M13 = mat.M31;
+			result.M23 = mat.M32;
+			result.M33 = mat.M33;
 			result.dummy0 = 0;
 			result.dummy1 = 0;
 			result.dummy2 = 0;
@@ -114,19 +224,22 @@ namespace OpenTK
 
 		public static void Multiply (ref NMatrix3 left, ref NMatrix3 right, out NMatrix3 result)
 		{
-			result.R0C0 = left.R0C0 * right.R0C0 + left.R0C1 * right.R1C0 + left.R0C2 * right.R2C0;
-			result.R0C1 = left.R0C0 * right.R0C1 + left.R0C1 * right.R1C1 + left.R0C2 * right.R2C1;
-			result.R0C2 = left.R0C0 * right.R0C2 + left.R0C1 * right.R1C2 + left.R0C2 * right.R2C2;
+#if !NET
+			result = new NMatrix3 ();
+#endif
+			result.M11 = left.M11 * right.M11 + left.M12 * right.M21 + left.M13 * right.M31;
+			result.M12 = left.M11 * right.M12 + left.M12 * right.M22 + left.M13 * right.M32;
+			result.M13 = left.M11 * right.M13 + left.M12 * right.M23 + left.M13 * right.M33;
 			result.dummy0 = 0;
 
-			result.R1C0 = left.R1C0 * right.R0C0 + left.R1C1 * right.R1C0 + left.R1C2 * right.R2C0;
-			result.R1C1 = left.R1C0 * right.R0C1 + left.R1C1 * right.R1C1 + left.R1C2 * right.R2C1;
-			result.R1C2 = left.R1C0 * right.R0C2 + left.R1C1 * right.R1C2 + left.R1C2 * right.R2C2;
+			result.M21 = left.M21 * right.M11 + left.M22 * right.M21 + left.M23 * right.M31;
+			result.M22 = left.M21 * right.M12 + left.M22 * right.M22 + left.M23 * right.M32;
+			result.M23 = left.M21 * right.M13 + left.M22 * right.M23 + left.M23 * right.M33;
 			result.dummy1 = 0;
 
-			result.R2C0 = left.R2C0 * right.R0C0 + left.R2C1 * right.R1C0 + left.R2C2 * right.R2C0;
-			result.R2C1 = left.R2C0 * right.R0C1 + left.R2C1 * right.R1C1 + left.R2C2 * right.R2C1;
-			result.R2C2 = left.R2C0 * right.R0C2 + left.R2C1 * right.R1C2 + left.R2C2 * right.R2C2;
+			result.M31 = left.M31 * right.M11 + left.M32 * right.M21 + left.M33 * right.M31;
+			result.M32 = left.M31 * right.M12 + left.M32 * right.M22 + left.M33 * right.M32;
+			result.M33 = left.M31 * right.M13 + left.M32 * right.M23 + left.M33 * right.M33;
 			result.dummy2 = 0;
 		}
 
@@ -149,9 +262,9 @@ namespace OpenTK
 		public static explicit operator global::OpenTK.Matrix3 (NMatrix3 value)
 		{
 			return new global::OpenTK.Matrix3 (
-				value.R0C0, value.R0C1, value.R0C2,
-				value.R1C0, value.R1C1, value.R1C2,
-				value.R2C0, value.R2C1, value.R2C2);
+				value.M11, value.M12, value.M13,
+				value.M21, value.M22, value.M23,
+				value.M31, value.M32, value.M33);
 		}
 
 		public static explicit operator NMatrix3 (global::OpenTK.Matrix3 value)
@@ -166,17 +279,17 @@ namespace OpenTK
 		public override string ToString ()
 		{
 			return
-				$"({R0C0}, {R0C1}, {R0C2})\n" +
-				$"({R1C0}, {R1C1}, {R1C2})\n" +
-				$"({R2C0}, {R2C1}, {R2C2})";
+				$"({M11}, {M12}, {M13})\n" +
+				$"({M21}, {M22}, {M23})\n" +
+				$"({M31}, {M32}, {M33})";
 		}
 
 		public override int GetHashCode ()
 		{
 			return
-				R0C0.GetHashCode () ^ R0C1.GetHashCode () ^ R0C2.GetHashCode () ^
-				R1C0.GetHashCode () ^ R1C1.GetHashCode () ^ R1C2.GetHashCode () ^
-				R2C0.GetHashCode () ^ R2C1.GetHashCode () ^ R2C2.GetHashCode ();
+				M11.GetHashCode () ^ M12.GetHashCode () ^ M13.GetHashCode () ^
+				M21.GetHashCode () ^ M22.GetHashCode () ^ M23.GetHashCode () ^
+				M31.GetHashCode () ^ M32.GetHashCode () ^ M33.GetHashCode ();
 		}
 
 		public override bool Equals (object? obj)
@@ -190,9 +303,9 @@ namespace OpenTK
 		public bool Equals (NMatrix3 other)
 		{
 			return
-				R0C0 == other.R0C0 && R0C1 == other.R0C1 && R0C2 == other.R0C2 &&
-				R1C0 == other.R1C0 && R1C1 == other.R1C1 && R1C2 == other.R1C2 &&
-				R2C0 == other.R2C0 && R2C1 == other.R2C1 && R2C2 == other.R2C2;
+				M11 == other.M11 && M12 == other.M12 && M13 == other.M13 &&
+				M21 == other.M21 && M22 == other.M22 && M23 == other.M23 &&
+				M31 == other.M31 && M32 == other.M32 && M33 == other.M33;
 		}
 	}
 }

--- a/src/Simd/MatrixFloat3x3RM.cs
+++ b/src/Simd/MatrixFloat3x3RM.cs
@@ -4,15 +4,21 @@
 //
 // Copyright (c) 2022 Microsoft Inc
 //
-
 //
 // This represents the native GLKMatrix3 type, which has a row-major layout
 // (same as OpenTK.Matrix3).
+//
+// One day we might be able to remove this type in favor of a System.Numerics.Matrix3x3 type (which doesn't exist yet),
+// so the only API available here is the one that I _think_ System.Numerics.Matrix3x3 will have (based on the existing
+// System.Numerics.Matrix4x4 type). In particular it must not have any API that *doesn't* exist in a potential
+// System.Numerics.Matrix3x3 type (🔮).
 //
 
 #nullable enable
 
 using System;
+using System.ComponentModel;
+using System.Numerics;
 using System.Runtime.InteropServices;
 
 // This type does not come from the CoreGraphics framework
@@ -22,133 +28,271 @@ namespace CoreGraphics
 	[StructLayout (LayoutKind.Sequential)]
 	public struct RMatrix3 : IEquatable<RMatrix3>
 	{
-		public float R0C0;
-		public float R0C1;
-		public float R0C2;
-		public float R1C0;
-		public float R1C1;
-		public float R1C2;
-		public float R2C0;
-		public float R2C1;
-		public float R2C2;
+		public float M11;
+		public float M12;
+		public float M13;
+		public float M21;
+		public float M22;
+		public float M23;
+		public float M31;
+		public float M32;
+		public float M33;
+
+#if !XAMCORE_5_0
+		// Add hidden obsolete members for names used in OpenTK's Matrix3 type to ease migration to .NET.
+		[Obsolete ("Use 'M11' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R0C0 { get => M11; set => M11 = value; }
+		[Obsolete ("Use 'M21' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R1C0 { get => M21; set => M21 = value; }
+		[Obsolete ("Use 'M31' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R2C0 { get => M31; set => M31 = value; }
+		[Obsolete ("Use 'M12' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R0C1 { get => M12; set => M12 = value; }
+		[Obsolete ("Use 'M22' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R1C1 { get => M22; set => M22 = value; }
+		[Obsolete ("Use 'M32' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R2C1 { get => M32; set => M32 = value; }
+		[Obsolete ("Use 'M13' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R0C2 { get => M13; set => M13 = value; }
+		[Obsolete ("Use 'M23' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R1C2 { get => M23; set => M23 = value; }
+		[Obsolete ("Use 'M33' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public float R2C2 { get => M33; set => M33 = value; }
+#endif // !XAMCORE_5_0
 
 		public RMatrix3 (
-			float r0c0, float r0c1, float r0c2,
-			float r1c0, float r1c1, float r1c2,
-			float r2c0, float r2c1, float r2c2)
+			float m11, float m12, float m13,
+			float m21, float m22, float m23,
+			float m31, float m32, float m33)
 		{
-			R0C0 = r0c0;
-			R1C0 = r1c0;
-			R2C0 = r2c0;
-			R0C1 = r0c1;
-			R1C1 = r1c1;
-			R2C1 = r2c1;
-			R0C2 = r0c2;
-			R1C2 = r1c2;
-			R2C2 = r2c2;
+			M11 = m11;
+			M21 = m21;
+			M31 = m31;
+			M12 = m12;
+			M22 = m22;
+			M32 = m32;
+			M13 = m13;
+			M23 = m23;
+			M33 = m33;
 		}
 
-		public float Determinant {
+		static readonly RMatrix3 _identity = new RMatrix3
+		(
+			1, 0, 0,
+			0, 1, 0,
+			0, 0, 1
+		);
+
+		public static RMatrix3 Identity { get => _identity; }
+
+		public float this [int row, int column] {
 			get {
-				return
-					R0C0 * (R1C1 * R2C2 - R1C2 * R2C1) -
-					R0C1 * (R1C0 * R2C2 - R1C2 * R2C0) +
-					R0C2 * (R1C0 * R2C1 - R1C1 * R2C0);
+				switch (row) {
+				case 0:
+					switch (column) {
+					case 0: return M11;
+					case 1: return M12;
+					case 2: return M13;
+					}
+					break;
+				case 1:
+					switch (column) {
+					case 0: return M21;
+					case 1: return M22;
+					case 2: return M23;
+					}
+					break;
+				case 2:
+					switch (column) {
+					case 0: return M31;
+					case 1: return M32;
+					case 2: return M33;
+					}
+					break;
+				}
+
+				throw new IndexOutOfRangeException();
+			}
+			set {
+				switch (row) {
+				case 0:
+					switch (column) {
+					case 0: M11 = value; return;
+					case 1: M12 = value; return;
+					case 2: M13 = value; return;
+					}
+					break;
+				case 1:
+					switch (column) {
+					case 0: M21 = value; return;
+					case 1: M22 = value; return;
+					case 2: M23 = value; return;
+					}
+					break;
+				case 2:
+					switch (column) {
+					case 0: M31 = value; return;
+					case 1: M32 = value; return;
+					case 2: M33 = value; return;
+					}
+					break;
+				}
+
+				throw new IndexOutOfRangeException();
 			}
 		}
 
-		public void Transpose ()
+		public static RMatrix3 CreateFromQuaternion (Quaternion quaternion)
 		{
-			this = Transpose (this);
+			quaternion = Quaternion.Normalize (quaternion);
+
+			float xx = (float) (quaternion.X * quaternion.X);
+			float yy = (float) (quaternion.Y * quaternion.Y);
+			float zz = (float) (quaternion.Z * quaternion.Z);
+			float xy = (float) (quaternion.X * quaternion.Y);
+			float xz = (float) (quaternion.X * quaternion.Z);
+			float yz = (float) (quaternion.Y * quaternion.Z);
+			float wx = (float) (quaternion.W * quaternion.X);
+			float wy = (float) (quaternion.W * quaternion.Y);
+			float wz = (float) (quaternion.W * quaternion.Z);
+
+			var result = new RMatrix3 ();
+			result.M11 = 1 - 2 * (yy + zz);
+			result.M12 = 2 * (xy - wz);
+			result.M13 = 2 * (xz + wy);
+
+			result.M21 = 2 * (xy + wz);
+			result.M22 = 1 - 2 * (xx + zz);
+			result.M23 = 2 * (yz - wx);
+
+			result.M31 = 2 * (xz - wy);
+			result.M32 = 2 * (yz + wx);
+			result.M33 = 1 - 2 * (xx + yy);
+
+			return result;
 		}
 
-		public static RMatrix3 Transpose (RMatrix3 mat)
+		public readonly float GetDeterminant ()
+		{
+			return
+				M11 * (M22 * M33 - M23 * M32) -
+				M12 * (M21 * M33 - M23 * M31) +
+				M13 * (M21 * M32 - M22 * M31);
+		}
+
+		public static RMatrix3 Transpose (RMatrix3 matrix)
 		{
 			RMatrix3 result = new RMatrix3 ();
-			Transpose (ref mat, out result);
+			result.M11 = matrix.M11;
+			result.M21 = matrix.M12;
+			result.M31 = matrix.M13;
+			result.M12 = matrix.M21;
+			result.M22 = matrix.M22;
+			result.M32 = matrix.M23;
+			result.M13 = matrix.M31;
+			result.M23 = matrix.M32;
+			result.M33 = matrix.M33;
 			return result;
 		}
 
-		public static void Transpose (ref RMatrix3 mat, out RMatrix3 result)
-		{
-			result.R0C0 = mat.R0C0;
-			result.R1C0 = mat.R0C1;
-			result.R2C0 = mat.R0C2;
-			result.R0C1 = mat.R1C0;
-			result.R1C1 = mat.R1C1;
-			result.R2C1 = mat.R1C2;
-			result.R0C2 = mat.R2C0;
-			result.R1C2 = mat.R2C1;
-			result.R2C2 = mat.R2C2;
-		}
-
-		public static RMatrix3 Multiply (RMatrix3 left, RMatrix3 right)
+		public static RMatrix3 Multiply (RMatrix3 value1, RMatrix3 value2)
 		{
 			RMatrix3 result;
-			Multiply (ref left, ref right, out result);
+			result.M11 = value1.M11 * value2.M11 + value1.M12 * value2.M21 + value1.M13 * value2.M31;
+			result.M12 = value1.M11 * value2.M12 + value1.M12 * value2.M22 + value1.M13 * value2.M32;
+			result.M13 = value1.M11 * value2.M13 + value1.M12 * value2.M23 + value1.M13 * value2.M33;
+
+			result.M21 = value1.M21 * value2.M11 + value1.M22 * value2.M21 + value1.M23 * value2.M31;
+			result.M22 = value1.M21 * value2.M12 + value1.M22 * value2.M22 + value1.M23 * value2.M32;
+			result.M23 = value1.M21 * value2.M13 + value1.M22 * value2.M23 + value1.M23 * value2.M33;
+
+			result.M31 = value1.M31 * value2.M11 + value1.M32 * value2.M21 + value1.M33 * value2.M31;
+			result.M32 = value1.M31 * value2.M12 + value1.M32 * value2.M22 + value1.M33 * value2.M32;
+			result.M33 = value1.M31 * value2.M13 + value1.M32 * value2.M23 + value1.M33 * value2.M33;
 			return result;
 		}
 
-		public static void Multiply (ref RMatrix3 left, ref RMatrix3 right, out RMatrix3 result)
+		public static RMatrix3 Multiply (RMatrix3 value1, float value2)
 		{
-			result.R0C0 = left.R0C0 * right.R0C0 + left.R0C1 * right.R1C0 + left.R0C2 * right.R2C0;
-			result.R0C1 = left.R0C0 * right.R0C1 + left.R0C1 * right.R1C1 + left.R0C2 * right.R2C1;
-			result.R0C2 = left.R0C0 * right.R0C2 + left.R0C1 * right.R1C2 + left.R0C2 * right.R2C2;
-
-			result.R1C0 = left.R1C0 * right.R0C0 + left.R1C1 * right.R1C0 + left.R1C2 * right.R2C0;
-			result.R1C1 = left.R1C0 * right.R0C1 + left.R1C1 * right.R1C1 + left.R1C2 * right.R2C1;
-			result.R1C2 = left.R1C0 * right.R0C2 + left.R1C1 * right.R1C2 + left.R1C2 * right.R2C2;
-
-			result.R2C0 = left.R2C0 * right.R0C0 + left.R2C1 * right.R1C0 + left.R2C2 * right.R2C0;
-			result.R2C1 = left.R2C0 * right.R0C1 + left.R2C1 * right.R1C1 + left.R2C2 * right.R2C1;
-			result.R2C2 = left.R2C0 * right.R0C2 + left.R2C1 * right.R1C2 + left.R2C2 * right.R2C2;
+			var result = new RMatrix3 ();
+			result.M11 = value2 * value1.M11;
+			result.M12 = value2 * value1.M12;
+			result.M13 = value2 * value1.M13;
+			result.M21 = value2 * value1.M21;
+			result.M22 = value2 * value1.M22;
+			result.M23 = value2 * value1.M23;
+			result.M31 = value2 * value1.M31;
+			result.M32 = value2 * value1.M32;
+			result.M33 = value2 * value1.M33;
+			return result;
 		}
 
-		public static RMatrix3 operator * (RMatrix3 left, RMatrix3 right)
+		public static RMatrix3 Add (RMatrix3 value1, RMatrix3 value2)
 		{
-			return Multiply (left, right);
+			var result = new RMatrix3 ();
+			result.M11 = value1.M11 + value2.M11;
+			result.M12 = value1.M12 + value2.M12;
+			result.M13 = value1.M13 + value2.M13;
+			result.M21 = value1.M21 + value2.M21;
+			result.M22 = value1.M22 + value2.M22;
+			result.M23 = value1.M23 + value2.M23;
+			result.M31 = value1.M31 + value2.M31;
+			result.M32 = value1.M32 + value2.M32;
+			result.M33 = value1.M33 + value2.M33;
+			return result;
 		}
 
-		public static bool operator == (RMatrix3 left, RMatrix3 right)
+		public static RMatrix3 Subtract (RMatrix3 value1, RMatrix3 value2)
 		{
-			return left.Equals (right);
+			var result = new RMatrix3 ();
+			result.M11 = value1.M11 - value2.M11;
+			result.M12 = value1.M12 - value2.M12;
+			result.M13 = value1.M13 - value2.M13;
+			result.M21 = value1.M21 - value2.M21;
+			result.M22 = value1.M22 - value2.M22;
+			result.M23 = value1.M23 - value2.M23;
+			result.M31 = value1.M31 - value2.M31;
+			result.M32 = value1.M32 - value2.M32;
+			result.M33 = value1.M33 - value2.M33;
+			return result;
 		}
 
-		public static bool operator != (RMatrix3 left, RMatrix3 right)
+		public static RMatrix3 operator * (RMatrix3 value1, RMatrix3 value2)
 		{
-			return !left.Equals (right);
+			return Multiply (value1, value2);
 		}
 
-		public static explicit operator NMatrix3 (RMatrix3 value)
+		public static bool operator == (RMatrix3 value1, RMatrix3 value2)
 		{
-			return new NMatrix3 (
-				value.R0C0, value.R0C1, value.R0C2,
-				value.R1C0, value.R1C1, value.R1C2,
-				value.R2C0, value.R2C1, value.R2C2);
+			return value1.Equals (value2);
 		}
 
-		public static explicit operator RMatrix3 (NMatrix3 value)
+		public static bool operator != (RMatrix3 value1, RMatrix3 value2)
 		{
-			return new RMatrix3 (
-				value.R0C0, value.R0C1, value.R0C2,
-				value.R1C0, value.R1C1, value.R1C2,
-				value.R2C0, value.R2C1, value.R2C2);
+			return !value1.Equals (value2);
 		}
 
 		public override string ToString ()
 		{
 			return
-				$"({R0C0}, {R0C1}, {R0C2})\n" +
-				$"({R1C0}, {R1C1}, {R1C2})\n" +
-				$"({R2C0}, {R2C1}, {R2C2})";
+				$"{{ {{M11:{M11} M12:{M12} M13:{M13}}} {{M21:{M21} M22:{M22} M23:{M23}}} {{M31:{M31} M32:{M32} M33:{M33}}} }}";
 		}
 
 		public override int GetHashCode ()
 		{
 			return
-				R0C0.GetHashCode () ^ R0C1.GetHashCode () ^ R0C2.GetHashCode () ^
-				R1C0.GetHashCode () ^ R1C1.GetHashCode () ^ R1C2.GetHashCode () ^
-				R2C0.GetHashCode () ^ R2C1.GetHashCode () ^ R2C2.GetHashCode ();
+				M11.GetHashCode () ^ M12.GetHashCode () ^ M13.GetHashCode () ^
+				M21.GetHashCode () ^ M22.GetHashCode () ^ M23.GetHashCode () ^
+				M31.GetHashCode () ^ M32.GetHashCode () ^ M33.GetHashCode ();
 		}
 
 		public override bool Equals (object? obj)
@@ -162,10 +306,10 @@ namespace CoreGraphics
 		public bool Equals (RMatrix3 other)
 		{
 			return
-				R0C0 == other.R0C0 && R0C1 == other.R0C1 && R0C2 == other.R0C2 &&
-				R1C0 == other.R1C0 && R1C1 == other.R1C1 && R1C2 == other.R1C2 &&
-				R2C0 == other.R2C0 && R2C1 == other.R2C1 && R2C2 == other.R2C2;
+				M11 == other.M11 && M12 == other.M12 && M13 == other.M13 &&
+				M21 == other.M21 && M22 == other.M22 && M23 == other.M23 &&
+				M31 == other.M31 && M32 == other.M32 && M33 == other.M33;
 		}
 	}
 }
-#endif
+#endif // NET

--- a/tests/monotouch-test/Asserts.cs
+++ b/tests/monotouch-test/Asserts.cs
@@ -37,12 +37,12 @@ public static class Asserts
 {
 	public static void AreEqual (bool expected, bool actual, string message)
 	{
-		Assert.AreEqual (expected, actual, message + " (M)");
+		Assert.AreEqual (expected, actual, $"{message} (M) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (float expected, float actual, string message)
 	{
-		Assert.AreEqual (expected, actual, message + " (M)");
+		Assert.AreEqual (expected, actual, $"{message} (M) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (float expected, float actual, float delta, string message)
@@ -52,172 +52,173 @@ public static class Asserts
 
 	public static void AreEqual (Vector2 expected, Vector2 actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, message + " (Y)");
+		Assert.AreEqual (expected.X, actual.X, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, $"{message} (Y) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector3 expected, Vector3 actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, 0.001, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, 0.001, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, 0.001, message + " (Z)");
+
+		Assert.AreEqual (expected.X, actual.X, 0.001, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, 0.001, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, 0.001, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector3 expected, Vector3 actual, float delta, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, delta, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, delta, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, delta, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, delta, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, delta, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, delta, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector3 expected, VectorFloat3 actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, 0.001, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, 0.001, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, 0.001, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, 0.001, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, 0.001, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, 0.001, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (VectorFloat3 expected, Vector3 actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, 0.001, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, 0.001, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, 0.001, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, 0.001, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, 0.001, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, 0.001, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (VectorFloat3 expected, VectorFloat3 actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, 0.001, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, 0.001, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, 0.001, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, 0.001, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, 0.001, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, 0.001, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (VectorFloat3 expected, VectorFloat3 actual, float delta, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, delta, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, delta, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, delta, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, delta, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, delta, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, delta, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector4 expected, Vector4 actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, message + " (Z)");
-		Assert.AreEqual (expected.W, actual.W, message + " (W)");
+		Assert.AreEqual (expected.X, actual.X, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, $"{message} (Z) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.W, actual.W, $"{message} (W) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector4 expected, Vector4 actual, float delta, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, delta, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, delta, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, delta, message + " (Z)");
-		Assert.AreEqual (expected.W, actual.W, delta, message + " (W)");
+		Assert.AreEqual (expected.X, actual.X, delta, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, delta, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, delta, $"{message} (Z) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.W, actual.W, delta, $"{message} (W) expected: {expected} actual: {actual}");
 	}
 
 #if !NET
 	public static void AreEqual (Matrix2 expected, Matrix2 actual, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, message + " (R0C0)");
-		AreEqual (expected.R0C1, actual.R0C1, message + " (R0C1)");
-		AreEqual (expected.R1C0, actual.R1C0, message + " (R1C0)");
-		AreEqual (expected.R1C1, actual.R1C1, message + " (R1C1)");
+		AreEqual (expected.R0C0, actual.R0C0, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, $"{message} (R1C1) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Matrix3 expected, Matrix3 actual, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, message + " (R0C0)");
-		AreEqual (expected.R0C1, actual.R0C1, message + " (R0C1)");
-		AreEqual (expected.R0C2, actual.R0C2, message + " (R0C2)");
-		AreEqual (expected.R1C0, actual.R1C0, message + " (R1C0)");
-		AreEqual (expected.R1C1, actual.R1C1, message + " (R1C1)");
-		AreEqual (expected.R1C2, actual.R1C2, message + " (R1C2)");
-		AreEqual (expected.R2C0, actual.R2C0, message + " (R2C0)");
-		AreEqual (expected.R2C1, actual.R2C1, message + " (R2C1)");
-		AreEqual (expected.R2C2, actual.R2C2, message + " (R2C2)");
+		AreEqual (expected.R0C0, actual.R0C0, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C2, actual.R0C2, $"{message} (R0C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, $"{message} (R1C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C2, actual.R1C2, $"{message} (R1C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C0, actual.R2C0, $"{message} (R2C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C1, actual.R2C1, $"{message} (R2C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C2, actual.R2C2, $"{message} (R2C2) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Matrix3 expected, Matrix3 actual, float delta, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, delta, message + " (R0C0)");
-		AreEqual (expected.R0C1, actual.R0C1, delta, message + " (R0C1)");
-		AreEqual (expected.R0C2, actual.R0C2, delta, message + " (R0C2)");
-		AreEqual (expected.R1C0, actual.R1C0, delta, message + " (R1C0)");
-		AreEqual (expected.R1C1, actual.R1C1, delta, message + " (R1C1)");
-		AreEqual (expected.R1C2, actual.R1C2, delta, message + " (R1C2)");
-		AreEqual (expected.R2C0, actual.R2C0, delta, message + " (R2C0)");
-		AreEqual (expected.R2C1, actual.R2C1, delta, message + " (R2C1)");
-		AreEqual (expected.R2C2, actual.R2C2, delta, message + " (R2C2)");
+		AreEqual (expected.R0C0, actual.R0C0, delta, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, delta, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C2, actual.R0C2, delta, $"{message} (R0C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, delta, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, delta, $"{message} (R1C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C2, actual.R1C2, delta, $"{message} (R1C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C0, actual.R2C0, delta, $"{message} (R2C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C1, actual.R2C1, delta, $"{message} (R2C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C2, actual.R2C2, delta, $"{message} (R2C2) expected: {expected} actual: {actual}");
 	}
 #endif
 
 	public static void AreEqual (Matrix4 expected, Matrix4 actual, string message)
 	{
-		AreEqual (expected.M11, actual.M11, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Matrix4 expected, Matrix4 actual, float delta, string message)
 	{
-		AreEqual (expected.M11, actual.M11, delta, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, delta, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, delta, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, delta, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, delta, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, delta, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, delta, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, delta, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, delta, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, delta, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, delta, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, delta, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, delta, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, delta, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, delta, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, delta, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, delta, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, delta, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, delta, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, delta, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, delta, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, delta, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, delta, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, delta, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, delta, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, delta, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, delta, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, delta, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, delta, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, delta, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, delta, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, delta, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector2i expected, Vector2i actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, message + " (Y)");
+		Assert.AreEqual (expected.X, actual.X, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, $"{message} (Y) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector4i expected, Vector4i actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, message + " (Z)");
-		Assert.AreEqual (expected.W, actual.W, message + " (W)");
+		Assert.AreEqual (expected.X, actual.X, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, $"{message} (Z) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.W, actual.W, $"{message} (W) expected: {expected} actual: {actual}");
 	}
 
 #if !__WATCHOS__
 	public static void AreEqual (MDLAxisAlignedBoundingBox expected, MDLAxisAlignedBoundingBox actual, string message)
 	{
-		AreEqual (expected.MaxBounds, actual.MaxBounds, message + " (MaxBounds)");
-		AreEqual (expected.MinBounds, actual.MinBounds, message + " (MinBounds)");
+		AreEqual (expected.MaxBounds, actual.MaxBounds, $"{message} (MaxBounds) expected: {expected} actual: {actual}");
+		AreEqual (expected.MinBounds, actual.MinBounds, $"{message} (MinBounds) expected: {expected} actual: {actual}");
 	}
 #endif // !__WATCHOS__
 
 	public static void AreEqual (Quaternion expected, Quaternion actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, message + " (Z)");
-		Assert.AreEqual (expected.W, actual.W, message + " (W)");
+		Assert.AreEqual (expected.X, actual.X, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, $"{message} (Z) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.W, actual.W, $"{message} (W) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Quaternion [] expected, Quaternion [] actual, string message)
@@ -230,7 +231,7 @@ public static class Asserts
 			Assert.Fail ($"Expected {expected}, got null. {message}");
 		}
 
-		Assert.AreEqual (expected.Length, actual.Length, message + " array lengths");
+		Assert.AreEqual (expected.Length, actual.Length, $"{message} array lengths");
 		for (var i = 0; i < expected.Length; i++) {
 			AreEqual (expected [i], actual [i], message + $" [{i}]");
 		}
@@ -246,23 +247,23 @@ public static class Asserts
 			Assert.Fail ($"Expected {expected}, got null. {message}");
 		}
 
-		Assert.AreEqual (expected.X, actual.X, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, message + " (Z)");
-		Assert.AreEqual (expected.W, actual.W, message + " (W)");
+		Assert.AreEqual (expected.X, actual.X, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, $"{message} (Z) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.W, actual.W, $"{message} (W) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Quaterniond expected, Quaterniond actual, double delta, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, delta, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, delta, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, delta, message + " (Z)");
-		Assert.AreEqual (expected.W, actual.W, delta, message + " (W)");
+		Assert.AreEqual (expected.X, actual.X, delta, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, delta, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, delta, $"{message} (Z) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.W, actual.W, delta, $"{message} (W) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Quaterniond [] expected, Quaterniond [] actual, string message)
 	{
-		Assert.AreEqual (expected.Length, actual.Length, message + " array lengths");
+		Assert.AreEqual (expected.Length, actual.Length, $"{message} array lengths");
 		for (var i = 0; i < expected.Length; i++) {
 			AreEqual (expected [i], actual [i], message + $" [{i}]");
 		}
@@ -271,205 +272,205 @@ public static class Asserts
 #if !__WATCHOS__
 	public static void AreEqual (MPSImageHistogramInfo expected, MPSImageHistogramInfo actual, string message)
 	{
-		Assert.AreEqual (expected.HistogramForAlpha, actual.HistogramForAlpha, message + " HistogramForAlpha");
-		Asserts.AreEqual (expected.MaxPixelValue, actual.MaxPixelValue, message + " MaxPixelValue");
-		Asserts.AreEqual (expected.MinPixelValue, actual.MinPixelValue, message + " MinPixelValue");
-		Assert.AreEqual (expected.NumberOfHistogramEntries, actual.NumberOfHistogramEntries, message + " NumberOfHistogramEntries");
+		Assert.AreEqual (expected.HistogramForAlpha, actual.HistogramForAlpha, $"{message} HistogramForAlpha expected: {expected} actual: {actual}");
+		Asserts.AreEqual (expected.MaxPixelValue, actual.MaxPixelValue, $"{message} MaxPixelValue expected: {expected} actual: {actual}");
+		Asserts.AreEqual (expected.MinPixelValue, actual.MinPixelValue, $"{message} MinPixelValue expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.NumberOfHistogramEntries, actual.NumberOfHistogramEntries, $"{message} NumberOfHistogramEntries expected: {expected} actual: {actual}");
 	}
 #endif // !__WATCHOS__
 
 	public static void AreEqual (MatrixFloat2x2 expected, MatrixFloat2x2 actual, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, message + " (R0C0)");
-		AreEqual (expected.R1C0, actual.R1C0, message + " (R1C0)");
-		AreEqual (expected.R0C1, actual.R0C1, message + " (R0C1)");
-		AreEqual (expected.R1C1, actual.R1C1, message + " (R1C1)");
+		AreEqual (expected.R0C0, actual.R0C0, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, $"{message} (R1C1) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (MatrixFloat2x2 expected, MatrixFloat2x2 actual, float delta, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, delta, message + " (R0C0)");
-		AreEqual (expected.R1C0, actual.R1C0, delta, message + " (R1C0)");
-		AreEqual (expected.R0C1, actual.R0C1, delta, message + " (R0C1)");
-		AreEqual (expected.R1C1, actual.R1C1, delta, message + " (R1C1)");
+		AreEqual (expected.R0C0, actual.R0C0, delta, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, delta, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, delta, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, delta, $"{message} (R1C1) expected: {expected} actual: {actual}");
 	}
 
 #if !NET
 	public static void AreEqual (Matrix2 expected, MatrixFloat2x2 actual, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, message + " (R0C0)");
-		AreEqual (expected.R0C1, actual.R0C1, message + " (R0C1)");
-		AreEqual (expected.R1C0, actual.R1C0, message + " (R1C0)");
-		AreEqual (expected.R1C1, actual.R1C1, message + " (R1C1)");
+		AreEqual (expected.R0C0, actual.R0C0, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, $"{message} (R1C1) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (MatrixFloat2x2 expected, Matrix2 actual, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, message + " (R0C0)");
-		AreEqual (expected.R0C1, actual.R0C1, message + " (R0C1)");
-		AreEqual (expected.R1C0, actual.R1C0, message + " (R1C0)");
-		AreEqual (expected.R1C1, actual.R1C1, message + " (R1C1)");
+		AreEqual (expected.R0C0, actual.R0C0, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, $"{message} (R1C1) expected: {expected} actual: {actual}");
 	}
 #endif // !NET
 
 	public static void AreEqual (MatrixFloat3x3 expected, MatrixFloat3x3 actual, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, message + " (R0C0)");
-		AreEqual (expected.R1C0, actual.R1C0, message + " (R1C0)");
-		AreEqual (expected.R2C0, actual.R2C0, message + " (R2C0)");
-		AreEqual (expected.R0C1, actual.R0C1, message + " (R0C1)");
-		AreEqual (expected.R1C1, actual.R1C1, message + " (R1C1)");
-		AreEqual (expected.R2C1, actual.R2C1, message + " (R2C1)");
-		AreEqual (expected.R0C2, actual.R0C2, message + " (R0C2)");
-		AreEqual (expected.R1C2, actual.R1C2, message + " (R1C2)");
-		AreEqual (expected.R2C2, actual.R2C2, message + " (R2C2)");
+		AreEqual (expected.R0C0, actual.R0C0, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C0, actual.R2C0, $"{message} (R2C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, $"{message} (R1C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C1, actual.R2C1, $"{message} (R2C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C2, actual.R0C2, $"{message} (R0C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C2, actual.R1C2, $"{message} (R1C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C2, actual.R2C2, $"{message} (R2C2) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (MatrixFloat3x3 expected, MatrixFloat3x3 actual, float delta, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, delta, message + " (R0C0)");
-		AreEqual (expected.R1C0, actual.R1C0, delta, message + " (R1C0)");
-		AreEqual (expected.R2C0, actual.R2C0, delta, message + " (R2C0)");
-		AreEqual (expected.R0C1, actual.R0C1, delta, message + " (R0C1)");
-		AreEqual (expected.R1C1, actual.R1C1, delta, message + " (R1C1)");
-		AreEqual (expected.R2C1, actual.R2C1, delta, message + " (R2C1)");
-		AreEqual (expected.R0C2, actual.R0C2, delta, message + " (R0C2)");
-		AreEqual (expected.R1C2, actual.R1C2, delta, message + " (R1C2)");
-		AreEqual (expected.R2C2, actual.R2C2, delta, message + " (R2C2)");
+		AreEqual (expected.R0C0, actual.R0C0, delta, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, delta, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C0, actual.R2C0, delta, $"{message} (R2C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, delta, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, delta, $"{message} (R1C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C1, actual.R2C1, delta, $"{message} (R2C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C2, actual.R0C2, delta, $"{message} (R0C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C2, actual.R1C2, delta, $"{message} (R1C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C2, actual.R2C2, delta, $"{message} (R2C2) expected: {expected} actual: {actual}");
 	}
 
 #if !NET
 	public static void AreEqual (Matrix3 expected, MatrixFloat3x3 actual, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, message + " (R0C0)");
-		AreEqual (expected.R0C1, actual.R0C1, message + " (R0C1)");
-		AreEqual (expected.R0C2, actual.R0C2, message + " (R0C2)");
-		AreEqual (expected.R1C0, actual.R1C0, message + " (R1C0)");
-		AreEqual (expected.R1C1, actual.R1C1, message + " (R1C1)");
-		AreEqual (expected.R1C2, actual.R1C2, message + " (R1C2)");
-		AreEqual (expected.R2C0, actual.R2C0, message + " (R2C0)");
-		AreEqual (expected.R2C1, actual.R2C1, message + " (R2C1)");
-		AreEqual (expected.R2C2, actual.R2C2, message + " (R2C2)");
+		AreEqual (expected.R0C0, actual.R0C0, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C2, actual.R0C2, $"{message} (R0C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, $"{message} (R1C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C2, actual.R1C2, $"{message} (R1C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C0, actual.R2C0, $"{message} (R2C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C1, actual.R2C1, $"{message} (R2C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C2, actual.R2C2, $"{message} (R2C2) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (MatrixFloat3x3 expected, Matrix3 actual, string message)
 	{
-		AreEqual (expected.R0C0, actual.R0C0, message + " (R0C0)");
-		AreEqual (expected.R0C1, actual.R0C1, message + " (R0C1)");
-		AreEqual (expected.R0C2, actual.R0C2, message + " (R0C2)");
-		AreEqual (expected.R1C0, actual.R1C0, message + " (R1C0)");
-		AreEqual (expected.R1C1, actual.R1C1, message + " (R1C1)");
-		AreEqual (expected.R1C2, actual.R1C2, message + " (R1C2)");
-		AreEqual (expected.R2C0, actual.R2C0, message + " (R2C0)");
-		AreEqual (expected.R2C1, actual.R2C1, message + " (R2C1)");
-		AreEqual (expected.R2C2, actual.R2C2, message + " (R2C2)");
+		AreEqual (expected.R0C0, actual.R0C0, $"{message} (R0C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C1, actual.R0C1, $"{message} (R0C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R0C2, actual.R0C2, $"{message} (R0C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C0, actual.R1C0, $"{message} (R1C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C1, actual.R1C1, $"{message} (R1C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R1C2, actual.R1C2, $"{message} (R1C2) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C0, actual.R2C0, $"{message} (R2C0) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C1, actual.R2C1, $"{message} (R2C1) expected: {expected} actual: {actual}");
+		AreEqual (expected.R2C2, actual.R2C2, $"{message} (R2C2) expected: {expected} actual: {actual}");
 	}
 #endif
 
 	public static void AreEqual (MatrixFloat4x4 expected, MatrixFloat4x4 actual, string message)
 	{
-		AreEqual (expected.M11, actual.M11, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (MatrixFloat4x4 expected, MatrixFloat4x4 actual, float delta, string message)
 	{
-		AreEqual (expected.M11, actual.M11, delta, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, delta, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, delta, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, delta, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, delta, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, delta, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, delta, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, delta, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, delta, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, delta, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, delta, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, delta, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, delta, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, delta, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, delta, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, delta, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, delta, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, delta, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, delta, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, delta, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, delta, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, delta, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, delta, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, delta, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, delta, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, delta, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, delta, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, delta, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, delta, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, delta, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, delta, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, delta, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Matrix4 expected, MatrixFloat4x4 actual, string message)
 	{
-		AreEqual (expected.M11, actual.M11, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Matrix4 expected, MatrixFloat4x4 actual, float delta, string message)
 	{
-		AreEqual (expected.M11, actual.M11, delta, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, delta, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, delta, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, delta, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, delta, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, delta, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, delta, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, delta, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, delta, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, delta, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, delta, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, delta, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, delta, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, delta, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, delta, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, delta, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, delta, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, delta, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, delta, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, delta, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, delta, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, delta, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, delta, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, delta, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, delta, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, delta, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, delta, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, delta, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, delta, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, delta, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, delta, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, delta, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (MatrixFloat4x4 expected, Matrix4 actual, string message)
 	{
-		AreEqual (expected.M11, actual.M11, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 
 #region Double Based Types
 	public static void AreEqual (double expected, double actual, string message)
 	{
-		Assert.AreEqual (expected, actual, message + " (M)");
+		Assert.AreEqual (expected, actual, $"{message} (M) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (double expected, double actual, double delta, string message)
@@ -480,8 +481,8 @@ public static class Asserts
 #if !NET
 	public static void AreEqual (Vector2d expected, Vector2d actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, message + " (Y)");
+		Assert.AreEqual (expected.X, actual.X, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, $"{message} (Y) expected: {expected} actual: {actual}");
 	}
 #endif
 
@@ -502,215 +503,215 @@ public static class Asserts
 #if !NET
 	public static void AreEqual (Vector3d expected, Vector3d actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, 0.001, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, 0.001, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, 0.001, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, 0.001, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, 0.001, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, 0.001, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector3d expected, Vector3d actual, double delta, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, delta, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, delta, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, delta, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, delta, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, delta, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, delta, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector3d expected, VectorDouble3 actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, 0.001, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, 0.001, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, 0.001, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, 0.001, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, 0.001, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, 0.001, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (VectorDouble3 expected, Vector3d actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, 0.001, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, 0.001, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, 0.001, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, 0.001, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, 0.001, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, 0.001, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 #endif
 
 	public static void AreEqual (VectorDouble3 expected, VectorDouble3 actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, 0.001, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, 0.001, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, 0.001, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, 0.001, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, 0.001, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, 0.001, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (VectorDouble3 expected, VectorDouble3 actual, double delta, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, delta, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, delta, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, delta, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, delta, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, delta, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, delta, $"{message} (Z) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector4d expected, Vector4d actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, message + " (Z)");
-		Assert.AreEqual (expected.W, actual.W, message + " (W)");
+		Assert.AreEqual (expected.X, actual.X, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, $"{message} (Z) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.W, actual.W, $"{message} (W) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Vector4d expected, Vector4d actual, double delta, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, delta, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, delta, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, delta, message + " (Z)");
-		Assert.AreEqual (expected.W, actual.W, delta, message + " (W)");
+		Assert.AreEqual (expected.X, actual.X, delta, $"{message} (X) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Y, actual.Y, delta, $"{message} (Y) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.Z, actual.Z, delta, $"{message} (Z) expected: {expected} actual: {actual}");
+		Assert.AreEqual (expected.W, actual.W, delta, $"{message} (W) expected: {expected} actual: {actual}");
 	}
 
 #if !NET
 	public static void AreEqual (Matrix4d expected, Matrix4d actual, string message)
 	{
-		AreEqual (expected.Column0, actual.Column0, message + " (Col0)");
-		AreEqual (expected.Column1, actual.Column1, message + " (Col1)");
-		AreEqual (expected.Column2, actual.Column2, message + " (Col2)");
-		AreEqual (expected.Column3, actual.Column3, message + " (Col3)");
+		AreEqual (expected.Column0, actual.Column0, $"{message} (Col0) expected: {expected} actual: {actual}");
+		AreEqual (expected.Column1, actual.Column1, $"{message} (Col1) expected: {expected} actual: {actual}");
+		AreEqual (expected.Column2, actual.Column2, $"{message} (Col2) expected: {expected} actual: {actual}");
+		AreEqual (expected.Column3, actual.Column3, $"{message} (Col3) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Matrix4d expected, Matrix4d actual, double delta, string message)
 	{
-		AreEqual (expected.Column0, actual.Column0, delta, message + " (Col0)");
-		AreEqual (expected.Column1, actual.Column1, delta, message + " (Col1)");
-		AreEqual (expected.Column2, actual.Column2, delta, message + " (Col2)");
-		AreEqual (expected.Column3, actual.Column3, delta, message + " (Col3)");
+		AreEqual (expected.Column0, actual.Column0, delta, $"{message} (Col0) expected: {expected} actual: {actual}");
+		AreEqual (expected.Column1, actual.Column1, delta, $"{message} (Col1) expected: {expected} actual: {actual}");
+		AreEqual (expected.Column2, actual.Column2, delta, $"{message} (Col2) expected: {expected} actual: {actual}");
+		AreEqual (expected.Column3, actual.Column3, delta, $"{message} (Col3) expected: {expected} actual: {actual}");
 	}
 #endif //!NET
 
 	public static void AreEqual (MatrixDouble4x4 expected, MatrixDouble4x4 actual, string message)
 	{
-		AreEqual (expected.M11, actual.M11, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (MatrixDouble4x4 expected, MatrixDouble4x4 actual, double delta, string message)
 	{
-		AreEqual (expected.M11, actual.M11, delta, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, delta, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, delta, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, delta, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, delta, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, delta, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, delta, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, delta, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, delta, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, delta, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, delta, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, delta, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, delta, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, delta, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, delta, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, delta, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, delta, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, delta, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, delta, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, delta, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, delta, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, delta, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, delta, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, delta, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, delta, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, delta, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, delta, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, delta, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, delta, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, delta, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, delta, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, delta, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 
 #if !NET
 	public static void AreEqual (Matrix4d expected, MatrixDouble4x4 actual, string message)
 	{
-		AreEqual (expected.M11, actual.M11, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 
 	public static void AreEqual (Matrix4d expected, NMatrix4d actual, double delta, string message)
 	{
-		AreEqual (expected.M11, actual.M11, delta, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, delta, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, delta, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, delta, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, delta, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, delta, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, delta, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, delta, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, delta, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, delta, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, delta, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, delta, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, delta, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, delta, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, delta, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, delta, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, delta, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, delta, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, delta, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, delta, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, delta, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, delta, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, delta, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, delta, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, delta, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, delta, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, delta, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, delta, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, delta, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, delta, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, delta, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, delta, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 #endif // !NET
 
 	public static void AreEqual (NMatrix4x3 expected, NMatrix4x3 actual, float delta, string message)
 	{
-		AreEqual (expected.M11, actual.M11, delta, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, delta, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, delta, message + " (M31)");
-		AreEqual (expected.M12, actual.M12, delta, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, delta, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, delta, message + " (M32)");
-		AreEqual (expected.M13, actual.M13, delta, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, delta, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, delta, message + " (M33)");
-		AreEqual (expected.M14, actual.M14, delta, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, delta, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, delta, message + " (M34)");
+		AreEqual (expected.M11, actual.M11, delta, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, delta, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, delta, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, delta, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, delta, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, delta, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, delta, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, delta, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, delta, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, delta, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, delta, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, delta, $"{message} (M34) expected: {expected} actual: {actual}");
 	}
 
 #if !NET
 	public static void AreEqual (NMatrix4d expected, Matrix4d actual, string message)
 	{
-		AreEqual (expected.M11, actual.M11, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, message + " (M31)");
-		AreEqual (expected.M41, actual.M41, message + " (M41)");
-		AreEqual (expected.M12, actual.M12, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, message + " (M32)");
-		AreEqual (expected.M42, actual.M42, message + " (M42)");
-		AreEqual (expected.M13, actual.M13, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, message + " (M33)");
-		AreEqual (expected.M43, actual.M43, message + " (M43)");
-		AreEqual (expected.M14, actual.M14, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, message + " (M34)");
-		AreEqual (expected.M44, actual.M44, message + " (M44)");
+		AreEqual (expected.M11, actual.M11, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M41, actual.M41, $"{message} (M41) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M42, actual.M42, $"{message} (M42) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M43, actual.M43, $"{message} (M43) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, $"{message} (M34) expected: {expected} actual: {actual}");
+		AreEqual (expected.M44, actual.M44, $"{message} (M44) expected: {expected} actual: {actual}");
 	}
 #endif
 
 	public static void AreEqual (NMatrix4x3 expected, NMatrix4x3 actual, string message)
 	{
-		AreEqual (expected.M11, actual.M11, message + " (M11)");
-		AreEqual (expected.M21, actual.M21, message + " (M21)");
-		AreEqual (expected.M31, actual.M31, message + " (M31)");
-		AreEqual (expected.M12, actual.M12, message + " (M12)");
-		AreEqual (expected.M22, actual.M22, message + " (M22)");
-		AreEqual (expected.M32, actual.M32, message + " (M32)");
-		AreEqual (expected.M13, actual.M13, message + " (M13)");
-		AreEqual (expected.M23, actual.M23, message + " (M23)");
-		AreEqual (expected.M33, actual.M33, message + " (M33)");
-		AreEqual (expected.M14, actual.M14, message + " (M14)");
-		AreEqual (expected.M24, actual.M24, message + " (M24)");
-		AreEqual (expected.M34, actual.M34, message + " (M34)");
+		AreEqual (expected.M11, actual.M11, $"{message} (M11) expected: {expected} actual: {actual}");
+		AreEqual (expected.M21, actual.M21, $"{message} (M21) expected: {expected} actual: {actual}");
+		AreEqual (expected.M31, actual.M31, $"{message} (M31) expected: {expected} actual: {actual}");
+		AreEqual (expected.M12, actual.M12, $"{message} (M12) expected: {expected} actual: {actual}");
+		AreEqual (expected.M22, actual.M22, $"{message} (M22) expected: {expected} actual: {actual}");
+		AreEqual (expected.M32, actual.M32, $"{message} (M32) expected: {expected} actual: {actual}");
+		AreEqual (expected.M13, actual.M13, $"{message} (M13) expected: {expected} actual: {actual}");
+		AreEqual (expected.M23, actual.M23, $"{message} (M23) expected: {expected} actual: {actual}");
+		AreEqual (expected.M33, actual.M33, $"{message} (M33) expected: {expected} actual: {actual}");
+		AreEqual (expected.M14, actual.M14, $"{message} (M14) expected: {expected} actual: {actual}");
+		AreEqual (expected.M24, actual.M24, $"{message} (M24) expected: {expected} actual: {actual}");
+		AreEqual (expected.M34, actual.M34, $"{message} (M34) expected: {expected} actual: {actual}");
 	}
 #endregion
 }


### PR DESCRIPTION
Hoping that one day we'll have a System.Numerics.Matrix3x3 type we can replace our
RMatrix3 type with:

* Add all API in OpenTK.Matrix3 that also exists in equivalent form in System.Numerics.Matrix4x4.
* Remove all API that doesn't exist in equivalent form in System.Numerics.Matrix4x4.

For NMatrix2 and NMatrix3:

* Change the fields to be M## instead of R#C# (this is how System.Numerics does
  it, and also how we do it in other matrix types).
* Add obsolete and hidden R#C# versions of the fields to ease migrating existing
  code to .NET (but let's try to remove these in xamcore 5).
* Add properties in legacy Xamarin recommending users to use the new naming.
* A few other API additions to add equivalent API to the matrix types in System.Numerics.

For CGAffineMatrix:

* Add obsolete and hidden versions of the legacy field names to .NET to ease
  migrating existing (but let's try to remove these in xamcore 5).

Fixes https://github.com/xamarin/xamarin-macios/issues/14125.