### PR TITLE
[dotnet] Don't set '_RunAotCompiler' on macOS if 'MtouchInterpreter' is set.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -871,7 +871,7 @@
 			<!-- We need it for device builds for mobile platforms -->
 			<_RunAotCompiler Condition="'$(_SdkIsSimulator)' != 'true' And '$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'">true</_RunAotCompiler>
 			<!-- We need it if the interpreter is enabled, no matter where -->
-			<_RunAotCompiler Condition="'$(MtouchInterpreter)' != ''">true</_RunAotCompiler>
+			<_RunAotCompiler Condition="'$(MtouchInterpreter)' != '' And '$(_PlatformName)' != 'macOS'">true</_RunAotCompiler>
 			<!-- We need it for Mac Catalyst on arm64 -->
 			<_RunAotCompiler Condition="'$(RuntimeIdentifier)' == 'maccatalyst-arm64'">true</_RunAotCompiler>
 			<!-- We need it for iOS/tvOS simulator on arm64 -->


### PR DESCRIPTION
There's no AOT compiler for macOS, so setting _RunAotCompiler causes problems
because if it's set, we try to find the AOT compiler, and because there is
none, the build fails.

So don't set '_RunAotCompiler' if 'MtouchInterpreter' is set (which also
indirectly means if 'UseInterpreter' is set) to avoid the problem altogether.