### PR TITLE
[CI] Allow to skip all tests in the parallel implementation.

### DIFF
--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -96,7 +96,8 @@ steps:
         "trigger-device-tests",
         "run-sample-tests",
         "skip-packaged-xamarin-mac-tests",
-        "skip-api-comparison"
+        "skip-api-comparison",
+        "skip-all-tests"
       )
 
       foreach ($l in $labelsOfInterest) {

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -104,7 +104,7 @@ stages:
   - ${{ each label in parameters.simTestsConfigurations }}:
     - job: "tests_${{ replace(label, '-', '_') }}"
       ${{ if eq(parameters.parseLabels, true) }}:
-        condition: $[ eq(dependencies.configure.outputs['labels.build-package'], '') ]
+        condition: eq(dependencies.configure.outputs['labels.build-package'], '')
       dependsOn:
       - ${{ if eq(parameters.parseLabels, true) }}:
         - configure
@@ -148,7 +148,9 @@ stages:
 
   - job: publish_html
     ${{ if eq(parameters.parseLabels, true) }}:
-      condition: $[ eq(dependencies.configure.outputs['labels.build-package'], '') ]
+      condition: and(eq(dependencies.configure.outputs['labels.build-package'], ''),  succeededOrFailed())
+    ${{ else }}:
+      condition: succeededOrFailed()
     displayName: 'Publish Html report in VSDrops'
     timeoutInMinutes: 1000
     dependsOn: # has to wait for the tests to be done AND the data to be uploaded
@@ -156,7 +158,6 @@ stages:
       - configure
     - ${{ each label in parameters.simTestsConfigurations }}:
       - tests_${{ replace(label, '-', '_') }}
-    condition: succeededOrFailed()
     variables:
       ${{ each label in parameters.simTestsConfigurations }}:
         # Define the variable FOO from the previous job

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -103,6 +103,8 @@ stages:
 
   - ${{ each label in parameters.simTestsConfigurations }}:
     - job: "tests_${{ replace(label, '-', '_') }}"
+      ${{ if eq(parameters.parseLabels, true) }}:
+        condition: $[ eq(dependencies.configure.outputs['labels.build-package'], '') ]
       dependsOn:
       - ${{ if eq(parameters.parseLabels, true) }}:
         - configure
@@ -145,9 +147,13 @@ stages:
           xqaCertPass: ${{ parameters.xqaCertPass }}
 
   - job: publish_html
+    ${{ if eq(parameters.parseLabels, true) }}:
+      condition: $[ eq(dependencies.configure.outputs['labels.build-package'], '') ]
     displayName: 'Publish Html report in VSDrops'
     timeoutInMinutes: 1000
     dependsOn: # has to wait for the tests to be done AND the data to be uploaded
+    - ${{ if eq(parameters.parseLabels, true) }}:
+      - configure
     - ${{ each label in parameters.simTestsConfigurations }}:
       - tests_${{ replace(label, '-', '_') }}
     condition: succeededOrFailed()

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -151,7 +151,7 @@ stages:
       condition: and(eq(dependencies.configure.outputs['labels.skip-all-tests'], ''),  succeededOrFailed())
     ${{ else }}:
       condition: succeededOrFailed()
-    displayName: 'GiHub comment - Publish results'
+    displayName: 'GitHub comment - Publish results'
     timeoutInMinutes: 1000
     dependsOn: # has to wait for the tests to be done AND the data to be uploaded
     - ${{ if eq(parameters.parseLabels, true) }}:

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -104,7 +104,7 @@ stages:
   - ${{ each label in parameters.simTestsConfigurations }}:
     - job: "tests_${{ replace(label, '-', '_') }}"
       ${{ if eq(parameters.parseLabels, true) }}:
-        condition: eq(dependencies.configure.outputs['labels.build-package'], '')
+        condition: eq(dependencies.configure.outputs['labels.skip-all-tests'], '')
       dependsOn:
       - ${{ if eq(parameters.parseLabels, true) }}:
         - configure
@@ -148,7 +148,7 @@ stages:
 
   - job: publish_test_results
     ${{ if eq(parameters.parseLabels, true) }}:
-      condition: and(eq(dependencies.configure.outputs['labels.build-package'], ''),  succeededOrFailed())
+      condition: and(eq(dependencies.configure.outputs['labels.skip-all-tests'], ''),  succeededOrFailed())
     ${{ else }}:
       condition: succeededOrFailed()
     displayName: 'GiHub comment - Publish results'
@@ -179,14 +179,13 @@ stages:
 
   - job: publish_skipped_tests
     ${{ if eq(parameters.parseLabels, true) }}:
-      condition: ne(dependencies.configure.outputs['labels.build-package'], '')
+      condition: ne(dependencies.configure.outputs['labels.skip-all-tests'], '')
     ${{ else }}:
       condition: false
     displayName: 'GitHub comment - Skipped tests'
     timeoutInMinutes: 1000
     dependsOn: # has to wait for the tests to be done AND the data to be uploaded
-    - ${{ if eq(parameters.parseLabels, true) }}:
-      - configure
+    -  configure
 
     pool:
       vmImage: 'windows-latest'
@@ -200,7 +199,7 @@ stages:
         $gihubComments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH -Debug
         $sb = [System.Text.StringBuilder]::new()
         $sb.AppendLine("All tests have been skipped because the label 'skip-all-tests' was set.")
-        $result = $gihubComments.NewCommentFromMessage("Test results", ":bangbang:", $sb.ToString())
+        $result = $gihubComments.NewCommentFromMessage("Test results", ":seedling:", $sb.ToString())
       displayName: 'Set comment'
       env:
         CONTEXT: ${{ parameters.statusContext }}

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -146,12 +146,12 @@ stages:
           gitHubToken: ${{ parameters.gitHubToken }}
           xqaCertPass: ${{ parameters.xqaCertPass }}
 
-  - job: publish_html
+  - job: publish_test_results
     ${{ if eq(parameters.parseLabels, true) }}:
       condition: and(eq(dependencies.configure.outputs['labels.build-package'], ''),  succeededOrFailed())
     ${{ else }}:
       condition: succeededOrFailed()
-    displayName: 'Publish Html report in VSDrops'
+    displayName: 'GiHub comment - Publish results'
     timeoutInMinutes: 1000
     dependsOn: # has to wait for the tests to be done AND the data to be uploaded
     - ${{ if eq(parameters.parseLabels, true) }}:
@@ -176,3 +176,34 @@ stages:
         statusContext: ${{ parameters.statusContext }}
         vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
         testPrefix: ${{ parameters.testPrefix }}
+
+  - job: publish_skipped_tests
+    ${{ if eq(parameters.parseLabels, true) }}:
+      condition: ne(dependencies.configure.outputs['labels.build-package'], '')
+    ${{ else }}:
+      condition: false
+    displayName: 'GitHub comment - Skipped tests'
+    timeoutInMinutes: 1000
+    dependsOn: # has to wait for the tests to be done AND the data to be uploaded
+    - ${{ if eq(parameters.parseLabels, true) }}:
+      - configure
+
+    pool:
+      vmImage: 'windows-latest'
+      workspace:
+        clean: all
+
+    steps:
+    - pwsh: |
+        Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
+
+        $gihubComments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH -Debug
+        $sb = [System.Text.StringBuilder]::new()
+        $sb.AppendLine("All tests have been skipped because the label 'skip-all-tests' was set.")
+        $result = $gihubComments.NewCommentFromMessage("Test results", ":bangbang:", $sb.ToString())
+      displayName: 'Set comment'
+      env:
+        CONTEXT: ${{ parameters.statusContext }}
+        DEVICE_PREFIX: ${{ parameters.testPrefix }}
+        GITHUB_TOKEN: $(GitHub.Token)
+        ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION
Since we are generating jobs in parallel, we want to not even create the jobs which is more efficient than letting xharness skip the tests.