### PR TITLE
[tests] Ignore the new MnistTester test on the bots.

### DIFF
--- a/tests/monotouch-test/MetalPerformanceShaders/MnistTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MnistTest.cs
@@ -36,10 +36,8 @@ namespace MonoTouchFixtures.MetalPerformanceShadersGraph {
 #if __TVOS__
 			if (Runtime.Arch == Arch.SIMULATOR)
 				Assert.Inconclusive ("Metal Performance Shaders Graph is not supported in the tvOS simulator");
-#elif __IOS__ && !__MACCATALYST__
-			if (Runtime.Arch == Arch.SIMULATOR)
-				TestRuntime.IgnoreInCI ("This test seems to make bots keel over and die.");
 #endif
+			TestRuntime.IgnoreInCI ("This test seems to make bots keel over and die.");
 
 			var device = MTLDevice.SystemDefault;
 			// some older hardware won't have a default


### PR DESCRIPTION
Bots seems to break more often after this change, so let's see if this improves matters.

This is what happens with the bots:

    We stopped hearing from agent [...]. Verify the agent machine is running and has a healthy network connection. Anything that terminates an agent process, starves it for CPU, or blocks its network access can cause this error. For more information, see: https://go.microsoft.com/fwlink/?linkid=846610