### PR TITLE
[release/6.0.2xx-preview14] [CI] Allow to override the pool that will be used in a manual build.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -12,6 +12,15 @@ parameters:
   type: string
   default: 'latest'
 
+- name: pool
+  type: string
+  displayName: Bot pool to use
+  default: automatic
+  values:
+  - pr
+  - ci
+  - automatic
+
 - name: runTests
   displayName: Run Simulator Tests
   type: boolean
@@ -282,6 +291,7 @@ stages:
         enableDotnet: ${{ parameters.enableDotnet }}
         enableAPIDiff: ${{ parameters.enableAPIDiff }}
         skipESRP: ${{ parameters.skipESRP }}
+        pool: ${{ parameters.pool }}
 
 # .NET 6 Release Prep and VS Insertion Stages, only execute them when the build comes from an official branch and is not a schedule build from OneLoc
 - ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), eq(parameters.forceInsertion, true))) }}:

--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -33,6 +33,10 @@ parameters:
   type: boolean
   default: false # only to be used when testing the CI and we do not need a signed pkg
 
+- name: pool
+  type: string
+  default: automatic
+
 jobs:
 - job: configure
   displayName: 'Configure build'
@@ -46,28 +50,35 @@ jobs:
   steps:
   - template: configure.yml
 
-- job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
-  pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
-    vmImage: ubuntu-latest
-  steps:
-  - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
+- ${{ if eq(parameters.pool, 'automatic') }}:
+  - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
+    pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
+      vmImage: ubuntu-latest
+    steps:
+    - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
 
-  # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-  - template: azure-devops-pools/agent-pool-selector.yml@templates
-    parameters:
-      agentPoolPR: $(PRBuildPool)
-      agentPoolPRUrl: $(PRBuildPoolUrl)
-      agentPoolCI: $(CIBuildPool)
-      agentPoolCIUrl: $(CIBuildPoolUrl)
+    # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
+    - template: azure-devops-pools/agent-pool-selector.yml@templates
+      parameters:
+        agentPoolPR: $(PRBuildPool)
+        agentPoolPRUrl: $(PRBuildPoolUrl)
+        agentPoolCI: $(CIBuildPool)
+        agentPoolCIUrl: $(CIBuildPoolUrl)
 
 - job: build
   dependsOn:
-  - AgentPoolSelector
+  - ${{ if eq(parameters.pool, 'automatic') }}:
+    - AgentPoolSelector
   - configure
   displayName: 'Build packages'
   timeoutInMinutes: 1000
   variables:
-    AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
+    ${{ if eq(parameters.pool, 'automatic') }}:
+      AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
+    ${{ if eq(parameters.pool, 'ci') }}:
+      AgentPoolComputed: $(CIBuildPool)
+    ${{ if eq(parameters.pool, 'pr') }}:
+      AgentPoolComputed: $(PRBuildPool)
     # add all the variables that have been parsed by the configuration step. Could we have a less verbose way??
     #
     # build-package
@@ -119,12 +130,18 @@ jobs:
 - ${{ if eq(parameters.enableAPIDiff, true) }}:
   - job: api_diff
     dependsOn:
-    - AgentPoolSelector
+    - ${{ if eq(parameters.pool, 'automatic') }}:
+      - AgentPoolSelector
     - configure
     displayName: 'Generate API diff'
     timeoutInMinutes: 1000
     variables:
-      AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
+      ${{ if eq(parameters.pool, 'automatic') }}:
+        AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
+      ${{ if eq(parameters.pool, 'ci') }}:
+        AgentPoolComputed: $(CIBuildPool)
+      ${{ if eq(parameters.pool, 'pr') }}:
+        AgentPoolComputed: $(PRBuildPool)
       PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
       # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
       BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]


### PR DESCRIPTION
Provide an extra parameter that allows to choose the agent pool to be used for a manually triggered build. The UI will allow to select 3 possible values:

* automatic - Default, the pipeline will decide
* ci - Use the bot pool used for the CI
* pr - Use the bot pool dedicated for PRs

The following is the UI that will be shown in VSTS
<img width="441" alt="Screenshot 2022-03-04 at 18 01 05" src="https://user-images.githubusercontent.com/2190086/156853920-8a2e9f2f-0d32-4fdb-90ad-1eaf86817a25.png">




Backport of #14320
