### PR TITLE
Adjust versioning logic/instructions to support stable releases.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -78,27 +78,80 @@ else ifneq ($(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER),)
 PULL_REQUEST_ID=$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)
 endif
 
-# For release branches, modify the following variables to hardcode a version name
-# Set the NUGET_HARDCODED_PRERELEASE_IDENTIFIER variable to the prerelease identifer you want (say "rc.1")
-## NUGET_HARDCODED_PRERELEASE_IDENTIFIER=rc.3
-# Set the NUGET_HARDCODED_PRERELEASE_BRANCH variable to the exact name for the branch the above variable should apply to (so that any other branches won't pick it up by accident).
-# For the previous example, this would be "release/6.0.2xx-rc1"
-# When creating a release branch from main, this must be changed from "main" to the new release branch.
-## NUGET_HARDCODED_PRERELEASE_BRANCH=main
+# We have three types of branches:
+#
+# 1. Release (stable) branches. These have stable versioning (no prerelease identifiers).
+# 2. Pre-release branches. These have stable versioning + prerelease identifiers.
+# 3. Any other branches, These have CI/PR versioning.
+#
+# * A PR branch (case 3 above) is identified by the PULL_REQUEST_ID variable
+#   (set in the environment). This takes precedence over any other variable.
+# * Otherwise a release branch (case 1 above) is identified by setting the
+#   NUGET_RELEASE_BRANCH variable to the name of the release branch (this
+#   seems redundant: why should a branch name itself? but it's important if
+#   another branch is created from the release branch: that other branch might
+#   be any other random branch for whatever purpose, and shouldn't be
+#   considered a release branch just because someone forgot to unset a
+#   variable).
+# * Otherwise a prerelease branch (case 2 above) is identified by the
+#   NUGET_HARDCODED_PRERELEASE_IDENTIFIER variable, which is used to hardcode
+#   a prerelease version. Note that NUGET_HARDCODED_PRERELEASE_BRANCH must
+#   also be set to the name of the current branch, otherwise
+#   NUGET_HARDCODED_PRERELEASE_IDENTIFIER will be ignored.
+# * Otherwise we're a CI branch (case 3 above).
 
-# compute the alphanumeric version of the hardcoded prerelease branch
-## NUGET_HARDCODED_PRERELEASE_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(NUGET_HARDCODED_PRERELEASE_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')
+## If this branch is a release branch, set NUGET_RELEASE_BRANCH to the exact branch name (so that any other branches won't become release branches just by branching off from a release branch).
+## Example: release/6.0.3xx
+# NUGET_RELEASE_BRANCH=
 
