### PR TITLE
[CI] Allow to pass the xcode channel.

### DIFF
--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -188,6 +188,7 @@ schedules:
 stages:
 - template: templates/main-stage.yml
   parameters:
+    xcodeChannel: Beta
     isPR: false
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -198,6 +198,7 @@ trigger:
 stages:
 - template: templates/main-stage.yml
   parameters:
+    xcodeChannel: Beta
     isPR: false
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -181,6 +181,7 @@ pr:
 stages:
 - template: templates/main-stage.yml
   parameters:
+    xcodeChannel: Beta
     isPR: true
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}

--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -24,6 +24,9 @@ parameters:
 - name: isPR
   type: boolean
 
+- name: xcodeChannel
+  type: string
+
 jobs:
 - job: configure
   displayName: 'Configure build'
@@ -79,6 +82,7 @@ jobs:
     demands:
     - Agent.OS -equals Darwin
     - macios_image -equals v2.1     # Big Sur image with Xcode 12.4 and 12.5 installed
+    - XcodeChannel -equals ${{ parameters.xcodeChannel }}
   workspace:
     clean: all
 

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -36,6 +36,9 @@ parameters:
 - name: isPR
   type: boolean
 
+- name: xcodeChannel
+  type: string
+
 jobs:
 - job: configure
   displayName: 'Configure build'
@@ -117,6 +120,7 @@ jobs:
     demands:
     - Agent.OS -equals Darwin
     - macios_image -equals v2.1     # Big Sur image with Xcode 12.4 and 12.5 installed
+    - XcodeChannel -equals ${{ parameters.xcodeChannel }}
   workspace:
     clean: all
 

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -55,6 +55,9 @@ parameters:
 - name: isPR
   type: boolean
 
+- name: xcodeChannel
+  type: string
+
 - name: simTestsConfigurations
   type: object
   default: [
@@ -135,6 +138,7 @@ stages:
   jobs:
     - template: ./build/build-stage.yml
       parameters:
+        xcodeChannel: ${{ parameters.xcodeChannel }}
         isPR: ${{ parameters.isPR }}
         vsdropsPrefix: ${{ variables.vsdropsPrefix }}
         runTests: ${{ and(parameters.runTests, ne(variables['Build.Reason'], 'Schedule'))}}
@@ -166,6 +170,7 @@ stages:
     jobs:
       - template: ./build/api-diff-stage.yml
         parameters:
+          xcodeChannel: ${{ parameters.xcodeChannel }}
           isPR: ${{ parameters.isPR }}
           vsdropsPrefix: ${{ variables.vsdropsPrefix }}
           keyringPass: $(pass--lab--mac--builder--keychain)
@@ -185,6 +190,7 @@ stages:
 # always run simulator tests
 - template: ./tests/stage.yml
   parameters:
+    xcodeChannel: ${{ parameters.xcodeChannel }}
     isPR: ${{ parameters.isPR }}
     simTestsConfigurations: ${{ parameters.simTestsConfigurations }}
     testPrefix: 'simulator_'
@@ -208,6 +214,7 @@ stages:
     - ${{ each config in parameters.deviceTestsConfigurations }}:
       - template: ./tests/stage.yml
         parameters:
+          xcodeChannel: ${{ parameters.xcodeChannel }}
           isPR: ${{ parameters.isPR }}
           testPrefix: ${{ config.testPrefix }} 
           stageName: ${{ config.stageName }} 

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -76,6 +76,9 @@ parameters:
 - name: isPR
   type: boolean
 
+- name: XcodeChannel
+  type: string
+
 stages:
 - stage: ${{ parameters.stageName }}
   displayName: ${{ parameters.displayName }}
@@ -122,9 +125,10 @@ stages:
 
       pool:
         name: $(AgentPoolComputed)
-        demands: 
+        demands:
         - Agent.OS -equals Darwin
         - macios_image -equals v2.1     # Big Sur image with Xcode 12.4 and 12.5 installed
+        - XcodeChannel -equals ${{ parameters.XcodeChannel }}
         - ${{ each demand in parameters.extraBotDemands }}:
           - demand
         workspace:


### PR DESCRIPTION
Allow to pass the xcode channel we are going to be using. This is to
ensure that we do not try to build the xcode14 branch in beta bots. At
the moment all bots are using the Beta channel, but once the lab has
been updated we should be able to move main to Stable.