### PR TITLE
[msbuild] Pass full paths to 'ditto'.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
@@ -41,8 +41,8 @@ namespace Xamarin.MacDev.Tasks
 		{
 			var args = new CommandLineArgumentBuilder ();
 
-			args.AddQuoted (Source!.ItemSpec);
-			args.AddQuoted (Destination!.ItemSpec);
+			args.AddQuoted (Path.GetFullPath (Source!.ItemSpec));
+			args.AddQuoted (Path.GetFullPath (Destination!.ItemSpec));
 			if (!string.IsNullOrEmpty (AdditionalArguments))
 				args.Add (AdditionalArguments);
 


### PR DESCRIPTION
For reasons I don't quite understand, ditto might fail when executed by XMA:

    Target Name=_CopyDirectoriesToBundle Project=C:\Users\rolf\source\iOSApp4\iOSApp4.csproj
        Building target "_CopyDirectoriesToBundle" completely.
        Output file "bin\Debug\net6.0-ios\iossimulator-x64\publish\..\device-builds\iphone11.6-14.8.1\iOSApp4.app\\Frameworks\\ArcGIS-arm64.framework/ArcGIS-arm64" does not exist.
        Output file "bin\Debug\net6.0-ios\iossimulator-x64\publish\..\device-builds\iphone11.6-14.8.1\iOSApp4.app\\Frameworks\\Runtimecore.framework/Runtimecore" does not exist.
        Ditto
            Assembly = C:\Users\rolf\source\maui\bin\dotnet\packs\Microsoft.iOS.Sdk\15.2.303-ci.ditto-windows.56\tools\msbuild\iOS\..\iOS\Xamarin.iOS.Tasks.dll
            Parameters
                Destination = bin\Debug\net6.0-ios\iossimulator-x64\publish\..\device-builds\iphone11.6-14.8.1\iOSApp4.app\\Frameworks\\ArcGIS-arm64.framework
                TouchDestinationFiles = True
                SessionId = <SessionId>
                Source = C:\Users\rolf\.nuget\packages\esri.arcgisruntime.runtimes.ios\100.13.0\framework\ios-arm64\native\ArcGIS-arm64.framework\
            Ditto: <timestamp> - Started
            Ditto: <timestamp> - Initializing
            [xma]: Trying to get a Build Connection for Session '<SessionId>': Xamarin.Messaging.Build.Client.BuildConnection.<SessionId>, Lifetime: Build
            Ditto: <timestamp> - Initialized
            Ditto: <timestamp> - There's no available inputs to copy to the Mac
            Ditto: <timestamp> - Serializing intputs
            Ditto: <timestamp> - Executing
            [xma]: Starting remote task execution for 'iOSApp4': Xamarin.MacDev.Tasks.Ditto
            [xma]: Sending Request Xamarin.Messaging.Build.Contracts.ExecuteTaskMessage to topic xvs/build/execute-task/iOSApp4/15f3833002fDitto
            [xma]: Received Response of Xamarin.Messaging.Build.Contracts.ExecuteTaskMessage to topic build<SessionId>4396rolf/+/xvs/build/execute-task/iOSApp4/15f3833002fDitto
            Ditto: <timestamp> - Logging messages
            /usr/bin/ditto C:/Users/rolf/.nuget/packages/esri.arcgisruntime.runtimes.ios/100.13.0/framework/ios-arm64/native/ArcGIS-arm64.framework/ bin/Debug/net6.0-ios/iossimulator-x64/publish/../device-builds/iphone11.6-14.8.1/iOSApp4.app//Frameworks//ArcGIS-arm64.framework
            ditto: bin/Debug/net6.0-ios/iossimulator-x64/publish/../device-builds/iphone11.6-14.8.1/iOSApp4.app//Frameworks//ArcGIS-arm64.framework: File exists
            Errors
                C:\Users\rolf\source\maui\bin\dotnet\packs\Microsoft.iOS.Sdk\15.2.303-ci.ditto-windows.56\targets\Xamarin.Shared.Sdk.targets(668,3): error MSB6006: "ditto" exited with code 1. [C:\Users\rolf\source\iOSApp4\iOSApp4.csproj]
            Ditto: <timestamp> - Finished

This doesn't happen when building on macOS, nor if I copy the offending ditto
command and execute it manually on macOS.

Since I don't know why the problem occurs in the first place, I don't know why
passing full paths to 'ditto' works either. It shouldn't cause problems
elsewhere though.

Ref: https://github.com/xamarin/xamarin-macios/issues/13665