### PR TITLE
[businesschat] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/BusinessChat/BCChatAction.cs
+++ b/src/BusinessChat/BCChatAction.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Foundation;
@@ -9,9 +11,11 @@ namespace BusinessChat {
 			var values = new NSString [intentParameters.Keys.Count];
 			var index = 0;
 			foreach (var k in intentParameters.Keys) {
-				keys [index] = k.GetConstant ();
-				values [index] = new NSString (intentParameters [k]);
-				index++; 
+				if (k.GetConstant () is NSString s) {
+					keys [index] = s;
+					values [index] = new NSString (intentParameters [k]);
+					index++;
+				}
 			}
 			using (var dict = NSDictionary<NSString, NSString>.FromObjectsAndKeys (values, keys, keys.Length))
 				OpenTranscript (businessIdentifier, dict);


### PR DESCRIPTION
This PR aims to bring nullability changes to BusinessChat.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes