### PR TITLE
[xcode14] [UIKit] Remove the preprocessor directives for watchOS.

### DIFF
--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -1010,10 +1010,6 @@ namespace UIKit {
 		PreferredFramesPerSecond30 = 7 << 24,
 	}
 
-#if !WATCH
-	delegate void UIPrintInteractionCompletionHandler (UIPrintInteractionController printInteractionController, bool completed, NSError error);
-#endif
-
 	// untyped (and unamed) enum -> UIPrintError.h
 	// note: it looks unused by any API
 	[NoTV][NoWatch]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -44,6 +44,13 @@ using Intents;
 // to avoid the usage of more #if's
 #if WATCH
 using CATransform3D = Foundation.NSObject;
+using CALayer = Foundation.NSObject;
+using CADisplayLink = Foundation.NSObject;
+using CoreAnimation = Foundation.NSObject;
+using CIColor = Foundation.NSObject;
+using CIImage = Foundation.NSObject;
+
+using MPMoviePlayerViewController = Foundation.NSObject;
 
 using UIInteraction = Foundation.NSObjectProtocol;
 using UIDynamicItem = Foundation.NSObjectProtocol;
@@ -83,6 +90,22 @@ using UILayoutGuide = Foundation.NSObject;
 using UISwipeActionsConfiguration = Foundation.NSObject;
 using UINib = Foundation.NSObject;
 using UIFocusSystem = Foundation.NSObject;
+using UIPrinterPickerController = Foundation.NSObject;
+using UISplitViewController = Foundation.NSObject;
+using UIAdaptivePresentationControllerDelegate = Foundation.NSObject;
+using UIPresentationController = Foundation.NSObject;
+using UIToolbar = Foundation.NSObject;
+using UITabBar = Foundation.NSObject;
+using UIEvent = Foundation.NSObject;
+using UIUserActivityRestoring = Foundation.NSObject;
+using UITouch = Foundation.NSObject;
+using UIPress = Foundation.NSObject;
+using UIPressesEvent = Foundation.NSObject;
+using UIRegion = Foundation.NSObject;
+using UITextInputPasswordRules = Foundation.NSObject;
+using UIUserNotificationSettings = Foundation.NSObject;
+using UIScrollView = Foundation.NSObject;
+using UIFloatRange = Foundation.NSObject;
 #endif // WATCH
 
 #if !IOS
@@ -231,10 +254,6 @@ namespace UIKit {
 		Always,
 	}
 
-#if WATCH
-	// hacks to ease compilation
-	interface CIColor {}
-#else
 	delegate void UICompletionHandler (bool finished);
 	delegate void UIOperationHandler (bool success);
 	delegate void UICollectionViewLayoutInteractiveTransitionCompletion (bool completed, bool finished);
@@ -440,8 +459,6 @@ namespace UIKit {
 		bool ContainsAttachments (NSRange range);
 	}
 
