### PR TITLE
[builds] Don't use DOTNET6_VERSION anymore, it's DOTNET_VERSION.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -82,7 +82,7 @@ downloads/$(basename $(basename $(DOTNET_TARBALL_NAME))): dotnet-install.sh
 # This is just a helpful target to print the url to the .pkg to download and install the current .NET version into the system.
 print-dotnet-pkg-urls: dotnet-install.sh
 	$(Q) rm -f $@-found-it.stamp
-	$(Q) for url in $$(./dotnet-install.sh --version "$(DOTNET6_VERSION)" --architecture x64 --no-path $$DOTNET_INSTALL_EXTRA_ARGS --dry-run | grep URL.*primary: | sed 's/.*primary: //'); do \
+	$(Q) for url in $$(./dotnet-install.sh --version "$(DOTNET_VERSION)" --architecture x64 --no-path $$DOTNET_INSTALL_EXTRA_ARGS --dry-run | grep URL.*primary: | sed 's/.*primary: //'); do \
 		pkg=$${url/tar.gz/pkg}; \
 		if curl -LI --fail "$$pkg" >/dev/null 2>&1; then echo "$$pkg"; touch $@-found-it.stamp; break; fi; \
 	done


### PR DESCRIPTION
This wasn't caught when we renamed DOTNET6_VERSION to DOTNET_VERSION (probably
because it was in the process of being added in a different PR).