### PR TITLE
[release/6.0.3xx-rc1] Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 8287d1978617996f5a0f1c83c9264cc582c957fe
+NEEDED_MACCORE_VERSION := 1c5dfc89f0a104d5ef4fcf839ca2d02acf547415
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@1c5dfc89f0 [mlaunch] Fix booting simulator devices when the simulator app is already running in Xcode 13.3. Fixes #14560.
* xamarin/maccore@4eb40042c1 Support --killdev with PID argument

Diff: https://github.com/xamarin/maccore/compare/8287d1978617996f5a0f1c83c9264cc582c957fe..1c5dfc89f0a104d5ef4fcf839ca2d02acf547415