### PR TITLE
[xcode14] [devops] Try parallelize less during the API diff build.

### DIFF
--- a/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
+++ b/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
@@ -34,6 +34,7 @@ steps:
     gitHubToken: ${{ parameters.gitHubToken }}
     xqaCertPass: ${{ parameters.xqaCertPass }}
     enableDotnet: ${{ parameters.enableDotnet }}
+    makeParallelism: '4'
 
 # detect changes
 - bash:  $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/compare.sh

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -27,6 +27,10 @@ parameters:
   type: stepList 
   default: []
 
+- name: makeParallelism
+  type: string
+  default: '8'
+
 steps:
 
 - template: ../common/checkout.yml
@@ -252,8 +256,12 @@ steps:
       MAKE_FLAGS="V=1 -w"
     fi
 
-    time make -C $(Build.SourcesDirectory)/xamarin-macios/ all -j8 $MAKE_FLAGS
-    time make -C $(Build.SourcesDirectory)/xamarin-macios/ install -j8 $MAKE_FLAGS
+    if test -z "$makeParallelism"; then
+      makeParallelism=8
+    fi
+
+    time make -C $(Build.SourcesDirectory)/xamarin-macios/ all -j$makeParallelism $MAKE_FLAGS
+    time make -C $(Build.SourcesDirectory)/xamarin-macios/ install -j$makeParallelism $MAKE_FLAGS
   name: build
   displayName: 'Build'
   timeoutInMinutes: 300


### PR DESCRIPTION
For some reason the C# compilers crash a lot during the build in src/ when
building for the API diff (but not the normal build!). So test the theory that
we're overloading the bot in question (OOM maybe?) by slowing down a bit.

I have to say that if this works and the theory is proven, it's kind of sad
that after over a decade doing -j8 the bot situation has gotten worse...


Backport of #15471
