### PR TITLE
[xcode13.3] Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,8 +7,8 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 8287d1978617996f5a0f1c83c9264cc582c957fe
-NEEDED_MACCORE_BRANCH := main
+NEEDED_MACCORE_VERSION := 59583606121bcc15bad6580f3b0ee6ced8d0bdeb
+NEEDED_MACCORE_BRANCH := xcode13.3
 
 MACCORE_DIRECTORY := maccore
 MACCORE_MODULE    := git@github.com:xamarin/maccore.git


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@5958360612 [mlaunch] Fix booting simulator devices when the simulator app is already running in Xcode 13.3. Fixes #14560.

Diff: https://github.com/xamarin/maccore/compare/8287d1978617996f5a0f1c83c9264cc582c957fe..59583606121bcc15bad6580f3b0ee6ced8d0bdeb