### PR TITLE
[xcode14] [devops] Make sure BUILD_REVISION is set to something during the build.

### DIFF
--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -114,6 +114,7 @@ jobs:
     PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
     # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
     BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+    BUILD_REVISION: $[ variables['Build.SourceVersion'] ]
     XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness-labels'] ]
   pool:
     name: $(AgentPoolComputed)


### PR DESCRIPTION
We have logic that depend on this variable to determine whether we're in CI or not.


Backport of #15374
