### PR TITLE
[CI] Add a status for the PR API diff.

### DIFF
--- a/tools/devops/automation/scripts/bash/compare.sh
+++ b/tools/devops/automation/scripts/bash/compare.sh
@@ -77,12 +77,15 @@ cp -R ./tools/comparison/generator-diff "$API_COMPARISON"
 if ! grep "href=" "$API_COMPARISON/api-diff.html" >/dev/null 2>&1; then
 	STATUS_MESSAGE=":white_check_mark: API Diff (from PR only) (no change)"
 	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS_MESSAGE;isOutput=true]$STATUS_MESSAGE"
+	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS;isOutput=true]success"
 elif perl -0777 -pe 's/<script type="text\/javascript">.*?<.script>/script removed/gs' "$API_COMPARISON"/*.html | grep data-is-breaking; then
 	STATUS_MESSAGE=":warning: API Diff (from PR only) (:fire: breaking changes :fire:)"
 	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS_MESSAGE;isOutput=true]$STATUS_MESSAGE"
+	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS;isOutput=true]error"
 else
 	STATUS_MESSAGE=":information_source: API Diff (from PR only) (please review changes)"
 	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS_MESSAGE;isOutput=true]$STATUS_MESSAGE"
+	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS;isOutput=true]error"
 fi
 
 if ! test -s $API_COMPARISON/generator-diff/generator.diff; then

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -7,6 +7,17 @@ parameters:
   default: '' # default empty, meaning we are building in CI 
 
 steps:
+
+- template: ../common/status.yml
+  parameters:
+    status: "pending"
+    description: "Generating API diff."
+    context: "API Diff (PR)"
+    githubToken: $(GitHub.Token)
+    continueOnError: true
+    condition: succeededOrFailed() # re-starting the daemon should not be an issue
+    timeoutInMinutes: 5
+
 - bash:  $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/vsts-compare.sh
   displayName: 'API & Generator comparison'
   condition: and(succeeded(), contains(variables['configuration.SkipPublicJenkins'], 'False'))
@@ -15,6 +26,14 @@ steps:
     BUILD_REVISION: 'jenkins'
     PR_ID:  ${{ parameters.prID }} # reusing jenkins vars, to be fixed
 
+- pwsh: |
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
+    $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+
+    $statuses.SetStatus($(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS), $(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE), "API Diff (PR)")
+  displayName: "API diff final status"
+  timeoutInMinutes: 5
+  condition: succeededOrFailed() # re-starting the daemon should not be an issue
 
 - task: ArchiveFiles@1
   displayName: 'Archive API & Generator comparison'

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -30,7 +30,7 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
 
-    $statuses.SetStatus($(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS), $(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE), "API Diff (PR)")
+    $statuses.SetStatus("$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS)", "$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE)", "API Diff (PR)")
   displayName: "API diff final status"
   timeoutInMinutes: 5
   condition: succeededOrFailed() # re-starting the daemon should not be an issue

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -30,7 +30,8 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
 
-    $statuses.SetStatus("$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS)", "$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE)", "API Diff (PR)")
+    $msg = "$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE)".Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
+    $statuses.SetStatus("$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS)", $msg, "API Diff (PR)")
   displayName: "API diff final status"
   timeoutInMinutes: 5
   condition: succeededOrFailed() # re-starting the daemon should not be an issue


### PR DESCRIPTION
To avoid issues when setting automerging we add a status for the API
diff. If human intervention is needed to check the changes the status
will be set to error, this way the automerging wont happen. We set the
status to error even when we only have a warning, better safe than
sorry.