### PR TITLE
[tools] Fix nunit3-console shell scripts.

### DIFF
--- a/tools/nunit3-console-3.10.0
+++ b/tools/nunit3-console-3.10.0
@@ -1,3 +1,10 @@
 #!/bin/bash -eu
 
-exec mono ~/.nuget/packages/nunit.consolerunner/3.10.0/tools/nunit3-console.exe "$@"
+# This makes it so that stack traces have source code location
+if test -z "${MONO_ENV_OPTIONS:-}"; then
+	export MONO_ENV_OPTIONS=--debug
+fi
+
+TOP="$(cd "$(dirname "$0")/.." && pwd)"
+
+exec mono --debug "$TOP"/packages/nunit.consolerunner/3.10.0/tools/nunit3-console.exe "$@"

--- a/tools/nunit3-console-3.11.1
+++ b/tools/nunit3-console-3.11.1
@@ -5,4 +5,6 @@ if test -z "${MONO_ENV_OPTIONS:-}"; then
 	export MONO_ENV_OPTIONS=--debug
 fi
 
-exec mono --debug ~/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe "$@"
+TOP="$(cd "$(dirname "$0")/.." && pwd)"
+
+exec mono --debug "$TOP"/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe "$@"

--- a/tools/nunit3-console-3.9.0
+++ b/tools/nunit3-console-3.9.0
@@ -1,3 +1,10 @@
 #!/bin/bash -eu
 
-exec mono ~/.nuget/packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe "$@"
+# This makes it so that stack traces have source code location
+if test -z "${MONO_ENV_OPTIONS:-}"; then
+	export MONO_ENV_OPTIONS=--debug
+fi
+
+TOP="$(cd "$(dirname "$0")/.." && pwd)"
+
+exec mono --debug "$TOP"/packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe "$@"


### PR DESCRIPTION
We're putting all packages in the xamarin-macios/packages directory, and that
includes the nunit3-console package, so we need to point these shell scripts
that way.

Also make them behave the same with regards to stsack traces and the --debug
option to mono.