### PR TITLE
[release/6.0.4xx] Automatically bump commit distance.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -2,16 +2,19 @@ include $(TOP)/mk/subdirs.mk
 
 # calculate commit distance and store it in a file so that we don't have to re-calculate it every time make is executed.
 
+# Hardcode this for now. This is for this branch only (main doesn't need hardcoding).
+NUGET_VERSION_BAND_DIGIT=4
+
 -include $(TOP)/Make.config.inc
 $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 	@rm -f $@
 	@printf "IOS_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep IOS_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
 	@printf "MAC_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MAC_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
-	@printf "IOS_NUGET_COMMIT_DISTANCE:=$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep IOS_NUGET_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
-	@printf "TVOS_NUGET_COMMIT_DISTANCE:=$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep TVOS_NUGET_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
-	@printf "WATCHOS_NUGET_COMMIT_DISTANCE:=$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep WATCHOS_NUGET_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
-	@printf "MACOS_NUGET_COMMIT_DISTANCE:=$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MACOS_NUGET_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
-	@printf "MACCATALYST_NUGET_COMMIT_DISTANCE:=$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MACCATALYST_NUGET_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
+	@printf "IOS_NUGET_COMMIT_DISTANCE:=$(NUGET_VERSION_BAND_DIGIT)$(shell printf "%02d" "$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep IOS_NUGET_OS_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')")\\n" >> $@
+	@printf "TVOS_NUGET_COMMIT_DISTANCE:=$(NUGET_VERSION_BAND_DIGIT)$(shell printf "%02d" "$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep TVOS_NUGET_OS_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')")\\n" >> $@
+	@printf "WATCHOS_NUGET_COMMIT_DISTANCE:=$(NUGET_VERSION_BAND_DIGIT)$(shell printf "%02d" "$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep WATCHOS_NUGET_OS_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')")\\n" >> $@
+	@printf "MACOS_NUGET_COMMIT_DISTANCE:=$(NUGET_VERSION_BAND_DIGIT)$(shell printf "%02d" "$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MACOS_NUGET_OS_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')")\\n" >> $@
+	@printf "MACCATALYST_NUGET_COMMIT_DISTANCE:=$(NUGET_VERSION_BAND_DIGIT)$(shell printf "%02d" "$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MACCATALYST_NUGET_OS_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')")\\n" >> $@
 	@if which ccache > /dev/null 2>&1; then printf "ENABLE_CCACHE=1\nexport CCACHE_BASEDIR=$(abspath $(TOP)/..)\n" >> $@; echo "Found ccache on the system, enabling it"; fi
 	@if test -d $(TOP)/../maccore; then printf "ENABLE_XAMARIN=1\n" >> $@; echo "Detected the maccore repository, automatically enabled the Xamarin build"; fi
 	@# Build from source if we're on CI and packages aren't available.
@@ -124,6 +127,7 @@ IOS_PACKAGE_VERSION_BUILD=$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_MAJOR) $(IOS_PACKAGE_VERSION_MINOR) $(IOS_PACKAGE_VERSION_REV) $(IOS_PACKAGE_VERSION_BUILD))
 
 IOS_NUGET=Microsoft.iOS
+IOS_NUGET_VERSION=$(IOS_NUGET_OS_VERSION).$(IOS_NUGET_COMMIT_DISTANCE)
 IOS_NUGET_VERSION_MAJOR=$(word 1, $(subst ., ,$(IOS_NUGET_VERSION)))
 IOS_NUGET_VERSION_MINOR=$(word 2, $(subst ., ,$(IOS_NUGET_VERSION)))
 IOS_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(IOS_NUGET_VERSION)))
@@ -138,6 +142,7 @@ IOS_WINDOWS_NUGET_VERSION_NO_METADATA=$(IOS_NUGET_VERSION_NO_METADATA)
 IOS_WINDOWS_NUGET_VERSION_FULL=$(IOS_NUGET_VERSION_FULL)
 
 TVOS_NUGET=Microsoft.tvOS
+TVOS_NUGET_VERSION=$(TVOS_NUGET_OS_VERSION).$(TVOS_NUGET_COMMIT_DISTANCE)
 TVOS_NUGET_VERSION_MAJOR=$(word 1, $(subst ., ,$(TVOS_NUGET_VERSION)))
 TVOS_NUGET_VERSION_MINOR=$(word 2, $(subst ., ,$(TVOS_NUGET_VERSION)))
 TVOS_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(TVOS_NUGET_VERSION)))
@@ -145,6 +150,7 @@ TVOS_NUGET_VERSION_NO_METADATA=$(TVOS_NUGET_VERSION)$(TVOS_NUGET_PRERELEASE_IDEN
 TVOS_NUGET_VERSION_FULL=$(TVOS_NUGET_VERSION_NO_METADATA)+$(NUGET_BUILD_METADATA)
 
 WATCHOS_NUGET=Microsoft.watchOS
+WATCHOS_NUGET_VERSION=$(WATCHOS_NUGET_OS_VERSION).$(WATCHOS_NUGET_COMMIT_DISTANCE)
 WATCHOS_NUGET_VERSION_MAJOR=$(word 1, $(subst ., ,$(WATCHOS_NUGET_VERSION)))
 WATCHOS_NUGET_VERSION_MINOR=$(word 2, $(subst ., ,$(WATCHOS_NUGET_VERSION)))
 WATCHOS_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(WATCHOS_NUGET_VERSION)))
