### PR TITLE
[src] Remove .NET-style availability attributes from API definitions.

### DIFF
--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -41,9 +41,7 @@ namespace AVFoundation {
 		Max = 0x7F
 	}
 
-#if !NET
 	[Watch (6, 0)]
-#endif
 	[Native]
 	// NSInteger - AVAssetExportSession.h
 	public enum AVAssetExportSessionStatus : long {
@@ -55,9 +53,7 @@ namespace AVFoundation {
 		Cancelled
 	}
 
-#if !NET
 	[Watch (6, 0)]
-#endif
 	[Native]
 	// NSInteger - AVAssetReader.h
 	public enum AVAssetReaderStatus : long {
@@ -68,9 +64,7 @@ namespace AVFoundation {
 		Cancelled,
 	}
 
-#if !NET
 	[Watch (6, 0)]
-#endif
 	[Native]
 	// NSInteger - AVAssetWriter.h
 	public enum AVAssetWriterStatus : long {
@@ -81,14 +75,9 @@ namespace AVFoundation {
 		Cancelled,
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoTV]
 	[NoWatch]
-#endif
 	[Native]
 	// NSInteger - AVCaptureSession.h
 	public enum AVCaptureVideoOrientation : long {
@@ -98,56 +87,36 @@ namespace AVFoundation {
 		LandscapeLeft,
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
-#endif
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureFlashMode : long {
 		Off, On, Auto
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
-#endif
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureTorchMode : long {
 		Off, On, Auto
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
-#endif
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureFocusMode : long {
 		Locked, AutoFocus, ContinuousAutoFocus,
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
-#endif
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureDevicePosition : long {
@@ -156,40 +125,23 @@ namespace AVFoundation {
 		Front = 2
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
-#endif
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureExposureMode : long {
 		Locked,
 		AutoExpose,
 		ContinuousAutoExposure,
-#if NET
-		[SupportedOSPlatform ("ios8.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("maccatalyst14.0")]
-		[UnsupportedOSPlatform ("tvos")]
-#else
 		[iOS (8, 0)]
 		[Mac (10, 15)]
-#endif
 		Custom,
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
-#endif
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureWhiteBalanceMode : long {
@@ -197,14 +149,7 @@ namespace AVFoundation {
 	}
 
 #if !NET
-#if NET
-	[UnsupportedOSPlatform ("ios6.0")]
-#if IOS
-	[Obsolete ("Starting with ios6.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-#else
 	[Deprecated (PlatformName.iOS, 6, 0)]
-#endif
 	[Flags]
 	[Native]
 	// NSUInteger - AVAudioSession.h
@@ -215,9 +160,7 @@ namespace AVFoundation {
 
 	// Populated in NSError.Code, an NSInteger
 	// anonymous enum - AVError.h
-#if !NET
 	[Watch (6, 0)]
-#endif
 	[Native]
 	public enum AVError : long {
 		Unknown = -11800,
@@ -302,9 +245,7 @@ namespace AVFoundation {
 		RequestCancelled = -11879,
 	}
 
-#if !NET
 	[Watch (6, 0)]
-#endif
 	[Native]
 	// NSInteger - AVPlayer.h
 	public enum AVPlayerActionAtItemEnd : long {
@@ -313,9 +254,7 @@ namespace AVFoundation {
 		None
 	}
 
-#if !NET
 	[Watch (6, 0)]
-#endif
 	[Native]
 	// NSInteger - AVPlayerItem.h
 	public enum AVPlayerItemStatus : long {
@@ -323,16 +262,8 @@ namespace AVFoundation {
 	}
 
 #if !NET
-#if NET
-	[UnsupportedOSPlatform ("ios6.0")]
-#if IOS
-	[Obsolete ("Starting with ios6.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoTV]
 	[Deprecated (PlatformName.iOS, 6, 0)]
-#endif
 	[Flags]
 	[Native]
 	// declared as AVAudioSessionSetActiveOptions (NSUInteger) - AVAudioSession.h
@@ -341,18 +272,14 @@ namespace AVFoundation {
 	}
 #endif
 
-#if !NET
 	[Watch (6, 0)]
-#endif
 	[Native]
 	// NSInteger - AVAsynchronousKeyValueLoading.h
 	public enum AVKeyValueStatus : long {
 		Unknown, Loading, Loaded, Failed, Cancelled
 	}
 
-#if !NET
 	[Watch (6, 0)]
-#endif
 	[Native]
 	// NSInteger - AVPlayer.h
 	public enum AVPlayerStatus : long {
@@ -361,9 +288,7 @@ namespace AVFoundation {
 		Failed
 	}
 
-#if !NET
 	[Watch (6, 0)]
-#endif
 	[Flags]
 	[Native]
 	// NSUInteger - AVAsset.h
@@ -376,61 +301,41 @@ namespace AVFoundation {
 		ForbidAll = 0xFFFF,
 	}
 
-#if !NET
 	[Watch (6, 0)]
-#endif
 	[Native]
 	// NSInteger - AVAssetImageGenerator.h
 	public enum AVAssetImageGeneratorResult : long {
 		Succeeded, Failed, Cancelled
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 #if XAMCORE_3_0
 	[NoiOS]
 	[NoWatch]
 #endif
 	[Unavailable (PlatformName.MacCatalyst)]
 	[NoTV]
-#endif
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureDeviceTransportControlsPlaybackMode : long {
 		NotPlaying, Playing
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 #if XAMCORE_3_0
 	[NoiOS]
 #endif
 	[Unavailable (PlatformName.MacCatalyst)]
 	[NoTV]
 	[NoWatch]
-#endif
 	[Native]
 	// NSInteger - AVCaptureSession.h
 	public enum AVVideoFieldMode : long {
 		Both, TopOnly, BottomOnly, Deinterlace
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.15")]
-	[SupportedOSPlatform ("ios8.0")]
-	[SupportedOSPlatform ("tvos12.0")]
-#else
 	[Mac (10, 15)]
 	[iOS (8, 0)]
 	[TV (12, 0)]
 	[Watch (7, 0)]
-#endif
 	[Flags]
 	[Native]
 	// NSUInteger - AVAudioSession.h
@@ -438,12 +343,8 @@ namespace AVFoundation {
 		ShouldResume = 1
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.15")]
-#else
 	[Mac (10, 15)]
 	[Watch (7, 0)]
-#endif
 	[Flags]
 	[Native]
 	// NSUInteger - AVAudioSession.h
@@ -451,33 +352,20 @@ namespace AVFoundation {
 		NotifyOthersOnDeactivation = 1
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.15")]
-#else
 	[Mac (10, 15)]
 	[Watch (7, 0)]
-#endif
 	[Native]
 	// NSUInteger - AVAudioSession.h
 	public enum AVAudioSessionPortOverride : ulong {
 		None = 0,
-#if NET
-		[UnsupportedOSPlatform ("tvos")]
-		[UnsupportedOSPlatform ("macos")]
-#else
 		[NoTV]
 		[NoMac] // Removed in Xcode 12 GM
 		[NoWatch] // Removed in Xcode 12 GM
-#endif
 		Speaker = 0x73706b72 // 'spkr'
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.15")]
-#else
 	[Mac (10, 15)]
 	[Watch (7, 0)]
-#endif
 	[Native]
 	// NSUInteger - AVAudioSession.h
 	public enum AVAudioSessionRouteChangeReason : ulong {
@@ -497,85 +385,44 @@ namespace AVFoundation {
 	public enum AVAudioSessionCategoryOptions : ulong {
 		MixWithOthers = 1,
 		DuckOthers = 2,
-#if NET
-		[UnsupportedOSPlatform ("macos")]
-		[UnsupportedOSPlatform ("tvos")]
-#else
 		[NoMac] // Removed in Xcode 12 GM
 		[NoWatch] // Removed in Xcode 12 GM
 		[NoTV]
-#endif
 		AllowBluetooth = 4,
-#if NET
-		[UnsupportedOSPlatform ("macos")]
-		[UnsupportedOSPlatform ("tvos")]
-#else
 		[NoMac] // Removed in Xcode 12 GM
 		[NoWatch] // Removed in Xcode 12 GM
 		[NoTV]
-#endif
 		DefaultToSpeaker = 8,
 
-#if NET
-		[SupportedOSPlatform ("ios9.0")]
-		[UnsupportedOSPlatform ("macos")]
-#else
 		[NoMac] // Removed in Xcode 12 GM
 		[iOS (9, 0)]
-#endif
 		InterruptSpokenAudioAndMixWithOthers = 17,
-#if NET
-		[SupportedOSPlatform ("ios10.0")]
-		[SupportedOSPlatform ("tvos10.0")]
-		[UnsupportedOSPlatform ("macos")]
-#else
 		[NoMac] // Removed in Xcode 12 GM
 		[Watch (3, 0)]
 		[iOS (10, 0)]
 		[TV (10, 0)]
-#endif
 		AllowBluetoothA2DP = 32,
-#if NET
-		[SupportedOSPlatform ("ios10.0")]
-		[SupportedOSPlatform ("tvos10.0")]
-		[UnsupportedOSPlatform ("macos")]
-#else
 		[NoMac] // Removed in Xcode 12 GM
 		[NoWatch]
 		[iOS (10, 0)]
 		[TV (10, 0)]
-#endif
 		AllowAirPlay = 64,
-#if NET
-		[SupportedOSPlatform ("ios14.5")]
-		[UnsupportedOSPlatform ("macos")]
-		[UnsupportedOSPlatform ("tvos")]
-#else
 		[NoMac]
 		[NoTV]
 		[iOS (14, 5)]
 		[Watch (7, 3)]
-#endif
 		OverrideMutedMicrophoneInterruption = 128,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.15")]
-#else
 	[Mac (10, 15)]
 	[Watch (7, 0)]
-#endif
 	[Native]
 	// NSUInteger - AVAudioSession.h
 	public enum AVAudioSessionInterruptionType : ulong {
 		Ended, Began
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.15")]
-#else
 	[Mac (10, 15)]
-#endif
 	[Native]
 	// NSInteger - AVAudioSession.h
 	// typedef CF_ENUM(NSInteger, AVAudioSessionErrorCode) -> CoreAudioTypes.framework/Headers/AudioSessionTypes.h
@@ -601,14 +448,9 @@ namespace AVFoundation {
 		SessionNotActive = 0x696e6163, // 'inac'
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
-#endif
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureAutoFocusRangeRestriction : long {
@@ -631,29 +473,18 @@ namespace AVFoundation {
 		Mastering
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("macos10.14")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[Mac (10, 14)]
 	[NoWatch]
 	[NoTV]
-#endif
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVAuthorizationStatus : long {
 		NotDetermined, Restricted, Denied, Authorized
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios7.0")]
-	[SupportedOSPlatform ("macos10.14")]
-#else
 	[iOS (7, 0)]
 	[Mac (10, 14)]
-#endif
 	[Native]
 	// NSInteger - AVSpeechSynthesis.h
 	public enum AVSpeechBoundary : long {
@@ -661,11 +492,7 @@ namespace AVFoundation {
 		Word
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios8.0")]
-#else
 	[iOS (8, 0)]
-#endif
 	[Native]
 	public enum AVAudioCommonFormat : ulong {
 		Other = 0,
@@ -682,37 +509,20 @@ namespace AVFoundation {
 		HRTF = 2,
 		SoundField = 3,
 		StereoPassThrough = 5,
-#if NET
-		[SupportedOSPlatform ("ios8.0")]
-		[SupportedOSPlatform ("macos10.10")]
-#else
 		[iOS (8, 0)]
 		[Mac (10, 10)]
-#endif
 		HrtfHQ = 6,
-#if NET
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-#else
 		[iOS (13, 0)]
 		[TV (13, 0)]
 		[Mac (10, 15)]
 		[NoWatch]
-#endif
 		Auto = 7,
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios8.0")]
-	[SupportedOSPlatform ("macos10.15")]
-	[SupportedOSPlatform ("tvos12.0")]
-#else
 	[iOS (8, 0)]
 	[Mac (10, 15)]
 	[TV (12, 0)]
 	[Watch (7, 0)]
-#endif
 	[Native]
 	public enum AVAudioSessionRecordPermission : ulong {
 		Undetermined = 1970168948 /*'undt'*/,
@@ -720,14 +530,9 @@ namespace AVFoundation {
 		Granted = 1735552628 /*'grnt'*/
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios8.0")]
-	[SupportedOSPlatform ("macos10.15")]
-#else
 	[iOS (8, 0)]
 	[Mac (10, 15)]
 	[Watch (7, 0)]
-#endif
 	[Native]
 	public enum AVAudioSessionSilenceSecondaryAudioHintType : ulong {
 		Begin = 1,
@@ -807,55 +612,32 @@ namespace AVFoundation {
 		Linear = 3
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos10.2")]
-#else
 	[TV (10, 2)]
 	[Watch (6, 0)]
-#endif
 	[Native]
 	public enum AVQueuedSampleBufferRenderingStatus : long {
 		Unknown, Rendering, Failed
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("ios8.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[iOS (8, 0)]
 	[NoWatch]
 	[NoTV]
-#endif
 	[Native]
 	public enum AVCaptureVideoStabilizationMode : long {
 		Off,
 		Standard,
 		Cinematic,
-#if NET
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst14.0")]
-		[UnsupportedOSPlatform ("tvos")]
-#else
 		[iOS (13, 0)]
-#endif
 		CinematicExtended,
 		Auto = -1
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.15")]
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("ios8.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Mac (10, 15)]
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoTV]
 	[NoWatch]
 	[iOS (8, 0)]
-#endif
 	[Native]
 	public enum AVCaptureAutoFocusSystem : long {
 		None,
@@ -864,54 +646,31 @@ namespace AVFoundation {
 	}
 
 #if !MONOMAC
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("ios9.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoTV]
 	[NoWatch]
 	[iOS (9, 0)]
-#endif
 	[Native]
 	public enum AVCaptureSessionInterruptionReason : long {
 		VideoDeviceNotAvailableInBackground = 1,
 		AudioDeviceInUseByAnotherClient = 2,
 		VideoDeviceInUseByAnotherClient = 3,
 		VideoDeviceNotAvailableWithMultipleForegroundApps = 4,
-#if NET
-		[SupportedOSPlatform ("ios11.1")]
-		[SupportedOSPlatform ("maccatalyst14.0")]
-		[UnsupportedOSPlatform ("tvos")]
-#else
 		[iOS (11, 1)]
-#endif
 		VideoDeviceNotAvailableDueToSystemPressure = 5,
 	}
-
 #endif
 
-#if NET
-	[SupportedOSPlatform ("ios9.0")]
-	[SupportedOSPlatform ("macos10.15")]
-#else
 	[iOS (9, 0)]
 	[Mac (10, 15)]
-#endif
 	[Native]
 	public enum AVSpeechSynthesisVoiceQuality : long {
 		Default = 1,
 		Enhanced
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios9.0")]
-	[SupportedOSPlatform ("macos10.11")]
-#else
 	[iOS (9, 0)]
 	[Mac (10, 11)]
-#endif
 	[Native]
 	public enum AVAudioConverterPrimeMethod : long {
 		Pre = 0,
@@ -919,13 +678,8 @@ namespace AVFoundation {
 		None = 2
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios9.0")]
-	[SupportedOSPlatform ("macos10.11")]
-#else
 	[iOS (9, 0)]
 	[Mac (10, 11)]
-#endif
 	[Native]
 	public enum AVAudioConverterInputStatus : long {
 		HaveData = 0,
@@ -933,13 +687,8 @@ namespace AVFoundation {
 		EndOfStream = 2
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios9.0")]
-	[SupportedOSPlatform ("macos10.11")]
-#else
 	[iOS (9, 0)]
 	[Mac (10, 11)]
-#endif
 	[Native]
 	public enum AVAudioConverterOutputStatus : long {
 		HaveData = 0,
@@ -948,13 +697,8 @@ namespace AVFoundation {
 		Error = 3
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios9.0")]
-	[SupportedOSPlatform ("macos10.11")]
-#else
 	[iOS (9, 0)]
 	[Mac (10, 11)]
-#endif
 	[Flags]
 	[Native]
 	public enum AVMusicSequenceLoadOptions : ulong {
@@ -962,16 +706,10 @@ namespace AVFoundation {
 		ChannelsToTracks = (1 << 0)
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios13.0")]
-	[SupportedOSPlatform ("macos10.11")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoTV]
 	[iOS (13, 0)]
 	[Watch (6, 0)]
 	[Mac (10, 11)]
-#endif
 	[Flags]
 	[Native]
 	public enum AVMovieWritingOptions : ulong {
@@ -979,14 +717,9 @@ namespace AVFoundation {
 		TruncateDestinationToMovieHeaderOnly = (1 << 0)
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoiOS]
 	[NoTV]
 	[NoWatch]
-#endif
 	[Native]
 	public enum AVContentAuthorizationStatus : long {
 		Unknown,
@@ -998,18 +731,11 @@ namespace AVFoundation {
 		NotPossible,
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios15.0")]
-	[SupportedOSPlatform ("tvos15.0")]
-	[SupportedOSPlatform ("macos10.10")]
-	[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 	[iOS (15, 0)]
 	[TV (15, 0)]
 	[Watch (8, 0)]
 	[Mac (10, 10)]
 	[MacCatalyst (15, 0)]
-#endif
 	[Native]
 	public enum AVSampleBufferRequestDirection : long {
 		Forward = 1,
@@ -1017,82 +743,44 @@ namespace AVFoundation {
 		Reverse = -1,
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios15.0")]
-	[SupportedOSPlatform ("tvos15.0")]
-	[SupportedOSPlatform ("macos10.10")]
-	[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 	[iOS (15, 0)]
 	[TV (15, 0)]
 	[Watch (8, 0)]
 	[Mac (10, 10)]
 	[MacCatalyst (15, 0)]
-#endif
 	[Native]
 	public enum AVSampleBufferRequestMode : long {
 		Immediate,
 		Scheduled,
-#if NET
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios15.0")]
-		[SupportedOSPlatform ("tvos15.0")]
-		[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 		[Mac (10, 15)]
-#endif
 		Opportunistic = 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("macos10.15")]
-	[SupportedOSPlatform ("ios10.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoTV]
 	[NoWatch]
 	[Mac (10, 15)]
 	[iOS (10, 0)]
-#endif
 	[Native]
 	public enum AVCaptureColorSpace : long {
 		Srgb = 0,
 		P3D65 = 1,
-#if NET
-		[SupportedOSPlatform ("maccatalyst14.1")]
-		[SupportedOSPlatform ("ios14.1")]
-		[UnsupportedOSPlatform ("macos")]
-		[UnsupportedOSPlatform ("tvos")]
-#else
 		[Introduced (PlatformName.MacCatalyst, 14, 1)]
 		[iOS (14, 1)]
 		[NoMac]
-#endif
 		HlgBT2020 = 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios8.0")]
-#else
 	[iOS (8, 0)]
-#endif
 	[Native]
 	public enum AVMusicTrackLoopCount : long {
 		Forever = -1
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios10.0")]
-	[SupportedOSPlatform ("tvos10.0")]
-	[SupportedOSPlatform ("macos10.12")]
-#else
 	[Watch (6, 0)]
 	[iOS (10, 0)]
 	[TV (10, 0)]
 	[Mac (10, 12)]
-#endif
 	[Native]
 	public enum AVPlayerTimeControlStatus : long {
 		Paused,
@@ -1100,32 +788,20 @@ namespace AVFoundation {
 		Playing
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios10.0")]
-	[SupportedOSPlatform ("macos10.15")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoWatch]
 	[NoTV]
 	[iOS (10, 0)]
 	[Mac (10, 15)]
-#endif
 	[Native]
 	public enum AVAudioSessionIOType : long {
 		NotSpecified = 0,
 		Aggregated = 1,
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios10.0")]
-	[SupportedOSPlatform ("tvos10.0")]
-	[SupportedOSPlatform ("macos10.12")]
-#else
 	[Watch (6, 0)]
 	[iOS (10, 0)]
 	[TV (10, 0)]
 	[Mac (10, 12)]
-#endif
 	[Native]
 	public enum AVPlayerLooperStatus : long {
 		Unknown,
@@ -1134,16 +810,10 @@ namespace AVFoundation {
 		Cancelled
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos10.0")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("macos")]
-#else
 	[NoiOS]
 	[TV (10, 0)]
 	[NoWatch]
 	[NoMac]
-#endif
 	[Native]
 	public enum AVContentProposalAction : long {
 		Accept,
@@ -1151,32 +821,20 @@ namespace AVFoundation {
 		Defer
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos10.0")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("macos")]
-#else
 	[NoiOS]
 	[TV (10, 0)]
 	[NoWatch]
 	[NoMac]
-#endif
 	[Native]
 	public enum AVPlayerViewControllerSkippingBehavior : long {
 		Default = 0,
 		SkipItem
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos10.2")]
-	[SupportedOSPlatform ("macos10.12.4")]
-	[SupportedOSPlatform ("ios10.3")]
-#else
 	[TV (10, 2)]
 	[Mac (10, 12, 4)]
 	[iOS (10, 3)]
 	[Watch (7, 0)]
-#endif
 	[Native]
 	public enum AVContentKeyRequestStatus : long {
 		Requesting,
@@ -1187,16 +845,10 @@ namespace AVFoundation {
 		Failed
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos10.2")]
-	[SupportedOSPlatform ("macos10.12.4")]
-	[SupportedOSPlatform ("ios10.3")]
-#else
 	[TV (10, 2)]
 	[Mac (10, 12, 4)]
 	[iOS (10, 3)]
 	[Watch (7, 0)]
-#endif
 	public enum AVContentKeyRequestRetryReason {
 		[Field ("AVContentKeyRequestRetryReasonTimedOut")]
 		TimedOut,
@@ -1206,75 +858,41 @@ namespace AVFoundation {
 		ReceivedObsoleteContentKey,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos10.2")]
-	[SupportedOSPlatform ("macos10.12.4")]
-	[SupportedOSPlatform ("ios10.3")]
-#else
 	[TV (10, 2)]
 	[Mac (10, 12, 4)]
 	[iOS (10, 3)]
 	[Watch (7, 0)]
-#endif
 	public enum AVContentKeySystem {
 		[Field ("AVContentKeySystemFairPlayStreaming")]
 		FairPlayStreaming = 0,
 
-#if NET
-		[SupportedOSPlatform ("tvos11.0")]
-		[SupportedOSPlatform ("macos10.13")]
-		[SupportedOSPlatform ("ios11.0")]
-#else
 		[TV (11, 0)]
 		[Mac (10, 13)]
 		[iOS (11, 0)]
-#endif
 		[Field ("AVContentKeySystemClearKey")]
 		ClearKey = 1,
 
-#if !NET
 		[NoWatch]
-#endif
 		[Obsolete ("Use 'AVContentKeySystem.SystemClearKey' instead.")]
 		AVContentKeySystemClearKey = ClearKey,
 
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-#else
 		[TV (13, 0)]
 		[Mac (10, 15)]
 		[iOS (13, 0)]
-#endif
 		[Field ("AVContentKeySystemAuthorizationToken")]
 		AuthorizationToken = 2,
 	}
 
 	// Convience enum for native string values 
-#if !NET
 	[NoWatch]
-#endif
 	public enum AVAssetExportSessionPreset {
-#if NET
-		[SupportedOSPlatform ("macos10.11")]
-#else
 		[Mac (10, 11)]
-#endif
 		[Field ("AVAssetExportPresetLowQuality")]
 		LowQuality = 0, // AVAssetExportPresetLowQuality
-#if NET
-		[SupportedOSPlatform ("macos10.11")]
-#else
 		[Mac (10, 11)]
-#endif
 		[Field ("AVAssetExportPresetMediumQuality")]
 		MediumQuality = 1, // AVAssetExportPresetMediumQuality
-#if NET
-		[SupportedOSPlatform ("macos10.11")]
-#else
 		[Mac (10, 11)]
-#endif
 		[Field ("AVAssetExportPresetHighestQuality")]
 		HighestQuality = 2, // AVAssetExportPresetHighestQuality
 		[Field ("AVAssetExportPreset640x480")]
@@ -1286,13 +904,8 @@ namespace AVFoundation {
 		[Field ("AVAssetExportPreset1920x1080")]
 		Preset1920x1080 = 6, // AVAssetExportPreset1920x1080
 
-#if NET
-		[SupportedOSPlatform ("ios9.0")]
-		[SupportedOSPlatform ("macos10.10")]
-#else
 		[iOS (9, 0)]
 		[Mac (10, 10)]
-#endif
 		[Field ("AVAssetExportPreset3840x2160")]
 		Preset3840x2160 = 7, // AVAssetExportPreset3840x2160
 
@@ -1301,43 +914,25 @@ namespace AVFoundation {
 		[Field ("AVAssetExportPresetPassthrough")]
 		Passthrough = 9, // AVAssetExportPresetPassthrough
 
-#if NET
-		[SupportedOSPlatform ("ios11.0")]
-		[SupportedOSPlatform ("macos10.13")]
-		[SupportedOSPlatform ("tvos11.0")]
-#else
 		[iOS (11, 0)]
 		[Mac (10, 13)]
 		[TV (11, 0)]
-#endif
 		[Obsolete ("Use 'AVOutputSettingsPreset.PresetHevc1920x1080' instead.")]
 		[Field ("AVOutputSettingsPresetHEVC1920x1080")]
 		PresetHevc1920x1080 = 11,
 
-#if NET
-		[SupportedOSPlatform ("ios11.0")]
-		[SupportedOSPlatform ("macos10.13")]
-		[SupportedOSPlatform ("tvos11.0")]
-#else
 		[iOS (11, 0)]
 		[Mac (10, 13)]
 		[TV (11, 0)]
-#endif
 		[Obsolete ("Use 'AVOutputSettingsPreset.PresetHevc3840x2160' instead.")]
 		[Field ("AVOutputSettingsPresetHEVC3840x2160")]
 		PresetHevc3840x2160 = 12,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos9.0")]
-	[SupportedOSPlatform ("macos10.9")]
-	[SupportedOSPlatform ("ios7.0")]
-#else
 	[TV (9, 0)]
 	[NoWatch]
 	[Mac (10, 9)]
 	[iOS (7, 0)]
-#endif
 	public enum AVOutputSettingsPreset {
 		[Field ("AVOutputSettingsPreset640x480")]
 		Preset640x480 = 0,
@@ -1351,125 +946,70 @@ namespace AVFoundation {
 		[Field ("AVOutputSettingsPreset1920x1080")]
 		Preset1920x1080 = 3,
 
-#if NET
-		[SupportedOSPlatform ("macos10.10")]
-		[SupportedOSPlatform ("ios9.0")]
-		[SupportedOSPlatform ("tvos9.0")]
-#else
 		[Mac (10, 10)]
 		[iOS (9, 0)]
-#endif
 		[Field ("AVOutputSettingsPreset3840x2160")]
 		Preset3840x2160 = 4,
 
-#if NET
-		[SupportedOSPlatform ("ios11.0")]
-		[SupportedOSPlatform ("macos10.13")]
-		[SupportedOSPlatform ("tvos11.0")]
-#else
 		[iOS (11, 0)]
 		[Mac (10, 13)]
 		[TV (11, 0)]
-#endif
 		[Field ("AVOutputSettingsPresetHEVC1920x1080")]
 		PresetHevc1920x1080 = 11, // we added the wrong value in the export enum, we use the same so that they can be swap
 
-#if NET
-		[SupportedOSPlatform ("ios11.0")]
-		[SupportedOSPlatform ("macos10.13")]
-		[SupportedOSPlatform ("tvos11.0")]
-#else
 		[iOS (11, 0)]
 		[Mac (10, 13)]
 		[TV (11, 0)]
-#endif
 		[Field ("AVOutputSettingsPresetHEVC3840x2160")]
 		PresetHevc3840x2160 = 12, // we added the wrong value in the export enum, we use the same so that they can be swap
 
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-#else
 		[TV (13, 0)]
 		[NoWatch]
 		[Mac (10, 15)]
 		[iOS (13, 0)]
-#endif
 		[Field ("AVOutputSettingsPresetHEVC1920x1080WithAlpha")]
 		PresetHevc1920x1080WithAlpha = 13,
 
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-#else
 		[TV (13, 0)]
 		[NoWatch]
 		[Mac (10, 15)]
 		[iOS (13, 0)]
-#endif
 		[Field ("AVOutputSettingsPresetHEVC3840x2160WithAlpha")]
 		PresetHevc3840x2160WithAlpha = 14,
 
-#if NET
-		[SupportedOSPlatform ("macos12.1")]
-		[UnsupportedOSPlatform ("tvos")]
-		[UnsupportedOSPlatform ("ios")]
-#else
 		[NoTV]
 		[NoWatch]
 		[Mac (12, 1)]
 		[NoiOS]
-#endif
 		[Field ("AVOutputSettingsPresetHEVC7680x4320")]
 		PresetHevc7680x4320 = 15,
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("tvos11.0")]
-	[SupportedOSPlatform ("macos10.13")]
-	[SupportedOSPlatform ("ios11.0")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[TV (11, 0)]
 	[NoWatch]
 	[Mac (10, 13)]
 	[iOS (11, 0)]
-#endif
 	[Native]
 	public enum AVDepthDataAccuracy : long {
 		Relative = 0,
 		Absolute = 1,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos11.0")]
-	[SupportedOSPlatform ("macos10.13")]
-	[SupportedOSPlatform ("ios11.0")]
-#else
 	[Watch (4, 0)]
 	[TV (11, 0)]
 	[Mac (10, 13)]
 	[iOS (11, 0)]
-#endif
 	[Native]
 	public enum AVAudioEngineManualRenderingMode : long {
 		Offline = 0,
 		Realtime = 1
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos11.0")]
-	[SupportedOSPlatform ("macos10.13")]
-	[SupportedOSPlatform ("ios11.0")]
-#else
 	[Watch (4, 0)]
 	[TV (11, 0)]
 	[Mac (10, 13)]
 	[iOS (11, 0)]
-#endif
 	[Native]
 	public enum AVAudioEngineManualRenderingStatus : long {
 		Error = -1,
@@ -1478,44 +1018,26 @@ namespace AVFoundation {
 		CannotDoInCurrentContext = 2
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos11.0")]
-	[SupportedOSPlatform ("macos10.13")]
-	[SupportedOSPlatform ("ios11.0")]
-#else
 	[TV (11, 0)]
 	[Watch (5, 0)]
 	[Mac (10, 13)]
 	[iOS (11, 0)]
-#endif
 	[Native]
 	public enum AVAudioSessionRouteSharingPolicy : ulong {
 		Default = 0,
 		LongForm = 1,
 		Independent = 2,
-#if NET
-		[SupportedOSPlatform ("ios14.0")]
-		[UnsupportedOSPlatform ("tvos")]
-		[UnsupportedOSPlatform ("macos")]
-#else
 		[iOS (14, 0)]
 		[NoWatch]
 		[NoTV]
 		[NoMac]
-#endif
 		LongFormVideo = 3,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos11.0")]
-	[SupportedOSPlatform ("macos10.13")]
-	[SupportedOSPlatform ("ios11.0")]
-#else
 	[Watch (4, 0)]
 	[TV (11, 0)]
 	[Mac (10, 13)]
 	[iOS (11, 0)]
-#endif
 	[Native]
 	public enum AVAudioPlayerNodeCompletionCallbackType : long {
 		Consumed = 0,
@@ -1523,32 +1045,20 @@ namespace AVFoundation {
 		PlayedBack = 2
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos11.0")]
-	[SupportedOSPlatform ("macos10.13")]
-	[SupportedOSPlatform ("ios11.0")]
-#else
 	[Watch (4, 0)]
 	[TV (11, 0)]
 	[Mac (10, 13)]
 	[iOS (11, 0)]
-#endif
 	public enum AVAudioEngineManualRenderingError {
 		InvalidMode = -80800,
 		Initialized = -80801,
 		NotRunning = -80802,
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("ios11.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoTV]
 	[iOS (11, 0)]
 	[NoWatch]
-#endif
 	[Native]
 	public enum AVCaptureLensStabilizationStatus : long {
 		Unsupported = 0,
@@ -1558,18 +1068,11 @@ namespace AVFoundation {
 		Unavailable = 4
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.15")]
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("ios11.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[Mac (10, 15)]
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
 	[iOS (11, 0)]
-#endif
 	[Native]
 	public enum AVCaptureOutputDataDroppedReason : long {
 		None = 0,
@@ -1578,16 +1081,10 @@ namespace AVFoundation {
 		Discontinuity = 3,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos11.0")]
-	[SupportedOSPlatform ("macos10.13")]
-	[SupportedOSPlatform ("ios11.0")]
-#else
 	[TV (11, 0)]
 	[NoWatch]
 	[Mac (10, 13)]
 	[iOS (11, 0)]
-#endif
 	public enum AVVideoApertureMode {
 		[Field ("AVVideoApertureModeCleanAperture")]
 		CleanAperture = 0,
@@ -1598,17 +1095,10 @@ namespace AVFoundation {
 		[Field ("AVVideoApertureModeEncodedPixels")]
 		EncodedPixels = 2,
 	}
-
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[SupportedOSPlatform ("ios11.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoWatch]
 	[NoTV]
 	[Mac (12, 0)]
 	[iOS (11, 0)]
-#endif
 	public enum AVAssetDownloadedAssetEvictionPriority {
 		[Field ("AVAssetDownloadedAssetEvictionPriorityDefault")]
 		Default = 0,
@@ -1617,16 +1107,10 @@ namespace AVFoundation {
 		Important = 1,
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios11.0")]
-	[SupportedOSPlatform ("tvos11.0")]
-	[SupportedOSPlatform ("macos10.13")]
-#else
 	[NoWatch]
 	[iOS (11, 0)]
 	[TV (11, 0)]
 	[Mac (10, 13)]
-#endif
 	public enum AVAssetWriterInputMediaDataLocation {
 		[Field ("AVAssetWriterInputMediaDataLocationInterleavedWithMainMediaData")]
 		InterleavedWithMainMediaData = 0,
@@ -1635,18 +1119,11 @@ namespace AVFoundation {
 		BeforeMainMediaDataNotInterleaved = 1,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos11.0")]
-	[SupportedOSPlatform ("macos10.13")]
-	[SupportedOSPlatform ("ios11.0")]
-	[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 	[TV (11, 0)]
 	[NoWatch]
 	[Mac (10, 13)]
 	[iOS (11, 0)]
 	[MacCatalyst (15, 0)]
-#endif
 	public enum AVVideoCodecType {
 		[Field ("AVVideoCodecTypeH264")]
 		H264 = 0,
@@ -1663,93 +1140,51 @@ namespace AVFoundation {
 		[Field ("AVVideoCodecTypeHEVC")]
 		Hevc = 5,
 
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 		[TV (13, 0)]
 		[NoWatch]
 		[Mac (10, 15)]
 		[iOS (13, 0)]
-#endif
 		[Field ("AVVideoCodecTypeAppleProRes422HQ")]
 		AppleProRes422HQ = 6,
 
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 		[TV (13, 0)]
 		[NoWatch]
 		[Mac (10, 15)]
 		[iOS (13, 0)]
-#endif
 		[Field ("AVVideoCodecTypeAppleProRes422LT")]
 		AppleProRes422LT = 7,
 
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 		[TV (13, 0)]
 		[NoWatch]
 		[Mac (10, 15)]
 		[iOS (13, 0)]
-#endif
 		[Field ("AVVideoCodecTypeAppleProRes422Proxy")]
 		AppleProRes422Proxy = 8,
 
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 		[TV (13, 0)]
 		[NoWatch]
 		[Mac (10, 15)]
 		[iOS (13, 0)]
-#endif
 		[Field ("AVVideoCodecTypeHEVCWithAlpha")]
 		HevcWithAlpha = 9,
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("tvos11.0")]
-	[SupportedOSPlatform ("macos10.13")]
-	[SupportedOSPlatform ("ios11.0")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[TV (11, 0)]
 	[NoWatch]
 	[Mac (10, 13)]
 	[iOS (11, 0)]
-#endif
 	[Native]
 	public enum AVDepthDataQuality : long {
 		Low = 0,
 		High = 1
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("ios11.1")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("macos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
 	[NoMac]
 	[iOS (11, 1)]
-#endif
 	[Flags]
 	[Native]
 	public enum AVCaptureSystemPressureFactors : ulong {
@@ -1759,16 +1194,10 @@ namespace AVFoundation {
 		DepthModuleTemperature = (1 << 2)
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos11.2")]
-	[SupportedOSPlatform ("ios11.2")]
-	[UnsupportedOSPlatform ("macos")]
-#else
 	[TV (11, 2)]
 	[NoWatch]
 	[NoMac]
 	[iOS (11, 2)]
-#endif
 	[Native]
 	[Flags]
 	public enum AVPlayerHdrMode : long {
@@ -1777,16 +1206,10 @@ namespace AVFoundation {
 		DolbyVision = 0x4,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos12.0")]
-	[SupportedOSPlatform ("ios12.0")]
-	[SupportedOSPlatform ("macos10.15")]
-#else
 	[Watch (5, 0)]
 	[TV (12, 0)]
 	[iOS (12, 0)]
 	[Mac (10, 15)]
-#endif
 	[Flags]
 	[Native]
 	public enum AVAudioSessionActivationOptions : ulong {
@@ -1800,35 +1223,21 @@ namespace AVFoundation {
 		Normal = 0x6e726d6c, //1852992876 - 'nrml'
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios13.0")]
-	[SupportedOSPlatform ("tvos13.0")]
-	[SupportedOSPlatform ("macos10.15")]
-#else
 	[Watch (6, 0)]
 	[iOS (13, 0)]
 	[TV (13, 0)]
 	[Mac (10, 15)]
-#endif
 	[Native]
 	public enum AVSpeechSynthesisVoiceGender : long {
 		Unspecified,
 		Male,
 		Female,
 	}
-
-#if NET
-	[SupportedOSPlatform ("maccatalyst14.0")]
-	[SupportedOSPlatform ("ios13.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("macos")]
-#else
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
 	[NoMac]
 	[iOS (13, 0)]
-#endif
 	[Native]
 	public enum AVCapturePhotoQualityPrioritization : long {
 		Speed = 1,
@@ -1836,16 +1245,10 @@ namespace AVFoundation {
 		Quality = 3,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos13.0")]
-	[SupportedOSPlatform ("macos10.15")]
-	[SupportedOSPlatform ("ios13.0")]
-#else
 	[TV (13, 0)]
 	[NoWatch]
 	[Mac (10, 15)]
 	[iOS (13, 0)]
-#endif
 	[Native]
 	public enum AVAudioEnvironmentOutputType : long {
 		Auto = 0,
@@ -1854,16 +1257,10 @@ namespace AVFoundation {
 		ExternalSpeakers = 3,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos13.0")]
-	[SupportedOSPlatform ("macos10.15")]
-	[SupportedOSPlatform ("ios13.0")]
-#else
 	[TV (13, 0)]
 	[NoWatch]
 	[Mac (10, 15)]
 	[iOS (13, 0)]
-#endif
 	[Native]
 	public enum AVAudio3DMixingSourceMode : long {
 		SpatializeIfMono = 0,
@@ -1872,48 +1269,30 @@ namespace AVFoundation {
 		AmbienceBed = 3,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos13.0")]
-	[SupportedOSPlatform ("macos10.15")]
-	[SupportedOSPlatform ("ios13.0")]
-#else
 	[TV (13, 0)]
 	[NoWatch]
 	[Mac (10, 15)]
 	[iOS (13, 0)]
-#endif
 	[Native]
 	public enum AVAudio3DMixingPointSourceInHeadMode : long {
 		Mono = 0,
 		Bypass = 1,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos14.0")]
-	[SupportedOSPlatform ("macos11.0")]
-	[SupportedOSPlatform ("ios14.0")]
-#else
 	[TV (14, 0)]
 	[NoWatch]
 	[Mac (11, 0)]
 	[iOS (14, 0)]
-#endif
 	[Native]
 	public enum AVAssetSegmentType : long {
 		Initialization = 1,
 		Separable = 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos14.0")]
-	[SupportedOSPlatform ("macos11.0")]
-	[SupportedOSPlatform ("ios14.0")]
-#else
 	[TV (14, 0)]
 	[Watch (7, 0)]
 	[Mac (11, 0)]
 	[iOS (14, 0)]
-#endif
 	[Flags]
 	[Native]
 	public enum AVAudioSpatializationFormats : ulong {
@@ -1923,16 +1302,10 @@ namespace AVFoundation {
 		MonoStereoAndMultichannel = 7,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos14.0")]
-	[SupportedOSPlatform ("macos11.0")]
-	[SupportedOSPlatform ("ios14.0")]
-#else
 	[TV (14, 0)]
 	[Watch (7, 0)]
 	[Mac (11, 0)]
 	[iOS (14, 0)]
-#endif
 	[Native]
 	public enum AVAudioStereoOrientation : long {
 		None = 0,
@@ -1942,16 +1315,10 @@ namespace AVFoundation {
 		LandscapeLeft = 4,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos14.0")]
-	[SupportedOSPlatform ("macos11.0")]
-	[SupportedOSPlatform ("ios14.0")]
-#else
 	[TV (14, 0)]
 	[Watch (7, 0)]
 	[Mac (11, 0)]
 	[iOS (14, 0)]
-#endif
 	public enum AVFileTypeProfile {
 		[Field (null)]
 		None = 0,
@@ -1961,18 +1328,11 @@ namespace AVFoundation {
 		Mpeg4CmafCompliant,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos15.0")]
-	[SupportedOSPlatform ("macos11.0")]
-	[SupportedOSPlatform ("ios15.0")]
-	[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 	[TV (15, 0)]
 	[Watch (8, 0)]
 	[Mac (11, 0)]
 	[iOS (15, 0)]
 	[MacCatalyst (15, 0)]
-#endif
 	[Native]
 	public enum AVAudioRoutingArbitrationCategory : long {
 		Playback = 0,
@@ -1981,44 +1341,25 @@ namespace AVFoundation {
 	}
 
 #if !WATCH
-#if NET
-	[SupportedOSPlatform ("tvos10.2")]
-	[SupportedOSPlatform ("macos10.12.4")]
-	[SupportedOSPlatform ("ios10.3")]
-#else
 	[TV (10, 2)]
 	[Mac (10, 12, 4)]
 	[iOS (10, 3)]
 	[NoWatch]
-#endif
 	public enum AVContentKeyResponseDataType {
 		FairPlayStreamingKeyResponseData,
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-#else
 		[TV (13, 0)]
 		[NoWatch]
 		[Mac (10, 15)]
 		[iOS (13, 0)]
-#endif
 		AuthorizationTokenData,
 	}
 #endif
 
-#if NET
-	[SupportedOSPlatform ("tvos15.0")]
-	[SupportedOSPlatform ("macos12.0")]
-	[SupportedOSPlatform ("ios15.0")]
-	[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 	[TV (15, 0)]
 	[Mac (12, 0)]
 	[iOS (15, 0)]
 	[Watch (8, 0)]
 	[MacCatalyst (15, 0)]
-#endif
 	[Flags]
 	[Native]
 	public enum AVDelegatingPlaybackCoordinatorRateChangeOptions : ulong {
@@ -2026,18 +1367,11 @@ namespace AVFoundation {
 		PlayImmediately = (1uL << 0),
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos15.0")]
-	[SupportedOSPlatform ("macos12.0")]
-	[SupportedOSPlatform ("ios15.0")]
-	[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 	[TV (15, 0)]
 	[Mac (12, 0)]
 	[iOS (15, 0)]
 	[Watch (8, 0)]
 	[MacCatalyst (15, 0)]
-#endif
 	[Flags]
 	[Native]
 	public enum AVDelegatingPlaybackCoordinatorSeekOptions : ulong {
@@ -2045,18 +1379,11 @@ namespace AVFoundation {
 		ResumeImmediately = (1uL << 0),
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[SupportedOSPlatform ("ios15.0")]
-	[SupportedOSPlatform ("maccatalyst15.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoWatch]
 	[NoTV]
 	[Mac (12, 0)]
 	[iOS (15, 0)]
 	[MacCatalyst (15, 0)]
-#endif
 	[Native]
 	public enum AVCaptureMicrophoneMode : long {
 		Standard = 0,
@@ -2064,36 +1391,22 @@ namespace AVFoundation {
 		VoiceIsolation = 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[SupportedOSPlatform ("ios15.0")]
-	[SupportedOSPlatform ("maccatalyst15.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoWatch]
 	[NoTV]
 	[Mac (12, 0)]
 	[iOS (15, 0)]
 	[MacCatalyst (15, 0)]
-#endif
 	[Native]
 	public enum AVCaptureSystemUserInterface : long {
 		VideoEffects = 1,
 		MicrophoneModes = 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos15.0")]
-	[SupportedOSPlatform ("macos12.0")]
-	[SupportedOSPlatform ("ios15.0")]
-	[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 	[Watch (8, 0)]
 	[TV (15, 0)]
 	[Mac (12, 0)]
 	[iOS (15, 0)]
 	[MacCatalyst (15, 0)]
-#endif
 	[Native]
 	public enum AVPlayerAudiovisualBackgroundPlaybackPolicy : long {
 		Automatic = 1,
@@ -2101,18 +1414,11 @@ namespace AVFoundation {
 		ContinuesIfPossible = 3,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos15.0")]
-	[SupportedOSPlatform ("macos12.0")]
-	[SupportedOSPlatform ("ios15.0")]
-	[SupportedOSPlatform ("maccatalyst15.0")]
-#else
 	[TV (15, 0)]
 	[NoWatch]
 	[Mac (12, 0)]
 	[iOS (15, 0)]
 	[MacCatalyst (15, 0)]
-#endif
 	public enum AVCoordinatedPlaybackSuspensionReason {
 
 		[Field ("AVCoordinatedPlaybackSuspensionReasonAudioSessionInterrupted")]
@@ -2134,36 +1440,22 @@ namespace AVFoundation {
 		UserIsChangingCurrentTime,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionAnimation : long {
 		None = 0,
 		CharacterReveal = 1,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionFontWeight : long {
 		Unknown = 0,
@@ -2171,18 +1463,11 @@ namespace AVFoundation {
 		Bold = 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionFontStyle : long {
 		Unknown = 0,
@@ -2190,18 +1475,11 @@ namespace AVFoundation {
 		Italic = 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Flags]
 	[Native]
 	public enum AVCaptionDecoration : ulong {
@@ -2211,18 +1489,11 @@ namespace AVFoundation {
 		Overline = 1uL << 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionTextCombine : long {
 		All = -1,
@@ -2233,18 +1504,11 @@ namespace AVFoundation {
 		FourDigits = 4,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionTextAlignment : long {
 		Start = 0,
@@ -2254,54 +1518,33 @@ namespace AVFoundation {
 		Right = 4,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionRegionWritingMode : long {
 		LeftToRightAndTopToBottom = 0,
 		TopToBottomAndRightToLeft = 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionRegionScroll : long {
 		None = 0,
 		RollUp = 1,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionRegionDisplayAlignment : long {
 		Before = 0,
@@ -2309,36 +1552,22 @@ namespace AVFoundation {
 		After = 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionRubyPosition : long {
 		Before = 0,
 		After = 1,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionRubyAlignment : long {
 		Start = 0,
@@ -2347,18 +1576,11 @@ namespace AVFoundation {
 		DistributeSpaceAround = 3,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos12.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoiOS]
 	[Mac (12, 0)]
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum AVCaptionConversionValidatorStatus : long {
 		Unknown = 0,
@@ -2367,18 +1589,11 @@ namespace AVFoundation {
 		Stopped = 3,
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst15.0")]
-	[SupportedOSPlatform ("macos12.0")]
-	[SupportedOSPlatform ("ios15.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoWatch]
 	[NoTV]
 	[MacCatalyst (15, 0)]
 	[Mac (12, 0)]
 	[iOS (15, 0)]
-#endif
 	[Native]
 	public enum AVCapturePrimaryConstituentDeviceSwitchingBehavior : long {
 		Unsupported = 0,
@@ -2387,18 +1602,11 @@ namespace AVFoundation {
 		Locked = 3,
 	}
 
-#if NET
-	[SupportedOSPlatform ("maccatalyst15.0")]
-	[SupportedOSPlatform ("macos12.0")]
-	[SupportedOSPlatform ("ios15.0")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoWatch]
 	[NoTV]
 	[MacCatalyst (15, 0)]
 	[Mac (12, 0)]
 	[iOS (15, 0)]
-#endif
 	[Flags]
 	[Native]
 	public enum AVCapturePrimaryConstituentDeviceRestrictedSwitchingBehaviorConditions : ulong {

--- a/src/AVKit/Enums.cs
+++ b/src/AVKit/Enums.cs
@@ -37,16 +37,10 @@ namespace AVKit {
 		ContentDisallowedByProfile = -1102,
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios13.0")]
-	[UnsupportedOSPlatform ("tvos")]
-	[UnsupportedOSPlatform ("macos")]
-#else
 	[NoWatch]
 	[NoTV]
 	[NoMac]
 	[iOS (13,0)]
-#endif
 	[Native]
 	public enum AVAudioSessionRouteSelection : long {
 		None = 0,
@@ -54,16 +48,10 @@ namespace AVKit {
 		External = 2,
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.15")]
-	[UnsupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoiOS]
 	[NoWatch]
 	[NoTV]
 	[Mac (10,15)]
-#endif
 	[Native]
 	public enum AVRoutePickerViewButtonState : long {
 		Normal,

--- a/src/AudioToolbox/Enums.cs
+++ b/src/AudioToolbox/Enums.cs
@@ -4,16 +4,10 @@ using Foundation;
 using ObjCRuntime;
 
 namespace AudioToolbox {
-#if NET
-	[SupportedOSPlatform ("tvos10.0")]
-	[SupportedOSPlatform ("macos10.12")]
-	[SupportedOSPlatform ("ios10.0")]
-#else
 	[NoWatch]
 	[TV (10, 0)]
 	[Mac (10, 12)]
 	[iOS (10, 0)]
-#endif
 	[Flags]
 	public enum AudioSettingsFlags : uint
 	{
@@ -23,16 +17,10 @@ namespace AudioToolbox {
 		UserInterfaceParameter = (1u << 3),
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos14.0")]
-	[SupportedOSPlatform ("macos11.0")]
-	[SupportedOSPlatform ("ios14.0")]
-#else
 	[NoWatch]
 	[TV (14, 0)]
 	[Mac (11, 0)]
 	[iOS (14, 0)]
-#endif
 	public enum AUSpatialMixerOutputType : uint
 	{
 		Headphones = 1,
@@ -40,32 +28,20 @@ namespace AudioToolbox {
 		ExternalSpeakers = 3,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos14.0")]
-	[SupportedOSPlatform ("macos11.0")]
-	[SupportedOSPlatform ("ios14.0")]
-#else
 	[NoWatch]
 	[TV (14, 0)]
 	[Mac (11, 0)]
 	[iOS (14, 0)]
-#endif
 	public enum AUSpatialMixerPointSourceInHeadMode : uint
 	{
 		Mono = 0,
 		Bypass = 1,
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos14.0")]
-	[SupportedOSPlatform ("macos11.0")]
-	[SupportedOSPlatform ("ios14.0")]
-#else
 	[NoWatch]
 	[TV (14, 0)]
 	[Mac (11, 0)]
 	[iOS (14, 0)]
-#endif
 	public enum AUSpatialMixerSourceMode : uint
 	{
 		SpatializeIfMono = 0,

--- a/src/AudioUnit/AUEnums.cs
+++ b/src/AudioUnit/AUEnums.cs
@@ -195,14 +195,7 @@ namespace AudioUnit
 		[Deprecated (PlatformName.MacOSX, 12,0, message : "Use the 'ProcessIsMain' element instead.")]
 		[Obsolete ("Use the 'ProcessIsMain' element instead.")]
 		ProcessIsMaster = 1835103092, // 'mast'
-#if !NET
 		[iOS (15,0), MacCatalyst (15,0), Mac (12,0), NoTV, NoWatch]
-#else
-		[SupportedOSPlatform ("ios15.0")]
-		[SupportedOSPlatform ("maccatalyst15.0")]
-		[SupportedOSPlatform ("macos12.0")]
-		[UnsupportedOSPlatform ("tvos")]
-#endif
 		ProcessIsMain = 1835100526, // 'main'
 		IsInitingOrExiting = 1768845172, // 'inot'
 		UserIDChanged = 1702193508, // 'euid'
@@ -216,14 +209,7 @@ namespace AudioUnit
 		ActualSampleRate = 1634955892,// 'asrt',
 		ClockDevice = 1634755428, // 'apcd',
 		IOThreadOSWorkgroup = 1869838183, // 'oswg'
-#if !NET
 		[iOS (15,0), MacCatalyst (15,0), Mac (12,0), NoTV, NoWatch]
-#else
-		[SupportedOSPlatform ("ios15.0")]
-		[SupportedOSPlatform ("maccatalyst15.0")]
-		[SupportedOSPlatform ("macos12.0")]
-		[UnsupportedOSPlatform ("tvos")]
-#endif
 		ProcessMute = 1634758765, // 'appm'
 	}
 

--- a/src/CoreImage/Enums.cs
+++ b/src/CoreImage/Enums.cs
@@ -77,14 +77,9 @@ namespace CoreImage {
 		RGf = 22
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios11.0")]
-	[SupportedOSPlatform ("tvos11.0")]
-#else
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-#endif
 	[Native]
 	public enum CIQRCodeErrorCorrectionLevel : long {
 		L = 76,
@@ -93,14 +88,9 @@ namespace CoreImage {
 		H = 72,
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios11.0")]
-	[SupportedOSPlatform ("tvos11.0")]
-#else
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-#endif
 	[Native]
 	public enum CIDataMatrixCodeEccVersion : long {
 		V000 = 0,
@@ -111,14 +101,9 @@ namespace CoreImage {
 		V200 = 200,
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios11.0")]
-	[SupportedOSPlatform ("tvos11.0")]
-#else
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-#endif
 	[Native]
 	public enum CIRenderDestinationAlphaMode : ulong {
 		None = 0,

--- a/src/CoreWlan/Enums.cs
+++ b/src/CoreWlan/Enums.cs
@@ -11,11 +11,7 @@ using System.Runtime.Versioning;
 
 namespace CoreWlan {
 
-#if NET
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoMacCatalyst]
-#endif
 	[Native]
 	[ErrorDomain ("CWErrorDomain")] // enum named `CWErr` in headers
 	public enum CWStatus : long {
@@ -55,11 +51,7 @@ namespace CoreWlan {
 		Status = -3931,
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum CWPhyMode : ulong {
 		None = 0,
@@ -71,11 +63,7 @@ namespace CoreWlan {
 		AX = 6,
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum CWInterfaceMode : ulong {
 		None = 0,
@@ -84,11 +72,7 @@ namespace CoreWlan {
 		HostAP = 3,
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum CWSecurity : ulong {
 		None = 0,
@@ -111,11 +95,7 @@ namespace CoreWlan {
 		Unknown = long.MaxValue,
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoMacCatalyst]
-#endif
 	[Deprecated (PlatformName.MacOSX, 11,0)]
 	[Native]
 	public enum CWIbssModeSecurity : ulong {
@@ -124,11 +104,7 @@ namespace CoreWlan {
 		WEP104 = 2,
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum CWChannelWidth : ulong {
 		Unknown = 0,
@@ -138,11 +114,7 @@ namespace CoreWlan {
 		OneHundredSixtyMHz = 4,
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum CWChannelBand : ulong {
 		Unknown = 0,
@@ -150,11 +122,7 @@ namespace CoreWlan {
 		FiveGHz = 2,
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum CWCipherKeyFlags : ulong {
 		None = 0,
@@ -164,11 +132,7 @@ namespace CoreWlan {
 		Rx = 1 << 4,
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum CWKeychainDomain : ulong {
 		None = 0,
@@ -176,11 +140,7 @@ namespace CoreWlan {
 		System = 2,
 	}
 
-#if NET
-	[UnsupportedOSPlatform ("maccatalyst")]
-#else
 	[NoMacCatalyst]
-#endif
 	[Native]
 	public enum CWEventType : long {
 		None = 0,

--- a/src/MediaPlayer/MediaPlayer.cs
+++ b/src/MediaPlayer/MediaPlayer.cs
@@ -17,19 +17,10 @@ using System.Runtime.Versioning;
 
 namespace MediaPlayer {
 	// NSInteger -> MPMoviePlayerController.h
-#if NET
-	[UnsupportedOSPlatform ("ios9.0")]
-#if IOS
-	[Obsolete ("Starting with ios9.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
 	[Deprecated (PlatformName.iOS, 9, 0)]
-#endif
 	[Native]
 	public enum MPMoviePlaybackState : long {
 		Stopped,
@@ -41,19 +32,10 @@ namespace MediaPlayer {
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
-#if NET
-	[UnsupportedOSPlatform ("ios9.0")]
-#if IOS
-	[Obsolete ("Starting with ios9.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
 	[Deprecated (PlatformName.iOS, 9, 0)]
-#endif
 	[Native]
 	public enum MPMovieLoadState : long {
 		Unknown        = 0,
@@ -63,76 +45,40 @@ namespace MediaPlayer {
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
-#if NET
-	[UnsupportedOSPlatform ("ios9.0")]
-#if IOS
-	[Obsolete ("Starting with ios9.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
 	[Deprecated (PlatformName.iOS, 9, 0)]
-#endif
 	[Native]
 	public enum MPMovieRepeatMode : long {
 		None, One
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
-#if NET
-	[UnsupportedOSPlatform ("ios9.0")]
-#if IOS
-	[Obsolete ("Starting with ios9.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
 	[Deprecated (PlatformName.iOS, 9, 0)]
-#endif
 	[Native]
 	public enum MPMovieControlStyle : long {
 		None, Embedded, Fullscreen, Default = Embedded
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
-#if NET
-	[UnsupportedOSPlatform ("ios9.0")]
-#if IOS
-	[Obsolete ("Starting with ios9.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
 	[Deprecated (PlatformName.iOS, 9, 0)]
-#endif
 	[Native]
 	public enum MPMovieFinishReason : long {
 		PlaybackEnded, PlaybackError, UserExited
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
-#if NET
-	[UnsupportedOSPlatform ("ios9.0")]
-#if IOS
-	[Obsolete ("Starting with ios9.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
 	[Deprecated (PlatformName.iOS, 9, 0)]
-#endif
 	[Native]
 	[Flags]
 	public enum MPMovieMediaType : long {
@@ -142,38 +88,20 @@ namespace MediaPlayer {
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
-#if NET
-	[UnsupportedOSPlatform ("ios9.0")]
-#if IOS
-	[Obsolete ("Starting with ios9.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
 	[Deprecated (PlatformName.iOS, 9, 0)]
-#endif
 	[Native]
 	public enum MPMovieSourceType : long {
 		Unknown, File, Streaming
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
-#if NET
-	[UnsupportedOSPlatform ("ios9.0")]
-#if IOS
-	[Obsolete ("Starting with ios9.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
 	[Deprecated (PlatformName.iOS, 9, 0)]
-#endif
 	[Native]
 	public enum MPMovieTimeOption : long {
 		NearestKeyFrame,
@@ -181,9 +109,7 @@ namespace MediaPlayer {
 	}
 
 	// NSUInteger -> MPMediaItem.h
-#if !NET
 	[Watch (7,0)]
-#endif
 	[Native]
 	[Flags]
 	public enum MPMediaType : ulong {
@@ -193,62 +119,28 @@ namespace MediaPlayer {
 		AudioITunesU = 1 << 3,
 		AnyAudio     = 0x00ff,
 		
-#if NET
-		[SupportedOSPlatform ("macos10.12.2")]
-#else
 		[Mac (10,12,2)]
-#endif
 		Movie = 1 << 8,
-#if NET
-		[SupportedOSPlatform ("macos10.12.2")]
-#else
 		[Mac (10,12,2)]
-#endif
 		TVShow = 1 << 9,
-#if NET
-		[SupportedOSPlatform ("macos10.12.2")]
-#else
 		[Mac (10,12,2)]
-#endif
 		VideoPodcast = 1 << 10,
-#if NET
-		[SupportedOSPlatform ("macos10.12.2")]
-#else
 		[Mac (10,12,2)]
-#endif
 		MusicVideo = 1 << 11,
-#if NET
-		[SupportedOSPlatform ("macos10.12.2")]
-#else
 		[Mac (10,12,2)]
-#endif
 		VideoITunesU = 1 << 12,
-#if NET
-		[SupportedOSPlatform ("ios7.0")]
-		[SupportedOSPlatform ("macos10.12.2")]
-#else
 		[iOS (7,0)]
 		[Mac (10,12,2)]
-#endif
 		HomeVideo = 1 << 13,
-#if NET
-		[SupportedOSPlatform ("macos10.12.2")]
-#else
 		[Mac (10,12,2)]
-#endif
 		TypeAnyVideo = 0xff00,
 		Any          = 0xFFFFFFFFFFFFFFFF
 	}
 
 	// NSInteger -> MPMediaPlaylist.h
-#if NET
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
-#endif
 	[Native]
 	[Flags]
 	public enum MPMediaPlaylistAttribute : long {
@@ -259,14 +151,9 @@ namespace MediaPlayer {
 	};
 			
 	// NSInteger -> MPMediaQuery.h
-#if NET
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
-#endif
 	[Native]
 	public enum MPMediaGrouping : long {
 		Title,
@@ -280,14 +167,9 @@ namespace MediaPlayer {
 	}
 
 	// NSInteger -> MPMediaQuery.h
-#if NET
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
-#endif
 	[Native]
 	public enum MPMediaPredicateComparison : long {
 		EqualsTo,
@@ -295,19 +177,10 @@ namespace MediaPlayer {
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
-#if NET
-	[UnsupportedOSPlatform ("ios9.0")]
-#if IOS
-	[Obsolete ("Starting with ios9.0.", DiagnosticId = "BI1234", UrlFormat = "https://github.com/xamarin/xamarin-macios/wiki/Obsolete")]
-#endif
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
 	[Deprecated (PlatformName.iOS, 9, 0)]
-#endif
 	[Native]
 	public enum MPMovieScalingMode : long {
 		None,
@@ -317,11 +190,7 @@ namespace MediaPlayer {
 	}
 	
 	// untyped enum -> MPMoviePlayerController.h
-#if NET
-	[UnsupportedOSPlatform ("macos")]
-#else
 	[NoMac]
-#endif
 	public enum MPMovieControlMode {
 		Default, 
 		VolumeOnly,
@@ -329,14 +198,9 @@ namespace MediaPlayer {
 	}
 
 	// NSInteger -> /MPMusicPlayerController.h
-#if NET
-	[SupportedOSPlatform ("tvos14.0")]
-	[UnsupportedOSPlatform ("macos")]
-#else
 	[NoMac]
 	[NoWatch]
 	[TV (14,0)]
-#endif
 	[Native]
 	public enum MPMusicPlaybackState : long {
 		Stopped,
@@ -348,14 +212,9 @@ namespace MediaPlayer {
 	}
 	
 	// NSInteger -> /MPMusicPlayerController.h
-#if NET
-	[SupportedOSPlatform ("tvos14.0")]
-	[UnsupportedOSPlatform ("macos")]
-#else
 	[NoMac]
 	[NoWatch]
 	[TV (14,0)]
-#endif
 	[Native]
 	public enum MPMusicRepeatMode : long {
 		Default,
@@ -365,14 +224,9 @@ namespace MediaPlayer {
 	}
 	
 	// NSInteger -> /MPMusicPlayerController.h
-#if NET
-	[SupportedOSPlatform ("tvos14.0")]
-	[UnsupportedOSPlatform ("macos")]
-#else
 	[NoMac]
 	[NoWatch]
 	[TV (14,0)]
-#endif
 	[Native]
 	public enum MPMusicShuffleMode : long {
 		Default,
@@ -383,12 +237,8 @@ namespace MediaPlayer {
 
 	public delegate void MPMediaItemEnumerator (string property, NSObject value, ref bool stop);
 
-#if NET
-	[SupportedOSPlatform ("macos10.12.2")]
-#else
 	[Mac (10,12,2)]
 	[Watch (5,0)]
-#endif
 	[Native]
 	public enum MPShuffleType : long
 	{
@@ -397,12 +247,8 @@ namespace MediaPlayer {
 		Collections
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.12.2")]
-#else
 	[Mac (10,12,2)]
 	[Watch (5,0)]
-#endif
 	[Native]
 	public enum MPRepeatType : long
 	{
@@ -411,14 +257,9 @@ namespace MediaPlayer {
 		All
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.12.2")]
-	[SupportedOSPlatform ("ios10.0")]
-#else
 	[Mac (10,12,2)]
 	[iOS (10,0)]
 	[Watch (5,0)]
-#endif
 	[Native]
 	public enum MPChangeLanguageOptionSetting : long
 	{
@@ -428,75 +269,44 @@ namespace MediaPlayer {
 	}
 
 	// NSInteger -> MPRemoteCommand.h
-#if NET
-	[SupportedOSPlatform ("macos10.12.2")]
-	[SupportedOSPlatform ("ios7.1")]
-#else
 	[Mac (10,12,2)]
 	[iOS (7,1)]
 	[Watch (5,0)]
-#endif
 	[Native]
 	public enum MPRemoteCommandHandlerStatus : long {
 		Success = 0,
 		NoSuchContent = 100,
-#if NET
-		[SupportedOSPlatform ("ios9.1")]
-		[SupportedOSPlatform ("macos10.12.2")]
-#else
 		[iOS (9,1)]
-#endif
 		NoActionableNowPlayingItem = 110,
-#if NET
-		[SupportedOSPlatform ("ios11.0")]
-		[SupportedOSPlatform ("tvos11.0")]
-		[SupportedOSPlatform ("macos10.13")]
-#else
 		[iOS (11,0)]
 		[TV (11,0)]
 		[Mac (10,13)]
-#endif
 		DeviceNotFound = 120,
 		CommandFailed = 200
 	}
 
 	// NSUInteger -> MPRemoteCommandEvent.h
-#if NET
-	[SupportedOSPlatform ("macos10.12.2")]
-	[SupportedOSPlatform ("ios7.1")]
-#else
 	[Mac (10,12,2)]
 	[iOS (7,1)]
 	[Watch (5,0)]
-#endif
 	[Native]
 	public enum MPSeekCommandEventType : ulong {
 		BeginSeeking,
 		EndSeeking
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.12.2")]
-	[SupportedOSPlatform ("ios9.0")]
-#else
 	[Mac (10,12,2)]
 	[iOS (9,0)]
 	[Watch (5,0)]
-#endif
 	[Native]
 	public enum MPNowPlayingInfoLanguageOptionType : ulong {
 		Audible,
 		Legible
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.14.2")]
-	[SupportedOSPlatform ("ios9.3")]
-#else
 	[Mac (10,14,2)]
 	[Watch (7,0)]
 	[iOS (9,3)]
-#endif
 	[Native]
 	[ErrorDomain ("MPErrorDomain")]
 	public enum MPErrorCode : long {
@@ -510,16 +320,10 @@ namespace MediaPlayer {
 		RequestTimedOut,
 	}
 
-#if NET
-	[SupportedOSPlatform ("ios9.3")]
-	[UnsupportedOSPlatform ("macos")]
-	[UnsupportedOSPlatform ("tvos")]
-#else
 	[NoMac]
 	[NoTV]
 	[NoWatch]
 	[iOS (9,3)]
-#endif
 	[Native]
 	public enum MPMediaLibraryAuthorizationStatus : long {
 		NotDetermined = 0,
@@ -528,16 +332,10 @@ namespace MediaPlayer {
 		Authorized
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.12.2")]
-	[SupportedOSPlatform ("ios10.0")]
-	[SupportedOSPlatform ("tvos10.0")]
-#else
 	[Mac (10,12,2)]
 	[iOS (10,0)]
 	[TV (10,0)]
 	[Watch (5,0)]
-#endif
 	[Native]
 	public enum MPNowPlayingInfoMediaType : ulong
 	{
@@ -546,16 +344,10 @@ namespace MediaPlayer {
 		Video
 	}
 
-#if NET
-	[SupportedOSPlatform ("macos10.12.2")]
-	[SupportedOSPlatform ("ios11.0")]
-	[SupportedOSPlatform ("tvos11.0")]
-#else
 	[Mac (10,12,2)]
 	[Watch (5,0)]
 	[iOS (11, 0)]
 	[TV (11, 0)]
-#endif
 	[Native]
 	public enum MPNowPlayingPlaybackState : ulong
 	{

--- a/src/TVServices/TVEnums.cs
+++ b/src/TVServices/TVEnums.cs
@@ -12,11 +12,7 @@ using ObjCRuntime;
 
 namespace TVServices {
 
-#if NET
-	[SupportedOSPlatform ("tvos9.0")]
-#else
 	[TV (9,0)]
-#endif
 	[Native]
 	public enum TVContentItemImageShape : long {
 		None = 0,
@@ -28,22 +24,14 @@ namespace TVServices {
 		ExtraWide
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos9.0")]
-#else
 	[TV (9,0)]
-#endif
 	[Native]
 	public enum TVTopShelfContentStyle : long {
 		Inset = 1,
 		Sectioned = 2
 	}
 
-#if NET
-	[SupportedOSPlatform ("tvos11.0")]
-#else
 	[TV (11,0)]
-#endif
 	[Native]
 	[Flags]
 	public enum TVContentItemImageTrait : ulong {


### PR DESCRIPTION
It's not necessary, the generator will generate the .NET-style attributes.