### PR TITLE
[msbuild] Enable nullability for the CompileAppManifest task.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
@@ -1,6 +1,8 @@
 using Xamarin.MacDev.Tasks;
 using Xamarin.MacDev;
 
+#nullable enable
+
 namespace Xamarin.Mac.Tasks {
 	public abstract class CompileAppManifestTaskCore : CompileAppManifestTaskBase {
 

--- a/msbuild/Xamarin.Mac.Tasks.Core/Xamarin.Mac.Tasks.Core.csproj
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Xamarin.Mac.Tasks.Core.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/CompileAppManifest.cs
@@ -6,6 +6,8 @@
 //
 // Copyright 2014 Xamarin Inc.
 
+#nullable enable
+
 namespace Xamarin.Mac.Tasks {
 	public class CompileAppManifest : CompileAppManifestTaskCore {
 	}

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -6,6 +6,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../product.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);8002</NoWarn> <!-- Referenced projects aren't signed: this doesn't matter, because we use ILMerge to merge into a single assembly which we sign -->
+    <LangVersion>latest</LangVersion>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Messaging.Build.Client" Version="$(MessagingVersion)" />

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -9,6 +9,8 @@ using Microsoft.Build.Utilities;
 using Xamarin.Localization.MSBuild;
 using Xamarin.Utils;
 
+#nullable enable
+
 namespace Xamarin.MacDev.Tasks
 {
 	public abstract class CompileAppManifestTaskBase : XamarinTask
@@ -16,39 +18,39 @@ namespace Xamarin.MacDev.Tasks
 		#region Inputs
 
 		// Single-project property that maps to CFBundleIdentifier for Apple platforms
-		public string ApplicationId { get; set; }
+		public string ApplicationId { get; set; } = String.Empty;
 
 		// Single-project property that maps to CFBundleShortVersionString for Apple platforms
-		public string ApplicationDisplayVersion { get; set; }
+		public string ApplicationDisplayVersion { get; set; } = String.Empty;
 
 		// Single-project property that maps to CFBundleDisplayName for Apple platforms
-		public string ApplicationTitle { get; set; }
+		public string ApplicationTitle { get; set; } = String.Empty;
 
 		// Single-project property that maps to CFBundleVersion for Apple platforms
-		public string ApplicationVersion { get; set; }
+		public string ApplicationVersion { get; set; } = String.Empty;
 
 		[Required]
-		public string AppBundleName { get; set; }
+		public string AppBundleName { get; set; } = String.Empty;
 
 		// This must be an ITaskItem to copy the file to Windows for remote builds.
-		public ITaskItem AppManifest { get; set; }
+		public ITaskItem? AppManifest { get; set; }
 
 		[Required]
-		public string AssemblyName { get; set; }
+		public string AssemblyName { get; set; } = String.Empty;
 
 		[Required]
 		[Output] // This is required to create an empty file on Windows for the Input/Outputs check.
-		public ITaskItem CompiledAppManifest { get; set; }
+		public ITaskItem? CompiledAppManifest { get; set; }
 
 		[Required]
 		public bool Debug { get; set; }
 
-		public string DebugIPAddresses { get; set; }
+		public string DebugIPAddresses { get; set; } = String.Empty;
 
 		[Required]
-		public string DefaultSdkVersion { get; set; }
+		public string DefaultSdkVersion { get; set; } = String.Empty;
 
-		public ITaskItem [] FontFilesToRegister { get; set; }
+		public ITaskItem [] FontFilesToRegister { get; set; } = Array.Empty<ITaskItem> ();
 
 		// Single-project property that determines whether other single-project properties should have any effect
 		public bool GenerateApplicationManifest { get; set; }
@@ -62,28 +64,28 @@ namespace Xamarin.MacDev.Tasks
 
 		public bool IsWatchExtension { get; set; }
 
-		public ITaskItem[] PartialAppManifests { get; set; }
+		public ITaskItem [] PartialAppManifests { get; set; } = Array.Empty<ITaskItem> ();
 
 		[Required]
-		public string ProjectDir { get; set; }
+		public string ProjectDir { get; set; } = String.Empty;
 
 		[Required]
-		public string ResourcePrefix { get; set; }
+		public string ResourcePrefix { get; set; } = String.Empty;
 
-		public string ResourceRules { get; set; }
+		public string ResourceRules { get; set; } = String.Empty;
 
 		[Required]
-		public string SdkPlatform { get; set; }
+		public string SdkPlatform { get; set; } = String.Empty;
 
 		[Required]
 		public bool SdkIsSimulator { get; set; }
 
 		[Required]
-		public string SdkVersion { get; set; }
+		public string SdkVersion { get; set; } = String.Empty;
 
-		public string SupportedOSPlatformVersion { get; set; }
+		public string SupportedOSPlatformVersion { get; set; } = String.Empty;
 
-		public string TargetArchitectures { get; set; }
+		public string TargetArchitectures { get; set; } = String.Empty;
 
 		public bool Validate { get; set; }
 		#endregion
@@ -92,10 +94,10 @@ namespace Xamarin.MacDev.Tasks
 
 		public override bool Execute ()
 		{
-			PDictionary plist = null;
+			PDictionary plist;
 
 			var appManifest = AppManifest?.ItemSpec;
-			if (File.Exists (appManifest)) {
+			if (appManifest is not null && File.Exists (appManifest)) {
 				try {
 					plist = PDictionary.FromFile (appManifest);
 				} catch (Exception ex) {
@@ -127,7 +129,7 @@ namespace Xamarin.MacDev.Tasks
 				defaultBundleVersion = ApplicationVersion;
 			plist.SetIfNotPresent (ManifestKeys.CFBundleVersion, defaultBundleVersion);
 
-			string defaultBundleShortVersion = null;
+			string? defaultBundleShortVersion = null;
 			if (GenerateApplicationManifest) {
 				if (!string.IsNullOrEmpty (ApplicationDisplayVersion))
 					defaultBundleShortVersion = ApplicationDisplayVersion;
@@ -154,7 +156,7 @@ namespace Xamarin.MacDev.Tasks
 			Validation (plist);
 
 			// write the resulting app manifest
-			if (FileUtils.UpdateFile (CompiledAppManifest.ItemSpec, (tmpfile) => plist.Save (tmpfile, true, true)))
+			if (FileUtils.UpdateFile (CompiledAppManifest!.ItemSpec, (tmpfile) => plist.Save (tmpfile, true, true)))
 				Log.LogMessage (MessageImportance.Low, "The file {0} is up-to-date.", CompiledAppManifest.ItemSpec);
 
 			return !Log.HasLoggedErrors;
@@ -189,7 +191,7 @@ namespace Xamarin.MacDev.Tasks
 
 		void RegisterFonts (PDictionary plist)
 		{
-			if (FontFilesToRegister == null || FontFilesToRegister.Length == 0)
+			if (FontFilesToRegister is null || FontFilesToRegister.Length == 0)
 				return;
 
 			// https://developer.apple.com/documentation/swiftui/applying-custom-fonts-to-text
@@ -209,7 +211,7 @@ namespace Xamarin.MacDev.Tasks
 			case ApplePlatform.MacCatalyst:
 				// Fonts are listed in the Info.plist in a UIAppFonts entry for iOS, tvOS, watchOS and Mac Catalyst.
 				var uiAppFonts = plist.GetArray ("UIAppFonts");
-				if (uiAppFonts == null) {
+				if (uiAppFonts is null) {
 					uiAppFonts = new PArray ();
 					plist ["UIAppFonts"] = uiAppFonts;
 				}
@@ -223,7 +225,7 @@ namespace Xamarin.MacDev.Tasks
 				var allSubdirectories = FontFilesToRegister.Select (v => Path.GetDirectoryName (v.GetMetadata (logicalNameKey)));
 				var distinctSubdirectories = allSubdirectories.Distinct ().ToArray ();
 				if (distinctSubdirectories.Length > 1) {
-					Log.LogError (MSBStrings.E7083 /* "All font files must be located in the same directory in the app bundle. The following font files have different target directories in the app bundle:" */, CompiledAppManifest.ItemSpec);
+					Log.LogError (MSBStrings.E7083 /* "All font files must be located in the same directory in the app bundle. The following font files have different target directories in the app bundle:" */, CompiledAppManifest!.ItemSpec);
 					foreach (var fonts in FontFilesToRegister)
 						Log.LogError (null, null, null, fonts.ItemSpec, 0, 0, 0, 0, MSBStrings.E7084 /* "The target directory is {0}" */, fonts.GetMetadata (logicalNameKey));
 				} else {
@@ -238,7 +240,7 @@ namespace Xamarin.MacDev.Tasks
 		bool SetMinimumOSVersion (PDictionary plist)
 		{
 			var minimumVersionKey = PlatformFrameworkHelper.GetMinimumOSVersionKey (Platform);
-			var minimumOSVersionInManifest = plist?.Get<PString> (minimumVersionKey)?.Value;
+			var minimumOSVersionInManifest = plist.Get<PString> (minimumVersionKey)?.Value;
 			string convertedSupportedOSPlatformVersion;
 			string minimumOSVersion;
 
@@ -254,10 +256,10 @@ namespace Xamarin.MacDev.Tasks
 
 			if (Platform == ApplePlatform.MacCatalyst && string.IsNullOrEmpty (minimumOSVersionInManifest)) {
 				// If there was no value for the macOS min version key, then check the iOS min version key.
-				var minimumiOSVersionInManifest = plist?.Get<PString> (ManifestKeys.MinimumOSVersion)?.Value;
+				var minimumiOSVersionInManifest = plist.Get<PString> (ManifestKeys.MinimumOSVersion)?.Value;
 				if (!string.IsNullOrEmpty (minimumiOSVersionInManifest)) {
 					// Convert to the macOS version
-					if (!MacCatalystSupport.TryGetMacOSVersion (Sdks.GetAppleSdk (Platform).GetSdkPath (SdkVersion, false), minimumiOSVersionInManifest, out var convertedVersion, out var knowniOSVersions))
+					if (!MacCatalystSupport.TryGetMacOSVersion (Sdks.GetAppleSdk (Platform).GetSdkPath (SdkVersion, false), minimumiOSVersionInManifest!, out var convertedVersion, out var knowniOSVersions))
 						Log.LogError (MSBStrings.E0188, minimumiOSVersionInManifest, string.Join (", ", knowniOSVersions));
 					minimumOSVersionInManifest = convertedVersion;
 				}
@@ -271,14 +273,14 @@ namespace Xamarin.MacDev.Tasks
 					minimumOSVersion = SdkVersion;
 				}
 			} else if (!IAppleSdkVersion_Extensions.TryParse (minimumOSVersionInManifest, out var _)) {
-				LogAppManifestError (MSBStrings.E0011, minimumOSVersionInManifest);
+				LogAppManifestError (MSBStrings.E0011, minimumOSVersionInManifest!);
 				return false;
 			} else if (!string.IsNullOrEmpty (convertedSupportedOSPlatformVersion) && convertedSupportedOSPlatformVersion != minimumOSVersionInManifest) {
 				// SupportedOSPlatformVersion and the value in the Info.plist are not the same. This is an error.
-				LogAppManifestError (MSBStrings.E7082, minimumVersionKey, minimumOSVersionInManifest, SupportedOSPlatformVersion);
+				LogAppManifestError (MSBStrings.E7082, minimumVersionKey, minimumOSVersionInManifest!, SupportedOSPlatformVersion);
 				return false;
 			} else {
-				minimumOSVersion = minimumOSVersionInManifest;
+				minimumOSVersion = minimumOSVersionInManifest!;
 			}
 
 			// Write out our value
@@ -287,10 +289,10 @@ namespace Xamarin.MacDev.Tasks
 			return true;
 		}
 
-		protected string GetMinimumOSVersion (PDictionary plist, out Version version)
+		protected string? GetMinimumOSVersion (PDictionary plist, out Version version)
 		{
 			var rv = plist.Get<PString> (PlatformFrameworkHelper.GetMinimumOSVersionKey (Platform))?.Value;
-			version = Version.Parse (rv);
+			Version.TryParse (rv, out version);
 			return rv;
 		}
 
@@ -299,7 +301,7 @@ namespace Xamarin.MacDev.Tasks
 		protected void LogAppManifestError (string format, params object[] args)
 		{
 			// Log an error linking to the Info.plist file
-			if (AppManifest != null) {
+			if (AppManifest is not null) {
 				Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, format, args);
 			} else {
 				Log.LogError (format, args);
@@ -310,7 +312,7 @@ namespace Xamarin.MacDev.Tasks
 		protected void LogAppManifestWarning (string format, params object[] args)
 		{
 			// Log a warning linking to the Info.plist file
-			if (AppManifest != null) {
+			if (AppManifest is not null) {
 				Log.LogWarning (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, format, args);
 			} else {
 				Log.LogWarning (format, args);
@@ -347,7 +349,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public static void MergePartialPLists (Task task, PDictionary plist, IEnumerable<ITaskItem> partialLists)
 		{
-			if (partialLists == null)
+			if (partialLists is null)
 				return;
 
 			foreach (var template in partialLists) {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
@@ -35,7 +35,7 @@ namespace Xamarin.MacDev.Tasks
 
 		// This property is required for XVS to work properly, even though it's not used for anything in the targets.
 		[Output]
-		public ITaskItem[] CopiedFiles { get; set; }
+		public ITaskItem [] CopiedFiles { get; set; } = Array.Empty<ITaskItem> ();
 
 		#endregion
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -5,6 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
     <DefineConstants>$(DefineConstants);MSBUILD_TASKS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskCore.cs
@@ -10,6 +10,8 @@ using Xamarin.MacDev;
 using Xamarin.Utils;
 using Xamarin.Localization.MSBuild;
 
+#nullable enable
+
 namespace Xamarin.iOS.Tasks
 {
 	public abstract class CompileAppManifestTaskCore : CompileAppManifestTaskBase
@@ -56,13 +58,13 @@ namespace Xamarin.iOS.Tasks
 			if (!plist.ContainsKey (ManifestKeys.CFBundleSupportedPlatforms))
 				plist[ManifestKeys.CFBundleSupportedPlatforms] = new PArray { SdkPlatform };
 
-			string dtCompiler = null;
-			string dtPlatformBuild = null;
-			string dtSDKBuild = null;
-			string dtPlatformName = null;
-			string dtPlatformVersion = null;
-			string dtXcode = null;
-			string dtXcodeBuild = null;
+			string? dtCompiler = null;
+			string? dtPlatformBuild = null;
+			string? dtSDKBuild = null;
+			string? dtPlatformName;
+			string? dtPlatformVersion = null;
+			string? dtXcode = null;
+			string? dtXcodeBuild = null;
 
 			if (!SdkIsSimulator) {
 				dtCompiler = sdkSettings.DTCompiler;
@@ -138,9 +140,9 @@ namespace Xamarin.iOS.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		void SetValueIfNotNull (PDictionary dict, string key, string value)
+		void SetValueIfNotNull (PDictionary dict, string key, string? value)
 		{
-			if (value == null)
+			if (value is null)
 				return;
 			SetValue (dict, key, value);
 		}
@@ -158,7 +160,7 @@ namespace Xamarin.iOS.Tasks
 					for (int i = 0; i < array.Count; i++) {
 						var value = array[i] as PString;
 
-						if (value == null || !architectureValues.Contains (value.Value))
+						if (value is null || !architectureValues.Contains (value.Value))
 							continue;
 
 						array.RemoveAt (i);

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <Import Project="..\..\eng\Versions.props" />

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/CompileAppManifest.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using Xamarin.iOS.Tasks.Windows.Properties;
 using Xamarin.MacDev;
 
+#nullable enable
+
 namespace Xamarin.iOS.HotRestart.Tasks
 {
 	public class CompileAppManifest : Task
@@ -26,12 +28,12 @@ namespace Xamarin.iOS.HotRestart.Tasks
 		#region Inputs
 
 		[Required]
-		public string AppBundlePath { get; set; }
+		public string AppBundlePath { get; set; } = String.Empty;
 
 		[Required]
-		public string AppManifestPath { get; set; }
+		public string AppManifestPath { get; set; } = String.Empty;
 
-		public string ApplicationTitle { get; set; }
+		public string ApplicationTitle { get; set; } = String.Empty;
 
 		#endregion
 

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -9,6 +9,8 @@
     <AssemblyOriginatorKeyFile>../../product.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);8002</NoWarn> <!-- Referenced projects aren't signed: this doesn't matter, because we use ILMerge to merge into a single assembly which we sign -->
     <RuntimeIdentifier>win</RuntimeIdentifier>
+    <LangVersion>latest</LangVersion>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
   <Import Project="..\..\eng\Versions.props" />
   <ItemGroup>

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CompileAppManifest.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 
+#nullable enable
+
 namespace Xamarin.iOS.Tasks
 {
 	public class CompileAppManifest : CompileAppManifestTaskCore, ITaskCallback, ICancelableTask
@@ -18,7 +20,7 @@ namespace Xamarin.iOS.Tasks
 		public bool ShouldCopyToBuildServer (ITaskItem item)
 		{
 			// We don't want to copy partial generated manifest files
-			if (PartialAppManifests != null && PartialAppManifests.Contains (item))
+			if (PartialAppManifests is not null && PartialAppManifests.Contains (item))
 				return false;
 
 			return true;

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -7,6 +7,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../product.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);8002</NoWarn> <!-- Referenced projects aren't signed: this doesn't matter, because we use ILMerge to merge into a single assembly which we sign -->
+    <LangVersion>latest</LangVersion>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <Import Project="..\..\eng\Versions.props" />


### PR DESCRIPTION
This also meant:

* Using 'latest' as the C# language version for all msbuild/ project files.
* Enabling warnaserror for nullability warnings.
* Fix any nullability warnings in the CompileAppManifest files.
* Fix a nullability warning in the Ditto task.
* Fix any '== null' or '!= null' to use 'is null' and 'is not null'.