### PR TITLE
Make tput silent if there's an error.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -196,7 +196,7 @@ MACCATALYST_NUGET_VERSION_FULL=$(MACCATALYST_NUGET_VERSION_NO_METADATA)+$(NUGET_
 XCODE_VERSION=13.3
 XCODE_URL=https://dl.internalx.com/internal-files/xcodes/Xcode_13.3.xip
 XCODE_DEVELOPER_ROOT=/Applications/Xcode_13.3.0.app/Contents/Developer
-XCODE_PRODUCT_BUILD_VERSION:=$(shell /usr/libexec/PlistBuddy -c 'Print :ProductBuildVersion' $(XCODE_DEVELOPER_ROOT)/../version.plist 2>/dev/null || echo "    $(shell tput setaf 1)The required Xcode ($(XCODE_VERSION)) is not installed in $(basename $(basename $(XCODE_DEVELOPER_ROOT)))$(shell tput sgr0)" >&2)
+XCODE_PRODUCT_BUILD_VERSION:=$(shell /usr/libexec/PlistBuddy -c 'Print :ProductBuildVersion' $(XCODE_DEVELOPER_ROOT)/../version.plist 2>/dev/null || echo "    $(shell tput setaf 1 2>/dev/null)The required Xcode ($(XCODE_VERSION)) is not installed in $(basename $(basename $(XCODE_DEVELOPER_ROOT)))$(shell tput sgr0 2>/dev/null)" >&2)
 
 # Mono version embedded in XI/XM (NEEDED_MONO_VERSION/BRANCH) are specified in mk/mono.mk
 include $(TOP)/mk/mono.mk


### PR DESCRIPTION
tput typically fails on bots (where there's no attahed terminal) with:

> tput: No value for $TERM and no -T specified

This avoids those messages in the logs.