### PR TITLE
[xtro] Generate a proj file that contains variables for the current pch and assembly.

### DIFF
--- a/tests/xtro-sharpie/.gitignore
+++ b/tests/xtro-sharpie/.gitignore
@@ -1,3 +1,4 @@
+pch-info.proj
 *.results
 *.pch*
 *.unclassified

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -20,7 +20,7 @@ clean-local::
 
 bin/Debug/xtro-sharpie.exe xtro-report/bin/Debug/xtro-report.exe xtro-sanity/bin/Debug/xtro-sanity.exe build: .stamp-build
 
-.stamp-build: $(wildcard *.cs)
+.stamp-build: $(wildcard *.cs) pch-info.proj
 	$(Q_BUILD) $(SYSTEM_MSBUILD) $(MSBUILD_VERBOSITY) xtro-sharpie.sln /r /bl:$@.binlog
 	$(Q) touch $@
 
@@ -93,6 +93,16 @@ dotnet-$(1)-$($(2)_SDK_VERSION).g.cs: .stamp-check-sharpie
 	$$(SHARPIE) query -bind $$(X$(2)_PCH) > $$@
 endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call DotNetAssembly,$(platform),$(shell echo $(platform) | tr a-z A-Z))))
+
+pch-info.proj: Makefile
+	$(Q) rm -f $@.tmp
+	$(Q) printf "<Project>\\n" >> $@.tmp
+	$(Q) printf "\\t<PropertyGroup>\\n" >> $@.tmp
+	$(Q) printf "$(foreach platform,$(ALL_DOTNET_PLATFORMS) watchOS,\\t\\t<$(platform)_PCH>$(X$(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_PCH)</$(platform)_PCH>\\n)" >> $@.tmp
+	$(Q) printf "$(foreach platform,$(ALL_DOTNET_PLATFORMS),\\t\\t<$(platform)_DLL>$(X$(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_DOTNET)</$(platform)_DLL>\\n)" >> $@.tmp
+	$(Q) printf "\\t</PropertyGroup>\\n" >> $@.tmp
+	$(Q) printf "</Project>\\n" >> $@.tmp
+	$(Q_GEN) mv $@.tmp $@
 
 ios-$(IOS_SDK_VERSION).g.cs: $(XIOS_PCH)
 

--- a/tests/xtro-sharpie/xtro-sharpie.csproj
+++ b/tests/xtro-sharpie/xtro-sharpie.csproj
@@ -33,49 +33,45 @@
     <Externalconsole>true</Externalconsole>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <Import Project="pch-info.proj" />
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'watchOS' ">
     <StartAction>Project</StartAction>
-    <StartArguments>watchos8.0-armv7.pch ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/32bits/watchOS/Xamarin.WatchOS.dll</StartArguments>
+    <StartArguments>$(WATCHOS_PCH) ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/32bits/watchOS/Xamarin.WatchOS.dll</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'iOS' ">
     <StartAction>Project</StartAction>
-    <StartArguments>iphoneos15.0-arm64.pch ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/iOS/Xamarin.iOS.dll ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll</StartArguments>
+    <StartArguments>$(iOS_PCH) ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/iOS/Xamarin.iOS.dll ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'tvOS' ">
     <StartAction>Project</StartAction>
-    <StartArguments>appletvos15.0-arm64.pch ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/Xamarin.TVOS.dll ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll</StartArguments>
+    <StartArguments>$(tvOS_PCH) ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/Xamarin.TVOS.dll ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'macOS' ">
     <StartAction>Project</StartAction>
-    <StartArguments>macosx12.0-x86_64.pch ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/64bits/mobile/Xamarin.Mac.dll</StartArguments>
-    <StartWorkingDirectory>.</StartWorkingDirectory>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(RunConfiguration)' == 'MacCatalyst' ">
-    <StartAction>Project</StartAction>
-    <StartArguments>ios15.0-macabi-x86_64.pch ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/MacCatalyst/Xamarin.MacCatalyst.dll</StartArguments>
+    <StartArguments>$(macOS_PCH) ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/64bits/mobile/Xamarin.Mac.dll</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'iOS (.NET)' ">
     <StartAction>Project</StartAction>
-    <StartArguments>iphoneos15.0-arm64.pch --output-directory api-annotations-dotnet ../../_build/Microsoft.iOS.Runtime.ios-arm64/runtimes/ios-arm64/lib/net6.0/Xamarin.iOS.dll</StartArguments>
+    <StartArguments>$(iOS_PCH) --output-directory api-annotations-dotnet $(iOS_DLL)</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'tvOS (.NET)' ">
     <StartAction>Project</StartAction>
-    <StartArguments>appletvos15.0-arm64.pch --output-directory api-annotations-dotnet ../../_build/Microsoft.tvOS.Runtime.tvos-arm64/runtimes/tvos-arm64/lib/net6.0/Xamarin.TVOS.dll</StartArguments>
+    <StartArguments>$(tvOS_PCH) --output-directory api-annotations-dotnet $(tvOS_DLL)</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'macOS (.NET)' ">
     <StartAction>Project</StartAction>
-    <StartArguments>macosx12.0-x86_64.pch --output-directory api-annotations-dotnet ../../_build/Microsoft.macOS.Runtime.osx-x64/runtimes/osx-x64/lib/net6.0/Xamarin.Mac.dll</StartArguments>
+    <StartArguments>$(macOS_PCH) --output-directory api-annotations-dotnet $(macOS_DLL)</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'MacCatalyst (.NET)' ">
     <StartAction>Project</StartAction>
-    <StartArguments>ios15.0-macabi-x86_64.pch --output-directory api-annotations-dotnet ../../_build/Microsoft.MacCatalyst.Runtime.maccatalyst-x64/runtimes/maccatalyst-x64/lib/net6.0/Xamarin.MacCatalyst.dll</StartArguments>
+    <StartArguments>$(MacCatalyst_PCH) --output-directory api-annotations-dotnet $(MacCatalyst_DLL)</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Generate a proj file that contains variables for the current pch and assembly,
and include this proj file in the main xtro-sharpie project file. This way we
can use these variables for the pch and assembly arguments in the run
configurations, so we don't have to update the project file every time these
change (in particular the pch file changes name with every Xcode bump).