### PR TITLE
[runtime] Ask curl to fail (--fail) if fetching the URL fails for coreclrhost.h.

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -33,7 +33,8 @@ SHARED_FILES = $(SHARED_SOURCES) $(SHARED_HEADERS) $(SHARED_I386_SOURCES) $(SHAR
 EXTRA_DEPENDENCIES = $(SHARED_HEADERS) $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 coreclrhost.h: Makefile
-	$(Q_CURL) curl -L --output "$@" https://raw.githubusercontent.com/dotnet/runtime/6c8f9fff6adcf6c661072646dbdafabed5267ec5/src/coreclr/hosts/inc/coreclrhost.h
+	$(Q_CURL) curl -L --fail --output "$@.tmp" https://raw.githubusercontent.com/dotnet/runtime/6c8f9fff6adcf6c661072646dbdafabed5267ec5/src/coreclr/hosts/inc/coreclrhost.h
+	$(Q) mv "$@.tmp" "$@"
 
 coreclr-bridge.m: coreclrhost.h
 


### PR DESCRIPTION
This fixes an issue where the build would continue if the server in question
serves an error page (and eventually fail with weird errors because the error
page wouldn't be valid C code).