### PR TITLE
[actions] Add action to re-generate global.json for a dotnet/installer bump.

### DIFF
--- a/.github/workflows/bump-global-json.yml
+++ b/.github/workflows/bump-global-json.yml
@@ -1,0 +1,31 @@
+name: Bump global.json for dotnet/installer bumps
+on: pull_request_target
+
+jobs:
+  bump-global-json:
+    name: Bump global.json
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, 'Update dependencies from dotnet/installer') && github.actor == 'dotnet-maestro[bot]'
+    steps:
+    - name: 'Checkout repo'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: 'Update global.json'
+      run: |
+        set -exo pipefail
+        touch Make.config.inc # create a dummy file to avoid logic we don't need executed here
+        make global.json
+        if git diff --exit-code -- global.json; then
+          echo "No global.json update necessary"
+          exit 0
+        fi
+        git add -- global.json
+        git config --global user.email "github-actions@xamarin.com"
+        git config --global user.name "GitHub Actions"
+        git checkout "$GITHUB_HEAD_REF"
+        git commit -m "Re-generate global.json"
+        git push

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 all-local:: global.json
 
 # This tells NuGet to use the exact same dotnet version we've configured in Make.config
-global.json: $(TOP)/Make.config.inc Makefile $(TOP)/.git/HEAD $(TOP)/.git/index
+global.json: $(TOP)/dotnet.config Makefile $(TOP)/.git/HEAD $(TOP)/.git/index
 	$(Q_GEN) \
 		printf "{\n" > $@; \
 		printf "  \"sdk\": {\n    \"version\": \"$(DOTNET_VERSION)\"\n  }\n" >> $@; \


### PR DESCRIPTION
Otherwise we have to do this manually, which becomes tedious quite fast.

See commit list: https://github.com/xamarin/xamarin-macios/pull/15426/commits for an example.

This logic has been tested here: https://github.com/xamarin/xamarin-macios/pull/15455