### PR TITLE
[CI] Clean the statuses mess.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -424,7 +424,7 @@ stages:
       useXamarinStorage: False
       testsLabels: '--label=run-ios-32-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests'
       statusContext: 'VSTS: device tests iOS32b'
-      extraBotDemands: 'xismoke-32'
+      extraBotDemands: ['xismoke-32']
       vsdropsPrefix: ${{ variables.vsdropsPrefix }}
       keyringPass: $(pass--lab--mac--builder--keychain)
       gitHubToken: ${{ variables['GitHub.Token'] }}

--- a/tools/devops/automation/scripts/GitHub.Tests.ps1
+++ b/tools/devops/automation/scripts/GitHub.Tests.ps1
@@ -4,122 +4,6 @@ Github interaction unit tests.
 
 Import-Module ./GitHub -Force
 
-Describe 'Set-GitHubStatus' {
-    Context 'with all env variables present' -Skip {
-
-        It 'calls the rest method succesfully' {
-            # set the required enviroments in the context
-            $envVariables = @{
-                "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
-                "SYSTEM_TEAMPROJECT" = "SYSTEM_TEAMPROJECT";
-                "BUILD_BUILDID" = "BUILD_BUILDID";
-                "SYSTEM_JOBNAME" = "SYSTEM_JOBNAME";
-                "SYSTEM_STAGEDISPLAYNAME" = "SYSTEM_STAGEDISPLAYNAME"
-                "BUILD_REVISION" = "BUILD_REVISION";
-                "GITHUB_TOKEN" = "GITHUB_TOKEN"
-            }
-
-            $envVariables.GetEnumerator() | ForEach-Object { 
-                $key = $_.Key
-                Set-Item -Path "Env:$key" -Value $_.Value
-            }
-
-            Mock Invoke-RestMethod {
-                return @{"status"=200;}
-            }
-            $status = "error"
-            $context = "My context"
-            $description = "Testing Status API"
-
-            Set-GitHubStatus -Status $status -Description $description -Context $context
-
-            # assert the call and compare the expected parameters to the received ones
-            Assert-MockCalled -CommandName Invoke-RestMethod -Times 1 -Scope It -ParameterFilter {
-                # validate each of the params and the payload
-                if ($Uri -ne "https://api.github.com/repos/xamarin/xamarin-macios/statuses/BUILD_REVISION") {
-                    return $False
-                }
-                if ($Headers.Authorization -ne ("token {0}" -f $envVariables["GITHUB_TOKEN"])) {
-                    return $False
-                }
-                if ($Method -ne "POST") {
-                    return $False
-                }
-                if ($ContentType -ne "application/json") {
-                    return $False
-                }
-                # compare the payload
-                $bodyObj = ConvertFrom-Json $Body
-                if ($bodyObj.state -ne $status) {
-                    return $False
-                }
-
-                if ($bodyObj.context -ne $context) {
-                    return $False
-                }
-
-                if ($bodyObj.description -ne $description) {
-                    return $False
-                }
-
-                return $True
-            }
-        }
-
-        It 'calls the rest method with an error' {
-            # set the required enviroments in the context
-            $envVariables = @{
-                "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
-                "SYSTEM_TEAMPROJECT" = "SYSTEM_TEAMPROJECT";
-                "BUILD_BUILDID" = "BUILD_BUILDID";
-                "SYSTEM_JOBNAME" = "SYSTEM_JOBNAME";
-                "SYSTEM_STAGEDISPLAYNAME" = "SYSTEM_STAGEDISPLAYNAME"
-                "BUILD_REVISION" = "BUILD_REVISION";
-                "GITHUB_TOKEN" = "GITHUB_TOKEN"
-            }
-
-            $envVariables.GetEnumerator() | ForEach-Object { 
-                $key = $_.Key
-                Set-Item -Path "Env:$key" -Value $_.Value
-            }
-            Mock Invoke-RestMethod {
-                throw [System.Exception]::("Test")
-            }
-            #set env vars
-            { Set-GitHubStatus -Status $status -Description $description -Context $context } | Should -Throw
-        }
-    }
-    Context 'without an env var' -Skip {
-        It 'failed calling the rest method' {
-            Mock Invoke-RestMethod {
-                return @{"status"=200;}
-            }
-
-            # clear the env vars
-            $envVariables = @{
-                "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
-                "SYSTEM_TEAMPROJECT" = "SYSTEM_TEAMPROJECT";
-                "BUILD_BUILDID" = "BUILD_BUILDID";
-                "SYSTEM_JOBNAME" = "SYSTEM_JOBNAME";
-                "SYSTEM_STAGEDISPLAYNAME" = "SYSTEM_STAGEDISPLAYNAME"
-                "BUILD_REVISION" = "BUILD_REVISION";
-                "GITHUB_TOKEN" = "GITHUB_TOKEN"
-            }
-            $envVariables.GetEnumerator() | ForEach-Object { 
-                $key = $_.Key
-                Remove-Item -Path "Env:$key"
-            }
-
-            $status = "error"
-            $context = "My context"
-            $description = "Testing Status API"
-
-            { Set-GitHubStatus -Status $status -Description $description -Context $context } | Should -Throw
-            Assert-MockCalled -CommandName Invoke-RestMethod -Times 0 -Scope It 
-        }
-    }
-}
-
 Describe 'New-GitHubComment' {
     Context 'with all env variables present' -Skip {
 
@@ -311,7 +195,6 @@ Describe 'New-GitHubSummaryComment' {
         }
 
         It 'calls rest methods on a completed and succesful test run' {
-            Mock Set-GitHubStatus
             Mock New-GitHubCommentFromFile
             Mock Test-Path { return $true }
 
@@ -321,22 +204,6 @@ Describe 'New-GitHubSummaryComment' {
             New-GitHubSummaryComment -Context $Script:context -TestSummaryPath $Script:tempPath
 
             # assert rest calls
-            Assert-MockCalled -CommandName Set-GitHubStatus -Times 1 -Scope It -ParameterFilter {
-                if ($Status -ne "success") {
-                    return $False
-                }
-
-                if ($Context -ne $Script:context) {
-                    return $False
-                }
-
-                if ($Description -ne "Device tests passed on $Script:context.") {
-                    return $False
-                }
-
-                return $True
-            }
-
             Assert-MockCalled -CommandName New-GitHubCommentFromFile -Times 1 -Scope It -ParameterFilter {
                 if (-not ($Header -like "Device tests passed on $Script:context*")) {
                     return $False
@@ -355,29 +222,12 @@ Describe 'New-GitHubSummaryComment' {
         }
 
         It 'calls rest methods on a completed failed test run' {
-            Mock Set-GitHubStatus
             Mock New-GitHubCommentFromFile
             Mock Test-Path { return $true }
 
             Set-Item -Path "Env:TESTS_JOBSTATUS" -Value "Failed"
 
             New-GitHubSummaryComment -Context $Script:context -TestSummaryPath $Script:tempPath
-
-            Assert-MockCalled -CommandName Set-GitHubStatus -Times 1 -Scope It -ParameterFilter {
-                if ($Status -ne "failure") {
-                    return $False
-                }
-
-                if ($Context -ne $Script:context) {
-                    return $False
-                }
-
-                if ($Description -ne "Device tests failed on $Script:context.") {
-                    return $False
-                }
-
-                return $True
-            }
 
             Assert-MockCalled -CommandName New-GitHubCommentFromFile -Times 1 -Scope It -ParameterFilter {
                 if (-not ($Header -like "Device tests failed on $Script:context*")) {
@@ -397,29 +247,12 @@ Describe 'New-GitHubSummaryComment' {
         }
 
         It 'calls rest methods on a failed test run (TestSummay.md missing)' {
-            Mock Set-GitHubStatus
             Mock New-GitHubComment
             Mock Test-Path { return $false}
 
             Set-Item -Path "Env:TESTS_JOBSTATUS" -Value "Failed"
 
             New-GitHubSummaryComment -Context $Script:context -TestSummaryPath $Script:tempPath
-
-            Assert-MockCalled -CommandName Set-GitHubStatus -Times 1 -Scope It -ParameterFilter {
-                if ($Status -ne "failure") {
-                    return $False
-                }
-
-                if ($Context -ne $Script:context) {
-                    return $False
-                }
-
-                if (-not ($Description -like "Tests failed catastrophically on $Script:context (no summary found).")) {
-                    return $False
-                }
-
-                return $True
-            }
 
             Assert-MockCalled -CommandName New-GitHubComment -Times 1 -Scope It -ParameterFilter {
                 if ($Header -ne "Tests failed catastrophically on $Script:context (no summary found).") {

--- a/tools/devops/automation/scripts/MaciosCI.psd1
+++ b/tools/devops/automation/scripts/MaciosCI.psd1
@@ -72,7 +72,7 @@ NestedModules = @('APIDiff.psm1',
                'MLaunch.psm1', 
                'StaticPages.psm1', 
                'System.psm1', 
-               'TestResults.psm1', 
+               'TestResults.psm1',
                'VSTS.psm1')
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.

--- a/tools/devops/automation/scripts/TestResults.psm1
+++ b/tools/devops/automation/scripts/TestResults.psm1
@@ -62,3 +62,22 @@ class TestResults {
         return $status
     }
 }
+
+
+<# 
+    .SYNOPSIS
+        Creates a new TestResults object.
+#>
+function New-TestResults {
+    param (
+        [string]
+        $Path,
+        [string]
+        $Status,
+        [string]
+        $Context
+    )
+    return [TestResults]::new($Path, $Status, $Context)
+}
+
+Export-ModuleMember -Function New-TestResults

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -446,7 +446,7 @@ steps:
       set -e
 
       make -C $(Build.SourcesDirectory)/xamarin-macios/tests package-tests
-      
+
     name: macTestPkg
     displayName: 'Package macOS tests'
     condition: and(succeeded(), contains(variables['configuration.RunMacTests'], 'True'))
@@ -519,13 +519,12 @@ steps:
   parameters:
     keyringPass: ${{ parameters.keyringPass }}
 
+# if we failed, write a comment and set the pipeline to failure. In this case, we do not want to hide the fact that we failed but we also want
+# to write a comment.
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-    New-GitHubComment -Header "Build failed" -Emoji ":fire:" -Description "Build failed for the job '$Env:SYSTEM_JOBDISPLAYNAME'"
+
+    $githubComments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token) -Hash $Env:GIT_HASH
+    $githubComments.NewCommentFromMessage("Build failed", ":fire:", "Build failed for the job '$(System.JobDisplayName)'")
   condition: failed()
   displayName: 'Report build failure'
-  env:
-    BUILD_REVISION: $(Build.SourceVersion)
-    CONTEXT: "Build"
-    GITHUB_TOKEN: $(GitHub.Token)
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -50,18 +50,6 @@ steps:
   displayName: 'Fix device discovery (reset launchctl)'
   condition: succeededOrFailed() # making mlaunch verbose should be a non blocker
 
-# Update the status to pending, that way the monitoring person knows that we started running the tests. Up to this
-# point we were just setting up the agent.
-- template: ../common/status.yml
-  parameters:
-    status: "pending"
-    description: "Running device tests on ${{ parameters.statusContext }}"
-    context: ${{ parameters.statusContext }}
-    githubToken: $(GitHub.Token)
-    continueOnError: true
-    condition: succeededOrFailed() # re-starting the daemon should not be an issue
-    timeoutInMinutes: 5
-
 - bash: |
     make -C src build/generator-frameworks.g.cs
     make -C src build/ios/Constants.cs
@@ -223,6 +211,18 @@ steps:
   displayName: Expand test libraries.
   timeoutInMinutes: 10
 
+# Update the status to pending, that way the monitoring person knows that we started running the tests. Up to this
+# point we were just setting up the agent.
+- template: ../common/status.yml
+  parameters:
+    status: "pending"
+    description: "Running device tests on ${{ parameters.statusContext }}"
+    context: ${{ parameters.statusContext }}
+    githubToken: $(GitHub.Token)
+    continueOnError: true
+    condition: succeededOrFailed() # re-starting the daemon should not be an issue
+    timeoutInMinutes: 5
+
 # Run tests. If we are using xamarin-storage add a periodic command to be executed by xharness, else, since we are using vsdrops do nothing.
 - bash: |
     set -x
@@ -250,6 +250,20 @@ steps:
   displayName: 'Run tests'
   name: runTests # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
   timeoutInMinutes: 720
+
+# set the status of the test results. Do not add a comment yet since we have not uploaded any of the needed files for the commnet, this way
+# we report the result as soon as we have it and ensure that we set the status from pending to the appropiate value.
+
+- pwsh: |
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
+
+    $testResultsPath = "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin/tests/TestSummary.md"
+    $testResult = [TestResults]::new($testResultsPath, "$(runTests.TESTS_JOBSTATUS)", "${{ parameters.statusContext }}")
+
+    $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+    $statuses.SetStatus($testResult.GetStatus())
+  displayName: "Set tests status."
+  timeoutInMinutes: 5
 
 # Upload TestSummary as an artifact.
 - task: PublishPipelineArtifact@1

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -258,7 +258,7 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
 
     $testResultsPath = "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tests/TestSummary.md"
-    $testResult = New-TestResults -Path $testResultsPath, -Status "$(runTests.TESTS_JOBSTATUS)" -Context "${{ parameters.statusContext }}"
+    $testResult = New-TestResults -Path $testResultsPath -Status "$(runTests.TESTS_JOBSTATUS)" -Context "${{ parameters.statusContext }}"
 
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
     $statuses.SetStatus($testResult.GetStatus())

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -257,7 +257,7 @@ steps:
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
 
-    $testResultsPath = "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin/tests/TestSummary.md"
+    $testResultsPath = "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tests/TestSummary.md"
     $testResult = New-TestResults -Path $testResultsPath, -Status "$(runTests.TESTS_JOBSTATUS)" -Context "${{ parameters.statusContext }}"
 
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -258,7 +258,7 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
 
     $testResultsPath = "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin/tests/TestSummary.md"
-    $testResult = [TestResults]::new($testResultsPath, "$(runTests.TESTS_JOBSTATUS)", "${{ parameters.statusContext }}")
+    $testResult = New-TestResults -Path $testResultsPath, -Status "$(runTests.TESTS_JOBSTATUS)" -Context "${{ parameters.statusContext }}"
 
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
     $statuses.SetStatus($testResult.GetStatus())


### PR DESCRIPTION
We have been leaving statueses as pending, the main reason is that when
we ran the tests, we set the wrong status. This was complicated because
we wrote comments AND set the statuses mixing two operations. We now
have the status and the comment separated for easy debugging and more
flexibility.