### PR TITLE
[tests] There's no need to have different logic to compute the source root path on Azure DevOps.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -318,31 +318,18 @@ namespace Xamarin.Tests
 
 		public static string RootPath {
 			get {
-				if (IsVsts) {
-					var workingDir = Environment.GetEnvironmentVariable ("SYSTEM_DEFAULTWORKINGDIRECTORY");
-					var git = Path.Combine (workingDir, ".git");
-					if (Directory.Exists (git)) {
-						return workingDir;
-					} else {
-						var xamarin = Path.Combine (workingDir, "xamarin-macios");
-						if (!Directory.Exists (xamarin))
-							throw new Exception ($"Could not find the xamarin-macios repo given the test working directory {workingDir}");
-						return xamarin;
-					}
-				} else {
-					var dir = TestAssemblyDirectory;
-					var path = Path.Combine (dir, ".git");
-					while (!Directory.Exists (path) && path.Length > 3) {
-						dir = Path.GetDirectoryName (dir);
-						if (dir is null)
-							throw new Exception ($"Could not find the xamarin-macios repo given the test assembly directory {TestAssemblyDirectory}");
-						path = Path.Combine (dir, ".git");
-					}
-					path = Path.GetDirectoryName (path);
-					if (!Directory.Exists (path))
+				var dir = TestAssemblyDirectory;
+				var path = Path.Combine (dir, ".git");
+				while (!Directory.Exists (path) && path.Length > 3) {
+					dir = Path.GetDirectoryName (dir);
+					if (dir is null)
 						throw new Exception ($"Could not find the xamarin-macios repo given the test assembly directory {TestAssemblyDirectory}");
-					return path;
+					path = Path.Combine (dir, ".git");
 				}
+				path = Path.GetDirectoryName (path);
+				if (!Directory.Exists (path))
+					throw new Exception ($"Could not find the xamarin-macios repo given the test assembly directory {TestAssemblyDirectory}");
+				return path;
 			}
 		}
 


### PR DESCRIPTION
When running on older macOS bots, we specifically execute tests outside of the source tree, and the tests expect that so they may fail if they end up finding a checkout.

Fixes the following xammac/monotouch test on older macOS versions:

    MonoTouchFixtures.ObjCRuntime.RegistrarTest
    	[FAIL] CustomUserTypeWithDynamicallyLoadedAssembly :   existence
      Expected: file or directory exists
      But was:  "/Users/runner/work/1/s/xamarin-macios/tests/test-libraries/custom-type-assembly/.libs/macos/custom-type-assembly.dll"