### PR TITLE
[tests] Fix packaging mac tests by generating valid bash code for test.config.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -77,7 +77,7 @@ test.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.De
 	@echo "DOTNET6_BCL_DIR=$(DOTNET6_BCL_DIR)" >> $@
 	@echo "ENABLE_DOTNET=$(ENABLE_DOTNET)" >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),DOTNET_$(platform)_RUNTIME_IDENTIFIERS='$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS)'\\n)" | sed 's/^ //' >> $@
-	@echo "DOTNET_CSC_COMMAND=$(DOTNET6_CSC)" >> $@
+	@echo "DOTNET_CSC_COMMAND='$(DOTNET6_CSC)'" >> $@
 
 test-system.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.Details.xml
 	@rm -f $@

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -276,7 +276,7 @@ namespace Xamarin.Tests
 			include_device = !string.IsNullOrEmpty (GetVariable ("INCLUDE_DEVICE", ""));
 			include_dotnet = !string.IsNullOrEmpty (GetVariable ("ENABLE_DOTNET", ""));
 			DotNet6BclDir = GetVariable ("DOTNET6_BCL_DIR", null);
-			DotNetCscCommand = GetVariable ("DOTNET_CSC_COMMAND", null);
+			DotNetCscCommand = GetVariable ("DOTNET_CSC_COMMAND", null)?.Trim ('\'');
 			DotNetExecutable = GetVariable ("DOTNET6", null);
 
 			XcodeVersionString = GetXcodeVersion (xcode_root);


### PR DESCRIPTION
Fixes this failure:

    ++ DOTNET_CSC_COMMAND=/Users/builder/azdo/_work/1/s/xamarin-macios/builds/downloads/dotnet-sdk-6.0.300-preview.22118.1-osx-x64/dotnet
    ++ exec /Users/builder/azdo/_work/1/s/xamarin-macios/builds/downloads/dotnet-sdk-6.0.300-preview.22118.1-osx-x64/sdk/6.0.300-preview.22118.1/Roslyn/bincore/csc.dll
    test.config: line 22: /Users/builder/azdo/_work/1/s/xamarin-macios/builds/downloads/dotnet-sdk-6.0.300-preview.22118.1-osx-x64/sdk/6.0.300-preview.22118.1/Roslyn/bincore/csc.dll: Permission denied
    make[1]: *** [mac-test-package.zip] Error 1
    make: *** [package-tests] Error 2