### PR TITLE
[nnyeah] fix incorrect attribute

### DIFF
--- a/tools/nnyeah/nnyeah/Reworker.cs
+++ b/tools/nnyeah/nnyeah/Reworker.cs
@@ -196,7 +196,8 @@ namespace Microsoft.MaciOS.Nnyeah {
 			typeDef.CustomAttributes.Add (attr_Embedded);
 
 			// add [AttributeUsage(...)]
-			var attrUsageCtorReference = new MethodReference (".ctor", module.TypeSystem.Void, AttributeTargetsTypeReference);
+			module.ImportReference (AttributeUsageTypeReference);
+			var attrUsageCtorReference = new MethodReference (".ctor", module.TypeSystem.Void, AttributeUsageTypeReference);
 			attrUsageCtorReference.HasThis = true;
 			attrUsageCtorReference.Parameters.Add (new ParameterDefinition (AttributeTargetsTypeReference));
 			module.ImportReference (attrUsageCtorReference);

--- a/tools/nnyeah/tests/unit/DependencyRemovedTests.cs
+++ b/tools/nnyeah/tests/unit/DependencyRemovedTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Mono.Cecil;
 using Microsoft.MaciOS.Nnyeah;
 using Xamarin;
+using System.Linq;
 
 
 namespace Microsoft.MaciOS.Nnyeah.Tests {
@@ -37,6 +38,41 @@ public class Foo {{
 
 			var platform = module.XamarinPlatformName ();
 			Assert.AreEqual (Microsoft.MaciOS.Nnyeah.PlatformName.None, platform, "still has Xamarin dependency");
+		}
+
+		[TestCase]
+		public async Task CorrectAttributes ()
+		{
+			var dir = Cache.CreateTemporaryDirectory ("CorrectAttributes");
+			var code = @"
+using System;
+public class Foo {
+	public nint Ident (nint e) => e;
+}
+";
+			await TestRunning.BuildLibrary (code, "NoName", dir);
+			var expectedOutputFile = Path.Combine (dir, "NoName.dll");
+			var targetRewrite = Path.Combine (dir, "NoNameRemoved.dll");
+
+			Assert.DoesNotThrow (() => {
+				AssemblyConverter.Convert (Compiler.XamarinPlatformLibraryPath (PlatformName.macOS),
+					Compiler.MicrosoftPlatformLibraryPath (PlatformName.macOS), expectedOutputFile,
+					targetRewrite, verbose: false, forceOverwrite: true, suppressWarnings: true);
+			}, $"Failed to process assembly for type nint");
+
+			Assert.IsTrue (File.Exists (targetRewrite), $"target file not created for type nint");
+			var module = ModuleDefinition.ReadModule (targetRewrite);
+
+			var nativeIntAttribute = module.GetType ("System.Runtime.CompilerServices.NativeIntegerAttribute")!;
+
+			Assert.IsTrue (ContainsAttribute (nativeIntAttribute, "System.Runtime.CompilerServices.CompilerGeneratedAttribute"), "No CompilerGenerateAttribute");
+			Assert.IsTrue (ContainsAttribute (nativeIntAttribute, "Microsoft.CodeAnalysis.EmbeddedAttribute"), "No Microsoft.CodeAnalysis.EmbeddedAttribute");
+			Assert.IsTrue (ContainsAttribute (nativeIntAttribute, "System.AttributeUsageAttribute"), "No System.AttributeUsageAttribute");
+		}
+
+		static bool ContainsAttribute (TypeDefinition theType, string attributeName)
+		{
+			return theType.CustomAttributes.Any (attr => attr.AttributeType.FullName == attributeName);
 		}
 	}
 }


### PR DESCRIPTION
The code that creates the `NativeIntegerAttribute` class was putting the wrong attribute onto it (`AttributeTargets` instead of `AttributeUsageAttribute`).

Added a test for all the attributes on `NativeIntegerAttribute`