### PR TITLE
Bump maccore to get fix for #14834.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 749e84cb162b945dafa85fd6dffe80a727a491cf
+NEEDED_MACCORE_VERSION := 29a1c1382e005e568b57d1b45e3877c8081dfc8b
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@29a1c1382e [mlaunch] Redirect stdout and stderr through a pty when launching in the simulator. Fixes #14834.

Diff: https://github.com/xamarin/maccore/compare/749e84cb162b945dafa85fd6dffe80a727a491cf..29a1c1382e005e568b57d1b45e3877c8081dfc8b

Fixes https://github.com/xamarin/xamarin-macios/issues/14834.