### PR TITLE
[coregraphics] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/CoreGraphics/CGAffineTransform.cs
+++ b/src/CoreGraphics/CGAffineTransform.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
@@ -88,13 +90,16 @@ namespace CoreGraphics {
 		[Obsolete ("Use 'Ty' instead.")]
 		public /* CGFloat */ nfloat y0;   // ty
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public /* CGFloat */ nfloat A { get => xx; set => xx = value; }
 		public /* CGFloat */ nfloat B { get => yx; set => yx = value; }
 		public /* CGFloat */ nfloat C { get => xy; set => xy = value; }
 		public /* CGFloat */ nfloat D { get => yy; set => yy = value; }
 		public /* CGFloat */ nfloat Tx { get => x0; set => x0 = value; }
 		public /* CGFloat */ nfloat Ty { get => y0; set => y0 = value; }
-#endif
+#pragma warning restore CS0618 // Type or member is obsolete
+
+#endif // NET
 
 #if !COREBUILD
 		//
@@ -113,15 +118,17 @@ namespace CoreGraphics {
 #else
 		public CGAffineTransform (nfloat xx, nfloat yx, nfloat xy, nfloat yy, nfloat x0, nfloat y0)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			this.xx = xx;
 			this.yx = yx;
 			this.xy = xy;
 			this.yy = yy;
 			this.x0 = x0;
 			this.y0 = y0;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
-#endif
-		
+#endif // NET
+
 		// Identity
 		public static CGAffineTransform MakeIdentity ()
 		{
@@ -161,13 +168,15 @@ namespace CoreGraphics {
 						      a.Tx * b.A + a.Ty * b.C + b.Tx,
 						      a.Tx * b.B + a.Ty * b.D + b.Ty);
 #else
+#pragma warning disable CS0618 // Type or member is obsolete
 			return new CGAffineTransform (a.xx * b.xx + a.yx * b.xy,
 						      a.xx * b.yx + a.yx * b.yy,
 						      a.xy * b.xx + a.yy * b.xy,
 						      a.xy * b.yx + a.yy * b.yy,
 						      a.x0 * b.xx + a.y0 * b.xy + b.x0,
 						      a.x0 * b.yx + a.y0 * b.yy + b.y0);
-#endif
+#pragma warning restore CS0618 // Type or member is obsolete
+#endif // NET
 		}
 
 		public void Multiply (CGAffineTransform b)
@@ -181,13 +190,16 @@ namespace CoreGraphics {
 			Tx = a.Tx * b.A + a.Ty * b.C + b.Tx;
 			Ty = a.Tx * b.B + a.Ty * b.D + b.Ty;
 #else
+#pragma warning disable CS0618 // Type or member is obsolete
 			xx = a.xx * b.xx + a.yx * b.xy;
 			yx = a.xx * b.yx + a.yx * b.yy;
 			xy = a.xy * b.xx + a.yy * b.xy;
 			yy = a.xy * b.yx + a.yy * b.yy;
 			x0 = a.x0 * b.xx + a.y0 * b.xy + b.x0;
 			y0 = a.x0 * b.yx + a.y0 * b.yy + b.y0;
-#endif
+#pragma warning restore CS0618 // Type or member is obsolete
+
+#endif // NET
 		}
 
 		public void Scale (nfloat sx, nfloat sy, MatrixOrder order)
@@ -221,6 +233,7 @@ namespace CoreGraphics {
 				transform.Tx,
 				transform.Ty);
 #else
+#pragma warning disable CS0618 // Type or member is obsolete
 			return new CGAffineTransform (
 				sx * transform.xx,
 				sx * transform.yx,
@@ -228,7 +241,8 @@ namespace CoreGraphics {
 				sy * transform.yy,
 				transform.x0,
 				transform.y0);
-#endif
+#pragma warning restore CS0618 // Type or member is obsolete
+#endif // NET
 		}
 
 		public void Translate (nfloat tx, nfloat ty, MatrixOrder order)
@@ -262,6 +276,7 @@ namespace CoreGraphics {
 				tx * transform.A + ty * transform.C + transform.Tx,
 				tx * transform.B + ty * transform.D + transform.Ty);
 #else
+#pragma warning disable CS0618 // Type or member is obsolete
 			return new CGAffineTransform (
 				transform.xx,
 				transform.yx,
@@ -269,7 +284,9 @@ namespace CoreGraphics {
 				transform.yy,
 				tx * transform.xx + ty * transform.xy + transform.x0,
 				tx * transform.yx + ty * transform.yy + transform.y0);
-#endif
+#pragma warning disable CS0618 // Type or member is obsolete
+
+#endif // NET
 		}
 
 		public void Rotate (nfloat angle, MatrixOrder order)
@@ -335,16 +352,16 @@ namespace CoreGraphics {
 		extern static /* NSString */ IntPtr NSStringFromCGAffineTransform (CGAffineTransform transform);
 #endif
 
-		public override String ToString ()
+		public override String? ToString ()
 		{
 #if NET
 	#if MONOMAC
-			String s = $"[{A}, {B}, {C}, {D}, {Tx}, {Ty}]";
+			var s = $"[{A}, {B}, {C}, {D}, {Tx}, {Ty}]";
 	#else
-			String s = CFString.FromHandle (NSStringFromCGAffineTransform (this));
+			var s = CFString.FromHandle (NSStringFromCGAffineTransform (this));
 	#endif
 #else
-			String s = String.Format ("xx:{0:##0.0#} yx:{1:##0.0#} xy:{2:##0.0#} yy:{3:##0.0#} x0:{4:##0.0#} y0:{5:##0.0#}", xx, yx, xy, yy, x0, y0);
+			var s = String.Format ("xx:{0:##0.0#} yx:{1:##0.0#} xy:{2:##0.0#} yy:{3:##0.0#} x0:{4:##0.0#} y0:{5:##0.0#}", xx, yx, xy, yy, x0, y0);
 #endif
 			return s;
 		}
@@ -386,7 +403,7 @@ namespace CoreGraphics {
 #endif
 		}
 
-		public override bool Equals(object o)
+		public override bool Equals(object? o)
 		{
 			if (o is CGAffineTransform transform) {
 				return this == transform;

--- a/src/CoreGraphics/CGBitmapContext.cs
+++ b/src/CoreGraphics/CGBitmapContext.cs
@@ -81,7 +81,7 @@ namespace CoreGraphics {
 		static IntPtr Create (byte []? data, nint width, nint height, nint bitsPerComponent, nint bytesPerRow, CGColorSpace? colorSpace, CGImageAlphaInfo bitmapInfo, out GCHandle buffer)
 		{
 			buffer = default (GCHandle);
-			if (data != null)
+			if (data is not null)
 				buffer = GCHandle.Alloc (data, GCHandleType.Pinned); // This requires a pinned GCHandle, because unsafe code is scoped to the current block, and the address of the byte array will be used after this function returns.
 			return CGBitmapContextCreate (data, width, height, bitsPerComponent, bytesPerRow, colorSpace.GetHandle (), (uint) bitmapInfo);
 		}
@@ -95,7 +95,7 @@ namespace CoreGraphics {
 		static IntPtr Create (byte []? data, nint width, nint height, nint bitsPerComponent, nint bytesPerRow, CGColorSpace? colorSpace, CGBitmapFlags bitmapInfo, out GCHandle buffer)
 		{
 			buffer = default (GCHandle);
-			if (data != null)
+			if (data is not null)
 				buffer = GCHandle.Alloc (data, GCHandleType.Pinned); // This requires a pinned GCHandle, because unsafe code is scoped to the current block, and the address of the byte array will be used after this function returns.
 			return CGBitmapContextCreate (data, width, height, bitsPerComponent, bytesPerRow, colorSpace.GetHandle (), (uint) bitmapInfo);
 		}

--- a/src/CoreGraphics/CGColor.cs
+++ b/src/CoreGraphics/CGColor.cs
@@ -119,7 +119,7 @@ namespace CoreGraphics {
 		static IntPtr Create (string name)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
 			var nameHandle = CFString.CreateNative (name);
 			try {
@@ -143,7 +143,7 @@ namespace CoreGraphics {
 		{
 			var constant = color.GetConstant ();
 			if (constant is null)
-				throw new ArgumentNullException (nameof (color));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (color));
 			var handle = CGColorGetConstantColor (constant.Handle);
 			if (handle == IntPtr.Zero)
 				throw new ArgumentException (nameof (color));
@@ -194,7 +194,7 @@ namespace CoreGraphics {
 		static IntPtr Create (CGColor source, nfloat alpha)
 		{
 			if (source is null)
-				throw new ArgumentNullException (nameof (source));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (source));
 			return CGColorCreateCopyWithAlpha (source.GetCheckedHandle (), alpha);
 		}
 

--- a/src/CoreGraphics/CGColorConversionInfo.cs
+++ b/src/CoreGraphics/CGColorConversionInfo.cs
@@ -104,7 +104,7 @@ namespace CoreGraphics {
 			// the API won't return a valid instance if no triple is given, i.e. at least one is needed. 
 			// `null` is accepted to mark the end of the list, not to make it optional
 			if ((triples is null) || (triples.Length == 0))
-				throw new ArgumentNullException (nameof (triples));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (triples));
 			if (triples.Length > 3)
 				throw new ArgumentException ("A maximum of 3 triples are supported");
 			
@@ -150,9 +150,9 @@ namespace CoreGraphics {
 		{
 			// API accept null arguments but returns null, which we can't use
 			if (source is null)
-				throw new ArgumentNullException (nameof (source));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (source));
 			if (destination is null)
-				throw new ArgumentNullException (nameof (destination));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (destination));
 			return CGColorConversionInfoCreate (source.Handle, destination.Handle);
 		}
 
@@ -178,9 +178,9 @@ namespace CoreGraphics {
 		static IntPtr Create (CGColorSpace source, CGColorSpace destination, NSDictionary? options)
 		{
 			if (source is null)
-				throw new ArgumentNullException (nameof (source));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (source));
 			if (destination is null)
-				throw new ArgumentNullException (nameof (destination));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (destination));
 
 			return CGColorConversionInfoCreateWithOptions (source.Handle, destination.Handle, options.GetHandle ());
 		}

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -105,7 +105,7 @@ namespace CoreGraphics {
 		static IntPtr Create (CFPropertyList propertyList)
 		{
 			if (propertyList is null)
-				throw new ArgumentNullException (nameof (propertyList));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (propertyList));
 			return CGColorSpaceCreateWithPropertyList (propertyList.GetCheckedHandle ());
 		}
 
@@ -186,7 +186,7 @@ namespace CoreGraphics {
 		public static CGColorSpace? CreateCalibratedGray (nfloat [] whitepoint, nfloat []? blackpoint, nfloat gamma)
 		{
 			if (whitepoint is null)
-				throw new ArgumentNullException (nameof (whitepoint));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (whitepoint));
 			if (whitepoint.Length != 3)
 				throw new ArgumentException ("Must have exactly 3 values", nameof (whitepoint));
 			if (blackpoint is not null && blackpoint.Length != 3)
@@ -203,7 +203,7 @@ namespace CoreGraphics {
 		public static CGColorSpace? CreateCalibratedRGB (nfloat [] whitepoint, nfloat []? blackpoint, nfloat []? gamma, nfloat []? matrix)
 		{
 			if (whitepoint is null)
-				throw new ArgumentNullException (nameof (whitepoint));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (whitepoint));
 			if (whitepoint.Length != 3)
 				throw new ArgumentException ("Must have exactly 3 values", nameof (whitepoint));
 			if (blackpoint is not null && blackpoint.Length != 3)
@@ -224,7 +224,7 @@ namespace CoreGraphics {
 		public static CGColorSpace? CreateLab (nfloat [] whitepoint, nfloat []? blackpoint, nfloat []? range)
 		{
 			if (whitepoint is null)
-				throw new ArgumentNullException (nameof (whitepoint));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (whitepoint));
 			if (whitepoint.Length != 3)
 				throw new ArgumentException ("Must have exactly 3 values", nameof (whitepoint));
 			if (blackpoint is not null && blackpoint.Length != 3)
@@ -262,7 +262,7 @@ namespace CoreGraphics {
 		public static CGColorSpace? CreateWithName (string name)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 			using (var ns = new NSString (name)) {
 				var cs = CGColorSpaceCreateWithName (ns.Handle);
 				return FromHandle (cs, true);

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -276,7 +276,7 @@ namespace CoreGraphics {
 		public void AddRects (CGRect [] rects)
 		{
 			if (rects is null)
-				throw new ArgumentNullException (nameof (rects));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (rects));
 			CGContextAddRects (Handle, rects, rects.Length);
 		}
 		
@@ -285,7 +285,7 @@ namespace CoreGraphics {
 		public void AddLines (CGPoint [] points)
 		{
 			if (points is null)
-				throw new ArgumentNullException (nameof (points));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (points));
 			CGContextAddLines (Handle, points, points.Length);
 		}
 			
@@ -319,7 +319,7 @@ namespace CoreGraphics {
 		public void AddPath (CGPath path)
 		{
 			if (path is null)
-				throw new ArgumentNullException (nameof (path));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (path));
 			CGContextAddPath (Handle, path.Handle);
 		}
 
@@ -412,7 +412,7 @@ namespace CoreGraphics {
 		public void ContextFillRects (CGRect [] rects)
 		{
 			if (rects is null)
-				throw new ArgumentNullException (nameof (rects));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (rects));
 			CGContextFillRects (Handle, rects, rects.Length);
 		}
 			
@@ -543,7 +543,7 @@ namespace CoreGraphics {
 		public void ClipToRects (CGRect [] rects)
 		{
 			if (rects is null)
-				throw new ArgumentNullException (nameof (rects));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (rects));
 			CGContextClipToRects (Handle, rects, rects.Length);
 		}
 		
@@ -1411,7 +1411,7 @@ namespace CoreGraphics {
 		public void DrawLayer (CGLayer layer, CGRect rect)
 		{
 			if (layer is null)
-				throw new ArgumentNullException (nameof (layer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (layer));
 			CGContextDrawLayerInRect (Handle, rect, layer.Handle);
 		}
 
@@ -1421,7 +1421,7 @@ namespace CoreGraphics {
 		public void DrawLayer (CGLayer layer, CGPoint point)
 		{
 			if (layer is null)
-				throw new ArgumentNullException (nameof (layer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (layer));
 			CGContextDrawLayerAtPoint (Handle, point, layer.Handle);
 		}
 

--- a/src/CoreGraphics/CGContextPDF.cs
+++ b/src/CoreGraphics/CGContextPDF.cs
@@ -270,7 +270,7 @@ namespace CoreGraphics {
 		public void SetUrl (NSUrl url, CGRect region)
 		{
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 			CGPDFContextSetURLForRect (Handle, url.Handle, region);
 		}
 
@@ -280,7 +280,7 @@ namespace CoreGraphics {
 		public void AddDestination (string name, CGPoint point)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
 			var nameHandle = CFString.CreateNative (name);
 			try {
@@ -296,7 +296,7 @@ namespace CoreGraphics {
 		public void SetDestination (string name, CGRect rect)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
 			var nameHandle = CFString.CreateNative (name);
 			try {

--- a/src/CoreGraphics/CGDataConsumer.cs
+++ b/src/CoreGraphics/CGDataConsumer.cs
@@ -79,7 +79,7 @@ namespace CoreGraphics {
 		{
 			// not it's a __nullable parameter but it would return nil (see unit tests) and create an invalid instance
 			if (data is null)
-				throw new ArgumentNullException (nameof (data));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 			return CGDataConsumerCreateWithCFData (data.Handle);
 		}
 
@@ -95,7 +95,7 @@ namespace CoreGraphics {
 		{
 			// not it's a __nullable parameter but it would return nil (see unit tests) and create an invalid instance
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 			return CGDataConsumerCreateWithURL (url.Handle);
 		}
 

--- a/src/CoreGraphics/CGDataProvider.cs
+++ b/src/CoreGraphics/CGDataProvider.cs
@@ -87,7 +87,7 @@ namespace CoreGraphics {
 		static public CGDataProvider? FromFile (string file)
 		{
 			if (file is null)
-				throw new ArgumentNullException (nameof (file));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (file));
 
 			var handle = CGDataProviderCreateWithFilename (file);
 			if (handle == IntPtr.Zero)
@@ -99,7 +99,7 @@ namespace CoreGraphics {
 		static IntPtr Create (string file)
 		{
 			if (file is null)
-				throw new ArgumentNullException (nameof (file));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (file));
 
 			var handle = CGDataProviderCreateWithFilename (file);
 			if (handle == IntPtr.Zero)
@@ -119,7 +119,7 @@ namespace CoreGraphics {
 		{
 			// not it's a __nullable parameter but it would return nil (see unit tests) and create an invalid instance
 			if (url is null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 			return CGDataProviderCreateWithURL (url.Handle);
 		}
 
@@ -135,7 +135,7 @@ namespace CoreGraphics {
 		{
 			// not it's a __nullable parameter but it would return nil (see unit tests) and create an invalid instance
 			if (data is null)
-				throw new ArgumentNullException (nameof (data));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 			return CGDataProviderCreateWithCFData (data.Handle);
 		}
 
@@ -199,7 +199,7 @@ namespace CoreGraphics {
 		static IntPtr Create (IntPtr memoryBlock, int size, Action<IntPtr> releaseMemoryBlockCallback)
 		{
 			if (releaseMemoryBlockCallback is null)
-				throw new ArgumentNullException (nameof (releaseMemoryBlockCallback));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (releaseMemoryBlockCallback));
 
 			var gch = GCHandle.Alloc (releaseMemoryBlockCallback);
 			return CGDataProviderCreateWithData (GCHandle.ToIntPtr (gch), memoryBlock, size, release_func_callback);
@@ -213,7 +213,7 @@ namespace CoreGraphics {
 		static IntPtr Create (byte [] buffer, int offset, int count)
 		{
 			if (buffer is null)
-				throw new ArgumentNullException (nameof (buffer));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffer));
 			if (offset < 0 || offset > buffer.Length)
 				throw new ArgumentException (nameof (offset));
 			if (offset + count > buffer.Length)

--- a/src/CoreGraphics/CGDisplay.cs
+++ b/src/CoreGraphics/CGDisplay.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 #if MONOMAC || __MACCATALYST__
 using System;
 using System.Runtime.InteropServices;

--- a/src/CoreGraphics/CGEnums.cs
+++ b/src/CoreGraphics/CGEnums.cs
@@ -7,6 +7,8 @@
 // Copyright 2018-2019 Microsoft Corporation
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;

--- a/src/CoreGraphics/CGEvent.cs
+++ b/src/CoreGraphics/CGEvent.cs
@@ -62,7 +62,7 @@ namespace CoreGraphics {
 		static IntPtr Create (NSData source)
 		{
 			if (source is null)
-				throw new ArgumentNullException (nameof (source));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (source));
 
 			return CGEventCreateFromData (IntPtr.Zero, source.Handle);
 		}
@@ -281,7 +281,7 @@ namespace CoreGraphics {
 		public void SetEventSource (CGEventSource eventSource)
 		{
 			if (eventSource is null)
-				throw new ArgumentNullException (nameof (eventSource));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (eventSource));
 			CGEventSetSource (Handle, eventSource.Handle);
 		}
 
@@ -334,14 +334,14 @@ namespace CoreGraphics {
 		public static void TapEnable (CFMachPort machPort)
 		{
 			if (machPort is null)
-				throw new ArgumentNullException (nameof (machPort));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (machPort));
 			CGEventTapEnable (machPort.Handle, true);
 		}
 
 		public static void TapDisable (CFMachPort machPort)
 		{
 			if (machPort is null)
-				throw new ArgumentNullException (nameof (machPort));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (machPort));
 			CGEventTapEnable (machPort.Handle, false);
 		}
 
@@ -352,7 +352,7 @@ namespace CoreGraphics {
 		public static bool IsTapEnabled (CFMachPort machPort)
 		{
 			if (machPort is null)
-				throw new ArgumentNullException (nameof (machPort));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (machPort));
 			return CGEventTapIsEnabled (machPort.Handle);
 		}
 
@@ -372,7 +372,7 @@ namespace CoreGraphics {
 		public void SetUnicodeString (string value)
 		{
 			if (value is null)
-				throw new ArgumentNullException (nameof (value));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 			CGEventKeyboardSetUnicodeString (Handle, (nuint) value.Length, value);
 		}
 
@@ -382,7 +382,7 @@ namespace CoreGraphics {
 		public static void TapPostEven (IntPtr tapProxyEvent, CGEvent evt)
 		{
 			if (evt is null)
-				throw new ArgumentNullException (nameof (evt));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (evt));
 			
 			CGEventTapPostEvent (tapProxyEvent, evt.Handle);
 		}
@@ -393,7 +393,7 @@ namespace CoreGraphics {
 		public static void Post (CGEvent evt, CGEventTapLocation location)
 		{
 			if (evt is null)
-				throw new ArgumentNullException (nameof (evt));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (evt));
 			
 			CGEventPost (location, evt.Handle);
 		}
@@ -404,7 +404,7 @@ namespace CoreGraphics {
 		public static void PostToPSN (CGEvent evt, IntPtr processSerialNumber)
 		{
 			if (evt is null)
-				throw new ArgumentNullException (nameof (evt));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (evt));
 			
 			CGEventPostToPSN (processSerialNumber, evt.Handle);
 		}

--- a/src/CoreGraphics/CGEventTypes.cs
+++ b/src/CoreGraphics/CGEventTypes.cs
@@ -8,6 +8,8 @@
  *    Miguel de Icaza
  */
 
+#nullable enable
+
 #if MONOMAC || __MACCATALYST__
 
 using System;

--- a/src/CoreGraphics/CGFont.cs
+++ b/src/CoreGraphics/CGFont.cs
@@ -64,7 +64,7 @@ namespace CoreGraphics {
 		static CGFont Create (IntPtr handle)
 		{
 			if (handle == IntPtr.Zero)
-				throw new ArgumentNullException (nameof (handle));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handle));
 			return new CGFont (handle, true);
 		}
 
@@ -248,7 +248,7 @@ namespace CoreGraphics {
 		{
 			// note: the API is marked to accept a null CFStringRef but it currently (iOS9 beta 4) crash when provided one
 			if (s is null)
-				throw new ArgumentNullException (nameof (s));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (s));
 			var sHandle = CFString.CreateNative (s);
 			try {
 				return CGFontGetGlyphWithGlyphName (Handle, sHandle);

--- a/src/CoreGraphics/CGFunction.cs
+++ b/src/CoreGraphics/CGFunction.cs
@@ -128,7 +128,7 @@ namespace CoreGraphics {
 					throw new ArgumentException ("The range array must consist of pairs of values", nameof (range));
 			}
 			if (callback is null)
-				throw new ArgumentNullException (nameof (callback));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			this.evaluate = callback;
 

--- a/src/CoreGraphics/CGFunction.cs
+++ b/src/CoreGraphics/CGFunction.cs
@@ -133,7 +133,7 @@ namespace CoreGraphics {
 			this.evaluate = callback;
 
 			var gch = GCHandle.Alloc (this);
-			var handle = CGFunctionCreate (GCHandle.ToIntPtr (gch), domain != null ? domain.Length / 2 : 0, domain, range != null ? range.Length / 2 : 0, range, ref cbacks);
+			var handle = CGFunctionCreate (GCHandle.ToIntPtr (gch), domain is not null ? domain.Length / 2 : 0, domain, range is not null ? range.Length / 2 : 0, range, ref cbacks);
 			InitializeHandle (handle);
 		}
 

--- a/src/CoreGraphics/CGGeometry.cs
+++ b/src/CoreGraphics/CGGeometry.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/src/CoreGraphics/CGGradient.cs
+++ b/src/CoreGraphics/CGGradient.cs
@@ -91,9 +91,9 @@ namespace CoreGraphics {
 			// those parameters are __nullable but would return a `nil` instance back,
 			// which is not something we can handle nicely from a .NET constructor
 			if (colorspace is null)
-				throw new ArgumentNullException (nameof (colorspace));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (colorspace));
 			if (components is null)
-				throw new ArgumentNullException (nameof (components));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (components));
 
 			return CGGradientCreateWithColorComponents (colorspace.GetCheckedHandle (), components, locations, components.Length / (colorspace.Components + 1));
 		}
@@ -108,9 +108,9 @@ namespace CoreGraphics {
 			// those parameters are __nullable but would return a `nil` instance back,
 			// which is not something we can handle nicely from a .NET constructor
 			if (colorspace is null)
-				throw new ArgumentNullException (nameof (colorspace));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (colorspace));
 			if (components is null)
-				throw new ArgumentNullException (nameof (components));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (components));
 
 			return CGGradientCreateWithColorComponents (colorspace.GetCheckedHandle (), components, null, components.Length / (colorspace.Components + 1));
 		}
@@ -130,7 +130,7 @@ namespace CoreGraphics {
 			// colors is __nullable but would return a `nil` instance back,
 			// which is not something we can handle nicely from a .NET constructor
 			if (colors is null)
-				throw new ArgumentNullException (nameof (colors));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (colors));
 
 			using (var array = CFArray.FromNativeObjects (colors))
 				return CGGradientCreateWithColors (colorspace.GetHandle (), array.Handle, locations);
@@ -144,7 +144,7 @@ namespace CoreGraphics {
 		static IntPtr Create (CGColorSpace? colorspace, CGColor [] colors)
 		{
 			if (colors is null)
-				throw new ArgumentNullException (nameof (colors));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (colors));
 
 			using (var array = CFArray.FromNativeObjects (colors))
 				return CGGradientCreateWithColors (colorspace.GetHandle (), array.Handle, null);

--- a/src/CoreGraphics/CGImage.cs
+++ b/src/CoreGraphics/CGImage.cs
@@ -377,7 +377,7 @@ namespace CoreGraphics {
 		public CGImage? WithMask (CGImage mask)
 		{
 			if (mask is null)
-				throw new ArgumentNullException (nameof (mask));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (mask));
 			return FromHandle (CGImageCreateWithMask (Handle, mask.Handle), true);
 		}
 

--- a/src/CoreGraphics/CGImageProperties.cs
+++ b/src/CoreGraphics/CGImageProperties.cs
@@ -25,6 +25,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.Versioning;
 
@@ -63,7 +65,7 @@ namespace CoreGraphics {
 		{
 		}
 
-		public CGImageProperties (NSDictionary dictionary)
+		public CGImageProperties (NSDictionary? dictionary)
 			: base (dictionary)
 		{
 		}
@@ -196,7 +198,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string ProfileName {
+		public string? ProfileName {
 			get {
 				return GetStringValue (Keys.ProfileName);
 			}
@@ -205,42 +207,42 @@ namespace CoreGraphics {
 			}
 		}
 
-		public CGImagePropertiesExif Exif {
+		public CGImagePropertiesExif? Exif {
 			get {
 				var dict = GetNSDictionary (Keys.ExifDictionary);
 				return dict == null ? null : new CGImagePropertiesExif (dict);
 			}
 		}
 
-		public CGImagePropertiesGps Gps {
+		public CGImagePropertiesGps? Gps {
 			get {
 				var dict = GetNSDictionary (Keys.GPSDictionary);
 				return dict == null ? null : new CGImagePropertiesGps (dict);
 			}
 		}
 
-		public CGImagePropertiesIptc Iptc {
+		public CGImagePropertiesIptc? Iptc {
 			get {
 				var dict = GetNSDictionary (Keys.IPTCDictionary);
 				return dict == null ? null : new CGImagePropertiesIptc (dict);
 			}
 		}
 
-		public CGImagePropertiesPng Png {
+		public CGImagePropertiesPng? Png {
 			get {
 				var dict = GetNSDictionary (Keys.PNGDictionary);
 				return dict == null ? null : new CGImagePropertiesPng (dict);
 			}
 		}
 
-		public CGImagePropertiesJfif Jfif {
+		public CGImagePropertiesJfif? Jfif {
 			get {
 				var dict = GetNSDictionary (Keys.JFIFDictionary);
 				return dict == null ? null : new CGImagePropertiesJfif (dict);
 			}
 		}
 
-		public CGImagePropertiesTiff Tiff {
+		public CGImagePropertiesTiff? Tiff {
 			get {
 				var dict = GetNSDictionary (Keys.TIFFDictionary);
 				return dict == null ? null : new CGImagePropertiesTiff (dict);
@@ -386,7 +388,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public int[] ISOSpeedRatings {
+		public int[]? ISOSpeedRatings {
 			get {
 				return GetArray (Keys.ExifISOSpeedRatings, l => new NSNumber (l).Int32Value);
 			}
@@ -487,7 +489,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string Software {
+		public string? Software {
 			get {
 				return GetStringValue (Keys.TIFFSoftware);
 			}
@@ -556,7 +558,7 @@ namespace CoreGraphics {
 		{
 		}
 
-		public string Author {
+		public string? Author {
 			get {
 				return GetStringValue (Keys.PNGAuthor);
 			}
@@ -565,7 +567,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string Description {
+		public string? Description {
 			get {
 				return GetStringValue (Keys.PNGDescription);
 			}
@@ -583,7 +585,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string Software {
+		public string? Software {
 			get {
 				return GetStringValue (Keys.PNGSoftware);
 			}
@@ -610,7 +612,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string Title {
+		public string? Title {
 			get {
 				return GetStringValue (Keys.PNGTitle);
 			}
@@ -689,7 +691,7 @@ namespace CoreGraphics {
 		{
 		}
 
-		public string Byline {
+		public string? Byline {
 			get {
 				return GetStringValue (Keys.IPTCByline);
 			}
@@ -698,7 +700,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string BylineTitle {
+		public string? BylineTitle {
 			get {
 				return GetStringValue (Keys.IPTCBylineTitle);
 			}
@@ -707,7 +709,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string CaptionAbstract {
+		public string? CaptionAbstract {
 			get {
 				return GetStringValue (Keys.IPTCCaptionAbstract);
 			}
@@ -716,7 +718,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string City {
+		public string? City {
 			get {
 				return GetStringValue (Keys.IPTCCity);
 			}
@@ -725,7 +727,7 @@ namespace CoreGraphics {
 			}
 		}
 		
-		public string ContentLocationName {
+		public string? ContentLocationName {
 			get {
 				return GetStringValue (Keys.IPTCContentLocationName);
 			}
@@ -734,7 +736,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string CountryPrimaryLocationName {
+		public string? CountryPrimaryLocationName {
 			get {
 				return GetStringValue (Keys.IPTCCountryPrimaryLocationName);
 			}
@@ -743,7 +745,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string CopyrightNotice {
+		public string? CopyrightNotice {
 			get {
 				return GetStringValue (Keys.IPTCCopyrightNotice);
 			}
@@ -752,7 +754,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string Credit {
+		public string? Credit {
 			get {
 				return GetStringValue (Keys.IPTCCredit);
 			}
@@ -761,7 +763,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string Source {
+		public string? Source {
 			get {
 				return GetStringValue (Keys.IPTCSource);
 			}
@@ -770,7 +772,7 @@ namespace CoreGraphics {
 			}
 		}
 
-		public string WriterEditor {
+		public string? WriterEditor {
 			get {
 				return GetStringValue (Keys.IPTCWriterEditor);
 			}

--- a/src/CoreGraphics/CGImageProperties.cs
+++ b/src/CoreGraphics/CGImageProperties.cs
@@ -210,42 +210,42 @@ namespace CoreGraphics {
 		public CGImagePropertiesExif? Exif {
 			get {
 				var dict = GetNSDictionary (Keys.ExifDictionary);
-				return dict == null ? null : new CGImagePropertiesExif (dict);
+				return dict is null ? null : new CGImagePropertiesExif (dict);
 			}
 		}
 
 		public CGImagePropertiesGps? Gps {
 			get {
 				var dict = GetNSDictionary (Keys.GPSDictionary);
-				return dict == null ? null : new CGImagePropertiesGps (dict);
+				return dict is null ? null : new CGImagePropertiesGps (dict);
 			}
 		}
 
 		public CGImagePropertiesIptc? Iptc {
 			get {
 				var dict = GetNSDictionary (Keys.IPTCDictionary);
-				return dict == null ? null : new CGImagePropertiesIptc (dict);
+				return dict is null ? null : new CGImagePropertiesIptc (dict);
 			}
 		}
 
 		public CGImagePropertiesPng? Png {
 			get {
 				var dict = GetNSDictionary (Keys.PNGDictionary);
-				return dict == null ? null : new CGImagePropertiesPng (dict);
+				return dict is null ? null : new CGImagePropertiesPng (dict);
 			}
 		}
 
 		public CGImagePropertiesJfif? Jfif {
 			get {
 				var dict = GetNSDictionary (Keys.JFIFDictionary);
-				return dict == null ? null : new CGImagePropertiesJfif (dict);
+				return dict is null ? null : new CGImagePropertiesJfif (dict);
 			}
 		}
 
 		public CGImagePropertiesTiff? Tiff {
 			get {
 				var dict = GetNSDictionary (Keys.TIFFDictionary);
-				return dict == null ? null : new CGImagePropertiesTiff (dict);
+				return dict is null ? null : new CGImagePropertiesTiff (dict);
 			}
 		}
 

--- a/src/CoreGraphics/CGPDFArray.cs
+++ b/src/CoreGraphics/CGPDFArray.cs
@@ -265,7 +265,7 @@ namespace CoreGraphics {
 		public bool Apply (ApplyCallback callback, object? info = null)
 		{
 			if (callback is null)
-				throw new ArgumentNullException (nameof (callback));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			BlockLiteral block_handler = new BlockLiteral ();
 			block_handler.SetupBlockUnsafe (applyblock_handler, callback);

--- a/src/CoreGraphics/CGPDFContentStream.cs
+++ b/src/CoreGraphics/CGPDFContentStream.cs
@@ -65,7 +65,7 @@ namespace CoreGraphics {
 		static IntPtr Create (CGPDFStream stream, NSDictionary? streamResources = null, CGPDFContentStream? parent = null)
 		{
 			if (stream is null)
-				throw new ArgumentNullException (nameof (stream));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (stream));
 
 			return CGPDFContentStreamCreateWithStream (stream.Handle, streamResources.GetHandle (), parent.GetHandle ());
 		}
@@ -100,9 +100,9 @@ namespace CoreGraphics {
 		public CGPDFObject? GetResource (string category, string name)
 		{
 			if (category is null)
-				throw new ArgumentNullException (nameof (category));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (category));
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
 			var h = CGPDFContentStreamGetResource (Handle, category, name);
 			return (h == IntPtr.Zero) ? null : new CGPDFObject (h);

--- a/src/CoreGraphics/CGPDFDictionary.cs
+++ b/src/CoreGraphics/CGPDFDictionary.cs
@@ -83,7 +83,7 @@ namespace CoreGraphics {
 		public bool GetBoolean (string key, out bool result)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			return CGPDFDictionaryGetBoolean (Handle, key, out result);
 		}
 
@@ -96,7 +96,7 @@ namespace CoreGraphics {
 		public bool GetInt (string key, out nint result)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			return CGPDFDictionaryGetInteger (Handle, key, out result);
 		}
 
@@ -109,7 +109,7 @@ namespace CoreGraphics {
 		public bool GetFloat (string key, out nfloat result)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			return CGPDFDictionaryGetNumber (Handle, key, out result);
 		}
 
@@ -120,7 +120,7 @@ namespace CoreGraphics {
 		public bool GetName (string key, out string? result)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			var r = CGPDFDictionaryGetName (Handle, key, out var res);
 			result = r ? Marshal.PtrToStringAnsi (res) : null;
 			return r;
@@ -133,7 +133,7 @@ namespace CoreGraphics {
 		public bool GetDictionary (string key, out CGPDFDictionary? result)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			var r = CGPDFDictionaryGetDictionary (Handle, key, out var res);
 			result = r ? new CGPDFDictionary (res) : null;
 			return r;
@@ -146,7 +146,7 @@ namespace CoreGraphics {
 		public bool GetStream (string key, out CGPDFStream? result)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			var r = CGPDFDictionaryGetStream (Handle, key, out var ptr);
 			result = r ? new CGPDFStream (ptr) : null;
 			return r;
@@ -159,7 +159,7 @@ namespace CoreGraphics {
 		public bool GetArray (string key, out CGPDFArray? array)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			var r = CGPDFDictionaryGetArray (Handle, key, out var ptr);
 			array = r ? new CGPDFArray (ptr) : null;
 			return r;
@@ -251,7 +251,7 @@ namespace CoreGraphics {
 		public bool GetString (string key, out string? result)
 		{
 			if (key is null)
-				throw new ArgumentNullException (nameof (key));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			var r = CGPDFDictionaryGetString (Handle, key, out var res);
 			result = r ? CGPDFString.ToString (res) : null;
 			return r;

--- a/src/CoreGraphics/CGPDFOperatorTable.cs
+++ b/src/CoreGraphics/CGPDFOperatorTable.cs
@@ -97,7 +97,7 @@ namespace CoreGraphics {
 		public void SetCallback (string name, Action<CGPDFScanner?,object?>? callback)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
 			if (callback is null)
 				CGPDFOperatorTableSetCallback (Handle, name, (CGPDFOperatorCallback?) null);
@@ -118,7 +118,7 @@ namespace CoreGraphics {
 		public void SetCallback (string name, Action<IntPtr,IntPtr>? callback)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
 			CGPDFOperatorTableSetCallback (Handle, name, callback);
 		}
@@ -129,7 +129,7 @@ namespace CoreGraphics {
 		public unsafe void SetCallback (string name, delegate* unmanaged<IntPtr, IntPtr, void> callback)
 		{
 			if (name is null)
-				throw new ArgumentNullException (nameof (name));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
 			CGPDFOperatorTableSetCallback (Handle, name, callback);
 		}

--- a/src/CoreGraphics/CGPDFScanner.cs
+++ b/src/CoreGraphics/CGPDFScanner.cs
@@ -46,9 +46,9 @@ namespace CoreGraphics {
 		public CGPDFScanner (CGPDFContentStream cs, CGPDFOperatorTable table, object userInfo)
 		{
 			if (cs is null)
-				throw new ArgumentNullException (nameof (cs));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (cs));
 			if (table is null)
-				throw new ArgumentNullException (nameof (table));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (table));
 
 			info = userInfo;
 			gch = GCHandle.Alloc (this);

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -282,14 +282,14 @@ namespace CoreGraphics {
 		public unsafe void AddRects (CGAffineTransform m, CGRect [] rects)
 		{
 			if (rects is null)
-				throw new ArgumentNullException (nameof (rects));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (rects));
 			CGPathAddRects (Handle, &m, rects, rects.Length);
 		}
 
 		public unsafe void AddRects (CGAffineTransform m, CGRect [] rects, int count)
 		{
 			if (rects is null)
-				throw new ArgumentNullException (nameof (rects));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (rects));
 			if (count > rects.Length)
 				throw new ArgumentException (nameof (count));
 			CGPathAddRects (Handle, &m, rects, count);
@@ -298,14 +298,14 @@ namespace CoreGraphics {
 		public unsafe void AddRects (CGRect [] rects)
 		{
 			if (rects is null)
-				throw new ArgumentNullException (nameof (rects));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (rects));
 			CGPathAddRects (Handle, null, rects, rects.Length);
 		}
 
 		public unsafe void AddRects (CGRect [] rects, int count)
 		{
 			if (rects is null)
-				throw new ArgumentNullException (nameof (rects));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (rects));
 			if (count > rects.Length)
 				throw new ArgumentException (nameof (count));
 			CGPathAddRects (Handle, null, rects, count);
@@ -317,14 +317,14 @@ namespace CoreGraphics {
 		public unsafe void AddLines (CGAffineTransform m, CGPoint [] points)
 		{
 			if (points is null)
-				throw new ArgumentNullException (nameof (points));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (points));
 			CGPathAddLines (Handle, &m, points, points.Length);
 		}
 
 		public unsafe void AddLines (CGAffineTransform m, CGPoint [] points, int count)
 		{
 			if (points is null)
-				throw new ArgumentNullException (nameof (points));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (points));
 			if (count > points.Length)
 				throw new ArgumentException (nameof (count));
 			CGPathAddLines (Handle, &m, points, count);
@@ -333,14 +333,14 @@ namespace CoreGraphics {
 		public unsafe void AddLines (CGPoint [] points)
 		{
 			if (points is null)
-				throw new ArgumentNullException (nameof (points));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (points));
 			CGPathAddLines (Handle, null, points, points.Length);
 		}
 
 		public unsafe void AddLines (CGPoint [] points, int count)
 		{
 			if (points is null)
-				throw new ArgumentNullException (nameof (points));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (points));
 			if (count > points.Length)
 				throw new ArgumentException (nameof (count));
 			CGPathAddLines (Handle, null, points, count);
@@ -404,14 +404,14 @@ namespace CoreGraphics {
 		public unsafe void AddPath (CGAffineTransform t, CGPath path2)
 		{
 			if (path2 is null)
-				throw new ArgumentNullException (nameof (path2));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (path2));
 			CGPathAddPath (Handle, &t, path2.Handle);
 		}
 		
 		public unsafe void AddPath (CGPath path2)
 		{
 			if (path2 is null)
-				throw new ArgumentNullException (nameof (path2));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (path2));
 			CGPathAddPath (Handle, null, path2.Handle);
 		}
 

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -25,6 +25,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -114,9 +117,10 @@ namespace CoreGraphics {
 		static void DrawCallback (IntPtr voidptr, IntPtr cgcontextptr)
 		{
 			GCHandle gch = GCHandle.FromIntPtr (voidptr);
-			DrawPattern draw_pattern = (DrawPattern) gch.Target;
-			using (var ctx = new CGContext (cgcontextptr, false))
-				draw_pattern (ctx);
+			if (gch.Target is DrawPattern draw_pattern) {
+				using (var ctx = new CGContext (cgcontextptr, false))
+					draw_pattern (ctx);
+			}
 		}
 
 #if !MONOMAC

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -104,7 +104,7 @@ namespace CoreGraphics {
 		
 		public CGPattern (CGRect bounds, CGAffineTransform matrix, nfloat xStep, nfloat yStep, CGPatternTiling tiling, bool isColored, DrawPattern drawPattern)
 		{
-			if (drawPattern == null)
+			if (drawPattern is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (drawPattern));
 
 			gch = GCHandle.Alloc (drawPattern);

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -105,7 +105,7 @@ namespace CoreGraphics {
 		public CGPattern (CGRect bounds, CGAffineTransform matrix, nfloat xStep, nfloat yStep, CGPatternTiling tiling, bool isColored, DrawPattern drawPattern)
 		{
 			if (drawPattern == null)
-				throw new ArgumentNullException (nameof (drawPattern));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (drawPattern));
 
 			gch = GCHandle.Alloc (drawPattern);
 			Handle = CGPatternCreate (GCHandle.ToIntPtr (gch), bounds, matrix, xStep, yStep, tiling, isColored, ref callbacks);

--- a/src/CoreGraphics/CGPdfTagType.cs
+++ b/src/CoreGraphics/CGPdfTagType.cs
@@ -7,6 +7,8 @@
 // Copyright 2018-2019 Microsoft Corporation
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
@@ -29,7 +31,7 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		static extern /* const char * _Nullable */ IntPtr CGPDFTagTypeGetName (CGPdfTagType tagType);
 
-		public static string GetName (this CGPdfTagType self)
+		public static string? GetName (this CGPdfTagType self)
 		{
 			return Marshal.PtrToStringAnsi (CGPDFTagTypeGetName (self));
 		}

--- a/src/CoreGraphics/CGPoint.cs
+++ b/src/CoreGraphics/CGPoint.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -34,7 +36,7 @@ namespace CoreGraphics {
 #endif // MONOMAC
 
 #if !COREBUILD
-		public override string ToString ()
+		public override string? ToString ()
 		{
 			return CFString.FromHandle (NSStringFromCGPoint (this));
 		}

--- a/src/CoreGraphics/CGRect.cs
+++ b/src/CoreGraphics/CGRect.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -26,7 +28,7 @@ namespace CoreGraphics {
 #endif // MONOMAC
 
 #if !COREBUILD
-		public override string ToString ()
+		public override string? ToString ()
 		{
 			return CFString.FromHandle (NSStringFromCGRect (this));
 		}

--- a/src/CoreGraphics/CGShading.cs
+++ b/src/CoreGraphics/CGShading.cs
@@ -83,9 +83,9 @@ namespace CoreGraphics {
 		public static CGShading CreateAxial (CGColorSpace colorspace, CGPoint start, CGPoint end, CGFunction function, bool extendStart, bool extendEnd)
 		{
 			if (colorspace is null)
-				throw new ArgumentNullException (nameof (colorspace));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (colorspace));
 			if (function is null)
-				throw new ArgumentNullException (nameof (function));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (function));
 
 			return new CGShading (CGShadingCreateAxial (colorspace.GetCheckedHandle (), start, end, function.GetCheckedHandle (), extendStart, extendEnd), true);
 		}
@@ -99,9 +99,9 @@ namespace CoreGraphics {
 						      CGFunction function, bool extendStart, bool extendEnd)
 		{
 			if (colorspace is null)
-				throw new ArgumentNullException (nameof (colorspace));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (colorspace));
 			if (function is null)
-				throw new ArgumentNullException (nameof (function));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (function));
 
 			return new CGShading (CGShadingCreateRadial (colorspace.GetCheckedHandle (), start, startRadius, end, endRadius,
 								     function.GetCheckedHandle (), extendStart, extendEnd), true);

--- a/src/CoreGraphics/CGSize.cs
+++ b/src/CoreGraphics/CGSize.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -26,7 +28,7 @@ namespace CoreGraphics {
 #endif // MONOMAC
 
 #if !COREBUILD
-		public override string ToString ()
+		public override string? ToString ()
 		{
 			return CFString.FromHandle (NSStringFromCGSize (this));
 		}

--- a/src/CoreGraphics/CGVector.cs
+++ b/src/CoreGraphics/CGVector.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -73,7 +75,7 @@ namespace CoreGraphics {
 #endif
 		}
 
-		public override bool Equals (object other)
+		public override bool Equals (object? other)
 		{
 			if (other is CGVector vector)
 				return dx == vector.dx && dy == vector.dy;
@@ -101,7 +103,7 @@ namespace CoreGraphics {
 #else
 		[iOS (8,0)]
 #endif
-		public override string ToString ()
+		public override string? ToString ()
 		{
 			return CFString.FromHandle (NSStringFromCGVector (this));
 		}


### PR DESCRIPTION
This PR aims to bring nullability changes to CoreGraphics.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`