### PR TITLE
Set custom home env var from XMA Build Agent

### DIFF
--- a/msbuild/Messaging/Xamarin.Messaging.Build/TaskRunner.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/TaskRunner.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Messaging.Build {
 			var dotnetPath = Path.Combine (sdkRootPath, "dotnet", "dotnet");
 
 			if (File.Exists (dotnetPath)) {
-				Environment.SetEnvironmentVariable ("HOME", Path.Combine (sdkRootPath, ".home"));
+				Environment.SetEnvironmentVariable ("DOTNET_CUSTOM_HOME", Path.Combine (sdkRootPath, ".home"));
 			} else {
 				//In case the XMA dotnet has not been installed yet
 				dotnetPath = "/usr/local/share/dotnet/dotnet";

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -268,7 +268,13 @@ namespace Xamarin.MacDev.Tasks {
 			BTouchToolPath = PathUtils.ConvertToMacPath (BTouchToolPath);
 			DotNetCscCompiler = PathUtils.ConvertToMacPath (DotNetCscCompiler);
 
-			if (!IsDotNet) {
+			if (IsDotNet) {
+				var customHome = Environment.GetEnvironmentVariable ("DOTNET_CUSTOM_HOME");
+
+				if(!string.IsNullOrEmpty(customHome)) {
+					EnvironmentVariables = EnvironmentVariables.CopyAndAdd ($"HOME={customHome}");
+				}
+			} else {
 				ToolExe = BTouchToolExe;
 				ToolPath = BTouchToolPath;
 			}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeRemoteGeneratorPropertiesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ComputeRemoteGeneratorPropertiesTaskBase.cs
@@ -90,11 +90,19 @@ namespace Xamarin.MacDev.Tasks {
 			File.WriteAllText (projectPath, csproj);
 
 			var arguments = new List<string> ();
-			if (IsDotNet) {
+			var environment = default (Dictionary<string, string>);
+
+			if (IsDotNet) {				
 				executable = Environment.GetEnvironmentVariable ("DOTNET_HOST_PATH");
 				if (string.IsNullOrEmpty (executable))
 					executable = "dotnet";
 				arguments.Add ("build");
+
+				var customHome = Environment.GetEnvironmentVariable ("DOTNET_CUSTOM_HOME");
+
+				if (!string.IsNullOrEmpty (customHome)) {
+					environment = new Dictionary<string, string> { { "HOME", customHome } };
+				}
 			} else {
 				executable = "/Library/Frameworks/Mono.framework/Commands/msbuild";
 			}
@@ -108,7 +116,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			arguments.Add (projectPath);
 
-			ExecuteAsync (executable, arguments).Wait ();
+			ExecuteAsync (executable, arguments, environment: environment).Wait ();
 			var computedPropertes = File.ReadAllLines (outputFile);
 			foreach (var line in computedPropertes) {
 				var property = line.Substring (0, line.IndexOf ('='));

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
@@ -74,8 +74,15 @@ namespace Xamarin.MacDev.Tasks {
 			arguments.Add ("/t:ComputeAotCompilerPath");
 			arguments.Add (projectPath);
 
+			var environment = default (Dictionary<string, string>);
+			var customHome = Environment.GetEnvironmentVariable ("DOTNET_CUSTOM_HOME");
+
+			if (!string.IsNullOrEmpty (customHome)) {
+				environment = new Dictionary<string, string> { { "HOME", customHome } };
+			}
+
 			try {
-				ExecuteAsync (executable, arguments).Wait ();
+				ExecuteAsync (executable, arguments, environment: environment).Wait ();
 				return File.ReadAllText (outputFile).Trim ();
 			} finally {
 				File.Delete (projectPath);


### PR DESCRIPTION
Overriding HOME is dangerous because it could cause unwanted side effects, like breaking the keychain API logic.

For this reason, we need to use a custom environment variable to store the custom home used by the XMA dotnet SDK.

This custom home should be passed everywhere as environment settings when we invoke the dotnet tool