### PR TITLE
[watchkit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/WatchKit/WKAccessibility.cs
+++ b/src/WatchKit/WKAccessibility.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using Foundation;

--- a/src/WatchKit/WKInterfaceController.cs
+++ b/src/WatchKit/WKInterfaceController.cs
@@ -1,5 +1,7 @@
 // Copyright 2014-2015 Xamarin Inc. All rights reserved.
 
+#nullable enable
+
 #if WATCH
 
 using System;
@@ -16,20 +18,20 @@ namespace WatchKit {
 		public void PushController (string name, string context)
 		{
 			using (var ns = context == null ? null : new NSString (context)) {
-				PushController (name, (NSObject) ns);
+				PushController (name, (NSObject?) ns);
 			}
 		}
 
 		public void PresentController (string name, string context)
 		{
 			using (var ns = context == null ? null : new NSString (context)) {
-				PresentController (name, (NSObject) ns);
+				PresentController (name, (NSObject?) ns);
 			}
 		}
 
 		public void PresentController (string [] names, string [] contexts)
 		{
-			NSObject[] array = null;
+			NSObject[]? array = null;
 			try {
 				if (contexts != null) {
 					array = new NSObject [contexts.Length];

--- a/src/WatchKit/WKInterfaceController.cs
+++ b/src/WatchKit/WKInterfaceController.cs
@@ -59,7 +59,7 @@ namespace WatchKit {
 		{
 			var del = action as Delegate;
 			if (del == null)
-				throw new ArgumentNullException ("action");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (action));
 			var met = del.Method;
 			// <quote>The method must be defined on the current interface controller object.</quote>
 			if (met.DeclaringType != GetType ())

--- a/src/WatchKit/WKInterfaceController.cs
+++ b/src/WatchKit/WKInterfaceController.cs
@@ -17,14 +17,14 @@ namespace WatchKit {
 
 		public void PushController (string name, string context)
 		{
-			using (var ns = context == null ? null : new NSString (context)) {
+			using (var ns = context is null ? null : new NSString (context)) {
 				PushController (name, (NSObject?) ns);
 			}
 		}
 
 		public void PresentController (string name, string context)
 		{
-			using (var ns = context == null ? null : new NSString (context)) {
+			using (var ns = context is null ? null : new NSString (context)) {
 				PresentController (name, (NSObject?) ns);
 			}
 		}
@@ -33,7 +33,7 @@ namespace WatchKit {
 		{
 			NSObject[]? array = null;
 			try {
-				if (contexts != null) {
+				if (contexts is not null) {
 					array = new NSObject [contexts.Length];
 					for (int i = 0; i < array.Length; i++)
 						array [i] = new NSString (contexts [i]);
@@ -41,7 +41,7 @@ namespace WatchKit {
 				PresentController (names, array);
 			}
 			finally {
-				if (array != null) {
+				if (array is not null) {
 					foreach (var ns in array)
 						ns.Dispose ();
 				}
@@ -58,7 +58,7 @@ namespace WatchKit {
 		MethodInfo GetMethodInfo (Action action)
 		{
 			var del = action as Delegate;
-			if (del == null)
+			if (del is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (action));
 			var met = del.Method;
 			// <quote>The method must be defined on the current interface controller object.</quote>

--- a/src/WatchKit/WKInterfaceDevice.cs
+++ b/src/WatchKit/WKInterfaceDevice.cs
@@ -1,5 +1,7 @@
 // Copyright 2015 Xamarin Inc. All rights reserved.
 
+#nullable enable
+
 #if WATCH
 
 using System;

--- a/src/WatchKit/iOS/WKAccessibility.cs
+++ b/src/WatchKit/iOS/WKAccessibility.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKAccessibilityImageRegion.cs
+++ b/src/WatchKit/iOS/WKAccessibilityImageRegion.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKErrorCode.cs
+++ b/src/WatchKit/iOS/WKErrorCode.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKImageAnimatable.cs
+++ b/src/WatchKit/iOS/WKImageAnimatable.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceButton.cs
+++ b/src/WatchKit/iOS/WKInterfaceButton.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceController.cs
+++ b/src/WatchKit/iOS/WKInterfaceController.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceDate.cs
+++ b/src/WatchKit/iOS/WKInterfaceDate.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceDevice.cs
+++ b/src/WatchKit/iOS/WKInterfaceDevice.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.Collections.Generic;

--- a/src/WatchKit/iOS/WKInterfaceGroup.cs
+++ b/src/WatchKit/iOS/WKInterfaceGroup.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceImage.cs
+++ b/src/WatchKit/iOS/WKInterfaceImage.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceLabel.cs
+++ b/src/WatchKit/iOS/WKInterfaceLabel.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceMap.cs
+++ b/src/WatchKit/iOS/WKInterfaceMap.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceMapPinColor.cs
+++ b/src/WatchKit/iOS/WKInterfaceMapPinColor.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceObject.cs
+++ b/src/WatchKit/iOS/WKInterfaceObject.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceSeparator.cs
+++ b/src/WatchKit/iOS/WKInterfaceSeparator.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceSlider.cs
+++ b/src/WatchKit/iOS/WKInterfaceSlider.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceSwitch.cs
+++ b/src/WatchKit/iOS/WKInterfaceSwitch.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceTable.cs
+++ b/src/WatchKit/iOS/WKInterfaceTable.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKInterfaceTimer.cs
+++ b/src/WatchKit/iOS/WKInterfaceTimer.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKMenuItemIcon.cs
+++ b/src/WatchKit/iOS/WKMenuItemIcon.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKTextInputMode.cs
+++ b/src/WatchKit/iOS/WKTextInputMode.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;

--- a/src/WatchKit/iOS/WKUserNotificationInterfaceController.cs
+++ b/src/WatchKit/iOS/WKUserNotificationInterfaceController.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;
@@ -45,7 +47,7 @@ namespace WatchKit {
 			throw new PlatformNotSupportedException (Constants.WatchKitRemoved);
 		}
 
-		public virtual void DismissController ()
+		public new virtual void DismissController ()
 		{
 			throw new PlatformNotSupportedException (Constants.WatchKitRemoved);
 		}

--- a/src/WatchKit/iOS/WKUserNotificationInterfaceType.cs
+++ b/src/WatchKit/iOS/WKUserNotificationInterfaceType.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if __IOS__ && !NET
 using System;
 using System.ComponentModel;


### PR DESCRIPTION
This PR aims to bring nullability changes to WatchKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`