### PR TITLE
[addressbookui] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/AddressBookUI/ABAddressFormatting.cs
+++ b/src/AddressBookUI/ABAddressFormatting.cs
@@ -34,7 +34,7 @@ namespace AddressBookUI {
 		
 		static public string ToString (NSDictionary address, bool addCountryName)
 		{
-			if (address == null)
+			if (address is null)
 				throw new ArgumentNullException ("address");
 			
 			using (NSString s = new NSString (ABCreateStringWithAddressDictionary (address.Handle, addCountryName)))

--- a/src/AddressBookUI/ABAddressFormatting.cs
+++ b/src/AddressBookUI/ABAddressFormatting.cs
@@ -7,6 +7,8 @@
 // Copyright (C) 2012 Xamarin Inc. All rights reserved.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/src/AddressBookUI/ABAddressFormatting.cs
+++ b/src/AddressBookUI/ABAddressFormatting.cs
@@ -35,7 +35,7 @@ namespace AddressBookUI {
 		static public string ToString (NSDictionary address, bool addCountryName)
 		{
 			if (address is null)
-				throw new ArgumentNullException ("address");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (address));
 			
 			using (NSString s = new NSString (ABCreateStringWithAddressDictionary (address.Handle, addCountryName)))
 				return s.ToString ();

--- a/src/AddressBookUI/ABNewPersonViewController.cs
+++ b/src/AddressBookUI/ABNewPersonViewController.cs
@@ -64,8 +64,8 @@ namespace AddressBookUI {
 #endif
 	partial class ABNewPersonViewController {
 
-		ABPerson displayedPerson;
-		public ABPerson DisplayedPerson {
+		ABPerson? displayedPerson;
+		public ABPerson? DisplayedPerson {
 			get {
 				MarkDirty ();
 				return BackingField.Get (ref displayedPerson, _DisplayedPerson, h => new ABPerson (h, AddressBook));
@@ -76,8 +76,8 @@ namespace AddressBookUI {
 			}
 		}
 
-		ABAddressBook addressBook;
-		public ABAddressBook AddressBook {
+		ABAddressBook? addressBook;
+		public ABAddressBook? AddressBook {
 			get {
 				MarkDirty ();
 				return BackingField.Get (ref addressBook, _AddressBook, h => new ABAddressBook (h, false));
@@ -88,8 +88,8 @@ namespace AddressBookUI {
 			}
 		}
 
-		ABGroup parentGroup;
-		public ABGroup ParentGroup {
+		ABGroup? parentGroup;
+		public ABGroup? ParentGroup {
 			get {
 				MarkDirty ();
 				return BackingField.Get (ref parentGroup, _ParentGroup, h => new ABGroup (h, AddressBook));

--- a/src/AddressBookUI/ABNewPersonViewController.cs
+++ b/src/AddressBookUI/ABNewPersonViewController.cs
@@ -34,7 +34,7 @@ namespace AddressBookUI {
 
 		public ABPerson? Person {get; private set;}
 		public bool Completed {
-			get {return Person != null;}
+			get {return Person is not null;}
 		}
 	}
 
@@ -103,7 +103,7 @@ namespace AddressBookUI {
 		InternalABNewPersonViewControllerDelegate EnsureEventDelegate ()
 		{
 			var d = WeakDelegate as InternalABNewPersonViewControllerDelegate;
-			if (d == null) {
+			if (d is null) {
 				d = new InternalABNewPersonViewControllerDelegate ();
 				WeakDelegate = d;
 			}
@@ -113,7 +113,7 @@ namespace AddressBookUI {
 		protected internal virtual void OnNewPersonComplete (ABNewPersonCompleteEventArgs e)
 		{
 			var h = EnsureEventDelegate ().newPersonComplete;
-			if (h != null)
+			if (h is not null)
 				h (this, e);
 		}
 

--- a/src/AddressBookUI/ABNewPersonViewController.cs
+++ b/src/AddressBookUI/ABNewPersonViewController.cs
@@ -6,6 +6,8 @@
 // Copyright (C) 2009 Novell, Inc
 //
 
+#nullable enable
+
 using System;
 
 using AddressBook;
@@ -25,12 +27,12 @@ namespace AddressBookUI {
 #endif
 	public class ABNewPersonCompleteEventArgs : EventArgs {
 
-		public ABNewPersonCompleteEventArgs (ABPerson person)
+		public ABNewPersonCompleteEventArgs (ABPerson? person)
 		{
 			Person = person;
 		}
 
-		public ABPerson Person {get; private set;}
+		public ABPerson? Person {get; private set;}
 		public bool Completed {
 			get {return Person != null;}
 		}
@@ -38,7 +40,7 @@ namespace AddressBookUI {
 
 	class InternalABNewPersonViewControllerDelegate : ABNewPersonViewControllerDelegate {
 
-		internal EventHandler<ABNewPersonCompleteEventArgs> newPersonComplete;
+		internal EventHandler<ABNewPersonCompleteEventArgs>? newPersonComplete;
 
 		public InternalABNewPersonViewControllerDelegate ()
 		{
@@ -46,7 +48,7 @@ namespace AddressBookUI {
 		}
 
 		[Preserve (Conditional = true)]
-		public override void DidCompleteWithNewPerson (ABNewPersonViewController controller, ABPerson person)
+		public override void DidCompleteWithNewPerson (ABNewPersonViewController controller, ABPerson? person)
 		{
 			controller.OnNewPersonComplete (new ABNewPersonCompleteEventArgs (person));
 		}

--- a/src/AddressBookUI/ABPeoplePickerNavigationController.cs
+++ b/src/AddressBookUI/ABPeoplePickerNavigationController.cs
@@ -109,13 +109,13 @@ namespace AddressBookUI {
 		{
 			switch (sel?.Name) {
 			case "peoplePickerNavigationController:shouldContinueAfterSelectingPerson:":
-				return (selectPerson != null);
+				return (selectPerson is not null);
 			case "peoplePickerNavigationController:shouldContinueAfterSelectingPerson:property:identifier:":
-				return (performAction != null);
+				return (performAction is not null);
 			case "peoplePickerNavigationController:didSelectPerson:":
-				return (selectPerson2 != null);
+				return (selectPerson2 is not null);
 			case "peoplePickerNavigationController:didSelectPerson:property:identifier:":
-				return (performAction2 != null);
+				return (performAction2 is not null);
 			}
 			return base.RespondsToSelector (sel);
 		}
@@ -182,7 +182,7 @@ namespace AddressBookUI {
 		DisplayedPropertiesCollection displayedProperties;
 		public DisplayedPropertiesCollection DisplayedProperties {
 			get {
-				if (displayedProperties == null) {
+				if (displayedProperties is null) {
 					displayedProperties = new DisplayedPropertiesCollection (
 						() => _DisplayedProperties, 
 						v => _DisplayedProperties = v);
@@ -206,8 +206,8 @@ namespace AddressBookUI {
 
 		T EnsureEventDelegate<T> () where T : NSObject, new()
 		{
-			var d = WeakDelegate == null ? null : (T)WeakDelegate;
-			if (d == null) {
+			var d = WeakDelegate is null ? null : (T)WeakDelegate;
+			if (d is null) {
 				d = new T ();
 				WeakDelegate = d;
 			}
@@ -217,35 +217,35 @@ namespace AddressBookUI {
 		protected internal virtual void OnSelectPerson (ABPeoplePickerSelectPersonEventArgs e)
 		{
 			var h = EnsureEventDelegate<InternalABPeoplePickerNavigationControllerDelegate> ().selectPerson;
-			if (h != null)
+			if (h is not null)
 				h (this, e);
 		}
 
 		protected internal virtual void OnSelectPerson2 (ABPeoplePickerSelectPerson2EventArgs e)
 		{
 			var h = EnsureEventDelegate<InternalABPeoplePickerNavigationControllerDelegate> ().selectPerson2;
-			if (h != null)
+			if (h is not null)
 				h (this, e);
 		}
 
 		protected internal virtual void OnPerformAction (ABPeoplePickerPerformActionEventArgs e)
 		{
 			var h = EnsureEventDelegate<InternalABPeoplePickerNavigationControllerDelegate> ().performAction;
-			if (h != null)
+			if (h is not null)
 				h (this, e);
 		}
 
 		protected internal virtual void OnPerformAction2 (ABPeoplePickerPerformAction2EventArgs e)
 		{
 			var h = EnsureEventDelegate<InternalABPeoplePickerNavigationControllerDelegate> ().performAction2;
-			if (h != null)
+			if (h is not null)
 				h (this, e);
 		}
 
 		protected internal virtual void OnCancelled (EventArgs e)
 		{
 			var h = EnsureEventDelegate<InternalABPeoplePickerNavigationControllerDelegate> ().cancelled;
-			if (h != null)
+			if (h is not null)
 				h (this, e);
 		}
 

--- a/src/AddressBookUI/ABPeoplePickerNavigationController.cs
+++ b/src/AddressBookUI/ABPeoplePickerNavigationController.cs
@@ -6,6 +6,8 @@
 // Copyright (C) 2009 Novell, Inc
 //
 
+#nullable enable
+
 using System;
 
 using AddressBook;
@@ -96,14 +98,14 @@ namespace AddressBookUI {
 	}
 
 	class InternalABPeoplePickerNavigationControllerDelegate : ABPeoplePickerNavigationControllerDelegate {
-		internal EventHandler<ABPeoplePickerSelectPersonEventArgs> selectPerson;
-		internal EventHandler<ABPeoplePickerPerformActionEventArgs> performAction;
-		internal EventHandler<ABPeoplePickerSelectPerson2EventArgs> selectPerson2;
-		internal EventHandler<ABPeoplePickerPerformAction2EventArgs> performAction2;
-		internal EventHandler cancelled;
+		internal EventHandler<ABPeoplePickerSelectPersonEventArgs>? selectPerson;
+		internal EventHandler<ABPeoplePickerPerformActionEventArgs>? performAction;
+		internal EventHandler<ABPeoplePickerSelectPerson2EventArgs>? selectPerson2;
+		internal EventHandler<ABPeoplePickerPerformAction2EventArgs>? performAction2;
+		internal EventHandler? cancelled;
 
 		[Preserve (Conditional = true)]
-		public override bool RespondsToSelector (Selector sel)
+		public override bool RespondsToSelector (Selector? sel)
 		{
 			switch (sel?.Name) {
 			case "peoplePickerNavigationController:shouldContinueAfterSelectingPerson:":

--- a/src/AddressBookUI/ABPeoplePickerNavigationController.cs
+++ b/src/AddressBookUI/ABPeoplePickerNavigationController.cs
@@ -179,8 +179,8 @@ namespace AddressBookUI {
 #endif
 	partial class ABPeoplePickerNavigationController {
 
-		DisplayedPropertiesCollection displayedProperties;
-		public DisplayedPropertiesCollection DisplayedProperties {
+		DisplayedPropertiesCollection? displayedProperties;
+		public DisplayedPropertiesCollection? DisplayedProperties {
 			get {
 				if (displayedProperties is null) {
 					displayedProperties = new DisplayedPropertiesCollection (
@@ -192,8 +192,8 @@ namespace AddressBookUI {
 			}
 		}
 
-		ABAddressBook addressBook;
-		public ABAddressBook AddressBook {
+		ABAddressBook? addressBook;
+		public ABAddressBook? AddressBook {
 			get {
 				MarkDirty ();
 				return BackingField.Get (ref addressBook, _AddressBook, h => new ABAddressBook (h, false));

--- a/src/AddressBookUI/ABPersonViewController.cs
+++ b/src/AddressBookUI/ABPersonViewController.cs
@@ -6,6 +6,8 @@
 // Copyright (C) 2009 Novell, Inc
 //
 
+#nullable enable
+
 using System;
 
 using AddressBook;
@@ -39,7 +41,7 @@ namespace AddressBookUI {
 
 	class InternalABPersonViewControllerDelegate : ABPersonViewControllerDelegate {
 
-		internal EventHandler<ABPersonViewPerformDefaultActionEventArgs> performDefaultAction;
+		internal EventHandler<ABPersonViewPerformDefaultActionEventArgs>? performDefaultAction;
 
 		public InternalABPersonViewControllerDelegate ()
 		{
@@ -108,14 +110,14 @@ namespace AddressBookUI {
 		public void SetHighlightedItemForProperty (ABPersonProperty property, int? identifier)
 		{
 			SetHighlightedItemForProperty (
-					ABPersonPropertyId.ToId (property),
-					identifier.HasValue ? identifier.Value : ABRecord.InvalidPropertyId);
+					property,
+					identifier ?? ABRecord.InvalidPropertyId);
 		}
 
 		public void SetHighlightedProperty (ABPersonProperty property)
 		{
 			SetHighlightedItemForProperty (
-					ABPersonPropertyId.ToId (property),
+					property,
 					ABRecord.InvalidPropertyId);
 		}
 

--- a/src/AddressBookUI/ABPersonViewController.cs
+++ b/src/AddressBookUI/ABPersonViewController.cs
@@ -110,14 +110,14 @@ namespace AddressBookUI {
 		public void SetHighlightedItemForProperty (ABPersonProperty property, int? identifier)
 		{
 			SetHighlightedItemForProperty (
-					property,
+					ABPersonPropertyId.ToId (property),
 					identifier ?? ABRecord.InvalidPropertyId);
 		}
 
 		public void SetHighlightedProperty (ABPersonProperty property)
 		{
 			SetHighlightedItemForProperty (
-					property,
+					ABPersonPropertyId.ToId (property),
 					ABRecord.InvalidPropertyId);
 		}
 

--- a/src/AddressBookUI/ABPersonViewController.cs
+++ b/src/AddressBookUI/ABPersonViewController.cs
@@ -70,8 +70,8 @@ namespace AddressBookUI {
 #endif
 	partial class ABPersonViewController {
 
-		ABPerson displayedPerson;
-		public ABPerson DisplayedPerson {
+		ABPerson? displayedPerson;
+		public ABPerson? DisplayedPerson {
 			get {
 				MarkDirty ();
 				return BackingField.Get (ref displayedPerson, _DisplayedPerson, h => new ABPerson (h, AddressBook));
@@ -82,8 +82,8 @@ namespace AddressBookUI {
 			}
 		}
 
-		DisplayedPropertiesCollection displayedProperties;
-		public DisplayedPropertiesCollection DisplayedProperties {
+		DisplayedPropertiesCollection? displayedProperties;
+		public DisplayedPropertiesCollection? DisplayedProperties {
 			get {
 				if (displayedProperties is null) {
 					displayedProperties = new DisplayedPropertiesCollection (
@@ -95,8 +95,8 @@ namespace AddressBookUI {
 			}
 		}
 
-		ABAddressBook addressBook;
-		public ABAddressBook AddressBook {
+		ABAddressBook? addressBook;
+		public ABAddressBook? AddressBook {
 			get {
 				MarkDirty ();
 				return BackingField.Get (ref addressBook, _AddressBook, h => new ABAddressBook (h, false));

--- a/src/AddressBookUI/ABPersonViewController.cs
+++ b/src/AddressBookUI/ABPersonViewController.cs
@@ -85,7 +85,7 @@ namespace AddressBookUI {
 		DisplayedPropertiesCollection displayedProperties;
 		public DisplayedPropertiesCollection DisplayedProperties {
 			get {
-				if (displayedProperties == null) {
+				if (displayedProperties is null) {
 					displayedProperties = new DisplayedPropertiesCollection (
 							() => _DisplayedProperties, 
 							v => _DisplayedProperties = v);
@@ -124,7 +124,7 @@ namespace AddressBookUI {
 		InternalABPersonViewControllerDelegate EnsureEventDelegate ()
 		{
 			var d = WeakDelegate as InternalABPersonViewControllerDelegate;
-			if (d == null) {
+			if (d is null) {
 				d = new InternalABPersonViewControllerDelegate ();
 				WeakDelegate = d;
 			}
@@ -134,7 +134,7 @@ namespace AddressBookUI {
 		protected internal virtual void OnPerformDefaultAction (ABPersonViewPerformDefaultActionEventArgs e)
 		{
 			var h = EnsureEventDelegate ().performDefaultAction;
-			if (h != null)
+			if (h is not null)
 				h (this, e);
 		}
 

--- a/src/AddressBookUI/ABUnknownPersonViewController.cs
+++ b/src/AddressBookUI/ABUnknownPersonViewController.cs
@@ -98,7 +98,7 @@ namespace AddressBookUI {
 		InternalABUnknownPersonViewControllerDelegate EnsureEventDelegate ()
 		{
 			var d = WeakDelegate as InternalABUnknownPersonViewControllerDelegate;
-			if (d == null) {
+			if (d is null) {
 				d = new InternalABUnknownPersonViewControllerDelegate ();
 				WeakDelegate = d;
 			}
@@ -108,14 +108,14 @@ namespace AddressBookUI {
 		protected internal virtual void OnPerformDefaultAction (ABPersonViewPerformDefaultActionEventArgs e)
 		{
 			var h = EnsureEventDelegate ().performDefaultAction;
-			if (h != null)
+			if (h is not null)
 				h (this, e);
 		}
 
 		protected internal virtual void OnPersonCreated (ABUnknownPersonCreatedEventArgs e)
 		{
 			var h = EnsureEventDelegate ().personCreated;
-			if (h != null)
+			if (h is not null)
 				h (this, e);
 		}
 

--- a/src/AddressBookUI/ABUnknownPersonViewController.cs
+++ b/src/AddressBookUI/ABUnknownPersonViewController.cs
@@ -6,6 +6,8 @@
 // Copyright (C) 2009 Novell, Inc
 //
 
+#nullable enable
+
 using System;
 
 using AddressBook;
@@ -24,17 +26,17 @@ namespace AddressBookUI {
 #endif
 	public class ABUnknownPersonCreatedEventArgs : EventArgs {
 
-		public ABUnknownPersonCreatedEventArgs (ABPerson person)
+		public ABUnknownPersonCreatedEventArgs (ABPerson? person)
 		{
 			Person = person;
 		}
 
-		public ABPerson Person {get; private set;}
+		public ABPerson? Person {get; private set;}
 	}
 
 	class InternalABUnknownPersonViewControllerDelegate : ABUnknownPersonViewControllerDelegate {
-		internal EventHandler<ABPersonViewPerformDefaultActionEventArgs> performDefaultAction;
-		internal EventHandler<ABUnknownPersonCreatedEventArgs> personCreated;
+		internal EventHandler<ABPersonViewPerformDefaultActionEventArgs>? performDefaultAction;
+		internal EventHandler<ABUnknownPersonCreatedEventArgs>? personCreated;
 
 		public InternalABUnknownPersonViewControllerDelegate ()
 		{
@@ -42,7 +44,7 @@ namespace AddressBookUI {
 		}
 
 		[Preserve (Conditional = true)]
-		public override void DidResolveToPerson (ABUnknownPersonViewController personViewController, ABPerson person)
+		public override void DidResolveToPerson (ABUnknownPersonViewController personViewController, ABPerson? person)
 		{
 			personViewController.OnPersonCreated (new ABUnknownPersonCreatedEventArgs (person));
 		}

--- a/src/AddressBookUI/ABUnknownPersonViewController.cs
+++ b/src/AddressBookUI/ABUnknownPersonViewController.cs
@@ -71,8 +71,8 @@ namespace AddressBookUI {
 #endif
 	partial class ABUnknownPersonViewController {
 
-		ABPerson displayedPerson;
-		public ABPerson DisplayedPerson {
+		ABPerson? displayedPerson;
+		public ABPerson? DisplayedPerson {
 			get {
 				MarkDirty ();
 				return BackingField.Get (ref displayedPerson, _DisplayedPerson, h => new ABPerson (h, AddressBook));
@@ -83,8 +83,8 @@ namespace AddressBookUI {
 			}
 		}
 
-		ABAddressBook addressBook;
-		public ABAddressBook AddressBook {
+		ABAddressBook? addressBook;
+		public ABAddressBook? AddressBook {
 			get {
 				MarkDirty ();
 				return BackingField.Get (ref addressBook, _AddressBook, h => new ABAddressBook (h, false));

--- a/src/AddressBookUI/DisplayedPropertiesCollection.cs
+++ b/src/AddressBookUI/DisplayedPropertiesCollection.cs
@@ -52,7 +52,7 @@ namespace AddressBookUI {
 		{
 			List<NSNumber> values;
 			var dp = g ();
-			if (dp != null)
+			if (dp is not null)
 				values = new List<NSNumber> (dp);
 			else
 				values = new List<NSNumber> ();
@@ -69,7 +69,7 @@ namespace AddressBookUI {
 		{
 			int id = ABPersonPropertyId.ToId (item);
 			var values = g ();
-			if (values == null)
+			if (values is null)
 				return false;
 
 			for (int i = 0; i < values.Length; ++i)
@@ -80,7 +80,7 @@ namespace AddressBookUI {
 
 		public void CopyTo (ABPersonProperty[] array, int arrayIndex)
 		{
-			if (array == null)
+			if (array is null)
 				throw new ArgumentNullException ("array");
 			if (arrayIndex < 0)
 				throw new ArgumentOutOfRangeException ("arrayIndex");
@@ -97,7 +97,7 @@ namespace AddressBookUI {
 		public bool Remove (ABPersonProperty item)
 		{
 			var dp = g ();
-			if (dp == null)
+			if (dp is null)
 				return false;
 			var id = ABPersonPropertyId.ToId (item);
 			var values = new List<NSNumber> (dp);

--- a/src/AddressBookUI/DisplayedPropertiesCollection.cs
+++ b/src/AddressBookUI/DisplayedPropertiesCollection.cs
@@ -81,7 +81,7 @@ namespace AddressBookUI {
 		public void CopyTo (ABPersonProperty[] array, int arrayIndex)
 		{
 			if (array is null)
-				throw new ArgumentNullException ("array");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 			if (arrayIndex < 0)
 				throw new ArgumentOutOfRangeException ("arrayIndex");
 			if (arrayIndex > array.Length)

--- a/src/AddressBookUI/DisplayedPropertiesCollection.cs
+++ b/src/AddressBookUI/DisplayedPropertiesCollection.cs
@@ -6,6 +6,8 @@
 // Copyright (C) 2009 Novell, Inc
 //
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -29,17 +31,17 @@ namespace AddressBookUI {
 #endif
 	public class DisplayedPropertiesCollection : ICollection<ABPersonProperty> {
 
-		ABFunc<NSNumber[]> g;
-		Action<NSNumber[]> s;
+		ABFunc<NSNumber[]?> g;
+		Action<NSNumber[]?> s;
 
-		internal DisplayedPropertiesCollection (ABFunc<NSNumber[]> g, Action<NSNumber[]> s)
+		internal DisplayedPropertiesCollection (ABFunc<NSNumber[]?> g, Action<NSNumber[]?> s)
 		{
 			this.g = g;
 			this.s = s;
 		}
 
 		public int Count {
-			get {return g ().Length;}
+			get {return g ()!.Length;}
 		}
 
 		bool ICollection<ABPersonProperty>.IsReadOnly {
@@ -117,7 +119,7 @@ namespace AddressBookUI {
 
 		public IEnumerator<ABPersonProperty> GetEnumerator ()
 		{
-			var values = g ();
+			var values = g ()!;
 			for (int i = 0; i < values.Length; ++i)
 				yield return ABPersonPropertyId.ToPersonProperty (values [i].Int32Value);
 		}

--- a/src/AddressBookUI/DisplayedPropertiesCollection.cs
+++ b/src/AddressBookUI/DisplayedPropertiesCollection.cs
@@ -119,7 +119,10 @@ namespace AddressBookUI {
 
 		public IEnumerator<ABPersonProperty> GetEnumerator ()
 		{
-			var values = g ()!;
+			var values = g ();
+			if (values is null) {
+				yield break;
+			}
 			for (int i = 0; i < values.Length; ++i)
 				yield return ABPersonPropertyId.ToPersonProperty (values [i].Int32Value);
 		}

--- a/src/addressbookui.cs
+++ b/src/addressbookui.cs
@@ -164,7 +164,6 @@ namespace AddressBookUI {
 		// Obsolete for public use; we should "remove" this member by making
 		// it [Internal] in some future release, as it's needed internally.
 		[Internal]
-		[Obsolete ("Use SetHighlightedItemForProperty(ABPersonProperty,int?).")]
 		[Export ("setHighlightedItemForProperty:withIdentifier:")]
 		void SetHighlightedItemForProperty (int /* ABPropertyId = int32 */ property, int /* ABMultiValueIdentifier = int32 */ identifier);
 	}


### PR DESCRIPTION
This PR aims to bring nullability changes to AddressBookUI.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am looking for any `!missing-null-allowed!` in this frameworks ignore files and applying them
2. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
3. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
4. Changing any `== null` or `!= null` to `is null` and `is not null`

*Note, I'd like extra focus on the DisplayedPropertiesCollection method changes

Inside AddressBookUI, I removed 
`[Obsolete ("Use SetHighlightedItemForProperty(ABPersonProperty,int?).")] `
since it is already marked as Internal thus not for public use. The issue with leaving it in is that with '#nullable enable`, the compiler tells us that we can't use this method since it is obsoleted, but we use this method in many places.