### PR TITLE
[release/6.0.3xx] Bump maccore to get fix for #14834.

### DIFF
--- a/Make.versions
+++ b/Make.versions
@@ -66,11 +66,11 @@ MAC_PACKAGE_VERSION=8.11.0.$(MAC_COMMIT_DISTANCE)
 # WARNING: Do **not** use versions higher than the available Xcode SDK or else we will have issues with mtouch (See https://github.com/xamarin/xamarin-macios/issues/7705)
 # When bumping the major macOS version in MACOS_NUGET_VERSION also update the macOS version where we execute on bots in jenkins/Jenkinsfile (in the 'node' element)
 
-IOS_NUGET_VERSION=15.4.302
-TVOS_NUGET_VERSION=15.4.302
-WATCHOS_NUGET_VERSION=8.5.302
-MACOS_NUGET_VERSION=12.3.302
-MACCATALYST_NUGET_VERSION=15.4.302
+IOS_NUGET_VERSION=15.4.303
+TVOS_NUGET_VERSION=15.4.303
+WATCHOS_NUGET_VERSION=8.5.303
+MACOS_NUGET_VERSION=12.3.303
+MACCATALYST_NUGET_VERSION=15.4.303
 
 
 # Defines the default platform version if it's not specified in the TFM. The default should not change for a given .NET version:

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := cf9f7409e9a79d0d0835863cc9f5afe77ba5e74a
+NEEDED_MACCORE_VERSION := 29a1c1382e005e568b57d1b45e3877c8081dfc8b
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@29a1c1382e [mlaunch] Redirect stdout and stderr through a pty when launching in the simulator. Fixes #14834.
* xamarin/maccore@749e84cb16 [mlaunch] Make minor improvements to Main.cs

Diff: https://github.com/xamarin/maccore/compare/cf9f7409e9a79d0d0835863cc9f5afe77ba5e74a..29a1c1382e005e568b57d1b45e3877c8081dfc8b

Fixes https://github.com/xamarin/xamarin-macios/issues/14834.

Backport of #14946.