### PR TITLE
[callkit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/CallKit/CXProvider.cs
+++ b/src/CallKit/CXProvider.cs
@@ -7,6 +7,8 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
+#nullable enable
+
 #if !MONOMAC
 using System;
 using Foundation;


### PR DESCRIPTION
I am adding nullable enable to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes. In this case, only one file does not have the header.