### PR TITLE
[xcode13.3] Updated Hot Restart client version

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<MessagingVersion>1.4.28</MessagingVersion>
-		<HotRestartVersion>1.0.82</HotRestartVersion>
+		<HotRestartVersion>1.0.90</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
This should fix a bug where Hot Restart doesn't work with net6 because of a strong naming exception on build time

We need this in xcode13.3 to bump then in XamarinVS in order to service release 17.1 with this fix


Backport of #14682
