### PR TITLE
[dotnet-linker] Improve the error message from the linker when we run into a problem.

### DIFF
--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -457,10 +457,9 @@ namespace Xamarin.Linker {
 			var list = ErrorHelper.CollectExceptions (exceptions);
 			var allWarnings = list.All (v => v is ProductException pe && !pe.Error);
 			if (!allWarnings) {
-				// Revisit the error code after https://github.com/mono/linker/issues/1596 has been fixed.
 				var instance = GetInstance (context, false);
 				var platform = (instance?.Platform)?.ToString () ?? "unknown";
-				var msg = MessageContainer.CreateCustomErrorMessage ("Failed to execute the custom steps.", 6999, platform);
+				var msg = MessageContainer.CreateCustomErrorMessage (Errors.MX7000 /* An error occured while executing the custom linker steps. Please review the build log for more information. */, 7000, platform);
 				context.LogMessage (msg);
 			}
 			// ErrorHelper.Show will print our errors and warnings to stderr.

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -4043,6 +4043,15 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An error occured while executing the custom linker steps. Please review the build log for more information..
+        /// </summary>
+        public static string MX7000 {
+            get {
+                return ResourceManager.GetString("MX7000", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Don&apos;t know how to marshal the parameter of type {0} for parameter {1} in call to {2}.
         /// </summary>
         public static string MX8037 {

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2114,6 +2114,13 @@
 		</value>
 	</data>
 
+	<!-- The linker says custom linker steps can't use error codes between 1000 and 6000, so we use >= 7000 -->
+	<data name="MX7000" xml:space="preserve">
+		<value>An error occured while executing the custom linker steps. Please review the build log for more information.</value>
+	</data>
+
+	<!-- 8XXX are for errors that occur at runtime -->
+
 	<data name="MT8018" xml:space="preserve">
 		<value>Internal consistency error. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.
 		</value>


### PR DESCRIPTION
* Better text.
* Better number ("7000" is more like "this is kind of normal" - while "6999"
  was more like "something quite expected happened").
* Use resources to make it localizable.