### PR TITLE
[msbuild] Remove dead code from the Codesign task.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/Codesign.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/Codesign.cs
@@ -9,8 +9,6 @@ using Xamarin.iOS.Windows;
 
 namespace Xamarin.iOS.HotRestart.Tasks {
 	public class Codesign : Task, ICancelableTask {
-		CancellationTokenSource cancellationSource;
-
 		#region Inputs
 
 		[Required]
@@ -53,7 +51,9 @@ namespace Xamarin.iOS.HotRestart.Tasks {
 			return !Log.HasLoggedErrors;
 		}
 
-		public void Cancel () => cancellationSource?.Cancel ();
+		public void Cancel ()
+		{
+		}
 
 		string GetFullExceptionMesage (Exception ex)
 		{


### PR DESCRIPTION
Fixes this warning:

    xamarin-macios/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/Codesign.cs(12,27): warning CS0649: Field 'Codesign.cancellationSource' is never assigned to, and will always have its default value null [xamarin-macios/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj]