### PR TITLE
[release/6.0.3xx-rc2] [build] Use new MSI versioning schema

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -29,6 +29,7 @@ stages:
       artifactName: nuget-signed
       propsArtifactName: package
       signType: Real
+      useDateTimeVersion: true
 
   # Check - "xamarin-macios (Prepare Release Push NuGets)"
   - job: push_signed_nugets


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/185

Opts in to the new DateTime based MSI versioning to fix a recent issue
we saw with an MSI version moving backwards.


Backport of #14752
