### PR TITLE
Remove unnecessary conditional defines from wkwebkit.cs

### DIFF
--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -17,10 +17,19 @@ using Security;
 #if MONOMAC
 using AppKit;
 using UIColor=AppKit.NSColor;
+using UIPreviewActionItem = Foundation.NSObject;
+using UIScrollView = AppKit.NSScrollView;
+using UIImage = AppKit.NSImage;
+using IUIContextMenuInteractionCommitAnimating = Foundation.NSObject;
+using UIContextMenuConfiguration = Foundation.NSObject;
+using UIViewController = AppKit.NSViewController;
+using IWKPreviewActionItem = Foundation.NSObject;
 #else
 using UIKit;
 using NSPrintInfo = Foundation.NSObject;
 using NSPrintOperation = Foundation.NSObject;
+using NSEventModifierMask = System.Object;
+using NSImage = UIKit.UIImage;
 #endif
 
 #if !NET
@@ -199,13 +208,13 @@ namespace WebKit
 		[Export ("request", ArgumentSemantic.Copy)]
 		NSUrlRequest Request { get; }
 
-#if MONOMAC
+		[NoiOS][NoMacCatalyst]
 		[Export ("modifierFlags")]
 		NSEventModifierMask ModifierFlags { get; }
 
+		[NoiOS][NoMacCatalyst]
 		[Export ("buttonNumber")]
 		nint ButtonNumber { get; }
-#endif
 
 		[Mac (11,3)][iOS (14,5)]
 		[MacCatalyst (14,5)]
@@ -297,20 +306,21 @@ namespace WebKit
 		[Export ("javaScriptCanOpenWindowsAutomatically")]
 		bool JavaScriptCanOpenWindowsAutomatically { get; set; }
 
-#if MONOMAC
+		[NoiOS][NoMacCatalyst]
 		[Deprecated (PlatformName.MacOSX, 10,15, message: "Feature no longer supported.")]
 		[Export ("javaEnabled")]
 		bool JavaEnabled { get; set; }
 
+		[NoiOS][NoMacCatalyst]
 		[Deprecated (PlatformName.MacOSX, 10,15, message: "Feature no longer supported.")]
 		[Export ("plugInsEnabled")]
 		bool PlugInsEnabled { get; set; }
 
 		// Headers says 10,12,3 but it is not available likely they meant 10,12,4
+		[NoiOS][NoMacCatalyst]
 		[Mac (10,12,4)]
 		[Export ("tabFocusesLinks")]
 		bool TabFocusesLinks { get; set; }
-#endif
 
 		[Mac (10, 15), iOS (13, 0)]
 		[Export ("fraudulentWebsiteWarningEnabled")]
@@ -574,9 +584,9 @@ namespace WebKit
 		[Export ("webView:shouldPreviewElement:")]
 		bool ShouldPreviewElement (WKWebView webView, WKPreviewElementInfo elementInfo);
 
-#if !MONOMAC
 		[iOS (10,0)][NoMac]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'SetContextMenuConfiguration' instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'SetContextMenuConfiguration' instead.")]
 		[Export ("webView:previewingViewControllerForElement:defaultActions:")]
 		[return: NullAllowed]
 		UIViewController GetPreviewingViewController (WKWebView webView, WKPreviewElementInfo elementInfo, IWKPreviewActionItem[] previewActions);
@@ -586,14 +596,15 @@ namespace WebKit
 		[Export ("webView:commitPreviewingViewController:")]
 		void CommitPreviewingViewController (WKWebView webView, UIViewController previewingViewController);
 
+		[MacCatalyst (13,1)]
 		[iOS (13,0)][NoMac]
 		[Export ("webView:contextMenuConfigurationForElement:completionHandler:")]
 		void SetContextMenuConfiguration (WKWebView webView, WKContextMenuElementInfo elementInfo, Action<UIContextMenuConfiguration> completionHandler);
 
+		[MacCatalyst (13,1)]
 		[iOS (13,0)][NoMac]
 		[Export ("webView:contextMenuForElement:willCommitWithAnimator:")]
 		void WillCommitContextMenu (WKWebView webView, WKContextMenuElementInfo elementInfo, IUIContextMenuInteractionCommitAnimating animator);
-#endif
 
 		[iOS (13,0)][NoMac]
 		[Export ("webView:contextMenuWillPresentForElement:")]
@@ -767,13 +778,13 @@ namespace WebKit
 		[Export ("allowsBackForwardNavigationGestures")]
 		bool AllowsBackForwardNavigationGestures { get; set; }
 
-#if MONOMAC
+		[NoiOS][NoMacCatalyst]
 		[Export ("allowsMagnification")]
 		bool AllowsMagnification { get; set; }
 
+		[NoiOS][NoMacCatalyst]
 		[Export ("magnification")]
 		nfloat Magnification { get; set; }
-#endif
 
 		[Export ("loadRequest:")]
 		[return: NullAllowed]
@@ -818,13 +829,13 @@ namespace WebKit
 		[Async]
 		void EvaluateJavaScript (string javascript, WKJavascriptEvaluationResult completionHandler);
 
-#if MONOMAC
+		[NoiOS][NoMacCatalyst]
 		[Export ("setMagnification:centeredAtPoint:")]
 		void SetMagnification (nfloat magnification, CGPoint centerPoint);
-#else
+
+		[NoMac][MacCatalyst (13,1)]
 		[Export ("scrollView", ArgumentSemantic.Strong)]
 		UIScrollView ScrollView { get; }
-#endif
 
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("loadData:MIMEType:characterEncodingName:baseURL:")]
@@ -856,11 +867,13 @@ namespace WebKit
 		SecTrust ServerTrust { get; }
 
 #if !MONOMAC
+		[NoMac][MacCatalyst (13,1)]
 		[iOS (11,0)]
 		[Async]
 		[Export ("takeSnapshotWithConfiguration:completionHandler:")]
 		void TakeSnapshot ([NullAllowed] WKSnapshotConfiguration snapshotConfiguration, Action<UIImage, NSError> completionHandler);
 #else
+		[NoiOS][NoMacCatalyst]
 		[Mac (10,13)]
 		[Export ("takeSnapshotWithConfiguration:completionHandler:")]
 		[Async]
@@ -1057,34 +1070,43 @@ namespace WebKit
 		[Export ("allowsAirPlayForMediaPlayback")]
 		bool AllowsAirPlayForMediaPlayback { get; set; }
 
-#if !MONOMAC
+		[NoMac][MacCatalyst (13,1)]
 		[Export ("allowsInlineMediaPlayback")]
 		bool AllowsInlineMediaPlayback { get; set; }
 
+		[NoMac]
 		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'RequiresUserActionForMediaPlayback' or 'MediaTypesRequiringUserActionForPlayback' instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'RequiresUserActionForMediaPlayback' or 'MediaTypesRequiringUserActionForPlayback' instead.")]
 		[Export ("mediaPlaybackRequiresUserAction")]
 		bool MediaPlaybackRequiresUserAction { get; set; }
 
+		[NoMac]
 		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'AllowsAirPlayForMediaPlayback' instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'AllowsAirPlayForMediaPlayback' instead.")]
 		[Export ("mediaPlaybackAllowsAirPlay")]
 		bool MediaPlaybackAllowsAirPlay { get; set; }
 
+		[NoMac][MacCatalyst (13,1)]
 		[Export ("selectionGranularity")]
 		WKSelectionGranularity SelectionGranularity { get; set; }
 
+		[NoMac]
 		[iOS (9, 0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'MediaTypesRequiringUserActionForPlayback' instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'MediaTypesRequiringUserActionForPlayback' instead.")]
 		[Export ("requiresUserActionForMediaPlayback")]
 		bool RequiresUserActionForMediaPlayback { get; set; }
 
+		[NoMac][MacCatalyst (13,1)]
 		[iOS (9,0)]
 		[Export ("allowsPictureInPictureMediaPlayback")]
 		bool AllowsPictureInPictureMediaPlayback { get; set; }
 
+		[NoMac][MacCatalyst (13,1)]
 		[iOS (10, 0)]
 		[Export ("dataDetectorTypes", ArgumentSemantic.Assign)]
 		WKDataDetectorTypes DataDetectorTypes { get; set; }
-#endif
+
 		[iOS (10,0)][Mac (10,12)]
 		[Export ("mediaTypesRequiringUserActionForPlayback", ArgumentSemantic.Assign)]
 		WKAudiovisualMediaTypes MediaTypesRequiringUserActionForPlayback { get; set; }
@@ -1169,6 +1191,7 @@ namespace WebKit
 
 	[iOS (10,0)][NoMac]
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'TBD' instead.")]
+	[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'TBD' instead.")]
 	[Protocol]
 	interface WKPreviewActionItem : UIPreviewActionItem {
 		[Abstract]


### PR DESCRIPTION
This PR works to remove the unneeded conditional defines and put in a better input for the generator!

- Part of [Removal of platform preprocessor blocks in binding definations #14444](https://github.com/xamarin/xamarin-macios/issues/14444)