### PR TITLE
[mediaplayer] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/MediaPlayer/MPMediaItem.cs
+++ b/src/MediaPlayer/MPMediaItem.cs
@@ -24,7 +24,7 @@ namespace MediaPlayer {
 		ulong UInt64ForProperty (NSString property)
 		{
 			var prop = ValueForProperty (property) as NSNumber;
-			if (prop == null)
+			if (prop is null)
 				return 0;
 			return prop.UInt64Value;
 		}
@@ -32,7 +32,7 @@ namespace MediaPlayer {
 		uint UInt32ForProperty (NSString property)
 		{
 			var prop = ValueForProperty (property) as NSNumber;
-			if (prop == null)
+			if (prop is null)
 				return 0;
 			return prop.UInt32Value;
 		}
@@ -40,7 +40,7 @@ namespace MediaPlayer {
 		int Int32ForProperty (NSString property)
 		{
 			var prop = ValueForProperty (property) as NSNumber;
-			if (prop == null)
+			if (prop is null)
 				return 0;
 			return prop.Int32Value;
 		}
@@ -48,7 +48,7 @@ namespace MediaPlayer {
 		double DoubleForProperty (NSString property)
 		{
 			var prop = ValueForProperty (property) as NSNumber;
-			if (prop == null)
+			if (prop is null)
 				return 0;
 			return prop.DoubleValue;
 		}
@@ -56,7 +56,7 @@ namespace MediaPlayer {
 		bool BoolForProperty (NSString property)
 		{
 			var prop = ValueForProperty (property) as NSNumber;
-			if (prop == null)
+			if (prop is null)
 				return false;
 			return prop.BoolValue;
 		}

--- a/src/MediaPlayer/MPNowPlayingInfoCenter.cs
+++ b/src/MediaPlayer/MPNowPlayingInfoCenter.cs
@@ -170,15 +170,15 @@ namespace MediaPlayer {
 			if (DefaultPlaybackRate.HasValue)
 				Add (dict, MPNowPlayingInfoCenter.PropertyDefaultPlaybackRate, new NSNumber (DefaultPlaybackRate.Value));
 
-			if (AvailableLanguageOptions != null && AvailableLanguageOptions.Length != 0)
+			if (AvailableLanguageOptions is not null && AvailableLanguageOptions.Length != 0)
 				Add (dict, MPNowPlayingInfoCenter.PropertyAvailableLanguageOptions, NSArray.FromObjects (AvailableLanguageOptions));
-			if (CurrentLanguageOptions != null && CurrentLanguageOptions.Length != 0)
+			if (CurrentLanguageOptions is not null && CurrentLanguageOptions.Length != 0)
 				Add (dict, MPNowPlayingInfoCenter.PropertyCurrentLanguageOptions, NSArray.FromObjects (CurrentLanguageOptions));
-			if (CollectionIdentifier != null)
+			if (CollectionIdentifier is not null)
 				Add (dict, MPNowPlayingInfoCenter.PropertyCollectionIdentifier, new NSString (CollectionIdentifier));
-			if (ExternalContentIdentifier != null)
+			if (ExternalContentIdentifier is not null)
 				Add (dict, MPNowPlayingInfoCenter.PropertyExternalContentIdentifier, new NSString (ExternalContentIdentifier));
-			if (ExternalUserProfileIdentifier != null)
+			if (ExternalUserProfileIdentifier is not null)
 				Add (dict, MPNowPlayingInfoCenter.PropertyExternalUserProfileIdentifier, new NSString (ExternalUserProfileIdentifier));
 			if (PlaybackProgress.HasValue)
 				Add (dict, MPNowPlayingInfoCenter.PropertyPlaybackProgress, new NSNumber (PlaybackProgress.Value));
@@ -186,9 +186,9 @@ namespace MediaPlayer {
 				Add (dict, MPNowPlayingInfoCenter.PropertyMediaType, new NSNumber ((int)MediaType.Value));
 			if (IsLiveStream.HasValue)
 				Add (dict, MPNowPlayingInfoCenter.PropertyIsLiveStream, new NSNumber (IsLiveStream.Value));
-			if (AssetUrl != null)
+			if (AssetUrl is not null)
 				Add (dict, MPNowPlayingInfoCenter.PropertyAssetUrl, AssetUrl);
-			if (CurrentPlaybackDate != null)
+			if (CurrentPlaybackDate is not null)
 				Add (dict, MPNowPlayingInfoCenter.PropertyCurrentPlaybackDate, CurrentPlaybackDate);
 
 			if (AlbumTrackCount.HasValue)
@@ -204,17 +204,17 @@ namespace MediaPlayer {
 			if (PlaybackDuration.HasValue)
 				dict.Add (MPMediaItem.PlaybackDurationProperty, new NSNumber (PlaybackDuration.Value));
 
-			if (AlbumTitle != null)
+			if (AlbumTitle is not null)
 				dict.Add (MPMediaItem.AlbumTitleProperty, new NSString (AlbumTitle));
-			if (Artist != null)
+			if (Artist is not null)
 				dict.Add (MPMediaItem.ArtistProperty, new NSString (Artist));
-			if (Artwork != null)
+			if (Artwork is not null)
 				dict.Add (MPMediaItem.ArtworkProperty, Artwork);
-			if (Composer != null)
+			if (Composer is not null)
 				dict.Add (MPMediaItem.ComposerProperty, new NSString (Composer));
-			if (Genre != null)
+			if (Genre is not null)
 				dict.Add (MPMediaItem.GenreProperty, new NSString (Genre));
-			if (Title != null)
+			if (Title is not null)
 				dict.Add (MPMediaItem.TitleProperty, new NSString (Title));
 
 			return dict;
@@ -222,13 +222,13 @@ namespace MediaPlayer {
 
 		void Add (NSMutableDictionary dictionary, NSObject key, NSObject value)
 		{
-			if (key != null)
+			if (key is not null)
 				dictionary.Add (key, value);
 		}
 
 		bool TryGetValue (NSDictionary source, NSObject? key, [NotNullWhen (true)] out NSObject? result)
 		{
-			if (key != null)
+			if (key is not null)
 				return source.TryGetValue (key, out result);
 			result = null;
 			return false;
@@ -236,7 +236,7 @@ namespace MediaPlayer {
 
 		internal MPNowPlayingInfo (NSDictionary? source)
 		{
-			if (source == null)
+			if (source is null)
 				return;
 			
 			NSObject? result;

--- a/src/MediaPlayer/MPSkipIntervalCommand.cs
+++ b/src/MediaPlayer/MPSkipIntervalCommand.cs
@@ -18,7 +18,7 @@ namespace MediaPlayer {
 		public double[]? PreferredIntervals {
 			get {
 				NSArray a = _PreferredIntervals;
-				if ((a == null) || (a.Count == 0))
+				if ((a is null) || (a.Count == 0))
 					return null;
 
                 return NSArray.ArrayFromHandle<double> (a.Handle, input => {
@@ -26,7 +26,7 @@ namespace MediaPlayer {
 				});
 			}
 			set {
-				if (value == null)
+				if (value is null)
 					_PreferredIntervals = new NSArray ();
 				else {
 					NSObject [] nsoa = new NSObject [value.Length];

--- a/tests/monotouch-test/MediaPlayer/MPRemoteCommandTest.cs
+++ b/tests/monotouch-test/MediaPlayer/MPRemoteCommandTest.cs
@@ -1,0 +1,41 @@
+//
+// Unit tests for MPRemoteCommandTest
+//
+// Authors:
+//	TJ Lambert <TJ.Lambert@microsoft.com>
+//
+//
+// Copyright 2022 Microsoft. All rights reserved.
+//
+
+using System;
+using System.IO;
+using System.Drawing;
+using CoreGraphics;
+using Foundation;
+using MediaPlayer;
+using UIKit;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.MediaPlayer {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class MPRemoteCommandTest {
+
+		[Test]
+		public void RemoteTargetNull ()
+		{
+			var center = MPRemoteCommandCenter.Shared;
+			Func<MPRemoteCommandEvent, MPRemoteCommandHandlerStatus> handler = m => MPRemoteCommandHandlerStatus.Success;
+			center.PlayCommand.AddTarget (handler);
+
+			// at this point, the PlayCommand contains the target.
+
+			Assert.DoesNotThrow (delegate { center.PlayCommand.RemoveTarget (null, null); },
+				"MPRemoteCommand.RemoveTarget should not throw an ArgumentNullException.");
+
+			// at this point, the PlayCommand does not contain any targets as expected.
+		}
+	}
+}

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-MediaPlayer.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-MediaPlayer.ignore
@@ -41,5 +41,5 @@
 !missing-selector! MPMediaItem::userGrouping not bound
 !missing-selector! MPMediaItem::isPreorder not bound
 
-# Initial result from new rule extra-null-allowed
+# Headers do not show that null is allowed, but docs do allow it. Testing shows nullable functionality does work.
 !extra-null-allowed! 'System.Void MediaPlayer.MPRemoteCommand::RemoveTarget(Foundation.NSObject,ObjCRuntime.Selector)' has a extraneous [NullAllowed] on parameter #0

--- a/tests/xtro-sharpie/common-MediaPlayer.ignore
+++ b/tests/xtro-sharpie/common-MediaPlayer.ignore
@@ -41,5 +41,5 @@
 !missing-selector! MPMediaItem::userGrouping not bound
 !missing-selector! MPMediaItem::isPreorder not bound
 
-# Initial result from new rule extra-null-allowed
+# Headers do not show that null is allowed, but docs do allow it. Testing shows nullable functionality does work.
 !extra-null-allowed! 'System.Void MediaPlayer.MPRemoteCommand::RemoveTarget(Foundation.NSObject,ObjCRuntime.Selector)' has a extraneous [NullAllowed] on parameter #0


### PR DESCRIPTION
This PR aims to bring nullability changes to MediaPlayer.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. I am looking for any `!missing-null-allowed!` in this frameworks ignore files and applying them
2. Changing any `== null` or `!= null` to `is null` and `is not null`