@@ -152,6 +158,7 @@ WATCHOS_NUGET_VERSION_NO_METADATA=$(WATCHOS_NUGET_VERSION)$(WATCHOSOS_NUGET_PRER
 WATCHOS_NUGET_VERSION_FULL=$(WATCHOS_NUGET_VERSION_NO_METADATA)+$(NUGET_BUILD_METADATA)
 
 MACCATALYST_NUGET=Microsoft.MacCatalyst
+MACCATALYST_NUGET_VERSION=$(MACCATALYST_NUGET_OS_VERSION).$(MACCATALYST_NUGET_COMMIT_DISTANCE)
 MACCATALYST_NUGET_VERSION_MAJOR=$(word 1, $(subst ., ,$(MACCATALYST_NUGET_VERSION)))
 MACCATALYST_NUGET_VERSION_MINOR=$(word 2, $(subst ., ,$(MACCATALYST_NUGET_VERSION)))
 MACCATALYST_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(MACCATALYST_NUGET_VERSION)))
@@ -454,6 +461,7 @@ MAC_PACKAGE_UPDATE_ID=$(shell echo $(subst ., ,$(MAC_PACKAGE_VERSION).$(MAC_PACK
 MAC_PACKAGE_TITLE=Xamarin $(MAC_PACKAGE_NAME) $(MAC_PACKAGE_VERSION)
 
 MACOS_NUGET=Microsoft.macOS
+MACOS_NUGET_VERSION=$(MACOS_NUGET_OS_VERSION).$(MACOS_NUGET_COMMIT_DISTANCE)
 MACOS_NUGET_VERSION_MAJOR=$(word 1, $(subst ., ,$(MACOS_NUGET_VERSION)))
 MACOS_NUGET_VERSION_MINOR=$(word 2, $(subst ., ,$(MACOS_NUGET_VERSION)))
 MACOS_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(MACOS_NUGET_VERSION)))

--- a/Make.versions
+++ b/Make.versions
@@ -66,12 +66,11 @@ MAC_PACKAGE_VERSION=8.11.0.$(MAC_COMMIT_DISTANCE)
 # WARNING: Do **not** use versions higher than the available Xcode SDK or else we will have issues with mtouch (See https://github.com/xamarin/xamarin-macios/issues/7705)
 # When bumping the major macOS version in MACOS_NUGET_VERSION also update the macOS version where we execute on bots in jenkins/Jenkinsfile (in the 'node' element)
 
-IOS_NUGET_VERSION=15.4.400
-TVOS_NUGET_VERSION=15.4.400
-WATCHOS_NUGET_VERSION=8.5.400
-MACOS_NUGET_VERSION=12.3.400
-MACCATALYST_NUGET_VERSION=15.4.400
-
+IOS_NUGET_OS_VERSION=15.4
+TVOS_NUGET_OS_VERSION=15.4
+WATCHOS_NUGET_OS_VERSION=8.5
+MACOS_NUGET_OS_VERSION=12.3
+MACCATALYST_NUGET_OS_VERSION=15.4
 
 # Defines the default platform version if it's not specified in the TFM. The default should not change for a given .NET version:
 # * We release support for iOS 14.5 with .NET 6

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -552,10 +552,10 @@ function check_xcode () {
 
 	local IOS_SDK_VERSION MACOS_SDK_VERSION WATCH_SDK_VERSION TVOS_SDK_VERSION
 	local XCODE_DEVELOPER_ROOT=`grep ^XCODE_DEVELOPER_ROOT= Make.config | sed 's/.*=//'`
-	IOS_SDK_VERSION=$(grep ^IOS_NUGET_VERSION= Make.versions | sed -e 's/.*=//' -e 's/.[0-9]*$//')
-	MACOS_SDK_VERSION=$(grep ^MACOS_NUGET_VERSION= Make.versions | sed -e 's/.*=//' -e 's/.[0-9]*$//')
-	WATCH_SDK_VERSION=$(grep ^WATCHOS_NUGET_VERSION= Make.versions | sed -e 's/.*=//' -e 's/.[0-9]*$//')
-	TVOS_SDK_VERSION=$(grep ^TVOS_NUGET_VERSION= Make.versions | sed -e 's/.*=//' -e 's/.[0-9]*$//')
+	IOS_SDK_VERSION=$(grep ^IOS_NUGET_OS_VERSION= Make.versions | sed -e 's/.*=//')
+	MACOS_SDK_VERSION=$(grep ^MACOS_NUGET_OS_VERSION= Make.versions | sed -e 's/.*=//')
+	WATCH_SDK_VERSION=$(grep ^WATCHOS_NUGET_OS_VERSION= Make.versions | sed -e 's/.*=//')
+	TVOS_SDK_VERSION=$(grep ^TVOS_NUGET_OS_VERSION= Make.versions | sed -e 's/.*=//')
 
 	local D=$XCODE_DEVELOPER_ROOT/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator${IOS_SDK_VERSION}.sdk
 	if test ! -d $D -a -z "$FAIL"; then


### PR DESCRIPTION
This is just a quick fix with as few changes as possible to auto-bump the versions so we don't have to do it manually.