### PR TITLE
[scenekit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/SceneKit/SCNAnimatable.cs
+++ b/src/SceneKit/SCNAnimatable.cs
@@ -22,7 +22,7 @@ namespace SceneKit
 		
 		public void AddAnimation (CAAnimation animation, string? key = null)
 		{
-			var nskey = key == null ? null : new NSString (key);
+			var nskey = key is null ? null : new NSString (key);
 			
 			AddAnimation (animation, nskey);
 			nskey?.Dispose ();

--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -22,7 +22,7 @@ namespace SceneKit {
 		[Obsolete ("Use 'TimingFunction2' property.")]
 		public virtual Action<float>? TimingFunction {
 			get {
-				if (TimingFunction2 == null)
+				if (TimingFunction2 is null)
 					return null;
 				else
 					return (f) => {
@@ -30,7 +30,7 @@ namespace SceneKit {
 					};
 			}
 			set {
-				if (value == null)
+				if (value is null)
 					TimingFunction2 = null;
 				else
 					TimingFunction2 = (f) => {
@@ -76,7 +76,7 @@ namespace SceneKit {
 		[Mac (10, 9)]
 		public virtual bool WriteToUrl (NSUrl url, SCNSceneLoadingOptions options, SCNSceneExportDelegate handler, SCNSceneExportProgressHandler exportProgressHandler)
 		{
-			return WriteToUrl (url: url, options: options == null ? null : options.Dictionary, aDelegate: handler, exportProgressHandler: exportProgressHandler);
+			return WriteToUrl (url: url, options: options?.Dictionary, aDelegate: handler, exportProgressHandler: exportProgressHandler);
 		}
 
 		[Obsolete ("Use the 'ISCNSceneExportDelegate' overload instead.")]
@@ -134,7 +134,7 @@ namespace SceneKit {
 		static public void AddAnimation (this ISCNAnimatable self, SCNAnimation animation, string key)
 		{
 			using (var ca = CAAnimation.FromSCNAnimation (animation))
-			using (var st = key != null ? new NSString (key) : null)
+			using (var st = key is not null ? new NSString (key) : null)
 				self.AddAnimation (ca, st);
 		}
 	}

--- a/src/SceneKit/SCNGeometrySource.cs
+++ b/src/SceneKit/SCNGeometrySource.cs
@@ -22,7 +22,7 @@ namespace SceneKit {
 
 		public static unsafe SCNGeometrySource FromVertices (SCNVector3 [] vertices)
 		{
-			if (vertices == null)
+			if (vertices is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException  (nameof (vertices));
 
 			fixed (SCNVector3 *ptr = &vertices [0])
@@ -31,7 +31,7 @@ namespace SceneKit {
 
 		public static unsafe SCNGeometrySource FromNormals (SCNVector3 [] normals)
 		{
-			if (normals == null)
+			if (normals is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException  (nameof (normals));
 
 			fixed (SCNVector3 *ptr = &normals[0])
@@ -40,7 +40,7 @@ namespace SceneKit {
 
 		public static unsafe SCNGeometrySource FromTextureCoordinates (CGPoint [] texcoords)
 		{
-			if (texcoords == null)
+			if (texcoords is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException  (nameof (texcoords));
 
 			fixed (CGPoint *ptr = &texcoords[0])

--- a/src/SceneKit/SCNJavaScript.cs
+++ b/src/SceneKit/SCNJavaScript.cs
@@ -35,7 +35,7 @@ namespace SceneKit
 
 		public static void ExportModule (JSContext context)
 		{
-			if (context == null)
+			if (context is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (context));
 
 			SCNExportJavaScriptModule (context.Handle);

--- a/src/SceneKit/SCNNode.cs
+++ b/src/SceneKit/SCNNode.cs
@@ -30,7 +30,7 @@ namespace SceneKit
 
 		public void AddNodes (params SCNNode [] nodes)
 		{
-			if (nodes == null)
+			if (nodes is null)
 				return;
 			foreach (var n in nodes)
 				AddChildNode (n);
@@ -50,7 +50,7 @@ namespace SceneKit
 #if !WATCH
 		public void AddAnimation (CAAnimation animation, string? key)
 		{
-			if (key == null) {
+			if (key is null) {
 				((ISCNAnimatable) this).AddAnimation (animation, (NSString?) null);
 			} else {
 				using (var s = new NSString (key))

--- a/src/SceneKit/SCNParticleSystem.cs
+++ b/src/SceneKit/SCNParticleSystem.cs
@@ -43,7 +43,7 @@ namespace SceneKit
 
 		internal void Set (NSString key, SCNParticlePropertyController? value)
 		{
-			if (mutDict == null){
+			if (mutDict is null){
 				mutDict = new NSMutableDictionary (dict);
 				dict = mutDict;
 			}
@@ -183,7 +183,7 @@ namespace SceneKit
 		public SCNPropertyControllers? PropertyControllers {
 			get {
 				var weak = WeakPropertyControllers;
-				if (weak == null)
+				if (weak is null)
 					return null;
 				return new SCNPropertyControllers (weak);
 			}

--- a/src/SceneKit/SCNPhysicsShape.cs
+++ b/src/SceneKit/SCNPhysicsShape.cs
@@ -21,10 +21,10 @@ namespace SceneKit
 	{
 		public static SCNPhysicsShape Create (SCNPhysicsShape [] shapes, SCNMatrix4 [] transforms)
 		{
-			if (shapes == null)
+			if (shapes is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentException (nameof (shapes));
 
-			if (transforms == null)
+			if (transforms is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentException (nameof (transforms));
 
 			var t = new NSValue [transforms.Length];
@@ -38,10 +38,10 @@ namespace SceneKit
 		[Obsolete ("Use the 'Create' method that takes a 'SCNMatrix4 []'.")]
 		public static SCNPhysicsShape Create (SCNPhysicsShape [] shapes, SCNVector3 [] transforms)
 		{
-			if (shapes == null)
+			if (shapes is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentException (nameof (shapes));
 
-			if (transforms == null)
+			if (transforms is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentException (nameof (transforms));
 
 			var t = new NSValue [transforms.Length];
@@ -89,7 +89,7 @@ namespace SceneKit
 		public SCNPhysicsShapeOptions? Options {
 			get {
 				var o = _Options;
-				if (o == null)
+				if (o is null)
 					return null;
 				return new SCNPhysicsShapeOptions (o);
 			}
@@ -116,7 +116,7 @@ namespace SceneKit
 		internal SCNPhysicsShapeOptions (NSDictionary source)
 		{
 			var ret = source [SCNPhysicsShapeOptionsKeys.Type] as NSString;
-			if (ret != null){
+			if (ret is not null){
 				if (ret == SCNPhysicsShapeOptionsTypes.BoundingBox)
 					ShapeType = SCNPhysicsShapeType.BoundingBox;
 				else if (ret == SCNPhysicsShapeOptionsTypes.ConcavePolyhedron)
@@ -125,10 +125,10 @@ namespace SceneKit
 					ShapeType = SCNPhysicsShapeType.ConvexHull;
 			}
 			var bret = source [SCNPhysicsShapeOptionsKeys.KeepAsCompound] as NSNumber;
-			if (bret != null)
+			if (bret is not null)
 				KeepAsCompound = bret.Int32Value != 0;
 			var nret = source [SCNPhysicsShapeOptionsKeys.Scale] as NSValue;
-			if (nret != null)
+			if (nret is not null)
 				Scale = nret.Vector3Value;
 		}
 		

--- a/src/SceneKit/SCNRenderingOptions.cs
+++ b/src/SceneKit/SCNRenderingOptions.cs
@@ -20,7 +20,7 @@ namespace SceneKit
 		public SCNRenderingApi? RenderingApi {
 			get {
 				var val = GetNUIntValue (SCNRenderingOptionsKeys.RenderingApiKey);
-				if (val != null)
+				if (val is not null)
 					return (SCNRenderingApi)(uint) val;
 				return null;
 			}

--- a/src/SceneKit/SCNSkinner.cs
+++ b/src/SceneKit/SCNSkinner.cs
@@ -42,7 +42,7 @@ namespace SceneKit {
 
 			for (nint i = 0; i < count; i++) {
 				var item = NSValue.FromSCNMatrix4 (items [i]);
-				var h = item == null ? NSNull.Null.Handle : item.Handle;
+				var h = item?.Handle ??  NSNull.Null.Handle;
 				Marshal.WriteIntPtr (buf, (int)(i * IntPtr.Size), h);
 			}
 


### PR DESCRIPTION
This PR aims to bring nullability changes to SceneKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. Changing any `== null` or `!= null` to `is null` and `is not null`