### PR TITLE
[msbuild] Store the .NET version in the app's Info.plist when building an app using .NET. Fixes #14108.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -584,6 +584,9 @@ DOTNET_TVOS_ASSEMBLY_NAME=Microsoft.tvOS
 DOTNET_MACCATALYST_ASSEMBLY_NAME=Microsoft.MacCatalyst
 DOTNET_MACOS_ASSEMBLY_NAME=Microsoft.macOS
 
+# This variable includes is all the platforms we support, even those that might be disabled in this build.
+ALL_DOTNET_PLATFORMS=iOS macOS tvOS MacCatalyst
+
 DOTNET_PLATFORMS=
 ifdef INCLUDE_IOS
 DOTNET_PLATFORMS+=iOS

--- a/Make.config
+++ b/Make.config
@@ -584,7 +584,7 @@ DOTNET_TVOS_ASSEMBLY_NAME=Microsoft.tvOS
 DOTNET_MACCATALYST_ASSEMBLY_NAME=Microsoft.MacCatalyst
 DOTNET_MACOS_ASSEMBLY_NAME=Microsoft.macOS
 
-# This variable includes is all the platforms we support, even those that might be disabled in this build.
+# This variable includes all the platforms we support, even those that might be disabled in this build.
 ALL_DOTNET_PLATFORMS=iOS macOS tvOS MacCatalyst
 
 DOTNET_PLATFORMS=

--- a/dotnet/BreakingChanges.md
+++ b/dotnet/BreakingChanges.md
@@ -185,3 +185,13 @@ API and behavior on all platforms.
 The type 'CFNetwork.MessageHandler' has been removed. Please use
 'System.Net.Http.CFNetworkHandler' or the more recent
 'Foundation.NSUrlSessionHandler' instead.
+
+## Changed name of the Info.plist entry with our version number.
+
+We add an entry to the app's Info.plist with the version number used to build
+the app. In .NET, we've changed the name of this entry from `com.xamarin.ios`
+to `com.microsoft.<platform in lower case>` (for instance `com.microsoft.tvos`
+for tvOS apps).
+
+The version format has also changed, from "X.Y.Z.W (`branch`: `hash`)" to the
+semantic versioning we use for .NET: "X.Y.Z-`branch`.Z+sha.`hash`".

--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -26,6 +26,7 @@ ALL_SOURCES:= \
 	$(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.csproj) \
 	Versions.ios.g.cs \
 	Versions.mac.g.cs \
+	Versions.dotnet.g.cs \
 
 CONFIG      = Debug
 TARGETFRAMEWORK = netstandard2.0
@@ -566,6 +567,14 @@ Versions.mac.g.cs: Makefile $(TOP)/Make.config.inc
 Versions.ios.g.cs: Makefile $(TOP)/Make.config.inc
 	$(Q) printf "static class VersionConstants {\\n" > $@.tmp
 	$(Q) printf "\\tpublic const string XamarinIOSVersion = \"$(IOS_PACKAGE_VERSION)\";\\n" >> $@.tmp
+	$(Q) printf "\\tpublic const string NuGetPrereleaseIdentifier = \"$(NUGET_PRERELEASE_IDENTIFIER)\";\\n" >> $@.tmp
+	$(Q) printf "\\tpublic const string NuGetBuildMetadata = \"$(NUGET_BUILD_METADATA)\";\\n" >> $@.tmp
+	$(Q) printf "}\\n" >> $@.tmp
+	$(Q) mv $@.tmp $@
+
+Versions.dotnet.g.cs: Makefile $(TOP)/Make.config.inc
+	$(Q) printf "static class DotNetVersionConstants {\\n" > $@.tmp
+	$(Q) echo $(foreach platform,$(ALL_DOTNET_PLATFORMS),"\\tpublic const string Microsoft_$(platform)_Version = \"$($(shell echo $(platform) | tr 'a-z' 'A-Z')_NUGET_VERSION_FULL)\";\\n") >> $@.tmp
 	$(Q) printf "\\tpublic const string NuGetPrereleaseIdentifier = \"$(NUGET_PRERELEASE_IDENTIFIER)\";\\n" >> $@.tmp
 	$(Q) printf "\\tpublic const string NuGetBuildMetadata = \"$(NUGET_BUILD_METADATA)\";\\n" >> $@.tmp
 	$(Q) printf "}\\n" >> $@.tmp

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -164,22 +164,25 @@ namespace Xamarin.MacDev.Tasks
 			if (IsWatchApp)
 				return;
 
