### PR TITLE
[imagekit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/ImageKit/Enums.cs
+++ b/src/ImageKit/Enums.cs
@@ -26,6 +26,9 @@
 //
 // Enums.cs: Enums for ImageKit
 //
+
+#nullable enable
+
 using System;
 
 using ObjCRuntime;


### PR DESCRIPTION
This PR aims to bring nullability changes to ImageKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
