### PR TITLE
[CI] Checkout the head ref rather than the merge or a reset, this should fix issues with the test selector.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -52,7 +52,8 @@ steps:
 
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
   - pwsh: |
-      git reset --hard HEAD^2 
+      $branch="$BUILD_SOURCEBRANCH".Replace("merge", "head")
+      git checkout $branch
     displayName: "Undo Github merge"
     workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios
 

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -54,7 +54,8 @@ steps:
 
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
   - pwsh: |
-      git reset --hard HEAD^2 
+      $branch="$BUILD_SOURCEBRANCH".Replace("merge", "head")
+      git checkout $branch
     displayName: "Undo Github merge"
     workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios
 

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -113,6 +113,10 @@ stages:
     timeoutInMinutes: 1000
 
     variables:
+      # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
+      PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
+      # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
+      BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
       XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness-labels'] ]
       ${{ if eq(parameters.testPool, '') }}:
         AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]


### PR DESCRIPTION
We get the following error when trying to get list of files changed in a PR:
```
atal: ambiguous argument 'origin/pr/14488/merge^..origin/pr/14488/merge': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
Checking out the head version of the ref should have the same effect as the reset --hard and yet allow us to compare the changes correctly.