### PR TITLE
[multipeerconnectivity] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/MultipeerConnectivity/Compat.cs
+++ b/src/MultipeerConnectivity/Compat.cs
@@ -7,6 +7,8 @@
 // Copyright 2015 Xamarin Inc.
 //
 
+#nullable enable
+
 using System;
 
 namespace MultipeerConnectivity {

--- a/src/MultipeerConnectivity/MCSession.cs
+++ b/src/MultipeerConnectivity/MCSession.cs
@@ -37,7 +37,7 @@ namespace MultipeerConnectivity {
 				if (certificates == null)
 					Handle = Init (myPeerID, null, encryptionPreference);
 				else
-					throw new ArgumentNullException ("identity");
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (identity));
 			} else {
 				using (var certs = NSArray.FromNativeObjects (certificates))
 					Handle = Init (myPeerID, certs, encryptionPreference);

--- a/src/MultipeerConnectivity/MCSession.cs
+++ b/src/MultipeerConnectivity/MCSession.cs
@@ -7,6 +7,8 @@
 // Copyright 2013-2014 Xamarin Inc.
 //
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/MultipeerConnectivity/MCSession.cs
+++ b/src/MultipeerConnectivity/MCSession.cs
@@ -22,7 +22,7 @@ namespace MultipeerConnectivity {
 		public MCSession (MCPeerID myPeerID, SecIdentity identity, MCEncryptionPreference encryptionPreference)
 			: base (NSObjectFlag.Empty)
 		{
-			if (identity == null) {
+			if (identity is null) {
 				Handle = Init (myPeerID, null, encryptionPreference);
 			} else {
 				using (var a = NSArray.FromNSObjects (identity))
@@ -33,8 +33,8 @@ namespace MultipeerConnectivity {
 		public MCSession (MCPeerID myPeerID, SecIdentity identity, SecCertificate[] certificates, MCEncryptionPreference encryptionPreference)
 			: base (NSObjectFlag.Empty)
 		{
-			if (identity == null) {
-				if (certificates == null)
+			if (identity is null) {
+				if (certificates is null)
 					Handle = Init (myPeerID, null, encryptionPreference);
 				else
 					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (identity));


### PR DESCRIPTION
This PR aims to bring nullability changes to MultipeerConnectivity.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`