### PR TITLE
[generator] Avoid NRE when using native enums on delegates

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2155,7 +2155,7 @@ public partial class Generator : IMemberGatherer {
 		// in question actually has that value at least). Same goes for Int32.MinValue/Int64.MinValue.
 		// var isDefined = enumType.IsEnumDefined (maxValue);
 		var definedMaxField = enumType.GetFields ().Where (v => v.IsLiteral).FirstOrDefault (isMaxDefinedFunc);
-		if (definedMaxField != null) {
+		if (definedMaxField is not null && postproc is not null) {
 			postproc.AppendLine ("#if ARCH_32");
 			postproc.AppendFormat ("if (({0}) ret == ({0}) {1}.MaxValue)\n", underlyingTypeName, itype);
 			postproc.AppendFormat ("\tret = {0}.{1}; // = {2}.MaxValue\n", renderedEnumType, definedMaxField.Name, underlyingTypeName);

--- a/tests/generator/tests/nativeenum.cs
+++ b/tests/generator/tests/nativeenum.cs
@@ -53,6 +53,8 @@ namespace NS {
 		Value2 = ulong.MaxValue,
 	}
 
+	delegate void EnumHandler (MyEnum7 seven, MyEnum8 eight);
+
 	[BaseType (typeof (NSObject))]
 	interface MyClass {
 		[Export ("myProp1")]
@@ -90,5 +92,10 @@ namespace NS {
 		MyEnum8 MyProp8 { get; set; }
 		[Export ("myMethod8:")]
 		MyEnum8 MyMethod8 (MyEnum8 arg);
+
+		[Export ("myDelegateProp")]
+		EnumHandler MyDelegateProp { get; set; }
+		[Export ("myDelegateMethod:")]
+		EnumHandler MyDelegateMethod (EnumHandler arg);
 	}
 }


### PR DESCRIPTION
Fixes NRE in GetNativeEnumToManagedExpression when a native enum
with MaxValue is used on delegates.