### PR TITLE
[dotnet] Rename the DOTNET make variable to SYSTEM_DOTNET.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -68,7 +68,7 @@ test.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.De
 	@echo "MONO_IOS_SDK_DESTDIR=$(MONO_IOS_SDK_DESTDIR)" >> $@
 	@echo "MONO_MAC_SDK_DESTDIR=$(MONO_MAC_SDK_DESTDIR)" >> $@
 	@echo "ENABLE_XAMARIN=$(ENABLE_XAMARIN)" >> $@
-	@echo "DOTNET=$(DOTNET)" >> $@
+	@echo "SYSTEM_DOTNET=$(SYSTEM_DOTNET)" >> $@
 	@echo "DOTNET6=$(DOTNET6)" >> $@
 	@echo "IOS_SDK_VERSION=$(IOS_SDK_VERSION)" >> $@
 	@echo "TVOS_SDK_VERSION=$(TVOS_SDK_VERSION)" >> $@
@@ -88,7 +88,7 @@ test-system.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Ver
 	@echo "INCLUDE_DEVICE=$(INCLUDE_DEVICE)" >> $@
 	@echo "MONO_IOS_SDK_DESTDIR=$(MONO_IOS_SDK_DESTDIR)" >> $@
 	@echo "MONO_MAC_SDK_DESTDIR=$(MONO_MAC_SDK_DESTDIR)" >> $@
-	@echo "DOTNET=$(DOTNET)" >> $@
+	@echo "SYSTEM_DOTNET=$(SYSTEM_DOTNET)" >> $@
 	@echo "DOTNET6=$(DOTNET6)" >> $@
 	@echo "IOS_SDK_VERSION=$(IOS_SDK_VERSION)" >> $@
 	@echo "TVOS_SDK_VERSION=$(TVOS_SDK_VERSION)" >> $@

--- a/tests/xharness/AppBundleLocator.cs
+++ b/tests/xharness/AppBundleLocator.cs
@@ -17,19 +17,19 @@ namespace Xharness {
 		readonly IProcessManager processManager;
 		readonly Func<ILog> getLog;
 		readonly string msBuildPath;
-		readonly string dotnetPath;
+		readonly string systemDotnetPath;
 		readonly string dotnet6Path;
 
 		// Gets either the SYSTEM_DOTNET or DOTNET6 variable, depending on any global.json
 		// config file found in the specified directory or any containing directories.
 		readonly Dictionary<string, string> dotnet_executables = new Dictionary<string, string> ();
 
-		public AppBundleLocator (IProcessManager processManager, Func<ILog> getLog, string msBuildPath, string dotnetPath, string dotnet6Path)
+		public AppBundleLocator (IProcessManager processManager, Func<ILog> getLog, string msBuildPath, string systemDotnetPath, string dotnet6Path)
 		{
 			this.processManager = processManager;
 			this.getLog = getLog;
 			this.msBuildPath = msBuildPath;
-			this.dotnetPath = dotnetPath;
+			this.systemDotnetPath = systemDotnetPath;
 			this.dotnet6Path = dotnet6Path;
 		}
 
@@ -169,7 +169,7 @@ namespace Xharness {
 			switch (version [0]) {
 			case '3':
 			case '5':
-				executable = dotnetPath;
+				executable = systemDotnetPath;
 				break;
 			default:
 				executable = dotnet6Path;

--- a/tests/xharness/AppBundleLocator.cs
+++ b/tests/xharness/AppBundleLocator.cs
@@ -20,7 +20,7 @@ namespace Xharness {
 		readonly string dotnetPath;
 		readonly string dotnet6Path;
 
-		// Gets either the DOTNET or DOTNET6 variable, depending on any global.json
+		// Gets either the SYSTEM_DOTNET or DOTNET6 variable, depending on any global.json
 		// config file found in the specified directory or any containing directories.
 		readonly Dictionary<string, string> dotnet_executables = new Dictionary<string, string> ();
 

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -207,7 +207,7 @@ namespace Xharness {
 				SdkRoot = config ["XCODE_DEVELOPER_ROOT"] ?? configuration.SdkRoot;
 
 			processManager = new MlaunchProcessManager (XcodeRoot, MlaunchPath);
-			AppBundleLocator = new AppBundleLocator (processManager, () => HarnessLog, XIBuildPath, config ["DOTNET"], config ["DOTNET6"]);
+			AppBundleLocator = new AppBundleLocator (processManager, () => HarnessLog, XIBuildPath, config ["SYSTEM_DOTNET"], config ["DOTNET6"]);
 			TunnelBore = new TunnelBore (processManager);
 		}
 


### PR DESCRIPTION
This makes it line up with our other make variables (SYSTEM_MSBUILD,
SYSTEM_MONO, SYSTEM_CSC, etc.), and also prepares for removing the version
from the DOTNET6 variable (so that it becomes just DOTNET).