### PR TITLE
[release/6.0.4xx] [CoreCLR] Avoid having any internal calls in managed code for CoreCLR. Fixes #15343.

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -281,28 +281,18 @@ namespace Foundation {
 		}
 #endif
 
+#if !NET || !__MACOS__
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		extern static void RegisterToggleRef (NSObject obj, IntPtr handle, bool isCustomType);
+#endif // !NET || !__MACOS__
 
 		[DllImport ("__Internal")]
 		static extern void xamarin_release_managed_ref (IntPtr handle, [MarshalAs (UnmanagedType.I1)] bool user_type);
 
-#if NET
-		static void RegisterToggleRefMonoVM (NSObject obj, IntPtr handle, bool isCustomType)
-		{
-			// We need this indirection for CoreCLR, otherwise JITting RegisterToggleReference will throw System.Security.SecurityException: ECall methods must be packaged into a system module.
-			RegisterToggleRef (obj, handle, isCustomType);
-		}
-#endif
-
 		static void RegisterToggleReference (NSObject obj, IntPtr handle, bool isCustomType)
 		{
-#if NET
-			if (Runtime.IsCoreCLR) {
-				Runtime.RegisterToggleReferenceCoreCLR (obj, handle, isCustomType);
-			} else {
-				RegisterToggleRefMonoVM (obj, handle, isCustomType);
-			}
+#if NET && __MACOS__
+			Runtime.RegisterToggleReferenceCoreCLR (obj, handle, isCustomType);
 #else
 			RegisterToggleRef (obj, handle, isCustomType);
 #endif


### PR DESCRIPTION
CoreCLR does not like running into methods declared as internal calls:

    [MethodImplAttribute (MethodImplOptions.InternalCall)]

and will fail with an error, even if the method is never executed, just encountered by the JIT:

    ECall methods must be packaged into a system module

In the early days of .NET support we solved this by adding an indirection for
CoreCLR, where the internal call was hidden inside a managed call that would
never be executed at runtime. This seems to work fine in most cases, except
when the debugger attached, when I'm guessing the JIT is more aggressive, and
looks further ahead (and fails).

On the other hand, in the early days of .NET support on macOS the managed code
had to work for both Mono and CoreCLR without modification (since the same
implementation assembly would be picked by the build independent on the actual
runtime). This is no longer the case, since we only support CoreCLR on macOS
now, which allows us to put any Mono-specific managed code (such as the
internal call) in !macOS conditions.

Fixes https://github.com/xamarin/xamarin-macios/issues/15343.


Backport of #15358
