### PR TITLE
[release/6.0.3xx] [dotnet/Templates] Remove preview language

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "MacCatalyst Application (Preview)",
+  "name": "MacCatalyst Application",
   "description": "A project for creating a .NET MacCatalyst application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [ "macOS", "Mac Catalyst" ],
   "identity": "Microsoft.MacCatalyst.MacCatalystApp",
-  "name": "MacCatalyst Application (Preview)",
+  "name": "MacCatalyst Application",
   "description": "A project for creating a .NET MacCatalyst application",
   "shortName": "maccatalyst",
   "tags": {

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/localize/templatestrings.en.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
-  "name": "MacCatalyst Binding Library (Preview)",
+  "name": "MacCatalyst Binding Library",
   "description": "A project for creating a .NET MacCatalyst binding library"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [ "macOS", "Mac Catalyst" ],
   "identity": "Microsoft.MacCatalyst.MacCatalystBinding",
-  "name": "MacCatalyst Binding Library (Preview)",
+  "name": "MacCatalyst Binding Library",
   "description": "A project for creating a .NET MacCatalyst binding library",
   "shortName": "maccatalystbinding",
   "tags": {

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "iOS Controller template (Preview)",
+  "name": "iOS Controller template",
   "description": "An iOS Controller class",
   "symbols/namespace/description": "namespace for the generated code"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/template.json
@@ -2,7 +2,7 @@
     "$schema": "http://json.schemastore.org/template",
     "author": "Microsoft",
     "classifications": [ "iOS", "Mobile" ],
-    "name": "iOS Controller template (Preview)",
+    "name": "iOS Controller template",
     "description": "An iOS Controller class",
     "tags": {
       "language": "C#",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "iOS Tabbed Application (Preview)",
+  "name": "iOS Tabbed Application",
   "description": "A project for creating a .NET iOS tabbed application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/.template.config/template.json
@@ -3,7 +3,7 @@
     "author": "Microsoft",
     "classifications": [ "iOS", "Mobile" ],
     "identity": "Microsoft.iOS.iOSTabbedApp",
-    "name": "iOS Tabbed Application (Preview)",
+    "name": "iOS Tabbed Application",
     "description": "A project for creating a .NET iOS tabbed application",
     "shortName": "ios-tabbed",
     "tags": {

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "iOS Application (Preview)",
+  "name": "iOS Application",
   "description": "A project for creating a .NET iOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file",

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/.template.config/template.json
@@ -3,7 +3,7 @@
     "author": "Microsoft",
     "classifications": [ "iOS", "Mobile" ],
     "identity": "Microsoft.iOS.iOSApp",
-    "name": "iOS Application (Preview)",
+    "name": "iOS Application",
     "description": "A project for creating a .NET iOS application",
     "shortName": "ios",
     "tags": {

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/localize/templatestrings.en.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
-  "name": "iOS Binding Library (Preview)",
+  "name": "iOS Binding Library",
   "description": "A project for creating a .NET iOS binding library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [ "iOS", "Mobile" ],
   "identity": "Microsoft.iOS.iOSBinding",
-  "name": "iOS Binding Library (Preview)",
+  "name": "iOS Binding Library",
   "description": "A project for creating a .NET iOS binding library",
   "shortName": "iosbinding",
   "tags": {

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/localize/templatestrings.en.json
@@ -1,5 +1,5 @@
 {
   "author": "Microsoft",
-  "name": "iOS Class Library (Preview)",
+  "name": "iOS Class Library",
   "description": "A project for creating a .NET iOS class library"
 }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [ "iOS", "Mobile" ],
   "identity": "Microsoft.iOS.iOSLib",
-  "name": "iOS Class Library (Preview)",
+  "name": "iOS Class Library",
   "description": "A project for creating a .NET iOS class library",
   "shortName": "ioslib",
   "tags": {

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "macOS Application (Preview)",
+  "name": "macOS Application",
   "description": "A project for creating a .NET macOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/.template.config/template.json
@@ -3,7 +3,7 @@
     "author": "Microsoft",
     "classifications": [ "macOS" ],
     "identity": "Microsoft.macOS.macOSApp",
-    "name": "macOS Application (Preview)",
+    "name": "macOS Application",
     "description": "A project for creating a .NET macOS application",
     "shortName": "macos",
     "tags": {

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "tvOS Application (Preview)",
+  "name": "tvOS Application",
   "description": "A project for creating a .NET tvOS application",
   "symbols/bundleId/description": "Overrides CFBundleIdentifier in the Info.plist",
   "symbols/minOSVersion/description": "Overrides SupportedOSPlatformVersion in the project file"

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [ "tvOS", "Mobile" ],
   "identity": "Microsoft.tvOS.tvOSApp",
-  "name": "tvOS Application (Preview)",
+  "name": "tvOS Application",
   "description": "A project for creating a .NET tvOS application",
   "shortName": "tvos",
   "tags": {


### PR DESCRIPTION
Removes the "(Preview)" string from the title of the .NET templates.


Backport of #14842
