### PR TITLE
[nnyeah] better help, change priority of processing help request.

### DIFF
--- a/tools/nnyeah/nnyeah/Errors.Designer.cs
+++ b/tools/nnyeah/nnyeah/Errors.Designer.cs
@@ -209,7 +209,8 @@ namespace Microsoft.MaciOS.Nnyeah {
                 return ResourceManager.GetString("E0017", resourceCulture);
             }
         }
-
+        
+        /// <summary>
         ///   Looks up a localized string similar to The supplied Microsoft assembly, {0}, is not macOS or iOS and is not currently supported..
         /// </summary>
         internal static string E0018 {
@@ -282,7 +283,14 @@ namespace Microsoft.MaciOS.Nnyeah {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If you want to compare assemblies, the earlier and later assembly options *must* be set..
+        ///   Looks up a localized string similar to nnyeah is a tool for converting legacy Xamarin assemblies (pre .NET 6)
+        ///to work with .NET 6 or later. It does this by scanning the --input assembly for
+        ///dependencies of legacy methods, types, or fields and converts them to references
+        ///in the --microsoft-assembly and writes the result in the --ouput assembly.
+        ///nnyeah attempts to find the legacy Xamarin assembly automatically. If it can&apos;t
+        ///find it, you will need to supply a path to it with the --xamarin-assembly
+        ///argument.
+        ///nnyeah needs to have a path to target Micr [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string N0007 {
             get {

--- a/tools/nnyeah/nnyeah/Errors.resx
+++ b/tools/nnyeah/nnyeah/Errors.resx
@@ -38,7 +38,26 @@
 	</data>
 
 	<data name="N0007" xml:space="preserve">
-		<value>If you want to compare assemblies, the earlier and later assembly options *must* be set.</value>
+		<value>nnyeah is a tool for converting legacy Xamarin assemblies (pre .NET 6)
+to work with .NET 6 or later. It does this by scanning the --input assembly for
+dependencies of legacy methods, types, or fields and converts them to references
+in the --microsoft-assembly and writes the result in the --ouput assembly.
+nnyeah attempts to find the legacy Xamarin assembly automatically. If it can't
+find it, you will need to supply a path to it with the --xamarin-assembly
+argument.
+nnyeah needs to have a path to target Microsoft assembly using the
+--microsoft-assembly argument. If you do not have a specific version in mind,
+you can use this command for iOS:
+find $(dirname $(which dotnet)) -name Microsoft.iOS.dll -print | grep ref
+or this command for macOS:
+find $(dirname $(which dotnet)) -name Microsoft.macOS.dll -print | grep ref
+These commands may list more than one choice. You will probably want to use the
+one with the highest version.
+Example invocation for an assembly that originally targets Xamarin.iOS.dll:
+dotnet nnyeah --input=/path/to/AssemblyToConvert.dll \
+              --output=/path/to/Converted.dll \
+	      --microsoft-assembly=/path/to/Microsoft.iOS.dll
+		</value>
 	</data>
 
 	<data name="N0008" xml:space="preserve">

--- a/tools/nnyeah/nnyeah/Program.cs
+++ b/tools/nnyeah/nnyeah/Program.cs
@@ -44,6 +44,12 @@ namespace Microsoft.MaciOS.Nnyeah {
 				doHelp = true;
 			}
 
+			if (doHelp) {
+				options.WriteOptionDescriptions (Console.Out);
+				Console.Out.WriteLine (Errors.N0007);
+				return 0;
+			}
+
 			if (infile is null || outfile is null) {
 				throw new ConversionException (Errors.E0014);
 			}
@@ -53,14 +59,7 @@ namespace Microsoft.MaciOS.Nnyeah {
 				throw new ConversionException (Errors.E0015);
 			}
 
-			if (doHelp) {
-				options.WriteOptionDescriptions (Console.Out);
-				Console.Out.WriteLine (Errors.N0007);
-				return 0;
-			}
-			else {
-				return AssemblyConverter.Convert (xamarinAssembly, microsoftAssembly!, infile!, outfile!, verbose, forceOverwrite, suppressWarnings);
-			}
+			return AssemblyConverter.Convert (xamarinAssembly, microsoftAssembly!, infile!, outfile!, verbose, forceOverwrite, suppressWarnings);
 		}
 	}
 


### PR DESCRIPTION
Output:
```
% dotnet nnyeah --help
  -h, -?, --help             
  -i, --input=VALUE          
  -o, --output=VALUE         
  -v, --verbose              
  -f, --force-overwrite      
  -s, --suppress-warnings    
  -x, --xamarin-assembly=VALUE
                             
  -m, --microsoft-assembly=VALUE
                             
nnyeah is a tool for converting legacy Xamarin assemblies (pre .NET 6)
to work with .NET 6 or later. It does this by scanning the --input assembly for
dependencies of legacy methods, types, or fields and converts them to references
in the --microsoft-assembly and writes the result in the --ouput assembly.
nnyeah attempts to find the legacy Xamarin assembly automatically. If it can't
find it, you will need to supply a path to it with the --xamarin-assembly
argument.
nnyeah needs to have a path to target Microsoft assembly using the
--microsoft-assembly argument. If you do not have a specific version in mind,
you can use this command for iOS:
find $(dirname $(which dotnet)) -name Microsoft.iOS.dll -print | grep ref
or this command for macOS:
find $(dirname $(which dotnet)) -name Microsoft.macOS.dll -print | grep ref
These commands may list more than one choice. You will probably want to use the
one with the highest version.
Example invocation for an assembly that originally targets Xamarin.iOS.dll:
dotnet nnyeah --input=/path/to/AssemblyToConvert.dll \
              --output=/path/to/Converted.dll \
	      --microsoft-assembly=/path/to/Microsoft.iOS.dll
```