### PR TITLE
[CI] Provide hardware information.

### DIFF
--- a/tools/devops/automation/templates/common/setup.yml
+++ b/tools/devops/automation/templates/common/setup.yml
@@ -32,6 +32,8 @@ steps:
     }
 
     gci env: | format-table -autosize -wrap
+
+    system_profiler SPSoftwareDataType SPHardwareDataType SPDeveloperToolsDataType
   displayName: 'Show Environment'
 
 - powershell: |


### PR DESCRIPTION
Get the bot information to improve the debugging of build failures. The
following is an example of the output:

Software:

    System Software Overview:

      System Version: macOS 12.4 (21F79)
      Kernel Version: Darwin 21.5.0
      Boot Volume: Macintosh HD
      Boot Mode: Normal
      Computer Name: Mandels Home iMac Pro
      User Name: Manuel de la Pena Saenz (mandel)
      Secure Virtual Memory: Enabled
      System Integrity Protection: Enabled
      Time since boot: 3 days 23:43

Hardware:

    Hardware Overview:

      Model Name: iMac Pro
      Model Identifier: iMacPro1,1
      Processor Name: 8-Core Intel Xeon W
      Processor Speed: 3,2 GHz
      Number of Processors: 1
      Total Number of Cores: 8
      L2 Cache (per Core): 1 MB
      L3 Cache: 11 MB
      Hyper-Threading Technology: Enabled
      Memory: 64 GB
      System Firmware Version: 1731.120.10.0.0 (iBridge: 19.16.15071.0.0,0)
      OS Loader Version: 540.120.3~6
      Serial Number (system): C02WD0V7HX8F
      Hardware UUID: 85EE3276-4E8F-592A-A47B-599DFAB6DF1C
      Provisioning UDID: 85EE3276-4E8F-592A-A47B-599DFAB6DF1C
      Activation Lock Status: Disabled

Developer:

    Developer Tools:

      Version: 13.3.1 (13E500a)
      Location: /Applications/Xcode_13.3.0.app
      Applications:
          Xcode: 13.3.1 (20103)
          Instruments: 13.3.1 (64552.71)
      SDKs:
          DriverKit:
              21,4:
          iOS:
              15,4: (19E239)
          iOS Simulator:
              15,4: (19E239)
          macOS:
              12,3: (21E226)
          tvOS:
              15,4: (19L439)
          tvOS Simulator:
              15,4: (19L439)
          watchOS:
              8,5: (19T241)
          watchOS Simulator:
              8,5: (19T241)