### PR TITLE
[mediatoolbox] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/MediaToolbox/MTAudioProcessingTap.cs
+++ b/src/MediaToolbox/MTAudioProcessingTap.cs
@@ -97,7 +97,7 @@ namespace MediaToolbox
 		public MTAudioProcessingTap (MTAudioProcessingTapCallbacks callbacks, MTAudioProcessingTapCreationFlags flags)
 		{
 			if (callbacks is null)
-				throw new ArgumentNullException (nameof (callbacks));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callbacks));
 
 			const MTAudioProcessingTapCreationFlags all_flags = MTAudioProcessingTapCreationFlags.PreEffects | MTAudioProcessingTapCreationFlags.PostEffects;
 			if ((flags & all_flags) == all_flags)
@@ -165,7 +165,7 @@ namespace MediaToolbox
 		public MTAudioProcessingTapError GetSourceAudio (nint frames, AudioBuffers bufferList, out MTAudioProcessingTapFlags flags, out CMTimeRange timeRange, out nint framesProvided)
 		{
 			if (bufferList is null)
-				throw new ArgumentNullException (nameof (bufferList));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (bufferList));
 
 			IntPtr result;
 			var r = MTAudioProcessingTapGetSourceAudio (Handle, (IntPtr) frames, (IntPtr) bufferList, out flags, out timeRange, out result);
@@ -267,7 +267,7 @@ namespace MediaToolbox
 		public MTAudioProcessingTapCallbacks (MTAudioProcessingTapProcessDelegate process)
 		{
 			if (process is null)
-				throw new ArgumentNullException (nameof (process));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (process));
 
 			Processing = process;
 		}

--- a/src/MediaToolbox/MTFormatNames.cs
+++ b/src/MediaToolbox/MTFormatNames.cs
@@ -1,5 +1,7 @@
 // Copyright 2015 Xamarin Inc.
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using CoreFoundation;
@@ -28,7 +30,7 @@ namespace MediaToolbox {
 		[iOS (9,0)]
 		[Mac (10,11)]
 #endif
-		static public string GetLocalizedName (this CMMediaType mediaType)
+		static public string? GetLocalizedName (this CMMediaType mediaType)
 		{
 			return CFString.FromHandle (MTCopyLocalizedNameForMediaType (mediaType), releaseHandle: true);
 		}
@@ -51,7 +53,7 @@ namespace MediaToolbox {
 		[iOS (9,0)]
 		[Mac (10,11)]
 #endif
-		static public string GetLocalizedName (this CMMediaType mediaType, uint mediaSubType)
+		static public string? GetLocalizedName (this CMMediaType mediaType, uint mediaSubType)
 		{
 			return CFString.FromHandle (MTCopyLocalizedNameForMediaSubType (mediaType, mediaSubType), releaseHandle: true);
 		}

--- a/src/MediaToolbox/MTProfessionalVideoWorkflow.cs
+++ b/src/MediaToolbox/MTProfessionalVideoWorkflow.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if MONOMAC
 
 using System;


### PR DESCRIPTION
This PR aims to bring nullability changes to MediaToolbox.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
