### PR TITLE
[AddressBookUI] Fix nullability compilation error.

### DIFF
--- a/src/AddressBookUI/ABNewPersonViewController.cs
+++ b/src/AddressBookUI/ABNewPersonViewController.cs
@@ -92,7 +92,7 @@ namespace AddressBookUI {
 		public ABGroup? ParentGroup {
 			get {
 				MarkDirty ();
-				return BackingField.Get (ref parentGroup, _ParentGroup, h => new ABGroup (h, AddressBook));
+				return BackingField.Get (ref parentGroup, _ParentGroup, h => (AddressBook is null) ? null : new ABGroup (h, AddressBook));
 			}
 			set {
 				_AddressBook = BackingField.Save (ref parentGroup, value);


### PR DESCRIPTION
Landing https://github.com/xamarin/xamarin-macios/pull/14221 bronke main with the following nullability error:
```
AddressBookUI/ABNewPersonViewController.cs(95,82): warning CS8604: Possible null reference argument for parameter 'addressbook' in 'ABGroup.ABGroup(NativeHandle handle, ABAddressBook addressbook)'.
AddressBookUI/ABNewPersonViewController.cs(95,82): error CS8604: Possible null reference argument for parameter 'addressbook' in 'ABGroup.ABGroup(IntPtr handle, ABAddressBook addressbook)'.
```

This is because https://github.com/xamarin/xamarin-macios/pull/1422 was merged without being in sync with main, the lastests tests were ran 9 days before the PR was landed. Tests passed because ce24fe5f817171c747508ac60b55769cda5b6dcf was landed later and it enabled nullability in the AddressBook source. Because AddressBookUI uses AddressBook when this changed the PR results were useless.