### PR TITLE
[replaykit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/ReplayKit/RPBroadcastConfiguration.cs
+++ b/src/ReplayKit/RPBroadcastConfiguration.cs
@@ -25,6 +25,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 #if !MONOMAC
 
 using System;
@@ -40,7 +42,7 @@ using AVFoundation;
 
 namespace ReplayKit {
 	public partial class RPBroadcastConfiguration {
-		public AVVideoCodecSettings VideoCompressionProperties {
+		public AVVideoCodecSettings? VideoCompressionProperties {
 			get {
 				var weak = WeakVideoCompressionProperties; 
 				return weak == null ? null : new AVVideoCodecSettings (new NSMutableDictionary (weak));

--- a/src/ReplayKit/RPBroadcastConfiguration.cs
+++ b/src/ReplayKit/RPBroadcastConfiguration.cs
@@ -45,10 +45,10 @@ namespace ReplayKit {
 		public AVVideoCodecSettings? VideoCompressionProperties {
 			get {
 				var weak = WeakVideoCompressionProperties; 
-				return weak == null ? null : new AVVideoCodecSettings (new NSMutableDictionary (weak));
+				return weak is null ? null : new AVVideoCodecSettings (new NSMutableDictionary (weak));
 			}
 			set {
-				WeakVideoCompressionProperties = value == null ? null : new NSDictionary<NSString, INSSecureCoding> (value.Dictionary.Handle);
+				WeakVideoCompressionProperties = value is null ? null : new NSDictionary<NSString, INSSecureCoding> (value.Dictionary.Handle);
 			}
 		}		
 	}


### PR DESCRIPTION
This PR aims to bring nullability changes to ReplayKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing any `== null` or `!= null` to `is null` and `is not null`