### PR TITLE
[release/6.0.2xx-preview14] [msbuild] Fix a few paths to have consistently macOS paths.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/LoggingExtensions.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/LoggingExtensions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -86,6 +89,20 @@ namespace Xamarin.MacDev.Tasks
 		public static void LogWarning (this TaskLoggingHelper log, int errorCode, string fileName, string message, params object[] args)
 		{
 			log.LogWarning (null, $"{ErrorPrefix}{errorCode}", null, fileName ?? "MSBuild", 0, 0, 0, 0, message, args);
+		}
+
+		public static bool LogErrorsFromException (this TaskLoggingHelper log, Exception exception, bool showStackTrace = true, bool showDetail = true)
+		{
+			var exceptions = new List<Exception> ();
+			if (exception is AggregateException ae) {
+				exceptions.AddRange (ae.InnerExceptions);
+			} else {
+				exceptions.Add (exception);
+			}
+			foreach (var e in exceptions) {
+				log.LogErrorFromException (e, showStackTrace, showDetail, null);
+			}
+			return false;
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -88,7 +88,9 @@ namespace Xamarin.MacDev.Tasks
 
 		string GetCodesignStampFile (ITaskItem item)
 		{
-			return GetNonEmptyStringOrFallback (item, "CodesignStampFile", StampFile, "StampFile", required: true);
+			var rv = GetNonEmptyStringOrFallback (item, "CodesignStampFile", StampFile, "StampFile", required: true);
+			rv = PathUtils.ConvertToMacPath (rv);
+			return rv;
 		}
 
 		string GetCodesignAllocate (ITaskItem item)
@@ -311,6 +313,15 @@ namespace Xamarin.MacDev.Tasks
 		}
 
 		public override bool Execute ()
+		{
+			try {
+				return ExecuteUnsafe ();
+			} catch (Exception e) {
+				return Log.LogErrorsFromException (e);
+			}
+		}
+
+		bool ExecuteUnsafe ()
 		{
 			if (Resources.Length == 0)
 				return true;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/LinkNativeCodeTaskBase.cs
@@ -52,6 +52,15 @@ namespace Xamarin.MacDev.Tasks {
 
 		public override bool Execute ()
 		{
+			try {
+				return ExecuteUnsafe ();
+			} catch (Exception e) {
+				return Log.LogErrorsFromException (e);
+			}
+		}
+
+		bool ExecuteUnsafe ()
+		{
 			if (!Enum.TryParse (TargetArchitectures, out architectures)) {
 				Log.LogError (12, null, MSBStrings.E0012, TargetArchitectures);
 				return false;

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
+using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks
 {
@@ -13,7 +14,7 @@ namespace Xamarin.MacDev.Tasks
 		public override bool Execute ()
 		{
 			if (ShouldExecuteRemotely ()) {
-				outputPath = Path.GetDirectoryName (OutputFile).Replace ("\\", "/");
+				outputPath = PathUtils.ConvertToMacPath (Path.GetDirectoryName (OutputFile));
 
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 			}
@@ -23,7 +24,7 @@ namespace Xamarin.MacDev.Tasks
 
 		// We should avoid copying files from the output path because those already exist on the Mac
 		// and the ones on Windows are empty, so we will break the build
-		public bool ShouldCopyToBuildServer (ITaskItem item) => !item.ItemSpec.StartsWith (outputPath);
+		public bool ShouldCopyToBuildServer (ITaskItem item) => !PathUtils.ConvertToMacPath (item.ItemSpec).StartsWith (outputPath);
 
 		public bool ShouldCreateOutputFile (ITaskItem item) => false;
 

--- a/tools/common/PathUtils.cs
+++ b/tools/common/PathUtils.cs
@@ -227,5 +227,14 @@ namespace Xamarin.Utils
 
 			return false;
 		}
+
+		// Replace any windows-style slashes with mac-style slashes.
+		public static string ConvertToMacPath (string path)
+		{
+			if (string.IsNullOrEmpty (path))
+				return path;
+
+			return path.Replace ('\\', '/');
+		}
 	}
 }


### PR DESCRIPTION
This fixes an issue where we'd do logic with Windows-style paths on macOS, and that's
never the right thing to do.

For the LinkNativeCode task, this would manifest as this error when building from windows:

> ld: file too small (length=0) file 'obj/Debug/net6.0-ios/iossimulator-x64/nativelibraries/libSystem.Native.dylib' for architecture x86_64

because the 'ShouldCopyToBuildServer' method would return incorrect results.

For the Codesign task, it would manifest as an exception trying to create a
directory with an empty string (because the directory name of a windows-style
path is an empty string on macOS).

Since this exception was quite useless (just getting the exception message
didn't tell me much about what caused the exception, because it had no stack
trace information), I've also improved error reporting in both of these tasks.


Backport of #14354
