### PR TITLE
[Runtime] Provide better diagnostics if we fail to invoke a method in CoreCLR.

### DIFF
--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -694,6 +694,8 @@ namespace ObjCRuntime {
 				var ex = tie.InnerException ?? tie;
 				// This will re-throw the original exception and preserve the stacktrace.
 				ExceptionDispatchInfo.Capture (ex).Throw ();
+			} catch (Exception e) {
+				throw ErrorHelper.CreateError (8042, e, Errors.MX8042 /* An exception occurred while trying to invoke the function {0}: {1}. */, GetMethodFullName (method), e.Message);
 			}
 
 			// Copy any byref parameters back out again

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -4104,5 +4104,14 @@ namespace Xamarin.Bundler {
                 return ResourceManager.GetString("MX8041", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An exception occurred while trying to invoke the function {0}: {1}..
+        /// </summary>
+        public static string MX8042 {
+            get {
+                return ResourceManager.GetString("MX8042", resourceCulture);
+            }
+        }
     }
 }

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2164,4 +2164,11 @@
 		<value>Unable to create an instance of the type {0}.</value>
 	</data>
 
+	<data name="MX8042" xml:space="preserve">
+		<value>An exception occurred while trying to invoke the function {0}: {1}.</value>
+		<comment>
+			0: name of function
+			1: exception info
+		</comment>
+	</data>
 </root>


### PR DESCRIPTION
A stack trace like this isn't all that helpful:

    *** Terminating app due to uncaught exception 'System.Reflection.TargetException', reason: 'Object does not match target type. (System.Reflection.TargetException)
    at System.Reflection.RuntimeConstructorInfo.CheckConsistency(Object target)
    at System.Reflection.RuntimeConstructorInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    at ObjCRuntime.Runtime.InvokeMethod(MethodBase method, Object instance, IntPtr native_parameters) in /Users/builder/azdo/_work/1/s/xamarin-macios/src/ObjCRuntime/Runtime.CoreCLR.cs:line 655
    at ObjCRuntime.Runtime.InvokeMethod(MonoObject* methodobj, MonoObject* instanceobj, IntPtr native_parameters) in /Users/builder/azdo/_work/1/s/xamarin-macios/src/ObjCRuntime/Runtime.CoreCLR.cs:line 552
    at ObjCRuntime.Runtime.bridge_runtime_invoke_method(MonoObject* method, MonoObject* instance, IntPtr parameters, IntPtr& exception_gchandle) in /Users/builder/azdo/_work/1/s/xamarin-macios/runtime/Delegates.generated.cs:line 1210

with this change we'll be told exactly which function we failed to call.