### PR TITLE
[CI] Bump timeout.

### DIFF
--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -250,7 +250,7 @@ steps:
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios
   displayName: 'Run tests'
   name: runTests # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
-  timeoutInMinutes: 720
+  timeoutInMinutes: 840
 
 # set the status of the test results. Do not add a comment yet since we have not uploaded any of the needed files for the commnet, this way
 # we report the result as soon as we have it and ensure that we set the status from pending to the appropiate value.


### PR DESCRIPTION
Until we parallize the tests we need to bump the timeout since we are
getting timeout issues in some bots, for example: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6134329&view=logs&j=673140f8-3abe-5ac0-6769-091785cf5576&t=27d47212-35cf-595c-16ff-96a3671a2d41