### PR TITLE
[nnyeah] Centralize error handling

### DIFF
--- a/tools/nnyeah/nnyeah/Errors.Designer.cs
+++ b/tools/nnyeah/nnyeah/Errors.Designer.cs
@@ -88,6 +88,12 @@ namespace Microsoft.MaciOS.Nnyeah {
                 return ResourceManager.GetString("N0007", resourceCulture);
             }
         }
+
+        internal static string N0008 {
+            get {
+                return ResourceManager.GetString("N0008", resourceCulture);
+            }
+        }
         
         internal static string E0001 {
             get {

--- a/tools/nnyeah/nnyeah/Errors.resx
+++ b/tools/nnyeah/nnyeah/Errors.resx
@@ -41,6 +41,10 @@
 		<value>If you want to compare assemblies, the earlier and later assembly options *must* be set.</value>
 	</data>
 
+	<data name="N0008" xml:space="preserve">
+		<value>Unexpected error - Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new</value>
+	</data>
+	
 	<data name="E0001" xml:space="preserve">
 		<value>Input file '{0}' doesn't exist.</value>
 	</data>

--- a/tools/nnyeah/nnyeah/MemberNotFoundException.cs
+++ b/tools/nnyeah/nnyeah/MemberNotFoundException.cs
@@ -1,6 +1,6 @@
 using System;
 namespace Microsoft.MaciOS.Nnyeah {
-	public class MemberNotFoundException : Exception {
+	public class MemberNotFoundException : ConversionException {
 		public MemberNotFoundException (string memberName)
 			: base ($"Member {memberName} not found.")
 		{

--- a/tools/nnyeah/nnyeah/Program.cs
+++ b/tools/nnyeah/nnyeah/Program.cs
@@ -23,8 +23,7 @@ namespace Microsoft.MaciOS.Nnyeah {
 			try {
 				Main2 (args);
 				return 0;
-			}
-			catch (ConversionException c) {
+			} catch (ConversionException c) {
 				Console.Error.WriteLine (c.Message);
 				return 1;
 			}

--- a/tools/nnyeah/nnyeah/Program.cs
+++ b/tools/nnyeah/nnyeah/Program.cs
@@ -23,8 +23,8 @@ namespace Microsoft.MaciOS.Nnyeah {
 			try {
 				Main2 (args);
 				return 0;
-			} catch (ConversionException c) {
-				Console.Error.WriteLine (c.Message);
+			} catch (Exception e) {
+				Console.Error.WriteLine (e.Message);
 				return 1;
 			}
 		}

--- a/tools/nnyeah/nnyeah/Program.cs
+++ b/tools/nnyeah/nnyeah/Program.cs
@@ -23,8 +23,13 @@ namespace Microsoft.MaciOS.Nnyeah {
 			try {
 				Main2 (args);
 				return 0;
-			} catch (Exception e) {
+			}
+			catch (ConversionException e) {
 				Console.Error.WriteLine (e.Message);
+				return 1;
+			} catch (Exception e) {
+				Console.Error.WriteLine (Errors.N0008);
+				Console.Error.WriteLine (e);
 				return 1;
 			}
 		}

--- a/tools/nnyeah/nnyeah/TypeNotFoundException.cs
+++ b/tools/nnyeah/nnyeah/TypeNotFoundException.cs
@@ -1,6 +1,6 @@
 using System;
 namespace Microsoft.MaciOS.Nnyeah {
-	public class TypeNotFoundException : Exception {
+	public class TypeNotFoundException : ConversionException {
 		public TypeNotFoundException (string typeName)
 			: base ($"The type {typeName} was not found.")
 		{


### PR DESCRIPTION
- Due to https://github.com/microsoft/vstest/issues/3658 it is not possible to test code that exits the process on error
- Create a base class for nnyeah exceptions that we want to explicitly report (and not crash), ConversionException
- Move Main to Main2 and wrap it in a try/catch for this exception
- ~~I did not catch everything as for now I want to crash with stack trace on unexpected failures~~