### PR TITLE
[release/6.0.2xx-preview14] Backport fixes for #13531.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -181,6 +181,10 @@ monoobject_dict_free_value (CFAllocatorRef allocator, const void *value)
  *       (NSObjectFlagsInFinalizerQueue), which we fetch in managed code in
  *       the Flags getter.
  *
+ *    Note: we call ObjectiveCMarshal.CreateReferenceTrackingHandle for all
+ *    NSObjects, not only toggled ones, because we need point 5) below to
+ *    happen for all NSObjects, not just toggled ones.
+ *
  * 4) The CoreCLR GC will invoke a callback we installed when calling
  *    ObjectiveCMarshal.Initialize to check if that toggled managed object can
  *    be collected or not. This callback is executed during the GC, which
@@ -194,7 +198,7 @@ monoobject_dict_free_value (CFAllocatorRef allocator, const void *value)
  *    to let us know, and we'll set the corresponding flag in the flags
  *
  * 6) Finally, the GCHandle we got in step 3) is freed when the managed peer
- *    is freed.
+ *    is freed and removed from our object map.
  *
  * Caveat: we don't support the server GC (because it uses multiple threads,
  * and thus may call xamarin_coreclr_reference_tracking_begin_end_callback
@@ -292,26 +296,32 @@ xamarin_coreclr_reference_tracking_is_referenced_callback (void* ptr)
 	int rv = 0;
 	struct TrackedObjectInfo *info = (struct TrackedObjectInfo *) ptr;
 	enum NSObjectFlags flags = info->flags;
+	bool isRegisteredToggleRef = (flags & NSObjectFlagsRegisteredToggleRef) == NSObjectFlagsRegisteredToggleRef;
 	id handle = info->handle;
-	MonoToggleRefStatus res;
+	MonoToggleRefStatus res = (MonoToggleRefStatus) 0;
 
-	res = xamarin_gc_toggleref_callback (flags, handle, NULL, NULL);
+	if (isRegisteredToggleRef) {
+		res = xamarin_gc_toggleref_callback (flags, handle, NULL, NULL);
 
-	switch (res) {
-	case MONO_TOGGLE_REF_DROP:
-		// There's no equivalent to DROP in CoreCLR, so just treat it as weak.
-	case MONO_TOGGLE_REF_WEAK:
+		switch (res) {
+		case MONO_TOGGLE_REF_DROP:
+			// There's no equivalent to DROP in CoreCLR, so just treat it as weak.
+		case MONO_TOGGLE_REF_WEAK:
+			rv = 0;
+			break;
+		case MONO_TOGGLE_REF_STRONG:
+			rv = 1;
+			break;
+		default:
+			LOG_CORECLR (stderr, "%s (%p -> handle: %p flags: %i): INVALID toggle ref value: %i\n", __func__, ptr, handle, flags, res);
+			break;
+		}
+	} else {
+		// If this isn't a toggle ref, it's effectively a weak gchandle
 		rv = 0;
-		break;
-	case MONO_TOGGLE_REF_STRONG:
-		rv = 1;
-		break;
-	default:
-		LOG_CORECLR (stderr, "%s (%p -> handle: %p flags: %i): INVALID toggle ref value: %i\n", __func__, ptr, handle, flags, res);
-		break;
 	}
 
-	LOG_CORECLR (stderr, "%s (%p -> handle: %p flags: %i) => %i (res: %i)\n", __func__, ptr, handle, flags, rv, res);
+	LOG_CORECLR (stderr, "%s (%p -> handle: %p flags: %i) => %i (res: %i) isRegisteredToggleRef: %i\n", __func__, ptr, handle, flags, rv, res, isRegisteredToggleRef);
 
 	return rv;
 }

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -664,6 +664,20 @@
 			OnlyDynamicUsage = false,
 			OnlyCoreCLR = true,
 		},
