### PR TITLE
[CI] Set msbuild env vars to try and workaround https://github.com/dotnet/msbuild/issues/6753

### DIFF
--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -64,6 +64,9 @@ jobs:
   displayName: 'Detect API changes'
   timeoutInMinutes: 1000
   variables:
+    # try to workaround https://github.com/dotnet/msbuild/issues/6753
+    MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
+    MSBUILDNOINPROCNODE: 1
     ${{ if eq(parameters.pool, 'automatic') }}:
       AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
     ${{ if eq(parameters.pool, 'ci') }}:

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -80,6 +80,9 @@ jobs:
   displayName: 'Build packages'
   timeoutInMinutes: 1000
   variables:
+    # try to workaround https://github.com/dotnet/msbuild/issues/6753
+    MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
+    MSBUILDNOINPROCNODE: 1
     ${{ if eq(parameters.pool, 'automatic') }}:
       AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
     ${{ if eq(parameters.pool, 'ci') }}:


### PR DESCRIPTION
Some of the bots are getting deadlock during the following:

```
MSBuild.dll /nologo -consoleloggerparameters:Summary -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,/Users/builder/azdo/_work/3/s/xamarin-macios/builds/downloads/dotnet-sdk-6.0.301-rtm.22280.1-osx-x64/sdk/6.0.301/dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,/Users/builder/azdo/_work/3/s/xamarin-macios/builds/downloads/dotnet-sdk-6.0.301-rtm.22280.1-osx-x64/sdk/6.0.301/dotnet.dll -maxcpucount -restore -verbosity:m /verbosity:quiet /bl:/Users/builder/azdo/_work/3/s/xamarin-macios/msbuild/Xamarin.HotRestart.PreBuilt/msbuild.binlog Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
```

And we know that https://github.com/dotnet/msbuild/issues/6753 exists and has not been fixed. Lets set those vars before we build to see if it fixes the issue.