### PR TITLE
[tests] Fix registrar tests to not return unretained INativeObjects to Objective-C. Fixes #xamarin/maccore@2572.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -190,7 +190,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Assert.True (Messaging.bool_objc_msgSend_IntPtr (receiver, new Selector ("INativeObject1:").Handle, new CGPath ().Handle), "#a2");
 			
 			Assert.That ((NativeHandle) Messaging.IntPtr_objc_msgSend_bool (receiver, new Selector ("INativeObject2:").Handle, false), Is.EqualTo (NativeHandle.Zero), "#b1");
-			Assert.That ((NativeHandle) Messaging.IntPtr_objc_msgSend_bool (receiver, new Selector ("INativeObject2:").Handle, true), Is.Not.EqualTo (NativeHandle.Zero), "#b2");
+			ptr = Messaging.IntPtr_objc_msgSend_bool (receiver, new Selector ("INativeObject2:").Handle, true);
+			Assert.That ((NativeHandle) ptr, Is.Not.EqualTo (NativeHandle.Zero), "#b2");
+			CGPathRelease (ptr);
 			
 			void_objc_msgSend_out_IntPtr_bool (receiver, new Selector ("INativeObject3:create:").Handle, out ptr, true);
 			Assert.That (ptr, Is.Not.EqualTo (NativeHandle.Zero), "#c1");
@@ -212,6 +214,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Assert.That (ptr, Is.Not.EqualTo (NativeHandle.Zero), "#e2");
 			path = Runtime.GetINativeObject<CGPath> (ptr, false);
 			path.AddArc (1, 2, 3, 4, 5, false); // this should crash if we get back a bogus ptr
+			CGPathRelease (ptr);
 		}
 
 		[Test]
@@ -437,6 +440,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
 		internal static extern IntPtr object_getClass (IntPtr obj);
+
+		[DllImport (Constants.CoreGraphicsLibrary)]
+		extern static void CGPathRelease (/* CGPathRef */ IntPtr path);
 
 		[Test]
 		public void TestNonVirtualProperty ()
@@ -871,6 +877,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 			
 			[Export ("INativeObject2:")]
+			[return: ReleaseAttribute] // can't return an INativeObject without retaining it (we can autorelease NSObjects, but that doesn't work for INativeObjects)
 			static CGPath INativeObject2 (bool create)
 			{
 				return create ? new CGPath () : null;
@@ -889,6 +896,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 			
 			[Export ("INativeObject5:")]
+			[return: ReleaseAttribute] // can't return an INativeObject without retaining it (we can autorelease NSObjects, but that doesn't work for INativeObjects)
 			static CGPath INativeObject5 (bool create)
 			{
 				return create ? new CGPath () : null;


### PR DESCRIPTION
We can't return unretained INativeObjects to Objective-C, because they might
be freed at any point when the GC collects the managed object. Instead return
retained objects, that way they're not freed even if the GC collects the
managed object.

This fixes a random crash in the TestRegistrar.TestINativeObject when the GC
would run just after we've returned an INativeObject to native code, and later
used that native handle thinking it would still be valid.

Fixes https://github.com/xamarin/maccore/issues/2572.