-# The prerelease identifier is missing the per-product commit distance, which is added below
-# DO NOT MODIFY THE BELOW CONDITIONS TO HARDCODE A VERSION NUMBER FOR RELEASE BRANCHES.
+## If this is a pre-release (alpha, beta, rc, xcode, etc.) branch, set NUGET_HARDCODED_PRERELASE_BRANCH to the exact branch name. Also set NUGET_HARDCODED_PRELEASE_IDENTIFIER to the prerelease identifier to use.
+## Example:
+##   NUGET_HARDCODED_PRERELEASE_BRANCH=release/6.0.3xx-rc3
+##   NUGET_HARDCODED_PRERELEASE_IDENTIFIER=rc.3
+## Example 2: we might sometimes make 'main' a prerelease branch:
+##   NUGET_HARDCODED_PRERELEASE_BRANCH=main
+##   NUGET_HARDCODED_PRERELEASE_IDENTIFIER=rc.4
+## In this case, when we create an actual rc4 branch, the value for
+## NUGET_HARDCODED_PRERELEASE_IDENTIFIER in main must be changed to "rc.5" (or
+## anything else), while the value for NUGET_HARDCODED_PRERELEASE_BRANCH in
+## the rc4 branch will become the rc4 branch name. The value in main must
+## change *first*, otherwise we'll produce builds with the same version from
+## two different branches (which is very, very bad).
+##
+# NUGET_HARDCODED_PRERELEASE_IDENTIFIER=rc.3
+# NUGET_HARDCODED_PRERELEASE_BRANCH=release/6.0.3xx
+
+# compute the alphanumeric version of branch names
+NUGET_RELEASE_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(NUGET_RELEASE_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')
+NUGET_HARDCODED_PRERELEASE_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(NUGET_HARDCODED_PRERELEASE_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')
+
+# Compute the prerelease identifier based on the variables above
+# DO NOT MODIFY THE BELOW CONDITIONS TO HARDCODE A VERSION NUMBER FOR (PRE)RELEASE BRANCHES.
+# READ INSTRUCTIONS ABOVE INSTEAD.
 ifneq ($(PULL_REQUEST_ID),)
+# we're a PR, so PR versioning
 NUGET_PRERELEASE_IDENTIFIER=ci.pr.gh$(PULL_REQUEST_ID).
+else ifeq ($(NUGETNUGET_RELEASE_BRANCH_ALPHANUMERIC_RELEASE_BRANCH),$(CURRENT_BRANCH_ALPHANUMERIC))
+# this is a release branch, so no prerelease identifier
+NUGET_PRERELEASE_IDENTIFIER=
 else ifeq ($(NUGET_HARDCODED_PRERELEASE_BRANCH_ALPHANUMERIC),$(CURRENT_BRANCH_ALPHANUMERIC))
+# this is a prerelease branch!
 NUGET_PRERELEASE_IDENTIFIER=$(NUGET_HARDCODED_PRERELEASE_IDENTIFIER).
 else
+# this is a CI branch!
 NUGET_PRERELEASE_IDENTIFIER=ci.$(CURRENT_BRANCH_ALPHANUMERIC).
 endif
+
 NUGET_BUILD_METADATA=sha.$(CURRENT_HASH)
+
+# The prerelease identifier is missing the per-product commit distance, which is added here
+ifneq ($(NUGET_PRERELEASE_IDENTIFIER),)
+IOS_NUGET_PRERELEASE_IDENTIFIER=-$(NUGET_PRERELEASE_IDENTIFIER)$(IOS_NUGET_COMMIT_DISTANCE)
+TVOS_NUGET_PRERELEASE_IDENTIFIER=-$(NUGET_PRERELEASE_IDENTIFIER)$(TVOS_NUGET_COMMIT_DISTANCE)
+WATCHOSOS_NUGET_PRERELEASE_IDENTIFIER=-$(NUGET_PRERELEASE_IDENTIFIER)$(WATCHOSOS_NUGET_COMMIT_DISTANCE)
+MACCATALYST_NUGET_PRERELEASE_IDENTIFIER=-$(NUGET_PRERELEASE_IDENTIFIER)$(MACCATALYST_NUGET_COMMIT_DISTANCE)
+MACOS_NUGET_PRERELEASE_IDENTIFIER=-$(NUGET_PRERELEASE_IDENTIFIER)$(MACOS_NUGET_COMMIT_DISTANCE)
+endif
 
 IOS_PRODUCT=Xamarin.iOS
 IOS_PACKAGE_NAME=Xamarin.iOS
@@ -113,7 +166,7 @@ IOS_NUGET=Microsoft.iOS
 IOS_NUGET_VERSION_MAJOR=$(word 1, $(subst ., ,$(IOS_NUGET_VERSION)))
 IOS_NUGET_VERSION_MINOR=$(word 2, $(subst ., ,$(IOS_NUGET_VERSION)))
 IOS_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(IOS_NUGET_VERSION)))
-IOS_NUGET_VERSION_NO_METADATA=$(IOS_NUGET_VERSION)-$(NUGET_PRERELEASE_IDENTIFIER)$(IOS_NUGET_COMMIT_DISTANCE)
+IOS_NUGET_VERSION_NO_METADATA=$(IOS_NUGET_VERSION)$(IOS_NUGET_PRERELEASE_IDENTIFIER)
 IOS_NUGET_VERSION_FULL=$(IOS_NUGET_VERSION_NO_METADATA)+$(NUGET_BUILD_METADATA)
 
 IOS_WINDOWS_NUGET=Microsoft.iOS.Windows
