### PR TITLE
[dotnet] Use only the first three parts of our product version as the assembly version.

### DIFF
--- a/src/AssemblyInfo.cs.in
+++ b/src/AssemblyInfo.cs.in
@@ -29,5 +29,12 @@ using System.Runtime.CompilerServices;
 #endif
 
 #if NET
-[assembly: AssemblyVersion ("@NUGET_VERSION_MAJOR@.@NUGET_VERSION_MINOR@.@NUGET_VERSION_REV@.@NUGET_VERSION_BUILD@")]
+// Use a three-part version, because there shouldn't be any API changes when only the fourth digit changes.
+// In other words: the following scenario is safe:
+// - Assembly A builds against Microsoft.*.dll v1.0.0.1
+// - Assembly B builds against Assembly A and Microsoft.*.dll v1.0.0.0
+// - Assembly B should build just fine, because those two versions of Microsoft.*.dll have the exact same API.
+// To avoid scenarios where everybody would have to update to the latest patch version of Microsoft.*.dll
+// in order to compile stuff, we erase the fourth number and only use 0.
+[assembly: AssemblyVersion ("@NUGET_VERSION_MAJOR@.@NUGET_VERSION_MINOR@.@NUGET_VERSION_REV@.0")]
 #endif


### PR DESCRIPTION
Problem:

* Assembly A is compiled referencing Microsoft.*.dll v1.0.0.123
* Assembly B is compiled referencing assembly A, and Microsoft.*.dll v1.0.0.0

The C# compiler doesn't like this, and says something like:

> error CS1705: Assembly 'A' with identity 'A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' uses 'Microsoft.iOS, Version=1.0.0.123, Culture=neutral, PublicKeyToken=84e04ff9cfb79065' which has a higher version than referenced assembly 'Microsoft.iOS' with identity 'Microsoft.iOS, Version=1.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'

The C# compiler is right: you need all your local references to be at least
the version of any indirect references, otherwise you're compiling using
outdated API.

On the other hand, we know that [1] we don't have any API differences (neither
additions nor removals) between stable versions of assemblies where only the
fourth digit is different.

In that case, the C# compiler error is just making things more complicated for
users, because if a upstream dependency is compiled with a newer (but
API-identical) version of Microsoft.*.dll, it forces all their users to update
as well.

The fix is to always use '0' as the fourth digit. That way the C# compiler
will accept different versions of any API-identical assemblies, and everybody
is happy [2].

[1]: We know that we _shouldn't_ have API changes when the fourth digit
changes. Hopefully we won't make any mistakes here...

[2]: However, for people using preview versions, there may very well be API
differences when the fourth digit changes. In that case, you're own your own,
and if the build breaks, you get to guess the actual problem and then figure
out the fix (which would usually be to use the latest version of the preview).