### PR TITLE
[tools] Make the TargetFramework.DotNet* variables version-agnostic.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,6 +27,8 @@ MACCATALYST_DOTNET_BUILD_DIR=$(DOTNET_BUILD_DIR)/maccatalyst
 
 GENERATOR_FLAGS=-process-enums -core -nologo -nostdlib -noconfig -native-exception-marshalling --ns:ObjCRuntime
 
+GENERATOR_TF_VERSION=$(subst net,,$(DOTNET_TFM))
+
 DOTNET_REFERENCES = \
 	/r:$(DOTNET_BCL_DIR)/System.Buffers.dll \
 	/r:$(DOTNET_BCL_DIR)/System.Collections.Concurrent.dll \
@@ -241,7 +243,7 @@ $(IOS_DOTNET_BUILD_DIR)/ios.rsp: Makefile Makefile.generator frameworks.sources 
 		-sourceonly=$(IOS_DOTNET_BUILD_DIR)/ios-generated-sources \
 		-tmpdir=$(IOS_DOTNET_BUILD_DIR)/generated-sources \
 		-baselib=$(IOS_DOTNET_BUILD_DIR)/core-ios.dll \
-		--target-framework=.NETCoreApp,Version=6.0,Profile=ios \
+		--target-framework=.NETCoreApp,Version=$(GENERATOR_TF_VERSION),Profile=ios \
 		$(IOS_APIS) \
 		@$(DOTNET_BUILD_DIR)/ios-defines-dotnet.rsp \
 		> $@
@@ -663,7 +665,7 @@ $(MACOS_DOTNET_BUILD_DIR)/macos.rsp: Makefile Makefile.generator frameworks.sour
 		-sourceonly:$(MACOS_DOTNET_BUILD_DIR)/macos-generated-sources \
 		-tmpdir:$(MACOS_DOTNET_BUILD_DIR)/generated-sources \
 		-baselib:$(MACOS_DOTNET_BUILD_DIR)/core-macos.dll \
-		--target-framework=.NETCoreApp,Version=6.0,Profile=macos \
+		--target-framework=.NETCoreApp,Version=$(GENERATOR_TF_VERSION),Profile=macos \
 		$(MACOS_DOTNET_APIS) \
 		@$(DOTNET_BUILD_DIR)/macos-defines-dotnet.rsp \
 		> $@
@@ -917,7 +919,7 @@ $(WATCHOS_DOTNET_BUILD_DIR)/watchos.rsp: Makefile Makefile.generator frameworks.
 		-sourceonly=$(WATCHOS_DOTNET_BUILD_DIR)/watchos-generated-sources \
 		-tmpdir=$(WATCHOS_DOTNET_BUILD_DIR)/generated-sources \
 		-baselib=$(WATCHOS_DOTNET_BUILD_DIR)/core-watchos.dll \
-		--target-framework=.NETCoreApp,Version=6.0,Profile=watchos \
+		--target-framework=.NETCoreApp,Version=$(GENERATOR_TF_VERSION),Profile=watchos \
 		$(WATCHOS_APIS) \
 		@$(DOTNET_BUILD_DIR)/watchos-defines-dotnet.rsp \
 		> $@
@@ -1226,7 +1228,7 @@ $(TVOS_DOTNET_BUILD_DIR)/tvos.rsp: Makefile Makefile.generator frameworks.source
 		-sourceonly=$(TVOS_DOTNET_BUILD_DIR)/tvos-generated-sources \
 		-tmpdir=$(TVOS_DOTNET_BUILD_DIR)/generated-sources \
 		-baselib=$(TVOS_DOTNET_BUILD_DIR)/core-tvos.dll \
-		--target-framework=.NETCoreApp,Version=6.0,Profile=tvos \
+		--target-framework=.NETCoreApp,Version=$(GENERATOR_TF_VERSION),Profile=tvos \
 		$(TVOS_DOTNET_APIS) \
 		@$(DOTNET_BUILD_DIR)/tvos-defines-dotnet.rsp \
 		> $@
@@ -1411,7 +1413,7 @@ $(MACCATALYST_DOTNET_BUILD_DIR)/maccatalyst.rsp: Makefile Makefile.generator fra
 		-sourceonly=$(MACCATALYST_DOTNET_BUILD_DIR)/maccatalyst-generated-sources \
 		-tmpdir=$(MACCATALYST_DOTNET_BUILD_DIR)/generated-sources \
 		-baselib=$(MACCATALYST_DOTNET_BUILD_DIR)/core-maccatalyst.dll \
