### PR TITLE
[xcode14] [CI] Remove older pkgs in the system to make sure we are not running the tests with an older version.

### DIFF
--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -63,6 +63,11 @@ steps:
   parameters:
     keyringPass: ${{ parameters.keyringPass }}
 
+- bash: |
+    rm -Rf /Library/Frameworks/Xamarin.Mac.framework
+    rm -Rf /Library/Frameworks/Xamarin.iOS.framework
+  displayName: 'Remove older Frameworks'
+
 # Use a cmdlet to check if the space available in the devices root system is larger than 50 gb. If there is not
 # enough space available it:
 # 1. Set the status of the build to error. It is not a failure since no tests have been ran.


### PR DESCRIPTION



Backport of #15545
