### PR TITLE
[Network] Remove obsolete API from .NET.

### DIFF
--- a/src/Network/NWProtocolDefinition.cs
+++ b/src/Network/NWProtocolDefinition.cs
@@ -108,18 +108,13 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_protocol_definition nw_protocol_copy_ws_definition ();
 
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-		[Obsolete ("Use 'CreateWebSocketDefinition' method instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#else
+#if !NET
 		[TV (13,0)]
 		[Mac (10,15)]
 		[iOS (13,0)]
 		[Obsolete ("Use 'CreateWebSocketDefinition' method instead.")]
-#endif
 		public static NWProtocolDefinition WebSocketDefinition => new NWProtocolDefinition (nw_protocol_copy_ws_definition (), owns: true);
+#endif
 
 #if NET
 		[SupportedOSPlatform ("tvos13.0")]

--- a/src/Network/NWProtocolOptions.cs
+++ b/src/Network/NWProtocolOptions.cs
@@ -52,29 +52,35 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern IntPtr nw_tls_create_options ();
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTlsOptions' class methods and constructors instead.")]
 		public static NWProtocolOptions CreateTls ()
 		{
 			return new NWProtocolTlsOptions (nw_tls_create_options (), owns: true);
 		}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern IntPtr nw_tcp_create_options ();
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class methods and constructors instead.")]
 		public static NWProtocolOptions CreateTcp ()
 		{
 			return new NWProtocolTcpOptions (nw_tcp_create_options (), owns: true);
 		}
+#endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern IntPtr nw_udp_create_options ();
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolUdpOptions' class methods and constructors instead.")]
 		public static NWProtocolOptions CreateUdp ()
 		{
 			return new NWProtocolUdpOptions (nw_udp_create_options (), owns: true);
 		}
+#endif
 
 		// added to have a consistent API, but obsolete it
 
@@ -93,34 +99,13 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern IntPtr nw_quic_create_options ();
 
-#if NET
-		[SupportedOSPlatform ("tvos12.0")]
-		[SupportedOSPlatform ("macos10.14")]
-		[SupportedOSPlatform ("ios12.0")]
-		[UnsupportedOSPlatform ("tvos15.0")]
-		[UnsupportedOSPlatform ("maccatalyst15.0")]
-		[UnsupportedOSPlatform ("macos12.0")]
-		[UnsupportedOSPlatform ("ios15.0")]
-#if TVOS
-		[Obsolete ("Starting with tvos15.0 use the 'NWProtocolQuciOptions' class methods and constructors instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#elif __MACCATALYST__
-		[Obsolete ("Starting with maccatalyst15.0 use the 'NWProtocolQuciOptions' class methods and constructors instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#elif MONOMAC
-		[Obsolete ("Starting with macos12.0 use the 'NWProtocolQuciOptions' class methods and constructors instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#elif IOS
-		[Obsolete ("Starting with ios15.0 use the 'NWProtocolQuciOptions' class methods and constructors instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-#else
-		[Deprecated (PlatformName.iOS, 15, 0, message: "Use the 'NWProtocolQuciOptions' class methods and constructors instead.")]
-		[Deprecated (PlatformName.TvOS, 15, 0, message: "Use the 'NWProtocolQuciOptions' class methods and constructors instead.")]
-		[Deprecated (PlatformName.MacCatalyst, 15, 0, message: "Use the 'NWProtocolQuciOptions' class methods and constructors instead.")]
-		[Deprecated (PlatformName.MacOSX, 12, 0, message: "Use the 'NWProtocolQuciOptions' class methods and constructors instead.")]
-		[Deprecated (PlatformName.WatchOS, 8, 0, message:  "Use the 'NWProtocolQuciOptions' class methods and constructors instead.")]
-#endif
+#if !NET
+		[Obsolete ("Use the 'NWProtocolQuicOptions' class methods and constructors instead.")]
 		public static NWProtocolOptions CreateQuic ()
 		{
 			return new NWProtocolUdpOptions (nw_quic_create_options (), owns: true);
 		}
+#endif
 
 //
 // IP Options
@@ -128,47 +113,57 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern void nw_ip_options_set_version (IntPtr options, NWIPVersion version);
 
-		[Obsolete ("Use the 'NWProtocolIPOptions' class instead.")]
+#if !NET
+		[Obsolete ("Use the 'NWProtocolIPOptions' class instead (and the 'SetVersion' method).")]
 		public void IPSetVersion (NWIPVersion version)
 		{
 			nw_ip_options_set_version (GetCheckedHandle (), version);
 		}
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern void nw_ip_options_set_hop_limit (IntPtr options, byte hop_limit);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolIPOptions' class instead.")]
 		public void IPSetHopLimit (byte hopLimit)
 		{
 			nw_ip_options_set_hop_limit (GetCheckedHandle (), hopLimit);
 		}
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern void nw_ip_options_set_use_minimum_mtu (IntPtr options, [MarshalAs (UnmanagedType.I1)] bool use_minimum_mtu);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolIPOptions' class instead.")]
 		public void IPSetUseMinimumMtu (bool useMinimumMtu)
 		{
 			nw_ip_options_set_use_minimum_mtu (GetCheckedHandle (), useMinimumMtu);
 		}
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern void nw_ip_options_set_disable_fragmentation (IntPtr options, [MarshalAs (UnmanagedType.I1)] bool disable_fragmentation);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolIPOptions' class instead.")]
 		public void IPSetDisableFragmentation (bool disableFragmentation)
 		{
 			nw_ip_options_set_disable_fragmentation (GetCheckedHandle (), disableFragmentation);
 		}
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern void nw_ip_options_set_calculate_receive_time (IntPtr options,[MarshalAs (UnmanagedType.I1)]  bool calculateReceiveTime);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolIPOptions' class instead.")]
 		public void IPSetCalculateReceiveTime (bool calculateReceiveTime)
 		{
 			nw_ip_options_set_calculate_receive_time (GetCheckedHandle (), calculateReceiveTime);
 		}
+#endif // !NET
 
 
 #if NET
@@ -183,13 +178,7 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern void nw_ip_options_set_local_address_preference (IntPtr options, NWIPLocalAddressPreference preference);
 
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-		[UnsupportedOSPlatform ("maccatalyst")]
-		[Obsolete ("Use the 'NWProtocolIPOptions' class instead.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#else
+#if !NET
 		[TV (13,0)]
 		[Mac (10,15)]
 		[iOS (13,0)]
@@ -205,92 +194,122 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_no_delay (IntPtr handle, [MarshalAs (UnmanagedType.U1)] bool noDelay);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetNoDelay (bool noDelay) => nw_tcp_options_set_no_delay (GetCheckedHandle (), noDelay);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_no_push (IntPtr handle, [MarshalAs (UnmanagedType.U1)] bool noPush);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetNoPush (bool noPush) => nw_tcp_options_set_no_push (GetCheckedHandle (), noPush);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_no_options (IntPtr handle, [MarshalAs (UnmanagedType.U1)] bool noOptions);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetNoOptions (bool noOptions) => nw_tcp_options_set_no_options (GetCheckedHandle (), noOptions);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_enable_keepalive (IntPtr handle, [MarshalAs (UnmanagedType.U1)] bool enableKeepAlive);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetEnableKeepAlive (bool enableKeepAlive) => nw_tcp_options_set_enable_keepalive (GetCheckedHandle (), enableKeepAlive);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_keepalive_count (IntPtr handle, uint keepaliveCount);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetKeepAliveCount (uint keepaliveCount) => nw_tcp_options_set_keepalive_count (GetCheckedHandle (), keepaliveCount);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_keepalive_idle_time (IntPtr handle, uint keepaliveIdleTime);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetKeepAliveIdleTime (uint keepaliveIdleTime) => nw_tcp_options_set_keepalive_idle_time (GetCheckedHandle (), keepaliveIdleTime);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_keepalive_interval (IntPtr handle, uint keepaliveInterval);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetKeepAliveInterval (uint keepaliveInterval) => nw_tcp_options_set_keepalive_interval (GetCheckedHandle (), keepaliveInterval);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_maximum_segment_size (IntPtr handle, uint maximumSegmentSize);
 		
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetMaximumSegmentSize (uint maximumSegmentSize) => nw_tcp_options_set_maximum_segment_size (GetCheckedHandle (), maximumSegmentSize);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_connection_timeout (IntPtr handle, uint connectionTimeout);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetConnectionTimeout (uint connectionTimeout) => nw_tcp_options_set_connection_timeout (GetCheckedHandle (), connectionTimeout);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_persist_timeout (IntPtr handle, uint persistTimeout);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetPersistTimeout (uint persistTimeout) => nw_tcp_options_set_persist_timeout (GetCheckedHandle (), persistTimeout);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_retransmit_connection_drop_time (IntPtr handle, uint retransmitConnectionDropTime);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetRetransmitConnectionDropTime (uint retransmitConnectionDropTime) => nw_tcp_options_set_retransmit_connection_drop_time (GetCheckedHandle (), retransmitConnectionDropTime);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_retransmit_fin_drop (IntPtr handle, [MarshalAs (UnmanagedType.U1)] bool retransmitFinDrop);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetRetransmitFinDrop (bool retransmitFinDrop) => nw_tcp_options_set_retransmit_fin_drop (GetCheckedHandle (), retransmitFinDrop);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_disable_ack_stretching (IntPtr handle, [MarshalAs (UnmanagedType.U1)] bool disableAckStretching);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetDisableAckStretching (bool disableAckStretching) => nw_tcp_options_set_disable_ack_stretching (GetCheckedHandle (), disableAckStretching);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_enable_fast_open (IntPtr handle, [MarshalAs (UnmanagedType.U1)] bool enableFastOpen);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetEnableFastOpen (bool enableFastOpen) => nw_tcp_options_set_enable_fast_open (GetCheckedHandle (), enableFastOpen);
+#endif // !NET
 
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_tcp_options_set_disable_ecn (IntPtr handle, [MarshalAs (UnmanagedType.U1)] bool disableEcn);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTcpOptions' class instead.")]
 		public void TcpSetDisableEcn (bool disableEcn) => nw_tcp_options_set_disable_ecn (GetCheckedHandle (), disableEcn);
+#endif // !NET
 
 //
 // UDP Options
@@ -298,8 +317,10 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static void nw_udp_options_set_prefer_no_checksum (IntPtr handle, [MarshalAs (UnmanagedType.U1)] bool preferNoChecksums);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolUdpOptions' class instead.")]
 		public void UdpSetPreferNoChecksum (bool preferNoChecksums) => nw_udp_options_set_prefer_no_checksum (GetCheckedHandle (), preferNoChecksums);
+#endif // !NET
 
 //
 // TLS options
@@ -308,8 +329,10 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		internal extern static IntPtr nw_tls_copy_sec_protocol_options (IntPtr options);
 
+#if !NET
 		[Obsolete ("Use the 'NWProtocolTlsOptions' class instead.")]
 		public SecProtocolOptions TlsProtocolOptions => new SecProtocolOptions (nw_tls_copy_sec_protocol_options (GetCheckedHandle ()), owns: true);
+#endif
 		
 #if NET
 		[SupportedOSPlatform ("tvos15.0")]

--- a/tests/monotouch-test/Network/NWBrowserTest.cs
+++ b/tests/monotouch-test/Network/NWBrowserTest.cs
@@ -119,8 +119,13 @@ namespace MonoTouchFixtures.Network {
 				browser.Start ();
 				browserReady.WaitOne (30000);
 				using (var advertiser = NWAdvertiseDescriptor.CreateBonjourService ("MonoTouchFixtures.Network", type))
+#if NET
+				using (var tcpOptions = new NWProtocolTcpOptions ())
+				using (var tlsOptions = new NWProtocolTlsOptions ())
+#else
 				using (var tcpOptions = NWProtocolOptions.CreateTcp ())
 				using (var tlsOptions = NWProtocolOptions.CreateTls ())
+#endif
 				using (var paramenters = NWParameters.CreateTcp ()) {
 					paramenters.ProtocolStack.PrependApplicationProtocol (tlsOptions);
 					paramenters.ProtocolStack.PrependApplicationProtocol (tcpOptions);

--- a/tests/monotouch-test/Network/NWConnectionTest.cs
+++ b/tests/monotouch-test/Network/NWConnectionTest.cs
@@ -49,7 +49,11 @@ namespace MonoTouchFixtures.Network {
 			{
 				using (var protocolStack = parameters.ProtocolStack) {
 					var ipOptions = protocolStack.InternetProtocol;
+#if NET
+					ipOptions.SetVersion (NWIPVersion.Version4);
+#else
 					ipOptions.IPSetVersion (NWIPVersion.Version4);
+#endif
 				}
 				connection = new NWConnection (endpoint, parameters);
 				connection.SetQueue (DispatchQueue.DefaultGlobalQueue); // important, else we will get blocked

--- a/tests/monotouch-test/Network/NWEstablishmentReportTest.cs
+++ b/tests/monotouch-test/Network/NWEstablishmentReportTest.cs
@@ -50,7 +50,11 @@ namespace MonoTouchFixtures.Network {
 			{
 				using (var protocolStack = parameters.ProtocolStack) {
 					var ipOptions = protocolStack.InternetProtocol;
+#if NET
+					ipOptions.SetVersion (NWIPVersion.Version4);
+#else
 					ipOptions.IPSetVersion (NWIPVersion.Version4);
+#endif
 				}
 				connection = new NWConnection (endpoint, parameters);
 				connection.SetQueue (DispatchQueue.DefaultGlobalQueue); // important, else we will get blocked

--- a/tests/monotouch-test/Network/NWListenerTest.cs
+++ b/tests/monotouch-test/Network/NWListenerTest.cs
@@ -19,8 +19,13 @@ namespace MonoTouchFixtures.Network {
 		[SetUp]
 		public void SetUp ()
 		{
+#if NET
+			using (var tcpOptions = new NWProtocolTcpOptions ())
+			using (var tlsOptions = new NWProtocolTlsOptions ())
+#else
 			using (var tcpOptions = NWProtocolOptions.CreateTcp ())
 			using (var tlsOptions = NWProtocolOptions.CreateTls ())
+#endif
 			using (var parameters = NWParameters.CreateTcp ()) {
 				parameters.ProtocolStack.PrependApplicationProtocol (tlsOptions);
 				parameters.ProtocolStack.PrependApplicationProtocol (tcpOptions);

--- a/tests/monotouch-test/Network/NWPathTest.cs
+++ b/tests/monotouch-test/Network/NWPathTest.cs
@@ -37,7 +37,11 @@ namespace MonoTouchFixtures.Network {
 			{
 				using (var protocolStack = parameters.ProtocolStack) {
 					var ipOptions = protocolStack.InternetProtocol;
+#if NET
+					ipOptions.SetVersion (NWIPVersion.Version4);
+#else
 					ipOptions.IPSetVersion (NWIPVersion.Version4);
+#endif
 				}
 				connection = new NWConnection (endpoint, parameters);
 				connection.SetQueue (DispatchQueue.DefaultGlobalQueue); // important, else we will get blocked

--- a/tests/monotouch-test/Network/NWProtocolIPOptionsTest.cs
+++ b/tests/monotouch-test/Network/NWProtocolIPOptionsTest.cs
@@ -51,7 +51,11 @@ namespace MonoTouchFixtures.Network {
 				stack = parameters.ProtocolStack;
 				using (var ipOptions = stack.InternetProtocol) {
 					if (ipOptions != null) {
+#if NET
+						ipOptions.SetVersion (NWIPVersion.Version4);
+#else
 						ipOptions.IPSetVersion (NWIPVersion.Version4);
+#endif
 						stack.PrependApplicationProtocol (ipOptions);
 					}
 				}

--- a/tests/monotouch-test/Network/NWProtocolOptionsTest.cs
+++ b/tests/monotouch-test/Network/NWProtocolOptionsTest.cs
@@ -20,8 +20,13 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void CreateTlsTest ()
 		{
+#if NET
+			using (var options = new NWProtocolTlsOptions ()) {
+				var sec = options.ProtocolOptions;
+#else
 			using (var options = NWProtocolOptions.CreateTls ()) {
 				var sec = options.TlsProtocolOptions;
+#endif
 				// we cannot test much more :(
 				Assert.AreNotEqual (IntPtr.Zero, options.Handle);
 			}
@@ -30,7 +35,11 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void CreateTcpTest ()
 		{
+#if NET
+			using (var options = new NWProtocolTcpOptions ()) {
+#else
 			using (var options = NWProtocolOptions.CreateTcp ()) {
+#endif
 				// we cannot test much more :(
 				Assert.AreNotEqual (IntPtr.Zero, options.Handle);
 			}
@@ -39,7 +48,11 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void CreateUdpTest ()
 		{
+#if NET
+			using (var options = new NWProtocolUdpOptions ()) {
+#else
 			using (var options = NWProtocolOptions.CreateUdp ()) {
+#endif
 				// we cannot test much more :(
 				Assert.AreNotEqual (IntPtr.Zero, options.Handle);
 			}
@@ -51,11 +64,23 @@ namespace MonoTouchFixtures.Network {
 			TestRuntime.AssertXcodeVersion (11, 0);
 
 			foreach (var ipOption in new [] { NWIPLocalAddressPreference.Default, NWIPLocalAddressPreference.Stable, NWIPLocalAddressPreference.Temporary}) {
+#if NET
+				using (var options = new NWProtocolTlsOptions ())
+#else
 				using (var options = NWProtocolOptions.CreateTls ())
+#endif
 					Assert.DoesNotThrow (() => options.IPLocalAddressPreference = ipOption, "Tls");
+#if NET
+				using (var options = new NWProtocolTcpOptions ())
+#else
 				using (var options = NWProtocolOptions.CreateTcp ())
+#endif
 					Assert.DoesNotThrow (() => options.IPLocalAddressPreference = ipOption, "Tcp");
+#if NET
+				using (var options = new NWProtocolUdpOptions ())
+#else
 				using (var options = NWProtocolOptions.CreateUdp ())
+#endif
 					Assert.DoesNotThrow (() => options.IPLocalAddressPreference = ipOption, "Udp");
 			}
 		}

--- a/tests/monotouch-test/Network/NWProtocolStackTest.cs
+++ b/tests/monotouch-test/Network/NWProtocolStackTest.cs
@@ -38,7 +38,11 @@ namespace MonoTouchFixtures.Network {
 				stack = parameters.ProtocolStack;
 				using (var ipOptions = stack.InternetProtocol) {
 					if (ipOptions != null) {
+#if NET
+						ipOptions.SetVersion (NWIPVersion.Version4);
+#else
 						ipOptions.IPSetVersion (NWIPVersion.Version4);
+#endif
 						stack.PrependApplicationProtocol (ipOptions);
 					}
 				}

--- a/tests/monotouch-test/Network/NWProtocolTlsOptionsTest.cs
+++ b/tests/monotouch-test/Network/NWProtocolTlsOptionsTest.cs
@@ -24,7 +24,14 @@ namespace MonoTouchFixtures.Network {
 		public void TearDown () => options.Dispose ();
 
 		[Test]
-		public void ProtocolOptionsTest () => Assert.NotNull (options.TlsProtocolOptions);
+		public void ProtocolOptionsTest ()
+		{
+#if NET
+			Assert.NotNull (options.ProtocolOptions);
+#else
+			Assert.NotNull (options.TlsProtocolOptions);
+#endif
+		}
 	}
 }
 #endif

--- a/tests/monotouch-test/Network/NWResolutionReportTest.cs
+++ b/tests/monotouch-test/Network/NWResolutionReportTest.cs
@@ -50,7 +50,11 @@ namespace MonoTouchFixtures.Network {
 			{
 				using (var protocolStack = parameters.ProtocolStack) {
 					var ipOptions = protocolStack.InternetProtocol;
+#if NET
+					ipOptions.SetVersion (NWIPVersion.Version4);
+#else
 					ipOptions.IPSetVersion (NWIPVersion.Version4);
+#endif
 				}
 				connection = new NWConnection (endpoint, parameters);
 				connection.SetQueue (DispatchQueue.DefaultGlobalQueue); // important, else we will get blocked

--- a/tests/monotouch-test/Security/ProtocolOptionsTest.cs
+++ b/tests/monotouch-test/Security/ProtocolOptionsTest.cs
@@ -28,8 +28,13 @@ namespace MonoTouchFixtures.Security {
 		public void Equals ()
 		{
 			TestRuntime.AssertXcodeVersion (11, 0);
+#if NET
+			using (var npo = new NWProtocolTlsOptions ()) {
+				var options = npo.ProtocolOptions;
+#else
 			using (var npo = NWProtocolOptions.CreateTls ()) {
 				var options = npo.TlsProtocolOptions;
+#endif
 
 				Assert.True (SecProtocolOptions.Equals (null, null), "1");
 				Assert.True (SecProtocolOptions.Equals (options, options), "2");
@@ -45,8 +50,13 @@ namespace MonoTouchFixtures.Security {
 		public void NewTlsOptions ()
 		{
 			TestRuntime.AssertXcodeVersion (11, 0);
+#if NET
+			using (var npo = new NWProtocolTlsOptions ()) {
+				var options = npo.ProtocolOptions;
+#else
 			using (var npo = NWProtocolOptions.CreateTls ()) {
 				var options = npo.TlsProtocolOptions;
+#endif
 				options.SetTlsMaxVersion (TlsProtocolVersion.Tls12);
 				options.SetTlsMinVersion (TlsProtocolVersion.Tls10);
 				options.AddTlsCipherSuite (TlsCipherSuite.Aes128GcmSha256);


### PR DESCRIPTION
All the obsolete API has replacement API that works just fine.