### PR TITLE
[tests] Be explicit about parameters when looking for the Class.FindType method.

### DIFF
--- a/tests/api-shared/ObjCRuntime/Registrar.cs
+++ b/tests/api-shared/ObjCRuntime/Registrar.cs
@@ -29,7 +29,12 @@ namespace XamarinTests.ObjCRuntime {
 
 		public static Registrars CurrentRegistrar {
 			get {
-				var find_type = typeof (Class).GetMethod ("FindType", BindingFlags.Static | BindingFlags.NonPublic);
+#if NET
+				var types = new Type [] { typeof (NativeHandle), typeof (bool).MakeByRefType () };
+#else
+				var types = new Type [] { typeof (IntPtr), typeof (bool).MakeByRefType () };
+#endif
+				var find_type = typeof (Class).GetMethod ("FindType", BindingFlags.Static | BindingFlags.NonPublic, null, types, null);
 				var type_to_find = typeof (RegistrationTestClass);
 				var type = (Type) find_type.Invoke (null, new object [] { Class.GetHandle (type_to_find), false });
 				var is_static = type_to_find == type;


### PR DESCRIPTION
This makes sure that adding FindType overloads won't break the tests.