### PR TITLE
Updated Xamarin.Messaging to 1.6.1

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.5.27</MessagingVersion>
+		<MessagingVersion>1.6.1</MessagingVersion>
 		<HotRestartVersion>1.0.90</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Changed from 1.5.* to 1.6.* to match the versioning used in XamarinVS main branch (1.5.* now remains only for 17.2 based branches)