### PR TITLE
Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 1c5dfc89f0a104d5ef4fcf839ca2d02acf547415
+NEEDED_MACCORE_VERSION := cf9f7409e9a79d0d0835863cc9f5afe77ba5e74a
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 4eb40042c193d156b1f34e41a854bbf79f54eea6
+NEEDED_MACCORE_VERSION := 1c5dfc89f0a104d5ef4fcf839ca2d02acf547415
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@1c5dfc89f0 [mlaunch] Fix booting simulator devices when the simulator app is already running in Xcode 13.3. Fixes #14560. Fixes AB#1509963
 xamarin/maccore@cf9f7409e9 [mlaunch] Fix booting simulator devices on older Xcode versions.

Diff: https://github.com/xamarin/maccore/compare/4eb40042c193d156b1f34e41a854bbf79f54eea6..cf9f7409e9a79d0d0835863cc9f5afe77ba5e74a