### PR TITLE
[messageui] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/MessageUI/MessageUI2.cs
+++ b/src/MessageUI/MessageUI2.cs
@@ -7,6 +7,8 @@
 // Copyright 2009, Novell, Inc.
 //
 
+#nullable enable
+
 using System;
 using ObjCRuntime;
 using Foundation;
@@ -15,21 +17,21 @@ using CoreFoundation;
 namespace MessageUI {
 
 	public class MFComposeResultEventArgs : EventArgs {
-		public MFComposeResultEventArgs (MFMailComposeViewController controller, MFMailComposeResult result, NSError error)
+		public MFComposeResultEventArgs (MFMailComposeViewController controller, MFMailComposeResult result, NSError? error)
 		{
 			Result = result;
 			Error = error;
 			Controller = controller;
 		}
 		public MFMailComposeResult Result { get; private set; }
-		public NSError Error { get; private set; }
+		public NSError? Error { get; private set; }
 		public MFMailComposeViewController Controller { get; private set; }
 	}
 	
 	public partial class MFMailComposeViewController {
 		Mono_MFMailComposeViewControllerDelegate EnsureDelegate ()
 		{
-			NSObject del = WeakMailComposeDelegate;
+			NSObject? del = WeakMailComposeDelegate;
 			if (del == null || (!(del is Mono_MFMailComposeViewControllerDelegate))){
 				del = new Mono_MFMailComposeViewControllerDelegate ();
 				WeakMailComposeDelegate = del;
@@ -49,7 +51,7 @@ namespace MessageUI {
 	}
 
 	class Mono_MFMailComposeViewControllerDelegate : MFMailComposeViewControllerDelegate {
-		internal EventHandler<MFComposeResultEventArgs> cbFinished;
+		internal EventHandler<MFComposeResultEventArgs>? cbFinished;
 
 		public Mono_MFMailComposeViewControllerDelegate ()
 		{
@@ -57,7 +59,7 @@ namespace MessageUI {
 		}
 
 		[Preserve (Conditional = true)]
-		public override void Finished (MFMailComposeViewController controller, MFMailComposeResult result, NSError error)
+		public override void Finished (MFMailComposeViewController controller, MFMailComposeResult result, NSError? error)
 		{
 			if (cbFinished != null)
 				cbFinished (controller, new MFComposeResultEventArgs (controller, result, error));
@@ -79,7 +81,7 @@ namespace MessageUI {
 	public partial class MFMessageComposeViewController {
 		Mono_MFMessageComposeViewControllerDelegate EnsureDelegate ()
 		{
-			NSObject del = WeakMessageComposeDelegate;
+			NSObject? del = WeakMessageComposeDelegate;
 			if (del == null || (!(del is Mono_MFMessageComposeViewControllerDelegate))){
 				del = new Mono_MFMessageComposeViewControllerDelegate ();
 				WeakMessageComposeDelegate = del;
@@ -99,7 +101,7 @@ namespace MessageUI {
 	}
 
 	class Mono_MFMessageComposeViewControllerDelegate : MFMessageComposeViewControllerDelegate {
-		internal EventHandler<MFMessageComposeResultEventArgs> cbFinished;
+		internal EventHandler<MFMessageComposeResultEventArgs>? cbFinished;
 
 		public Mono_MFMessageComposeViewControllerDelegate ()
 		{

--- a/src/MessageUI/MessageUI2.cs
+++ b/src/MessageUI/MessageUI2.cs
@@ -32,7 +32,7 @@ namespace MessageUI {
 		Mono_MFMailComposeViewControllerDelegate EnsureDelegate ()
 		{
 			NSObject? del = WeakMailComposeDelegate;
-			if (del == null || (!(del is Mono_MFMailComposeViewControllerDelegate))){
+			if (del is null || (!(del is Mono_MFMailComposeViewControllerDelegate))){
 				del = new Mono_MFMailComposeViewControllerDelegate ();
 				WeakMailComposeDelegate = del;
 			}
@@ -61,7 +61,7 @@ namespace MessageUI {
 		[Preserve (Conditional = true)]
 		public override void Finished (MFMailComposeViewController controller, MFMailComposeResult result, NSError? error)
 		{
-			if (cbFinished != null)
+			if (cbFinished is not null)
 				cbFinished (controller, new MFComposeResultEventArgs (controller, result, error));
 		}
 	}
@@ -82,7 +82,7 @@ namespace MessageUI {
 		Mono_MFMessageComposeViewControllerDelegate EnsureDelegate ()
 		{
 			NSObject? del = WeakMessageComposeDelegate;
-			if (del == null || (!(del is Mono_MFMessageComposeViewControllerDelegate))){
+			if (del is null || (!(del is Mono_MFMessageComposeViewControllerDelegate))){
 				del = new Mono_MFMessageComposeViewControllerDelegate ();
 				WeakMessageComposeDelegate = del;
 			}
@@ -111,7 +111,7 @@ namespace MessageUI {
 		[Preserve (Conditional = true)]
 		public override void Finished (MFMessageComposeViewController controller, MessageComposeResult result)
 		{
-			if (cbFinished != null)
+			if (cbFinished is not null)
 				cbFinished (controller, new MFMessageComposeResultEventArgs (controller, result));
 		}
 	}


### PR DESCRIPTION
This PR aims to bring nullability changes to MessageUI.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing any `== null` or `!= null` to `is null` and `is not null`