### PR TITLE
[devops] Ignore failures to install brew components.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -62,6 +62,7 @@ steps:
     provisioning_extra_args: '-vvvv'
   timeoutInMinutes: 30
   enabled: true
+  continueOnError: true # brew installation can be temperamental, and things usually work even if the installation fail.
 
 - bash: |
     make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops build-provisioning.csx


### PR DESCRIPTION
Hopefully works around this problem:

    [...]
    [08:14:16 VRB] Preloading sudo access since brew installation cannot be run as root
    [08:14:16 VRB] Exec[0] (flags: RedirectStdout, RedirectStderr, Default): /usr/bin/sudo -v
    [08:14:16 DBG] Adding main (originally refs/heads/main) to telemetry
    [08:14:16 DBG] Adding main (originally refs/heads/main) to telemetry
    [08:14:16 VRB] Exec[0] exited 1
    Unhandled exception. Xamarin.Provisioning.Exec+ExitException: /usr/bin/sudo terminated with exit code 1
       at Xamarin.Provisioning.Exec.Run(ExecFlags flags, String command, String[] arguments) in /Users/runner/work/1/s/Provisionator/Exec.cs:line 297
       at Xamarin.Provisioning.ProvisioningScript.BrewPackages(BrewOptions options, String[] packages) in /Users/runner/work/1/s/Provisionator/ProvisioningScript_Brew.cs:line 104
       at Xamarin.Provisioning.ProvisioningScript.BrewPackages(String[] packages) in /Users/runner/work/1/s/Provisionator/ProvisioningScript_Brew.cs:line 23
       at Submission#0.<<Initialize>>d__0.MoveNext()
    --- End of stack trace from previous location ---
       at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)
       at Microsoft.CodeAnalysis.Scripting.Script`1.RunSubmissionsAsync(ScriptExecutionState executionState, ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, Func`2 catchExceptionOpt, CancellationToken cancellationToken)
       at Xamarin.Provisioning.ProvisioningScript.RunScriptAsync(String scriptContents, String scriptFile, CancellationToken cancellationToken) in /Users/runner/work/1/s/Provisionator/ProvisioningScript.cs:line 118
       at Xamarin.Provisioning.Entry.MainAsync(String[] args) in /Users/runner/work/1/s/Provisionator/Entry.cs:line 256
       at Xamarin.Provisioning.Entry.MainAsync(String[] args) in /Users/runner/work/1/s/Provisionator/Entry.cs:line 339
       at Xamarin.Provisioning.Entry.Main(String[] args) in /Users/runner/work/1/s/Provisionator/Entry.cs:line 60
    ##[error]The process '/Users/builder/azdo/_work/_tool/provisionator/0.2.635/x64/provisionator' failed with exit code null