### PR TITLE
[Tests] Bump Newtonsoft.Json version

### DIFF
--- a/tests/common/TestProjects/BasicPCLTest/MyLibrary/MyLibrary.csproj
+++ b/tests/common/TestProjects/BasicPCLTest/MyLibrary/MyLibrary.csproj
@@ -45,7 +45,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Mac" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/tests/common/TestProjects/MyAppWithPackageReference/MyAppWithPackageReference.csproj
+++ b/tests/common/TestProjects/MyAppWithPackageReference/MyAppWithPackageReference.csproj
@@ -51,7 +51,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/common/TestProjects/MyAppWithPackageReference/MyAppWithPackageReference.dotnet.csproj
+++ b/tests/common/TestProjects/MyAppWithPackageReference/MyAppWithPackageReference.dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.csproj
+++ b/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.csproj
@@ -54,7 +54,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.dotnet.csproj
+++ b/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.dotnet.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/tests/mmptest/src/PackageReferenceTests.cs
+++ b/tests/mmptest/src/PackageReferenceTests.cs
@@ -8,7 +8,7 @@ namespace Xamarin.MMP.Tests
 	[TestFixture]
 	public class PackageReferenceTests
 	{
-		const string PackageReference = @"<ItemGroup><PackageReference Include = ""Newtonsoft.Json"" Version = ""10.0.3"" /></ItemGroup>";
+		const string PackageReference = @"<ItemGroup><PackageReference Include = ""Newtonsoft.Json"" Version = ""13.0.1"" /></ItemGroup>";
 		const string TestCode = @"var output = Newtonsoft.Json.JsonConvert.SerializeObject (new int[] { 1, 2, 3 });";
 
 		[TestCase (true)]


### PR DESCRIPTION
Bump the version to fix:

* https://github.com/xamarin/xamarin-macios/security/dependabot/1
* https://github.com/xamarin/xamarin-macios/security/dependabot/2

The dependency is in a tests, but this way we make the warning fo away.