### PR TITLE
[msbuild/dotnet] Add support for passing --aot arguments to the AOT compiler.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -995,6 +995,7 @@
 		<AOTCompile
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
+			AotArguments="@(_AotArguments)"
 			Assemblies="@(_AssembliesToAOT)"
 			AOTCompilerPath="$(_AOTCompiler)"
 			InputDirectory="$(_AOTInputDirectory)"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/AOTCompileTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/AOTCompileTaskBase.cs
@@ -14,6 +14,8 @@ using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks {
 	public abstract class AOTCompileTaskBase : XamarinTask {
+		public ITaskItem [] AotArguments { get; set; } = Array.Empty<ITaskItem> ();
+
 		[Required]
 		public string AOTCompilerPath { get; set; } = string.Empty;
 
@@ -71,6 +73,7 @@ namespace Xamarin.MacDev.Tasks {
 				{ "MONO_PATH", Path.GetFullPath (InputDirectory) },
 			};
 
+			var globalAotArguments = AotArguments?.Select (v => v.ItemSpec).ToList ();
 			for (var i = 0; i < Assemblies.Length; i++) {
 				var asm = Assemblies [i];
 				var input = inputs [i];
@@ -95,6 +98,8 @@ namespace Xamarin.MacDev.Tasks {
 					return false;
 				}
 				arguments.Add ($"{string.Join (",", parsedArguments)}");
+				if (globalAotArguments is not null)
+					arguments.Add ($"--aot={string.Join (",", globalAotArguments)}");
 				arguments.AddRange (parsedProcessArguments);
 				arguments.Add (input);
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ParseBundlerArgumentsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ParseBundlerArgumentsTaskBase.cs
@@ -11,6 +11,9 @@ namespace Xamarin.MacDev.Tasks {
 		public string ExtraArgs { get; set; }
 
 		[Output]
+		public ITaskItem [] Aot { get; set; }
+
+		[Output]
 		public ITaskItem [] DlSym { get; set; }
 
 		[Output]
@@ -65,6 +68,7 @@ namespace Xamarin.MacDev.Tasks {
 				var args = CommandLineArgumentBuilder.Parse (ExtraArgs);
 				List<string> xml = null;
 				List<string> customLinkFlags = null;
+				var aot = new List<ITaskItem> ();
 				var envVariables = new List<ITaskItem> ();
 				var dlsyms = new List<ITaskItem> ();
 
@@ -100,6 +104,9 @@ namespace Xamarin.MacDev.Tasks {
 					}
 
 					switch (name) {
+					case "aot":
+						aot.Add (new TaskItem (value));
+						break;
 					case "nosymbolstrip":
 						// There's also a version that takes symbols as arguments:
 						// --nosymbolstrip:symbol1,symbol2
@@ -206,6 +213,12 @@ namespace Xamarin.MacDev.Tasks {
 					if (DlSym != null)
 						dlsyms.AddRange (DlSym);
 					DlSym = dlsyms.ToArray ();
+				}
+
+				if (aot.Count > 0) {
+					if (Aot is not null)
+						aot.AddRange (Aot);
+					Aot = aot.ToArray ();
 				}
 			}
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1763,12 +1763,14 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="_ParseBundlerArguments">
 		<ParseBundlerArguments
+			Aot="@(_AotArguments)"
 			ExtraArgs="$(_BundlerArguments)"
 			NoSymbolStrip="$(NoSymbolStrip)"
 			NoDSymUtil="$(NoDSymUtil)"
 			PackageDebugSymbols="$(PackageDebugSymbols)"
 			Verbosity="$(_BundlerVerbosity)"
 			>
+			<Output TaskParameter="Aot" ItemName="_AotArguments" />
 			<Output TaskParameter="CustomBundleName" PropertyName="_CustomBundleName" />
 			<Output TaskParameter="CustomLinkFlags" ItemName="_CustomLinkFlags" />
 			<Output TaskParameter="DlSym" ItemName="_BundlerDlsym" />


### PR DESCRIPTION
Pick up --aot arguments in MtouchExtraArgs and pass them to the AOT compiler
when building a .NET project. This makes it possible to work around #14887 by
manually increasing the number of trampolines.

Ref: https://github.com/xamarin/xamarin-macios/issues/14887