### PR TITLE
[CI] Ignore branches that start with dev/*

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -180,6 +180,7 @@ trigger:
     - '*'
     exclude:
     - refs/heads/locfiles/*
+    - refs/heads/dev/*
   paths:
     exclude:
     - .github


### PR DESCRIPTION
Other teams in xamarin/microsoft do no use forks but use dev branches.
The correct thing in our repo is to use forks, yet other developers
insist in not following our developement practices. The fact that this
branches are created results in 2 builds:

- One for CI
- On for the PR

It is harder to educate other developers than it is to ignore their
branches, therefore we have added the pattern dev/* to the exclude
list for branches in the CI build.