### PR TITLE
[CI] Do not use variable interpolation.

### DIFF
--- a/tools/devops/automation/scripts/bash/compare.sh
+++ b/tools/devops/automation/scripts/bash/compare.sh
@@ -81,16 +81,22 @@ cp -R ./tools/comparison/generator-diff "$API_COMPARISON"
 
 if ! grep "href=" "$API_COMPARISON/api-diff.html" >/dev/null 2>&1; then
 	STATUS_MESSAGE=":white_check_mark: API Diff (from PR only) (no change)"
+	set +x
 	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS_MESSAGE;isOutput=true]$STATUS_MESSAGE"
 	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS;isOutput=true]success"
+	set -x
 elif perl -0777 -pe 's/<script type="text\/javascript">.*?<.script>/script removed/gs' "$API_COMPARISON"/*.html | grep data-is-breaking; then
 	STATUS_MESSAGE=":warning: API Diff (from PR only) (:fire: breaking changes :fire:)"
+	set +x
 	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS_MESSAGE;isOutput=true]$STATUS_MESSAGE"
 	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS;isOutput=true]error"
+	set -x
 else
 	STATUS_MESSAGE=":information_source: API Diff (from PR only) (please review changes)"
+	set +x
 	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS_MESSAGE;isOutput=true]$STATUS_MESSAGE"
 	echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_STATUS;isOutput=true]error"
+	set -x
 fi
 
 if ! test -s $API_COMPARISON/generator-diff/generator.diff; then
@@ -107,5 +113,7 @@ if test -f "$COMPARE_FAILURE_FILE"; then
 	cp "$COMPARE_FAILURE_FILE" "$API_COMPARISON"
 fi
 MESSAGE="*** Comparing API & creating generator diff completed ***"
+set +x
 echo "##vso[task.setvariable variable=API_GENERATOR_DIFF_MESSAGE;isOutput=true]$MESSAGE"
 echo "##vso[task.setvariable variable=API_GENERATOR_BUILT;isOutput=true]True"
+set -x

--- a/tools/devops/automation/scripts/bash/vsts-compare.sh
+++ b/tools/devops/automation/scripts/bash/vsts-compare.sh
@@ -11,6 +11,8 @@ fi
 
 
 if ! ./tools/devops/automation/scripts/bash/compare.sh; then
+    set +x
     echo "##vso[task.setvariable variable=API_GENERATOR_BUILT;isOutput=true]False"
+    set -x
     exit 1
 fi

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -8,6 +8,11 @@ parameters:
 
 steps:
 
+- bash: |
+    git restore .
+  displayName: 'Reset git changes'
+  workingDirectory: $(Build.SourcesDirectory)/xamarin-macios
+
 - template: ../common/status.yml
   parameters:
     status: "pending"

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -30,13 +30,21 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
 
-    $msg = "$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE)"
+    $msg = "$Env:API_GENERATOR_DIFF_STATUS_MESSAGE"
+    if (-not $msg) {
+      $msg = "Catastrophic failure." 
+      # set the status to error to be used instead
+      $Env:API_GENERATOR_DIFF_STATUS = "error"
+    } 
     $msg = $msg.Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
-    $statuses.SetStatus("$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS)", $msg, "API Diff (PR)")
+    $statuses.SetStatus("$Env:API_GENERATOR_DIFF_STATUS", $msg, "API Diff (PR)")
   displayName: "API diff final status"
   timeoutInMinutes: 5
   condition: succeededOrFailed() # re-starting the daemon should not be an issue
   continueOnError: true
+  env:
+    API_GENERATOR_DIFF_STATUS_MESSAGE: $(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE)
+    API_GENERATOR_DIFF_STATUS: $(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS)
 
 - task: ArchiveFiles@1
   displayName: 'Archive API & Generator comparison'
@@ -97,13 +105,22 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
 
-    $msg = "$(apidiff.APIDIFF_MESSAGE)"
+    $msg = "$Env:APIDIFF_MESSAGE"
+    if (-not $msg) {
+      $msg = "Catastrophic failure.." 
+      # set the status to error to be used instead
+      $Env:APIDIFF_STATUS = "error"
+    } 
+
     $msg = $msg.Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
-    $statuses.SetStatus("$(apidiff.APIDIFF_STATUS)", $msg, "API Diff (stable)")
+    $statuses.SetStatus("$Env:APIDIFF_STATUS", $msg, "API Diff (stable)")
   displayName: "API diff final status"
   timeoutInMinutes: 5
   condition: succeededOrFailed() # re-starting the daemon should not be an issue
   continueOnError: true
+  env: 
+    APIDIFF_MESSAGE: $(apidiff.APIDIFF_MESSAGE)
+    APIDIFF_STATUS: $(apidiff.APIDIFF_STATUS)
 
 - task: ArchiveFiles@1
   displayName: 'Archive API diff (from stable)'

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -30,21 +30,13 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
 
-    $msg = "$Env:API_GENERATOR_DIFF_STATUS_MESSAGE"
-    if (-not $msg) {
-      $msg = "Catastrophic failure." 
-      # set the status to error to be used instead
-      $Env:API_GENERATOR_DIFF_STATUS = "error"
-    } 
+    $msg = "$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE)"
     $msg = $msg.Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
-    $statuses.SetStatus("$Env:API_GENERATOR_DIFF_STATUS", $msg, "API Diff (PR)")
+    $statuses.SetStatus("$(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS)", $msg, "API Diff (PR)")
   displayName: "API diff final status"
   timeoutInMinutes: 5
   condition: succeededOrFailed() # re-starting the daemon should not be an issue
   continueOnError: true
-  env:
-    API_GENERATOR_DIFF_STATUS_MESSAGE: $(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS_MESSAGE)
-    API_GENERATOR_DIFF_STATUS: $(apiGeneratorDiff.API_GENERATOR_DIFF_STATUS)
 
 - task: ArchiveFiles@1
   displayName: 'Archive API & Generator comparison'
@@ -105,22 +97,13 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
 
-    $msg = "$Env:APIDIFF_MESSAGE"
-    if (-not $msg) {
-      $msg = "Catastrophic failure.." 
-      # set the status to error to be used instead
-      $Env:APIDIFF_STATUS = "error"
-    } 
-
+    $msg = "$(apidiff.APIDIFF_MESSAGE)"
     $msg = $msg.Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
-    $statuses.SetStatus("$Env:APIDIFF_STATUS", $msg, "API Diff (stable)")
+    $statuses.SetStatus("$(apidiff.APIDIFF_STATUS)", $msg, "API Diff (stable)")
   displayName: "API diff final status"
   timeoutInMinutes: 5
   condition: succeededOrFailed() # re-starting the daemon should not be an issue
   continueOnError: true
-  env: 
-    APIDIFF_MESSAGE: $(apidiff.APIDIFF_MESSAGE)
-    APIDIFF_STATUS: $(apidiff.APIDIFF_STATUS)
 
 - task: ArchiveFiles@1
   displayName: 'Archive API diff (from stable)'

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -32,14 +32,11 @@ steps:
 
     $msg = "$Env:API_GENERATOR_DIFF_STATUS_MESSAGE"
     if (-not $msg) {
-      Write-Host "Message is null"
       $msg = "Catastrophic failure." 
       # set the status to error to be used instead
       $Env:API_GENERATOR_DIFF_STATUS = "error"
     } 
     $msg = $msg.Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
-    Write-Host "Message is $msg"
-    Write-Host "Status is $Env:API_GENERATOR_DIFF_STATUS" 
     $statuses.SetStatus("$Env:API_GENERATOR_DIFF_STATUS", $msg, "API Diff (PR)")
   displayName: "API diff final status"
   timeoutInMinutes: 5

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -70,9 +70,11 @@ steps:
     report_error ()
     {
       MESSAGE=$(printf ":fire: Failed to create API Diff from stable (%s/console) :fire:")
+      set +x
       echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
       echo "##vso[task.setvariable variable=APIDIFF_STATUS;isOutput=true]error"
       echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]False"
+      set -x
     }
     trap report_error ERR
 
@@ -82,9 +84,11 @@ steps:
     cd $(Build.SourcesDirectory)/xamarin-macios/tools/apidiff/
     rm -Rf *.exe *.pdb *.stamp *.zip *.sh ./references ./temp
     MESSAGE=":white_check_mark: API Diff from stable"
+    set +x
     echo "##vso[task.setvariable variable=APIDIFF_MESSAGE;isOutput=true]$MESSAGE"
     echo "##vso[task.setvariable variable=APIDIFF_STATUS;isOutput=true]success"
     echo "##vso[task.setvariable variable=APIDIFF_BUILT;isOutput=true]True"
+    set -x
   displayName: 'API diff (from stable)'
   name: apidiff
   condition: and(succeeded(), contains(variables['configuration.SkipPublicJenkins'], 'False'))

--- a/tools/devops/automation/templates/build/api-diff.yml
+++ b/tools/devops/automation/templates/build/api-diff.yml
@@ -32,11 +32,14 @@ steps:
 
     $msg = "$Env:API_GENERATOR_DIFF_STATUS_MESSAGE"
     if (-not $msg) {
+      Write-Host "Message is null"
       $msg = "Catastrophic failure." 
       # set the status to error to be used instead
       $Env:API_GENERATOR_DIFF_STATUS = "error"
     } 
     $msg = $msg.Replace(":white_check_mark: ", "").Replace(":warning: ", "").Replace(":information_source: ", "")
+    Write-Host "Message is $msg"
+    Write-Host "Status is $Env:API_GENERATOR_DIFF_STATUS" 
     $statuses.SetStatus("$Env:API_GENERATOR_DIFF_STATUS", $msg, "API Diff (PR)")
   displayName: "API diff final status"
   timeoutInMinutes: 5


### PR DESCRIPTION
Due to a bug in azp we have some builds that fail due to
https://developercommunity.visualstudio.com/t/intermittent-quote-failure-in-bash-taskvariable-su/1391412

In order to work around it, we use a env var which is set. If the
interpolation did not work, we consider the build a failure to be
re-triggered.