### PR TITLE
[CI] Build the rollback file in the build bot.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -353,6 +353,35 @@ steps:
       GitHubToken: $(GitHub.Token)
       ArtifactDirectory: $(Build.SourcesDirectory)/package-internal
 
+  - bash: |
+      var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=IOS_NUGET_VERSION_FULL)
+      IOS_NUGET_VERSION_FULL=${var#*=}
+      IOS_NUGET_VERSION_FULL=$(echo $IOS_NUGET_VERSION_FULL | cut -d "+" -f1)
+
+      var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=TVOS_NUGET_VERSION_FULL)
+      TVOS_NUGET_VERSION_FULL=${var#*=}
+      TVOS_NUGET_VERSION_FULL=$(echo $TVOS_NUGET_VERSION_FULL | cut -d "+" -f1)
+
+      var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=MACOS_NUGET_VERSION_FULL)
+      MACOS_NUGET_VERSION_FULL=${var#*=}
+      MACOS_NUGET_VERSION_FULL=$(echo $MACOS_NUGET_VERSION_FULL | cut -d "+" -f1)
+
+      var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=MACCATALYST_NUGET_VERSION_FULL)
+      MACCATALYST_NUGET_VERSION_FULL=${var#*=}
+      MACCATALYST_NUGET_VERSION_FULL=$(echo $MACCATALYST_NUGET_VERSION_FULL | cut -d "+" -f1)
+      WORKLOAD_DST="$(Build.SourcesDirectory)/package-internal/WorkloadRollback.json"
+
+      echo "{" > $WORKLOAD_DST
+      echo "\"microsoft.net.sdk.ios\": \"$IOS_NUGET_VERSION_FULL\"," >>  $WORKLOAD_DST
+      echo "\"microsoft.net.sdk.tvos\": \"$TVOS_NUGET_VERSION_FULL\"," >> $WORKLOAD_DST
+      echo "\"microsoft.net.sdk.macos\": \"$MACOS_NUGET_VERSION_FULL\"," >>  $WORKLOAD_DST
+      echo "\"microsoft.net.sdk.maccatalyst\": \"$MACCATALYST_NUGET_VERSION_FULL\"" >> $WORKLOAD_DST
+      echo "}" >>  $WORKLOAD_DST
+
+      echo "Rollback file contents:" 
+      echo "$(cat $WORKLOAD_DST)"
+    displayName: 'Generate "WorkloadRollback.json'
+
   # upload each of the pkgs into the pipeline artifacts
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Build Artifacts'

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -113,7 +113,7 @@ steps:
 
 # download the artifacts.json, which will use to find the URI of the built pkg to later be installed by provisionator
 - task: DownloadPipelineArtifact@2
-  displayName: Download artifacts.json
+  displayName: Download json artifacts
   inputs:
     patterns: '**/*.json'
     allowFailedBuilds: true

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -116,7 +116,7 @@ steps:
     DOTNET_NUPKG_DIR=${var#*=}
     echo "Using nuget dir $DOTNET_NUPKG_DIR"
 
-    ROLLBACK_PATH="$(Build.SourcesDirectory)/artifacts/pkg-info/WorkloadRollback.json"
+    ROLLBACK_PATH="$(Build.SourcesDirectory)/artifacts/package-internal/WorkloadRollback.json"
 
     echo "Rollback file contents:" 
     echo "$(cat $ROLLBACK_PATH)"

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -116,34 +116,10 @@ steps:
     DOTNET_NUPKG_DIR=${var#*=}
     echo "Using nuget dir $DOTNET_NUPKG_DIR"
 
-    echo "Build WorkloadRollback.json"
-    VERSIONS=""
-
-    var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=IOS_NUGET_VERSION_FULL)
-    IOS_NUGET_VERSION_FULL=${var#*=}
-    IOS_NUGET_VERSION_FULL=$(echo $IOS_NUGET_VERSION_FULL | cut -d "+" -f1)
-
-    var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=TVOS_NUGET_VERSION_FULL)
-    TVOS_NUGET_VERSION_FULL=${var#*=}
-    TVOS_NUGET_VERSION_FULL=$(echo $TVOS_NUGET_VERSION_FULL | cut -d "+" -f1)
-
-    var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=MACOS_NUGET_VERSION_FULL)
-    MACOS_NUGET_VERSION_FULL=${var#*=}
-    MACOS_NUGET_VERSION_FULL=$(echo $MACOS_NUGET_VERSION_FULL | cut -d "+" -f1)
-
-    var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=MACCATALYST_NUGET_VERSION_FULL)
-    MACCATALYST_NUGET_VERSION_FULL=${var#*=}
-    MACCATALYST_NUGET_VERSION_FULL=$(echo $MACCATALYST_NUGET_VERSION_FULL | cut -d "+" -f1)
-
-    echo "{" >  "WorkloadRollback.json"
-    echo "\"microsoft.net.sdk.ios\": \"$IOS_NUGET_VERSION_FULL\"," >>  "WorkloadRollback.json"
-    echo "\"microsoft.net.sdk.tvos\": \"$TVOS_NUGET_VERSION_FULL\"," >>  "WorkloadRollback.json"
-    echo "\"microsoft.net.sdk.macos\": \"$MACOS_NUGET_VERSION_FULL\"," >>  "WorkloadRollback.json"
-    echo "\"microsoft.net.sdk.maccatalyst\": \"$MACCATALYST_NUGET_VERSION_FULL\"" >>  "WorkloadRollback.json"
-    echo "}" >>  "WorkloadRollback.json"
+    ROLLBACK_PATH="$(Build.SourcesDirectory)/artifacts/pkg-info/WorkloadRollback.json"
 
     echo "Rollback file contents:" 
-    echo "$(cat WorkloadRollback.json)"
+    echo "$(cat $ROLLBACK_PATH)"
 
     mkdir -p $DOTNET_NUPKG_DIR
     ls -R $(Build.SourcesDirectory)/artifacts/package
@@ -165,7 +141,7 @@ steps:
 
     rm global.json
     cp global6.json global.json
-    $DOTNET6 workload install --from-rollback-file WorkloadRollback.json --source $DOTNET_NUPKG_DIR $SOURCES --verbosity diag $PLATFORMS
+    $DOTNET6 workload install --from-rollback-file $ROLLBACK_PATH --source $DOTNET_NUPKG_DIR $SOURCES --verbosity diag $PLATFORMS
 
     var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=DOTNET6_DIR)
     DOTNET6_DIR=${var#*=}


### PR DESCRIPTION
Or make files canculate the version of the nuget based on the hash of
the source, because VSTS does a merge of the branhc rather than checking
out, the version calculated in the tests bot via de makefiles is
different to the one that was used in the build bots.

We solve this by creating the rollback file at build time so that it is
consumed by the test bot.