### PR TITLE
[xcode13.3] [msbuild] Make codesigned output files relative, and don't list directories.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -429,6 +429,28 @@ namespace Xamarin.MacDev.Tasks
 				});
 			}
 
+			// The list of codesigned files has two requirements for Windows:
+			// * Only files, no directories
+			// * No absolute paths.
+			for (var i = codesignedFiles.Count - 1; i >= 0; i--) {
+				var item = codesignedFiles [i];
+				// Remove directories
+				if (Directory.Exists (item.ItemSpec)) {
+					codesignedFiles.RemoveAt (i);
+					continue;
+				}
+				if (!Path.IsPathRooted (item.ItemSpec))
+					continue;
+
+				// Make path relative. Unfortunately Path.GetRelativePath isn't available in netstandard2.0, which we're targetting, so use a very simple substitute.
+				var absolutePath = item.ItemSpec;
+				var relativeTo = Environment.CurrentDirectory;
+				if (absolutePath.StartsWith (relativeTo, StringComparison.Ordinal)) {
+					var relativePath = absolutePath.Substring (relativeTo.Length);
+					relativePath = relativePath.TrimStart (Path.DirectorySeparatorChar);
+					codesignedFiles [i] = new TaskItem (relativePath);
+				}
+			}
 			CodesignedFiles = codesignedFiles.ToArray ();
 
 			return !Log.HasLoggedErrors;


### PR DESCRIPTION
When XVS creates output/stamp files on Windows, the paths must be relative,
because otherwise XVS will append the full macOS path to the current Windows
directory and get garbage.

XVS also expects only files as output, so don't return any directories.

Fixes part of https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1505990/.


Backport of #14610
