### PR TITLE
[Localization] Use force-with-lease

### DIFF
--- a/.github/workflows/localization_branch_sync.yml
+++ b/.github/workflows/localization_branch_sync.yml
@@ -1,3 +1,5 @@
+# Disabling this action since we do something similar already in the CI
+
 name: Sync Localization Branch
 on:
   pull_request:

--- a/tools/devops/automation/templates/loc-translations.yml
+++ b/tools/devops/automation/templates/loc-translations.yml
@@ -52,7 +52,7 @@ steps:
     git push origin --delete Localization
 
     git checkout -b Localization
-    git push origin Localization
+    git push --force-with-lease origin Localization
   displayName: "Create a new Localization branch from main"
   workingDirectory: $(Build.SourcesDirectory)
 


### PR DESCRIPTION
In the localization process, we try to delete the Localization branch, and then create a new Localization branch from main in order to sync main and Localization. In this seemingly random instance, the Localization branch was not able to be deleted https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6164579&view=logs&j=ee797c9a-308f-58f3-15cb-bf937fe4c606&t=83c41547-0a37-55a1-12ce-d2da371355ea. 
This caused us not to be able to push to the localization branch. If this happens again, let's force-with-lease the push to override this.

I will also be turning off the github action that also syncs the Localization branch in a similar manner since we do not need two automations that do the same thing.