### PR TITLE
[release/6.0.3xx] [dotnet] Use only the first two parts of our product version as the assembly version.

### DIFF
--- a/Make.versions
+++ b/Make.versions
@@ -62,6 +62,8 @@ MAC_PACKAGE_VERSION=8.11.0.$(MAC_COMMIT_DISTANCE)
 # * Bump last two digits of the patch version for service releases.
 # * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
 #
+# IMPORTANT: There must be *no* managed API differences unless the two first
+# numbers (major.minor) changes.
 
 # WARNING: Do **not** use versions higher than the available Xcode SDK or else we will have issues with mtouch (See https://github.com/xamarin/xamarin-macios/issues/7705)
 # When bumping the major macOS version in MACOS_NUGET_VERSION also update the macOS version where we execute on bots in jenkins/Jenkinsfile (in the 'node' element)

--- a/src/AssemblyInfo.cs.in
+++ b/src/AssemblyInfo.cs.in
@@ -29,12 +29,12 @@ using System.Runtime.CompilerServices;
 #endif
 
 #if NET
-// Use a three-part version, because there shouldn't be any API changes when only the fourth digit changes.
+// Use a two-part version, because there shouldn't be any API changes when the third or fourth digit changes (according to Semver 2.0 rules).
 // In other words: the following scenario is safe:
-// - Assembly A builds against Microsoft.*.dll v1.0.0.1
-// - Assembly B builds against Assembly A and Microsoft.*.dll v1.0.0.0
+// - Assembly A builds against Microsoft.*.dll v1.0.1
+// - Assembly B builds against Assembly A and Microsoft.*.dll v1.0.0
 // - Assembly B should build just fine, because those two versions of Microsoft.*.dll have the exact same API.
 // To avoid scenarios where everybody would have to update to the latest patch version of Microsoft.*.dll
-// in order to compile stuff, we erase the fourth number and only use 0.
-[assembly: AssemblyVersion ("@NUGET_VERSION_MAJOR@.@NUGET_VERSION_MINOR@.@NUGET_VERSION_REV@.0")]
+// in order to compile stuff, we erase the third and fourth number and only use 0 for both.
+[assembly: AssemblyVersion ("@NUGET_VERSION_MAJOR@.@NUGET_VERSION_MINOR@.0.0")]
 #endif


### PR DESCRIPTION
This is a follow up to 92ee92eeb57f470eea28a2119f7d329be6a24030, where we
changed the assembly version from four digits to three digits (i.e not include
the build number), because our managed API should be identical for (released)
versions where only the build number changes.

In this PR we go a bit further, because we're not supposed to have any API
differences unless the first two parts of the product version changes, which
means that we should only use need the two first parts of our product version
as the assembly version.


Backport of #14846
