### PR TITLE
[corevideo] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -85,7 +85,7 @@ namespace CoreVideo {
 		public void RemoveAttachment (NSString key)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 
 			CVBufferRemoveAttachment (Handle, key.Handle);
 		}
@@ -137,7 +137,7 @@ namespace CoreVideo {
 		public T? GetAttachment<T> (NSString key, out CVAttachmentMode attachmentMode) where T : class, INativeObject
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 #if IOS || __MACCATALYST__ || TVOS
 			if (SystemVersion.CheckiOS (15, 0))
 #elif WATCH
@@ -150,7 +150,7 @@ namespace CoreVideo {
 		public NSObject? GetAttachment (NSString key, out CVAttachmentMode attachmentMode)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			if (SystemVersion.CheckmacOS (12, 0))
 				return Runtime.GetNSObject<NSObject> (CVBufferCopyAttachment (Handle, key.Handle, out attachmentMode), true);
 			else
@@ -225,7 +225,7 @@ namespace CoreVideo {
 		public void PropogateAttachments (CVBuffer destinationBuffer)
 		{
 			if (destinationBuffer is null)
-				throw new ArgumentNullException (nameof (destinationBuffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (destinationBuffer));
 
 			CVBufferPropagateAttachments (Handle, destinationBuffer.Handle);
 		}
@@ -236,9 +236,9 @@ namespace CoreVideo {
 		public void SetAttachment (NSString key, INativeObject @value, CVAttachmentMode attachmentMode)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			if (@value is null)
-				throw new ArgumentNullException (nameof (value));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 			CVBufferSetAttachment (Handle, key.Handle, @value.Handle, attachmentMode);
 		}
 
@@ -248,7 +248,7 @@ namespace CoreVideo {
 		public void SetAttachments (NSDictionary theAttachments, CVAttachmentMode attachmentMode)
 		{
 			if (theAttachments is null)
-				throw new ArgumentNullException (nameof (theAttachments));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (theAttachments));
 			CVBufferSetAttachments (Handle, theAttachments.Handle, attachmentMode);
 		}
 
@@ -283,7 +283,7 @@ namespace CoreVideo {
 		public bool HasAttachment (NSString key)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			return CVBufferHasAttachment (Handle, key.Handle);
 		}
 

--- a/src/CoreVideo/CVDisplayLink.cs
+++ b/src/CoreVideo/CVDisplayLink.cs
@@ -133,7 +133,7 @@ namespace CoreVideo {
 		public static CVDisplayLink? CreateFromDisplayIds (uint[] displayIds, out CVReturn error)
 		{
 			if (displayIds is null)
-				throw new ArgumentNullException (nameof (displayIds));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (displayIds));
 			error = 0;
 			IntPtr handle = IntPtr.Zero;
 			error = CVDisplayLinkCreateWithCGDisplays (displayIds, displayIds.Length, out handle);

--- a/src/CoreVideo/CVImageBuffer.cs
+++ b/src/CoreVideo/CVImageBuffer.cs
@@ -130,7 +130,7 @@ namespace CoreVideo {
 		public static CGColorSpace? CreateFrom (NSDictionary attachments)
 		{
 			if (attachments is null)
-				throw new ArgumentNullException (nameof (attachments));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (attachments));
 			var h = CVImageBufferCreateColorSpaceFromAttachments (attachments.Handle);
 			return h == IntPtr.Zero ? null : new CGColorSpace (h, true);
 		}

--- a/src/CoreVideo/CVMetalTextureCache.cs
+++ b/src/CoreVideo/CVMetalTextureCache.cs
@@ -52,7 +52,7 @@ namespace CoreVideo {
 		static IntPtr Create (IMTLDevice metalDevice, CVMetalTextureAttributes? textureAttributes)
 		{
 			if (metalDevice is null)
-				throw new ArgumentNullException (nameof (metalDevice));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (metalDevice));
 
 			CVReturn err = (CVReturn) CVMetalTextureCacheCreate (IntPtr.Zero,
 								IntPtr.Zero, /* change one day to support cache attributes */
@@ -73,7 +73,7 @@ namespace CoreVideo {
 		public static CVMetalTextureCache? FromDevice (IMTLDevice metalDevice)
 		{
 			if (metalDevice is null)
-				throw new ArgumentNullException (nameof (metalDevice));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (metalDevice));
 			IntPtr handle;
 			if (CVMetalTextureCacheCreate (IntPtr.Zero,
 						       IntPtr.Zero, /* change one day to support cache attributes */
@@ -92,7 +92,7 @@ namespace CoreVideo {
 		public static CVMetalTextureCache? FromDevice (IMTLDevice metalDevice, CVMetalTextureAttributes? textureAttributes, out CVReturn creationErr)
 		{
 			if (metalDevice is null)
-				throw new ArgumentNullException (nameof (metalDevice));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (metalDevice));
 			IntPtr handle;
 			creationErr = (CVReturn) CVMetalTextureCacheCreate (IntPtr.Zero,
 								IntPtr.Zero, /* change one day to support cache attributes */
@@ -113,7 +113,7 @@ namespace CoreVideo {
 		public CVMetalTexture? TextureFromImage (CVImageBuffer imageBuffer, MTLPixelFormat format, nint width, nint height, nint planeIndex, out CVReturn errorCode)
 		{
 			if (imageBuffer is null)
-				throw new ArgumentNullException (nameof (imageBuffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (imageBuffer));
 			
 			IntPtr texture;
 			errorCode = CVMetalTextureCacheCreateTextureFromImage (

--- a/src/CoreVideo/CVOpenGLESTextureCache.cs
+++ b/src/CoreVideo/CVOpenGLESTextureCache.cs
@@ -80,7 +80,7 @@ namespace CoreVideo {
 		public CVOpenGLESTextureCache (EAGLContext context)
 		{
 			if (context == null)
-				throw new ArgumentNullException ("context");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (context));
 			
 			if (CVOpenGLESTextureCacheCreate (IntPtr.Zero,
 							  IntPtr.Zero, /* change one day to support cache attributes */
@@ -95,7 +95,7 @@ namespace CoreVideo {
 		public static CVOpenGLESTextureCache FromEAGLContext (EAGLContext context)
 		{
 			if (context == null)
-				throw new ArgumentNullException ("context");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (context));
 			IntPtr handle;
 			if (CVOpenGLESTextureCacheCreate (IntPtr.Zero,
 							  IntPtr.Zero, /* change one day to support cache attributes */
@@ -109,7 +109,7 @@ namespace CoreVideo {
 		public CVOpenGLESTexture TextureFromImage (CVImageBuffer imageBuffer, bool isTexture2d, OpenTK.Graphics.ES20.All internalFormat, int width, int height, OpenTK.Graphics.ES20.All pixelFormat, OpenTK.Graphics.ES20.DataType pixelType, int planeIndex, out CVReturn errorCode)
 		{
 			if (imageBuffer == null)
-				throw new ArgumentNullException ("imageBuffer");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (imageBuffer));
 			
 			int target = isTexture2d ? 0x0DE1 /* GL_TEXTURE_2D */ : 0x8D41 /* GL_RENDERBUFFER */;
 			IntPtr texture;

--- a/src/CoreVideo/CVOpenGLESTextureCache.cs
+++ b/src/CoreVideo/CVOpenGLESTextureCache.cs
@@ -79,7 +79,7 @@ namespace CoreVideo {
 		
 		public CVOpenGLESTextureCache (EAGLContext context)
 		{
-			if (context == null)
+			if (context is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (context));
 			
 			if (CVOpenGLESTextureCacheCreate (IntPtr.Zero,
@@ -94,7 +94,7 @@ namespace CoreVideo {
 
 		public static CVOpenGLESTextureCache FromEAGLContext (EAGLContext context)
 		{
-			if (context == null)
+			if (context is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (context));
 			IntPtr handle;
 			if (CVOpenGLESTextureCacheCreate (IntPtr.Zero,
@@ -108,7 +108,7 @@ namespace CoreVideo {
 
 		public CVOpenGLESTexture TextureFromImage (CVImageBuffer imageBuffer, bool isTexture2d, OpenTK.Graphics.ES20.All internalFormat, int width, int height, OpenTK.Graphics.ES20.All pixelFormat, OpenTK.Graphics.ES20.DataType pixelType, int planeIndex, out CVReturn errorCode)
 		{
-			if (imageBuffer == null)
+			if (imageBuffer is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (imageBuffer));
 			
 			int target = isTexture2d ? 0x0DE1 /* GL_TEXTURE_2D */ : 0x8D41 /* GL_RENDERBUFFER */;

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -175,7 +175,7 @@ namespace CoreVideo {
 			GCHandle gchandle;
 
 			if (data == null)
-				throw new ArgumentNullException (nameof (data));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 
 			if (data.Length < height * bytesPerRow)
 				throw new ArgumentOutOfRangeException (nameof (data), "The length of data is smaller than height * bytesPerRow");
@@ -250,16 +250,16 @@ namespace CoreVideo {
 			GCHandle data_handle;
 
 			if (planes == null)
-				throw new ArgumentNullException (nameof (planes));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (planes));
 
 			if (planeWidths == null)
-				throw new ArgumentNullException (nameof (planeWidths));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (planeWidths));
 
 			if (planeHeights == null)
-				throw new ArgumentNullException (nameof (planeHeights));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (planeHeights));
 
 			if (planeBytesPerRow == null)
-				throw new ArgumentNullException (nameof (planeBytesPerRow));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (planeBytesPerRow));
 
 			var planeCount = planes.Length;
 

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -52,7 +52,7 @@ namespace CoreVideo {
 		}
 
 		public CVPixelBuffer (nint width, nint height, CVPixelFormatType pixelFormatType, CVPixelBufferAttributes? attributes)
-			: this (width, height, pixelFormatType, attributes == null ? null : attributes.Dictionary)
+			: this (width, height, pixelFormatType, attributes?.Dictionary)
 		{
 		}
 
@@ -88,7 +88,7 @@ namespace CoreVideo {
 		{
 			CVReturn ret;
 			IntPtr resolvedDictionaryOut;
-			if (attributes == null) {
+			if (attributes is null) {
 				ret = CVPixelBufferCreateResolvedAttributesDictionary (IntPtr.Zero, IntPtr.Zero, out resolvedDictionaryOut);
 			} else {
 				using (var array = NSArray.FromNSObjects (attributes)) {
@@ -174,7 +174,7 @@ namespace CoreVideo {
 			IntPtr handle;
 			GCHandle gchandle;
 
-			if (data == null)
+			if (data is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 
 			if (data.Length < height * bytesPerRow)
@@ -249,16 +249,16 @@ namespace CoreVideo {
 			PlaneData data;
 			GCHandle data_handle;
 
-			if (planes == null)
+			if (planes is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (planes));
 
-			if (planeWidths == null)
+			if (planeWidths is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (planeWidths));
 
-			if (planeHeights == null)
+			if (planeHeights is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (planeHeights));
 
-			if (planeBytesPerRow == null)
+			if (planeBytesPerRow is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (planeBytesPerRow));
 
 			var planeCount = planes.Length;

--- a/src/CoreVideo/CVPixelBufferAttributes.cs
+++ b/src/CoreVideo/CVPixelBufferAttributes.cs
@@ -186,7 +186,7 @@ namespace CoreVideo {
 					RemoveValue (CVPixelBuffer.IOSurfacePropertiesKey);
 			}
 			get {
-				return GetNSDictionary (CVPixelBuffer.IOSurfacePropertiesKey) != null;
+				return GetNSDictionary (CVPixelBuffer.IOSurfacePropertiesKey) is not null;
 			}
 		}
 

--- a/src/CoreVideo/CVPixelBufferIOSurface.cs
+++ b/src/CoreVideo/CVPixelBufferIOSurface.cs
@@ -85,7 +85,7 @@ namespace CoreVideo {
 #endif
 		public static CVPixelBuffer? Create (IOSurface.IOSurface surface, out CVReturn result, CVPixelBufferAttributes? pixelBufferAttributes = null)
 		{
-			if (surface == null)
+			if (surface is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (surface));
 
 			IntPtr pixelBufferPtr;

--- a/src/CoreVideo/CVPixelBufferIOSurface.cs
+++ b/src/CoreVideo/CVPixelBufferIOSurface.cs
@@ -86,7 +86,7 @@ namespace CoreVideo {
 		public static CVPixelBuffer? Create (IOSurface.IOSurface surface, out CVReturn result, CVPixelBufferAttributes? pixelBufferAttributes = null)
 		{
 			if (surface == null)
-				throw new ArgumentNullException (nameof (surface));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (surface));
 
 			IntPtr pixelBufferPtr;
 			result = CVPixelBufferCreateWithIOSurface (

--- a/src/CoreVideo/CVPixelFormatDescription.cs
+++ b/src/CoreVideo/CVPixelFormatDescription.cs
@@ -203,7 +203,7 @@ namespace CoreVideo {
 #if !XAMCORE_3_0
 		public static void Register (NSDictionary description, int pixelFormat)
 		{
-			if (description == null)
+			if (description is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (description));
 
 			CVPixelFormatDescriptionRegisterDescriptionWithPixelFormatType (description.Handle, pixelFormat);
@@ -212,7 +212,7 @@ namespace CoreVideo {
 
 		public static void Register (NSDictionary description, CVPixelFormatType pixelFormat)
 		{
-			if (description == null)
+			if (description is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (description));
 
 			CVPixelFormatDescriptionRegisterDescriptionWithPixelFormatType (description.Handle, (int) pixelFormat);

--- a/src/CoreVideo/CVPixelFormatDescription.cs
+++ b/src/CoreVideo/CVPixelFormatDescription.cs
@@ -204,7 +204,7 @@ namespace CoreVideo {
 		public static void Register (NSDictionary description, int pixelFormat)
 		{
 			if (description == null)
-				throw new ArgumentNullException ("description");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (description));
 
 			CVPixelFormatDescriptionRegisterDescriptionWithPixelFormatType (description.Handle, pixelFormat);
 		}
@@ -213,7 +213,7 @@ namespace CoreVideo {
 		public static void Register (NSDictionary description, CVPixelFormatType pixelFormat)
 		{
 			if (description == null)
-				throw new ArgumentNullException ("description");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (description));
 
 			CVPixelFormatDescriptionRegisterDescriptionWithPixelFormatType (description.Handle, (int) pixelFormat);
 		}


### PR DESCRIPTION
This PR aims to bring nullability changes to CoreVideo.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
2. Changing any `== null` or `!= null` to `is null` and `is not null`