### PR TITLE
[coremotion] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/CoreMotion/CMCompat.cs
+++ b/src/CoreMotion/CMCompat.cs
@@ -1,5 +1,7 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 
+#nullable enable
+
 #if !XAMCORE_3_0 && !MONOMAC
 
 using System;
@@ -10,7 +12,7 @@ namespace CoreMotion {
 	public partial class CMSensorRecorder {
 
 		[Obsolete ("Apple removed this API in iOS 9.3.")]
-		public virtual CMSensorDataList GetAccelerometerDataSince (ulong identifier)
+		public virtual CMSensorDataList? GetAccelerometerDataSince (ulong identifier)
 		{
 			return null;
 		}

--- a/src/CoreMotion/CMDeviceMotion.cs
+++ b/src/CoreMotion/CMDeviceMotion.cs
@@ -3,6 +3,8 @@
 //
 // Copyright (C) 2011-2014 Xamarin Inc
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/CoreMotion/CMMagnetometer.cs
+++ b/src/CoreMotion/CMMagnetometer.cs
@@ -6,6 +6,9 @@
 // Authors:
 //   Miguel de Icaza 
 //
+
+#nullable enable
+
 using System.Runtime.InteropServices;
 
 namespace CoreMotion {

--- a/src/CoreMotion/CMSensorDataList.cs
+++ b/src/CoreMotion/CMSensorDataList.cs
@@ -7,6 +7,8 @@
 //   Rolf Bjarne Kvinge
 //
 
+#nullable enable
+
 #if !MONOMAC
 
 using System.Collections.Generic;

--- a/src/CoreMotion/Defs.cs
+++ b/src/CoreMotion/Defs.cs
@@ -2,6 +2,8 @@
 // CoreMotion's struct and enum definitions used by the API file
 //
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/src/CoreMotion/Extras.cs
+++ b/src/CoreMotion/Extras.cs
@@ -1,6 +1,9 @@
 //
 // CoreMotion's extra methods
 //
+
+#nullable enable
+
 using Foundation;
 using System;
 


### PR DESCRIPTION
This PR aims to bring nullability changes to CoreMotion.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
