### PR TITLE
Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 29e384e9e3eada3066d9b70c03c48803876a9ea6
+NEEDED_MACCORE_VERSION := 713bcb2442ac70e1741f4dccd2afa5cfed546fdb
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@713bcb2442 [mlaunch] Flush the output from the pty.

Diff: https://github.com/xamarin/maccore/compare/29e384e9e3eada3066d9b70c03c48803876a9ea6..713bcb2442ac70e1741f4dccd2afa5cfed546fdb