### PR TITLE
[tests] Don't try to parse stderr from assetutil. Fixes #xamarin/maccore@2559.

### DIFF
--- a/tests/dotnet/UnitTests/AssetsTest.cs
+++ b/tests/dotnet/UnitTests/AssetsTest.cs
@@ -157,10 +157,11 @@ namespace Xamarin.Tests {
 		JsonDocument ProcessAssets (string assetsPath, string sdkVersion)
 		{
 			var output = new StringBuilder ();
+			var stderr = new StringBuilder ();
 			var executable = "xcrun";
 			var arguments = new string [] { "--sdk", sdkVersion, "assetutil", "--info", assetsPath };
-			var rv = Execution.RunWithStringBuildersAsync (executable, arguments, standardOutput: output, standardError: output, timeout: TimeSpan.FromSeconds (120)).Result;
-			Assert.AreEqual (0, rv.ExitCode, $"Processing Assets Error: {rv.StandardError}. Unexpected ExitCode");
+			var rv = Execution.RunWithStringBuildersAsync (executable, arguments, standardOutput: output, standardError: stderr, timeout: TimeSpan.FromSeconds (120)).Result;
+			Assert.AreEqual (0, rv.ExitCode, $"Processing Assets Error: {stderr}. Unexpected ExitCode");
 			var s = output.ToString ();
 
 			// This Execution call produces an output with an objc warning. We just want the json below it.


### PR DESCRIPTION
Hopefully fixes https://github.com/xamarin/maccore/issues/2559.