### PR TITLE
[CI] Add another pipeline just for cronjobs so that we can easily identify those builds.

### DIFF
--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -198,25 +198,18 @@ variables:
 - name: MicrobuildConnector
   value: 'MicroBuild Signing Task (DevDiv)'
 
-trigger:
+trigger: none
+
+schedules:
+
+# the translations team wants a green build, we can do that on sundays even if 
+# the code did not change and without the device tests.
+- cron: "0 12 * * 0"
+  displayName: Weekly Translations build (Sunday @ noon)
   branches:
     include:
-    - '*'
-    exclude:
-    - refs/heads/locfiles/*
-  paths:
-    exclude:
-    - .github
-    - docs
-    - CODEOWNERS
-    - ISSUE_TEMPLATE.md
-    - LICENSE
-    - NOTICE.txt
-    - SECURITY.MD
-    - README.md
-    - src/README.md
-    - tools/mtouch/README.md
-    - msbuild/Xamarin.Localization.MSBuild/README.md
+    - main
+  always: true
 
 stages:
 - template: templates/main-stage.yml


### PR DESCRIPTION
We already have 2 pipelines which is making the logic easier since we can tell when we are in a CI or a PR build. The same idea is going to work with cron jobs, making it very easy to indentify those jobs that fail and fix the translators or ios32 issues. 