### PR TITLE
[nnyeah] removed constructor size limit

### DIFF
--- a/tools/nnyeah/nnyeah/ConstructorTransforms.cs
+++ b/tools/nnyeah/nnyeah/ConstructorTransforms.cs
@@ -99,13 +99,6 @@ namespace Microsoft.MaciOS.Nnyeah {
 
 			if (IsNSObjectDerived (definition.BaseType, this)) {
 				if (definition.GetConstructors ().FirstOrDefault (IsIntPtrCtor) is MethodDefinition ctor) {
-					// How many instructions it takes to invoke a 1 or 2 param base ctor
-					// We can not safely process things that might store off the IntPtr
-					// or other such insanity, so just fail fast
-					if (ctor.Body.Instructions.Count > 7) {
-						throw new ConversionException (Errors.E0016, definition);
-					}
-
 					ctor.Parameters [0].ParameterType = NewNativeHandleTypeDefinition;
 					Transformed?.Invoke (this, new TransformEventArgs (ctor.DeclaringType.FullName,
 						ctor.Name, "IntPtr", 0, 0));

--- a/tools/nnyeah/tests/unit/ConstructorTransformTests.cs
+++ b/tools/nnyeah/tests/unit/ConstructorTransformTests.cs
@@ -79,18 +79,6 @@ public class Foo : NSObject {
 		}
 
 		[Test]
-		public async Task RefuseToProcessCtorWithBehavior ()
-		{
-			var type = await ReworkerHelper.CompileTypeForTest (@"
-using System;
-using Foundation;
-public class Foo : NSObject {
-	public Foo (IntPtr p) : base (p) { Console.Error.WriteLine (typeof(int)); }
-}");
-			Assert.Throws<ConversionException> (() => CreateTestTransform (type).ReworkAsNeeded (type));
-		}
-
-		[Test]
 		public async Task DerivedFromNSObjectDerived ()
 		{
 			var type = await ReworkerHelper.CompileTypeForTest (@"


### PR DESCRIPTION
Turns out that if you have a lot of instance fields that are initialized in line, these get added to the ctor and it makes it substantially larger but doesn't break the reworking process. I can think of a couple cases where constructors will break but (1) they're aren't practically detectable and (2) they would still break here:
```
public class SomeClass : NSObject {
    static HashSet<IntPtr> cache = new HashSet<IntPtr>();
    static IntPtr CacheAdd (IntPtr handle) {
        cache.Add (handle);
        return handle;
    }
    public SomeClass(IntPtr handle) : base (CacheAdd (handle)) { }
}
```
This will generate a small constructor that will not convert correctly - at least the call to CacheAdd() will fail because of a type mismatch. However, since the typical use case is to just call the `base` and otherwise ignore the handle, it's not an issue however big the constructor is.