### PR TITLE
[dotnet] Complete rename of DOTNET to SYSTEM_DOTNET.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -529,12 +529,12 @@ $(TOP)/dotnet.config: $(TOP)/eng/Versions.props
 	$(Q) mv $@.tmp $@
 
 ifneq ("$(wildcard /usr/local/share/dotnet/dotnet)","")
-DOTNET=/usr/local/share/dotnet/dotnet
+SYSTEM_DOTNET=/usr/local/share/dotnet/dotnet
 else
 ifneq ("$(wildcard /usr/local/share/dotnet/x64/dotnet)","")
-DOTNET=/usr/local/share/dotnet/x64/dotnet
+SYSTEM_DOTNET=/usr/local/share/dotnet/x64/dotnet
 else
-DOTNET=/must/install/dotnet
+SYSTEM_DOTNET=/must/install/dotnet
 endif
 endif
 


### PR DESCRIPTION
This was supposed to happen in d3643414e7900134df13f1962f0ffba85965c25e, but
it looks like due to a merge conflict, this remaining part disappeared.