### PR TITLE
[introspection] Fix ApiCMAttachmentTest on macOS / Mac Catalyst.

### DIFF
--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -385,6 +385,12 @@ namespace Introspection {
 						ForegroundColorFromContext =  true,
 						Font = new CTFont ("ArialMT", 24)
 					}));
+#if __MACCATALYST__ || __MACOS__
+			case "CGEvent":
+				return new CGEvent ((CGEventSource) null);
+			case "CGEventSource":
+				return new CGEventSource (CGEventSourceStateID.CombinedSession);
+#endif
 			case "CGImageDestination":
 				var storage = new NSMutableData ();
 				return CGImageDestination.Create (new CGDataConsumer (storage), "public.png", 1);


### PR DESCRIPTION
Fixes:

    Introspection.ApiCMAttachmentTest
        [FAIL] CheckFailAttachments : System.InvalidOperationException : Could not create the new instance for type CGEvent.
            at Introspection.ApiCMAttachmentTest.GetINativeInstance(Type t) in xamarin-macios/tests/introspection/ApiCMAttachmentTest.cs:line 498
            at Introspection.ApiCMAttachmentTest.CheckFailAttachments() in xamarin-macios/tests/introspection/ApiCMAttachmentTest.cs:line 572
            at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)