### PR TITLE
[msbuild] Just use the 'AppBundleDir' variable to find the app bundle in the CreateInstallerPackage task. Fixes #14751.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateInstallerPackageTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateInstallerPackageTaskBase.cs
@@ -95,7 +95,7 @@ namespace Xamarin.MacDev.Tasks
 			}
 
 			args.Add ("--component");
-			args.AddQuoted (Path.Combine (OutputDirectory, Path.GetFileName (AppBundleDir)));
+			args.AddQuoted (Path.GetFullPath (AppBundleDir));
 			args.Add ("/Applications");
 
 			if (EnablePackageSigning) {
@@ -117,7 +117,10 @@ namespace Xamarin.MacDev.Tasks
 				string target = string.Format ("{0}{1}.pkg", Name, String.IsNullOrEmpty (projectVersion) ? "" : "-" + projectVersion);
 				PkgPackagePath = Path.Combine (OutputDirectory, target);
 			}
+			PkgPackagePath = Path.GetFullPath (PkgPackagePath);
 			args.AddQuoted (PkgPackagePath);
+
+			Directory.CreateDirectory (Path.GetDirectoryName (PkgPackagePath));
 
 			return args.ToString ();
 		}


### PR DESCRIPTION
The output directory might or might not be where the app bundle is: by default
it is, but if someone sets the PkgPackageDir variable to provide an alternate
directory for the pkg, then that won't be where we'll find the app bundle.

The good news is that we already have a property that tells us where the app
bundle is (the 'AppBundleDir' property), so just use that instead.

Also:

* Make sure that the output directory exists before we try to write to it.
* Only pass full paths to productbuild, which for some reason doesn't seem to
  like relative paths.

Fixes https://github.com/xamarin/xamarin-macios/issues/14751.