### PR TITLE
[tests] Request labels after each test from NUnit.

### DIFF
--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -10,7 +10,7 @@ build-unit-tests:
 
 run-unit-tests: build-unit-tests
 	rm -f .failed-stamp
-	$(TOP)/tools/nunit3-console-3.11.1 $(abspath $(TOP)/tests/generator/bin/Debug/generator-tests.dll) "--result=$(abspath $(CURDIR)/TestResult.xml);format=nunit2" $(TEST_FIXTURE) --labels=All || touch $(CURDIR)/.failed-stamp
+	$(TOP)/tools/nunit3-console-3.11.1 $(abspath $(TOP)/tests/generator/bin/Debug/generator-tests.dll) "--result=$(abspath $(CURDIR)/TestResult.xml);format=nunit2" $(TEST_FIXTURE) --labels=After || touch $(CURDIR)/.failed-stamp
 	@# Create an html file and tell MonkeyWrench to upload it (if we're running there)
 	@[[ -z "$$BUILD_REPOSITORY" ]] || \
 		( xsltproc $(TOP)/tests/HtmlTransform.xslt TestResult.xml  > index.html && \

--- a/tests/mmptest/Makefile
+++ b/tests/mmptest/Makefile
@@ -29,7 +29,7 @@ endif
 
 run: build
 	rm -f .failed-stamp
-	$(TOP)/tools/nunit3-console-3.11.1 $(abspath $(TOP)/tests/mmptest/bin/Debug/mmptest.dll) "--result=$(abspath $(CURDIR)/TestResult.xml);format=nunit2" $(TEST_FIXTURE) --labels=All || touch $(CURDIR)/.failed-stamp
+	$(TOP)/tools/nunit3-console-3.11.1 $(abspath $(TOP)/tests/mmptest/bin/Debug/mmptest.dll) "--result=$(abspath $(CURDIR)/TestResult.xml);format=nunit2" $(TEST_FIXTURE) --labels=After || touch $(CURDIR)/.failed-stamp
 	@# Create an html file and tell MonkeyWrench to upload it (if we're running there)
 	@[[ -z "$$BUILD_REPOSITORY" ]] || \
 		( xsltproc $(TOP)/tests/HtmlTransform.xslt TestResult.xml  > index.html && \

--- a/tests/mtouch/Makefile
+++ b/tests/mtouch/Makefile
@@ -20,7 +20,7 @@ all-local::
 
 run-tests: bin/Debug/mtouchtests.dll test.config
 	rm -f .failed-stamp
-	$(TOP)/tools/nunit3-console-3.11.1 "$(abspath $<)" "--result=$(abspath $(CURDIR)/TestResult.xml);format=nunit2" $(TEST_FIXTURE) --labels=All --inprocess || touch $(CURDIR)/.failed-stamp
+	$(TOP)/tools/nunit3-console-3.11.1 "$(abspath $<)" "--result=$(abspath $(CURDIR)/TestResult.xml);format=nunit2" $(TEST_FIXTURE) --labels=After --inprocess || touch $(CURDIR)/.failed-stamp
 	@# Create an html file and tell MonkeyWrench to upload it (if we're running there)
 	@[[ -z "$$BUILD_REPOSITORY" ]] || \
 		( xsltproc $(TOP)/tests/HtmlTransform.xslt TestResult.xml  > index.html && \

--- a/tests/sampletester/Makefile
+++ b/tests/sampletester/Makefile
@@ -14,7 +14,7 @@ build: bin/Debug/sampletester.dll
 
 run-tests: bin/Debug/sampletester.dll
 	$(Q) rm -f .failed-stamp
-	$(Q) $(TOP)/tools/nunit3-console-3.11.1 $(WHERE_CONDITION) $(abspath $(CURDIR)/bin/Debug/sampletester.dll) "--result=$(abspath $(CURDIR)/$(TEST_RESULT).xml)" $${TEST_FIXTURE:+"$$TEST_FIXTURE"} --labels=All --inprocess || touch $(CURDIR)/.failed-stamp
+	$(Q) $(TOP)/tools/nunit3-console-3.11.1 $(WHERE_CONDITION) $(abspath $(CURDIR)/bin/Debug/sampletester.dll) "--result=$(abspath $(CURDIR)/$(TEST_RESULT).xml)" $${TEST_FIXTURE:+"$$TEST_FIXTURE"} --labels=After --inprocess || touch $(CURDIR)/.failed-stamp
 	$(Q) xsltproc HtmlReport.xslt "$(TEST_RESULT).xml" > "$(TEST_RESULT).html"
 	$(Q) $(CP) "$(TEST_RESULT).html" index.html
 	@[[ ! -e .failed-stamp ]]

--- a/tests/xharness/Jenkins/TestTasks/NUnitExecuteTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/NUnitExecuteTask.cs
@@ -143,7 +143,7 @@ namespace Xharness.Jenkins.TestTasks {
 				args.Add (Path.GetFullPath (TestLibrary));
 				if (IsNUnit3) {
 					args.Add ("-result=" + xmlLog + ";format=nunit2");
-					args.Add ("--labels=All");
+					args.Add ("--labels=After");
 					if (InProcess)
 						args.Add ("--inprocess");
 				} else {


### PR DESCRIPTION
Fixes this NUnit warning:

> labels=All is deprecated and will be removed in a future release. Please use labels=Before instead.

We don't follow the suggestion from the warning, because the advantage of
writing the label after each test is that the test result will also be
printed, which means it's possible to see if any tests failed during the test
run, as opposed to having to wait until the entire test run is completed
(which can take a while) to realize that pretty much every test failed with
some silly mistake which could have been quickly fixed before re-running the
tests.