### PR TITLE
[registrar] Improve naming of generated P/Invoke wrappers.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4945,10 +4945,12 @@ namespace Registrar {
 
 			string wrapperName;
 			if (!signatures.TryGetValue (signature.ToString (), out wrapperName)) {
-				var name = "xamarin_pinvoke_wrapper_" + method.Name;
+				var methodName = method.Name.Replace ('<', '_').Replace ('>', '_').Replace ('|', '_');
+				var baseName = "xamarin_pinvoke_wrapper_" + methodName;
+				var name = baseName;
 				var counter = 0;
 				while (names.Contains (name)) {
-					name = "xamarin_pinvoke_wrapper_" + method.Name + (++counter).ToString ();
+					name = baseName + (++counter).ToString ();
 				}
 				names.Add (name);
 				signatures [signature.ToString ()] = wrapperName = name;


### PR DESCRIPTION
C# method names generated by the C# compiler can have all sorts of invalid
characters, so just sanitize this a bit.

Fixes errors like these:

    /Users/builder/azdo/_work/2/s/xamarin-macios/tests/dotnet/MySimpleApp/iOS/obj/Debug/net7.0-ios/iossimulator-x64/linker-cache/pinvokes.mm:23:70: error: use of undeclared identifier 'NSOperatingSystemVersion_objc_msgSend_stret'
            typedef struct trampoline_struct_ppp(*func_xamarin_pinvoke_wrapper_<NSOperatingSystemVersion_objc_msgSend_stret>g____PInvoke|6_0) (void * basePtr, void * selector);
                                                                                ^
    /Users/builder/azdo/_work/2/s/xamarin-macios/tests/dotnet/MySimpleApp/iOS/obj/Debug/net7.0-ios/iossimulator-x64/linker-cache/pinvokes.mm:23:114: error: expected ')'
            typedef struct trampoline_struct_ppp(*func_xamarin_pinvoke_wrapper_<NSOperatingSystemVersion_objc_msgSend_stret>g____PInvoke|6_0) (void * basePtr, void * selector);
                                                                                                                            ^
    /Users/builder/azdo/_work/2/s/xamarin-macios/tests/dotnet/MySimpleApp/iOS/obj/Debug/net7.0-ios/iossimulator-x64/linker-cache/pinvokes.mm:23:38: note: to match this '('
            typedef struct trampoline_struct_ppp(*func_xamarin_pinvoke_wrapper_<NSOperatingSystemVersion_objc_msgSend_stret>g____PInvoke|6_0) (void * basePtr, void * selector);
                                                ^
    /Users/builder/azdo/_work/2/s/xamarin-macios/tests/dotnet/MySimpleApp/iOS/obj/Debug/net7.0-ios/iossimulator-x64/linker-cache/pinvokes.mm:25:27: error: use of undeclared identifier 'NSOperatingSystemVersion_objc_msgSend_stret'
            xamarin_pinvoke_wrapper_<NSOperatingSystemVersion_objc_msgSend_stret>g____PInvoke|6_0 (void * basePtr, void * selector)