### PR TITLE
[tests] Use 'BundledNETCoreAppTargetFrameworkVersion' to specify the .NET version in the project files.

### DIFF
--- a/tests/BundledResources/dotnet/MacCatalyst/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/MacCatalyst/BundledResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/BundledResources/dotnet/iOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/iOS/BundledResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/BundledResources/dotnet/macOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/macOS/BundledResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/BundledResources/dotnet/tvOS/BundledResources.csproj
+++ b/tests/BundledResources/dotnet/tvOS/BundledResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/EmbeddedResources/dotnet/MacCatalyst/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/dotnet/MacCatalyst/EmbeddedResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/EmbeddedResources/dotnet/iOS/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/dotnet/iOS/EmbeddedResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/EmbeddedResources/dotnet/macOS/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/dotnet/macOS/EmbeddedResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/EmbeddedResources/dotnet/tvOS/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/dotnet/tvOS/EmbeddedResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/bgen/bgen-tests.csproj
+++ b/tests/bgen/bgen-tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
     <RootNamespace>bgen_tests</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/tests/bindings-framework-test/dotnet/MacCatalyst/bindings-framework-test.csproj
+++ b/tests/bindings-framework-test/dotnet/MacCatalyst/bindings-framework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/bindings-framework-test/dotnet/iOS/bindings-framework-test.csproj
+++ b/tests/bindings-framework-test/dotnet/iOS/bindings-framework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/bindings-framework-test/dotnet/macOS/bindings-framework-test.csproj
+++ b/tests/bindings-framework-test/dotnet/macOS/bindings-framework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/bindings-framework-test/dotnet/tvOS/bindings-framework-test.csproj
+++ b/tests/bindings-framework-test/dotnet/tvOS/bindings-framework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be processed by xharness -->

--- a/tests/bindings-test/dotnet/MacCatalyst/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/MacCatalyst/bindings-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/bindings-test/dotnet/iOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/iOS/bindings-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be processed by xharness -->

--- a/tests/bindings-test/dotnet/macOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/macOS/bindings-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/bindings-test/dotnet/tvOS/bindings-test.csproj
+++ b/tests/bindings-test/dotnet/tvOS/bindings-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/bindings-test2/dotnet/MacCatalyst/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/MacCatalyst/bindings-test2.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be processed by xharness -->

--- a/tests/bindings-test2/dotnet/iOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/iOS/bindings-test2.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be processed by xharness -->

--- a/tests/bindings-test2/dotnet/macOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/macOS/bindings-test2.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be processed by xharness -->

--- a/tests/bindings-test2/dotnet/tvOS/bindings-test2.csproj
+++ b/tests/bindings-test2/dotnet/tvOS/bindings-test2.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be processed by xharness -->

--- a/tests/bindings-xcframework-test/dotnet/MacCatalyst/bindings-xcframework-test.csproj
+++ b/tests/bindings-xcframework-test/dotnet/MacCatalyst/bindings-xcframework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/bindings-xcframework-test/dotnet/iOS/bindings-xcframework-test.csproj
+++ b/tests/bindings-xcframework-test/dotnet/iOS/bindings-xcframework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/bindings-xcframework-test/dotnet/macOS/bindings-xcframework-test.csproj
+++ b/tests/bindings-xcframework-test/dotnet/macOS/bindings-xcframework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/bindings-xcframework-test/dotnet/tvOS/bindings-xcframework-test.csproj
+++ b/tests/bindings-xcframework-test/dotnet/tvOS/bindings-xcframework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be processed by xharness -->

--- a/tests/common/TestProjects/AppWithExtraArgumentThatOverrides/AppWithExtraArgumentThatOverrides.dotnet.csproj
+++ b/tests/common/TestProjects/AppWithExtraArgumentThatOverrides/AppWithExtraArgumentThatOverrides.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <MtouchLink>None</MtouchLink>

--- a/tests/common/TestProjects/Bug60536/Bug60536.dotnet.csproj
+++ b/tests/common/TestProjects/Bug60536/Bug60536.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.3</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/ComplexAssembly/ComplexAssembly.csproj
+++ b/tests/common/TestProjects/ComplexAssembly/ComplexAssembly.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
 

