### PR TITLE
[d17-2] Bump maccore to get fix for xamarin/maccorexamarin/maccore#14834.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,8 +7,8 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := cf9f7409e9a79d0d0835863cc9f5afe77ba5e74a
-NEEDED_MACCORE_BRANCH := main
+NEEDED_MACCORE_VERSION := 29a1c1382e005e568b57d1b45e3877c8081dfc8b
+NEEDED_MACCORE_BRANCH := d17-2
 
 MACCORE_DIRECTORY := maccore
 MACCORE_MODULE    := git@github.com:xamarin/maccore.git


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@29a1c1382e [mlaunch] Redirect stdout and stderr through a pty when launching in the simulator. Fixes #xamarin/xamarin-macios@14834.
* xamarin/maccore@749e84cb16 [mlaunch] Make minor improvements to Main.cs

Diff: https://github.com/xamarin/maccore/compare/cf9f7409e9a79d0d0835863cc9f5afe77ba5e74a..29a1c1382e005e568b57d1b45e3877c8081dfc8b