### PR TITLE
[tests] Simplify some logic in mmptest and msbuild tests.

### DIFF
--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -160,17 +160,6 @@ namespace Xamarin.MMP.Tests
 			}
 		}
 
-		public static string AssemblyDirectory
-		{
-			get
-			{
-				string codeBase = Assembly.GetExecutingAssembly ().CodeBase;
-				UriBuilder uri = new UriBuilder (codeBase);
-				string path = Uri.UnescapeDataString (uri.Path);
-				return Path.GetDirectoryName (path);
-			}
-		}
-
 		public static Version FindMonoVersion ()
 		{
 			string output = RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mono", new [] { "--version" }, "FindMonoVersion");
@@ -453,26 +442,11 @@ namespace Xamarin.MMP.Tests
 				});
 		}
 
-		public static string TestDirectory => Path.Combine (FindRootDirectory (), "..", "tests") + "/";
+		public static string TestDirectory => Path.Combine (Configuration.RootPath, "tests");
 
 		public static string FindSourceDirectory ()
 		{
-			if (Configuration.IsVsts) {
-				// use the working directory from vsts
-				var vstsWorkingDirectory = Environment.GetEnvironmentVariable ("SYSTEM_DEFAULTWORKINGDIRECTORY");
-				var gitDirectory = Path.Combine (vstsWorkingDirectory, ".git");
-				if (Directory.Exists (gitDirectory)) {
-					return Path.Combine (vstsWorkingDirectory, TestDirectory + "common/mac");
-				} else {
-					return Path.Combine (vstsWorkingDirectory, "xamarin-macios" ,TestDirectory + "common/mac");
-				}
-			} else {
-				string codeBase = System.Reflection.Assembly.GetExecutingAssembly ().CodeBase;
-				UriBuilder uri = new UriBuilder (codeBase);
-				string path = Uri.UnescapeDataString (uri.Path);
-				string assemblyDirectory = Path.GetDirectoryName (path);
-				return Path.Combine(assemblyDirectory, TestDirectory + "common/mac");
-			}
+			return Path.Combine (TestDirectory, "common", "mac");
 		}
 
 		public static void CopyDirectory (string src, string target)

--- a/tests/mmptest/src/NativeReferencesTests.cs
+++ b/tests/mmptest/src/NativeReferencesTests.cs
@@ -51,7 +51,7 @@ namespace Xamarin.MMP.Tests
 			string dylibPath = Path.Combine (tmpDir, "dll/");
 			string filePath = Path.Combine (dylibPath, fileName);
 			Directory.CreateDirectory (dylibPath);
-			File.Copy (Path.Combine (TI.AssemblyDirectory, TI.TestDirectory + "mac-binding-project/bin/SimpleClassDylib.dylib"), filePath);
+			File.Copy (Path.Combine (TI.TestDirectory, "mac-binding-project", "bin", "SimpleClassDylib.dylib"), filePath);
 			return filePath;
 		}
 

--- a/tests/msbuild/Xamarin.MacDev.Tests/MSBuild-Smoke.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/MSBuild-Smoke.cs
@@ -40,7 +40,7 @@ namespace Xamarin.MMP.Tests
 
 		void TestBCLCore (string tmpDir, string projectName)
 		{
-			var dll = Path.GetFullPath (Path.Combine (TI.TestDirectory + "common", "mac", "System.Collections.Immutable.dll"));
+			var dll = Path.GetFullPath (Path.Combine (TI.TestDirectory, "common", "mac", "System.Collections.Immutable.dll"));
 			string reference = $"<Reference Include=\"System.Collections.Immutable\"><HintPath>{dll}</HintPath></Reference>";
 			string testCode = "var v = System.Collections.Immutable.ImmutableArray.CreateRange (new int [] { 42 });";
 			string projectPath = TI.GenerateEXEProject (new TI.UnifiedTestConfig (tmpDir) { ProjectName = projectName, References = reference, TestCode = testCode });


### PR DESCRIPTION
Use already existing logic in the Configuration class to find files on disk.

Also remove some dead code and use Path.Combine instead of string
concatenation to compute paths.

Fixes https://github.com/xamarin/maccore/issues/2553.