--- a/tests/common/TestProjects/My Spaced App/My Spaced App.dotnet.csproj
+++ b/tests/common/TestProjects/My Spaced App/My Spaced App.dotnet.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <AssemblyName>MySpacedApp</AssemblyName>

--- a/tests/common/TestProjects/MyActionExtension/MyActionExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyActionExtension/MyActionExtension.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyAppWithPackageReference/MyAppWithPackageReference.dotnet.csproj
+++ b/tests/common/TestProjects/MyAppWithPackageReference/MyAppWithPackageReference.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyCoreMLApp/MyCoreMLApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyCoreMLApp/MyCoreMLApp.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyDocumentPickerExtension/MyDocumentPickerExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyDocumentPickerExtension/MyDocumentPickerExtension.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.dotnet.csproj
+++ b/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyIBToolLinkTest/MyIBToolLinkTest.dotnet.csproj
+++ b/tests/common/TestProjects/MyIBToolLinkTest/MyIBToolLinkTest.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyKeyboardExtension/MyKeyboardExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyKeyboardExtension/MyKeyboardExtension.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
     <SupportedOSPlatformVersion>9.3</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyLinkedAssets/MyLinkedAssets.dotnet.csproj
+++ b/tests/common/TestProjects/MyLinkedAssets/MyLinkedAssets.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.2</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyMasterDetailApp/MyMasterDetailApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyMasterDetailApp/MyMasterDetailApp.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyMetalGame/MyMetalGame.dotnet.csproj
+++ b/tests/common/TestProjects/MyMetalGame/MyMetalGame.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyOpenGLApp/MyOpenGLApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyOpenGLApp/MyOpenGLApp.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>8.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyPhotoEditingExtension/MyPhotoEditingExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyPhotoEditingExtension/MyPhotoEditingExtension.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyReleaseBuild/MyReleaseBuild.dotnet.csproj
+++ b/tests/common/TestProjects/MyReleaseBuild/MyReleaseBuild.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MySceneKitApp/MySceneKitApp.dotnet.csproj
+++ b/tests/common/TestProjects/MySceneKitApp/MySceneKitApp.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyShareExtension/MyShareExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyShareExtension/MyShareExtension.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MySingleView/MyLibrary/MyLibrary.dotnet.csproj
+++ b/tests/common/TestProjects/MySingleView/MyLibrary/MyLibrary.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/tests/common/TestProjects/MySingleView/MySingleView.dotnet.csproj
+++ b/tests/common/TestProjects/MySingleView/MySingleView.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <DefaultItemExcludes>$(DefaultItemExcludes);MyLibrary\**</DefaultItemExcludes>

--- a/tests/common/TestProjects/MySpriteKitGame/MySpriteKitGame.dotnet.csproj
+++ b/tests/common/TestProjects/MySpriteKitGame/MySpriteKitGame.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyTVApp/MyTVApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyTVApp/MyTVApp.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <RuntimeIdentifier>tvossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyTVMetalGame/MyTVMetalGame.dotnet.csproj
+++ b/tests/common/TestProjects/MyTVMetalGame/MyTVMetalGame.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>tvossimulator-x64</RuntimeIdentifier>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyTVServicesExtension/MyTVServicesExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyTVServicesExtension/MyTVServicesExtension.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <RuntimeIdentifier>tvossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyTabbedApplication/MyTabbedApplication.dotnet.csproj
+++ b/tests/common/TestProjects/MyTabbedApplication/MyTabbedApplication.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyTodayExtension/MyTodayExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyTodayExtension/MyTodayExtension.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
     <SupportedOSPlatformVersion>8.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyWatch2Container/MyWatch2Container.dotnet.csproj
+++ b/tests/common/TestProjects/MyWatch2Container/MyWatch2Container.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyWatchApp2/MyWatchApp2.dotnet.csproj
+++ b/tests/common/TestProjects/MyWatchApp2/MyWatchApp2.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-watchos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-watchos</TargetFramework>
     <RuntimeIdentifier>watchos-x86</RuntimeIdentifier>
     <IsWatchOSApp>true</IsWatchOSApp>
   </PropertyGroup>

