### PR TITLE
[runtime] Allow `IntPtr` for native objects in the dynamic registrar. Fixes #15708

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -201,7 +201,6 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 					}
 				}
 			} else {
-				char *fullname = xamarin_class_get_full_name (r_klass, exception_gchandle);
 #if DOTNET
 				if (xamarin_is_class_intptr (r_klass) || xamarin_is_class_nativehandle (r_klass)) {
 #else
@@ -209,9 +208,8 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 #endif
 					returnValue = *(void **) mono_object_unbox (retval);
 				} else {
-					xamarin_assertion_message ("Don't know how to marshal a return value of type '%s'. Please file a bug with a test case at https://github.com/xamarin/xamarin-macios/issues/new\n", fullname);
+					xamarin_assertion_message ("Don't know how to marshal a return value of type '%s.%s'. Please file a bug with a test case at https://github.com/xamarin/xamarin-macios/issues/new\n", mono_class_get_namespace (r_klass), mono_class_get_name (r_klass));
 				}
-				xamarin_free (fullname);
 			}
 
 			xamarin_mono_object_release (&r_klass);

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -205,7 +205,7 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 				if (!strcmp (fullname, "System.IntPtr")) {
 					returnValue =  *(void **) mono_object_unbox (retval);
 				} else {
-					xamarin_assertion_message ("Don't know how to marshal a return value of type '%s.%s'. Please file a bug with a test case at https://github.com/xamarin/xamarin-macios/issues/new\n", mono_class_get_namespace (r_klass), mono_class_get_name (r_klass));
+					xamarin_assertion_message ("Don't know how to marshal a return value of type '%s'. Please file a bug with a test case at https://github.com/xamarin/xamarin-macios/issues/new\n", fullname);
 				}
 				xamarin_free (fullname);
 			}

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -201,7 +201,13 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 					}
 				}
 			} else {
-				xamarin_assertion_message ("Don't know how to marshal a return value of type '%s.%s'. Please file a bug with a test case at https://github.com/xamarin/xamarin-macios/issues/new\n", mono_class_get_namespace (r_klass), mono_class_get_name (r_klass)); 
+				char *fullname = xamarin_class_get_full_name (r_klass, exception_gchandle);
+				if (!strcmp (fullname, "System.IntPtr")) {
+					returnValue =  *(void **) mono_object_unbox (retval);
+				} else {
+					xamarin_assertion_message ("Don't know how to marshal a return value of type '%s.%s'. Please file a bug with a test case at https://github.com/xamarin/xamarin-macios/issues/new\n", mono_class_get_namespace (r_klass), mono_class_get_name (r_klass));
+				}
+				xamarin_free (fullname);
 			}
 
 			xamarin_mono_object_release (&r_klass);

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -202,7 +202,11 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 				}
 			} else {
 				char *fullname = xamarin_class_get_full_name (r_klass, exception_gchandle);
+#if DOTNET
+				if (!strcmp (fullname, "System.IntPtr") || !strcmp (fullname, "ObjCRuntime.NativeHandle")) {
+#else
 				if (!strcmp (fullname, "System.IntPtr")) {
+#endif
 					returnValue =  *(void **) mono_object_unbox (retval);
 				} else {
 					xamarin_assertion_message ("Don't know how to marshal a return value of type '%s'. Please file a bug with a test case at https://github.com/xamarin/xamarin-macios/issues/new\n", fullname);

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -203,11 +203,11 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 			} else {
 				char *fullname = xamarin_class_get_full_name (r_klass, exception_gchandle);
 #if DOTNET
-				if (!strcmp (fullname, "System.IntPtr") || !strcmp (fullname, "ObjCRuntime.NativeHandle")) {
+				if (xamarin_is_class_intptr (r_klass) || xamarin_is_class_nativehandle (r_klass)) {
 #else
-				if (!strcmp (fullname, "System.IntPtr")) {
+				if (xamarin_is_class_intptr (r_klass)) {
 #endif
-					returnValue =  *(void **) mono_object_unbox (retval);
+					returnValue = *(void **) mono_object_unbox (retval);
 				} else {
 					xamarin_assertion_message ("Don't know how to marshal a return value of type '%s'. Please file a bug with a test case at https://github.com/xamarin/xamarin-macios/issues/new\n", fullname);
 				}


### PR DESCRIPTION
Allow code like this

```csharp
[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSendSuper")
static extern IntPtr IntPtr_objc_msgSendSuper(IntPtr receiver, IntPtr selector);

[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSendSuper")]
static extern void void_objc_msgSendSuper(IntPtr receiver, IntPtr selector, IntPtr arg);

[Export("selectedTextRange")]
public new IntPtr SelectedTextRange
{
    get { return IntPtr_objc_msgSendSuper(SuperHandle, Selector.GetHandle("selectedTextRange")); }
    set => void_objc_msgSendSuper(SuperHandle, Selector.GetHandle("setSelectedTextRange:"), value);
}
```

to work on the dynamic registrar since it already work with the static one.
This allows the simulators (which defaults to dynamic) to share the same code which is useful for implementing a workaround for related issue #15677.