### PR TITLE
[nnyeah] Added correct mapping for NSObject.Handle fixing #15261

### DIFF
--- a/tools/nnyeah/nnyeah/AssemblyComparator/TypeReworker.cs
+++ b/tools/nnyeah/nnyeah/AssemblyComparator/TypeReworker.cs
@@ -92,13 +92,21 @@ namespace Microsoft.MaciOS.Nnyeah.AssemblyComparator {
 			}
 
 			nativeTypes.Clear ();
+			var isNSObject = method.DeclaringType.Name == "NSObject";
 			if (TryReworkTypeReference (method.ReturnType, nativeTypes, out var newReturnType)) {
 				method.ReturnType = newReturnType;
-			} else if (method.Name == "get_ClassHandle" && method.ReturnType.ToString () == "System.IntPtr") {
+			} else if (IsHandleMethod (method)) {
 				method.ReturnType = newNHandleTypeReference;
 			}
 
 			return method;
+		}
+
+		static bool IsHandleMethod (MethodDefinition method)
+		{
+			return method.DeclaringType.Name == "NSObject" &&
+				(method.Name == "get_ClassHandle" || method.Name == "get_Handle") &&
+				method.ReturnType.ToString () == "System.IntPtr";
 		}
 
 		bool TryReworkTypeReference (TypeReference type, List<bool> nativeTypes, [NotNullWhen (returnValue: true)] out TypeReference result)

--- a/tools/nnyeah/nnyeah/AssemblyComparator/TypeReworker.cs
+++ b/tools/nnyeah/nnyeah/AssemblyComparator/TypeReworker.cs
@@ -92,7 +92,6 @@ namespace Microsoft.MaciOS.Nnyeah.AssemblyComparator {
 			}
 
 			nativeTypes.Clear ();
-			var isNSObject = method.DeclaringType.Name == "NSObject";
 			if (TryReworkTypeReference (method.ReturnType, nativeTypes, out var newReturnType)) {
 				method.ReturnType = newReturnType;
 			} else if (IsHandleMethod (method)) {

--- a/tools/nnyeah/tests/unit/ClassHandleUnitTests.cs
+++ b/tools/nnyeah/tests/unit/ClassHandleUnitTests.cs
@@ -43,6 +43,41 @@ public class Handlicious : NSObject {
 			Assert.Fail ("didn't find instruction");
 		}
 
+		[Test]
+		public async Task ChangeHandleUsage ()
+		{
+			var pathToModule = await TestRunning.BuildTemporaryLibrary (@"
+using System;
+using Foundation;
+public class Handliciousness : NSObject {
+    public Handliciousness (IntPtr p) : base (p) { }
+    public IntPtr DoAThing () {
+        return Handle;
+    }
+}
+");
+
+			var editedModule = ReworkerHelper.GetReworkedModule (pathToModule);
+			Assert.IsNotNull (editedModule, "edited module is null (oops)");
+
+			var type = editedModule!.Types.First (t => t.Name == "Handliciousness");
+
+			var method = type.Methods.First (m => m.Name == "DoAThing");
+
+			for (int i = 0; i < method.Body.Instructions.Count; i++) {
+				var instr = method.Body.Instructions [i];
+				if (instr.Operand is null)
+					continue;
+				if (instr.Operand.ToString ()!.Contains ("get_Handle")) {
+					var nextInstr = method.Body.Instructions [i + 1];
+					Assert.AreEqual (OpCodes.Call, nextInstr.OpCode, "wrong opcode");
+					Assert.IsTrue (nextInstr.Operand.ToString ()!.Contains ("get_Handle"), "wrong operand");
+					return;
+				}
+			}
+			Assert.Fail ("didn't find instruction");
+		}
+
 	}
 }
 


### PR DESCRIPTION
This is very similar code to the `get_ClassHandle` case, so I refactored the code to handle it in the same way.

In the code to ensure that a method is `get_Handle` or `get_ClassHandle`, I added one extra layer of safety by asking if the declaring type is `NSObject` first.

Tests pass.