### PR TITLE
[cfnetwork] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/CFNetwork/CFHTTPAuthentication.cs
+++ b/src/CFNetwork/CFHTTPAuthentication.cs
@@ -43,7 +43,7 @@ namespace CoreServices {
 		public static CFHTTPAuthentication? CreateFromResponse (CFHTTPMessage response)
 		{
 			if (response is null)
-				throw new ArgumentNullException (nameof (response));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (response));
 
 			if (response.IsRequest)
 				throw new InvalidOperationException ();
@@ -70,7 +70,7 @@ namespace CoreServices {
 		public bool AppliesToRequest (CFHTTPMessage request)
 		{
 			if (request is null)
-				throw new ArgumentNullException (nameof (request));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (request));
 
 			if (!request.IsRequest)
 				throw new InvalidOperationException ();

--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -258,7 +258,7 @@ namespace CoreServices {
 			/* CFHTTPAuthenticationRef */ IntPtr auth, /* CFString */ IntPtr username, /* CFString */ IntPtr password,
 			/* CFStreamError* */ out CFStreamError error);
 
-		public void ApplyCredentials (CFHTTPAuthentication auth, NetworkCredential credential)
+		public void ApplyCredentials (CFHTTPAuthentication? auth, NetworkCredential credential)
 		{
 			if (auth is null)
 				throw new ArgumentNullException (nameof (auth));

--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -90,9 +90,9 @@ namespace CoreServices {
 		public static CFHTTPMessage CreateRequest (CFUrl url, NSString method, Version? version)
 		{
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 			if (method is null)
-				throw new ArgumentNullException (nameof (method));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (method));
 
 			var handle = CFHTTPMessageCreateRequest (
 				IntPtr.Zero, method.Handle, url.Handle, GetVersion (version));
@@ -107,7 +107,7 @@ namespace CoreServices {
 		public static CFHTTPMessage CreateRequest (Uri uri, string method, Version? version)
 		{
 			if (uri is null)
-				throw new ArgumentNullException (nameof (uri));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (uri));
 
 			// the method is obsolete, but EscapeDataString does not work the same way. We could get the components
 			// of the Uri and then EscapeDataString, but this might introduce bugs, so for now we will ignore the warning
@@ -201,7 +201,7 @@ namespace CoreServices {
 		public bool AppendBytes (byte[] bytes)
 		{
 			if (bytes is null)
-				throw new ArgumentNullException (nameof (bytes));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (bytes));
 
 			return CFHTTPMessageAppendBytes (Handle, bytes, bytes.Length);
 		}
@@ -209,7 +209,7 @@ namespace CoreServices {
 		public bool AppendBytes (byte[] bytes, nint count)
 		{
 			if (bytes is null)
-				throw new ArgumentNullException (nameof (bytes));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (bytes));
 
 			return CFHTTPMessageAppendBytes (Handle, bytes, count);
 		}
@@ -261,9 +261,9 @@ namespace CoreServices {
 		public void ApplyCredentials (CFHTTPAuthentication? auth, NetworkCredential credential)
 		{
 			if (auth is null)
-				throw new ArgumentNullException (nameof (auth));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (auth));
 			if (credential is null)
-				throw new ArgumentNullException (nameof (credential));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (credential));
 
 			if (auth.RequiresAccountDomain) {
 				ApplyCredentialDictionary (auth, credential);
@@ -349,9 +349,9 @@ namespace CoreServices {
 		                               bool forProxy)
 		{
 			if (username is null)
-				throw new ArgumentNullException (nameof (username));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (username));
 			if (password is null)
-				throw new ArgumentNullException (nameof (password));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (password));
 
 			return CFHTTPMessageAddAuthentication (
 				Handle, failureResponse.GetHandle (), username.Handle,
@@ -366,9 +366,9 @@ namespace CoreServices {
 		public void ApplyCredentialDictionary (CFHTTPAuthentication auth, NetworkCredential credential)
 		{
 			if (auth is null)
-				throw new ArgumentNullException (nameof (auth));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (auth));
 			if (credential is null)
-				throw new ArgumentNullException (nameof (credential));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (credential));
 
 			var length = credential.Domain is null ? 2 : 3;
 			var keys = new NSString [length];
@@ -408,7 +408,7 @@ namespace CoreServices {
 		public void SetHeaderFieldValue (string name, string value)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
 			var nameHandle = CFString.CreateNative (name);
 			var valueHandle = CFString.CreateNative (value);
@@ -427,7 +427,7 @@ namespace CoreServices {
 		public void SetBody (byte[] buffer)
 		{
 			if (buffer is null)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 			
 			using (var data = new CFDataBuffer (buffer))
 				CFHTTPMessageSetBody (Handle, data.Handle);

--- a/src/CFNetwork/CFHTTPStream.cs
+++ b/src/CFNetwork/CFHTTPStream.cs
@@ -148,7 +148,7 @@ namespace CoreServices {
 		public void SetProxy (CFProxySettings proxySettings)
 		{
 			if (proxySettings is null)
-				throw new ArgumentNullException (nameof (proxySettings));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (proxySettings));
 
 			SetProperty (_Proxy, proxySettings.Dictionary);
 		}

--- a/src/CFNetwork/Content.cs
+++ b/src/CFNetwork/Content.cs
@@ -27,6 +27,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 #if !NET
 
 using System;
@@ -40,7 +42,7 @@ using Foundation;
 namespace CFNetwork {
 
 	class Content : StreamContent {
-		WebResponseStream responseStream;
+		WebResponseStream? responseStream;
 		long? contentLength;
 
 		internal Content (WebResponseStream stream)

--- a/src/CFNetwork/Content.cs
+++ b/src/CFNetwork/Content.cs
@@ -57,13 +57,13 @@ namespace CFNetwork {
 		protected override bool TryComputeLength (out long length)
 		{
 			length = contentLength ?? 0;
-			return contentLength != null;
+			return contentLength is not null;
 		}
 
 		protected override void Dispose (bool disposing)
 		{
 			if (disposing) {
-				if (responseStream != null)
+				if (responseStream is not null)
 					responseStream.Dispose ();
 				responseStream = null;
 			}

--- a/src/CFNetwork/MessageHandler.cs
+++ b/src/CFNetwork/MessageHandler.cs
@@ -105,7 +105,7 @@ namespace CFNetwork {
 
 			SetupRequest (request, message, isFirstRequest);
 
-			if ((auth == null) || (Credentials == null) || !PreAuthenticate)
+			if ((auth is null) || (Credentials is null) || !PreAuthenticate)
 				return message;
 
 			if (auth is not null && !auth.AppliesToRequest (message))
@@ -113,7 +113,7 @@ namespace CFNetwork {
 
 			var method = auth?.GetMethod ();
 			var credential = Credentials.GetCredential (request.RequestUri, method);
-			if (credential == null)
+			if (credential is null)
 				return message;
 
 			if (isFirstRequest)
@@ -127,11 +127,11 @@ namespace CFNetwork {
 			if ((AutomaticDecompression & DecompressionMethods.GZip) != 0)
 				accept_encoding = "gzip";
 			if ((AutomaticDecompression & DecompressionMethods.Deflate) != 0)
-				accept_encoding = accept_encoding != null ? "gzip, deflate" : "deflate";
-			if (accept_encoding != null)
+				accept_encoding = accept_encoding is not null ? "gzip, deflate" : "deflate";
+			if (accept_encoding is not null)
 				message.SetHeaderFieldValue ("Accept-Encoding", accept_encoding);
 
-			if (request.Content != null) {
+			if (request.Content is not null) {
 				foreach (var header in request.Content.Headers) {
 					if (!isFirstRequest && header.Key == "Authorization")
 						continue;
@@ -141,13 +141,13 @@ namespace CFNetwork {
 			}
 
 			foreach (var header in request.Headers) {
-				if ((accept_encoding != null) && header.Key.Equals ("Accept-Encoding"))
+				if ((accept_encoding is not null) && header.Key.Equals ("Accept-Encoding"))
 					continue;
 				var value = string.Join (",", header.Value);
 				message.SetHeaderFieldValue (header.Key, value);
 			}
 
-			if (UseCookies && (CookieContainer != null)) {
+			if (UseCookies && (CookieContainer is not null)) {
 				string cookieHeader = CookieContainer.GetCookieHeader (request.RequestUri);
 				if (cookieHeader != "")
 					message.SetHeaderFieldValue ("Cookie", cookieHeader);
@@ -157,7 +157,7 @@ namespace CFNetwork {
 		async Task<WebRequestStream?> CreateBody (HttpRequestMessage request, CFHTTPMessage message,
 		                                         CancellationToken? cancellationToken)
 		{
-			if (request.Content == null)
+			if (request.Content is null)
 				return null;
 
 			/*
@@ -176,7 +176,7 @@ namespace CFNetwork {
 			 *
 			 */
 			var length = request.Content.Headers.ContentLength;
-			if (((request.Content is StreamContent) || (length == null))) {
+			if (((request.Content is StreamContent) || (length is null))) {
 				var stream = await request.Content.ReadAsStreamAsync ().ConfigureAwait (false);
 				return new WebRequestStream (stream, cancellationToken ?? CancellationToken.None);
 			}
@@ -219,11 +219,11 @@ namespace CFNetwork {
 			cancellationToken.ThrowIfCancellationRequested ();
 
 			WebResponseStream? stream;
-			if (body != null)
+			if (body is not null)
 				stream = WebResponseStream.Create (message, body);
 			else
 				stream = WebResponseStream.Create (message);
-			if (stream == null)
+			if (stream is null)
 				throw new HttpRequestException (string.Format (
 					"Failed to create web request for '{0}'.",
 					request.RequestUri)
@@ -254,7 +254,7 @@ namespace CFNetwork {
 				}
 				
 			}
-			if (retryWithCredentials && (body == null) &&
+			if (retryWithCredentials && (body is null) &&
 			    (status == HttpStatusCode.Unauthorized) ||
 			    (status == HttpStatusCode.ProxyAuthenticationRequired)) {
 				if (HandleAuthentication (request.RequestUri, message, response)) {
@@ -293,7 +293,7 @@ namespace CFNetwork {
 
 		bool HandleAuthentication (Uri uri, CFHTTPMessage request, CFHTTPMessage response)
 		{
-			if (Credentials == null)
+			if (Credentials is null)
 				return false;
 
 			if (PreAuthenticate) {
@@ -305,10 +305,10 @@ namespace CFNetwork {
 			var digest = Credentials.GetCredential (uri, "Digest");
 
 			bool ok = false;
-			if ((basic != null) && (digest == null))
+			if ((basic is not null) && (digest is null))
 				ok = HandleAuthentication (
 					request, response, CFHTTPMessage.AuthenticationScheme.Basic, basic);
-			if ((digest != null) && (basic == null))
+			if ((digest is not null) && (basic is null))
 				ok = HandleAuthentication (
 					request, response, CFHTTPMessage.AuthenticationScheme.Digest, digest);
 			if (ok)
@@ -322,7 +322,7 @@ namespace CFNetwork {
 		{
 			var method = auth?.GetMethod ();
 			var credential = Credentials.GetCredential (uri, method);
-			if (credential == null)
+			if (credential is null)
 				return false;
 
 			message.ApplyCredentials (auth, credential);
@@ -342,16 +342,16 @@ namespace CFNetwork {
 
 		void FindAuthenticationObject (CFHTTPMessage response)
 		{
-			if (auth != null) {
+			if (auth is not null) {
 				if (auth.IsValid)
 					return;
 				auth.Dispose ();
 				auth = null;
 			}
 
-			if (auth == null) {
+			if (auth is null) {
 				auth = CFHTTPAuthentication.CreateFromResponse (response);
-				if (auth == null)
+				if (auth is null)
 					throw new HttpRequestException ("Failed to create CFHTTPAuthentication");
 			}
 
@@ -397,7 +397,7 @@ namespace CFNetwork {
 		protected override void Dispose (bool disposing)
 		{
 			if (disposing) {
-				if (auth != null) {
+				if (auth is not null) {
 					auth.Dispose ();
 					auth = null;
 				}

--- a/src/CFNetwork/WebResponseStream.cs
+++ b/src/CFNetwork/WebResponseStream.cs
@@ -80,7 +80,7 @@ namespace CFNetwork {
 		public static WebResponseStream? Create (CFHTTPMessage request)
 		{
 			var stream = CFStream.CreateForHTTPRequest (request);
-			if (stream == null)
+			if (stream is null)
 				return null;
 
 			return new WebResponseStream (stream, null);
@@ -89,7 +89,7 @@ namespace CFNetwork {
 		public static WebResponseStream? Create (CFHTTPMessage request, WebRequestStream body)
 		{
 			var stream = CFStream.CreateForStreamedHTTPRequest (request, body.ReadStream);
-			if (stream == null)
+			if (stream is null)
 				return null;
 
 			return new WebResponseStream (stream, body);
@@ -114,11 +114,11 @@ namespace CFNetwork {
 		{
 			if (disposing) {
 				OnCanceled ();
-				if (stream != null) {
+				if (stream is not null) {
 					stream.Dispose ();
 					stream = null;
 				}
-				if (openCts != null) {
+				if (openCts is not null) {
 					openCts.Dispose ();
 					openCts = null;
 				}
@@ -128,7 +128,7 @@ namespace CFNetwork {
 
 		void OnError (Exception? error)
 		{
-			if (error == null)
+			if (error is null)
 				error = new InvalidOperationException ("Unknown error.");
 
 			if (completed)
@@ -142,7 +142,7 @@ namespace CFNetwork {
 				openTcs?.SetException (error);
 
 			var operation = Interlocked.Exchange (ref currentOperation, null);
-			if (operation != null)
+			if (operation is not null)
 				operation.SetException (error);
 		}
 
@@ -158,7 +158,7 @@ namespace CFNetwork {
 				openTcs?.SetCanceled ();
 
 			var operation = Interlocked.Exchange (ref currentOperation, null);
-			if (operation != null)
+			if (operation is not null)
 				operation.SetCanceled ();
 		}
 
@@ -176,7 +176,7 @@ namespace CFNetwork {
 			}
 
 			var operation = Interlocked.Exchange (ref currentOperation, null);
-			if (operation != null)
+			if (operation is not null)
 				operation.SetCompleted ();
 		}
 
@@ -196,14 +196,14 @@ namespace CFNetwork {
 		{
 			bool isCrossThread;
 			lock (syncRoot) {
-				if (!open || (currentOperation != null))
+				if (!open || (currentOperation is not null))
 					throw new InvalidOperationException ();
 
 				if (canceled) {
 					operation.SetCanceled ();
 					return;
 				}
-				if (lastError != null) {
+				if (lastError is not null) {
 					operation.SetException (lastError);
 					return;
 				}
@@ -227,7 +227,7 @@ namespace CFNetwork {
 			 * don't have to worry about any locking or anything.
 			 * 
 			 */
-			if ((worker != null) && !Thread.CurrentThread.Equals (workerThread)) {
+			if ((worker is not null) && !Thread.CurrentThread.Equals (workerThread)) {
 				await worker.Post (async () => {
 					if (bytesAvailable)
 						await OnBytesAvailable (false);
@@ -280,7 +280,7 @@ namespace CFNetwork {
 			 * 
 			 */
 			if (!crossThreadAccess) {
-				if ((currentOperation == null) || busy) {
+				if ((currentOperation is null) || busy) {
 					bytesAvailable = true;
 					return;
 				}
@@ -298,7 +298,7 @@ namespace CFNetwork {
 
 			Monitor.Enter (syncRoot);
 
-			if ((currentOperation == null) || busy) {
+			if ((currentOperation is null) || busy) {
 				bytesAvailable = true;
 				Monitor.Exit (syncRoot);
 				return;
@@ -485,7 +485,7 @@ namespace CFNetwork {
 			{
 				if (disposing) {
 					SetCanceled ();
-					if (cts != null) {
+					if (cts is not null) {
 						cts.Dispose ();
 						cts = null;
 					}
@@ -575,7 +575,7 @@ namespace CFNetwork {
 			mainThread = Thread.CurrentThread;
 
 			try {
-				if (worker != null)
+				if (worker is not null)
 					await worker.Post (c => DoOpen (), openCts.Token);
 				else
 					DoOpen ();
@@ -589,7 +589,7 @@ namespace CFNetwork {
 
 		void DoOpen ()
 		{
-			if (lastError != null) {
+			if (lastError is not null) {
 				openTcs?.SetException (lastError);
 				return;
 			}
@@ -624,7 +624,7 @@ namespace CFNetwork {
 				await HasBytesAvailable ();
 			};
 			stream.OpenCompletedEvent += async (sender, e) => {
-				if (body == null)
+				if (body is null)
 					return;
 				await body.Open ();
 			};

--- a/src/CFNetwork/WorkerThread.cs
+++ b/src/CFNetwork/WorkerThread.cs
@@ -27,6 +27,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 #if !NET
 
 using System;
@@ -43,9 +45,9 @@ using CFRunLoopModeString = global::Foundation.NSString;
 namespace CFNetwork {
 
 	public class WorkerThread {
-		CFRunLoop loop;
-		Source source;
-		Context context;
+		CFRunLoop? loop;
+		Source? source;
+		Context? context;
 		CancellationTokenSource cts;
 		ManualResetEventSlim readyEvent;
 		ConcurrentQueue<Event> eventQueue = new ConcurrentQueue<Event> ();
@@ -88,8 +90,8 @@ namespace CFNetwork {
 		public void Stop ()
 		{
 			cts.Cancel ();
-			loop.RemoveSource (source, CFRunLoop.ModeDefault);
-			loop.Stop ();
+			loop?.RemoveSource (source, CFRunLoop.ModeDefault);
+			loop?.Stop ();
 		}
 
 		protected void PostNoResult (Action callback)
@@ -100,8 +102,8 @@ namespace CFNetwork {
 				return null;
 			};
 			eventQueue.Enqueue (ev);
-			source.Signal ();
-			loop.WakeUp ();
+			source?.Signal ();
+			loop?.WakeUp ();
 		}
 
 		public Task Post (Action callback)
@@ -116,11 +118,11 @@ namespace CFNetwork {
 				callback (c);
 				return null;
 			};
-			ev.Tcs = new TaskCompletionSource<object> ();
+			ev.Tcs = new TaskCompletionSource<object?> ();
 			ev.Cts = CancellationTokenSource.CreateLinkedTokenSource (cts.Token, cancellationToken);
 			eventQueue.Enqueue (ev);
-			source.Signal ();
-			loop.WakeUp ();
+			source?.Signal ();
+			loop?.WakeUp ();
 
 			try {
 				await ev.Tcs.Task;
@@ -129,21 +131,21 @@ namespace CFNetwork {
 			}
 		}
 
-		public Task<T> Post<T> (Func<T> callback)
+		public Task<T?> Post<T> (Func<T> callback)
 		{
 			return Post (c => callback (), CancellationToken.None);
 		}
 
-		public async Task<T> Post<T> (Func<CancellationToken, T> callback,
+		public async Task<T?> Post<T> (Func<CancellationToken, T> callback,
 		                              CancellationToken cancellationToken)
 		{
 			var ev = new Event ();
 			ev.Callback = c => callback (c);
-			ev.Tcs = new TaskCompletionSource<object> ();
+			ev.Tcs = new TaskCompletionSource<object?> ();
 			ev.Cts = CancellationTokenSource.CreateLinkedTokenSource (cts.Token, cancellationToken);
 			eventQueue.Enqueue (ev);
-			source.Signal ();
-			loop.WakeUp ();
+			source?.Signal ();
+			loop?.WakeUp ();
 
 			try {
 				var result = await ev.Tcs.Task;
@@ -183,8 +185,8 @@ namespace CFNetwork {
 		}
 
 		struct Event {
-			public Func<CancellationToken, object> Callback;
-			public TaskCompletionSource<object> Tcs;
+			public Func<CancellationToken, object?> Callback;
+			public TaskCompletionSource<object?> Tcs;
 			public CancellationTokenSource Cts;
 		}
 

--- a/src/CFNetwork/WorkerThread.cs
+++ b/src/CFNetwork/WorkerThread.cs
@@ -149,7 +149,7 @@ namespace CFNetwork {
 
 			try {
 				var result = await ev.Tcs.Task;
-				if (result != null)
+				if (result is not null)
 					return (T)result;
 				else
 					return default(T);
@@ -164,7 +164,7 @@ namespace CFNetwork {
 			if (!eventQueue.TryDequeue (out ev))
 				return;
 
-			if ((ev.Cts != null) && ev.Cts.IsCancellationRequested) {
+			if ((ev.Cts is not null) && ev.Cts.IsCancellationRequested) {
 				ev.Tcs.SetCanceled ();
 				return;
 			}
@@ -173,13 +173,13 @@ namespace CFNetwork {
 
 			try {
 				var result = ev.Callback (effectiveCts.Token);
-				if (ev.Tcs != null)
+				if (ev.Tcs is not null)
 					ev.Tcs.SetResult (result);
 			} catch (TaskCanceledException) {
-				if (ev.Tcs != null)
+				if (ev.Tcs is not null)
 					ev.Tcs.SetCanceled ();
 			} catch (Exception ex) {
-				if (ev.Tcs != null)
+				if (ev.Tcs is not null)
 					ev.Tcs.SetException (ex);
 			}
 		}

--- a/src/CoreFoundation/CFReadStream.cs
+++ b/src/CoreFoundation/CFReadStream.cs
@@ -152,7 +152,7 @@ namespace CoreFoundation {
 			return Read (buffer, 0, buffer.Length);
 		}
 
-		public unsafe nint Read (byte[] buffer, int offset, int count)
+		public unsafe nint Read (byte[]? buffer, int offset, int count)
 		{
 			if (buffer is null)
 				throw new ArgumentNullException (nameof (buffer));

--- a/src/CoreFoundation/CFRunLoop.cs
+++ b/src/CoreFoundation/CFRunLoop.cs
@@ -307,7 +307,7 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static void CFRunLoopRemoveSource (/* CFRunLoopRef */ IntPtr rl, /* CFRunLoopSourceRef */ IntPtr source, /* CFStringRef */ IntPtr mode);
 
-		public void RemoveSource (CFRunLoopSource source, NSString mode)
+		public void RemoveSource (CFRunLoopSource? source, NSString mode)
 		{
 			if (source is null)
 				throw new ArgumentNullException (nameof (source));


### PR DESCRIPTION
This PR aims to bring nullability changes to CFNetwork.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`

**********
Something interesting about this framework is that the following files are not inside the src/frameworks.sources, but when removed or `#nullable enable`'d, it did not compile:
src/CFNetwork/Content.cs
src/CFNetwork/MessageHandler.cs
src/CFNetwork/WebRequestStream.cs
src/CFNetwork/WebResponseStream.cs
src/CFNetwork/WorkerThread.cs

Extra attention on the async/await changes would be great! These changes were brought by the compiler complaining about awaitable methods not using await so for most of them I added async and await but for two that were returning Tasks, I added a progma ignore warning. If desired, I can ignore the others as well! - These changes are in the `Enable Nullability and fix errors including async and await changes` commit!