-		--target-framework=.NETCoreApp,Version=6.0,Profile=maccatalyst \
+		--target-framework=.NETCoreApp,Version=$(GENERATOR_TF_VERSION),Profile=maccatalyst \
 		$(MACCATALYST_DOTNET_APIS) \
 		@$(DOTNET_BUILD_DIR)/maccatalyst-defines-dotnet.rsp \
 		> $@

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -389,7 +389,7 @@ public class BindingTouch : IDisposable {
 					baselibdll = Path.Combine (GetSDKRoot (), "lib", "reference", "mobile", "Xamarin.Mac.dll");
 				else if (target_framework == TargetFramework.Xamarin_Mac_4_5_Full || target_framework == TargetFramework.Xamarin_Mac_4_5_System)
 					baselibdll = Path.Combine (GetSDKRoot (), "lib", "reference", "full", "Xamarin.Mac.dll");
-				else if (target_framework == TargetFramework.DotNet_5_0_macOS)
+				else if (target_framework == TargetFramework.DotNet_macOS)
 					baselibdll = Path.Combine (GetSDKRoot (), "lib", "mono", "Xamarin.Mac", "Xamarin.Mac.dll");
 				else
 					throw ErrorHelper.CreateError (1053, target_framework); 
@@ -405,7 +405,7 @@ public class BindingTouch : IDisposable {
 			} else if (target_framework == TargetFramework.Xamarin_Mac_4_5_System) {
 				skipSystemDrawing = false;
 				ReferenceFixer.FixSDKReferences ("/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5", references, forceSystemDrawing : true);
-			} else if (target_framework == TargetFramework.DotNet_5_0_macOS) {
+			} else if (target_framework == TargetFramework.DotNet_macOS) {
 				skipSystemDrawing = false;
 			} else {
 				throw ErrorHelper.CreateError (1053, target_framework); 

--- a/tests/cecil-tests/AttributeTest.cs
+++ b/tests/cecil-tests/AttributeTest.cs
@@ -157,13 +157,13 @@ namespace Cecil.Tests {
 		string AssemblyToAttributeName (string assemblyPath)
 		{
 			var baseName = Path.GetFileName (assemblyPath);
-			if (Configuration.GetBaseLibraryName (TargetFramework.DotNet_5_0_iOS.Platform, true) == baseName)
+			if (Configuration.GetBaseLibraryName (TargetFramework.DotNet_iOS.Platform, true) == baseName)
 				return "ios";
-			if (Configuration.GetBaseLibraryName (TargetFramework.DotNet_5_0_tvOS.Platform, true) == baseName)
+			if (Configuration.GetBaseLibraryName (TargetFramework.DotNet_tvOS.Platform, true) == baseName)
 				return "tvos";
-			if (Configuration.GetBaseLibraryName (TargetFramework.DotNet_5_0_macOS.Platform, true) == baseName)
+			if (Configuration.GetBaseLibraryName (TargetFramework.DotNet_macOS.Platform, true) == baseName)
 				return "macos";
-			if (Configuration.GetBaseLibraryName (TargetFramework.DotNet_5_0_MacCatalyst.Platform, true) == baseName)
+			if (Configuration.GetBaseLibraryName (TargetFramework.DotNet_MacCatalyst.Platform, true) == baseName)
 				return "maccatalyst";
 			throw new NotImplementedException ();
 		}

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -83,16 +83,16 @@ namespace Xamarin.Tests
 			case Profile.None:
 				break;
 			case Profile.iOS:
-				targetFramework = TargetFramework.DotNet_6_0_iOS_String;
+				targetFramework = TargetFramework.DotNet_iOS_String;
 				break;
 			case Profile.tvOS:
-				targetFramework = TargetFramework.DotNet_6_0_tvOS_String;
+				targetFramework = TargetFramework.DotNet_tvOS_String;
 				break;
 			case Profile.watchOS:
-				targetFramework = TargetFramework.DotNet_6_0_watchOS_String;
+				targetFramework = TargetFramework.DotNet_watchOS_String;
 				break;
 			case Profile.macOSMobile:
-				targetFramework = TargetFramework.DotNet_6_0_macOS_String;
+				targetFramework = TargetFramework.DotNet_macOS_String;
 				break;
 			case Profile.macOSFull:
 			case Profile.macOSSystem:

--- a/tests/generator/GeneratorTests.cs
+++ b/tests/generator/GeneratorTests.cs
@@ -24,7 +24,7 @@ namespace GeneratorTests
 
 			var arguments = new List<string> ();
 #if NET
-			var targetFramework = TargetFramework.DotNet_6_0_iOS_String;
+			var targetFramework = TargetFramework.DotNet_iOS_String;
 			var tf = TargetFramework.Parse (targetFramework);
 			arguments.Add ($"--baselib={Configuration.GetBaseLibrary (tf)}");
 			arguments.Add ($"--attributelib={Configuration.GetBindingAttributePath (tf)}");

--- a/tools/common/TargetFramework.cs
+++ b/tools/common/TargetFramework.cs
@@ -14,11 +14,12 @@ namespace Xamarin.Utils
 {
 	public struct TargetFramework : IEquatable<TargetFramework>
 	{
-		public const string DotNet_6_0_iOS_String = ".NETCoreApp,Version=6.0,Profile=ios"; // Short form: net6.0-ios
-		public const string DotNet_6_0_tvOS_String = ".NETCoreApp,Version=6.0,Profile=tvos"; // Short form: net6.0-tvos
-		public const string DotNet_6_0_watchOS_String = ".NETCoreApp,Version=6.0,Profile=watchos"; // Short form: net6.0-watchos
-		public const string DotNet_6_0_macOS_String = ".NETCoreApp,Version=6.0,Profile=macos"; // Short form: net6.0-macos
-		public const string DotNet_6_0_MacCatalyst_String = ".NETCoreApp,Version=6.0,Profile=maccatalyst"; // Short form: net6.0-maccatalyst
+		const string TFMVersion = "6.0";
+		public const string DotNet_iOS_String = ".NETCoreApp,Version=" + TFMVersion + ",Profile=ios"; // Short form: netX.Y-ios
+		public const string DotNet_tvOS_String = ".NETCoreApp,Version=" + TFMVersion + ",Profile=tvos"; // Short form: netX.Y-tvos
+		public const string DotNet_watchOS_String = ".NETCoreApp,Version=" + TFMVersion + ",Profile=watchos"; // Short form: netX.Y-watchos
+		public const string DotNet_macOS_String = ".NETCoreApp,Version=" + TFMVersion + ",Profile=macos"; // Short form: netX.Y-macos
+		public const string DotNet_MacCatalyst_String = ".NETCoreApp,Version=" + TFMVersion + ",Profile=maccatalyst"; // Short form: netX.Y-maccatalyst
 
 		public static readonly TargetFramework Empty = new TargetFramework ();
 		public static readonly TargetFramework Net_2_0 = Parse ("2.0");
@@ -37,21 +38,21 @@ namespace Xamarin.Utils
 		public static readonly TargetFramework Xamarin_Mac_4_5_Full = Parse ("Xamarin.Mac,Version=v4.5,Profile=Full");
 		public static readonly TargetFramework Xamarin_Mac_4_5_System = Parse ("Xamarin.Mac,Version=v4.5,Profile=System");
 
-		public static readonly TargetFramework DotNet_5_0_iOS = Parse (DotNet_6_0_iOS_String);
-		public static readonly TargetFramework DotNet_5_0_tvOS = Parse (DotNet_6_0_tvOS_String);
-		public static readonly TargetFramework DotNet_5_0_watchOS = Parse (DotNet_6_0_watchOS_String);
-		public static readonly TargetFramework DotNet_5_0_macOS = Parse (DotNet_6_0_macOS_String);
-		public static readonly TargetFramework DotNet_5_0_MacCatalyst = Parse (DotNet_6_0_MacCatalyst_String);
+		public static readonly TargetFramework DotNet_iOS = Parse (DotNet_iOS_String);
+		public static readonly TargetFramework DotNet_tvOS = Parse (DotNet_tvOS_String);
+		public static readonly TargetFramework DotNet_watchOS = Parse (DotNet_watchOS_String);
+		public static readonly TargetFramework DotNet_macOS = Parse (DotNet_macOS_String);
+		public static readonly TargetFramework DotNet_MacCatalyst = Parse (DotNet_MacCatalyst_String);
 
 		public static readonly TargetFramework [] ValidFrameworksMac = new [] {
 			Xamarin_Mac_2_0_Mobile, Xamarin_Mac_4_5_Full, Xamarin_Mac_4_5_System,
-			DotNet_5_0_macOS,
+			DotNet_macOS,
 		};
 
 		public static readonly TargetFramework [] ValidFrameworksiOS = new [] {
 			Xamarin_iOS_1_0, Xamarin_WatchOS_1_0, Xamarin_TVOS_1_0,
 			Xamarin_MacCatalyst_1_0,
-			DotNet_5_0_iOS, DotNet_5_0_tvOS, DotNet_5_0_watchOS, DotNet_5_0_MacCatalyst,
+			DotNet_iOS, DotNet_tvOS, DotNet_watchOS, DotNet_MacCatalyst,
 		};
 
 		public static IEnumerable<TargetFramework> AllValidFrameworks {
@@ -251,15 +252,15 @@ namespace Xamarin.Utils
 		{
 			switch (platform) {
 			case ApplePlatform.iOS:
-				return isDotNet ? DotNet_5_0_iOS : Xamarin_iOS_1_0;
+				return isDotNet ? DotNet_iOS : Xamarin_iOS_1_0;
 			case ApplePlatform.TVOS:
-				return isDotNet ? DotNet_5_0_tvOS : Xamarin_TVOS_1_0;
+				return isDotNet ? DotNet_tvOS : Xamarin_TVOS_1_0;
 			case ApplePlatform.MacCatalyst:
-				return DotNet_5_0_MacCatalyst;
+				return DotNet_MacCatalyst;
 			case ApplePlatform.WatchOS:
 				return Xamarin_WatchOS_1_0;
 			case ApplePlatform.MacOSX:
-				return isDotNet ? DotNet_5_0_macOS : Xamarin_Mac_2_0;
+				return isDotNet ? DotNet_macOS : Xamarin_Mac_2_0;
 			default:
 				throw new ArgumentOutOfRangeException (nameof (platform), string.Format ("Unknown platform: {0}", platform.ToString ()));
 			}

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -80,11 +80,11 @@ Xamarin.Mac.registrar.mobile.arm64.m: $(TOP)/src/build/mac/mobile-64/Xamarin.Mac
 	$(Q) touch Xamarin.Mac.registrar.mobile.arm64.m Xamarin.Mac.registrar.mobile.arm64.h
 
 Microsoft.macOS.registrar.x86_64.m: $(TOP)/src/build/dotnet/macos/64/Microsoft.macOS.dll $(LOCAL_MMP)
-	$(GENERATE_PART_REGISTRAR) --arch=x86_64 --target-framework .NETCoreApp,Version=6.0,Profile=macos -a:$(DOTNET_BCL_DIR)/System.Runtime.dll -a:$(DOTNET_SYSTEM_RUNTIME_INTEROPSERVICES_REF_ASSEMBLY_DIR)/System.Runtime.InteropServices.dll
+	$(GENERATE_PART_REGISTRAR) --arch=x86_64 --target-framework .NETCoreApp,Version=$(subst net,,$(DOTNET_TFM)),Profile=macos -a:$(DOTNET_BCL_DIR)/System.Runtime.dll -a:$(DOTNET_SYSTEM_RUNTIME_INTEROPSERVICES_REF_ASSEMBLY_DIR)/System.Runtime.InteropServices.dll
 	$(Q) touch $@ $(basename $@).h
 
 Microsoft.macOS.registrar.coreclr.x86_64.m: $(TOP)/src/build/dotnet/macos/64/Microsoft.macOS.dll $(LOCAL_MMP)
-	$(GENERATE_PART_REGISTRAR) --arch=x86_64 --target-framework .NETCoreApp,Version=6.0,Profile=macos -a:$(DOTNET_BCL_DIR)/System.Runtime.dll -a:$(DOTNET_SYSTEM_RUNTIME_INTEROPSERVICES_REF_ASSEMBLY_DIR)/System.Runtime.InteropServices.dll --xamarin-runtime CoreCLR
+	$(GENERATE_PART_REGISTRAR) --arch=x86_64 --target-framework .NETCoreApp,Version=$(subst net,,$(DOTNET_TFM)),Profile=macos -a:$(DOTNET_BCL_DIR)/System.Runtime.dll -a:$(DOTNET_SYSTEM_RUNTIME_INTEROPSERVICES_REF_ASSEMBLY_DIR)/System.Runtime.InteropServices.dll --xamarin-runtime CoreCLR
 	$(Q) touch $@ $(basename $@).h
 
 Xamarin.Mac.registrar.full.x86_64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.dll $(LOCAL_MMP)
@@ -92,11 +92,11 @@ Xamarin.Mac.registrar.full.x86_64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.
 	$(Q) touch Xamarin.Mac.registrar.full.x86_64.m Xamarin.Mac.registrar.full.x86_64.h
 
 Microsoft.macOS.registrar.arm64.m: $(TOP)/src/build/dotnet/macos/64/Microsoft.macOS.dll $(LOCAL_MMP)
-	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework .NETCoreApp,Version=6.0,Profile=macos -a:$(DOTNET_BCL_DIR)/System.Runtime.dll -a:$(DOTNET_SYSTEM_RUNTIME_INTEROPSERVICES_REF_ASSEMBLY_DIR)/System.Runtime.InteropServices.dll
+	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework .NETCoreApp,Version=$(subst net,,$(DOTNET_TFM)),Profile=macos -a:$(DOTNET_BCL_DIR)/System.Runtime.dll -a:$(DOTNET_SYSTEM_RUNTIME_INTEROPSERVICES_REF_ASSEMBLY_DIR)/System.Runtime.InteropServices.dll
 	$(Q) touch $@ $(basename $@).h
 
 Microsoft.macOS.registrar.coreclr.arm64.m: $(TOP)/src/build/dotnet/macos/64/Microsoft.macOS.dll $(LOCAL_MMP)
-	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework .NETCoreApp,Version=6.0,Profile=macos -a:$(DOTNET_BCL_DIR)/System.Runtime.dll -a:$(DOTNET_SYSTEM_RUNTIME_INTEROPSERVICES_REF_ASSEMBLY_DIR)/System.Runtime.InteropServices.dll --xamarin-runtime CoreCLR
+	$(GENERATE_PART_REGISTRAR) --arch=arm64 --target-framework .NETCoreApp,Version=$(subst net,,$(DOTNET_TFM)),Profile=macos -a:$(DOTNET_BCL_DIR)/System.Runtime.dll -a:$(DOTNET_SYSTEM_RUNTIME_INTEROPSERVICES_REF_ASSEMBLY_DIR)/System.Runtime.InteropServices.dll --xamarin-runtime CoreCLR
 	$(Q) touch $@ $(basename $@).h
 
 Xamarin.Mac.registrar.full.arm64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.dll $(LOCAL_MMP)

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -230,7 +230,7 @@ define RunRegistrar
 	$$(Q) touch $$(basename $$@).m $$(basename $$@).h
 
 .libs/Microsoft.$(9).registrar.$(10)%m .libs/Microsoft.$(9).registrar.$(10)%h: $(TOP)/src/build/dotnet/$(1)/$(3)/Microsoft.$(9).dll $(LOCAL_MTOUCH) | .libs
-	$$(Q_GEN) $$(LOCAL_MTOUCH_COMMAND) --xamarin-framework-directory=$$(IOS_DESTDIR)/$$(MONOTOUCH_PREFIX) $$(MTOUCH_VERBOSITY) --runregistrar:$$(abspath $$(basename $$@).m) --sdkroot $$(XCODE_DEVELOPER_ROOT) --sdk $(4) $$< --registrar:static --target-framework .NETCoreApp,Version=6.0,Profile=$(1) --abi $(2) -r:$(DOTNET_BCL_DIR)/System.Runtime.dll -r:$(DOTNET_SYSTEM_RUNTIME_INTEROPSERVICES_REF_ASSEMBLY_DIR)/System.Runtime.InteropServices.dll --rid $(10)
+	$$(Q_GEN) $$(LOCAL_MTOUCH_COMMAND) --xamarin-framework-directory=$$(IOS_DESTDIR)/$$(MONOTOUCH_PREFIX) $$(MTOUCH_VERBOSITY) --runregistrar:$$(abspath $$(basename $$@).m) --sdkroot $$(XCODE_DEVELOPER_ROOT) --sdk $(4) $$< --registrar:static --target-framework .NETCoreApp,Version=$(subst net,,$(DOTNET_TFM)),Profile=$(1) --abi $(2) -r:$(DOTNET_BCL_DIR)/System.Runtime.dll -r:$(DOTNET_SYSTEM_RUNTIME_INTEROPSERVICES_REF_ASSEMBLY_DIR)/System.Runtime.InteropServices.dll --rid $(10)
 	$$(Q) touch $$(basename $$@).m $$(basename $$@).h
 
 %.registrar.$(1).$(2).a: %.registrar.$(1).$(2).m %.registrar.$(1).$(2).h


### PR DESCRIPTION
This minimizes the code changes required for .NET 7.