### PR TITLE
[CI] Using templates does not allow to run the pipeline without access to ESRP.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -195,6 +195,8 @@ variables:
 - ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
   - template: templates/vsts-variables.yml
 - template: templates/variables.yml
+- name: MicrobuildConnector
+  value: 'MicroBuild Signing Task (DevDiv)'
 
 trigger:
   branches:

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -245,3 +245,6 @@ stages:
     simTestsConfigurations: ${{ parameters.simTestsConfigurations }}
     deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}
     macTestsConfigurations: ${{ parameters.macTestsConfigurations }}
+    signingSetupSteps:
+      - template: ./templates/sign-and-notarized/setup.yml
+

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -178,6 +178,8 @@ resources:
 
 variables:
 - template: templates/variables.yml
+- name: MicrobuildConnector
+  value: ''
 
 trigger: none
 

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -61,6 +61,10 @@ parameters:
 - name: macTestsConfigurations
   type: object
 
+- name: signingSetupSteps
+  type: stepList
+  default: []
+
 stages:
 
 - ${{ if eq(parameters.runGovernanceTests, true) }}:
@@ -120,6 +124,7 @@ stages:
   jobs:
     - template: ./sign-and-notarized/prepare-pkg-stage.yml
       parameters:
+        signingSetupSteps: ${{ parameters.signingSetupSteps }}
         keyringPass: $(pass--lab--mac--builder--keychain)
         enableDotnet: ${{ parameters.enableDotnet }}
         skipESRP: ${{ parameters.skipESRP }}

--- a/tools/devops/automation/templates/sign-and-notarized/prepare-pkg-stage.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/prepare-pkg-stage.yml
@@ -11,6 +11,10 @@ parameters:
   type: boolean
   default: false # only to be used when testing the CI and we do not need a signed pkg
 
+- name: signingSetupSteps
+  type: stepList
+  default: []
+
 - name: packages
   type: object
   default: [
@@ -73,6 +77,7 @@ jobs:
     steps:
     - template: sign-and-notarized.yml
       parameters:
+        signingSetupSteps: ${{ parameters.signingSetupSteps }}
         keyringPass: ${{ parameters.keyringPass }}
         skipESRP: ${{ parameters.skipESRP }}
         packageName: ${{ pkg.name }}

--- a/tools/devops/automation/templates/sign-and-notarized/setup.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/setup.yml
@@ -37,7 +37,7 @@ steps:
   displayName: 'Install Signing Plugin'
   inputs:
     signType: '${{ parameters.signatureType }}'
-    azureSubscription: 'MicroBuild Signing Task (DevDiv)'
+    azureSubscription: $(MicrobuildConnector)
     zipSources: false  # we do not use the feature and makes the installation to last 10/12 mins instead of < 1 min
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -47,7 +47,7 @@ steps:
   displayName: 'Install Notarizing Plugin'
   inputs:
     signType: 'Real'  # test is not present for mac..
-    azureSubscription: 'MicroBuild Signing Task (DevDiv)'
+    azureSubscription: $(MicrobuildConnector)
     zipSources: false  # we do not use the feature and makes the installation to last 10/12 mins instead of < 1 min
   env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/tools/devops/automation/templates/sign-and-notarized/setup.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/setup.yml
@@ -8,10 +8,6 @@ parameters:
 - name: condition
   default: and(succeeded(), eq(variables['IsPRBuild'], 'False'))
 
-- name: skipESRP
-  type: boolean
-  default: false # only to be used when testing the CI and we do not need a signed pkg
-
 steps:
 
 # DO NOT USE THE checkout.yml template. The reason is that the template changes the hash which results in a problem with the artifacts scripts
@@ -30,30 +26,29 @@ steps:
 - checkout: release-scripts
   clean: true
 
-- ${{ if eq(parameters.skipESRP, false) }}: # do not install if not needd.
-  # the ddsign plugin needs this version or it will crash and will make the sign step fail
-  - task: UseDotNet@2
-    inputs:
-      packageType: sdk
-      version: 3.x
-    displayName: 'Install .NET Core SDK 3.x needed for ESRP'
+# the ddsign plugin needs this version or it will crash and will make the sign step fail
+- task: UseDotNet@2
+  inputs:
+    packageType: sdk
+    version: 3.x
+  displayName: 'Install .NET Core SDK 3.x needed for ESRP'
 
-  - task: MicroBuildSigningPlugin@3
-    displayName: 'Install Signing Plugin'
-    inputs:
-      signType: '${{ parameters.signatureType }}'
-      azureSubscription: 'MicroBuild Signing Task (DevDiv)'
-      zipSources: false  # we do not use the feature and makes the installation to last 10/12 mins instead of < 1 min
-    env:
+- task: MicroBuildSigningPlugin@3
+  displayName: 'Install Signing Plugin'
+  inputs:
+    signType: '${{ parameters.signatureType }}'
+    azureSubscription: 'MicroBuild Signing Task (DevDiv)'
+    zipSources: false  # we do not use the feature and makes the installation to last 10/12 mins instead of < 1 min
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+  condition: ${{ parameters.condition }}
+
+- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3
+  displayName: 'Install Notarizing Plugin'
+  inputs:
+    signType: 'Real'  # test is not present for mac..
+    azureSubscription: 'MicroBuild Signing Task (DevDiv)'
+    zipSources: false  # we do not use the feature and makes the installation to last 10/12 mins instead of < 1 min
+  env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: ${{ parameters.condition }}
-
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3
-    displayName: 'Install Notarizing Plugin'
-    inputs:
-      signType: 'Real'  # test is not present for mac..
-      azureSubscription: 'MicroBuild Signing Task (DevDiv)'
-      zipSources: false  # we do not use the feature and makes the installation to last 10/12 mins instead of < 1 min
-    env:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: ${{ parameters.condition }}
+  condition: ${{ parameters.condition }}

--- a/tools/devops/automation/templates/sign-and-notarized/sign-and-notarized.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/sign-and-notarized.yml
@@ -21,11 +21,15 @@ parameters:
 - name: condition
   default: and(succeeded(), eq(variables['IsPRBuild'], 'False'))
 
+- name: signingSetupSteps
+  type: stepList
+  default: []
+
 steps:
 
-- template: setup.yml
-  parameters:
-    skipESRP: ${{ parameters.skipESRP }}
+- ${{ each step in parameters.signingSetupSteps }}:
+  - ${{ each pair in step }}:
+      ${{ pair.key }}: ${{ pair.value }}       
 
 - task: DownloadPipelineArtifact@2
   displayName: Download not notarized build


### PR DESCRIPTION
 Passing the steps as a param does.