### PR TITLE
[metal] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/Metal/MTLCompat.cs
+++ b/src/Metal/MTLCompat.cs
@@ -29,7 +29,7 @@ namespace Metal {
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static IMTLCounterSampleBuffer? CreateIMTLCounterSampleBuffer (this IMTLDevice This, MTLCounterSampleBufferDescriptor descriptor, out NSError? error)
 		{
-			if (descriptor == null)
+			if (descriptor is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (descriptor));
 			var errorValue = NativeHandle.Zero;
 
@@ -46,7 +46,7 @@ namespace Metal {
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void SampleCounters (this IMTLComputeCommandEncoder This, IMTLCounterSampleBuffer sampleBuffer, nuint sampleIndex, bool barrier)
 		{
-			if (sampleBuffer == null)
+			if (sampleBuffer is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (sampleBuffer));
 			global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_UIntPtr_bool (This.Handle, Selector.GetHandle ("sampleCountersInBuffer:atSampleIndex:withBarrier:"), sampleBuffer.Handle, (UIntPtr) sampleIndex, barrier);
 		}

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -45,7 +45,7 @@ namespace Metal {
 			get {
 				// Metal could be unavailable on the hardware (and we don't want to return an invalid instance)
 				// also the instance could be disposed (by mistake) which would make the app unusable
-				if ((system_default == null) || (system_default.Handle == IntPtr.Zero)) {
+				if ((system_default is null) || (system_default.Handle == IntPtr.Zero)) {
 					try {
 						var h = MTLCreateSystemDefaultDevice ();
 						if (h != IntPtr.Zero)
@@ -149,7 +149,7 @@ namespace Metal {
 		{
 			var descriptor = (BlockLiteral*) block;
 			var del = (MTLDeviceNotificationHandler) (descriptor->Target);
-			if (del != null)
+			if (del is not null)
 				del ((IMTLDevice) Runtime.GetNSObject (device)!, (Foundation.NSString) Runtime.GetNSObject (notifyName)!);
 		}
 
@@ -177,7 +177,7 @@ namespace Metal {
 #endif
 		public static void RemoveObserver (NSObject observer)
 		{
-			if (observer == null)
+			if (observer is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (observer));
 
 			MTLRemoveDeviceObserver (observer.Handle);
@@ -194,7 +194,7 @@ namespace Metal {
 	public static partial class MTLDevice_Extensions {
 		public static IMTLBuffer? CreateBuffer<T> (this IMTLDevice This, T [] data, MTLResourceOptions options) where T : struct
 		{
-			if (data == null)
+			if (data is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 
 			var handle = GCHandle.Alloc (data, GCHandleType.Pinned); // This requires a pinned GCHandle, since it's not possible to use unsafe code to get the address of a generic object.
@@ -210,7 +210,7 @@ namespace Metal {
 		[Obsolete ("Use the overload that takes an IntPtr instead. The 'data' parameter must be page-aligned and allocated using vm_allocate or mmap, which won't be the case for managed arrays, so this method will always fail.")]
 		public static IMTLBuffer? CreateBufferNoCopy<T> (this IMTLDevice This, T [] data, MTLResourceOptions options, MTLDeallocator deallocator) where T : struct
 		{
-			if (data == null)
+			if (data is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (data));
 
 			var handle = GCHandle.Alloc (data, GCHandleType.Pinned); // This requires a pinned GCHandle, since it's not possible to use unsafe code to get the address of a generic object.
@@ -224,7 +224,7 @@ namespace Metal {
 
 		public unsafe static void GetDefaultSamplePositions (this IMTLDevice This, MTLSamplePosition [] positions, nuint count)
 		{
-			if (positions == null)
+			if (positions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (positions));
 
 			if (positions.Length < (nint)count)
@@ -250,9 +250,9 @@ namespace Metal {
 #endif
 		public static void ConvertSparseTileRegions (this IMTLDevice This, MTLRegion [] tileRegions, MTLRegion [] pixelRegions, MTLSize tileSize, nuint numRegions)
 		{
-			if (tileRegions == null)
+			if (tileRegions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (tileRegions));
-			if (pixelRegions == null)
+			if (pixelRegions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (pixelRegions));
 
 			var tileRegionsHandle = GCHandle.Alloc (tileRegions, GCHandleType.Pinned);
@@ -279,9 +279,9 @@ namespace Metal {
 #endif
 		public static void ConvertSparsePixelRegions (this IMTLDevice This, MTLRegion [] pixelRegions, MTLRegion [] tileRegions, MTLSize tileSize, MTLSparseTextureRegionAlignmentMode mode, nuint numRegions)
 		{
-			if (tileRegions == null)
+			if (tileRegions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (tileRegions));
-			if (pixelRegions == null)
+			if (pixelRegions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (pixelRegions));
 
 			var tileRegionsHandle = GCHandle.Alloc (tileRegions, GCHandleType.Pinned);

--- a/src/Metal/MTLIntersectionFunctionTable.cs
+++ b/src/Metal/MTLIntersectionFunctionTable.cs
@@ -28,9 +28,9 @@ namespace Metal {
 #endif
 		public static void SetBuffers (this IMTLIntersectionFunctionTable table, IMTLBuffer[] buffers, nuint[] offsets, NSRange range)
 		{
-			if (buffers == null)
+			if (buffers is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (buffers));
-			if (offsets == null)
+			if (offsets is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (offsets));
 
 			var bufferPtrArray = buffers.Length <= 1024 ? stackalloc IntPtr[buffers.Length] : new IntPtr [buffers.Length];

--- a/src/Metal/MTLRasterizationRateLayerDescriptor.cs
+++ b/src/Metal/MTLRasterizationRateLayerDescriptor.cs
@@ -55,9 +55,9 @@ namespace Metal {
 #endif
 		static public MTLRasterizationRateLayerDescriptor Create (MTLSize sampleCount, float[] horizontal, float[] vertical)
 		{
-			if (horizontal == null)
+			if (horizontal is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (horizontal));
-			if (vertical == null)
+			if (vertical is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (vertical));
 			if (sampleCount.Width != horizontal.Length)
 				throw new ArgumentOutOfRangeException ("Horizontal length should be equal to the sampleCount.Width.");

--- a/src/Metal/MTLResourceStateCommandEncoder.cs
+++ b/src/Metal/MTLResourceStateCommandEncoder.cs
@@ -34,13 +34,13 @@ namespace Metal {
 #endif
 		public static void Update (this IMTLResourceStateCommandEncoder This, IMTLTexture texture, MTLSparseTextureMappingMode mode, MTLRegion[] regions, nuint[] mipLevels, nuint[] slices)
 		{
-			if (texture == null)
+			if (texture is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (texture));
-			if (regions == null)
+			if (regions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (regions));
-			if (mipLevels == null)
+			if (mipLevels is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (mipLevels));
-			if (slices == null)
+			if (slices is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (slices));
 
 			var regionsHandle = GCHandle.Alloc (regions, GCHandleType.Pinned); 

--- a/src/Metal/MTLVertexDescriptor.cs
+++ b/src/Metal/MTLVertexDescriptor.cs
@@ -32,7 +32,7 @@ namespace Metal {
 #endif
 		public static MTLVertexDescriptor? FromModelIO (MDLVertexDescriptor descriptor)
 		{
-			if (descriptor == null)
+			if (descriptor is null)
 				throw new ArgumentException ("descriptor");
 			return Runtime.GetNSObject<MTLVertexDescriptor> (MTKMetalVertexDescriptorFromModelIO (descriptor.Handle));
 		}
@@ -62,7 +62,7 @@ namespace Metal {
 #endif
 		public static MTLVertexDescriptor? FromModelIO (MDLVertexDescriptor descriptor, out NSError? error)
 		{
-			if (descriptor == null)
+			if (descriptor is null)
 				throw new ArgumentException ("descriptor");
 			IntPtr err;
 			var vd = Runtime.GetNSObject<MTLVertexDescriptor> (MTKMetalVertexDescriptorFromModelIOWithError (descriptor.Handle, out err));


### PR DESCRIPTION
This PR aims to bring nullability changes to Metal.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. Changing any `== null` or `!= null` to `is null` and `is not null`