### PR TITLE
[fabricbot] Update FabricBot with more useful commands

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -5,31 +5,751 @@
 		"subCapability": "IssuesOnlyResponder",
 		"version": "1.0",
 		"config": {
-			"conditions": {
-				"operator": "and",
-				"operands": [
-					{
-						"name": "labelAdded",
-						"parameters": {
-							"label": "need-info"
-						}
-					}
-				]
-			},
-			"eventType": "issue",
-			"eventNames": [
-				"issues",
-				"project_card"
+		"conditions": {
+			"operator": "and",
+			"operands": [
+			{
+				"name": "labelAdded",
+				"parameters": {
+				"label": "need-info"
+				}
+			}
+			]
+		},
+		"eventType": "issue",
+		"eventNames": [
+			"issues",
+			"project_card"
+		],
+		"taskName": "Add comment when 'need-info' is applied to issue",
+		"actions": [
+			{
+			"name": "addReply",
+			"parameters": {
+				"comment": "Hi @${issueAuthor}. We have added the \"need-info\" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time."
+			}
+			}
+		]
+		}
+	},
+	{
+		"taskType": "scheduled",
+		"capabilityId": "ScheduledSearch",
+		"subCapability": "ScheduledSearch",
+		"version": "1.1",
+		"config": {
+		"frequency": [
+			{
+			"weekDay": 1,
+			"hours": [
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
 			],
-			"taskName": "Add comment when 'need-info' is applied to issue",
-			"actions": [
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 2,
+			"hours": [
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 3,
+			"hours": [
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 4,
+			"hours": [
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 5,
+			"hours": [
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
+			],
+			"timezoneOffset": -5
+			}
+		],
+		"searchTerms": [
+			{
+			"name": "isIssue",
+			"parameters": {}
+			},
+			{
+			"name": "isOpen",
+			"parameters": {}
+			},
+			{
+			"name": "hasLabel",
+			"parameters": {
+				"label": "need-info"
+			}
+			},
+			{
+			"name": "noActivitySince",
+			"parameters": {
+				"days": 7
+			}
+			}
+		],
+		"taskName": "[Idle Issue Management] Close stale 'need-info' issues",
+		"actions": [
+			{
+			"name": "addReply",
+			"parameters": {
+				"comment": "Hi @${issueAuthor}. Due to inactivity, we will be closing this issue. Please feel free to re-open this issue if the issue persists. For enhanced visibility, if over 7 days have passed, please open a new issue and link this issue there. Thank you."
+			}
+			},
+			{
+			"name": "closeIssue",
+			"parameters": {}
+			}
+		]
+		}
+	},
+	{
+		"taskType": "trigger",
+		"capabilityId": "IssueResponder",
+		"subCapability": "IssueCommentResponder",
+		"version": "1.0",
+		"config": {
+		"conditions": {
+			"operator": "and",
+			"operands": [
+			{
+				"name": "isAction",
+				"parameters": {
+				"action": "created"
+				}
+			},
+			{
+				"name": "isOpen",
+				"parameters": {}
+			},
+			{
+				"name": "hasLabel",
+				"parameters": {
+				"label": "need-info"
+				}
+			},
+			{
+				"operator": "not",
+				"operands": [
 				{
-					"name": "addReply",
+					"name": "activitySenderHasPermissions",
 					"parameters": {
-						"comment": "Hi @${issueAuthor}. We have added the \"need-info\" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time."
+					"permissions": "write"
 					}
 				}
+				]
+			}
 			]
+		},
+		"eventType": "issue",
+		"eventNames": [
+			"issue_comment"
+		],
+		"taskName": "[Idle Issue Management] Replace 'need-info' and 'awaiting-customer-response` with 'need-attention' label when the customer comments on an issue",
+		"actions": [
+			{
+			"name": "removeLabel",
+			"parameters": {
+				"label": "need-info"
+			}
+			},
+			{
+			"name": "addLabel",
+			"parameters": {
+				"label": "need-attention"
+			}
+			},
+			{
+			"name": "removeLabel",
+			"parameters": {
+				"label": "awaiting-customer-response"
+			}
+			}
+		]
+		}
+	},
+	{
+		"taskType": "trigger",
+		"capabilityId": "IssueResponder",
+		"subCapability": "IssueCommentResponder",
+		"version": "1.0",
+		"config": {
+		"conditions": {
+			"operator": "and",
+			"operands": [
+			{
+				"operator": "not",
+				"operands": [
+				{
+					"name": "isOpen",
+					"parameters": {}
+				}
+				]
+			},
+			{
+				"name": "isAction",
+				"parameters": {
+				"action": "created"
+				}
+			},
+			{
+				"operator": "or",
+				"operands": [
+				{
+					"name": "hasLabel",
+					"parameters": {
+					"label": "need-info"
+					}
+				},
+				{
+					"name": "hasLabel",
+					"parameters": {
+					"label": "awaiting-customer-response"
+					}
+				}
+				]
+			},
+			{
+				"operator": "not",
+				"operands": [
+				{
+					"name": "noActivitySince",
+					"parameters": {
+					"days": 7
+					}
+				}
+				]
+			},
+			{
+				"operator": "not",
+				"operands": [
+				{
+					"name": "isCloseAndComment",
+					"parameters": {}
+				}
+				]
+			},
+			{
+				"name": "isActivitySender",
+				"parameters": {
+				"user": {
+					"type": "author"
+				}
+				}
+			},
+			{
+				"name": "activitySenderHasPermissions",
+				"parameters": {
+				"permissions": "none"
+				}
+			}
+			]
+		},
+		"eventType": "issue",
+		"eventNames": [
+			"issue_comment"
+		],
+		"taskName": "[Idle Issue Management] For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.",
+		"actions": [
+			{
+			"name": "reopenIssue",
+			"parameters": {}
+			},
+			{
+			"name": "removeLabel",
+			"parameters": {
+				"label": "need-info"
+			}
+			},
+			{
+			"name": "removeLabel",
+			"parameters": {
+				"label": "awaiting-customer-response"
+			}
+			},
+			{
+			"name": "addLabel",
+			"parameters": {
+				"label": "need-attention"
+			}
+			}
+		]
+		}
+	},
+	{
+		"taskType": "trigger",
+		"capabilityId": "IssueResponder",
+		"subCapability": "IssueCommentResponder",
+		"version": "1.0",
+		"config": {
+		"conditions": {
+			"operator": "and",
+			"operands": [
+			{
+				"name": "isAction",
+				"parameters": {
+				"action": "created"
+				}
+			},
+			{
+				"operator": "not",
+				"operands": [
+				{
+					"name": "isOpen",
+					"parameters": {}
+				}
+				]
+			},
+			{
+				"name": "activitySenderHasPermissions",
+				"parameters": {
+				"permissions": "none"
+				}
+			},
+			{
+				"name": "noActivitySince",
+				"parameters": {
+				"days": 7
+				}
+			},
+			{
+				"operator": "not",
+				"operands": [
+				{
+					"name": "isCloseAndComment",
+					"parameters": {}
+				}
+				]
+			}
+			]
+		},
+		"eventType": "issue",
+		"eventNames": [
+			"issue_comment"
+		],
+		"taskName": "[Closed Issue Management] For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
+		"actions": [
+			{
+			"name": "addReply",
+			"parameters": {
+				"comment": "Hello lovely human, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!"
+			}
+			}
+		]
+		}
+	},
+	{
+		"taskType": "scheduled",
+		"capabilityId": "ScheduledSearch",
+		"subCapability": "ScheduledSearch",
+		"version": "1.1",
+		"config": {
+		"frequency": [
+			{
+			"weekDay": 0,
+			"hours": [
+				10,
+				22
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 1,
+			"hours": [
+				10,
+				22
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 2,
+			"hours": [
+				10,
+				22
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 3,
+			"hours": [
+				10,
+				22
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 4,
+			"hours": [
+				10,
+				22
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 5,
+			"hours": [
+				10,
+				22
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 6,
+			"hours": [
+				10,
+				22
+			],
+			"timezoneOffset": -5
+			}
+		],
+		"searchTerms": [
+			{
+			"name": "isClosed",
+			"parameters": {}
+			},
+			{
+			"name": "noActivitySince",
+			"parameters": {
+				"days": 30
+			}
+			},
+			{
+			"name": "isUnlocked",
+			"parameters": {}
+			},
+			{
+			"name": "isIssue",
+			"parameters": {}
+			}
+		],
+		"taskName": "[Closed Issue Management] Lock issues closed without activity for over 30 days",
+		"actions": [
+			{
+			"name": "lockIssue",
+			"parameters": {
+				"reason": "resolved"
+			}
+			}
+		]
+		}
+	},
+	{
+		"taskType": "scheduled",
+		"capabilityId": "ScheduledSearch",
+		"subCapability": "ScheduledSearch",
+		"version": "1.1",
+		"config": {
+		"frequency": [
+			{
+			"weekDay": 1,
+			"hours": [
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 2,
+			"hours": [
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 3,
+			"hours": [
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 4,
+			"hours": [
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
+			],
+			"timezoneOffset": -5
+			},
+			{
+			"weekDay": 5,
+			"hours": [
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
+			],
+			"timezoneOffset": -5
+			}
+		],
+		"searchTerms": [
+			{
+			"name": "isIssue",
+			"parameters": {}
+			},
+			{
+			"name": "isOpen",
+			"parameters": {}
+			},
+			{
+			"name": "hasLabel",
+			"parameters": {
+				"label": "awaiting-customer-response"
+			}
+			},
+			{
+			"name": "noActivitySince",
+			"parameters": {
+				"days": 7
+			}
+			}
+		],
+		"taskName": "[Idle Issue Management] Close stale 'awaiting-customer-response' issues",
+		"actions": [
+			{
+			"name": "addReply",
+			"parameters": {
+				"comment": "Hi @${issueAuthor}. Due to inactivity, we will be closing this issue. Please feel free to re-open this issue if the issue persists. For enhanced visibility, if over 7 days have passed, please open a new issue and link this issue there. Thank you."
+			}
+			},
+			{
+			"name": "closeIssue",
+			"parameters": {}
+			}
+		]
 		}
 	}
 ]

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,755 +1,537 @@
 [
 	{
-		"taskType": "trigger",
-		"capabilityId": "IssueResponder",
-		"subCapability": "IssuesOnlyResponder",
-		"version": "1.0",
-		"config": {
+	  "taskType": "trigger",
+	  "capabilityId": "IssueResponder",
+	  "subCapability": "IssuesOnlyResponder",
+	  "version": "1.0",
+	  "config": {
 		"conditions": {
-			"operator": "and",
-			"operands": [
+		  "operator": "and",
+		  "operands": [
 			{
-				"name": "labelAdded",
-				"parameters": {
+			  "name": "labelAdded",
+			  "parameters": {
 				"label": "need-info"
-				}
+			  }
 			}
-			]
+		  ]
 		},
 		"eventType": "issue",
 		"eventNames": [
-			"issues",
-			"project_card"
+		  "issues",
+		  "project_card"
 		],
 		"taskName": "Add comment when 'need-info' is applied to issue",
 		"actions": [
-			{
+		  {
 			"name": "addReply",
 			"parameters": {
-				"comment": "Hi @${issueAuthor}. We have added the \"need-info\" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time."
+			  "comment": "Hi @${issueAuthor}. We have added the \"need-info\" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time."
 			}
-			}
+		  }
 		]
-		}
+	  }
 	},
 	{
-		"taskType": "scheduled",
-		"capabilityId": "ScheduledSearch",
-		"subCapability": "ScheduledSearch",
-		"version": "1.1",
-		"config": {
+	  "taskType": "scheduled",
+	  "capabilityId": "ScheduledSearch",
+	  "subCapability": "ScheduledSearch",
+	  "version": "1.1",
+	  "config": {
 		"frequency": [
-			{
+		  {
 			"weekDay": 1,
 			"hours": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7,
-				8,
-				9,
-				10,
-				11,
-				12,
-				13,
-				14,
-				15,
-				16,
-				17,
-				18,
-				19,
-				20,
-				21,
-				22,
-				23
+			  0,
+			  1,
+			  2,
+			  3,
+			  4,
+			  5,
+			  6,
+			  7,
+			  8,
+			  9,
+			  10,
+			  11,
+			  12,
+			  13,
+			  14,
+			  15,
+			  16,
+			  17,
+			  18,
+			  19,
+			  20,
+			  21,
+			  22,
+			  23
 			],
 			"timezoneOffset": -5
-			},
-			{
+		  },
+		  {
 			"weekDay": 2,
 			"hours": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7,
-				8,
-				9,
-				10,
-				11,
-				12,
-				13,
-				14,
-				15,
-				16,
-				17,
-				18,
-				19,
-				20,
-				21,
-				22,
-				23
+			  0,
+			  1,
+			  2,
+			  3,
+			  4,
+			  5,
+			  6,
+			  7,
+			  8,
+			  9,
+			  10,
+			  11,
+			  12,
+			  13,
+			  14,
+			  15,
+			  16,
+			  17,
+			  18,
+			  19,
+			  20,
+			  21,
+			  22,
+			  23
 			],
 			"timezoneOffset": -5
-			},
-			{
+		  },
+		  {
 			"weekDay": 3,
 			"hours": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7,
-				8,
-				9,
-				10,
-				11,
-				12,
-				13,
-				14,
-				15,
-				16,
-				17,
-				18,
-				19,
-				20,
-				21,
-				22,
-				23
+			  0,
+			  1,
+			  2,
+			  3,
+			  4,
+			  5,
+			  6,
+			  7,
+			  8,
+			  9,
+			  10,
+			  11,
+			  12,
+			  13,
+			  14,
+			  15,
+			  16,
+			  17,
+			  18,
+			  19,
+			  20,
+			  21,
+			  22,
+			  23
 			],
 			"timezoneOffset": -5
-			},
-			{
+		  },
+		  {
 			"weekDay": 4,
 			"hours": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7,
-				8,
-				9,
-				10,
-				11,
-				12,
-				13,
-				14,
-				15,
-				16,
-				17,
-				18,
-				19,
-				20,
-				21,
-				22,
-				23
+			  0,
+			  1,
+			  2,
+			  3,
+			  4,
+			  5,
+			  6,
+			  7,
+			  8,
+			  9,
+			  10,
+			  11,
+			  12,
+			  13,
+			  14,
+			  15,
+			  16,
+			  17,
+			  18,
+			  19,
+			  20,
+			  21,
+			  22,
+			  23
 			],
 			"timezoneOffset": -5
-			},
-			{
+		  },
+		  {
 			"weekDay": 5,
 			"hours": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7,
-				8,
-				9,
-				10,
-				11,
-				12,
-				13,
-				14,
-				15,
-				16,
-				17,
-				18,
-				19,
-				20,
-				21,
-				22,
-				23
+			  0,
+			  1,
+			  2,
+			  3,
+			  4,
+			  5,
+			  6,
+			  7,
+			  8,
+			  9,
+			  10,
+			  11,
+			  12,
+			  13,
+			  14,
+			  15,
+			  16,
+			  17,
+			  18,
+			  19,
+			  20,
+			  21,
+			  22,
+			  23
 			],
 			"timezoneOffset": -5
-			}
+		  }
 		],
 		"searchTerms": [
-			{
+		  {
 			"name": "isIssue",
 			"parameters": {}
-			},
-			{
+		  },
+		  {
 			"name": "isOpen",
 			"parameters": {}
-			},
-			{
+		  },
+		  {
 			"name": "hasLabel",
 			"parameters": {
-				"label": "need-info"
+			  "label": "need-info"
 			}
-			},
-			{
+		  },
+		  {
 			"name": "noActivitySince",
 			"parameters": {
-				"days": 7
+			  "days": 7
 			}
-			}
+		  }
 		],
 		"taskName": "[Idle Issue Management] Close stale 'need-info' issues",
 		"actions": [
-			{
+		  {
 			"name": "addReply",
 			"parameters": {
-				"comment": "Hi @${issueAuthor}. Due to inactivity, we will be closing this issue. Please feel free to re-open this issue if the issue persists. For enhanced visibility, if over 7 days have passed, please open a new issue and link this issue there. Thank you."
+			  "comment": "Hi @${issueAuthor}. Due to inactivity, we will be closing this issue. Please feel free to re-open this issue if the issue persists. For enhanced visibility, if over 7 days have passed, please open a new issue and link this issue there. Thank you."
 			}
-			},
-			{
+		  },
+		  {
 			"name": "closeIssue",
 			"parameters": {}
-			}
+		  }
 		]
-		}
+	  }
 	},
 	{
-		"taskType": "trigger",
-		"capabilityId": "IssueResponder",
-		"subCapability": "IssueCommentResponder",
-		"version": "1.0",
-		"config": {
+	  "taskType": "trigger",
+	  "capabilityId": "IssueResponder",
+	  "subCapability": "IssueCommentResponder",
+	  "version": "1.0",
+	  "config": {
 		"conditions": {
-			"operator": "and",
-			"operands": [
+		  "operator": "and",
+		  "operands": [
 			{
-				"name": "isAction",
-				"parameters": {
+			  "name": "isAction",
+			  "parameters": {
 				"action": "created"
-				}
+			  }
 			},
 			{
-				"name": "isOpen",
-				"parameters": {}
+			  "name": "isOpen",
+			  "parameters": {}
 			},
 			{
-				"name": "hasLabel",
-				"parameters": {
+			  "name": "hasLabel",
+			  "parameters": {
 				"label": "need-info"
-				}
+			  }
 			},
 			{
-				"operator": "not",
-				"operands": [
+			  "operator": "not",
+			  "operands": [
 				{
-					"name": "activitySenderHasPermissions",
-					"parameters": {
+				  "name": "activitySenderHasPermissions",
+				  "parameters": {
 					"permissions": "write"
-					}
+				  }
 				}
-				]
+			  ]
 			}
-			]
+		  ]
 		},
 		"eventType": "issue",
 		"eventNames": [
-			"issue_comment"
+		  "issue_comment"
 		],
-		"taskName": "[Idle Issue Management] Replace 'need-info' and 'awaiting-customer-response` with 'need-attention' label when the customer comments on an issue",
+		"taskName": "[Idle Issue Management] Replace 'need-info' with 'need-attention' label when the customer comments on an issue",
 		"actions": [
-			{
+		  {
 			"name": "removeLabel",
 			"parameters": {
-				"label": "need-info"
+			  "label": "need-info"
 			}
-			},
-			{
+		  },
+		  {
 			"name": "addLabel",
 			"parameters": {
-				"label": "need-attention"
+			  "label": "need-attention"
 			}
-			},
-			{
-			"name": "removeLabel",
-			"parameters": {
-				"label": "awaiting-customer-response"
-			}
-			}
+		  }
 		]
-		}
+	  }
 	},
 	{
-		"taskType": "trigger",
-		"capabilityId": "IssueResponder",
-		"subCapability": "IssueCommentResponder",
-		"version": "1.0",
-		"config": {
+	  "taskType": "trigger",
+	  "capabilityId": "IssueResponder",
+	  "subCapability": "IssueCommentResponder",
+	  "version": "1.0",
+	  "config": {
 		"conditions": {
-			"operator": "and",
-			"operands": [
+		  "operator": "and",
+		  "operands": [
 			{
-				"operator": "not",
-				"operands": [
+			  "operator": "not",
+			  "operands": [
 				{
-					"name": "isOpen",
-					"parameters": {}
+				  "name": "isOpen",
+				  "parameters": {}
 				}
-				]
+			  ]
 			},
 			{
-				"name": "isAction",
-				"parameters": {
+			  "name": "isAction",
+			  "parameters": {
 				"action": "created"
-				}
+			  }
 			},
 			{
-				"operator": "or",
-				"operands": [
+			  "operator": "not",
+			  "operands": [
 				{
-					"name": "hasLabel",
-					"parameters": {
-					"label": "need-info"
-					}
-				},
-				{
-					"name": "hasLabel",
-					"parameters": {
-					"label": "awaiting-customer-response"
-					}
-				}
-				]
-			},
-			{
-				"operator": "not",
-				"operands": [
-				{
-					"name": "noActivitySince",
-					"parameters": {
+				  "name": "noActivitySince",
+				  "parameters": {
 					"days": 7
-					}
+				  }
 				}
-				]
+			  ]
 			},
 			{
-				"operator": "not",
-				"operands": [
+			  "operator": "not",
+			  "operands": [
 				{
-					"name": "isCloseAndComment",
-					"parameters": {}
+				  "name": "isCloseAndComment",
+				  "parameters": {}
 				}
-				]
+			  ]
 			},
 			{
-				"name": "isActivitySender",
-				"parameters": {
+			  "name": "isActivitySender",
+			  "parameters": {
 				"user": {
-					"type": "author"
+				  "type": "author"
 				}
-				}
+			  }
 			},
 			{
-				"name": "activitySenderHasPermissions",
-				"parameters": {
+			  "name": "activitySenderHasPermissions",
+			  "parameters": {
 				"permissions": "none"
-				}
+			  }
+			},
+			{
+			  "name": "hasLabel",
+			  "parameters": {
+				"label": "need-info"
+			  }
 			}
-			]
+		  ]
 		},
 		"eventType": "issue",
 		"eventNames": [
-			"issue_comment"
+		  "issue_comment"
 		],
 		"taskName": "[Idle Issue Management] For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.",
 		"actions": [
-			{
+		  {
 			"name": "reopenIssue",
 			"parameters": {}
-			},
-			{
+		  },
+		  {
 			"name": "removeLabel",
 			"parameters": {
-				"label": "need-info"
+			  "label": "need-info"
 			}
-			},
-			{
-			"name": "removeLabel",
-			"parameters": {
-				"label": "awaiting-customer-response"
-			}
-			},
-			{
+		  },
+		  {
 			"name": "addLabel",
 			"parameters": {
-				"label": "need-attention"
+			  "label": "need-attention"
 			}
-			}
+		  }
 		]
-		}
+	  }
 	},
 	{
-		"taskType": "trigger",
-		"capabilityId": "IssueResponder",
-		"subCapability": "IssueCommentResponder",
-		"version": "1.0",
-		"config": {
+	  "taskType": "trigger",
+	  "capabilityId": "IssueResponder",
+	  "subCapability": "IssueCommentResponder",
+	  "version": "1.0",
+	  "config": {
 		"conditions": {
-			"operator": "and",
-			"operands": [
+		  "operator": "and",
+		  "operands": [
 			{
-				"name": "isAction",
-				"parameters": {
+			  "name": "isAction",
+			  "parameters": {
 				"action": "created"
-				}
+			  }
 			},
 			{
-				"operator": "not",
-				"operands": [
+			  "operator": "not",
+			  "operands": [
 				{
-					"name": "isOpen",
-					"parameters": {}
+				  "name": "isOpen",
+				  "parameters": {}
 				}
-				]
+			  ]
 			},
 			{
-				"name": "activitySenderHasPermissions",
-				"parameters": {
+			  "name": "activitySenderHasPermissions",
+			  "parameters": {
 				"permissions": "none"
-				}
+			  }
 			},
 			{
-				"name": "noActivitySince",
-				"parameters": {
+			  "name": "noActivitySince",
+			  "parameters": {
 				"days": 7
-				}
+			  }
 			},
 			{
-				"operator": "not",
-				"operands": [
+			  "operator": "not",
+			  "operands": [
 				{
-					"name": "isCloseAndComment",
-					"parameters": {}
+				  "name": "isCloseAndComment",
+				  "parameters": {}
 				}
-				]
+			  ]
 			}
-			]
+		  ]
 		},
 		"eventType": "issue",
 		"eventNames": [
-			"issue_comment"
+		  "issue_comment"
 		],
 		"taskName": "[Closed Issue Management] For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
 		"actions": [
-			{
+		  {
 			"name": "addReply",
 			"parameters": {
-				"comment": "Hello lovely human, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!"
+			  "comment": "Hello lovely human, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!"
 			}
-			}
+		  }
 		]
-		}
+	  }
 	},
 	{
-		"taskType": "scheduled",
-		"capabilityId": "ScheduledSearch",
-		"subCapability": "ScheduledSearch",
-		"version": "1.1",
-		"config": {
+	  "taskType": "scheduled",
+	  "capabilityId": "ScheduledSearch",
+	  "subCapability": "ScheduledSearch",
+	  "version": "1.1",
+	  "config": {
 		"frequency": [
-			{
+		  {
 			"weekDay": 0,
 			"hours": [
-				10,
-				22
+			  10,
+			  22
 			],
 			"timezoneOffset": -5
-			},
-			{
+		  },
+		  {
 			"weekDay": 1,
 			"hours": [
-				10,
-				22
+			  10,
+			  22
 			],
 			"timezoneOffset": -5
-			},
-			{
+		  },
+		  {
 			"weekDay": 2,
 			"hours": [
-				10,
-				22
+			  10,
+			  22
 			],
 			"timezoneOffset": -5
-			},
-			{
+		  },
+		  {
 			"weekDay": 3,
 			"hours": [
-				10,
-				22
+			  10,
+			  22
 			],
 			"timezoneOffset": -5
-			},
-			{
+		  },
+		  {
 			"weekDay": 4,
 			"hours": [
-				10,
-				22
+			  10,
+			  22
 			],
 			"timezoneOffset": -5
-			},
-			{
+		  },
+		  {
 			"weekDay": 5,
 			"hours": [
-				10,
-				22
+			  10,
+			  22
 			],
 			"timezoneOffset": -5
-			},
-			{
+		  },
+		  {
 			"weekDay": 6,
 			"hours": [
-				10,
-				22
+			  10,
+			  22
 			],
 			"timezoneOffset": -5
-			}
+		  }
 		],
 		"searchTerms": [
-			{
+		  {
 			"name": "isClosed",
 			"parameters": {}
-			},
-			{
+		  },
+		  {
 			"name": "noActivitySince",
 			"parameters": {
-				"days": 30
+			  "days": 30
 			}
-			},
-			{
+		  },
+		  {
 			"name": "isUnlocked",
 			"parameters": {}
-			},
-			{
+		  },
+		  {
 			"name": "isIssue",
 			"parameters": {}
-			}
+		  }
 		],
 		"taskName": "[Closed Issue Management] Lock issues closed without activity for over 30 days",
 		"actions": [
-			{
+		  {
 			"name": "lockIssue",
 			"parameters": {
-				"reason": "resolved"
+			  "reason": "resolved"
 			}
-			}
+		  }
 		]
-		}
-	},
-	{
-		"taskType": "scheduled",
-		"capabilityId": "ScheduledSearch",
-		"subCapability": "ScheduledSearch",
-		"version": "1.1",
-		"config": {
-		"frequency": [
-			{
-			"weekDay": 1,
-			"hours": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7,
-				8,
-				9,
-				10,
-				11,
-				12,
-				13,
-				14,
-				15,
-				16,
-				17,
-				18,
-				19,
-				20,
-				21,
-				22,
-				23
-			],
-			"timezoneOffset": -5
-			},
-			{
-			"weekDay": 2,
-			"hours": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7,
-				8,
-				9,
-				10,
-				11,
-				12,
-				13,
-				14,
-				15,
-				16,
-				17,
-				18,
-				19,
-				20,
-				21,
-				22,
-				23
-			],
-			"timezoneOffset": -5
-			},
-			{
-			"weekDay": 3,
-			"hours": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7,
-				8,
-				9,
-				10,
-				11,
-				12,
-				13,
-				14,
-				15,
-				16,
-				17,
-				18,
-				19,
-				20,
-				21,
-				22,
-				23
-			],
-			"timezoneOffset": -5
-			},
-			{
-			"weekDay": 4,
-			"hours": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7,
-				8,
-				9,
-				10,
-				11,
-				12,
-				13,
-				14,
-				15,
-				16,
-				17,
-				18,
-				19,
-				20,
-				21,
-				22,
-				23
-			],
-			"timezoneOffset": -5
-			},
-			{
-			"weekDay": 5,
-			"hours": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7,
-				8,
-				9,
-				10,
-				11,
-				12,
-				13,
-				14,
-				15,
-				16,
-				17,
-				18,
-				19,
-				20,
-				21,
-				22,
-				23
-			],
-			"timezoneOffset": -5
-			}
-		],
-		"searchTerms": [
-			{
-			"name": "isIssue",
-			"parameters": {}
-			},
-			{
-			"name": "isOpen",
-			"parameters": {}
-			},
-			{
-			"name": "hasLabel",
-			"parameters": {
-				"label": "awaiting-customer-response"
-			}
-			},
-			{
-			"name": "noActivitySince",
-			"parameters": {
-				"days": 7
-			}
-			}
-		],
-		"taskName": "[Idle Issue Management] Close stale 'awaiting-customer-response' issues",
-		"actions": [
-			{
-			"name": "addReply",
-			"parameters": {
-				"comment": "Hi @${issueAuthor}. Due to inactivity, we will be closing this issue. Please feel free to re-open this issue if the issue persists. For enhanced visibility, if over 7 days have passed, please open a new issue and link this issue there. Thank you."
-			}
-			},
-			{
-			"name": "closeIssue",
-			"parameters": {}
-			}
-		]
-		}
+	  }
 	}
-]
+  ]


### PR DESCRIPTION
Hi team, this PR introduces some updates to FabricBot to help us automate some steps in our triaging. A lot of these were brought over from the MAUI fabricbot.json but modified to fit into our workflow. As the person who has done the least amount of triaging on this team, feel free to let me know modifications / "things won't work because of ..." things!

While I cannot link the UI here, **if you want to see the items in the UI, you can download this json file and import it here** with FabricBot's UI Tool: https://portal.fabricbot.ms/bot/


### 1. Add comment when 'need-info' is applied to issue 

When a `need-info` label is added, we send out a message saying the issue will be closed in 7 days if no info is provided
* This one is already implemented by @rolfbjarne and shows up here: https://github.com/xamarin/xamarin-macios/issues/14725#issuecomment-1099576199


### 2. [Idle Issue Management] Close stale 'need-info' issues

If we have a `need-info` label and there has been no activity from anyone in the past 7 days, we will close this issue


### 3. [Idle Issue Management] Replace 'need-info' ~~and 'awaiting-customer-response`~~ with 'need-attention' label when the customer comments on an issue

If there is a `need-info` ~~or `awaiting-customer-response`~~ label and someone who does not have write permissions (I think anyone not on our team) comments, it will remove the `need-info` label and add the `need-attention` label


### 4. [Idle Issue Management] For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.

If an issue has been closed for less than 7 days, has the labels either `need-info` ~~or `awaiting-customer-response`~~, and is commented on by issue author, then we will remove the `need-info` ~~and or `awaiting-customer-response`~~ labels, add the `need-attention` label, and reopen the issue


### 5. [Closed Issue Management] For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.

If an issue has been closed for over 7 days and someone not on our team comments, we send out a message asking non-contributor to open a new issue and link this issue there for enhanced visibility


### 6. [Closed Issue Management] Lock issues closed without activity for over 30 days

If an issue has been closed with no activity for over 30 days, lock the issue

- @mandel-macaque  Do we already do something like this?


~~### 7. [Idle Issue Management] Close stale 'awaiting-customer-response' issues~~

~~If an issue has the label `awaiting-customer-response` for over 7 days, we can close the issue and provide a nice message~~


## New Labels

* `need-attention` - when a customer has provided feedback for us. This will be useful to alert us which issues really need our attention as these issues become more automated
~~* `awaiting-customer-response` - after we send a message to the customer and we are waiting on their response. New fabricbot action will allow auto-closing an issue if we are waiting for a response for over 7 days~~