### PR TITLE
[release/6.0.3xx] Bumps Xamarin.HotRestart.Application to 1.1.5

### DIFF
--- a/Make.versions
+++ b/Make.versions
@@ -66,11 +66,11 @@ MAC_PACKAGE_VERSION=8.11.0.$(MAC_COMMIT_DISTANCE)
 # WARNING: Do **not** use versions higher than the available Xcode SDK or else we will have issues with mtouch (See https://github.com/xamarin/xamarin-macios/issues/7705)
 # When bumping the major macOS version in MACOS_NUGET_VERSION also update the macOS version where we execute on bots in jenkins/Jenkinsfile (in the 'node' element)
 
-IOS_NUGET_VERSION=15.4.301
-TVOS_NUGET_VERSION=15.4.301
-WATCHOS_NUGET_VERSION=8.5.301
-MACOS_NUGET_VERSION=12.3.301
-MACCATALYST_NUGET_VERSION=15.4.301
+IOS_NUGET_VERSION=15.4.302
+TVOS_NUGET_VERSION=15.4.302
+WATCHOS_NUGET_VERSION=8.5.302
+MACOS_NUGET_VERSION=12.3.302
+MACCATALYST_NUGET_VERSION=15.4.302
 
 
 # Defines the default platform version if it's not specified in the TFM. The default should not change for a given .NET version:

--- a/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
@@ -13,7 +13,7 @@
     <MtouchExtraArgs>--registrar:dynamic</MtouchExtraArgs>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.iOS.HotRestart.Application" Version="1.1.4" />
+    <PackageReference Include="Xamarin.iOS.HotRestart.Application" Version="1.1.5" />
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\appiconfg.png" />


### PR DESCRIPTION
This new version contains a fix for incremental deployments when using Xamarin iOS Hot Restart.


Backport of #14925
