### PR TITLE
[CI] Do not use relative paths in the updated json.

### DIFF
--- a/tools/devops/automation/scripts/update-locproject.ps1
+++ b/tools/devops/automation/scripts/update-locproject.ps1
@@ -13,8 +13,8 @@ $jsonTemplateFiles | ForEach-Object {
 Push-Location "$SourcesDirectory"
 $projectObject = Get-Content $LocProjectPath | ConvertFrom-Json
 $jsonFiles | ForEach-Object {
-    $sourceFile = ($_.FullName | Resolve-Path -Relative)
-    $outputPath = "$(($_.DirectoryName | Resolve-Path -Relative) + "\")"
+    $sourceFile = $_.FullName
+    $outputPath = "$($_.DirectoryName + "\")"
     $projectObject.Projects[0].LocItems += (@{
         SourceFile = $sourceFile
         CopyOption = "LangIDOnName"


### PR DESCRIPTION
Full paths are valid and local paths are error prone because they depend on the number of checkouts done by vsts.