### PR TITLE
Fix multiple API mistakes made in define removal

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -538,7 +538,7 @@ namespace Foundation
 		CGRect GetBoundingRect (CGSize size, NSStringDrawingOptions options, [NullAllowed] NSStringDrawingContext context);
 #endif
 
-		[NoMac]
+		[MacCatalyst (13, 1)][TV (9, 0)][Mac (10, 0)][iOS (6, 0)]
 		[Export ("size")]
 		CGSize Size { get; }
 

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -858,7 +858,7 @@ namespace MapKit {
 		NativeHandle Constructor (CLLocationCoordinate2D coordinate, [NullAllowed] NSDictionary addressDictionary);
 
 		// This requires the AddressBook framework, which afaict isn't bound on Mac, tvOS and watchOS yet
-		[NoMac][NoMacCatalyst][NoWatch][NoTV]
+		[NoMac][NoWatch][NoTV]
 		[Wrap ("this (coordinate, addressDictionary.GetDictionary ())")]
 		NativeHandle Constructor (CLLocationCoordinate2D coordinate, MKPlacemarkAddress addressDictionary);
 
@@ -878,7 +878,7 @@ namespace MapKit {
 		string CountryCode { get; }
 	}
 		
-	[NoMac][NoMacCatalyst][NoWatch][NoTV]
+	[NoMac][NoWatch][NoTV]
 	[BaseType (typeof (NSObject))]
 	[Deprecated (PlatformName.iOS, 5, 0, message: "Use 'CoreLocation.CLGeocoder' instead.")]
 	// crash (at least) at Dispose time when instance is created by 'init'
@@ -911,7 +911,9 @@ namespace MapKit {
 	}
 
 #pragma warning disable 618
-	[NoMac][NoMacCatalyst][NoWatch][NoTV]
+	[NoMac][NoWatch][NoTV][MacCatalyst (13, 1)]
+	[Deprecated (PlatformName.iOS, 5, 0)]
+	[Deprecated (PlatformName.MacCatalyst, 13, 1)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/quicklook.cs
+++ b/src/quicklook.cs
@@ -34,9 +34,6 @@ using CoreGraphics;
 #if MONOMAC
 using AppKit;
 using UIWindowSceneActivationConfiguration=Foundation.NSObject;
-using UIViewController = AppKit.NSViewController;
-using UIView = AppKit.NSView;
-using UIImage = AppKit.NSImage;
 #else
 using UIKit;
 #endif
@@ -49,7 +46,7 @@ using NativeHandle = System.IntPtr;
 #endif
 
 namespace QuickLook {
-	[NoMac]
+#if !MONOMAC
 	[BaseType (typeof (UIViewController), Delegates = new string [] { "WeakDelegate" }, Events=new Type [] { typeof (QLPreviewControllerDelegate)})]
 	interface QLPreviewController {
 		[Export ("initWithNibName:bundle:")]
@@ -89,7 +86,6 @@ namespace QuickLook {
 		void RefreshCurrentPreviewItem ();
 	}
 
-	[NoMac]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -104,7 +100,6 @@ namespace QuickLook {
 		QLPreviewItem GetPreviewItem (QLPreviewController controller, nint index);
 	}
 
-	[NoMac]
 	[iOS (13,0)]
 	[Native]
 	public enum QLPreviewItemEditingMode : long {
@@ -113,7 +108,6 @@ namespace QuickLook {
 		CreateCopy,
 	}
 
-	[NoMac]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -127,6 +121,7 @@ namespace QuickLook {
 		[Export ("previewController:shouldOpenURL:forPreviewItem:"), DelegateName ("QLOpenUrl"), DefaultValue (false)]
 		bool ShouldOpenUrl (QLPreviewController controller, NSUrl url, [Protocolize] QLPreviewItem item);
 
+#if !MONOMAC
 		// UIView and UIImage do not exists in MonoMac
 		
 		[Export ("previewController:frameForPreviewItem:inSourceView:"), DelegateName ("QLFrame"), DefaultValue (typeof (CGRect))]
@@ -152,12 +147,12 @@ namespace QuickLook {
 		[iOS (13,0)]
 		[Export ("previewController:didSaveEditedCopyOfPreviewItem:atURL:"), EventArgs ("QLPreviewControllerDelegateDidSave")]
 		void DidSaveEditedCopy (QLPreviewController controller, IQLPreviewItem previewItem, NSUrl modifiedContentsUrl);
+
+#endif
 	}
 
-	[NoMac]
 	interface IQLPreviewItem {}
 
-	[NoMac]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -252,7 +247,6 @@ namespace QuickLook {
 		nint InitialPreviewIndex { get; set; }
 	}
 
-	[NoMac]
 	[iOS (15,0), MacCatalyst (15,0)]
 	[BaseType (typeof(UIWindowSceneActivationConfiguration))]
 	interface QLPreviewSceneActivationConfiguration
@@ -267,7 +261,6 @@ namespace QuickLook {
 		NativeHandle Constructor (NSUserActivity userActivity);
 	}
 
-	[NoMac]
 	[iOS (11,0)]
 	[Protocol]
 	interface QLPreviewingController {
@@ -281,8 +274,7 @@ namespace QuickLook {
 		[Export ("providePreviewForFileRequest:completionHandler:")]
 		void ProvidePreview (QLFilePreviewRequest request, Action<QLPreviewReply, NSError> handler);
 	}
-
-	[NoiOS][NoMacCatalyst]
+#else
 	[Static]
 	interface QLThumbnailImage {
 		[Internal, Field ("kQLThumbnailOptionScaleFactorKey")]
@@ -291,4 +283,6 @@ namespace QuickLook {
 		[Internal, Field ("kQLThumbnailOptionIconModeKey")]
 		NSString OptionIconModeKey { get; }
 	}
+#endif
+
 }

--- a/src/quicklook.cs
+++ b/src/quicklook.cs
@@ -47,6 +47,7 @@ using NativeHandle = System.IntPtr;
 
 namespace QuickLook {
 #if !MONOMAC
+	[NoMac]
 	[BaseType (typeof (UIViewController), Delegates = new string [] { "WeakDelegate" }, Events=new Type [] { typeof (QLPreviewControllerDelegate)})]
 	interface QLPreviewController {
 		[Export ("initWithNibName:bundle:")]
@@ -89,6 +90,7 @@ namespace QuickLook {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
+	[NoMac]
 	interface QLPreviewControllerDataSource {
 		[Abstract]
 		[Export ("numberOfPreviewItemsInPreviewController:")]
@@ -100,6 +102,7 @@ namespace QuickLook {
 		QLPreviewItem GetPreviewItem (QLPreviewController controller, nint index);
 	}
 
+	[NoMac]
 	[iOS (13,0)]
 	[Native]
 	public enum QLPreviewItemEditingMode : long {
@@ -108,6 +111,7 @@ namespace QuickLook {
 		CreateCopy,
 	}
 
+	[NoMac]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -153,6 +157,7 @@ namespace QuickLook {
 
 	interface IQLPreviewItem {}
 
+	[NoMac]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -180,7 +185,8 @@ namespace QuickLook {
 	delegate NSData QLPreviewReplyDataCreationHandler (QLPreviewReply reply, out NSError error);
 	delegate CGPDFDocument QLPreviewReplyUIDocumentCreationHandler (QLPreviewReply reply, out NSError error);
 
-	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
+	[NoMac]
+	[NoWatch, NoTV, iOS (15,0), MacCatalyst (15,0)]
 	[BaseType (typeof(NSObject))]
 	interface QLPreviewReply
 	{
@@ -207,7 +213,8 @@ namespace QuickLook {
 		NativeHandle Constructor (CGSize defaultPageSize, QLPreviewReplyUIDocumentCreationHandler documentCreationHandler);
 	}
 
-	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
+	[NoMac]
+	[NoWatch, NoTV, iOS (15,0), MacCatalyst (15,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
 	interface QLPreviewReplyAttachment
@@ -222,7 +229,8 @@ namespace QuickLook {
 		NativeHandle Constructor (NSData data, UTType contentType);
 	}
 
-	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
+	[NoMac]
+	[NoWatch, NoTV, iOS (15,0), MacCatalyst (15,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
 	interface QLFilePreviewRequest
@@ -231,7 +239,8 @@ namespace QuickLook {
 		NSUrl FileUrl { get; }
 	}
 
-	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
+	[NoMac]
+	[NoWatch, NoTV, iOS (15,0), MacCatalyst (15,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof(NSObject))]
 	interface QLPreviewProvider : NSExtensionRequestHandling
@@ -247,6 +256,7 @@ namespace QuickLook {
 		nint InitialPreviewIndex { get; set; }
 	}
 
+	[NoMac]
 	[iOS (15,0), MacCatalyst (15,0)]
 	[BaseType (typeof(UIWindowSceneActivationConfiguration))]
 	interface QLPreviewSceneActivationConfiguration
@@ -261,6 +271,7 @@ namespace QuickLook {
 		NativeHandle Constructor (NSUserActivity userActivity);
 	}
 
+	[NoMac]
 	[iOS (11,0)]
 	[Protocol]
 	interface QLPreviewingController {
@@ -276,6 +287,7 @@ namespace QuickLook {
 	}
 #else
 	[Static]
+	[NoiOS][NoMacCatalyst][NoWatch][NoTV]
 	interface QLThumbnailImage {
 		[Internal, Field ("kQLThumbnailOptionScaleFactorKey")]
 		NSString OptionScaleFactorKey { get; }

--- a/src/quicklookUI.cs
+++ b/src/quicklookUI.cs
@@ -6,7 +6,6 @@ using AppKit;
 using System;
 using System.ComponentModel;
 using UniformTypeIdentifiers;
-using QuickLook;
 
 #if !NET
 using NativeHandle = System.IntPtr;
@@ -182,5 +181,67 @@ namespace QuickLookUI {
 		[iOS (15,0), Mac (12,0), MacCatalyst (15,0)]
 		[Export ("providePreviewForFileRequest:completionHandler:")]
 		void ProvidePreview (QLFilePreviewRequest request, Action<QLPreviewReply, NSError> handler);
+	}
+
+	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
+	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor]
+	interface QLFilePreviewRequest
+	{
+		[Export ("fileURL")]
+		NSUrl FileUrl { get; }
+	}
+
+	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
+	[DisableDefaultCtor]
+	[BaseType (typeof(NSObject))]
+	interface QLPreviewProvider : NSExtensionRequestHandling
+	{
+	}
+
+	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
+	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor]
+	interface QLPreviewReplyAttachment
+	{
+		[Export ("data")]
+		NSData Data { get; }
+
+		[Export ("contentType")]
+		UTType ContentType { get; }
+
+		[Export ("initWithData:contentType:")]
+		NativeHandle Constructor (NSData data, UTType contentType);
+	}
+
+	delegate bool QLPreviewReplyDrawingHandler (CGContext context, QLPreviewReply reply, out NSError error);
+	delegate NSData QLPreviewReplyDataCreationHandler (QLPreviewReply reply, out NSError error);
+	delegate CGPDFDocument QLPreviewReplyUIDocumentCreationHandler (QLPreviewReply reply, out NSError error);
+
+	[NoWatch, NoTV, Mac (12,0), iOS (15,0), MacCatalyst (15,0)]
+	[BaseType (typeof(NSObject))]
+	interface QLPreviewReply
+	{
+		[Export ("stringEncoding")]
+		NSStringEncoding StringEncoding { get; set; }
+
+		[Export ("attachments", ArgumentSemantic.Copy)]
+		NSDictionary<NSString, QLPreviewReplyAttachment> Attachments { get; set; }
+
+		[Export ("title")]
+		string Title { get; set; }
+
+		[Export ("initWithContextSize:isBitmap:drawingBlock:")]
+		NativeHandle Constructor (CGSize contextSize, bool isBitmap, QLPreviewReplyDrawingHandler drawingHandler);
+
+		[Export ("initWithFileURL:")]
+		NativeHandle Constructor (NSUrl fileUrl);
+
+		[Export ("initWithDataOfContentType:contentSize:dataCreationBlock:")]
+		NativeHandle Constructor (UTType contentType, CGSize contentSize, QLPreviewReplyDataCreationHandler dataCreationHandler);
+
+		// QLPreviewReply_UI
+		[Export ("initForPDFWithPageSize:documentCreationBlock:")]
+		NativeHandle Constructor (CGSize defaultPageSize, QLPreviewReplyUIDocumentCreationHandler documentCreationHandler);
 	}
 }


### PR DESCRIPTION
- A number of small correction in foundation and mapkit
- The [quicklook PR](https://github.com/xamarin/xamarin-macios/pull/14491) was completed reverted and redone
- Instead of trying to remove duplication (which can't be done since they are in different namespaces), I just took the originals and slapped attributes [NoMac] or NoEverythingElse on everything.

In the future we can do a better quicklook job, but this is good enough, and we have time pressure due to branching. 

API diff run locally. Only green additions, and each of those was confirmed to be either valid addition from a define removal or unrelated to a define removal PR. 