### PR TITLE
[Localization] Update the Lcl paths

### DIFF
--- a/tools/devops/LocProject.json.in
+++ b/tools/devops/LocProject.json.in
@@ -8,7 +8,7 @@
 			"Languages": "",
 			"CopyOption": "LangIDOnName",
 			"OutputPath": "@WORKING_DIRECTORY@/../../msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies",
-			"LclFile": "",
+			"LclFile": "@WORKING_DIRECTORY@/../../Localize/loc/{Lang}/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl",
 			"LciFile": "",
 			"Parser": "",
 			"LssFiles": []
@@ -18,7 +18,7 @@
 			"Languages": "",
 			"CopyOption": "LangIDOnName",
 			"OutputPath": "@WORKING_DIRECTORY@/../../tools/mtouch/TranslatedAssemblies",
-			"LclFile": "",
+			"LclFile": "@WORKING_DIRECTORY@/../../Localize/loc/{Lang}/tools/mtouch/Errors.resx.lcl",
 			"LciFile": "",
 			"Parser": "",
 			"LssFiles": []

--- a/tools/devops/automation/scripts/update-locproject.ps1
+++ b/tools/devops/automation/scripts/update-locproject.ps1
@@ -16,8 +16,13 @@ $jsonFiles | ForEach-Object {
     $sourceFile = $_.FullName
     $outputPath = "$($_.DirectoryName + "\")"
     $fullNameString = Convert-Path -Path $_.FullName
-    $maciosPath = $fullNameString -split "xamarin-macios", 2
-    $lclFile = "$($LocalizeDirectory + $maciosPath[1] + ".lcl")"
+    $maciosPathArray = $fullNameString -split "xamarin-macios", 2
+    $maciosPath = $maciosPathArray[1]
+    if ($null -eq $maciosPath) {
+        Write-Host "'fullNameString' could not be split at 'xamarin-macios'!"
+        exit 1
+    }
+    $lclFile = Join-Path -Path $LocalizeDirectory -ChildPath "$($maciosPath).lcl"
     $projectObject.Projects[0].LocItems += (@{
         SourceFile = $sourceFile
         CopyOption = "LangIDOnName"

--- a/tools/devops/automation/scripts/update-locproject.ps1
+++ b/tools/devops/automation/scripts/update-locproject.ps1
@@ -1,4 +1,4 @@
-param ($SourcesDirectory, $LocProjectPath)
+param ($SourcesDirectory, $LocalizeDirectory, $LocProjectPath)
 
 $jsonFiles = @()
 $jsonTemplateFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | Where-Object { $_.FullName -Match "\.template\.config\\localize\\.+\.en\.json" } # .NET templating pattern
@@ -15,10 +15,14 @@ $projectObject = Get-Content $LocProjectPath | ConvertFrom-Json
 $jsonFiles | ForEach-Object {
     $sourceFile = $_.FullName
     $outputPath = "$($_.DirectoryName + "\")"
+    $fullNameString = Convert-Path -Path $_.FullName
+    $maciosPath = $fullNameString -split "xamarin-macios", 2
+    $lclFile = "$($LocalizeDirectory + $maciosPath[1] + ".lcl")"
     $projectObject.Projects[0].LocItems += (@{
         SourceFile = $sourceFile
         CopyOption = "LangIDOnName"
         OutputPath = $outputPath
+        LclFile = $lclFile
     })
 }
 Pop-Location

--- a/tools/devops/automation/templates/loc-translations.yml
+++ b/tools/devops/automation/templates/loc-translations.yml
@@ -13,7 +13,7 @@ steps:
   inputs:
     targetType: 'filePath'
     filePath: $(Build.SourcesDirectory)\\xamarin-macios\\tools\\devops\\automation\\scripts\\update-locproject.ps1
-    arguments: -SourcesDirectory "$(Build.SourcesDirectory)\\xamarin-macios" -LocProjectPath "$(Build.SourcesDirectory)\\xamarin-macios\\Localize\\LocProject.json"
+    arguments: -SourcesDirectory "$(Build.SourcesDirectory)\\xamarin-macios" -LocalizeDirectory "$(Build.SourcesDirectory)\xamarin-macios\Localize\loc\{Lang}" -LocProjectPath "$(Build.SourcesDirectory)\\xamarin-macios\\Localize\\LocProject.json"
 
 - pwsh: |
     git remote remove origin


### PR DESCRIPTION
Allow the Lcl paths to be updated to the correct paths and should stop OneLocBuild trying to move our lcl files which is happening every day in PRs like this: https://github.com/xamarin/xamarin-macios/pull/14806

Here is the updated LocProject.json that is generated: https://gist.github.com/tj-devel709/70bbb9e12345502f42d598834f26196c