### PR TITLE
[CI] Do not show a warning if we cannot disable the lock screen.

### DIFF
--- a/tools/devops/automation/templates/common/setup.yml
+++ b/tools/devops/automation/templates/common/setup.yml
@@ -67,6 +67,7 @@ steps:
   continueOnError: true
 
 - bash: |
+    RC=0
     security set-key-partition-list -S apple-tool:,apple: -s -k $OSX_KEYCHAIN_PASS login.keychain || RC=$?
     if [ $RC -eq 0 ]; then
       echo "Security UI-prompt removed."

--- a/tools/devops/automation/templates/common/setup.yml
+++ b/tools/devops/automation/templates/common/setup.yml
@@ -67,7 +67,12 @@ steps:
   continueOnError: true
 
 - bash: |
-    security set-key-partition-list -S apple-tool:,apple: -s -k $OSX_KEYCHAIN_PASS login.keychain
+    security set-key-partition-list -S apple-tool:,apple: -s -k $OSX_KEYCHAIN_PASS login.keychain || RC=$?
+    if [ $RC -eq 0 ]; then
+      echo "Security UI-prompt removed."
+    else
+      echo "Security UI-prompt could NOT be removed."
+    fi
   env:
     OSX_KEYCHAIN_PASS: ${{ parameters.keyringPass }}
   displayName: 'Remove security UI-prompt (http://stackoverflow.com/a/40039594/183422)'

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -20,6 +20,7 @@ steps:
   persistCredentials: true  # hugely important, else there are some scripts that check a single file from maccore that will fail
 
 - bash: |
+    RC=0
     security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS login.keychain || RC=$?
     if [ $RC -eq 0 ]; then
       echo "Security UI-prompt removed."

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -20,7 +20,12 @@ steps:
   persistCredentials: true  # hugely important, else there are some scripts that check a single file from maccore that will fail
 
 - bash: |
-    security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS login.keychain
+    security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS login.keychain || RC=$?
+    if [ $RC -eq 0 ]; then
+      echo "Security UI-prompt removed."
+    else
+      echo "Security UI-prompt could NOT be removed."
+    fi
   env:
     KEYCHAIN_PASS: ${{ parameters.keyringPass }}
   displayName: 'Remove security UI-prompt (http://stackoverflow.com/a/40039594/183422)'


### PR DESCRIPTION
If we have an issue unlocking the UI prompt we continue on error. This
is considered a warning in the pipeline, but doing so teaches users to
ignore warnings and will result in us ignoring real actual issues.
Setting the step to not have a warning will ensure that we only see
warnings that we care about.