### PR TITLE
[msbuild] Don't create output files for ditto'ed directories on Windows.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
@@ -1,9 +1,11 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace Xamarin.MacDev.Tasks
 {
@@ -27,10 +29,14 @@ namespace Xamarin.MacDev.Tasks
 		public ITaskItem? Source { get; set; }
 
 		[Required]
-		[Output]
 		public ITaskItem? Destination { get; set; }
 
 		public bool TouchDestinationFiles { get; set; }
+
+		// This property is required for XVS to work properly, even though it's not used for anything in the targets.
+		[Output]
+		public ITaskItem[] CopiedFiles { get; set; }
+
 		#endregion
 
 		protected override string ToolName {
@@ -64,11 +70,19 @@ namespace Xamarin.MacDev.Tasks
 			if (!base.Execute ())
 				return false;
 
-			if (TouchDestinationFiles) {
-				foreach (var file in Directory.EnumerateFiles (Destination!.ItemSpec, "*", SearchOption.AllDirectories)) {
-					File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
+			// Create a list of all the files we've copied
+			var copiedFiles = new List<ITaskItem> ();
+			var destination = Destination!.ItemSpec;
+			if (Directory.Exists (destination)) {
+				foreach (var file in Directory.EnumerateFiles (destination, "*", SearchOption.AllDirectories)) {
+					if (TouchDestinationFiles)
+						File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
+					copiedFiles.Add (new TaskItem (file));
 				}
+			} else {
+				copiedFiles.Add (Destination);
 			}
+			CopiedFiles = copiedFiles.ToArray ();
 
 			return !Log.HasLoggedErrors;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
@@ -46,11 +46,6 @@ namespace Xamarin.MacDev.Tasks
 
 		public bool ShouldCopyToBuildServer (ITaskItem item) => true;
 
-		public bool ShouldCreateOutputFile (ITaskItem item)
-		{
-			var fileExtension = Path.GetExtension (item.ItemSpec);
-
-			return fileExtension != ".app" && fileExtension != ".appex";
-		}
+		public bool ShouldCreateOutputFile (ITaskItem item) => true;
 	}
 }


### PR DESCRIPTION
Fixes this warning from the Codesign task:

    C:\Users\rolf\...\Microsoft.iOS.Sdk\15.4.200-...\tools\msbuild\iOS\Xamarin.Shared.targets(2045,3): Cannot create 'C:\Users\rolf\source\iOSApp4\bin\Debug\net6.0-ios\ios-arm64\device-builds\iphone14.2-15.3.1\iOSApp4.app\Frameworks\ArcGIS-arm64.framework' because a file or directory with the same name already exists.
    C:\Users\rolf\...\Microsoft.iOS.Sdk\15.4.200-...\tools\msbuild\iOS\Xamarin.Shared.targets(2045,3): Cannot create 'C:\Users\rolf\source\iOSApp4\bin\Debug\net6.0-ios\ios-arm64\device-builds\iphone14.2-15.3.1\iOSApp4.app\Frameworks\Runtimecore.framework' because a file or directory with the same name already exists.

which occurs when the Codesign task asks XVS to create output files for files from
inside ditto'ed directories, and if XVS created output files for those directories
in the Ditto task, then XVS would be trying to create files inside these output files
as if they were directories. That doesn't work (thus the warning).

I've fixed this by:

* Removing the 'ShouldCreateOutputFile' implementation. The ShouldCreateOutputFile
  method is called on Windows, and we can't determine from Windows whether the destination
  is a directory or a file.
* Remove the [Output] attribute for the Destination property, this way XVS doesn't
  automatically try to create an output file for whatever the destination is.
* Add another CopiedFiles output property, which contains all the copied files
  (and only files), so that XVS mirrors this with output files on Windows.

Fixes part of https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1505990/.