### PR TITLE
[make] Add better error message when the required Xcode isn't installed.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -196,7 +196,7 @@ MACCATALYST_NUGET_VERSION_FULL=$(MACCATALYST_NUGET_VERSION_NO_METADATA)+$(NUGET_
 XCODE_VERSION=13.3
 XCODE_URL=https://dl.internalx.com/internal-files/xcodes/Xcode_13.3.xip
 XCODE_DEVELOPER_ROOT=/Applications/Xcode_13.3.0.app/Contents/Developer
-XCODE_PRODUCT_BUILD_VERSION:=$(shell /usr/libexec/PlistBuddy -c 'Print :ProductBuildVersion' $(XCODE_DEVELOPER_ROOT)/../version.plist)
+XCODE_PRODUCT_BUILD_VERSION:=$(shell /usr/libexec/PlistBuddy -c 'Print :ProductBuildVersion' $(XCODE_DEVELOPER_ROOT)/../version.plist 2>/dev/null || echo "    $(shell tput setaf 1)The required Xcode ($(XCODE_VERSION)) is not installed in $(basename $(basename $(XCODE_DEVELOPER_ROOT)))$(shell tput sgr0)" >&2)
 
 # Mono version embedded in XI/XM (NEEDED_MONO_VERSION/BRANCH) are specified in mk/mono.mk
 include $(TOP)/mk/mono.mk


### PR DESCRIPTION
Before:

<img width="378" alt="Screen Shot 2022-05-11 at 23 17 11" src="https://user-images.githubusercontent.com/249268/167949580-b8f49d01-e7bb-4edd-9d74-484c78f28d21.png">

After:

<img width="704" alt="Screen Shot 2022-05-11 at 23 17 40" src="https://user-images.githubusercontent.com/249268/167949601-2219170f-28b3-4362-b30a-6b5d230c8567.png">

