### PR TITLE
[javascriptcore] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/JavaScriptCore/Extensions.cs
+++ b/src/JavaScriptCore/Extensions.cs
@@ -6,6 +6,8 @@
 //
 // Copyright 2013 Xamarin, Inc.
 
+#nullable enable
+
 using System;
 using Foundation;
 


### PR DESCRIPTION
This PR aims to bring nullability changes to JavaScriptCore.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes