### PR TITLE
[release/6.0.3xx] [dotnet] Accept invalid runtime identifiers for Restore.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1737,7 +1737,7 @@
 
 	<Target Name="_ValidateRuntimeIdentifier"
 		Condition="'$(RuntimeIdentifier)' != '' And '$(_RuntimeIdentifierValidation)' != 'false' And '$(_RuntimeIdentifierIsRequired)' == 'true'"
-		BeforeTargets="Restore;Build;ResolvedFrameworkReference;ResolveRuntimePackAssets;ProcessFrameworkReferences">
+		BeforeTargets="Build;ResolvedFrameworkReference;ResolveRuntimePackAssets">
 		<PropertyGroup>
 			<_IsValidRuntimeIdentifier Condition="@(_XamarinValidRuntimeIdentifier->WithMetadataValue('Platform', '$(_PlatformName)')->WithMetadataValue('Filename', '$(RuntimeIdentifier)')->Count()) &gt; 0">true</_IsValidRuntimeIdentifier>
 		</PropertyGroup>

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -50,6 +50,11 @@ namespace Xamarin.Tests {
 			return rv;
 		}
 
+		public static ExecutionResult AssertRestore (string project, Dictionary<string, string> properties = null)
+		{
+			return Execute ("restore", project, properties, true);
+		}
+
 		public static ExecutionResult AssertBuild (string project, Dictionary<string, string> properties = null)
 		{
 			return Execute ("build", project, properties, true);
@@ -103,6 +108,7 @@ namespace Xamarin.Tests {
 			case "build":
 			case "pack":
 			case "publish":
+			case "restore":
 				var args = new List<string> ();
 				args.Add (verb);
 				args.Add (project);

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -470,24 +470,24 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		[TestCase (ApplePlatform.iOS, "ios-x64")] // valid RID in a previous preview (and common mistake)
-		[TestCase (ApplePlatform.iOS, "iossimulator-x84")] // it's x86, not x84
-		[TestCase (ApplePlatform.iOS, "iossimulator-arm")] // we don't support this
-		[TestCase (ApplePlatform.iOS, "helloworld")] // random text
-		[TestCase (ApplePlatform.iOS, "osx-x64")] // valid RID for another platform
-		[TestCase (ApplePlatform.TVOS, "tvos-x64")] // valid RID in a previous preview (and common mistake)
-		[TestCase (ApplePlatform.TVOS, "tvossimulator-x46")] // it's x64, not x46
-		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm")] // we don't support this
-		[TestCase (ApplePlatform.TVOS, "helloworld")] // random text
-		[TestCase (ApplePlatform.TVOS, "osx-x64")] // valid RID for another platform
-		[TestCase (ApplePlatform.MacOSX, "osx-x46")] // it's x64, not x46
-		[TestCase (ApplePlatform.MacOSX, "macos-arm64")] // it's osx, not macos
-		[TestCase (ApplePlatform.MacOSX, "helloworld")] // random text
-		[TestCase (ApplePlatform.MacOSX, "ios-arm64")] // valid RID for another platform
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x46")] // it's x64, not x46
-		[TestCase (ApplePlatform.MacCatalyst, "helloworld")] // random text
-		[TestCase (ApplePlatform.MacCatalyst, "osx-x64")] // valid RID for another platform
-		public void InvalidRuntimeIdentifier (ApplePlatform platform, string runtimeIdentifier)
+		[TestCase (ApplePlatform.iOS, "ios-x64", false)] // valid RID in a previous preview (and common mistake)
+		[TestCase (ApplePlatform.iOS, "iossimulator-x84", true)] // it's x86, not x84
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm", true)] // we don't support this
+		[TestCase (ApplePlatform.iOS, "helloworld", true)] // random text
+		[TestCase (ApplePlatform.iOS, "osx-x64", false)] // valid RID for another platform
+		[TestCase (ApplePlatform.TVOS, "tvos-x64", false)] // valid RID in a previous preview (and common mistake)
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-x46", true)] // it's x64, not x46
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm", true)] // we don't support this
+		[TestCase (ApplePlatform.TVOS, "helloworld", true)] // random text
+		[TestCase (ApplePlatform.TVOS, "osx-x64", false)] // valid RID for another platform
+		[TestCase (ApplePlatform.MacOSX, "osx-x46", true)] // it's x64, not x46
+		[TestCase (ApplePlatform.MacOSX, "macos-arm64", true)] // it's osx, not macos
+		[TestCase (ApplePlatform.MacOSX, "helloworld", true)] // random text
+		[TestCase (ApplePlatform.MacOSX, "ios-arm64", false)] // valid RID for another platform
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x46", true)] // it's x64, not x46
+		[TestCase (ApplePlatform.MacCatalyst, "helloworld", true)] // random text
+		[TestCase (ApplePlatform.MacCatalyst, "osx-x64", false)] // valid RID for another platform
+		public void InvalidRuntimeIdentifier (ApplePlatform platform, string runtimeIdentifier, bool notRecognized)
 		{
 			var project = "MySimpleApp";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
@@ -499,7 +499,13 @@ namespace Xamarin.Tests {
 			var errors = BinLog.GetBuildLogErrors (rv.BinLogPath).ToArray ();
 			var uniqueErrors = errors.Select (v => v.Message).Distinct ().ToArray ();
 			Assert.AreEqual (1, uniqueErrors.Length, "Error count");
-			Assert.AreEqual ($"The RuntimeIdentifier '{runtimeIdentifier}' is invalid.", uniqueErrors [0], "Error message");
+			string expectedError;
+			if (notRecognized) {
+				expectedError = $"The specified RuntimeIdentifier '{runtimeIdentifier}' is not recognized.";
+			} else {
+				expectedError = $"The RuntimeIdentifier '{runtimeIdentifier}' is invalid.";
+			}
+			Assert.AreEqual (expectedError, uniqueErrors [0], "Error message");
 		}
 
 		[Test]

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -503,6 +503,22 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		[TestCase (ApplePlatform.iOS, "win10-x86")]
+		[TestCase (ApplePlatform.TVOS, "win10-x64")]
+		[TestCase (ApplePlatform.MacOSX, "win10-arm")]
+		[TestCase (ApplePlatform.MacCatalyst, "win10-arm64")]
+		public void InvalidRuntimeIdentifier_Restore (ApplePlatform platform, string runtimeIdentifier)
+		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, platform: platform);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifier);
+			DotNet.AssertRestore (project_path, properties);
+		}
+
+		[Test]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
 		public void FilesInAppBundle (ApplePlatform platform, string runtimeIdentifiers)
 		{


### PR DESCRIPTION
Validating that projects are only restored using valid runtime identifiers
have turned out to be an interesting rabbit hole.

Nobody seems to dispute the fact that it's a correct validation, the problem
is that it apparently turns out quite complicated to not do the wrong thing
for projects with multiple target frameworks.

In some scenarios apparently the Restore target might want to restore all
target frameworks, which breaks down if whatever the user wants to do requires
setting a runtime identifier, because then that runtime identifier is set for
all target frameworks.

So for the sake of simplicity, we're going to try removing this validation for
the Restore target (we're keeping it for the Build target).

There are thus two potential scenarios:

1. The Restore succeeds using invalid runtime identifiers. This shouldn't
   affect valid builds (since those should be completely separate due to using
   different runtime identifiers).
2. Something else breaks. At worst the user will be given a less
   comprehensible error message. Time will tell if this is better or worse
   than the current experience.

Ref: https://github.com/NuGet/Home/issues/11653
Ref: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1558247


Backport of #15357
