### PR TITLE
Updated Xamarin.Messaging version to 1.5.27

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.5.24</MessagingVersion>
+		<MessagingVersion>1.5.27</MessagingVersion>
 		<HotRestartVersion>1.0.90</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Includes an important fix for an MSBuild hang when the connection to the Mac can't be established