### PR TITLE
[coreservices] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/CoreServices/FSEvents.cs
+++ b/src/CoreServices/FSEvents.cs
@@ -361,7 +361,7 @@ namespace CoreServices
 			ulong sinceWhenId, TimeSpan latency, FSEventStreamCreateFlags flags)
 			: this (new () {
 				Allocator = allocator,
-				NSPathsToWatch = pathsToWatch ?? ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (pathsToWatch)),
+				NSPathsToWatch = pathsToWatch ?? throw new ArgumentNullException (nameof (pathsToWatch)),
 				SinceWhenId = sinceWhenId,
 				Latency = latency,
 				Flags = flags
@@ -371,7 +371,7 @@ namespace CoreServices
 
 		public FSEventStream (string [] pathsToWatch, TimeSpan latency, FSEventStreamCreateFlags flags)
 			: this (new () {
-				PathsToWatch = pathsToWatch ?? ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (pathsToWatch)),
+				PathsToWatch = pathsToWatch ?? throw new ArgumentNullException (nameof (pathsToWatch)),
 				Latency = latency,
 				Flags = flags
 			})

--- a/src/CoreServices/FSEvents.cs
+++ b/src/CoreServices/FSEvents.cs
@@ -296,7 +296,7 @@ namespace CoreServices
 		public FSEventStream (FSEventStreamCreateOptions options)
 		{
 			if (options is null)
-				throw new ArgumentNullException (nameof (options));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (options));
 
 			NSArray pathsToWatch;
 
@@ -361,7 +361,7 @@ namespace CoreServices
 			ulong sinceWhenId, TimeSpan latency, FSEventStreamCreateFlags flags)
 			: this (new () {
 				Allocator = allocator,
-				NSPathsToWatch = pathsToWatch ?? throw new ArgumentNullException (nameof (pathsToWatch)),
+				NSPathsToWatch = pathsToWatch ?? ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (pathsToWatch)),
 				SinceWhenId = sinceWhenId,
 				Latency = latency,
 				Flags = flags
@@ -371,7 +371,7 @@ namespace CoreServices
 
 		public FSEventStream (string [] pathsToWatch, TimeSpan latency, FSEventStreamCreateFlags flags)
 			: this (new () {
-				PathsToWatch = pathsToWatch ?? throw new ArgumentNullException (nameof (pathsToWatch)),
+				PathsToWatch = pathsToWatch ?? ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (pathsToWatch)),
 				Latency = latency,
 				Flags = flags
 			})

