### PR TITLE
Update Messaging to 1.6.2 (revert changes)

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.6.1</MessagingVersion>
+		<MessagingVersion>1.6.2</MessagingVersion>
 		<HotRestartVersion>1.0.90</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
It includes a change revert because of threading freeze issues.
An issue has been detected in Xamarin.Messaging 1.5.26 and 1.6.1 that makes the code unstable and sensitive to thread freeze issues, so we are reverting back the changes until we can stabilize it.
This delays the fix of a bug in MSBuild command line builds for iOS remote builds.