### PR TITLE
Set IsImplicitlyDefined="true" on the System.Runtime.InteropServices.NFloat.Internal PackageReference

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -111,7 +111,7 @@
 
   <ItemGroup>
     <!-- Add a reference to our custom nfloat reference assembly for .NET 6 (but only for .NET 6, once we switch to .NET 7 this can be removed) -->
-    <PackageReference Include="System.Runtime.InteropServices.NFloat.Internal" Condition="'$(BundledNETCorePlatformsPackageVersion.Substring(0,1))' == '6'" Version="[6.0.1, )" />
+    <PackageReference Include="System.Runtime.InteropServices.NFloat.Internal" Condition="'$(BundledNETCorePlatformsPackageVersion.Substring(0,1))' == '6'" Version="[6.0.1, )" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!--

--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -56,7 +56,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NUnitLite" Version="3.12.0" />
+		<PackageReference Include="NUnitLite" Version="3.12.0" Condition="'$(ExcludeNUnitLiteReference)' != 'true'" />
 		<ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\external\Touch.Unit\Touch.Client\dotnet\$(_PlatformName)\Touch.Client-$(_PlatformName).dotnet.csproj" Condition="'$(ExcludeTouchUnitReference)' != 'true'" />
 	</ItemGroup>
 

--- a/tests/dotnet/CentralPackageVersionsApp/AppDelegate.cs
+++ b/tests/dotnet/CentralPackageVersionsApp/AppDelegate.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace MySimpleApp
+{
+	public class Program
+	{
+		static int Main (string[] args)
+		{
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return args.Length;
+		}
+	}
+}

--- a/tests/dotnet/CentralPackageVersionsApp/MacCatalyst/CentralPackageVersionsApp.csproj
+++ b/tests/dotnet/CentralPackageVersionsApp/MacCatalyst/CentralPackageVersionsApp.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
+	<PropertyGroup>
+		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CentralPackageVersionsApp/MacCatalyst/Makefile
+++ b/tests/dotnet/CentralPackageVersionsApp/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CentralPackageVersionsApp/Makefile
+++ b/tests/dotnet/CentralPackageVersionsApp/Makefile
@@ -1,0 +1,2 @@
+TOP=../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/CentralPackageVersionsApp/Packages.props
+++ b/tests/dotnet/CentralPackageVersionsApp/Packages.props
@@ -1,0 +1,5 @@
+<Project >
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/CentralPackageVersionsApp/README.md
+++ b/tests/dotnet/CentralPackageVersionsApp/README.md
@@ -1,0 +1,1 @@
+This test can be removed in .NET 7.

--- a/tests/dotnet/CentralPackageVersionsApp/iOS/CentralPackageVersionsApp.csproj
+++ b/tests/dotnet/CentralPackageVersionsApp/iOS/CentralPackageVersionsApp.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
+	<PropertyGroup>
+		<TargetFramework>net6.0-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CentralPackageVersionsApp/iOS/Makefile
+++ b/tests/dotnet/CentralPackageVersionsApp/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CentralPackageVersionsApp/macOS/CentralPackageVersionsApp.csproj
+++ b/tests/dotnet/CentralPackageVersionsApp/macOS/CentralPackageVersionsApp.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
+	<PropertyGroup>
+		<TargetFramework>net6.0-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CentralPackageVersionsApp/macOS/Makefile
+++ b/tests/dotnet/CentralPackageVersionsApp/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CentralPackageVersionsApp/shared.csproj
+++ b/tests/dotnet/CentralPackageVersionsApp/shared.csproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This test can be removed in .NET 7 -->
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationId>com.xamarin.centralpackageversionsapp</ApplicationId>
+		<ExcludeNUnitLiteReference>true</ExcludeNUnitLiteReference>
+		<ExcludeTouchUnitReference>true</ExcludeTouchUnitReference>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<CentralPackagesFile>$(MSBuildThisFileDirectory)Packages.props</CentralPackagesFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/CentralPackageVersionsApp/shared.mk
+++ b/tests/dotnet/CentralPackageVersionsApp/shared.mk
@@ -1,0 +1,2 @@
+TOP=../../../..
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/CentralPackageVersionsApp/tvOS/CentralPackageVersionsApp.csproj
+++ b/tests/dotnet/CentralPackageVersionsApp/tvOS/CentralPackageVersionsApp.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
+	<PropertyGroup>
+		<TargetFramework>net6.0-tvos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CentralPackageVersionsApp/tvOS/Makefile
+++ b/tests/dotnet/CentralPackageVersionsApp/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -873,5 +873,21 @@ namespace Xamarin.Tests {
 			properties ["ExcludeTouchUnitReference"] = "true";
 			DotNet.AssertBuild (project_path, properties);
 		}
+
+		// This test can be removed in .NET 7
+		[TestCase (ApplePlatform.iOS)]
+		[TestCase (ApplePlatform.TVOS)]
+		[TestCase (ApplePlatform.MacCatalyst)]
+		[TestCase (ApplePlatform.MacOSX)]
+		public void CentralPackageVersionsApp (ApplePlatform platform)
+		{
+			var project = "CentralPackageVersionsApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, platform: platform);
+			Clean (project_path);
+			var properties = GetDefaultProperties ();
+			DotNet.AssertBuild (project_path, properties);
+		}
 	}
 }


### PR DESCRIPTION
This unbreaks Central Package Management via https://github.com/microsoft/MSBuildSdks/tree/main/src/CentralPackageVersions which is being worked on for NuGet, see https://github.com/NuGet/Home/issues/6764

Fixes https://github.com/xamarin/xamarin-macios/issues/14452