### PR TITLE
[xharness] Fix logic to include the .NET xtro tests.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -202,7 +202,7 @@ namespace Xharness.Jenkins {
 				TestName = "Xtro",
 				Target = "dotnet-wrench",
 				WorkingDirectory = Path.Combine (HarnessConfiguration.RootDirectory, "xtro-sharpie"),
-				Ignored = !IncludeXtro && !IncludeDotNet,
+				Ignored = !(IncludeXtro && IncludeDotNet),
 				Timeout = TimeSpan.FromMinutes (15),
 				SupportsParallelExecution = false,
 			};


### PR DESCRIPTION
Both 'IncludeXtro' and 'IncludeDotNet' must be set to run the .NET xtro tests
(which means they're ignored if either is false).