### PR TITLE
[corefoundation] Cache `kCFNull` to avoid native calls

### DIFF
--- a/src/CoreFoundation/CFArray.cs
+++ b/src/CoreFoundation/CFArray.cs
@@ -53,6 +53,9 @@ namespace CoreFoundation {
 	// interesting bits: https://github.com/opensource-apple/CF/blob/master/CFArray.c
 	public partial class CFArray : NativeObject {
 
+		// this cache the handle instead of issuing a native call
+		internal static NativeHandle CFNullHandle = _CFNullHandle;
+
 #if !NET
 		internal CFArray (NativeHandle handle)
 			: base (handle, false)

--- a/src/corefoundation.cs
+++ b/src/corefoundation.cs
@@ -33,7 +33,7 @@ namespace CoreFoundation {
 	interface CFArray {
 
 		[Internal][Field ("kCFNull")]
-		IntPtr /* CFNullRef */ CFNullHandle { get; }
+		IntPtr /* CFNullRef */ _CFNullHandle { get; }
 	}
 
 	[Partial]

--- a/tests/perftest/NativeArrayPerf.cs
+++ b/tests/perftest/NativeArrayPerf.cs
@@ -32,5 +32,17 @@ namespace PerfTest {
 			var native = CFArray.Create (array);
 			CFString.ReleaseNative (native); // that's a `CFObject.CFRelease` with a null-check
 		}
+
+		int error;
+
+		[Benchmark]
+		public void ArrayFromHandleFunc ()
+		{
+			var native = CFArray.Create (array);
+			var managed = CFArray.ArrayFromHandle<NSNumber> (native);
+			if (managed.Length != array.Length)
+				error++;
+			CFString.ReleaseNative (native); // that's a `CFObject.CFRelease` with a null-check
+		}
 	}
 }


### PR DESCRIPTION
Calling `Dlfcn.GetIntPtr` is quite slow and doing for each element of
an native array slows them down.

**Before**

```
BenchmarkDotNet=v0.12.1, OS=macOS 12.3.1 (21E258) [Darwin 21.4.0]
Apple M1, 1 CPU, 8 logical and 8 physical cores
.NET Core SDK=        6.0.100 [/usr/local/share/dotnet/sdk]
  [Host] : .NET Core 6.0 (CoreCLR 6.0.522.21309, CoreFX 6.0.522.21309), Arm64 RyuJIT

Job=InProcess  Toolchain=InProcessEmitToolchain  IterationCount=3
LaunchCount=1  WarmupCount=3
```

|              Method | Length |            Mean |         Error |       StdDev |
|-------------------- |------- |----------------:|--------------:|-------------:|
| ArrayFromHandleFunc |      0 |       102.93 ns |     10.035 ns |     0.550 ns |
| ArrayFromHandleFunc |      1 |       559.07 ns |      0.533 ns |     0.029 ns |
| ArrayFromHandleFunc |     16 |     6,524.67 ns |      8.773 ns |     0.481 ns |
| ArrayFromHandleFunc |    256 |   102,833.36 ns | 22,060.169 ns | 1,209.192 ns |
| ArrayFromHandleFunc |   4096 | 1,635,076.63 ns |  9,698.879 ns |   531.628 ns |

**After**

```
BenchmarkDotNet=v0.12.1, OS=macOS 12.3.1 (21E258) [Darwin 21.4.0]
Apple M1, 1 CPU, 8 logical and 8 physical cores
.NET Core SDK=        6.0.100 [/usr/local/share/dotnet/sdk]
  [Host] : .NET Core 6.0 (CoreCLR 6.0.522.21309, CoreFX 6.0.522.21309), Arm64 RyuJIT

Job=InProcess  Toolchain=InProcessEmitToolchain  IterationCount=3
LaunchCount=1  WarmupCount=3
```

|              Method | Length |          Mean |      Error |    StdDev |
|-------------------- |------- |--------------:|-----------:|----------:|
| ArrayFromHandleFunc |      0 |     102.70 ns |   4.991 ns |  0.274 ns |
| ArrayFromHandleFunc |      1 |     207.97 ns |   2.064 ns |  0.113 ns |
| ArrayFromHandleFunc |     16 |     984.68 ns |   7.795 ns |  0.427 ns |
| ArrayFromHandleFunc |    256 |  13,555.05 ns | 147.095 ns |  8.063 ns |
| ArrayFromHandleFunc |   4096 | 216,002.44 ns | 617.544 ns | 33.850 ns |
