### PR TITLE
[dotnet] Only add a global nfloat using if we're compiling for C# 10 or later. Fixes #14434.

### DIFF
--- a/dotnet/targets/Microsoft.MacCatalyst.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.MacCatalyst.Sdk.ImplicitNamespaceImports.props
@@ -33,8 +33,18 @@
 		This is not grouped with the other usings, because those are not enabled by default (ImplicitUsings is empty by default, but set in our templates).
 		However, the main target for this using is upgraded projects, which won't have ImplicitUsings set to anything, so we
 		use a different condition (NoNFloatUsing) to disable if desired.
+		Note: we only add this if compiling using C# 10 or later.
 	-->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst' And '$(Language)' == 'C#' And '$(NoNFloatUsing)' != 'true'">
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst'
+						 And '$(Language)' == 'C#'
+						 And '$(NoNFloatUsing)' != 'true'
+						 And ('$(LangVersion)' == ''
+							Or '$(LangVersion)' == 'preview'
+							Or '$(LangVersion)' == 'latest'
+							Or '$(LangVersion)' == 'latestMajor'
+							Or '$(LangVersion)' == 'default'
+							Or $([MSBuild]::VersionGreaterThanOrEquals('$(LangVersion)','10.0'))
+							)">
 		<Using Include="System.Runtime.InteropServices.NFloat" Platform="MacCatalyst" Alias="nfloat" />
 	</ItemGroup>
 </Project>

--- a/dotnet/targets/Microsoft.iOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.iOS.Sdk.ImplicitNamespaceImports.props
@@ -33,8 +33,18 @@
 		This is not grouped with the other usings, because those are not enabled by default (ImplicitUsings is empty by default, but set in our templates).
 		However, the main target for this using is upgraded projects, which won't have ImplicitUsings set to anything, so we
 		use a different condition (NoNFloatUsing) to disable if desired.
+		Note: we only add this if compiling using C# 10 or later.
 	-->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'iOS' And '$(Language)' == 'C#' And '$(NoNFloatUsing)' != 'true'">
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'iOS'
+						 And '$(Language)' == 'C#'
+						 And '$(NoNFloatUsing)' != 'true'
+						 And ('$(LangVersion)' == ''
+							Or '$(LangVersion)' == 'preview'
+							Or '$(LangVersion)' == 'latest'
+							Or '$(LangVersion)' == 'latestMajor'
+							Or '$(LangVersion)' == 'default'
+							Or $([MSBuild]::VersionGreaterThanOrEquals('$(LangVersion)','10.0'))
+							)">
 		<Using Include="System.Runtime.InteropServices.NFloat" Platform="iOS" Alias="nfloat" />
 	</ItemGroup>
 </Project>

--- a/dotnet/targets/Microsoft.macOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.macOS.Sdk.ImplicitNamespaceImports.props
@@ -33,8 +33,18 @@
 		This is not grouped with the other usings, because those are not enabled by default (ImplicitUsings is empty by default, but set in our templates).
 		However, the main target for this using is upgraded projects, which won't have ImplicitUsings set to anything, so we
 		use a different condition (NoNFloatUsing) to disable if desired.
+		Note: we only add this if compiling using C# 10 or later.
 	-->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'macOS' And '$(Language)' == 'C#' And '$(NoNFloatUsing)' != 'true'">
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'macOS'
+						 And '$(Language)' == 'C#'
+						 And '$(NoNFloatUsing)' != 'true'
+						 And ('$(LangVersion)' == ''
+							Or '$(LangVersion)' == 'preview'
+							Or '$(LangVersion)' == 'latest'
+							Or '$(LangVersion)' == 'latestMajor'
+							Or '$(LangVersion)' == 'default'
+							Or $([MSBuild]::VersionGreaterThanOrEquals('$(LangVersion)','10.0'))
+							)">
 		<Using Include="System.Runtime.InteropServices.NFloat" Platform="macOS" Alias="nfloat" />
 	</ItemGroup>
 </Project>

--- a/dotnet/targets/Microsoft.tvOS.Sdk.ImplicitNamespaceImports.props
+++ b/dotnet/targets/Microsoft.tvOS.Sdk.ImplicitNamespaceImports.props
@@ -33,8 +33,18 @@
 		This is not grouped with the other usings, because those are not enabled by default (ImplicitUsings is empty by default, but set in our templates).
 		However, the main target for this using is upgraded projects, which won't have ImplicitUsings set to anything, so we
 		use a different condition (NoNFloatUsing) to disable if desired.
+		Note: we only add this if compiling using C# 10 or later.
 	-->
-	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'tvOS' And '$(Language)' == 'C#' And '$(NoNFloatUsing)' != 'true'">
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'tvOS'
+						 And '$(Language)' == 'C#'
+						 And '$(NoNFloatUsing)' != 'true'
+						 And ('$(LangVersion)' == ''
+							Or '$(LangVersion)' == 'preview'
+							Or '$(LangVersion)' == 'latest'
+							Or '$(LangVersion)' == 'latestMajor'
+							Or '$(LangVersion)' == 'default'
+							Or $([MSBuild]::VersionGreaterThanOrEquals('$(LangVersion)','10.0'))
+							)">
 		<Using Include="System.Runtime.InteropServices.NFloat" Platform="tvOS" Alias="nfloat" />
 	</ItemGroup>
 </Project>

--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -57,7 +57,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="NUnitLite" Version="3.12.0" />
-		<ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\external\Touch.Unit\Touch.Client\dotnet\$(_PlatformName)\Touch.Client-$(_PlatformName).dotnet.csproj" />
+		<ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\external\Touch.Unit\Touch.Client\dotnet\$(_PlatformName)\Touch.Client-$(_PlatformName).dotnet.csproj" Condition="'$(ExcludeTouchUnitReference)' != 'true'" />
 	</ItemGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)/../nunit.framework.targets" />

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -859,5 +859,19 @@ namespace Xamarin.Tests {
 			var appExecutable = GetNativeExecutable (platform, appPath);
 			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
 		}
+
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
+		public void OlderCSharpLanguage (ApplePlatform platform, string runtimeIdentifier)
+		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, platform: platform);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifier);
+			properties ["LangVersion"] = "8";
+			properties ["ExcludeTouchUnitReference"] = "true";
+			DotNet.AssertBuild (project_path, properties);
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/14434.