### PR TITLE
[CI] Set a prefix in the status so that if we have both builds we are not confused.

### DIFF
--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -103,6 +103,14 @@ class GitHubStatuses {
         return $url
     }
 
+    [string] GetStatusPrefix() {
+        if ($Env:BUILD_REASON -eq "PullRequest") {
+            return "[PR]"
+        } else {
+            return "[CI]"
+        }
+    }
+
     [object] SetStatus($status) {
         return $this.SetStatus(
             $status.Status,
@@ -112,6 +120,8 @@ class GitHubStatuses {
     }
 
     [object] SetStatus($status, $description, $context, $targetUrl) {
+        # set a prefix to be more clear
+        $context = "$($this.GetStatusPrefix()) $context"
         $headers = @{
             Authorization = ("token {0}" -f $this.Token)
         }


### PR DESCRIPTION
If we don't do this, we are stepping on the statuses when running both toes of builds. This way, we know when the status failed or not.