### PR TITLE
[webkit] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/WebKit/DomCssRuleList.cs
+++ b/src/WebKit/DomCssRuleList.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace WebKit {
 	
 	public partial class DomCssRuleList {

--- a/src/WebKit/DomHelpers.cs
+++ b/src/WebKit/DomHelpers.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using ObjCRuntime;
 using Foundation;

--- a/src/WebKit/DomNode.cs
+++ b/src/WebKit/DomNode.cs
@@ -80,7 +80,7 @@ namespace WebKit {
 #endif
 		{
 			if (handler == null)
-				throw new ArgumentNullException ("handler");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 			var obj = new DomNodeEventProxy (this, handler);
 			AddEventListener (type, obj, useCapture);
 			return obj;
@@ -93,7 +93,7 @@ namespace WebKit {
 #endif
 		{
 			if (callback == null)
-				throw new ArgumentNullException ("callback");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 			var obj = new DomNodeEventProxy2 (callback);
 			AddEventListener (type, obj, useCapture);
 			return obj;

--- a/src/WebKit/DomNode.cs
+++ b/src/WebKit/DomNode.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.Versioning;
 

--- a/src/WebKit/DomNode.cs
+++ b/src/WebKit/DomNode.cs
@@ -79,7 +79,7 @@ namespace WebKit {
 		public DomEventListener AddEventListener (string type, DomEventListenerHandler handler, bool useCapture)
 #endif
 		{
-			if (handler == null)
+			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 			var obj = new DomNodeEventProxy (this, handler);
 			AddEventListener (type, obj, useCapture);
@@ -92,7 +92,7 @@ namespace WebKit {
 		public DomEventListener AddEventListener (string type, Action<DomEvent> callback, bool useCapture)
 #endif
 		{
-			if (callback == null)
+			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 			var obj = new DomNodeEventProxy2 (callback);
 			AddEventListener (type, obj, useCapture);

--- a/src/WebKit/Enumerators.cs
+++ b/src/WebKit/Enumerators.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -24,15 +26,17 @@ namespace WebKit {
 
 		public T Current {
 			get {
-				return _container [_index];
+				return _container! [_index];
 			}
 		}
 
-		object IEnumerator.Current {
+		object? IEnumerator.Current {
 			get { return ((IEnumerator<T>) this).Current; }
 		}
 
 		public bool MoveNext () {
+			if (_container is null)
+				return false;
 			return ++_index < _container.Count;
 		}
 
@@ -40,7 +44,7 @@ namespace WebKit {
 			_index = -1;
 		}
 
-		IIndexedContainer<T> _container;
+		IIndexedContainer<T>? _container;
 		int _index;
 	}
 

--- a/src/WebKit/Indexers.cs
+++ b/src/WebKit/Indexers.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace WebKit {
 	
 	public partial class DomCssRuleList {

--- a/src/WebKit/WebKit.cs
+++ b/src/WebKit/WebKit.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Foundation;
 
 namespace WebKit {

--- a/src/WebKit/WebNavigationPolicyEventArgs.cs
+++ b/src/WebKit/WebNavigationPolicyEventArgs.cs
@@ -36,7 +36,7 @@ namespace WebKit {
 		public WebActionMouseButton MouseButton {
 			get {
 				var number = ActionInformation[WebPolicyDelegate.WebActionButtonKey] as NSNumber;
-				if (number == null) {
+				if (number is null) {
 					return WebActionMouseButton.None;
 				}
 

--- a/src/WebKit/WebNavigationPolicyEventArgs.cs
+++ b/src/WebKit/WebNavigationPolicyEventArgs.cs
@@ -6,6 +6,8 @@
 //
 // Copyright 2013 Xamarin Inc
 
+#nullable enable
+
 using System;
 
 using Foundation;
@@ -27,7 +29,7 @@ namespace WebKit {
 			get { return (WebNavigationType)((NSNumber)ActionInformation[WebPolicyDelegate.WebActionNavigationTypeKey]).Int32Value; }
 		}
 
-		public NSDictionary ElementInfo {
+		public NSDictionary? ElementInfo {
 			get { return ActionInformation[WebPolicyDelegate.WebActionElementKey] as NSDictionary; }
 		}
 
@@ -46,7 +48,7 @@ namespace WebKit {
 			get { return ((NSNumber)ActionInformation[WebPolicyDelegate.WebActionModifierFlagsKey]).UInt32Value; }
 		}
 
-		public NSUrl OriginalUrl {
+		public NSUrl? OriginalUrl {
 			get { return ActionInformation[WebPolicyDelegate.WebActionOriginalUrlKey] as NSUrl; }
 		}
 	}

--- a/src/WebKit/WebPolicyDelegate.cs
+++ b/src/WebKit/WebPolicyDelegate.cs
@@ -37,7 +37,7 @@ namespace WebKit {
 		public static void DecideUse (NSObject decisionToken)
 		{
 			if (decisionToken == null)
-				throw new ArgumentNullException ("token");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (token));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selUse);
 		}
@@ -45,7 +45,7 @@ namespace WebKit {
 		public static void DecideDownload (NSObject decisionToken)
 		{
 			if (decisionToken == null)
-				throw new ArgumentNullException ("decisionToken");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (decisionToken));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selDownload);
 		}
@@ -53,7 +53,7 @@ namespace WebKit {
 		public static void DecideIgnore (NSObject decisionToken)
 		{
 			if (decisionToken == null)
-				throw new ArgumentNullException ("decisionToken");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (decisionToken));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selIgnore);
 		}

--- a/src/WebKit/WebPolicyDelegate.cs
+++ b/src/WebKit/WebPolicyDelegate.cs
@@ -20,6 +20,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/WebKit/WebPolicyDelegate.cs
+++ b/src/WebKit/WebPolicyDelegate.cs
@@ -36,7 +36,7 @@ namespace WebKit {
 		
 		public static void DecideUse (NSObject decisionToken)
 		{
-			if (decisionToken == null)
+			if (decisionToken is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (token));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selUse);
@@ -44,7 +44,7 @@ namespace WebKit {
 		
 		public static void DecideDownload (NSObject decisionToken)
 		{
-			if (decisionToken == null)
+			if (decisionToken is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (decisionToken));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selDownload);
@@ -52,7 +52,7 @@ namespace WebKit {
 		
 		public static void DecideIgnore (NSObject decisionToken)
 		{
-			if (decisionToken == null)
+			if (decisionToken is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (decisionToken));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selIgnore);

--- a/src/WebKit/WebPolicyDelegate.cs
+++ b/src/WebKit/WebPolicyDelegate.cs
@@ -37,7 +37,7 @@ namespace WebKit {
 		public static void DecideUse (NSObject decisionToken)
 		{
 			if (decisionToken is null)
-				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (token));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (decisionToken));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selUse);
 		}

--- a/src/WebKit/WebView.cs
+++ b/src/WebKit/WebView.cs
@@ -37,7 +37,7 @@ namespace WebKit {
 		public static void DecideUse (NSObject decisionToken)
 		{
 			if (decisionToken == null)
-				throw new ArgumentNullException ("token");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (token));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selUse);
 		}
@@ -45,7 +45,7 @@ namespace WebKit {
 		public static void DecideDownload (NSObject decisionToken)
 		{
 			if (decisionToken == null)
-				throw new ArgumentNullException ("decisionToken");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (decisionToken));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selDownload);
 		}
@@ -53,7 +53,7 @@ namespace WebKit {
 		public static void DecideIgnore (NSObject decisionToken)
 		{
 			if (decisionToken == null)
-				throw new ArgumentNullException ("decisionToken");
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (decisionToken));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selIgnore);
 		}

--- a/src/WebKit/WebView.cs
+++ b/src/WebKit/WebView.cs
@@ -20,6 +20,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using Foundation;
 using ObjCRuntime;

--- a/src/WebKit/WebView.cs
+++ b/src/WebKit/WebView.cs
@@ -36,7 +36,7 @@ namespace WebKit {
 		
 		public static void DecideUse (NSObject decisionToken)
 		{
-			if (decisionToken == null)
+			if (decisionToken is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (token));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selUse);
@@ -44,7 +44,7 @@ namespace WebKit {
 		
 		public static void DecideDownload (NSObject decisionToken)
 		{
-			if (decisionToken == null)
+			if (decisionToken is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (decisionToken));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selDownload);
@@ -52,7 +52,7 @@ namespace WebKit {
 		
 		public static void DecideIgnore (NSObject decisionToken)
 		{
-			if (decisionToken == null)
+			if (decisionToken is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (decisionToken));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selIgnore);

--- a/src/WebKit/WebView.cs
+++ b/src/WebKit/WebView.cs
@@ -37,7 +37,7 @@ namespace WebKit {
 		public static void DecideUse (NSObject decisionToken)
 		{
 			if (decisionToken is null)
-				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (token));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (decisionToken));
 			
 			ObjCRuntime.Messaging.void_objc_msgSend (decisionToken.Handle, selUse);
 		}


### PR DESCRIPTION
This PR aims to bring nullability changes to WebKit.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`