### PR TITLE
[release/6.0.3xx] Avoid executing _VerifyXcodeVersion when there's no connection to a Mac

### DIFF
--- a/Make.versions
+++ b/Make.versions
@@ -66,11 +66,11 @@ MAC_PACKAGE_VERSION=8.11.0.$(MAC_COMMIT_DISTANCE)
 # WARNING: Do **not** use versions higher than the available Xcode SDK or else we will have issues with mtouch (See https://github.com/xamarin/xamarin-macios/issues/7705)
 # When bumping the major macOS version in MACOS_NUGET_VERSION also update the macOS version where we execute on bots in jenkins/Jenkinsfile (in the 'node' element)
 
-IOS_NUGET_VERSION=15.4.303
-TVOS_NUGET_VERSION=15.4.303
-WATCHOS_NUGET_VERSION=8.5.303
-MACOS_NUGET_VERSION=12.3.303
-MACCATALYST_NUGET_VERSION=15.4.303
+IOS_NUGET_VERSION=15.4.304
+TVOS_NUGET_VERSION=15.4.304
+WATCHOS_NUGET_VERSION=8.5.304
+MACOS_NUGET_VERSION=12.3.304
+MACCATALYST_NUGET_VERSION=15.4.304
 
 
 # Defines the default platform version if it's not specified in the TFM. The default should not change for a given .NET version:

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.Messaging.Apple.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.Messaging.Apple.targets
@@ -27,7 +27,7 @@
 	<!-- AfterConnect belongs to Xamarin.Messaging.Build.targets -->
 	<Target Name="AfterConnect" Condition="'$(IsRemoteBuild)' == 'true'" DependsOnTargets="_VerifyXcodeVersion" />
 	
-	<Target Name="_VerifyXcodeVersion" Condition="'$(IsRemoteBuild)' == 'true'">
+	<Target Name="_VerifyXcodeVersion" Condition="'$(IsRemoteBuild)' == 'true' And '$(IsMacEnabled)' == 'true'">
 		<VerifyXcodeVersion SessionId="$(BuildSessionId)" />
 	</Target>
 


### PR DESCRIPTION
This should fix an annoying warning where the user builds an iOS project offline and get a message about that target couldn't be executed


Backport of #15026
