### PR TITLE
Update code-behind templates to correctly support Dark Mode, bind text to the center of the screen.

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/AppDelegate.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/AppDelegate.cs
@@ -15,9 +15,9 @@ public class AppDelegate : UIApplicationDelegate {
 		// create a UIViewController with a single UILabel
 		var vc = new UIViewController ();
 		vc.View!.AddSubview (new UILabel (Window!.Frame) {
-			BackgroundColor = UIColor.White,
 			TextAlignment = UITextAlignment.Center,
-			Text = "Hello, Catalyst!"
+			Text = "Hello, Catalyst!",
+			AutoresizingMask = UIViewAutoresizing.All,
 		});
 		Window.RootViewController = vc;
 

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/AppDelegate.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/AppDelegate.cs
@@ -15,9 +15,9 @@ public class AppDelegate : UIApplicationDelegate {
 		// create a UIViewController with a single UILabel
 		var vc = new UIViewController ();
 		vc.View!.AddSubview (new UILabel (Window!.Frame) {
-			BackgroundColor = UIColor.White,
 			TextAlignment = UITextAlignment.Center,
-			Text = "Hello, iOS!"
+			Text = "Hello, iOS!",
+			AutoresizingMask = UIViewAutoresizing.All,
 		});
 		Window.RootViewController = vc;
 


### PR DESCRIPTION
The .NET 6 Mac Catalyst and iOS templates have a default of a white background and the text has no mask. That makes the text impossible to see if you're using dark mode (since the label will be white, making the whole screen white) and, since it has no mask, it will stay static in position on the screen even if you rotate or change the window size, depending on the platform.

This updates the templates to get rid of the default white background (or it should use whatever the system has) which fixes the text issue, and adds an `AutoresizingMask` to the label so it will always be centered.