### PR TITLE
[tests] Don't try to create an instance of PKPaymentAuthorizationViewController.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
@@ -131,6 +131,11 @@ namespace Xamarin.Mac.Tests
 			case "SKView":
 				// on vms results on a crash
 				return TestRuntime.IsVM;
+#if !NET
+			case "PKPaymentAuthorizationViewController":
+				// The default constructor doesn't work (it's also obsolete)
+				return true;
+#endif
 			}
 
 			switch (t.Namespace) {


### PR DESCRIPTION
The default constructor doesn't work (it's already obsolete).

Fixes:

    Xamarin.Mac.Tests.DelegateAndDataSourceTest
        [FAIL] DelegateAndDataSourceAllowsNull : 1 failing types
            1 failing types:
            PassKit.PKPaymentAuthorizationViewController: Could not initialize an instance of the type 'PassKit.PKPaymentAuthorizationViewController': the native 'init' method returned nil.
            It is possible to ignore this condition by setting ObjCRuntime.Class.ThrowOnInitFailure to false.
                at Xamarin.Mac.Tests.DelegateAndDataSourceTest.DelegateAndDataSourceAllowsNull () [0x0026c] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs:90