### PR TITLE
[CI] Add new pwsh to allow to use the new code for test result comments.

### DIFF
--- a/.github/workflows/pwsh-ci.yml
+++ b/.github/workflows/pwsh-ci.yml
@@ -2,6 +2,7 @@ name: CI for pwsh
 on:
   push:
     branches: [ main ]
+  pull_request:
 jobs:
   test-pwsh:
     runs-on: windows-latest
@@ -15,4 +16,5 @@ jobs:
         Invoke-Pester -Path ./tools/devops/automation/scripts/APIDiff.Tests.ps1
         Invoke-Pester -Path ./tools/devops/automation/scripts/StaticPages.Tests.ps1
         Invoke-Pester -Path ./tools/devops/automation/scripts/Artifacts.Tests.ps1
+        Invoke-Pester -Path ./tools/devops/automation/scripts/TestResults.Tests.ps1
       shell: pwsh

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -41,6 +41,113 @@ function Invoke-Request {
     } while ($true)
 }
 
+class GitHubStatus {
+    [ValidateNotNullOrEmpty ()] [string] $Status
+    [ValidateNotNullOrEmpty ()] [string] $Description
+    [ValidateNotNullOrEmpty ()] [string] $Context
+    [string] $TargetUrl
+
+    GitHubStatus(
+        $status,
+        $description,
+        $context
+    ) {
+        if (-not $("error", "failure", "pending", "success").Contains($status)) {
+            throw [System.ArgumentOutOfRangeException]::new("status")
+        }
+        $this.Status = $status
+        $this.Description = $description
+        $this.Context = $context
+        $this.TargetUrl = $null
+    }
+
+    GitHubStatus(
+        $status,
+        $description,
+        $context,
+        $targetUrl
+    ) {
+        if (-not $("error", "failure", "pending", "success").Contains($status)) {
+            throw [System.ArgumentOutOfRangeException]::new("status")
+        }
+        $this.Status = $status
+        $this.Description = $description
+        $this.Context = $context
+        $this.TargetUrl = $targetUrl
+    }
+
+}
+
+class GitHubStatuses {
+    [ValidateNotNullOrEmpty ()][string] $Org
+    [ValidateNotNullOrEmpty ()][string] $Repo
+    [ValidateNotNullOrEmpty ()][string] $Token
+
+    GitHubStatuses (
+        $githubOrg,
+        $githubRepo,
+        $githubToken
+    ) {
+        $this.Org = $githubOrg
+        $this.Repo = $githubRepo
+        $this.Token = $githubToken
+    }
+
+    hidden [string] GetStatusUrl() {
+        if ($Env:BUILD_REASON -eq "PullRequest") {
+            # the env var is only provided for PR not for builds.
+            $url = "https://api.github.com/repos/$($this.Org)/$($this.Repo)/statuses/$Env:SYSTEM_PULLREQUEST_SOURCECOMMITID"
+        } else {
+            $url = "https://api.github.com/repos/$($this.Org)/$($this.Repo)/statuses/$Env:BUILD_REVISION"
+        }
+        return $url
+    }
+
+    [object] SetStatus($status) {
+        return $this.SetStatus(
+            $status.Status,
+            $status.Description,
+            $status.Context,
+            $status.TargetUrl)
+    }
+
+    [object] SetStatus($status, $description, $context, $targetUrl) {
+        $headers = @{
+            Authorization = ("token {0}" -f $this.Token)
+        }
+
+        $url = [GitHubStatuses]::GetStatusUrl()
+
+        # Check if the status was already set, if it was we will override yet print a message for the user to know this action was done.
+        $presentStatuses = Invoke-Request -Request { Invoke-RestMethod -Uri $url -Headers $headers -Method "GET" -ContentType 'application/json' }
+
+        # try to find the status with the same context and make a decision, this is not a dict but an array :/ 
+        foreach ($s in $presentStatuses) {
+            # we found a status from a previous build that was a success, we do not want to step on it
+            if (($s.context -eq $context) -and ($s.state -eq "success")) {
+                Write-Host "WARNING: Found status for $Context because it was already set as a success, overriding result."
+            }
+        }
+
+        # use the GitHub API to set the status for the given commit
+        $detailsUrl = ""
+        if ($targetUrl) {
+            $detailsUrl = $targetUrl
+        } else {
+            $detailsUrl = Get-TargetUrl
+        }
+
+        $payload= @{
+            state = $status
+            target_url = $detailsUrl
+            description = $description
+            context = $context
+        }
+
+        return Invoke-Request -Request { Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body ($payload | ConvertTo-json) -ContentType 'application/json' }
+    }
+}
+
 class GitHubComments {
     [ValidateNotNullOrEmpty ()][string] $Org
     [ValidateNotNullOrEmpty ()][string] $Repo
@@ -85,6 +192,37 @@ class GitHubComments {
         return $url
     }
 
+    [string] GetPayload($stringBuilder) {
+        # github has a max size for the comments to be added in a PR, it can be the case that because we failed so much, that we
+        # cannot add the full message, in that case, we add part of it, then a link to a gist with the content.
+        $maxLength = 32768
+        $body = $stringBuilder.ToString()
+        if ($body.Length -ge $maxLength) {
+            # create a gist with the contents, next, add substring of the message - the length of the info about the gist so that users
+            # can click, set that as the body
+            $gist =  New-GistWithContent -Description "Build results" -FileName "TestResult.md" -GistContent $body -FileType "md"
+            $linkMessage = "The message from CI is too large for the GitHub comments. You can find the full results [here]($gist)."
+            $messageLength = $maxLength - ($linkMessage.Length + 2) # +2 is to add a nice space
+            $body = $body.Substring(0, $messageLength);
+            $body = $body + "\n\n" + $linkMessage
+        }
+        return $body
+    }
+
+    hidden [object] NewComment($stringBuilder) {
+        $payload = @{
+            body = $this.GetPayload($stringBuilder)
+        }
+
+        $headers = @{
+            Authorization = ("token {0}" -f $this.Token)
+        }
+
+        $url = $this.GetCommentUrl()
+        $request = Invoke-Request -Request { Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body ($payload | ConvertTo-Json) -ContentType 'application/json' }
+        return $request
+    }
+
     [object] NewCommentFromObject(
         [string] $commentTitle,
         [string] $commentEmoji,
@@ -104,32 +242,7 @@ class GitHubComments {
         # footer
         $this.WriteCommentFooter($msg)
 
-
-        # github has a max size for the comments to be added in a PR, it can be the case that because we failed so much, that we
-        # cannot add the full message, in that case, we add part of it, then a link to a gist with the content.
-        $maxLength = 32768
-        $body = $msg.ToString()
-        if ($body.Length -ge $maxLength) {
-            # create a gist with the contents, next, add substring of the message - the length of the info about the gist so that users
-            # can click, set that as the body
-            $gist =  New-GistWithContent -Description "Build results" -FileName "TestResult.md" -GistContent $body -FileType "md"
-            $linkMessage = "The message from CI is too large for the GitHub comments. You can find the full results [here]($gist)."
-            $messageLength = $maxLength - ($linkMessage.Length + 2) # +2 is to add a nice space
-            $body = $body.Substring(0, $messageLength);
-            $body = $body + "\n\n" + $linkMessage
-        }
-
-        $payload = @{
-            body = $body
-        }
-
-        $headers = @{
-            Authorization = ("token {0}" -f $this.Token)
-        }
-
-        $url = $this.GetCommentUrl()
-        $request = Invoke-Request -Request { Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body ($payload | ConvertTo-Json) -ContentType 'application/json' }
-        return $request
+        return $this.NewComment($msg)
     }
 }
 

--- a/tools/devops/automation/scripts/MaciosCI.psd1
+++ b/tools/devops/automation/scripts/MaciosCI.psd1
@@ -72,6 +72,7 @@ NestedModules = @('APIDiff.psm1',
                'MLaunch.psm1', 
                'StaticPages.psm1', 
                'System.psm1', 
+               'TestResults.psm1', 
                'VSTS.psm1')
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.

--- a/tools/devops/automation/scripts/TestResults.Tests.ps1
+++ b/tools/devops/automation/scripts/TestResults.Tests.ps1
@@ -1,0 +1,129 @@
+$modulePath = "$PSScriptRoot\\TestResults.psm1"  # windows path separators work on unix and windows
+$scriptBody = "using module $modulePath"
+$script = [ScriptBlock]::Create($scriptBody)
+. $script
+
+Describe "TestResults tests" {
+    BeforeAll {
+        $dataPath = Join-Path -Path $PSScriptRoot -ChildPath "test_data" 
+        $dataPath = Join-Path -Path $dataPath -ChildPath "TestSummary.md"
+        $context = "tests"
+        $jobStatus = "Succeeded"
+    }
+
+    It "is correctly created" {
+        $testResult = [TestResults]::new($dataPath, $jobStatus, $context)
+        $testResult.ResultsPath | Should -Be $dataPath
+        $testResult.TestsJobStatus | Should -Be $jobStatus
+        $testResult.Context | Should -Be $context
+    }
+
+    It "is successfull" {
+        $testResult = [TestResults]::new($dataPath, "Succeeded", $context)
+        $testResult.IsSuccess() | Should -Be $true
+    }
+
+    It "is failure" {
+        $testResult = [TestResults]::new($dataPath, "Failure", $context)
+        $testResult.IsSuccess() | Should -Be $false
+    }
+
+    Context "missing file" {
+        BeforeAll {
+            $dataPath = Join-Path -Path $PSScriptRoot -ChildPath "test_data" 
+            $dataPath = Join-Path -Path $dataPath -ChildPath "MissingFile.md"
+            $testResult = [TestResults]::new($dataPath, $jobStatus, $context)
+        }
+
+        It "writes the correct comment." {
+            $sb = [System.Text.StringBuilder]::new()
+            $testResult.WriteComment($sb)
+            $content = $sb.ToString()
+            $content.Contains(":fire: Tests failed catastrophically on $($testResult.Context) (no summary found).") | Should -Be $true 
+        }
+
+        It "returns the correct status." {
+            $status = $testResult.GetStatus()
+            $status.Status | Should -Be "failure"
+            $status.Context | Should -Be $testResult.Context
+            $status.Description | Should -Be "Tests failed catastrophically on $($testResult.Context) (no summary found)."
+        }
+    }
+
+    Context "missing job status" {
+        BeforeAll {
+            $dataPath = Join-Path -Path $PSScriptRoot -ChildPath "test_data" 
+            $dataPath = Join-Path -Path $dataPath -ChildPath "TestSummary.md"
+            $testResult = [TestResults]::new($dataPath, "", $context)
+        }
+
+        It "writes the correct comment." {
+            $sb = [System.Text.StringBuilder]::new()
+            $testResult.WriteComment($sb)
+            $content = $sb.ToString()
+            $content.Contains(":x: Tests didn't execute on $($testResult.Context).") | Should -Be $true 
+        }
+
+        It "returns the correct status." {
+            $status = $testResult.GetStatus()
+            $status.Status | Should -Be "error"
+            $status.Context | Should -Be $testResult.Context
+            $status.Description | Should -Be "Tests didn't execute on $($testResult.Context)."
+        }
+    }
+
+    Context "success job status" {
+        BeforeAll {
+            $dataPath = Join-Path -Path $PSScriptRoot -ChildPath "test_data" 
+            $dataPath = Join-Path -Path $dataPath -ChildPath "TestSummary.md"
+            $testResult = [TestResults]::new($dataPath, $jobStatus, $context)
+        }
+
+        It "writes the correct comment." {
+            $sb = [System.Text.StringBuilder]::new()
+            $testResult.WriteComment($sb)
+            $content = $sb.ToString()
+            $content.Contains(":white_check_mark: Tests passed on $($testResult.Context).") | Should -Be $true 
+
+            # assert that each of the lines in the data file are present in the sb
+            foreach ($line in Get-Content -Path $testResult.ResultsPath)
+            {
+                $content.Contains($line) | Should -Be $true 
+            }
+        }
+
+        It "returns the correct status." {
+            $status = $testResult.GetStatus()
+            $status.Status | Should -Be "success"
+            $status.Context | Should -Be $testResult.Context
+            $status.Description | Should -Be "All tests passed on $($testResult.Context)."
+        }
+    }
+
+    Context "error job status" {
+        BeforeAll {
+            $testResult = [TestResults]::new($dataPath, "Failure", $context)
+        }
+
+        It "writes the correct comment." {
+            $sb = [System.Text.StringBuilder]::new()
+            $testResult.WriteComment($sb)
+            $content = $sb.ToString()
+            $content.Contains(":x: Tests failed on $($this.Context)") | Should -Be $true 
+
+            # assert that each of the lines in the data file are present in the sb
+            foreach ($line in Get-Content -Path $testResult.ResultsPath)
+            {
+                $content.Contains($line) | Should -Be $true 
+            }
+        }
+
+        It "returns the correct status." {
+            $status = $testResult.GetStatus()
+            $status.Status | Should -Be "error"
+            $status.Context | Should -Be $testResult.Context
+            $status.Description | Should -Be "Tests failed on $($testResult.Context)."
+        }
+    }
+
+}

--- a/tools/devops/automation/scripts/TestResults.psm1
+++ b/tools/devops/automation/scripts/TestResults.psm1
@@ -1,0 +1,64 @@
+using module ".\\GitHub.psm1"
+
+class TestResults {
+    [string] $ResultsPath # path to the file with the results
+    [string] $TestsJobStatus # the value of the env var that lets us know if the tests passed or not can be null or empty
+    [string] $Context
+
+    TestResults (
+        [string] $path,
+        [string] $status,
+        [string] $context
+    ) {
+        $this.ResultsPath = $path
+        $this.TestsJobStatus = $status
+        $this.Context = $context
+    }
+
+    [bool] IsSuccess() {
+        return $this.TestsJobStatus -eq "Succeeded"
+    }
+
+    [void] WriteComment($stringBuilder) {
+        $stringBuilder.AppendLine("## Test results")
+        $stringBuilder.AppendLine("")
+        if (-not (Test-Path $this.ResultsPath -PathType Leaf)) {
+             $stringBuilder.AppendLine(":fire: Tests failed catastrophically on $($this.Context) (no summary found).") 
+        } else {
+            if ($this.TestsJobStatus -eq "") {
+                $stringBuilder.AppendLine(":x: Tests didn't execute on $($this.Context).")
+            } elseif ($this.IsSuccess()) {
+                $stringBuilder.AppendLine(":white_check_mark: Tests passed on $($this.Context).")
+                $stringBuilder.AppendLine("")
+                foreach ($line in Get-Content -Path $this.ResultsPath)
+                {
+                    $stringBuilder.AppendLine($line)
+                }
+            } else {
+                $stringBuilder.AppendLine(":x: Tests failed on $($this.Context)") 
+                $stringBuilder.AppendLine("")
+                foreach ($line in Get-Content -Path $this.ResultsPath)
+                {
+                    $stringBuilder.AppendLine($line)
+                }
+            }
+        } 
+
+    }
+
+    [object] GetStatus() {
+        $status = $null
+        if (-not (Test-Path $this.ResultsPath -PathType Leaf)) {
+            $status = [GitHubStatus]::new("failure", "Tests failed catastrophically on $($this.Context) (no summary found).", $this.Context)
+        } else {
+            if ($this.TestsJobStatus -eq "") {
+                $status = [GitHubStatus]::new("error", "Tests didn't execute on $($this.Context).", $this.Context)
+            } elseif ($this.IsSuccess()) {
+                $status = [GitHubStatus]::new("success", "All tests passed on $($this.Context).", $this.Context)
+            } else {
+                $status = [GitHubStatus]::new("error", "Tests failed on $($this.Context).", $this.Context)
+            }
+        } 
+        return $status
+    }
+}

--- a/tools/devops/automation/scripts/test_data/TestSummary.md
+++ b/tools/devops/automation/scripts/test_data/TestSummary.md
@@ -1,0 +1,2 @@
+# :tada: All 105 tests passed :tada:
+


### PR DESCRIPTION
Add a few classes that will be later used to create the comments for the
tests.

- GitHubStatus/es: Allows to represent a github status, we are addign a
  class per concern.
- TestResults: Contains the information and logic of a test result.
  Implements the same interface as the other comment objects so that we
  resuse the comment code.

Tests have been added and modified the github action to run on pull
requests too.