### PR TITLE
Use the tip of the 6.0.3xx-rc1 branch as the baseline for .NET API diffs.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -38,10 +38,10 @@ include $(TOP)/Make.versions
 
 APIDIFF_REFERENCES_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/xcode13.1/8fd9e62891f8e4fbaa040cdfbf8b96467060c85c/5371501/package/bundle.zip
 APIDIFF_REFERENCES_Mac=https://bosstoragemirror.blob.core.windows.net/wrench/xcode13.1/8fd9e62891f8e4fbaa040cdfbf8b96467060c85c/5371501/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/main/e25163f573d31b28fa60f000ce084b8cdb0ca697/5763690/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_tvOS=https://bosstoragemirror.blob.core.windows.net/wrench/main/e25163f573d31b28fa60f000ce084b8cdb0ca697/5763690/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_macOS=https://bosstoragemirror.blob.core.windows.net/wrench/main/e25163f573d31b28fa60f000ce084b8cdb0ca697/5763690/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_MacCatalyst=https://bosstoragemirror.blob.core.windows.net/wrench/main/e25163f573d31b28fa60f000ce084b8cdb0ca697/5763690/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.3xx-rc1/9f2735684cbb390bb4fd98171e473e2d875d0627/5970061/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_tvOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.3xx-rc1/9f2735684cbb390bb4fd98171e473e2d875d0627/5970061/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_macOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.3xx-rc1/9f2735684cbb390bb4fd98171e473e2d875d0627/5970061/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_MacCatalyst=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.3xx-rc1/9f2735684cbb390bb4fd98171e473e2d875d0627/5970061/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION
Since we're not planning on any more breaking changes after RC 1, we can
ensure we don't have any accidental breaking changes by using the RC 1
assemblies as the baseline.