### PR TITLE
[tests] Fix MonoNativeFunctionWrapper/MonoPInvokeCallback to report specific errors

### DIFF
--- a/tests/introspection/iOS/iOSApiPInvokeTest.cs
+++ b/tests/introspection/iOS/iOSApiPInvokeTest.cs
@@ -96,7 +96,6 @@ namespace Introspection {
 				let attr = type.GetCustomAttribute<MonoNativeFunctionWrapperAttribute> () where attr != null
 				select type;
 
-			var failed_api = new List<string> ();
 			Errors = 0;
 			int c = 0, n = 0;
 			foreach (var t in nativeDelegates) {
@@ -109,13 +108,12 @@ namespace Introspection {
 				}
 				n++;
 			}
-			Assert.AreEqual (0, Errors, "{0} errors found in {1} native delegate validated: {2}", Errors, n, string.Join (", ", failed_api));
+			AssertIfErrors ("{0} errors found in {1} native delegate validated", Errors, n);
 		}
 
 		[Test]
 		public void MonoPInvokeCallback ()
 		{
-			var failed_api = new List<string> ();
 			Errors = 0;
 			int c = 0, n = 0;
 			foreach (var type in Assembly.GetTypes ()) {
@@ -142,7 +140,7 @@ namespace Introspection {
 					n++;
 				}
 			}
-			Assert.AreEqual (0, Errors, "{0} errors found in {1} native delegate validated: {2}", Errors, n, string.Join (", ", failed_api));
+			AssertIfErrors ("{0} errors found in {1} native delegate validated", Errors, n);
 		}
 	}
 }


### PR DESCRIPTION
- Both tests directly asserted there were no errors, and tried to print results from an unused 'failed_api' variable.
- However, details were being written via `ReportError` in the base class's 'error_output' that was not being printed
- AssertIfErrors on the base class prints that, and asserts that there are no errors so it works for both these cases

I checked the other tests that asserted against 0 errors, and they all seems to have valid test data to report, and thus
appear fine.