### PR TITLE
[tests] Don't include ErrorHelper.cs nor error.cs in Xamarin.MacDev.Tasks.Tests.

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj
@@ -57,12 +57,6 @@
     <Compile Include="..\..\common\Profile.cs">
       <Link>external\Profile.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\src\ObjCRuntime\ErrorHelper.cs">
-      <Link>external\ErrorHelper.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\tools\common\error.cs">
-      <Link>external\error.cs</Link>
-    </Compile>
     <Compile Include="..\..\common\ErrorHelper.tests.cs">
       <Link>external\ErrorHelper.tests.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes these compiler warnings:

    xamarin-macios/src/ObjCRuntime/ErrorHelper.cs(22,17): warning CS0436: The type 'ProductException' in 'xamarin-macios/tests/msbuild/Xamarin.MacDev.Tasks.Tests/../../../tools/common/error.cs' conflicts with the imported type 'ProductException' in 'Xamarin.iOS.Tasks, Version=15.11.0.465, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'. Using the type defined in 'xamarin-macios/tests/msbuild/Xamarin.MacDev.Tasks.Tests/../../../tools/common/error.cs'. [xamarin-macios/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj]
    xamarin-macios/tools/common/error.cs(10,34): warning CS0436: The type 'ErrorHelper' in 'xamarin-macios/tests/msbuild/Xamarin.MacDev.Tasks.Tests/../../common/ErrorHelper.tests.cs' conflicts with the imported type 'ErrorHelper' in 'Xamarin.iOS.Tasks, Version=15.11.0.465, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'. Using the type defined in 'xamarin-macios/tests/msbuild/Xamarin.MacDev.Tasks.Tests/../../common/ErrorHelper.tests.cs'. [xamarin-macios/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj]