### PR TITLE
[tests] Don't use reflection to create HttpClient handlers.

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -41,13 +41,29 @@ namespace MonoTests.System.Net.Http
 #if !__WATCHOS__
 			Console.WriteLine (new HttpClientHandler ());
 			Console.WriteLine (new CFNetworkHandler ());
+#if NET
+			Console.WriteLine (new SocketsHttpHandler ());
+#endif
 #endif
 			Console.WriteLine (new NSUrlSessionHandler ());
 		}
 
 		HttpMessageHandler GetHandler (Type handler_type)
 		{
-			return (HttpMessageHandler) Activator.CreateInstance (handler_type);
+#if !__WATCHOS__
+			if (handler_type == typeof (HttpClientHandler))
+				return new HttpClientHandler ();
+			if (handler_type == typeof (CFNetworkHandler))
+				return new CFNetworkHandler ();
+#endif
+#if NET
+			if (handler_type == typeof (SocketsHttpHandler))
+				return new SocketsHttpHandler ();
+#endif
+			if (handler_type == typeof (NSUrlSessionHandler))
+				return new NSUrlSessionHandler ();
+
+			throw new NotImplementedException ($"Unknown handler type: {handler_type}");
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes two test failures on tvOS with all optimizations enabled:

    MonoTests.System.Net.Http.MessageHandlerTest.DnsFailure
        [FAIL] DnsFailure(System.Net.Http.SocketsHttpHandler) :   Exception
            Expected: instance of <System.Net.Http.HttpRequestException>
            But was:  <System.MissingMethodException: No parameterless constructor defined for type 'System.Net.Http.SocketsHttpHandler'.
                at System.RuntimeType.CreateInstanceMono(Boolean , Boolean )
                at System.RuntimeType.CreateInstanceDefaultCtor(Boolean , Boolean )
                at System.Activator.CreateInstance(Type , Boolean , Boolean )
                at System.Activator.CreateInstance(Type , Boolean )
                at System.Activator.CreateInstance(Type )
                at MonoTests.System.Net.Http.MessageHandlerTest.GetHandler(Type ) in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/System.Net.Http/MessageHandlers.cs:line 50
                at MonoTests.System.Net.Http.MessageHandlerTest.<>c__DisplayClass3_0.<<DnsFailure>b__0>d.MoveNext() in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/System.Net.Http/MessageHandlers.cs:line 76>

    MonoTests.System.Net.Http.MessageHandlerTest.RejectSslCertificatesServicePointManager
        [FAIL] RejectSslCertificatesServicePointManager(System.Net.Http.SocketsHttpHandler) : System.MissingMethodException : No parameterless constructor defined for type 'System.Net.Http.SocketsHttpHandler'.
            at System.RuntimeType.CreateInstanceMono(Boolean , Boolean )
            at System.RuntimeType.CreateInstanceDefaultCtor(Boolean , Boolean )
            at System.Activator.CreateInstance(Type , Boolean , Boolean )
            at System.Activator.CreateInstance(Type , Boolean )
            at System.Activator.CreateInstance(Type )
            at MonoTests.System.Net.Http.MessageHandlerTest.GetHandler(Type ) in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/System.Net.Http/MessageHandlers.cs:line 50
            at MonoTests.System.Net.Http.MessageHandlerTest.RejectSslCertificatesServicePointManager(Type ) in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/System.Net.Http/MessageHandlers.cs:line 405
            at System.Reflection.RuntimeMethodInfo.Invoke(Object , BindingFlags , Binder , Object[] , CultureInfo )