### PR TITLE
[dotnet] Make it possible to specify the registrar using a 'Registrar' property in MSBuild.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -498,7 +498,7 @@
 				Platform=$(_PlatformName)
 				PlatformAssembly=$(_PlatformAssemblyName).dll
 				RelativeAppBundlePath=$(_RelativeAppBundlePath)
-				Registrar=$(_BundlerRegistrar)
+				Registrar=$(Registrar)
 				RequirePInvokeWrappers=$(_RequirePInvokeWrappers)
 				RuntimeConfigurationFile=$(_RuntimeConfigurationFile)
 				SdkDevPath=$(_SdkDevPath)

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -103,6 +103,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			ExtraArgs="$(_BundlerArguments)"
 			NativeReferences="@(_FrameworkNativeReference);@(_FileNativeReference)"
 			References="@(ReferencePath);@(_BundlerReferencePath)"
+			Registrar="$(Registrar)"
 			ResponseFilePath="$(IntermediateOutputPath)response-file.rsp"
 			SdkRoot="$(_SdkDevPath)"
 			IntermediateOutputPath="$(IntermediateOutputPath)mmp-cache"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BundlerToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BundlerToolTaskBase.cs
@@ -56,6 +56,8 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public ITaskItem [] References { get; set; }
 
+		public string Registrar { get; set; }
+
 		[Required]
 		public string ResponseFilePath { get; set; }
 
