### PR TITLE
[Xtro] Fix xtro runs for classic when performed in a bot that did not build

### DIFF
--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -191,10 +191,10 @@ endif
 gen-all: gen-ios gen-tvos gen-watchos gen-macos
 
 wrench:
-	$(MAKE) -j8 classify
+	$(MAKE) -j8 classify V=1
 
 dotnet-wrench:
-	$(MAKE) -j8 dotnet-classify
+	$(MAKE) -j8 dotnet-classify V=1
 
 report/index.html: xtro-report/bin/Debug/xtro-report.exe .stamp-classify
 	rm -rf report/

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -37,7 +37,7 @@ bin/Debug/xtro-sharpie.exe xtro-report/bin/Debug/xtro-report.exe xtro-sanity/bin
 	$(Q) touch $@
 
 ifdef TESTS_USE_SYSTEM
-XIOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/iOS/Xamarin.iOS.dll
+XIOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/Xamarin.iOS.dll
 XIOS_GL ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll
 else
 XIOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/iOS/Xamarin.iOS.dll
@@ -56,7 +56,7 @@ $(XIOS_PCH): .stamp-check-sharpie
 
 
 ifdef TESTS_USE_SYSTEM
-XWATCHOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/32bits/watchOS/Xamarin.WatchOS.dll
+XWATCHOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/32bits/Xamarin.WatchOS.dll
 else
 XWATCHOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/32bits/watchOS/Xamarin.WatchOS.dll
 endif
@@ -68,7 +68,7 @@ $(XWATCHOS_PCH): .stamp-check-sharpie
 	$(SHARPIE) sdk-db --xcode $(XCODE) -s watchos$(WATCH_SDK_VERSION) -a $(XWATCHOS_ARCH) -exclude RealityKit
 
 ifdef TESTS_USE_SYSTEM
-XTVOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/tvOS/Xamarin.TVOS.dll
+XTVOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/Xamarin.TVOS.dll
 XTVOS_GL ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
 else
 XTVOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/tvOS/Xamarin.TVOS.dll
@@ -225,7 +225,12 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call DotNetClassify,$(platform),
 ifdef INCLUDE_IOS
 INCLUDED_PLATFORMS+=iOS
 CLASSIFY+=.stamp-classify-ios
-.stamp-classify-ios: bin/Debug/xtro-sharpie.exe $(XIOS_PCH) $(XIOS) $(XIOS_GL)
+STAMP_CLASSIFY_IOS_DEPS := bin/Debug/xtro-sharpie.exe $(XIOS_PCH) 
+ifndef TESTS_USE_SYSTEM
+STAMP_CLASSIFY_IOS_DEPS += $(XIOS)
+STAMP_CLASSIFY_IOS_DEPS += $(XIOS_GL)
+endif
+.stamp-classify-ios: $(STAMP_CLASSIFY_IOS_DEPS) 
 	rm -f $(ANNOTATIONS_DIR)/iOS-*.raw
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XIOS_PCH) $(XIOS) $(XIOS_GL)
 	$(Q) touch $@
@@ -234,7 +239,12 @@ endif
 ifdef INCLUDE_TVOS
 INCLUDED_PLATFORMS+=tvOS
 CLASSIFY+=.stamp-classify-tvos
-.stamp-classify-tvos: bin/Debug/xtro-sharpie.exe $(XTVOS_PCH) $(XTVOS) $(XTVOS_GL)
+STAMP_CLASSIFY_TVOS_DEPS := bin/Debug/xtro-sharpie.exe $(XTVOS_PCH)
+ifndef TESTS_USE_SYSTEM
+STAMP_CLASSIFY_TVOS_DEPS += $(XTVOS) 
+STAMP_CLASSIFY_TVOS_DEPS += $(XTVOS_GL)
+endif
+.stamp-classify-tvos: $(STAMP_CLASSIFY_TVOS_DEPS)
 	rm -f $(ANNOTATIONS_DIR)/tvOS-*.raw
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XTVOS_PCH) $(XTVOS) $(XTVOS_GL)
 	$(Q) touch $@
