### PR TITLE
[dotnet] Update template strings.

### DIFF
--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "iOS Controller template",
+  "name": "iOS Controller template (Preview)",
   "description": "An iOS Controller class",
   "symbols/namespace/description": "namespace for the generated code"
 }


### PR DESCRIPTION
When adding support for localizing template strings, this wasn't included
because it was merged after the template localization work started.