### PR TITLE
Avoid executing _VerifyXcodeVersion when there's no connection to a Mac

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.Messaging.Apple.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.Messaging.Apple.targets
@@ -27,7 +27,7 @@
 	<!-- AfterConnect belongs to Xamarin.Messaging.Build.targets -->
 	<Target Name="AfterConnect" Condition="'$(IsRemoteBuild)' == 'true'" DependsOnTargets="_VerifyXcodeVersion" />
 	
-	<Target Name="_VerifyXcodeVersion" Condition="'$(IsRemoteBuild)' == 'true'">
+	<Target Name="_VerifyXcodeVersion" Condition="'$(IsRemoteBuild)' == 'true' And '$(IsMacEnabled)' == 'true'">
 		<VerifyXcodeVersion SessionId="$(BuildSessionId)" />
 	</Target>
 


### PR DESCRIPTION
This should fix an annoying warning where the user builds an iOS project offline and get a message about that target couldn't be executed