### PR TITLE
[coreml] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/CoreML/MLDictionaryFeatureProvider.cs
+++ b/src/CoreML/MLDictionaryFeatureProvider.cs
@@ -7,6 +7,8 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
+#nullable enable
+
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -14,7 +16,7 @@ using ObjCRuntime;
 namespace CoreML {
 	public partial class MLDictionaryFeatureProvider {
 
-		public MLFeatureValue this [string featureName] {
+		public MLFeatureValue? this [string featureName] {
 			get { return GetFeatureValue (featureName); }
 		}
 	}

--- a/src/CoreML/MLMultiArray.cs
+++ b/src/CoreML/MLMultiArray.cs
@@ -7,6 +7,8 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
+#nullable enable
+
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -16,7 +18,7 @@ namespace CoreML {
 		static NSNumber[] ConvertArray (nint[] value)
 		{
 			if (value == null)
-				return null;
+				return null!;
 
 			return Array.ConvertAll<nint, NSNumber> (value, NSNumber.FromNInt);
 		}

--- a/src/CoreML/MLMultiArray.cs
+++ b/src/CoreML/MLMultiArray.cs
@@ -17,7 +17,7 @@ namespace CoreML {
 	public partial class MLMultiArray {
 		static NSNumber[] ConvertArray (nint[] value)
 		{
-			if (value == null)
+			if (value is null)
 				return null!;
 
 			return Array.ConvertAll<nint, NSNumber> (value, NSNumber.FromNInt);

--- a/src/CoreML/MLMultiArrayConstraint.cs
+++ b/src/CoreML/MLMultiArrayConstraint.cs
@@ -7,6 +7,8 @@
 // Copyright 2017 Microsoft Inc. All rights reserved.
 //
 
+#nullable enable
+
 using System;
 using Foundation;
 using ObjCRuntime;


### PR DESCRIPTION
This PR aims to bring nullability changes to CoreML.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing any `== null` or `!= null` to `is null` and `is not null`