### PR TITLE
[audiotoolbox] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/AudioToolbox/AudioClassDescription.cs
+++ b/src/AudioToolbox/AudioClassDescription.cs
@@ -61,7 +61,7 @@ namespace AudioToolbox {
 		// The documentation is wrong too
 		public unsafe static uint? HardwareCodecCapabilities (AudioClassDescription[] descriptions)
 		{
-			if (descriptions == null)
+			if (descriptions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptions));
 
 			fixed (AudioClassDescription* item = &descriptions[0]) {

--- a/src/AudioToolbox/AudioClassDescription.cs
+++ b/src/AudioToolbox/AudioClassDescription.cs
@@ -62,7 +62,7 @@ namespace AudioToolbox {
 		public unsafe static uint? HardwareCodecCapabilities (AudioClassDescription[] descriptions)
 		{
 			if (descriptions == null)
-				throw new ArgumentNullException ("descriptions");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptions));
 
 			fixed (AudioClassDescription* item = &descriptions[0]) {
 				uint successfulCodecs;

--- a/src/AudioToolbox/AudioClassDescription.cs
+++ b/src/AudioToolbox/AudioClassDescription.cs
@@ -35,6 +35,7 @@ using Foundation;
 using AudioUnit;
 
 namespace AudioToolbox {
+
 	// CoreAudio.framework - CoreAudioTypes.h
 	[StructLayout (LayoutKind.Sequential)]
 	public struct AudioClassDescription

--- a/src/AudioToolbox/AudioClassDescription.cs
+++ b/src/AudioToolbox/AudioClassDescription.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using CoreFoundation;
@@ -33,7 +35,6 @@ using Foundation;
 using AudioUnit;
 
 namespace AudioToolbox {
-
 	// CoreAudio.framework - CoreAudioTypes.h
 	[StructLayout (LayoutKind.Sequential)]
 	public struct AudioClassDescription

--- a/src/AudioToolbox/AudioConverter.cs
+++ b/src/AudioToolbox/AudioConverter.cs
@@ -223,7 +223,7 @@ namespace AudioToolbox
 
 			set {
 				if (value is null)
-					throw new ArgumentNullException (nameof (value));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 
 				var res = AudioConverterSetProperty (Handle, AudioConverterPropertyID.CompressionMagicCookie, value.Length, value);
 				if (res != AudioConverterError.None)
@@ -246,7 +246,7 @@ namespace AudioToolbox
 			}
 			set {
 				if (value is null)
-					throw new ArgumentNullException (nameof (value));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 
 				var res = AudioConverterSetProperty (Handle, AudioConverterPropertyID.DecompressionMagicCookie, value.Length, value);
 				if (res != AudioConverterError.None)
@@ -412,7 +412,7 @@ namespace AudioToolbox
 		public static AudioConverter? Create (AudioStreamBasicDescription sourceFormat, AudioStreamBasicDescription destinationFormat, AudioClassDescription[] descriptions)
 		{
 			if (descriptions is null)
-				throw new ArgumentNullException (nameof (descriptions));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptions));
 
 			IntPtr ptr = new IntPtr ();
 			var res = AudioConverterNewSpecific (ref sourceFormat, ref destinationFormat, descriptions.Length, ref descriptions, ref ptr);
@@ -450,9 +450,9 @@ namespace AudioToolbox
 		public AudioConverterError ConvertBuffer (byte[] input, byte[] output)
 		{
 			if (input is null)
-				throw new ArgumentNullException (nameof (input));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (input));
 			if (output is null)
-				throw new ArgumentNullException (nameof (output));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (output));
 
 			int outSize = output.Length;
 			return AudioConverterConvertBuffer (Handle, input.Length, input, ref outSize, output);
@@ -461,9 +461,9 @@ namespace AudioToolbox
 		public AudioConverterError ConvertComplexBuffer (int numberPCMFrames, AudioBuffers inputData, AudioBuffers outputData)
 		{
 			if (inputData is null)
-				throw new ArgumentNullException (nameof (inputData));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inputData));
 			if (outputData is null)
-				throw new ArgumentNullException (nameof (outputData));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputData));
 
 			return AudioConverterConvertComplexBuffer (Handle, numberPCMFrames, (IntPtr) inputData, (IntPtr) outputData);
 		}
@@ -472,10 +472,10 @@ namespace AudioToolbox
 			AudioBuffers outputData, AudioStreamPacketDescription[] packetDescription, AudioConverterComplexInputData newInputDataHandler)
 		{
 			if (outputData is null)
-				throw new ArgumentNullException (nameof (outputData));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputData));
 
 			if (newInputDataHandler is null)
-				throw new ArgumentNullException (nameof (newInputDataHandler));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (newInputDataHandler));
 
 			return FillComplexBuffer (ref outputDataPacketSize, outputData, packetDescription, new Tuple<AudioConverter, AudioConverterComplexInputData?> (this, newInputDataHandler));
 		}
@@ -484,7 +484,7 @@ namespace AudioToolbox
 			AudioBuffers outputData, AudioStreamPacketDescription[] packetDescription)
 		{
 			if (outputData is null)
-				throw new ArgumentNullException (nameof (outputData));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputData));
 
 			return FillComplexBuffer (ref outputDataPacketSize, outputData, packetDescription, new Tuple<AudioConverter, AudioConverterComplexInputData?> (this, null));
 		}
@@ -521,7 +521,7 @@ namespace AudioToolbox
 			var instanceData = handler.Target as Tuple<AudioConverter, AudioConverterComplexInputData?>;
 
 			if (instanceData is null)
-				throw new ArgumentNullException (nameof (instanceData));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (instanceData));
 
 			var inst = instanceData.Item1;
 			var callback = instanceData.Item2;
@@ -529,7 +529,7 @@ namespace AudioToolbox
 			// Invoke event handler with an argument
 			// since callback is not provided, must come from the old FillComplexBuffer call
 			if (callback is null && inst.InputData is null)
-				throw new ArgumentNullException ("InputData");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException ("InputData");
 			// Check if subscribed to event and provided a callback, error out if true
 			else if (callback is not null && inst.InputData is not null)
 				throw new InvalidOperationException ("Please either only subscribe to InputData event or provide newInputDataHandler in FillComplexBuffer, using both is unsuported.");