--- a/tests/common/TestProjects/MyWatchKit2Extension/MyWatchKit2Extension.dotnet.csproj
+++ b/tests/common/TestProjects/MyWatchKit2Extension/MyWatchKit2Extension.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-watchos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-watchos</TargetFramework>
     <RuntimeIdentifier>watchos-x86</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>

--- a/tests/common/TestProjects/MyWatchKit2IntentsExtension/MyWatchKit2IntentsExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyWatchKit2IntentsExtension/MyWatchKit2IntentsExtension.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-watchos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-watchos</TargetFramework>
     <RuntimeIdentifier>watchos-x86</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
   </PropertyGroup>

--- a/tests/common/TestProjects/MyWebViewApp/MyWebViewApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyWebViewApp/MyWebViewApp.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyXamarinFormsApp/MyXamarinFormsApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyXamarinFormsApp/MyXamarinFormsApp.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tests/common/TestProjects/MyiOSAppWithBinding/MyiOSAppWithBinding.dotnet.csproj
+++ b/tests/common/TestProjects/MyiOSAppWithBinding/MyiOSAppWithBinding.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/common/TestProjects/MyiOSFrameworkBinding/MyiOSFrameworkBinding.dotnet.csproj
+++ b/tests/common/TestProjects/MyiOSFrameworkBinding/MyiOSFrameworkBinding.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsBindingProject>true</IsBindingProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/MacCatalyst/Library.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/MacCatalyst/Library.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!-- The point is to have netstandard2.1 + another which isn't the TargetFramework we're building for -->
-		<TargetFrameworks>net6.0-macos;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)-macos;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/iOS/Library.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/iOS/Library.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!-- The point is to have netstandard2.1 + another which isn't the TargetFramework we're building for -->
-		<TargetFrameworks>net6.0-macos;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)-macos;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/macOS/Library.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/macOS/Library.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!-- The point is to have netstandard2.1 + another which isn't the TargetFramework we're building for -->
-		<TargetFrameworks>net6.0-ios;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)-ios;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/Library/tvOS/Library.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/Library/tvOS/Library.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!-- The point is to have netstandard2.1 + another which isn't the TargetFramework we're building for -->
-		<TargetFrameworks>net6.0-macos;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)-macos;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/MacCatalyst/AppWithGenericLibraryReference.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/MacCatalyst/AppWithGenericLibraryReference.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/iOS/AppWithGenericLibraryReference.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/iOS/AppWithGenericLibraryReference.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/macOS/AppWithGenericLibraryReference.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/macOS/AppWithGenericLibraryReference.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithGenericLibraryReference/tvOS/AppWithGenericLibraryReference.csproj
+++ b/tests/dotnet/AppWithGenericLibraryReference/tvOS/AppWithGenericLibraryReference.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithResources/MacCatalyst/AppWithResources.csproj
+++ b/tests/dotnet/AppWithResources/MacCatalyst/AppWithResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithResources/iOS/AppWithResources.csproj
+++ b/tests/dotnet/AppWithResources/iOS/AppWithResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 	  <BundleResource Update="Resources\C.ttf">

--- a/tests/dotnet/AppWithResources/macOS/AppWithResources.csproj
+++ b/tests/dotnet/AppWithResources/macOS/AppWithResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithResources/tvOS/AppWithResources.csproj
+++ b/tests/dotnet/AppWithResources/tvOS/AppWithResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithXCAssets/MacCatalyst/AppWithXCAssets.csproj
+++ b/tests/dotnet/AppWithXCAssets/MacCatalyst/AppWithXCAssets.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithXCAssets/iOS/AppWithXCAssets.csproj
+++ b/tests/dotnet/AppWithXCAssets/iOS/AppWithXCAssets.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 	  <BundleResource Update="Resources\C.ttf">

