### PR TITLE
[ObjCRuntime] Specify the string comparison to use when comparing strings in Runtime.IsARM64CallingConvention.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2018,7 +2018,7 @@ namespace ObjCRuntime {
 				return false;
 
 			unsafe {
-				return NXGetLocalArchInfo ()->Name.StartsWith ("arm64");
+				return NXGetLocalArchInfo ()->Name.StartsWith ("arm64", StringComparison.OrdinalIgnoreCase);
 			}
 		}
 


### PR DESCRIPTION
This may in some cases delay loading big chunks of .NET's globalization code
at startup until after reaching user's Main method.