### PR TITLE
[msbuild] Only conditionally copy entire input directory from Windows in the Ditto task.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -668,6 +668,7 @@
 		<Ditto
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
+			CopyFromWindows="true"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="%(_DirectoriesToPublish.SourceDirectory)"
@@ -1543,6 +1544,7 @@
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
 			AdditionalArguments="-x -k"
+			CopyFromWindows="true"
 			Source="%(_CompressedAppleBindingResourcePackage.Identity)"
 			Destination="$(_IntermediateDecompressionDir)/%(Filename)"
 			>
@@ -1590,6 +1592,7 @@
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
 			AdditionalArguments="-x -k"
+			CopyFromWindows="true"
 			Source="%(_CompressedPlugIns.Identity)"
 			Destination="$(_IntermediateDecompressionDir)/%(Filename)%(Extension)"
 			>
@@ -1636,6 +1639,7 @@
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
 			AdditionalArguments="-x -k"
+			CopyFromWindows="true"
 			Source="%(_CompressedAppleFrameworks.Identity)"
 			Destination="$(_IntermediateFrameworksDir)/%(Filename)%(Extension)"
 			>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
@@ -13,6 +13,16 @@ namespace Xamarin.MacDev.Tasks
 
 		public string? AdditionalArguments { get; set; }
 
+		// If the input directory should be copied from Windows to the Mac in
+		// a remote build. In some cases we only maintain empty files on
+		// Windows to keep track of modified files, so that we don't have to
+		// transfer the entire file back to Windows, and in those cases we
+		// don't want to copy the empty content back to the Mac. In other
+		// cases the input comes from Windows, and in that case we want to
+		// copy the entire input to the Mac - so we need an option to select
+		// the mode.
+		public bool CopyFromWindows { get; set; }
+
 		[Required]
 		public ITaskItem? Source { get; set; }
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
@@ -35,6 +35,9 @@ namespace Xamarin.MacDev.Tasks
 			if (!Directory.Exists(Source.ItemSpec))
 				return Enumerable.Empty<ITaskItem> ();
 
+			if (!CopyFromWindows)
+				return Enumerable.Empty<ITaskItem> ();
+
 			// TaskRunner doesn't know how to copy directories to Mac but `ditto` can take directories (and that's why we use ditto often).
 			// If Source is a directory path, let's add each file within it as an TaskItem, as TaskRunner knows how to copy files to Mac.
 			return Directory.GetFiles (Source.ItemSpec, "*", SearchOption.AllDirectories)

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2345,6 +2345,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<Ditto
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And Exists ('$(_Source)')"
+			CopyFromWindows="true"
 			Source="$(_Source)"
 			Destination="$(_Destination)"
 		>


### PR DESCRIPTION
Sometimes we want to copy the entire input directory from Windows to the Mac
when executing the Ditto task remotely, and sometimes we don't.

In particular we do not want to copy the input directory when the directory on
Windows is an incomplete mirror of what's on the Mac - one scenario being when
copying the app bundle to prepare for IPA creation. The .app directory on
Windows is not complete - all the files are there (maybe? not quite sure, but
that's beside the point here), but some may be empty, because when we only
care about the timestamp for a file, we'll create an empty file on Windows to
mirror the actual file on Mac. Copying this incomplete directory to the Mac,
overwriting the correct files there, will break things badly.

However, sometimes we're not mirroring a directory on Windows, but instead we
have directories as actual build input (for instances frameworks from NuGets),
and in that case we want to copy everything to the Mac.

So this PR adds a parameter to the Ditto task to optionally copy the directory
from Windows for remote builds, and we enable this behavior when we want it -
specifically when copying frameworks.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1506009 while not
regressing https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1492635.

Ref: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1506009
Ref: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1492635
Ref: https://github.com/xamarin/xamarin-macios/pull/14375