### PR TITLE
[nnyeah] Fix race on error message output

### DIFF
--- a/tools/nnyeah/nnyeah/Program.cs
+++ b/tools/nnyeah/nnyeah/Program.cs
@@ -72,7 +72,7 @@ namespace Microsoft.MaciOS.Nnyeah {
 						warnings.ForEach (Console.WriteLine);
 					}
 				} catch (Exception e) {
-					Console.Error.Write (Errors.E0004, e.Message);
+					Console.Error.WriteLine (Errors.E0004, e.Message);
 					Environment.Exit (1);
 				}
 			} else {


### PR DESCRIPTION
- Errors were written with Write and then Exit which at least in VSCode would exit before the write flushed to the console
- WriteLine seems better behaved