### PR TITLE
[CI] Use the Stable Xcode channel in main related branches.

### DIFF
--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -188,7 +188,7 @@ schedules:
 stages:
 - template: templates/main-stage.yml
   parameters:
-    xcodeChannel: Beta
+    xcodeChannel: Stable
     isPR: false
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -198,7 +198,7 @@ trigger:
 stages:
 - template: templates/main-stage.yml
   parameters:
-    xcodeChannel: Beta
+    xcodeChannel: Stable
     isPR: false
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -181,7 +181,7 @@ pr:
 stages:
 - template: templates/main-stage.yml
   parameters:
-    xcodeChannel: Beta
+    xcodeChannel: Stable
     isPR: true
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}


### PR DESCRIPTION
Xcode14 broke actool. We have created two diff bot images:

- Stable: Contains the latests stable xcode (xcode13.4)
- Beta: Contains the latests beta xcode OR will allow it to be
  installed.

By doing this we mitigate the possible issues that the new Xcode might
create. Some of the bots have already been migrated.

This commit SHOULD NOT be backported to xcode14.