### PR TITLE
[release/6.0.4xx] [devops] Fix the post-build pipeline after dependent pipeline rename.

### DIFF
--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -7,7 +7,7 @@ pr: none
 resources:
   pipelines:
   - pipeline: macios
-    source: xamarin-macios
+    source: xamarin-macios-ci
     trigger:
       branches:
       - main


### PR DESCRIPTION
It looks like this is needed for the post-build pipeline to kick in and publish builds to meastro.

Backport of #15129
