### PR TITLE
[CI] Fix the skip of tests.

### DIFF
--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -107,7 +107,7 @@ stages:
   - ${{ each label in parameters.simTestsConfigurations }}:
     - job: "tests_${{ replace(label, '-', '_') }}"
       ${{ if eq(parameters.parseLabels, true) }}:
-        condition: eq(dependencies.configure.outputs['labels.skip-all-tests'], '')
+        condition: eq(dependencies.configure.outputs['labels.skip-all-tests'], 'False')
       dependsOn:
       - ${{ if eq(parameters.parseLabels, true) }}:
         - configure
@@ -152,7 +152,7 @@ stages:
 
   - job: publish_test_results
     ${{ if eq(parameters.parseLabels, true) }}:
-      condition: and(eq(dependencies.configure.outputs['labels.skip-all-tests'], ''),  succeededOrFailed())
+      condition: and(eq(dependencies.configure.outputs['labels.skip-all-tests'], 'False'),  succeededOrFailed())
     ${{ else }}:
       condition: succeededOrFailed()
     displayName: 'GitHub comment - Publish results'
@@ -183,7 +183,7 @@ stages:
 
   - job: publish_skipped_tests
     ${{ if eq(parameters.parseLabels, true) }}:
-      condition: ne(dependencies.configure.outputs['labels.skip-all-tests'], '')
+      condition: ne(dependencies.configure.outputs['labels.skip-all-tests'], 'False')
     ${{ else }}:
       condition: false
     displayName: 'GitHub comment - Skipped tests'
@@ -197,6 +197,11 @@ stages:
         clean: all
 
     steps:
+
+    - template: ../common/checkout.yml
+      parameters:
+        isPR: ${{ parameters.isPR }}
+
     - pwsh: |
         Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
 


### PR DESCRIPTION
When the label is not present we set the value to false. We also needed
to make sure that the project is checked out when we try to write the
comment.

This should be backported to xcode14.