### PR TITLE
[nnyeah] Bump to NET6

### DIFF
--- a/tools/nnyeah/nnyeah/nnyeah.csproj
+++ b/tools/nnyeah/nnyeah/nnyeah.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.MaciOS.Nnyeah</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
- .NET5 on my mac has inconsistent debugging due to lack of support for apple's arm arch
- The tool is going to run against NET6, so why built it on NET5