### PR TITLE
[assetslibrary] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/AssetsLibrary/ALAsset.cs
+++ b/src/AssetsLibrary/ALAsset.cs
@@ -47,7 +47,7 @@ namespace AssetsLibrary {
 				// note: this can return an NSString like: ALErrorInvalidProperty
 				// which causes an InvalidCastException with a normal cast
 				var n = ValueForProperty (_PropertyDuration) as NSNumber;
-				return n == null ? double.NaN : n.DoubleValue;
+				return n?.DoubleValue ?? double.NaN;
 			}
 		}
 
@@ -81,9 +81,7 @@ namespace AssetsLibrary {
 			get {
 				// do not show an ArgumentNullException inside the
 				// debugger for releases before 6.0
-				if (_PropertyAssetURL == null)
-					return null;
-				return (NSUrl) ValueForProperty (_PropertyAssetURL);
+				return _PropertyAssetURL is not null ? (NSUrl) ValueForProperty (_PropertyAssetURL) : null;
 			}
 		}
 	}


### PR DESCRIPTION
This PR aims to bring nullability changes to AssetsLibrary.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. Changing any `== null` or `!= null` to `is null` and `is not null`
    * In this case, use updated features to replace "== null"