### PR TITLE
[mmptest] Fix resolving paths to required test files. Fixes #xamarin/maccore@2560.

### DIFF
--- a/tests/mmptest/src/NativeReferencesTests.cs
+++ b/tests/mmptest/src/NativeReferencesTests.cs
@@ -17,27 +17,24 @@ namespace Xamarin.MMP.Tests
 
 		public static string SimpleDylibPath {
 			get {
-				string rootDir = TI.FindRootDirectory ();
-				string buildLibPath = Path.Combine (rootDir, "../tests/mac-binding-project/bin/SimpleClassDylib.dylib");
-				Assert.IsTrue (File.Exists (buildLibPath), string.Format ("SimpleDylibPath missing? {0}", buildLibPath));
+				var buildLibPath = Path.Combine (Configuration.RootPath, "tests", "mac-binding-project", "bin", "SimpleClassDylib.dylib");
+				Assert.That (buildLibPath, Does.Exist, "SimpleDylibPath missing?");
 				return buildLibPath;
 			}
 		}
 
 		public static string SimpleStaticPath {
 			get {
-				string rootDir = TI.FindRootDirectory ();
-				string buildLibPath = Path.Combine (rootDir, "../tests/mac-binding-project/bin/SimpleClassStatic.a");
-				Assert.IsTrue (File.Exists (buildLibPath), string.Format ("SimpleStaticPath missing? {0}", buildLibPath));
+				var buildLibPath = Path.Combine (Configuration.RootPath, "tests", "mac-binding-project", "bin", "SimpleClassStatic.a");
+				Assert.That (buildLibPath, Does.Exist, "SimpleStaticPath missing?");
 				return buildLibPath;
 			}
 		}
 
 		public static string MobileStaticBindingPath {
 			get {
-				string rootDir = TI.FindRootDirectory ();
-				string buildLibPath = Path.Combine (rootDir, "../tests/mac-binding-project/bin/Mobile-static/MobileBinding.dll");
-				Assert.IsTrue (File.Exists (buildLibPath), string.Format ("MobileStaticBindingPath missing? {0}", buildLibPath));
+				var buildLibPath = Path.Combine (Configuration.RootPath, "tests", "mac-binding-project", "bin", "Mobile-static", "MobileBinding.dll");
+				Assert.That (buildLibPath, Does.Exist, "MobileStaticBindingPath missing?");
 				return buildLibPath;
 			}
 		}


### PR DESCRIPTION
Test files can be found relative to the root path of the repository, not
relative to where Xamarin.Mac is installed.

Fixes https://github.com/xamarin/maccore/issues/2560.