### PR TITLE
[devops] Build xibuild manually before running the tests.

### DIFF
--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -169,6 +169,7 @@ steps:
     set -x
     set -e
     make -C tests -j8 all
+    make -C tools/xibuild
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios
   displayName: Build test dependencies
   timeoutInMinutes: 30


### PR DESCRIPTION
Some tests will build xibuild automatically when needed, some won't. This
means that the ones that don't won't succeed if executed before the ones that
do.

To avoid this scenario, just manually build xibuild before running the tests.