### PR TITLE
[devops] Fix publishing in the presence of our global.json

### DIFF
--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -40,9 +40,6 @@ jobs:
   - script: make -C $(Build.SourcesDirectory)/dotnet targets/Microsoft.iOS.Sdk.Versions.props
     displayName: make Microsoft.iOS.Sdk.Versions.props
 
-  - script: rm -f $(Build.SourcesDirectory)/global.json
-    displayName: 'Remove global.json'
-
   - powershell: >-
       & dotnet build -v:n -t:PushManifestToBuildAssetRegistry
       -p:BarManifestOutputPath=$(Agent.BuildDirectory)\macios\AssetManifests -p:BuildAssetRegistryToken=$(MaestroAccessToken)

--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -40,12 +40,18 @@ jobs:
   - script: make -C $(Build.SourcesDirectory)/dotnet targets/Microsoft.iOS.Sdk.Versions.props
     displayName: make Microsoft.iOS.Sdk.Versions.props
 
+  - script: rm -f $(Build.SourcesDirectory)/global.json
+    displayName: 'Remove global.json'
+
   - powershell: >-
       & dotnet build -v:n -t:PushManifestToBuildAssetRegistry
       -p:BarManifestOutputPath=$(Agent.BuildDirectory)\macios\AssetManifests -p:BuildAssetRegistryToken=$(MaestroAccessToken)
       $(Build.SourcesDirectory)\dotnet\package\Microsoft.iOS.Ref\package.csproj
       -bl:$(Build.ArtifactStagingDirectory)\post-build-binlogs\push-bar-manifest.binlog
     displayName: push manifest to build asset registry
+    # We can't use the global.json located in the root of our repo, because makes it required to use the exact .NET version we're referencing in our eng/Versions.Details.xml file.
+    # So in order to not use it, we set the working directory to the parent directory of xamarin-macios.
+    workingDirectory: $(Build.SourcesDirectory)\..
 
   - powershell: |
       $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'


### PR DESCRIPTION
We can't use the global.json located in the root of our repo, because makes it
required to use the exact .NET version we're referencing in our
eng/Versions.Details.xml file. So in order to not use it, we set the working
directory to the parent directory of xamarin-macios.

Otherwise this happens:

    Could not execute because the application was not found or a compatible .NET SDK is not installed.
    Possible reasons for this include:
      * You intended to execute a .NET program:
          The application 'build' does not exist.
      * You intended to execute a .NET SDK command:
          A compatible installed .NET SDK for global.json version [6.0.301-rtm.22280.1] from [D:\a\1\s\xamarin-macios\global.json] was not found.
            6.0.201 [C:\hostedtoolcache\windows\dotnet\sdk]
          Install the [6.0.301-rtm.22280.1] .NET SDK or update [D:\a\1\s\xamarin-macios\global.json] with an installed .NET SDK: