### PR TITLE
Allow overriding HOME variable in dotnet remote builds

### DIFF
--- a/msbuild/Messaging/Xamarin.Messaging.Build/TaskRunner.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/TaskRunner.cs
@@ -17,14 +17,16 @@ namespace Xamarin.Messaging.Build {
 		{
 			this.serializer = serializer;
 
-			var dotnetPath = Path.Combine (MessagingContext.GetXmaPath (), "SDKs", "dotnet", "dotnet");
+			var sdkRootPath = Path.Combine (MessagingContext.GetXmaPath (), "SDKs");
+			var dotnetPath = Path.Combine (sdkRootPath, "dotnet", "dotnet");
 
-			//In case the XMA dotnet has not been installed yet
-			if (!File.Exists (dotnetPath)) {
+			if (File.Exists (dotnetPath)) {
+				Environment.SetEnvironmentVariable ("HOME", Path.Combine (sdkRootPath, ".home"));
+			} else {
+				//In case the XMA dotnet has not been installed yet
 				dotnetPath = "/usr/local/share/dotnet/dotnet";
 			}
 
-			// TODO: Needed by the ILLinkTask, we need to add support for doing this from Windows
 			Environment.SetEnvironmentVariable ("DOTNET_HOST_PATH", dotnetPath);
 		}
 


### PR DESCRIPTION
With remote builds, a dedicated dotnet location is being used so the right versioning can be used and managed from VS in Windows. This dedicated dotnet location requires a custom .home location so the donet and nuget caches doesn't conflict with the global installation.

We need to consider and use this custom .home location when running dotnet commands remotely so the right caches are used

This should fix Bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1543495