### PR TITLE
[spritekit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/SpriteKit/SKNode.cs
+++ b/src/SpriteKit/SKNode.cs
@@ -48,7 +48,7 @@ namespace SpriteKit
 
 		public void AddNodes (params SKNode []? nodes)
 		{
-			if (nodes == null)
+			if (nodes is null)
 				return;
 			foreach (var n in nodes)
 				AddChild (n);
@@ -79,9 +79,9 @@ namespace SpriteKit
 		public static SKNode? Create (string filename, Type [] types, out NSError error)
 		{
 			// Let's fail early.
-			if (filename == null)
+			if (filename is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (filename));
-			if (types == null)
+			if (types is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (types));
 			if (types.Length == 0)
 				ObjCRuntime.ThrowHelper.ThrowArgumentException (nameof (types), "Length must be greater than zero.");
@@ -107,7 +107,7 @@ namespace SpriteKit
 		public static SKNode? Create (string filename, NSSet<Class> classes, out NSError error)
 		{
 			// `filename` will be checked by `Create` later
-			if (classes == null)
+			if (classes is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (classes));
 			if (classes.Count == 0)
 				ObjCRuntime.ThrowHelper.ThrowArgumentException (nameof (classes), "Length must be greater than zero.");

--- a/src/SpriteKit/SKShapeNode.cs
+++ b/src/SpriteKit/SKShapeNode.cs
@@ -27,7 +27,7 @@ namespace SpriteKit {
 #endif
 		public static SKShapeNode FromPoints (CGPoint [] points)
 		{
-			if (points == null)
+			if (points is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (points));
 
 			return FromPoints (ref points[0], (nuint) points.Length);
@@ -44,7 +44,7 @@ namespace SpriteKit {
 #endif
 		public static SKShapeNode FromPoints (CGPoint [] points, int offset, int length)
 		{
-			if (points == null)
+			if (points is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (points));
 			if (offset > points.Length - length)
 				throw new InvalidOperationException ("offset + length must not be greater than the length of the array");
@@ -63,7 +63,7 @@ namespace SpriteKit {
 #endif
 		public static SKShapeNode FromSplinePoints (CGPoint [] points)
 		{
-			if (points == null)
+			if (points is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (points));
 
 			return FromSplinePoints (ref points[0], (nuint) points.Length);
@@ -80,7 +80,7 @@ namespace SpriteKit {
 #endif
 		public static SKShapeNode FromSplinePoints (CGPoint [] points, int offset, int length)
 		{
-			if (points == null)
+			if (points is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (points));
 			if (offset > points.Length - length)
 				throw new InvalidOperationException ("offset + length must not be greater than the length of the array");

--- a/src/SpriteKit/SKWarpGeometryGrid.cs
+++ b/src/SpriteKit/SKWarpGeometryGrid.cs
@@ -58,7 +58,7 @@ namespace SpriteKit
 
 		public unsafe SKWarpGeometryGrid GetGridByReplacingSourcePositions (Vector2 [] sourcePositions)
 		{
-			if (sourcePositions == null)
+			if (sourcePositions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (sourcePositions));
 			// TODO: Verify this assumption when/if doc is updated or headers changed in newer betas.
 			if (sourcePositions.Length < ((NumberOfColumns + 1) * (NumberOfRows + 1)))
@@ -70,7 +70,7 @@ namespace SpriteKit
 
 		public unsafe SKWarpGeometryGrid GetGridByReplacingDestPositions (Vector2 [] destPositions)
 		{
-			if (destPositions == null)
+			if (destPositions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (destPositions));
 			// TODO: Verify this assumption when/if doc is updated or headers changed in newer betas.
 			if (destPositions.Length < ((NumberOfColumns + 1) * (NumberOfRows + 1)))


### PR DESCRIPTION
This PR aims to bring nullability changes to SpriteKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. Changing any `== null` or `!= null` to `is null` and `is not null`