--- a/tests/dotnet/AppWithXCAssets/macOS/AppWithXCAssets.csproj
+++ b/tests/dotnet/AppWithXCAssets/macOS/AppWithXCAssets.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/AppWithXCAssets/tvOS/AppWithXCAssets.csproj
+++ b/tests/dotnet/AppWithXCAssets/tvOS/AppWithXCAssets.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BindingOldStyle/MacCatalyst/BindingOldStyle.csproj
+++ b/tests/dotnet/BindingOldStyle/MacCatalyst/BindingOldStyle.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BindingOldStyle/iOS/BindingOldStyle.csproj
+++ b/tests/dotnet/BindingOldStyle/iOS/BindingOldStyle.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BindingOldStyle/macOS/BindingOldStyle.csproj
+++ b/tests/dotnet/BindingOldStyle/macOS/BindingOldStyle.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BindingOldStyle/tvOS/BindingOldStyle.csproj
+++ b/tests/dotnet/BindingOldStyle/tvOS/BindingOldStyle.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-tvos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
 	</PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BindingWithDefaultCompileInclude/MacCatalyst/BindingWithDefaultCompileInclude.csproj
+++ b/tests/dotnet/BindingWithDefaultCompileInclude/MacCatalyst/BindingWithDefaultCompileInclude.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BindingWithDefaultCompileInclude/iOS/BindingWithDefaultCompileInclude.csproj
+++ b/tests/dotnet/BindingWithDefaultCompileInclude/iOS/BindingWithDefaultCompileInclude.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BindingWithDefaultCompileInclude/macOS/BindingWithDefaultCompileInclude.csproj
+++ b/tests/dotnet/BindingWithDefaultCompileInclude/macOS/BindingWithDefaultCompileInclude.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BindingWithDefaultCompileInclude/tvOS/BindingWithDefaultCompileInclude.csproj
+++ b/tests/dotnet/BindingWithDefaultCompileInclude/tvOS/BindingWithDefaultCompileInclude.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-tvos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
 	</PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BundleStructure/MacCatalyst/BundleStructure.csproj
+++ b/tests/dotnet/BundleStructure/MacCatalyst/BundleStructure.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BundleStructure/iOS/BundleStructure.csproj
+++ b/tests/dotnet/BundleStructure/iOS/BundleStructure.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BundleStructure/macOS/BundleStructure.csproj
+++ b/tests/dotnet/BundleStructure/macOS/BundleStructure.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/BundleStructure/tvOS/BundleStructure.csproj
+++ b/tests/dotnet/BundleStructure/tvOS/BundleStructure.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/CentralPackageVersionsApp/MacCatalyst/CentralPackageVersionsApp.csproj
+++ b/tests/dotnet/CentralPackageVersionsApp/MacCatalyst/CentralPackageVersionsApp.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/CentralPackageVersionsApp/iOS/CentralPackageVersionsApp.csproj
+++ b/tests/dotnet/CentralPackageVersionsApp/iOS/CentralPackageVersionsApp.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/CentralPackageVersionsApp/macOS/CentralPackageVersionsApp.csproj
+++ b/tests/dotnet/CentralPackageVersionsApp/macOS/CentralPackageVersionsApp.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/CentralPackageVersionsApp/tvOS/CentralPackageVersionsApp.csproj
+++ b/tests/dotnet/CentralPackageVersionsApp/tvOS/CentralPackageVersionsApp.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
 	<PropertyGroup>
-		<TargetFramework>net6.0-tvos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/ExtensionConsumer/iOS/MySimpleApp.csproj
+++ b/tests/dotnet/ExtensionConsumer/iOS/MySimpleApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/ExtensionConsumer/macOS/MySimpleApp.csproj
+++ b/tests/dotnet/ExtensionConsumer/macOS/MySimpleApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/ExtensionConsumer/tvOS/MySimpleApp.csproj
+++ b/tests/dotnet/ExtensionConsumer/tvOS/MySimpleApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/ExtensionProject/iOS/ExtensionProject.csproj
+++ b/tests/dotnet/ExtensionProject/iOS/ExtensionProject.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/ExtensionProject/macOS/ExtensionProject.csproj
+++ b/tests/dotnet/ExtensionProject/macOS/ExtensionProject.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
     <CodesignEntitlements>$(SourceDirectory)Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />

--- a/tests/dotnet/ExtensionProject/tvOS/ExtensionProject.csproj
+++ b/tests/dotnet/ExtensionProject/tvOS/ExtensionProject.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MyCatalystApp/MyCatalystApp.csproj
+++ b/tests/dotnet/MyCatalystApp/MyCatalystApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <RuntimeIdentifier>maccatalyst-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
 

