### PR TITLE
[release/6.0.2xx-preview13] [CI] Disable the device tests until we have sorted out the pipeline pool.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -20,7 +20,7 @@ parameters:
 - name: runDeviceTests
   displayName: Run Device Tests 
   type: boolean
-  default: true
+  default: false
 
 - name: runOldMacOSTests
   displayName: Run Tests on older macOS versions 


### PR DESCRIPTION
The infra teams are working on the devices which results in no bots with a device. This ends up making the jobs wait for ever.


Backport of #14353
