### PR TITLE
[net7.0] [CI] Do not provision simulators on builds.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -64,12 +64,6 @@ steps:
     provisioning_extra_args: '-vvvv'
   timeoutInMinutes: 250
 
-- bash: |
-    set -x
-    set -e
-    $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators
-  displayName: 'Provision simulators'
-
 # Use the env variables that were set by the label parsing in the configure step
 # print some useful logging to allow to know what is going on AND allow make some
 # choices, there are labels that contradict each other (skip-package vs build-packages)


### PR DESCRIPTION
There is no need to provision the simulators on a build. Provisioning
simuatlors is giving problems with the EO pool after an upgrade to macOS
12.4.

We remove the provisioning from the build BUT not from the tests since
those tests are executed in non EO complient machines.


Backport of #15268