+			string name;
 			string value;
 
 			// This key is our supported way of determining if an app
 			// was built with Xamarin, so it needs to be present in all apps.
 			if (TargetFramework.IsDotNet) {
 				value = DotNetVersion;
+				name = "com.microsoft." + Platform.AsString ().ToLowerInvariant ();
 			} else if (Platform != ApplePlatform.MacOSX) {
 				var version = Sdks.XamIOS.ExtendedVersion;
 				value = string.Format ("{0} ({1}: {2})", version.Version, version.Branch, version.Hash);
+				name = "com.xamarin.ios";
 			} else {
 				return;
 			}
 
 			var dict = new PDictionary ();
 			dict.Add ("Version", new PString (value));
-			plist.Add ("com.xamarin.ios", dict);
+			plist.Add (name, dict);
 		}
 
 		void RegisterFonts (PDictionary plist)

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -146,6 +146,8 @@ namespace Xamarin.MacDev.Tasks
 			if (!Compile (plist))
 				return false;
 
+			AddXamarinVersionNumber (plist);
+
 			// Merge with any partial plists...
 			MergePartialPlistTemplates (plist);
 
@@ -154,6 +156,30 @@ namespace Xamarin.MacDev.Tasks
 				Log.LogMessage (MessageImportance.Low, "The file {0} is up-to-date.", CompiledAppManifest.ItemSpec);
 
 			return !Log.HasLoggedErrors;
+		}
+
+		void AddXamarinVersionNumber (PDictionary plist)
+		{
+			// Add our own version number
+			if (IsWatchApp)
+				return;
+
+			string value;
+
+			// This key is our supported way of determining if an app
+			// was built with Xamarin, so it needs to be present in all apps.
+			if (TargetFramework.IsDotNet) {
+				value = DotNetVersion;
+			} else if (Platform != ApplePlatform.MacOSX) {
+				var version = Sdks.XamIOS.ExtendedVersion;
+				value = string.Format ("{0} ({1}: {2})", version.Version, version.Branch, version.Hash);
+			} else {
+				return;
+			}
+
+			var dict = new PDictionary ();
+			dict.Add ("Version", new PString (value));
+			plist.Add ("com.xamarin.ios", dict);
 		}
 
 		void RegisterFonts (PDictionary plist)

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XamarinTask.cs
@@ -80,6 +80,23 @@ namespace Xamarin.MacDev.Tasks {
 			}
 		}
 
+		public string DotNetVersion {
+			get {
+				switch (Platform) {
+				case ApplePlatform.iOS:
+					return DotNetVersionConstants.Microsoft_iOS_Version;
+				case ApplePlatform.MacCatalyst:
+					return DotNetVersionConstants.Microsoft_MacCatalyst_Version;
+				case ApplePlatform.MacOSX:
+					return DotNetVersionConstants.Microsoft_macOS_Version;
+				case ApplePlatform.TVOS:
+					return DotNetVersionConstants.Microsoft_tvOS_Version;
+				default:
+					throw new InvalidOperationException (string.Format (MSBStrings.InvalidPlatform, Platform));
+				}
+			}
+		}
+
 		protected string GetSdkPlatform (bool isSimulator)
 		{
 			return PlatformFrameworkHelper.GetSdkPlatform (Platform, isSimulator);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -61,6 +61,9 @@
     <Compile Include="..\..\tools\common\FileUtils.cs">
       <Link>external\FileUtils.cs</Link>
     </Compile>
+    <Compile Include="..\Versions.dotnet.g.cs">
+      <Link>Versions.dotnet.g.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
@@ -31,16 +31,6 @@ namespace Xamarin.iOS.Tasks
 
 			supportedDevices = plist.GetUIDeviceFamily ();
 
-			if (!IsWatchApp) {
-				var version = Sdks.XamIOS.ExtendedVersion;
-				// This key is our supported way of determining if an app
-				// was built with Xamarin, so it needs to be present in all apps.
-
-				var dict = new PDictionary ();
-				dict.Add ("Version", new PString (string.Format ("{0} ({1}: {2})", version.Version, version.Branch, version.Hash)));
-				plist.Add ("com.xamarin.ios", dict);
-			}
-
 			var sdkSettings = currentSDK.GetSdkSettings (sdkVersion, SdkIsSimulator);
 			var dtSettings = currentSDK.GetAppleDTSettings ();
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/14108.