### PR TITLE
[xharness] Honor the TESTS_USE_SYSTEM environment variable in addition to the --use-system command-line argument.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -172,6 +172,8 @@ namespace Xharness {
 			target = configuration.Target;
 			Timeout = configuration.TimeoutInMinutes;
 			useSystemXamarinIOSMac = configuration.UseSystemXamarinIOSMac;
+			if (!string.IsNullOrEmpty ("TESTS_USE_SYSTEM"))
+				useSystemXamarinIOSMac = true;
 			Verbosity = configuration.Verbosity;
 			WatchOSAppTemplate = configuration.WatchOSAppTemplate;
 			WatchOSContainerTemplate = configuration.WatchOSContainerTemplate;


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2561.