### PR TITLE
[CI] Ignore test on macOS because the class is not present. Fixes test failures.

### DIFF
--- a/tests/monotouch-test/HomeKit/HMCharacteristicTest.cs
+++ b/tests/monotouch-test/HomeKit/HMCharacteristicTest.cs
@@ -8,7 +8,7 @@
 // Copyright 2022 Microsoft. All rights reserved.
 //
 
-#if HAS_HOMEKIT && !MONOMAC
+#if HAS_HOMEKIT
 
 using System;
 using NUnit.Framework;
@@ -27,6 +27,7 @@ namespace MonoTouchFixtures.HomeKit
 		[Test]
 		public void WriteValueNullTest ()
 		{
+			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14,0);
 			var characteristic = new HMCharacteristic ();
 			Assert.Throws<ArgumentNullException> (delegate { characteristic.WriteValue (null, null); }, $"WriteValue should accept a null argument for 'value'.");
 		}

--- a/tests/monotouch-test/HomeKit/HMCharacteristicTest.cs
+++ b/tests/monotouch-test/HomeKit/HMCharacteristicTest.cs
@@ -8,7 +8,7 @@
 // Copyright 2022 Microsoft. All rights reserved.
 //
 
-#if HAS_HOMEKIT
+#if HAS_HOMEKIT && !MONOMAC
 
 using System;
 using NUnit.Framework;


### PR DESCRIPTION
Failing test example: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6258744&view=logs&j=2fda2bbb-61e0-581a-db35-947a0a9403f6&t=600bbb3b-ca38-5b81-eb71-a3c932424b24&l=18562

