### PR TITLE
[xcode14] [Xtro] Ensure that when we do auto sanitize we do not return a fail.

### DIFF
--- a/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
+++ b/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
@@ -302,7 +302,10 @@ namespace Extrospection {
 				Console.WriteLine ($"Sanity check failed ({count})");
 
 			// useful when updating stuff locally - we report but we don't fail
-			return Environment.GetEnvironmentVariable ("XTRO_SANITY_SKIP") == "1" ? 0 : count;
+			var sanitizedOrSkippedSanity =
+				!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("XTRO_SANITY_SKIP"))
+				|| !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("AUTO_SANITIZE"));
+			return  sanitizedOrSkippedSanity ? 0 : count;
 		}
 	}
 }


### PR DESCRIPTION
When working on the bindings we can use the "AUTO_SANITIZE" env var to
let xtro know that we want the lines that have been fixed to be removed,
unfortunatly this mode has a bug. When we autosanitized we should do the
same as the skip and not return the lines that have been cleaned as the
return code.

Returning the error code meant that when we did make all, the
first target (classic) would work, but the second target would not
because the first one failed.

Doing this allows to work on the bindings and have AUTO_SANITIZE work
both for classic and dotnet when doing make all.


Backport of #15551
