### PR TITLE
[CI] Use public bots to run tests.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -328,6 +328,7 @@ stages:
       testPrefix: ${{ config.testPrefix }} 
       stageName: ${{ config.stageName }} 
       displayName: ${{ config.displayName }} 
+      testPool: '' # use the default
       useXamarinStorage: ${{ config.useXamarinStorage }} 
       testsLabels: ${{ config.testsLabels }}
       statusContext: ${{ config.statusContext }} 

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -75,21 +75,6 @@ stages:
   condition: and(succeeded(), ${{ parameters.condition }})
 
   jobs:
-  - ${{ if eq(parameters.testPool, '') }}:
-    - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
-      pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
-        vmImage: ubuntu-latest
-      steps:
-      - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-
-      # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-      - template: azure-devops-pools/agent-pool-selector.yml@templates
-        parameters:
-          agentPoolPR: $(PRBuildPool)
-          agentPoolPRUrl: $(PRBuildPoolUrl)
-          agentPoolCI: $(CIBuildPool)
-          agentPoolCIUrl: $(CIBuildPoolUrl)
-
   - ${{ if eq(parameters.parseLabels, true) }}:
     - job: configure
       displayName: 'Configure build'
@@ -105,8 +90,6 @@ stages:
 
   - job: tests
     dependsOn:
-    - ${{ if eq(parameters.testPool, '') }}:
-      - AgentPoolSelector
     - ${{ if eq(parameters.parseLabels, true) }}:
       - configure
     displayName: 'Run ${{ parameters.testPrefix }} Device Tests'
@@ -119,7 +102,7 @@ stages:
       BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
       XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness-labels'] ]
       ${{ if eq(parameters.testPool, '') }}:
-        AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
+        AgentPoolComputed: $(PRBuildPool)
       ${{ else }}:
         AgentPoolComputed: ${{ parameters.testPool }}
 


### PR DESCRIPTION
The internal bots are giving issues running xtro, public ones are ok.
There is no real reason to use the internal pool to run tests and we can
debug the bots in that pool better.

We move to run tests in the public bots unless told otherwise (when
using devices for example).