### PR TITLE
[CI] Fix error when collecting the sim logs.

### DIFF
--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -253,10 +253,12 @@ steps:
     set -x
     set -e
 
+    rm -Rf $(System.DefaultWorkingDirectory)/diagnostic-sim-output/output
     mkdir -p $(System.DefaultWorkingDirectory)/diagnostic-sim-output/output
     printf "\n" | xcrun simctl diagnose -b -X --output=$(System.DefaultWorkingDirectory)/diagnostic-sim-output/output
 
   displayName: 'Collect diagnostic info from simulators'
+  continueOnError: true
   name: collectSimulatorInfo
   timeoutInMinutes: 30
 


### PR DESCRIPTION
We are getting errors with the following:

> Error creating archive at '/Users/builder/azdo/_work/2/s/diagnostic-sim-output/output.tar.gz'.
> Files are still in /Users/builder/azdo/_work/2/s/diagnostic-sim-output/output
> An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=17):
> Unable to write or file already exists
> File exists

we remove the path in case it is present and continue even if there was
an error since it does not imply a test failure.