### PR TITLE
[runtime] Don't try process managed exceptions in xamarin_initialize.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1302,12 +1302,14 @@ xamarin_initialize ()
 	xamarin_bridge_call_runtime_initialize (&options, &exception_gchandle);
 	if (exception_gchandle != INVALID_GCHANDLE) {
 		NSLog (@PRODUCT ": An exception occurred when calling Runtime.Initialize:\n%@", xamarin_print_all_exceptions (exception_gchandle));
-		xamarin_process_managed_exception_gchandle (exception_gchandle);
 		xamarin_assertion_message ("Can't continue if Runtime.Initialize fails.");
 	}
 
 	xamarin_bridge_register_product_assembly (&exception_gchandle);
-	xamarin_process_managed_exception_gchandle (exception_gchandle);
+	if (exception_gchandle != INVALID_GCHANDLE) {
+		NSLog (@PRODUCT ": An exception occurred when registering the product assembly:\n%@", xamarin_print_all_exceptions (exception_gchandle));
+		xamarin_assertion_message ("Can't continue if registering the product assembly fails.");
+	}
 
 #if !defined (CORECLR_RUNTIME)
 	xamarin_install_mono_profiler (); // must be called before xamarin_install_nsautoreleasepool_hooks or xamarin_enable_new_refcount


### PR DESCRIPTION
If we try to process any exceptions, we'll throw an Objective-C exception,
which will likely be unhandled because we're pretty much at the top of the
stack, and when we handle this Objective-C exception we'll try to convert it
into a managed exception and throw that, and since there are no managed frames
on the stack we'll end up converting it to an Objective-C exception, which
we'll try to throw, and so on, eventually running into a stack overflow.

This is unnecessary, so just abort directly.