### PR TITLE
[UIKit] Hide the obsolete UIApplication.Main overload.

### DIFF
--- a/src/UIKit/UIApplication.cs
+++ b/src/UIKit/UIApplication.cs
@@ -10,6 +10,7 @@
 //
 
 using System;
+using System.ComponentModel;
 using System.Threading;
 using ObjCRuntime;
 using System.Runtime.InteropServices;
@@ -65,6 +66,7 @@ namespace UIKit {
 		
 #if !WATCH
 		[Obsolete ("Use the overload with 'Type' instead of 'String' parameters for type safety.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		public static void Main (string []? args, string? principalClassName, string? delegateClassName)
 		{
 			var p = CFString.CreateNative (principalClassName);


### PR DESCRIPTION
Hide the obsolete UIApplication.Main overload that takes string parameters
from intellisense. This overload is used *a lot*, so it's not worth it to
remove it, since it would break a lot of user code.