--- a/tests/dotnet/MyClassLibrary/MacCatalyst/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/MacCatalyst/MyClassLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MyClassLibrary/iOS/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/iOS/MyClassLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MyClassLibrary/macOS/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/macOS/MyClassLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MyClassLibrary/tvOS/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/tvOS/MyClassLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MyCocoaApp/MyCocoaApp.csproj
+++ b/tests/dotnet/MyCocoaApp/MyCocoaApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
   </PropertyGroup>

--- a/tests/dotnet/MyInterpretedApp/MacCatalyst/MyInterpretedApp.csproj
+++ b/tests/dotnet/MyInterpretedApp/MacCatalyst/MyInterpretedApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <RuntimeIdentifier>maccatalyst-arm64</RuntimeIdentifier>
   </PropertyGroup>
   <Import Project="../shared.csproj" />

--- a/tests/dotnet/MyInterpretedApp/iOS/MyInterpretedApp.csproj
+++ b/tests/dotnet/MyInterpretedApp/iOS/MyInterpretedApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
   <Import Project="../shared.csproj" />
 </Project>

--- a/tests/dotnet/MyInterpretedApp/tvOS/MyInterpretedApp.csproj
+++ b/tests/dotnet/MyInterpretedApp/tvOS/MyInterpretedApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="../shared.csproj" />
 </Project>

--- a/tests/dotnet/MyPartialAppManifestApp/MacCatalyst/MyPartialAppManifestApp.csproj
+++ b/tests/dotnet/MyPartialAppManifestApp/MacCatalyst/MyPartialAppManifestApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MyPartialAppManifestApp/iOS/MyPartialAppManifestApp.csproj
+++ b/tests/dotnet/MyPartialAppManifestApp/iOS/MyPartialAppManifestApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MyPartialAppManifestApp/macOS/MyPartialAppManifestApp.csproj
+++ b/tests/dotnet/MyPartialAppManifestApp/macOS/MyPartialAppManifestApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MyPartialAppManifestApp/tvOS/MyPartialAppManifestApp.csproj
+++ b/tests/dotnet/MyPartialAppManifestApp/tvOS/MyPartialAppManifestApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-tvos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MySatelliteAssembliesLibrary/MacCatalyst/MySatelliteAssembliesLibrary.csproj
+++ b/tests/dotnet/MySatelliteAssembliesLibrary/MacCatalyst/MySatelliteAssembliesLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MySatelliteAssembliesLibrary/iOS/MySatelliteAssembliesLibrary.csproj
+++ b/tests/dotnet/MySatelliteAssembliesLibrary/iOS/MySatelliteAssembliesLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MySatelliteAssembliesLibrary/macOS/MySatelliteAssembliesLibrary.csproj
+++ b/tests/dotnet/MySatelliteAssembliesLibrary/macOS/MySatelliteAssembliesLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MySatelliteAssembliesLibrary/tvOS/MySatelliteAssembliesLibrary.csproj
+++ b/tests/dotnet/MySatelliteAssembliesLibrary/tvOS/MySatelliteAssembliesLibrary.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 </Project>
 

--- a/tests/dotnet/MySimpleApp/MacCatalyst/MySimpleApp.csproj
+++ b/tests/dotnet/MySimpleApp/MacCatalyst/MySimpleApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MySimpleApp/iOS/MySimpleApp.csproj
+++ b/tests/dotnet/MySimpleApp/iOS/MySimpleApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MySimpleApp/macOS/MySimpleApp.csproj
+++ b/tests/dotnet/MySimpleApp/macOS/MySimpleApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MySimpleApp/tvOS/MySimpleApp.csproj
+++ b/tests/dotnet/MySimpleApp/tvOS/MySimpleApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MySimpleAppWithSatelliteReference/MacCatalyst/MySimpleAppWithSatelliteReference.csproj
+++ b/tests/dotnet/MySimpleAppWithSatelliteReference/MacCatalyst/MySimpleAppWithSatelliteReference.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MySimpleAppWithSatelliteReference/iOS/MySimpleAppWithSatelliteReference.csproj
+++ b/tests/dotnet/MySimpleAppWithSatelliteReference/iOS/MySimpleAppWithSatelliteReference.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MySimpleAppWithSatelliteReference/macOS/MySimpleAppWithSatelliteReference.csproj
+++ b/tests/dotnet/MySimpleAppWithSatelliteReference/macOS/MySimpleAppWithSatelliteReference.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MySimpleAppWithSatelliteReference/tvOS/MySimpleAppWithSatelliteReference.csproj
+++ b/tests/dotnet/MySimpleAppWithSatelliteReference/tvOS/MySimpleAppWithSatelliteReference.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/MySingleView/MySingleView.csproj
+++ b/tests/dotnet/MySingleView/MySingleView.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <OutputType>Exe</OutputType>
 
     <ApplicationTitle>MySingleTitle</ApplicationTitle>

