### PR TITLE
[nnyeah] Manage DisposableObject

### DIFF
--- a/tools/nnyeah/nnyeah/ConstructorTransforms.cs
+++ b/tools/nnyeah/nnyeah/ConstructorTransforms.cs
@@ -64,7 +64,7 @@ namespace Microsoft.MaciOS.Nnyeah {
 				if (typeReference is null) {
 					return false;
 				}
-				if (typeReference.FullName == "Foundation.NSObject") {
+				if (typeReference.FullName == "Foundation.NSObject" || typeReference.FullName == "ObjCRuntime.DisposableObject") {
 					if (reworkNeededOnTheWayUp && firstIssuedTypeReference is not null) {
 						if (self is not null) {
 							self.WarningIssued?.Invoke (self, new WarningEventArgs (initialTypeReference.DeclaringType.FullName,

--- a/tools/nnyeah/nnyeah/Reworker.cs
+++ b/tools/nnyeah/nnyeah/Reworker.cs
@@ -58,7 +58,8 @@ namespace Microsoft.MaciOS.Nnyeah {
 					tr.FullName == "System.nint" ||
 					tr.FullName == "System.nuint" ||
 					tr.FullName == "System.nfloat" ||
-					tr.FullName == "Foundation.NSObject"
+					tr.FullName == "Foundation.NSObject" ||
+					tr.FullName == "ObjCRuntime.DisposableObject"
 				);
 		}
 
@@ -623,7 +624,8 @@ namespace Microsoft.MaciOS.Nnyeah {
 
 		bool IsHandleReference (string operandStr)
 		{
-			return operandStr == "ObjCRuntime.NativeHandle Foundation.NSObject::get_ClassHandle()" ||
+			return operandStr == "ObjCRuntime.NativeHandle ObjCRuntime.DisposableObject::get_Handle()" ||
+				operandStr == "ObjCRuntime.NativeHandle Foundation.NSObject::get_ClassHandle()" ||
 				operandStr == "ObjCRuntime.NativeHandle Foundation.NSObject::get_Handle()";
 		}
 


### PR DESCRIPTION
For this one, there are a number of objects in macios that do not descend from `NSObject` but instead descend from `DisposableObject` so now we special case those too.
