### PR TITLE
[CI] Add the job id to the agent logs.

### DIFF
--- a/tools/devops/automation/templates/common/mac-agent-logs.yml
+++ b/tools/devops/automation/templates/common/mac-agent-logs.yml
@@ -80,5 +80,5 @@ steps:
         targetPath: ${{ parameters.outputPath }}
       ${{ else }}:
         targetPath: ${{ parameters.workingDirectory }}/${{ parameters.outputPath }} 
-      artifactName: $(Agent.Name)-${{ parameters.outputPath }} 
+      artifactName: $(Agent.Name)-$(System.JobName)-$(System.JobId)-${{ parameters.outputPath }} 
     continueOnError: true


### PR DESCRIPTION
It can happen that we use the same agent for more than one bot, if that
is the case, we need to make sure that we do not have the same name for
the logs. We use the job id + job name for that.