### PR TITLE
[gamekit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/GameKit/GKScore.cs
+++ b/src/GameKit/GKScore.cs
@@ -53,7 +53,7 @@ namespace GameKit {
 		// start to differ in future releases (in IOS7 it looks like the older is called, nothing else)
 		public GKScore (string categoryOrIdentifier)
 		{
-			if (categoryOrIdentifier == null)
+			if (categoryOrIdentifier is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (categoryOrIdentifier));
 
 #if WATCH

--- a/src/GameKit/GameKit2.cs
+++ b/src/GameKit/GameKit2.cs
@@ -44,7 +44,7 @@ namespace GameKit {
 			[Preserve (Conditional = true)]
 			void Receive (NSData data, string peer, GKSession session, IntPtr context)
 			{
-				if (receiver != null)
+				if (receiver is not null)
 					receiver (session, new GKDataReceivedEventArgs (data, peer, session));
 			}
 				
@@ -55,7 +55,7 @@ namespace GameKit {
 		ReceiverObject? receiver;
 		public event EventHandler<GKDataReceivedEventArgs>? ReceiveData {
 			add {
-				if (receiver == null){
+				if (receiver is null){
 					receiver = new ReceiverObject ();
 					_SetDataReceiveHandler (receiver, IntPtr.Zero);
 					MarkDirty ();
@@ -64,7 +64,7 @@ namespace GameKit {
 			}
 			
 			remove {
-				if (receiver == null)
+				if (receiver is null)
 					return;
 				receiver.receiver -= value;
 			}
@@ -82,7 +82,7 @@ namespace GameKit {
 		Mono_GKSessionDelegate EnsureDelegate ()
 		{
 			var del = WeakDelegate;
-			if (del == null || (!(del is Mono_GKSessionDelegate))){
+			if (del is null || (!(del is Mono_GKSessionDelegate))){
 					del = new Mono_GKSessionDelegate ();
 					WeakDelegate = del;
 			}
@@ -141,21 +141,21 @@ namespace GameKit {
 		[Preserve (Conditional = true)]
 		public override void PeerChangedState (GKSession session, string peerID, GKPeerConnectionState state)
 		{
-			if (cbPeerChanged != null)
+			if (cbPeerChanged is not null)
 				cbPeerChanged (session, new GKPeerChangedStateEventArgs (session, peerID, state));
 		}
 		
 		[Preserve (Conditional = true)]
 		public override void PeerConnectionRequest (GKSession session, string peerID)
 		{
-			if (cbConnectionRequest != null)
+			if (cbConnectionRequest is not null)
 				cbConnectionRequest (session, new GKPeerConnectionEventArgs (session, peerID, null));
 		}
 			
 		[Preserve (Conditional = true)]
 		public override void PeerConnectionFailed (GKSession session, string peerID, NSError error)
 		{
-			if (cbConnectionFailed != null)
+			if (cbConnectionFailed is not null)
 				cbConnectionFailed (session, new GKPeerConnectionEventArgs (session, peerID, error));
 
 		}
@@ -163,7 +163,7 @@ namespace GameKit {
 		[Preserve (Conditional = true)]
 		public override void FailedWithError (GKSession session, NSError error)
 		{
-			if (cbFailedWithError != null)
+			if (cbFailedWithError is not null)
 				cbFailedWithError (session, new GKPeerConnectionEventArgs (session, null, error));
 		}
 	}
@@ -201,7 +201,7 @@ namespace GameKit {
 		[Obsolete ("Use 'SetMute (bool, string)' method.")]
 		public virtual void SetMute (bool isMuted, GKPlayer player)
 		{
-			if (player == null)
+			if (player is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (player));
 
 			SetMute (isMuted, player.PlayerID);


### PR DESCRIPTION
This PR aims to bring nullability changes to GameKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

Changing any == null or != null to is null and is not null