### PR TITLE
[xcode13.3] Bump maccore to get fix for #14834.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 59583606121bcc15bad6580f3b0ee6ced8d0bdeb
+NEEDED_MACCORE_VERSION := b457f4bdee9138998a3e875bfbca6993f73a47ff
 NEEDED_MACCORE_BRANCH := xcode13.3
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@b457f4bdee [xcode13.3] [mlaunch] Redirect stdout and stderr through a pty when launching in the simulator. Fixes #14834.

Diff: https://github.com/xamarin/maccore/compare/59583606121bcc15bad6580f3b0ee6ced8d0bdeb..b457f4bdee9138998a3e875bfbca6993f73a47ff

Fixes https://github.com/xamarin/xamarin-macios/issues/14834.

Backport of #14946.