### PR TITLE
[CI] Add missing PR_ID env var.

### DIFF
--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -101,6 +101,7 @@ stages:
       # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
       BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
       XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness-labels'] ]
+      PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
       ${{ if eq(parameters.testPool, '') }}:
         AgentPoolComputed: $(PRBuildPool)
       ${{ else }}:


### PR DESCRIPTION
Needed so that we do know we are running the tests for a PR.