### PR TITLE
[CI] Add a prefix to the comment headers.

### DIFF
--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -61,7 +61,13 @@ class GitHubComments {
         [string] $commentTitle,
         [string] $commentEmoji
     ) {
-        $stringBuilder.AppendLine("# $commentEmoji $commentTitle $commentEmoji")
+        if ([string]::IsNullOrEmpty($Env:PR_ID)) {
+            $prefix = "[CI Build]"
+        } else {
+            $prefix = "[PR Build]"
+        }
+
+        $stringBuilder.AppendLine("# $commentEmoji $prefix $commentTitle $commentEmoji")
     }
 
     [void] WriteCommentFooter(


### PR DESCRIPTION
Add a prefix that lets us know if the comment comes from a PR build
(using the public bots) or a CI build (using the private bots).