### PR TITLE
[CI] Re-enable the upload of the api diff.

### DIFF
--- a/tools/devops/automation/templates/build/stage.yml
+++ b/tools/devops/automation/templates/build/stage.yml
@@ -198,7 +198,7 @@ jobs:
   dependsOn: # can start as soon as the tests are done and the api diff
   - build 
   - api_diff
-  condition: and(succeededOrFailed() , contains (dependencies.build.outputs['runTests.TESTS_RAN'], 'True')) # only run when we did run the tests
+  condition: succeededOrFailed() 
 
   variables:
     API_GENERATOR_DIFF_BUILT: $[ dependencies.api_diff.outputs['apiGeneratorDiff.API_GENERATOR_BUILT'] ]


### PR DESCRIPTION
The build steps do not longer run tests which resulted in the api diff not uploading.