--- a/tests/dotnet/MyTVApp/MyTVApp.csproj
+++ b/tests/dotnet/MyTVApp/MyTVApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
   </PropertyGroup>

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/iOS/NativeDynamicLibraryReferencesApp.csproj
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/iOS/NativeDynamicLibraryReferencesApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
 		<FatName>ios-fat</FatName>
 	</PropertyGroup>

--- a/tests/dotnet/NativeDynamicLibraryReferencesApp/macOS/NativeDynamicLibraryReferencesApp.csproj
+++ b/tests/dotnet/NativeDynamicLibraryReferencesApp/macOS/NativeDynamicLibraryReferencesApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 		<RuntimeIdentifier>osx-x64</RuntimeIdentifier>
 		<FatName>macos-fat</FatName>
 	</PropertyGroup>

--- a/tests/dotnet/NativeFileReferencesApp/iOS/NativeFileReferencesApp.csproj
+++ b/tests/dotnet/NativeFileReferencesApp/iOS/NativeFileReferencesApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
 		<FatName>ios-fat</FatName>
 	</PropertyGroup>

--- a/tests/dotnet/NativeFileReferencesApp/macOS/NativeFileReferencesApp.csproj
+++ b/tests/dotnet/NativeFileReferencesApp/macOS/NativeFileReferencesApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 		<RuntimeIdentifier>osx-x64</RuntimeIdentifier>
 		<FatName>macos-fat</FatName>
 	</PropertyGroup>

--- a/tests/dotnet/NativeFrameworkReferencesApp/iOS/NativeFrameworkReferencesApp.csproj
+++ b/tests/dotnet/NativeFrameworkReferencesApp/iOS/NativeFrameworkReferencesApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
 		<FatName>ios-fat</FatName>
 	</PropertyGroup>

--- a/tests/dotnet/NativeFrameworkReferencesApp/macOS/NativeFrameworkReferencesApp.csproj
+++ b/tests/dotnet/NativeFrameworkReferencesApp/macOS/NativeFrameworkReferencesApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 		<RuntimeIdentifier>osx-x64</RuntimeIdentifier>
 		<FatName>macos-fat</FatName>
 	</PropertyGroup>

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/iOS/NativeXCFrameworkReferencesApp.csproj
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/iOS/NativeXCFrameworkReferencesApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
 		<FatName>ios-fat</FatName>
 	</PropertyGroup>

--- a/tests/dotnet/NativeXCFrameworkReferencesApp/macOS/NativeXCFrameworkReferencesApp.csproj
+++ b/tests/dotnet/NativeXCFrameworkReferencesApp/macOS/NativeXCFrameworkReferencesApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 		<RuntimeIdentifier>osx-x64</RuntimeIdentifier>
 		<FatName>macos-fat</FatName>
 	</PropertyGroup>

--- a/tests/dotnet/SimpleAppWithOldReferences/MacCatalyst/SimpleAppWithOldReferences.csproj
+++ b/tests/dotnet/SimpleAppWithOldReferences/MacCatalyst/SimpleAppWithOldReferences.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/SimpleAppWithOldReferences/iOS/SimpleAppWithOldReferences.csproj
+++ b/tests/dotnet/SimpleAppWithOldReferences/iOS/SimpleAppWithOldReferences.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/SimpleAppWithOldReferences/macOS/SimpleAppWithOldReferences.csproj
+++ b/tests/dotnet/SimpleAppWithOldReferences/macOS/SimpleAppWithOldReferences.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/SimpleAppWithOldReferences/tvOS/SimpleAppWithOldReferences.csproj
+++ b/tests/dotnet/SimpleAppWithOldReferences/tvOS/SimpleAppWithOldReferences.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/UnitTests/DotNetUnitTests.csproj
+++ b/tests/dotnet/UnitTests/DotNetUnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);NET;TESTS</DefineConstants>
   </PropertyGroup>

