### PR TITLE
[msbuild] Handle relative paths with wrong directory separator character for metadata passed to the InstallNameTool task.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/InstallNameToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/InstallNameToolTaskBase.cs
@@ -26,7 +26,9 @@ namespace Xamarin.MacDev.Tasks {
 			for (var i = 0; i < DynamicLibrary.Length; i++) {
 				var input = DynamicLibrary [i];
 				var src = Path.GetFullPath (input.ItemSpec);
-				var target = input.GetMetadata ("ReidentifiedPath");
+				// Make sure we use the correct path separator, these are relative paths, so it doesn't look
+				// like MSBuild does the conversion automatically.
+				var target = input.GetMetadata ("ReidentifiedPath").Replace ('\\', Path.DirectorySeparatorChar);
 				var temporaryTarget = target + ".tmp";
 
 				// install_name_tool modifies the file in-place, so copy it first to a temporary file first.


### PR DESCRIPTION
This fixes an issue where we'd create files on mac containing windows directory separators.

Ref: [Teams link](https://teams.microsoft.com/l/message/19:5b7decdb4a714a13bad3ff714961f6fe@thread.skype/1646345177907?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=0056f60b-301f-43ac-bbcf-f356d3c42c92&parentMessageId=1646159601280&teamName=VS%20Client%20Experiences&channelName=MaciOS%20%F0%9F%8D%8E&createdTime=1646345177907)