### PR TITLE
[nnyeah] Fix for branch targets and AVMediaTypes

### DIFF
--- a/tools/nnyeah/nnyeah/InstructionExtensions.cs
+++ b/tools/nnyeah/nnyeah/InstructionExtensions.cs
@@ -1,0 +1,50 @@
+using System;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Microsoft.MaciOS.Nnyeah {
+	public static class InstructionExtensions {
+		// The ctor for Instruction is internal and there is no clone/copy method,
+		// therefore we have to drill through the types.
+		public static Instruction Copy (this Instruction i)
+		{
+			if (i.Operand is null)
+				return Instruction.Create (i.OpCode);
+			switch (i.Operand) {
+			case TypeReference tr:
+				return Instruction.Create (i.OpCode, tr);
+			case CallSite cs:
+				return Instruction.Create (i.OpCode, cs);
+			case MethodReference mr:
+				return Instruction.Create (i.OpCode, mr);
+			case FieldReference fr:
+				return Instruction.Create (i.OpCode, fr);
+			case string str:
+				return Instruction.Create (i.OpCode, str);
+			case sbyte sb:
+				return Instruction.Create (i.OpCode, sb);
+			case byte b:
+				return Instruction.Create (i.OpCode, b);
+			case int it:
+				return Instruction.Create (i.OpCode, it);
+			case long lg:
+				return Instruction.Create (i.OpCode, lg);
+			case float ft:
+				return Instruction.Create (i.OpCode, ft);
+			case double db:
+				return Instruction.Create (i.OpCode, db);
+			case Instruction instr:
+				return Instruction.Create (i.OpCode, instr);
+			case Instruction [] instrArr:
+				return Instruction.Create (i.OpCode, instrArr);
+			case VariableDefinition vd:
+				return Instruction.Create (i.OpCode, vd);
+			case ParameterDefinition pd:
+				return Instruction.Create (i.OpCode, pd);
+			default: // can't happen (in theory)
+				throw new InvalidOperationException ();
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
Fixed an issue that prevented the geo sample from working.

There are three tightly entwined changes in this.
The first is adding special case mapping from `AVMediaType` -> `AVMediaTypes`.
This is fairly straight forward in that the old code will have calls to things like `AVMediaType.Video`, which is a method that doesn't exist in .NET 6 and returns the NSString equivalent of "Video". The change is to replace the call to the property with the following code:
```
ldc.i4 someConstant
call AVMediaExtensions.GetConstant ()
```
which is equivalent to the old code. Sorry about the magic numbers. Without putting in a reference to AVFoundation (no thanks), this seemed to be a reasonable concession.

The second change is that Cecil needs to know if we change a branch target, so whenever we make a change to an instruction (replace/remove), we patch any branch/switch targets to point to the new instruction. In the case of remove, we end up replacing the old instruction with `nop`, otherwise we don't know which instruction (if any) we should retarget to. In addition, we call `SimplifyMacros` and `OptimizeMacros` before and after modifying the method body. This will ensure that short branches don't overflow if they get changed (guess how I learned this).

The third change is to use copies of instructions rather than the actual instructions in a transform. Cecil doesn't like it when an instruction instance lives in multiple methods at the same time, especially when they're branch targets (guess how I learned this).

This enables the samples for "Plugins.Permissions" and "Plugins.Geolocation" to work (PR coming later).
