### PR TITLE
[mmptest] Fix TESTS_USE_SYSTEM logic.

### DIFF
--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -37,8 +37,8 @@
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <Reference Include="mmp">
       <Aliases>global,mmp</Aliases>
-      <HintPath Condition="$(TESTS_USE_SYSTEM) != 'true'">..\..\_mac-build\Library\Frameworks\Xamarin.Mac.framework\Versions\git\lib\mmp\mmp.exe</HintPath>
-      <HintPath Condition="$(TESTS_USE_SYSTEM) == 'true'">\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\lib\mmp\mmp.exe</HintPath>
+      <HintPath Condition="$(TESTS_USE_SYSTEM) == ''">..\..\_mac-build\Library\Frameworks\Xamarin.Mac.framework\Versions\git\lib\mmp\mmp.exe</HintPath>
+      <HintPath Condition="$(TESTS_USE_SYSTEM) != ''">\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\lib\mmp\mmp.exe</HintPath>
     </Reference>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />


### PR DESCRIPTION
As long as the variable is set, we're using the system installation for testing.