### PR TITLE
[release/6.0.2xx-preview13] [CI] Ensure we have dotnet 3.x to be able to run ESRP.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -89,6 +89,7 @@ steps:
   inputs:
     packageType: runtime
     version: 3.x
+    installationPath: '/usr/local/share/dotnet/'
   displayName: 'Install .NET Core runtime 3.x needed for ESRP'
 
 - task: xamops.azdevex.provisionator-task.provisionator@2

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -84,6 +84,12 @@ steps:
     MacDeveloper: $(mac-developer)
     HostedMacKeychainPassword: ${{ parameters.keyringPass }}
 
+# the ddsign plugin needs this version or it will crash and will make the sign step fail
+- task: UseDotNet@2
+  inputs:
+    version: 3.x
+  displayName: 'Use .NET Core sdk 3.x needed for ESRP'
+
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: 'Provision Brew components'
   inputs:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -84,14 +84,6 @@ steps:
     MacDeveloper: $(mac-developer)
     HostedMacKeychainPassword: ${{ parameters.keyringPass }}
 
-# the ddsign plugin needs this version or it will crash and will make the sign step fail
-- task: UseDotNet@2
-  inputs:
-    packageType: runtime
-    version: 3.x
-    installationPath: '/usr/local/share/dotnet/'
-  displayName: 'Install .NET Core runtime 3.x needed for ESRP'
-
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: 'Provision Brew components'
   inputs:
@@ -339,6 +331,13 @@ steps:
   - ${{ if eq(parameters.enableDotnet, true) }}:
     - template: build-nugets.yml
 
+# the ddsign plugin needs this version or it will crash and will make the sign step fail
+- task: UseDotNet@2
+  inputs:
+    packageType: runtime
+    version: 3.x
+    installationPath: '/usr/local/share/dotnet/'
+  displayName: 'Install .NET Core runtime 3.x needed for ESRP'
 
 - ${{ if eq(parameters.signAndNotarize, true) }}:
   # only sign an notarize in no PR executions

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -336,7 +336,7 @@ steps:
   inputs:
     packageType: runtime
     version: 3.x
-    installationPath: '/usr/local/share/dotnet/'
+    installationPath: '/usr/local/share/dotnet'
   displayName: 'Install .NET Core runtime 3.x needed for ESRP'
 
 - ${{ if eq(parameters.signAndNotarize, true) }}:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -344,6 +344,7 @@ steps:
   - ${{ if eq(parameters.enableDotnet, true) }}:
     - template: build-nugets.yml
 
+
 - ${{ if eq(parameters.signAndNotarize, true) }}:
   # only sign an notarize in no PR executions
   - template: sign-and-notarized.yml

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -84,6 +84,19 @@ steps:
     MacDeveloper: $(mac-developer)
     HostedMacKeychainPassword: ${{ parameters.keyringPass }}
 
+# the ddsign plugin needs this version or it will crash and will make the sign step fail
+- task: UseDotNet@2
+  inputs:
+    packageType: sdk
+    version: 3.x
+  displayName: 'Install .NET Core SDK 3.x needed for ESRP'
+  
+- task: UseDotNet@2
+  inputs:
+    packageType: sdk
+    version: 5.x
+  displayName: 'Install .NET 5.x SDK'
+
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: 'Provision Brew components'
   inputs:
@@ -330,14 +343,6 @@ steps:
   # build nugets
   - ${{ if eq(parameters.enableDotnet, true) }}:
     - template: build-nugets.yml
-
-# the ddsign plugin needs this version or it will crash and will make the sign step fail
-- task: UseDotNet@2
-  inputs:
-    packageType: runtime
-    version: 3.x
-    installationPath: '/usr/local/share/dotnet'
-  displayName: 'Install .NET Core runtime 3.x needed for ESRP'
 
 - ${{ if eq(parameters.signAndNotarize, true) }}:
   # only sign an notarize in no PR executions

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -87,8 +87,9 @@ steps:
 # the ddsign plugin needs this version or it will crash and will make the sign step fail
 - task: UseDotNet@2
   inputs:
+    packageType: runtime
     version: 3.x
-  displayName: 'Use .NET Core sdk 3.x needed for ESRP'
+  displayName: 'Install .NET Core runtime 3.x needed for ESRP'
 
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: 'Provision Brew components'


### PR DESCRIPTION
This is needed to make the CI work

Backport of #14323
