### PR TITLE
[monotouch-test] Fix UbiquitousKeyValueStoreTest to work on newer versions of macOS.

### DIFF
--- a/tests/monotouch-test/Foundation/UbiquitousKeyValueStoreTest.cs
+++ b/tests/monotouch-test/Foundation/UbiquitousKeyValueStoreTest.cs
@@ -32,6 +32,10 @@ namespace MonoTouchFixtures.Foundation {
 						if ((Runtime.Arch == Arch.DEVICE) && TestRuntime.CheckXcodeVersion (12,0))
 							Assert.Null (store [key], "key 1");
 						else
+#elif __MACCATALYST__ || __MACOS__
+						if (TestRuntime.CheckXcodeVersion (13, 0))
+							Assert.Null (store [key], "key 1");
+						else
 #endif
 						Assert.AreEqual (value, store [key], "key 1");
 
@@ -39,6 +43,10 @@ namespace MonoTouchFixtures.Foundation {
 #if __TVOS__
 						// broken on appletv devices running tvOS 14, test will fail when fixed
 						if ((Runtime.Arch == Arch.DEVICE) && TestRuntime.CheckXcodeVersion (12,0))
+							Assert.Null (store [(string) key], "key 2");
+						else
+#elif __MACCATALYST__ || __MACOS__
+						if (TestRuntime.CheckXcodeVersion (13, 0))
 							Assert.Null (store [(string) key], "key 2");
 						else
 #endif


### PR DESCRIPTION
Fixes:

    MonoTouchFixtures.Foundation.NSUbiquitousKeyValueStoreTest
        [FAIL] Indexer :   key 1
            Expected: <value>
            But was:  null