### PR TITLE
[authenticationservices] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/AuthenticationServices/ASAuthorization.cs
+++ b/src/AuthenticationServices/ASAuthorization.cs
@@ -7,14 +7,16 @@
 // Copyright 2019 Microsoft Corporation
 //
 
+#nullable enable
+
 using Foundation;
 using ObjCRuntime;
 
 namespace AuthenticationServices {
 
 	public partial class ASAuthorization {
-		public T GetProvider<T> () where T : NSObject, IASAuthorizationProvider => Runtime.GetINativeObject<T> (_Provider, false);
+		public T? GetProvider<T> () where T : NSObject, IASAuthorizationProvider => Runtime.GetINativeObject<T> (_Provider, false);
 
-		public T GetCredential<T> () where T : NSObject, IASAuthorizationCredential => Runtime.GetINativeObject<T> (_Credential, false);
+		public T? GetCredential<T> () where T : NSObject, IASAuthorizationCredential => Runtime.GetINativeObject<T> (_Credential, false);
 	}
 }

--- a/src/AuthenticationServices/ASAuthorizationRequest.cs
+++ b/src/AuthenticationServices/ASAuthorizationRequest.cs
@@ -7,11 +7,13 @@
 // Copyright 2019 Microsoft Corporation
 //
 
+#nullable enable
+
 using Foundation;
 using ObjCRuntime;
 
 namespace AuthenticationServices {
 	public partial class ASAuthorizationRequest {
-			public T GetProvider<T> () where T : NSObject, IASAuthorizationProvider => Runtime.GetINativeObject<T> (_Provider, false);
+			public T? GetProvider<T> () where T : NSObject, IASAuthorizationProvider => Runtime.GetINativeObject<T> (_Provider, false);
 	}
 }

--- a/src/AuthenticationServices/PublicPrivateKeyAuthentication.cs
+++ b/src/AuthenticationServices/PublicPrivateKeyAuthentication.cs
@@ -40,7 +40,7 @@ namespace AuthenticationServices {
 		public static ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport[]? GetAllSupportedPublicKeyCredentialDescriptorTransports () {
 			NSString[]? nsStringArray = NSArray.ArrayFromHandle<NSString> (ASAuthorizationAllSupportedPublicKeyCredentialDescriptorTransports ());
 
-			if (nsStringArray == null)
+			if (nsStringArray is null)
 				return null;
 
 			ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport[] asArray = new ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport[nsStringArray.Count ()];


### PR DESCRIPTION
This PR aims to bring nullability changes to AuthenticationServices.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing any `== null` or `!= null` to `is null` and `is not null`