### PR TITLE
[mediaaccessibility] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/MediaAccessibility/MAImageCaptioning.cs
+++ b/src/MediaAccessibility/MAImageCaptioning.cs
@@ -29,7 +29,7 @@ namespace MediaAccessibility {
 		static public string? GetCaption (NSUrl url, out NSError? error)
 		{
 			if (url == null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			var result = MAImageCaptioningCopyCaption (url.Handle, out var e);
 			error = e == IntPtr.Zero ? null : new NSError (e);
@@ -43,7 +43,7 @@ namespace MediaAccessibility {
 		static public bool SetCaption (NSUrl url, string @string, out NSError? error)
 		{
 			if (url == null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			var s = CFString.CreateNative (@string);
 			try {

--- a/src/MediaAccessibility/MAImageCaptioning.cs
+++ b/src/MediaAccessibility/MAImageCaptioning.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -24,7 +26,7 @@ namespace MediaAccessibility {
 		// __attribute__((cf_returns_retained))
 		static extern /* CFStringRef _Nullable */ IntPtr MAImageCaptioningCopyCaption (/* CFURLRef _Nonnull */ IntPtr url, /* CFErrorRef _Nullable * */ out IntPtr error);
 
-		static public string GetCaption (NSUrl url, out NSError error)
+		static public string? GetCaption (NSUrl url, out NSError? error)
 		{
 			if (url == null)
 				throw new ArgumentNullException (nameof (url));
@@ -38,12 +40,12 @@ namespace MediaAccessibility {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool MAImageCaptioningSetCaption (/* CFURLRef _Nonnull */ IntPtr url, /* CFStringRef _Nullable */ IntPtr @string, /* CFErrorRef _Nullable * */ out IntPtr error);
 
-		static public bool SetCaption (NSUrl url, string @string, out NSError error)
+		static public bool SetCaption (NSUrl url, string @string, out NSError? error)
 		{
 			if (url == null)
 				throw new ArgumentNullException (nameof (url));
 
-			var s = NSString.CreateNative (@string);
+			var s = CFString.CreateNative (@string);
 			try {
 				var result = MAImageCaptioningSetCaption (url.Handle, s, out var e);
 				error = e == IntPtr.Zero ? null : new NSError (e);
@@ -57,7 +59,7 @@ namespace MediaAccessibility {
 		// __attribute__((cf_returns_retained))
 		static extern /* CFStringRef _Nonnull */ IntPtr MAImageCaptioningCopyMetadataTagPath ();
 
-		static public string GetMetadataTagPath ()
+		static public string? GetMetadataTagPath ()
 		{
 			return CFString.FromHandle (MAImageCaptioningCopyMetadataTagPath (), releaseHandle: true);
 		}

--- a/src/MediaAccessibility/MAImageCaptioning.cs
+++ b/src/MediaAccessibility/MAImageCaptioning.cs
@@ -28,7 +28,7 @@ namespace MediaAccessibility {
 
 		static public string? GetCaption (NSUrl url, out NSError? error)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			var result = MAImageCaptioningCopyCaption (url.Handle, out var e);
@@ -42,7 +42,7 @@ namespace MediaAccessibility {
 
 		static public bool SetCaption (NSUrl url, string @string, out NSError? error)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			var s = CFString.CreateNative (@string);

--- a/src/MediaAccessibility/MediaAccessibility.cs
+++ b/src/MediaAccessibility/MediaAccessibility.cs
@@ -249,7 +249,7 @@ namespace MediaAccessibility {
 #endif
 		public static void DidDisplayCaptions (string[] strings)
 		{
-			if ((strings == null) || (strings.Length == 0))
+			if ((strings is null) || (strings.Length == 0))
 				MACaptionAppearanceDidDisplayCaptions (IntPtr.Zero);
 			else {
 				using (var array = NSArray.FromStrings (strings))
@@ -270,7 +270,7 @@ namespace MediaAccessibility {
 		{
 			// CFAttributedString is “toll-free bridged” with its Foundation counterpart, NSAttributedString.
 			// https://developer.apple.com/documentation/corefoundation/cfattributedstring?language=objc
-			if ((strings == null) || (strings.Length == 0))
+			if ((strings is null) || (strings.Length == 0))
 				MACaptionAppearanceDidDisplayCaptions (IntPtr.Zero);
 			else {
 				using (var array = NSArray.FromNSObjects (strings))

--- a/src/MediaAccessibility/MediaAccessibility.cs
+++ b/src/MediaAccessibility/MediaAccessibility.cs
@@ -6,6 +6,8 @@
 //
 // Copyright 2013, 2015 Xamarin Inc.
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -28,13 +30,13 @@ namespace MediaAccessibility {
 
 #if !NET
 		// FIXME: make this a real notification
-		public static readonly NSString SettingsChangedNotification;
+		public static readonly NSString? SettingsChangedNotification;
 
 		[Advice ("Use 'MediaCharacteristic.DescribesMusicAndSoundForAccessibility' getter.")]
-		public static readonly NSString MediaCharacteristicDescribesMusicAndSoundForAccessibility;
+		public static readonly NSString? MediaCharacteristicDescribesMusicAndSoundForAccessibility;
 
 		[Advice ("Use 'MediaCharacteristic.TranscribesSpokenDialogForAccessibility' getter.")]
-		public static readonly NSString MediaCharacteristicTranscribesSpokenDialogForAccessibility;
+		public static readonly NSString? MediaCharacteristicTranscribesSpokenDialogForAccessibility;
 
 		static MACaptionAppearance ()
 		{
@@ -64,10 +66,10 @@ namespace MediaAccessibility {
 		[DllImport (Constants.MediaAccessibilityLibrary)]
 		static extern /* CFArrayRef __nonnull */ IntPtr MACaptionAppearanceCopySelectedLanguages (nint domain);
 
-		public static string [] GetSelectedLanguages (MACaptionAppearanceDomain domain)
+		public static string? [] GetSelectedLanguages (MACaptionAppearanceDomain domain)
 		{
 			using (var langs = new CFArray (MACaptionAppearanceCopySelectedLanguages ((int) domain), owns: true)) {
-				var languages = new string [langs.Count];
+				var languages = new string? [langs.Count];
 				for (int i = 0; i < langs.Count; i++) {
 					languages[i] = CFString.FromHandle (langs.GetValue (i));
 				}
@@ -290,7 +292,7 @@ namespace MediaAccessibility {
 
 		// according to webkit source code (the only use I could find) this is an array of CFString
 		// https://github.com/WebKit/webkit/blob/master/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
-		static public string[] GetPreferredCharacteristics ()
+		static public string?[]? GetPreferredCharacteristics ()
 		{
 			var handle = MAAudibleMediaCopyPreferredCharacteristics ();
 			if (handle == IntPtr.Zero)


### PR DESCRIPTION
This PR aims to bring nullability changes to MediaAccessibility.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`