### PR TITLE
[Foundation] Make NSUserDefaults.VolatileDomainNames a property in XAMCORE_5_0.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -5644,7 +5644,11 @@ namespace Foundation
 		NSDictionary ToDictionary ();
 	
 		[Export ("volatileDomainNames")]
+#if XAMCORE_5_0
+		string [] VolatileDomainNames { get; }
+#else
 		string [] VolatileDomainNames ();
+#endif
 	
 		[Export ("volatileDomainForName:")]
 		NSDictionary GetVolatileDomain (string domainName);


### PR DESCRIPTION
That's how it's in Swift.