### PR TITLE
[nnyeah] fixing logic error in ConstructorTransform

### DIFF
--- a/tools/nnyeah/nnyeah/ConstructorTransforms.cs
+++ b/tools/nnyeah/nnyeah/ConstructorTransforms.cs
@@ -38,15 +38,17 @@ namespace Microsoft.MaciOS.Nnyeah {
 
         static bool IsIntPtrCtor (MethodDefinition d)
         {
+            if (d.Name != ".ctor")
+                return false;
             bool isSingle = d.Parameters.Count == 1 &&
                 d.Parameters.First ().ParameterType.FullName == "System.IntPtr";
             bool isDouble = d.Parameters.Count == 2 &&
-                d.Parameters.First ().ParameterType.FullName == "System.IntPtr" ||
+                d.Parameters.First ().ParameterType.FullName == "System.IntPtr" &&
                 d.Parameters.Last ().ParameterType.FullName == "System.Boolean";
             return isSingle || isDouble;
         }
 
-        public bool IsNSObjectDerived (TypeReference? typeReference)
+        static bool IsNSObjectDerived (TypeReference? typeReference)
         {
             if (typeReference is null) {
                 return false;


### PR DESCRIPTION
In looking at this being used in another context, I caught this logic error. The result was that if you called it with a constructor that had 0 arguments, the second `d.Parameters.Last ()` was getting called and crashing.

I also added the "fail fast" test for non-constructors.