### PR TITLE
[apidiff] Switch to getting mono-api-[info|html] from rolfbjarne/api-tools.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,7 @@
     path = external/MonoTouch.Dialog
     url = ../../migueldeicaza/MonoTouch.Dialog
     branch = dotnet
+[submodule "api-tools"]
+	path = external/api-tools
+	url = ../../rolfbjarne/api-tools
+	branch = main

--- a/Make.config
+++ b/Make.config
@@ -459,6 +459,7 @@ MACCORE_PATH=$(TOP)/../maccore
 MACIOS_BINARIES_PATH=$(TOP)/external/macios-binaries
 IKVM_PATH=$(TOP)/external/ikvm-fork
 MONOTOUCH_DIALOG_PATH=$(TOP)/external/MonoTouch.Dialog
+API_TOOLS_PATH=$(TOP)/external/api-tools
 
 MONO_PREFIX ?= /Library/Frameworks/Mono.framework/Versions/Current
 SYSTEM_MCS=$(MONO_PREFIX)/bin/mcs

--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -70,6 +70,7 @@ $(eval $(call CheckSubmoduleTemplate,Xamarin.MacDev,XAMARIN_MACDEV))
 $(eval $(call CheckSubmoduleTemplate,macios-binaries,MACIOS_BINARIES))
 $(eval $(call CheckSubmoduleTemplate,ikvm-fork,IKVM))
 $(eval $(call CheckSubmoduleTemplate,MonoTouch.Dialog,MONOTOUCH_DIALOG))
+$(eval $(call CheckSubmoduleTemplate,api-tools,API_TOOLS))
 
 include $(TOP)/mk/xamarin.mk
 

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -12,12 +12,12 @@ endif
 
 APIDIFF_DIR=.
 
-MONO_API_INFO = $(MONO_IOS_SDK_DESTDIR)/ios-bcl/monotouch_tools/mono-api-info.exe
-MONO_API_HTML = $(MONO_IOS_SDK_DESTDIR)/ios-bcl/monotouch_tools/mono-api-html.exe
+MONO_API_INFO = $(API_TOOLS_PATH)/mono-api-info/bin/Debug/net6.0/mono-api-info.dll
+MONO_API_HTML = $(API_TOOLS_PATH)/mono-api-html/bin/Debug/net6.0/mono-api-html.dll
 MONO_BUILD = $(SYSTEM_MONO)
 
-MONO_API_INFO_EXEC = $(MONO_BUILD) --debug $(MONO_API_INFO) --ignore-inherited-interfaces
-MONO_API_HTML_EXEC = $(MONO_BUILD) --debug $(MONO_API_HTML)
+MONO_API_INFO_EXEC = $(SYSTEM_DOTNET) $(MONO_API_INFO) --ignore-inherited-interfaces
+MONO_API_HTML_EXEC = $(SYSTEM_DOTNET) $(MONO_API_HTML)
 
 # I18N are excluded - but otherwise if should be like ../../builds/Makefile + what XI adds
 # in the order to the api-diff.html merged file
@@ -53,12 +53,13 @@ MAC_ARCH_ASSEMBLIES =                       native-64/Xamarin.Mac
 
 APIDIFF_IGNORE = -i 'INSObjectProtocol'
 
-$(APIDIFF_DIR)/.download-$(MONO_HASH).stamp:
-	$(MAKE) -C $(TOP)/builds download
-	$(Q) mkdir -p $(dir $@)
+$(MONO_API_INFO): $(wildcard $(API_TOOLS_PATH)/mono-api-info/*.cs*)
+	$(Q) $(SYSTEM_DOTNET) build $(API_TOOLS_PATH)/mono-api-info/mono-api-info.csproj /bl:$@.binlog $(MSBUILD_VERBOSITY)
 	$(Q) touch $@
 
-$(MONO_API_INFO) $(MONO_API_HTML): $(APIDIFF_DIR)/.download-$(MONO_HASH).stamp
+$(MONO_API_HTML): $(wildcard $(API_TOOLS_PATH)/mono-api-html/*.cs*)
+	$(Q) $(SYSTEM_DOTNET) build $(API_TOOLS_PATH)/mono-api-html/mono-api-html.csproj /bl:$@.binlog $(MSBUILD_VERBOSITY)
+	$(Q) touch $@
 
 # create api info. Directory hierarchy is based on installed hierarchy
 # (XM goes into temp/xm, and XI goes into temp/xi)


### PR DESCRIPTION
Switch to getting mono-api-[info|html] from a newly created repository we
control and where we can easily fix issues, since mono/mono isn't getting many
fixes anymore. In the past I know I've been reluctant to look at these tools,
just because of the hassle of setting things up to debug, and then the
paperwork to get the fixes in mono/mono, and then backported to the branch
where we need them.

This repo has a few other benefits:

* The tools are built using normal projects, which means they're easy to debug
  in an IDE (mono/mono's code has generated project files, which used in-tree versions
  of the BCL, and it got quite complex quite fast).
* One fewer dependency on the mono archive, so we're getting closed to be able
  to drop it completely when we drop support for legacy Xamarin.
* #13669 is already fixed there.
* It contains a few other misc fixes.

Fixes https://github.com/xamarin/xamarin-macios/issues/13669.