### PR TITLE
[inputmethodkit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/InputMethodKit/Enums.cs
+++ b/src/InputMethodKit/Enums.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace InputMethodKit {
 
 	[Native]


### PR DESCRIPTION
This PR aims to bring nullability changes to InputMethodKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes

* This one was not in the src/frameworks.source either, but I will document this to fix later!