### PR TITLE
Fix bundle.zip structure in 'Sign bundle.zip' step

### DIFF
--- a/tools/devops/automation/templates/sign-and-notarized/dotnet-signing.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/dotnet-signing.yml
@@ -84,7 +84,7 @@ steps:
     ConvertTo-Json -InputObject $SignFileList -Depth 100 | Out-File -FilePath $(Build.ArtifactStagingDirectory)/bundle.json -Force
     dotnet $Env:MBSIGN_APPFOLDER/ddsignfiles.dll /filelist:$(Build.ArtifactStagingDirectory)/bundle.json
     # rezip and move back
-    ditto -c -k --sequesterRsrc --keepParent $bundlePath bundle.zip
+    ditto -c -k --sequesterRsrc $bundlePath bundle.zip
     mv bundle.zip $(Build.SourcesDirectory)/package/bundle.zip
   displayName: 'Sign bundle.zip'
   workingDirectory: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
The files of the bundle.zip are being re-zipped inside a 'bundle' folder after signing, which is wrong since everything else is expecting the files directly inside the zip file without parent folders (as we were doing before)