### PR TITLE
[release/6.0.4xx] Adjust a few tests to cope with broken networks.

### DIFF
--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -232,6 +232,12 @@ namespace LinkAll {
 				// caching means it will be called at least for the first run, but it might not
 				// be called again in subsequent requests (unless it expires)
 				Assert.That (test_policy.CheckCount, Is.GreaterThan (0), "policy checked");
+			} catch (WebException we) {
+				// The remote server returned an error: (502) Bad Gateway.
+				// The remote server returned an error: (503) Service Unavailable.
+				if (we.Message.Contains ("(502)") || we.Message.Contains ("(503)"))
+					Assert.Inconclusive (we.Message);
+				throw;
 			} finally {
 				ServicePointManager.CertificatePolicy = old;
 			}

--- a/tests/linker/ios/link sdk/CryptoTest.cs
+++ b/tests/linker/ios/link sdk/CryptoTest.cs
@@ -68,6 +68,12 @@ namespace LinkSdk {
 				// caching means it will be called at least for the first run, but it might not
 				// be called again in subsequent requests (unless it expires)
 				Assert.That (trust_validation_callback, Is.GreaterThan (0), "validation done");
+			} catch (WebException we) {
+				// The remote server returned an error: (502) Bad Gateway.
+				// The remote server returned an error: (503) Service Unavailable.
+				if (we.Message.Contains ("(502)") || we.Message.Contains ("(503)"))
+					Assert.Inconclusive (we.Message);
+				throw;
 			}
 			finally {
 				ServicePointManager.ServerCertificateValidationCallback = null;

--- a/tests/linker/ios/link sdk/CryptoTest.cs
+++ b/tests/linker/ios/link sdk/CryptoTest.cs
@@ -84,8 +84,6 @@ namespace LinkSdk {
 			Assert.Ignore ("WatchOS doesn't support BSD sockets, which our network stack currently requires.");
 #endif
 			WebClient wc = new WebClient ();
-			// the certificate contains (several rules) the host name
-			Assert.NotNull (wc.DownloadString (NetworkResources.MicrosoftUrl));
 
 			// IP are (generally) not allowed
 			foreach (var ip in Dns.GetHostAddresses ("www.google.com")) {

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -671,10 +671,21 @@ namespace LinkSdk {
 #if __WATCHOS__
 			Assert.Ignore ("WatchOS doesn't support BSD sockets, which our network stack currently requires.");
 #endif
+			var exceptions = new List<string> ();
 			WebClient wc = new WebClient ();
-			// note: needs to be executed under Instrument to verify it does not leak
-			string s = wc.DownloadString (NetworkResources.MicrosoftUrl);
-			Assert.NotNull (s);
+			foreach (var url in NetworkResources.HttpsUrls) {
+				try {
+					// note: needs to be executed under Instrument to verify it does not leak
+					string s = wc.DownloadString (url);
+					Assert.NotNull (s);
+					return; // one url succeeded, that's enough
+				} catch (Exception e) {
+					var msg = $"Url '{url}' failed: {e.ToString ()}";
+					Console.WriteLine (msg); // If this keeps occurring locally for the same url, we might have to take it off the list of urls to test.
+					exceptions.Add (msg);
+				}
+			}
+			Assert.That (exceptions, Is.Empty, "At least one url should work");
 		}
 
 #if !__TVOS__ && !__WATCHOS__ && !__MACOS__

--- a/tests/linker/mac/LinkAnyTest.cs
+++ b/tests/linker/mac/LinkAnyTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
@@ -63,22 +64,35 @@ namespace LinkAnyTest {
 			}
 		}
 
-		[Test]
-		public void WebClientTest ()
+		void WebClientTest (string[] urls)
 		{
-			var wc = new WebClient ();
-			var data = wc.DownloadString (NetworkResources.MicrosoftUrl);
+			var exceptions = new List<string> ();
+			foreach (var url in urls) {
+				try {
+					var wc = new WebClient ();
+					var data = wc.DownloadString (url);
 
-			Assert.That (data, Is.Not.Empty, "Downloaded content");
+					Assert.That (data, Is.Not.Empty, "Downloaded content");
+					return; // one url succeeded, that's enough
+				} catch (Exception e) {
+					var msg = $"Url '{url}' failed: {e.ToString ()}";
+					Console.WriteLine (msg); // If this keeps occurring locally for the same url, we might have to take it off the list of urls to test.
+					exceptions.Add (msg);
+				}
+			}
+			Assert.That (exceptions, Is.Empty, "At least one url should work");
+		}
+
+		[Test]
+		public void WebClientTest_Http ()
+		{
+			WebClientTest (NetworkResources.HttpUrls);
 		}
 
 		[Test]
 		public void WebClientTest_Https ()
 		{
-			var wc = new WebClient ();
-			var data = wc.DownloadString (NetworkResources.MicrosoftUrl);
-
-			Assert.That (data, Is.Not.Empty, "Downloaded content");
+			WebClientTest (NetworkResources.HttpsUrls);
 		}
 
 		[Test]
@@ -91,15 +105,26 @@ namespace LinkAnyTest {
 
 				string data = null;
 
-				async Task GetWebPage (string url)
-				{
-					var wc = new WebClient ();
-					var task = wc.DownloadStringTaskAsync (new Uri (url));
-					data = await task;
-				}
+				var exceptions = new List<string> ();
+				foreach (var url in NetworkResources.HttpsUrls) {
+					try {
+						async Task GetWebPage (string url)
+						{
+							var wc = new WebClient ();
+							var task = wc.DownloadStringTaskAsync (new Uri (url));
+							data = await task;
+						}
 
-				GetWebPage (NetworkResources.MicrosoftUrl).Wait ();
-				Assert.That (data, Is.Not.Empty, "Downloaded content");
+						GetWebPage (url).Wait ();
+						Assert.That (data, Is.Not.Empty, "Downloaded content");
+						return; // one url succeeded, that's enough
+					} catch (Exception e) {
+						var msg = $"Url '{url}' failed: {e.ToString ()}";
+						Console.WriteLine (msg); // If this keeps occurring locally for the same url, we might have to take it off the list of urls to test.
+						exceptions.Add (msg);
+					}
+				}
+				Assert.That (exceptions, Is.Empty, "At least one url should work");
 			} finally {
 				SynchronizationContext.SetSynchronizationContext (current_sc);
 

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -9,12 +9,20 @@ namespace MonoTests.System.Net.Http
 	{
 		public static readonly string MicrosoftUrl = "https://www.microsoft.com";
 		public static readonly Uri MicrosoftUri = new Uri (MicrosoftUrl);
+		public static readonly string MicrosoftHttpUrl = "http://www.microsoft.com";
 		public static readonly string XamarinUrl = "https://dotnet.microsoft.com/apps/xamarin";
+		public static readonly string XamarinHttpUrl = "http://dotnet.microsoft.com/apps/xamarin";
 		public static readonly Uri XamarinUri = new Uri (XamarinUrl);
 		public static readonly string StatsUrl = "https://api.imgur.com/2/stats";
 
-		public static readonly string [] Urls = {
+		public static readonly string [] HttpsUrls = {
 			MicrosoftUrl,
+			XamarinUrl,
+		};
+
+		public static readonly string [] HttpUrls = {
+			MicrosoftHttpUrl,
+			XamarinHttpUrl,
 		};
 
 		// Robots urls, useful when we want to get a small file

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -18,11 +18,13 @@ namespace MonoTests.System.Net.Http
 		public static readonly string [] HttpsUrls = {
 			MicrosoftUrl,
 			XamarinUrl,
+			Httpbin.Url,
 		};
 
 		public static readonly string [] HttpUrls = {
 			MicrosoftHttpUrl,
 			XamarinHttpUrl,
+			Httpbin.HttpUrl,
 		};
 
 		// Robots urls, useful when we want to get a small file
@@ -51,6 +53,7 @@ namespace MonoTests.System.Net.Http
 			public static readonly string PostUrl = "https://httpbin.org/post";
 			public static readonly string PutUrl = "https://httpbin.org/put";
 			public static readonly string CookiesUrl = $"https://httpbin.org/cookies";
+			public static readonly string HttpUrl = "http://httpbin.org";
 
 
 			public static string GetAbsoluteRedirectUrl (int count) => $"https://httpbin.org/absolute-redirect/{count}";


### PR DESCRIPTION
This is a backport of #14943 and #15018.