### PR TITLE
[tests] Adjust a few tests to try network requests multiple times.

### DIFF
--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -9,12 +9,20 @@ namespace MonoTests.System.Net.Http
 	{
 		public static readonly string MicrosoftUrl = "https://www.microsoft.com";
 		public static readonly Uri MicrosoftUri = new Uri (MicrosoftUrl);
+		public static readonly string MicrosoftHttpUrl = "http://www.microsoft.com";
 		public static readonly string XamarinUrl = "https://dotnet.microsoft.com/apps/xamarin";
+		public static readonly string XamarinHttpUrl = "http://dotnet.microsoft.com/apps/xamarin";
 		public static readonly Uri XamarinUri = new Uri (XamarinUrl);
 		public static readonly string StatsUrl = "https://api.imgur.com/2/stats";
 
-		public static readonly string [] Urls = {
+		public static readonly string [] HttpsUrls = {
 			MicrosoftUrl,
+			XamarinUrl,
+		};
+
+		public static readonly string [] HttpUrls = {
+			MicrosoftHttpUrl,
+			XamarinHttpUrl,
 		};
 
 		// Robots urls, useful when we want to get a small file


### PR DESCRIPTION
* A few tests seem to be failing rather consistently with network errors.
  Rewrite these tests to try multiple urls before failing (we'll be assuming
  that if one of the urls succeed, the other failures were network related).

* Rename the LinkAnyTest.WebClientTest to LinkAnyTest.WebClientTest_Http to
  follow it's original intent, and make it test http instead of https.