### PR TITLE
[CI] Set all comments as oudated after every build.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -298,6 +298,20 @@ stages:
         steps:
         - template: templates/governance-checks.yml
 
+
+- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - stage: clean
+    displayName: 'Clean up'
+    dependsOn: []
+    jobs:
+      -job:
+        displayName: 'Clean comments'
+        pool:
+          vmImage: windows-latest
+        steps:
+          - template: templates/common/clean.yml
+
+
 - stage: build_packages
   displayName: 'Build'
   dependsOn: []

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -304,7 +304,7 @@ stages:
     displayName: 'Clean up'
     dependsOn: []
     jobs:
-      -job:
+      - job:
         displayName: 'Clean comments'
         pool:
           vmImage: windows-latest

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -311,7 +311,7 @@ class GitHubComments {
 query {
     repository(owner:"$($this.Org)", name:"$($this.Repo)"){
         pullRequest(number: $prID) {
-            comments(first: 100) {
+            comments(last: 100) {
                 edges {
                     node {
                         id
@@ -352,7 +352,7 @@ query {
 query{
     repository(owner:"$($this.Org)", name:"$($this.Repo)") {
         pullRequest(number: $prID){
-            commits(first:100) {
+            commits(last:100) {
                 edges {
                     node {
                         commit {
@@ -360,7 +360,7 @@ query{
                                 oid
                                 message
                             } 
-                            comments (first:100) {
+                            comments (last:100) {
                                 edges {
                                     node {
                                         id

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -172,6 +172,7 @@ class GitHubComments {
     [ValidateNotNullOrEmpty ()][string] $Repo
     [ValidateNotNullOrEmpty ()][string] $Token
     [string] $Hash
+    hidden static [string] $GitHubGraphQLEndpoint = "https://api.github.com/graphql"
 
     GitHubComments (
         $githubOrg,
@@ -301,6 +302,7 @@ class GitHubComments {
 
     [object] GetCommentsForPR ($prId) {
         # build the query, create the json and perform a rest request againt the grapichQl api
+        $url = [GitHubComments]::GitHubGraphQLEndpoint
         $headers = @{
             Authorization = ("Bearer {0}" -f $this.Token)
         }
@@ -329,7 +331,7 @@ query {
             query=$query
         }
         $body = ConvertTo-Json $payload
-        $response= Invoke-RestMethod -Uri "https://api.github.com/graphql" -Headers $headers -Method "POST" -Body $body
+        $response = Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
         # loop over the result and remove all the extra noise we are not interested in
         $comments = [System.Collections.ArrayList]@()
         foreach ($edge in $response.data.repository.pullRequest.comments.edges) {
@@ -381,7 +383,7 @@ query{
             query=$query
         }
         $body = ConvertTo-Json $payload
-        $response= Invoke-RestMethod -Uri "https://api.github.com/graphql" -Headers $headers -Method "POST" -Body $body
+        $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
         foreach ($edge in $response.data.repository.pullRequest.commits.edges) {
             # at this point a node is a commit, which has the following:
             # commit
@@ -427,7 +429,8 @@ mutation {
                 query=$mutation
             }
             $body = ConvertTo-Json $payload
-            $response= Invoke-RestMethod -Uri "https://api.github.com/graphql" -Headers $headers -Method "POST" -Body $body
+            $url = [GitHubComments]::GitHubGraphQLEndpoint
+            $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
         } # foreach
     }
 }

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -427,9 +427,7 @@ mutation {
                 query=$mutation
             }
             $body = ConvertTo-Json $payload
-            Write-Host "$body"
             $response= Invoke-RestMethod -Uri "https://api.github.com/graphql" -Headers $headers -Method "POST" -Body $body
-            Write-Host "Respose $($response.errors)"
         } # foreach
     }
 }

--- a/tools/devops/automation/templates/common/clean.yml
+++ b/tools/devops/automation/templates/common/clean.yml
@@ -1,0 +1,27 @@
+# Perform gihub cleaning steps
+
+steps:
+- checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
+  clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
+  submodules: false
+  persistCredentials: true
+  path: s/xamarin-macios
+
+
+- pwsh: |
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/tools/devops/automation/scripts/MaciosCI.psd1
+    $comments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+
+    $prId = "$(Build.SourceBranch)".Replace("refs/pull/", "").Replace("/merge", "")
+    $prComments = $comments.GetCommentsForPR($prId)
+
+    $botComments = [System.Collections.ArrayList]@()
+    foreach ($c in $prComments) {
+      if ($c.Author -eq "vs-mobiletools-engineering-service2") {
+        if ($c.Body.Contains("[PR Build]") -or $c.Body.Contains("[CI Build]")) {
+          $botComments.Add($c)
+        }
+      }
+    }
+    $comments.MinimizeComments($botComments)
+  displayName: Clear past comments

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -14,6 +14,26 @@ steps:
   persistCredentials: true
   path: s/xamarin-macios
 
+
+- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - pwsh: |
+      Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/tools/devops/automation/scripts/MaciosCI.psd1
+      $comments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+
+      $prId = $configuration.BuildSourceBranch.Replace("refs/pull/", "").Replace("/merge", "")
+      $prComments = comments.GetCommentsForPR($prId)
+
+      $botComments = [System.Collections.ArrayList]@()
+      foreach ($c in $prComments) {
+        if ($c.Author -eq "vs-mobiletools-engineering-service2") {
+          if ($c.Body.Contains("[PR Build]") -or $c.Body.Contains("[CI Build]")) {
+            $botComments.Add($c)
+          }
+        }
+      }
+      $comments.MinimizeComments($botComments)
+    displayName: Clear past comments
+
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/tools/devops/automation/scripts/MaciosCI.psd1
 

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -20,7 +20,7 @@ steps:
       Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/tools/devops/automation/scripts/MaciosCI.psd1
       $comments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
 
-      $prId = $configuration.BuildSourceBranch.Replace("refs/pull/", "").Replace("/merge", "")
+      $prId = "$(Build.SourceBranch)".Replace("refs/pull/", "").Replace("/merge", "")
       $prComments = comments.GetCommentsForPR($prId)
 
       $botComments = [System.Collections.ArrayList]@()

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -21,7 +21,7 @@ steps:
       $comments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
 
       $prId = "$(Build.SourceBranch)".Replace("refs/pull/", "").Replace("/merge", "")
-      $prComments = comments.GetCommentsForPR($prId)
+      $prComments = $comments.GetCommentsForPR($prId)
 
       $botComments = [System.Collections.ArrayList]@()
       foreach ($c in $prComments) {

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -14,26 +14,6 @@ steps:
   persistCredentials: true
   path: s/xamarin-macios
 
-
-- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-  - pwsh: |
-      Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/tools/devops/automation/scripts/MaciosCI.psd1
-      $comments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
-
-      $prId = "$(Build.SourceBranch)".Replace("refs/pull/", "").Replace("/merge", "")
-      $prComments = $comments.GetCommentsForPR($prId)
-
-      $botComments = [System.Collections.ArrayList]@()
-      foreach ($c in $prComments) {
-        if ($c.Author -eq "vs-mobiletools-engineering-service2") {
-          if ($c.Body.Contains("[PR Build]") -or $c.Body.Contains("[CI Build]")) {
-            $botComments.Add($c)
-          }
-        }
-      }
-      $comments.MinimizeComments($botComments)
-    displayName: Clear past comments
-
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/tools/devops/automation/scripts/MaciosCI.psd1
 


### PR DESCRIPTION
Since we have several builds per PR and several comments per build, the
comments sections are getting very noise. To fix that, we use GitHub
GraphQL to query all the comments for a PR (includes PR comments and
commit comments), filter them by user and title and minimize them
accordingly.