### PR TITLE
[release/6.0.3xx] [msbuild/tools] Fix path issues in the FilterStaticFrameworks task and ExtractBindingLibraries step. Fixes #15289.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -653,7 +653,7 @@
 			<!-- Set TargetDirectory and SourceDirectory for all frameworks we have to publish -->
 			<_FrameworkToPublish Update="@(_FrameworkToPublish)">
 				<TargetDirectory>$(_RelativePublishDir)$(_AppBundleFrameworksDir)\%(Filename).framework</TargetDirectory>
-				<SourceDirectory>%(Identity)</SourceDirectory>
+				<SourceDirectory>%(RelativeDir)</SourceDirectory>
 			</_FrameworkToPublish>
 		</ItemGroup>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -653,7 +653,7 @@
 			<!-- Set TargetDirectory and SourceDirectory for all frameworks we have to publish -->
 			<_FrameworkToPublish Update="@(_FrameworkToPublish)">
 				<TargetDirectory>$(_RelativePublishDir)$(_AppBundleFrameworksDir)\%(Filename).framework</TargetDirectory>
-				<SourceDirectory>%(RootDir)%(Directory)</SourceDirectory>
+				<SourceDirectory>%(Identity)</SourceDirectory>
 			</_FrameworkToPublish>
 		</ItemGroup>
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FilterStaticFrameworksTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FilterStaticFrameworksTaskBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.Build.Framework;
 
 using Xamarin.Localization.MSBuild;
+using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks {
 	// This task takes an itemgroup of frameworks, and filters out frameworks that aren't dynamic libraries.
@@ -20,10 +21,15 @@ namespace Xamarin.MacDev.Tasks {
 				var list = FrameworkToPublish.ToList ();
 				for (var i = list.Count - 1; i >= 0; i--) {
 					var item = list [i];
-					var frameworkExecutablePath = item.ItemSpec;
+					var frameworkExecutablePath = PathUtils.ConvertToMacPath (item.ItemSpec);
 					try {
 						if (frameworkExecutablePath.EndsWith (".framework", StringComparison.OrdinalIgnoreCase) && Directory.Exists (frameworkExecutablePath)) {
 							frameworkExecutablePath = Path.Combine (frameworkExecutablePath, Path.GetFileNameWithoutExtension (frameworkExecutablePath));
+						}
+
+						if (!File.Exists (frameworkExecutablePath)) {
+							Log.LogError (158, frameworkExecutablePath, MSBStrings.E0158 /* The file '{0}' does not exist. */, frameworkExecutablePath);
+							continue;
 						}
 
 						if (MachO.IsDynamicFramework (frameworkExecutablePath))

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworks.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworks.cs
@@ -32,6 +32,8 @@ namespace Xamarin.MacDev.Tasks {
 					// Copy all the files from the framework to the mac (copying only the executable won't work if it's just a symlink to elsewhere)
 					if (File.Exists (fw))
 						fw = Path.GetDirectoryName (fw);
+					if (!Directory.Exists (fw))
+						continue;
 					foreach (var file in Directory.EnumerateFiles (fw, "*.*", SearchOption.AllDirectories)) {
 						yield return new TaskItem (file);
 					}

--- a/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
+++ b/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
@@ -72,16 +72,12 @@ namespace Xamarin.Linker {
 					if (!Configuration.Application.VerifyDynamicFramework (fwk))
 						continue;
 
-					var executable = Path.Combine (fwk, Path.GetFileNameWithoutExtension (fwk));
-
 					// Store a relative path if possible, it makes things easier with XVS.
-					if (Path.IsPathRooted (executable)) {
-						var resolvedExecutable = PathUtils.ResolveSymbolicLinks (executable);
-						if (resolvedExecutable.StartsWith (Environment.CurrentDirectory, StringComparison.Ordinal)) {
-							resolvedExecutable = resolvedExecutable.Substring (Environment.CurrentDirectory.Length).TrimStart ('/').TrimStart ('\\');
-							executable = resolvedExecutable;
-						}
-					}
+					var fwkDirectory = fwk;
+					if (Path.IsPathRooted (fwkDirectory))
+						fwkDirectory = Path.GetRelativePath (Environment.CurrentDirectory, PathUtils.ResolveSymbolicLinks (fwkDirectory));
+
+					var executable = Path.Combine (fwkDirectory, Path.GetFileNameWithoutExtension (fwkDirectory));
 
 					var item = new MSBuildItem {
 						Include = executable,

--- a/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
+++ b/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
+using Xamarin.Utils;
+
 namespace Xamarin.Linker {
 
 	public class ExtractBindingLibrariesStep : ConfigurationAwareStep {
@@ -71,6 +73,15 @@ namespace Xamarin.Linker {
 						continue;
 
 					var executable = Path.Combine (fwk, Path.GetFileNameWithoutExtension (fwk));
+
+					// Store a relative path if possible, it makes things easier with XVS.
+					if (Path.IsPathRooted (executable)) {
+						var resolvedExecutable = PathUtils.ResolveSymbolicLinks (executable);
+						if (resolvedExecutable.StartsWith (Environment.CurrentDirectory, StringComparison.Ordinal)) {
+							resolvedExecutable = resolvedExecutable.Substring (Environment.CurrentDirectory.Length).TrimStart ('/').TrimStart ('\\');
+							executable = resolvedExecutable;
+						}
+					}
 
 					var item = new MSBuildItem {
 						Include = executable,


### PR DESCRIPTION
In the FilterStaticFrameworks task:

* Convert Windows-style paths to Mac-style paths.
* Give a better error if a framework can't be found.
* Don't try to copy frameworks that don't exist on Windows to the Mac.

In the ExtractBindingLibrariesStep:

* Return a relative path to frameworks we've extracted to make things easier for
  remote builds.

* In the _ComputeFrameworkFilesToPublish target, don't compute the source
  directory for frameworks using RootDir + Directory, because some frameworks
  may only exist on the mac, and RootDir + Directory will be a Windows path
  when building remotely. Instead use 'Identity', which is a relative path and
  will work on both Windows and Mac.

Fixes https://github.com/xamarin/xamarin-macios/issues/15289.


Backport of #15321
