### PR TITLE
[msbuild] Ignore CS0169 in a few places.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks/Model/DataItem.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Model/DataItem.cs
@@ -19,9 +19,11 @@ namespace Xamarin.iOS.Tasks {
 		[JsonProperty ("filename", NullValueHandling = NullValueHandling.Ignore)]
 		public string Filename { get; set; }
 
+#pragma warning disable 0169 // warning CS0169: The field 'DataItem.UnsupportedData' is never used
 		//This stores the Asset Catalogs properties we don't support yet, 
 		//by doing this we avoid loosing any change made to the json file outside VS.
 		[JsonExtensionData]
 		IDictionary<string, JToken> UnsupportedData;
+#pragma warning restore 0169
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks/Model/DataSet.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Model/DataSet.cs
@@ -7,8 +7,10 @@ namespace Xamarin.iOS.Tasks {
 		[JsonProperty ("data")]
 		public IEnumerable<DataItem> DataItems { get; set; }
 
+#pragma warning disable 0169 // warning CS0169: The field 'DataSet.JsonData' is never used
 		//This stores the properties we don't need to deserialize but exist, just to avoid loosing information
 		[JsonExtensionData]
 		IDictionary<string, JToken> JsonData;
+#pragma warning restore 0169
 	}
 }


### PR DESCRIPTION
Fixes these warnings:

    msbuild/Xamarin.iOS.Tasks/Model/DataItem.cs(25,31): warning CS0169: The field 'DataItem.UnsupportedData' is never used [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    msbuild/Xamarin.iOS.Tasks/Model/DataSet.cs(12,31): warning CS0169: The field 'DataSet.JsonData' is never used [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]