### PR TITLE
[naturallanguage] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/NaturalLanguage/NLEmbedding.cs
+++ b/src/NaturalLanguage/NLEmbedding.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 using CoreFoundation;
@@ -7,7 +9,7 @@ namespace NaturalLanguage {
 
 	public partial class NLEmbedding {
 
-		unsafe public bool TryGetVector (string @string, out float[] vector)
+		unsafe public bool TryGetVector (string @string, out float[]? vector)
 		{
 			var result = false;
 			vector = new float [Dimension];

--- a/src/NaturalLanguage/NLLanguage.cs
+++ b/src/NaturalLanguage/NLLanguage.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Collections.Generic;

--- a/src/NaturalLanguage/NLLanguageRecognizer.cs
+++ b/src/NaturalLanguage/NLLanguageRecognizer.cs
@@ -19,9 +19,12 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Collections.Generic;
-
+using CoreFoundation;
 using Foundation;
 
 namespace NaturalLanguage {
@@ -30,7 +33,7 @@ namespace NaturalLanguage {
 
 		public static NLLanguage GetDominantLanguage (string @string)
 		{
-			var nsstring = NSString.CreateNative (@string);
+			var nsstring = CFString.CreateNative (@string);
 			try {
 				using (var nslang = _GetDominantLanguage (nsstring))
 					return NLLanguageExtensions.GetValue (nslang);
@@ -54,14 +57,20 @@ namespace NaturalLanguage {
 			}
 			set {
 				var i = 0;
+				var skipCount = 0;
 				var nsKeys = new NSString[value.Keys.Count];
 				var nsValues = new NSNumber[value.Keys.Count];
 				foreach (var item in value) {
-					nsKeys[i] = NLLanguageExtensions.GetConstant (item.Key);
+					var constant = NLLanguageExtensions.GetConstant (item.Key);
+					if (constant is null) {
+						skipCount++;
+						continue;
+					}
+					nsKeys [i] = constant;
 					nsValues[i] = new NSNumber (item.Value);
 					i++;
 				}
-				NativeLanguageHints = NSDictionary<NSString, NSNumber>.FromObjectsAndKeys (nsValues, nsKeys, nsKeys.Length);
+				NativeLanguageHints = NSDictionary<NSString, NSNumber>.FromObjectsAndKeys (nsValues, nsKeys, nsKeys.Length - skipCount);
 			}
 		}
 	}

--- a/src/NaturalLanguage/NLModel.cs
+++ b/src/NaturalLanguage/NLModel.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/NaturalLanguage/NLStrongDictionary.cs
+++ b/src/NaturalLanguage/NLStrongDictionary.cs
@@ -21,7 +21,7 @@ namespace NaturalLanguage {
 
 		public string[] this [NSString key] {
 			get {
-				if (key == null)
+				if (key is null)
 					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 
 				var value = CFDictionary.GetValue (Dictionary.Handle, key.Handle);

--- a/src/NaturalLanguage/NLStrongDictionary.cs
+++ b/src/NaturalLanguage/NLStrongDictionary.cs
@@ -22,7 +22,7 @@ namespace NaturalLanguage {
 		public string[] this [NSString key] {
 			get {
 				if (key == null)
-					throw new ArgumentNullException (nameof (key));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 
 				var value = CFDictionary.GetValue (Dictionary.Handle, key.Handle);
 				var array = CFArray.StringArrayFromHandle (value) ?? throw new ArgumentOutOfRangeException (nameof (key));

--- a/src/NaturalLanguage/NLStrongDictionary.cs
+++ b/src/NaturalLanguage/NLStrongDictionary.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 using CoreFoundation;
@@ -23,7 +25,12 @@ namespace NaturalLanguage {
 					throw new ArgumentNullException (nameof (key));
 
 				var value = CFDictionary.GetValue (Dictionary.Handle, key.Handle);
-				return CFArray.StringArrayFromHandle (value);
+				var array = CFArray.StringArrayFromHandle (value) ?? throw new ArgumentOutOfRangeException (nameof (key));
+				foreach (var str in array) {
+					if (str is null)
+						ObjCRuntime.ThrowHelper.ThrowArgumentNullException ($"Key value {nameof (key)} contains a null string.");
+				}
+				return array!;
 			}
 			set {
 				SetArrayValue (key, value);

--- a/src/NaturalLanguage/NLTagger.cs
+++ b/src/NaturalLanguage/NLTagger.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 
@@ -9,13 +11,19 @@ namespace NaturalLanguage {
 
 		public Dictionary<NLLanguage, double> GetTagHypotheses (nuint characterIndex, NLTokenUnit unit, NLTagScheme scheme, nuint maximumCount)
 		{
-			using (var hypo = GetNativeTagHypotheses (characterIndex, unit, scheme.GetConstant (), maximumCount))
+			var constant = scheme.GetConstant ();
+			if (constant is null)
+				throw new ArgumentOutOfRangeException (nameof (scheme));
+			using (var hypo = GetNativeTagHypotheses (characterIndex, unit, constant, maximumCount))
 				return NLLanguageExtensions.Convert (hypo);
 		}
 
 		public Dictionary<NLLanguage, double> GetTagHypotheses (nuint characterIndex, NLTokenUnit unit, NLTagScheme scheme, nuint maximumCount, out NSRange tokenRange)
 		{
-			using (var hypo = GetNativeTagHypotheses (characterIndex, unit, scheme.GetConstant (), maximumCount, out tokenRange))
+			var constant = scheme.GetConstant ();
+			if (constant is null)
+				throw new ArgumentOutOfRangeException (nameof (scheme));
+			using (var hypo = GetNativeTagHypotheses (characterIndex, unit, constant, maximumCount, out tokenRange))
 				return NLLanguageExtensions.Convert (hypo);
 		}
 	}

--- a/src/NaturalLanguage/NLVectorDictionary.cs
+++ b/src/NaturalLanguage/NLVectorDictionary.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 using CoreFoundation;

--- a/src/NaturalLanguage/NLVectorDictionary.cs
+++ b/src/NaturalLanguage/NLVectorDictionary.cs
@@ -21,7 +21,7 @@ namespace NaturalLanguage {
 
 		public float[] this [NSString key] {
 			get {
-				if (key == null)
+				if (key is null)
 					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 
 				var a = CFDictionary.GetValue (Dictionary.Handle, key.Handle);
@@ -30,10 +30,10 @@ namespace NaturalLanguage {
 				});
 			}
 			set {
-				if (key == null)
+				if (key is null)
 					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 
-				if (value == null)
+				if (value is null)
 					RemoveValue (key);
 				else
 					Dictionary [key] = NSArray.From (value);

--- a/src/NaturalLanguage/NLVectorDictionary.cs
+++ b/src/NaturalLanguage/NLVectorDictionary.cs
@@ -22,7 +22,7 @@ namespace NaturalLanguage {
 		public float[] this [NSString key] {
 			get {
 				if (key == null)
-					throw new ArgumentNullException (nameof (key));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 
 				var a = CFDictionary.GetValue (Dictionary.Handle, key.Handle);
                 return NSArray.ArrayFromHandle<float> (a, input => {
@@ -31,7 +31,7 @@ namespace NaturalLanguage {
 			}
 			set {
 				if (key == null)
-					throw new ArgumentNullException (nameof (key));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 
 				if (value == null)
 					RemoveValue (key);

--- a/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
@@ -88,5 +88,16 @@ namespace MonoTouchFixtures.NaturalLanguage {
 				Assert.That (range.Length, Is.EqualTo ((nint) 88), "Length");
 			}
 		}
+
+		[Test]
+		public void GetNativeTagHypothesesNullSchemeTest ()
+		{
+			TestRuntime.AssertXcodeVersion (12, TestRuntime.MinorXcode12APIMismatch);
+			using (var tagger = new NLTagger (NLTagScheme.LexicalClass) { String = Text }) {
+				var fakeScheme = (NLTagScheme)int.MaxValue;
+				Assert.Throws<ArgumentOutOfRangeException> (() => { _ = tagger.GetTagHypotheses (0, NLTokenUnit.Sentence, fakeScheme, nuint.MaxValue); }, "We should throw an ArgumentOutOfRangeException if GetTagHypotheses (nuint characterIndex, NLTokenUnit unit, NSString scheme, nuint maximumCount, IntPtr tokenRange) has a null value for the 'scheme' parameter.");
+				Assert.Throws<ArgumentOutOfRangeException> (() => { _ = tagger.GetTagHypotheses (0, NLTokenUnit.Sentence, fakeScheme, nuint.MaxValue, out NSRange range); }, "We should throw an ArgumentOutOfRangeException if GetTagHypotheses (nuint characterIndex, NLTokenUnit unit, NSString scheme, nuint maximumCount, IntPtr tokenRange) has a null value for the 'scheme' parameter.");
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR aims to bring nullability changes to NaturalLanguage.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`