### PR TITLE
[coretext] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/CoreText/Adapter.cs
+++ b/src/CoreText/Adapter.cs
@@ -67,7 +67,7 @@ namespace CoreText {
 		public static int? GetInt32Value (IDictionary<NSObject, NSObject> dictionary, NSObject key)
 		{
 			var value = dictionary [key];
-			if (value == null)
+			if (value is null)
 				return null;
 			return ((NSNumber) value).Int32Value;
 		}
@@ -75,7 +75,7 @@ namespace CoreText {
 		public static nuint? GetUnsignedIntegerValue (IDictionary<NSObject, NSObject> dictionary, NSObject key)
 		{
 			var value = dictionary [key];
-			if (value == null)
+			if (value is null)
 				return null;
 			return ((NSNumber) value).NUIntValue;
 		}
@@ -91,7 +91,7 @@ namespace CoreText {
 		public static float? GetSingleValue (IDictionary<NSObject, NSObject> dictionary, NSObject key)
 		{
 			var value = dictionary [key];
-			if (value == null)
+			if (value is null)
 				return null;
 			return ((NSNumber) value).FloatValue;
 		}
@@ -99,7 +99,7 @@ namespace CoreText {
 		public static string[] GetStringArray (IDictionary<NSObject, NSObject> dictionary, NSObject key)
 		{
 			var value = dictionary [key];
-			if (value == null)
+			if (value is null)
 				return Array.Empty<string> ();
 			return CFArray.StringArrayFromHandle (value.Handle)!;
 		}
@@ -107,7 +107,7 @@ namespace CoreText {
 		public static string? GetStringValue (IDictionary<NSObject, NSObject> dictionary, NSObject key)
 		{
 			var value = dictionary [key];
-			if (value == null)
+			if (value is null)
 				return null;
 			return ((NSString) value).ToString ();
 		}
@@ -115,7 +115,7 @@ namespace CoreText {
 		public static uint? GetUInt32Value (IDictionary<NSObject, NSObject> dictionary, NSObject key)
 		{
 			var value = dictionary [key];
-			if (value == null)
+			if (value is null)
 				return null;
 			return ((NSNumber) value).UInt32Value;
 		}
@@ -123,7 +123,7 @@ namespace CoreText {
 		public static bool? GetBoolValue (NSDictionary dictionary, NSObject key)
 		{
 			var value = dictionary [key];
-			if (value == null)
+			if (value is null)
 				return null;
 			return ((NSNumber) value).BoolValue;
 		}
@@ -171,7 +171,7 @@ namespace CoreText {
 		public static void SetValue (IDictionary<NSObject, NSObject> dictionary, NSObject key, IEnumerable<string> value)
 		{
 			List<string> v;
-			if (value == null || (v = new List<string>(value)).Count == 0)
+			if (value is null || (v = new List<string>(value)).Count == 0)
 				SetValue (dictionary, key, (NSObject?) null);
 			else
 				using (var array = NSArray.FromStrings (v.ToArray ()))
@@ -180,7 +180,7 @@ namespace CoreText {
 
 		public static void SetValue (IDictionary<NSObject, NSObject> dictionary, NSObject key, NSObject? value)
 		{
-			if (value != null)
+			if (value is not null)
 				dictionary [key] = value;
 			else
 				dictionary.Remove (key);
@@ -188,7 +188,7 @@ namespace CoreText {
 
 		public static void SetValue (IDictionary<NSObject, NSObject> dictionary, NSObject key, string? value)
 		{
-			if (value == null)
+			if (value is null)
 				SetValue (dictionary, key, (NSObject?) null);
 			else
 				using (var s = new NSString (value))
@@ -199,7 +199,7 @@ namespace CoreText {
 			where T : INativeObject
 		{
 			List<NativeHandle> v;
-			if (value == null || (v = GetHandles (value)).Count == 0) 
+			if (value is null || (v = GetHandles (value)).Count == 0) 
 				SetNativeValue (dictionary, key, (INativeObject?) null);
 			else 
 				using (var array = CFArray.FromIntPtrs (v.ToArray ()))
@@ -217,7 +217,7 @@ namespace CoreText {
 
 		public static void SetNativeValue (NSDictionary dictionary, NSObject key, INativeObject? value)
 		{
-			if (value != null) {
+			if (value is not null) {
 				AssertWritable (dictionary);
 				CFMutableDictionary.SetValue (dictionary.Handle, key.Handle, value.Handle);
 			}

--- a/src/CoreText/Adapter.cs
+++ b/src/CoreText/Adapter.cs
@@ -27,6 +27,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 
@@ -99,10 +101,10 @@ namespace CoreText {
 			var value = dictionary [key];
 			if (value == null)
 				return Array.Empty<string> ();
-			return CFArray.StringArrayFromHandle (value.Handle);
+			return CFArray.StringArrayFromHandle (value.Handle)!;
 		}
 
-		public static string GetStringValue (IDictionary<NSObject, NSObject> dictionary, NSObject key)
+		public static string? GetStringValue (IDictionary<NSObject, NSObject> dictionary, NSObject key)
 		{
 			var value = dictionary [key];
 			if (value == null)
@@ -170,13 +172,13 @@ namespace CoreText {
 		{
 			List<string> v;
 			if (value == null || (v = new List<string>(value)).Count == 0)
-				SetValue (dictionary, key, (NSObject) null);
+				SetValue (dictionary, key, (NSObject?) null);
 			else
 				using (var array = NSArray.FromStrings (v.ToArray ()))
 					SetValue (dictionary, key, array);
 		}
 
-		public static void SetValue (IDictionary<NSObject, NSObject> dictionary, NSObject key, NSObject value)
+		public static void SetValue (IDictionary<NSObject, NSObject> dictionary, NSObject key, NSObject? value)
 		{
 			if (value != null)
 				dictionary [key] = value;
@@ -184,10 +186,10 @@ namespace CoreText {
 				dictionary.Remove (key);
 		}
 
-		public static void SetValue (IDictionary<NSObject, NSObject> dictionary, NSObject key, string value)
+		public static void SetValue (IDictionary<NSObject, NSObject> dictionary, NSObject key, string? value)
 		{
 			if (value == null)
-				SetValue (dictionary, key, (NSObject) null);
+				SetValue (dictionary, key, (NSObject?) null);
 			else
 				using (var s = new NSString (value))
 					SetValue (dictionary, key, (NSObject) s);
@@ -198,7 +200,7 @@ namespace CoreText {
 		{
 			List<NativeHandle> v;
 			if (value == null || (v = GetHandles (value)).Count == 0) 
-				SetNativeValue (dictionary, key, (INativeObject) null);
+				SetNativeValue (dictionary, key, (INativeObject?) null);
 			else 
 				using (var array = CFArray.FromIntPtrs (v.ToArray ()))
 					SetNativeValue (dictionary, key, array);
@@ -213,7 +215,7 @@ namespace CoreText {
 			return v;
 		}
 
-		public static void SetNativeValue (NSDictionary dictionary, NSObject key, INativeObject value)
+		public static void SetNativeValue (NSDictionary dictionary, NSObject key, INativeObject? value)
 		{
 			if (value != null) {
 				AssertWritable (dictionary);

--- a/src/CoreText/CTBaselineClass.cs
+++ b/src/CoreText/CTBaselineClass.cs
@@ -25,6 +25,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 
 using ObjCRuntime;
@@ -54,12 +57,12 @@ namespace CoreText {
 		static CTBaselineClassID ()
 		{
 			var handle = Libraries.CoreText.Handle;
-			Roman = Dlfcn.GetStringConstant (handle, "kCTBaselineClassRoman");
-			IdeographicCentered = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicCentered");
-			IdeographicLow = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicLow");
-			IdeographicHigh = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicHigh");
-			Hanging = Dlfcn.GetStringConstant (handle, "kCTBaselineClassHanging");
-			Math = Dlfcn.GetStringConstant (handle, "kCTBaselineClassMath");
+			Roman = Dlfcn.GetStringConstant (handle, "kCTBaselineClassRoman")!;
+			IdeographicCentered = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicCentered")!;
+			IdeographicLow = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicLow")!;
+			IdeographicHigh = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicHigh")!;
+			Hanging = Dlfcn.GetStringConstant (handle, "kCTBaselineClassHanging")!;
+			Math = Dlfcn.GetStringConstant (handle, "kCTBaselineClassMath")!;
 		}
 #endif
 
@@ -104,8 +107,8 @@ namespace CoreText {
 		static CTBaselineFontID ()
 		{
 			var handle = Libraries.CoreText.Handle;
-			Reference = Dlfcn.GetStringConstant (handle, "kCTBaselineReferenceFont");
-			Original = Dlfcn.GetStringConstant (handle, "kCTBaselineOriginalFont");
+			Reference = Dlfcn.GetStringConstant (handle, "kCTBaselineReferenceFont")!;
+			Original = Dlfcn.GetStringConstant (handle, "kCTBaselineOriginalFont")!;
 		}
 #endif // !NET
 

--- a/src/CoreText/CTFont.Generator.cs
+++ b/src/CoreText/CTFont.Generator.cs
@@ -25,6 +25,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using CoreFoundation;
 
 namespace CoreText {

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -251,7 +251,7 @@ namespace CoreText {
 		public CTFontFeatures (NSDictionary dictionary)
 		{
 			if (dictionary is null)
-				throw new ArgumentNullException (nameof (dictionary));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 
@@ -313,7 +313,7 @@ namespace CoreText {
 		public CTFontFeatureSelectors (NSDictionary dictionary)
 		{
 			if (dictionary is null)
-				throw new ArgumentNullException (nameof (dictionary));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 
@@ -1680,7 +1680,7 @@ namespace CoreText {
 		internal CTFontFeatureSettings (NSDictionary dictionary)
 		{
 			if (dictionary is null)
-				throw new ArgumentNullException (nameof (dictionary));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 
@@ -1715,7 +1715,7 @@ namespace CoreText {
 		public CTFontVariationAxes (NSDictionary dictionary)
 		{
 			if (dictionary is null)
-				throw new ArgumentNullException (nameof (dictionary));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 
@@ -1779,7 +1779,7 @@ namespace CoreText {
 		public CTFontVariation (NSDictionary dictionary)
 		{
 			if (dictionary is null)
-				throw new ArgumentNullException (nameof (dictionary));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 
@@ -1842,7 +1842,7 @@ namespace CoreText {
 		static IntPtr Create (CTFontDescriptor descriptor, nfloat size)
 		{
 			if (descriptor is null)
-				throw new ArgumentNullException (nameof (descriptor));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptor));
 			var handle = CTFontCreateWithFontDescriptor (descriptor.Handle, size, IntPtr.Zero);
 			if (handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (typeof (CTFont));
@@ -1860,7 +1860,7 @@ namespace CoreText {
 		static IntPtr Create (CTFontDescriptor descriptor, nfloat size, ref CGAffineTransform matrix)
 		{
 			if (descriptor is null)
-				throw new ArgumentNullException (nameof (descriptor));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptor));
 			var handle = CTFontCreateWithFontDescriptor (descriptor.Handle, size, ref matrix);
 			if (handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (typeof (CTFont));
@@ -1886,7 +1886,7 @@ namespace CoreText {
 		static IntPtr Create (string name, nfloat size, CTFontOptions options)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 			var n = CFString.CreateNative (name);
 			try {
 				var handle = CTFontCreateWithNameAndOptions (n, size, IntPtr.Zero, (nuint) (ulong) options);
@@ -1925,7 +1925,7 @@ namespace CoreText {
 		static IntPtr Create (string name, nfloat size, ref CGAffineTransform matrix, CTFontOptions options)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 			var n = CFString.CreateNative (name);
 			try {
 				var handle = CTFontCreateWithNameAndOptions (n, size, ref matrix, (nuint) (ulong) options);
@@ -1964,7 +1964,7 @@ namespace CoreText {
 		static IntPtr Create (CTFontDescriptor descriptor, nfloat size, CTFontOptions options)
 		{
 			if (descriptor is null)
-				throw new ArgumentNullException (nameof (descriptor));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptor));
 			var handle = CTFontCreateWithFontDescriptorAndOptions (descriptor.Handle, size, IntPtr.Zero, (nuint) (ulong) options);
 			if (handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (typeof (CTFont));
@@ -1998,7 +1998,7 @@ namespace CoreText {
 		static IntPtr Create (CTFontDescriptor descriptor, nfloat size, CTFontOptions options, ref CGAffineTransform matrix)
 		{
 			if (descriptor is null)
-				throw new ArgumentNullException (nameof (descriptor));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptor));
 			var handle = CTFontCreateWithFontDescriptorAndOptions (descriptor.Handle, size, ref matrix, (nuint) (ulong) options);
 			if (handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (typeof (CTFont));
@@ -2027,7 +2027,7 @@ namespace CoreText {
 		static IntPtr Create (CGFont font, nfloat size, CGAffineTransform transform, CTFontDescriptor descriptor)
 		{
 			if (font is null)
-				throw new ArgumentNullException (nameof (font));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (font));
 			var handle = CTFontCreateWithGraphicsFont (font.Handle, size, ref transform, descriptor.GetHandle ());
 			if (handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (typeof (CTFont));
@@ -2045,7 +2045,7 @@ namespace CoreText {
 		static IntPtr Create (CGFont font, nfloat size, CTFontDescriptor descriptor)
 		{
 			if (font is null)
-				throw new ArgumentNullException (nameof (font));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (font));
 			var handle = CTFontCreateWithGraphicsFont2 (font.Handle, size, IntPtr.Zero, descriptor.GetHandle ());
 			if (handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (typeof (CTFont));
@@ -2060,7 +2060,7 @@ namespace CoreText {
 		static IntPtr Create (CGFont font, nfloat size, CGAffineTransform transform)
 		{
 			if (font is null)
-				throw new ArgumentNullException (nameof (font));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (font));
 			var handle = CTFontCreateWithGraphicsFont (font.Handle, size, ref transform, IntPtr.Zero);
 			if (handle == IntPtr.Zero)
 				throw ConstructorError.Unknown (typeof (CTFont));
@@ -2098,7 +2098,7 @@ namespace CoreText {
 		public CTFont? WithAttributes (nfloat size, CTFontDescriptor attributes)
 		{
 			if (attributes is null)
-				throw new ArgumentNullException (nameof (attributes));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (attributes));
 			return CreateFont (CTFontCreateCopyWithAttributes (Handle, size, IntPtr.Zero, attributes.Handle));
 		}
 
@@ -2137,7 +2137,7 @@ namespace CoreText {
 		public CTFont? WithFamily (nfloat size, string family)
 		{
 			if (family is null)
-				throw new ArgumentNullException (nameof (family));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (family));
 			var n = CFString.CreateNative (family);
 			try {
 				return CreateFont (CTFontCreateCopyWithFamily (Handle, size, IntPtr.Zero, n));
@@ -2151,7 +2151,7 @@ namespace CoreText {
 		public CTFont? WithFamily (nfloat size, string family, ref CGAffineTransform matrix)
 		{
 			if (family is null)
-				throw new ArgumentNullException (nameof (family));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (family));
 			var n = CFString.CreateNative (family);
 			try {
 				return CreateFont (CTFontCreateCopyWithFamily (Handle, size, ref matrix, n));
@@ -2173,7 +2173,7 @@ namespace CoreText {
 		public CTFont? ForString (string value, NSRange range)
 		{
 			if (value is null)
-				throw new ArgumentNullException (nameof (value));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 			var n = CFString.CreateNative (value);
 			try {
 				return CreateFont (CTFontCreateForString (Handle, n, range));
@@ -2214,7 +2214,7 @@ namespace CoreText {
 		public CTFont? ForString (string value, NSRange range, string? language)
 		{
 			if (value is null)
-				throw new ArgumentNullException (nameof (value));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 
 			var v = CFString.CreateNative (value);
 			var l = CFString.CreateNative (language);
@@ -2248,7 +2248,7 @@ namespace CoreText {
 		public NSObject? GetAttribute (NSString attribute)
 		{
 			if (attribute is null)
-				throw new ArgumentNullException (nameof (attribute));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (attribute));
 			return Runtime.GetNSObject (CTFontCopyAttribute (Handle, attribute.Handle));
 		}
 
@@ -2429,7 +2429,7 @@ namespace CoreText {
 			if (canBeNull && array is null)
 				return;
 			if (array is null)
-				throw new ArgumentNullException (name);
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 			if (array.Length < count)
 				throw new ArgumentException (string.Format ("{0}.Length cannot be < count", name), name);
 		}
@@ -2517,7 +2517,7 @@ namespace CoreText {
 		public CGGlyph GetGlyphWithName (string glyphName)
 		{
 			if (glyphName is null)
-				throw new ArgumentNullException (nameof (glyphName));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (glyphName));
 			var nameHandle = CFString.CreateNative (glyphName);
 			try {
 				return CTFontGetGlyphWithName (Handle, nameHandle);
@@ -2552,7 +2552,7 @@ namespace CoreText {
 		public CGRect GetBoundingRects (CTFontOrientation orientation, CGGlyph[] glyphs)
 		{
 			if (glyphs is null)
-				throw new ArgumentNullException (nameof (glyphs));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (glyphs));
 			return GetBoundingRects (orientation, glyphs, null, glyphs.Length);
 		}
 
@@ -2570,7 +2570,7 @@ namespace CoreText {
 		public double GetAdvancesForGlyphs (CTFontOrientation orientation, CGGlyph[] glyphs)
 		{
 			if (glyphs is null)
-				throw new ArgumentNullException (nameof (glyphs));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (glyphs));
 			return GetAdvancesForGlyphs (orientation, glyphs, null, glyphs.Length);
 		}
 
@@ -2613,11 +2613,11 @@ namespace CoreText {
 		public void DrawGlyphs (CGContext context, CGGlyph [] glyphs, CGPoint [] positions)
 		{
 			if (context is null)
-				throw new ArgumentNullException (nameof (context));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (context));
 			if (glyphs is null)
-				throw new ArgumentNullException (nameof (glyphs));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (glyphs));
 			if (positions is null)
-				throw new ArgumentNullException (nameof (positions));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (positions));
 			int gl = glyphs.Length;
 			if (gl != positions.Length)
 				throw new ArgumentException ("array sizes fo context and glyphs differ");
@@ -2630,7 +2630,7 @@ namespace CoreText {
 		public nint GetLigatureCaretPositions (CGGlyph glyph, nfloat [] positions)
 		{
 			if (positions is null)
-				throw new ArgumentNullException (nameof (positions));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (positions));
 			return CTFontGetLigatureCaretPositions (Handle, glyph, positions, positions.Length);
 		}
 #endregion

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -257,7 +257,7 @@ namespace CoreText {
 
 		public NSDictionary Dictionary {get; private set;}
 
-		public string Name {
+		public string? Name {
 			get {return Adapter.GetStringValue (Dictionary, CTFontFeatureKey.Name);}
 			set {Adapter.SetValue (Dictionary, CTFontFeatureKey.Name, value);}
 		}
@@ -411,7 +411,7 @@ namespace CoreText {
 			}
 		}
 
-		public string Name {
+		public string? Name {
 			get {return Adapter.GetStringValue (Dictionary, CTFontFeatureSelectorKey.Name);}
 			set {Adapter.SetValue (Dictionary, CTFontFeatureSelectorKey.Name, value);}
 		}
@@ -1741,7 +1741,7 @@ namespace CoreText {
 			set {Adapter.SetValue (Dictionary, CTFontVariationAxisKey.DefaultValue, value);}
 		}
 
-		public string Name {
+		public string? Name {
 			get {return Adapter.GetStringValue (Dictionary, CTFontVariationAxisKey.Name);}
 			set {Adapter.SetValue (Dictionary, CTFontVariationAxisKey.Name, value);}
 		}

--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -76,7 +76,7 @@ namespace CoreText {
 		public CTFontCollectionOptions (NSDictionary dictionary)
 		{
 			if (dictionary is null)
-				throw new ArgumentNullException (nameof (dictionary));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 

--- a/src/CoreText/CTFontDescriptor.cs
+++ b/src/CoreText/CTFontDescriptor.cs
@@ -155,7 +155,7 @@ namespace CoreText {
 		public CTFontDescriptorAttributes (NSDictionary dictionary)
 		{
 			if (dictionary is null)
-				throw new ArgumentNullException (nameof (dictionary));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 
@@ -379,7 +379,7 @@ namespace CoreText {
 		static IntPtr Create (string name, nfloat size)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 			var nameHandle = CFString.CreateNative (name);
 			try {
 				return CTFontDescriptorCreateWithNameAndSize (nameHandle, size);
@@ -405,7 +405,7 @@ namespace CoreText {
 		public CTFontDescriptor? WithAttributes (NSDictionary attributes)
 		{
 			if (attributes is null)
-				throw new ArgumentNullException (nameof (attributes));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (attributes));
 			return CreateDescriptor (CTFontDescriptorCreateCopyWithAttributes (Handle, attributes.Handle));
 		}
 
@@ -419,7 +419,7 @@ namespace CoreText {
 		public CTFontDescriptor? WithAttributes (CTFontDescriptorAttributes attributes)
 		{
 			if (attributes == null)
-				throw new ArgumentNullException (nameof (attributes));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (attributes));
 			return CreateDescriptor (CTFontDescriptorCreateCopyWithAttributes (Handle, attributes.Dictionary.Handle));
 		}
 
@@ -688,7 +688,7 @@ namespace CoreText {
 		public NSObject? GetAttribute (NSString attribute)
 		{
 			if (attribute is null)
-				throw new ArgumentNullException (nameof (attribute));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (attribute));
 			return Runtime.GetNSObject<NSObject> (CTFontDescriptorCopyAttribute (Handle, attribute.Handle), true);
 		}
 

--- a/src/CoreText/CTFontDescriptor.cs
+++ b/src/CoreText/CTFontDescriptor.cs
@@ -217,7 +217,7 @@ namespace CoreText {
 		public unsafe CGAffineTransform? Matrix {
 			get {
 				var d = (NSData) Dictionary [CTFontDescriptorAttributeKey.Matrix];
-				if (d == null)
+				if (d is null)
 					return null;
 				return Marshal.PtrToStructure<CGAffineTransform> (d.Bytes);
 			}
@@ -418,7 +418,7 @@ namespace CoreText {
 
 		public CTFontDescriptor? WithAttributes (CTFontDescriptorAttributes attributes)
 		{
-			if (attributes == null)
+			if (attributes is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (attributes));
 			return CreateDescriptor (CTFontDescriptorCreateCopyWithAttributes (Handle, attributes.Dictionary.Handle));
 		}
@@ -734,7 +734,7 @@ namespace CoreText {
 			// FIXME: the P/Invoke used below is wrong, it expects a block, not a function pointer.
 			// throwing a NIE instead of crashing until this is implemented properly.
 			throw new NotImplementedException ();
-//			var ma = mandatoryAttributes == null ? IntPtr.Zero : mandatoryAttributes.Handle;
+//			var ma = mandatoryAttributes is null ? IntPtr.Zero : mandatoryAttributes.Handle;
 //			// FIXME: SIGSEGV probably due to mandatoryAttributes mismatch
 //			using (var ar = CFArray.FromNativeObjects (descriptors)) {
 //				return CTFontDescriptorMatchFontDescriptorsWithProgressHandler (ar.Handle, ma, progressHandler);

--- a/src/CoreText/CTFontDescriptor.cs
+++ b/src/CoreText/CTFontDescriptor.cs
@@ -166,22 +166,22 @@ namespace CoreText {
 			set {Adapter.SetValue (Dictionary, CTFontDescriptorAttributeKey.Url, value);}
 		}
 
-		public string Name {
+		public string? Name {
 			get {return Adapter.GetStringValue (Dictionary, CTFontDescriptorAttributeKey.Name);}
 			set {Adapter.SetValue (Dictionary, CTFontDescriptorAttributeKey.Name, value);}
 		}
 
-		public string DisplayName {
+		public string? DisplayName {
 			get {return Adapter.GetStringValue (Dictionary, CTFontDescriptorAttributeKey.DisplayName);}
 			set {Adapter.SetValue (Dictionary, CTFontDescriptorAttributeKey.DisplayName, value);}
 		}
 
-		public string FamilyName {
+		public string? FamilyName {
 			get {return Adapter.GetStringValue (Dictionary, CTFontDescriptorAttributeKey.FamilyName);}
 			set {Adapter.SetValue (Dictionary, CTFontDescriptorAttributeKey.FamilyName, value);}
 		}
 
-		public string StyleName {
+		public string? StyleName {
 			get {return Adapter.GetStringValue (Dictionary, CTFontDescriptorAttributeKey.StyleName);}
 			set {Adapter.SetValue (Dictionary, CTFontDescriptorAttributeKey.StyleName, value);}
 		}

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -116,7 +116,7 @@ namespace CoreText {
 		public static bool IsFontSupported (NSUrl url)
 		{
 			if (url == null)
-				throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 			return CTFontManagerIsSupportedFont (url.Handle);
 		}
 #elif !XAMCORE_3_0
@@ -134,7 +134,7 @@ namespace CoreText {
 		public static bool IsFontSupported (NSUrl url)
 		{
 			if (url == null)
-				throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 			return false;
 		}
 #endif
@@ -145,7 +145,7 @@ namespace CoreText {
 		public static NSError? RegisterFontsForUrl (NSUrl fontUrl, CTFontManagerScope scope)
 		{
 			if (fontUrl == null)
-				throw new ArgumentNullException ("fontUrl");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (fontUrl));
 			
 			IntPtr error = IntPtr.Zero;
 
@@ -163,7 +163,7 @@ namespace CoreText {
 		static NSArray EnsureNonNullArray (object [] items, string name)
 		{
 			if (items == null)
-				throw new ArgumentNullException (name);
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
 			foreach (var i in items)
 				if (i == null)
@@ -325,7 +325,7 @@ namespace CoreText {
 		public static NSError? UnregisterFontsForUrl (NSUrl fontUrl, CTFontManagerScope scope)
 		{
 			if (fontUrl == null)
-				throw new ArgumentNullException ("fontUrl");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (fontUrl));
 
 			IntPtr error = IntPtr.Zero;
 
@@ -472,7 +472,7 @@ namespace CoreText {
 		public static CTFontDescriptor[] GetFonts (NSUrl url)
 		{
 			if (url == null)
-				throw new ArgumentNullException ("url");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			var arrayPtr = CTFontManagerCreateFontDescriptorsFromURL (url.Handle);
 			if (arrayPtr == IntPtr.Zero)
@@ -494,7 +494,7 @@ namespace CoreText {
 		public static bool RegisterGraphicsFont (CGFont font, out NSError? error)
 		{
 			if (font == null)
-				throw new ArgumentNullException ("font");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (font));
 			IntPtr h = IntPtr.Zero;
 			bool ret;
 			try {
@@ -517,7 +517,7 @@ namespace CoreText {
 		public static bool UnregisterGraphicsFont (CGFont font, out NSError? error)
 		{
 			if (font == null)
-				throw new ArgumentNullException ("font");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (font));
 			IntPtr h = IntPtr.Zero;
 			bool ret;
 			try {
@@ -726,7 +726,7 @@ namespace CoreText {
 		public static CTFontDescriptor? CreateFontDescriptor (NSData data)
 		{
 			if (data == null)
-				throw new ArgumentNullException (nameof (data));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 
 			var p = CTFontManagerCreateFontDescriptorFromData (data.Handle);
 			if (p == IntPtr.Zero)
@@ -763,7 +763,7 @@ namespace CoreText {
 		public static CTFontDescriptor[]? CreateFontDescriptors (NSData data)
 		{
 			if (data == null)
-				throw new ArgumentNullException (nameof (data));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 
 			var p = CTFontManagerCreateFontDescriptorsFromData (data.Handle);
 			// Copy/Create rule - we must release the CFArrayRef
@@ -879,7 +879,7 @@ namespace CoreText {
 		public static void RequestFonts (CTFontDescriptor[] fontDescriptors, CTFontManagerRequestFontsHandler completionHandler)
 		{
 			if (completionHandler == null)
-				throw new ArgumentNullException (nameof (completionHandler));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (completionHandler));
 
 			using (var arr = EnsureNonNullArray (fontDescriptors, nameof (fontDescriptors))) {
 				BlockLiteral block_handler = new BlockLiteral ();

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -27,6 +27,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -139,7 +142,7 @@ namespace CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerRegisterFontsForURL (IntPtr fontUrl, CTFontManagerScope scope, ref IntPtr error);
-		public static NSError RegisterFontsForUrl (NSUrl fontUrl, CTFontManagerScope scope)
+		public static NSError? RegisterFontsForUrl (NSUrl fontUrl, CTFontManagerScope scope)
 		{
 			if (fontUrl == null)
 				throw new ArgumentNullException ("fontUrl");
@@ -169,7 +172,7 @@ namespace CoreText {
 			return NSArray.FromObjects (items);
 		}
 
-		static T[] ArrayFromHandle<T> (IntPtr handle, bool releaseAfterUse) where T : class, INativeObject
+		static T[]? ArrayFromHandle<T> (IntPtr handle, bool releaseAfterUse) where T : class, INativeObject
 		{
 			if (handle == IntPtr.Zero)
 				return null;
@@ -228,7 +231,7 @@ namespace CoreText {
 		[Deprecated (PlatformName.WatchOS, 6,0, message: "Use 'RegisterFonts' instead.")]
 		[Deprecated (PlatformName.TvOS, 13,0, message: "Use 'RegisterFonts' instead.")]
 #endif
-		public static NSError [] RegisterFontsForUrl (NSUrl [] fontUrls, CTFontManagerScope scope)
+		public static NSError []? RegisterFontsForUrl (NSUrl [] fontUrls, CTFontManagerScope scope)
 		{
 			using (var arr = EnsureNonNullArray (fontUrls, nameof (fontUrls))) {
 				IntPtr error_array = IntPtr.Zero;
@@ -319,7 +322,7 @@ namespace CoreText {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerUnregisterFontsForURL(IntPtr fotUrl, CTFontManagerScope scope, ref IntPtr error);
 
-		public static NSError UnregisterFontsForUrl (NSUrl fontUrl, CTFontManagerScope scope)
+		public static NSError? UnregisterFontsForUrl (NSUrl fontUrl, CTFontManagerScope scope)
 		{
 			if (fontUrl == null)
 				throw new ArgumentNullException ("fontUrl");
@@ -383,7 +386,7 @@ namespace CoreText {
 		[Deprecated (PlatformName.WatchOS, 6,0, message : "Use 'UnregisterFonts' instead.")]
 		[Deprecated (PlatformName.TvOS, 13,0, message : "Use 'UnregisterFonts' instead.")]
 #endif
-		public static NSError [] UnregisterFontsForUrl (NSUrl [] fontUrls, CTFontManagerScope scope)
+		public static NSError []? UnregisterFontsForUrl (NSUrl [] fontUrls, CTFontManagerScope scope)
 		{
 			IntPtr error_array = IntPtr.Zero;
 			using (var arr = EnsureNonNullArray (fontUrls, nameof (fontUrls))) {
@@ -488,7 +491,7 @@ namespace CoreText {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerRegisterGraphicsFont (IntPtr cgfont, out IntPtr error);
 
-		public static bool RegisterGraphicsFont (CGFont font, out NSError error)
+		public static bool RegisterGraphicsFont (CGFont font, out NSError? error)
 		{
 			if (font == null)
 				throw new ArgumentNullException ("font");
@@ -511,7 +514,7 @@ namespace CoreText {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontManagerUnregisterGraphicsFont (IntPtr cgfont, out IntPtr error);
 
-		public static bool UnregisterGraphicsFont (CGFont font, out NSError error)
+		public static bool UnregisterGraphicsFont (CGFont font, out NSError? error)
 		{
 			if (font == null)
 				throw new ArgumentNullException ("font");
@@ -535,13 +538,15 @@ namespace CoreText {
 		{
 			var handle = Libraries.CoreText.Handle;
 #if !XAMCORE_3_0
-			ErrorDomain  = Dlfcn.GetStringConstant (handle, "kCTFontManagerErrorDomain");
+			ErrorDomain  = Dlfcn.GetStringConstant (handle, "kCTFontManagerErrorDomain")!;
 #endif
-			ErrorFontUrlsKey  = Dlfcn.GetStringConstant (handle, "kCTFontManagerErrorFontURLsKey");
+#pragma warning disable CS0618 // Type or member is obsolete
+			ErrorFontUrlsKey  = Dlfcn.GetStringConstant (handle, "kCTFontManagerErrorFontURLsKey")!;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 #endif // !NET
 
-		static NSString _RegisteredFontsChangedNotification;
+		static NSString? _RegisteredFontsChangedNotification;
 
 #if NET
 		[SupportedOSPlatform ("ios7.0")]
@@ -551,7 +556,7 @@ namespace CoreText {
 #else
 		[iOS (7,0)]
 #endif
-		static NSString RegisteredFontsChangedNotification {
+		static NSString? RegisteredFontsChangedNotification {
 			get {
 				if (_RegisteredFontsChangedNotification == null)
 					_RegisteredFontsChangedNotification = Dlfcn.GetStringConstant (Libraries.CoreText.Handle, "kCTFontManagerRegisteredFontsChangedNotification");
@@ -706,7 +711,7 @@ namespace CoreText {
 		[NoTV]
 		[NoMac]
 #endif
-		public static CTFontDescriptor[] GetRegisteredFontDescriptors (CTFontManagerScope scope, bool enabled)
+		public static CTFontDescriptor[]? GetRegisteredFontDescriptors (CTFontManagerScope scope, bool enabled)
 		{
 			var p = CTFontManagerCopyRegisteredFontDescriptors (scope, enabled);
 			// Copy/Create rule - we must release the CFArrayRef
@@ -718,7 +723,7 @@ namespace CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern unsafe /* CTFontDescriptorRef _Nullable */ IntPtr CTFontManagerCreateFontDescriptorFromData (/* CFDataRef */ IntPtr data);
 
-		public static CTFontDescriptor CreateFontDescriptor (NSData data)
+		public static CTFontDescriptor? CreateFontDescriptor (NSData data)
 		{
 			if (data == null)
 				throw new ArgumentNullException (nameof (data));
@@ -755,7 +760,7 @@ namespace CoreText {
 		[Mac (10,15)]
 		[iOS (13,0)]
 #endif
-		public static CTFontDescriptor[] CreateFontDescriptors (NSData data)
+		public static CTFontDescriptor[]? CreateFontDescriptors (NSData data)
 		{
 			if (data == null)
 				throw new ArgumentNullException (nameof (data));

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -115,7 +115,7 @@ namespace CoreText {
 #endif
 		public static bool IsFontSupported (NSUrl url)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 			return CTFontManagerIsSupportedFont (url.Handle);
 		}
@@ -133,7 +133,7 @@ namespace CoreText {
 		[Obsolete ("API not available on iOS, it will always return false.")]
 		public static bool IsFontSupported (NSUrl url)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 			return false;
 		}
@@ -144,7 +144,7 @@ namespace CoreText {
 		static extern bool CTFontManagerRegisterFontsForURL (IntPtr fontUrl, CTFontManagerScope scope, ref IntPtr error);
 		public static NSError? RegisterFontsForUrl (NSUrl fontUrl, CTFontManagerScope scope)
 		{
-			if (fontUrl == null)
+			if (fontUrl is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (fontUrl));
 			
 			IntPtr error = IntPtr.Zero;
@@ -162,11 +162,11 @@ namespace CoreText {
 
 		static NSArray EnsureNonNullArray (object [] items, string name)
 		{
-			if (items == null)
+			if (items is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
 			foreach (var i in items)
-				if (i == null)
+				if (i is null)
 					throw new ArgumentException ("Array contains a null entry", name);
 
 			return NSArray.FromObjects (items);
@@ -261,7 +261,7 @@ namespace CoreText {
 		static unsafe bool TrampolineRegistrationHandler (IntPtr block, /* NSArray */ IntPtr errors, bool done)
 		{
 			var del = BlockLiteral.GetTarget<CTFontRegistrationHandler> (block);
-			return del != null ? del (NSArray.ArrayFromHandle<NSError> (errors), done) : true;
+			return del is not null ? del (NSArray.ArrayFromHandle<NSError> (errors), done) : true;
 		}
 
 #if NET
@@ -307,7 +307,7 @@ namespace CoreText {
 		public static void RegisterFonts (NSUrl [] fontUrls, CTFontManagerScope scope, bool enabled, CTFontRegistrationHandler registrationHandler)
 		{
 			using (var arr = EnsureNonNullArray (fontUrls, nameof (fontUrls))) {
-				if (registrationHandler == null) {
+				if (registrationHandler is null) {
 					CTFontManagerRegisterFontURLs (arr.Handle, scope, enabled, IntPtr.Zero);
 				} else {
 					BlockLiteral block_handler = new BlockLiteral ();
@@ -324,7 +324,7 @@ namespace CoreText {
 
 		public static NSError? UnregisterFontsForUrl (NSUrl fontUrl, CTFontManagerScope scope)
 		{
-			if (fontUrl == null)
+			if (fontUrl is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (fontUrl));
 
 			IntPtr error = IntPtr.Zero;
@@ -439,7 +439,7 @@ namespace CoreText {
 		public static void UnregisterFonts (NSUrl [] fontUrls, CTFontManagerScope scope, CTFontRegistrationHandler registrationHandler)
 		{
 			using (var arr = EnsureNonNullArray (fontUrls, nameof (fontUrls))) {
-				if (registrationHandler == null) {
+				if (registrationHandler is null) {
 					CTFontManagerUnregisterFontURLs (arr.Handle, scope, IntPtr.Zero);
 				} else {
 					BlockLiteral block_handler = new BlockLiteral ();
@@ -471,7 +471,7 @@ namespace CoreText {
 #endif
 		public static CTFontDescriptor[] GetFonts (NSUrl url)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			var arrayPtr = CTFontManagerCreateFontDescriptorsFromURL (url.Handle);
@@ -493,7 +493,7 @@ namespace CoreText {
 
 		public static bool RegisterGraphicsFont (CGFont font, out NSError? error)
 		{
-			if (font == null)
+			if (font is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (font));
 			IntPtr h = IntPtr.Zero;
 			bool ret;
@@ -516,7 +516,7 @@ namespace CoreText {
 
 		public static bool UnregisterGraphicsFont (CGFont font, out NSError? error)
 		{
-			if (font == null)
+			if (font is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (font));
 			IntPtr h = IntPtr.Zero;
 			bool ret;
@@ -558,7 +558,7 @@ namespace CoreText {
 #endif
 		static NSString? RegisteredFontsChangedNotification {
 			get {
-				if (_RegisteredFontsChangedNotification == null)
+				if (_RegisteredFontsChangedNotification is null)
 					_RegisteredFontsChangedNotification = Dlfcn.GetStringConstant (Libraries.CoreText.Handle, "kCTFontManagerRegisteredFontsChangedNotification");
 				return _RegisteredFontsChangedNotification;
 			}
@@ -623,7 +623,7 @@ namespace CoreText {
 		public static void RegisterFontDescriptors (CTFontDescriptor[] fontDescriptors, CTFontManagerScope scope, bool enabled, CTFontRegistrationHandler registrationHandler)
 		{
 			using (var arr = EnsureNonNullArray (fontDescriptors, nameof (fontDescriptors))) {
-				if (registrationHandler == null) {
+				if (registrationHandler is null) {
 					CTFontManagerRegisterFontDescriptors (arr.Handle, scope, enabled, IntPtr.Zero);
 				} else {
 					BlockLiteral block_handler = new BlockLiteral ();
@@ -677,7 +677,7 @@ namespace CoreText {
 		public static void UnregisterFontDescriptors (CTFontDescriptor[] fontDescriptors, CTFontManagerScope scope, CTFontRegistrationHandler registrationHandler)
 		{
 			using (var arr = EnsureNonNullArray (fontDescriptors, nameof (fontDescriptors))) {
-				if (registrationHandler == null) {
+				if (registrationHandler is null) {
 					CTFontManagerUnregisterFontDescriptors (arr.Handle, scope, IntPtr.Zero);
 				} else {
 					BlockLiteral block_handler = new BlockLiteral ();
@@ -725,7 +725,7 @@ namespace CoreText {
 
 		public static CTFontDescriptor? CreateFontDescriptor (NSData data)
 		{
-			if (data == null)
+			if (data is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 
 			var p = CTFontManagerCreateFontDescriptorFromData (data.Handle);
@@ -762,7 +762,7 @@ namespace CoreText {
 #endif
 		public static CTFontDescriptor[]? CreateFontDescriptors (NSData data)
 		{
-			if (data == null)
+			if (data is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 
 			var p = CTFontManagerCreateFontDescriptorsFromData (data.Handle);
@@ -815,7 +815,7 @@ namespace CoreText {
 		public static void RegisterFonts (string[] assetNames, CFBundle bundle, CTFontManagerScope scope, bool enabled, CTFontRegistrationHandler registrationHandler)
 		{
 			using (var arr = EnsureNonNullArray (assetNames, nameof (assetNames))) {
-				if (registrationHandler == null) {
+				if (registrationHandler is null) {
 					CTFontManagerRegisterFontsWithAssetNames (arr.Handle, bundle.GetHandle (), scope, enabled, IntPtr.Zero);
 				} else {
 					BlockLiteral block_handler = new BlockLiteral ();
@@ -860,7 +860,7 @@ namespace CoreText {
 		static unsafe void TrampolineRequestFonts (IntPtr block, /* CFArray */ IntPtr fontDescriptors)
 		{
 			var del = BlockLiteral.GetTarget<CTFontManagerRequestFontsHandler> (block);
-			if (del != null)
+			if (del is not null)
 				del (NSArray.ArrayFromHandle<CTFontDescriptor> (fontDescriptors));
 		}
 
@@ -878,7 +878,7 @@ namespace CoreText {
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void RequestFonts (CTFontDescriptor[] fontDescriptors, CTFontManagerRequestFontsHandler completionHandler)
 		{
-			if (completionHandler == null)
+			if (completionHandler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (completionHandler));
 
 			using (var arr = EnsureNonNullArray (fontDescriptors, nameof (fontDescriptors))) {

--- a/src/CoreText/CTFontNameKey.cs
+++ b/src/CoreText/CTFontNameKey.cs
@@ -26,6 +26,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -80,24 +83,24 @@ namespace CoreText {
 		static CTFontNameKeyId ()
 		{
 			var handle = Libraries.CoreText.Handle;
-			Copyright     = Dlfcn.GetStringConstant (handle, "kCTFontCopyrightNameKey");
-			Family        = Dlfcn.GetStringConstant (handle, "kCTFontFamilyNameKey");
-			SubFamily     = Dlfcn.GetStringConstant (handle, "kCTFontSubFamilyNameKey");
-			Style         = Dlfcn.GetStringConstant (handle, "kCTFontStyleNameKey");
-			Unique        = Dlfcn.GetStringConstant (handle, "kCTFontUniqueNameKey");
-			Full          = Dlfcn.GetStringConstant (handle, "kCTFontFullNameKey");
-			Version       = Dlfcn.GetStringConstant (handle, "kCTFontVersionNameKey");
-			PostScript    = Dlfcn.GetStringConstant (handle, "kCTFontPostScriptNameKey");
-			Trademark     = Dlfcn.GetStringConstant (handle, "kCTFontTrademarkNameKey");
-			Manufacturer  = Dlfcn.GetStringConstant (handle, "kCTFontManufacturerNameKey");
-			Designer      = Dlfcn.GetStringConstant (handle, "kCTFontDesignerNameKey");
-			Description   = Dlfcn.GetStringConstant (handle, "kCTFontDescriptionNameKey");
-			VendorUrl     = Dlfcn.GetStringConstant (handle, "kCTFontVendorURLNameKey");
-			DesignerUrl   = Dlfcn.GetStringConstant (handle, "kCTFontDesignerURLNameKey");
-			License       = Dlfcn.GetStringConstant (handle, "kCTFontLicenseNameKey");
-			LicenseUrl    = Dlfcn.GetStringConstant (handle, "kCTFontLicenseURLNameKey");
-			SampleText    = Dlfcn.GetStringConstant (handle, "kCTFontSampleTextNameKey");
-			PostscriptCid = Dlfcn.GetStringConstant (handle, "kCTFontPostScriptCIDNameKey");
+			Copyright     = Dlfcn.GetStringConstant (handle, "kCTFontCopyrightNameKey")!;
+			Family        = Dlfcn.GetStringConstant (handle, "kCTFontFamilyNameKey")!;
+			SubFamily     = Dlfcn.GetStringConstant (handle, "kCTFontSubFamilyNameKey")!;
+			Style         = Dlfcn.GetStringConstant (handle, "kCTFontStyleNameKey")!;
+			Unique        = Dlfcn.GetStringConstant (handle, "kCTFontUniqueNameKey")!;
+			Full          = Dlfcn.GetStringConstant (handle, "kCTFontFullNameKey")!;
+			Version       = Dlfcn.GetStringConstant (handle, "kCTFontVersionNameKey")!;
+			PostScript    = Dlfcn.GetStringConstant (handle, "kCTFontPostScriptNameKey")!;
+			Trademark     = Dlfcn.GetStringConstant (handle, "kCTFontTrademarkNameKey")!;
+			Manufacturer  = Dlfcn.GetStringConstant (handle, "kCTFontManufacturerNameKey")!;
+			Designer      = Dlfcn.GetStringConstant (handle, "kCTFontDesignerNameKey")!;
+			Description   = Dlfcn.GetStringConstant (handle, "kCTFontDescriptionNameKey")!;
+			VendorUrl     = Dlfcn.GetStringConstant (handle, "kCTFontVendorURLNameKey")!;
+			DesignerUrl   = Dlfcn.GetStringConstant (handle, "kCTFontDesignerURLNameKey")!;
+			License       = Dlfcn.GetStringConstant (handle, "kCTFontLicenseNameKey")!;
+			LicenseUrl    = Dlfcn.GetStringConstant (handle, "kCTFontLicenseURLNameKey")!;
+			SampleText    = Dlfcn.GetStringConstant (handle, "kCTFontSampleTextNameKey")!;
+			PostscriptCid = Dlfcn.GetStringConstant (handle, "kCTFontPostScriptCIDNameKey")!;
 		}
 #endif
 

--- a/src/CoreText/CTFontTrait.cs
+++ b/src/CoreText/CTFontTrait.cs
@@ -105,7 +105,7 @@ namespace CoreText {
 
 		public CTFontTraits (NSDictionary dictionary)
 		{
-			if (dictionary == null)
+			if (dictionary is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}

--- a/src/CoreText/CTFontTrait.cs
+++ b/src/CoreText/CTFontTrait.cs
@@ -106,7 +106,7 @@ namespace CoreText {
 		public CTFontTraits (NSDictionary dictionary)
 		{
 			if (dictionary == null)
-				throw new ArgumentNullException ("dictionary");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 

--- a/src/CoreText/CTFontTrait.cs
+++ b/src/CoreText/CTFontTrait.cs
@@ -26,6 +26,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -46,10 +49,10 @@ namespace CoreText {
 		static CTFontTraitKey ()
 		{
 			var handle = Libraries.CoreText.Handle;
-			Symbolic  = Dlfcn.GetStringConstant (handle, "kCTFontSymbolicTrait");
-			Weight    = Dlfcn.GetStringConstant (handle, "kCTFontWeightTrait");
-			Width     = Dlfcn.GetStringConstant (handle, "kCTFontWidthTrait");
-			Slant     = Dlfcn.GetStringConstant (handle, "kCTFontSlantTrait");
+			Symbolic  = Dlfcn.GetStringConstant (handle, "kCTFontSymbolicTrait")!;
+			Weight    = Dlfcn.GetStringConstant (handle, "kCTFontWeightTrait")!;
+			Width     = Dlfcn.GetStringConstant (handle, "kCTFontWidthTrait")!;
+			Slant     = Dlfcn.GetStringConstant (handle, "kCTFontSlantTrait")!;
 		}
 	}
 #endif

--- a/src/CoreText/CTFrame.cs
+++ b/src/CoreText/CTFrame.cs
@@ -93,7 +93,7 @@ namespace CoreText {
 		public CTFrameAttributes (NSDictionary dictionary)
 		{
 			if (dictionary is null)
-				throw new ArgumentNullException (nameof (dictionary));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 
@@ -186,7 +186,7 @@ namespace CoreText {
 		public void GetLineOrigins (NSRange range, CGPoint[] origins)
 		{
 			if (origins is null)
-				throw new ArgumentNullException (nameof (origins));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (origins));
 			if (range.Length != 0 && origins.Length < range.Length)
 				throw new ArgumentException ("origins must contain at least range.Length elements.", nameof (origins));
 			else if (origins.Length < CFArray.GetCount (CTFrameGetLines (Handle)))
@@ -200,7 +200,7 @@ namespace CoreText {
 		public void Draw (CGContext ctx)
 		{
 			if (ctx is null)
-				throw new ArgumentNullException (nameof (ctx));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (ctx));
 
 			CTFrameDraw (Handle, ctx.Handle);
 		}

--- a/src/CoreText/CTFramesetter.cs
+++ b/src/CoreText/CTFramesetter.cs
@@ -69,7 +69,7 @@ namespace CoreText {
 		public CTFrame? GetFrame (NSRange stringRange, CGPath path, CTFrameAttributes? frameAttributes)
 		{
 			if (path is null)
-				throw new ArgumentNullException (nameof (path));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (path));
 			var frame = CTFramesetterCreateFrame (Handle, stringRange, path.Handle, frameAttributes.GetHandle ());
 			if (frame == IntPtr.Zero)
 				return null;
@@ -128,7 +128,7 @@ namespace CoreText {
 		public static CTFramesetter? Create (CTTypesetter typesetter)
 		{
 			if (typesetter is null)
-				throw new ArgumentNullException (nameof (typesetter));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (typesetter));
 
 			var ret = CTFramesetterCreateWithTypesetter (typesetter.Handle);
 			if (ret == IntPtr.Zero)

--- a/src/CoreText/CTGlyphInfo.cs
+++ b/src/CoreText/CTGlyphInfo.cs
@@ -74,11 +74,11 @@ namespace CoreText {
 		static IntPtr Create (string glyphName, CTFont font, string baseString)
 		{
 			if (glyphName is null)
-				throw new ArgumentNullException (nameof (glyphName));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (glyphName));
 			if (font is null)
-				throw new ArgumentNullException (nameof (font));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (font));
 			if (baseString is null)
-				throw new ArgumentNullException (nameof (baseString));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (baseString));
 
 			var gnHandle = CFString.CreateNative (glyphName);
 			var bsHandle = CFString.CreateNative (baseString);
@@ -101,9 +101,9 @@ namespace CoreText {
 		static IntPtr Create (CGGlyph glyph, CTFont font, string baseString)
 		{
 			if (font is null)
-				throw new ArgumentNullException (nameof (font));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (font));
 			if (baseString is null)
-				throw new ArgumentNullException (nameof (baseString));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (baseString));
 
 			var bsHandle = CFString.CreateNative (baseString);
 			try {
@@ -124,7 +124,7 @@ namespace CoreText {
 		static IntPtr Create (CGFontIndex cid, CTCharacterCollection collection, string baseString)
 		{
 			if (baseString is null)
-				throw new ArgumentNullException (nameof (baseString));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (baseString));
 
 			var bsHandle = CFString.CreateNative (baseString);
 			try {

--- a/src/CoreText/CTLine.cs
+++ b/src/CoreText/CTLine.cs
@@ -141,7 +141,7 @@ namespace CoreText {
 		public void Draw (CGContext context)
 		{
 			if (context is null)
-				throw new ArgumentNullException (nameof (context));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (context));
 			CTLineDraw (Handle, context.Handle);
 		}
 #endregion
@@ -245,7 +245,7 @@ namespace CoreText {
 		public void EnumerateCaretOffsets (CaretEdgeEnumerator enumerator)
 		{
 			if (enumerator is null)
-				throw new ArgumentNullException (nameof (enumerator));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (enumerator));
 
 			var block_handler = new BlockLiteral ();
 			block_handler.SetupBlockUnsafe (static_enumerate, enumerator);

--- a/src/CoreText/CTRunDelegate.cs
+++ b/src/CoreText/CTRunDelegate.cs
@@ -143,7 +143,7 @@ namespace CoreText {
 		static void Deallocate (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);
-			if (self == null)
+			if (self is null)
 				return;
 
 			self.Dispose ();
@@ -164,7 +164,7 @@ namespace CoreText {
 		static nfloat GetAscent (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);
-			if (self == null)
+			if (self is null)
 				return 0;
 			return (nfloat) self.GetAscent ();
 		}
@@ -173,7 +173,7 @@ namespace CoreText {
 		static nfloat GetDescent (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);
-			if (self == null)
+			if (self is null)
 				return 0;
 			return (nfloat) self.GetDescent ();
 		}
@@ -182,7 +182,7 @@ namespace CoreText {
 		static nfloat GetWidth (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);
-			if (self == null)
+			if (self is null)
 				return 0;
 			return (nfloat) self.GetWidth ();
 		}
@@ -207,7 +207,7 @@ namespace CoreText {
 
 		static IntPtr Create (CTRunDelegateOperations operations)
 		{
-			if (operations == null)
+			if (operations is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (operations));
 
 			CTRunDelegateCallbacks callbacks = operations.GetCallbacks ();

--- a/src/CoreText/CTRunDelegate.cs
+++ b/src/CoreText/CTRunDelegate.cs
@@ -24,6 +24,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -150,7 +153,7 @@ namespace CoreText {
 			self.handle = new GCHandle ();
 		}
 
-		internal static CTRunDelegateOperations GetOperations (IntPtr refCon)
+		internal static CTRunDelegateOperations? GetOperations (IntPtr refCon)
 		{
 			GCHandle c = GCHandle.FromIntPtr (refCon);
 
@@ -221,7 +224,7 @@ namespace CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTRunDelegateGetRefCon (IntPtr runDelegate);
 
-		public CTRunDelegateOperations Operations {
+		public CTRunDelegateOperations? Operations {
 			get {
 				return CTRunDelegateOperations.GetOperations (CTRunDelegateGetRefCon (Handle));
 			}

--- a/src/CoreText/CTRunDelegate.cs
+++ b/src/CoreText/CTRunDelegate.cs
@@ -208,7 +208,7 @@ namespace CoreText {
 		static IntPtr Create (CTRunDelegateOperations operations)
 		{
 			if (operations == null)
-				throw new ArgumentNullException (nameof (operations));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (operations));
 
 			CTRunDelegateCallbacks callbacks = operations.GetCallbacks ();
 			return CTRunDelegateCreate (ref callbacks, operations.Handle);

--- a/src/CoreText/CTStringAttributes.cs
+++ b/src/CoreText/CTStringAttributes.cs
@@ -28,6 +28,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -106,28 +109,28 @@ namespace CoreText {
 		static CTStringAttributeKey ()
 		{
 			var handle = Libraries.CoreText.Handle;
-			Font                        = Dlfcn.GetStringConstant (handle, "kCTFontAttributeName");
-			ForegroundColorFromContext  = Dlfcn.GetStringConstant (handle, "kCTForegroundColorFromContextAttributeName");
-			KerningAdjustment           = Dlfcn.GetStringConstant (handle, "kCTKernAttributeName");
-			LigatureFormation           = Dlfcn.GetStringConstant (handle, "kCTLigatureAttributeName");
-			ForegroundColor             = Dlfcn.GetStringConstant (handle, "kCTForegroundColorAttributeName");
-			BackgroundColor             = Dlfcn.GetStringConstant (handle, "kCTBackgroundColorAttributeName");
-			ParagraphStyle              = Dlfcn.GetStringConstant (handle, "kCTParagraphStyleAttributeName");
-			StrokeWidth                 = Dlfcn.GetStringConstant (handle, "kCTStrokeWidthAttributeName");
-			StrokeColor                 = Dlfcn.GetStringConstant (handle, "kCTStrokeColorAttributeName");
-			UnderlineStyle              = Dlfcn.GetStringConstant (handle, "kCTUnderlineStyleAttributeName");
-			Superscript                 = Dlfcn.GetStringConstant (handle, "kCTSuperscriptAttributeName");
-			UnderlineColor              = Dlfcn.GetStringConstant (handle, "kCTUnderlineColorAttributeName");
-			VerticalForms               = Dlfcn.GetStringConstant (handle, "kCTVerticalFormsAttributeName");
-			HorizontalInVerticalForms   = Dlfcn.GetStringConstant (handle, "kCTHorizontalInVerticalFormsAttributeName");
-			GlyphInfo                   = Dlfcn.GetStringConstant (handle, "kCTGlyphInfoAttributeName");
-			CharacterShape              = Dlfcn.GetStringConstant (handle, "kCTCharacterShapeAttributeName");
-			RunDelegate                 = Dlfcn.GetStringConstant (handle, "kCTRunDelegateAttributeName");
-			BaselineOffset              = Dlfcn.GetStringConstant (handle, "kCTBaselineOffsetAttributeName");
-			BaselineClass               = Dlfcn.GetStringConstant (handle, "kCTBaselineClassAttributeName");
-			BaselineInfo                = Dlfcn.GetStringConstant (handle, "kCTBaselineInfoAttributeName");
-			BaselineReferenceInfo       = Dlfcn.GetStringConstant (handle, "kCTBaselineReferenceInfoAttributeName");
-			WritingDirection            = Dlfcn.GetStringConstant (handle, "kCTWritingDirectionAttributeName");
+			Font                        = Dlfcn.GetStringConstant (handle, "kCTFontAttributeName")!;
+			ForegroundColorFromContext  = Dlfcn.GetStringConstant (handle, "kCTForegroundColorFromContextAttributeName")!;
+			KerningAdjustment           = Dlfcn.GetStringConstant (handle, "kCTKernAttributeName")!;
+			LigatureFormation           = Dlfcn.GetStringConstant (handle, "kCTLigatureAttributeName")!;
+			ForegroundColor             = Dlfcn.GetStringConstant (handle, "kCTForegroundColorAttributeName")!;
+			BackgroundColor             = Dlfcn.GetStringConstant (handle, "kCTBackgroundColorAttributeName")!;
+			ParagraphStyle              = Dlfcn.GetStringConstant (handle, "kCTParagraphStyleAttributeName")!;
+			StrokeWidth                 = Dlfcn.GetStringConstant (handle, "kCTStrokeWidthAttributeName")!;
+			StrokeColor                 = Dlfcn.GetStringConstant (handle, "kCTStrokeColorAttributeName")!;
+			UnderlineStyle              = Dlfcn.GetStringConstant (handle, "kCTUnderlineStyleAttributeName")!;
+			Superscript                 = Dlfcn.GetStringConstant (handle, "kCTSuperscriptAttributeName")!;
+			UnderlineColor              = Dlfcn.GetStringConstant (handle, "kCTUnderlineColorAttributeName")!;
+			VerticalForms               = Dlfcn.GetStringConstant (handle, "kCTVerticalFormsAttributeName")!;
+			HorizontalInVerticalForms   = Dlfcn.GetStringConstant (handle, "kCTHorizontalInVerticalFormsAttributeName")!;
+			GlyphInfo                   = Dlfcn.GetStringConstant (handle, "kCTGlyphInfoAttributeName")!;
+			CharacterShape              = Dlfcn.GetStringConstant (handle, "kCTCharacterShapeAttributeName")!;
+			RunDelegate                 = Dlfcn.GetStringConstant (handle, "kCTRunDelegateAttributeName")!;
+			BaselineOffset              = Dlfcn.GetStringConstant (handle, "kCTBaselineOffsetAttributeName")!;
+			BaselineClass               = Dlfcn.GetStringConstant (handle, "kCTBaselineClassAttributeName")!;
+			BaselineInfo                = Dlfcn.GetStringConstant (handle, "kCTBaselineInfoAttributeName")!;
+			BaselineReferenceInfo       = Dlfcn.GetStringConstant (handle, "kCTBaselineReferenceInfoAttributeName")!;
+			WritingDirection            = Dlfcn.GetStringConstant (handle, "kCTWritingDirectionAttributeName")!;
 		}
 	}
 #endif // !NET
@@ -155,7 +158,7 @@ namespace CoreText {
 
 		public NSDictionary Dictionary {get; private set;}
 
-		public CTFont Font {
+		public CTFont? Font {
 			get {
 				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.Font.Handle);
 				return h == IntPtr.Zero ? null : new CTFont (h, false);
@@ -193,7 +196,7 @@ namespace CoreText {
 			}
 		}
 
-		public CGColor ForegroundColor {
+		public CGColor? ForegroundColor {
 			get {
 				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.ForegroundColor.Handle);
 				return h == IntPtr.Zero ? null : new CGColor (h, false);
@@ -210,7 +213,7 @@ namespace CoreText {
 		[iOS (10,0)]
 		[Mac (10,12)]
 #endif
-		public CGColor BackgroundColor {
+		public CGColor? BackgroundColor {
 			get {
 				var h = IntPtr.Zero;
 				var x = CTStringAttributeKey.BackgroundColor;
@@ -225,7 +228,7 @@ namespace CoreText {
 			}
 		}
 
-		public CTParagraphStyle ParagraphStyle {
+		public CTParagraphStyle? ParagraphStyle {
 			get {
 				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.ParagraphStyle.Handle);
 				return h == IntPtr.Zero ? null : new CTParagraphStyle (h, false);
@@ -239,7 +242,7 @@ namespace CoreText {
 			set {Adapter.SetValue (Dictionary, CTStringAttributeKey.StrokeWidth, value);}
 		}
 
-		public CGColor StrokeColor {
+		public CGColor? StrokeColor {
 			get {
 				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.StrokeColor.Handle);
 				return h == IntPtr.Zero ? null : new CGColor (h, false);
@@ -309,7 +312,7 @@ namespace CoreText {
 			}
 		}
 
-		public CGColor UnderlineColor {
+		public CGColor? UnderlineColor {
 			get {
 				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.UnderlineColor.Handle);
 				return h == IntPtr.Zero ? null : new CGColor (h, false);
@@ -368,7 +371,7 @@ namespace CoreText {
 			set { Adapter.SetValue (Dictionary, CTStringAttributeKey.BaselineOffset, value); }
 		}
 
-		public CTGlyphInfo GlyphInfo {
+		public CTGlyphInfo? GlyphInfo {
 			get {
 				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.GlyphInfo.Handle);
 				return h == IntPtr.Zero ? null : new CTGlyphInfo (h, false);
@@ -381,7 +384,7 @@ namespace CoreText {
 			set {Adapter.SetValue (Dictionary, CTStringAttributeKey.CharacterShape, value);}
 		}
 
-		public CTRunDelegate RunDelegate {
+		public CTRunDelegate? RunDelegate {
 			get {
 				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.RunDelegate.Handle);
 				return h == IntPtr.Zero ? null : new CTRunDelegate (h, false);

--- a/src/CoreText/CTStringAttributes.cs
+++ b/src/CoreText/CTStringAttributes.cs
@@ -152,7 +152,7 @@ namespace CoreText {
 		public CTStringAttributes (NSDictionary dictionary)
 		{
 			if (dictionary == null)
-				throw new ArgumentNullException ("dictionary");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 

--- a/src/CoreText/CTStringAttributes.cs
+++ b/src/CoreText/CTStringAttributes.cs
@@ -151,7 +151,7 @@ namespace CoreText {
 
 		public CTStringAttributes (NSDictionary dictionary)
 		{
-			if (dictionary == null)
+			if (dictionary is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
@@ -217,13 +217,13 @@ namespace CoreText {
 			get {
 				var h = IntPtr.Zero;
 				var x = CTStringAttributeKey.BackgroundColor;
-				if (x != null)
+				if (x is not null)
 					h = CFDictionary.GetValue (Dictionary.Handle, x.Handle);
 				return h == IntPtr.Zero ? null : new CGColor (h, false);
 			}
 			set {
 				var x = CTStringAttributeKey.BackgroundColor;
-				if (x != null)
+				if (x is not null)
 					Adapter.SetNativeValue (Dictionary, x, value);
 			}
 		}
@@ -346,11 +346,11 @@ namespace CoreText {
 		public int? HorizontalInVerticalForms {
 			get {
 				var x = CTStringAttributeKey.HorizontalInVerticalForms;
-				return x != null ? Adapter.GetInt32Value (Dictionary, x) : null;
+				return x is not null ? Adapter.GetInt32Value (Dictionary, x) : null;
 			}
 			set {
 				var x = CTStringAttributeKey.HorizontalInVerticalForms;
-				if (x != null)
+				if (x is not null)
 					Adapter.SetValue (Dictionary, x, value);
 			}
 		}
@@ -398,7 +398,7 @@ namespace CoreText {
 				return value == IntPtr.Zero ? (CTBaselineClass?) null : CTBaselineClassID.FromHandle (value);
 			}
 			set {
-				var ns_value = value == null ? null : CTBaselineClassID.ToNSString (value.Value);
+				var ns_value = value is null ? null : CTBaselineClassID.ToNSString (value.Value);
 				Adapter.SetNativeValue (Dictionary, CTStringAttributeKey.BaselineClass, ns_value);
 			}
 		}

--- a/src/CoreText/CTTextTab.cs
+++ b/src/CoreText/CTTextTab.cs
@@ -70,7 +70,7 @@ namespace CoreText {
 		public CTTextTabOptions (NSDictionary dictionary)
 		{
 			if (dictionary is null)
-				throw new ArgumentNullException (nameof (dictionary));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 

--- a/src/CoreText/CTTypesetter.cs
+++ b/src/CoreText/CTTypesetter.cs
@@ -61,7 +61,7 @@ namespace CoreText {
 		public CTTypesetterOptions (NSDictionary dictionary)
 		{
 			if (dictionary is null)
-				throw new ArgumentNullException (nameof (dictionary));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dictionary));
 			Dictionary = dictionary;
 		}
 

--- a/src/CoreText/CTTypesetterOptionKeyCompat.cs
+++ b/src/CoreText/CTTypesetterOptionKeyCompat.cs
@@ -7,6 +7,9 @@
 // Copyright 2018 Microsoft Corporation.
 //
 
+#nullable enable
+
+
 #if !NET
 using System;
 using ObjCRuntime;

--- a/src/CoreText/ConstructorError.cs
+++ b/src/CoreText/ConstructorError.cs
@@ -42,7 +42,7 @@ namespace CoreText {
 		public static Exception ArgumentNull (object self, string argument)
 		{
 			GC.SuppressFinalize (self);
-			return new ArgumentNullException (argument);
+			return ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (argument));
 		}
 
 		public static Exception Unknown (object self)

--- a/src/CoreText/ConstructorError.cs
+++ b/src/CoreText/ConstructorError.cs
@@ -24,6 +24,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 


### PR DESCRIPTION
This PR aims to bring nullability changes to CoreText.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`


I decided to mark the GetStringConstants that deal with handles with a `!` since these GetX (handle) methods tend to be safe with nullability from previous PRs and there were already some files in CoreText following this pattern.
`Dlfcn.GetStringConstant (handle, "kCTFontCopyrightNameKey")!;`