### PR TITLE
[msbuild] Use the full path to the symbols list file. Fixes #15046.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2435,6 +2435,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<BCSymbolMapName>%(Filename)%(Extension).bcsymbolmap</BCSymbolMapName>
 			</_PostProcessingItem>
 
+			<!-- Add any items from app extensions -->
+			<_PostProcessingItem Include="@(_AppExtensionPostProcessingItems -> '$(_AppBundleName)$(AppBundleExtension)\$(_AppPlugInsRelativePath)%(Identity)')" Condition="@(_AppExtensionPostProcessingItems->Count()) &gt; 0" /> <!-- The condition here shouldn't be necessary, but https://github.com/dotnet/msbuild/issues/4056 -->
+
 			<!-- Add any items from watch app -->
 			<!-- We must update metadata with paths relative to the root of the app bundle to be relative to the root of the current app bundle -->
 			<_PostProcessingItem Include="@(_WatchAppPostProcessingItems -> '$(_AppBundleName)$(AppBundleExtension)/Watch/%(Identity)')" />


### PR DESCRIPTION
Give the full path to the symbols list file in the extension project to the
main project, so that strip can find it.

When building a solution remotely from Windows, we can't compute a relative
path between projects, because they're laid out differently on disk. This
means that we have to use full paths when passing paths between projects (such
as the path to the symbol list file).

Fixes https://github.com/xamarin/xamarin-macios/issues/15046.