### PR TITLE
[main] [devops] Fix computing the BRANCH_NAME variable.

### DIFF
--- a/tools/devops/automation/templates/common/setup.yml
+++ b/tools/devops/automation/templates/common/setup.yml
@@ -93,5 +93,7 @@ steps:
 
 - pwsh: |
     # some steps expect this to be set to be able to get the correct nuget name
-    Write-Host "##vso[task.setvariable variable=BRANCH_NAME]$(Build.SourceBranchName)"
+    Write-Host "##vso[task.setvariable variable=BRANCH_NAME]$Env:BRANCH_NAME"
   displayName: 'Set Jenkins variables'
+  variables:
+    BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]

--- a/tools/devops/automation/templates/common/setup.yml
+++ b/tools/devops/automation/templates/common/setup.yml
@@ -95,5 +95,5 @@ steps:
     # some steps expect this to be set to be able to get the correct nuget name
     Write-Host "##vso[task.setvariable variable=BRANCH_NAME]$Env:BRANCH_NAME"
   displayName: 'Set Jenkins variables'
-  variables:
+  env:
     BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]


### PR DESCRIPTION
This is what Azure Devops defines:

* Build.SourceBranchName: the last path component of the branch.
* Build.SourceBranch: the complete ref spec for the branch.

We want the branch name without the 'refs/heads/' part. Unfortunately we can't
use Build.SourceBranchName, because for a branch name like
'release/6.0.3xx-rc1' the last path component is '6.0.3xx-rc1', not
'release/6.0.3xx-rc' - in other words it doesn't have all the information we
need.

That means we need to use the Build.SourceBranch value instead, and remove the
'refs/heads/' part. We already compute BRANCH_NAME like this everywhere else,
so just copy that implementation.


Backport of #14568
