### PR TITLE
[CI] Separate API diff from the test comment to move running the tests in a diff agent.

### DIFF
--- a/.github/workflows/pwsh-ci.yml
+++ b/.github/workflows/pwsh-ci.yml
@@ -1,0 +1,16 @@
+name: CI for pwsh
+on:
+  push:
+    branches: [ main ]
+jobs:
+  test-pwsh:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run Pester tests
+      run: |
+        Set-PSRepository psgallery -InstallationPolicy trusted
+        Install-Module -Name Pester -RequiredVersion 5.0.4 -Confirm:$false -Force
+
+        Invoke-Pester -Path ./tools/devops/automation/scripts/APIDiff.Tests.ps1
+      shell: pwsh

--- a/tools/devops/automation/scripts/APIDiff.Tests.ps1
+++ b/tools/devops/automation/scripts/APIDiff.Tests.ps1
@@ -75,7 +75,7 @@ Describe "API diff tests" {
 
         $diff.Header | Should -Be $header 
 
-        # assert that the linsk are correct
+        # assert that the links are correct
         foreach($platform in $gists.Keys) {
             $diff.Platforms.ContainsKey($platform) | Should -Be $true
             $diff.Platforms[$platform].Gist | Should -Be $gists[$platform]
@@ -130,7 +130,7 @@ Describe "API diff tests" {
 
         $diff = [APIDiff]::new($header, $apiDiffData)
 
-        # assert that the linsk are correct
+        # assert that the links are correct
         foreach($platform in $gists.Keys) {
             $diff.Platforms.ContainsKey($platform) | Should -Be $true
             $diff.Platforms[$platform].Gist | Should -Be $gists[$platform]
@@ -146,7 +146,7 @@ Describe "API diff tests" {
 
         $diff = [APIDiff]::new($header, $apiDiffData)
 
-        # assert that the linsk are correct
+        # assert that the links are correct
         foreach($platform in $gists.Keys) {
             $diff.Platforms.ContainsKey($platform) | Should -Be $true
             $diff.Platforms[$platform].Gist | Should -Be $gists[$platform]
@@ -155,7 +155,7 @@ Describe "API diff tests" {
     }
 }
 
-Describe "API difff comment tests" {
+Describe "API diff comment tests" {
     BeforeAll {
         # this headers help to check the content is there
         $prHeader = "API Current PR diff"

--- a/tools/devops/automation/scripts/APIDiff.Tests.ps1
+++ b/tools/devops/automation/scripts/APIDiff.Tests.ps1
@@ -1,0 +1,251 @@
+Using module ./APIDiff.psm1
+
+Describe "Platform diff tests" {
+
+    BeforeAll {
+        $platform = "ios"
+        $html = "http://test.com"
+        $gist = "httP://gist.github.com"
+    }
+
+    It "creates with no links" {
+        $diff = [PlatformDiff]::new($platform)
+        $diff.Platform | Should -Be $platform
+        $diff.Html | Should -Be $null
+        $diff.Gist | Should -Be $null
+    }
+
+    It "creates with links" {
+        $diff = [PlatformDiff]::new($platform, $html, $gist)
+        $diff.Platform | Should -Be $platform
+        $diff.Html | Should -Be $html
+        $diff.Gist | Should -Be $gist
+    }
+
+}
+
+Describe "API diff tests" {
+
+    BeforeAll {
+        $header = "API diff"
+        $result = "Success"
+        $message = "Review diff."
+
+        $gists = @{
+          "iOS" = "https://gist.github.com/ios.md$";
+          "macOS" = "https://gist.github.com/macos.md$";
+          "tvOS" = "https://gist.github.com/tvos.md$";
+          "watchOS" = "https://gist.github.com/watchos.md$";
+          "dotnet-iOS" = "https://gist.github.com/dotnet-ios.md$";
+          "dotnet-tvOS" = "https://gist.github.com/dotnet-tvos.md$";
+          "dotnet-MacCatalyst" = "https://gist.github.com/dotnet-maccatalyst.md$";
+          "dotnet-macOS" = "https://gist.github.com/dotnet-macos.md$";
+          "dotnet-legacy-iOS" = "https://gist.github.com/dotnet-legacy-ios.md$";
+          "dotnet-legacy-tvOS" = "https://gist.github.com/dotnet-legacy-tvos.md$";
+          "dotnet-legacy-macOS" = "https://gist.github.com/dotnet-legacy-macos.md$";
+          "dotnet-macCatiOS" = "https://gist.github.com/dotnet-maccatios.md$";
+        }
+
+        $html =  @{
+          "iOS" = "http://example.com/ios-api-diff.html"; 
+          "macOS" = "http://example.com/mac-api-diff.html";
+          "tvOS" = "http://example.com/tvos-api-diff.html";
+          "watchOS" = "http://example.com/watchos-api-diff.html";
+          "index"= "http://example.com/api-diff.html";
+          "dotnet-iOS" = "http://example.com/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html";
+          "dotnet-tvOS" = "http://example.com/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html";
+          "dotnet-MacCatalyst" = "http://example.com/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst-api-diff.html";
+          "dotnet-macOS" = "http://example.com/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html";
+          "dotnet-legacy-iOS" = "http://example.com/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html";
+          "dotnet-legacy-tvOS" = "http://example.com/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html";
+          "dotnet-legacy-macOS" = "http://example.com/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html";
+          "dotnet-macCatiOS" = "http://example.com/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.MacCatalyst-api-diff.html";
+        }
+
+        $apiDiffData = @{
+          "gist" = $gists;
+          "html" = $html;
+          "result" = $result;
+          "message" = $message;
+        }
+    }
+
+    It "creates with all data" {
+        $diff = [APIDiff]::new($header, $apiDiffData)
+
+        $diff.Header | Should -Be $header 
+
+        # assert that the linsk are correct
+        foreach($platform in $gists.Keys) {
+            $diff.Platforms.ContainsKey($platform) | Should -Be $true
+            $diff.Platforms[$platform].Gist | Should -Be $gists[$platform]
+        }
+
+        foreach($platform in $html.Keys) {
+            $diff.Platforms.ContainsKey($platform) | Should -Be $true
+            $diff.Platforms[$platform].Html | Should -Be $html[$platform]
+        }
+    }
+
+    It "creates with only html links" {
+        $apiDiffData = @{
+          "gist" = @{};
+          "html" = $html;
+          "result" = $result;
+          "message" = $message;
+        }
+
+        $diff = [APIDiff]::new($header, $apiDiffData)
+
+        foreach($platform in $html.Keys) {
+            $diff.Platforms.ContainsKey($platform) | Should -Be $true
+            $diff.Platforms[$platform].Html | Should -Be $html[$platform]
+            $diff.Platforms[$platform].Gist | Should -Be $null
+        }
+
+        $apiDiffData = @{
+          "gist" = $null 
+          "html" = $html;
+          "result" = $result;
+          "message" = $message;
+        }
+
+        $diff = [APIDiff]::new($header, $apiDiffData)
+
+        foreach($platform in $html.Keys) {
+            $diff.Platforms.ContainsKey($platform) | Should -Be $true
+            $diff.Platforms[$platform].Html | Should -Be $html[$platform]
+            $diff.Platforms[$platform].Gist | Should -Be $null
+        }
+    }
+    
+    It "creates with only gists links" {
+
+        $apiDiffData = @{
+          "gist" = $gists;
+          "html" =  @{};
+          "result" = $result;
+          "message" = $message;
+        }
+
+        $diff = [APIDiff]::new($header, $apiDiffData)
+
+        # assert that the linsk are correct
+        foreach($platform in $gists.Keys) {
+            $diff.Platforms.ContainsKey($platform) | Should -Be $true
+            $diff.Platforms[$platform].Gist | Should -Be $gists[$platform]
+            $diff.Platforms[$platform].Html | Should -Be $null
+        }
+
+        $apiDiffData = @{
+          "gist" = $gists;
+          "html" = $null 
+          "result" = $result;
+          "message" = $message;
+        }
+
+        $diff = [APIDiff]::new($header, $apiDiffData)
+
+        # assert that the linsk are correct
+        foreach($platform in $gists.Keys) {
+            $diff.Platforms.ContainsKey($platform) | Should -Be $true
+            $diff.Platforms[$platform].Gist | Should -Be $gists[$platform]
+            $diff.Platforms[$platform].Html | Should -Be $null
+        }
+    }
+}
+
+Describe "API difff comment tests" {
+    BeforeAll {
+        # this headers help to check the content is there
+        $prHeader = "API Current PR diff"
+        $stableHeader = "API diff"
+        $result = "Success"
+        $message = "Review diff."
+
+        $prGists = @{
+          "iOS" = "https://gist.github.com/ios.md$";
+          "macOS" = "https://gist.github.com/macos.md$";
+          "tvOS" = "https://gist.github.com/tvos.md$";
+          "watchOS" = "https://gist.github.com/watchos.md$";
+          "dotnet-iOS" = "https://gist.github.com/dotnet-ios.md$";
+          "dotnet-tvOS" = "https://gist.github.com/dotnet-tvos.md$";
+          "dotnet-MacCatalyst" = "https://gist.github.com/dotnet-maccatalyst.md$";
+          "dotnet-macOS" = "https://gist.github.com/dotnet-macos.md$";
+          "dotnet-legacy-iOS" = "https://gist.github.com/dotnet-legacy-ios.md$";
+          "dotnet-legacy-tvOS" = "https://gist.github.com/dotnet-legacy-tvos.md$";
+          "dotnet-legacy-macOS" = "https://gist.github.com/dotnet-legacy-macos.md$";
+          "dotnet-macCatiOS" = "https://gist.github.com/dotnet-maccatios.md$";
+        }
+        $stableGists = @{}
+
+        foreach($p in $prGists.Keys) {
+            $stableGists[$p] = $prGists[$p] + ".stable"
+        }
+
+        $prHtml =  @{
+          "iOS" = "http://example.com/ios-api-diff.html"; 
+          "macOS" = "http://example.com/mac-api-diff.html";
+          "tvOS" = "http://example.com/tvos-api-diff.html";
+          "watchOS" = "http://example.com/watchos-api-diff.html";
+          "index"= "http://example.com/api-diff.html";
+          "dotnet-iOS" = "http://example.com/dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html";
+          "dotnet-tvOS" = "http://example.com/dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html";
+          "dotnet-MacCatalyst" = "http://example.com/dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst-api-diff.html";
+          "dotnet-macOS" = "http://example.com/dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html";
+          "dotnet-legacy-iOS" = "http://example.com/dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html";
+          "dotnet-legacy-tvOS" = "http://example.com/dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html";
+          "dotnet-legacy-macOS" = "http://example.com/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html";
+          "dotnet-macCatiOS" = "http://example.com/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.MacCatalyst-api-diff.html";
+        }
+
+        $stableHtml = @{}
+
+        foreach($p in $prHtml.Keys) {
+            $stableHtml[$p] = $prHtml[$p] + ".stable"
+        }
+
+        $prDiff = @{
+          "gist" = $prGists;
+          "html" = $prHtml;
+          "result" = $result;
+          "message" = $message;
+        }
+
+        $stableDiff = @{
+          "gist" = $stableGists;
+          "html" = $stableHtml;
+          "result" = $result;
+          "message" = $message;
+        }
+
+        # write a temp file that we will use to contain as text
+        $generatorDiff = [System.IO.Path]::GetTempFileName()
+        $generatorContent = "This is the generator data\nWe do not really care about it."
+        Set-Content -Path $generatorDiff $generatorContent 
+    }
+
+    It "creates with null stable" {
+        $comment = [APIDiffComment]::new($prDiff, $null, $generatorDiff)
+
+        $comment.FromPR.Header | Should -Be $prHeader
+        $comment.FromStable | Should -Be $null
+        $comment.Generator | Should -Be $generatorDiff
+    }
+
+    It "creates with null pr" {
+        $comment = [APIDiffComment]::new($null, $stableDiff, $generatorDiff)
+
+        $comment.FromPR | Should -Be $null
+        $comment.FromStable.Header | Should -Be $stableHeader
+        $comment.Generator | Should -Be $generatorDiff
+    }
+
+    It "create with null generator" {
+        $comment = [APIDiffComment]::new($prDiff, $stableDiff, $null)
+
+        $comment.FromPR.Header | Should -Be $prHeader
+        $comment.FromStable.Header | Should -Be $stableHeader
+        $comment.Generator | Should -Be ""
+    }
+}

--- a/tools/devops/automation/scripts/APIDiff.psm1
+++ b/tools/devops/automation/scripts/APIDiff.psm1
@@ -31,7 +31,7 @@ class APIDiff {
         # the content object has the following format:
         # 
         #     gist: Hastable with platform as a key and the gist as content
-        #     html: Hastable with platform as a jey and the html url as content
+        #     html: Hastable with platform as a key and the html url as content
         #     result: string with the result
         #     message: string with the message
         $this.Header = $header

--- a/tools/devops/automation/scripts/APIDiff.psm1
+++ b/tools/devops/automation/scripts/APIDiff.psm1
@@ -1,0 +1,154 @@
+class PlatformDiff {
+    [ValidateNotNullOrEmpty()] [string] $Platform
+    [string] $Html
+    [string] $Gist
+
+    PlatformDiff (
+        [string] $platform
+    ) {
+        $this.Platform = $platform
+    }
+
+    PlatformDiff (
+        [string] $platform,
+        [string] $html,
+        [string] $gist) {
+        $this.Platform = $platform
+        $this.Html = $html
+        $this.Gist = $gist
+    }
+}
+
+class APIDiff {
+    [string] $Header
+    [string] $Result
+    [string] $Message
+    [Hashtable] $Platforms
+
+    APIDiff (
+        [string] $header,
+        [Hashtable] $content) {
+        # the content object has the following format:
+        # 
+        #     gist: Hastable with platform as a key and the gist as content
+        #     html: Hastable with platform as a jey and the html url as content
+        #     result: string with the result
+        #     message: string with the message
+        $this.Header = $header
+        $this.Result = $content.result
+        $this.Message = $content.message
+        $this.Platforms = @{}
+        
+        # loop over the gists and create the Platform diff as needed
+        if ($null -ne $content.gist -and $null -ne $content.gist.Keys) {
+            foreach ($platform in $content.gist.Keys) {
+                $diff = $null
+                if (-not $this.Platforms.ContainsKey($platform)) {
+                    $diff = [PlatformDiff]::new($platform) 
+                    $this.Platforms[$platform] = $diff
+                } else {
+                    $diff = $this.Platforms[$platform]
+                }
+                $diff.Gist = $content.gist[$platform]
+            }
+        }
+        if ($null -ne $content.html -and $null -ne $content.html.Keys) {
+            foreach ($platform in $content.html.Keys) {
+                $diff = $null
+                if (-not $this.Platforms.ContainsKey($platform)) {
+                    $diff = [PlatformDiff]::new($platform) 
+                    $this.Platforms[$platform] = $diff
+                } else {
+                    $diff = $this.Platforms[$platform]
+                }
+                $diff.Html = $content.html[$platform]
+            }
+        }
+    }
+}
+
+class APIDiffComment {
+    [object] $FromPR = $null
+    [object] $FromStable = $null
+    [string] $Generator = $null
+
+    APIDiffComment (
+        [object] $prContent,
+        [object] $stableContent,
+        [string] $generatorContent) {
+        $this.FromPR = $null -ne $prContent ? [APIDiff]::new("API Current PR diff", $prContent) : $null
+        $this.FromStable = $null -ne $stableContent ? [APIDiff]::new("API diff", $stableContent) : $null
+        $this.Generator = $null -ne $generatorContent ? $generatorContent : $null
+    }
+
+    [void] WriteDiff($diff, $stringBuilder) {
+        # loop over the platforms and write the data
+        $stringBuilder.AppendLine("# $($diff.Header)")
+
+        # group the platforms as how the diffs were done
+        $commonPlatforms = "iOS", "macOS", "tvOS"
+        $legacyPlatforms = @{Title="API diff"; Platforms=@($commonPlatforms + "watchOS");}
+        $dotnetPlatforms = @{Title="dotnet API diff"; Platforms=@($commonPlatforms + "MacCatalyst").ForEach({"dotnet-" + $_});}
+        $dotnetLegacyPlatforms = @{Title="dotnet legacy API diff"; Platforms=@($commonPlatforms).ForEach({"dotnet-legacy-" + $_});}
+        $dotnetMaciOSPlatforms = @{Title="dotnet iOS-MacCatalayst API diff"; Platforms=@("macCatiOS").ForEach({"dotnet-" + $_});}
+        $platforms = @($legacyPlatforms, $dotnetPlatforms, $dotnetLegacyPlatforms, $dotnetMaciOSPlatforms)
+
+        foreach ($group in $platforms) {
+            $stringBuilder.AppendLine("<details><summary>View $($group.Title)</summary>")
+            $stringBuilder.AppendLine("") # no new line results in a bad rendering in the links
+
+            foreach ($platform in $group.Platforms) {
+                if ($diff.Platforms.ContainsKey($platform)) {
+                    $platformDiff = $diff.Platforms[$platform]
+                    $htmlLink  = ""
+                    $gistLink = ""
+                    if ($null -ne $platformDiff.Html) {
+                        $htmlLink = "[vsdrops]($($platformDiff.Html))"
+                    }
+                    if ($null -ne $platformDiff.Gist) {
+                        $gistLink = "[gist]($($platformDiff.Gist))"
+                    }
+                    $line = @("*", $platform, $htmlLink, $gistLink) -join " "
+                    $stringBuilder.AppendLine($line)
+                } else {
+                    $stringBuilder.AppendLine("* :fire: $platform :fire: Missing files")
+                }
+            }
+            $StringBuilder.AppendLine("</details>")
+            $StringBuilder.AppendLine("")
+        }
+        $StringBuilder.AppendLine("")
+    }
+
+    [void] WriteComment($stringBuilder) {
+        if ($null -eq $this.FromPR) {
+            $stringBuilder.AppendLine("* :warning: API diff urls have not been provided.")
+        } else {
+            $this.WriteDiff($this.FromPR, $stringBuilder)
+        }
+
+        if ($null -eq $this.FromStable) {
+            $stringBuilder.AppendLine("* :warning: API Current PR diff urls have not been provided.")
+        } else {
+            $this.WriteDiff($this.FromStable, $stringBuilder)
+        }
+
+        # the generator content is a file which we simply read
+        if ($null -eq $this.Generator) {
+            $stringBuilder.AppendLine("* :warning: Generator diff comments have not been provided.")
+        } else {
+            if (Test-Path $this.Generator -PathType Leaf) {
+                $stringBuilder.AppendLine("# Generator diff")
+                $stringBuilder.AppendLine("")
+                # ugly workaround to get decent new lines
+                foreach ($line in Get-Content -Path $this.Generator)
+                {
+                    $stringBuilder.AppendLine($line)
+                }
+                $stringBuilder.AppendLine("")
+            } else {
+                $stringBuilder.AppendLine("* :warning: Path $($this.Generator) was not found!")
+            }
+        }
+    }
+}


### PR DESCRIPTION
The new module is not yet used. This is a first step, review the code, next create a PR in which the module is used. We add a yaml to have a github action ensuring the pwsh tests are run, that way we at least have a way to validate the pwsh used in the azure pipeline without using the pipeline.