### PR TITLE
[release/6.0.2xx-preview14] [DittoTask] If Source is a folder, add all its content as ITaskItem

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.MacDev.Tasks
@@ -34,6 +35,8 @@ namespace Xamarin.MacDev.Tasks
 			if (!Directory.Exists(Source.ItemSpec))
 				return Enumerable.Empty<ITaskItem> ();
 
+			// TaskRunner doesn't know how to copy directories to Mac but `ditto` can take directories (and that's why we use ditto often).
+			// If Source is a directory path, let's add each file within it as an TaskItem, as TaskRunner knows how to copy files to Mac.
 			return Directory.GetFiles (Source.ItemSpec, "*", SearchOption.AllDirectories)
 				.Select(f => new TaskItem(f));
 		} 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
@@ -29,7 +29,14 @@ namespace Xamarin.MacDev.Tasks
 				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
 		}
 
-		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied ()
+		{	
+			if (!Directory.Exists(Source.ItemSpec))
+				return Enumerable.Empty<ITaskItem> ();
+
+			return Directory.GetFiles (Source.ItemSpec, "*", SearchOption.AllDirectories)
+				.Select(f => new TaskItem(f));
+		} 
 
 		public bool ShouldCopyToBuildServer (ITaskItem item) => true;
 


### PR DESCRIPTION
Possible fix for https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1492635

If the `ITaskItem` input property of the task is a folder path, the `TaskRunner` doesn't know how to copy the folder content to Mac. Let's use the `GetAdditionalItemsToBeCopied` method to tell the `TaskRunner` to copy all the folder content to Mac.


Backport of #14375
