### PR TITLE
[CI] Fix the links for the API diff in dotnet.

### DIFF
--- a/tools/devops/automation/templates/build/api-diff-github-comment.yml
+++ b/tools/devops/automation/templates/build/api-diff-github-comment.yml
@@ -94,14 +94,14 @@ steps:
       "tvOS" = $apiDiffRoot + "tvos-api-diff.html";
       "watchOS" =$apiDiffRoot + "watchos-api-diff.html";
       "index"= $apiDiffRoot + "api-diff.html";
-      "dotnet-iOS" = $apiDiffRoot + "dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html";
-      "dotnet-tvOS" = $apiDiffRoot + "dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html";
-      "dotnet-MacCatalyst" = $apiDiffRoot + "dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst-api-diff.html";
-      "dotnet-macOS" = $apiDiffRoot + "dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html";
-      "dotnet-legacy-iOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html";
-      "dotnet-legacy-tvOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html";
-      "dotnet-legacy-macOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html";
-      "dotnet-macCatiOS" = $apiDiffRoot + "dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.MacCatalyst-api-diff.html";
+      "dotnet-iOS" = $apiDiffRoot + "dotnet/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS-api-diff.html";
+      "dotnet-tvOS" = $apiDiffRoot + "dotnet/Microsoft.tvOS.Ref/ref/net6.0/Microsoft.TVOS-api-diff.html";
+      "dotnet-MacCatalyst" = $apiDiffRoot + "dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Microsoft.MacCatalyst-api-diff.html";
+      "dotnet-macOS" = $apiDiffRoot + "dotnet/Microsoft.macOS.Ref/ref/net6.0/Microsoft.Mac-api-diff.html";
+      "dotnet-legacy-iOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS-api-diff.html";
+      "dotnet-legacy-tvOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Microsoft.TVOS-api-diff.html";
+      "dotnet-legacy-macOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Microsoft.Mac-api-diff.html";
+      "dotnet-macCatiOS" = $apiDiffRoot + "dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS.MacCatalyst-api-diff.html";
     }
 
     # build a json object that will be used by the comment to write the data for users
@@ -177,14 +177,14 @@ steps:
       "tvOS" = $apiDiffRoot + "tvos-api-diff.html";
       "watchOS" =$apiDiffRoot + "watchos-api-diff.html";
       "index"= $apiDiffRoot + "api-diff.html";
-      "dotnet-iOS" = $apiDiffRoot + "dotnet/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html";
-      "dotnet-tvOS" = $apiDiffRoot + "dotnet/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html";
-      "dotnet-MacCatalyst" = $apiDiffRoot + "dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Xamarin.MacCatalyst-api-diff.html";
-      "dotnet-macOS" = $apiDiffRoot + "dotnet/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html";
-      "dotnet-legacy-iOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS-api-diff.html";
-      "dotnet-legacy-tvOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Xamarin.TVOS-api-diff.html";
-      "dotnet-legacy-macOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Xamarin.Mac-api-diff.html";
-      "dotnet-macCatiOS" = $apiDiffRoot + "dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Xamarin.iOS.MacCatalyst-api-diff.html";
+      "dotnet-iOS" = $apiDiffRoot + "dotnet/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS-api-diff.html";
+      "dotnet-tvOS" = $apiDiffRoot + "dotnet/Microsoft.tvOS.Ref/ref/net6.0/Microsoft.TVOS-api-diff.html";
+      "dotnet-MacCatalyst" = $apiDiffRoot + "dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Microsoft.MacCatalyst-api-diff.html";
+      "dotnet-macOS" = $apiDiffRoot + "dotnet/Microsoft.macOS.Ref/ref/net6.0/Microsoft.Mac-api-diff.html";
+      "dotnet-legacy-iOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS-api-diff.html";
+      "dotnet-legacy-tvOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Microsoft.TVOS-api-diff.html";
+      "dotnet-legacy-macOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Microsoft.Mac-api-diff.html";
+      "dotnet-macCatiOS" = $apiDiffRoot + "dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS.MacCatalyst-api-diff.html";
     }
 
     # build a json object that will be used by the comment to write the data for users

--- a/tools/devops/automation/templates/build/api-diff-github-comment.yml
+++ b/tools/devops/automation/templates/build/api-diff-github-comment.yml
@@ -97,10 +97,10 @@ steps:
       "dotnet-iOS" = $apiDiffRoot + "dotnet/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS-api-diff.html";
       "dotnet-tvOS" = $apiDiffRoot + "dotnet/Microsoft.tvOS.Ref/ref/net6.0/Microsoft.TVOS-api-diff.html";
       "dotnet-MacCatalyst" = $apiDiffRoot + "dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Microsoft.MacCatalyst-api-diff.html";
-      "dotnet-macOS" = $apiDiffRoot + "dotnet/Microsoft.macOS.Ref/ref/net6.0/Microsoft.Mac-api-diff.html";
+      "dotnet-macOS" = $apiDiffRoot + "dotnet/Microsoft.macOS.Ref/ref/net6.0/Microsoft.macOS-api-diff.html";
       "dotnet-legacy-iOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS-api-diff.html";
       "dotnet-legacy-tvOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Microsoft.TVOS-api-diff.html";
-      "dotnet-legacy-macOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Microsoft.Mac-api-diff.html";
+      "dotnet-legacy-macOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Microsoft.macOS-api-diff.html";
       "dotnet-macCatiOS" = $apiDiffRoot + "dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS.MacCatalyst-api-diff.html";
     }
 
@@ -180,10 +180,10 @@ steps:
       "dotnet-iOS" = $apiDiffRoot + "dotnet/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS-api-diff.html";
       "dotnet-tvOS" = $apiDiffRoot + "dotnet/Microsoft.tvOS.Ref/ref/net6.0/Microsoft.TVOS-api-diff.html";
       "dotnet-MacCatalyst" = $apiDiffRoot + "dotnet/Microsoft.MacCatalyst.Ref/ref/net6.0/Microsoft.MacCatalyst-api-diff.html";
-      "dotnet-macOS" = $apiDiffRoot + "dotnet/Microsoft.macOS.Ref/ref/net6.0/Microsoft.Mac-api-diff.html";
+      "dotnet-macOS" = $apiDiffRoot + "dotnet/Microsoft.macOS.Ref/ref/net6.0/Microsoft.macOS-api-diff.html";
       "dotnet-legacy-iOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS-api-diff.html";
       "dotnet-legacy-tvOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.tvOS.Ref/ref/net6.0/Microsoft.TVOS-api-diff.html";
-      "dotnet-legacy-macOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Microsoft.Mac-api-diff.html";
+      "dotnet-legacy-macOS" = $apiDiffRoot + "dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Microsoft.macOS-api-diff.html";
       "dotnet-macCatiOS" = $apiDiffRoot + "dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/net6.0/Microsoft.iOS.MacCatalyst-api-diff.html";
     }
 


### PR DESCRIPTION
The dlls were renamed, the links were not, and the files use the name of the dll.