### PR TITLE
[NSObject] Unify some code between iOS and macOS.

### DIFF
--- a/src/Foundation/NSObject.iOS.cs
+++ b/src/Foundation/NSObject.iOS.cs
@@ -3,51 +3,15 @@
 
 using System;
 using System.Reflection;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
-
-using UIKit;
-using ObjCRuntime;
 
 namespace Foundation {
-	public partial class NSObject : INativeObject
-#if !COREBUILD
-	, IDisposable
-#endif
-	{
+	public partial class NSObject {
 #if !COREBUILD
 
 #if !NET && !WATCH
 		[Obsolete ("Use 'PlatformAssembly' for easier code sharing across platforms.")]
 		public readonly static Assembly MonoTouchAssembly = typeof (NSObject).Assembly;
 #endif
-
-		public static NSObject Alloc (Class kls) {
-			var h = Messaging.IntPtr_objc_msgSend (kls.Handle, Selector.GetHandle (Selector.Alloc));
-			return new NSObject (h, true);
-		}
-
-		public void Init () {
-			if (handle == IntPtr.Zero)
-				throw new Exception ("you have not allocated the native object");
-
-			handle = Messaging.IntPtr_objc_msgSend (handle, Selector.GetHandle ("init"));
-		}
-
-		public static void InvokeInBackground (Action action)
-		{
-			// using the parameterized Thread.Start to avoid capturing
-			// the 'action' parameter (it'll needlessly create an extra
-			// object).
-			new System.Threading.Thread ((v) =>
-			{
-				((Action) v) ();
-			})
-			{
-				IsBackground = true,
-			}.Start (action);
-		}
 #endif // !COREBUILD
 	}
 }

--- a/src/Foundation/NSObject.mac.cs
+++ b/src/Foundation/NSObject.mac.cs
@@ -26,17 +26,11 @@
 
 using System;
 using System.Reflection;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 using ObjCRuntime;
 
 namespace Foundation {
-	public partial class NSObject : INativeObject
-#if !COREBUILD
-		, IDisposable
-#endif
-		{
+	public partial class NSObject {
 #if !COREBUILD
 
 		// note: the linker will remove the unrequired `dlopen` calls

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -77,9 +77,10 @@ namespace Foundation {
 	[SupportedOSPlatform ("tvos")]
 #endif
 	[StructLayout (LayoutKind.Sequential)]
-	public partial class NSObject 
+	public partial class NSObject : INativeObject
 #if !COREBUILD
-		: IEquatable<NSObject> 
+		, IEquatable<NSObject>
+		, IDisposable
 #endif
 	{
 #if !COREBUILD
@@ -1044,6 +1045,34 @@ namespace Foundation {
 			var o = new Observer (this, key, observer);
 			AddObserver (o, key, options, o.Handle);
 			return o;
+		}
+
+		public static NSObject Alloc (Class kls)
+		{
+			var h = Messaging.IntPtr_objc_msgSend (kls.Handle, Selector.GetHandle (Selector.Alloc));
+			return new NSObject (h, true);
+		}
+
+		public void Init ()
+		{
+			if (handle == IntPtr.Zero)
+				throw new Exception ("you have not allocated the native object");
+
+			handle = Messaging.IntPtr_objc_msgSend (handle, Selector.GetHandle ("init"));
+		}
+
+		public static void InvokeInBackground (Action action)
+		{
+			// using the parameterized Thread.Start to avoid capturing
+			// the 'action' parameter (it'll needlessly create an extra
+			// object).
+			new System.Threading.Thread ((v) =>
+			{
+				((Action) v) ();
+			})
+			{
+				IsBackground = true,
+			}.Start (action);
 		}
 #endif // !COREBUILD
 	}


### PR DESCRIPTION
* Add these methods to shared code so they're available on all platforms
  (they're already available on mobile platforms), since there's no reason to
  exclude them on macOS:
    * NSObject.Init
    * NSObject.Alloc
    * NSObject.InvokeInBackground
* Remove unused usings.
* Move identical code in platform-specific files to shared code.