### PR TITLE
[release/7.0.1xx-preview7] Ensure the Hot Restart bundle does not have any entitlements set

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/PrepareAppBundle.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/PrepareAppBundle.cs
@@ -3,6 +3,7 @@ using Microsoft.Build.Utilities;
 using System.IO;
 using System.IO.Compression;
 using Xamarin.iOS.Windows;
+using Xamarin.MacDev;
 
 namespace Xamarin.iOS.HotRestart.Tasks {
 	public class PrepareAppBundle : Task {
@@ -36,6 +37,10 @@ namespace Xamarin.iOS.HotRestart.Tasks {
 					"Xamarin.PreBuilt.iOS.app.zip");
 
 				ZipFile.ExtractToDirectory (preBuiltAppBundlePath, AppBundlePath);
+
+				// Ensure the archived-expanded-entitlements.xcent is empty. If there are any entitlements in that file, the new signature will be invalid
+				new PDictionary ().Save (Path.Combine (AppBundlePath, "archived-expanded-entitlements.xcent"));
+
 				File.WriteAllText (Path.Combine (AppBundlePath, "Extracted"), string.Empty);
 			}
 


### PR DESCRIPTION
Hot Restart expects the archived-expanded-entitlements.xcent to be empty. If any entitlements are added to that file, the new app signature will be invalid.

These changes ensure that file will be an empty plist when extracting the PreBuilt app.

Partial fix for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1550700


Backport of #15558
