### PR TITLE
[ituneslibrary] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/iTunesLibrary/ITCompat.cs
+++ b/src/iTunesLibrary/ITCompat.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 namespace iTunesLibrary


### PR DESCRIPTION
This PR aims to bring nullability changes to iTunesLibrary.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding nullable enable to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes