### PR TITLE
Bump the min macOS version to 12.0.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -178,7 +178,7 @@ MAX_SHARPIE_VERSION=3.5.99
 MIN_SHARPIE_URL=https://download.visualstudio.microsoft.com/download/pr/401d21b7-58c2-4f86-9009-76c15bf9a804/fd5dc34d033d9949a378ca4b3332c02c/objectivesharpie-3.5.50.pkg
 
 # Minimum OSX versions for building XI/XM
-MIN_OSX_BUILD_VERSION=11.0
+MIN_OSX_BUILD_VERSION=12.0
 # Minimum OSX version for executing XI/XM tooling.
 MIN_OSX_VERSION_FOR_IOS=10.11
 MIN_OSX_VERSION_FOR_MAC=10.11


### PR DESCRIPTION
Because that's what Xcode 13.3 requires.