### PR TITLE
[tests] Adjust a few linker tests to cope with unreliable networks.

### DIFF
--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -232,6 +232,12 @@ namespace LinkAll {
 				// caching means it will be called at least for the first run, but it might not
 				// be called again in subsequent requests (unless it expires)
 				Assert.That (test_policy.CheckCount, Is.GreaterThan (0), "policy checked");
+			} catch (WebException we) {
+				// The remote server returned an error: (502) Bad Gateway.
+				// The remote server returned an error: (503) Service Unavailable.
+				if (we.Message.Contains ("(502)") || we.Message.Contains ("(503)"))
+					Assert.Inconclusive (we.Message);
+				throw;
 			} finally {
 				ServicePointManager.CertificatePolicy = old;
 			}

--- a/tests/linker/ios/link sdk/CryptoTest.cs
+++ b/tests/linker/ios/link sdk/CryptoTest.cs
@@ -68,6 +68,12 @@ namespace LinkSdk {
 				// caching means it will be called at least for the first run, but it might not
 				// be called again in subsequent requests (unless it expires)
 				Assert.That (trust_validation_callback, Is.GreaterThan (0), "validation done");
+			} catch (WebException we) {
+				// The remote server returned an error: (502) Bad Gateway.
+				// The remote server returned an error: (503) Service Unavailable.
+				if (we.Message.Contains ("(502)") || we.Message.Contains ("(503)"))
+					Assert.Inconclusive (we.Message);
+				throw;
 			}
 			finally {
 				ServicePointManager.ServerCertificateValidationCallback = null;

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -18,11 +18,13 @@ namespace MonoTests.System.Net.Http
 		public static readonly string [] HttpsUrls = {
 			MicrosoftUrl,
 			XamarinUrl,
+			Httpbin.Url,
 		};
 
 		public static readonly string [] HttpUrls = {
 			MicrosoftHttpUrl,
 			XamarinHttpUrl,
+			Httpbin.HttpUrl,
 		};
 
 		// Robots urls, useful when we want to get a small file
@@ -51,6 +53,7 @@ namespace MonoTests.System.Net.Http
 			public static readonly string PostUrl = "https://httpbin.org/post";
 			public static readonly string PutUrl = "https://httpbin.org/put";
 			public static readonly string CookiesUrl = $"https://httpbin.org/cookies";
+			public static readonly string HttpUrl = "http://httpbin.org";
 
 
 			public static string GetAbsoluteRedirectUrl (int count) => $"https://httpbin.org/absolute-redirect/{count}";


### PR DESCRIPTION
* Handle 502 and 503 errors in the TrustUsingOldPolicy and TrustUsingNewCallback tests. Fixes:

    [FAIL] TrustUsingOldPolicy : System.Net.WebException : The remote server returned an error: (503) Service Unavailable.
    [FAIL] TrustUsingNewCallback : System.Net.WebException : The remote server returned an error: (503) Service Unavailable.

* Add more http and https urls to try (and don't use microsoft.com). Hopefully fixes:

    [FAIL] WebClient_SSL_Leak : At least one url should work

This is a follow-up to #14943.