### PR TITLE
[mobilecoreservices] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/MobileCoreServices/UTType.cs
+++ b/src/MobileCoreServices/UTType.cs
@@ -25,6 +25,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
@@ -136,7 +138,7 @@ namespace MobileCoreServices {
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static IntPtr /* NSString */ UTTypeCreatePreferredIdentifierForTag (IntPtr /* CFStringRef */ tagClassStr, IntPtr /* CFStringRef */ tagStr, IntPtr /* CFStringRef */ conformingToUtiStr);
 
-		public static string CreatePreferredIdentifier (string tagClass, string tag, string conformingToUti)
+		public static string? CreatePreferredIdentifier (string tagClass, string tag, string conformingToUti)
 		{
 			var a = CFString.CreateNative (tagClass);
 			var b = CFString.CreateNative (tag);
@@ -151,7 +153,7 @@ namespace MobileCoreServices {
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static IntPtr /* NSString Array */ UTTypeCreateAllIdentifiersForTag (IntPtr /* CFStringRef */ tagClassStr, IntPtr /* CFStringRef */ tagStr, IntPtr /* CFStringRef */ conformingToUtiStr);
 
-		public static string [] CreateAllIdentifiers (string tagClass, string tag, string conformingToUti)
+		public static string? []? CreateAllIdentifiers (string tagClass, string tag, string conformingToUti)
 		{
 			if (tagClass is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (tagClass));
@@ -205,7 +207,7 @@ namespace MobileCoreServices {
 		[iOS (8,0)]
 		[Mac (10,10)]
 #endif
-		public static string [] CopyAllTags (string uti, string tagClass)
+		public static string? []? CopyAllTags (string uti, string tagClass)
 		{
 			if (uti is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (uti));
@@ -242,7 +244,7 @@ namespace MobileCoreServices {
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static IntPtr /* NSString */ UTTypeCopyDescription (IntPtr /* CFStringRef */ utiStr);
 
-		public static string GetDescription (string uti)
+		public static string? GetDescription (string uti)
 		{
 			if (uti is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (uti));
@@ -256,7 +258,7 @@ namespace MobileCoreServices {
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static IntPtr /* CFStringRef */ UTTypeCopyPreferredTagWithClass (IntPtr /* CFStringRef */ uti, IntPtr /* CFStringRef */ tagClass);
 
-		public static string GetPreferredTag (string uti, string tagClass)
+		public static string? GetPreferredTag (string uti, string tagClass)
 		{
 			if (uti is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (uti));
@@ -274,7 +276,7 @@ namespace MobileCoreServices {
 		[DllImport (Constants.CoreServicesLibrary)]
 		extern static IntPtr /* NSDictionary */ UTTypeCopyDeclaration (IntPtr utiStr);
 
-		public static NSDictionary GetDeclaration (string uti)
+		public static NSDictionary? GetDeclaration (string uti)
 		{
 			if (uti is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (uti));
@@ -289,9 +291,9 @@ namespace MobileCoreServices {
 		extern static IntPtr /* NSUrl */ UTTypeCopyDeclaringBundleURL (IntPtr utiStr);
 
 #if NET
-		public static NSUrl GetDeclaringBundleUrl (string uti)
+		public static NSUrl? GetDeclaringBundleUrl (string uti)
 #else
-		public static NSUrl GetDeclaringBundleURL (string uti)
+		public static NSUrl? GetDeclaringBundleURL (string uti)
 #endif
 		{
 			if (uti is null)


### PR DESCRIPTION
This PR aims to bring nullability changes to MobileCoreServices.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes