### PR TITLE
[nnyeah] Fix path to nnyeah.dll.

### DIFF
--- a/tools/nnyeah/Makefile
+++ b/tools/nnyeah/Makefile
@@ -1,11 +1,11 @@
 TOP=../..
 include $(TOP)/Make.config
 
-all-local:: bin/Debug/net5.0/nnyeah.dll
+all-local:: nnyeah/bin/Debug/net5.0/nnyeah.dll
 
 install-local:: all-local
 
-bin/Debug/net5.0/nnyeah.dll: $(wildcard **/*.cs) $(wildcard **/*.csproj) $(wildcard *.sln) Makefile
+nnyeah/bin/Debug/net5.0/nnyeah.dll: $(wildcard **/*.cs) $(wildcard **/*.csproj) $(wildcard *.sln) Makefile
 	$(Q_BUILD) $(SYSTEM_DOTNET) build "/bl:$@.binlog" /restore $(MSBUILD_VERBOSITY) $(wildcard *.sln)
 
 clean:


### PR DESCRIPTION
This makes rebuilds detect that the dll has already been built.