### PR TITLE
[compression] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/Compression/Compression.cs
+++ b/src/Compression/Compression.cs
@@ -91,7 +91,7 @@ namespace Compression
 		public CompressionStream (Stream stream, CompressionMode mode, CompressionAlgorithm algorithm, bool leaveOpen)
 		{
 			if (stream == null)
-				throw new ArgumentNullException (nameof (stream));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (stream));
 
 			_stream = stream;
 			_leaveOpen = leaveOpen;
@@ -279,7 +279,7 @@ namespace Compression
 		private void ValidateParameters (byte[] array, int offset, int count)
 		{
 			if (array == null)
-				throw new ArgumentNullException (nameof (array));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 
 			if (offset < 0)
 				throw new ArgumentOutOfRangeException (nameof (offset));
@@ -671,9 +671,9 @@ namespace Compression
 			public CopyToAsyncStream (CompressionStream deflateStream, Stream destination, int bufferSize, CancellationToken cancellationToken)
 			{
 				if (deflateStream == null)
-					throw new ArgumentNullException (nameof (deflateStream));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (deflateStream));
 				if (destination == null)
-					throw new ArgumentNullException (nameof (destination));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (destination));
 				if (bufferSize <= 0)
 					throw new ArgumentOutOfRangeException (nameof (bufferSize));
 

--- a/src/Compression/Compression.cs
+++ b/src/Compression/Compression.cs
@@ -35,7 +35,7 @@ namespace Compression
 		private Stream? _stream;
 		Stream Stream {
 			get {
-				if (_stream == null)
+				if (_stream is null)
 					throw new ObjectDisposedException (null, "Can not access a closed Stream.");
 				return _stream;
 			}
@@ -61,7 +61,7 @@ namespace Compression
 		private byte[]? _buffer;
 		Byte[] Buffer {
 			get {
-				if (_buffer == null)
+				if (_buffer is null)
 					_buffer = ArrayPool<byte>.Shared.Rent (DefaultBufferSize);
 				return _buffer;
 			}
@@ -90,7 +90,7 @@ namespace Compression
 		/// </summary>
 		public CompressionStream (Stream stream, CompressionMode mode, CompressionAlgorithm algorithm, bool leaveOpen)
 		{
-			if (stream == null)
+			if (stream is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (stream));
 
 			_stream = stream;
@@ -133,7 +133,7 @@ namespace Compression
 		public override bool CanRead
 		{
 			get {
-				if (_stream == null) {
+				if (_stream is null) {
 					return false;
 				}
 
@@ -143,7 +143,7 @@ namespace Compression
 
 		public override bool CanWrite {
 			get {
-				if (_stream == null) {
+				if (_stream is null) {
 					return false;
 				}
 
@@ -278,7 +278,7 @@ namespace Compression
 
 		private void ValidateParameters (byte[] array, int offset, int count)
 		{
-			if (array == null)
+			if (array is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 
 			if (offset < 0)
@@ -293,7 +293,7 @@ namespace Compression
 
 		private void EnsureNotDisposed ()
 		{
-			if (_stream == null)
+			if (_stream is null)
 				ThrowStreamClosedException ();
 		}
 
@@ -499,7 +499,7 @@ namespace Compression
 			if (!disposing)
 				return;
 
-			if (_stream == null)
+			if (_stream is null)
 				return;
 
 			if (_mode != CompressionMode.Compress)
@@ -559,7 +559,7 @@ namespace Compression
 						_inflater = null;
 
 						byte[]? buffer = _buffer;
-						if (buffer != null) {
+						if (buffer is not null) {
 							_buffer = null;
 							if (!AsyncOperationIsActive) {
 								ArrayPool<byte>.Shared.Return (buffer);
@@ -670,9 +670,9 @@ namespace Compression
 
 			public CopyToAsyncStream (CompressionStream deflateStream, Stream destination, int bufferSize, CancellationToken cancellationToken)
 			{
-				if (deflateStream == null)
+				if (deflateStream is null)
 					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (deflateStream));
-				if (destination == null)
+				if (destination is null)
 					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (destination));
 				if (bufferSize <= 0)
 					throw new ArgumentOutOfRangeException (nameof (bufferSize));

--- a/src/Compression/CompressionStreamStruct.cs
+++ b/src/Compression/CompressionStreamStruct.cs
@@ -4,6 +4,8 @@ using System.Runtime.InteropServices;
 
 using ObjCRuntime;
 
+#nullable enable
+
 namespace Compression
 {
 #if NET

--- a/src/Compression/Deflater.cs
+++ b/src/Compression/Deflater.cs
@@ -85,7 +85,7 @@ namespace Compression
 			if (! NeedsInput ())
 				throw new InvalidOperationException ("We have something left in previous input!");
 			if (inputBufferPtr == null)
-				throw new ArgumentNullException ( nameof (inputBufferPtr));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inputBufferPtr));
 			if (_inputBufferHandle.Pointer != null)
 				throw new InvalidOperationException ("Unexpected input buffer handler found.");
 
@@ -102,7 +102,7 @@ namespace Compression
 		internal int GetDeflateOutput (byte[] outputBuffer)
 		{
 			if (outputBuffer == null) 
-				throw new ArgumentNullException (nameof (outputBuffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputBuffer));
 			if (NeedsInput ())
 				throw new InvalidOperationException ("GetDeflateOutput should only be called after providing input");
 
@@ -148,7 +148,7 @@ namespace Compression
 		internal bool Finish (byte[] outputBuffer, out int bytesRead)
 		{
 			if (outputBuffer == null)
-				throw new ArgumentNullException (nameof (outputBuffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputBuffer));
 			if (outputBuffer.Length < 0)
 				throw new ArgumentException ("Can't pass in an empty output buffer!");
 
@@ -162,7 +162,7 @@ namespace Compression
 		internal unsafe bool Flush (byte[] outputBuffer, out int bytesRead)
 		{
 			if (outputBuffer == null)
-				throw new ArgumentNullException (nameof (outputBuffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputBuffer));
 			if (outputBuffer.Length < 0)
 				throw new ArgumentException ("Can't pass in an empty output buffer!");
 			if (!NeedsInput ())

--- a/src/Compression/Deflater.cs
+++ b/src/Compression/Deflater.cs
@@ -65,7 +65,7 @@ namespace Compression
 		{
 			if (!NeedsInput ())
 				throw new InvalidOperationException ("We have something left in previous input!");
-			if (_inputBufferHandle.Pointer != null)
+			if (_inputBufferHandle.Pointer is not null)
 				throw new InvalidOperationException ("Unexpected input buffer handler found.");
 
 			if (0 == inputBuffer.Length) {
@@ -84,9 +84,9 @@ namespace Compression
 		{
 			if (! NeedsInput ())
 				throw new InvalidOperationException ("We have something left in previous input!");
-			if (inputBufferPtr == null)
+			if (inputBufferPtr is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inputBufferPtr));
-			if (_inputBufferHandle.Pointer != null)
+			if (_inputBufferHandle.Pointer is not null)
 				throw new InvalidOperationException ("Unexpected input buffer handler found.");
 
 			if (count == 0) {
@@ -101,7 +101,7 @@ namespace Compression
 
 		internal int GetDeflateOutput (byte[] outputBuffer)
 		{
-			if (outputBuffer == null) 
+			if (outputBuffer is null) 
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputBuffer));
 			if (NeedsInput ())
 				throw new InvalidOperationException ("GetDeflateOutput should only be called after providing input");
@@ -147,7 +147,7 @@ namespace Compression
 
 		internal bool Finish (byte[] outputBuffer, out int bytesRead)
 		{
-			if (outputBuffer == null)
+			if (outputBuffer is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputBuffer));
 			if (outputBuffer.Length < 0)
 				throw new ArgumentException ("Can't pass in an empty output buffer!");
@@ -161,13 +161,13 @@ namespace Compression
 		/// </summary>
 		internal unsafe bool Flush (byte[] outputBuffer, out int bytesRead)
 		{
-			if (outputBuffer == null)
+			if (outputBuffer is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputBuffer));
 			if (outputBuffer.Length < 0)
 				throw new ArgumentException ("Can't pass in an empty output buffer!");
 			if (!NeedsInput ())
 				throw new InvalidOperationException ("We have something left in previous input!");
-			if (_inputBufferHandle.Pointer != null)
+			if (_inputBufferHandle.Pointer is not null)
 				throw new InvalidOperationException ("InputHandler should not be set");
 
 			// Note: we require that NeedsInput() == true, i.e. that 0 == _zlibStream.AvailIn.

--- a/src/Compression/Deflater.cs
+++ b/src/Compression/Deflater.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Buffers;
 using System.Diagnostics;
@@ -105,8 +107,7 @@ namespace Compression
 				throw new InvalidOperationException ("GetDeflateOutput should only be called after providing input");
 
 			try {
-				int bytesRead;
-				ReadDeflateOutput (outputBuffer, StreamFlag.Continue, out bytesRead);
+				ReadDeflateOutput (outputBuffer, StreamFlag.Continue, out var bytesRead);
 				return bytesRead;
 			} finally {
 				// Before returning, make sure to release input buffer if necessary:
@@ -118,7 +119,10 @@ namespace Compression
 
 		private unsafe CompressionStatus ReadDeflateOutput (byte[] outputBuffer, StreamFlag flushCode, out int bytesRead)
 		{
-			if (outputBuffer?.Length < 0)
+			if (outputBuffer is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputBuffer));
+
+			if (outputBuffer.Length < 0)
 				throw new ArgumentException ("outputbuffer length must be bigger than 0");
 			lock (SyncLock) {
 				fixed (byte* bufPtr = &outputBuffer[0]) {

--- a/src/Compression/Enums.cs
+++ b/src/Compression/Enums.cs
@@ -1,6 +1,7 @@
 using System;
 
 using ObjCRuntime;
+#nullable enable
 
 namespace Compression {
 

--- a/src/Compression/Inflater.cs
+++ b/src/Compression/Inflater.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -50,8 +52,8 @@ namespace Compression
 
 		public unsafe int Inflate (byte[] bytes, int offset, int length)
 		{
-			if (bytes == null)
-				throw new ArgumentNullException (nameof (bytes));
+			if (bytes is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (bytes));
 			// If Inflate is called on an invalid or unready inflater, return 0 to indicate no bytes have been read.
 			if (length == 0)
 				return 0;
@@ -68,7 +70,7 @@ namespace Compression
 			if (destination.Length == 0)
 				return 0;
 
-			fixed (byte* bufPtr = &MemoryMarshal.GetReference (destination))
+			fixed (byte* bufPtr = &MemoryMarshal.GetReference (destination!))
 			{
 				return InflateVerified (bufPtr, destination.Length);
 			}
@@ -78,8 +80,7 @@ namespace Compression
 		{
 			// State is valid; attempt inflation
 			try {
-				int bytesRead;
-				var errCode = ReadInflateOutput (bufPtr, length, out bytesRead);
+				var errCode = ReadInflateOutput (bufPtr, length, out var bytesRead);
 				if (errCode == CompressionStatus.End) {
 					_finished = true;
 				}
@@ -97,8 +98,8 @@ namespace Compression
 
 		public void SetInput (byte[] inputBuffer, int startIndex, int count)
 		{
-			if (inputBuffer == null)
-				throw new ArgumentNullException (nameof (inputBuffer));
+			if (inputBuffer is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inputBuffer));
 			if (!NeedsInput ())
 				throw new InvalidOperationException ("We have something left in previous input!");
 			if (_inputBufferHandle.IsAllocated)

--- a/src/Compression/TaskToApm.cs
+++ b/src/Compression/TaskToApm.cs
@@ -84,7 +84,7 @@ namespace System.Threading.Tasks
             /// <param name="callback">Callback to invoke when the wrapped task completes.</param>
             internal TaskAsyncResult(Task task, object? state, AsyncCallback? callback)
             {
-                Debug.Assert(task != null);
+                Debug.Assert(task is not null);
                 _task = task;
                 AsyncState = state;
 
@@ -94,7 +94,7 @@ namespace System.Threading.Tasks
                     CompletedSynchronously = true;
                     callback?.Invoke(this);
                 }
-                else if (callback != null)
+                else if (callback is not null)
                 {
                     // Asynchronous completion, and we have a callback; schedule it. We use OnCompleted rather than ContinueWith in
                     // order to avoid running synchronously if the task has already completed by the time we get here but still run
@@ -110,7 +110,7 @@ namespace System.Threading.Tasks
             private void InvokeCallback()
             {
                 Debug.Assert(!CompletedSynchronously);
-                Debug.Assert(_callback != null);
+                Debug.Assert(_callback is not null);
                 _callback.Invoke(this);
             }
 

--- a/src/Compression/TaskToApm.cs
+++ b/src/Compression/TaskToApm.cs
@@ -50,7 +50,7 @@ namespace System.Threading.Tasks
                 return;
             }
 
-            throw new ArgumentNullException();
+            ObjCRuntime.ThrowHelper.ThrowArgumentNullException ();
         }
 
         /// <summary>Processes an IAsyncResult returned by Begin.</summary>
@@ -62,7 +62,7 @@ namespace System.Threading.Tasks
                 return task.GetAwaiter().GetResult();
             }
 
-            throw new ArgumentNullException();
+            ObjCRuntime.ThrowHelper.ThrowArgumentNullException ();
         }
 
         /// <summary>Provides a simple IAsyncResult that wraps a Task.</summary>

--- a/src/Compression/TaskToApm.cs
+++ b/src/Compression/TaskToApm.cs
@@ -50,7 +50,7 @@ namespace System.Threading.Tasks
                 return;
             }
 
-            ObjCRuntime.ThrowHelper.ThrowArgumentNullException ();
+            throw new ArgumentNullException();
         }
 
         /// <summary>Processes an IAsyncResult returned by Begin.</summary>
@@ -61,8 +61,7 @@ namespace System.Threading.Tasks
             {
                 return task.GetAwaiter().GetResult();
             }
-
-            ObjCRuntime.ThrowHelper.ThrowArgumentNullException ();
+            throw new ArgumentNullException();
         }
 
         /// <summary>Provides a simple IAsyncResult that wraps a Task.</summary>


### PR DESCRIPTION
This PR aims to bring nullability changes to Compression.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`

-------------
I am replacing this older PR: https://github.com/xamarin/xamarin-macios/pull/14408
with this one! @mandel-macaque helped me through this process making this API a little cleaner than my previous PR!