### PR TITLE
[Nnyeah] Ensure that we have all the needed xamarin-macios dlls when using make.

### DIFF
--- a/tools/nnyeah/Makefile
+++ b/tools/nnyeah/Makefile
@@ -8,7 +8,7 @@ install-local:: all-local
 IOS_DLL=$(TOP)/src/build/ios/native-64/Xamarin.iOS.dll
 
 $(IOS_DLL):
-	@echo "Thou shall run 'make all' in the root directory first"
+	@echo "Thou shalt run 'make all' in the root directory first"
 	@exit 1
 
 nnyeah/bin/Debug/net5.0/nnyeah.dll: $(IOS_DLL) $(wildcard **/*.cs) $(wildcard **/*.csproj) $(wildcard *.sln) Makefile

--- a/tools/nnyeah/Makefile
+++ b/tools/nnyeah/Makefile
@@ -5,7 +5,13 @@ all-local:: nnyeah/bin/Debug/net5.0/nnyeah.dll
 
 install-local:: all-local
 
-nnyeah/bin/Debug/net5.0/nnyeah.dll: $(wildcard **/*.cs) $(wildcard **/*.csproj) $(wildcard *.sln) Makefile
+IOS_DLL=$(TOP)/src/build/ios/native-64/Xamarin.iOS.dll
+
+$(IOS_DLL):
+	@echo "Thou shall run 'make all' in the root directory first"
+	@exit 1
+
+nnyeah/bin/Debug/net5.0/nnyeah.dll: $(IOS_DLL) $(wildcard **/*.cs) $(wildcard **/*.csproj) $(wildcard *.sln) Makefile
 	$(Q_BUILD) $(SYSTEM_DOTNET) build "/bl:$@.binlog" /restore $(MSBUILD_VERBOSITY) $(wildcard *.sln)
 
 clean:


### PR DESCRIPTION
We need to be able to embed the dlls as a resource to compare the diff
assemblies. To do so we are going to ensure that we have called make in
the root dir so that the needed deps are present. This change is not yet
in the csproj, that will be a diff commit.