### PR TITLE
[dotnet] Adjust template descriptions to not say .NET 6, just plain .NET instead.

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.cs.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.de.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.es.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.fr.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.it.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ja.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ko.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.pl.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.pt-BR.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.ru.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.tr.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": [ "macOS", "Mac Catalyst" ],
   "identity": "Microsoft.MacCatalyst.MacCatalystApp",
   "name": "MacCatalyst Application (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst application",
+  "description": "A project for creating a .NET MacCatalyst application",
   "shortName": "maccatalyst",
   "tags": {
     "language": "C#",

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.cs.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.de.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.en.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.es.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.fr.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.it.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ja.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ko.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.pl.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.pt-BR.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.ru.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.tr.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library"
+  "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": [ "macOS", "Mac Catalyst" ],
   "identity": "Microsoft.MacCatalyst.MacCatalystBinding",
   "name": "MacCatalyst Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 MacCatalyst binding library",
+  "description": "A project for creating a .NET MacCatalyst binding library",
   "shortName": "maccatalystbinding",
   "tags": {
     "language": "C#",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.cs.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.de.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.es.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.fr.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.it.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ja.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ko.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.pl.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.pt-BR.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.ru.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.tr.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "iOS Application (Preview)",
-  "description": "A project for creating a .NET 6 iOS application",
+  "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",
   "symbols/deviceFamily/choices/universal/description": "Support both iPhone and iPad devices",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/template.json
@@ -4,7 +4,7 @@
     "classifications": [ "iOS", "Mobile" ],
     "identity": "Microsoft.iOS.iOSApp",
     "name": "iOS Application (Preview)",
-    "description": "A project for creating a .NET 6 iOS application",
+    "description": "A project for creating a .NET iOS application",
     "shortName": "ios",
     "tags": {
       "language": "C#",

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.cs.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.de.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.en.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.es.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.fr.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.it.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ja.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ko.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.pl.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.pt-BR.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.ru.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.tr.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library"
+  "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": [ "iOS", "Mobile" ],
   "identity": "Microsoft.iOS.iOSBinding",
   "name": "iOS Binding Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS binding library",
+  "description": "A project for creating a .NET iOS binding library",
   "shortName": "iosbinding",
   "tags": {
     "language": "C#",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.cs.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.de.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.en.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.es.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.fr.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.it.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ja.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ko.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.pl.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.pt-BR.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.ru.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.tr.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library"
+  "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": [ "iOS", "Mobile" ],
   "identity": "Microsoft.iOS.iOSLib",
   "name": "iOS Class Library (Preview)",
-  "description": "A project for creating a .NET 6 iOS class library",
+  "description": "A project for creating a .NET iOS class library",
   "shortName": "ioslib",
   "tags": {
     "language": "C#",

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.cs.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.de.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.es.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.fr.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.it.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ja.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ko.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.pl.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.pt-BR.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.ru.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.tr.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "macOS Application (Preview)",
-  "description": "A project for creating a .NET 6 macOS application",
+  "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/template.json
@@ -4,7 +4,7 @@
     "classifications": [ "macOS" ],
     "identity": "Microsoft.macOS.macOSApp",
     "name": "macOS Application (Preview)",
-    "description": "A project for creating a .NET 6 macOS application",
+    "description": "A project for creating a .NET macOS application",
     "shortName": "macos",
     "tags": {
       "language": "C#",

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.cs.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.de.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.es.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.fr.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.it.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ja.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ko.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.pl.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.pt-BR.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.ru.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.tr.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"
 }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": [ "tvOS", "Mobile" ],
   "identity": "Microsoft.tvOS.tvOSApp",
   "name": "tvOS Application (Preview)",
-  "description": "A project for creating a .NET 6 tvOS application",
+  "description": "A project for creating a .NET tvOS application",
   "shortName": "tvos",
   "tags": {
     "language": "C#",


### PR DESCRIPTION
Makes things easier once we switch to .NET 7.