### PR TITLE
[monotouch-test] Fix the BaseEffectTest and EffectPropertyMaterialTest tests.

### DIFF
--- a/tests/monotouch-test/GLKit/BaseEffectTest.cs
+++ b/tests/monotouch-test/GLKit/BaseEffectTest.cs
@@ -30,9 +30,11 @@ namespace MonoTouchFixtures.GLKit {
 
 			var effect = new GLKBaseEffect ();
 #if NET
-#else
 			Assert.That (effect.LightModelAmbientColor.ToString (), Is.EqualTo ("<0.2, 0.2, 0.2, 1>"), "LightModelAmbientColor");
 			Assert.That (effect.ConstantColor.ToString (), Is.EqualTo ("<1, 1, 1, 1>"), "ConstantColor");
+#else
+			Assert.That (effect.LightModelAmbientColor.ToString (), Is.EqualTo ("(0.2, 0.2, 0.2, 1)"), "LightModelAmbientColor");
+			Assert.That (effect.ConstantColor.ToString (), Is.EqualTo ("(1, 1, 1, 1)"), "ConstantColor");
 #endif
 
 			effect.Light0.Enabled = true;

--- a/tests/monotouch-test/GLKit/BaseEffectTest.cs
+++ b/tests/monotouch-test/GLKit/BaseEffectTest.cs
@@ -23,18 +23,25 @@ namespace MonoTouchFixtures.GLKit {
 	public class BaseEffectTest {
 		
 		[Test]
-		[Culture ("en")]
+		[SetCulture ("en")]
 		public void Properties ()
 		{
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var effect = new GLKBaseEffect ();
-			Assert.That (effect.LightModelAmbientColor.ToString (), Is.EqualTo ("(0.2, 0.2, 0.2, 1)"), "LightModelAmbientColor");
-			Assert.That (effect.ConstantColor.ToString (), Is.EqualTo ("(1, 1, 1, 1)"), "ConstantColor");
+#if NET
+#else
+			Assert.That (effect.LightModelAmbientColor.ToString (), Is.EqualTo ("<0.2, 0.2, 0.2, 1>"), "LightModelAmbientColor");
+			Assert.That (effect.ConstantColor.ToString (), Is.EqualTo ("<1, 1, 1, 1>"), "ConstantColor");
+#endif
 
 			effect.Light0.Enabled = true;
 			effect.Light0.DiffuseColor = new Vector4 (1.0f, 0.4f, 0.4f, 1.0f);
+#if NET
+			Assert.That (effect.Light0.DiffuseColor.ToString (), Is.EqualTo ("<1, 0.4, 0.4, 1>"), "Light0");
+#else
 			Assert.That (effect.Light0.DiffuseColor.ToString (), Is.EqualTo ("(1, 0.4, 0.4, 1)"), "Light0");
+#endif
 		}
 	}
 }

--- a/tests/monotouch-test/GLKit/EffectPropertyMaterialTest.cs
+++ b/tests/monotouch-test/GLKit/EffectPropertyMaterialTest.cs
@@ -17,22 +17,36 @@ namespace MonoTouchFixtures.GLKit {
 	public class EffectPropertytMaterialTest {
 		
 		[Test]
-		[Culture ("en")]
+		[SetCulture ("en")]
 		public void Properties ()
 		{
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
 
 			var material = new GLKEffectPropertyMaterial ();
+#if NET
+			Assert.That (material.AmbientColor.ToString (), Is.EqualTo ("<0.2, 0.2, 0.2, 1>"), "AmbientColor");
+			Assert.That (material.DiffuseColor.ToString (), Is.EqualTo ("<0.8, 0.8, 0.8, 1>"), "DiffuseColor");
+			Assert.That (material.SpecularColor.ToString (), Is.EqualTo ("<0, 0, 0, 1>"), "SpecularColor");
+			Assert.That (material.EmissiveColor.ToString (), Is.EqualTo ("<0, 0, 0, 1>"), "EmissiveColor");
+#else
 			Assert.That (material.AmbientColor.ToString (), Is.EqualTo ("(0.2, 0.2, 0.2, 1)"), "AmbientColor");
 			Assert.That (material.DiffuseColor.ToString (), Is.EqualTo ("(0.8, 0.8, 0.8, 1)"), "DiffuseColor");
 			Assert.That (material.SpecularColor.ToString (), Is.EqualTo ("(0, 0, 0, 1)"), "SpecularColor");
 			Assert.That (material.EmissiveColor.ToString (), Is.EqualTo ("(0, 0, 0, 1)"), "EmissiveColor");
+#endif
 
 			material = new GLKBaseEffect ().Material;
+#if NET
+			Assert.That (material.AmbientColor.ToString (), Is.EqualTo ("<0.2, 0.2, 0.2, 1>"), "AmbientColor");
+			Assert.That (material.DiffuseColor.ToString (), Is.EqualTo ("<0.8, 0.8, 0.8, 1>"), "DiffuseColor");
+			Assert.That (material.SpecularColor.ToString (), Is.EqualTo ("<0, 0, 0, 1>"), "SpecularColor");
+			Assert.That (material.EmissiveColor.ToString (), Is.EqualTo ("<0, 0, 0, 1>"), "EmissiveColor");
+#else
 			Assert.That (material.AmbientColor.ToString (), Is.EqualTo ("(0.2, 0.2, 0.2, 1)"), "AmbientColor");
 			Assert.That (material.DiffuseColor.ToString (), Is.EqualTo ("(0.8, 0.8, 0.8, 1)"), "DiffuseColor");
 			Assert.That (material.SpecularColor.ToString (), Is.EqualTo ("(0, 0, 0, 1)"), "SpecularColor");
 			Assert.That (material.EmissiveColor.ToString (), Is.EqualTo ("(0, 0, 0, 1)"), "EmissiveColor");
+#endif
 		}
 	}
 }


### PR DESCRIPTION
The [Culture ("en")] attribute means: only run this test if the culture is
"en". This usually meant not running this test (apparently we don't run often
with culture = "en"), leading to outdated tests that happened to fail when
actually run under culture = "en" (such as on older macOS bots).

So change these tests to actually change the culture to "en" (by using the
SetCulture attribute), and also fix them.