### PR TITLE
[src] Adjust AssemblyVersion for .NET with Xcode 13.3.

### DIFF
--- a/src/AssemblyInfo.cs.in
+++ b/src/AssemblyInfo.cs.in
@@ -36,5 +36,5 @@ using System.Runtime.CompilerServices;
 // - Assembly B should build just fine, because those two versions of Microsoft.*.dll have the exact same API.
 // To avoid scenarios where everybody would have to update to the latest patch version of Microsoft.*.dll
 // in order to compile stuff, we erase the third and fourth number and only use 0 for both.
-[assembly: AssemblyVersion ("@NUGET_VERSION_MAJOR@.@NUGET_VERSION_MINOR@.0.0")]
+[assembly: AssemblyVersion ("@NUGET_VERSION_MAJOR@.@NUGET_VERSION_MINOR@.@NUGET_VERSION_THIRD_DIGIT_WORKAROUND@.0")]
 #endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,6 +29,23 @@ GENERATOR_FLAGS=-process-enums -core -nologo -nostdlib -noconfig -native-excepti
 
 GENERATOR_TF_VERSION=$(subst net,,$(DOTNET_TFM))
 
+# This is a workaround to create assemblies with a higher version than the
+# stable versions we released for Xcode 13.3. The stable versions we released
+# for Xcode 13.3 has a <osmajor>.<osminor>.300 version number, but that
+# version scheme has been changed, where the third digit from now on will
+# always be 0 in the assembly version. However, this means that until Apple
+# releases new OS versions (and we bind those versions), the assembly version
+# will be lower than the stable version wherever we've implemented the new
+# versioning scheme. This complicates testing, so just bump the third digit to
+# 600 until we're using a new Xcode (and thus presumably new OS versions as
+# well). This workaround can be removed at that point, but implement it so
+# that it will just be skipped/ignored if it isn't removed.
+ifeq ($(XCODE_VERSION),13.3)
+NUGET_VERSION_THIRD_DIGIT_WORKAROUND=600
+else
+NUGET_VERSION_THIRD_DIGIT_WORKAROUND=0
+endif
+
 DOTNET_REFERENCES = \
 	/r:$(DOTNET_BCL_DIR)/System.Buffers.dll \
 	/r:$(DOTNET_BCL_DIR)/System.Collections.Concurrent.dll \
@@ -177,6 +194,7 @@ $(IOS_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in | $(IOS_BUILD_DI
 		-e 's|@NUGET_VERSION_NO_METADATA@|$(IOS_NUGET_VERSION_NO_METADATA)|g' \
 		-e 's|@NUGET_VERSION_MAJOR@|$(IOS_NUGET_VERSION_MAJOR)|g' \
 		-e 's|@NUGET_VERSION_MINOR@|$(IOS_NUGET_VERSION_MINOR)|g' \
+		-e 's|@NUGET_VERSION_THIRD_DIGIT_WORKAROUND@|$(NUGET_VERSION_THIRD_DIGIT_WORKAROUND)|g' \
 		-e 's|@NUGET_VERSION_REV@|$(IOS_NUGET_VERSION_PATCH)|g' \
 		-e 's|@NUGET_VERSION_BUILD@|$(IOS_NUGET_COMMIT_DISTANCE)|g' \
 		-e 's|@DOTNET_PLATFORM@|iOS|g' \
@@ -550,6 +568,7 @@ $(MAC_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in | $(MAC_BUILD_DI
 		-e 's|@NUGET_VERSION_NO_METADATA@|$(MACOS_NUGET_VERSION_NO_METADATA)|g' \
 		-e 's|@NUGET_VERSION_MAJOR@|$(MACOS_NUGET_VERSION_MAJOR)|g' \
 		-e 's|@NUGET_VERSION_MINOR@|$(MACOS_NUGET_VERSION_MINOR)|g' \
+		-e 's|@NUGET_VERSION_THIRD_DIGIT_WORKAROUND@|$(NUGET_VERSION_THIRD_DIGIT_WORKAROUND)|g' \
 		-e 's|@NUGET_VERSION_REV@|$(MACOS_NUGET_VERSION_PATCH)|g' \
 		-e 's|@NUGET_VERSION_BUILD@|$(MACOS_NUGET_COMMIT_DISTANCE)|g' \
 		-e 's|@DOTNET_PLATFORM@|macOS|g' \
@@ -1161,6 +1180,7 @@ $(TVOS_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in $(TOP)/Make.con
 		-e 's|@NUGET_VERSION_NO_METADATA@|$(TVOS_NUGET_VERSION_NO_METADATA)|g' \
 		-e 's|@NUGET_VERSION_MAJOR@|$(TVOS_NUGET_VERSION_MAJOR)|g' \
 		-e 's|@NUGET_VERSION_MINOR@|$(TVOS_NUGET_VERSION_MINOR)|g' \
+		-e 's|@NUGET_VERSION_THIRD_DIGIT_WORKAROUND@|$(NUGET_VERSION_THIRD_DIGIT_WORKAROUND)|g' \
 		-e 's|@NUGET_VERSION_REV@|$(TVOS_NUGET_VERSION_PATCH)|g' \
 		-e 's|@NUGET_VERSION_BUILD@|$(TVOS_NUGET_COMMIT_DISTANCE)|g' \
 		-e 's|@DOTNET_PLATFORM@|tvOS|g' \
@@ -1379,6 +1399,7 @@ $(MACCATALYST_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in $(TOP)/M
 		-e 's|@NUGET_VERSION_NO_METADATA@|$(MACCATALYST_NUGET_VERSION_NO_METADATA)|g' \
 		-e 's|@NUGET_VERSION_MAJOR@|$(MACCATALYST_NUGET_VERSION_MAJOR)|g' \
 		-e 's|@NUGET_VERSION_MINOR@|$(MACCATALYST_NUGET_VERSION_MINOR)|g' \
+		-e 's|@NUGET_VERSION_THIRD_DIGIT_WORKAROUND@|$(NUGET_VERSION_THIRD_DIGIT_WORKAROUND)|g' \
 		-e 's|@NUGET_VERSION_REV@|$(MACCATALYST_NUGET_VERSION_PATCH)|g' \
 		-e 's|@NUGET_VERSION_BUILD@|$(MACCATALYST_NUGET_COMMIT_DISTANCE)|g' \
 		-e 's|@DOTNET_PLATFORM@|MacCatalyst|g' \


### PR DESCRIPTION
This is a workaround to create assemblies with a higher version than the
stable versions we released for Xcode 13.3. The stable versions we released
for Xcode 13.3 has a <osmajor>.<osminor>.300 version number, but that version
scheme has been changed, where the third digit from now on will always be 0 in
the assembly version. However, this means that until Apple releases new OS
versions (and we bind those versions), the assembly version will be lower than
the stable version wherever we've implemented the new versioning scheme. This
complicates testing, so just bump the third digit to 600 until we're using a
new Xcode (and thus presumably new OS versions as well). This workaround can
be removed at that point, but implement it so that it will just be
skipped/ignored if it isn't removed.