### PR TITLE
Bump maccore

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 6e6b84249bf9cac6d4d7ddc25326784c4f641092
+NEEDED_MACCORE_VERSION := 696db0a953d62adc90cfbeaf42ebd1c901e7276b
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in `xamarin/maccore`:

* xamarin/maccore@696db0a953d62adc90cfbeaf42ebd1c901e7276b Allow launch Simulator as the only action

Diff: https://github.com/xamarin/maccore/compare/0402961be3c1ef0466c29a104247f2e3a2d9163c..696db0a953d62adc90cfbeaf42ebd1c901e7276b