--- a/src/CoreServices/LaunchServices.cs
+++ b/src/CoreServices/LaunchServices.cs
@@ -102,7 +102,7 @@ namespace CoreServices
 #endif
 		public static NSUrl? GetDefaultApplicationUrlForUrl (NSUrl url, LSRoles roles = LSRoles.All)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return Runtime.GetNSObject<NSUrl> (
@@ -125,7 +125,7 @@ namespace CoreServices
 #endif
 		public static NSUrl? GetDefaultApplicationUrlForContentType (string contentType, LSRoles roles = LSRoles.All)
 		{
-			if (contentType == null)
+			if (contentType is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (contentType));
 
 			return Runtime.GetNSObject<NSUrl> (
@@ -138,7 +138,7 @@ namespace CoreServices
 
 		public static NSUrl [] GetApplicationUrlsForUrl (NSUrl url, LSRoles roles = LSRoles.All)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return NSArray.ArrayFromHandle<NSUrl> (
@@ -155,9 +155,9 @@ namespace CoreServices
 		public static bool CanUrlAcceptUrl (NSUrl itemUrl, NSUrl targetUrl,
 			LSRoles roles, LSAcceptanceFlags acceptanceFlags, out LSResult result)
 		{
-			if (itemUrl == null)
+			if (itemUrl is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (itemUrl));
-			if (targetUrl == null)
+			if (targetUrl is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (targetUrl));
 
 			byte acceptsItem;
@@ -187,7 +187,7 @@ namespace CoreServices
 #endif
 		public static NSUrl [] GetApplicationUrlsForBundleIdentifier (string bundleIdentifier)
 		{
-			if (bundleIdentifier == null)
+			if (bundleIdentifier is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (bundleIdentifier));
 
 			return NSArray.ArrayFromHandle<NSUrl> (
@@ -204,7 +204,7 @@ namespace CoreServices
 
 		public unsafe static LSResult Open (NSUrl url)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return LSOpenCFURLRef (url.Handle, (void **)0);
@@ -212,7 +212,7 @@ namespace CoreServices
 
 		public unsafe static LSResult Open (NSUrl url, out NSUrl? launchedUrl)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			void *launchedUrlHandle;
@@ -230,7 +230,7 @@ namespace CoreServices
 
 		public static LSResult Register (NSUrl url, bool update)
 		{
-			if (url == null)
+			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return LSRegisterURL (url.Handle, (byte)(update ? 1 : 0));
@@ -245,7 +245,7 @@ namespace CoreServices
 
 		public static string?[]? GetAllRoleHandlersForContentType (string contentType, LSRoles roles = LSRoles.All)
 		{
-			if (contentType == null)
+			if (contentType is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (contentType));
 
 			return CFArray.StringArrayFromHandle (
@@ -258,7 +258,7 @@ namespace CoreServices
 
 		public static string GetDefaultRoleHandlerForContentType (string contentType, LSRoles roles = LSRoles.All)
 		{
-			if (contentType == null)
+			if (contentType is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (contentType));
 
 			return (string)Runtime.GetNSObject<NSString> (
@@ -274,9 +274,9 @@ namespace CoreServices
 		public static LSResult SetDefaultRoleHandlerForContentType (string contentType, string handlerBundleId,
 			LSRoles roles = LSRoles.All)
 		{
-			if (contentType == null)
+			if (contentType is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (contentType));
-			if (handlerBundleId == null)
+			if (handlerBundleId is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handlerBundleId));
 
 			return LSSetDefaultRoleHandlerForContentType (
@@ -309,7 +309,7 @@ namespace CoreServices
 #endif
 		public static string?[]? GetAllHandlersForUrlScheme (string urlScheme)
 		{
-			if (urlScheme == null)
+			if (urlScheme is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (urlScheme));
 
 			return CFArray.StringArrayFromHandle (
@@ -340,7 +340,7 @@ namespace CoreServices
 #endif
 		public static string GetDefaultHandlerForUrlScheme (string urlScheme)
 		{
-			if (urlScheme == null)
+			if (urlScheme is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (urlScheme));
 
 			return (string)Runtime.GetNSObject<NSString> (
@@ -353,9 +353,9 @@ namespace CoreServices
 
 		public static LSResult SetDefaultHandlerForUrlScheme (string urlScheme, string handlerBundleId)
 		{
-			if (urlScheme == null)
+			if (urlScheme is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (urlScheme));
-			if (handlerBundleId == null)
+			if (handlerBundleId is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handlerBundleId));
 
 			return LSSetDefaultHandlerForURLScheme (

--- a/src/CoreServices/LaunchServices.cs
+++ b/src/CoreServices/LaunchServices.cs
@@ -19,6 +19,8 @@
 //
 // NOTE: KEEP IN SYNC WITH TESTS!
 
+#nullable enable
+
 #if MONOMAC
 
 using System;
@@ -98,7 +100,7 @@ namespace CoreServices
 #else
 		[Mac (10, 10)]
 #endif
-		public static NSUrl GetDefaultApplicationUrlForUrl (NSUrl url, LSRoles roles = LSRoles.All)
+		public static NSUrl? GetDefaultApplicationUrlForUrl (NSUrl url, LSRoles roles = LSRoles.All)
 		{
 			if (url == null)
 				throw new ArgumentNullException (nameof (url));
@@ -121,7 +123,7 @@ namespace CoreServices
 #else
 		[Mac (10, 10)]
 #endif
-		public static NSUrl GetDefaultApplicationUrlForContentType (string contentType, LSRoles roles = LSRoles.All)
+		public static NSUrl? GetDefaultApplicationUrlForContentType (string contentType, LSRoles roles = LSRoles.All)
 		{
 			if (contentType == null)
 				throw new ArgumentNullException (nameof (contentType));
@@ -208,7 +210,7 @@ namespace CoreServices
 			return LSOpenCFURLRef (url.Handle, (void **)0);
 		}
 
-		public unsafe static LSResult Open (NSUrl url, out NSUrl launchedUrl)
+		public unsafe static LSResult Open (NSUrl url, out NSUrl? launchedUrl)
 		{
 			if (url == null)
 				throw new ArgumentNullException (nameof (url));
@@ -241,7 +243,7 @@ namespace CoreServices
 		[DllImport (Constants.CoreServicesLibrary)]
 		static extern IntPtr LSCopyAllRoleHandlersForContentType (IntPtr inContentType, LSRoles inRole);
 
-		public static string [] GetAllRoleHandlersForContentType (string contentType, LSRoles roles = LSRoles.All)
+		public static string?[]? GetAllRoleHandlersForContentType (string contentType, LSRoles roles = LSRoles.All)
 		{
 			if (contentType == null)
 				throw new ArgumentNullException (nameof (contentType));
@@ -305,7 +307,7 @@ namespace CoreServices
 #else
 		[Deprecated (PlatformName.MacOSX, 10,15, message: "Use 'GetApplicationUrlsForUrl' instead.")]
 #endif
-		public static string [] GetAllHandlersForUrlScheme (string urlScheme)
+		public static string?[]? GetAllHandlersForUrlScheme (string urlScheme)
 		{
 			if (urlScheme == null)
 				throw new ArgumentNullException (nameof (urlScheme));

--- a/src/CoreServices/LaunchServices.cs
+++ b/src/CoreServices/LaunchServices.cs
@@ -103,7 +103,7 @@ namespace CoreServices
 		public static NSUrl? GetDefaultApplicationUrlForUrl (NSUrl url, LSRoles roles = LSRoles.All)
 		{
 			if (url == null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return Runtime.GetNSObject<NSUrl> (
 				LSCopyDefaultApplicationURLForURL (url.Handle, roles, IntPtr.Zero)
@@ -126,7 +126,7 @@ namespace CoreServices
 		public static NSUrl? GetDefaultApplicationUrlForContentType (string contentType, LSRoles roles = LSRoles.All)
 		{
 			if (contentType == null)
-				throw new ArgumentNullException (nameof (contentType));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (contentType));
 
 			return Runtime.GetNSObject<NSUrl> (
 				LSCopyDefaultApplicationURLForContentType (new NSString (contentType).Handle, roles, IntPtr.Zero)
@@ -139,7 +139,7 @@ namespace CoreServices
 		public static NSUrl [] GetApplicationUrlsForUrl (NSUrl url, LSRoles roles = LSRoles.All)
 		{
 			if (url == null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return NSArray.ArrayFromHandle<NSUrl> (
 				LSCopyApplicationURLsForURL (url.Handle, roles)
@@ -156,9 +156,9 @@ namespace CoreServices
 			LSRoles roles, LSAcceptanceFlags acceptanceFlags, out LSResult result)
 		{
 			if (itemUrl == null)
-				throw new ArgumentNullException (nameof (itemUrl));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (itemUrl));
 			if (targetUrl == null)
-				throw new ArgumentNullException (nameof (targetUrl));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (targetUrl));
 
 			byte acceptsItem;
 			result = LSCanURLAcceptURL (itemUrl.Handle, targetUrl.Handle, roles, acceptanceFlags, out acceptsItem);
@@ -188,7 +188,7 @@ namespace CoreServices
 		public static NSUrl [] GetApplicationUrlsForBundleIdentifier (string bundleIdentifier)
 		{
 			if (bundleIdentifier == null)
-				throw new ArgumentNullException (nameof (bundleIdentifier));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (bundleIdentifier));
 
 			return NSArray.ArrayFromHandle<NSUrl> (
 				LSCopyApplicationURLsForBundleIdentifier (new NSString (bundleIdentifier).Handle, IntPtr.Zero)
@@ -205,7 +205,7 @@ namespace CoreServices
 		public unsafe static LSResult Open (NSUrl url)
 		{
 			if (url == null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return LSOpenCFURLRef (url.Handle, (void **)0);
 		}
@@ -213,7 +213,7 @@ namespace CoreServices
 		public unsafe static LSResult Open (NSUrl url, out NSUrl? launchedUrl)
 		{
 			if (url == null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			void *launchedUrlHandle;
 			var result = LSOpenCFURLRef (url.Handle, &launchedUrlHandle);
@@ -231,7 +231,7 @@ namespace CoreServices
 		public static LSResult Register (NSUrl url, bool update)
 		{
 			if (url == null)
-				throw new ArgumentNullException (nameof (url));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
 
 			return LSRegisterURL (url.Handle, (byte)(update ? 1 : 0));
 		}
@@ -246,7 +246,7 @@ namespace CoreServices
 		public static string?[]? GetAllRoleHandlersForContentType (string contentType, LSRoles roles = LSRoles.All)
 		{
 			if (contentType == null)
-				throw new ArgumentNullException (nameof (contentType));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (contentType));
 
 			return CFArray.StringArrayFromHandle (
 				LSCopyAllRoleHandlersForContentType (new NSString (contentType).Handle, roles)
@@ -259,7 +259,7 @@ namespace CoreServices
 		public static string GetDefaultRoleHandlerForContentType (string contentType, LSRoles roles = LSRoles.All)
 		{
 			if (contentType == null)
-				throw new ArgumentNullException (nameof (contentType));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (contentType));
 
 			return (string)Runtime.GetNSObject<NSString> (
 				LSCopyDefaultRoleHandlerForContentType (new NSString (contentType).Handle, roles)
@@ -275,9 +275,9 @@ namespace CoreServices
 			LSRoles roles = LSRoles.All)
 		{
 			if (contentType == null)
-				throw new ArgumentNullException (nameof (contentType));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (contentType));
 			if (handlerBundleId == null)
-				throw new ArgumentNullException (nameof (handlerBundleId));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handlerBundleId));
 
 			return LSSetDefaultRoleHandlerForContentType (
 				new NSString (contentType).Handle,
@@ -310,7 +310,7 @@ namespace CoreServices
 		public static string?[]? GetAllHandlersForUrlScheme (string urlScheme)
 		{
 			if (urlScheme == null)
-				throw new ArgumentNullException (nameof (urlScheme));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (urlScheme));
 
 			return CFArray.StringArrayFromHandle (
 				LSCopyAllHandlersForURLScheme (new NSString (urlScheme).Handle)
@@ -341,7 +341,7 @@ namespace CoreServices
 		public static string GetDefaultHandlerForUrlScheme (string urlScheme)
 		{
 			if (urlScheme == null)
-				throw new ArgumentNullException (nameof (urlScheme));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (urlScheme));
 
 			return (string)Runtime.GetNSObject<NSString> (
 				LSCopyDefaultHandlerForURLScheme (new NSString (urlScheme).Handle)
@@ -354,9 +354,9 @@ namespace CoreServices
 		public static LSResult SetDefaultHandlerForUrlScheme (string urlScheme, string handlerBundleId)
 		{
 			if (urlScheme == null)
-				throw new ArgumentNullException (nameof (urlScheme));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (urlScheme));
 			if (handlerBundleId == null)
-				throw new ArgumentNullException (nameof (handlerBundleId));
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handlerBundleId));
 
 			return LSSetDefaultHandlerForURLScheme (
 				new NSString (urlScheme).Handle,


### PR DESCRIPTION
This PR aims to bring nullability changes to CoreServices.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am adding `nullable enable` to all manual files that are not "API_SOURCES" in src/frameworks.sources and making the required nullability changes
2. Changing all `throw new ArgumentNullException ("object"));` to `ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (object));` for size saving optimization as well to mark that this framework contains nullability changes
3. Changing any `== null` or `!= null` to `is null` and `is not null`