### PR TITLE
[tests] Improve output when writing log events in test logs.

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tests/TestHelpers/LogEvent.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TestHelpers/LogEvent.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System.Text;
+
 namespace Xamarin.Tests {
 	public class LogEvent {
 		public int ColumnNumber;
@@ -11,5 +13,26 @@ namespace Xamarin.Tests {
 		public string? File;
 		public string? ProjectFile;
 		public string? Message;
+
+		public override string ToString ()
+		{
+			// http://blogs.msdn.com/b/msbuild/archive/2006/11/03/msbuild-visual-studio-aware-error-messages-and-message-formats.aspx
+			var sb = new StringBuilder ();
+			if (!string.IsNullOrEmpty (Code)) {
+				sb.Append (Code);
+				sb.Append (": ");
+			}
+			if (!string.IsNullOrEmpty (File)) {
+				sb.Append (File);
+				if (LineNumber != 0) {
+					sb.Append ('(');
+					sb.Append (LineNumber);
+					sb.Append (')');
+				}
+				sb.Append (": ");
+			}
+			sb.Append (Message ?? "<no message>");
+			return sb.ToString ();
+		}
 	}
 }


### PR DESCRIPTION
This should improve output from the quite useless:

    [22:15:50.7076240] Xamarin.Tests.LogEvent
    [22:15:50.7076470] Xamarin.Tests.LogEvent
    [22:15:50.7076660] Xamarin.Tests.LogEvent
    [22:15:50.7076850] Xamarin.Tests.LogEvent

to something better.