### PR TITLE
Updated Xamarin.Messaging version

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.5.5</MessagingVersion>
+		<MessagingVersion>1.5.8</MessagingVersion>
 		<HotRestartVersion>1.0.90</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Updated to 1.5.8, including fixes for a hang in build cancellation during SayHello and also an improvement in the port forwarding logic when establishing the SSH connection