### PR TITLE
[static registrar] Fix lookup of block proxy attributes.

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -184,6 +184,24 @@ namespace Registrar {
 					return all_protocols;
 				}
 			}
+
+			HashSet<ObjCType> all_protocols_in_hierarchy;
+			public IEnumerable<ObjCType> AllProtocolsInHierarchy {
+				get {
+					if (all_protocols_in_hierarchy is null) {
+						all_protocols_in_hierarchy = new HashSet<ObjCType> ();
+						var type = this;
+						while (type is not null && (object) type != (object) type.BaseType) {
+							var allProtocols = type.AllProtocols;
+							if (allProtocols is not null)
+								all_protocols_in_hierarchy.UnionWith (allProtocols);
+							type = type.BaseType;
+						}
+					}
+
+					return all_protocols_in_hierarchy;
+				}
+			}
 #endif
 
 			public void VerifyRegisterAttribute (ref List<Exception> exceptions)

--- a/tests/bindings-test/RegistrarBindingTest.cs
+++ b/tests/bindings-test/RegistrarBindingTest.cs
@@ -93,6 +93,89 @@ namespace Xamarin.BindingTests
 			}
 		}
 
+		[Test]
+		public void DerivedClassBlockCallback ()
+		{
+			using (var obj = new BlockCallbackTester ()) {
+				DerivedBlockCallbackClass.Answer = 42;
+				obj.TestObject = new DerivedBlockCallbackClass ();
+				obj.CallOptionalCallback ();
+				// obj.CallRequiredCallback ();
+				ObjCBlockTester.TestClass = new Class (typeof (DerivedBlockCallbackClass));
+				ObjCBlockTester.CallRequiredStaticCallback ();
+				ObjCBlockTester.CallOptionalStaticCallback ();
+				DerivedBlockCallbackClass.Answer = 2;
+			}
+		}
+
+		abstract class BaseBlockCallbackClass : NSObject, IObjCProtocolBlockTest
+		{
+			public abstract void RequiredCallback (Action<int> completionHandler);
+			public abstract Action<int> RequiredReturnValue ();
+		}
+
+		class DerivedBlockCallbackClass : BaseBlockCallbackClass
+		{
+			public static int Answer = 42;
+			public override void RequiredCallback (Action<int> completionHandler)
+			{
+				completionHandler (Answer);
+			}
+
+			[Export ("optionalCallback:")]
+			public void OptionalCallback (Action<int> completionHandler)
+			{
+				Console.WriteLine ("OptionalCallback");
+				completionHandler (Answer);
+			}
+
+			[Export ("requiredStaticCallback:")]
+			public static void RequiredStaticCallback (Action<int> completionHandler)
+			{
+				completionHandler (Answer);
+			}
+
+			[Export ("optionalStaticCallback:")]
+			public static void OptionalStaticCallback (Action<int> completionHandler)
+			{
+				Console.WriteLine ("OptionalStaticCallback");
+				completionHandler (Answer);
+			}
+
+			public override Action<int> RequiredReturnValue ()
+			{
+				return new Action<int> ((v) => {
+					Assert.AreEqual (Answer, v, "RequiredReturnValue");
+				});
+			}
+
+			[Export ("optionalReturnValue")]
+			public Action<int> OptionalReturnValue ()
+			{
+				return new Action<int> ((v) => {
+				Console.WriteLine ("OptionalReturnValue");
+					Assert.AreEqual (Answer, v, "RequiredReturnValue");
+				});
+			}
+
+			[Export ("requiredStaticReturnValue")]
+			public static Action<int> RequiredStaticReturnValue ()
+			{
+				return new Action<int> ((v) => {
+					Assert.AreEqual (Answer, v, "RequiredReturnValue");
+				});
+			}
+
+			[Export ("optionalStaticReturnValue")]
+			public static Action<int> OptionalStaticReturnValue ()
+			{
+				return new Action<int> ((v) => {
+				Console.WriteLine ("OptionalStaticReturnValue");
+					Assert.AreEqual (Answer, v, "RequiredReturnValue");
+				});
+			}
+		}
+
 		class BlockCallbackClassExplicit : NSObject, IObjCProtocolBlockTest
 		{
 			// Explicitly implemented interface member

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -1982,5 +1982,171 @@ class C : NSObject {
 				mtouch.AssertWarning (4179, $"The registrar found the abstract type 'SomeNativeObject' in the signature for 'C.M2'. Abstract types should not be used in the signature for a member exported to Objective-C.", "testApp.cs", 21);
 			}
 		}
+
+		[Test]
+		public void OptionalProtocolMemberLookup ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				var code = @"
+namespace NS {
+	using System;
+	using Foundation;
+	using ObjCRuntime;
+
+	// Old style, where we look up the block proxy attribute on the extension method
+	public class Subclassable1Consumer : NSObject, IProtocolWithOptionalMembers1
+	{
+	}
+
+	public class Subclassed1Consumer1 : Subclassable1Consumer
+	{
+		[Export (""doActionWithCompletion:"")]
+		public void DoAction (Action<bool> completion)
+		{
+		}
+	}
+
+	public class Subclassed1Consumer2 : Subclassable1Consumer, IProtocolWithOptionalMembers1
+	{
+		[Export (""doActionWithCompletion:"")]
+		public void DoAction (Action<bool> completion)
+		{
+		}
+	}
+
+	public class DirectConsumer1 : NSObject, IProtocolWithOptionalMembers1
+	{
+		[Export (""doActionWithCompletion:"")]
+		public void DoAction (Action<bool> completion)
+		{
+		}
+	}
+
+	[Protocol (Name = ""IProtocolWithOptionalMembers1"", WrapperType = typeof (IProtocolWithOptionalMembers1Wrapper))]
+	[ProtocolMember (IsRequired = false, IsProperty = false, IsStatic = false, Name = ""DoAction"", Selector = ""doActionWithCompletion:"", ParameterType = new Type [] { typeof (global::System.Action<bool>) }, ParameterByRef = new bool [] { false })]
+	public interface IProtocolWithOptionalMembers1 : INativeObject, IDisposable
+	{
+	}
+
+	public static partial class ProtocolWithOptionalMembers1_Extensions {
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		public static void DoAction (this IProtocolWithOptionalMembers1 This, [BlockProxy (typeof (NIDActionArity1V89))]global::System.Action<bool> completion)
+		{
+		}
+	}
+
+	internal sealed class IProtocolWithOptionalMembers1Wrapper : BaseWrapper, IProtocolWithOptionalMembers1 {
+		[Preserve (Conditional = true)]
+		public IProtocolWithOptionalMembers1Wrapper (IntPtr handle, bool owns)
+			: base (handle, owns)
+		{
+		}
+	}
+
+	// New style, where we find the block proxy attribute in the ProtocolMember attribute
+	public class Subclassable2Consumer : NSObject, IProtocolWithOptionalMembers2
+	{
+	}
+
+	public class Subclassed2Consumer1 : Subclassable2Consumer
+	{
+		[Export (""doAction2WithCompletion:"")]
+		public void DoAction2 (Action<bool> completion)
+		{
+		}
+	}
+
+	public class Subclassed2Consumer2 : Subclassable2Consumer, IProtocolWithOptionalMembers2
+	{
+		[Export (""doAction2WithCompletion:"")]
+		public void DoAction2 (Action<bool> completion)
+		{
+		}
+	}
+
+	public class DirectConsumer2: NSObject, IProtocolWithOptionalMembers2
+	{
+		[Export (""doAction2WithCompletion:"")]
+		public void DoAction2 (Action<bool> completion)
+		{
+		}
+	}
+
+	[Protocol (Name = ""IProtocolWithOptionalMembers2"", WrapperType = typeof (IProtocolWithOptionalMembers2Wrapper))]
+	[ProtocolMember (IsRequired = false, IsProperty = false, IsStatic = false, Name = ""DoAction2"", Selector = ""doAction2WithCompletion:"", ParameterType = new Type [] { typeof (global::System.Action<bool>) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type [] {typeof (NIDActionArity1V89)})]
+	public interface IProtocolWithOptionalMembers2 : INativeObject, IDisposable
+	{
+	}
+
+	public static partial class ProtocolWithOptionalMembers2_Extensions {
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		public static void DoAction (this IProtocolWithOptionalMembers2 This, [BlockProxy (typeof (NIDActionArity1V89))]global::System.Action<bool> completion)
+		{
+		}
+	}
+
+	internal sealed class IProtocolWithOptionalMembers2Wrapper : BaseWrapper, IProtocolWithOptionalMembers2 {
+		[Preserve (Conditional = true)]
+		public IProtocolWithOptionalMembers2Wrapper (IntPtr handle, bool owns)
+			: base (handle, owns)
+		{
+		}
+	}
+
+	// Supporting block classes
+	[UserDelegateType (typeof (global::System.Action<bool>))]
+	internal delegate void DActionArity1V89 (IntPtr block, IntPtr obj);
+
+	static internal class SDActionArity1V89 {
+		static internal readonly DActionArity1V89 Handler = Invoke;
+
+		[MonoPInvokeCallback (typeof (DActionArity1V89))]
+		static void Invoke (IntPtr block, IntPtr obj) {
+			throw new NotImplementedException ();
+		}
+	}
+
+	internal class NIDActionArity1V89 {
+		IntPtr blockPtr;
+		DActionArity1V89 invoker;
+
+		[Preserve (Conditional=true)]
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		public NIDActionArity1V89 (ref BlockLiteral block)
+		{
+			throw new NotImplementedException ();
+		}
+
+		[Preserve (Conditional=true)]
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		~NIDActionArity1V89 ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		[Preserve (Conditional=true)]
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		public static global::System.Action<bool> Create (IntPtr block)
+		{
+			throw new NotImplementedException ();
+		}
+
+		[Preserve (Conditional=true)]
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		void Invoke (bool arg1)
+		{
+		}
+	}
+}
+
+";
+				mtouch.Linker = MTouchLinker.DontLink; // faster
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.CreateTemporaryApp (extraCode: code, extraArgs: new [] { "-debug" });
+				mtouch.AssertExecute ("build");
+				mtouch.AssertErrorCount (0);
+				mtouch.AssertWarningCount (0);
+			}
+		}
 	}
 }

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4282,7 +4282,7 @@ namespace Registrar {
 			}
 
 			// Might be an implementation of an optional protocol member.
-			var allProtocols = obj_method.DeclaringType.AllProtocols;
+			var allProtocols = obj_method.DeclaringType.AllProtocolsInHierarchy;
 			if (allProtocols != null) {
 				string selector = null;
 
@@ -4329,7 +4329,7 @@ namespace Registrar {
 			}
 
 			// Might be an implementation of an optional protocol member.
-			var allProtocols = obj_method.DeclaringType.AllProtocols;
+			var allProtocols = obj_method.DeclaringType.AllProtocolsInHierarchy;
 			if (allProtocols != null) {
 				string selector = null;
 
@@ -4353,7 +4353,7 @@ namespace Registrar {
 								continue;
 							if (!TypeMatch (pMethod.ReturnType, method.ReturnType))
 								continue;
-							if (ParametersMatch (method.Parameters, pMethod.Parameters))
+							if (!ParametersMatch (method.Parameters, pMethod.Parameters))
 								continue;
 
 							MethodDefinition extensionMethod = pMethod.Method;
@@ -4402,8 +4402,21 @@ namespace Registrar {
 
 			if (!method.HasCustomAttributes)
 				return false;
-			
-			var t = method.DeclaringType;
+
+			var type = method.DeclaringType;
+			while (type is not null && (object) type != (object) type.BaseType) {
+				if (MapProtocolMember (type, method, out extensionMethod))
+					return true;
+
+				type = type.BaseType?.Resolve ();
+			}
+
+			return false;
+		}
+
+		public bool MapProtocolMember (TypeDefinition t, MethodDefinition method, out MethodDefinition extensionMethod)
+		{
+			extensionMethod = null;
 
 			if (!t.HasInterfaces)
 				return false;


### PR DESCRIPTION
Fix lookup of block proxy attributes to look in protocols declared on base classes.

Broken pseudo code:

    class BaseApplicationDelegate : NSObject, IUIApplicationDelegate {}
    class MyApplicationDelegate : BaseApplicationDelegate {
        [Export("application:didReceiveRemoteNotification:fetchCompletionHandler:")]
        public void DidReceiveRemoteNotification (UIApplication application, NSDictionary userInfo, Action<UIBackgroundFetchResult> completionHandler) { }
    }

the static registrar wouldn't figure out that the DidReceiveRemoteNotification method
comes from the UIApplicationDelegate, because it would only look in protocols defined
on MyApplicationDelegate, not any base classes.

The fix is to look in base classes too.

Also:

* Fix a boolean logic error when matching parameters between methods in another
  (rarely used) code path when looking for matching binding methods in the extension
  class for protocols with optional members.
* Add tests.

Fixes https://github.com/dotnet/maui/issues/6259.