### PR TITLE
[msbuild] Remove the AppBundleDir and Architectures properties from the DSymUtil task.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
@@ -12,11 +12,6 @@ namespace Xamarin.MacDev.Tasks
 		#region Inputs
 
 		[Required]
-		public string AppBundleDir { get; set; }
-
-		public string Architectures { get; set; }
-
-		[Required]
 		public string DSymDir { get; set; }
 
 		[Output]
@@ -27,6 +22,7 @@ namespace Xamarin.MacDev.Tasks
 
 		#region Outputs
 
+		// This property is required for XVS to work properly, even though it's not used for anything in the targets.
 		[Output]
 		public ITaskItem[] DsymContentFiles { get; set; }
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2295,8 +2295,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<DSymUtil
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '%(_AppExtensionDebugSymbolProperties.NoDSymUtil)' == 'false'"
-			AppBundleDir="$(_AppExtensionRoot)PlugIns\%(_AppExtensionDebugSymbolProperties.Identity)"
-			Architectures="%(_AppExtensionDebugSymbolProperties.CompiledArchitectures)"
 			DSymDir="$(AppBundleDir)\..\%(_AppExtensionDebugSymbolProperties.Identity).dSYM"
 			Executable="$(_AppExtensionRoot)PlugIns\%(_AppExtensionDebugSymbolProperties.Identity)\%(_AppExtensionDebugSymbolProperties.NativeExecutable)"
 			ToolExe="$(DSymUtilExe)"
@@ -2367,8 +2365,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<DSymUtil
 			SessionId="$(BuildSessionId)"
 			Condition="'$(_NoDSymUtil)' == 'false' and '%(_Frameworks._DestinationExists)' != 'true' "
-			AppBundleDir="$(AppBundleDir)"
-			Architectures=""
 			DSymDir="%(_Frameworks._Destination)"
 			Executable="%(_Frameworks.Identity)"
 			ToolExe="$(DSymUtilExe)"
@@ -2407,7 +2403,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<_AppExtensionDebugSymbolProperties Remove="@(_AppExtensionDebugSymbolProperties)" />
 
 			<_AppExtensionDebugSymbolProperties Include="$(_AppBundleFileName)">
-				<CompiledArchitectures>$(_CompiledArchitectures)</CompiledArchitectures>
 				<NativeExecutable>$(_NativeExecutableFileName)</NativeExecutable>
 				<NoSymbolStrip>$(_NoSymbolStrip)</NoSymbolStrip>
 				<SymbolsList>$(_SymbolsListFullPath)</SymbolsList>
@@ -2446,8 +2441,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<DSymUtil
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '$(_NoDSymUtil)' == 'false' And '$(IsAppExtension)' == 'false'"
-			AppBundleDir="$(AppBundleDir)"
-			Architectures="$(_CompiledArchitectures)"
 			DSymDir="$(AppBundleDir).dSYM"
 			Executable="$(_NativeExecutable)"
 			ToolExe="$(DSymUtilExe)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -64,9 +64,6 @@ namespace Xamarin.iOS.Tasks
 
 		#region Outputs
 
-		[Output]
-		public string CompiledArchitectures { get; set; }
-
 		// This property is required for VS to write the output native executable files
 		// and ensure the Inputs/Outputs of the msbuild target works correcly
 		[Output]
@@ -228,9 +225,6 @@ namespace Xamarin.iOS.Tasks
 				if (string.IsNullOrEmpty (abi))
 					abi = "armv7" + llvm + thumb;
 			}
-
-			// Output the CompiledArchitectures
-			CompiledArchitectures = architectures.ToString ();
 
 			args.AddLine ($"--abi={abi}");
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -279,7 +279,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			StandardOutputImportance="High"
 			XamarinSdkRoot="$(_XamarinSdkRoot)"
 			>
-			<Output TaskParameter="CompiledArchitectures" PropertyName="_CompiledArchitectures" />
 		</MTouch>
 
 		<Touch


### PR DESCRIPTION
These properties aren't used.

This also allows us to remove the CompiledArchitectures output property from
the MTouch task, because it's not longer used anymore either.