+
+		new XDelegate ("void", "void", "xamarin_retain_nativeobject",
+			"GCHandle->MonoObject *", "IntPtr", "obj"
+		) {
+			WrappedManagedFunction = "RetainNativeObject",
+			OnlyDynamicUsage = false,
+		},
+
+		new XDelegate ("bool", "bool", "xamarin_attempt_retain_nsobject",
+			"GCHandle->MonoObject *", "IntPtr", "obj"
+		) {
+			WrappedManagedFunction = "AttemptRetainNSObject",
+			OnlyDynamicUsage = false,
+		},
 	};
 	delegates.CalculateLengths ();
 #><#+
@@ -786,7 +800,7 @@
 					if (i > 0)
 						invoke_args.Append (", ");
 					if (arg.IsGCHandleConversion) {
-						// Convert to GCHandle before calling the managed functino
+						// Convert to GCHandle before calling the managed function
 						var argname = $"{arg.Name}__handle";
 						sb.AppendLine ($"\tGCHandle {argname} = xamarin_gchandle_new ((MonoObject *) {arg.Name}, false);");
 						invoke_args.Append (argname);

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -181,6 +181,25 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 				}
 			} else if (xamarin_is_class_inativeobject (r_klass)) {
 				returnValue = xamarin_get_handle_for_inativeobject (retval, exception_gchandle);
+				if (*exception_gchandle != INVALID_GCHANDLE)
+					return returnValue;
+				if (returnValue != NULL) {
+					if (retain) {
+						xamarin_retain_nativeobject (retval, exception_gchandle);
+						if (*exception_gchandle != INVALID_GCHANDLE)
+							return returnValue;
+					} else {
+						// This will try to retain the object if and only if it's an NSObject -
+						// in which case we known it's 'id' here and we can call autorelease on it.
+						bool retained = xamarin_attempt_retain_nsobject (retval, exception_gchandle);
+						if (*exception_gchandle != INVALID_GCHANDLE)
+							return returnValue;
+						if (retained) {
+							id i = (id) returnValue;
+							[i autorelease];
+						}
+					}
+				}
 			} else {
 				xamarin_assertion_message ("Don't know how to marshal a return value of type '%s.%s'. Please file a bug with a test case at https://github.com/xamarin/xamarin-macios/issues/new\n", mono_class_get_namespace (r_klass), mono_class_get_name (r_klass)); 
 			}

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -86,12 +86,12 @@ namespace CoreFoundation {
 		[DllImport (Constants.libcLibrary)]
 		extern static IntPtr dispatch_retain (IntPtr o);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			dispatch_retain (Handle);
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			dispatch_release (Handle);
 		}

--- a/src/CoreFoundation/DispatchBlock.cs
+++ b/src/CoreFoundation/DispatchBlock.cs
@@ -76,12 +76,12 @@ namespace CoreFoundation {
 			return new DispatchBlock (dispatch_block_create_with_qos_class ((nuint) (ulong) flags, qosClass, relative_priority, GetCheckedHandle ()), true);
 		}
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			Handle = BlockLiteral._Block_copy (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			BlockLiteral._Block_release (GetCheckedHandle ());
 		}

--- a/src/CoreFoundation/NativeObject.cs
+++ b/src/CoreFoundation/NativeObject.cs
@@ -58,10 +58,10 @@ namespace CoreFoundation {
 
 		// <quote>If cf is NULL, this will cause a runtime error and your application will crash.</quote>
 		// https://developer.apple.com/documentation/corefoundation/1521269-cfretain?language=occ
-		protected virtual void Retain () => CFObject.CFRetain (GetCheckedHandle ());
+		protected internal virtual void Retain () => CFObject.CFRetain (GetCheckedHandle ());
 
 		// <quote>If cf is NULL, this will cause a runtime error and your application will crash.</quote>
 		// https://developer.apple.com/documentation/corefoundation/1521153-cfrelease
-		protected virtual void Release () => CFObject.CFRelease (GetCheckedHandle ());
+		protected internal virtual void Release () => CFObject.CFRelease (GetCheckedHandle ());
 	}
 }

