### PR TITLE
[tests] A few test fixes to make testing system installs better.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -254,7 +254,11 @@ MAC_CXX=$(CCACHE)$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr
 MAC_INSTALL_VERSION ?= git
 IOS_INSTALL_VERSION ?= git
 
+ifneq ($(TESTS_USE_SYSTEM),)
+IOS_DESTDIR ?= /
+else
 IOS_DESTDIR ?= $(TOP)/_ios-build
+endif
 IOS_TARGETDIR ?= $(IOS_DESTDIR)
 
 USE_SOURCE_LINKS ?= 1
@@ -442,7 +446,11 @@ MACOS_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(MACOS_NUGET_VERSION)))
 MACOS_NUGET_VERSION_NO_METADATA=$(MACOS_NUGET_VERSION)-$(NUGET_PRERELEASE_IDENTIFIER)$(MACOS_NUGET_COMMIT_DISTANCE)
 MACOS_NUGET_VERSION_FULL=$(MACOS_NUGET_VERSION_NO_METADATA)+$(NUGET_BUILD_METADATA)
 
+ifneq ($(TESTS_USE_SYSTEM),)
+MAC_DESTDIR ?= /
+else
 MAC_DESTDIR ?= $(TOP)/_mac-build
+endif
 MAC_TARGETDIR ?= $(MAC_DESTDIR)
 
 # make sure we have full paths. The patsubst function is to remove any trailing slash (this may leave the variable empty)

--- a/tests/test-libraries/custom-type-assembly/Makefile
+++ b/tests/test-libraries/custom-type-assembly/Makefile
@@ -3,13 +3,22 @@ TOP=../../..
 include $(TOP)/Make.config
 
 .libs/macos/custom-type-assembly.dll: custom-type-assembly.cs Makefile | .libs/macos
-	$(Q_CSC) $(MAC_mobile_CSC) $< -out:$@ -r:$(TOP)/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/Xamarin.Mac/Xamarin.Mac.dll -target:library
+	$(Q_CSC) $(MAC_mobile_CSC) $< -out:$@ -r:$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/Xamarin.Mac/Xamarin.Mac.dll -target:library /nologo
 
-.libs/dotnet/macos/custom-type-assembly.dll: custom-type-assembly.cs Makefile | .libs/dotnet/macos
-	$(Q_CSC) $(DOTNET_CSC) $< -out:$@ -r:$(TOP)/_build/Microsoft.macOS.Ref/ref/$(DOTNET_TFM)/Microsoft.macOS.dll -target:library -r:$(DOTNET_BCL_DIR)/System.Runtime.dll /nologo
+.libs/dotnet/macos/custom-type-assembly.dll: bin/Debug/$(DOTNET_TFM)-macos/custom-type-assembly.dll | .libs/dotnet/macos
+	$(Q) $(CP) $< $@
 
 .libs/macos .libs/dotnet/macos:
 	$(Q) mkdir -p $@
+
+NuGet.config: $(TOP)/tests/dotnet/NuGet.config
+	$(Q) $(CP) $< $@
+
+global.json: $(TOP)/tests/dotnet/global.json
+	$(Q) $(CP) $< $@
+
+bin/Debug/$(DOTNET_TFM)-macos/custom-type-assembly.dll: custom-type-assembly.csproj custom-type-assembly.cs global.json NuGet.config
+	$(Q) $(DOTNET) build $< "/bl:$@.binlog" $(MSBUILD_VERBOSITY)
 
 ifdef INCLUDE_XAMARIN_LEGACY
 TARGETS += \

--- a/tests/test-libraries/custom-type-assembly/custom-type-assembly.csproj
+++ b/tests/test-libraries/custom-type-assembly/custom-type-assembly.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+  </PropertyGroup>
+</Project>
+

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -310,7 +310,7 @@
   </Target>
   <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" DependsOnTargets="CustomMetalSmelting"
       Condition="!Exists('$(TestLibrariesDirectory)/.libs/macos/custom-type-assembly.dll') Or !Exists('$(TestLibrariesDirectory)/.libs/dotnet/macos/custom-type-assembly.dll')" >
-    <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
-    <Exec Command="make -j8 -C $(TestLibrariesDirectory)/custom-type-assembly build-assembly" />
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)" EnvironmentVariables="MSBUILD_EXE_PATH=;MSBuildSDKsPath="/>
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)/custom-type-assembly build-assembly" EnvironmentVariables="MSBUILD_EXE_PATH=;MSBuildSDKsPath="/>
   </Target>
 </Project>


### PR DESCRIPTION
* Make the custom-type-assembly library build using assemblies relative to
  MAC_DESTDIR, instead of poking into $(TOP)/_mac-build (for legacy Xamarin).
* Build the custom-type-assembly using a project file for .NET (and use our
  local .NET).
* Change the default for [IOS|MAC]_DESTDIR when TESTS_USE_SYSTEM is set to
  point to the system installation.
* Make sure 'MSBuildSDKsPath' isn't set when building the custom-type-assembly
  (set by xibuild), it breaks a lot of things.