### PR TITLE
[release/6.0.4xx] A .NET 'servicing' release is also a stable release.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -618,7 +618,11 @@ DOTNET_CSC_PATH_STABLE=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION_BAND)/Roslyn/bincore/c
 ifeq (rtm,$(findstring rtm,$(DOTNET_VERSION)))
 DOTNET_CSC=$(DOTNET) exec $(DOTNET_CSC_PATH_STABLE)
 else
+ifeq (servicing,$(findstring servicing,$(DOTNET_VERSION)))
+DOTNET_CSC=$(DOTNET) exec $(DOTNET_CSC_PATH_STABLE)
+else
 DOTNET_CSC=$(DOTNET) exec $(DOTNET_CSC_PATH_PREVIEW)
+endif
 endif
 
 # How are our assemblies named?


### PR DESCRIPTION



Backport of #15311
