### PR TITLE
[devops] Fix publishing in the presence of our global.json (second part)

### DIFF
--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -57,6 +57,9 @@ jobs:
       & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
       & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
     displayName: add build to default darc channel
+    # We can't use the global.json located in the root of our repo, because makes it required to use the exact .NET version we're referencing in our eng/Versions.Details.xml file.
+    # So in order to not use it, we set the working directory to the parent directory of xamarin-macios.
+    workingDirectory: $(Build.SourcesDirectory)\..
 
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: post-build-binlogs'


### PR DESCRIPTION
We can't use the global.json located in the root of our repo, because makes it
required to use the exact .NET version we're referencing in our
eng/Versions.Details.xml file. So in order to not use it, we set the working
directory to the parent directory of xamarin-macios.

Otherwise this happens:

    Could not execute because the application was not found or a compatible .NET SDK is not installed.
    Possible reasons for this include:
      * You intended to execute a .NET program:
          The application 'build' does not exist.
      * You intended to execute a .NET SDK command:
          A compatible installed .NET SDK for global.json version [6.0.301-rtm.22280.1] from [D:\a\1\s\xamarin-macios\global.json] was not found.
            6.0.201 [C:\hostedtoolcache\windows\dotnet\sdk]
          Install the [6.0.301-rtm.22280.1] .NET SDK or update [D:\a\1\s\xamarin-macios\global.json] with an installed .NET SDK:
    & : The term 'C:\hostedtoolcache\windows\darc\darc' is not recognized as the name of a cmdlet, function, script file,
    or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and
    try again.