--- a/src/AudioToolbox/AudioFile.cs
+++ b/src/AudioToolbox/AudioFile.cs
@@ -616,7 +616,7 @@ namespace AudioToolbox {
 		public static AudioFile? Create (string url, AudioFileType fileType, AudioStreamBasicDescription format, AudioFileFlags inFlags)
 		{
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			using (var cfurl = CFUrl.FromUrlString (url, null)!)
 				return Create (cfurl, fileType, format, inFlags);
@@ -625,7 +625,7 @@ namespace AudioToolbox {
 		public static AudioFile? Create (CFUrl url, AudioFileType fileType, AudioStreamBasicDescription format, AudioFileFlags inFlags)
 		{
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			IntPtr h;
 
@@ -637,7 +637,7 @@ namespace AudioToolbox {
 		public static AudioFile? Create (NSUrl url, AudioFileType fileType, AudioStreamBasicDescription format, AudioFileFlags inFlags)
 		{
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			IntPtr h;
 
@@ -689,7 +689,7 @@ namespace AudioToolbox {
 		public static AudioFile? Open (string url, AudioFilePermission permissions, out AudioFileError error, AudioFileType fileTypeHint = 0)
 		{
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			using (var cfurl = CFUrl.FromUrlString (url, null)!)
 				return Open (cfurl, permissions, out error, fileTypeHint);
@@ -704,7 +704,7 @@ namespace AudioToolbox {
 		public static AudioFile? Open (CFUrl url, AudioFilePermission permissions, out AudioFileError error, AudioFileType fileTypeHint = 0)
 		{
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return Open (url.Handle, permissions, fileTypeHint, out error);
 		}
@@ -718,7 +718,7 @@ namespace AudioToolbox {
 		public static AudioFile? Open (NSUrl url, AudioFilePermission permissions, out AudioFileError error, AudioFileType fileTypeHint = 0)
 		{
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return Open (url.Handle, permissions, fileTypeHint, out error);
 		}
@@ -829,7 +829,7 @@ namespace AudioToolbox {
 		public AudioStreamPacketDescription []? ReadPacketData (long inStartingPacket, int nPackets, byte [] buffer, out AudioFileError error)
 		{
 			if (buffer is null)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 			int count = buffer.Length;
 			return RealReadPacketData (false, inStartingPacket, ref nPackets, buffer, 0, ref count, out error);
 		}
@@ -870,7 +870,7 @@ namespace AudioToolbox {
 		public AudioStreamPacketDescription []? ReadPacketData (bool useCache, long inStartingPacket, ref int nPackets, byte [] buffer, int offset, ref int count, out AudioFileError error)
 		{
 			if (buffer is null)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 			if (offset < 0)
 				throw new ArgumentException (nameof (offset), "<0");
 			if (count < 0)
@@ -899,11 +899,11 @@ namespace AudioToolbox {
 		public unsafe AudioStreamPacketDescription []? ReadPacketData (bool useCache, long inStartingPacket, ref int nPackets, IntPtr buffer, ref int count, out AudioFileError error, AudioStreamPacketDescription[] descriptions)
 		{
 			if (buffer == IntPtr.Zero)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 			if (count < 0)
 				throw new ArgumentException (nameof (count), "<0");
 			if (descriptions is null)
-				throw new ArgumentNullException (nameof (descriptions));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptions));
 
 			fixed (AudioStreamPacketDescription *p = descriptions) {
 				return RealReadPacketData (useCache, inStartingPacket, ref nPackets, buffer, ref count, out error, descriptions);
@@ -953,7 +953,7 @@ namespace AudioToolbox {
 		public AudioStreamPacketDescription []? ReadFixedPackets (long inStartingPacket, int nPackets, byte [] buffer, out AudioFileError error)
 		{
 			if (buffer is null)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 			return RealReadFixedPackets (false, inStartingPacket, nPackets, buffer, 0, buffer.Length, out error);
 		}
 
@@ -966,7 +966,7 @@ namespace AudioToolbox {
 		public AudioStreamPacketDescription []? ReadFixedPackets (bool useCache, long inStartingPacket, int nPackets, byte [] buffer, int offset, int count, out AudioFileError error)
 		{
 			if (buffer is null)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 			if (offset < 0)
 				throw new ArgumentException (nameof (offset), "<0");
 			if (count < 0)
@@ -1007,7 +1007,7 @@ namespace AudioToolbox {
 		public int WritePackets (bool useCache, long startingPacket, int numPackets, IntPtr buffer, int byteCount)
 		{
 			if (buffer == IntPtr.Zero)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 
 			if (AudioFileWritePackets (Handle, useCache, byteCount, null, startingPacket, ref numPackets, buffer) == 0)
 				return numPackets;
@@ -1018,9 +1018,9 @@ namespace AudioToolbox {
 		public int WritePackets (bool useCache, long startingPacket, AudioStreamPacketDescription [] packetDescriptions, IntPtr buffer, int byteCount)
 		{
 			if (packetDescriptions is null)
-				throw new ArgumentNullException (nameof (packetDescriptions));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (packetDescriptions));
 			if (buffer == IntPtr.Zero)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 			int nPackets = packetDescriptions.Length;
 			if (AudioFileWritePackets (Handle, useCache, byteCount, packetDescriptions, startingPacket, ref nPackets, buffer) == 0)
 				return nPackets;
@@ -1030,9 +1030,9 @@ namespace AudioToolbox {
 		unsafe public int WritePackets (bool useCache, long startingPacket, AudioStreamPacketDescription [] packetDescriptions, byte [] buffer, int offset, int byteCount)
 		{
 			if (packetDescriptions is null)
-				throw new ArgumentNullException (nameof (packetDescriptions));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (packetDescriptions));
 			if (buffer is null)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 			if (offset < 0)
 				throw new ArgumentOutOfRangeException (nameof (offset), "< 0");
 			if (byteCount < 0)
@@ -1051,7 +1051,7 @@ namespace AudioToolbox {
 		public int WritePackets (bool useCache, long startingPacket, AudioStreamPacketDescription [] packetDescriptions, IntPtr buffer, int byteCount, out int errorCode)
 		{
 			if (packetDescriptions is null)
-				throw new ArgumentNullException (nameof (packetDescriptions));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (packetDescriptions));
 			if (buffer == IntPtr.Zero)
 				throw new ArgumentException (nameof (buffer));
 			int nPackets = packetDescriptions.Length;
@@ -1065,9 +1065,9 @@ namespace AudioToolbox {
 		unsafe public int WritePackets (bool useCache, long startingPacket, AudioStreamPacketDescription [] packetDescriptions, byte [] buffer, int offset, int byteCount, out int errorCode)
 		{
 			if (packetDescriptions is null)
-				throw new ArgumentNullException (nameof (packetDescriptions));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (packetDescriptions));
 			if (buffer is null)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 			if (offset < 0)
 				throw new ArgumentOutOfRangeException (nameof (offset), "< 0");
 			if (byteCount < 0)
@@ -1128,7 +1128,7 @@ namespace AudioToolbox {
 		public int SetUserData (int userDataId, int index, int userDataSize, IntPtr userData)
 		{
 			if (userData == IntPtr.Zero)
-				throw new ArgumentNullException (nameof (userData));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (userData));
 			return AudioFileSetUserData (Handle, userDataId, index, userDataSize, userData);
 		}
 		
@@ -1265,7 +1265,7 @@ namespace AudioToolbox {
 		public bool SetProperty (AudioFileProperty property, int dataSize, IntPtr propertyData)
 		{
 			if (propertyData == IntPtr.Zero)
-					throw new ArgumentNullException (nameof (propertyData));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (propertyData));
 			return AudioFileSetProperty (Handle, property, dataSize, propertyData) == 0;
 		}
 
@@ -1345,7 +1345,7 @@ namespace AudioToolbox {
 
 			set {
 				if (value is null)
-					throw new ArgumentNullException (nameof (value));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 
 				unsafe {
 					fixed (byte *bp = &value [0]){
@@ -1470,7 +1470,7 @@ namespace AudioToolbox {
 			}
 			set {
 				if (value is null)
-					throw new ArgumentNullException (nameof (value));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 
 				AudioFilePacketTableInfo afpti = value.Value;
 				var res = AudioFileSetProperty (Handle, AudioFileProperty.PacketTableInfo, sizeof (AudioFilePacketTableInfo), ref afpti);

--- a/src/AudioToolbox/AudioFileGlobalInfo.cs
+++ b/src/AudioToolbox/AudioFileGlobalInfo.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Collections.Generic;
@@ -39,7 +41,7 @@ namespace AudioToolbox {
 
 	public unsafe static class AudioFileGlobalInfo
 	{
-		public static AudioFileType[] ReadableTypes {
+		public static AudioFileType[]? ReadableTypes {
 			get {
 				uint size;
 				if (AudioFileGetGlobalInfoSize (AudioFileGlobalProperty.ReadableTypes, 0, IntPtr.Zero, out size) != 0)
@@ -56,7 +58,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public static AudioFileType[] WritableTypes {
+		public static AudioFileType[]? WritableTypes {
 			get {
 				uint size;
 				if (AudioFileGetGlobalInfoSize (AudioFileGlobalProperty.WritableTypes, 0, IntPtr.Zero, out size) != 0)
@@ -73,7 +75,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public static string GetFileTypeName (AudioFileType fileType)
+		public static string? GetFileTypeName (AudioFileType fileType)
 		{
 			IntPtr ptr;
 			var size = (uint) sizeof (IntPtr);
@@ -83,7 +85,7 @@ namespace AudioToolbox {
 			return CFString.FromHandle (ptr);
 		}
 
-		public static AudioFormatType[] GetAvailableFormats (AudioFileType fileType)
+		public static AudioFormatType[]? GetAvailableFormats (AudioFileType fileType)
 		{
 			uint size;
 			if (AudioFileGetGlobalInfoSize (AudioFileGlobalProperty.AvailableFormatIDs, sizeof (AudioFileType), ref fileType, out size) != 0)
@@ -99,7 +101,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public static AudioStreamBasicDescription[] GetAvailableStreamDescriptions (AudioFileType fileType, AudioFormatType formatType)
+		public static AudioStreamBasicDescription[]? GetAvailableStreamDescriptions (AudioFileType fileType, AudioFormatType formatType)
 		{
 			AudioFileTypeAndFormatID input;
 			input.FileType = fileType;
@@ -119,7 +121,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public static string[] AllExtensions {
+		public static string?[]? AllExtensions {
 			get {
 				IntPtr ptr;
 				var size = (uint) sizeof (IntPtr);
@@ -130,7 +132,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public static string[] AllUTIs {
+		public static string?[]? AllUTIs {
 			get {
 				IntPtr ptr;
 				var size = (uint) sizeof (IntPtr);
@@ -141,7 +143,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public static string[] AllMIMETypes {
+		public static string?[]? AllMIMETypes {
 			get {
 				IntPtr ptr;
 				var size = (uint) sizeof (IntPtr);
@@ -172,7 +174,7 @@ namespace AudioToolbox {
 		}
 		*/
 
-		public static string[] GetExtensions (AudioFileType fileType)
+		public static string?[]? GetExtensions (AudioFileType fileType)
 		{
 			IntPtr ptr;
 			var size = (uint) sizeof (IntPtr);
@@ -182,7 +184,7 @@ namespace AudioToolbox {
 			return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FromHandle (l));
 		}
 
-		public static string[] GetUTIs (AudioFileType fileType)
+		public static string?[]? GetUTIs (AudioFileType fileType)
 		{
 			IntPtr ptr;
 			var size = (uint) sizeof (IntPtr);
@@ -192,7 +194,7 @@ namespace AudioToolbox {
 			return NSArray.ArrayFromHandleFunc (ptr, l => CFString.FromHandle (l));
 		}
 
-		public static string[] GetMIMETypes (AudioFileType fileType)
+		public static string?[]? GetMIMETypes (AudioFileType fileType)
 		{
 			IntPtr ptr;
 			var size = (uint) sizeof (IntPtr);

--- a/src/AudioToolbox/AudioFileStream.cs
+++ b/src/AudioToolbox/AudioFileStream.cs
@@ -188,7 +188,7 @@ namespace AudioToolbox {
 		protected virtual void OnPacketDecoded (int numberOfBytes, IntPtr inputData, AudioStreamPacketDescription []? packetDescriptions)
 		{
 			var p = PacketDecoded;
-			if (p != null)
+			if (p is not null)
 				p (this, new PacketReceivedEventArgs (numberOfBytes, inputData, packetDescriptions));
 		}
 
@@ -196,7 +196,7 @@ namespace AudioToolbox {
 		protected virtual void OnPropertyFound (AudioFileStreamProperty propertyID, ref AudioFileStreamPropertyFlag ioFlags)
 		{
 			var p = PropertyFound;
-			if (p != null){
+			if (p is not null){
 				var pf = new PropertyFoundEventArgs (propertyID, ioFlags);
 				p (this, pf);
 				ioFlags = pf.Flags; 
@@ -240,7 +240,7 @@ namespace AudioToolbox {
 
 		public AudioFileStreamStatus ParseBytes (byte [] bytes, bool discontinuity)
 		{
-			if (bytes == null)
+			if (bytes is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (bytes));
 			unsafe {
 				fixed (byte *bp = &bytes[0]){
@@ -251,7 +251,7 @@ namespace AudioToolbox {
 		
 		public AudioFileStreamStatus ParseBytes (byte [] bytes, int offset, int count, bool discontinuity)
 		{
-			if (bytes == null)
+			if (bytes is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (bytes));
 			if (offset < 0)
 				throw new ArgumentException ("offset");

--- a/src/AudioToolbox/AudioFileStream.cs
+++ b/src/AudioToolbox/AudioFileStream.cs
@@ -428,7 +428,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe AudioFormat[]? FormatList {
+		public unsafe AudioFormat []? FormatList {
 			get {
 				int size;
 				var r = GetProperty (AudioFileStreamProperty.FormatList, out size);

--- a/src/AudioToolbox/AudioFileStream.cs
+++ b/src/AudioToolbox/AudioFileStream.cs
@@ -27,6 +27,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Collections.Generic;
@@ -102,7 +104,7 @@ namespace AudioToolbox {
 	}
 
 	public class PacketReceivedEventArgs : EventArgs {
-		public PacketReceivedEventArgs (int numberOfBytes, IntPtr inputData, AudioStreamPacketDescription [] packetDescriptions)
+		public PacketReceivedEventArgs (int numberOfBytes, IntPtr inputData, AudioStreamPacketDescription []? packetDescriptions)
 		{
 			this.Bytes = numberOfBytes;
 			this.InputData = inputData;
@@ -110,11 +112,11 @@ namespace AudioToolbox {
 		}
 		public int Bytes { get; private set; }
 		public IntPtr InputData { get; private set; }
-		public AudioStreamPacketDescription [] PacketDescriptions { get; private set;}
+		public AudioStreamPacketDescription []? PacketDescriptions { get; private set;}
 
 		public override string ToString ()
 		{
-			return String.Format ("Packet (Bytes={0} InputData={1} PacketDescriptions={2}", Bytes, InputData, PacketDescriptions.Length);
+			return String.Format ("Packet (Bytes={0} InputData={1} PacketDescriptions={2}", Bytes, InputData, PacketDescriptions!.Length);
 		}
 	}
 	
@@ -179,18 +181,18 @@ namespace AudioToolbox {
 			var afs = handle.Target as AudioFileStream;
 
 			var desc = AudioFile.PacketDescriptionFrom (numberPackets, packetDescriptions);
-			afs.OnPacketDecoded (numberBytes, inputData, desc);
+			afs!.OnPacketDecoded (numberBytes, inputData, desc);
 		}
 
-		public EventHandler<PacketReceivedEventArgs> PacketDecoded;
-		protected virtual void OnPacketDecoded (int numberOfBytes, IntPtr inputData, AudioStreamPacketDescription [] packetDescriptions)
+		public EventHandler<PacketReceivedEventArgs>? PacketDecoded;
+		protected virtual void OnPacketDecoded (int numberOfBytes, IntPtr inputData, AudioStreamPacketDescription []? packetDescriptions)
 		{
 			var p = PacketDecoded;
 			if (p != null)
 				p (this, new PacketReceivedEventArgs (numberOfBytes, inputData, packetDescriptions));
 		}
 
-		public EventHandler<PropertyFoundEventArgs> PropertyFound;
+		public EventHandler<PropertyFoundEventArgs>? PropertyFound;
 		protected virtual void OnPropertyFound (AudioFileStreamProperty propertyID, ref AudioFileStreamPropertyFlag ioFlags)
 		{
 			var p = PropertyFound;
@@ -207,7 +209,7 @@ namespace AudioToolbox {
 			GCHandle handle = GCHandle.FromIntPtr (clientData);
 			var afs = handle.Target as AudioFileStream;
 
-			afs.OnPropertyFound (propertyID, ref ioFlags);
+			afs!.OnPropertyFound (propertyID, ref ioFlags);
 		}
 		
 		public AudioFileStream (AudioFileType fileTypeHint)
@@ -374,7 +376,7 @@ namespace AudioToolbox {
 			try {
 				LastError = AudioFileStreamGetProperty (handle, property, ref size, buffer);
 				if (LastError == 0){
-					return (T) Marshal.PtrToStructure (buffer, typeof (T));
+					return (T) Marshal.PtrToStructure (buffer, typeof (T))!;
 				}
 
 				return null;
@@ -426,7 +428,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe AudioFormat [] FormatList {
+		public unsafe AudioFormat[]? FormatList {
 			get {
 				int size;
 				var r = GetProperty (AudioFileStreamProperty.FormatList, out size);
@@ -491,7 +493,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public AudioChannelLayout ChannelLayout {
+		public AudioChannelLayout? ChannelLayout {
 			get {
 				int size;
 				var h = GetProperty (AudioFileStreamProperty.ChannelLayout, out size);

--- a/src/AudioToolbox/AudioFileStream.cs
+++ b/src/AudioToolbox/AudioFileStream.cs
@@ -234,14 +234,14 @@ namespace AudioToolbox {
 		public AudioFileStreamStatus ParseBytes (int size, IntPtr data, bool discontinuity)
 		{
 			if (data == IntPtr.Zero)
-				throw new ArgumentNullException ("data");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 			return LastError = AudioFileStreamParseBytes (handle, size, data, discontinuity ? (uint) 1 : (uint) 0);
 		}
 
 		public AudioFileStreamStatus ParseBytes (byte [] bytes, bool discontinuity)
 		{
 			if (bytes == null)
-				throw new ArgumentNullException ("bytes");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (bytes));
 			unsafe {
 				fixed (byte *bp = &bytes[0]){
 					return LastError = AudioFileStreamParseBytes (handle, bytes.Length, (IntPtr) bp, discontinuity ? (uint) 1 : (uint) 0);
@@ -252,7 +252,7 @@ namespace AudioToolbox {
 		public AudioFileStreamStatus ParseBytes (byte [] bytes, int offset, int count, bool discontinuity)
 		{
 			if (bytes == null)
-				throw new ArgumentNullException ("bytes");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (bytes));
 			if (offset < 0)
 				throw new ArgumentException ("offset");
 			if (count < 0)
@@ -303,7 +303,7 @@ namespace AudioToolbox {
 		public bool GetProperty (AudioFileStreamProperty property, ref int dataSize, IntPtr outPropertyData)
 		{
 			if (outPropertyData == IntPtr.Zero)
-				throw new ArgumentNullException ("outPropertyData");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outPropertyData));
 			return AudioFileStreamGetProperty (handle, property, ref dataSize, outPropertyData) == 0;
 		}
 
@@ -395,7 +395,7 @@ namespace AudioToolbox {
 		public bool SetProperty (AudioFileStreamProperty property, int dataSize, IntPtr propertyData)
 		{
 			if (propertyData == IntPtr.Zero)
-				throw new ArgumentNullException ("propertyData");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (propertyData));
 			LastError = AudioFileStreamSetProperty (handle, property, dataSize, propertyData);
 			return LastError == 0;
 		}

--- a/src/AudioToolbox/AudioFileStream.cs
+++ b/src/AudioToolbox/AudioFileStream.cs
@@ -116,7 +116,7 @@ namespace AudioToolbox {
 
 		public override string ToString ()
 		{
-			return String.Format ("Packet (Bytes={0} InputData={1} PacketDescriptions={2}", Bytes, InputData, PacketDescriptions!.Length);
+			return String.Format ("Packet (Bytes={0} InputData={1} PacketDescriptions={2}", Bytes, InputData, PacketDescriptions?.Length ?? -1);
 		}
 	}
 	

--- a/src/AudioToolbox/AudioFormat.cs
+++ b/src/AudioToolbox/AudioFormat.cs
@@ -26,6 +26,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.IO;
 using System.Collections.Generic;
@@ -129,7 +132,7 @@ namespace AudioToolbox {
 		public AudioBalanceFadeType Type { get; set; }
 		public AudioChannelLayout ChannelLayout { get; private set; }
 
-		public unsafe float[] GetBalanceFade ()
+		public unsafe float[]? GetBalanceFade ()
 		{
 			var type_size = sizeof (Layout);
 
@@ -201,11 +204,11 @@ namespace AudioToolbox {
 
 		public PanningMode PanningMode { get; set; }
 		public AudioChannelFlags CoordinateFlags { get; set; }
-		public float[] Coordinates { get; private set; }
+		public float [] Coordinates { get; private set; } = Array.Empty<float> ();
 		public float GainScale { get; set; }
 		public AudioChannelLayout OutputChannelMap { get; private set; }
 
-		public unsafe float[] GetPanningMatrix ()
+		public unsafe float[]? GetPanningMatrix ()
 		{
 			var type_size = sizeof (Layout);
 

--- a/src/AudioToolbox/AudioFormat.cs
+++ b/src/AudioToolbox/AudioFormat.cs
@@ -56,7 +56,7 @@ namespace AudioToolbox {
 #if !WATCH
 		public unsafe static AudioFormat? GetFirstPlayableFormat (AudioFormat[] formatList)
 		{
-			if (formatList == null)
+			if (formatList is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (formatList));
 			if (formatList.Length < 2)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (formatList));
@@ -121,7 +121,7 @@ namespace AudioToolbox {
 
 		public AudioBalanceFade (AudioChannelLayout channelLayout)
 		{
-			if (channelLayout == null)
+			if (channelLayout is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (channelLayout));
 
 			this.ChannelLayout = channelLayout;
@@ -165,7 +165,7 @@ namespace AudioToolbox {
 				Type = Type,
 			};
 
-			if (ChannelLayout != null) {
+			if (ChannelLayout is not null) {
 				int temp;
 				l.ChannelLayoutWeak = ChannelLayout.ToBlock (out temp);
 			}
@@ -196,7 +196,7 @@ namespace AudioToolbox {
 
 		public AudioPanningInfo (AudioChannelLayout outputChannelMap)
 		{
-			if (outputChannelMap == null)
+			if (outputChannelMap is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputChannelMap));
 
 			this.OutputChannelMap = outputChannelMap;
@@ -244,7 +244,7 @@ namespace AudioToolbox {
 				GainScale = GainScale
 			};
 
-			if (OutputChannelMap != null) {
+			if (OutputChannelMap is not null) {
 				int temp;
 				l.OutputChannelMapWeak = OutputChannelMap.ToBlock (out temp);
 			}

--- a/src/AudioToolbox/AudioFormat.cs
+++ b/src/AudioToolbox/AudioFormat.cs
@@ -204,7 +204,7 @@ namespace AudioToolbox {
 
 		public PanningMode PanningMode { get; set; }
 		public AudioChannelFlags CoordinateFlags { get; set; }
-		public float [] Coordinates { get; private set; } = Array.Empty<float> ();
+		public float[] Coordinates { get; private set; } = Array.Empty<float> ();
 		public float GainScale { get; set; }
 		public AudioChannelLayout OutputChannelMap { get; private set; }
 

--- a/src/AudioToolbox/AudioFormat.cs
+++ b/src/AudioToolbox/AudioFormat.cs
@@ -57,9 +57,9 @@ namespace AudioToolbox {
 		public unsafe static AudioFormat? GetFirstPlayableFormat (AudioFormat[] formatList)
 		{
 			if (formatList == null)
-				throw new ArgumentNullException ("formatList");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (formatList));
 			if (formatList.Length < 2)
-				throw new ArgumentException ("formatList");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (formatList));
 
  			fixed (AudioFormat* item = &formatList[0]) {
 				uint index;
@@ -122,7 +122,7 @@ namespace AudioToolbox {
 		public AudioBalanceFade (AudioChannelLayout channelLayout)
 		{
 			if (channelLayout == null)
-				throw new ArgumentNullException ("channelLayout");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (channelLayout));
 
 			this.ChannelLayout = channelLayout;
 		}
@@ -197,7 +197,7 @@ namespace AudioToolbox {
 		public AudioPanningInfo (AudioChannelLayout outputChannelMap)
 		{
 			if (outputChannelMap == null)
-				throw new ArgumentNullException ("outputChannelMap");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputChannelMap));
 
 			this.OutputChannelMap = outputChannelMap;
 		}

--- a/src/AudioToolbox/AudioFormatAvailability.cs
+++ b/src/AudioToolbox/AudioFormatAvailability.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -37,27 +39,27 @@ namespace AudioToolbox {
 
 	public static class AudioFormatAvailability
 	{
-		public static AudioValueRange[] GetAvailableEncodeBitRates (AudioFormatType format)
+		public static AudioValueRange[]? GetAvailableEncodeBitRates (AudioFormatType format)
 		{
 			return GetAvailable<AudioValueRange> (AudioFormatProperty.AvailableEncodeBitRates, format);
 		}
 
-		public static AudioValueRange[] GetAvailableEncodeSampleRates (AudioFormatType format)
+		public static AudioValueRange[]? GetAvailableEncodeSampleRates (AudioFormatType format)
 		{
 			return GetAvailable<AudioValueRange> (AudioFormatProperty.AvailableEncodeSampleRates, format);
 		}
 
-		public static AudioClassDescription[] GetDecoders (AudioFormatType format)
+		public static AudioClassDescription[]? GetDecoders (AudioFormatType format)
 		{
 			return GetAvailable<AudioClassDescription> (AudioFormatProperty.Decoders, format);
 		}
 
-		public static AudioClassDescription[] GetEncoders (AudioFormatType format)
+		public static AudioClassDescription[]? GetEncoders (AudioFormatType format)
 		{
 			return GetAvailable<AudioClassDescription> (AudioFormatProperty.Encoders, format);
 		}
 
-		unsafe static T[] GetAvailable<T> (AudioFormatProperty prop, AudioFormatType format)
+		unsafe static T[]? GetAvailable<T> (AudioFormatProperty prop, AudioFormatType format)
 		{		
 			uint size;
 			if (AudioFormatPropertyNative.AudioFormatGetPropertyInfo (prop, sizeof (AudioFormatType), ref format, out size) != 0)

--- a/src/AudioToolbox/AudioQueue.cs
+++ b/src/AudioToolbox/AudioQueue.cs
@@ -386,7 +386,7 @@ namespace AudioToolbox {
 		{
 			if (handle != IntPtr.Zero){
 				if (disposing){
-					if (listeners != null){
+					if (listeners is not null){
 						foreach (AudioQueueProperty prop in listeners.Keys){
 							AudioQueueRemovePropertyListener (handle, prop, property_changed, GCHandle.ToIntPtr (gch));
 						}
@@ -509,10 +509,10 @@ namespace AudioToolbox {
 
 		public unsafe AudioQueueStatus EnqueueBuffer (AudioQueueBuffer* audioQueueBuffer, AudioStreamPacketDescription [] desc)
 		{
-			if (audioQueueBuffer == null)
+			if (audioQueueBuffer is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
-			return AudioQueueEnqueueBuffer (handle, audioQueueBuffer, desc == null ? 0 : desc.Length, desc);
+			return AudioQueueEnqueueBuffer (handle, audioQueueBuffer, desc?.Length ?? 0, desc);
 		}
 
 		public unsafe AudioQueueStatus EnqueueBuffer (IntPtr audioQueueBuffer, AudioStreamPacketDescription [] desc)
@@ -520,7 +520,7 @@ namespace AudioToolbox {
 			if (audioQueueBuffer == IntPtr.Zero)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
-			return AudioQueueEnqueueBuffer (handle, (AudioQueueBuffer *) audioQueueBuffer, desc == null ? 0 : desc.Length, desc);
+			return AudioQueueEnqueueBuffer (handle, (AudioQueueBuffer *) audioQueueBuffer, desc?.Length ?? 0, desc);
 		}
 		
 		[DllImport (Constants.AudioToolboxLibrary)]
@@ -561,8 +561,8 @@ namespace AudioToolbox {
 				buffer->AudioDataByteSize = (uint) bytes;
 
 				return AudioQueueEnqueueBufferWithParameters (
-					handle, buffer, desc == null ? 0 : desc.Length, desc,
-					trimFramesAtStart, trimFramesAtEnd, parameterEvents == null ? 0 : parameterEvents.Length,
+					handle, buffer, desc?.Length ?? 0, desc,
+					trimFramesAtStart, trimFramesAtEnd, parameterEvents?.Length ?? 0,
 					parameterEvents,
 					ref startTime,
 					out actualStartTime);
@@ -580,8 +580,8 @@ namespace AudioToolbox {
 				buffer->AudioDataByteSize = (uint) bytes;
 
 				return AudioQueueEnqueueBufferWithParameters (
-					handle, buffer, desc == null ? 0 : desc.Length, desc,
-					trimFramesAtStart, trimFramesAtEnd, parameterEvents == null ? 0 : parameterEvents.Length,
+					handle, buffer, desc?.Length ?? 0, desc,
+					trimFramesAtStart, trimFramesAtEnd, parameterEvents?.Length ?? 0,
 					parameterEvents,
 					null,
 					out actualStartTime);
@@ -592,12 +592,12 @@ namespace AudioToolbox {
 						       int trimFramesAtStart, int trimFramesAtEnd, AudioQueueParameterEvent [] parameterEvents,
 						       ref AudioTimeStamp startTime, out AudioTimeStamp actualStartTime)
 		{
-			if (audioQueueBuffer == null)
+			if (audioQueueBuffer is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			return AudioQueueEnqueueBufferWithParameters (
-				handle, audioQueueBuffer, desc == null ? 0 : desc.Length, desc,
-				trimFramesAtStart, trimFramesAtEnd, parameterEvents == null ? 0 : parameterEvents.Length,
+				handle, audioQueueBuffer, desc?.Length ?? 0, desc,
+				trimFramesAtStart, trimFramesAtEnd,parameterEvents?.Length ?? 0,
 				parameterEvents,
 				ref startTime,
 				out actualStartTime);
@@ -607,12 +607,12 @@ namespace AudioToolbox {
 						       int trimFramesAtStart, int trimFramesAtEnd, AudioQueueParameterEvent [] parameterEvents,
 						       out AudioTimeStamp actualStartTime)
 		{
-			if (audioQueueBuffer == null)
+			if (audioQueueBuffer is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			return AudioQueueEnqueueBufferWithParameters (
-				handle, audioQueueBuffer, desc == null ? 0 : desc.Length, desc,
-				trimFramesAtStart, trimFramesAtEnd, parameterEvents == null ? 0 : parameterEvents.Length,
+				handle, audioQueueBuffer, desc?.Length ?? 0, desc,
+				trimFramesAtStart, trimFramesAtEnd, parameterEvents?.Length ?? 0,
 				parameterEvents,
 				null,
 				out actualStartTime);
@@ -636,7 +636,7 @@ namespace AudioToolbox {
 		public AudioQueueStatus GetCurrentTime (AudioQueueTimeline timeline, ref AudioTimeStamp time, ref bool timelineDiscontinuty)
 		{
 			IntPtr arg;
-			if (timeline == null)
+			if (timeline is null)
 				arg = IntPtr.Zero;
 			else {
 				arg = timeline.timelineHandle;
@@ -755,7 +755,7 @@ namespace AudioToolbox {
 			var aq = gch.Target as AudioQueue;
 			lock (aq!.listeners!){
 				ArrayList a = (ArrayList)aq.listeners [id]!;
-				if (a == null)
+				if (a is null)
 					return;
 				foreach (AudioQueuePropertyChanged cback in a){
 					cback (id);
@@ -767,15 +767,15 @@ namespace AudioToolbox {
 		
 		public AudioQueueStatus AddListener (AudioQueueProperty property, AudioQueuePropertyChanged callback)
 		{
-			if (callback == null)
+			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
-			if (listeners == null)
+			if (listeners is null)
 				listeners = new Hashtable ();
 			
 			AudioQueueStatus res = AudioQueueStatus.Ok;
 			lock (listeners){
 				var a = (ArrayList) listeners [property]!;
-				if (a == null){
+				if (a is null){
 					res = AudioQueueAddPropertyListener (handle, property, property_changed, GCHandle.ToIntPtr (gch));
 					if (res != AudioQueueStatus.Ok)
 						return res;
@@ -790,13 +790,13 @@ namespace AudioToolbox {
 
 		public void RemoveListener (AudioQueueProperty property, AudioQueuePropertyChanged callback)
 		{
-			if (callback == null)
+			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
-			if (listeners == null)
+			if (listeners is null)
 				return;
 			lock (listeners){
 				var a = (ArrayList) listeners [property]!;
-				if (a == null)
+				if (a is null)
 					return;
 				a.Remove (callback);
 				if (a.Count == 0){
@@ -986,7 +986,7 @@ namespace AudioToolbox {
 			}
 
 			set {
-				if (value == null)
+				if (value is null)
 					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 
 				if (value.Length == 0)
@@ -1014,7 +1014,7 @@ namespace AudioToolbox {
 			}
 
 			set {
-				if (value == null)
+				if (value is null)
 					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value)); // TODO: enable ?
 
 				int size;
@@ -1118,7 +1118,7 @@ namespace AudioToolbox {
 
 		public AudioQueueStatus SetChannelAssignments (params AudioQueueChannelAssignment[] channelAssignments)
 		{
-			if (channelAssignments == null)
+			if (channelAssignments is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (channelAssignments));
 
 			int length;
@@ -1236,7 +1236,7 @@ namespace AudioToolbox {
 		public AudioQueueStatus GetSourceAudio (uint numberOfFrames, ref AudioTimeStamp timeStamp,
 		                                        out AudioQueueProcessingTapFlags flags, out uint parentNumberOfFrames, AudioBuffers data)
 		{
-			if (data == null)
+			if (data is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 
 			return AudioQueueProcessingTapGetSourceAudio (TapHandle, numberOfFrames, ref timeStamp,
@@ -1269,7 +1269,7 @@ namespace AudioToolbox {
 						
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static OSStatus AudioQueueNewOutput (ref AudioStreamBasicDescription format, AudioQueueOutputCallback callback,
-							    IntPtr userData, IntPtr? cfrunLoop_callbackRunloop, IntPtr? cfstr_runMode,
+							    IntPtr userData, IntPtr cfrunLoop_callbackRunloop, IntPtr cfstr_runMode,
 							    uint flags, out IntPtr audioQueue);
 
 		[MonoPInvokeCallback (typeof(AudioQueueOutputCallback))]
@@ -1285,7 +1285,7 @@ namespace AudioToolbox {
 		protected virtual void OnBufferCompleted (IntPtr audioQueueBuffer)
 		{
 			var h = BufferCompleted;
-			if (h != null)
+			if (h is not null)
 				h (this, new BufferCompletedEventArgs (audioQueueBuffer));
 		}
 
@@ -1294,7 +1294,7 @@ namespace AudioToolbox {
 		}
 
 		public OutputAudioQueue (AudioStreamBasicDescription desc, CFRunLoop runLoop, string runMode)
-			: this (desc, runLoop, runMode == null ? null : new CFString (runMode))
+			: this (desc, runLoop, runMode is null ? null : new CFString (runMode))
 		{
 		}
 
@@ -1305,7 +1305,7 @@ namespace AudioToolbox {
 
 			var code = AudioQueueNewOutput (ref desc, dOutputCallback, GCHandle.ToIntPtr (gch),
 							runLoop is null ? IntPtr.Zero : runLoop.Handle,
-							runMode == null ? IntPtr.Zero : runMode.Handle, 0, out h);
+							runMode is null ? IntPtr.Zero : runMode.Handle, 0, out h);
 
 			if (code != 0) {
 				gch.Free ();
@@ -1325,7 +1325,7 @@ namespace AudioToolbox {
 		public AudioQueueStatus SetOfflineRenderFormat (AudioStreamBasicDescription desc, AudioChannelLayout layout)
 		{
 			int size;
-			var h = layout == null ? IntPtr.Zero : layout.ToBlock (out size);
+			var h = layout is null ? IntPtr.Zero : layout.ToBlock (out size);
 			try {
 				return AudioQueueSetOfflineRenderFormat (handle, ref desc, h);
 			} finally {
@@ -1343,7 +1343,7 @@ namespace AudioToolbox {
 
 		public unsafe AudioQueueStatus RenderOffline (double timeStamp, AudioQueueBuffer* audioQueueBuffer, int frameCount)
 		{
-			if (audioQueueBuffer == null)
+			if (audioQueueBuffer is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			var stamp = new AudioTimeStamp () {
@@ -1371,7 +1371,7 @@ namespace AudioToolbox {
 		protected virtual void OnInputCompleted (IntPtr audioQueueBuffer, AudioTimeStamp timeStamp, AudioStreamPacketDescription []? packetDescriptions)
 		{
 			var h = InputCompleted;
-			if (h != null)
+			if (h is not null)
 				h (this, new InputCompletedEventArgs (audioQueueBuffer, timeStamp, packetDescriptions));
 		}
 		
@@ -1394,12 +1394,12 @@ namespace AudioToolbox {
 		{
 			IntPtr h;
 			GCHandle mygch = GCHandle.Alloc (this);
-			CFString? s = runMode == null ? null : new CFString (runMode);
+			CFString? s = runMode is null ? null : new CFString (runMode);
 			
 			var code = AudioQueueNewInput (ref desc, dInputCallback, GCHandle.ToIntPtr (mygch),
 						       runLoop is null ? IntPtr.Zero : runLoop.Handle,
-						       s == null ? IntPtr.Zero : s.Handle, 0, out h);
-			if (s != null)
+						       s is null ? IntPtr.Zero : s.Handle, 0, out h);
+			if (s is not null)
 				s.Dispose ();
 			
 			if (code == 0){

--- a/src/AudioToolbox/AudioQueue.cs
+++ b/src/AudioToolbox/AudioQueue.cs
@@ -254,7 +254,7 @@ namespace AudioToolbox {
 		public IntPtr IntPtrPacketDescriptions;
 		public int PacketDescriptionCount;
 
-		public AudioStreamPacketDescription[]? PacketDescriptions {
+		public AudioStreamPacketDescription []? PacketDescriptions {
 			get {
 				return AudioFile.PacketDescriptionFrom (PacketDescriptionCount, IntPtrPacketDescriptions);
 			}

--- a/src/AudioToolbox/AudioQueue.cs
+++ b/src/AudioToolbox/AudioQueue.cs
@@ -1304,8 +1304,8 @@ namespace AudioToolbox {
 			GCHandle gch = GCHandle.Alloc (this);
 
 			var code = AudioQueueNewOutput (ref desc, dOutputCallback, GCHandle.ToIntPtr (gch),
-							runLoop is null ? IntPtr.Zero : runLoop.Handle,
-							runMode is null ? IntPtr.Zero : runMode.Handle, 0, out h);
+							runLoop.GetHandle (),
+							runMode.GetHandle (), 0, out h);
 
 			if (code != 0) {
 				gch.Free ();
@@ -1397,8 +1397,8 @@ namespace AudioToolbox {
 			CFString? s = runMode is null ? null : new CFString (runMode);
 			
 			var code = AudioQueueNewInput (ref desc, dInputCallback, GCHandle.ToIntPtr (mygch),
-						       runLoop is null ? IntPtr.Zero : runLoop.Handle,
-						       s is null ? IntPtr.Zero : s.Handle, 0, out h);
+						       runLoop.GetHandle (),
+						       s.GetHandle (), 0, out h);
 			if (s is not null)
 				s.Dispose ();
 			

--- a/src/AudioToolbox/AudioQueue.cs
+++ b/src/AudioToolbox/AudioQueue.cs
@@ -480,7 +480,7 @@ namespace AudioToolbox {
 		public void FreeBuffer (IntPtr audioQueueBuffer)
 		{
 			if (audioQueueBuffer == IntPtr.Zero)
-				throw new ArgumentNullException ("audioQueueBuffer");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 			AudioQueueFreeBuffer (handle, audioQueueBuffer);
 		}
 		
@@ -498,7 +498,7 @@ namespace AudioToolbox {
 		public AudioQueueStatus EnqueueBuffer (IntPtr audioQueueBuffer, int bytes, AudioStreamPacketDescription [] desc)
 		{
 			if (audioQueueBuffer == IntPtr.Zero)
-				throw new ArgumentNullException ("audioQueueBuffer");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			unsafe {
 				AudioQueueBuffer *buffer = (AudioQueueBuffer *) audioQueueBuffer;
@@ -510,7 +510,7 @@ namespace AudioToolbox {
 		public unsafe AudioQueueStatus EnqueueBuffer (AudioQueueBuffer* audioQueueBuffer, AudioStreamPacketDescription [] desc)
 		{
 			if (audioQueueBuffer == null)
-				throw new ArgumentNullException ("audioQueueBuffer");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			return AudioQueueEnqueueBuffer (handle, audioQueueBuffer, desc == null ? 0 : desc.Length, desc);
 		}
@@ -518,7 +518,7 @@ namespace AudioToolbox {
 		public unsafe AudioQueueStatus EnqueueBuffer (IntPtr audioQueueBuffer, AudioStreamPacketDescription [] desc)
 		{
 			if (audioQueueBuffer == IntPtr.Zero)
-				throw new ArgumentNullException ("audioQueueBuffer");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			return AudioQueueEnqueueBuffer (handle, (AudioQueueBuffer *) audioQueueBuffer, desc == null ? 0 : desc.Length, desc);
 		}
@@ -554,7 +554,7 @@ namespace AudioToolbox {
 						       ref AudioTimeStamp startTime, out AudioTimeStamp actualStartTime)
 		{
 			if (audioQueueBuffer == IntPtr.Zero)
-				throw new ArgumentNullException ("audioQueueBuffer");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			unsafe {
 				AudioQueueBuffer *buffer = (AudioQueueBuffer *) audioQueueBuffer;
@@ -573,7 +573,7 @@ namespace AudioToolbox {
 						       out AudioTimeStamp actualStartTime)
 		{
 			if (audioQueueBuffer == IntPtr.Zero)
-				throw new ArgumentNullException ("audioQueueBuffer");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			unsafe {
 				AudioQueueBuffer *buffer = (AudioQueueBuffer *) audioQueueBuffer;
@@ -593,7 +593,7 @@ namespace AudioToolbox {
 						       ref AudioTimeStamp startTime, out AudioTimeStamp actualStartTime)
 		{
 			if (audioQueueBuffer == null)
-				throw new ArgumentNullException ("audioQueueBuffer");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			return AudioQueueEnqueueBufferWithParameters (
 				handle, audioQueueBuffer, desc == null ? 0 : desc.Length, desc,
@@ -608,7 +608,7 @@ namespace AudioToolbox {
 						       out AudioTimeStamp actualStartTime)
 		{
 			if (audioQueueBuffer == null)
-				throw new ArgumentNullException ("audioQueueBuffer");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			return AudioQueueEnqueueBufferWithParameters (
 				handle, audioQueueBuffer, desc == null ? 0 : desc.Length, desc,
@@ -768,7 +768,7 @@ namespace AudioToolbox {
 		public AudioQueueStatus AddListener (AudioQueueProperty property, AudioQueuePropertyChanged callback)
 		{
 			if (callback == null)
-				throw new ArgumentNullException ("callback");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 			if (listeners == null)
 				listeners = new Hashtable ();
 			
@@ -791,7 +791,7 @@ namespace AudioToolbox {
 		public void RemoveListener (AudioQueueProperty property, AudioQueuePropertyChanged callback)
 		{
 			if (callback == null)
-				throw new ArgumentNullException ("callback");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 			if (listeners == null)
 				return;
 			lock (listeners){
@@ -825,7 +825,7 @@ namespace AudioToolbox {
 		public bool GetProperty (AudioQueueProperty property, ref int dataSize, IntPtr outdata)
 		{
 			if (outdata == IntPtr.Zero)
-				throw new ArgumentNullException ("outdata");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outdata));
 			return AudioQueueGetProperty (handle, (uint) property, outdata, ref dataSize) == 0;
 		}
 
@@ -833,7 +833,7 @@ namespace AudioToolbox {
 		public bool SetProperty (AudioQueueProperty property, int dataSize, IntPtr propertyData)
 		{
 			if (propertyData == IntPtr.Zero)
-				throw new ArgumentNullException ("propertyData");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (propertyData));
 			return AudioQueueSetProperty (handle, property, propertyData, dataSize) == 0;
 		}
 
@@ -987,7 +987,7 @@ namespace AudioToolbox {
 
 			set {
 				if (value == null)
-					throw new ArgumentNullException ("value");
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 
 				if (value.Length == 0)
 					return;
@@ -1015,7 +1015,7 @@ namespace AudioToolbox {
 
 			set {
 				if (value == null)
-					throw new ArgumentNullException ("value"); // TODO: enable ?
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value)); // TODO: enable ?
 
 				int size;
 				var h = value.ToBlock (out size);
@@ -1119,7 +1119,7 @@ namespace AudioToolbox {
 		public AudioQueueStatus SetChannelAssignments (params AudioQueueChannelAssignment[] channelAssignments)
 		{
 			if (channelAssignments == null)
-				throw new ArgumentNullException ("channelAssignments");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (channelAssignments));
 
 			int length;
 			var ptr = MarshalArray (ref channelAssignments, out length);
@@ -1237,7 +1237,7 @@ namespace AudioToolbox {
 		                                        out AudioQueueProcessingTapFlags flags, out uint parentNumberOfFrames, AudioBuffers data)
 		{
 			if (data == null)
-				throw new ArgumentNullException ("data");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 
 			return AudioQueueProcessingTapGetSourceAudio (TapHandle, numberOfFrames, ref timeStamp,
 		                                                  out flags, out parentNumberOfFrames, (IntPtr) data);
@@ -1344,7 +1344,7 @@ namespace AudioToolbox {
 		public unsafe AudioQueueStatus RenderOffline (double timeStamp, AudioQueueBuffer* audioQueueBuffer, int frameCount)
 		{
 			if (audioQueueBuffer == null)
-				throw new ArgumentNullException ("audioQueueBuffer");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioQueueBuffer));
 
 			var stamp = new AudioTimeStamp () {
 				SampleTime = timeStamp,

--- a/src/AudioToolbox/AudioServices.cs
+++ b/src/AudioToolbox/AudioServices.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/AudioToolbox/AudioSession.cs
+++ b/src/AudioToolbox/AudioSession.cs
@@ -800,7 +800,7 @@ namespace AudioToolbox {
 		public static AudioSessionErrors AddListener (AudioSessionProperty property, PropertyListener listener)
 		{
 			if (listener == null)
-				throw new ArgumentNullException ("listener");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (listener));
 
 			if (listeners == null)
 				listeners = new Hashtable ();
@@ -827,7 +827,7 @@ namespace AudioToolbox {
 		public static void RemoveListener (AudioSessionProperty property, PropertyListener listener)
 		{
 			if (listener == null)
-				throw new ArgumentNullException ("listener");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (listener));
 
 			ArrayList a = (ArrayList) listeners ![property];
 			if (a == null)

--- a/src/AudioToolbox/AudioSession.cs
+++ b/src/AudioToolbox/AudioSession.cs
@@ -28,6 +28,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Collections;
@@ -92,20 +94,20 @@ namespace AudioToolbox {
 
 	public class AccessoryInfo
 	{
-		internal AccessoryInfo (int id, string description)
+		internal AccessoryInfo (int id, string? description)
 		{
 			ID = id;
 			Description = description;
 		}
 
 		public int ID { get; private set; }
-		public string Description { get; private set; }
+		public string? Description { get; private set; }
 	}
 
 	public class InputSourceInfo
 	{
 		public int ID { get; private set; }
-		public string Description { get; private set; }
+		public string? Description { get; private set; }
 	}
 	
 	public class AudioSessionPropertyEventArgs :EventArgs {
@@ -154,7 +156,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		NSArray Extract (IntPtr key, NSString secondKey)
+		NSArray? Extract (IntPtr key, NSString secondKey)
 		{
 			var dictH = Dictionary.LowlevelObjectForKey (key);
 			if (dictH == IntPtr.Zero)
@@ -181,7 +183,7 @@ namespace AudioToolbox {
 #endif
 		public AudioSessionInputRouteKind PreviousInputRoute {
 			get {
-				using (var array = Extract (previous_route_key, AudioSession.AudioRouteKey_Inputs))
+				using (var array = Extract (previous_route_key, AudioSession.AudioRouteKey_Inputs!))
 					return AudioSession.GetInputRoute (array);
 			}
 		}
@@ -194,9 +196,9 @@ namespace AudioToolbox {
 #else
 		[Deprecated (PlatformName.iOS, 7, 0)]
 #endif
-		public AudioSessionOutputRouteKind [] PreviousOutputRoutes {
+		public AudioSessionOutputRouteKind []? PreviousOutputRoutes {
 			get {
-				using (var array = Extract (previous_route_key, AudioSession.AudioRouteKey_Outputs))
+				using (var array = Extract (previous_route_key, AudioSession.AudioRouteKey_Outputs!))
 					return AudioSession.GetOutputRoutes (array);
 			}
 		}
@@ -211,7 +213,7 @@ namespace AudioToolbox {
 #endif
 		public AudioSessionInputRouteKind CurrentInputRoute {
 			get {
-				using (var array = Extract (current_route_key, AudioSession.AudioRouteKey_Inputs))
+				using (var array = Extract (current_route_key, AudioSession.AudioRouteKey_Inputs!))
 					return AudioSession.GetInputRoute (array);
 			}
 		}
@@ -224,9 +226,9 @@ namespace AudioToolbox {
 #else
 		[Deprecated (PlatformName.iOS, 7, 0)]
 #endif
-		public AudioSessionOutputRouteKind [] CurrentOutputRoutes {
+		public AudioSessionOutputRouteKind []? CurrentOutputRoutes {
 			get {
-				using (var array = Extract (current_route_key, AudioSession.AudioRouteKey_Outputs))
+				using (var array = Extract (current_route_key, AudioSession.AudioRouteKey_Outputs!))
 					return AudioSession.GetOutputRoutes (array);
 			}
 		}
@@ -242,32 +244,32 @@ namespace AudioToolbox {
 #endif
 	public static class AudioSession {
 		static bool initialized;
-		public static event EventHandler Interrupted;
-		public static event EventHandler Resumed;
+		public static event EventHandler? Interrupted;
+		public static event EventHandler? Resumed;
 
-		internal static NSString AudioRouteKey_Type;
-		internal static NSString AudioRouteKey_Inputs;
-		internal static NSString AudioRouteKey_Outputs;
+		internal static NSString? AudioRouteKey_Type;
+		internal static NSString? AudioRouteKey_Inputs;
+		internal static NSString? AudioRouteKey_Outputs;
 		
-		static NSString InputRoute_LineIn;
-		static NSString InputRoute_BuiltInMic;
-		static NSString InputRoute_HeadsetMic;
-		static NSString InputRoute_BluetoothHFP;
-		static NSString InputRoute_USBAudio;
+		static NSString? InputRoute_LineIn;
+		static NSString? InputRoute_BuiltInMic;
+		static NSString? InputRoute_HeadsetMic;
+		static NSString? InputRoute_BluetoothHFP;
+		static NSString? InputRoute_USBAudio;
 		
-		static NSString OutputRoute_LineOut;
-		static NSString OutputRoute_Headphones;
-		static NSString OutputRoute_BluetoothHFP;
-		static NSString OutputRoute_BluetoothA2DP;
-		static NSString OutputRoute_BuiltInReceiver;
-		static NSString OutputRoute_BuiltInSpeaker;
-		static NSString OutputRoute_USBAudio;
-		static NSString OutputRoute_HDMI;
-		static NSString OutputRoute_AirPlay;
-		static NSString InputSourceKey_ID;
-		static NSString InputSourceKey_Description;
-		static NSString OutputDestinationKey_ID;
-		static NSString OutputDestinationKey_Description;
+		static NSString? OutputRoute_LineOut;
+		static NSString? OutputRoute_Headphones;
+		static NSString? OutputRoute_BluetoothHFP;
+		static NSString? OutputRoute_BluetoothA2DP;
+		static NSString? OutputRoute_BuiltInReceiver;
+		static NSString? OutputRoute_BuiltInSpeaker;
+		static NSString? OutputRoute_USBAudio;
+		static NSString? OutputRoute_HDMI;
+		static NSString? OutputRoute_AirPlay;
+		static NSString? InputSourceKey_ID;
+		static NSString? InputSourceKey_Description;
+		static NSString? OutputDestinationKey_ID;
+		static NSString? OutputDestinationKey_Description;
 		
 		[DllImport (Constants.AudioToolboxLibrary)]
 #if NET
@@ -281,16 +283,16 @@ namespace AudioToolbox {
 			Initialize (null, null);
 		}
 
-		public static void Initialize (CFRunLoop runLoop, string runMode)
+		public static void Initialize (CFRunLoop? runLoop, string? runMode)
 		{
-			CFString s = runMode == null ? null : new CFString (runMode);
+			CFString? s = runMode == null ? null : new CFString (runMode);
 #if NET
 			int k;
 			unsafe {
 				k = AudioSessionInitialize (runLoop.GetHandle (), s.GetHandle (), &Interruption, IntPtr.Zero);
 			}
 #else
-			int k = AudioSessionInitialize (runLoop == null ? IntPtr.Zero : runLoop.Handle, s == null ? IntPtr.Zero : s.Handle, Interruption, IntPtr.Zero);
+			int k = AudioSessionInitialize (runLoop is null ? IntPtr.Zero : runLoop.Handle, s == null ? IntPtr.Zero : s.Handle, Interruption, IntPtr.Zero);
 #endif
 			if (k != 0 && k != (int)AudioSessionErrors.AlreadyInitialized)
 				throw new AudioSessionException (k);
@@ -342,7 +344,7 @@ namespace AudioToolbox {
 		{
 			EventHandler h;
 
-			h = (state == 1) ? Interrupted : Resumed;
+			h = (state == 1) ? Interrupted! : Resumed!;
 			if (h != null)
 				h (null, EventArgs.Empty);
 		}
@@ -494,7 +496,7 @@ namespace AudioToolbox {
 #else
 		[Deprecated (PlatformName.iOS, 5, 0, message : "Use 'InputRoute' or 'OutputRoute' instead.")]
 #endif
-		static public string AudioRoute {
+		static public string? AudioRoute {
 			get {
 				return CFString.FromHandle (GetIntPtr (AudioSessionProperty.AudioRoute));
 			}
@@ -502,13 +504,13 @@ namespace AudioToolbox {
 
 		static public AccessoryInfo[] InputSources {
 			get {
-				return ExtractAccessoryInfo (GetIntPtr (AudioSessionProperty.InputSources), InputSourceKey_ID, InputSourceKey_Description);
+				return ExtractAccessoryInfo (GetIntPtr (AudioSessionProperty.InputSources), InputSourceKey_ID!, InputSourceKey_Description!);
 			}
 		}
 
 		static public AccessoryInfo[] OutputDestinations {
 			get {
-				return ExtractAccessoryInfo (GetIntPtr (AudioSessionProperty.OutputDestinations), OutputDestinationKey_ID, OutputDestinationKey_Description);
+				return ExtractAccessoryInfo (GetIntPtr (AudioSessionProperty.OutputDestinations), OutputDestinationKey_ID!, OutputDestinationKey_Description!);
 			}
 		}
 
@@ -550,7 +552,7 @@ namespace AudioToolbox {
 
 		*/
 
-		static internal AudioSessionInputRouteKind GetInputRoute (NSArray arr)
+		static internal AudioSessionInputRouteKind GetInputRoute (NSArray? arr)
 		{
 			if (arr == null || arr.Count == 0)
 				return AudioSessionInputRouteKind.None;
@@ -580,7 +582,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		static internal AudioSessionOutputRouteKind [] GetOutputRoutes (NSArray arr)
+		static internal AudioSessionOutputRouteKind []? GetOutputRoutes (NSArray? arr)
 		{
 			if (arr == null || arr.Count == 0)
 				return null;
@@ -629,7 +631,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		static public AudioSessionOutputRouteKind [] OutputRoutes {
+		static public AudioSessionOutputRouteKind []? OutputRoutes {
 			get {
 				return GetOutputRoutes ((NSArray) AudioRouteDescription [AudioRouteKey_Outputs]);
 			}
@@ -775,7 +777,7 @@ namespace AudioToolbox {
 #endif
 		static void Listener (IntPtr userData, AudioSessionProperty prop, int size, IntPtr data)
 		{
-			ArrayList a = (ArrayList) listeners [prop];
+			ArrayList a = (ArrayList) listeners ![prop];
 			if (a == null){
 				// Should never happen
 				return;
@@ -793,7 +795,7 @@ namespace AudioToolbox {
 		extern static AudioSessionErrors AudioSessionAddPropertyListener(AudioSessionProperty id, _PropertyListener inProc, IntPtr userData);
 #endif
 
-		static Hashtable listeners;
+		static Hashtable? listeners;
 
 		public static AudioSessionErrors AddListener (AudioSessionProperty property, PropertyListener listener)
 		{
@@ -827,7 +829,7 @@ namespace AudioToolbox {
 			if (listener == null)
 				throw new ArgumentNullException ("listener");
 
-			ArrayList a = (ArrayList) listeners [property];
+			ArrayList a = (ArrayList) listeners ![property];
 			if (a == null)
 				return;
 			a.Remove (listener);
@@ -835,7 +837,7 @@ namespace AudioToolbox {
 				listeners [property] = null;
 		}
 
-               static Hashtable strongListenerHash;
+               static Hashtable? strongListenerHash;
 
 		static void AddListenerEvent (AudioSessionProperty property, object handler, PropertyListener listener)
 		{
@@ -929,7 +931,7 @@ namespace AudioToolbox {
 		public static event Action<AccessoryInfo[]> InputSourcesChanged {
 			add {
 				AddListenerEvent (AudioSessionProperty.InputSources, value, 
-						  (prop, size, data) => value (ExtractAccessoryInfo (data, InputSourceKey_ID, InputSourceKey_Description)));
+						  (prop, size, data) => value (ExtractAccessoryInfo (data, InputSourceKey_ID!, InputSourceKey_Description!)));
 			}
 			remove {
 				RemoveListenerEvent (AudioSessionProperty.InputSources, value);
@@ -939,7 +941,7 @@ namespace AudioToolbox {
 		public static event Action<AccessoryInfo[]> OutputDestinationsChanged {
 			add {
 				AddListenerEvent (AudioSessionProperty.OutputDestinations, value, 
-						  (prop, size, data) => value (ExtractAccessoryInfo (data, OutputDestinationKey_ID, OutputDestinationKey_Description)));
+						  (prop, size, data) => value (ExtractAccessoryInfo (data, OutputDestinationKey_ID!, OutputDestinationKey_Description!)));
 			}
 			remove {
 				RemoveListenerEvent (AudioSessionProperty.OutputDestinations, value);

--- a/src/AudioToolbox/AudioSession.cs
+++ b/src/AudioToolbox/AudioSession.cs
@@ -292,7 +292,7 @@ namespace AudioToolbox {
 				k = AudioSessionInitialize (runLoop.GetHandle (), s.GetHandle (), &Interruption, IntPtr.Zero);
 			}
 #else
-			int k = AudioSessionInitialize (runLoop is null ? IntPtr.Zero : runLoop.Handle, s is null ? IntPtr.Zero : s.Handle, Interruption, IntPtr.Zero);
+			int k = AudioSessionInitialize (runLoop.GetHandle (), s.GetHandle (), Interruption, IntPtr.Zero);
 #endif
 			if (k != 0 && k != (int)AudioSessionErrors.AlreadyInitialized)
 				throw new AudioSessionException (k);

--- a/src/AudioToolbox/AudioSession.cs
+++ b/src/AudioToolbox/AudioSession.cs
@@ -285,14 +285,14 @@ namespace AudioToolbox {
 
 		public static void Initialize (CFRunLoop? runLoop, string? runMode)
 		{
-			CFString? s = runMode == null ? null : new CFString (runMode);
+			CFString? s = runMode is null ? null : new CFString (runMode);
 #if NET
 			int k;
 			unsafe {
 				k = AudioSessionInitialize (runLoop.GetHandle (), s.GetHandle (), &Interruption, IntPtr.Zero);
 			}
 #else
-			int k = AudioSessionInitialize (runLoop is null ? IntPtr.Zero : runLoop.Handle, s == null ? IntPtr.Zero : s.Handle, Interruption, IntPtr.Zero);
+			int k = AudioSessionInitialize (runLoop is null ? IntPtr.Zero : runLoop.Handle, s is null ? IntPtr.Zero : s.Handle, Interruption, IntPtr.Zero);
 #endif
 			if (k != 0 && k != (int)AudioSessionErrors.AlreadyInitialized)
 				throw new AudioSessionException (k);
@@ -345,7 +345,7 @@ namespace AudioToolbox {
 			EventHandler h;
 
 			h = (state == 1) ? Interrupted! : Resumed!;
-			if (h != null)
+			if (h is not null)
 				h (null, EventArgs.Empty);
 		}
 
@@ -554,17 +554,17 @@ namespace AudioToolbox {
 
 		static internal AudioSessionInputRouteKind GetInputRoute (NSArray? arr)
 		{
-			if (arr == null || arr.Count == 0)
+			if (arr is null || arr.Count == 0)
 				return AudioSessionInputRouteKind.None;
 			
 			var dict = new NSDictionary (arr.ValueAt (0));
 			
-			if (dict == null || dict.Count == 0)
+			if (dict is null || dict.Count == 0)
 				return AudioSessionInputRouteKind.None;
 			
 			var val = (NSString) dict [AudioRouteKey_Type];
 			
-			if (val == null)
+			if (val is null)
 				return AudioSessionInputRouteKind.None;
 			
 			if (val == InputRoute_LineIn) {
@@ -584,7 +584,7 @@ namespace AudioToolbox {
 
 		static internal AudioSessionOutputRouteKind []? GetOutputRoutes (NSArray? arr)
 		{
-			if (arr == null || arr.Count == 0)
+			if (arr is null || arr.Count == 0)
 				return null;
 			
 			var result = new AudioSessionOutputRouteKind [arr.Count];
@@ -593,12 +593,12 @@ namespace AudioToolbox {
 				
 				result [i] = AudioSessionOutputRouteKind.None;
 				
-				if (dict == null || dict.Count == 0)
+				if (dict is null || dict.Count == 0)
 					continue;
 				
 				var val = (NSString) dict [AudioRouteKey_Type];
 				
-				if (val == null)
+				if (val is null)
 					continue;
 				
 				if (val == OutputRoute_LineOut) {
@@ -778,7 +778,7 @@ namespace AudioToolbox {
 		static void Listener (IntPtr userData, AudioSessionProperty prop, int size, IntPtr data)
 		{
 			ArrayList a = (ArrayList) listeners ![prop];
-			if (a == null){
+			if (a is null){
 				// Should never happen
 				return;
 			}
@@ -799,14 +799,14 @@ namespace AudioToolbox {
 
 		public static AudioSessionErrors AddListener (AudioSessionProperty property, PropertyListener listener)
 		{
-			if (listener == null)
+			if (listener is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (listener));
 
-			if (listeners == null)
+			if (listeners is null)
 				listeners = new Hashtable ();
 
 			ArrayList a = (ArrayList) listeners [property];
-			if (a == null)
+			if (a is null)
 				listeners [property] = a = new ArrayList ();
 
 			a.Add (listener);
@@ -826,11 +826,11 @@ namespace AudioToolbox {
 
 		public static void RemoveListener (AudioSessionProperty property, PropertyListener listener)
 		{
-			if (listener == null)
+			if (listener is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (listener));
 
 			ArrayList a = (ArrayList) listeners ![property];
-			if (a == null)
+			if (a is null)
 				return;
 			a.Remove (listener);
 			if (a.Count == 0)
@@ -841,7 +841,7 @@ namespace AudioToolbox {
 
 		static void AddListenerEvent (AudioSessionProperty property, object handler, PropertyListener listener)
 		{
-			if (strongListenerHash == null)
+			if (strongListenerHash is null)
 				Interlocked.CompareExchange (ref strongListenerHash, new Hashtable (), null);
 
 			lock (strongListenerHash) {
@@ -853,13 +853,13 @@ namespace AudioToolbox {
 
 		static void RemoveListenerEvent (AudioSessionProperty property, object handler)
 		{
-			if (strongListenerHash == null)
+			if (strongListenerHash is null)
 				return;
 
 			PropertyListener listener;
 			lock (strongListenerHash) {
 				listener = (PropertyListener) strongListenerHash [handler]; 
-				if (listener == null)
+				if (listener is null)
 					return;
 
 				strongListenerHash.Remove (handler);

--- a/src/AudioToolbox/AudioToolbox.cs
+++ b/src/AudioToolbox/AudioToolbox.cs
@@ -4,6 +4,8 @@
 // Copyright 2013-2014 Xamarin Inc.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -34,15 +36,15 @@ namespace AudioToolbox {
 		}
 
 		public int MSB {
-			get { return (Dictionary [MSBKey] as NSNumber).Int32Value; }
+			get { return (Dictionary [MSBKey] as NSNumber)!.Int32Value; }
 		}
 
 		public int LSB {
-			get { return (Dictionary [LSBKey] as NSNumber).Int32Value; }
+			get { return (Dictionary [LSBKey] as NSNumber)!.Int32Value; }
 		}
 
 		public int Program {
-			get { return (Dictionary [ProgramKey] as NSNumber).Int32Value; }
+			get { return (Dictionary [ProgramKey] as NSNumber)!.Int32Value; }
 		}
 
 		// some API likely wants the [CF|NS]Dictionary
@@ -64,12 +66,12 @@ namespace AudioToolbox {
 #else
 		[iOS (7,0)] // 10.5
 #endif
-		public static string GetName (NSUrl url)
+		public static string? GetName (NSUrl url)
 		{
 			if (url == null)
 				throw new ArgumentNullException ("url");
 
-			string result = null;
+			string? result = null;
 			IntPtr name = IntPtr.Zero;
 			var error = CopyNameFromSoundBank (url.Handle, ref name);
 			if (name != IntPtr.Zero) {
@@ -96,12 +98,12 @@ namespace AudioToolbox {
 		[iOS (7,0)]
 		[Mac (10,9)]
 #endif
-		public static InstrumentInfo [] GetInstrumentInfo (NSUrl url)
+		public static InstrumentInfo []? GetInstrumentInfo (NSUrl url)
 		{
 			if (url == null)
 				throw new ArgumentNullException ("url");
 
-			InstrumentInfo [] result = null;
+			InstrumentInfo []? result = null;
 			IntPtr array = IntPtr.Zero;
 			var error = CopyInstrumentInfoFromSoundBank (url.Handle, ref array);
 			if (array != IntPtr.Zero) {

--- a/src/AudioToolbox/AudioToolbox.cs
+++ b/src/AudioToolbox/AudioToolbox.cs
@@ -69,7 +69,7 @@ namespace AudioToolbox {
 		public static string? GetName (NSUrl url)
 		{
 			if (url == null)
-				throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			string? result = null;
 			IntPtr name = IntPtr.Zero;
@@ -101,7 +101,7 @@ namespace AudioToolbox {
 		public static InstrumentInfo []? GetInstrumentInfo (NSUrl url)
 		{
 			if (url == null)
-				throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			InstrumentInfo []? result = null;
 			IntPtr array = IntPtr.Zero;

--- a/src/AudioToolbox/AudioToolbox.cs
+++ b/src/AudioToolbox/AudioToolbox.cs
@@ -68,7 +68,7 @@ namespace AudioToolbox {
 #endif
 		public static string? GetName (NSUrl url)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			string? result = null;
@@ -100,7 +100,7 @@ namespace AudioToolbox {
 #endif
 		public static InstrumentInfo []? GetInstrumentInfo (NSUrl url)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			InstrumentInfo []? result = null;

--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -259,7 +259,7 @@ namespace AudioToolbox {
 
 		public unsafe AudioFormat []? GetFormatList (byte[] magicCookie)
 		{
-			if (magicCookie == null)
+			if (magicCookie is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (magicCookie));
 
 			var afi = new AudioFormatInfo ();
@@ -966,7 +966,7 @@ namespace AudioToolbox {
 		// The returned block must be released with FreeHGlobal
 		internal unsafe IntPtr ToBlock (out int size)
 		{
-			if (Channels == null)
+			if (Channels is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (Channels));
 			
 			var desc_size = sizeof (AudioChannelDescription);
@@ -989,7 +989,7 @@ namespace AudioToolbox {
 #if !WATCH
 		public static AudioFormatError Validate (AudioChannelLayout layout)
 		{
-			if (layout == null)
+			if (layout is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (layout));
 
 			int ptr_size;
@@ -1002,13 +1002,13 @@ namespace AudioToolbox {
 
 		public unsafe static int []? GetChannelMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
 		{
-			if (inputLayout == null)
+			if (inputLayout is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inputLayout));
-			if (outputLayout == null)
+			if (outputLayout is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputLayout));
 
 			var channels_count = GetNumberOfChannels (outputLayout);
-			if (channels_count == null)
+			if (channels_count is null)
 				throw new ArgumentException ("outputLayout");
 
 			int ptr_size;
@@ -1036,17 +1036,17 @@ namespace AudioToolbox {
 
 		public unsafe static float [,]? GetMatrixMixMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
 		{
-			if (inputLayout == null)
+			if (inputLayout is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inputLayout));
-			if (outputLayout == null)
+			if (outputLayout is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputLayout));
 
 			var channels_count_output = GetNumberOfChannels (outputLayout);
-			if (channels_count_output == null)
+			if (channels_count_output is null)
 				throw new ArgumentException ("outputLayout");
 
 			var channels_count_input = GetNumberOfChannels (inputLayout);
-			if (channels_count_input == null)
+			if (channels_count_input is null)
 				throw new ArgumentException ("inputLayout");
 
 			int ptr_size;
@@ -1074,7 +1074,7 @@ namespace AudioToolbox {
 
 		public static int? GetNumberOfChannels (AudioChannelLayout layout)
 		{
-			if (layout == null)
+			if (layout is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (layout));
 
 			int ptr_size;
@@ -1089,7 +1089,7 @@ namespace AudioToolbox {
 
 		public static AudioChannelLayoutTag? GetTagForChannelLayout (AudioChannelLayout layout)
 		{
-			if (layout == null)
+			if (layout is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (layout));
 
 			int ptr_size;

--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -201,7 +201,7 @@ namespace AudioToolbox {
 		}
 
 #if !WATCH
-		public unsafe static AudioChannelLayoutTag []? GetAvailableEncodeChannelLayoutTags (AudioStreamBasicDescription format)
+		public unsafe static AudioChannelLayoutTag[]? GetAvailableEncodeChannelLayoutTags (AudioStreamBasicDescription format)
 		{
 			var type_size = sizeof (AudioStreamBasicDescription);
 			uint size;
@@ -218,7 +218,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe static int []? GetAvailableEncodeNumberChannels (AudioStreamBasicDescription format)
+		public unsafe static int[]? GetAvailableEncodeNumberChannels (AudioStreamBasicDescription format)
 		{
 			uint size;
 			if (AudioFormatPropertyNative.AudioFormatGetPropertyInfo (AudioFormatProperty.AvailableEncodeNumberChannels, sizeof (AudioStreamBasicDescription), ref format, out size) != 0)
@@ -234,7 +234,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe AudioFormat []? GetOutputFormatList (byte []? magicCookie = null)
+		public unsafe AudioFormat[]? GetOutputFormatList (byte[]? magicCookie = null)
 		{
 			var afi = new AudioFormatInfo ();
 			afi.AudioStreamBasicDescription = this;
@@ -257,7 +257,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe AudioFormat []? GetFormatList (byte[] magicCookie)
+		public unsafe AudioFormat[]? GetFormatList (byte[] magicCookie)
 		{
 			if (magicCookie is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (magicCookie));
@@ -888,7 +888,7 @@ namespace AudioToolbox {
 
 		public AudioChannelLayoutTag AudioTag;
 		public AudioChannelBit ChannelUsage;
-		public AudioChannelDescription []? Channels;
+		public AudioChannelDescription[]? Channels;
 
 #if !WATCH
 		public unsafe string? Name {
@@ -1000,7 +1000,7 @@ namespace AudioToolbox {
 			return res;
 		}
 
-		public unsafe static int []? GetChannelMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
+		public unsafe static int[]? GetChannelMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
 		{
 			if (inputLayout is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inputLayout));
@@ -1034,7 +1034,7 @@ namespace AudioToolbox {
 			return res == 0 ? value : null;
 		}
 
-		public unsafe static float [,]? GetMatrixMixMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
+		public unsafe static float[,]? GetMatrixMixMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
 		{
 			if (inputLayout is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inputLayout));
@@ -1102,7 +1102,7 @@ namespace AudioToolbox {
 			return res != 0 ? null : (AudioChannelLayoutTag?) value;
 		}
 
-		public unsafe static AudioChannelLayoutTag []? GetTagsForNumberOfChannels (int count)
+		public unsafe static AudioChannelLayoutTag[]? GetTagsForNumberOfChannels (int count)
 		{
 			const int type_size = sizeof (uint);
 			int size;

--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -30,6 +30,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Text;
 using System.Collections.Generic;
@@ -199,7 +201,7 @@ namespace AudioToolbox {
 		}
 
 #if !WATCH
-		public unsafe static AudioChannelLayoutTag[] GetAvailableEncodeChannelLayoutTags (AudioStreamBasicDescription format)
+		public unsafe static AudioChannelLayoutTag []? GetAvailableEncodeChannelLayoutTags (AudioStreamBasicDescription format)
 		{
 			var type_size = sizeof (AudioStreamBasicDescription);
 			uint size;
@@ -216,7 +218,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe static int[] GetAvailableEncodeNumberChannels (AudioStreamBasicDescription format)
+		public unsafe static int []? GetAvailableEncodeNumberChannels (AudioStreamBasicDescription format)
 		{
 			uint size;
 			if (AudioFormatPropertyNative.AudioFormatGetPropertyInfo (AudioFormatProperty.AvailableEncodeNumberChannels, sizeof (AudioStreamBasicDescription), ref format, out size) != 0)
@@ -232,7 +234,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe AudioFormat[] GetOutputFormatList (byte[] magicCookie = null)
+		public unsafe AudioFormat []? GetOutputFormatList (byte []? magicCookie = null)
 		{
 			var afi = new AudioFormatInfo ();
 			afi.AudioStreamBasicDescription = this;
@@ -255,7 +257,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe AudioFormat[] GetFormatList (byte[] magicCookie)
+		public unsafe AudioFormat []? GetFormatList (byte[] magicCookie)
 		{
 			if (magicCookie == null)
 				throw new ArgumentNullException ("magicCookie");
@@ -295,7 +297,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe string FormatName {
+		public unsafe string? FormatName {
 			get {
 				IntPtr ptr;
 				var size = sizeof (IntPtr);
@@ -562,7 +564,7 @@ namespace AudioToolbox {
 		}
 
 #if !WATCH
-		public unsafe string Name {
+		public unsafe string? Name {
 			get {
 				IntPtr sptr;
 				int size = sizeof (IntPtr);
@@ -578,7 +580,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe string ShortName {
+		public unsafe string? ShortName {
 			get {
 				IntPtr sptr;
 				int size = sizeof (IntPtr);
@@ -886,10 +888,10 @@ namespace AudioToolbox {
 
 		public AudioChannelLayoutTag AudioTag;
 		public AudioChannelBit ChannelUsage;
-		public AudioChannelDescription[] Channels;
+		public AudioChannelDescription []? Channels;
 
 #if !WATCH
-		public unsafe string Name {
+		public unsafe string? Name {
 			get {
 				IntPtr sptr;
 				int size = sizeof (IntPtr);
@@ -905,7 +907,7 @@ namespace AudioToolbox {
 			}
 		}
 
-		public unsafe string SimpleName {
+		public unsafe string? SimpleName {
 			get {
 				IntPtr sptr;
 				int size = sizeof (IntPtr);
@@ -921,22 +923,22 @@ namespace AudioToolbox {
 			}
 		}
 
-		public static AudioChannelLayout FromAudioChannelBitmap (AudioChannelBit channelBitmap)
+		public static AudioChannelLayout? FromAudioChannelBitmap (AudioChannelBit channelBitmap)
 		{
 			return GetChannelLayout (AudioFormatProperty.ChannelLayoutForBitmap, (int) channelBitmap);
 		}
 
-		public static AudioChannelLayout FromAudioChannelLayoutTag (AudioChannelLayoutTag channelLayoutTag)
+		public static AudioChannelLayout? FromAudioChannelLayoutTag (AudioChannelLayoutTag channelLayoutTag)
 		{
 			return GetChannelLayout (AudioFormatProperty.ChannelLayoutForTag, (int) channelLayoutTag);
 		}
 
-		static AudioChannelLayout GetChannelLayout (AudioFormatProperty property, int value)
+		static AudioChannelLayout? GetChannelLayout (AudioFormatProperty property, int value)
 		{
 			int size;
 			AudioFormatPropertyNative.AudioFormatGetPropertyInfo (property, sizeof (AudioFormatProperty), ref value, out size);
 
-			AudioChannelLayout layout;
+			AudioChannelLayout? layout;
 			IntPtr ptr = Marshal.AllocHGlobal (size);
 			if (AudioFormatPropertyNative.AudioFormatGetProperty (property, sizeof (AudioFormatProperty), ref value, ref size, ptr) == 0)
 				layout = new AudioChannelLayout (ptr);
@@ -948,7 +950,7 @@ namespace AudioToolbox {
 		}
 #endif // !WATCH
 
-		internal static AudioChannelLayout FromHandle (IntPtr handle)
+		internal static AudioChannelLayout? FromHandle (IntPtr handle)
 		{
 			if (handle == IntPtr.Zero)
 				return null;
@@ -958,7 +960,7 @@ namespace AudioToolbox {
 
 		public override string ToString ()
 		{
-			return String.Format ("AudioChannelLayout: Tag={0} Bitmap={1} Channels={2}", AudioTag, ChannelUsage, Channels.Length);
+			return String.Format ("AudioChannelLayout: Tag={0} Bitmap={1} Channels={2}", AudioTag, ChannelUsage, Channels!.Length);
 		}
 
 		// The returned block must be released with FreeHGlobal
@@ -998,7 +1000,7 @@ namespace AudioToolbox {
 			return res;
 		}
 
-		public unsafe static int[] GetChannelMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
+		public unsafe static int []? GetChannelMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
 		{
 			if (inputLayout == null)
 				throw new ArgumentNullException ("inputLayout");
@@ -1032,7 +1034,7 @@ namespace AudioToolbox {
 			return res == 0 ? value : null;
 		}
 
-		public unsafe static float[,] GetMatrixMixMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
+		public unsafe static float [,]? GetMatrixMixMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
 		{
 			if (inputLayout == null)
 				throw new ArgumentNullException ("inputLayout");
@@ -1100,7 +1102,7 @@ namespace AudioToolbox {
 			return res != 0 ? null : (AudioChannelLayoutTag?) value;
 		}
 
-		public unsafe static AudioChannelLayoutTag[] GetTagsForNumberOfChannels (int count)
+		public unsafe static AudioChannelLayoutTag []? GetTagsForNumberOfChannels (int count)
 		{
 			const int type_size = sizeof (uint);
 			int size;

--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -260,7 +260,7 @@ namespace AudioToolbox {
 		public unsafe AudioFormat []? GetFormatList (byte[] magicCookie)
 		{
 			if (magicCookie == null)
-				throw new ArgumentNullException ("magicCookie");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (magicCookie));
 
 			var afi = new AudioFormatInfo ();
 			afi.AudioStreamBasicDescription = this;
@@ -967,7 +967,7 @@ namespace AudioToolbox {
 		internal unsafe IntPtr ToBlock (out int size)
 		{
 			if (Channels == null)
-				throw new ArgumentNullException ("Channels");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (Channels));
 			
 			var desc_size = sizeof (AudioChannelDescription);
 
@@ -990,7 +990,7 @@ namespace AudioToolbox {
 		public static AudioFormatError Validate (AudioChannelLayout layout)
 		{
 			if (layout == null)
-				throw new ArgumentNullException ("layout");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (layout));
 
 			int ptr_size;
 			var ptr = layout.ToBlock (out ptr_size);
@@ -1003,9 +1003,9 @@ namespace AudioToolbox {
 		public unsafe static int []? GetChannelMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
 		{
 			if (inputLayout == null)
-				throw new ArgumentNullException ("inputLayout");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inputLayout));
 			if (outputLayout == null)
-				throw new ArgumentNullException ("outputLayout");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputLayout));
 
 			var channels_count = GetNumberOfChannels (outputLayout);
 			if (channels_count == null)
@@ -1037,9 +1037,9 @@ namespace AudioToolbox {
 		public unsafe static float [,]? GetMatrixMixMap (AudioChannelLayout inputLayout, AudioChannelLayout outputLayout)
 		{
 			if (inputLayout == null)
-				throw new ArgumentNullException ("inputLayout");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inputLayout));
 			if (outputLayout == null)
-				throw new ArgumentNullException ("outputLayout");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputLayout));
 
 			var channels_count_output = GetNumberOfChannels (outputLayout);
 			if (channels_count_output == null)
@@ -1075,7 +1075,7 @@ namespace AudioToolbox {
 		public static int? GetNumberOfChannels (AudioChannelLayout layout)
 		{
 			if (layout == null)
-				throw new ArgumentNullException ("layout");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (layout));
 
 			int ptr_size;
 			var ptr = layout.ToBlock (out ptr_size);
@@ -1090,7 +1090,7 @@ namespace AudioToolbox {
 		public static AudioChannelLayoutTag? GetTagForChannelLayout (AudioChannelLayout layout)
 		{
 			if (layout == null)
-				throw new ArgumentNullException ("layout");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (layout));
 
 			int ptr_size;
 			var ptr = layout.ToBlock (out ptr_size);

--- a/src/AudioToolbox/MusicPlayer.cs
+++ b/src/AudioToolbox/MusicPlayer.cs
@@ -89,7 +89,7 @@ namespace AudioToolbox {
 		{
 		}
 
-		protected virtual void Dispose (bool disposing)
+		new protected virtual void Dispose (bool disposing)
 		{
 			currentSequence = null;
 			if (Owns && Handle != IntPtr.Zero)

--- a/src/AudioToolbox/MusicSequence.cs
+++ b/src/AudioToolbox/MusicSequence.cs
@@ -124,7 +124,7 @@ namespace AudioToolbox {
 			}
 			set {
 				if (value is null)
-					throw new ArgumentNullException (nameof (value));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 
 				MusicSequenceSetAUGraph (Handle, value.Handle);
 			}
@@ -209,7 +209,7 @@ namespace AudioToolbox {
 		public MusicPlayerStatus GetTrackIndex (MusicTrack track, out int index)
 		{
 			if (track is null)
-				throw new ArgumentNullException (nameof (track));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (track));
 
 			return MusicSequenceGetTrackIndex (Handle, track.Handle, out index);
 		}
@@ -232,7 +232,7 @@ namespace AudioToolbox {
 		public MusicPlayerStatus SetMidiEndpoint (MidiEndpoint endpoint)
 		{
 			if (endpoint is null)
-				throw new ArgumentNullException (nameof (endpoint));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (endpoint));
 			return MusicSequenceSetMIDIEndpoint (Handle, endpoint.handle);
 		}
 #endif // IOS
@@ -315,7 +315,7 @@ namespace AudioToolbox {
 		public MusicPlayerStatus LoadFile (NSUrl url, MusicSequenceFileTypeID fileTypeId, MusicSequenceLoadFlags loadFlags = 0)
 		{
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 			
 			return MusicSequenceFileLoad (Handle, url.Handle, fileTypeId, loadFlags);
 		}
@@ -326,7 +326,7 @@ namespace AudioToolbox {
 		public MusicPlayerStatus LoadData (NSData data, MusicSequenceFileTypeID fileTypeId, MusicSequenceLoadFlags loadFlags = 0)
 		{
 			if (data is null)
-				throw new ArgumentNullException (nameof (data));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 			
 			return MusicSequenceFileLoadData (Handle, data.Handle, fileTypeId, loadFlags);
 		}
@@ -339,7 +339,7 @@ namespace AudioToolbox {
 		public MusicPlayerStatus CreateFile (NSUrl url, MusicSequenceFileTypeID fileType, MusicSequenceFileFlags flags = 0, ushort resolution = 0)
 		{
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 			
 			return MusicSequenceFileCreate (Handle, url.Handle, fileType, flags, resolution);
 		}

--- a/src/AudioToolbox/MusicTrack.cs
+++ b/src/AudioToolbox/MusicTrack.cs
@@ -143,7 +143,7 @@ namespace AudioToolbox {
 		internal MusicEventUserData (IntPtr handle)
 		{
 			if (handle == IntPtr.Zero)
-				throw new ArgumentNullException (nameof (handle));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handle));
 
 			int length = Marshal.ReadInt32 (handle);
 
@@ -231,7 +231,7 @@ namespace AudioToolbox {
 		public static MusicTrack? FromSequence (MusicSequence sequence)
 		{
 			if (sequence is null)
-				throw new ArgumentNullException (nameof (sequence));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (sequence));
 			return sequence.CreateTrack ();
 		}
 
@@ -363,7 +363,7 @@ namespace AudioToolbox {
 		public MusicPlayerStatus AddMidiRawDataEvent (double timestamp, MidiRawData rawData)
 		{
 			if (rawData is null)
-				throw new ArgumentNullException (nameof (rawData));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (rawData));
 			
 			var native = rawData.ToUnmanaged ();
 			var r = MusicTrackNewMIDIRawDataEvent (Handle, timestamp, native);
@@ -395,7 +395,7 @@ namespace AudioToolbox {
 		public MusicPlayerStatus AddMetaEvent (double timestamp, MidiMetaEvent metaEvent)
 		{
 			if (metaEvent is null)
-				throw new ArgumentNullException (nameof (metaEvent));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (metaEvent));
 			
 			var ptr = metaEvent.ToUnmanaged ();
 			var ret = MusicTrackNewMetaEvent (Handle, timestamp, ptr);
@@ -409,7 +409,7 @@ namespace AudioToolbox {
 		public MusicPlayerStatus AddUserEvent (double timestamp, MusicEventUserData userData)
 		{
 			if (userData is null)
-				throw new ArgumentNullException (nameof (userData));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (userData));
 			var ptr = userData.ToUnmanaged ();
 			var ret = MusicTrackNewUserEvent (Handle, timestamp, ptr);
 			Marshal.FreeHGlobal (ptr);
@@ -446,7 +446,7 @@ namespace AudioToolbox {
 		public MusicPlayerStatus CopyInsert (double sourceStartTime, double sourceEndTime, MusicTrack targetTrack, double targetInsertTime)
 		{
 			if (targetTrack is null)
-				throw new ArgumentNullException (nameof (targetTrack));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (targetTrack));
 			return MusicTrackCopyInsert (Handle, sourceStartTime, sourceEndTime, targetTrack.Handle, targetInsertTime);
 		}
 
@@ -456,7 +456,7 @@ namespace AudioToolbox {
 		public MusicPlayerStatus Merge (double sourceStartTime, double sourceEndTime, MusicTrack targetTrack, double targetInsertTime)
 		{
 			if (targetTrack is null)
-				throw new ArgumentNullException (nameof (targetTrack));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (targetTrack));
 			return MusicTrackMerge (Handle, sourceStartTime, sourceEndTime, targetTrack.Handle, targetInsertTime);
 		}
 #endif // !COREBUILD

--- a/src/AudioToolbox/SystemSound.cs
+++ b/src/AudioToolbox/SystemSound.cs
@@ -222,7 +222,7 @@ namespace AudioToolbox {
 		public void PlayAlertSound (Action onCompletion)
 		{
 			if (onCompletion is null)
-				throw new ArgumentNullException (nameof (onCompletion));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (onCompletion));
 			
 			AssertNotDisposed ();
 
@@ -262,7 +262,7 @@ namespace AudioToolbox {
 		public void PlaySystemSound (Action onCompletion)
 		{
 			if (onCompletion is null)
-				throw new ArgumentNullException (nameof (onCompletion));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (onCompletion));
 			
 			AssertNotDisposed ();
 
@@ -317,7 +317,7 @@ namespace AudioToolbox {
 		static uint Create (NSUrl fileUrl)
 		{
 			if (fileUrl is null)
-				throw new ArgumentNullException (nameof (fileUrl));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (fileUrl));
 
 			var error = AudioServicesCreateSystemSoundID (fileUrl.Handle, out var soundId);
 			if (error != AudioServicesError.None)
@@ -334,7 +334,7 @@ namespace AudioToolbox {
 		public static SystemSound? FromFile (NSUrl fileUrl)
 		{
 			if (fileUrl is null)
-				throw new ArgumentNullException (nameof (fileUrl));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (fileUrl));
 
 			var error = AudioServicesCreateSystemSoundID (fileUrl.Handle, out var soundId);
 			if (error != AudioServicesError.None)
@@ -345,7 +345,7 @@ namespace AudioToolbox {
 		public static SystemSound? FromFile (string filename)
 		{
 			if (filename is null)
-				throw new ArgumentNullException (nameof (filename));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (filename));
 
 			using (var url = new NSUrl (filename)){
 				var error = AudioServicesCreateSystemSoundID (url.Handle, out var soundId);

--- a/src/AudioToolbox/SystemSound.cs
+++ b/src/AudioToolbox/SystemSound.cs
@@ -391,7 +391,7 @@ namespace AudioToolbox {
 			unsafe {
 				return AudioServicesAddSystemSoundCompletion (soundId,
 			                                              runLoop.GetHandle (),
-			                                              IntPtr.Zero, // runLoopMode should be enum runLoopMode == null ? IntPtr.Zero : runLoopMode.Handle,
+			                                              IntPtr.Zero, // runLoopMode should be enum runLoopMode is null ? IntPtr.Zero : runLoopMode.Handle,
 #if NET
 			                                              &SoundCompletionShared,
 #else

--- a/src/AudioToolbox/SystemSound.cs
+++ b/src/AudioToolbox/SystemSound.cs
@@ -391,7 +391,7 @@ namespace AudioToolbox {
 			unsafe {
 				return AudioServicesAddSystemSoundCompletion (soundId,
 			                                              runLoop.GetHandle (),
-			                                              IntPtr.Zero, // runLoopMode should be enum runLoopMode is null ? IntPtr.Zero : runLoopMode.Handle,
+			                                              IntPtr.Zero, // runLoopMode should be enum runLoopMode.GetHandle (),
 #if NET
 			                                              &SoundCompletionShared,
 #else


### PR DESCRIPTION
This PR aims to bring nullability changes to <FRAMEWORK>.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`