### PR TITLE
[msbuild] Make sure to not use windows-style paths for resource rules and entitlements.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -206,11 +206,13 @@ namespace Xamarin.MacDev.Tasks
 			}
 
 			if (!string.IsNullOrEmpty (resourceRules)) {
+				resourceRules = PathUtils.ConvertToMacPath (resourceRules);
 				args.Add ("--resource-rules");
 				args.Add (Path.GetFullPath (resourceRules));
 			}
 
 			if (!string.IsNullOrEmpty (entitlements)) {
+				entitlements = PathUtils.ConvertToMacPath (entitlements);
 				args.Add ("--entitlements");
 				args.Add (Path.GetFullPath (entitlements));
 			}


### PR DESCRIPTION
Fixes this build failure:

    1>/Users/<user>/Library/Caches/Xamarin/mtbs/builds/MauiApp16/SessionId/obj\Debug\net6.0-ios\ios-arm64\device-builds\iphone14.5-15.2.1\Entitlements.xcent: cannot read entitlement data
    1>C:\Program Files\dotnet\packs\Microsoft.iOS.Sdk\15.2.302-preview.14.117\tools\msbuild\iOS\Xamarin.Shared.targets(2095,3): error : /usr/bin/codesign exited with code 1
    1>C:\Program Files\dotnet\packs\Microsoft.iOS.Sdk\15.2.302-preview.14.117\tools\msbuild\iOS\Xamarin.Shared.targets(2095,3): error :
    1>C:\Program Files\dotnet\packs\Microsoft.iOS.Sdk\15.2.302-preview.14.117\tools\msbuild\iOS\Xamarin.Shared.targets(2095,3): error : Failed to codesign '/Users/<user>/Library/Caches/Xamarin/mtbs/builds/MauiApp16/SessionId/bin/Debug/net6.0-ios/ios-arm64/device-builds/iphone14.5-15.2.1/MauiApp16.app': /Users/<user>/Library/Caches/Xamarin/mtbs/builds/MauiApp16/SessionId/obj\Debug\net6.0-ios\ios-arm64\device-builds\iphone14.5-15.2.1\Entitlements.xcent: cannot read entitlement data
    1>C:\Program Files\dotnet\packs\Microsoft.iOS.Sdk\15.2.302-preview.14.117\tools\msbuild\iOS\Xamarin.Shared.targets(2095,3): error :
    1>C:\Program Files\dotnet\packs\Microsoft.iOS.Sdk\15.2.302-preview.14.117\tools\msbuild\iOS\Xamarin.Shared.targets(2095,3): error :
    1>Done building project "MauiApp16.csproj" -- FAILED.
    ========== Build: 0 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
    ========== Deploy: 0 succeeded, 0 failed, 0 skipped ==========

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1496403.