### PR TITLE
[modelio] Add nullability to (generated and manual) bindings

### DIFF
--- a/src/ModelIO/MDLAnimatedQuaternion.cs
+++ b/src/ModelIO/MDLAnimatedQuaternion.cs
@@ -41,9 +41,9 @@ namespace ModelIO {
 	public partial class MDLAnimatedQuaternion {
 		public virtual void Reset (Quaternion [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			if (values.Length != times.Length)
 				throw new ArgumentOutOfRangeException ($"The '{nameof (values)}' and '{nameof (times)}' arrays must have the same length");
@@ -57,9 +57,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Quaterniond [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			if (values.Length != times.Length)
 				throw new ArgumentOutOfRangeException ($"The '{nameof (values)}' and '{nameof (times)}' arrays must have the same length");

--- a/src/ModelIO/MDLAnimatedValueTypes.cs
+++ b/src/ModelIO/MDLAnimatedValueTypes.cs
@@ -48,7 +48,7 @@ namespace ModelIO {
 		public double []? KeyTimes {
 			get {
 				var wkt = WeakKeyTimes;
-				if (wkt == null)
+				if (wkt is null)
 					return null;
 
 				var count = wkt.Length;
@@ -83,7 +83,7 @@ namespace ModelIO {
 
 		public virtual void SetValues (float [] array, double time)
 		{
-			if (array == null)
+			if (array is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 
 			unsafe {
@@ -94,7 +94,7 @@ namespace ModelIO {
 
 		public virtual void SetValues (double [] array, double time)
 		{
-			if (array == null)
+			if (array is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 
 			unsafe {
@@ -129,9 +129,9 @@ namespace ModelIO {
 
 		public virtual void Reset (float [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 
 			unsafe {
@@ -143,9 +143,9 @@ namespace ModelIO {
 
 		public virtual void Reset (double [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 
 			unsafe {
@@ -184,7 +184,7 @@ namespace ModelIO {
 
 		public virtual void SetValues (Vector3 [] array, double time)
 		{
-			if (array == null)
+			if (array is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 			int typeSize = Marshal.SizeOf (typeof (Vector3));
 
@@ -196,7 +196,7 @@ namespace ModelIO {
 
 		public virtual void SetValues (Vector3d [] array, double time)
 		{
-			if (array == null)
+			if (array is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 			int typeSize = Marshal.SizeOf (typeof (Vector3d));
 
@@ -236,9 +236,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Vector3 [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			int typeSize = Marshal.SizeOf (typeof (Vector3));
 
@@ -250,9 +250,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Vector3d [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			int typeSize = Marshal.SizeOf (typeof (Vector3d));
 
@@ -295,7 +295,7 @@ namespace ModelIO {
 
 		public virtual void SetValues (Quaternion [] array, double time)
 		{
-			if (array == null)
+			if (array is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 			int typeSize = Marshal.SizeOf (typeof (Quaternion));
 
@@ -307,7 +307,7 @@ namespace ModelIO {
 
 		public virtual void SetValues (Quaterniond [] array, double time)
 		{
-			if (array == null)
+			if (array is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 			int typeSize = Marshal.SizeOf (typeof (Quaterniond));
 
@@ -347,9 +347,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Quaternion [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			int typeSize = Marshal.SizeOf (typeof (Quaternion));
 
@@ -361,9 +361,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Quaterniond [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			int typeSize = Marshal.SizeOf (typeof (Quaterniond));
 
@@ -405,9 +405,9 @@ namespace ModelIO {
 
 		public virtual void Reset (float [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 
 			unsafe {
@@ -419,9 +419,9 @@ namespace ModelIO {
 
 		public virtual void Reset (double [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 
 			unsafe {
@@ -460,9 +460,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Vector2 [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			if (values.Length != times.Length)
 				throw new InvalidOperationException ($"The length of the '{nameof (values)}' array and the '{nameof (times)}' array must match.");
@@ -476,9 +476,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Vector2d [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			if (values.Length != times.Length)
 				throw new InvalidOperationException ($"The length of the '{nameof (values)}' array and the '{nameof (times)}' array must match.");
@@ -523,9 +523,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Vector3 [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			if (values.Length != times.Length)
 				throw new InvalidOperationException ($"The length of the '{nameof (values)}' array and the '{nameof (times)}' array must match.");
@@ -539,9 +539,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Vector3d [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			if (values.Length != times.Length)
 				throw new InvalidOperationException ($"The length of the '{nameof (values)}' array and the '{nameof (times)}' array must match.");
@@ -586,9 +586,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Vector4 [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			if (values.Length != times.Length)
 				throw new InvalidOperationException ($"The length of the '{nameof (values)}' array and the '{nameof (times)}' array must match.");
@@ -602,9 +602,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Vector4d [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			if (values.Length != times.Length)
 				throw new InvalidOperationException ($"The length of the '{nameof (values)}' array and the '{nameof (times)}' array must match.");
@@ -649,9 +649,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Matrix4 [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			if (values.Length != times.Length)
 				throw new InvalidOperationException ($"The length of the '{nameof (values)}' array and the '{nameof (times)}' array must match.");
@@ -665,9 +665,9 @@ namespace ModelIO {
 
 		public virtual void Reset (Matrix4d [] values, double [] times)
 		{
-			if (values == null)
+			if (values is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (values));
-			if (times == null)
+			if (times is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (times));
 			if (values.Length != times.Length)
 				throw new InvalidOperationException ($"The length of the '{nameof (values)}' array and the '{nameof (times)}' array must match.");
@@ -712,7 +712,7 @@ namespace ModelIO {
 
 		public virtual void SetValues (Matrix4 [] array)
 		{
-			if (array == null)
+			if (array is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 			int typeSize = Marshal.SizeOf (typeof (Matrix4));
 
@@ -724,7 +724,7 @@ namespace ModelIO {
 
 		public virtual void SetValues (Matrix4d [] array)
 		{
-			if (array == null)
+			if (array is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (array));
 			int typeSize = Marshal.SizeOf (typeof (Matrix4d));
 


### PR DESCRIPTION
This PR aims to bring nullability changes to ModelIO.
Following the steps [here](https://github.com/xamarin/xamarin-macios/wiki/Nullability):

1. Changing any `== null` or `!= null` to `is null` and `is not null`