### PR TITLE
[tools] Fix issue when doing api comparison for PRs with multiple commits

### DIFF
--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -189,8 +189,6 @@ if test -z "$BASE_HASH"; then
 elif test -n "$PULL_REQUEST_ID"; then
 	echo "${RED}Can't specify both --base and --pull-request.${CLEAR}"
 	exit 1
-else
-	BASE_HASH=HEAD^
 fi
 
 ROOT_DIR=$(git rev-parse --show-toplevel)

--- a/tools/devops/automation/scripts/bash/compare.sh
+++ b/tools/devops/automation/scripts/bash/compare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 #
 # How to run API comparison locally: check out tools/compare-commits.sh
@@ -42,7 +42,7 @@ fi
 
 # We always want to zip up (and later upload) whatever's in the results directory, so store the exit code here, and then exit with it later.
 RC=0
-./tools/compare-commits.sh --base="$BASE" "--output-dir=$CHANGE_DETECTION_OUTPUT_DIR" "--gh-comments-file=$CHANGE_DETECTION_GH_COMMENTS_FILE" || RC=$?
+./tools/compare-commits.sh -v --base="$BASE" "--output-dir=$CHANGE_DETECTION_OUTPUT_DIR" "--gh-comments-file=$CHANGE_DETECTION_GH_COMMENTS_FILE" || RC=$?
 
 rm -f "$CHANGE_DETECTION_OUTPUT_DIR/change-detection.zip"
 cd "$CHANGE_DETECTION_OUTPUT_DIR" && zip -9r "change-detection.zip" .

--- a/tools/devops/automation/scripts/bash/compare.sh
+++ b/tools/devops/automation/scripts/bash/compare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 #
 # How to run API comparison locally: check out tools/compare-commits.sh
@@ -42,7 +42,7 @@ fi
 
 # We always want to zip up (and later upload) whatever's in the results directory, so store the exit code here, and then exit with it later.
 RC=0
-./tools/compare-commits.sh -v --base="$BASE" "--output-dir=$CHANGE_DETECTION_OUTPUT_DIR" "--gh-comments-file=$CHANGE_DETECTION_GH_COMMENTS_FILE" || RC=$?
+./tools/compare-commits.sh --base="$BASE" "--output-dir=$CHANGE_DETECTION_OUTPUT_DIR" "--gh-comments-file=$CHANGE_DETECTION_GH_COMMENTS_FILE" || RC=$?
 
 rm -f "$CHANGE_DETECTION_OUTPUT_DIR/change-detection.zip"
 cd "$CHANGE_DETECTION_OUTPUT_DIR" && zip -9r "change-detection.zip" .


### PR DESCRIPTION
Fix an issue when doing API comparison for PRs with multiple commits, where we'd only do the comparison for the last commit, by not ignoring the provided base hash in the compare-commits script.