### PR TITLE
[photos] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/Photos/PHAssetChangeRequest.cs
+++ b/src/Photos/PHAssetChangeRequest.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if !MONOMAC
 
 using System;

--- a/src/Photos/PHAssetCreationRequest.cs
+++ b/src/Photos/PHAssetCreationRequest.cs
@@ -6,6 +6,8 @@
 // Authors:
 //    Miguel de Icaza (miguel@xamarin.com)
 
+#nullable enable
+
 using System;
 using Foundation;
 

--- a/src/Photos/PHChangeRequest.cs
+++ b/src/Photos/PHChangeRequest.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 namespace Photos {

--- a/src/Photos/PHCompat.cs
+++ b/src/Photos/PHCompat.cs
@@ -1,6 +1,8 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 // Copyright 2019 Microsoft Corporation
 
+#nullable enable
+
 using System;
 using CoreImage;
 using Foundation;
@@ -34,7 +36,7 @@ namespace Photos {
 	public partial class PHLivePhotoEditingContext {
 
 		[Obsolete ("Use 'FrameProcessor2' instead.", true)]
-		public virtual PHLivePhotoFrameProcessingBlock FrameProcessor { get; set; }
+		public virtual PHLivePhotoFrameProcessingBlock? FrameProcessor { get; set; }
 	}
 
 #if MONOMAC
@@ -42,14 +44,14 @@ namespace Photos {
 
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX)]
-		public static PHFetchResult FetchMoments (PHFetchOptions options)
+		public static PHFetchResult? FetchMoments (PHFetchOptions options)
 		{
 			return null;
 		}
 
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX)]
-		public static PHFetchResult FetchMoments (PHCollectionList momentList, PHFetchOptions options)
+		public static PHFetchResult? FetchMoments (PHCollectionList momentList, PHFetchOptions options)
 		{
 			return null;
 		}
@@ -59,14 +61,14 @@ namespace Photos {
 
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX)]
-		public static PHFetchResult FetchMomentLists (PHCollectionListSubtype subType, PHFetchOptions options)
+		public static PHFetchResult? FetchMomentLists (PHCollectionListSubtype subType, PHFetchOptions options)
 		{
 			return null;
 		}
 
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX)]
-		public static PHFetchResult FetchMomentLists (PHCollectionListSubtype subType, PHAssetCollection moment, PHFetchOptions options)
+		public static PHFetchResult? FetchMomentLists (PHCollectionListSubtype subType, PHAssetCollection moment, PHFetchOptions options)
 		{
 			return null;
 		}
@@ -75,7 +77,7 @@ namespace Photos {
 	public partial class PHContentEditingInput {
 		[Obsolete ("Compatibility stub - This was marked as unavailable on macOS with Xcode 11.")]
 		[Unavailable (PlatformName.MacOSX, message: "Use 'AudiovisualAsset' instead.")]
-		public virtual AVFoundation.AVAsset AvAsset {
+		public virtual AVFoundation.AVAsset? AvAsset {
 			get { return AudiovisualAsset; }
 		}
 	}

--- a/src/Photos/PHFetchResult.cs
+++ b/src/Photos/PHFetchResult.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using ObjCRuntime;
 using Foundation;
 using System;

--- a/src/Photos/PHLivePhoto.cs
+++ b/src/Photos/PHLivePhoto.cs
@@ -1,5 +1,7 @@
 // Copyright 2015 Xamarin Inc
 
+#nullable enable
+
 using System;
 using Foundation;
 

--- a/src/Photos/PHPhotoLibrary.cs
+++ b/src/Photos/PHPhotoLibrary.cs
@@ -6,6 +6,9 @@
 //
 // Copyright 2014 Xamarin Inc
 //
+
+#nullable enable
+
 using ObjCRuntime;
 using Foundation;
 using System;
@@ -39,10 +42,10 @@ namespace Photos
 
 		public void UnregisterChangeObserver (object registeredToken)
 		{
-			if (!(registeredToken is __phlib_observer))
+			if (registeredToken is __phlib_observer observer) 
+				UnregisterChangeObserver (observer);
+			else
 				throw new ArgumentException ("registeredToken should be a value returned by RegisterChangeObserver(PHChange)");
-			
-			UnregisterChangeObserver (registeredToken as __phlib_observer);
 		}
 	}
 }


### PR DESCRIPTION
This PR aims to bring nullability changes to Photos.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes