### PR TITLE
[release/6.0.4xx] [msbuild] Copy partial app manifests to build server if they exists on Windows. Fixes #15267.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CompileAppManifest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
@@ -19,8 +20,8 @@ namespace Xamarin.iOS.Tasks
 
 		public bool ShouldCopyToBuildServer (ITaskItem item)
 		{
-			// We don't want to copy partial generated manifest files
-			if (PartialAppManifests is not null && PartialAppManifests.Contains (item))
+			// We don't want to copy partial generated manifest files unless they exist
+			if (PartialAppManifests is not null && PartialAppManifests.Contains (item) && !File.Exists (item.ItemSpec))
 				return false;
 
 			return true;

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CompileAppManifest.cs
@@ -20,9 +20,12 @@ namespace Xamarin.iOS.Tasks
 
 		public bool ShouldCopyToBuildServer (ITaskItem item)
 		{
-			// We don't want to copy partial generated manifest files unless they exist
-			if (PartialAppManifests is not null && PartialAppManifests.Contains (item) && !File.Exists (item.ItemSpec))
-				return false;
+			// We don't want to copy partial generated manifest files unless they exist and have a non-zero length
+			if (PartialAppManifests is not null && PartialAppManifests.Contains (item)) {
+				var finfo = new FileInfo (item.ItemSpec);
+				if (!finfo.Exists || finfo.Length == 0)
+					return false;
+			}
 
 			return true;
 		}


### PR DESCRIPTION
The exclusion of partial app manifests happened here, but the commit doesn't explain why:

https://github.com/xamarin/xamarin-macios/commit/f4a4b232f8130a9172f6ac86c52a64c42d227bd5#diff-178de6110858688b9f7c2e8e57a873f5ac9498b355a456bfc18547ab2df876bc

It's certainly wrong if the partial app manifest is a part of the project, but
this exclusion might be because partial app manifests might be added as a part
of the build as well.

So change the logic to copy partial app manifests from Windows if they exist
there.

Fixes https://github.com/xamarin/xamarin-macios/issues/15267.


Backport of #15328
