### PR TITLE
[mtouch] Preserve the xamarin_dyn_* functions when we're handling Objective-C exceptions by unwinding managed code. Fixes #14193.

### DIFF
--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -47,13 +47,16 @@ namespace Xamarin.Utils
 			}
 		}
 
-		public void ReferenceSymbols (IEnumerable<Symbol> symbols)
+		public void ReferenceSymbols (IEnumerable<Symbol> symbols, Abi abi)
 		{
 			if (UnresolvedSymbols == null)
 				UnresolvedSymbols = new HashSet<string> ();
 
-			foreach (var symbol in symbols)
+			foreach (var symbol in symbols) {
+				if (symbol.ValidAbis.HasValue && (symbol.ValidAbis.Value & abi) == 0)
+					continue;
 				UnresolvedSymbols.Add (symbol.Prefix + symbol.Name);
+			}
 		}
 
 		public void AddDefine (string define)

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -344,7 +344,7 @@ namespace Xamarin.Bundler {
 				case ApplePlatform.iOS:
 				case ApplePlatform.TVOS:
 				case ApplePlatform.WatchOS:
-					has_dyn_msgSend = App.IsSimulatorBuild;
+					has_dyn_msgSend = App.IsSimulatorBuild || App.MarshalObjectiveCExceptions == MarshalObjectiveCExceptionMode.UnwindManagedCode;
 					break;
 				case ApplePlatform.MacCatalyst:
 				case ApplePlatform.MacOSX:

--- a/tools/mtouch/Target.mtouch.cs
+++ b/tools/mtouch/Target.mtouch.cs
@@ -1092,7 +1092,7 @@ namespace Xamarin.Bundler
 								link_dependencies.AddRange (tasks);
 								break;
 							case SymbolMode.Linker:
-								compiler_flags.ReferenceSymbols (symbols);
+								compiler_flags.ReferenceSymbols (symbols, abi);
 								break;
 							default:
 								throw ErrorHelper.CreateError (99, Errors.MX0099, $"invalid symbol mode: {App.SymbolMode}");
@@ -1470,7 +1470,7 @@ namespace Xamarin.Bundler
 				LinkWithTaskOutput (GenerateReferencingSource (Path.Combine (App.Cache.Location, "reference.m"), GetRequiredSymbols ()));
 				break;
 			case SymbolMode.Linker:
-				linker_flags.ReferenceSymbols (GetRequiredSymbols ());
+				linker_flags.ReferenceSymbols (GetRequiredSymbols (), abi);
 				break;
 			default:
 				throw ErrorHelper.CreateError (99, Errors.MX0099, $"invalid symbol mode: {App.SymbolMode}");


### PR DESCRIPTION
This also required a fix to not treat symbols that don't exist for a
particular abi as required.

Fixes https://github.com/xamarin/xamarin-macios/issues/14193.