### PR TITLE
[tests] Adjust the Xamarin.Tests.Misc.PublicSymbols test to accept Brotli-related symbols.

### DIFF
--- a/tests/mtouch/MiscTests.cs
+++ b/tests/mtouch/MiscTests.cs
@@ -136,6 +136,9 @@ namespace Xamarin.Tests
 				"___destroy_helper_block_",
 				// compiler-generated helper methods
 				"___os_log_helper_",
+				// Brotli compression symbols
+				"_kBrotli",
+				"__kBrotli",
 			};
 
 			paths.RemoveWhere ((v) => {


### PR DESCRIPTION
Our latest mono bump (in fd772aa82b972b8999caaafe4e34806621c7d360), brought in
these new public symbols. Accept them for now, but hopefully we'll be able to
make them private at some point.

Fixes https://github.com/xamarin/xamarin-macios/issues/14604.