### PR TITLE
Fixed remote archiving with iOS app extensions

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
@@ -11,7 +11,8 @@ namespace Xamarin.MacDev.Tasks
 			if (!ShouldExecuteRemotely ())
 				return base.Execute ();
 
-			TaskItemFixer.ReplaceItemSpecsWithBuildServerPath (AppExtensionReferences, SessionId);
+			if (AppExtensionReferences != null) 
+				TaskItemFixer.ReplaceItemSpecsWithBuildServerPath (AppExtensionReferences, SessionId);
 
 			return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
@@ -1,5 +1,6 @@
 using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
+using Xamarin.iOS.Tasks;
 
 namespace Xamarin.MacDev.Tasks
 {
@@ -7,10 +8,12 @@ namespace Xamarin.MacDev.Tasks
 	{
 		public override bool Execute ()
 		{
-			if (ShouldExecuteRemotely ())
-				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+			if (!ShouldExecuteRemotely ())
+				return base.Execute ();
 
-			return base.Execute ();
+			TaskItemFixer.ReplaceItemSpecsWithBuildServerPath (AppExtensionReferences, SessionId);
+
+			return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 		}
 
 		public void Cancel ()

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Zip.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Zip.cs
@@ -8,7 +8,7 @@ namespace Xamarin.iOS.Tasks.Windows {
 		internal static void Extract(string sourceFileName, string destinationPath)
 		{
 			// We use a temp dir because the extraction dir should not exist for the ZipFile API to work
-			var tempExtractionPath = Path.Combine (Path.GetTempPath (), "Xamarin", "Extractions", Guid.NewGuid ().ToString ());
+			var tempExtractionPath = Path.Combine (Path.GetTempPath (), Guid.NewGuid ().ToString ().Substring (0, 4));
 
 			ZipFile.ExtractToDirectory (sourceFileName, tempExtractionPath);
 


### PR DESCRIPTION
- Fix AppExtensionReferences ItemSpec in Archive:
 when the build is a remote build, we need to fix the ItemSpec of the AppExtensionReferences items so it uses the build server path correctly

- Shorten temp directory for remote zip extractions to avoid long path potential conflicts

Fixes Feedbak Ticket issue: https://developercommunity.visualstudio.com/t/Xamarin-iOS-project-wont-archive-anymor/1587820
