### PR TITLE
[dotnet] Only validate the RuntimeIdentifier if we need/use it. Fixes #13482.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -31,10 +31,13 @@
 		<!-- MSBuild will discard the 'PublishFolderType' metadata on items unless we set these properties -->
 		<MSBuildDisableGetCopyToOutputDirectoryItemsOptimization>true</MSBuildDisableGetCopyToOutputDirectoryItemsOptimization>
 		<MSBuildDisableGetCopyToPublishDirectoryItemsOptimization>true</MSBuildDisableGetCopyToPublishDirectoryItemsOptimization>
+
+		<!-- Do we need a RuntimeIdentifier? For apps and app extensions we do -->
+		<_RuntimeIdentifierIsRequired Condition="'$(OutputType)' == 'Exe' Or '$(IsAppExtension)' == 'true'">true</_RuntimeIdentifierIsRequired>
 	</PropertyGroup>
 
 	<!-- Set the default RuntimeIdentifier if not already specified. -->
-	<PropertyGroup Condition=" ('$(OutputType)' == 'Exe' Or '$(IsAppExtension)' == 'true') And '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">
+	<PropertyGroup Condition="'$(_RuntimeIdentifierIsRequired)' == 'true' And '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'iOS'">iossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'tvOS'">tvossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="'$(_PlatformName)' == 'macOS'">osx-x64</RuntimeIdentifier>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1700,7 +1700,7 @@
 	</Target>
 
 	<Target Name="_ValidateRuntimeIdentifier"
-		Condition="'$(RuntimeIdentifier)' != '' And '$(_RuntimeIdentifierValidation)' != 'false'"
+		Condition="'$(RuntimeIdentifier)' != '' And '$(_RuntimeIdentifierValidation)' != 'false' And '$(_RuntimeIdentifierIsRequired)' == 'true'"
 		BeforeTargets="Restore;Build;ResolvedFrameworkReference;ResolveRuntimePackAssets;ProcessFrameworkReferences">
 		<PropertyGroup>
 			<_IsValidRuntimeIdentifier Condition="@(_XamarinValidRuntimeIdentifier->WithMetadataValue('Platform', '$(_PlatformName)')->WithMetadataValue('Filename', '$(RuntimeIdentifier)')->Count()) &gt; 0">true</_IsValidRuntimeIdentifier>

--- a/tests/dotnet/AppWithGenericLibraryReference/AppDelegate.cs
+++ b/tests/dotnet/AppWithGenericLibraryReference/AppDelegate.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace MySimpleApp
+{
+	public class Program
+	{
+		static int Main (string[] args)
+		{
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return args.Length;
+		}
+	}
+}

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/AppDelegate.cs
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/AppDelegate.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace MySimpleApp
+{
+	public class Program
+	{
+		public static int SomeFunction ()
+		{
+			return 42;
+		}
+	}
+}

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/MacCatalyst/Library.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/MacCatalyst/Library.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<!-- The point is to have netstandard2.1 + another which isn't the TargetFramework we're building for -->
+		<TargetFrameworks>net6.0-macos;netstandard2.1</TargetFrameworks>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/MacCatalyst/Makefile
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/Makefile
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/Makefile
@@ -1,0 +1,2 @@
+TOP=../../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/iOS/Library.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/iOS/Library.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<!-- The point is to have netstandard2.1 + another which isn't the TargetFramework we're building for -->
+		<TargetFrameworks>net6.0-macos;netstandard2.1</TargetFrameworks>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/iOS/Makefile
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/macOS/Library.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/macOS/Library.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<!-- The point is to have netstandard2.1 + another which isn't the TargetFramework we're building for -->
+		<TargetFrameworks>net6.0-ios;netstandard2.1</TargetFrameworks>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/macOS/Makefile
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/shared.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/shared.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/shared.mk
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/shared.mk
@@ -1,0 +1,2 @@
+TOP=../../../../..
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/tvOS/Library.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/tvOS/Library.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<!-- The point is to have netstandard2.1 + another which isn't the TargetFramework we're building for -->
+		<TargetFrameworks>net6.0-macos;netstandard2.1</TargetFrameworks>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/tvOS/Makefile
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/MacCatalyst/AppWithGenericLibraryReference.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/MacCatalyst/AppWithGenericLibraryReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/MacCatalyst/Makefile
+++ b/tests/dotnet/AppWithGenericLibraryReference/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/Makefile
+++ b/tests/dotnet/AppWithGenericLibraryReference/Makefile
@@ -1,0 +1,2 @@
+TOP=../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/iOS/AppWithGenericLibraryReference.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/iOS/AppWithGenericLibraryReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/iOS/Makefile
+++ b/tests/dotnet/AppWithGenericLibraryReference/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/macOS/AppWithGenericLibraryReference.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/macOS/AppWithGenericLibraryReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/macOS/Makefile
+++ b/tests/dotnet/AppWithGenericLibraryReference/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/shared.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/shared.csproj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>AppWithGenericLibraryReference</ApplicationTitle>
+		<ApplicationId>com.xamarin.appwithgenericlibraryreference</ApplicationId>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+		<ProjectReference Include="../Library/$(_PlatformName)/Library.csproj" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/shared.mk
+++ b/tests/dotnet/AppWithGenericLibraryReference/shared.mk
@@ -1,0 +1,2 @@
+TOP=../../../..
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/AppWithGenericLibraryReference/tvOS/AppWithGenericLibraryReference.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/tvOS/AppWithGenericLibraryReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-tvos</TargetFramework>
+  </PropertyGroup>
+  <Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/tvOS/Makefile
+++ b/tests/dotnet/AppWithGenericLibraryReference/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -840,5 +840,24 @@ namespace Xamarin.Tests {
 			var extensionPath = Path.Combine (Path.GetDirectoryName (consumingProjectDir)!, appPath);
 			Assert.That (Directory.Exists (extensionPath), $"App extension directory does not exist: {extensionPath}");
 		}
+
+		[TestCase (ApplePlatform.iOS, "iossimulator-x64;iossimulator-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64")]
+		public void AppWithGenericLibraryReference (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "AppWithGenericLibraryReference";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+
+			DotNet.AssertBuild (project_path, GetDefaultProperties (runtimeIdentifiers));
+
+			var appExecutable = GetNativeExecutable (platform, appPath);
+			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/13482.