### PR TITLE
[tvmlkit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/TVMLKit/TVViewElement.cs
+++ b/src/TVMLKit/TVViewElement.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Foundation;
 using ObjCRuntime;


### PR DESCRIPTION
This PR aims to bring nullability changes to TVMLKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes