### PR TITLE
[nativetypes] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/NativeTypes/NMath.cs
+++ b/src/NativeTypes/NMath.cs
@@ -7,6 +7,8 @@
 // Copyright 2014 Xamarin Inc. All rights reserved.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.CompilerServices;
 

--- a/src/NativeTypes/test.cs
+++ b/src/NativeTypes/test.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Drawing;
 using CoreGraphics;


### PR DESCRIPTION
This PR aims to bring nullability changes to NativeTypes.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes