### PR TITLE
[nnyeah] Add unit test showing most common nuget failure

### DIFF
--- a/tools/nnyeah/tests/unit/CompileALibrary.cs
+++ b/tools/nnyeah/tests/unit/CompileALibrary.cs
@@ -30,6 +30,26 @@ public class Foo {
 		}
 
 		[Test]
+		public async Task LibraryWithXamarinReference ()
+		{
+			var dir = Cache.CreateTemporaryDirectory ("LibraryWithXamarinReference");
+			var code = @"
+using System;
+using Foundation;
+
+public class Foo {
+	public bool IsStaleHandle (NSObject o) => o.Handle != IntPtr.Zero;
+}
+";
+			await TestRunning.BuildLibrary (code, "NoName", dir);
+			var libraryFile = Path.Combine (dir, "NoName.dll");
+			Assert.IsTrue (File.Exists (libraryFile));
+
+			var convertedFile = Path.Combine (dir, "NoName-Converted.dll");
+			Program.ProcessAssembly (Compiler.XamarinPlatformLibraryPath (PlatformName.macOS), Compiler.MicrosoftPlatformLibraryPath (PlatformName.macOS), libraryFile, convertedFile, true, true, false);
+		}
+
+		[Test]
 		public void HasXamarinMacOSFile ()
 		{
 			var xamarinDll = Compiler.XamarinPlatformLibraryPath (PlatformName.macOS);

--- a/tools/nnyeah/tests/unit/utils/Compiler.cs
+++ b/tools/nnyeah/tests/unit/utils/Compiler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MaciOS.Nnyeah.Tests {
 
 		public static async Task<string> CompileText (string text, string outputFile, PlatformName platformName, bool isLibrary)
 		{
-			var dir = Cache.CreateTemporaryDirectory ();
+			var dir = Cache.CreateTemporaryDirectory ("CompileText");
 			var outputCSFile = Path.Combine (dir, "LibraryFile.cs");
 			File.WriteAllText (outputCSFile, text);
 			return await Compile (outputFile, platformName, isLibrary, dir, outputCSFile);


### PR DESCRIPTION
- 'Error while attempting to map member System.IntPtr Foundation.NSObject::get_Handle() in old assembly'
- Also fix a strange directory name created by Cache.CreateTemporaryDirectory being called from async test method