### PR TITLE
[release/6.0.3xx-rc1] Revert "[nnyeah] Fix makefile to use msbuild. (#14533)"

### DIFF
--- a/tools/nnyeah/Makefile
+++ b/tools/nnyeah/Makefile
@@ -6,7 +6,7 @@ all-local:: bin/Debug/net5.0/nnyeah.dll
 install-local:: all-local
 
 bin/Debug/net5.0/nnyeah.dll: $(wildcard **/*.cs) $(wildcard **/*.csproj) $(wildcard *.sln) Makefile
-	$(Q_BUILD) $(SYSTEM_MSBUILD) "/bl:$@.binlog" /restore $(MSBUILD_VERBOSITY) $(wildcard *.sln)
+	$(Q_BUILD) $(SYSTEM_DOTNET) build "/bl:$@.binlog" /restore $(MSBUILD_VERBOSITY) $(wildcard *.sln)
 
 clean:
-	$(Q_BUILD) $(SYSTEM_MSBUILD) "/bl:$@.binlog" /restore $(MSBUILD_VERBOSITY) /t:Clean $(wildcard *.sln)
+	$(Q_BUILD) $(SYSTEM_DOTNET) build "/bl:$@.binlog" /restore $(MSBUILD_VERBOSITY) /t:Clean $(wildcard *.sln)


### PR DESCRIPTION
This reverts commit 073165fef6f08eb277137e7213a8bf5e0d95878b.

Fixes this build error:

```
/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(1232,5): error MSB3971: The reference assemblies for ".NETFramework,Version=v5.0" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK. [/Users/rolf/work/maccore/dotnet/xamarin-macios/tools/nnyeah/nnyeah/nnyeah.csproj]
gmake[2]: *** [Makefile:9: bin/Debug/net5.0/nnyeah.dll] Error 1
```


Backport of #14546