@@ -83,6 +85,9 @@ namespace Xamarin.MacDev.Tasks {
 		protected CommandLineArgumentBuilder GenerateCommandLineArguments ()
 		{
 			var args = new CommandLineArgumentBuilder ();
+
+			if (!string.IsNullOrEmpty (Registrar))
+				args.AddLine ($"--registrar:" + Registrar);
 
 			if (bool.TryParse (ArchiveSymbols?.Trim (), out var msym))
 				args.AddLine ($"--msym={(msym ? "yes" : "no")}");

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1793,6 +1793,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			NoSymbolStrip="$(NoSymbolStrip)"
 			NoDSymUtil="$(NoDSymUtil)"
 			PackageDebugSymbols="$(PackageDebugSymbols)"
+			Registrar="$(Registrar)"
 			Verbosity="$(_BundlerVerbosity)"
 			>
 			<Output TaskParameter="Aot" ItemName="_AotArguments" />
@@ -1806,7 +1807,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<Output TaskParameter="NoDSymUtil" PropertyName="NoDSymUtil"/>
 			<Output TaskParameter="Optimize" PropertyName="_BundlerOptimize"/>
 			<Output TaskParameter="PackageDebugSymbols" PropertyName="PackageDebugSymbols" />
-			<Output TaskParameter="Registrar" PropertyName="_BundlerRegistrar" />
+			<Output TaskParameter="Registrar" PropertyName="Registrar" />
 			<Output TaskParameter="RequirePInvokeWrappers" PropertyName="_RequirePInvokeWrappers" />
 			<Output TaskParameter="Verbosity" PropertyName="_BundlerVerbosity" />
 			<Output TaskParameter="XmlDefinitions" ItemName="_BundlerXmlDefinitions" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -258,6 +258,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			Profiling="$(MtouchProfiling)"
 			ProjectDir="$(MtouchProjectDirectory)"
 			References="@(ReferencePath);@(_BundlerReferencePath)"
+			Registrar="$(Registrar)"
 			ResponseFilePath="$(DeviceSpecificIntermediateOutputPath)response-file.rsp"
 			SdkRoot="$(_SdkDevPath)"
 			SdkIsSimulator="$(_SdkIsSimulator)"

--- a/tests/ComputeRegistrarConstant.targets
+++ b/tests/ComputeRegistrarConstant.targets
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<Target Name="ComputeRegistrarConstant" BeforeTargets="BeforeBuild">
+		<PropertyGroup Condition="'$(_PlatformName)' == 'iOS' Or '$(TargetFramework.EndsWith('-ios')) Or '$(_PlatformName)' == 'tvOS' Or $(TargetFramework.EndsWith('-tvos'))">
+			<IsDynamicRegistrar Condition="'$(ComputedPlatform)' == 'iPhoneSimulator' And '$(Registrar)' == ''">true</IsDynamicRegistrar>
+			<IsDynamicRegistrar Condition="'$(Registrar)' == 'dynamic'">true</IsDynamicRegistrar>
+		</PropertyGroup>
+
+		<PropertyGroup Condition="'$(_PlatformName)' == 'macOS' Or $(TargetFramework.EndsWith('-macos')) Or '$(_PlatformName)' == 'MacCatalyst' Or $(TargetFramework.EndsWith('-maccatalyst'))">
+			<IsDynamicRegistrar Condition="'$(Configuration)' == 'Debug'">true</IsDynamicRegistrar>
+		</PropertyGroup>
+
+		<PropertyGroup Condition="'$(HasDynamicRegistrar)' == 'true'">
+			<IsDynamicRegistrar>$(DefineConstants);DYNAMIC_REGISTRAR</IsDynamicRegistrar>
+		</PropertyGroup>
+	</Target>
+</Project>

--- a/tests/ComputeRegistrarConstant.targets
+++ b/tests/ComputeRegistrarConstant.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 	<Target Name="ComputeRegistrarConstant" BeforeTargets="BeforeBuild">
-		<PropertyGroup Condition="'$(_PlatformName)' == 'iOS' Or '$(TargetFramework.EndsWith('-ios')) Or '$(_PlatformName)' == 'tvOS' Or $(TargetFramework.EndsWith('-tvos'))">
+		<PropertyGroup Condition="'$(_PlatformName)' == 'iOS' Or $(TargetFramework.EndsWith('-ios')) Or '$(_PlatformName)' == 'tvOS' Or $(TargetFramework.EndsWith('-tvos'))">
 			<IsDynamicRegistrar Condition="'$(ComputedPlatform)' == 'iPhoneSimulator' And '$(Registrar)' == ''">true</IsDynamicRegistrar>
 			<IsDynamicRegistrar Condition="'$(Registrar)' == 'dynamic'">true</IsDynamicRegistrar>
 		</PropertyGroup>

--- a/tests/ComputeRegistrarConstant.targets
+++ b/tests/ComputeRegistrarConstant.targets
@@ -7,7 +7,8 @@
 		</PropertyGroup>
 
 		<PropertyGroup Condition="'$(_PlatformName)' == 'macOS' Or $(TargetFramework.EndsWith('-macos')) Or '$(_PlatformName)' == 'MacCatalyst' Or $(TargetFramework.EndsWith('-maccatalyst'))">
-			<IsDynamicRegistrar Condition="'$(Configuration)' == 'Debug'">true</IsDynamicRegistrar>
+			<IsDynamicRegistrar Condition="'$(Configuration)' == 'Debug' And '$(Registrar)' == ''">true</IsDynamicRegistrar>
+			<IsDynamicRegistrar Condition="'$(Registrar)' == 'dynamic'">true</IsDynamicRegistrar>
 		</PropertyGroup>
 
 		<PropertyGroup Condition="'$(IsDynamicRegistrar)' == 'true'">

--- a/tests/ComputeRegistrarConstant.targets
+++ b/tests/ComputeRegistrarConstant.targets
@@ -10,7 +10,7 @@
 			<IsDynamicRegistrar Condition="'$(Configuration)' == 'Debug'">true</IsDynamicRegistrar>
 		</PropertyGroup>
 
-		<PropertyGroup Condition="'$(HasDynamicRegistrar)' == 'true'">
+		<PropertyGroup Condition="'$(IsDynamicRegistrar)' == 'true'">
 			<DefineConstants>$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
 		</PropertyGroup>
 	</Target>

--- a/tests/ComputeRegistrarConstant.targets
+++ b/tests/ComputeRegistrarConstant.targets
@@ -11,7 +11,7 @@
 		</PropertyGroup>
 
 		<PropertyGroup Condition="'$(HasDynamicRegistrar)' == 'true'">
-			<IsDynamicRegistrar>$(DefineConstants);DYNAMIC_REGISTRAR</IsDynamicRegistrar>
+			<DefineConstants>$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
 		</PropertyGroup>
 	</Target>
 </Project>

--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -63,5 +63,6 @@
 		<ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\external\Touch.Unit\Touch.Client\dotnet\$(_PlatformName)\Touch.Client-$(_PlatformName).dotnet.csproj" Condition="'$(ExcludeTouchUnitReference)' != 'true'" />
 	</ItemGroup>
 
+	<Import Project="$(MSBuildThisFileDirectory)/../ComputeRegistrarConstant.targets" />
 	<Import Project="$(MSBuildThisFileDirectory)/../nunit.framework.targets" />
 </Project>

--- a/tests/monotouch-test/dotnet/MacCatalyst/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/MacCatalyst/monotouch-test.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
-    <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/macOS/monotouch-test.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
     <DefineConstants>$(DefineConstants);XAMMAC_TESTS</DefineConstants>
-    <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be inlined by xharness -->

--- a/tests/monotouch-test/dotnet/shared.csproj
+++ b/tests/monotouch-test/dotnet/shared.csproj
@@ -201,7 +201,6 @@
       <DefineConstants Condition="'$(ComputedPlatform)' == 'iPhone'">$(DefineConstants);AOT</DefineConstants>
       <DefineConstants Condition="'$(RuntimeIdentifier)' == 'iossimulator-arm64'">$(DefineConstants);AOT</DefineConstants>
       <DefineConstants Condition="'$(RuntimeIdentifier)' == 'tvossimulator-arm64'">$(DefineConstants);AOT</DefineConstants>
-      <DefineConstants Condition="'$(ComputedPlatform)' == 'iPhoneSimulator'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
     </PropertyGroup>
   </Target>
 </Project>

--- a/tests/monotouch-test/dotnet/tvOS/monotouch-test.csproj
+++ b/tests/monotouch-test/dotnet/tvOS/monotouch-test.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
-    <DefineConstants Condition="'$(Platform)' == 'iPhoneSimulator'">$(DefineConstants);DYNAMIC_REGISTRAR</DefineConstants>
   </PropertyGroup>
 
   <!-- Imports of the form '../shared.csproj' will be processed by xharness -->

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhoneSimulator\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;DYNAMIC_REGISTRAR;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
@@ -40,7 +40,7 @@
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhoneSimulator\$(Configuration)-unified</OutputPath>
-    <DefineConstants>MONOTOUCH;DYNAMIC_REGISTRAR;$(DefineConstants)</DefineConstants>
+    <DefineConstants>MONOTOUCH;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <MtouchLink>None</MtouchLink>
@@ -226,6 +226,7 @@
     <Compile Include="SceneKit\SCNVector3Test.cs" />
     <Compile Include="SceneKit\SCNVector4Test.cs" />
   </ItemGroup>
+  <Import Project="$(RootTestsDirectory)\ComputeRegistrarConstant.targets" />
   <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\x86\Debug</OutputPath>
-    <DefineConstants>DEBUG;MONOMAC;XAMMAC_TESTS;DYNAMIC_REGISTRAR</DefineConstants>
+    <DefineConstants>DEBUG;MONOMAC;XAMMAC_TESTS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <EnableCodeSigning>false</EnableCodeSigning>
@@ -44,7 +44,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\arm64\Debug</OutputPath>
-    <DefineConstants>DEBUG;MONOMAC;XAMMAC_TESTS;DYNAMIC_REGISTRAR</DefineConstants>
+    <DefineConstants>DEBUG;MONOMAC;XAMMAC_TESTS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <EnableCodeSigning>false</EnableCodeSigning>
@@ -288,6 +288,7 @@
       <Link>Base.lproj\Localizable.strings</Link>
     </BundleResource>
   </ItemGroup>
+  <Import Project="$(RootTestsDirectory)\ComputeRegistrarConstant.targets" />
   <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <PropertyGroup>

--- a/tests/xharness/Jenkins/TestData.cs
+++ b/tests/xharness/Jenkins/TestData.cs
@@ -24,5 +24,6 @@ namespace Xharness.Jenkins {
 		public IEnumerable<IDevice> Candidates;
 		public string XamMacArch;
 		public string RuntimeIdentifier;
+		public string Registrar;
 	}
 }

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -83,10 +83,10 @@ namespace Xharness.Jenkins {
 					if (test.TestProject.IsDotNetProject)
 						ignore = true;
 					if (supports_dynamic_registrar_on_device)
-						yield return new TestData { Variation = "Debug (dynamic registrar)", MTouchExtraArgs = "--registrar:dynamic", Debug = true, Profiling = false, Ignored = ignore };
-					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL", Ignored = ignore };
+						yield return new TestData { Variation = "Debug (dynamic registrar)", Registrar = "dynamic", Debug = true, Profiling = false, Ignored = ignore };
+					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--optimize:all", Registrar = "static", Debug = false, Profiling = false, Defines = "OPTIMIZEALL", Ignored = ignore };
 					if (supports_debug) {
-						yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = true, Profiling = false, Defines = "OPTIMIZEALL", Ignored = ignore };
+						yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--optimize:all", Registrar = "static", Debug = true, Profiling = false, Defines = "OPTIMIZEALL", Ignored = ignore };
 						yield return new TestData { Variation = "Debug: SGenConc", MTouchExtraArgs = "", Debug = true, Profiling = false, MonoNativeLinkMode = MonoNativeLinkMode.Static, EnableSGenConc = true, Ignored = ignore };
 					}
 					if (supports_interpreter) {
@@ -120,9 +120,9 @@ namespace Xharness.Jenkins {
 				case "monotouch-test":
 					// The default is to run monotouch-test with the dynamic registrar (in the simulator), so that's already covered
 					yield return new TestData { Variation = "Debug (LinkSdk)", Debug = true, Profiling = false, LinkMode = test.TestProject.IsDotNetProject ? "SdkOnly" : "LinkSdk", Ignored = ignore };
-					yield return new TestData { Variation = "Debug (static registrar)", MTouchExtraArgs = "--registrar:static", Debug = true, Profiling = false, Undefines = "DYNAMIC_REGISTRAR", Ignored = ignore };
-					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Undefines = "DYNAMIC_REGISTRAR", Ignored = ignore };
-					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all,-remove-uithread-checks", Debug = true, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Undefines = "DYNAMIC_REGISTRAR", Ignored = ignore ?? !jenkins.TestSelection.IsEnabled (TestLabel.All) };
+					yield return new TestData { Variation = "Debug (static registrar)", Registrar = "static", Debug = true, Profiling = false, Ignored = ignore };
+					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--optimize:all", Registrar = "static", Debug = false, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Ignored = ignore };
+					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--optimize:all,-remove-uithread-checks", Registrar = "static", Debug = true, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Ignored = ignore ?? !jenkins.TestSelection.IsEnabled (TestLabel.All) };
 
 					if (test.TestProject.IsDotNetProject && mac_supports_arm64)
 						yield return new TestData { Variation = "Debug (ARM64)", Debug = true, Profiling = false, Ignored = !mac_supports_arm64 ? true : ignore, RuntimeIdentifier = arm64_sim_runtime_identifier, };
@@ -148,8 +148,8 @@ namespace Xharness.Jenkins {
 					if (test.TestProject.IsDotNetProject) {
 						yield return new TestData { Variation = "Debug (ARM64)", Debug = true, Profiling = false, Ignored = !jenkins.TestSelection.IsEnabled (TestLabel.Monotouch) || !jenkins.TestSelection.IsEnabled (PlatformLabel.Mac) || !mac_supports_arm64, RuntimeIdentifier = arm64_runtime_identifier, };
 						if (test.Platform != TestPlatform.MacCatalyst) {
-							yield return new TestData { Variation = "Debug (static registrar)", MonoBundlingExtraArgs = "--registrar:static", Debug = true, Undefines = "DYNAMIC_REGISTRAR", Ignored = !jenkins.TestSelection.IsEnabled (TestLabel.Monotouch) || !jenkins.TestSelection.IsEnabled (PlatformLabel.Mac), };
-							yield return new TestData { Variation = "Debug (static registrar, ARM64)", MonoBundlingExtraArgs = "--registrar:static", Debug = true, Undefines = "DYNAMIC_REGISTRAR", Profiling = false, Ignored = !jenkins.TestSelection.IsEnabled (TestLabel.Monotouch) || !jenkins.TestSelection.IsEnabled (PlatformLabel.Mac) || !mac_supports_arm64, RuntimeIdentifier = arm64_runtime_identifier, };
+							yield return new TestData { Variation = "Debug (static registrar)", Registrar = "static", Debug = true, Ignored = !jenkins.TestSelection.IsEnabled (TestLabel.Monotouch) || !jenkins.TestSelection.IsEnabled (PlatformLabel.Mac), };
+							yield return new TestData { Variation = "Debug (static registrar, ARM64)", Registrar = "static", Debug = true, Profiling = false, Ignored = !jenkins.TestSelection.IsEnabled (TestLabel.Monotouch) || !jenkins.TestSelection.IsEnabled (PlatformLabel.Mac) || !mac_supports_arm64, RuntimeIdentifier = arm64_runtime_identifier, };
 						}
 						if (test.Platform == TestPlatform.MacCatalyst)
 							yield return new TestData { Variation = "Release (ARM64, LLVM)", Debug = false, UseLlvm = true, Ignored = !jenkins.TestSelection.IsEnabled (TestLabel.Monotouch) || !jenkins.TestSelection.IsEnabled (PlatformLabel.MacCatalyst) || !mac_supports_arm64, RuntimeIdentifier = arm64_runtime_identifier };
@@ -158,11 +158,11 @@ namespace Xharness.Jenkins {
 				case "xammac tests":
 					switch (test.ProjectConfiguration) {
 					case "Release":
-						yield return new TestData { Variation = "Release (all optimizations)", MonoBundlingExtraArgs = "--registrar:static --optimize:all", Debug = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Undefines = "DYNAMIC_REGISTRAR" };
+						yield return new TestData { Variation = "Release (all optimizations)", MonoBundlingExtraArgs = "--optimize:all", Registrar = "static", Debug = false, LinkMode = "Full", Defines = "OPTIMIZEALL" };
 						yield return new TestData { Variation = "Release (ARM64)", XamMacArch = "ARM64", Debug = false, Ignored = !mac_supports_arm64 || !jenkins.TestSelection.IsEnabled (TestLabel.Xammac) || !jenkins.TestSelection.IsEnabled (PlatformLabel.Mac) };
 						break;
 					case "Debug":
-						yield return new TestData { Variation = "Debug (all optimizations)", MonoBundlingExtraArgs = "--registrar:static --optimize:all,-remove-uithread-checks", Debug = true, LinkMode = "Full", Defines = "OPTIMIZEALL", Undefines = "DYNAMIC_REGISTRAR", Ignored = !(jenkins.TestSelection.IsEnabled (TestLabel.All) && jenkins.TestSelection.IsEnabled (PlatformLabel.Mac)) };
+						yield return new TestData { Variation = "Debug (all optimizations)", MonoBundlingExtraArgs = "--optimize:all,-remove-uithread-checks", Registrar = "static", Debug = true, LinkMode = "Full", Defines = "OPTIMIZEALL", Ignored = !(jenkins.TestSelection.IsEnabled (TestLabel.All) && jenkins.TestSelection.IsEnabled (PlatformLabel.Mac)) };
 						yield return new TestData { Variation = "Debug (ARM64)", XamMacArch = "ARM64", Debug = true, Ignored = !mac_supports_arm64 || !jenkins.TestSelection.IsEnabled (TestLabel.Xammac) ||!jenkins.TestSelection.IsEnabled (PlatformLabel.Mac) };
 						break;
 					}
@@ -203,6 +203,7 @@ namespace Xharness.Jenkins {
 					var xammac_arch = test_data.XamMacArch;
 					var runtime_identifer = test_data.RuntimeIdentifier;
 					var use_llvm = test_data.UseLlvm;
+					var registrar = test_data.Registrar;
 
 					if (task.TestProject.IsDotNetProject)
 						variation += " [dotnet]";
@@ -264,6 +265,8 @@ namespace Xharness.Jenkins {
 							clone.Xml.SetNode ("XamMacArch", xammac_arch, task.ProjectPlatform, configuration);
 						if (!string.IsNullOrEmpty (runtime_identifer))
 							clone.Xml.SetTopLevelPropertyGroupValue ("RuntimeIdentifier", runtime_identifer);
+						if (!string.IsNullOrEmpty (registrar))
+							clone.Xml.SetTopLevelPropertyGroupValue ("Registrar", registrar);
 						clone.Xml.Save (clone.Path);
 					});
 


### PR DESCRIPTION
However, passing --registrar:... to mtouch/mmp will override any MSBuild property.