### PR TITLE
[src] Fix internal RemoveAttributesInstance directive for the linker.

### DIFF
--- a/src/ILLink.LinkAttributes.tvos.xml
+++ b/src/ILLink.LinkAttributes.tvos.xml
@@ -16,7 +16,7 @@
       <attribute internal="RemoveAttributeInstances" />
     </type>
     <type fullname="Foundation.FieldAttribute">
-      <attribute internal="LinkerSafeAttribute" />
+      <attribute internal="RemoveAttributeInstances" />
     </type>
 
     <!-- ObjCRuntime -->

--- a/src/ILLink.LinkAttributes.xml.in
+++ b/src/ILLink.LinkAttributes.xml.in
@@ -16,7 +16,7 @@
       <attribute internal="RemoveAttributeInstances" />
     </type>
     <type fullname="Foundation.FieldAttribute">
-      <attribute internal="LinkerSafeAttribute" />
+      <attribute internal="RemoveAttributeInstances" />
     </type>
 
     <!-- ObjCRuntime -->


### PR DESCRIPTION
Fixes this warning:

>  Microsoft.MacCatalyst: The internal attribute name 'LinkerSafeAttribute' being used in the xml is not supported by the linker, check the spelling and the supported internal attributes.

It also probably fixes removal of the [Field] attribute.