### PR TITLE
[xharness] Ignore case when comparing node names.

### DIFF
--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -83,7 +83,7 @@ namespace Xharness {
 				if (child == null)
 					continue;
 
-				if (child.NodeType == XmlNodeType.Element && child.Name == name)
+				if (child.NodeType == XmlNodeType.Element && string.Equals (child.Name, name, StringComparison.OrdinalIgnoreCase))
 					yield return child;
 
 				if (!child.HasChildNodes)


### PR DESCRIPTION
MSBuild is case-insensitive, so xharness needs to be the same way.

This fixes an issue where xharness would not process 'CodeSignEntitlements'
properties, because xharness was looking for 'CodesignEntitlements'
properties.