### PR TITLE
[nnyeah] limit to one reference to Microsoft.iOS

### DIFF
--- a/tools/nnyeah/nnyeah/Reworker.cs
+++ b/tools/nnyeah/nnyeah/Reworker.cs
@@ -125,6 +125,7 @@ namespace Microsoft.MaciOS.Nnyeah {
 			NewNativeHandleTypeDefinition = modules.MicrosoftModule.Types.First (t => t.FullName == "ObjCRuntime.NativeHandle");
 
 			var nativeHandleOpImplicit = NewNativeHandleTypeDefinition.Resolve ().GetMethods ().First (m => m.FullName == "ObjCRuntime.NativeHandle ObjCRuntime.NativeHandle::op_Implicit(System.IntPtr)");
+			ReplacePlatformAssemblyReference ();
 			ConstructorTransforms = new ConstructorTransforms (ModuleToEdit.ImportReference (NewNativeHandleTypeDefinition), ModuleToEdit.TypeSystem.Boolean, ModuleToEdit.ImportReference (nativeHandleOpImplicit), WarningIssued, Transformed);
 			NativeHandleGetHandleReference = NewNativeHandleTypeDefinition.Methods.First (m => m.Name == "get_Handle");
 
@@ -284,7 +285,6 @@ namespace Microsoft.MaciOS.Nnyeah {
 
 		public void Rework (Stream stm)
 		{
-			ReplacePlatformAssemblyReference ();
 			foreach (var type in ModuleToEdit.Types) {
 				ReworkType (type);
 			}
@@ -318,7 +318,7 @@ namespace Microsoft.MaciOS.Nnyeah {
 		{
 			for (int i = ModuleToEdit.AssemblyReferences.Count - 1; i >= 0; i--) {
 				if (IsXamarinReference (ModuleToEdit.AssemblyReferences [i])) {
-					ModuleToEdit.AssemblyReferences[i] = new AssemblyNameReference (Modules.MicrosoftModule.Assembly.Name.Name, Modules.MicrosoftModule.Assembly.Name.Version);
+					ModuleToEdit.AssemblyReferences [i] = AssemblyNameReference.Parse (Modules.MicrosoftModule.Assembly.ToString ());
 				}
 			}
 		}

--- a/tools/nnyeah/tests/unit/ConstructorTransformTests.cs
+++ b/tools/nnyeah/tests/unit/ConstructorTransformTests.cs
@@ -283,5 +283,20 @@ public class Foo : NSObject {
 			AssertInstruction (instructions [createInstructionIndex - 1], "ldloc");
 			AssertNativeHandleCtorCalled (instructions);
 		}
+
+
+		[Test]
+		public async Task OneReferenceThanks ()
+		{
+			var pathToModule = await TestRunning.BuildTemporaryLibrary (@"
+using System;
+using Foundation;
+public class Foo : NSObject {
+	public Foo (IntPtr p) : base (p) { }
+}");
+			var editedModule = ReworkerHelper.GetReworkedModule (pathToModule)!;
+			var totalMSModules = editedModule.AssemblyReferences.Count ((nameRef => nameRef.Name == "Microsoft.macOS"));
+			Assert.AreEqual (1, totalMSModules, "More than one Microsoft.macOS reference");
+		}
 	}
 }


### PR DESCRIPTION
In working on the sidebar navigation tool, we were getting compile errors with a needed reference to Microsoft.iOS. @rolfbjarne noted that the assembly had two references to it, one without a public key.

There were two mistakes:
1 - The code was making an incomplete AssemblyNameReference, because for some reason the only available constructor in Cecil doesn't give you the option of setting the public key (fixed this by using the `Parse` method which does create a much more complete reference)
2 - The code was calling `ReplacePlatformAssemblyReference` too late and as a result as adding in another copy of the new platform assembly reference.

Added a test to ensure that when we make that change we get exactly one copy of the platform assembly.