### PR TITLE
Updated Xamarin.Messaging to 1.6.3

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.6.2</MessagingVersion>
+		<MessagingVersion>1.6.3</MessagingVersion>
 		<HotRestartVersion>1.0.90</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Contains a fix to control build verbose logging of underlying Xamarin.Messaging libraries