### PR TITLE
[ci] Use nuget-msi-convert/job/v3.yml

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -25,14 +25,13 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v2.yml@templates
+  - template: nuget-msi-convert/job/v3.yml@templates
     parameters:
       yamlResourceName: templates
       dependsOn: signing
       artifactName: nuget-signed
       propsArtifactName: package
       signType: Real
-      useDateTimeVersion: true
 
   # Check - "xamarin-macios (Prepare Release Push NuGets)"
   - job: push_signed_nugets


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/180
Context: https://github.com/xamarin/yaml-templates/pull/195

Updates the build to the latest MSI generation template.  The `v3`
template uses the latest changes from arcade which include a large
refactoring and support for workload pack group MSIs.

The generation of workload pack group MSIs is enabled by default.  The
tooling will now generate a single MSI for each workload declared in our
WorkloadManifest.json file.  This should improve MSI based installation
scenarios as it dramatically reduces the number of MSIs that we ship.