@@ -243,7 +253,11 @@ endif
 ifdef INCLUDE_WATCH
 INCLUDED_PLATFORMS+=watchOS
 CLASSIFY+=.stamp-classify-watchos
-.stamp-classify-watchos: bin/Debug/xtro-sharpie.exe $(XWATCHOS_PCH) $(XWATCHOS)
+STAMP_CLASSIFY_WATCH_DEPS := bin/Debug/xtro-sharpie.exe $(XWATCHOS_PCH) 
+ifndef TESTS_USE_SYSTEM
+STAMP_CLASSIFY_WATCH_DEPS += $(XWATCHOS)
+endif
+.stamp-classify-watchos: $(STAMP_CLASSIFY_WATCH_DEPS)
 	rm -f $(ANNOTATIONS_DIR)/watchOS-*.raw
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XWATCHOS_PCH) $(XWATCHOS)
 	$(Q) touch $@
@@ -252,7 +266,11 @@ endif
 ifdef INCLUDE_MAC
 INCLUDED_PLATFORMS+=macOS
 CLASSIFY+=.stamp-classify-macos
-.stamp-classify-macos: bin/Debug/xtro-sharpie.exe $(XMACOS_PCH) $(XMACOS)
+STAMP_CLASSIFY_MAC_DEPS := bin/Debug/xtro-sharpie.exe $(XMACOS_PCH)
+ifndef TESTS_USE_SYSTEM
+STAMP_CLASSIFY_MAC_DEPS += $(XMACOS)
+endif
+.stamp-classify-macos: $(STAMP_CLASSIFY_MAC_DEPS)
 	rm -f $(ANNOTATIONS_DIR)/macOS-*.raw
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XMACOS_PCH) $(XMACOS)
 	$(Q) touch $@

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -36,8 +36,14 @@ bin/Debug/xtro-sharpie.exe xtro-report/bin/Debug/xtro-report.exe xtro-sanity/bin
 	$(Q_BUILD) $(SYSTEM_MSBUILD) $(MSBUILD_VERBOSITY) xtro-sharpie.sln /r /bl:$@.binlog
 	$(Q) touch $@
 
-XIOS ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/iOS/Xamarin.iOS.dll
-XIOS_GL ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll
+ifdef TESTS_USE_SYSTEM
+XIOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/iOS/Xamarin.iOS.dll
+XIOS_GL ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll
+else
+XIOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/iOS/Xamarin.iOS.dll
+XIOS_GL ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll
+endif
+
 XIOS_ARCH = arm64
 XIOS_PCH = iphoneos$(IOS_SDK_VERSION)-$(XIOS_ARCH).pch
 XIOS_RID = ios-arm64
@@ -48,15 +54,26 @@ $(XIOS_PCH): .stamp-check-sharpie
 	-i ThreadNetwork/THClient.h \
 	$(CORETELEPHONY_HEADERS) \
 
-XWATCHOS ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/32bits/watchOS/Xamarin.WatchOS.dll
+
+ifdef TESTS_USE_SYSTEM
+XWATCHOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/32bits/watchOS/Xamarin.WatchOS.dll
+else
+XWATCHOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/32bits/watchOS/Xamarin.WatchOS.dll
+endif
+
 XWATCHOS_ARCH = armv7
 XWATCHOS_PCH = watchos$(WATCH_SDK_VERSION)-$(XWATCHOS_ARCH).pch
 
 $(XWATCHOS_PCH): .stamp-check-sharpie
 	$(SHARPIE) sdk-db --xcode $(XCODE) -s watchos$(WATCH_SDK_VERSION) -a $(XWATCHOS_ARCH) -exclude RealityKit
 
-XTVOS ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/tvOS/Xamarin.TVOS.dll
-XTVOS_GL ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
+ifdef TESTS_USE_SYSTEM
+XTVOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/tvOS/Xamarin.TVOS.dll
+XTVOS_GL ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
+else
+XTVOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/tvOS/Xamarin.TVOS.dll
+XTVOS_GL ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
+endif
 
 XTVOS_ARCH = arm64
 XTVOS_PCH = appletvos$(TVOS_SDK_VERSION)-$(XTVOS_ARCH).pch
