### PR TITLE
Turn on template localization on dotnet CLI

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -20,6 +20,7 @@
     <add key="Dotnet arcade" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="macios-dependencies" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/macios-dependencies/nuget/v3/index.json" />
     <add key="xamarin-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
   </packageSources>

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Application (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Controller template",
+  "description": "An iOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Application (Preview)",
+  "description": "A project for creating a .NET 6 iOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
+  "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",
+  "symbols/deviceFamily/choices/iphone/description": "Support only iPhone devices",
+  "symbols/deviceFamily/choices/ipad/description": "Support only iPad devices"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Binding Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS binding library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Class Library (Preview)",
+  "description": "A project for creating a .NET 6 iOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Application (Preview)",
+  "description": "A project for creating a .NET 6 macOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Application (Preview)",
+  "description": "A project for creating a .NET 6 tvOS application",
+  "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
+  "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
+}

--- a/dotnet/package/microsoft.templates.csproj
+++ b/dotnet/package/microsoft.templates.csproj
@@ -4,10 +4,10 @@
     <PackageType>Template</PackageType>
     <Description>Templates for $(_PlatformName) platforms</Description>
     <_packagePath>$(MSBuildThisFileDirectory)..\Templates\Microsoft.$(_PlatformName).Templates\</_packagePath>
-    <LocalizeTemplates Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">true</LocalizeTemplates>
+    <LocalizeTemplates Condition=" '$(CIBuild)' != 'true' ">true</LocalizeTemplates>
     <LocalizableTemplatesPath>$(_packagePath)</LocalizableTemplatesPath>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">
+  <ItemGroup Condition=" '$(CIBuild)' != 'true' ">
     <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
   <Import Project="common.csproj" />

--- a/dotnet/package/microsoft.templates.csproj
+++ b/dotnet/package/microsoft.templates.csproj
@@ -4,6 +4,10 @@
     <PackageType>Template</PackageType>
     <Description>Templates for $(_PlatformName) platforms</Description>
     <_packagePath>$(MSBuildThisFileDirectory)..\Templates\Microsoft.$(_PlatformName).Templates\</_packagePath>
+    <LocalizeTemplates>true</LocalizeTemplates>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+  </ItemGroup>
   <Import Project="common.csproj" />
 </Project>

--- a/dotnet/package/microsoft.templates.csproj
+++ b/dotnet/package/microsoft.templates.csproj
@@ -4,9 +4,10 @@
     <PackageType>Template</PackageType>
     <Description>Templates for $(_PlatformName) platforms</Description>
     <_packagePath>$(MSBuildThisFileDirectory)..\Templates\Microsoft.$(_PlatformName).Templates\</_packagePath>
-    <LocalizeTemplates>true</LocalizeTemplates>
+    <LocalizeTemplates Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">true</LocalizeTemplates>
+    <LocalizableTemplatesPath>$(_packagePath)</LocalizableTemplatesPath>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+  <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">
     <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
   <Import Project="common.csproj" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,5 +27,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>db49d790a4bfa977a9ed7436bf2aa242cefae45e</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-alpha.1.21601.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha />
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,5 +7,6 @@
     <MicrosoftNETILStripTasksPackageVersion>6.0.0-rc.2.21468.3</MicrosoftNETILStripTasksPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>6.0.3</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion>6.0.2</MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion>
+    <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
   </PropertyGroup>
 </Project>

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -222,7 +222,7 @@ variables:
   value: 'https://devdiv.visualstudio.com/_settings/agentpools?poolId=367&view=agents'
 - name: IsPRBuild
   value: ${{ or(eq(variables['Build.Reason'], 'PullRequest'), and(eq(variables['Build.SourceBranchName'], 'merge'), or(eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'IndividualCI')))) }}
-- name: ContinuousIntegrationBuild
+- name: CIBuild
   value: true
 
 trigger:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -222,6 +222,8 @@ variables:
   value: 'https://devdiv.visualstudio.com/_settings/agentpools?poolId=367&view=agents'
 - name: IsPRBuild
   value: ${{ or(eq(variables['Build.Reason'], 'PullRequest'), and(eq(variables['Build.SourceBranchName'], 'merge'), or(eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'IndividualCI')))) }}
+- name: ContinuousIntegrationBuild
+  value: true
 
 trigger:
   branches:

--- a/tools/devops/automation/scripts/update-locproject.ps1
+++ b/tools/devops/automation/scripts/update-locproject.ps1
@@ -1,0 +1,28 @@
+param ($SourcesDirectory, $LocProjectPath)
+
+$jsonFiles = @()
+$jsonTemplateFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | Where-Object { $_.FullName -Match "\.template\.config\\localize\\.+\.en\.json" } # .NET templating pattern
+$jsonTemplateFiles | ForEach-Object {
+    $null = $_.Name -Match "(.+)\.[\w-]+\.json" # matches '[filename].[langcode].json
+    
+    $destinationFile = "$($_.Directory.FullName)\$($Matches.1).json"
+    $jsonFiles += Copy-Item "$($_.FullName)" -Destination $destinationFile -PassThru
+    Write-Host "Template loc file generated: $destinationFile"
+}
+
+Push-Location "$SourcesDirectory"
+$projectObject = Get-Content $LocProjectPath | ConvertFrom-Json
+$jsonFiles | ForEach-Object {
+    $sourceFile = ($_.FullName | Resolve-Path -Relative)
+    $outputPath = "$(($_.DirectoryName | Resolve-Path -Relative) + "\")"
+    $projectObject.Projects[0].LocItems += (@{
+        SourceFile = $sourceFile
+        CopyOption = "LangIDOnName"
+        OutputPath = $outputPath
+    })
+}
+Pop-Location
+
+$locProjectJson = ConvertTo-Json $projectObject -Depth 5
+Set-Content $LocProjectPath $locProjectJson
+Write-Host "LocProject.json was updated to contain template localizations:`n`n$locProjectJson`n`n"

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -180,7 +180,7 @@ steps:
   condition: and(succeeded(), in(variables['build.reason'], 'Schedule'), eq(variables.isMain, 'True'))
 
 - task: OneLocBuild@2
-#  condition: and(succeeded(), eq(variables.isMain, 'True'))
+  condition: and(succeeded(), eq(variables.isMain, 'True'))
   continueOnError: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -199,7 +199,7 @@ steps:
     gitHubPatVariable: '$(GitHub.Token)'
 
 - task: PublishBuildArtifacts@1
-#  condition: and(succeeded(), eq(variables.isMain, 'True'))
+  condition: and(succeeded(), eq(variables.isMain, 'True'))
   continueOnError: true
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -162,6 +162,15 @@ steps:
   continueOnError: true
   workingDirectory: $(Build.SourcesDirectory)\tools\devops 
 
+- task: PowerShell@2
+  displayName: "Update LocProject.json"
+  inputs:
+    targetType: 'filePath'
+    filePath: $(Build.SourcesDirectory)\tools\devops\automation\scripts\update-locproject.ps1
+    arguments:
+    - SourcesDirectory: $(Build.SourcesDirectory)
+    - LocProjectPath: $(Build.SourcesDirectory)\Localize\LocProject.json
+
 - powershell: |
     git config user.email "valco@microsoft.com"
     git config user.name "vs-mobiletools-engineering-service2"

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -167,9 +167,7 @@ steps:
   inputs:
     targetType: 'filePath'
     filePath: $(Build.SourcesDirectory)\tools\devops\automation\scripts\update-locproject.ps1
-    arguments:
-    - SourcesDirectory: $(Build.SourcesDirectory)
-    - LocProjectPath: $(Build.SourcesDirectory)\Localize\LocProject.json
+    arguments: -SourcesDirectory "$(Build.SourcesDirectory)" -LocProjectPath "$(Build.SourcesDirectory)\Localize\LocProject.json"
 
 - powershell: |
     git config user.email "valco@microsoft.com"

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -180,7 +180,7 @@ steps:
   condition: and(succeeded(), in(variables['build.reason'], 'Schedule'), eq(variables.isMain, 'True'))
 
 - task: OneLocBuild@2
-  condition: and(succeeded(), eq(variables.isMain, 'True'))
+#  condition: and(succeeded(), eq(variables.isMain, 'True'))
   continueOnError: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -199,7 +199,7 @@ steps:
     gitHubPatVariable: '$(GitHub.Token)'
 
 - task: PublishBuildArtifacts@1
-  condition: and(succeeded(), eq(variables.isMain, 'True'))
+#  condition: and(succeeded(), eq(variables.isMain, 'True'))
   continueOnError: true
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
<!--## Background:-->
 Template engine (`dotnet new`) added support for template localizations in .NET 6.0. This new system replaces the old way of localizing templates that only worked on Visual Studio and works on both .NET CLI as well as VS.

This PR introduces changes to switch to the new template localization system.

The PR is currently draft with remaining work:
- [x] Restore tasks package
- [x] Configure root templates path
- [x] Initial loc files need to be generated
- [x] Update `LocProject.json` (automate, if possible)
- [x] Test-run the pipeline

<!-- 
## Summary of the changes
- Adds `<UsingToolTemplateLocalizer>true</>` to projects containing templates.
- Adds necessary `id` fields into `template.json` files to allow localizing certain fields (specifically, post actions).
- Generates localization files to be translated by loc team


## What to expect after merging
Every time there is a change to one of the templates:
- The dev making the change should build (at the very least) the modified template project. This will update the loc files on the local working copy,
- Push the loc files together with the template modifications. Review & merge.
- OneLocBuild integration will automatically pick up the changes and will send them for translation.
- You will receive a PR containing the translated template loc files when they are ready. Review & merge.
-->