### PR TITLE
[release/6.0.3xx-rc3] [msbuild] Copy binding resource files back to Windows. Fixes #13393.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -2683,11 +2683,20 @@ namespace Xamarin.Localization.MSBuild {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Code signing has been requested multiple times for &apos;{0}&apos;, with different metadata. The metadata &apos;{1}&apos; has been values for each item (once it&apos;s &apos;{2}&apos;, another time it&apos;s &apos;{3}&apos;)..
+        ///   Looks up a localized string similar to Code signing has been requested multiple times for &apos;{0}&apos;, with different metadata. The metadata &apos;{1}&apos; has different values for each item (once it&apos;s &apos;{2}&apos;, another time it&apos;s &apos;{3}&apos;)..
         /// </summary>
         public static string W7097 {
             get {
                 return ResourceManager.GetString("W7097", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not find the binding resource package: {0}.
+        /// </summary>
+        public static string W7100 {
+            get {
+                return ResourceManager.GetString("W7100", resourceCulture);
             }
         }
     }

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1416,6 +1416,10 @@
         <value>The UIDeviceFamily value '6' requires macOS 11.0. Please set the 'SupportedOSPlatformVersion' in the project file to at least 14.0 (the Mac Catalyst version equivalent of macOS 11.0). The current value is {0} (equivalent to macOS {1}).</value>
     </data>
 
+    <data name="W7100" xml:space="preserve">
+        <value>Could not find the binding resource package: {0}</value>
+    </data>
+
     <data name="E7101" xml:space="preserve">
         <value>Unknown property '{0}' with value '{1}'.</value>
     </data>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackage.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackage.cs
@@ -13,10 +13,18 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (ShouldExecuteRemotely ())
-				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+			if (!ShouldExecuteRemotely ())
+				return base.Execute ();
 
-			return base.Execute ();
+			var taskRunner = new TaskRunner (SessionId, BuildEngine4);
+
+			var success = taskRunner.RunAsync (this).Result;
+
+			if (success) {
+				TransferBindingResourcePackagesToWindowsAsync (taskRunner).Wait ();
+			}
+
+			return success;
 		}
 
 		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied ()
@@ -47,6 +55,29 @@ namespace Xamarin.MacDev.Tasks
 				.EnumerateFiles (folderPath, "*", SearchOption.AllDirectories)
 				.Select (x => new TaskItem (x)))
 				yield return file;
+		}
+
+		async System.Threading.Tasks.Task TransferBindingResourcePackagesToWindowsAsync (TaskRunner taskRunner)
+		{
+			if (PackagedFiles is not null) {
+				foreach (var package in PackagedFiles) {
+					var localRelativePath = GetLocalRelativePath (package.ItemSpec);
+					await taskRunner.GetFileAsync (localRelativePath).ConfigureAwait (continueOnCapturedContext: false);
+				}
+			}
+		}
+
+		string GetLocalRelativePath (string path)
+		{
+			// convert mac full path in windows relative path
+			// must remove \users\{user}\Library\Caches\Xamarin\mtbs\builds\{appname}\{sessionid}\
+			if (path.Contains (SessionId)) {
+				var start = path.IndexOf (SessionId) + SessionId.Length + 1;
+
+				return path.Substring (start);
+			} else {
+				return path;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/13393.

Backport of #14702.