### PR TITLE
[msbuild] Only sign the prebuilt hotrestart app in CI

### DIFF
--- a/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
@@ -11,6 +11,8 @@
     <_LinkMode>None</_LinkMode>
     <UseInterpreter>true</UseInterpreter>
     <MtouchExtraArgs>--registrar:dynamic</MtouchExtraArgs>
+    <!-- disable code signing unless we're on building in CI, to avoid requiring code signing during developer builds (who will usually never need the prebuilt app) -->
+    <EnableCodeSigning Condition="'$(BUILD_REVISION)' == ''">false</EnableCodeSigning>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.iOS.HotRestart.Application" Version="1.1.5" />

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -581,6 +581,16 @@ namespace Xamarin.MacDev.Tasks
 
 					return !Log.HasLoggedErrors;
 				}
+
+				if (!SdkIsSimulator && !RequireCodeSigning) {
+					// The "-" key is a special value allowed by the codesign utility that
+					// allows us to get away with not having an actual codesign key.
+					DetectedCodeSigningKey = "-";
+
+					ReportDetectedCodesignInfo ();
+
+					return !Log.HasLoggedErrors;
+				}
 			}
 
 			// Note: if we make it this far, we absolutely need a codesigning certificate


### PR DESCRIPTION
Only sign the prebuilt hotrestart app in CI, to avoid making it required for
developers to configure code signing.

Also fix DetectSigningIdentity to not require a code signing certificate for
device builds when RequireCodeSigning is false.