### PR TITLE
[release/6.0.3xx] [runtime] Fix 'skip_nested_brace' to not read past the string. Fixes #15253.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -425,7 +425,6 @@ skip_nested_brace (const char *type)
 		case '}':
 			return type++;
 		default:
-			type++;
 			break;
 		}
 	}

--- a/tests/monotouch-test/ObjCRuntime/Messaging.cs
+++ b/tests/monotouch-test/ObjCRuntime/Messaging.cs
@@ -260,5 +260,18 @@ namespace ObjCRuntime
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public extern static void void_objc_msgSend_IntPtr_IntPtr_BlockLiteral (IntPtr receiver, IntPtr selector, IntPtr p1, IntPtr p2, ref BlockLiteral p3);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static void void_objc_msgSend_NSRange_out_NSRange_ref_NSRange (IntPtr receiver, IntPtr selector, _LongNSRange p1, out _LongNSRange p2, ref _LongNSRange p3);
+	}
+
+	public struct _LongNSRange {
+		public long Location;
+		public long Length;
+		public _LongNSRange (long location, long length)
+		{
+			Location = location;
+			Length = length;
+		}
 	}
 }

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -75,6 +75,36 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
+		public void NSRangeOutParameter ()
+		{
+			using var obj = new NSRangeOutParameterClass ();
+			var a = new _LongNSRange (-1, -2);
+			var c = new _LongNSRange (-5, -6);
+			Messaging.void_objc_msgSend_NSRange_out_NSRange_ref_NSRange (obj.Handle, Selector.GetHandle ("passRange:getRange:refRange:"), a, out var b, ref c);
+			Assert.AreEqual (a.Location, (long) (-1), "post a Location");
+			Assert.AreEqual (a.Length, (long) (-2), "post a Length");
+			Assert.AreEqual (b.Location, (long) 3, "post b Location");
+			Assert.AreEqual (b.Length, (long) 4, "post b Length");
+			Assert.AreEqual (c.Location, (long) 5, "post c Location");
+			Assert.AreEqual (c.Length, (long) 6, "post c Length");
+		}
+
+		class NSRangeOutParameterClass : NSObject {
+			[Export ("passRange:getRange:refRange:")]
+			public void DoIt (_LongNSRange a, out _LongNSRange b, ref _LongNSRange c)
+			{
+				Assert.AreEqual (a.Location, (long) (-1), "a Location");
+				Assert.AreEqual (a.Length, (long) (-2), "a Length");
+				Assert.AreEqual (c.Location, (long) (-5), "c Location");
+				Assert.AreEqual (c.Length, (long) (-6), "c Length");
+
+				a = new _LongNSRange (1, 2);
+				b = new _LongNSRange (3, 4);
+				c = new _LongNSRange (5, 6);
+			}
+		}
+
+		[Test]
 		public void RegistrarRemoval ()
 		{
 			// define set by xharness when creating test variations.
@@ -5423,7 +5453,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 #endif // !__WATCHOS__ && !__TVOS__
-
 	}
 
 #if !__WATCHOS__


### PR DESCRIPTION
Fix 'skip_nested_brace' to not double skip characters.

Also add a test.

Fixes https://github.com/xamarin/xamarin-macios/issues/15253.


Backport of #15257
