### PR TITLE
[Localization] Use a self checkout and revert the explicit lcl paths

### DIFF
--- a/tools/devops/LocProject.json.in
+++ b/tools/devops/LocProject.json.in
@@ -8,7 +8,7 @@
 			"Languages": "",
 			"CopyOption": "LangIDOnName",
 			"OutputPath": "@WORKING_DIRECTORY@/../../msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies",
-			"LclFile": "@WORKING_DIRECTORY@/../../Localize/loc/{Lang}/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl",
+			"LclFile": "",
 			"LciFile": "",
 			"Parser": "",
 			"LssFiles": []
@@ -18,7 +18,7 @@
 			"Languages": "",
 			"CopyOption": "LangIDOnName",
 			"OutputPath": "@WORKING_DIRECTORY@/../../tools/mtouch/TranslatedAssemblies",
-			"LclFile": "@WORKING_DIRECTORY@/../../Localize/loc/{Lang}/tools/mtouch/Errors.resx.lcl",
+			"LclFile": "",
 			"LciFile": "",
 			"Parser": "",
 			"LssFiles": []

--- a/tools/devops/automation/scripts/update-locproject.ps1
+++ b/tools/devops/automation/scripts/update-locproject.ps1
@@ -1,4 +1,4 @@
-param ($SourcesDirectory, $LocalizeDirectory, $LocProjectPath)
+param ($SourcesDirectory, $LocProjectPath)
 
 $jsonFiles = @()
 $jsonTemplateFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | Where-Object { $_.FullName -Match "\.template\.config\\localize\\.+\.en\.json" } # .NET templating pattern
@@ -15,19 +15,10 @@ $projectObject = Get-Content $LocProjectPath | ConvertFrom-Json
 $jsonFiles | ForEach-Object {
     $sourceFile = $_.FullName
     $outputPath = "$($_.DirectoryName + "\")"
-    $fullNameString = Convert-Path -Path $_.FullName
-    $maciosPathArray = $fullNameString -split "xamarin-macios", 2
-    $maciosPath = $maciosPathArray[1]
-    if ($null -eq $maciosPath) {
-        Write-Host "'fullNameString' could not be split at 'xamarin-macios'!"
-        exit 1
-    }
-    $lclFile = Join-Path -Path $LocalizeDirectory -ChildPath "$($maciosPath).lcl"
     $projectObject.Projects[0].LocItems += (@{
         SourceFile = $sourceFile
         CopyOption = "LangIDOnName"
         OutputPath = $outputPath
-        LclFile = $lclFile
     })
 }
 Pop-Location

--- a/tools/devops/automation/templates/loc-translations.yml
+++ b/tools/devops/automation/templates/loc-translations.yml
@@ -5,7 +5,6 @@ steps:
   submodules: recursive
   path: s/xamarin-macios
 
-
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
   - pwsh: |
       git config remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
@@ -39,7 +38,7 @@ steps:
   inputs:
     targetType: 'filePath'
     filePath: $(Build.SourcesDirectory)\\tools\\devops\\automation\\scripts\\update-locproject.ps1
-    arguments: -SourcesDirectory "$(Build.SourcesDirectory)" -LocalizeDirectory "$(Build.SourcesDirectory)\Localize\loc\{Lang}" -LocProjectPath "$(Build.SourcesDirectory)\\Localize\\LocProject.json"
+    arguments: -SourcesDirectory "$(Build.SourcesDirectory)" -LocProjectPath "$(Build.SourcesDirectory)\\Localize\\LocProject.json"
 
 - pwsh: |
     git remote remove origin

--- a/tools/devops/automation/templates/loc-translations.yml
+++ b/tools/devops/automation/templates/loc-translations.yml
@@ -1,19 +1,45 @@
 steps:
 
-- template: ./common/checkout.yml
+- checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
+  clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
+  submodules: recursive
+  path: s/xamarin-macios
+
+
+- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - pwsh: |
+      git config remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
+      git fetch origin
+      $branch="$(Build.SourceBranch)".Replace("merge", "head")
+      $branch=$branch.Replace("refs", "origin")
+      Write-Host "Checking out branch $branch"
+      git checkout $branch
+      $hash = git rev-parse HEAD
+      Write-Host "##vso[task.setvariable variable=GIT_HASH;isOutput=true]$hash"
+    name: fix_commit
+    displayName: "Undo Github merge"
+    workingDirectory: $(System.DefaultWorkingDirectory)
+- ${{ else }}:
+  - pwsh: |
+      $hash = git rev-parse HEAD
+      Write-Host "##vso[task.setvariable variable=GIT_HASH;isOutput=true]$hash"
+    name: fix_commit
+    displayName: "Undo Github merge"
+    workingDirectory: $(System.DefaultWorkingDirectory)
+
 
 - bash: |
     make LocProject.json
   displayName: 'Generate LocProject.json'
   continueOnError: true
-  workingDirectory: $(Build.SourcesDirectory)\\xamarin-macios\\tools\\devops
+  workingDirectory: $(Build.SourcesDirectory)\\tools\\devops
 
 - task: PowerShell@2
   displayName: "Update LocProject.json"
   inputs:
     targetType: 'filePath'
-    filePath: $(Build.SourcesDirectory)\\xamarin-macios\\tools\\devops\\automation\\scripts\\update-locproject.ps1
-    arguments: -SourcesDirectory "$(Build.SourcesDirectory)\\xamarin-macios" -LocalizeDirectory "$(Build.SourcesDirectory)\xamarin-macios\Localize\loc\{Lang}" -LocProjectPath "$(Build.SourcesDirectory)\\xamarin-macios\\Localize\\LocProject.json"
+    filePath: $(Build.SourcesDirectory)\\tools\\devops\\automation\\scripts\\update-locproject.ps1
+    arguments: -SourcesDirectory "$(Build.SourcesDirectory)" -LocalizeDirectory "$(Build.SourcesDirectory)\Localize\loc\{Lang}" -LocProjectPath "$(Build.SourcesDirectory)\\Localize\\LocProject.json"
 
 - pwsh: |
     git remote remove origin
@@ -29,14 +55,14 @@ steps:
     git checkout -b Localization
     git push origin Localization
   displayName: "Create a new Localization branch from main"
-  workingDirectory: $(Build.SourcesDirectory)\\xamarin-macios
+  workingDirectory: $(Build.SourcesDirectory)
 
 - task: OneLocBuild@2
   continueOnError: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
   inputs:
-    locProj: '$(Build.SourcesDirectory)\\xamarin-macios\\Localize\\LocProject.json'
+    locProj: '$(Build.SourcesDirectory)\\Localize\\LocProject.json'
     outDir: '$(Build.ArtifactStagingDirectory)'
     ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
       isCreatePrSelected: true


### PR DESCRIPTION
From my conversations with the Loc team in an issue found here: https://ceapex.visualstudio.com/CEINTL/_workitems/edit/595781

the OneLocBuild tool cannot process paths that begin with the repo name. If we checkout only one repo in Azure Devops, this is not an issue, but we were checking out multiple repos (xamarin-macios and maccore) and when we checkout more than one repo, the Build.SourceDirectory starts one level higher than the repos - hence we need to begin our paths with our repo name. This was an issue and caused OneLocBuild to point to different paths than we wanted. 

This PR makes sure that we only checkout xamarin-macios in the localization job and makes the appropriate changes changing the paths. We also need to revert a PR: https://github.com/xamarin/xamarin-macios/pull/14811, which updated all the lcl paths manually since we are changing the paths back to default.