@@ -204,12 +221,7 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call DotNetClassify,$(platform),
 ifdef INCLUDE_IOS
 INCLUDED_PLATFORMS+=iOS
 CLASSIFY+=.stamp-classify-ios
-STAMP_CLASSIFY_IOS_DEPS := bin/Debug/xtro-sharpie.exe $(XIOS_PCH) 
-ifndef TESTS_USE_SYSTEM
-STAMP_CLASSIFY_IOS_DEPS += $(XIOS)
-STAMP_CLASSIFY_IOS_DEPS += $(XIOS_GL)
-endif
-.stamp-classify-ios: $(STAMP_CLASSIFY_IOS_DEPS) 
+.stamp-classify-ios: bin/Debug/xtro-sharpie.exe $(XIOS_PCH) $(XIOS) $(XIOS_GL)
 	rm -f $(ANNOTATIONS_DIR)/iOS-*.raw
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XIOS_PCH) $(XIOS) $(XIOS_GL)
 	$(Q) touch $@
@@ -218,12 +230,7 @@ endif
 ifdef INCLUDE_TVOS
 INCLUDED_PLATFORMS+=tvOS
 CLASSIFY+=.stamp-classify-tvos
-STAMP_CLASSIFY_TVOS_DEPS := bin/Debug/xtro-sharpie.exe $(XTVOS_PCH)
-ifndef TESTS_USE_SYSTEM
-STAMP_CLASSIFY_TVOS_DEPS += $(XTVOS) 
-STAMP_CLASSIFY_TVOS_DEPS += $(XTVOS_GL)
-endif
-.stamp-classify-tvos: $(STAMP_CLASSIFY_TVOS_DEPS)
+.stamp-classify-tvos: bin/Debug/xtro-sharpie.exe $(XTVOS_PCH) $(XTVOS) $(XTVOS_GL)
 	rm -f $(ANNOTATIONS_DIR)/tvOS-*.raw
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XTVOS_PCH) $(XTVOS) $(XTVOS_GL)
 	$(Q) touch $@
@@ -232,11 +239,7 @@ endif
 ifdef INCLUDE_WATCH
 INCLUDED_PLATFORMS+=watchOS
 CLASSIFY+=.stamp-classify-watchos
-STAMP_CLASSIFY_WATCH_DEPS := bin/Debug/xtro-sharpie.exe $(XWATCHOS_PCH) 
-ifndef TESTS_USE_SYSTEM
-STAMP_CLASSIFY_WATCH_DEPS += $(XWATCHOS)
-endif
-.stamp-classify-watchos: $(STAMP_CLASSIFY_WATCH_DEPS)
+.stamp-classify-watchos: bin/Debug/xtro-sharpie.exe $(XWATCHOS_PCH) $(XWATCHOS)
 	rm -f $(ANNOTATIONS_DIR)/watchOS-*.raw
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XWATCHOS_PCH) $(XWATCHOS)
 	$(Q) touch $@
@@ -245,11 +248,7 @@ endif
 ifdef INCLUDE_MAC
 INCLUDED_PLATFORMS+=macOS
 CLASSIFY+=.stamp-classify-macos
-STAMP_CLASSIFY_MAC_DEPS := bin/Debug/xtro-sharpie.exe $(XMACOS_PCH)
-ifndef TESTS_USE_SYSTEM
-STAMP_CLASSIFY_MAC_DEPS += $(XMACOS)
-endif
-.stamp-classify-macos: $(STAMP_CLASSIFY_MAC_DEPS)
+.stamp-classify-macos: bin/Debug/xtro-sharpie.exe $(XMACOS_PCH) $(XMACOS)
 	rm -f $(ANNOTATIONS_DIR)/macOS-*.raw
 	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XMACOS_PCH) $(XMACOS)
 	$(Q) touch $@

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -33,6 +33,7 @@ clean-local::
 bin/Debug/xtro-sharpie.exe xtro-report/bin/Debug/xtro-report.exe xtro-sanity/bin/Debug/xtro-sanity.exe build: .stamp-build
 
 .stamp-build: $(wildcard *.cs) pch-info.proj
