### PR TITLE
[nnyeah] Fix 'System.Boolean System.nint::System.IConvertible.ToBoolean' duplicate key crash

### DIFF
--- a/tools/nnyeah/nnyeah/MethodTransformations.cs
+++ b/tools/nnyeah/nnyeah/MethodTransformations.cs
@@ -363,7 +363,9 @@ namespace Microsoft.MaciOS.Nnyeah {
 			transformTable = new Dictionary<string, Transformation> ();
 
 			foreach (var xform in allTransforms) {
-				transformTable.Add (xform.Operand, xform);
+				if (!transformTable.ContainsKey (xform.Operand)) {
+					transformTable.Add (xform.Operand, xform);
+				}
 			}
 			return transformTable;
 		}


### PR DESCRIPTION
nnyeah would crash when converting this test case

```csharp
    public class MyClass
    {
        public nint Echo(nint x) => x;
    }
```

with:

`Unable to generate output file, unexpected exception: An item with the same key has already been added. Key: System.Boolean System.nint::System.IConvertible.ToBoolean(System.IFormatProvider).`

I am uncertain if this fix is reasonable @stephen-hawley, but the first silly thing I thought of did let it successfully run. 

Please feel free to close this (and take the issue) if this fix is obviously wrong. 