### PR TITLE
Bumps Xamarin.HotRestart.Application to 1.1.5

### DIFF
--- a/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
@@ -13,7 +13,7 @@
     <MtouchExtraArgs>--registrar:dynamic</MtouchExtraArgs>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.iOS.HotRestart.Application" Version="1.1.4" />
+    <PackageReference Include="Xamarin.iOS.HotRestart.Application" Version="1.1.5" />
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\appiconfg.png" />


### PR DESCRIPTION
This new version contains a fix for incremental deployments when using Xamarin iOS Hot Restart.