--- a/tests/dotnet/size-comparison/MySingleView/dotnet/MySingleView.csproj
+++ b/tests/dotnet/size-comparison/MySingleView/dotnet/MySingleView.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/tests/framework-test/dotnet/MacCatalyst/framework-test.csproj
+++ b/tests/framework-test/dotnet/MacCatalyst/framework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/framework-test/dotnet/iOS/framework-test.csproj
+++ b/tests/framework-test/dotnet/iOS/framework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/framework-test/dotnet/macOS/framework-test.csproj
+++ b/tests/framework-test/dotnet/macOS/framework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/framework-test/dotnet/tvOS/framework-test.csproj
+++ b/tests/framework-test/dotnet/tvOS/framework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be processed by xharness -->

--- a/tests/fsharp/dotnet/MacCatalyst/fsharp.fsproj
+++ b/tests/fsharp/dotnet/MacCatalyst/fsharp.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/fsharp/dotnet/iOS/fsharp.fsproj
+++ b/tests/fsharp/dotnet/iOS/fsharp.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/fsharp/dotnet/macOS/fsharp.fsproj
+++ b/tests/fsharp/dotnet/macOS/fsharp.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/fsharp/dotnet/tvOS/fsharp.fsproj
+++ b/tests/fsharp/dotnet/tvOS/fsharp.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/fsharplibrary/dotnet/MacCatalyst/fsharplibrary.fsproj
+++ b/tests/fsharplibrary/dotnet/MacCatalyst/fsharplibrary.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/fsharplibrary/dotnet/iOS/fsharplibrary.fsproj
+++ b/tests/fsharplibrary/dotnet/iOS/fsharplibrary.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/fsharplibrary/dotnet/macOS/fsharplibrary.fsproj
+++ b/tests/fsharplibrary/dotnet/macOS/fsharplibrary.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/fsharplibrary/dotnet/tvOS/fsharplibrary.fsproj
+++ b/tests/fsharplibrary/dotnet/tvOS/fsharplibrary.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.fsproj' will be processed by xharness -->

--- a/tests/interdependent-binding-projects/dotnet/MacCatalyst/interdependent-binding-projects.csproj
+++ b/tests/interdependent-binding-projects/dotnet/MacCatalyst/interdependent-binding-projects.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/interdependent-binding-projects/dotnet/iOS/interdependent-binding-projects.csproj
+++ b/tests/interdependent-binding-projects/dotnet/iOS/interdependent-binding-projects.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/interdependent-binding-projects/dotnet/macOS/interdependent-binding-projects.csproj
+++ b/tests/interdependent-binding-projects/dotnet/macOS/interdependent-binding-projects.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/interdependent-binding-projects/dotnet/tvOS/interdependent-binding-projects.csproj
+++ b/tests/interdependent-binding-projects/dotnet/tvOS/interdependent-binding-projects.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/introspection/dotnet/MacCatalyst/introspection.csproj
+++ b/tests/introspection/dotnet/MacCatalyst/introspection.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/introspection/dotnet/iOS/introspection.csproj
+++ b/tests/introspection/dotnet/iOS/introspection.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/introspection/dotnet/macOS/introspection.csproj
+++ b/tests/introspection/dotnet/macOS/introspection.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/introspection/dotnet/tvOS/introspection.csproj
+++ b/tests/introspection/dotnet/tvOS/introspection.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/dont link/dotnet/MacCatalyst/dont link.csproj
+++ b/tests/linker/ios/dont link/dotnet/MacCatalyst/dont link.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/dont link/dotnet/iOS/dont link.csproj
+++ b/tests/linker/ios/dont link/dotnet/iOS/dont link.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/dont link/dotnet/macOS/dont link.csproj
+++ b/tests/linker/ios/dont link/dotnet/macOS/dont link.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/dont link/dotnet/tvOS/dont link.csproj
+++ b/tests/linker/ios/dont link/dotnet/tvOS/dont link.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/link all/dotnet/MacCatalyst/link all.csproj
+++ b/tests/linker/ios/link all/dotnet/MacCatalyst/link all.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/link all/dotnet/iOS/link all.csproj
+++ b/tests/linker/ios/link all/dotnet/iOS/link all.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/link all/dotnet/macOS/link all.csproj
+++ b/tests/linker/ios/link all/dotnet/macOS/link all.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/link all/dotnet/tvOS/link all.csproj
+++ b/tests/linker/ios/link all/dotnet/tvOS/link all.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/link sdk/dotnet/MacCatalyst/link sdk.csproj
+++ b/tests/linker/ios/link sdk/dotnet/MacCatalyst/link sdk.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/link sdk/dotnet/iOS/link sdk.csproj
+++ b/tests/linker/ios/link sdk/dotnet/iOS/link sdk.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/link sdk/dotnet/macOS/link sdk.csproj
+++ b/tests/linker/ios/link sdk/dotnet/macOS/link sdk.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/link sdk/dotnet/tvOS/link sdk.csproj
+++ b/tests/linker/ios/link sdk/dotnet/tvOS/link sdk.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/trimmode copy/dotnet/MacCatalyst/trimmode copy.csproj
+++ b/tests/linker/ios/trimmode copy/dotnet/MacCatalyst/trimmode copy.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/trimmode copy/dotnet/iOS/trimmode copy.csproj
+++ b/tests/linker/ios/trimmode copy/dotnet/iOS/trimmode copy.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/trimmode copy/dotnet/macOS/trimmode copy.csproj
+++ b/tests/linker/ios/trimmode copy/dotnet/macOS/trimmode copy.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/trimmode copy/dotnet/tvOS/trimmode copy.csproj
+++ b/tests/linker/ios/trimmode copy/dotnet/tvOS/trimmode copy.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/trimmode link/dotnet/MacCatalyst/trimmode link.csproj
+++ b/tests/linker/ios/trimmode link/dotnet/MacCatalyst/trimmode link.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/trimmode link/dotnet/iOS/trimmode link.csproj
+++ b/tests/linker/ios/trimmode link/dotnet/iOS/trimmode link.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/trimmode link/dotnet/macOS/trimmode link.csproj
+++ b/tests/linker/ios/trimmode link/dotnet/macOS/trimmode link.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/linker/ios/trimmode link/dotnet/tvOS/trimmode link.csproj
+++ b/tests/linker/ios/trimmode link/dotnet/tvOS/trimmode link.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/monotouch-test/dotnet/MacCatalyst/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/MacCatalyst/monotouch-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
   </PropertyGroup>
 

--- a/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/iOS/monotouch-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
     <DefineConstants>$(DefineConstants);XAMMAC_TESTS</DefineConstants>
     <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
   </PropertyGroup>

--- a/tests/monotouch-test/dotnet/tvOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/tvOS/monotouch-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <DefineConstants Condition="'$(Platform)' == 'iPhoneSimulator'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
   </PropertyGroup>
 

--- a/tests/perftest/dotnet/perftest.csproj
+++ b/tests/perftest/dotnet/perftest.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <MonoBundlingExtraArgs>--marshal-objectivec-exceptions:disable --registrar:static</MonoBundlingExtraArgs>

--- a/tests/xcframework-test/dotnet/MacCatalyst/xcframework-test.csproj
+++ b/tests/xcframework-test/dotnet/MacCatalyst/xcframework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/xcframework-test/dotnet/iOS/xcframework-test.csproj
+++ b/tests/xcframework-test/dotnet/iOS/xcframework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/xcframework-test/dotnet/macOS/xcframework-test.csproj
+++ b/tests/xcframework-test/dotnet/macOS/xcframework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/xcframework-test/dotnet/tvOS/xcframework-test.csproj
+++ b/tests/xcframework-test/dotnet/tvOS/xcframework-test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be processed by xharness -->


### PR DESCRIPTION
This way we don't have to update all these files when moving to .NET 7.