### PR TITLE
[d17-2] [introspection] Fix according to macOS 12.4. Fixes #15229.

### DIFF
--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -487,6 +487,8 @@ namespace Introspection {
 					break;
 				}
 				break;
+			case "NSUserActivityRestoring":
+				return true;
 			}
 			return false;
 		}
@@ -714,7 +716,9 @@ namespace Introspection {
 
 					if (t.IsPublic && !ConformTo (klass.Handle, protocol)) {
 						// note: some internal types, e.g. like UIAppearance subclasses, return false (and there's not much value in changing this)
-						list.Add ($"Type {t.FullName} (native: {klass.Name}) does not conform {protocolName}");
+						var msg = $"Type {t.FullName} (native: {klass.Name}) does not conform {protocolName}";
+						list.Add (msg);
+						ReportError (msg);
 					}
 				}
 			}

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -489,6 +489,22 @@ namespace Introspection {
 				break;
 			case "NSUserActivityRestoring":
 				return true;
+#if __MACCATALYST__
+			case "UIScrollViewDelegate":
+				// The headers say PKCanvasViewDelegate implements UIScrollViewDelegate
+				if (type.Name == "PKCanvasViewDelegate")
+					return true;
+				break;
+#endif
+			case "NSExtensionRequestHandling":
+				if (type.Name == "HMChipServiceRequestHandler") // Apple removed this class
+					return true;
+				break;
+			case "VNRequestRevisionProviding":
+				// Conformance added in Xcode 13
+				if (type.Name == "VNRecognizedText" && !TestRuntime.CheckXcodeVersion (13, 0))
+					return true;
+				break;
 			}
 			return false;
 		}

--- a/tests/introspection/Mac/MacApiProtocolTest.cs
+++ b/tests/introspection/Mac/MacApiProtocolTest.cs
@@ -19,10 +19,19 @@ using Xamarin.Tests;
 namespace Introspection {
 
 	[TestFixture]
-	public class MonoMacFixtures : ApiProtocolTest {
+	public class MacApiProtocolTest : ApiProtocolTest {
 
 		protected override bool Skip (Type type)
 		{
+#if !NET
+			switch (type.Namespace) {
+			case "Chip":
+				// The Chip framework is not stable, it's been added and removed and added and removed a few times already, so just skip verifying the entire framework.
+				// This is legacy Xamarin only, because we removed the framework for .NET.
+				return true;
+			}
+#endif
+
 			switch (type.Name) {
 #if !NET
 			case "NSDraggingInfo":

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -114,6 +114,12 @@ namespace Introspection {
 				if (Mac.CheckSystemVersion (10, 15))
 					return true;
 				break;
+#if !NET
+			case "Chip":
+				// The Chip framework is not stable, it's been added and removed and added and removed a few times already, so just skip verifying the entire framework.
+				// This is legacy Xamarin only, because we removed the framework for .NET.
+				return true;
+#endif
 			}
 
 			return base.Skip (type);

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -199,6 +199,7 @@ namespace Introspection {
 			case "UIStepper":
 			case "UISwitch":
 			case "ASAuthorizationAppleIdButton":
+			case "INUIAddVoiceShortcutButton":
 				if (protocolName == "UIContextMenuInteractionDelegate")
 					return !TestRuntime.CheckXcodeVersion (12, 0);
 				break;


### PR DESCRIPTION
* Ignore anything Chip-related, the framework was removed from macOS.
* Fix reporting errors some protocol-related errors so that they're actually
  reported as errors (by calling 'ReportError' instead of just adding the
  errors to a list that doesn't affect anything else).
* Ignore the NSUserActivityRestoring protocol, according to the macOS headers
  it's attached to NSResponder using a category, which is invisible at
  runtime. Due to the previous point this didn't show up before, but once at
  least another error (which happened with the Chip framework), then this was
  listed as well.

Fixes https://github.com/xamarin/xamarin-macios/issues/15229.


Backport of #15230
