### PR TITLE
[audiounit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/AudioUnit/AUGraph.cs
+++ b/src/AudioUnit/AUGraph.cs
@@ -134,7 +134,7 @@ namespace AudioUnit
 		public AudioUnitStatus AddRenderNotify (RenderDelegate callback)
 		{
 			if (callback is null)
-				throw new ArgumentNullException (nameof (callback));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			AudioUnitStatus error = AudioUnitStatus.OK;
 			if (graphUserCallbacks.Count == 0)
@@ -148,7 +148,7 @@ namespace AudioUnit
 		public AudioUnitStatus RemoveRenderNotify (RenderDelegate callback)
 		{
 			if (callback is null)
-				throw new ArgumentNullException (nameof (callback));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 			if (!graphUserCallbacks.Contains (callback))
 				throw new ArgumentException ("Cannot unregister a callback that has not been registered");
 

--- a/src/AudioUnit/AUParameter.cs
+++ b/src/AudioUnit/AUParameter.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/src/AudioUnit/AUParameter.cs
+++ b/src/AudioUnit/AUParameter.cs
@@ -19,7 +19,7 @@ namespace AudioUnit
 		public string GetString (float? value)
 		{
 			unsafe {
-				if (value is not null && value.HasValue) {
+				if (value is not null) {
 					float f = value.Value;
 					return this._GetString (new IntPtr (&f));
 				}

--- a/src/AudioUnit/AUParameter.cs
+++ b/src/AudioUnit/AUParameter.cs
@@ -19,7 +19,7 @@ namespace AudioUnit
 		public string GetString (float? value)
 		{
 			unsafe {
-				if (value != null && value.HasValue) {
+				if (value is not null && value.HasValue) {
 					float f = value.Value;
 					return this._GetString (new IntPtr (&f));
 				}

--- a/src/AudioUnit/AUScheduledAudioFileRegion.cs
+++ b/src/AudioUnit/AUScheduledAudioFileRegion.cs
@@ -8,6 +8,8 @@
 // Copyright 2015 Xamarin Inc.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -37,7 +39,7 @@ namespace AudioUnit {
 		}
 
 		GCHandle handle;
-		AUScheduledAudioFileRegionCompletionHandler completionHandler;
+		AUScheduledAudioFileRegionCompletionHandler? completionHandler;
 		bool alreadyUsed = false;
 
 		public AudioTimeStamp TimeStamp { get; set; }
@@ -46,7 +48,7 @@ namespace AudioUnit {
 		public long StartFrame { get; set; }
 		public uint FramesToPlay { get; set; }
 
-		public AUScheduledAudioFileRegion (AudioFile audioFile, AUScheduledAudioFileRegionCompletionHandler completionHandler = null)
+		public AUScheduledAudioFileRegion (AudioFile audioFile, AUScheduledAudioFileRegionCompletionHandler? completionHandler = null)
 		{
 			if (audioFile == null)
 				throw new ArgumentNullException (nameof (audioFile));
@@ -76,7 +78,7 @@ namespace AudioUnit {
 			
 			var handle = GCHandle.FromIntPtr (userData);
 			var inst = (AUScheduledAudioFileRegion) handle.Target;
-			inst?.completionHandler (inst, status);
+			inst?.completionHandler !(inst, status);
 		}
 
 		internal ScheduledAudioFileRegion GetAudioFileRegion ()

--- a/src/AudioUnit/AUScheduledAudioFileRegion.cs
+++ b/src/AudioUnit/AUScheduledAudioFileRegion.cs
@@ -50,7 +50,7 @@ namespace AudioUnit {
 
 		public AUScheduledAudioFileRegion (AudioFile audioFile, AUScheduledAudioFileRegionCompletionHandler? completionHandler = null)
 		{
-			if (audioFile == null)
+			if (audioFile is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioFile));
 
 			AudioFile = audioFile;
@@ -77,8 +77,9 @@ namespace AudioUnit {
 				return;
 			
 			var handle = GCHandle.FromIntPtr (userData);
-			var inst = (AUScheduledAudioFileRegion) handle.Target;
-			inst?.completionHandler !(inst, status);
+			var inst = (AUScheduledAudioFileRegion?) handle.Target;
+			if (inst is not null && inst.completionHandler is not null)
+				inst.completionHandler (inst, status);
 		}
 
 		internal ScheduledAudioFileRegion GetAudioFileRegion ()
@@ -87,7 +88,7 @@ namespace AudioUnit {
 				throw new InvalidOperationException ("You should not call SetScheduledFileRegion with a previously set region instance");
 
 			IntPtr ptr = IntPtr.Zero;
-			if (completionHandler != null) {
+			if (completionHandler is not null) {
 				handle = GCHandle.Alloc (this);
 				ptr = GCHandle.ToIntPtr (handle);
 			}

--- a/src/AudioUnit/AUScheduledAudioFileRegion.cs
+++ b/src/AudioUnit/AUScheduledAudioFileRegion.cs
@@ -78,7 +78,7 @@ namespace AudioUnit {
 			
 			var handle = GCHandle.FromIntPtr (userData);
 			var inst = (AUScheduledAudioFileRegion?) handle.Target;
-			if (inst is not null && inst.completionHandler is not null)
+			if (inst?.completionHandler is not null)
 				inst.completionHandler (inst, status);
 		}
 

--- a/src/AudioUnit/AUScheduledAudioFileRegion.cs
+++ b/src/AudioUnit/AUScheduledAudioFileRegion.cs
@@ -51,7 +51,7 @@ namespace AudioUnit {
 		public AUScheduledAudioFileRegion (AudioFile audioFile, AUScheduledAudioFileRegionCompletionHandler? completionHandler = null)
 		{
 			if (audioFile == null)
-				throw new ArgumentNullException (nameof (audioFile));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioFile));
 
 			AudioFile = audioFile;
 			this.completionHandler = completionHandler;

--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -560,7 +560,7 @@ namespace AudioUnit
 			}
 			set {
 				if (value is null)
-					throw new ArgumentNullException	(nameof	(value));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 				var nameHandle = CFString.CreateNative (Name);
 				try {
 					var dics = new NSDictionary [value.Length];

--- a/src/AudioUnit/AudioComponentDescription.cs
+++ b/src/AudioUnit/AudioComponentDescription.cs
@@ -29,6 +29,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -30,6 +30,7 @@
 
 #nullable enable
 
+// Adding this warning disable since AudioUnitPropertyIDType is removed from public API but used internally
 #if !XAMCORE_3_0
 #pragma warning disable CS0618
 #endif

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -30,6 +30,10 @@
 
 #nullable enable
 
+#if !XAMCORE_3_0
+#pragma warning disable CS0618
+#endif
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -1252,7 +1256,7 @@ namespace AudioUnit
 //
 //		public AURenderEvent? Next {
 //			get {
-//				if (UnsafeNext != null)
+//				if (UnsafeNext is not null)
 //					return (AURenderEvent?) Marshal.PtrToStructure ((IntPtr)UnsafeNext, typeof (AURenderEvent));
 //				return null;
 //			}

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -150,7 +150,7 @@ namespace AudioUnit
 		public SamplerInstrumentData (CFUrl fileUrl, InstrumentType instrumentType)
 		{
 			if (fileUrl is null)
-				throw new ArgumentNullException (nameof (fileUrl));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (fileUrl));
 
 			this.FileUrl = fileUrl;
 			this.InstrumentType = instrumentType;
@@ -327,7 +327,7 @@ namespace AudioUnit
 		static IntPtr Create (AudioComponent component)
 		{
 			if (component is null)
-				throw new ArgumentNullException (nameof (component));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (component));
 
 			var err = AudioComponentInstanceNew (component.GetCheckedHandle (), out var handle);
 			if (err != 0)
@@ -504,7 +504,7 @@ namespace AudioUnit
 		public AudioUnitStatus LoadInstrument (SamplerInstrumentData instrumentData, AudioUnitScopeType scope = AudioUnitScopeType.Global, uint audioUnitElement = 0)
 		{
 			if (instrumentData is null)
-				throw new ArgumentNullException (nameof (instrumentData));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (instrumentData));
 
 			var data = instrumentData.ToStruct ();
 			return AudioUnitSetProperty (Handle, AudioUnitPropertyIDType.LoadInstrument, scope, audioUnitElement, 
@@ -725,7 +725,7 @@ namespace AudioUnit
 		{
 
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 				
 			var nameHandle = CFString.CreateNative (name);
 			try {
@@ -845,7 +845,7 @@ namespace AudioUnit
 		public AudioUnitStatus Render (ref AudioUnitRenderActionFlags actionFlags, AudioTimeStamp timeStamp, uint busNumber, uint numberFrames, AudioBuffers data)
 		{
 			if ((IntPtr)data == IntPtr.Zero)
-				throw new ArgumentNullException (nameof (data));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 			return AudioUnitRender (Handle, ref actionFlags, ref timeStamp, busNumber, numberFrames, (IntPtr) data);
 		}
 
@@ -1010,7 +1010,7 @@ namespace AudioUnit
 		public AudioUnitStatus SetScheduledFileRegion (AUScheduledAudioFileRegion region)
 		{
 			if (region is null)
-				throw new ArgumentNullException (nameof (region));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (region));
 
 			var safr = region.GetAudioFileRegion ();
 			return AudioUnitSetProperty (GetCheckedHandle (), AudioUnitPropertyIDType.ScheduledFileRegion, AudioUnitScopeType.Global, 0, ref safr, Marshal.SizeOf (safr));
@@ -1028,7 +1028,7 @@ namespace AudioUnit
 		public AudioUnitStatus SetScheduledFiles (AudioFile audioFile)
 		{
 			if (audioFile is null)
-				throw new ArgumentNullException (nameof (audioFile));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioFile));
 
 			var audioFilehandle = audioFile.Handle;
 			return AudioUnitSetProperty (GetCheckedHandle (), AudioUnitPropertyIDType.ScheduledFileIDs, AudioUnitScopeType.Global, 0, ref audioFilehandle,  Marshal.SizeOf (Handle));
@@ -1041,7 +1041,7 @@ namespace AudioUnit
 		public unsafe AudioUnitStatus SetScheduledFiles (AudioFile[] audioFiles)
 		{
 			if (audioFiles is null)
-				throw new ArgumentNullException (nameof (audioFiles));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioFiles));
 
 			int count = audioFiles.Length;
 			IntPtr[] handles = new IntPtr[count];

--- a/src/AudioUnit/AudioUnitUtils.cs
+++ b/src/AudioUnit/AudioUnitUtils.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/AudioUnit/ClassInfoDictionary.cs
+++ b/src/AudioUnit/ClassInfoDictionary.cs
@@ -54,7 +54,7 @@ namespace AudioUnit
 		{
 		}
 
-		public ClassInfoDictionary (NSDictionary dictionary)
+		public ClassInfoDictionary (NSDictionary? dictionary)
 			: base (dictionary)
 		{
 		}

--- a/src/AudioUnit/ClassInfoDictionary.cs
+++ b/src/AudioUnit/ClassInfoDictionary.cs
@@ -25,6 +25,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 
 using Foundation;
@@ -64,7 +66,7 @@ namespace AudioUnit
 			}
 		}
 
-		public string Name {
+		public string? Name {
 			get {
 				return GetStringValue (NameKey);					
 			}

--- a/src/AudioUnit/ExtAudioFile.cs
+++ b/src/AudioUnit/ExtAudioFile.cs
@@ -29,6 +29,8 @@
 //
 //
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -106,7 +108,7 @@ namespace AudioUnit
             }
         }
 
-        public AudioConverter AudioConverter {
+        public AudioConverter? AudioConverter {
             get {
                 uint size = sizeof (uint);
                 IntPtr value;
@@ -185,7 +187,7 @@ namespace AudioUnit
 		// to the actual error code from the native API and we are not allowed to make Breaking Changes
 		// lets reimplement the method in a way to return the actual native value if any
 		// also we can share the underliying implementation so we so not break api and reduce code suplication
-		public static ExtAudioFile OpenUrl (NSUrl url, out ExtAudioFileError error)
+		public static ExtAudioFile? OpenUrl (NSUrl url, out ExtAudioFileError error)
 		{
 			if (url == null)
 				throw new ArgumentNullException ("url");
@@ -193,7 +195,7 @@ namespace AudioUnit
 			return OpenUrl (url.Handle, out error);
 		}
 
-		public static ExtAudioFile OpenUrl (CFUrl url, out ExtAudioFileError error)
+		public static ExtAudioFile? OpenUrl (CFUrl url, out ExtAudioFileError error)
 		{
 			if (url == null)
 				throw new ArgumentNullException ("url");
@@ -217,7 +219,7 @@ namespace AudioUnit
 			return audioFile;
         }
 
-		static ExtAudioFile OpenUrl (IntPtr urlHandle, out ExtAudioFileError error)
+		static ExtAudioFile? OpenUrl (IntPtr urlHandle, out ExtAudioFileError error)
 		{
 			IntPtr ptr;
 			error = ExtAudioFileOpenUrl (urlHandle, out ptr);
@@ -232,7 +234,7 @@ namespace AudioUnit
 		// to the actual error code from the native API and we are not allowed to make Breaking Changes
 		// lets reimplement the method in a way to return the actual native value if any
 		// also we can share the underliying implementation so we so not break api and reduce code suplication
-		public static ExtAudioFile CreateWithUrl (NSUrl url, AudioFileType fileType, AudioStreamBasicDescription inStreamDesc, AudioFileFlags fileFlags, out ExtAudioFileError error)
+		public static ExtAudioFile? CreateWithUrl (NSUrl url, AudioFileType fileType, AudioStreamBasicDescription inStreamDesc, AudioFileFlags fileFlags, out ExtAudioFileError error)
 		{
 			if (url == null)
 				throw new ArgumentNullException ("url");
@@ -240,7 +242,7 @@ namespace AudioUnit
 			return CreateWithUrl (url.Handle, fileType, inStreamDesc, fileFlags, out error);
 		}
 
-		public static ExtAudioFile CreateWithUrl (CFUrl url, AudioFileType fileType, AudioStreamBasicDescription inStreamDesc, AudioFileFlags flag,	out ExtAudioFileError error)
+		public static ExtAudioFile? CreateWithUrl (CFUrl url, AudioFileType fileType, AudioStreamBasicDescription inStreamDesc, AudioFileFlags flag,	out ExtAudioFileError error)
 		{
 			if (url == null)
 				throw new ArgumentNullException ("url");
@@ -268,7 +270,7 @@ namespace AudioUnit
 			return audioFile;
         }
 
-		static ExtAudioFile CreateWithUrl (IntPtr urlHandle, AudioFileType fileType, AudioStreamBasicDescription inStreamDesc, AudioFileFlags flag, out ExtAudioFileError error)
+		static ExtAudioFile? CreateWithUrl (IntPtr urlHandle, AudioFileType fileType, AudioStreamBasicDescription inStreamDesc, AudioFileFlags flag, out ExtAudioFileError error)
 		{
 			IntPtr ptr;
 			error = (ExtAudioFileError) ExtAudioFileCreateWithUrl (urlHandle, fileType, ref inStreamDesc, IntPtr.Zero, (uint)flag, out ptr);
@@ -278,7 +280,7 @@ namespace AudioUnit
 				return new ExtAudioFile (ptr);
 		}
 
-        public static ExtAudioFileError WrapAudioFileID (IntPtr audioFileID, bool forWriting, out ExtAudioFile outAudioFile)
+        public static ExtAudioFileError WrapAudioFileID (IntPtr audioFileID, bool forWriting, out ExtAudioFile? outAudioFile)
         {
             IntPtr ptr;
             ExtAudioFileError res;

--- a/src/AudioUnit/ExtAudioFile.cs
+++ b/src/AudioUnit/ExtAudioFile.cs
@@ -189,7 +189,7 @@ namespace AudioUnit
 		// also we can share the underliying implementation so we so not break api and reduce code suplication
 		public static ExtAudioFile? OpenUrl (NSUrl url, out ExtAudioFileError error)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return OpenUrl (url.Handle, out error);
@@ -197,7 +197,7 @@ namespace AudioUnit
 
 		public static ExtAudioFile? OpenUrl (CFUrl url, out ExtAudioFileError error)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return OpenUrl (url.Handle, out error);
@@ -205,7 +205,7 @@ namespace AudioUnit
 
         public static ExtAudioFile OpenUrl (CFUrl url)
         {
-            if (url == null)
+            if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			ExtAudioFileError err;
@@ -213,7 +213,7 @@ namespace AudioUnit
 
 			if (err != ExtAudioFileError.OK) // if (err != 0)  <- to keep old implementation
 				throw new ArgumentException (String.Format ("Error code:{0}", err));
-			if (audioFile == null) // if (ptr == IntPtr.Zero)  <- to keep old implementation
+			if (audioFile is null) // if (ptr == IntPtr.Zero)  <- to keep old implementation
 				throw new InvalidOperationException ("Can not get object instance");
 
 			return audioFile;
@@ -236,7 +236,7 @@ namespace AudioUnit
 		// also we can share the underliying implementation so we so not break api and reduce code suplication
 		public static ExtAudioFile? CreateWithUrl (NSUrl url, AudioFileType fileType, AudioStreamBasicDescription inStreamDesc, AudioFileFlags fileFlags, out ExtAudioFileError error)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return CreateWithUrl (url.Handle, fileType, inStreamDesc, fileFlags, out error);
@@ -244,7 +244,7 @@ namespace AudioUnit
 
 		public static ExtAudioFile? CreateWithUrl (CFUrl url, AudioFileType fileType, AudioStreamBasicDescription inStreamDesc, AudioFileFlags flag,	out ExtAudioFileError error)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return CreateWithUrl (url.Handle, fileType, inStreamDesc, flag, out error);
@@ -256,7 +256,7 @@ namespace AudioUnit
             //AudioChannelLayout channelLayout, 
             AudioFileFlags flag)
         {             
-            if (url == null)
+            if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
             ExtAudioFileError err;
@@ -264,7 +264,7 @@ namespace AudioUnit
 
 			if (err != ExtAudioFileError.OK) // if (err != 0)  <- to keep old implementation
 				throw new ArgumentException (String.Format ("Error code:{0}", err));
-			if (audioFile == null) // if (ptr == IntPtr.Zero)  <- to keep old implementation
+			if (audioFile is null) // if (ptr == IntPtr.Zero)  <- to keep old implementation
 				throw new InvalidOperationException ("Can not get object instance");
 
 			return audioFile;
@@ -320,7 +320,7 @@ namespace AudioUnit
 
         public uint Read (uint numberFrames, AudioBuffers audioBufferList, out ExtAudioFileError status)
         {
-            if (audioBufferList == null)
+            if (audioBufferList is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioBufferList));
 
             status = ExtAudioFileRead (_extAudioFile, ref numberFrames, (IntPtr) audioBufferList);
@@ -329,7 +329,7 @@ namespace AudioUnit
 
         public ExtAudioFileError WriteAsync (uint numberFrames, AudioBuffers audioBufferList)
         {
-            if (audioBufferList == null)
+            if (audioBufferList is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioBufferList));
 
             return ExtAudioFileWriteAsync (_extAudioFile, numberFrames, (IntPtr) audioBufferList);
@@ -337,7 +337,7 @@ namespace AudioUnit
 
         public ExtAudioFileError Write (uint numberFrames, AudioBuffers audioBufferList)
         {
-            if (audioBufferList == null)
+            if (audioBufferList is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioBufferList));
 
             return ExtAudioFileWrite (_extAudioFile, numberFrames, (IntPtr) audioBufferList);

--- a/src/AudioUnit/ExtAudioFile.cs
+++ b/src/AudioUnit/ExtAudioFile.cs
@@ -190,7 +190,7 @@ namespace AudioUnit
 		public static ExtAudioFile? OpenUrl (NSUrl url, out ExtAudioFileError error)
 		{
 			if (url == null)
-				throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return OpenUrl (url.Handle, out error);
 		}
@@ -198,7 +198,7 @@ namespace AudioUnit
 		public static ExtAudioFile? OpenUrl (CFUrl url, out ExtAudioFileError error)
 		{
 			if (url == null)
-				throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return OpenUrl (url.Handle, out error);
 		}
@@ -206,7 +206,7 @@ namespace AudioUnit
         public static ExtAudioFile OpenUrl (CFUrl url)
         {
             if (url == null)
-                throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			ExtAudioFileError err;
 			var audioFile = OpenUrl (url.Handle, out err);
@@ -237,7 +237,7 @@ namespace AudioUnit
 		public static ExtAudioFile? CreateWithUrl (NSUrl url, AudioFileType fileType, AudioStreamBasicDescription inStreamDesc, AudioFileFlags fileFlags, out ExtAudioFileError error)
 		{
 			if (url == null)
-				throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return CreateWithUrl (url.Handle, fileType, inStreamDesc, fileFlags, out error);
 		}
@@ -245,7 +245,7 @@ namespace AudioUnit
 		public static ExtAudioFile? CreateWithUrl (CFUrl url, AudioFileType fileType, AudioStreamBasicDescription inStreamDesc, AudioFileFlags flag,	out ExtAudioFileError error)
 		{
 			if (url == null)
-				throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return CreateWithUrl (url.Handle, fileType, inStreamDesc, flag, out error);
 		}
@@ -257,7 +257,7 @@ namespace AudioUnit
             AudioFileFlags flag)
         {             
             if (url == null)
-                throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
             ExtAudioFileError err;
 			var audioFile = CreateWithUrl (url.Handle, fileType, inStreamDesc, flag, out err);
@@ -321,7 +321,7 @@ namespace AudioUnit
         public uint Read (uint numberFrames, AudioBuffers audioBufferList, out ExtAudioFileError status)
         {
             if (audioBufferList == null)
-                throw new ArgumentNullException ("audioBufferList");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioBufferList));
 
             status = ExtAudioFileRead (_extAudioFile, ref numberFrames, (IntPtr) audioBufferList);
             return numberFrames;
@@ -330,7 +330,7 @@ namespace AudioUnit
         public ExtAudioFileError WriteAsync (uint numberFrames, AudioBuffers audioBufferList)
         {
             if (audioBufferList == null)
-                throw new ArgumentNullException ("audioBufferList");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioBufferList));
 
             return ExtAudioFileWriteAsync (_extAudioFile, numberFrames, (IntPtr) audioBufferList);
         }
@@ -338,7 +338,7 @@ namespace AudioUnit
         public ExtAudioFileError Write (uint numberFrames, AudioBuffers audioBufferList)
         {
             if (audioBufferList == null)
-                throw new ArgumentNullException ("audioBufferList");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioBufferList));
 
             return ExtAudioFileWrite (_extAudioFile, numberFrames, (IntPtr) audioBufferList);
         }


### PR DESCRIPTION
This PR aims to bring nullability changes to AudioUnit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`