### PR TITLE
[systemconfiguration] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/SystemConfiguration/CaptiveNetwork.cs
+++ b/src/SystemConfiguration/CaptiveNetwork.cs
@@ -9,6 +9,8 @@
 // Copyright 2012-2015 Xamarin Inc. All rights reserved.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using CoreFoundation;
@@ -26,15 +28,15 @@ namespace SystemConfiguration {
 #if !NET
 		[Obsolete ("Always return 'null'.")]
 		[Unavailable (PlatformName.TvOS)]
-		public static Foundation.NSString NetworkInfoKeyBSSID => null;
+		public static Foundation.NSString? NetworkInfoKeyBSSID => null;
 
 		[Obsolete ("Always return 'null'.")]
 		[Unavailable (PlatformName.TvOS)]
-		public static Foundation.NSString NetworkInfoKeySSID => null;
+		public static Foundation.NSString? NetworkInfoKeySSID => null;
 
 		[Obsolete ("Always return 'null'.")]
 		[Unavailable (PlatformName.TvOS)]
-		public static Foundation.NSString NetworkInfoKeySSIDData => null;
+		public static Foundation.NSString? NetworkInfoKeySSIDData => null;
 
 		[Obsolete ("Throw a 'NotSupportedException'.")]
 		[Unavailable (PlatformName.TvOS)]
@@ -81,7 +83,7 @@ namespace SystemConfiguration {
 #else
 		[Deprecated (PlatformName.iOS, 14,0)]
 #endif
-		static public StatusCode TryCopyCurrentNetworkInfo (string interfaceName, out NSDictionary currentNetworkInfo)
+		static public StatusCode TryCopyCurrentNetworkInfo (string interfaceName, out NSDictionary? currentNetworkInfo)
 		{
 			using (var nss = new NSString (interfaceName)) {
 				var ni = CNCopyCurrentNetworkInfo (nss.Handle);
@@ -113,7 +115,7 @@ namespace SystemConfiguration {
 #else
 		[Deprecated (PlatformName.iOS, 14,0, message: "Use 'NEHotspotNetwork.FetchCurrent' instead.")]
 #endif
-		static public StatusCode TryGetSupportedInterfaces (out string[] supportedInterfaces)
+		static public StatusCode TryGetSupportedInterfaces (out string?[]? supportedInterfaces)
 		{
 			IntPtr array = CNCopySupportedInterfaces ();
 			if (array == IntPtr.Zero) {

--- a/src/SystemConfiguration/NetworkReachability.cs
+++ b/src/SystemConfiguration/NetworkReachability.cs
@@ -70,7 +70,9 @@ namespace SystemConfiguration {
 				switch (address.AddressFamily) {
 				case AddressFamily.InterNetwork:
 					sin_family = 2;  // Address for IPv4
+#pragma warning disable CS0618 // Type or member is obsolete
 					sin_addr = (int) address.Address;
+#pragma warning restore CS0618 // Type or member is obsolete
 					break;
 				case AddressFamily.InterNetworkV6:
 					sin_family = 30; // Address for IPv6

--- a/src/SystemConfiguration/NetworkReachability.cs
+++ b/src/SystemConfiguration/NetworkReachability.cs
@@ -140,7 +140,7 @@ namespace SystemConfiguration {
 		static IntPtr Create (IPAddress ip)
 		{
 			if (ip is null)
-				throw new ArgumentNullException (nameof (ip));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (ip));
 
 			var s = new sockaddr_in (ip);
 			return CheckFailure (SCNetworkReachabilityCreateWithAddress (IntPtr.Zero, ref s));
@@ -154,7 +154,7 @@ namespace SystemConfiguration {
 		static IntPtr Create (string address)
 		{
 			if (address is null)
-				throw new ArgumentNullException (nameof (address));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (address));
 
 			return CheckFailure (SCNetworkReachabilityCreateWithName (IntPtr.Zero, address));
 		}
@@ -309,10 +309,10 @@ namespace SystemConfiguration {
 		public bool Schedule (CFRunLoop runLoop, string mode)
 		{
 			if (runLoop is null)
-				throw new ArgumentNullException (nameof (runLoop));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (runLoop));
 
 			if (mode is null)
-				throw new ArgumentNullException (nameof (mode));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (mode));
 
 			var modeHandle = CFString.CreateNative (mode);
 			try {
@@ -333,10 +333,10 @@ namespace SystemConfiguration {
 		public bool Unschedule (CFRunLoop runLoop, string mode)
 		{
 			if (runLoop is null)
-				throw new ArgumentNullException (nameof (runLoop));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (runLoop));
 
 			if (mode is null)
-				throw new ArgumentNullException (nameof (mode));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (mode));
 
 			var modeHandle = CFString.CreateNative (mode);
 			try {

--- a/src/SystemConfiguration/NetworkReachability.cs
+++ b/src/SystemConfiguration/NetworkReachability.cs
@@ -267,7 +267,7 @@ namespace SystemConfiguration {
 
 #if !NET
 				lock (typeof (NetworkReachability)){
-					if (callouth == null)
+					if (callouth is null)
 						callouth = Callback;
 				}
 #endif

--- a/src/SystemConfiguration/StatusCodeError.cs
+++ b/src/SystemConfiguration/StatusCodeError.cs
@@ -7,6 +7,8 @@
 // Copyright 2012, 2016 Xamarin Inc. All rights reserved.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -23,7 +25,7 @@ namespace SystemConfiguration {
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		extern static IntPtr /* const char* */ SCErrorString (int code);
 		
-		public static string GetErrorDescription (StatusCode statusCode)
+		public static string? GetErrorDescription (StatusCode statusCode)
 		{
 			var ptr = SCErrorString ((int) statusCode);
 			return Marshal.PtrToStringAnsi (ptr);

--- a/src/SystemConfiguration/SystemConfigurationException.cs
+++ b/src/SystemConfiguration/SystemConfigurationException.cs
@@ -7,6 +7,8 @@
 // Copyright 2012 Xamarin Inc. All rights reserved.
 //
 
+#nullable enable
+
 using System;
 
 namespace SystemConfiguration {


### PR DESCRIPTION
This PR aims to bring nullability changes to SystemConfiguration.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`