### PR TITLE
[AVFoundation] Remove the AVAssetsDownloadTaskKeys and AVAssetDownloadOptions API in .NET for tvOS.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -13687,7 +13687,11 @@ namespace AVFoundation {
 	}
 
 	[NoWatch, Mac (11,3)]
+#if NET
+	[NoTV]
+#else
 	[Obsoleted (PlatformName.TvOS, 12, 0)]
+#endif
 	[Static, Internal]
 	interface AVAssetDownloadTaskKeys {
 		[iOS (9,0), Mac (12,0)]
@@ -13718,7 +13722,11 @@ namespace AVFoundation {
 
 	[Mac (12,0)]
 	[NoWatch]
+#if NET
+	[NoTV]
+#else
 	[Obsoleted (PlatformName.TvOS, 12, 0)]
+#endif
 	[StrongDictionary ("AVAssetDownloadTaskKeys")]
 	interface AVAssetDownloadOptions {
 		NSNumber MinimumRequiredMediaBitrate { get; set; }

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-AVFoundation.ignore
@@ -4,9 +4,5 @@
 # as per the header comments, the following enum has to be ignored on tvOS
 !missing-enum! AVAudioSessionIOType not bound
 
-# removed in TV 12,0, API that used them was removed in TV 10, added obsolete attr.
-!unknown-field! AVAssetDownloadTaskMediaSelectionKey bound
-!unknown-field! AVAssetDownloadTaskMinimumRequiredMediaBitrateKey bound
-
 # not used on tvOS
 !missing-enum! AVAudioSessionInterruptionReason not bound


### PR DESCRIPTION
These API were never valid for tvOS, and now we can completely remove them in .NET.