### PR TITLE
[msbuild] Make the CollectBundleResourcesDependsOn property public. Fixes #11984.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -386,23 +386,33 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	</Target>
 
 	<PropertyGroup>
-		<_CollectBundleResourcesDependsOn>
-			$(_CollectBundleResourcesDependsOn);
+		<!--
+			Custom targets that add items to the BundleResource or Content item groups must do so before the _CollectBundleResources target.
+			This can be achieved by adding your custom target to the CollectBundleResourcesDependsOn property group:
+
+			<CollectBundleResourcesDependsOn>
+				$(CollectBundleResourcesDependsOn);
+				MyTargetThatAddsBundleResources;
+			</CollectBundleResourcesDependsOn>
+		-->
+
+		<CollectBundleResourcesDependsOn>
+			$(CollectBundleResourcesDependsOn);
 			_ComputeTargetArchitectures;
 			_ComputeTargetFrameworkMoniker;
-		</_CollectBundleResourcesDependsOn>
-		<_CollectBundleResourcesDependsOn Condition="'$(IsBindingProject)' != 'true'">
-			$(_CollectBundleResourcesDependsOn);
+		</CollectBundleResourcesDependsOn>
+		<CollectBundleResourcesDependsOn Condition="'$(IsBindingProject)' != 'true'">
+			$(CollectBundleResourcesDependsOn);
 			_CompileImageAssets;
 			_CompileInterfaceDefinitions;
 			_CompileSceneKitAssets;
 			_CompileColladaAssets;
 			_CompileTextureAtlases;
 			_CompileCoreMLModels;
-		</_CollectBundleResourcesDependsOn>
+		</CollectBundleResourcesDependsOn>
 	</PropertyGroup>
 
-	<Target Name="_CollectBundleResources" DependsOnTargets="$(_CollectBundleResourcesDependsOn)">
+	<Target Name="_CollectBundleResources" DependsOnTargets="$(CollectBundleResourcesDependsOn)">
 		<!-- For multi-RID builds, we first build once for each RuntimeIdentifier, then build again to create a universal app bundle.
 		     In the case of resources, it's wasteful to build them multiple times, so we hoist it out to the outer build, and store the
 		     list of resources we've procesed in _Processed*Path. Here we load that file, and remove them from the item group with the resources -->

--- a/tests/dotnet/BundleStructure/BundleResourceI.txt
+++ b/tests/dotnet/BundleStructure/BundleResourceI.txt
@@ -1,0 +1,1 @@
+BundleResourceI

--- a/tests/dotnet/BundleStructure/ContentI.txt
+++ b/tests/dotnet/BundleStructure/ContentI.txt
@@ -1,0 +1,1 @@
+ContentI

--- a/tests/dotnet/BundleStructure/shared.csproj
+++ b/tests/dotnet/BundleStructure/shared.csproj
@@ -291,4 +291,17 @@
 		<ProjectReference Include="$(RootTestsDirectory)/bindings-framework-test/dotnet/$(_PlatformName)/bindings-framework-test.csproj" />
 	</ItemGroup>
 
+	<!-- Adding resources using a custom target -->
+	<PropertyGroup>
+		<CollectBundleResourcesDependsOn>
+			$(CollectBundleResourcesDependsOn);
+			AddBundleResources;
+		</CollectBundleResourcesDependsOn>
+	</PropertyGroup>
+	<Target Name="AddBundleResources">
+		<ItemGroup>
+			<Content Include="../ContentI.txt" />
+			<BundleResource Include="../BundleResourceI.txt" />
+		</ItemGroup>
+	</Target>
 </Project>

--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -205,6 +205,7 @@ namespace Xamarin.Tests {
 			expectedFiles.Add ($"{resourcesDirectory}ContentC.txt");
 			expectedFiles.Add ($"{resourcesDirectory}ContentD.txt");
 			expectedFiles.Add ($"{resourcesDirectory}ContentE.txt");
+			expectedFiles.Add ($"{resourcesDirectory}ContentI.txt");
 
 			// expectedFiles.Add ($"{resourcesDirectory}EmbeddedResourceA.txt");
 			expectedFiles.Add ($"{resourcesDirectory}EmbeddedResourceB.txt");
@@ -217,6 +218,7 @@ namespace Xamarin.Tests {
 			expectedFiles.Add ($"{resourcesDirectory}BundleResourceC.txt");
 			expectedFiles.Add ($"{resourcesDirectory}BundleResourceD.txt");
 			expectedFiles.Add ($"{resourcesDirectory}BundleResourceE.txt");
+			expectedFiles.Add ($"{resourcesDirectory}BundleResourceI.txt");
 
 			expectedFiles.Add ($"{resourcesDirectory}AutoIncluded.txt");
 			expectedFiles.Add ($"{resourcesDirectory}SubDirectory");


### PR DESCRIPTION
Make the CollectBundleResourcesDependsOn property public, so that custom
targets can inject themselves into the build early enough to add additional
BundleResource or Content items (by adding their custom target's name to the
CollectBundleResourcesDependsOn property).

Fixes https://github.com/xamarin/xamarin-macios/issues/11984.