### PR TITLE
[monotouch-test] Adjust ImageCaptioningTest to work on older versions of macOS for Mac Catalyst.

### DIFF
--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -83,7 +83,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 					Assert.NotNull (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
 
 					var s = MAImageCaptioning.GetCaption (url, out e);
-					Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
+					Assert.Null (s, "ro / roundtrip 1"); // not very surprising since Set can't save it
 					Assert.Null (e, "ro / get / no error");
 
 					Assert.False (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
@@ -95,16 +95,24 @@ namespace MonoTouchFixtures.MediaAccessibility {
 					Assert.Null (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
 
 					var s = MAImageCaptioning.GetCaption (url, out e);
+#if __MACCATALYST__
+					if (true) {
+#else
 					if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
-						Assert.AreEqual ("xamarin", s, "ro / roundtrip");
+#endif
+						Assert.AreEqual ("xamarin", s, "ro / roundtrip 2");
 					} else {
-						Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
+						Assert.Null (s, "ro / roundtrip 3"); // not very surprising since Set can't save it
 					}
 					Assert.Null (e, "ro / get / no error");
 
 					Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
 					s = MAImageCaptioning.GetCaption (url, out e);
+#if __MACCATALYST__
+					if (true) {
+#else
 					if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
+#endif
 						Assert.AreEqual ("xamarin", s, "ro / back to original");
 					} else {
 						Assert.Null (s, "ro / back to original");
@@ -127,7 +135,11 @@ namespace MonoTouchFixtures.MediaAccessibility {
 				Assert.Null (e, "rw / set / no error"); // weird, it can't be saved back to the file metadata
 
 				var s = MAImageCaptioning.GetCaption (rw_url, out e);
-				if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
+#if __MACCATALYST__
+					if (true) {
+#else
+					if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
+#endif
 					Assert.AreEqual ("xamarin", s, "rw / roundtrip"); // :)
 				} else {
 					Assert.Null (s, "rw / roundtrip"); // :(
@@ -136,7 +148,11 @@ namespace MonoTouchFixtures.MediaAccessibility {
 
 				Assert.True (MAImageCaptioning.SetCaption (rw_url, "xamarin", out e), "Set 2");
 				s = MAImageCaptioning.GetCaption (rw_url, out e);
-				if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
+#if __MACCATALYST__
+					if (true) {
+#else
+					if (TestRuntime.CheckXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch)) {
+#endif
 					Assert.AreEqual ("xamarin", s, "rw / back to original");
 				} else {
 					Assert.Null (s, "rw / back to original");


### PR DESCRIPTION
Also improve assert messages a bit to not have multiple asserts with the same message.