@@ -127,21 +180,21 @@ TVOS_NUGET=Microsoft.tvOS
 TVOS_NUGET_VERSION_MAJOR=$(word 1, $(subst ., ,$(TVOS_NUGET_VERSION)))
 TVOS_NUGET_VERSION_MINOR=$(word 2, $(subst ., ,$(TVOS_NUGET_VERSION)))
 TVOS_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(TVOS_NUGET_VERSION)))
-TVOS_NUGET_VERSION_NO_METADATA=$(TVOS_NUGET_VERSION)-$(NUGET_PRERELEASE_IDENTIFIER)$(TVOS_NUGET_COMMIT_DISTANCE)
+TVOS_NUGET_VERSION_NO_METADATA=$(TVOS_NUGET_VERSION)$(TVOS_NUGET_PRERELEASE_IDENTIFIER)
 TVOS_NUGET_VERSION_FULL=$(TVOS_NUGET_VERSION_NO_METADATA)+$(NUGET_BUILD_METADATA)
 
 WATCHOS_NUGET=Microsoft.watchOS
 WATCHOS_NUGET_VERSION_MAJOR=$(word 1, $(subst ., ,$(WATCHOS_NUGET_VERSION)))
 WATCHOS_NUGET_VERSION_MINOR=$(word 2, $(subst ., ,$(WATCHOS_NUGET_VERSION)))
 WATCHOS_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(WATCHOS_NUGET_VERSION)))
-WATCHOS_NUGET_VERSION_NO_METADATA=$(WATCHOS_NUGET_VERSION)-$(NUGET_PRERELEASE_IDENTIFIER)$(WATCHOS_NUGET_COMMIT_DISTANCE)
+WATCHOS_NUGET_VERSION_NO_METADATA=$(WATCHOS_NUGET_VERSION)$(WATCHOSOS_NUGET_PRERELEASE_IDENTIFIER)
 WATCHOS_NUGET_VERSION_FULL=$(WATCHOS_NUGET_VERSION_NO_METADATA)+$(NUGET_BUILD_METADATA)
 
 MACCATALYST_NUGET=Microsoft.MacCatalyst
 MACCATALYST_NUGET_VERSION_MAJOR=$(word 1, $(subst ., ,$(MACCATALYST_NUGET_VERSION)))
 MACCATALYST_NUGET_VERSION_MINOR=$(word 2, $(subst ., ,$(MACCATALYST_NUGET_VERSION)))
 MACCATALYST_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(MACCATALYST_NUGET_VERSION)))
-MACCATALYST_NUGET_VERSION_NO_METADATA=$(MACCATALYST_NUGET_VERSION)-$(NUGET_PRERELEASE_IDENTIFIER)$(MACCATALYST_NUGET_COMMIT_DISTANCE)
+MACCATALYST_NUGET_VERSION_NO_METADATA=$(MACCATALYST_NUGET_VERSION)$(MACCATALYST_NUGET_PRERELEASE_IDENTIFIER)
 MACCATALYST_NUGET_VERSION_FULL=$(MACCATALYST_NUGET_VERSION_NO_METADATA)+$(NUGET_BUILD_METADATA)
 
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
@@ -443,7 +496,7 @@ MACOS_NUGET=Microsoft.macOS
 MACOS_NUGET_VERSION_MAJOR=$(word 1, $(subst ., ,$(MACOS_NUGET_VERSION)))
 MACOS_NUGET_VERSION_MINOR=$(word 2, $(subst ., ,$(MACOS_NUGET_VERSION)))
 MACOS_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(MACOS_NUGET_VERSION)))
-MACOS_NUGET_VERSION_NO_METADATA=$(MACOS_NUGET_VERSION)-$(NUGET_PRERELEASE_IDENTIFIER)$(MACOS_NUGET_COMMIT_DISTANCE)
+MACOS_NUGET_VERSION_NO_METADATA=$(MACOS_NUGET_VERSION)$(MACOS_NUGET_PRERELEASE_IDENTIFIER)
 MACOS_NUGET_VERSION_FULL=$(MACOS_NUGET_VERSION_NO_METADATA)+$(NUGET_BUILD_METADATA)
 
 ifneq ($(TESTS_USE_SYSTEM),)


### PR DESCRIPTION
This is a heavily modified backport of #14847.