### PR TITLE
[dotnet] Remove some dead build logic.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1054,11 +1054,6 @@
 			<_GeneratorAttributeAssembly>$(_XamarinSdkRootDirectory)/tools/lib/Xamarin.Apple.BindingAttributes.dll</_GeneratorAttributeAssembly>
 			<_DotNetCscCompiler>$(RoslynTargetsPath)\bincore\csc.dll</_DotNetCscCompiler>
 		</PropertyGroup>
-
-		<ItemGroup>
-			<_BTouchCompileCommand Include="$(DOTNET_HOST_PATH)" />
-			<_BTouchCompileCommand Include="$(RoslynTargetsPath)/bincore/csc.dll" />
-		</ItemGroup>
 	</Target>
 
 	<Target Name="_ComputeNativeExecutableInputs" DependsOnTargets="_ComputeVariables">


### PR DESCRIPTION
The _BTouchCompileCommand property is never used, so we can just delete it.