### PR TITLE
[xcode14] [generator] Do not zero-extend implied catalyst attributes

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3421,19 +3421,36 @@ public partial class Generator : IMemberGatherer {
 			}
 		}
 		else {
-			// Revision is optional, and is returned as -1 if not yet. However the Version ctor called inside the attributes throws if you pass -1 so coerse to 0
-			int revision = attr.Version.Revision == -1 ? 0 : attr.Version.Revision;
-			switch (attr.AvailabilityKind) {
-				case AvailabilityKind.Introduced:
-					return new IntroducedAttribute(platform, attr.Version.Major, attr.Version.Minor, revision, message: attr.Message);
-				case AvailabilityKind.Deprecated:
-					return new DeprecatedAttribute(platform, attr.Version.Major, attr.Version.Minor, revision, message: attr.Message);
-				case AvailabilityKind.Obsoleted:
-					return new ObsoletedAttribute(platform, attr.Version.Major, attr.Version.Minor, revision, message: attr.Message);
-				case AvailabilityKind.Unavailable:
-					return new UnavailableAttribute(platform, message: attr.Message);
-				default:
-					throw new NotImplementedException ();
+			// Due to the absurd API of Version, you can not pass a -1 to the revision constructor
+			// nor can you coerse to 0, as that will fail with "16.0.0 <= 16.0" => false in the registrar
+			// So determine if the revision is -1, and use the 2 or 3 param ctor...
+			if (attr.Version.Revision == -1) {
+				switch (attr.AvailabilityKind) {
+					case AvailabilityKind.Introduced:
+						return new IntroducedAttribute(platform, attr.Version.Major, attr.Version.Minor, message: attr.Message);
+					case AvailabilityKind.Deprecated:
+						return new DeprecatedAttribute(platform, attr.Version.Major, attr.Version.Minor, message: attr.Message);
+					case AvailabilityKind.Obsoleted:
+						return new ObsoletedAttribute(platform, attr.Version.Major, attr.Version.Minor, message: attr.Message);
+					case AvailabilityKind.Unavailable:
+						return new UnavailableAttribute(platform, message: attr.Message);
+					default:
+						throw new NotImplementedException ();
+				}
+			}
+			else {
+				switch (attr.AvailabilityKind) {
+					case AvailabilityKind.Introduced:
+						return new IntroducedAttribute(platform, attr.Version.Major, attr.Version.Minor, attr.Version.Revision, message: attr.Message);
+					case AvailabilityKind.Deprecated:
+						return new DeprecatedAttribute(platform, attr.Version.Major, attr.Version.Minor, attr.Version.Revision, message: attr.Message);
+					case AvailabilityKind.Obsoleted:
+						return new ObsoletedAttribute(platform, attr.Version.Major, attr.Version.Minor, attr.Version.Revision, message: attr.Message);
+					case AvailabilityKind.Unavailable:
+						return new UnavailableAttribute(platform, message: attr.Message);
+					default:
+						throw new NotImplementedException ();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- In the [Xcode 14 Photo PR](https://github.com/xamarin/xamarin-macios/pull/15608) a test is failing with this:

```
ILLINK : error MT2362: The linker step 'Registrar' failed during processing: One or more errors occurred. (The type 'Photos.PHPersistentObjectChangeDetails' (used as a return type in Photos.PHPersistentChange.ChangeDetails) is not available in MacCatalyst 16.0 (it was introduced in MacCatalyst 16.0.0). Please build with a newer MacCatalyst SDK (usually done by using the most recent version of Xcode). [/Users/donblas/Programming/xamarin-macios/tests/dotnet/MySimpleApp/MacCatalyst/MySimpleApp.csproj]
  		) (The type 'Photos.PHObjectType' (used as a parameter in Photos.PHPersistentChange.ChangeDetails) is not available in MacCatalyst 16.0 (it was introduced in MacCatalyst 16.0.0). Please build with a newer MacCatalyst SDK (usually done by using the most recent version of Xcode).
  		) (The type 'Photos.PHPersistentChangeFetchResult' (used as a return type in Photos.PHPhotoLibrary.FetchPersistentChanges) is not available in MacCatalyst 16.0 (it was introduced in MacCatalyst 16.0.0). Please build with a newer MacCatalyst SDK (usually done by using the most recent version of Xcode).
  		) (The type 'Photos.PHPersistentChangeToken' (used as a parameter in Photos.PHPhotoLibrary.FetchPersistentChanges) is not available in MacCatalyst 16.0 (it was introduced in MacCatalyst 16.0.0). Please build with a newer MacCatalyst SDK (usually done by using the most recent version of Xcode).
```

The details of how we fail are written up in [this issue](https://github.com/xamarin/xamarin-macios/issues/15643) but since sharpie never outputs versions in the form of x.y.z where .z is zero we only hit this with generated attributes.

Because of this fact, we can work around it with a generator change.

This commit changes how we "imply" attributes from iOS to Catalyst. As a brief reminder, because of historical bindings we assume anything that has iOS and not a Catalyst really means "treat iOS as if it was also Catalyst".

This work is done in `AddImpliedCatalyst` and uses `CloneFromOtherPlatform` to make a copy of an attribute, because there is no easy way to say "I want a copy of this, but with this other platform". `CloneFromOtherPlatform` used to always call the 3 version (Major, Minor, Revision) constructor, even when the attribute being cloned only used Major.Minor.

However, this caused us to "zero extend" the version with another zero, which triggers this bug, so stop doing that. Uglier code in the generator, but it works better.


Backport of #15648
