### PR TITLE
[CI] Add a title which will have [PR|CI Build] for the API diff.

### DIFF
--- a/tools/devops/automation/templates/build/api-diff-process-results.yml
+++ b/tools/devops/automation/templates/build/api-diff-process-results.yml
@@ -60,7 +60,7 @@ steps:
       $converted = $inputContents + "`n`nUnable to convert markdown: $_`n`n"
     }
     $githubComments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
-    $result = $githubComments.NewCommentFromMessage("", "", $converted)
+    $result = $githubComments.NewCommentFromMessage("API Diff", "", $converted)
   displayName: 'Publish GitHub comment for change detection'
   timeoutInMinutes: 10
   continueOnError: true # don't let any failures here stop us


### PR DESCRIPTION
The job that hides the previous bot comments tries to find comments with
[OR\CI build] to decide if a comment should be hidden. This is added
when a title is present, so we just add a titles so that we can hide the
comments.