### PR TITLE
[devops] Compute better base for comparing API diff.

### DIFF
--- a/tools/devops/automation/scripts/bash/compare.sh
+++ b/tools/devops/automation/scripts/bash/compare.sh
@@ -56,10 +56,12 @@ report_error ()
 }
 trap report_error ERR
 
-if test -z "$PR_ID"; then
-	BASE=HEAD
-else
-	BASE="origin/pr/$PR_ID/merge"
+if test -z "$BASE"; then
+	if test -z "$PR_ID"; then
+		BASE=HEAD^1
+	else
+		BASE="origin/pr/$PR_ID/merge^1"
+	fi
 fi
 
 if ! git rev-parse "$BASE" >/dev/null 2>&1; then
@@ -69,7 +71,7 @@ if ! git rev-parse "$BASE" >/dev/null 2>&1; then
 	exit 0
 fi
 
-./tools/compare-commits.sh --base="$BASE^1" "--failure-file=$COMPARE_FAILURE_FILE"
+./tools/compare-commits.sh --base="$BASE" "--failure-file=$COMPARE_FAILURE_FILE"
 
 mkdir -p "$API_COMPARISON"
 

--- a/tools/devops/automation/scripts/bash/vsts-compare.sh
+++ b/tools/devops/automation/scripts/bash/vsts-compare.sh
@@ -7,8 +7,15 @@ cd $XAM_TOP
 
 if [[ $PR_ID ]]; then
     git fetch --no-tags --progress https://github.com/xamarin/xamarin-macios +refs/pull/$PR_ID/*:refs/remotes/origin/pr/$PR_ID/*
-fi
 
+    # Compute the correct base hash to use for comparison by getting the merge base between the target branch and the commit we're building.
+    if MERGE_BASE=$(git merge-base "$SYSTEM_PULLREQUEST_SOURCECOMMITID" "refs/remotes/origin/$SYSTEM_PULLREQUEST_TARGETBRANCH"); then
+        if test -n "$MERGE_BASE"; then
+            echo "Computed merge base: $MERGE_BASE"
+            export BASE=$MERGE_BASE
+        fi
+    fi
+fi
 
 if ! ./tools/devops/automation/scripts/bash/compare.sh; then
     set +x


### PR DESCRIPTION
Previously we'd compare the tip of the PR branch with the commit before merge commit into the target branch created by GitHub.

This doesn't work in the following scenario:

   main  gh  pr

      |  G1 |          (merge commit created by GitHub)
      | / \ |
      |/   \|
      M2    |
      |     P2
      |    /|
      |   / |
      |  /  |
      | /   |
      |/    |
      M1    |
      |     |
      |     P1
      |    /
      |   /
      |  /
      | /
      |/

We'd end up comparing P2 with M2, which is not what we want, because M2 could
have API changes that would show up as missing in P2.

It's actually even worse than that, because we could be in the following
scenario:

      |  G2 |          (merge commit created by GitHub when api diff started)
      | / \ |
      |/   \|
      M3    |
      |     P3
      |     |
      |  G1 |          (merge commit created by GitHub when build started)
      | / \ |
      |/   \|
      M2    |
      |     P2
      |    /|
      |   / |
      |  /  |
      | /   |
      |/    |
      M1    |
      |     |
      |     P1
      |    /
      |   /
      |  /
      | /
      |/

And we still want to P2 with M2, but we'd compare P2 with M3.

We want to compare P2 with M1 instead. This is done by asking git for the
merge-base between P2 and M2.