### PR TITLE
[CI] Bump the build timeout.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -250,7 +250,7 @@ steps:
     time make -C $(Build.SourcesDirectory)/xamarin-macios/ install -j8
   name: build
   displayName: 'Build'
-  timeoutInMinutes: 180
+  timeoutInMinutes: 300
 
 - ${{ each step in parameters.buildSteps }}:
   - ${{ each pair in step }}:


### PR DESCRIPTION
There are certain bots misbehaving and taking longer. We believ ethat it
might be due to some throttiling depending on their positio in the lab.
We are increasing the timeout for those cases.