### PR TITLE
[sensorkit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/SensorKit/SRSensor.cs
+++ b/src/SensorKit/SRSensor.cs
@@ -11,7 +11,7 @@ namespace SensorKit {
 		public static SRSensor GetSensorForDeletionRecords (this SRSensor self)
 		{
 			var constant = self.GetConstant ();
-			if (constant == null)
+			if (constant is null)
 				return SRSensor.Invalid;
 			return GetValue (constant._GetSensorForDeletionRecordsFromSensor ());
 		}


### PR DESCRIPTION
This PR aims to bring nullability changes to SensorKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. Changing any `== null` or `!= null` to `is null` and `is not null`