### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/label-checker.yml
+++ b/.github/workflows/label-checker.yml
@@ -3,8 +3,13 @@ on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   labels-check:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     name: Labels verification
 

--- a/.github/workflows/localization-update.yml
+++ b/.github/workflows/localization-update.yml
@@ -4,8 +4,14 @@ on:
     branches:
     - "lego/*"
 
+permissions:
+  contents: read
+
 jobs:
   pull-request:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: write  # for repo-sync/pull-request to create pull requests
     name: '[Localization PR to main]'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pwsh-ci.yml
+++ b/.github/workflows/pwsh-ci.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ main ]
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   test-pwsh:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