--- a/src/CoreFoundation/OSLog.cs
+++ b/src/CoreFoundation/OSLog.cs
@@ -60,13 +60,13 @@ namespace CoreFoundation {
 			}
 		}
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			if (Handle != IntPtr.Zero)
 				os_retain (Handle);
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			if (Handle != IntPtr.Zero)
 				os_release (Handle);

--- a/src/CoreGraphics/CGColor.cs
+++ b/src/CoreGraphics/CGColor.cs
@@ -59,12 +59,12 @@ namespace CoreGraphics {
 		{
 		}
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGColorRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGColorRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -128,12 +128,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGColorSpaceRef */ IntPtr CGColorSpaceRetain (/* CGColorSpaceRef */ IntPtr space);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGColorSpaceRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGColorSpaceRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -64,12 +64,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGContextRef */ IntPtr CGContextRetain (/* CGContextRef */ IntPtr c);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGContextRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGContextRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGDataConsumer.cs
+++ b/src/CoreGraphics/CGDataConsumer.cs
@@ -62,12 +62,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGDataConsumerRef */ IntPtr CGDataConsumerRetain (/* CGDataConsumerRef */ IntPtr consumer);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGDataConsumerRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGDataConsumerRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGDataProvider.cs
+++ b/src/CoreGraphics/CGDataProvider.cs
@@ -62,12 +62,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGDataProviderRef */ IntPtr CGDataProviderRetain (/* CGDataProviderRef */ IntPtr provider);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGDataProviderRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGDataProviderRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGFont.cs
+++ b/src/CoreGraphics/CGFont.cs
@@ -66,12 +66,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGFontRelease (/* CGFontRef */ IntPtr font);
 		
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGFontRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGFontRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGFunction.cs
+++ b/src/CoreGraphics/CGFunction.cs
@@ -82,12 +82,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGFunctionRef */ IntPtr CGFunctionRetain (/* CGFunctionRef */ IntPtr function);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGFunctionRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGFunctionRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGGradient.cs
+++ b/src/CoreGraphics/CGGradient.cs
@@ -64,12 +64,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGGradientRelease (/* CGGradientRef */ IntPtr gradient);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGGradientRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGGradientRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGImage.cs
+++ b/src/CoreGraphics/CGImage.cs
@@ -158,12 +158,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGImageRef */ IntPtr CGImageRetain (/* CGImageRef */ IntPtr image);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGImageRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGImageRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGLayer.cs
+++ b/src/CoreGraphics/CGLayer.cs
@@ -57,12 +57,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGLayerRef */ IntPtr CGLayerRetain (/* CGLayerRef */ IntPtr layer);
 		
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGLayerRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGLayerRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGPDFContentStream.cs
+++ b/src/CoreGraphics/CGPDFContentStream.cs
@@ -67,12 +67,12 @@ namespace CoreGraphics {
 		{
 		}
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGPDFContentStreamRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGPDFContentStreamRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -71,12 +71,12 @@ namespace CoreGraphics {
 		{
 		}
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGPDFDocumentRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGPDFDocumentRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGPDFOperatorTable.cs
+++ b/src/CoreGraphics/CGPDFOperatorTable.cs
@@ -54,12 +54,12 @@ namespace CoreGraphics {
 		{
 		}
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGPDFOperatorTableRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGPDFOperatorTableRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGPDFPage.cs
+++ b/src/CoreGraphics/CGPDFPage.cs
@@ -44,12 +44,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGPDFPageRelease (/* CGPDFPageRef */ IntPtr page);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGPDFPageRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGPDFPageRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGPDFScanner.cs
+++ b/src/CoreGraphics/CGPDFScanner.cs
@@ -65,12 +65,12 @@ namespace CoreGraphics {
 			get { return info; }
 		}
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGPDFScannerRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGPDFScannerRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -116,12 +116,12 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGPathRef */ IntPtr CGPathRetain (/* CGPathRef */ IntPtr path);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGPathRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGPathRelease (GetCheckedHandle ());
 		}

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -73,8 +73,8 @@ namespace CoreGraphics {
 		{
 		}
 
-		protected override void Retain () => CGPatternRetain (Handle);
-		protected override void Release () => CGPatternRelease (Handle);
+		protected internal override void Retain () => CGPatternRetain (Handle);
+		protected internal override void Release () => CGPatternRelease (Handle);
 		
 		// This is what we expose on the API
 		public delegate void DrawPattern (CGContext ctx);

--- a/src/CoreGraphics/CGShading.cs
+++ b/src/CoreGraphics/CGShading.cs
@@ -58,12 +58,12 @@ namespace CoreGraphics {
 		{
 		}
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGShadingRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGShadingRelease (GetCheckedHandle ());
 		}

--- a/src/CoreServices/FSEvents.cs
+++ b/src/CoreServices/FSEvents.cs
@@ -171,12 +171,12 @@ namespace CoreServices
 		[DllImport (Constants.CoreServicesLibrary)]
 		static extern void FSEventStreamRelease (IntPtr handle);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			FSEventStreamRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			FSEventStreamRelease (GetCheckedHandle ());
 		}

--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -62,12 +62,12 @@ namespace CoreVideo {
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static /* CVBufferRef */ IntPtr CVBufferRetain (/* CVBufferRef */ IntPtr buffer);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CVBufferRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CVBufferRelease (GetCheckedHandle ());
 		}

--- a/src/CoreVideo/CVDisplayLink.cs
+++ b/src/CoreVideo/CVDisplayLink.cs
@@ -212,12 +212,12 @@ namespace CoreVideo {
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static void CVDisplayLinkRelease (IntPtr handle);
 		
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CVDisplayLinkRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CVDisplayLinkRelease (GetCheckedHandle ());
 		}

--- a/src/CoreVideo/CVPixelBufferPool.cs
+++ b/src/CoreVideo/CVPixelBufferPool.cs
@@ -45,12 +45,12 @@ namespace CoreVideo {
 		extern static /* CVPixelBufferPoolRef __nullable */ IntPtr CVPixelBufferPoolRetain (
 			/* CVPixelBufferPoolRef __nullable */ IntPtr handle);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CVPixelBufferPoolRetain (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CVPixelBufferPoolRelease (GetCheckedHandle ());
 		}

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -94,11 +94,10 @@ namespace Foundation {
 		// See  "Toggle-ref support for CoreCLR" in coreclr-bridge.m for more information.
 		Flags actual_flags;
 		internal unsafe Runtime.TrackedObjectInfo* tracked_object_info;
-		internal GCHandle? tracked_object_handle;
 
 		unsafe Flags flags {
 			get {
-				// Get back the InFinalizerQueue flag, it's the only flag we'll set in the tracked object info structure.
+				// Get back the InFinalizerQueue flag, it's the only flag we'll set in the tracked object info structure from native code.
 				// The InFinalizerQueue will never be cleared once set, so there's no need to unset it here if it's not set in the tracked_object_info structure.
 				if (tracked_object_info != null && ((tracked_object_info->Flags) & Flags.InFinalizerQueue) == Flags.InFinalizerQueue)
 					actual_flags |= Flags.InFinalizerQueue;
@@ -389,12 +388,6 @@ namespace Foundation {
 			}
 			xamarin_release_managed_ref (handle, user_type);
 			FreeData ();
-#if NET
-			if (tracked_object_handle.HasValue) {
-				tracked_object_handle.Value.Free ();
-				tracked_object_handle = null;
-			}
-#endif
 		}
 
 		static bool IsProtocol (Type type, IntPtr protocol)
@@ -917,20 +910,6 @@ namespace Foundation {
 				if (disposing) {
 					ReleaseManagedRef ();
 				} else {
-#if NET
-					// By adding an external reference to the object from finalizer we will
-					// resurrect it. Since Runtime class tracks the NSObject instances with
-					// GCHandle(..., WeakTrackResurrection) we need to make sure it's aware
-					// that the object was finalized.
-					//
-					// On CoreCLR the non-tracked objects don't get a callback from the
-					// garbage collector when they enter the finalization queue but the
-					// information is necessary for Runtime.TryGetNSObject to work correctly. 
-					// Since we are on the finalizer thread now we can just set the flag
-					// directly here.
-					actual_flags |= Flags.InFinalizerQueue;
-#endif
-
 					NSObject_Disposer.Add (this);
 				}
 			} else {

--- a/src/Network/NWContentContext.cs
+++ b/src/Network/NWContentContext.cs
@@ -60,7 +60,7 @@ namespace Network {
 			return new NWContentContext (handle, owns: true, global: true);
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			if (global)
 				return;

--- a/src/ObjCRuntime/BaseWrapper.cs
+++ b/src/ObjCRuntime/BaseWrapper.cs
@@ -26,13 +26,13 @@ namespace ObjCRuntime {
 		{
 		}
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			if (Handle != IntPtr.Zero)
 				Messaging.void_objc_msgSend (Handle, Selector.GetHandle ("retain"));
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			if (Handle != IntPtr.Zero)
 				Messaging.void_objc_msgSend (Handle, Selector.GetHandle ("release"));

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1077,6 +1077,10 @@ namespace ObjCRuntime {
 					if (managed_obj is null || wr.Target == (object) managed_obj) {
 						object_map.Remove (ptr);
 						wr.Free ();
+					} else if (wr.Target is null) {
+						// We can remove null entries, and free the corresponding GCHandle
+						object_map.Remove (ptr);
+						wr.Free ();
 					}
 
 				}
@@ -1089,6 +1093,8 @@ namespace ObjCRuntime {
 		internal static void RegisterNSObject (NSObject obj, IntPtr ptr) {
 			var handle = GCHandle.Alloc (obj, GCHandleType.WeakTrackResurrection);
 			lock (lock_obj) {
+				if (object_map.Remove (ptr, out var existing))
+					existing.Free ();
 				object_map [ptr] = handle;
 				obj.Handle = ptr;
 			}

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1091,7 +1091,17 @@ namespace ObjCRuntime {
 		}
 		
 		internal static void RegisterNSObject (NSObject obj, IntPtr ptr) {
+#if NET
+			GCHandle handle;
+			if (Runtime.IsCoreCLR) {
+				handle = CreateTrackingGCHandle (obj, ptr);
+			} else {
+				handle = GCHandle.Alloc (obj, GCHandleType.WeakTrackResurrection);
+			}
+#else
 			var handle = GCHandle.Alloc (obj, GCHandleType.WeakTrackResurrection);
+#endif
+
 			lock (lock_obj) {
 				if (object_map.Remove (ptr, out var existing))
 					existing.Free ();

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -19,6 +19,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
+using CoreFoundation;
 using Foundation;
 using Registrar;
 
@@ -1839,6 +1840,25 @@ namespace ObjCRuntime {
 				(char) (byte) (value >> 16),
 				(char) (byte) (value >> 8),
 				(char) (byte) value });
+		}
+
+		// Retain the input if it's either an NSObject or a NativeObject.
+		static void RetainNativeObject (IntPtr gchandle)
+		{
+			var obj = GetGCHandleTarget (gchandle);
+			if (obj is NativeObject nobj)
+				nobj.Retain ();
+			else if (obj is NSObject nsobj)
+				nsobj.DangerousRetain ();
+		}
+
+		// Check if the input is an NSObject, and in that case retain it (and return true)
+		// This way the caller knows if it can call 'autorelease' on our input.
+		static bool AttemptRetainNSObject (IntPtr gchandle)
+		{
+			var obj = GetGCHandleTarget (gchandle) as NSObject;
+			obj?.DangerousRetain ();
+			return obj is not null;
 		}
 #endif // !COREBUILD
 

--- a/src/OpenGL/CGLContext.cs
+++ b/src/OpenGL/CGLContext.cs
@@ -69,12 +69,12 @@ namespace OpenGL {
 		[DllImport (Constants.OpenGLLibrary)]
 		extern static void CGLReleaseContext (IntPtr handle);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGLRetainContext (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGLReleaseContext (GetCheckedHandle ());
 		}

--- a/src/OpenGL/CGLPixelFormat.cs
+++ b/src/OpenGL/CGLPixelFormat.cs
@@ -57,12 +57,12 @@ namespace OpenGL {
 		}
 #endif
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			CGLRetainPixelFormat (GetCheckedHandle ());
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			CGLReleasePixelFormat (GetCheckedHandle ());
 		}

--- a/src/PrintCore/PrintCore.cs
+++ b/src/PrintCore/PrintCore.cs
@@ -38,12 +38,12 @@ namespace PrintCore {
 		[DllImport (Constants.PrintCoreLibrary)]
 		internal extern static OSStatus PMRelease (PMObject obj);
 
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 			PMRetain (Handle);
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 			PMRelease (Handle);
 		}

--- a/src/SearchKit/SearchKit.cs
+++ b/src/SearchKit/SearchKit.cs
@@ -298,11 +298,11 @@ namespace SearchKit
 		}
 
 #if !NET
-		protected override void Retain ()
+		protected internal override void Retain ()
 		{
 		}
 
-		protected override void Release ()
+		protected internal override void Release ()
 		{
 		}
 #endif


### PR DESCRIPTION
This PR contains the changes required for #13531 (PRs #14690, #14783, #14784, #14785):

* [runtime] Don't call 'retain' and 'autorelease' selectors on returned NativeObjects.

    We were trying to call the 'retain' and 'autorelease' selectors on objects
    that weren't NSObjects when returning them from function calls. For some
    unfathomable reason that has worked until now, but I started running into this
    problem with other (unrelated) changes, so it needs to be fixed.

    The fix is to not call the 'retain' and 'autorelease' selectors on
    NativeObjects, instead call into managed code to either call the Retain method
    on the managed NativeObject (if we're supposed to retain the return value), or
    if we have to autorelease the return value, then check first if the input is
    an NSObject, and only then call retain+autorelease.

* [CoreCLR] Rework how we track the lifetime of managed NSObjects.

    * We now create a tracking GCHandle for all NSObjects, not only the
      toggled ones. CoreCLR will notify us when a tracked GCHandle's target
      enters finalization, and we need to be notified for all NSObjects, not
      just the toggled ones.
    * Augment the tracking callback to know about non-toggled objects, and in
      that case report that the tracking GCHandle is a weak GCHandle.
    * There's no need to store the tracking GCHandle in a field in the
      NSObject instance, since we store it in our runtime object_map.
    * Remove one place where we set the InFinalizerQueue flag, since it's no
      longer required there (this reverts a previous attempt at fixing this
      problem - 0622ae4af2482cb9e66e8bceced4e669ab25909b) - we only set the
      InFinalizerQueue flag in the
      xamarin_coreclr_reference_tracking_tracked_object_entered_finalization
      callback now.
    * Update a few comments accordingly.

    Partial fix for https://github.com/xamarin/xamarin-macios/issues/13531.

    Fixes https://github.com/xamarin/xamarin-macios/issues/13921 (again).

* [ObjCRuntime] Fix GCHandle leak in our NSObject map.

    * We can remove entries in the object_map when the target is null (and we
      don't need the corresponding GCHandle anymore, so it can be freed).
    * When replacing an existing entry, we have to free the GCHandle.

* [ObjCRuntime] Augment Runtime.GetNSObject to optionally create a new
  instance even if an existing instance was found.

    Augment Runtime.GetNSObject to optionally create a new instance even if an
    existing instance was found, if the existing instance isn't compatible with
    the requested instance type. Partial fix for
    https://github.com/xamarin/xamarin-macios/issues/13531.


Backport of #14793
