### PR TITLE
Bump Microsoft.DotNet.XHarness.iOS.Shared to `1.0.0-prerelease.22157.2`

### DIFF
--- a/tests/xharness/Xharness.Tests/Jenkins/MarkdownReportWriterTests.cs
+++ b/tests/xharness/Xharness.Tests/Jenkins/MarkdownReportWriterTests.cs
@@ -165,7 +165,7 @@ namespace Xharness.Tests.Jenkins {
 
 			for (var i = 0; i < count; i++) {
 				var failure = new Mock<ITestTask> ();
-				(string HumanMessage, string IssueLink)? knownIssue = (HumanMessage: "Testing known issues", IssueLink:"http://github.com");
+				var knownIssue = new KnownIssue(humanMessage: "Testing known issues", issueLink:"http://github.com");
 				failure.Setup (t => t.Finished).Returns (true);
 				failure.Setup (t => t.Succeeded).Returns (false);
 				failure.Setup (t => t.Failed).Returns (true);

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -65,7 +65,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.XHarness.iOS.Shared" Version="1.0.0-prerelease.21569.5" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.iOS.Shared" Version="1.0.0-prerelease.22157.2" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
   </ItemGroup>


### PR DESCRIPTION
I don't expect anything changed since Nov 19th but there might be miniature API changes this week so want to bump now and then after.