+	export MSBUILDNOINPROCNODE=1
 	$(Q_BUILD) $(SYSTEM_MSBUILD) $(MSBUILD_VERBOSITY) xtro-sharpie.sln /r /bl:$@.binlog
 	$(Q) touch $@
 
@@ -283,6 +284,7 @@ remove-empty-files:
 
 U2TODO = u2todo/bin/Debug/u2todo.exe
 $(U2TODO): $(wildcard u2todo/*.cs u2todo/*.csproj Filter.cs)
+	export MSBUILDNOINPROCNODE=1
 	$(Q) $(SYSTEM_MSBUILD) $(MSBUILD_VERBOSITY) /bl:$@.binlog /r
 	$(Q) touch $@
 

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -36,14 +36,8 @@ bin/Debug/xtro-sharpie.exe xtro-report/bin/Debug/xtro-report.exe xtro-sanity/bin
 	$(Q_BUILD) $(SYSTEM_MSBUILD) $(MSBUILD_VERBOSITY) xtro-sharpie.sln /r /bl:$@.binlog
 	$(Q) touch $@
 
-ifdef TESTS_USE_SYSTEM
-XIOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/Xamarin.iOS.dll
-XIOS_GL ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll
-else
-XIOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/iOS/Xamarin.iOS.dll
-XIOS_GL ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll
-endif
-
+XIOS ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/iOS/Xamarin.iOS.dll
+XIOS_GL ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll
 XIOS_ARCH = arm64
 XIOS_PCH = iphoneos$(IOS_SDK_VERSION)-$(XIOS_ARCH).pch
 XIOS_RID = ios-arm64
@@ -54,26 +48,15 @@ $(XIOS_PCH): .stamp-check-sharpie
 	-i ThreadNetwork/THClient.h \
 	$(CORETELEPHONY_HEADERS) \
 
-
-ifdef TESTS_USE_SYSTEM
-XWATCHOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/32bits/Xamarin.WatchOS.dll
-else
-XWATCHOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/32bits/watchOS/Xamarin.WatchOS.dll
-endif
-
+XWATCHOS ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/32bits/watchOS/Xamarin.WatchOS.dll
 XWATCHOS_ARCH = armv7
 XWATCHOS_PCH = watchos$(WATCH_SDK_VERSION)-$(XWATCHOS_ARCH).pch
 
 $(XWATCHOS_PCH): .stamp-check-sharpie
 	$(SHARPIE) sdk-db --xcode $(XCODE) -s watchos$(WATCH_SDK_VERSION) -a $(XWATCHOS_ARCH) -exclude RealityKit
 
-ifdef TESTS_USE_SYSTEM
-XTVOS ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/Xamarin.TVOS.dll
-XTVOS_GL ?= /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
-else
-XTVOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/tvOS/Xamarin.TVOS.dll
-XTVOS_GL ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
-endif
+XTVOS ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/tvOS/Xamarin.TVOS.dll
+XTVOS_GL ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
 
 XTVOS_ARCH = arm64
 XTVOS_PCH = appletvos$(TVOS_SDK_VERSION)-$(XTVOS_ARCH).pch
@@ -82,11 +65,7 @@ XTVOS_RID = tvos-arm64
 $(XTVOS_PCH): .stamp-check-sharpie
 	$(SHARPIE) sdk-db --xcode $(XCODE) -s appletvos$(TVOS_SDK_VERSION) -a $(XTVOS_ARCH) -exclude RealityKit
 
-ifdef TESTS_USE_SYSTEM
-XMACOS ?= /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/64bits/mobile/Xamarin.Mac.dll
-else
-XMACOS ?= $(TOP)/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/64bits/mobile/Xamarin.Mac.dll
-endif
+XMACOS ?= $(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/64bits/mobile/Xamarin.Mac.dll
 XMACOS_ARCH = x86_64
 XMACOS_PCH = macosx$(MACOS_SDK_VERSION)-$(XMACOS_ARCH).pch
 XMACOS_RID = osx-x64


### PR DESCRIPTION
Two small fixes:
1. Point to the correct paths.
2. Do not try to build the dll since we are using the system one.