### PR TITLE
Fix crash with NSUrl implicit conversion and null

### DIFF
--- a/src/Foundation/NSUrl.cs
+++ b/src/Foundation/NSUrl.cs
@@ -117,7 +117,7 @@ namespace Foundation {
 			if ((object?) x == (object?) y) // If both are null, or both are same instance, return true.
 				return true;
 
-			if (((object?) x == null) || ((object?) y == null)) // If one is null, but not both, return false.
+			if (x is null || y is null) // If one is null, but not both, return false.
 				return false;
 
 			return x.Equals (y);

--- a/src/Foundation/NSUrl.cs
+++ b/src/Foundation/NSUrl.cs
@@ -47,7 +47,7 @@ namespace Foundation {
 		// Converts from an NSURL to a System.Uri
 		public static implicit operator Uri (NSUrl url)
 		{
-			if (url == null) {
+			if (url is null) {
 				return null;
 			}
 			if (Uri.TryCreate (url.AbsoluteString, UriKind.Absolute, out var uri))
@@ -58,7 +58,7 @@ namespace Foundation {
 
 		public static implicit operator NSUrl (Uri uri)
 		{
-			if (uri == null) {
+			if (uri is null) {
 				return null;
 			}
 			if (uri.IsAbsoluteUri)

--- a/src/Foundation/NSUrl.cs
+++ b/src/Foundation/NSUrl.cs
@@ -47,6 +47,9 @@ namespace Foundation {
 		// Converts from an NSURL to a System.Uri
 		public static implicit operator Uri (NSUrl url)
 		{
+			if (url == null) {
+				return null;
+			}
 			if (Uri.TryCreate (url.AbsoluteString, UriKind.Absolute, out var uri))
 				return uri;
 			else
@@ -55,6 +58,9 @@ namespace Foundation {
 
 		public static implicit operator NSUrl (Uri uri)
 		{
+			if (uri == null) {
+				return null;
+			}
 			if (uri.IsAbsoluteUri)
 				return new NSUrl (uri.AbsoluteUri);
 			else

--- a/src/Foundation/NSUrl.cs
+++ b/src/Foundation/NSUrl.cs
@@ -21,6 +21,8 @@
 //
 using System;
 
+#nullable enable
+
 namespace Foundation {
 
 		// Equals(Object) and GetHashCode are provided by NSObject
@@ -36,16 +38,16 @@ namespace Foundation {
 		}
 
 		// but NSUrl has it's own isEqual: selector, which we re-expose in a more .NET-ish way
-		public bool Equals (NSUrl url)
+		public bool Equals (NSUrl? url)
 		{
-			if (url == null)
+			if (url is null)
 				return false;
 			// we can only ask `isEqual:` to test equality if both objects are direct bindings
 			return IsDirectBinding && url.IsDirectBinding ? IsEqual (url) : Equals ((object) url);
 		}
 
 		// Converts from an NSURL to a System.Uri
-		public static implicit operator Uri (NSUrl url)
+		public static implicit operator Uri? (NSUrl? url)
 		{
 			if (url is null) {
 				return null;
@@ -56,7 +58,7 @@ namespace Foundation {
 				return new Uri (url.AbsoluteString, UriKind.Relative);
 		}
 
-		public static implicit operator NSUrl (Uri uri)
+		public static implicit operator NSUrl? (Uri? uri)
 		{
 			if (uri is null) {
 				return null;
@@ -110,18 +112,18 @@ namespace Foundation {
 			}
 		}
 
-		public static bool operator == (NSUrl x, NSUrl y)
+		public static bool operator == (NSUrl? x, NSUrl? y)
 		{
-			if ((object) x == (object) y) // If both are null, or both are same instance, return true.
+			if ((object?) x == (object?) y) // If both are null, or both are same instance, return true.
 				return true;
 
-			if (((object) x == null) || ((object) y == null)) // If one is null, but not both, return false.
+			if (((object?) x == null) || ((object?) y == null)) // If one is null, but not both, return false.
 				return false;
 
 			return x.Equals (y);
 		}
 
-		public static bool operator != (NSUrl x, NSUrl y)
+		public static bool operator != (NSUrl? x, NSUrl? y)
 		{
 			return !(x == y);
 		}

--- a/tests/monotouch-test/Network/NSUrlTest.cs
+++ b/tests/monotouch-test/Network/NSUrlTest.cs
@@ -1,0 +1,20 @@
+#if !__WATCHOS__
+using Foundation;
+using Network;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.Network {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NSUrlTest {
+		[Test]
+		public void ImplicitConversion ()
+		{
+			global::System.Uri uri = null;
+			NSUrl sUrl = uri;
+			Assert.IsNull (sUrl);
+		}
+	}
+}
+#endif


### PR DESCRIPTION
- Fixes: https://github.com/xamarin/xamarin-macios/issues/14786

Before fix test crashed with same:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Foundation.NSUrl.op_Implicit(NSUrl url)
```