-#endif // !WATCH
-
 	[Category, BaseType (typeof (NSMutableAttributedString))]
 	interface NSMutableAttributedStringKitAdditions {
 		[iOS (7,0)] 
@@ -449,7 +466,6 @@ namespace UIKit {
 		void FixAttributesInRange (NSRange range);
 	}
 
-#if !WATCH
 	[NoWatch]
 	[iOS (7,0)] // Yup, it is declared as appearing in 7.0, even if it shipped with 8.0
 	[Category, BaseType(typeof(NSLayoutConstraint))]
@@ -460,7 +476,6 @@ namespace UIKit {
 		[Export ("setIdentifier:")]
 		void SetIdentifier ([NullAllowed] string id);
 	}
-#endif // !WATCH
 
 	[Category]
 	[BaseType (typeof (NSCoder))]
@@ -518,8 +533,7 @@ namespace UIKit {
 		UIOffset DecodeUIOffsetForKey (string key);
 	}
 
-#if !WATCH
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Deprecated (PlatformName.iOS, 5, 0, message: "Use 'CoreMotion' instead.")]
 	interface UIAcceleration {
@@ -536,7 +550,7 @@ namespace UIKit {
 		double Z { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIAccelerometerDelegate)})]
 	[Deprecated (PlatformName.iOS, 5, 0, message: "Use 'CoreMotion' instead.")]
 	interface UIAccelerometer {
@@ -554,7 +568,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -564,7 +578,6 @@ namespace UIKit {
 		void DidAccelerate (UIAccelerometer accelerometer, UIAcceleration acceleration);
 #pragma warning restore 618
 	}
-#endif // !WATCH
 
 	interface UIAccessibility {
 		[Export ("isAccessibilityElement")]
@@ -944,7 +957,7 @@ namespace UIKit {
 		bool WasSuccessful { get; }
 	}
 
-#if !WATCH
+	[NoWatch]
 	[Protocol (IsInformal = true)]
 	interface UIAccessibilityContainer {
 		[Export ("accessibilityElementCount")]
@@ -971,7 +984,7 @@ namespace UIKit {
 
 	interface IUIAccessibilityContainerDataTableCell {}
 
-	[iOS (11,0), TV (11,0)]
+	[iOS (11,0), TV (11,0), NoWatch]
 	[Protocol]
 	interface UIAccessibilityContainerDataTableCell {
 		[Abstract]
@@ -983,7 +996,7 @@ namespace UIKit {
 		NSRange GetAccessibilityColumnRange ();
 	}
 
-	[iOS (11,0), TV (11,0)]
+	[iOS (11,0), TV (11,0), NoWatch]
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
 	interface UIAccessibilityContainerDataTable {
@@ -1009,10 +1022,10 @@ namespace UIKit {
 		IUIAccessibilityContainerDataTableCell[] GetAccessibilityHeaderElementsForColumn (nuint column);
 	}
 
-	[TV (13,0), iOS (13,0)]
+	[TV (13,0), iOS (13,0), NoWatch]
 	delegate bool UIAccessibilityCustomActionHandler (UIAccessibilityCustomAction customAction);
 
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Please use the designated initializer
 	partial interface UIAccessibilityCustomAction {
@@ -1074,7 +1087,7 @@ namespace UIKit {
 
 	delegate UIAccessibilityCustomRotorItemResult UIAccessibilityCustomRotorSearch (UIAccessibilityCustomRotorSearchPredicate predicate);
 	
-	[iOS (10,0), TV (10,0)]
+	[iOS (10,0), TV (10,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIAccessibilityCustomRotor {
 
@@ -1104,7 +1117,7 @@ namespace UIKit {
 		UIAccessibilityCustomSystemRotorType SystemRotorType { get; }
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[iOS (10,0), TV (10,0), NoWatch]
 	[Category]
 	[BaseType (typeof (NSObject))]
 	interface NSObject_UIAccessibilityCustomRotor {
@@ -1117,7 +1130,7 @@ namespace UIKit {
 		void SetAccessibilityCustomRotors ([NullAllowed] UIAccessibilityCustomRotor [] customRotors);
 	}
 	
-	[iOS (10,0), TV (10,0)]
+	[iOS (10,0), TV (10,0), NoWatch]
 	[BaseType (typeof(NSObject))]
 	interface UIAccessibilityCustomRotorItemResult {
 
@@ -1131,7 +1144,7 @@ namespace UIKit {
 		UITextRange TargetRange { get; set; }
 	}
 	
-	[iOS (10,0), TV (10,0)]
+	[iOS (10,0), TV (10,0), NoWatch]
 	[BaseType (typeof(NSObject))]
 	interface UIAccessibilityCustomRotorSearchPredicate {
 
@@ -1142,6 +1155,7 @@ namespace UIKit {
 		UIAccessibilityCustomRotorDirection SearchDirection { get; set; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIResponder))]
 	// only happens on the simulator (not devices) on iOS8 (still make sense)
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Use initWithAccessibilityContainer:
@@ -1179,6 +1193,7 @@ namespace UIKit {
 		CGRect AccessibilityFrameInContainerSpace { get; set; }
 	}
 
+	[NoWatch]
 	interface UIAccessibilityFocus {
 		[Export ("accessibilityElementDidBecomeFocused")]
 		void AccessibilityElementDidBecomeFocused ();
@@ -1194,6 +1209,7 @@ namespace UIKit {
 		NSSet<NSString> AccessibilityAssistiveTechnologyFocusedIdentifiers { get; }
 	}
 
+	[NoWatch]
 	interface UIAccessibilityAction {
 		[Export ("accessibilityIncrement")]
 		void AccessibilityIncrement ();
@@ -1255,8 +1271,7 @@ namespace UIKit {
 		NSAttributedString AttributedName { get; }
 	}
 
-	[NoWatch]
-	[TV (11,0), iOS (11,0)][NoMac]
+	[TV (11,0), iOS (11,0)][NoMac][NoWatch]
 	[Protocol]
 	interface UIAccessibilityContentSizeCategoryImageAdjusting {
 		[Abstract]
@@ -1264,7 +1279,7 @@ namespace UIKit {
 		bool AdjustsImageSizeForAccessibilityContentSizeCategory { get; set; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIView), KeepRefUntil="Dismissed", Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIActionSheetDelegate)})]
 	[Deprecated (PlatformName.iOS, 8, 3, message: "Use 'UIAlertController' with 'UIAlertControllerStyle.ActionSheet' instead.")]
 	interface UIActionSheet {
@@ -1379,7 +1394,7 @@ namespace UIKit {
 
 	interface IUIActionSheetDelegate {}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -1405,7 +1420,7 @@ namespace UIKit {
 		void Dismissed (UIActionSheet actionSheet, nint buttonIndex);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIActivity {
 		[Export ("activityType")]
@@ -1437,7 +1452,7 @@ namespace UIKit {
 		UIActivityCategory Category  { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[Static]
 	interface UIActivityType
 	{
@@ -1505,6 +1520,7 @@ namespace UIKit {
 	// You're supposed to implement this protocol in your UIView subclasses, not provide
 	// a implementation for only this protocol, which is why there is no model to subclass.
 	//
+	[NoWatch]
 	[Protocol]
 	interface UIInputViewAudioFeedback {
 		[Export ("enableInputClicksWhenVisible")]
@@ -1514,7 +1530,7 @@ namespace UIKit {
 		bool EnableInputClicksWhenVisible { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSOperation))]
 	[ThreadSafe]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: Use initWithPlaceholderItem: to instantiate an instance of UIActivityItemProvider
@@ -1537,7 +1553,7 @@ namespace UIKit {
 
 	interface IUIActivityItemSource { }
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -1568,7 +1584,7 @@ namespace UIKit {
 		LPLinkMetadata GetLinkMetadata (UIActivityViewController activityViewController);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIViewController))]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: Use initWithActivityItems:applicationActivities: to instantiate an instance of UIActivityViewController
 	interface UIActivityViewController {
@@ -1600,7 +1616,7 @@ namespace UIKit {
 		NativeHandle Constructor (IUIActivityItemsConfigurationReading activityItemsConfiguration);
 	}
 
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	partial interface UIAlertAction : NSCopying, UIAccessibilityIdentification {
 		[Export ("title")]
@@ -1616,7 +1632,7 @@ namespace UIKit {
 		UIAlertAction Create (string title, UIAlertActionStyle style, [NullAllowed] Action<UIAlertAction> handler);
 	}
 	
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[BaseType (typeof (UIViewController))]
 	partial interface UIAlertController
 #if IOS
@@ -1659,7 +1675,7 @@ namespace UIKit {
 
 	interface IUIAlertViewDelegate {}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIView), KeepRefUntil="Dismissed", Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIAlertViewDelegate)})]
 	[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'UIAlertController' with a 'UIAlertControllerStyle.Alert' type instead.")]
 	interface UIAlertView : NSCoding {
@@ -1725,7 +1741,7 @@ namespace UIKit {
 		UITextField GetTextField (nint textFieldIndex);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -1761,6 +1777,7 @@ namespace UIKit {
 	// When a new class adopts UIAppearance, merely list it as one of the
 	// base interfaces, this will generate the stubs for it.
 	//
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[DisableDefaultCtor]
@@ -1768,7 +1785,7 @@ namespace UIKit {
 	interface UIAppearance {
 	}
 
-	[iOS (9,0)]
+	[iOS (9,0), NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UIStackView {
 		[Export ("initWithFrame:")]
@@ -1817,6 +1834,7 @@ namespace UIKit {
 		nfloat GetCustomSpacing (UIView arrangedSubview);
 	}
 		
+	[NoWatch]
 	[Static]
 	interface UIStateRestoration {
 		[Field ("UIStateRestorationViewControllerStoryboardKey")]
@@ -1824,7 +1842,7 @@ namespace UIKit {
 
 	}
 
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -1850,7 +1868,7 @@ namespace UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	interface UIObjectRestoration {
 #if false
 		// a bit hard to support *static* as part of an interface / extension methods
@@ -1861,7 +1879,7 @@ namespace UIKit {
 
 	interface IUIViewAnimating {}
 
-	[iOS(10,0)]
+	[iOS(10,0), NoWatch]
 	[Protocol]
 	interface UIViewAnimating
 	{
@@ -1903,7 +1921,7 @@ namespace UIKit {
 	}
 
 	interface IUIViewImplicitlyAnimating {}
-	[iOS(10,0)]
+	[iOS(10,0), NoWatch]
 	[Protocol]
 	interface UIViewImplicitlyAnimating : UIViewAnimating
 	{
@@ -1920,7 +1938,7 @@ namespace UIKit {
 		void ContinueAnimation ([NullAllowed] IUITimingCurveProvider parameters, nfloat durationFactor);
 	}
 		
-	[iOS (10,0), TV (10,0)]
+	[iOS (10,0), TV (10,0), NoWatch]
 	[BaseType (typeof(NSObject))]
 	interface UIViewPropertyAnimator : UIViewImplicitlyAnimating, NSCopying
 	{
@@ -1969,8 +1987,9 @@ namespace UIKit {
 	}
 	
 	interface IUIViewControllerPreviewing {}
+
 	[Protocol]
-	[iOS (9,0)]
+	[iOS (9,0), NoWatch]
 	interface UIViewControllerPreviewing {
 
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Replaced by 'UIContextMenuInteraction'.")]
@@ -2006,7 +2025,7 @@ namespace UIKit {
 	
 	[Protocol]
 	[Model]
-	[iOS (9,0)]
+	[iOS (9,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIViewControllerPreviewingDelegate {
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Replaced by 'UIContextMenuInteraction'.")]
@@ -2020,6 +2039,7 @@ namespace UIKit {
 		void CommitViewController (IUIViewControllerPreviewing previewingContext, UIViewController viewControllerToCommit);
 	}
 	
+	[NoWatch]
 	[Protocol]
 	interface UIViewControllerRestoration {
 #if false
@@ -2030,17 +2050,20 @@ namespace UIKit {
 #endif
 	}
 
+	[NoWatch]
 	interface UIStatusBarFrameChangeEventArgs {
 		[Export ("UIApplicationStatusBarFrameUserInfoKey")]
 		CGRect StatusBarFrame { get; }
 	}
 
+	[NoWatch]
 	interface UIStatusBarOrientationChangeEventArgs {
 		[NoTV]
 		[Export ("UIApplicationStatusBarOrientationUserInfoKey")]
 		UIInterfaceOrientation StatusBarOrientation { get; }
 	}
 
+	[NoWatch]
 	interface UIApplicationLaunchEventArgs {
 		[NullAllowed]
 		[Export ("UIApplicationLaunchOptionsURLKey")]
@@ -2060,6 +2083,7 @@ namespace UIKit {
 		bool LocationLaunch { get; }
 	}
 
+	[NoWatch]
 	[StrongDictionary ("UIApplicationOpenUrlOptionKeys")]
 	interface UIApplicationOpenUrlOptions {
 		NSObject Annotation { get; set; }
@@ -2070,7 +2094,7 @@ namespace UIKit {
 		bool UniversalLinksOnly { get; set; }
 	}
 
-	[iOS (9,0)]
+	[iOS (9,0), NoWatch]
 	[Static]
 	[Internal] // we'll make it public if there's a need for them (beside the strong dictionary we provide)
 	interface UIApplicationOpenUrlOptionKeys {
@@ -2631,7 +2655,7 @@ namespace UIKit {
 		string AlternateIconName { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
 	interface UIApplicationShortcutIcon : NSCopying
@@ -2656,7 +2680,7 @@ namespace UIKit {
 		UIApplicationShortcutIcon FromContact (CNContact contact);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
@@ -2689,7 +2713,7 @@ namespace UIKit {
 		NSObject TargetContentIdentifier { get; [NotImplemented] set; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof (UIApplicationShortcutItem))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Don't call -[UIApplicationShortcutItem init].
@@ -2728,7 +2752,7 @@ namespace UIKit {
 		NSObject TargetContentIdentifier { get; set; }
 	}
 
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[BaseType (typeof (UIDynamicBehavior))]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: init is undefined for objects of type UIAttachmentBehavior
 	interface UIAttachmentBehavior {
@@ -2799,7 +2823,7 @@ namespace UIKit {
 		nfloat FrictionTorque { get; set; }
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[iOS (10,0), TV (10,0), NoWatch]
 	[Protocol]
 	interface UIContentSizeCategoryAdjusting {
 		[Abstract]
@@ -2808,6 +2832,7 @@ namespace UIKit {
 		bool AdjustsFontForContentSizeCategory { get; set; }
 	}
 
+	[NoWatch]
 	interface UIContentSizeCategoryChangedEventArgs {
 		[Export ("UIContentSizeCategoryNewValueKey")]
 		NSString WeakNewValue { get; }
@@ -2954,7 +2979,7 @@ namespace UIKit {
 	[Model]
 	[BaseType (typeof (NSObject))]
 	[Abstract]
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	interface UICoordinateSpace {
 		[Abstract]
 		[Export ("bounds")]
@@ -2979,7 +3004,7 @@ namespace UIKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[NoMac]
+	[NoMac, NoWatch]
 	[Protocol]
 	interface UIApplicationDelegate {
 
@@ -3235,6 +3260,7 @@ namespace UIKit {
 		bool ShouldAutomaticallyLocalizeKeyCommands (UIApplication application);
 	}
 
+	[NoWatch]
 	[Static]
 	interface UIExtensionPointIdentifier {
 		[iOS (8,0)]
@@ -3242,6 +3268,7 @@ namespace UIKit {
 		NSString Keyboard { get; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DesignatedDefaultCtor]
 	interface UIBarItem : NSCoding, UIAppearance, UIAccessibility, UIAccessibilityIdentification {
@@ -3290,6 +3317,7 @@ namespace UIKit {
 		UIEdgeInsets LargeContentSizeImageInsets { get; set; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIBarItem))]
 	[DesignatedDefaultCtor]
 	interface UIBarButtonItem : NSCoding
@@ -3477,7 +3505,7 @@ namespace UIKit {
 		UIBarButtonItemGroup ButtonGroup { get; }
 	}
 
-	[iOS (9,0)]
+	[iOS (9,0), NoWatch]
 	[BaseType (typeof(NSObject))]
 	interface UIBarButtonItemGroup : NSCoding
 	{
@@ -3495,6 +3523,7 @@ namespace UIKit {
 		bool DisplayingRepresentativeItem { [Bind ("isDisplayingRepresentativeItem")] get; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UICollectionReusableView {
 		[Export ("initWithFrame:")]
@@ -3521,6 +3550,7 @@ namespace UIKit {
 		UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes (UICollectionViewLayoutAttributes layoutAttributes);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIScrollView))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: UICollectionView must be initialized with a non-nil layout parameter
 	[DisableDefaultCtor]
@@ -3800,7 +3830,7 @@ namespace UIKit {
 	interface IUICollectionViewDataSourcePrefetching {}
 	
 	[Protocol]
-	[iOS (10, 0)]
+	[iOS (10, 0), NoWatch]
 	interface UICollectionViewDataSourcePrefetching {
 		
 		[Abstract]
@@ -3814,6 +3844,7 @@ namespace UIKit {
 	//
 	// Combined version of UICollectionViewDataSource, UICollectionViewDelegate
 	//
+	[NoWatch]
 	[Model]
 	[BaseType (typeof (NSObject))]
 	[Protocol (IsInformal = true)]
@@ -3821,6 +3852,7 @@ namespace UIKit {
 		
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -3858,6 +3890,7 @@ namespace UIKit {
 		NSIndexPath GetIndexPath (UICollectionView collectionView, string title, nint atIndex);
 	}
 
+	[NoWatch]
 	[Model]
 	[Protocol]
 #if XAMCORE_3_0 && !NET
@@ -4011,6 +4044,7 @@ namespace UIKit {
 	[Watch (8,0), TV (15,0), iOS (15,0), MacCatalyst (15,0)]
 	delegate void UICollectionViewCellConfigurationUpdateHandler (UICollectionViewCell cell, UICellConfigurationState state);
 
+	[NoWatch]
 	[BaseType (typeof (UICollectionReusableView))]
 	interface UICollectionViewCell {
 		[Export ("initWithFrame:")]
@@ -4071,6 +4105,7 @@ namespace UIKit {
 		bool AutomaticallyUpdatesBackgroundConfiguration { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIViewController))]
 	interface UICollectionViewController : UICollectionViewSource, NSCoding {
 		[DesignatedInitializer]
@@ -4103,6 +4138,7 @@ namespace UIKit {
 		bool InstallsStandardGestureForInteractiveMovement { get; set; }		
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UICollectionViewDelegate))]
 	[Model]
 	[Protocol]
@@ -4126,6 +4162,7 @@ namespace UIKit {
 		CGSize GetReferenceSizeForFooter (UICollectionView collectionView, UICollectionViewLayout layout, nint section);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UICollectionViewLayout))]
 	interface UICollectionViewFlowLayout {
 		[Export ("minimumLineSpacing")]
@@ -4172,6 +4209,7 @@ namespace UIKit {
 		CGSize AutomaticSize { get; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DesignatedDefaultCtor]
 	interface UICollectionViewLayout : NSCoding {
@@ -4336,6 +4374,7 @@ namespace UIKit {
 		bool FlipsHorizontallyInOppositeLayoutDirection { get; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UICollectionViewLayoutAttributes : UIDynamicItem, NSCopying {
 		[Export ("frame")]
@@ -4390,7 +4429,7 @@ namespace UIKit {
 		
 	}
 
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UICollectionViewLayoutInvalidationContext {
 		[Export ("invalidateDataSourceCounts")]
@@ -4444,7 +4483,7 @@ namespace UIKit {
 		CGPoint InteractiveMovementTarget { get; }
 	}
 	
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[BaseType (typeof (UICollectionViewLayoutInvalidationContext))]
 	partial interface UICollectionViewFlowLayoutInvalidationContext {
 		[Export ("invalidateFlowLayoutDelegateMetrics")]
@@ -4454,7 +4493,7 @@ namespace UIKit {
 		bool InvalidateFlowLayoutAttributes { get; set; }
 	}
 	
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[BaseType (typeof (UICollectionViewLayout))]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: -[UICollectionViewTransitionLayout init] is not a valid initializer - use -initWithCurrentLayout:nextLayout: instead
 	interface UICollectionViewTransitionLayout : NSCoding {
@@ -4480,6 +4519,7 @@ namespace UIKit {
 		nfloat TransitionProgress { get; set; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UICollectionViewUpdateItem {
 		[NullAllowed]
@@ -4494,6 +4534,7 @@ namespace UIKit {
 		UICollectionUpdateAction UpdateAction { get;  }
 	}
 
+	[NoWatch]
 	[Static]
 	interface UICollectionElementKindSectionKey
 	{
@@ -4503,7 +4544,6 @@ namespace UIKit {
 		[Field ("UICollectionElementKindSectionFooter")]
 		NSString Footer { get; }
 	}
-#endif // !WATCH
 	
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
@@ -4534,13 +4574,11 @@ namespace UIKit {
 		[return: NullAllowed]
 		UIColor FromName (string name);
 
-#if !WATCH
-		[iOS (11,0), TV (11,0)]
+		[NoWatch, iOS (11,0), TV (11,0)]
 		[Static]
 		[Export ("colorNamed:inBundle:compatibleWithTraitCollection:")]
 		[return: NullAllowed]
 		UIColor FromName (string name, [NullAllowed] NSBundle inBundle, [NullAllowed] UITraitCollection compatibleWithTraitCollection);
-#endif
 	
 		[iOS (10,0), TV (10,0), Watch (3,0)]
 		[Static]
@@ -5268,8 +5306,7 @@ namespace UIKit {
 		string AccessibilityName { get; }
 	}
 
-#if !WATCH
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (UIDynamicBehavior),
 		   Delegates=new string [] { "CollisionDelegate" },
 		   Events=new Type [] { typeof (UICollisionBehaviorDelegate)})]
@@ -5324,7 +5361,7 @@ namespace UIKit {
 		void RemoveAllBoundaries ();
 	}
 	
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
 	[Model]
@@ -5342,7 +5379,7 @@ namespace UIKit {
 		void EndedBoundaryContact (UICollisionBehavior behavior, IUIDynamicItem dynamicItem, [NullAllowed] NSObject boundaryIdentifier);
 	}
 
-	[NoTV]
+	[NoWatch, NoTV]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: do not call -[UIDocument init] - the designated initializer is -[UIDocument initWithFileURL:
 	[DisableDefaultCtor]
@@ -5465,6 +5502,7 @@ namespace UIKit {
 
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
 	[Model]
@@ -5482,7 +5520,7 @@ namespace UIKit {
 		void DidPause (UIDynamicAnimator animator);
 	}
 
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIDynamicAnimator {
 		[DesignatedInitializer]
@@ -5543,7 +5581,7 @@ namespace UIKit {
 
 	}
 
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (UIDynamicBehavior))]
 	interface UIDynamicItemBehavior {
 		[DesignatedInitializer]
@@ -5600,7 +5638,7 @@ namespace UIKit {
 		bool Anchored { [Bind ("isAnchored")] get; set; }
 	}
 
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
 	[Model]
@@ -5626,7 +5664,7 @@ namespace UIKit {
 		UIBezierPath CollisionBoundingPath { get; }		
 	}
 
-	[iOS (9,0)]
+	[NoWatch, iOS (9,0)]
 	[BaseType (typeof(NSObject))]
 	interface UIDynamicItemGroup : UIDynamicItem
 	{
@@ -5640,7 +5678,7 @@ namespace UIKit {
 
 	interface IUIDynamicItem {}
 
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIDynamicBehavior {
 		[Export ("childBehaviors", ArgumentSemantic.Copy)]
@@ -5665,7 +5703,7 @@ namespace UIKit {
 		void WillMoveToAnimator ([NullAllowed] UIDynamicAnimator targetAnimator);
 	}
 
-	[iOS (9,0)]
+	[NoWatch, iOS (9,0)]
 	[BaseType (typeof(UIDynamicBehavior))]
 	[DisableDefaultCtor]
 	interface UIFieldBehavior
@@ -5749,7 +5787,6 @@ namespace UIKit {
 	}
 	
 	delegate CGVector UIFieldCustomEvaluator (UIFieldBehavior field, CGPoint position, CGVector velocity, nfloat mass, nfloat charge, double deltaTime);
-#endif // !WATCH
 	
 	[Static][Internal]
 	[iOS (8,2)]
@@ -5881,13 +5918,11 @@ namespace UIKit {
 		IntPtr _GetPreferredFontForTextStyle (NSString uiFontTextStyle);
 
 		// FIXME [Watch (3,0)] the API is present but UITraitCollection is not exposed / rdar 27785753
-#if !WATCH
-		[iOS (10,0), TV (10,0)]
+		[NoWatch, iOS (10,0), TV (10,0)]
 		[Static]
 		[Export ("preferredFontForTextStyle:compatibleWithTraitCollection:")]
 		[Internal]
 		IntPtr _GetPreferredFontForTextStyle (NSString uiFontTextStyle, [NullAllowed] UITraitCollection traitCollection);
-#endif
 	}
 
 	public enum UIFontTextStyle {
@@ -5986,17 +6021,15 @@ namespace UIKit {
 		UIFontDescriptor GetPreferredDescriptorForTextStyle (UIFontTextStyle uiFontTextStyle);
 
 		// FIXME [Watch (3,0)] the API is present but UITraitCollection is not exposed / rdar #27785753
-#if !WATCH
-		[iOS (10,0), TV (10,0)]
+		[NoWatch, iOS (10,0), TV (10,0)]
 		[Static]
 		[Export ("preferredFontDescriptorWithTextStyle:compatibleWithTraitCollection:")]
 		UIFontDescriptor GetPreferredDescriptorForTextStyle (NSString uiFontTextStyle, [NullAllowed] UITraitCollection traitCollection);
 
-		[iOS (10,0), TV (10,0)]
+		[NoWatch, iOS (10,0), TV (10,0)]
 		[Static]
 		[Wrap ("GetPreferredDescriptorForTextStyle (uiFontTextStyle.GetConstant ()!, traitCollection)")]
 		UIFontDescriptor GetPreferredDescriptorForTextStyle (UIFontTextStyle uiFontTextStyle, [NullAllowed] UITraitCollection traitCollection);
-#endif
 	
 		[DesignatedInitializer]
 		[Export ("initWithFontAttributes:")]
@@ -6100,7 +6133,7 @@ namespace UIKit {
 
 	}
 
-#if !WATCH
+	[NoWatch]
 	[BaseType (typeof(NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type[] {typeof (UIGestureRecognizerDelegate)})]
 	[Dispose ("OnDispose ();", Optimizable = true)]
 	interface UIGestureRecognizer {
@@ -6291,7 +6324,7 @@ namespace UIKit {
 		bool ShouldReceiveEvent (UIGestureRecognizer gestureRecognizer, UIEvent @event);
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[NoWatch, iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	interface UIGraphicsRendererFormat : NSCopying
 	{
@@ -6309,7 +6342,7 @@ namespace UIKit {
 		UIGraphicsRendererFormat PreferredFormat { get; }
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[NoWatch, iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	interface UIGraphicsRendererContext
 	{
@@ -6335,7 +6368,7 @@ namespace UIKit {
 		void ClipToRect (CGRect rect);
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[NoWatch, iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	[Abstract] // quote form headers "An abstract base class for creating graphics renderers. Do not use this class directly."
 	interface UIGraphicsRenderer
@@ -6375,7 +6408,7 @@ namespace UIKit {
 	// Not worth it, Action<UIGraphicsImageRendererContext> conveys more data
 	//delegate void UIGraphicsImageDrawingActions (UIGraphicsImageRendererContext context);
 
-	[iOS (10,0), TV (10,0)]
+	[NoWatch, iOS (10,0), TV (10,0)]
 	[BaseType (typeof(UIGraphicsRendererFormat))]
 	interface UIGraphicsImageRendererFormat
 	{
@@ -6405,7 +6438,7 @@ namespace UIKit {
 		UIGraphicsImageRendererFormatRange PreferredRange { get; set; }
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[NoWatch, iOS (10,0), TV (10,0)]
 	[BaseType (typeof(UIGraphicsRendererContext))]
 	interface UIGraphicsImageRendererContext
 	{
@@ -6413,7 +6446,7 @@ namespace UIKit {
 		UIImage CurrentImage { get; }
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[NoWatch, iOS (10,0), TV (10,0)]
 	[BaseType (typeof(UIGraphicsRenderer))]
 	interface UIGraphicsImageRenderer
 	{
@@ -6442,7 +6475,7 @@ namespace UIKit {
 	//delegate void UIGraphicsPdfDrawingActions (UIGraphicsPdfRendererContext context);
 	// Action<UIGraphicsPdfRendererContext>
 
-	[iOS (10,0), TV (10,0)]
+	[NoWatch, iOS (10,0), TV (10,0)]
 	[BaseType (typeof (UIGraphicsRendererFormat), Name="UIGraphicsPDFRendererFormat")]
 	interface UIGraphicsPdfRendererFormat
 	{
@@ -6456,7 +6489,7 @@ namespace UIKit {
 		UIGraphicsPdfRendererFormat DefaultFormat { get; }
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[NoWatch, iOS (10,0), TV (10,0)]
 	[BaseType (typeof (UIGraphicsRendererContext), Name="UIGraphicsPDFRendererContext")]
 	interface UIGraphicsPdfRendererContext
 	{
@@ -6480,7 +6513,7 @@ namespace UIKit {
 	}
 
 
-	[iOS (10,0), TV (10,0)]
+	[NoWatch, iOS (10,0), TV (10,0)]
 	[BaseType (typeof (UIGraphicsRenderer), Name = "UIGraphicsPDFRenderer")]
 	interface UIGraphicsPdfRenderer
 	{
@@ -6496,7 +6529,7 @@ namespace UIKit {
 	}
 
 	[BaseType (typeof (UIDynamicBehavior))]
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	interface UIGravityBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
@@ -6532,6 +6565,7 @@ namespace UIKit {
 	// Even more confusing it that respondToSelecttor return NO on them
 	// even if it works in _real_ life (compare unit and introspection tests)
 #endif
+	[NoWatch]
 	[Protocol]
 	interface UITextInputTraits {
 #if !NET
@@ -6603,6 +6637,7 @@ namespace UIKit {
 		UITextInputPasswordRules PasswordRules { get; set; }
 	}
 
+	[NoWatch]
 	interface UIKeyboardEventArgs {
 		[Export ("UIKeyboardFrameBeginUserInfoKey")]
 		CGRect FrameBegin { get; }
@@ -6620,7 +6655,7 @@ namespace UIKit {
 		UIViewAnimationCurve AnimationCurve { get; }
 	}
 	
-	[NoTV]
+	[NoTV, NoWatch]
 	[Static]
 	interface UIKeyboard {
 		[NoTV]
@@ -6698,7 +6733,7 @@ namespace UIKit {
 		NSString IsLocalUserInfoKey { get; }
 	}
 
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (UICommand))]
 	[DesignatedDefaultCtor]
 	interface UIKeyCommand {
@@ -6871,6 +6906,7 @@ namespace UIKit {
 
 	interface IUIKeyInput {}
 
+	[NoWatch]
 	[Protocol]
 	interface UIKeyInput : UITextInputTraits {
 		[Abstract]
@@ -6886,10 +6922,12 @@ namespace UIKit {
 		void DeleteBackward ();
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UITextPosition {
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UITextRange {
 		[Export ("isEmpty")]
@@ -6904,6 +6942,7 @@ namespace UIKit {
 
 	interface IUITextInput {}
 
+	[NoWatch]
 	[Protocol]
 	interface UITextInput : UIKeyInput {
 		[Abstract]
@@ -7104,7 +7143,7 @@ namespace UIKit {
 		void RemoveTextPlaceholder (UITextPlaceholder textPlaceholder);
 	}
 
-	[NoTV]
+	[NoWatch, NoTV]
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
 	interface UITextInputAssistantItem
@@ -7119,6 +7158,7 @@ namespace UIKit {
 		UIBarButtonItemGroup[] TrailingBarButtonGroups { get; set; }
 	}
 			
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -7141,12 +7181,14 @@ namespace UIKit {
 
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UITextInputStringTokenizer : UITextInputTokenizer{
 		[Export ("initWithTextInput:")]
 		NativeHandle Constructor (IUITextInput textInput);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -7168,6 +7210,7 @@ namespace UIKit {
 		void TextDidChange (IUITextInput textInput);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UITextSelectionRect {
 		[Export ("rect")]
@@ -7186,7 +7229,7 @@ namespace UIKit {
 		bool IsVertical { get;  }
 	}
 
-	[NoTV]
+	[NoWatch, NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	partial interface UILexicon : NSCopying {
@@ -7195,7 +7238,7 @@ namespace UIKit {
 	    UILexiconEntry [] Entries { get; }
 	}
 	
-	[NoTV]
+	[NoWatch, NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	partial interface UILexiconEntry : NSCopying {
@@ -7207,6 +7250,7 @@ namespace UIKit {
 	    string UserInput { get; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UILocalizedIndexedCollation {
 		[Export ("sectionTitles")]
@@ -7228,7 +7272,6 @@ namespace UIKit {
 		[Export ("sortedArrayFromArray:collationStringSelector:")]
 		NSObject [] SortedArrayFromArraycollationStringSelector (NSObject [] array, Selector collationStringSelector);
 	}
-#endif // !WATCH
 
 	[NoTV]
 	[BaseType (typeof (NSObject))]
@@ -7305,7 +7348,7 @@ namespace UIKit {
 		string AlertTitle { get; set; }
 	}
 	
-#if !WATCH
+	[NoWatch]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UILongPressGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7325,6 +7368,7 @@ namespace UIKit {
 		nint NumberOfTapsRequired { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UITapGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7342,6 +7386,7 @@ namespace UIKit {
 		UIEventButtonMask ButtonMaskRequired { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIPanGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7369,7 +7414,7 @@ namespace UIKit {
 		UIScrollTypeMask AllowedScrollTypesMask { get; set; }
 	}
 
-	[NoTV]
+	[NoWatch, NoTV]
 	[iOS (7,0)]
 	[BaseType (typeof (UIPanGestureRecognizer))]
 	interface UIScreenEdgePanGestureRecognizer {
@@ -7386,7 +7431,7 @@ namespace UIKit {
 	// This class comes with an "init" constructor (which we autogenerate)
 	// and does not require us to call this with initWithFrame:
 	//
-	[NoTV]
+	[NoWatch, NoTV]
 	[BaseType (typeof (UIControl))]
 	interface UIRefreshControl : UIAppearance {
 		[Export ("refreshing")]
@@ -7404,7 +7449,7 @@ namespace UIKit {
 		void EndRefreshing ();
 	}
 
-	[iOS (9,0)]
+	[NoWatch, iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIRegion : NSCopying, NSCoding {
 		[Static]
@@ -7433,7 +7478,7 @@ namespace UIKit {
 		bool Contains (CGPoint point);
 	}
 
-	[NoTV]
+	[NoWatch, NoTV]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIRotationGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7446,7 +7491,7 @@ namespace UIKit {
 		nfloat Velocity { get; }
 	}
 
-	[NoTV]
+	[NoWatch, NoTV]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIPinchGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7459,6 +7504,7 @@ namespace UIKit {
 		nfloat Velocity { get; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UISwipeGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7472,6 +7518,7 @@ namespace UIKit {
 		nuint NumberOfTouchesRequired { get; set; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof(UIView))]
 	interface UIActivityIndicatorView : NSCoding {
 		[DesignatedInitializer]
@@ -7501,7 +7548,6 @@ namespace UIKit {
 		[Appearance]
 		UIColor Color { get; set; }
 	}
-#endif // !WATCH
 
 	[NoWatch, NoTV]
 	[iOS (11,0)]
@@ -7575,11 +7621,10 @@ namespace UIKit {
 		[ThreadSafe]			
 		UIImage FromImage (CGImage image, nfloat scale, UIImageOrientation orientation);
 
-#if !WATCH
+		[NoWatch]
 		[Static][Export ("imageWithCIImage:")][Autorelease]
 		[ThreadSafe]			
 		UIImage FromImage (CIImage image);
-#endif // !WATCH
 
 		// From the NSItemProviderReading protocol, a static method.
 		[Static]
@@ -7677,22 +7722,20 @@ namespace UIKit {
 		[ThreadSafe]
 		NativeHandle Constructor (CGImage cgImage);
 
-#if !WATCH
+		[NoWatch]
 		[Export ("initWithCIImage:")]
 		[ThreadSafe]
 		NativeHandle Constructor (CIImage ciImage);
-#endif // !WATCH
 
 		[Export ("initWithCGImage:scale:orientation:")]
 		[ThreadSafe]
 		NativeHandle Constructor (CGImage cgImage, nfloat scale,  UIImageOrientation orientation);
 
-#if !WATCH
+		[NoWatch]
 		[Export ("CIImage")]
 		[ThreadSafe]
 		[NullAllowed]
 		CIImage CIImage { get; }
-#endif // !WATCH
 		
 		[Export ("images")]
 		[ThreadSafe]
@@ -7724,22 +7767,20 @@ namespace UIKit {
 		[return: NullAllowed]
 		UIImage LoadFromData (NSData data, nfloat scale);
 
-#if !WATCH
+		[NoWatch]
 		[Static]
 		[Export ("imageWithCIImage:scale:orientation:")]
 		[ThreadSafe, Autorelease]
 		UIImage FromImage (CIImage ciImage, nfloat scale, UIImageOrientation orientation);
-#endif // !WATCH
 
 		[Export ("initWithData:scale:")]
 		[ThreadSafe]
 		NativeHandle Constructor (NSData data, nfloat scale);
 
-#if !WATCH
+		[NoWatch]
 		[Export ("initWithCIImage:scale:orientation:")]
 		[ThreadSafe]
 		NativeHandle Constructor (CIImage ciImage, nfloat scale, UIImageOrientation orientation);
-#endif // !WATCH
 	
 		[Export ("resizableImageWithCapInsets:resizingMode:")]
 		[ThreadSafe]
@@ -7759,18 +7800,16 @@ namespace UIKit {
 		[ThreadSafe]
 		UIImageResizingMode ResizingMode { get; }
 
-#if !WATCH
-		[iOS (8,0)]
+		[NoWatch, iOS (8,0)]
 		[Export ("traitCollection")]
 		[ThreadSafe]
 		UITraitCollection TraitCollection { get; }
 
-		[iOS (8,0)]
+		[NoWatch, iOS (8,0)]
 		[Export ("imageAsset")]
 		[ThreadSafe]
 		[NullAllowed]
 		UIImageAsset ImageAsset { get; }
-#endif // !WATCH
 
 		[iOS (9,0)]
 		[Export ("imageFlippedForRightToLeftLayoutDirection")]
@@ -7780,11 +7819,9 @@ namespace UIKit {
 		[Export ("flipsForRightToLeftLayoutDirection")]
 		bool FlipsForRightToLeftLayoutDirection { get; }
 
-#if !WATCH
-		[iOS (10,0), TV (10,0)]
+		[NoWatch, iOS (10,0), TV (10,0)]
 		[Export ("imageRendererFormat")]
 		UIGraphicsImageRendererFormat ImageRendererFormat { get; }
-#endif
 
 		[Watch (3,0)]
 		[iOS (10,0), TV (10,0)]
@@ -7813,13 +7850,12 @@ namespace UIKit {
 		[return: NullAllowed]
 		UIImage GetSystemImage (string name, [NullAllowed] UIImageConfiguration configuration);
 
-#if !WATCH
 		[NoWatch, TV (13,0), iOS (13,0)] // UITraitCollection is not available on watch, it has been reported before.
 		[Static]
 		[Export ("systemImageNamed:compatibleWithTraitCollection:")]
 		[return: NullAllowed]
 		UIImage GetSystemImage (string name, [NullAllowed] UITraitCollection traitCollection);
-#endif
+
 		[Watch (6,0), TV (13,0), iOS (13,0)]
 		[Static]
 		[ThreadSafe]
@@ -7925,7 +7961,6 @@ namespace UIKit {
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface UIImageConfiguration : NSCopying, NSSecureCoding {
-#if !WATCH
 		[NoWatch] // UITraitCollection is not available in WatchOS it has been reported before
 		[NullAllowed, Export ("traitCollection")]
 		UITraitCollection TraitCollection { get; }
@@ -7933,7 +7968,7 @@ namespace UIKit {
 		[NoWatch] // UITraitCollection is not available in WatchOS it has been reported before
 		[Export ("configurationWithTraitCollection:")]
 		UIImageConfiguration GetConfiguration ([NullAllowed] UITraitCollection traitCollection);
-#endif
+
 		[Export ("configurationByApplyingConfiguration:")]
 		UIImageConfiguration GetConfiguration ([NullAllowed] UIImageConfiguration otherConfiguration);
 	}
@@ -8137,8 +8172,7 @@ namespace UIKit {
 		UITargetedPreview GetRetargetedPreview (UIPreviewTarget newTarget);
 	}
 
-#if !WATCH
-	[iOS (8,0)]
+	[NoWatch, iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DesignatedDefaultCtor]
 	partial interface UIImageAsset : NSSecureCoding {
@@ -8165,6 +8199,7 @@ namespace UIKit {
 		void UnregisterImageWithTraitCollection (UITraitCollection traitCollection);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIEvent {
 		[Export ("type")]
@@ -8210,6 +8245,7 @@ namespace UIKit {
 
 	// that's one of the few enums based on CGFloat - we expose the [n]float directly in the API
 	// but we need a way to give access to the constants to developers
+	[NoWatch]
 	[Static]
 	interface UIWindowLevel {
 		[Field ("UIWindowLevelNormal")]
@@ -8223,6 +8259,7 @@ namespace UIKit {
 		nfloat StatusBar { get; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UIWindow {
 
@@ -8311,6 +8348,7 @@ namespace UIKit {
 
 	delegate void UIControlEnumerateEventsIteratorHandler ([NullAllowed] UIAction actionHandler, [NullAllowed] NSObject target, [NullAllowed] Selector action, UIControlEvent controlEvents, out bool stop);
 
+	[NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UIControl
 #if IOS // UIControl() <UIContextMenuInteractionDelegate> category
@@ -8442,7 +8480,7 @@ namespace UIKit {
 		UIToolTipInteraction ToolTipInteraction { get; }
 	}
 
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -8455,7 +8493,7 @@ namespace UIKit {
 
 	interface IUIBarPositioning {}
 
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -8463,7 +8501,6 @@ namespace UIKit {
 		[Export ("positionForBar:")][DelegateName ("Func<IUIBarPositioning,UIBarPosition>"), NoDefaultValue]
 		UIBarPosition GetPositionForBar (IUIBarPositioning barPositioning);
 	}
-#endif // !WATCH
 	
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
@@ -8591,7 +8628,7 @@ namespace UIKit {
 	[NoWatch, NoTV, iOS (15,0), MacCatalyst (15,0)]
 	delegate void UIButtonConfigurationUpdateHandler (UIButton button);
 	
-#if !WATCH
+	[NoWatch]
 	[BaseType (typeof (UIControl))]
 	interface UIButton : UIAccessibilityContentSizeCategoryImageAdjusting
 #if IOS
@@ -8855,6 +8892,7 @@ namespace UIKit {
 		UIBehavioralStyle PreferredBehavioralStyle { get; set; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UILabel : UIContentSizeCategoryAdjusting {
 		[Export ("initWithFrame:")]
@@ -8953,6 +8991,7 @@ namespace UIKit {
 		bool ShowsExpansionTextWhenTruncated { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UIImageView
 #if !WATCH
@@ -9024,7 +9063,7 @@ namespace UIKit {
 		UIImageSymbolConfiguration PreferredSymbolConfiguration { get; set; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIControl))]
 	interface UIDatePicker {
 		[Export ("initWithFrame:")]
@@ -9082,6 +9121,7 @@ namespace UIKit {
 		bool RoundsToMinuteInterval { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
 	interface UIDevice {
@@ -9176,6 +9216,7 @@ namespace UIKit {
 		NSUuid IdentifierForVendor { get;  }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIDictationPhrase {
 		[Export ("alternativeInterpretations")]
@@ -9185,7 +9226,7 @@ namespace UIKit {
 		string Text { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[MacCatalyst (14,0)] // doc as 13.0 but throws: NSGenericException Reason: UIDocumentInteractionController not available
 	[BaseType (typeof (NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (UIDocumentInteractionControllerDelegate)})]
 	interface UIDocumentInteractionController {
@@ -9243,7 +9284,7 @@ namespace UIKit {
 		UIGestureRecognizer [] GestureRecognizers { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -9292,7 +9333,7 @@ namespace UIKit {
 		void WillPresentOptionsMenu (UIDocumentInteractionController controller);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UINavigationController), Delegates=new string [] { "Delegate" }, Events=new Type [] {typeof(UIImagePickerControllerDelegate)})]
 	interface UIImagePickerController {
 		[Export ("isSourceTypeAvailable:")][Static]
@@ -9415,7 +9456,7 @@ namespace UIKit {
 
 	// UINavigationControllerDelegate, UIImagePickerControllerDelegate
 	[BaseType (typeof (UINavigationControllerDelegate))]
-	[NoTV]
+	[NoTV, NoWatch]
 	[Model]
 	[Protocol]
 	interface UIImagePickerControllerDelegate {
@@ -9432,7 +9473,7 @@ namespace UIKit {
 		void Canceled (UIImagePickerController picker);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIDocument))]
 	// *** Assertion failure in -[UIManagedDocument init], /SourceCache/UIKit_Sim/UIKit-1914.84/UIDocument.m:258
 	[DisableDefaultCtor]
@@ -9475,7 +9516,7 @@ namespace UIKit {
 		bool WriteAdditionalContent (NSObject content, NSUrl absoluteURL, NSUrl absoluteOriginalContentsURL, out NSError error);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIMenuController {
 		[Static, Export ("sharedMenuController")]
@@ -9538,7 +9579,7 @@ namespace UIKit {
 		NSString MenuFrameDidChangeNotification { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIMenuItem {
 		[DesignatedInitializer] // TODO: Add an overload that takes an Action maybe?
@@ -9554,6 +9595,7 @@ namespace UIKit {
 		Selector Action { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UINavigationBar : UIBarPositioning, NSCoding {
 		[Export ("initWithFrame:")]
@@ -9705,6 +9747,7 @@ namespace UIKit {
 		UIStringAttributes LargeTitleTextAttributes { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIBarPositioningDelegate))]
 	[Model]
 	[Protocol]
@@ -9722,6 +9765,7 @@ namespace UIKit {
 		bool ShouldPushItem (UINavigationBar navigationBar, UINavigationItem item);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UINavigationItem : NSCoding {
 		[DesignatedInitializer]
@@ -9834,6 +9878,7 @@ namespace UIKit {
 		UINavigationBarAppearance CompactScrollEdgeAppearance { get; set; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIViewController))]
 	interface UINavigationController {
 		[DesignatedInitializer]
@@ -9954,6 +9999,7 @@ namespace UIKit {
 		UITapGestureRecognizer BarHideOnTapGestureRecognizer { get; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -9992,6 +10038,7 @@ namespace UIKit {
 		IUIViewControllerAnimatedTransitioning GetAnimationControllerForOperation (UINavigationController navigationController, UINavigationControllerOperation operation, UIViewController fromViewController, UIViewController toViewController);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UINib {
 		// note: the default `init` does not seems to create anything that can be used - but it does not crash when used
@@ -10011,6 +10058,7 @@ namespace UIKit {
 		NSString ExternalObjectsKey { get; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIControl))]
 	interface UIPageControl : UIAppearance {
 		[Export ("initWithFrame:")]
@@ -10075,6 +10123,7 @@ namespace UIKit {
 		void UpdateCurrentPageDisplay ();
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIViewController),
 		   Delegates = new string [] { "WeakDelegate", "WeakDataSource" },
 		   Events = new Type [] { typeof (UIPageViewControllerDelegate), typeof (UIPageViewControllerDataSource)} )]
@@ -10131,6 +10180,7 @@ namespace UIKit {
 		NSString OptionInterPageSpacingKey { get; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -10157,6 +10207,7 @@ namespace UIKit {
 		UIInterfaceOrientation GetPreferredInterfaceOrientationForPresentation (UIPageViewController pageViewController);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -10176,7 +10227,7 @@ namespace UIKit {
 		nint GetPresentationIndex (UIPageViewController pageViewController);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	interface UIPasteboardChangeEventArgs {
 		[Export ("UIPasteboardChangedTypesAddedKey")]
 		string [] TypesAdded { get; }
@@ -10185,7 +10236,7 @@ namespace UIKit {
 		string [] TypesRemoved { get; }
 	}
 	
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Calling -[UIPasteboard init] is not allowed.
 	[DisableDefaultCtor]
@@ -10382,7 +10433,7 @@ namespace UIKit {
 		void SetObjects (INSItemProviderWriting[] objects, bool localOnly, [NullAllowed] NSDate expirationDate);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[Static]
 	interface UIPasteboardNames {
 		[Field ("UIPasteboardNameGeneral")]
@@ -10410,7 +10461,7 @@ namespace UIKit {
 		NSString LocalOnlyKey { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" })]
 	interface UIPickerView {
 		[Export ("initWithFrame:")]
@@ -10481,7 +10532,7 @@ namespace UIKit {
 		UITableViewCell GetCell (UITableView tableView, NSIndexPath indexPath);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -10505,7 +10556,7 @@ namespace UIKit {
 		NSAttributedString GetAttributedTitle (UIPickerView pickerView, nint row, nint component);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[Protocol, Model]
 	[BaseType (typeof (UIPickerViewDelegate))]
 	interface UIPickerViewAccessibilityDelegate {
@@ -10534,7 +10585,7 @@ namespace UIKit {
 		NSAttributedString [] GetAccessibilityAttributedUserInputLabels (UIPickerView pickerView, nint component);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -10550,14 +10601,14 @@ namespace UIKit {
 
 	interface IUIPickerViewDataSource { }
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol (IsInformal = true)]
 	interface UIPickerViewModel : UIPickerViewDataSource, UIPickerViewDelegate {
 	}
 
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -10587,12 +10638,12 @@ namespace UIKit {
 		void WillTransitionToTraitCollection (UITraitCollection traitCollection, [NullAllowed] IUIViewControllerTransitionCoordinator coordinator);
 	}
 
-	[iOS(8,0),Protocol, Model]
+	[NoWatch, iOS(8,0),Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	partial interface UIAppearanceContainer {
 	}
 	
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Don't call -[UIPresentationController init].
 	partial interface UIPresentationController : UIAppearanceContainer, UITraitEnvironment, UIContentContainer, UIFocusEnvironment {
@@ -10663,7 +10714,7 @@ namespace UIKit {
 	delegate void UIPreviewHandler (UIPreviewAction action, UIViewController previewViewController);
 
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Replaced by 'UIContextMenuInteraction'.")]
-	[iOS (9,0)]
+	[iOS (9,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIPreviewAction : UIPreviewActionItem, NSCopying {
 		[Static, Export ("actionWithTitle:style:handler:")]
@@ -10676,7 +10727,7 @@ namespace UIKit {
 	}
 
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Replaced by 'UIContextMenuInteraction'.")]
-	[iOS (9,0)]
+	[iOS (9,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIPreviewActionGroup : UIPreviewActionItem, NSCopying {
 		[Static, Export ("actionGroupWithTitle:style:actions:")]
@@ -10685,7 +10736,7 @@ namespace UIKit {
 	
 	interface IUIPreviewActionItem {}
 	
-	[iOS (9,0)]
+	[iOS (9,0), NoWatch]
 	[Protocol]
 	interface UIPreviewActionItem {
 		[Abstract]
@@ -10693,6 +10744,7 @@ namespace UIKit {
 		string Title { get; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UIProgressView : NSCoding {
 		[DesignatedInitializer]
@@ -10737,7 +10789,7 @@ namespace UIKit {
 		NSProgress ObservedProgress { get; set; }
 	}
 
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (UIDynamicBehavior))]
 	partial interface UIPushBehavior {
 		[DesignatedInitializer]
@@ -10781,7 +10833,7 @@ namespace UIKit {
 	
 	}
 
-	[iOS (7,0)]
+	[NoWatch, iOS (7,0)]
 	[BaseType (typeof (UIDynamicBehavior))]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: init is undefined for objects of type UISnapBehavior
 	partial interface UISnapBehavior {
@@ -10798,7 +10850,7 @@ namespace UIKit {
 	}
 
 	[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIViewController))]
 	// iOS6 returns the following (confusing) message with the default .ctor:
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIReferenceLibraryViewController initWithNibName:bundle:] is not a valid initializer. You must call -[UIReferenceLibraryViewController initWithTerm:].
@@ -10816,6 +10868,7 @@ namespace UIKit {
 		NativeHandle Constructor (string term);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIResponder : UIAccessibilityAction, UIAccessibilityFocus, UIUserActivityRestoring, UIResponderStandardEditActions
 #if !TVOS
@@ -10991,6 +11044,7 @@ namespace UIKit {
 		NSTouchBar TouchBar { get; set; }
 	}
 	
+	[NoWatch]
 	[Protocol]
 	interface UIResponderStandardEditActions {
 		[Export ("cut:")]
@@ -11054,6 +11108,7 @@ namespace UIKit {
 	}
 
 #if !NET // These two methods are in the UIResponderStandardEditActions protocol
+	[NoWatch]
 	[Category, BaseType (typeof (UIResponder))]
 	interface UIResponder_NSObjectExtension {
 		[Export ("decreaseSize:")]
@@ -11064,6 +11119,7 @@ namespace UIKit {
 	}
 #endif
 	
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIScreen : UITraitEnvironment {
 		[Export ("bounds")]
@@ -11104,7 +11160,7 @@ namespace UIKit {
 		nfloat Scale { get; }
 
 		[Export ("displayLinkWithTarget:selector:")]
-		CoreAnimation.CADisplayLink CreateDisplayLink (NSObject target, Selector sel);
+		CADisplayLink CreateDisplayLink (NSObject target, Selector sel);
 
 		[iOS (10,3), TV (10,2)]
 		[Export ("maximumFramesPerSecond")]
@@ -11197,6 +11253,7 @@ namespace UIKit {
 		bool Captured { [Bind ("isCaptured")] get; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIScrollViewDelegate)})]
 	interface UIScrollView : UIFocusItemScrollableContainer {
 		[Export ("initWithFrame:")]
@@ -11382,7 +11439,7 @@ namespace UIKit {
 		UIRefreshControl RefreshControl { get; set; }
 	}
 
-	[NoMac]
+	[NoMac, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -11432,6 +11489,7 @@ namespace UIKit {
 		void DidChangeAdjustedContentInset (UIScrollView scrollView);
 	}
 
+	[NoWatch]
 	[Protocol, Model]
 	[BaseType (typeof (UIScrollViewDelegate))]
 	interface UIScrollViewAccessibilityDelegate {
@@ -11444,6 +11502,7 @@ namespace UIKit {
 		NSAttributedString GetAccessibilityAttributedScrollStatus (UIScrollView scrollView);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UISearchBarDelegate)})]
 #if TVOS
 	[DisableDefaultCtor] // - (instancetype)init __TVOS_PROHIBITED;
@@ -11620,6 +11679,7 @@ namespace UIKit {
 		UISearchTextField SearchTextField { get; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIBarPositioningDelegate))]
 	[Model]
 	[Protocol]
@@ -11662,7 +11722,7 @@ namespace UIKit {
 		void ListButtonClicked (UISearchBar searchBar);
 	}
 
-	[iOS (9,1)][TV (9,0)]
+	[NoWatch, iOS (9,1)][TV (9,0)]
 	[BaseType (typeof(UIViewController))]
 	interface UISearchContainerViewController
 	{
@@ -11678,7 +11738,7 @@ namespace UIKit {
 		NativeHandle Constructor (UISearchController searchController);
 	}
 	
-	[iOS (8,0)]
+	[NoWatch, iOS (8,0)]
 	[BaseType (typeof (UIViewController))]
 	[DisableDefaultCtor] // designated
 	partial interface UISearchController : UIViewControllerTransitioningDelegate, UIViewControllerAnimatedTransitioning
@@ -11757,6 +11817,7 @@ namespace UIKit {
 		UIScrollView SearchControllerObservedScrollView { get; set; }
 	}
 
+	[NoWatch]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	partial interface UISearchControllerDelegate {
@@ -11778,7 +11839,7 @@ namespace UIKit {
 		
 	[BaseType (typeof (NSObject))]
 	[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'UISearchController'.")]
-	[NoMacCatalyst] // Objective-C exception thrown.  Name: NSGenericException Reason: UISearchDisplayController is no longer supported when linking against this version of iOS. Please migrate your application to UISearchController.
+	[NoMacCatalyst, NoWatch] // Objective-C exception thrown.  Name: NSGenericException Reason: UISearchDisplayController is no longer supported when linking against this version of iOS. Please migrate your application to UISearchController.
 	[NoTV]
 	interface UISearchDisplayController {
 		[Export ("initWithSearchBar:contentsController:")]
@@ -11838,7 +11899,7 @@ namespace UIKit {
 	[Model]
 	[Protocol]
 	[NoTV]
-	[NoMacCatalyst]
+	[NoMacCatalyst, NoWatch]
 	interface UISearchDisplayDelegate {
 		
 		[Export ("searchDisplayControllerWillBeginSearch:")]
@@ -11890,6 +11951,7 @@ namespace UIKit {
 		bool ShouldReloadForSearchScope (UISearchDisplayController controller, nint forSearchOption);
 	}
 	
+	[NoWatch]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	partial interface UISearchResultsUpdating {
@@ -11902,6 +11964,7 @@ namespace UIKit {
 		void UpdateSearchResults (UISearchController searchController, IUISearchSuggestion searchSuggestion);
 	}
 	
+	[NoWatch]
 	[BaseType (typeof(UIControl))]
 	interface UISegmentedControl
 #if IOS
@@ -12039,7 +12102,7 @@ namespace UIKit {
 		UIOffset ContentPositionAdjustment (UISegmentedControlSegment leftCenterRightOrAlone, UIBarMetrics barMetrics);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof(UIControl))]
 	interface UISlider {
 		[Export ("initWithFrame:")]
@@ -12143,7 +12206,6 @@ namespace UIKit {
 		[Export ("preferredBehavioralStyle", ArgumentSemantic.Assign)]
 		UIBehavioralStyle PreferredBehavioralStyle { get; set; }
 	}
-#endif // !WATCH
 
 	[Static]
 	interface UIStringAttributeKey {
@@ -12312,8 +12374,7 @@ namespace UIKit {
 		NSString SourceTextScalingDocumentOption { get; }
 	}
 	
-#if !WATCH
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof(UIControl))]
 	interface UISwitch : NSCoding {
 		[DesignatedInitializer]
@@ -12361,6 +12422,7 @@ namespace UIKit {
 		UISwitchStyle PreferredStyle { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UITabBarDelegate)})]
 	interface UITabBar
 #if IOS
@@ -12479,6 +12541,7 @@ namespace UIKit {
 		UIView TrailingAccessoryView { get; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIViewController), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UITabBarControllerDelegate)})]
 	interface UITabBarController : UITabBarDelegate {
 		[Export ("initWithNibName:bundle:")]
@@ -12524,6 +12587,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -12548,6 +12612,7 @@ namespace UIKit {
 		void DidEndCustomizingItems (UITabBar tabbar, UITabBarItem [] items, bool changed);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -12597,6 +12662,7 @@ namespace UIKit {
 											   UIViewController toViewController);
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIBarItem))]
 	[DesignatedDefaultCtor]
 	interface UITabBarItem : NSCoding
@@ -12699,6 +12765,7 @@ namespace UIKit {
 		UITabBarAppearance ScrollEdgeAppearance { get; set; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof(UIScrollView))]
 	interface UITableView : NSCoding, UIDataSourceTranslating
 #if IOS
@@ -12879,20 +12946,20 @@ namespace UIKit {
 		nfloat AutomaticDimension { get; }
 
 		[Export ("allowsMultipleSelection")]
-                bool AllowsMultipleSelection { get; set;  }
+		bool AllowsMultipleSelection { get; set;  }
 
-                [Export ("allowsMultipleSelectionDuringEditing")]
-                bool AllowsMultipleSelectionDuringEditing { get; set;  }
+		[Export ("allowsMultipleSelectionDuringEditing")]
+		bool AllowsMultipleSelectionDuringEditing { get; set;  }
 
-                [Export ("moveSection:toSection:")]
-                void MoveSection (nint fromSection, nint toSection);
+		[Export ("moveSection:toSection:")]
+		void MoveSection (nint fromSection, nint toSection);
 
-                [Export ("moveRowAtIndexPath:toIndexPath:")]
-                void MoveRow (NSIndexPath fromIndexPath, NSIndexPath toIndexPath);
+		[Export ("moveRowAtIndexPath:toIndexPath:")]
+		void MoveRow (NSIndexPath fromIndexPath, NSIndexPath toIndexPath);
 
-                [NullAllowed]
-                [Export ("indexPathsForSelectedRows")]
-                NSIndexPath [] IndexPathsForSelectedRows { get; }
+		[NullAllowed]
+		[Export ("indexPathsForSelectedRows")]
+		NSIndexPath [] IndexPathsForSelectedRows { get; }
 
 		[Export ("registerNib:forCellReuseIdentifier:")]
 		void RegisterNibForCellReuse ([NullAllowed] UINib nib, NSString reuseIdentifier);
@@ -12941,17 +13008,17 @@ namespace UIKit {
 		//
 		// 7.0
 		//
-	        [iOS (7,0)]
+		[iOS (7,0)]
 		[Export ("estimatedRowHeight", ArgumentSemantic.Assign)]
-	        nfloat EstimatedRowHeight { get; set; }
+		nfloat EstimatedRowHeight { get; set; }
 	
-	        [iOS (7,0)]
+		[iOS (7,0)]
 		[Export ("estimatedSectionHeaderHeight", ArgumentSemantic.Assign)]
-	        nfloat EstimatedSectionHeaderHeight { get; set; }
+		nfloat EstimatedSectionHeaderHeight { get; set; }
 		
-	        [iOS (7,0)]
+		[iOS (7,0)]
 		[Export ("estimatedSectionFooterHeight", ArgumentSemantic.Assign)]
-	        nfloat EstimatedSectionFooterHeight { get; set; }
+		nfloat EstimatedSectionFooterHeight { get; set; }
 		
 		[iOS (7,0)]
 		[Appearance]
@@ -13059,7 +13126,7 @@ namespace UIKit {
 	}
 
 	interface IUITableViewDataSourcePrefetching {}
-	[iOS (10,0)]
+	[iOS (10,0), NoWatch]
 	[Protocol]
 	interface UITableViewDataSourcePrefetching
 	{
@@ -13074,6 +13141,7 @@ namespace UIKit {
 	//
 	// This mixed both the UITableViewDataSource and UITableViewDelegate in a single class
 	//
+	[NoWatch]
 	[Model]
 	[BaseType (typeof (UIScrollViewDelegate))]
 	[Synthetic]
@@ -13317,9 +13385,10 @@ namespace UIKit {
 		// WARNING: If you add more methods here, add them to UITableViewControllerDelegate as well.
 	}
 
-	[TV (15,0), Watch (8,0), iOS (15,0), MacCatalyst (15,0)]
+	[TV (15,0), Watch (8,0), iOS (15,0), MacCatalyst (15,0), NoWatch]
 	delegate void UITableViewCellConfigurationUpdateHandler (UITableViewCell cell, UICellConfigurationState state);
 
+	[NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UITableViewCell : NSCoding, UIGestureRecognizerDelegate {
 		[Export ("initWithFrame:")]
@@ -13475,6 +13544,7 @@ namespace UIKit {
 		bool UserInteractionEnabledWhileDragging { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIViewController))]
 	interface UITableViewController : UITableViewDataSource, UITableViewDelegate {
 		[DesignatedInitializer]
@@ -13497,6 +13567,7 @@ namespace UIKit {
 		UIRefreshControl RefreshControl { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 #if NET
 	[Protocol, Model]
@@ -13544,6 +13615,7 @@ namespace UIKit {
 		void MoveRow (UITableView tableView, NSIndexPath sourceIndexPath, NSIndexPath destinationIndexPath);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (UIScrollViewDelegate))]
 	[Model]
 	[Protocol]	
@@ -13745,9 +13817,10 @@ namespace UIKit {
 		void WillEndContextMenuInteraction (UITableView tableView, UIContextMenuConfiguration configuration, [NullAllowed] IUIContextMenuInteractionAnimating animator);
 	}
 
-	[TV (15,0), Watch (8,0), iOS (15,0), MacCatalyst (15,0)]
+	[TV (15,0), Watch (8,0), iOS (15,0), MacCatalyst (15,0), NoWatch]
 	delegate void UITableViewHeaderFooterViewConfigurationUpdateHandler (UITableViewHeaderFooterView headerFooterView, UIViewConfigurationState state);
 
+	[NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UITableViewHeaderFooterView : UIAppearance, NSCoding {
 		[Export ("initWithFrame:")]
@@ -13817,7 +13890,7 @@ namespace UIKit {
 
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'UIContextualAction' and corresponding APIs instead.")]
@@ -13841,6 +13914,7 @@ namespace UIKit {
 		UITableViewRowAction Create (UITableViewRowActionStyle style, [NullAllowed] string title, Action<UITableViewRowAction, NSIndexPath> handler);
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIControl), Delegates=new string [] { "WeakDelegate" })]
 	// , Events=new Type [] {typeof(UITextFieldDelegate)})] custom logic needed, see https://bugzilla.xamarin.com/show_bug.cgi?id=53174
 	interface UITextField : UITextInput, UIContentSizeCategoryAdjusting
@@ -14003,6 +14077,7 @@ namespace UIKit {
 		NSObject InteractionState { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -14038,6 +14113,7 @@ namespace UIKit {
 		void DidChangeSelection (UITextField textField);
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIScrollView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UITextViewDelegate)})]
 	interface UITextView : UITextInput, NSCoding, UIContentSizeCategoryAdjusting
 #if IOS
@@ -14168,7 +14244,7 @@ namespace UIKit {
 	}
 
 	[BaseType (typeof(UIScrollViewDelegate))]
-	[NoMac]
+	[NoMac, NoWatch]
 	[Model]
 	[Protocol]
 	interface UITextViewDelegate {
@@ -14213,7 +14289,7 @@ namespace UIKit {
 		bool ShouldInteractWithTextAttachment (UITextView textView, NSTextAttachment textAttachment, NSRange characterRange, UITextItemInteraction interaction);
 	}
 	
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UIToolbar : UIBarPositioning {
 		[Export ("initWithFrame:")]
@@ -14287,7 +14363,7 @@ namespace UIKit {
 
 	interface IUITimingCurveProvider {}
 
-	[iOS (10,0)]
+	[iOS (10,0), NoWatch]
 	[Protocol]
 	interface UITimingCurveProvider : NSCoding, NSCopying {
 		[Abstract]
@@ -14303,13 +14379,14 @@ namespace UIKit {
 		UISpringTimingParameters SpringTimingParameters { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIBarPositioningDelegate))]
 	[Model]
 	[Protocol]
 	interface UIToolbarDelegate {
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UITouch {
 		[Export ("locationInView:")]
@@ -14399,7 +14476,7 @@ namespace UIKit {
 		UITouchProperties EstimatedPropertiesExpectingUpdates { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UINavigationController), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIVideoEditorControllerDelegate)})]
 	interface UIVideoEditorController {
 		[Export ("canEditVideoAtPath:")][Static]
@@ -14425,7 +14502,7 @@ namespace UIKit {
 
 	// id<UINavigationControllerDelegate, UIVideoEditorControllerDelegate>
 	[BaseType (typeof (UINavigationControllerDelegate))]
-	[NoTV]
+	[NoTV, NoWatch]
 	[Model]
 	[Protocol]
 	interface UIVideoEditorControllerDelegate {
@@ -14439,10 +14516,14 @@ namespace UIKit {
 		void UserCancelled (UIVideoEditorController editor);
 	}
 		
+	[NoWatch]
 	[BaseType (typeof (UIResponder))]
-	interface UIView : UIAppearance, UIAppearanceContainer, UIAccessibility, UIDynamicItem, NSCoding, UIAccessibilityIdentification, UITraitEnvironment, UICoordinateSpace, UIFocusItem, CALayerDelegate, UIFocusItemContainer
+	interface UIView : UIAppearance, UIAppearanceContainer, UIAccessibility, UIDynamicItem, NSCoding, UIAccessibilityIdentification, UITraitEnvironment, UICoordinateSpace, UIFocusItem, UIFocusItemContainer
 #if !TVOS
 		, UILargeContentViewerItem
+#endif
+#if !WATCH
+		, CALayerDelegate
 #endif
 	{
 		[DesignatedInitializer]
@@ -14472,7 +14553,7 @@ namespace UIKit {
 
 		[ThreadSafe]
 		[Export ("layer", ArgumentSemantic.Retain)]
-		CoreAnimation.CALayer Layer { get; }
+		CALayer Layer { get; }
 
 		[Export ("frame")]
 		new CGRect Frame { get; set; }
@@ -15127,13 +15208,14 @@ namespace UIKit {
 #endif
 	}
 
+	[NoWatch]
 	[Category, BaseType (typeof (UIView))]
 	interface UIView_UITextField {
 		[Export ("endEditing:")]
 		bool EndEditing (bool force);
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[iOS (10,0), TV (10,0), NoWatch]
 	[Category]
 	[BaseType (typeof (UILayoutGuide))]
 	interface UILayoutGuide_UIConstraintBasedLayoutDebugging {
@@ -15147,6 +15229,7 @@ namespace UIKit {
 
 	interface IUIContentContainer {}
 	
+	[NoWatch]
 	[BaseType (typeof (UIResponder))]
 	interface UIViewController : NSCoding, UIAppearanceContainer, UIContentContainer, UITraitEnvironment, UIFocusEnvironment, NSExtensionRequestHandling {
 		[DesignatedInitializer]
@@ -15838,7 +15921,7 @@ namespace UIKit {
 		UIViewController ChildViewControllerForTouchBar { get; }
 	}
 
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[Protocol, Model, BaseType (typeof (NSObject))]
 	partial interface UIViewControllerContextTransitioning {
 		[Abstract]
@@ -15913,7 +15996,7 @@ namespace UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	partial interface UITraitEnvironment {
 		[Abstract]
 		[Export ("traitCollection")]
@@ -15924,7 +16007,7 @@ namespace UIKit {
 		void TraitCollectionDidChange ([NullAllowed] UITraitCollection previousTraitCollection);
 	}
 	
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DesignatedDefaultCtor]
 	[ThreadSafe] // Documentation doesn't say, but it this class doesn't seem to trigger Apple's Main Thread Checker.
@@ -16066,7 +16149,7 @@ namespace UIKit {
 		UIImageConfiguration ImageConfiguration { get; }
 	}
 	
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[Static]
 	partial interface UITransitionContext {
 		[Field ("UITransitionContextFromViewControllerKey")]
@@ -16084,7 +16167,7 @@ namespace UIKit {
 		NSString ToViewKey { get; }
 	}
 
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	partial interface UIViewControllerAnimatedTransitioning {
@@ -16105,7 +16188,7 @@ namespace UIKit {
 	}
 	interface IUIViewControllerAnimatedTransitioning {}
 
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	partial interface UIViewControllerInteractiveTransitioning {
@@ -16125,6 +16208,7 @@ namespace UIKit {
 	}
 	interface IUIViewControllerInteractiveTransitioning {}
 			
+	[NoWatch]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	partial interface UIViewControllerTransitioningDelegate {
@@ -16145,7 +16229,7 @@ namespace UIKit {
 		UIPresentationController GetPresentationControllerForPresentedViewController (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController, UIViewController sourceViewController);
 	}
 	
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	partial interface UIPercentDrivenInteractiveTransition : UIViewControllerInteractiveTransitioning {
 		[Export ("duration")]
@@ -16188,7 +16272,7 @@ namespace UIKit {
 	// This protocol is only for consumption (there is no API to set a transition coordinator context,
 	// you'll be provided an existing one), so we do not provide a model to subclass.
 	//
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[Protocol]
 	partial interface UIViewControllerTransitionCoordinatorContext {
 		[Abstract]
@@ -16259,7 +16343,7 @@ namespace UIKit {
 	// This protocol is only for consumption (there is no API to set a transition coordinator,
 	// only get an existing one), so we do not provide a model to subclass.
 	//
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[Protocol]
 	partial interface UIViewControllerTransitionCoordinator : UIViewControllerTransitionCoordinatorContext {
 		[Abstract]
@@ -16285,6 +16369,7 @@ namespace UIKit {
 	}
 	interface IUIViewControllerTransitionCoordinator {}
 
+	[NoWatch]
 	[Category, BaseType (typeof (UIViewController))]
 	partial interface TransitionCoordinator_UIViewController {
 		[Export ("transitionCoordinator")]
@@ -16292,7 +16377,7 @@ namespace UIKit {
 		IUIViewControllerTransitionCoordinator GetTransitionCoordinator ();
 	}
 
-	[NoMacCatalyst]
+	[NoMacCatalyst, NoWatch]
 	[NoTV]
 	[Deprecated (PlatformName.iOS, 12, 0, message: "No longer supported; please adopt 'WKWebView'.")]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIWebViewDelegate)})]
@@ -16396,7 +16481,7 @@ namespace UIKit {
 		bool AllowsLinkPreview { get; set; }
 	}
 
-	[NoMacCatalyst]
+	[NoMacCatalyst, NoWatch]
 	[NoTV]
 	[Deprecated (PlatformName.iOS, 12, 0, message: "No longer supported; please adopt 'WKWebView' APIs.")]
 	[BaseType (typeof (NSObject))]
@@ -16416,6 +16501,7 @@ namespace UIKit {
 		void LoadFailed (UIWebView webView, NSError error);
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UITextChecker {
 		[Export ("rangeOfMisspelledWordInString:range:startingAt:wrap:language:")]
@@ -16452,7 +16538,7 @@ namespace UIKit {
 	}
 
 	[Static]
-	[iOS (10,0), TV (10,0)]
+	[iOS (10,0), TV (10,0), NoWatch]
 	interface UITextContentType {
 		[Field ("UITextContentTypeName")]
 		NSString Name { get; }
@@ -16552,6 +16638,7 @@ namespace UIKit {
 		NSString DateTime { get; }
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIViewController), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UISplitViewControllerDelegate)})]
 	interface UISplitViewController {
 		[DesignatedInitializer]
@@ -16696,6 +16783,7 @@ namespace UIKit {
 		UISplitViewControllerBackgroundStyle PrimaryBackgroundStyle { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -16795,6 +16883,7 @@ namespace UIKit {
 		void InteractivePresentationGestureDidEnd (UISplitViewController svc);
 	}
 
+	[NoWatch]
 	[Category]
 	[BaseType (typeof (UIViewController))]
 	partial interface UISplitViewController_UIViewController {
@@ -16812,7 +16901,7 @@ namespace UIKit {
 		UIViewController SeparateSecondaryViewControllerForSplitViewController (UISplitViewController splitViewController);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIControl))]
 	interface UIStepper {
 		[Export ("initWithFrame:")]
@@ -16879,6 +16968,7 @@ namespace UIKit {
 	[iOS (13,0), TV (13,0), NoWatch]
 	delegate UIViewController UIStoryboardViewControllerCreator (NSCoder coder);
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIStoryboard {
 		[Static]
@@ -16900,6 +16990,7 @@ namespace UIKit {
 		UIViewController InstantiateViewController (string identifier, [NullAllowed] UIStoryboardViewControllerCreator creator);
 	}
 
+	[NoWatch]
 	[Deprecated (PlatformName.iOS, 9, 0)]
 	[DisableDefaultCtor] // as it subclass UIStoryboardSegue we end up with the same error
 	[BaseType (typeof (UIStoryboardSegue))]
@@ -16911,6 +17002,7 @@ namespace UIKit {
 		UIPopoverController PopoverController { get;  }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Don't call -[UIStoryboardSegue init]
 	interface UIStoryboardSegue {
@@ -16936,7 +17028,7 @@ namespace UIKit {
 		UIStoryboardSegue Create ([NullAllowed] string identifier, UIViewController source, UIViewController destination, Action performHandler);
 	}
 
-	[iOS (9,0)]
+	[iOS (9,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] 
 	interface UIStoryboardUnwindSegueSource {
@@ -16952,7 +17044,7 @@ namespace UIKit {
 		NSObject Sender { get; }
 	}
 	
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[Protocol]
 	interface UIPopoverBackgroundViewMethods {
 		// This method is required, but we don't generate the correct code for required static methods.
@@ -16971,6 +17063,7 @@ namespace UIKit {
 		UIEdgeInsets GetContentViewInsets ();
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (UIView))]
 	interface UIPopoverBackgroundView : UIPopoverBackgroundViewMethods {
 		[Export ("initWithFrame:")]
@@ -16989,6 +17082,7 @@ namespace UIKit {
 		bool WantsDefaultContentAppearance { get; }
 	}
 		
+	[NoWatch]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIPopoverControllerDelegate)})]
 	[DisableDefaultCtor] // bug #1786
 	[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'UIViewController' with style of 'UIModalPresentationStyle.Popover' or UIPopoverPresentationController' instead.")]
@@ -17034,12 +17128,12 @@ namespace UIKit {
 		void Dismiss (bool animated);
 		
 		// @property (nonatomic, readwrite) UIEdgeInsets popoverLayoutMargins
-[Export ("popoverLayoutMargins")]
+		[Export ("popoverLayoutMargins")]
 		UIEdgeInsets PopoverLayoutMargins { get; set; }
 		
 		// @property (nonatomic, readwrite, retain) Class popoverBackgroundViewClass
 		// Class is not pretty so we'll expose it manually as a System.Type
-[Internal][Export ("popoverBackgroundViewClass", ArgumentSemantic.Retain)]
+		[Internal][Export ("popoverBackgroundViewClass", ArgumentSemantic.Retain)]
 		IntPtr PopoverBackgroundViewClass { get; set; }
 
 		[iOS (7,0)]
@@ -17047,6 +17141,7 @@ namespace UIKit {
 		UIColor BackgroundColor { get; set; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -17062,7 +17157,7 @@ namespace UIKit {
 		void WillReposition (UIPopoverController popoverController, ref CGRect rect, ref UIView view);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[iOS (8,0)]
 	[BaseType (typeof (UIPresentationController),
 		Delegates=new string [] {"WeakDelegate"},
@@ -17119,6 +17214,7 @@ namespace UIKit {
 		UISheetPresentationController AdaptiveSheetPresentationController { get; }
 	}
 
+	[NoWatch]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	partial interface UIAdaptivePresentationControllerDelegate {
@@ -17166,7 +17262,7 @@ namespace UIKit {
 		void DidAttemptToDismiss (UIPresentationController presentationController);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[Protocol, Model]
 	[BaseType (typeof (UIAdaptivePresentationControllerDelegate))]
 	partial interface UIPopoverPresentationControllerDelegate {
@@ -17186,6 +17282,7 @@ namespace UIKit {
 		void WillRepositionPopover (UIPopoverPresentationController popoverPresentationController, ref CGRect targetRect, ref UIView inView);
 	}
 	
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIScreenMode {
 		[Export ("pixelAspectRatio")]
@@ -17195,6 +17292,7 @@ namespace UIKit {
 		CGSize Size { get; }
 	}
 
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UITextInputMode : NSSecureCoding {
 		[Export ("currentInputMode"), NullAllowed][Static]
@@ -17214,7 +17312,7 @@ namespace UIKit {
 		UITextInputMode [] ActiveInputModes { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Reason: -[UIPrinter init] not allowed
@@ -17248,7 +17346,7 @@ namespace UIKit {
 		void ContactPrinter (UIPrinterContactPrinterHandler completionHandler);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Reason: -[UIPrinterPickerController init] not allowed
@@ -17282,7 +17380,7 @@ namespace UIKit {
 		void Dismiss (bool animated);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	partial interface UIPrinterPickerControllerDelegate {
@@ -17309,7 +17407,7 @@ namespace UIKit {
 		void DidSelectPrinter (UIPrinterPickerController printerPickerController);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIPrintPaper {
 		[Export ("bestPaperForPageSize:withPapersFromArray:")][Static]
@@ -17322,7 +17420,7 @@ namespace UIKit {
 		CGRect PrintableRect { get; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIPrintPageRenderer {
 		[Export ("footerHeight")]
@@ -17374,7 +17472,7 @@ namespace UIKit {
 		UIPrintFormatter [] PrintFormattersForPage (nint index);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -17413,7 +17511,9 @@ namespace UIKit {
 		UIPrinterCutterBehavior ChooseCutterBehavior (UIPrintInteractionController printInteractionController, NSNumber [] availableBehaviors);
 	}
 
-	[NoTV]
+	delegate void UIPrintInteractionCompletionHandler (UIPrintInteractionController printInteractionController, bool completed, NSError error);
+
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIPrintInteractionControllerDelegate)})]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIPrintInteractionController init] not allowed
 	[DisableDefaultCtor]
@@ -17495,7 +17595,7 @@ namespace UIKit {
 		bool PrintToPrinter (UIPrinter printer, UIPrintInteractionCompletionHandler completion);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIPrintInfo init] not allowed
 	[DisableDefaultCtor]
@@ -17534,26 +17634,26 @@ namespace UIKit {
 		UIPrinterDestination[] GetPrinterDestinations (UIPrintInfo printInfo);
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIPrintFormatter))]
 	interface UIViewPrintFormatter {
 		[Export ("view")]
 		UIView View { get; }
 	}
 
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	partial interface UIVisualEffect : NSCopying, NSSecureCoding {
 	}
 
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[BaseType (typeof (UIVisualEffect))]
 	partial interface UIBlurEffect {
 	    [Static, Export ("effectWithStyle:")]
 	    UIBlurEffect FromStyle (UIBlurEffectStyle style);
 	}
 
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[BaseType (typeof (UIVisualEffect))]
 	partial interface UIVibrancyEffect {
 	    [Static, Export ("effectForBlurEffect:")]
@@ -17567,7 +17667,7 @@ namespace UIKit {
 		UIVibrancyEffect FromBlurEffect (UIBlurEffect blurEffect, UIVibrancyEffectStyle style);
 	}
 		
-	[iOS (8,0)]
+	[iOS (8,0), NoWatch]
 	[BaseType (typeof (UIView))]
 	partial interface UIVisualEffectView : NSSecureCoding {
 	
@@ -17575,15 +17675,15 @@ namespace UIKit {
 		[Export ("initWithEffect:")]
 		NativeHandle Constructor ([NullAllowed] UIVisualEffect effect);
 	
-	    [Export ("contentView", ArgumentSemantic.Retain)]
-	    UIView ContentView { get; }
+		[Export ("contentView", ArgumentSemantic.Retain)]
+		UIView ContentView { get; }
 	
 		[NullAllowed]
 		[Export ("effect", ArgumentSemantic.Copy)]
 		UIVisualEffect Effect { get; set; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIPrintFormatter))]
 	// accessing the properties fails with 7.0GM if the default `init` is used to create the instance, e.g. 
 	// [UISimpleTextPrintFormatter color]: unrecognized selector sent to instance 0x18bd70d0
@@ -17617,7 +17717,7 @@ namespace UIKit {
 		NSAttributedString AttributedText { get; set; }
 	}
 
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIPrintFormatter : NSCopying {
 
@@ -17655,7 +17755,7 @@ namespace UIKit {
 	}
 
 	[MacCatalyst (14,0)] // the headers lie, not usable until at least Mac Catalyst 14.0
-	[NoTV]
+	[NoTV, NoWatch]
 	[BaseType (typeof (UIPrintFormatter))]
 	[DisableDefaultCtor] // nonfunctional (and it doesn't show up in the header anyway)
 	interface UIMarkupTextPrintFormatter {
@@ -17667,7 +17767,7 @@ namespace UIKit {
 		NativeHandle Constructor ([NullAllowed] string text);
 	}
 
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DesignatedDefaultCtor]
 	interface UIMotionEffect : NSCoding, NSCopying {
@@ -17675,7 +17775,7 @@ namespace UIKit {
 		NSDictionary ComputeKeyPathsAndRelativeValues (UIOffset viewerOffset);
 	}
 
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[BaseType (typeof (UIMotionEffect))]
 	interface UIInterpolatingMotionEffect : NSCoding {
 		[DesignatedInitializer]
@@ -17697,7 +17797,7 @@ namespace UIKit {
 		NSObject MaximumRelativeValue { get; set;  }
 	}
 
-	[iOS (7,0)]
+	[iOS (7,0), NoWatch]
 	[BaseType (typeof (UIMotionEffect))]
 	interface UIMotionEffectGroup {
 		[NullAllowed] // by default this property is null
@@ -17705,7 +17805,7 @@ namespace UIKit {
 		UIMotionEffect [] MotionEffects { get; set; }
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[iOS (10,0), TV (10,0), NoWatch]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor] // designated
 	interface UISpringTimingParameters : UITimingCurveProvider
@@ -17729,7 +17829,7 @@ namespace UIKit {
 		NativeHandle Constructor (nfloat ratio);
 	}
 		
-	[NoTV]
+	[NoTV, NoWatch]
 	[Category, BaseType (typeof (NSString))]
 	interface UIStringDrawing {
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
@@ -17806,7 +17906,6 @@ namespace UIKit {
 		[Export ("sizeWithFont:minFontSize:actualFontSize:forWidth:lineBreakMode:")]
 		CGSize StringSize (UIFont font, nfloat minFontSize, ref nfloat actualFontSize, nfloat forWidth, UILineBreakMode lineBreakMode);
 	}
-#endif // !WATCH
 
 	[Category, BaseType (typeof (NSString))]
 	interface NSStringDrawing {
@@ -17835,7 +17934,6 @@ namespace UIKit {
 		void DrawString (CGRect rect, UIStringAttributes attributes);
 	}
 
-#if !WATCH
 	[NoWatch]
 	[iOS (7,0)]
 	[BaseType (typeof (UIView))]
@@ -17852,8 +17950,7 @@ namespace UIKit {
 		bool AllowsSelfSizing { get; set; }
 	}
 
-	interface IUITextInputDelegate {
-	}
+	interface IUITextInputDelegate {}
 
 	interface IUITextDocumentProxy {}
 	
@@ -17904,7 +18001,7 @@ namespace UIKit {
 		bool NeedsInputModeSwitchKey { get; }
 	}
 
-	[Watch (5,0), TV (13,0), iOS (11,0)]
+	[NoWatch, TV (13,0), iOS (11,0)]
 	[Protocol]
 	interface UIInteraction
 	{
@@ -18124,7 +18221,6 @@ namespace UIKit {
 	}
 
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UserNotifications.UNNotificationAction' instead.")]
-	[NoWatch]
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
@@ -18159,24 +18255,21 @@ namespace UIKit {
 		[Field ("UIUserNotificationTextInputActionButtonTitleKey")]
 		NSString TextInputActionButtonTitleKey { get; }
 
+#if !WATCH
 		// note: defined twice, where watchOS is defined it says it's not in iOS, the other one (for iOS 9) says it's not in tvOS
 		[iOS (9,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNTextInputNotificationResponse.UserText' instead.")]
 		[Field ("UIUserNotificationActionResponseTypedTextKey")]
 		NSString ResponseTypedTextKey { get; }
-	}
 #else
 #if !NET // No longer present in watchOS 7.0
-	[Watch (2,0)]
-	[Static]
-	[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UserNotifications.UNNotificationAction' or 'UserNotifications.UNTextInputNotificationAction' instead.")]
-	interface UIUserNotificationAction {
 		// note: defined twice, where watchOS is defined it says it's not in iOS, the other one (for iOS 9) says it's not in tvOS
+		[Watch (2,0)]
 		[Field ("UIUserNotificationActionResponseTypedTextKey")]
 		NSString ResponseTypedTextKey { get; }
-	}
 #endif // !NET
-#endif
+#endif // !WATCH
+	}
 
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UserNotifications.UNNotificationAction' instead.")]
 	[NoWatch]
@@ -18211,7 +18304,6 @@ namespace UIKit {
 		NSDictionary Parameters { get; set; }		
 	}
 
-#if !WATCH
 	[NoWatch]
 	[NoTV]
 	[iOS (8,0)]
@@ -18446,7 +18538,7 @@ namespace UIKit {
 
 	[DisableDefaultCtor] // [Assert] -init is not a useful initializer for this class. Use one of the designated initializers instead
 	[NoWatch]
-	[iOS (9,0)] // added in Xcode 7.1 / iOS 9.1 SDK
+	[iOS (9,0), NoWatch] // added in Xcode 7.1 / iOS 9.1 SDK
 	[BaseType (typeof (UIFocusUpdateContext))]
 	interface UICollectionViewFocusUpdateContext {
 		
@@ -18457,7 +18549,7 @@ namespace UIKit {
 		NSIndexPath NextFocusedIndexPath { [return: NullAllowed] get; }
 	}
 
-	[iOS (10,0), TV (10,0)]
+	[iOS (10,0), TV (10,0), NoWatch]
 	[BaseType (typeof(NSObject))]
 	[DesignatedDefaultCtor]
 	interface UICubicTimingParameters : UITimingCurveProvider
@@ -18482,7 +18574,7 @@ namespace UIKit {
 
 	interface IUIFocusAnimationContext {}
 
-	[iOS (11,0)]
+	[iOS (11,0), NoWatch]
 	[Protocol]
 	interface UIFocusAnimationContext {
 		[Abstract]
@@ -18525,7 +18617,7 @@ namespace UIKit {
 		IUIFocusEnvironment[] PreferredFocusEnvironments { get; set; }
 	}
 
-	[TV (12,0), iOS (12,0)]
+	[TV (12,0), iOS (12,0), NoWatch]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
 	interface UIFocusMovementHint : NSCopying
@@ -18547,7 +18639,8 @@ namespace UIKit {
 	}
 
 	interface IUIFocusItem {}
-	[iOS (10,0)]
+
+	[iOS (10,0), NoWatch]
 	[NoMac]
 	[Protocol]
 	interface UIFocusItem : UIFocusEnvironment
@@ -18806,6 +18899,7 @@ namespace UIKit {
 	}
 
 	interface IUIFocusEnvironment {}
+
 	[NoWatch]
 	[NoMac]
 	[iOS (9,0)]
@@ -18873,7 +18967,7 @@ namespace UIKit {
 		string FocusGroupIdentifier { get; }
 	}
 
-	[TV (12,0), iOS (12,0)]
+	[TV (12,0), iOS (12,0), NoWatch]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
 	interface UITextInputPasswordRules : NSSecureCoding, NSCopying
@@ -18885,7 +18979,6 @@ namespace UIKit {
 		[Export ("passwordRulesWithDescriptor:")]
 		UITextInputPasswordRules Create (string passwordRulesDescriptor);
 	}
-#endif // !WATCH
 
 	[NoWatch][NoTV]
 	[Static][Internal]
@@ -18903,8 +18996,6 @@ namespace UIKit {
 		NSString TextShadowOffset { get; }
 	}
 
-#if !WATCH
-#region Drag and Drop
 	interface IUIInteraction {}
 	interface IUIDropSession {}
 	interface IUIDragDropSession {}
@@ -19803,9 +19894,7 @@ namespace UIKit {
 		IUIDropSession DropSession { get; }
 	}
 
-#endregion
-
-	[TV (11,0), iOS (11,0)]
+	[NoWatch, TV (11,0), iOS (11,0)]
 	[Protocol]
 	interface UIDataSourceTranslating {
 		[Abstract]
@@ -20262,8 +20351,6 @@ namespace UIKit {
 		void RestoreUserActivityState (NSUserActivity activity);
 	}
 
-#endif // !WATCH
-
 	[Watch (4,0), TV (11,0), iOS (11,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
@@ -20289,7 +20376,6 @@ namespace UIKit {
 		[Export ("scaledValueForValue:")]
 		nfloat GetScaledValue (nfloat value);
 
-#if !WATCH
 		[NoWatch]
 		[Export ("scaledFontForFont:compatibleWithTraitCollection:")]
 		UIFont GetScaledFont (UIFont font, [NullAllowed] UITraitCollection traitCollection);
@@ -20301,10 +20387,8 @@ namespace UIKit {
 		[NoWatch]
 		[Export ("scaledValueForValue:compatibleWithTraitCollection:")]
 		nfloat GetScaledValue (nfloat value, [NullAllowed] UITraitCollection traitCollection);
-#endif // !WATCH
 	}
 
-#if !WATCH
 	[iOS (12,1)]
 	[NoWatch][NoTV]
 	[Native]
@@ -20349,7 +20433,6 @@ namespace UIKit {
 		[Export ("pencilInteractionDidTap:")]
 		void DidTap (UIPencilInteraction interaction);
 	}
-#endif // !WATCH
 
 	[iOS (13,0), TV (13,0), NoWatch]
 	[BaseType (typeof (NSObject), Name = "UIOpenURLContext")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -18227,29 +18227,37 @@ namespace UIKit {
 	[DesignatedDefaultCtor]
 	partial interface UIUserNotificationAction : NSCopying, NSMutableCopying, NSSecureCoding {
 
+		[NoWatch]
 		[Export ("identifier")]
 		string Identifier { get; }
 
+		[NoWatch]
 		[Export ("title")]
 		string Title { get; }
 
+		[NoWatch]
 		[Export ("activationMode", ArgumentSemantic.Assign)]
 		UIUserNotificationActivationMode ActivationMode { get; }
 
+		[NoWatch]
 		[Export ("authenticationRequired", ArgumentSemantic.Assign)]
 		bool AuthenticationRequired { [Bind ("isAuthenticationRequired")]get; }
 
+		[NoWatch]
 		[Export ("destructive", ArgumentSemantic.Assign)]
 		bool Destructive { [Bind ("isDestructive")]get; }
 
+		[NoWatch]
 		[iOS (9,0)]
 		[Export ("parameters", ArgumentSemantic.Copy)]
 		NSDictionary Parameters { get; [NotImplemented] set; }
 
+		[NoWatch]
 		[iOS (9,0)]
 		[Export ("behavior", ArgumentSemantic.Assign)]
 		UIUserNotificationActionBehavior Behavior { get; [NotImplemented] set;}
 
+		[NoWatch]
 		[iOS (9,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNTextInputNotificationAction.TextInputButtonTitle' instead.")]
 		[Field ("UIUserNotificationTextInputActionButtonTitleKey")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -711,28 +711,33 @@ namespace UIKit {
 		[Notification (typeof (UIAccessibilityAnnouncementFinishedEventArgs))]
 		NSString AnnouncementDidFinishNotification { get; }
 
+		[NoWatch]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'VoiceOverStatusDidChangeNotification' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'VoiceOverStatusDidChangeNotification' instead.")]
 		[Field ("UIAccessibilityVoiceOverStatusChanged")]
 		NSString VoiceOverStatusChanged { get; }
 
-		[TV (11,0), iOS (11,0)]
+		[TV (11,0), iOS (11,0), NoWatch]
 		[Field ("UIAccessibilityVoiceOverStatusDidChangeNotification")]
 		[Notification]
 		NSString VoiceOverStatusDidChangeNotification { get; }
 
+		[NoWatch]
 		[Field ("UIAccessibilityMonoAudioStatusDidChangeNotification")]
 		[Notification]
 		NSString MonoAudioStatusDidChangeNotification { get; }
 
+		[NoWatch]
 		[Field ("UIAccessibilityClosedCaptioningStatusDidChangeNotification")]
 		[Notification]
 		NSString ClosedCaptioningStatusDidChangeNotification { get; }
 
+		[NoWatch]
 		[Field ("UIAccessibilityInvertColorsStatusDidChangeNotification")]
 		[Notification]
 		NSString InvertColorsStatusDidChangeNotification { get; }
 
+		[NoWatch]
 		[Field ("UIAccessibilityGuidedAccessStatusDidChangeNotification")]
 		[Notification]
 		NSString GuidedAccessStatusDidChangeNotification { get; }
@@ -770,49 +775,49 @@ namespace UIKit {
 		[Field ("UIAccessibilitySpeechAttributePitch")]
 		NSString SpeechAttributePitch { get; }
 
-		[iOS (8,0)]
+		[iOS (8,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilityBoldTextStatusDidChangeNotification")]
 		NSString BoldTextStatusDidChangeNotification { get; }
 
-		[TV (14,0), iOS (14,0)]
+		[TV (14,0), iOS (14,0), NoWatch]
 		[MacCatalyst (14,0)]
 		[Notification]
 		[Field ("UIAccessibilityButtonShapesEnabledStatusDidChangeNotification")]
 		NSString ButtonShapesEnabledStatusDidChangeNotification { get; }
 
-		[iOS (8,0)]
+		[iOS (8,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilityDarkerSystemColorsStatusDidChangeNotification")]
 		NSString DarkerSystemColorsStatusDidChangeNotification { get; }
 
-		[iOS (8,0)]
+		[iOS (8,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilityGrayscaleStatusDidChangeNotification")]
 		NSString GrayscaleStatusDidChangeNotification { get; }
 
-		[iOS (8,0)]
+		[iOS (8,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilityReduceMotionStatusDidChangeNotification")]
 		NSString ReduceMotionStatusDidChangeNotification { get; }
 
-		[TV (14,0), iOS (14,0)]
+		[TV (14,0), iOS (14,0), NoWatch]
 		[MacCatalyst (14,0)]
 		[Notification]
 		[Field ("UIAccessibilityPrefersCrossFadeTransitionsStatusDidChangeNotification")]
 		NSString PrefersCrossFadeTransitionsStatusDidChangeNotification { get; }
 
-		[iOS (13,0), TV (13,0)]
+		[iOS (13,0), TV (13,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilityVideoAutoplayStatusDidChangeNotification")]
 		NSString VideoAutoplayStatusDidChangeNotification { get; }
 
-		[iOS (8,0)]
+		[iOS (8,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilityReduceTransparencyStatusDidChangeNotification")]
 		NSString ReduceTransparencyStatusDidChangeNotification { get; }
 
-		[iOS (8,0)]
+		[iOS (8,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilitySwitchControlStatusDidChangeNotification")]
 		NSString SwitchControlStatusDidChangeNotification { get; }
@@ -836,17 +841,17 @@ namespace UIKit {
 		[Field ("UIAccessibilityResumeAssistiveTechnologyNotification")]
 		int ResumeAssistiveTechnologyNotification { get; } // UIAccessibilityNotifications => uint32_t
 
-		[iOS (8,0)]
+		[iOS (8,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilitySpeakScreenStatusDidChangeNotification")]
 		NSString SpeakScreenStatusDidChangeNotification { get; }
 
-		[iOS (8,0)]
+		[iOS (8,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilitySpeakSelectionStatusDidChangeNotification")]
 		NSString SpeakSelectionStatusDidChangeNotification { get; }
 
-		[iOS (9,0)]
+		[iOS (9,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilityShakeToUndoDidChangeNotification")]
 		NSString ShakeToUndoDidChangeNotification { get; }
@@ -881,23 +886,23 @@ namespace UIKit {
 		[Field ("UIAccessibilityNotificationVoiceOverIdentifier")]
 		NSString NotificationVoiceOverIdentifier { get; }
 
-		[NoTV]
+		[NoTV, NoWatch]
 		[iOS (10,0)]
 		[Notification]
 		[Field ("UIAccessibilityHearingDevicePairedEarDidChangeNotification")]
 		NSString HearingDevicePairedEarDidChangeNotification { get; }
 
-		[iOS (10,0), TV (10,0)]
+		[iOS (10,0), TV (10,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilityAssistiveTouchStatusDidChangeNotification")]
 		NSString AssistiveTouchStatusDidChangeNotification { get; }
 
-		[iOS (13,0), TV (13,0)]
+		[iOS (13,0), TV (13,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilityShouldDifferentiateWithoutColorDidChangeNotification")]
 		NSString ShouldDifferentiateWithoutColorDidChangeNotification { get; }
 
-		[iOS (13,0), TV (13,0)]
+		[iOS (13,0), TV (13,0), NoWatch]
 		[Notification]
 		[Field ("UIAccessibilityOnOffSwitchLabelsDidChangeNotification")]
 		NSString OnOffSwitchLabelsDidChangeNotification { get; }

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -18221,11 +18221,19 @@ namespace UIKit {
 	}
 
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UserNotifications.UNNotificationAction' instead.")]
+#if WATCH
+	[Static]
+#else
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DesignatedDefaultCtor]
-	partial interface UIUserNotificationAction : NSCopying, NSMutableCopying, NSSecureCoding {
+#endif
+	partial interface UIUserNotificationAction 
+#if !WATCH
+		: NSCopying, NSMutableCopying, NSSecureCoding
+#endif
+		{
 
 		[NoWatch]
 		[Export ("identifier")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -711,36 +711,33 @@ namespace UIKit {
 		[Notification (typeof (UIAccessibilityAnnouncementFinishedEventArgs))]
 		NSString AnnouncementDidFinishNotification { get; }
 
-		[NoWatch]
+#if !WATCH
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'VoiceOverStatusDidChangeNotification' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'VoiceOverStatusDidChangeNotification' instead.")]
 		[Field ("UIAccessibilityVoiceOverStatusChanged")]
 		NSString VoiceOverStatusChanged { get; }
 
-		[TV (11,0), iOS (11,0), NoWatch]
+		[TV (11,0), iOS (11,0)]
 		[Field ("UIAccessibilityVoiceOverStatusDidChangeNotification")]
 		[Notification]
 		NSString VoiceOverStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[Field ("UIAccessibilityMonoAudioStatusDidChangeNotification")]
 		[Notification]
 		NSString MonoAudioStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[Field ("UIAccessibilityClosedCaptioningStatusDidChangeNotification")]
 		[Notification]
 		NSString ClosedCaptioningStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[Field ("UIAccessibilityInvertColorsStatusDidChangeNotification")]
 		[Notification]
 		NSString InvertColorsStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[Field ("UIAccessibilityGuidedAccessStatusDidChangeNotification")]
 		[Notification]
 		NSString GuidedAccessStatusDidChangeNotification { get; }
+#endif
 
 		[Field ("UIAccessibilityScreenChangedNotification")]
 		int ScreenChangedNotification { get; } // This is int, not nint
@@ -775,52 +772,54 @@ namespace UIKit {
 		[Field ("UIAccessibilitySpeechAttributePitch")]
 		NSString SpeechAttributePitch { get; }
 
-		[iOS (8,0), NoWatch]
+#if !WATCH
+		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilityBoldTextStatusDidChangeNotification")]
 		NSString BoldTextStatusDidChangeNotification { get; }
 
-		[TV (14,0), iOS (14,0), NoWatch]
+		[TV (14,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Notification]
 		[Field ("UIAccessibilityButtonShapesEnabledStatusDidChangeNotification")]
 		NSString ButtonShapesEnabledStatusDidChangeNotification { get; }
 
-		[iOS (8,0), NoWatch]
+		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilityDarkerSystemColorsStatusDidChangeNotification")]
 		NSString DarkerSystemColorsStatusDidChangeNotification { get; }
 
-		[iOS (8,0), NoWatch]
+		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilityGrayscaleStatusDidChangeNotification")]
 		NSString GrayscaleStatusDidChangeNotification { get; }
 
-		[iOS (8,0), NoWatch]
+		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilityReduceMotionStatusDidChangeNotification")]
 		NSString ReduceMotionStatusDidChangeNotification { get; }
 
-		[TV (14,0), iOS (14,0), NoWatch]
+		[TV (14,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Notification]
 		[Field ("UIAccessibilityPrefersCrossFadeTransitionsStatusDidChangeNotification")]
 		NSString PrefersCrossFadeTransitionsStatusDidChangeNotification { get; }
 
-		[iOS (13,0), TV (13,0), NoWatch]
+		[iOS (13,0), TV (13,0)]
 		[Notification]
 		[Field ("UIAccessibilityVideoAutoplayStatusDidChangeNotification")]
 		NSString VideoAutoplayStatusDidChangeNotification { get; }
 
-		[iOS (8,0), NoWatch]
+		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilityReduceTransparencyStatusDidChangeNotification")]
 		NSString ReduceTransparencyStatusDidChangeNotification { get; }
 
-		[iOS (8,0), NoWatch]
+		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilitySwitchControlStatusDidChangeNotification")]
 		NSString SwitchControlStatusDidChangeNotification { get; }
+#endif
 
 		[iOS (8,0)]
 		[Field ("UIAccessibilityNotificationSwitchControlIdentifier")]
@@ -841,20 +840,22 @@ namespace UIKit {
 		[Field ("UIAccessibilityResumeAssistiveTechnologyNotification")]
 		int ResumeAssistiveTechnologyNotification { get; } // UIAccessibilityNotifications => uint32_t
 
-		[iOS (8,0), NoWatch]
+#if !WATCH
+		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilitySpeakScreenStatusDidChangeNotification")]
 		NSString SpeakScreenStatusDidChangeNotification { get; }
 
-		[iOS (8,0), NoWatch]
+		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilitySpeakSelectionStatusDidChangeNotification")]
 		NSString SpeakSelectionStatusDidChangeNotification { get; }
 
-		[iOS (9,0), NoWatch]
+		[iOS (9,0)]
 		[Notification]
 		[Field ("UIAccessibilityShakeToUndoDidChangeNotification")]
 		NSString ShakeToUndoDidChangeNotification { get; }
+#endif
 
 		// FIXME: we only used this on a few types before, none of them available on tvOS
 		// but a new member was added to the platform... 
@@ -886,26 +887,28 @@ namespace UIKit {
 		[Field ("UIAccessibilityNotificationVoiceOverIdentifier")]
 		NSString NotificationVoiceOverIdentifier { get; }
 
-		[NoTV, NoWatch]
+#if !WATCH
+		[NoTV]
 		[iOS (10,0)]
 		[Notification]
 		[Field ("UIAccessibilityHearingDevicePairedEarDidChangeNotification")]
 		NSString HearingDevicePairedEarDidChangeNotification { get; }
 
-		[iOS (10,0), TV (10,0), NoWatch]
+		[iOS (10,0), TV (10,0)]
 		[Notification]
 		[Field ("UIAccessibilityAssistiveTouchStatusDidChangeNotification")]
 		NSString AssistiveTouchStatusDidChangeNotification { get; }
 
-		[iOS (13,0), TV (13,0), NoWatch]
+		[iOS (13,0), TV (13,0)]
 		[Notification]
 		[Field ("UIAccessibilityShouldDifferentiateWithoutColorDidChangeNotification")]
 		NSString ShouldDifferentiateWithoutColorDidChangeNotification { get; }
 
-		[iOS (13,0), TV (13,0), NoWatch]
+		[iOS (13,0), TV (13,0)]
 		[Notification]
 		[Field ("UIAccessibilityOnOffSwitchLabelsDidChangeNotification")]
 		NSString OnOffSwitchLabelsDidChangeNotification { get; }
+#endif
 
 		[iOS (11,0), TV (11,0), Watch (4,0)]
 		[Field ("UIAccessibilitySpeechAttributeQueueAnnouncement")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -711,34 +711,28 @@ namespace UIKit {
 		[Notification (typeof (UIAccessibilityAnnouncementFinishedEventArgs))]
 		NSString AnnouncementDidFinishNotification { get; }
 
-		[NoWatch]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'VoiceOverStatusDidChangeNotification' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'VoiceOverStatusDidChangeNotification' instead.")]
 		[Field ("UIAccessibilityVoiceOverStatusChanged")]
 		NSString VoiceOverStatusChanged { get; }
 
-		[NoWatch]
 		[TV (11,0), iOS (11,0)]
 		[Field ("UIAccessibilityVoiceOverStatusDidChangeNotification")]
 		[Notification]
 		NSString VoiceOverStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[Field ("UIAccessibilityMonoAudioStatusDidChangeNotification")]
 		[Notification]
 		NSString MonoAudioStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[Field ("UIAccessibilityClosedCaptioningStatusDidChangeNotification")]
 		[Notification]
 		NSString ClosedCaptioningStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[Field ("UIAccessibilityInvertColorsStatusDidChangeNotification")]
 		[Notification]
 		NSString InvertColorsStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[Field ("UIAccessibilityGuidedAccessStatusDidChangeNotification")]
 		[Notification]
 		NSString GuidedAccessStatusDidChangeNotification { get; }
@@ -776,57 +770,48 @@ namespace UIKit {
 		[Field ("UIAccessibilitySpeechAttributePitch")]
 		NSString SpeechAttributePitch { get; }
 
-		[NoWatch]
 		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilityBoldTextStatusDidChangeNotification")]
 		NSString BoldTextStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[TV (14,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Notification]
 		[Field ("UIAccessibilityButtonShapesEnabledStatusDidChangeNotification")]
 		NSString ButtonShapesEnabledStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilityDarkerSystemColorsStatusDidChangeNotification")]
 		NSString DarkerSystemColorsStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilityGrayscaleStatusDidChangeNotification")]
 		NSString GrayscaleStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilityReduceMotionStatusDidChangeNotification")]
 		NSString ReduceMotionStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[TV (14,0), iOS (14,0)]
 		[MacCatalyst (14,0)]
 		[Notification]
 		[Field ("UIAccessibilityPrefersCrossFadeTransitionsStatusDidChangeNotification")]
 		NSString PrefersCrossFadeTransitionsStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (13,0), TV (13,0)]
 		[Notification]
 		[Field ("UIAccessibilityVideoAutoplayStatusDidChangeNotification")]
 		NSString VideoAutoplayStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilityReduceTransparencyStatusDidChangeNotification")]
 		NSString ReduceTransparencyStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilitySwitchControlStatusDidChangeNotification")]
@@ -851,19 +836,16 @@ namespace UIKit {
 		[Field ("UIAccessibilityResumeAssistiveTechnologyNotification")]
 		int ResumeAssistiveTechnologyNotification { get; } // UIAccessibilityNotifications => uint32_t
 
-		[NoWatch]
 		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilitySpeakScreenStatusDidChangeNotification")]
 		NSString SpeakScreenStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (8,0)]
 		[Notification]
 		[Field ("UIAccessibilitySpeakSelectionStatusDidChangeNotification")]
 		NSString SpeakSelectionStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (9,0)]
 		[Notification]
 		[Field ("UIAccessibilityShakeToUndoDidChangeNotification")]
@@ -899,26 +881,22 @@ namespace UIKit {
 		[Field ("UIAccessibilityNotificationVoiceOverIdentifier")]
 		NSString NotificationVoiceOverIdentifier { get; }
 
-		[NoWatch]
 		[NoTV]
 		[iOS (10,0)]
 		[Notification]
 		[Field ("UIAccessibilityHearingDevicePairedEarDidChangeNotification")]
 		NSString HearingDevicePairedEarDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (10,0), TV (10,0)]
 		[Notification]
 		[Field ("UIAccessibilityAssistiveTouchStatusDidChangeNotification")]
 		NSString AssistiveTouchStatusDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (13,0), TV (13,0)]
 		[Notification]
 		[Field ("UIAccessibilityShouldDifferentiateWithoutColorDidChangeNotification")]
 		NSString ShouldDifferentiateWithoutColorDidChangeNotification { get; }
 
-		[NoWatch]
 		[iOS (13,0), TV (13,0)]
 		[Notification]
 		[Field ("UIAccessibilityOnOffSwitchLabelsDidChangeNotification")]
@@ -3306,12 +3284,10 @@ namespace UIKit {
 		[Appearance]
 		NSDictionary _GetTitleTextAttributes (UIControlState state);
 
-		[NoWatch]
 		[iOS (11,0), TV (11,0)]
 		[NullAllowed, Export ("largeContentSizeImage", ArgumentSemantic.Strong)]
 		UIImage LargeContentSizeImage { get; set; }
 
-		[NoWatch]
 		[iOS (11,0), TV (11,0)]
 		[Export ("largeContentSizeImageInsets", ArgumentSemantic.Assign)]
 		UIEdgeInsets LargeContentSizeImageInsets { get; set; }
@@ -14515,7 +14491,7 @@ namespace UIKit {
 		[Export ("videoEditorControllerDidCancel:")]
 		void UserCancelled (UIVideoEditorController editor);
 	}
-		
+
 	[NoWatch]
 	[BaseType (typeof (UIResponder))]
 	interface UIView : UIAppearance, UIAppearanceContainer, UIAccessibility, UIDynamicItem, NSCoding, UIAccessibilityIdentification, UITraitEnvironment, UICoordinateSpace, UIFocusItem, UIFocusItemContainer


### PR DESCRIPTION
This change should have 0/null/nine/nada changes in the API. The goal is
to remove the preprocessor directives to ensure that the xcode14
bindings have a smaller diff and are easier to review.


Backport of #15601
