### PR TITLE
[CI] Fix the API diff statuses on CI

### DIFF
--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -93,12 +93,12 @@ class GitHubStatuses {
         $this.Token = $githubToken
     }
 
-    hidden [string] GetStatusUrl() {
+    [string] GetStatusUrl() {
         if ($Env:BUILD_REASON -eq "PullRequest") {
             # the env var is only provided for PR not for builds.
             $url = "https://api.github.com/repos/$($this.Org)/$($this.Repo)/statuses/$Env:SYSTEM_PULLREQUEST_SOURCECOMMITID"
         } else {
-            $url = "https://api.github.com/repos/$($this.Org)/$($this.Repo)/statuses/$Env:BUILD_REVISION"
+            $url = "https://api.github.com/repos/$($this.Org)/$($this.Repo)/statuses/$Env:BUILD_SOURCEVERSION"
         }
         return $url
     }

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -30,11 +30,13 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
 
-    $msg = "$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE)".Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
+    $msg = "$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE)"
+    $msg = $msg.Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
     $statuses.SetStatus("$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS)", $msg, "API Diff (PR)")
   displayName: "API diff final status"
   timeoutInMinutes: 5
   condition: succeededOrFailed() # re-starting the daemon should not be an issue
+  continueOnError: true
 
 - task: ArchiveFiles@1
   displayName: 'Archive API & Generator comparison'
@@ -95,11 +97,13 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
 
-    $msg = "$(apidiff.APIDIFF_MESSAGE)".Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
+    $msg = "$(apidiff.APIDIFF_MESSAGE)"
+    $msg = $msg.Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
     $statuses.SetStatus("$(apidiff.APIDIFF_STATUS)", $msg, "API Diff (stable)")
   displayName: "API diff final status"
   timeoutInMinutes: 5
   condition: succeededOrFailed() # re-starting the daemon should not be an issue
+  continueOnError: true
 
 - task: ArchiveFiles@1
   displayName: 'Archive API diff (from stable)'


### PR DESCRIPTION
I miss calculated the url of the statues for a CI build vs a PR build.