### PR TITLE
[tests] We're not implementing Mac Catalyst for legacy Xamarin.iOS.

### DIFF
--- a/tests/introspection/ApiPInvokeTest.cs
+++ b/tests/introspection/ApiPInvokeTest.cs
@@ -368,9 +368,6 @@ namespace Introspection
 		// it's not complete (there's many more SDK assemblies) but we cannot add all of them into a single project anyway
 
 		[Test]
-#if __MACCATALYST__ && !NET
-		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/10883")]
-#endif
 		public void Corlib ()
 		{
 			var a = typeof (int).Assembly;
@@ -379,9 +376,6 @@ namespace Introspection
 		}
 
 		[Test]
-#if __MACCATALYST__ && !NET
-		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/10883")]
-#endif
 		public void System ()
 		{
 			var a = typeof (System.Net.WebClient).Assembly;
@@ -390,9 +384,6 @@ namespace Introspection
 		}
 
 		[Test]
-#if __MACCATALYST__ && !NET
-		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/10883")]
-#endif
 		public void SystemCore ()
 		{
 			var a = typeof (Enumerable).Assembly;


### PR DESCRIPTION
So there's no need to ignore tests for that particular scenario.