### PR TITLE
[foundation] Cache parts of `NSObject.ConformsToProtocol`

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -477,7 +477,6 @@ namespace Foundation {
 
 			// the linker/trimmer will remove the following code if the dynamic registrar is removed from the app
 			var classHandle = ClassHandle;
-			bool new_map = false;
 			lock (protocol_cache) {
 #if NET
 				ref var map = ref CollectionsMarshal.GetValueRefOrAddDefault (protocol_cache, classHandle, out var exists);
@@ -487,6 +486,7 @@ namespace Foundation {
 				if (!exists)
 					result = DynamicConformsToProtocol (protocol);
 #else
+				bool new_map = false;
 				if (!protocol_cache.TryGetValue (classHandle, out var map)) {
 					map = new ();
 					new_map = true;

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -477,9 +477,9 @@ namespace Foundation {
 
 			// the linker/trimmer will remove the following code if the dynamic registrar is removed from the app
 			var classHandle = ClassHandle;
-			lock (protocol_cache) {
+			lock (Runtime.protocol_cache) {
 #if NET
-				ref var map = ref CollectionsMarshal.GetValueRefOrAddDefault (protocol_cache, classHandle, out var exists);
+				ref var map = ref CollectionsMarshal.GetValueRefOrAddDefault (Runtime.protocol_cache, classHandle, out var exists);
 				if (!exists)
 					map = new ();
 				ref var result = ref CollectionsMarshal.GetValueRefOrAddDefault (map, protocol, out exists);
@@ -487,10 +487,10 @@ namespace Foundation {
 					result = DynamicConformsToProtocol (protocol);
 #else
 				bool new_map = false;
-				if (!protocol_cache.TryGetValue (classHandle, out var map)) {
+				if (!Runtime.protocol_cache.TryGetValue (classHandle, out var map)) {
 					map = new ();
 					new_map = true;
-					protocol_cache.Add (classHandle, map);
+					Runtime.protocol_cache.Add (classHandle, map);
 				}
 				if (new_map || !map.TryGetValue (protocol, out var result)) {
 					result = DynamicConformsToProtocol (protocol);
@@ -500,8 +500,6 @@ namespace Foundation {
 				return result;
 			}
 		}
-
-		static Dictionary<NativeHandle, Dictionary<NativeHandle, bool>> protocol_cache = new ();
 
 		bool DynamicConformsToProtocol (NativeHandle protocol)
 		{

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -35,6 +35,7 @@ namespace ObjCRuntime {
 		static Dictionary<IntPtrTypeValueTuple,Delegate> block_to_delegate_cache;
 		static Dictionary<Type, ConstructorInfo> intptr_ctor_cache;
 		static Dictionary<Type, ConstructorInfo> intptr_bool_ctor_cache;
+		internal static Dictionary<IntPtr, Dictionary<IntPtr, bool>> protocol_cache;
 
 		static List <object> delegates;
 		static List <Assembly> assemblies;
@@ -276,6 +277,7 @@ namespace ObjCRuntime {
 			usertype_cache = new Dictionary <IntPtr, bool> (IntPtrEqualityComparer);
 			intptr_ctor_cache = new Dictionary<Type, ConstructorInfo> (TypeEqualityComparer);
 			intptr_bool_ctor_cache = new Dictionary<Type, ConstructorInfo> (TypeEqualityComparer);
+			protocol_cache = new Dictionary<IntPtr, Dictionary<IntPtr, bool>> (IntPtrEqualityComparer);
 			lock_obj = new object ();
 
 			NSObjectClass = NSObject.Initialize ();

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -277,13 +277,14 @@ namespace ObjCRuntime {
 			usertype_cache = new Dictionary <IntPtr, bool> (IntPtrEqualityComparer);
 			intptr_ctor_cache = new Dictionary<Type, ConstructorInfo> (TypeEqualityComparer);
 			intptr_bool_ctor_cache = new Dictionary<Type, ConstructorInfo> (TypeEqualityComparer);
-			protocol_cache = new Dictionary<IntPtr, Dictionary<IntPtr, bool>> (IntPtrEqualityComparer);
 			lock_obj = new object ();
 
 			NSObjectClass = NSObject.Initialize ();
 
-			if (DynamicRegistrationSupported)
+			if (DynamicRegistrationSupported) {
 				Registrar = new DynamicRegistrar ();
+				protocol_cache = new Dictionary<IntPtr, Dictionary<IntPtr, bool>> (IntPtrEqualityComparer);
+			}
 			RegisterDelegates (options);
 			Class.Initialize (options);
 #if !NET


### PR DESCRIPTION
Note that the call to native code still _always_ happen (not cached) since the application could use `class_addProtocol` to add conformance to a protocol at runtime.

So the cache is limited to the .net specific reflection code that is present (only) when the dynamic registrar is included inside applications. This is the default for macOS apps, but not iOS / tvOS or MacCatalyst apps.

The linker/trimmer will remove the caching code when the dynamic registrar is removed. IOW this PR should not have any impact, performance or size, for most iOS apps (where the dynamic registrar is removed by default).

Fix https://github.com/xamarin/xamarin-macios/issues/14065

Running Dope on macOS, a 2 minutes benchmark, shows the following times (in seconds and percentage) spent calling this API:

## Before

<img width="1051" alt="Screen Shot 2022-06-15 at 9 21 22 PM" src="https://user-images.githubusercontent.com/260465/174201703-a91860a5-ec29-4e19-9de0-5158fd7aafa7.png">

* `RemoveFromSuperview` 7.99s (6.4%)
  * `NSObject.ConformsToProtocol` 3.26s (2.6%)

## After

<img width="1228" alt="Screen Shot 2022-06-15 at 9 24 42 PM" src="https://user-images.githubusercontent.com/260465/174201708-92193e77-ea8e-41bc-9672-bddaaa18a4f6.png">

* `RemoveFromSuperview` 4.67s (3.8%)
  * `NSObject.ConformsToProtocol` 0.32s (.26%)

So a 10x improvements on `ConformsToProtocol` which helps a lot the code path calling `RemoveFromSuperview`.