### PR TITLE
[tests] Update tests to find nunit.framework.dll in our own local package folder.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1987,7 +1987,7 @@ public class TestApp {
 		static string [] GetBindingsLibraryWithReferences (Profile profile)
 		{
 			var lib = GetBindingsLibrary (profile, out var version);
-			var nunit_framework = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), ".nuget", "packages", "nunit", version, "lib", "netstandard2.0", "nunit.framework.dll");
+			var nunit_framework = Path.Combine (Configuration.RootPath, "packages", "nunit", version, "lib", "netstandard2.0", "nunit.framework.dll");
 			if (!File.Exists (nunit_framework))
 				throw new FileNotFoundException ($"Could not find nunit.framework.dll in {nunit_framework}. Has the version changed?");
 			return new string [] { lib, nunit_framework };


### PR DESCRIPTION
Fixes these test failures:

    Xamarin.MTouch.FastDev_LinkAll(iOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_LinkAll(tvOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_LinkAll_Then_NoLink(iOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_LinkAll_Then_NoLink(tvOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_LinkSDK(iOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_LinkSDK(tvOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_LinkWithTest(iOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_LinkWithTest(tvOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_NoFastSim_LinkAll(iOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_NoFastSim_LinkAll(tvOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_NoFastSim_LinkSDK(iOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_NoFastSim_LinkSDK(tvOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_NoFastSim_NoLink(iOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_NoFastSim_NoLink(tvOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_NoLink(iOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_NoLink(tvOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_Sim(iOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.FastDev_Sim(tvOS): System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?
    Xamarin.MTouch.RebuildWhenReferenceSymbolsInCode: System.IO.FileNotFoundException : Could not find nunit.framework.dll in /Users/builder/.nuget/packages/nunit/3.12.0/lib/netstandard2.0/nunit.framework.dll. Has the version changed?