### PR TITLE
[appkit] Add missing NullAllowed on NSSavePanel.AllowedFileTypes

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -13322,6 +13322,7 @@ namespace AppKit {
 
 		[Deprecated (PlatformName.MacOSX, 12, 0, message: "Use 'AllowedContentTypes' instead.")]
 		[Export ("allowedFileTypes")]
+		[NullAllowed]
 		string [] AllowedFileTypes { get; set; }
 	
 		[Mac (11, 0)]


### PR DESCRIPTION
- Fixes https://github.com/xamarin/xamarin-macios/issues/15565
