### PR TITLE
[nnyeah] Added code to look up the legacy platform dll instead of requiring it.

### DIFF
--- a/tools/nnyeah/nnyeah/AssemblyConverter.cs
+++ b/tools/nnyeah/nnyeah/AssemblyConverter.cs
@@ -106,6 +106,12 @@ namespace Microsoft.MaciOS.Nnyeah {
 
 		static bool TryGetTargetPlatform (string msAssembly, [NotNullWhen (returnValue: true)] out PlatformName? platform)
 		{
+			// we're using the name of the supplied microsoft assembly to get the target platform.
+			// why?
+			// initially I tried looking inside the input assembly but that is not reliable.
+			// there were a number of cases where it would fail but we lack the context here to handle
+			// it gracefully. Instead, it's much more reliable to assume that the microsoft assembly and
+			// the input assembly are going to be in sync and ensure that the legacy assembly will match that.
 			var file = Path.GetFileNameWithoutExtension (msAssembly);
 			if (file.EndsWith (".iOS", StringComparison.OrdinalIgnoreCase)) {
 				platform = PlatformName.iOS;

--- a/tools/nnyeah/nnyeah/AssemblyConverter.cs
+++ b/tools/nnyeah/nnyeah/AssemblyConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MaciOS.Nnyeah {
 		bool SuppressWarnings;
 		NNyeahAssemblyResolver Resolver;
 
-    static int Convert (string? xamarinAssembly, string microsoftAssembly, string infile, string outfile, bool verbose, bool forceOverwrite, bool suppressWarnings)
+		public static int Convert (string? xamarinAssembly, string microsoftAssembly, string infile, string outfile, bool verbose, bool forceOverwrite, bool suppressWarnings)
 		{
 			var converter = new AssemblyConverter (xamarinAssembly, microsoftAssembly, infile, outfile, verbose, forceOverwrite, suppressWarnings);
 			return converter.Convert ();

--- a/tools/nnyeah/nnyeah/AssemblyConverter.cs
+++ b/tools/nnyeah/nnyeah/AssemblyConverter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MaciOS.Nnyeah {
 		AssemblyConverter (string? xamarinAssembly, string microsoftAssembly, string infile, string outfile, bool verbose, bool forceOverwrite, bool suppressWarnings)
 		{
 			if (!TryGetTargetPlatform (microsoftAssembly, out var platform)) {
-				throw new ConversionException (Errors.E0017, Infile);
+				throw new ConversionException (Errors.E0018, Infile);
 			}
 
 			XamarinAssembly = xamarinAssembly ?? GetPlatformModulePath (platform.Value);
@@ -133,7 +133,7 @@ namespace Microsoft.MaciOS.Nnyeah {
 				_ => throw new NotSupportedException ()
 			};
 			if (!File.Exists (path)) {
-				throw new ConversionException (Errors.E0018, path);
+				throw new ConversionException (Errors.E0019, path);
 			}
 			return path;
 		}

--- a/tools/nnyeah/nnyeah/Errors.Designer.cs
+++ b/tools/nnyeah/nnyeah/Errors.Designer.cs
@@ -157,7 +157,7 @@ namespace Microsoft.MaciOS.Nnyeah {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error while attempting to map type {0} in old assembly. This type does not exist in the new assembly or has been renamed. Conversion can&apos;t continue. Your best option is to port the old assembly to .NET 6.
+        ///   Looks up a localized string similar to Error while attempting to map type {0} in old assembly. This type does not exist in the new assembly or has been renamed. Conversion can&apos;t continue. Your best option is to port the old assembly to .NET 6..
         /// </summary>
         internal static string E0012 {
             get {
@@ -166,7 +166,7 @@ namespace Microsoft.MaciOS.Nnyeah {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error while attempting to map member {0} in old assembly. This member does not exist in the new assembly or has been renamed. Conversion can&apos;t continue. Your best option is to port the old assembly to .NET 6.
+        ///   Looks up a localized string similar to Error while attempting to map member {0} in old assembly. This member does not exist in the new assembly or has been renamed. Conversion can&apos;t continue. Your best option is to port the old assembly to .NET 6..
         /// </summary>
         internal static string E0013 {
             get {
@@ -198,6 +198,24 @@ namespace Microsoft.MaciOS.Nnyeah {
         internal static string E0016 {
             get {
                 return ResourceManager.GetString("E0016", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The supplied Microsoft assembly, {0}, is not macOS or iOS and is not currently supported..
+        /// </summary>
+        internal static string E0017 {
+            get {
+                return ResourceManager.GetString("E0017", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The legacy platform assembly {0} does not exist at the expected location. You will need to either install it or pass a path to nnyeah using the --xamarin-assembly argument..
+        /// </summary>
+        internal static string E0018 {
+            get {
+                return ResourceManager.GetString("E0018", resourceCulture);
             }
         }
         

--- a/tools/nnyeah/nnyeah/Errors.Designer.cs
+++ b/tools/nnyeah/nnyeah/Errors.Designer.cs
@@ -204,18 +204,18 @@ namespace Microsoft.MaciOS.Nnyeah {
         /// <summary>
         ///   Looks up a localized string similar to The supplied Microsoft assembly, {0}, is not macOS or iOS and is not currently supported..
         /// </summary>
-        internal static string E0017 {
+        internal static string E0018 {
             get {
-                return ResourceManager.GetString("E0017", resourceCulture);
+                return ResourceManager.GetString("E0018", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to The legacy platform assembly {0} does not exist at the expected location. You will need to either install it or pass a path to nnyeah using the --xamarin-assembly argument..
         /// </summary>
-        internal static string E0018 {
+        internal static string E0019 {
             get {
-                return ResourceManager.GetString("E0018", resourceCulture);
+                return ResourceManager.GetString("E0019", resourceCulture);
             }
         }
         

--- a/tools/nnyeah/nnyeah/Errors.resx
+++ b/tools/nnyeah/nnyeah/Errors.resx
@@ -101,5 +101,11 @@
 	<data name="E0016" xml:space="preserve">
 		<value>Error while processing constructor on type {0} in the old assembly. Constructors that do non-trivial work are not supported.</value>
 	</data>
+	<data name="E0017" xml:space="preserve">
+		<value>The supplied Microsoft assembly, {0}, is not macOS or iOS and is not currently supported.</value>
+	</data>
+	<data name="E0018" xml:space="preserve">
+		<value>The legacy platform assembly {0} does not exist at the expected location. You will need to either install it or pass a path to nnyeah using the --xamarin-assembly argument.</value>
+	</data>
 </root>
 

--- a/tools/nnyeah/nnyeah/Errors.resx
+++ b/tools/nnyeah/nnyeah/Errors.resx
@@ -101,10 +101,10 @@
 	<data name="E0016" xml:space="preserve">
 		<value>Error while processing constructor on type {0} in the old assembly. Constructors that do non-trivial work are not supported.</value>
 	</data>
-	<data name="E0017" xml:space="preserve">
+	<data name="E0018" xml:space="preserve">
 		<value>The supplied Microsoft assembly, {0}, is not macOS or iOS and is not currently supported.</value>
 	</data>
-	<data name="E0018" xml:space="preserve">
+	<data name="E0019" xml:space="preserve">
 		<value>The legacy platform assembly {0} does not exist at the expected location. You will need to either install it or pass a path to nnyeah using the --xamarin-assembly argument.</value>
 	</data>
 </root>

--- a/tools/nnyeah/nnyeah/Program.cs
+++ b/tools/nnyeah/nnyeah/Program.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MaciOS.Nnyeah {
 				Console.Out.WriteLine (Errors.N0007);
 			}
 			else {
-				AssemblyConverter.Convert (xamarinAssembly!, microsoftAssembly!, infile!, outfile!, verbose, forceOverwrite, suppressWarnings);
+				AssemblyConverter.Convert (xamarinAssembly, microsoftAssembly!, infile!, outfile!, verbose, forceOverwrite, suppressWarnings);
 			}
 		}
 	}

--- a/tools/nnyeah/tests/integration/IntegrationExamples.cs
+++ b/tools/nnyeah/tests/integration/IntegrationExamples.cs
@@ -55,15 +55,19 @@ namespace Microsoft.MaciOS.Nnyeah.Tests.Integration {
 			Assert.Zero (execution.ExitCode, $"Build Output: {output}");
 		}
 
-		void ExecuteNnyeah (string tmpDir, string inputPath, string convertedPath, ApplePlatform platform)
+		void ExecuteNnyeah (string tmpDir, string inputPath, string convertedPath, ApplePlatform platform, bool useCannedLegacyPlatform = true)
 		{
-			AssemblyConverter.Convert (GetLegacyPlatform (platform), GetNetPlatform (platform), inputPath, convertedPath, true, true, false);
+			var legacyPlatform = useCannedLegacyPlatform ? GetLegacyPlatform (platform) : null;
+			AssemblyConverter.Convert (legacyPlatform, GetNetPlatform (platform), inputPath, convertedPath, true, true, false);
 		}
 
 		[Test]
-		[TestCase ("API/macOSIntegration.csproj", "API/bin/Debug/macOSIntegration.dll", "Consumer/macOS/macOS.csproj", ApplePlatform.MacOSX)]
-		[TestCase ("API/iOSIntegration.csproj", "API/bin/Debug/iOSIntegration.dll", "Consumer/ios/ios.csproj", ApplePlatform.iOS)]
-		public async Task BuildAndRunSynthetic (string libraryProject, string libraryPath, string consumerProject, ApplePlatform platform)
+		[TestCase ("API/macOSIntegration.csproj", "API/bin/Debug/macOSIntegration.dll", "Consumer/macOS/macOS.csproj", ApplePlatform.MacOSX, true)]
+		[TestCase ("API/iOSIntegration.csproj", "API/bin/Debug/iOSIntegration.dll", "Consumer/ios/ios.csproj", ApplePlatform.iOS, true)]
+		[TestCase ("API/macOSIntegration.csproj", "API/bin/Debug/macOSIntegration.dll", "Consumer/macOS/macOS.csproj", ApplePlatform.MacOSX, false)]
+		[TestCase ("API/iOSIntegration.csproj", "API/bin/Debug/iOSIntegration.dll", "Consumer/ios/ios.csproj", ApplePlatform.iOS, false)]
+		public async Task BuildAndRunSynthetic (string libraryProject, string libraryPath, string consumerProject, ApplePlatform platform,
+			bool useCannedLegacyPlatform)
 		{
 			await AssertLegacyBuild (Path.Combine (IntegrationRoot, libraryProject), platform);
 
@@ -75,7 +79,7 @@ namespace Microsoft.MaciOS.Nnyeah.Tests.Integration {
 
 			var tmpDir = Cache.CreateTemporaryDirectory ("BuildAndRunSynthetic");
 
-			ExecuteNnyeah (tmpDir, inputPath, convertedPath, platform);
+			ExecuteNnyeah (tmpDir, inputPath, convertedPath, platform, useCannedLegacyPlatform);
 
 			DotNet.AssertBuild (Path.Combine (IntegrationRoot, consumerProject));
 		}


### PR DESCRIPTION
Added code to automagically find the legacy `Xamarin.platform.dll` file instead of requiring it on the command line.

As noted in the code comments, this is using the name of the Microsoft platform assembly to determine the platform. Pulling the platform out of the input assembly was both unreliable and at a place where we don't have the context to handle it gracefully and it's also slow since we're forcing a double load of the assembly in cecil. If the assembly has not platform dependencies, we will handle that at a place that is designed to handle it and the tool will exit without error having done no work.

Augmented existing tests to use this code.
