### PR TITLE
[d17-2] [Foundation] Ensure that post requests are not cached by the native code.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -857,7 +857,13 @@ namespace Foundation {
 			[Preserve (Conditional = true)]
 			public override void WillCacheResponse (NSUrlSession session, NSUrlSessionDataTask dataTask, NSCachedUrlResponse proposedResponse, Action<NSCachedUrlResponse> completionHandler)
 			{
-				completionHandler (sessionHandler.DisableCaching ? null! : proposedResponse);
+				var inflight = GetInflightData (dataTask);
+
+				if (inflight is null)
+					return;
+				// apple caches post request with a body, which should not happen. https://github.com/xamarin/maccore/issues/2571 
+				var disableCache = sessionHandler.DisableCaching || (inflight.Request.Method == HttpMethod.Post && inflight.Request.Content is not null);
+				completionHandler (disableCache ? null! : proposedResponse);
 			}
 
 			[Preserve (Conditional = true)]


### PR DESCRIPTION
The behaviour from apple is wrong, PUT and POST are differnet in that PUT is idempotent.
Calling PUT several times successively has the same effect (that is no side effect),
where successive identical POST may have additional effects

We should not let the native code cache the calls.

Related issue: https://github.com/xamarin/maccore/issues/2571 


Backport of #14729
