### PR TITLE
FSEventStream: bind FSEventStreamCreateRelativeToDevice, FSEventStreamGetDeviceBeingWatched

### DIFF
--- a/src/Foundation/NSArray.cs
+++ b/src/Foundation/NSArray.cs
@@ -197,14 +197,16 @@ namespace Foundation {
 			return arr;
 		}
 
-		static public NSArray FromStrings (params string [] items)
+		static public NSArray FromStrings (params string [] items) => FromStrings ((IReadOnlyList<string>)items);
+
+		static public NSArray FromStrings (IReadOnlyList<string> items)
 		{
 			if (items == null)
 				throw new ArgumentNullException (nameof (items));
 			
-			IntPtr buf = Marshal.AllocHGlobal (items.Length * IntPtr.Size);
+			IntPtr buf = Marshal.AllocHGlobal (items.Count * IntPtr.Size);
 			try {
-				for (int i = 0; i < items.Length; i++){
+				for (int i = 0; i < items.Count; i++){
 					IntPtr val;
 					
 					if (items [i] == null)
@@ -215,7 +217,7 @@ namespace Foundation {
 	
 					Marshal.WriteIntPtr (buf, i * IntPtr.Size, val);
 				}
-				NSArray arr = Runtime.GetNSObject<NSArray> (NSArray.FromObjects (buf, items.Length));
+				NSArray arr = Runtime.GetNSObject<NSArray> (NSArray.FromObjects (buf, items.Count));
 				return arr;
 			} finally {
 				Marshal.FreeHGlobal (buf);

--- a/tests/monotouch-test/CoreServices/FSEventStreamTest.cs
+++ b/tests/monotouch-test/CoreServices/FSEventStreamTest.cs
@@ -26,6 +26,46 @@ namespace MonoTouchFixtures.CoreServices {
 	[Preserve (AllMembers = true)]
 	public sealed class FSEventStreamTest {
 		[Test]
+		public void TestPathsBeingWatched ()
+		{
+			FSEventStreamCreateOptions createOptions = new () {
+				Flags = FileEvents | UseExtendedData,
+				PathsToWatch = new [] {
+					Xamarin.Cache.CreateTemporaryDirectory (),
+					Xamarin.Cache.CreateTemporaryDirectory (),
+					Xamarin.Cache.CreateTemporaryDirectory (),
+					Xamarin.Cache.CreateTemporaryDirectory ()
+				}
+			};
+
+			var stream = createOptions.CreateStream ();
+
+			CollectionAssert.AreEqual (
+				createOptions.PathsToWatch,
+				stream.PathsBeingWatched);
+
+			Assert.AreEqual (0, stream.DeviceBeingWatched);
+		}
+
+		[Test]
+		public void TestPathsBeingWatchedRelativeToDevice ()
+		{
+			FSEventStreamCreateOptions createOptions = new () {
+				Flags = FileEvents | UseExtendedData,
+				DeviceToWatch = 123456789,
+				PathsToWatch = new [] { string.Empty }
+			};
+
+			var stream = createOptions.CreateStream ();
+
+			CollectionAssert.AreEqual (
+				createOptions.PathsToWatch,
+				stream.PathsBeingWatched);
+
+			Assert.AreEqual (123456789, stream.DeviceBeingWatched);
+		}
+
+		[Test]
 		public void TestFileEvents ()
 			=> RunTest (FileEvents);
 
@@ -100,6 +140,8 @@ namespace MonoTouchFixtures.CoreServices {
 
 				while (isWorking)
 					NSRunLoop.Current.RunUntil (NSDate.Now.AddSeconds (0.1));
+
+				Invalidate ();
 
 				if (_exceptions.Count > 0) {
 					if (_exceptions.Count > 1)


### PR DESCRIPTION
Introduce `FSEventStreamCreateOptions` to avoid a slew of .ctor overrides, and make it easier to specify `DeviceToWatch` and `SinceWhenId`. `SinceWhenId` was previously only exposed on the "low level" .ctor, and it's a rather important parameter for supporting events that may have happened while the application was not running.

Make the existing constructors wrap `FSEventStreamCreateOptions` to avoid API break.

This is a followup to #14318. When using device-relative watches, files can be tracked via a tuple of their device ID and inode instead of paths. #14318 exposes inode data on `FSEvent`.