### PR TITLE
[Tests] Ignore certain tests that do not longer work on bots.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -203,6 +203,15 @@ partial class TestRuntime
 #endif
 	}
 
+	public static bool IsVSTS =>
+		!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_BUILDID"));  // Env var set by vsts
+																																									 //
+	public static void AssertNotVSTS ()
+	{
+		if (IsVSTS)
+			NUnit.Framework.Assert.Ignore ("This test only runs on developer desktops and not on VSTS.");
+	}
+
 	// This function checks if the current Xcode version is exactly (neither higher nor lower) the requested one.
 	public static bool CheckExactXcodeVersion (int major, int minor, int beta = 0)
 	{

--- a/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
+++ b/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
@@ -59,21 +59,30 @@ namespace MonoTouchFixtures.CoreVideo {
 		}
 
 		[Test]
-		public void DefaultConstructorTest () => Assert.DoesNotThrow (() => {
-			using var displayLink = new CVDisplayLink ();
-		});
+		public void DefaultConstructorTest () { 
+			TestRuntime.AssertNotVSTS ();
+			Assert.DoesNotThrow (() => {
+				using var displayLink = new CVDisplayLink ();
+			});
+		}
 
 		[Test]
-		public void SetCurrentDisplayOpenGLTest () => Assert.DoesNotThrow (() => {
-			using var displayLink = new CVDisplayLink ();
-			displayLink.SetCurrentDisplay (CGDisplay.MainDisplayID);
-		});
+		public void SetCurrentDisplayOpenGLTest () {
+			TestRuntime.AssertNotVSTS ();
+			Assert.DoesNotThrow (() => {
+				using var displayLink = new CVDisplayLink ();
+				displayLink.SetCurrentDisplay (CGDisplay.MainDisplayID);
+			});
+		}
 
 		[Test]
-		public void GetCurrentDisplayTest () => Assert.DoesNotThrow (() => {
-			using var displayLink = new CVDisplayLink ();
-			Assert.AreEqual (CGDisplay.MainDisplayID,  displayLink.GetCurrentDisplay ());
-		});
+		public void GetCurrentDisplayTest () {
+			TestRuntime.AssertNotVSTS ();
+			Assert.DoesNotThrow (() => {
+				using var displayLink = new CVDisplayLink ();
+				Assert.AreEqual (CGDisplay.MainDisplayID,  displayLink.GetCurrentDisplay ());
+			});
+		}
 
 		[Test]
 		public void GetTypeIdTest ()
@@ -87,6 +96,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		[Test]
 		public void TryTranslateTimeValidTest ()
 		{
+			TestRuntime.AssertNotVSTS ();
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12, 0);
 			var outTime = new CVTimeStamp {
 				Version = 0,

--- a/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
+++ b/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
@@ -59,7 +59,8 @@ namespace MonoTouchFixtures.CoreVideo {
 		}
 
 		[Test]
-		public void DefaultConstructorTest () { 
+		public void DefaultConstructorTest ()
+		{ 
 			TestRuntime.AssertNotVSTS ();
 			Assert.DoesNotThrow (() => {
 				using var displayLink = new CVDisplayLink ();
@@ -67,7 +68,8 @@ namespace MonoTouchFixtures.CoreVideo {
 		}
 
 		[Test]
-		public void SetCurrentDisplayOpenGLTest () {
+		public void SetCurrentDisplayOpenGLTest ()
+		{
 			TestRuntime.AssertNotVSTS ();
 			Assert.DoesNotThrow (() => {
 				using var displayLink = new CVDisplayLink ();
@@ -76,7 +78,8 @@ namespace MonoTouchFixtures.CoreVideo {
 		}
 
 		[Test]
-		public void GetCurrentDisplayTest () {
+		public void GetCurrentDisplayTest ()
+		{
 			TestRuntime.AssertNotVSTS ();
 			Assert.DoesNotThrow (() => {
 				using var displayLink = new CVDisplayLink ();


### PR DESCRIPTION
The new bots do not have a display and that makes certain mac tests
fail. Added a new TestRuntime function to let us know if we are on vsts
and ignore accordingly.

fixes https://github.com/xamarin/maccore/issues/2546