### PR TITLE
[dotnet] Honor existing values for BuildIpa and CreatePackage. Fixes #15696.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Target Name="_PrePublish">
 		<PropertyGroup>
-			<BuildIpa Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS'">true</BuildIpa>
-			<CreatePackage Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">true</CreatePackage>
+			<BuildIpa Condition="'$(BuildIpa)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')">true</BuildIpa>
+			<CreatePackage Condition="'$(CreatePackage)' == '' And ('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst')">true</CreatePackage>
 
 			<!-- Put packages in the publish directory unless asked to do otherwise -->
 			<IpaPackageDir Condition="'$(IpaPackageDir)' == '' And '$(IpaPackagePath)' == ''">$(PublishDir)</IpaPackageDir>
@@ -29,7 +29,7 @@
 		/>
 	</Target>
 	<Target Name="Publish" DependsOnTargets="_PrePublish;Build">
-		<Message Importance="high" Text="Created the package: $(IpaPackagePath)" Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS'" />
-		<Message Importance="high" Text="Created the package: $(PkgPackagePath)" Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'" />
+		<Message Importance="high" Text="Created the package: $(IpaPackagePath)" Condition="'$(BuildIpa)' == 'true' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')" />
+		<Message Importance="high" Text="Created the package: $(PkgPackagePath)" Condition="'$(CreatePackage)' == 'true' And ('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst')" />
 	</Target>
 </Project>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -180,7 +180,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 
 		<!-- If we should create a .pkg or not (only relevant for macOS / Mac Catalyst) -->
 		<!-- The equivalent property for the other platforms is 'BuildIpa' -->
-		<CreatePackage Condition="'$(CreatePackage)' == ''">false</CreatePackage>
+		<CreatePackage Condition="'$(CreatePackage)' == '' And '$(UsingAppleNETSdk)' != 'true'">false</CreatePackage>
 
 		<!-- If the .pkg should be signed or not. Applicable to macOS and Mac Catalyst. Defaults to false. -->
 		<EnablePackageSigning Condition="'$(EnablePackageSigning)' == ''">false</EnablePackageSigning>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -32,7 +32,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<MtouchVerbosity Condition="$(MtouchVerbosity) == ''">2</MtouchVerbosity>
 
 		<IpaIncludeArtwork Condition="'$(IpaIncludeArtwork)' == ''">False</IpaIncludeArtwork>
-		<BuildIpa Condition="'$(BuildIpa)' == ''">False</BuildIpa>
+		<BuildIpa Condition="'$(BuildIpa)' == '' And '$(UsingAppleNETSdk)' != 'true'">False</BuildIpa>
 		<BuildSessionId></BuildSessionId>
 
 		<!-- Backward Compatability -->


### PR DESCRIPTION
Don't blindly set the BuildIpa and CreatePackage values, but instead only set
them (when publishing) if they're not already set.

This makes it possible to publish and not create a package.

Fixes https://github.com/xamarin/xamarin-macios/issues/15696.