### PR TITLE
[tests] Augment TestRuntime.IgnoreInCI to detect Azure DevOps. Fixes #2557.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -114,6 +114,7 @@ partial class TestRuntime
 	public static void IgnoreInCI (string message)
 	{
 		var in_ci = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_REVISION"));
+		in_ci |= !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION")); // set by Azure DevOps
 		if (!in_ci)
 			return;
 		NUnit.Framework.Assert.Ignore (message);


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2557.