### PR TITLE
[quicklook] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/QuickLook/Thumbnail.cs
+++ b/src/QuickLook/Thumbnail.cs
@@ -48,7 +48,7 @@ namespace QuickLook {
 
 		public static CGImage? Create (NSUrl url, CGSize maxThumbnailSize, float scaleFactor = 1, bool iconMode = false)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			NSMutableDictionary? dictionary = null;

--- a/src/QuickLook/Thumbnail.cs
+++ b/src/QuickLook/Thumbnail.cs
@@ -26,7 +26,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 #if MONOMAC
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -43,12 +46,12 @@ namespace QuickLook {
 		[DllImport(Constants.QuickLookLibrary)]
 		extern static /* CGImageRef */ IntPtr QLThumbnailImageCreate (/* CFAllocatorRef */ IntPtr allocator, /* CFUrlRef */ IntPtr url, CGSize maxThumbnailSize, /* CFDictionaryRef */ IntPtr options);
 
-		public static CGImage Create (NSUrl url, CGSize maxThumbnailSize, float scaleFactor = 1, bool iconMode = false)
+		public static CGImage? Create (NSUrl url, CGSize maxThumbnailSize, float scaleFactor = 1, bool iconMode = false)
 		{
 			if (url == null)
 				throw new ArgumentNullException ("url");
 
-			NSMutableDictionary dictionary = null;
+			NSMutableDictionary? dictionary = null;
 
 			if (scaleFactor != 1 && iconMode != false) {
 				dictionary = new NSMutableDictionary ();

--- a/src/QuickLook/Thumbnail.cs
+++ b/src/QuickLook/Thumbnail.cs
@@ -59,7 +59,7 @@ namespace QuickLook {
 				dictionary.LowlevelSetObject (iconMode ? CFBoolean.TrueHandle : CFBoolean.FalseHandle, OptionIconModeKey.Handle);
 			}
 			
-			var handle = QLThumbnailImageCreate (IntPtr.Zero, url.Handle, maxThumbnailSize, dictionary is null ? IntPtr.Zero : dictionary.Handle);
+			var handle = QLThumbnailImageCreate (IntPtr.Zero, url.Handle, maxThumbnailSize, dictionary.GetHandle ());
 			GC.KeepAlive (dictionary);
 			if (handle != IntPtr.Zero)
 				return new CGImage (handle, true);

--- a/src/QuickLook/Thumbnail.cs
+++ b/src/QuickLook/Thumbnail.cs
@@ -49,7 +49,7 @@ namespace QuickLook {
 		public static CGImage? Create (NSUrl url, CGSize maxThumbnailSize, float scaleFactor = 1, bool iconMode = false)
 		{
 			if (url == null)
-				throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			NSMutableDictionary? dictionary = null;
 

--- a/src/QuickLook/Thumbnail.cs
+++ b/src/QuickLook/Thumbnail.cs
@@ -59,7 +59,7 @@ namespace QuickLook {
 				dictionary.LowlevelSetObject (iconMode ? CFBoolean.TrueHandle : CFBoolean.FalseHandle, OptionIconModeKey.Handle);
 			}
 			
-			var handle = QLThumbnailImageCreate (IntPtr.Zero, url.Handle, maxThumbnailSize, dictionary == null ? IntPtr.Zero : dictionary.Handle);
+			var handle = QLThumbnailImageCreate (IntPtr.Zero, url.Handle, maxThumbnailSize, dictionary is null ? IntPtr.Zero : dictionary.Handle);
 			GC.KeepAlive (dictionary);
 			if (handle != IntPtr.Zero)
 				return new CGImage (handle, true);


### PR DESCRIPTION
This PR aims to bring nullability changes to QuickLook.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`