### PR TITLE
[coretelephony] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/CoreTelephony/CoreTelephony.cs
+++ b/src/CoreTelephony/CoreTelephony.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Foundation;
 using ObjCRuntime;
 using System;


### PR DESCRIPTION
This PR aims to bring nullability changes to CoreTelephony.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes