### PR TITLE
[Foundation] Remove NSUrlSessionHandler.TrustOverride in .NET.

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -430,7 +430,11 @@ namespace MonoTests.System.Net.Http
 #endif // NET
 			} else if (handler is NSUrlSessionHandler ns) {
 				expectedExceptionType = typeof (WebException);
+#if NET
+				ns.TrustOverrideForUrl += (a,b,c) => {
+#else
 				ns.TrustOverride += (a,b) => {
+#endif
 					validationCbWasExecuted = true;
 					// return false, since we want to test that the exception is raised
 					return false;
@@ -484,7 +488,11 @@ namespace MonoTests.System.Net.Http
 
 			var handler = GetHandler (handlerType);
 			if (handler is NSUrlSessionHandler ns) {
+#if NET
+				ns.TrustOverrideForUrl += (a,b,c) => {
+#else
 				ns.TrustOverride += (a,b) => {
+#endif
 					servicePointManagerCbWasExcuted = true;
 					return true;
 				};


### PR DESCRIPTION
It's better to use the TrustOverrideForUrl property instead, which already exists.