### PR TITLE
[social] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/Social/SLCompat.cs
+++ b/src/Social/SLCompat.cs
@@ -1,5 +1,7 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 
+#nullable enable
+
 #if !XAMCORE_3_0 && !MONOMAC
 
 using System;

--- a/src/Social/SLComposeViewController.cs
+++ b/src/Social/SLComposeViewController.cs
@@ -6,6 +6,9 @@
 //
 // Copyright 2012 Xamarin Inc
 //
+
+#nullable enable
+
 #if !MONOMAC
 using System;
 using ObjCRuntime;

--- a/src/Social/SLRequest.cs
+++ b/src/Social/SLRequest.cs
@@ -7,6 +7,8 @@
 // Copyright 2012-2013 Xamarin Inc
 //
 
+#nullable enable
+
 using System;
 using ObjCRuntime;
 using Foundation;
@@ -30,8 +32,9 @@ namespace Social {
 			case SLServiceKind.LinkedIn:
 				return SLServiceType.LinkedIn;
 #endif
+			default:
+				throw new ArgumentOutOfRangeException (nameof (kind));
 			}
-			return null;
 		}
 		
 		public static SLRequest Create (SLServiceKind serviceKind, SLRequestMethod method, NSUrl url, NSDictionary parameters)


### PR DESCRIPTION
This PR aims to bring nullability changes to Social.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes