### PR TITLE
[iosurface] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/IOSurface/IODefs.cs
+++ b/src/IOSurface/IODefs.cs
@@ -7,6 +7,8 @@
 // Copyright 2017 Microsoft
 //
 
+#nullable enable
+
 using System;
 using ObjCRuntime;
 

--- a/src/IOSurface/IOSurface.cs
+++ b/src/IOSurface/IOSurface.cs
@@ -23,6 +23,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using CoreFoundation;

--- a/src/IOSurface/IOSurfacePropertyKey.cs
+++ b/src/IOSurface/IOSurfacePropertyKey.cs
@@ -23,6 +23,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using Foundation;
 using ObjCRuntime;


### PR DESCRIPTION
This PR aims to bring nullability changes to IOSurface.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes