### PR TITLE
[xharness/devops] Enable .NET tests by default.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -60,7 +60,7 @@ namespace Xharness.Jenkins {
 		public bool IncludeMscorlib;
 		public bool IncludeNonMonotouch = true;
 		public bool IncludeMonotouch = true;
-		public bool IncludeDotNet;
+		public bool IncludeDotNet = true;
 		public bool IncludeMacCatalyst = true;
 
 		public bool CleanSuccessfulTestRuns = true;

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -81,19 +81,6 @@ steps:
       $ref = $prInfo.base.ref
       $tags.Add("$ref")
 
-      # decide if we add the run-dotnet-tests label (if not present) this is done only for main
-      # we can use $ref for that :)
-      $xharnessLabels = $tags -join ","
-      if ($Env:ENABLE_DOTNET -eq "True" -and -not ("run-dotnet-tests" -in $xharnessLabels)) {
-        Write-Host "Adding label run-dotnet-tests to xharness."
-        $tags.Add("run-dotnet-tests")
-        if ($xharnessLabels -eq "") {
-          $xharnessLabels = "run-dotnet-tests"
-        } else {
-          $xharnessLabels = @($xharnessLabels, "run-dotnet-tests") -join ","
-        }
-      }
-
       Write-Host "##vso[task.setvariable variable=xharness-labels;isOutput=true]$xharnessLabels"
 
       # set output variables based on the git labels


### PR DESCRIPTION
Which alo means there's no need to select them if .NET is enabled.