### PR TITLE
[dotnet] Condition default inclusion on the target framework version.

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
+++ b/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
@@ -17,70 +17,53 @@
 
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- Default plist file inclusion -->
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0'))">
+		<!-- Default plist file inclusion -->
 		<None Include="*.plist">
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 		</None>
-	</ItemGroup>
 
-	<!-- Default SceneKit assets inclusion -->
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
+		<!-- Default SceneKit assets inclusion -->
 		<SceneKitAsset Include="**\*.scnassets\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<IsDefaultItem>true</IsDefaultItem>
 		</SceneKitAsset>
-	</ItemGroup>
 
-	<!-- Default Asset Catalog file inclusion -->
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
+		<!-- Default Asset Catalog file inclusion -->
 		<ImageAsset Include="**\*.xcassets\**\*.*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);**\*.xcassets\**\*.DS_Store">
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<Visible>false</Visible>
 			<IsDefaultItem>true</IsDefaultItem>
 		</ImageAsset>
-	</ItemGroup>
 
-	<!-- Default Storyboard file inclusion -->
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
+		<!-- Default Storyboard file inclusion -->
 		<InterfaceDefinition Include="**\*.storyboard;**\*.xib" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
 		</InterfaceDefinition>
-	</ItemGroup>
 
-	<!-- Default Atlas Texture file inclusion -->
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
+		<!-- Default Atlas Texture file inclusion -->
 		<AtlasTexture Include="**\*.atlas\*.png" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
 		</AtlasTexture>
-	</ItemGroup>
 
-	<!-- Default CoreMLModel inclusion -->
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
+		<!-- Default CoreMLModel inclusion -->
 		<CoreMLModel Include="**\*.mlmodel" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
 		</CoreMLModel>
-	</ItemGroup>
 
-	<!-- Default Metal inclusion -->
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
+		<!-- Default Metal inclusion -->
 		<Metal Include="**\*.metal" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
 		</Metal>
-	</ItemGroup>
 
-	<!-- Default SceneKit assets inclusion -->
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
+		<!-- Default SceneKit assets inclusion -->
 		<SceneKitAsset Include="**\*.scnassets\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
 			<IsDefaultItem>true</IsDefaultItem>
 		</SceneKitAsset>
-	</ItemGroup>
 
-	<!-- Default font files inclusion -->
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true'">
 		<!-- Include everything in the project's Resources folder (as represented by the _ResourcePrefix property, which is set from the IPhoneResourcePrefix/XamMacResourcePrefix properties),
 		     except for files that are already in any of the other resource type item groups -->
 		<BundleResource Include="$(_ResourcePrefix)\**\*" Exclude="


### PR DESCRIPTION
One problem we hit when trying to build `net6.0-ios` projects from
a .NET 7 SDK & iOS workload, was that we ended up importing *two*
`AutoImport.props` files.

These are imported for any pack in `WorkloadManifest.json` declared as
an SDK:

    "packs": {
      "Microsoft.iOS.Sdk": {
        "kind": "sdk",

So the way this has to work is that ny `<ItemGroup>` must be conditioned so
that `$(TargetFrameworkVersion)` matches the expected .NET SDK version.

I used `[MSBuild]::VersionEquals()` for all checks, because the value
is `v6.0` and the helper method properly handles this case for us.

When this change ships in a .NET 6 servicing release, we can then
update our .NET 7 packages to rely on this change.

This is equivalent to Android's change here:
https://github.com/xamarin/xamarin-android/commit/38b3fa6f2b5e7deada848cebefd2c62a38d88e0e