### PR TITLE
[dotnet] Change condition when to include the System.Runtime.InteropServices.NFloat.Internal package reference.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -111,7 +111,7 @@
 
   <ItemGroup>
     <!-- Add a reference to our custom nfloat reference assembly for .NET 6 (but only for .NET 6, once we switch to .NET 7 this can be removed) -->
-    <PackageReference Include="System.Runtime.InteropServices.NFloat.Internal" Condition="'$(BundledNETCorePlatformsPackageVersion.Substring(0,1))' == '6'" Version="[6.0.1, )" IsImplicitlyDefined="true" />
+    <PackageReference Include="System.Runtime.InteropServices.NFloat.Internal" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0'))" Version="[6.0.1, )" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
'BundledNETCorePlatformsPackageVersion' will be 7.0 when building with .NET 7
and using the 'net6.0-*' TFM, but we still need the package reference in that
case. So change the condition to go off TargetFrameworkVersion instead.