### PR TITLE
[ARKit] Ignore this framework on Mac Catalyst.

### DIFF
--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-ARKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-ARKit.ignore
@@ -1,3 +1,12 @@
+#
+# The entire ARKit framework does nothing on Mac Catalyst.
+#
+# "This framework ignores calls from Mac apps built with Mac Catalyst." (https://developer.apple.com/documentation/arkit/)
+#
+# If that changes, here's the start of the Mac Catalyst work at least:
+# https://github.com/xamarin/xamarin-macios/pull/14281
+#
+
 !missing-enum! ARAltitudeSource not bound
 !missing-enum! ARAppClipCodeURLDecodingState not bound
 !missing-enum! ARCoachingGoal not bound

--- a/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
+++ b/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
@@ -27,7 +27,7 @@ namespace Extrospection {
 					continue;
 				if (entry [0] != '#') {
 					Log ($"?bad-entry? '{entry}' in '{filename}'");
-				} else if (entry [1] == '!') {
+				} else if (entry.Length > 1 && entry [1] == '!') {
 					Log ($"?bad-comment? '{entry}' in '{filename}'");
 				}
 			}


### PR DESCRIPTION
It exists, but does nothing on Mac Catalyst.

"This framework ignores calls from Mac apps built with Mac Catalyst."

Ref: https://developer.apple.com/documentation/arkit?language=objc

Also augment xtro to not be confused when encountering lines starting with '#'
that has no other text.