### PR TITLE
[mlaunch] Fix permisisons after extracting from nuget

### DIFF
--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -26,7 +26,7 @@ $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mla
 	$(Q) mkdir -p $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/
 	$(Q) $(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$(MLAUNCH_NUGET_VERSION)/mlaunch/bin/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/
 	$(Q) $(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$(MLAUNCH_NUGET_VERSION)/mlaunch/lib/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/
-	$(Q) chmod ugo+x $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch
+	$(Q) chmod a+x $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch
 
 define DotNetInstall
 $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch: $$(DOWNLOAD_STAMP_FILE)
@@ -36,7 +36,7 @@ $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch: $$(DOWNLOAD_STAMP_FILE)
 	$$(Q) mkdir -p $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/lib
 	$$(Q) $$(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$$(MLAUNCH_NUGET_VERSION)/mlaunch/bin/mlaunch $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch
 	$$(Q) $$(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$$(MLAUNCH_NUGET_VERSION)/mlaunch/lib/mlaunch $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/lib
-	$$(Q) chmod ugo+x $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch
+	$$(Q) chmod a+x $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch
 endef
 
 $(foreach platform,$(DOTNET_PLATFORMS_MOBILE),$(eval $(call DotNetInstall,$(platform))))

--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -27,6 +27,7 @@ $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mla
 	$(Q) $(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$(MLAUNCH_NUGET_VERSION)/mlaunch/bin/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/
 	$(Q) $(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$(MLAUNCH_NUGET_VERSION)/mlaunch/lib/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/
 	$(Q) chmod a+x $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch
+	$(Q) chmod a+x $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mlaunch/mlaunch.app/Contents/MacOS/mlaunch
 
 define DotNetInstall
 $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch: $$(DOWNLOAD_STAMP_FILE)
@@ -37,6 +38,7 @@ $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch: $$(DOWNLOAD_STAMP_FILE)
 	$$(Q) $$(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$$(MLAUNCH_NUGET_VERSION)/mlaunch/bin/mlaunch $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch
 	$$(Q) $$(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$$(MLAUNCH_NUGET_VERSION)/mlaunch/lib/mlaunch $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/lib
 	$$(Q) chmod a+x $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch
+	$$(Q) chmod a+x $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/lib/mlaunch/mlaunch.app/Contents/MacOS/mlaunch
 endef
 
 $(foreach platform,$(DOTNET_PLATFORMS_MOBILE),$(eval $(call DotNetInstall,$(platform))))

--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -26,6 +26,7 @@ $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mla
 	$(Q) mkdir -p $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/
 	$(Q) $(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$(MLAUNCH_NUGET_VERSION)/mlaunch/bin/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/
 	$(Q) $(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$(MLAUNCH_NUGET_VERSION)/mlaunch/lib/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/
+	$(Q) chmod ugo+x $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch
 
 define DotNetInstall
 $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch: $$(DOWNLOAD_STAMP_FILE)
@@ -35,6 +36,7 @@ $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch: $$(DOWNLOAD_STAMP_FILE)
 	$$(Q) mkdir -p $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/lib
 	$$(Q) $$(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$$(MLAUNCH_NUGET_VERSION)/mlaunch/bin/mlaunch $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch
 	$$(Q) $$(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$$(MLAUNCH_NUGET_VERSION)/mlaunch/lib/mlaunch $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/lib
+	$$(Q) chmod ugo+x $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch
 endef
 
 $(foreach platform,$(DOTNET_PLATFORMS_MOBILE),$(eval $(call DotNetInstall,$(platform))))


### PR DESCRIPTION
- A side effect of https://github.com/xamarin/xamarin-macios/commit/ac1fa258168e16b6ece16f510135ebdf0d23b1ee is that the permission of bin/mlaunch is no longer +x for non-root, which means it is unusable.

This was with the fix:
```
% ls -la _ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch 
-rwxr-xr-x  1 donblas  staff  165 Jun 17 15:25 _ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch
```
and this is from an xcode14 build locally:
```
% ls -la _ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch
-rwxr--r--  1 donblas  staff  165 Jul 14 08:06 _ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch

```