### PR TITLE
[videosubscriberaccount] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/VideoSubscriberAccount/VSAccountManager.cs
+++ b/src/VideoSubscriberAccount/VSAccountManager.cs
@@ -21,9 +21,9 @@ namespace VideoSubscriberAccount {
 		public void CheckAccessStatus (VSAccountManagerAccessOptions accessOptions, Action<VSAccountAccessStatus, NSError> completionHandler)
 		{
 			if (accessOptions == null)
-				throw new ArgumentNullException (nameof (accessOptions));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (accessOptions));
 			if (completionHandler == null)
-				throw new ArgumentNullException (nameof (completionHandler));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (completionHandler));
 
 			CheckAccessStatus (accessOptions.Dictionary, completionHandler);
 		}
@@ -31,7 +31,7 @@ namespace VideoSubscriberAccount {
 		public Task<VSAccountAccessStatus> CheckAccessStatusAsync (VSAccountManagerAccessOptions accessOptions)
 		{
 			if (accessOptions == null)
-				throw new ArgumentNullException (nameof (accessOptions));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (accessOptions));
 
 			return CheckAccessStatusAsync (accessOptions.Dictionary);
 		}

--- a/src/VideoSubscriberAccount/VSAccountManager.cs
+++ b/src/VideoSubscriberAccount/VSAccountManager.cs
@@ -7,6 +7,8 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
 
+#nullable enable
+
 #if !MONOMAC && !__MACCATALYST__
 
 using System;

--- a/src/VideoSubscriberAccount/VSAccountManager.cs
+++ b/src/VideoSubscriberAccount/VSAccountManager.cs
@@ -20,9 +20,9 @@ namespace VideoSubscriberAccount {
 
 		public void CheckAccessStatus (VSAccountManagerAccessOptions accessOptions, Action<VSAccountAccessStatus, NSError> completionHandler)
 		{
-			if (accessOptions == null)
+			if (accessOptions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (accessOptions));
-			if (completionHandler == null)
+			if (completionHandler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (completionHandler));
 
 			CheckAccessStatus (accessOptions.Dictionary, completionHandler);
@@ -30,7 +30,7 @@ namespace VideoSubscriberAccount {
 
 		public Task<VSAccountAccessStatus> CheckAccessStatusAsync (VSAccountManagerAccessOptions accessOptions)
 		{
-			if (accessOptions == null)
+			if (accessOptions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (accessOptions));
 
 			return CheckAccessStatusAsync (accessOptions.Dictionary);

--- a/src/VideoSubscriberAccount/VSAccountMetadataRequest.cs
+++ b/src/VideoSubscriberAccount/VSAccountMetadataRequest.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if !__MACCATALYST__
 using System;
 using System.Threading.Tasks;
@@ -21,7 +23,10 @@ namespace VideoSubscriberAccount {
 				return VSAccountProviderAuthenticationSchemeExtensions.GetValues (SupportedAuthenticationSchemesString);
 			}
 			set {
-				SupportedAuthenticationSchemesString = value?.GetConstants ();
+				if (value.GetConstants () is not null)
+					SupportedAuthenticationSchemesString = value.GetConstants ()!;
+				else
+					throw new ArgumentNullException (nameof (value));
 			}
 		}
 	}

--- a/src/VideoSubscriberAccount/VSAccountMetadataRequest.cs
+++ b/src/VideoSubscriberAccount/VSAccountMetadataRequest.cs
@@ -26,7 +26,7 @@ namespace VideoSubscriberAccount {
 				if (value.GetConstants () is not null)
 					SupportedAuthenticationSchemesString = value.GetConstants ()!;
 				else
-					throw new ArgumentNullException (nameof (value));
+					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 			}
 		}
 	}

--- a/src/VideoSubscriberAccount/VSAccountMetadataRequest.cs
+++ b/src/VideoSubscriberAccount/VSAccountMetadataRequest.cs
@@ -23,10 +23,10 @@ namespace VideoSubscriberAccount {
 				return VSAccountProviderAuthenticationSchemeExtensions.GetValues (SupportedAuthenticationSchemesString);
 			}
 			set {
-				if (value.GetConstants () is not null)
-					SupportedAuthenticationSchemesString = value.GetConstants ()!;
-				else
+				var constants = value.GetConstants ();
+				if (constants is null)
 					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
+				SupportedAuthenticationSchemesString = constants!;
 			}
 		}
 	}

--- a/src/VideoSubscriberAccount/VSAccountProviderAuthenticationScheme.cs
+++ b/src/VideoSubscriberAccount/VSAccountProviderAuthenticationScheme.cs
@@ -14,7 +14,7 @@ namespace VideoSubscriberAccount {
 		public static NSString?[] GetConstants (this VSAccountProviderAuthenticationScheme[] self)
 		{
 			if (self == null)
-				throw new ArgumentNullException (nameof (self));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (self));
 			
 			var array = new NSString? [self.Length];
 			for (int n = 0; n < self.Length; n++)
@@ -25,7 +25,7 @@ namespace VideoSubscriberAccount {
 		public static VSAccountProviderAuthenticationScheme[] GetValues (NSString[] constants)
 		{
 			if (constants == null)
-				throw new ArgumentNullException (nameof (constants));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (constants));
 
 			var array = new VSAccountProviderAuthenticationScheme [constants.Length];
 			for (int n = 0; n < constants.Length; n++)

--- a/src/VideoSubscriberAccount/VSAccountProviderAuthenticationScheme.cs
+++ b/src/VideoSubscriberAccount/VSAccountProviderAuthenticationScheme.cs
@@ -13,7 +13,7 @@ namespace VideoSubscriberAccount {
 
 		public static NSString?[] GetConstants (this VSAccountProviderAuthenticationScheme[] self)
 		{
-			if (self == null)
+			if (self is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (self));
 			
 			var array = new NSString? [self.Length];
@@ -24,7 +24,7 @@ namespace VideoSubscriberAccount {
 
 		public static VSAccountProviderAuthenticationScheme[] GetValues (NSString[] constants)
 		{
-			if (constants == null)
+			if (constants is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (constants));
 
 			var array = new VSAccountProviderAuthenticationScheme [constants.Length];

--- a/src/VideoSubscriberAccount/VSAccountProviderAuthenticationScheme.cs
+++ b/src/VideoSubscriberAccount/VSAccountProviderAuthenticationScheme.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if !__MACCATALYST__
 using System;
 using System.Threading.Tasks;
@@ -9,12 +11,12 @@ namespace VideoSubscriberAccount {
 
 		// these are less common pattern so it's not automatically generated
 
-		public static NSString[] GetConstants (this VSAccountProviderAuthenticationScheme[] self)
+		public static NSString?[] GetConstants (this VSAccountProviderAuthenticationScheme[] self)
 		{
 			if (self == null)
 				throw new ArgumentNullException (nameof (self));
 			
-			var array = new NSString [self.Length];
+			var array = new NSString? [self.Length];
 			for (int n = 0; n < self.Length; n++)
 				array [n] = self [n].GetConstant ();
 			return array;


### PR DESCRIPTION
This PR aims to bring nullability changes to VideoSubscriberAccount.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`