### PR TITLE
[metrickit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/MetricKit/MXMetaData.cs
+++ b/src/MetricKit/MXMetaData.cs
@@ -1,4 +1,7 @@
 #if IOS
+
+#nullable enable
+
 using System;
 
 using Foundation;

--- a/src/MetricKit/MXMetric.cs
+++ b/src/MetricKit/MXMetric.cs
@@ -1,4 +1,7 @@
 #if IOS
+
+#nullable enable
+
 using System;
 
 using Foundation;

--- a/src/MetricKit/MXMetricManager.cs
+++ b/src/MetricKit/MXMetricManager.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 using CoreFoundation;

--- a/src/MetricKit/MXMetricPayload.cs
+++ b/src/MetricKit/MXMetricPayload.cs
@@ -1,4 +1,7 @@
 #if IOS
+
+#nullable enable
+
 using System;
 
 using Foundation;


### PR DESCRIPTION
This PR aims to bring nullability changes to MetricKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes