### PR TITLE
Stop branding main as a release branch for .NET.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -80,14 +80,14 @@ endif
 
 # For release branches, modify the following variables to hardcode a version name
 # Set the NUGET_HARDCODED_PRERELEASE_IDENTIFIER variable to the prerelease identifer you want (say "rc.1")
-NUGET_HARDCODED_PRERELEASE_IDENTIFIER=rc.3
+## NUGET_HARDCODED_PRERELEASE_IDENTIFIER=rc.3
 # Set the NUGET_HARDCODED_PRERELEASE_BRANCH variable to the exact name for the branch the above variable should apply to (so that any other branches won't pick it up by accident).
 # For the previous example, this would be "release/6.0.2xx-rc1"
 # When creating a release branch from main, this must be changed from "main" to the new release branch.
-NUGET_HARDCODED_PRERELEASE_BRANCH=main
+## NUGET_HARDCODED_PRERELEASE_BRANCH=main
 
 # compute the alphanumeric version of the hardcoded prerelease branch
-NUGET_HARDCODED_PRERELEASE_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(NUGET_HARDCODED_PRERELEASE_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')
+## NUGET_HARDCODED_PRERELEASE_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(NUGET_HARDCODED_PRERELEASE_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')
 
 # The prerelease identifier is missing the per-product commit distance, which is added below
 # DO NOT MODIFY THE BELOW CONDITIONS TO HARDCODE A VERSION NUMBER FOR RELEASE BRANCHES.

--- a/Make.versions
+++ b/Make.versions
@@ -66,11 +66,11 @@ MAC_PACKAGE_VERSION=8.11.0.$(MAC_COMMIT_DISTANCE)
 # WARNING: Do **not** use versions higher than the available Xcode SDK or else we will have issues with mtouch (See https://github.com/xamarin/xamarin-macios/issues/7705)
 # When bumping the major macOS version in MACOS_NUGET_VERSION also update the macOS version where we execute on bots in jenkins/Jenkinsfile (in the 'node' element)
 
-IOS_NUGET_VERSION=15.4.300
-TVOS_NUGET_VERSION=15.4.300
-WATCHOS_NUGET_VERSION=8.5.300
-MACOS_NUGET_VERSION=12.3.300
-MACCATALYST_NUGET_VERSION=15.4.300
+IOS_NUGET_VERSION=15.4.400
+TVOS_NUGET_VERSION=15.4.400
+WATCHOS_NUGET_VERSION=8.5.400
+MACOS_NUGET_VERSION=12.3.400
+MACCATALYST_NUGET_VERSION=15.4.400
 
 
 # Defines the default platform version if it's not specified in the TFM. The default should not change for a given .NET version:


### PR DESCRIPTION
Also bump our version band to try to avoid confusion.