### PR TITLE
[fabricbot] Add initial config file.

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,35 @@
+[
+	{
+		"taskType": "trigger",
+		"capabilityId": "IssueResponder",
+		"subCapability": "IssuesOnlyResponder",
+		"version": "1.0",
+		"config": {
+			"conditions": {
+				"operator": "and",
+				"operands": [
+					{
+						"name": "labelAdded",
+						"parameters": {
+							"label": "need-info"
+						}
+					}
+				]
+			},
+			"eventType": "issue",
+			"eventNames": [
+				"issues",
+				"project_card"
+			],
+			"taskName": "Add comment when 'need-info' is applied to issue",
+			"actions": [
+				{
+					"name": "addReply",
+					"parameters": {
+						"comment": "Hi @${issueAuthor}. We have added the \"need-info\" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time."
+					}
+				}
+			]
+		}
+	}
+]


### PR DESCRIPTION
This initial config file tells the author of an issue that if anybody adds the
`need-info` label, they have 7 days to answer before we close the issue due
to lack of response.