### PR TITLE
[release/6.0.2xx-preview14] Updated Messaging and Hot Restart versions

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.4.28</MessagingVersion>
-		<HotRestartVersion>1.0.82</HotRestartVersion>
+		<MessagingVersion>1.5.5</MessagingVersion>
+		<HotRestartVersion>1.0.90</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
This should fix a bug where Hot Restart doesn't work with net6 because of a strong naming exception on build time


Backport of #14431
