### PR TITLE
[systemcomponentmodel] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/System.ComponentModel/CancelEventArgs.cs
+++ b/src/System.ComponentModel/CancelEventArgs.cs
@@ -27,6 +27,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 
 namespace System.ComponentModel {


### PR DESCRIPTION
This PR aims to bring nullability changes to System.ComponentModel.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes