### PR TITLE
[msbuild] Automatically detect any Entitlements.plist files in the root project in .NET.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -120,11 +120,21 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 
 		<!-- Other variables that are used in code signing / packaging, but that are by default empty (so no need for any logic): -->
 		<!-- CodesignProvision: the name of the provisioning profile to use when signing the bundle -->
-		<!-- CodesignEntitlements: the path to the Entitlements.plist to use when signing the bundle -->
 		<!-- CodesignExtraArgs: any extra arguments to pass to 'codesign' -->
 		<!-- PackageSigningKey: the certificate used to sign packages (.pkg). Applicable to macOS and Mac Catalyst -->
 		<!-- PackagingExtraArgs: any extra arguments passed to the productbuild tool when creating packages (.pkg). Applicable to macOS and Mac Catalyst -->
 		<!-- ProductDefinition: the product definition template (plist) used when creating the product definition to pass to the product build tool when creating packages (.pkg). Applicable to mcOS and Mac Catalyst -->
+
+		<!-- CodesignEntitlements: the path to the Entitlements.plist to use when signing the bundle
+			If:
+			* We're building for .NET, and
+			* There's an Entitlements.plist file in the root project directory, and
+			* The CodesignEntitlements property is empty, and
+			* The EnableDefaultCodesignEntitlements property is not false
+
+			Then we'll automatically set the CodesignEntitlements property to "Entitlements.plist"
+		-->
+		<CodesignEntitlements Condition="'$(UsingAppleNETSdk)' == 'true' And '$(CodesignEntitlements)' == '' And Exists('Entitlements.plist') And '$(EnableDefaultCodesignEntitlements)' != 'false'">Entitlements.plist</CodesignEntitlements>
 
 		<!-- _RequireProvisioningProfile -->
 		<!-- Default: false -->

--- a/tests/dotnet/AutoDetectEntitlements/AppDelegate.cs
+++ b/tests/dotnet/AutoDetectEntitlements/AppDelegate.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace MySimpleApp
+{
+	public class Program
+	{
+		static int Main (string[] args)
+		{
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return args.Length;
+		}
+	}
+}

--- a/tests/dotnet/AutoDetectEntitlements/MacCatalyst/AutoDetectEntitlements.csproj
+++ b/tests/dotnet/AutoDetectEntitlements/MacCatalyst/AutoDetectEntitlements.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AutoDetectEntitlements/MacCatalyst/Entitlements.plist
+++ b/tests/dotnet/AutoDetectEntitlements/MacCatalyst/Entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- This is an invalid XML file -->
+	<!-- This way the test runs faster (if the file is included in the build) -->
+	<InvalidTag>
+</dict>
+</plist>

--- a/tests/dotnet/AutoDetectEntitlements/MacCatalyst/Makefile
+++ b/tests/dotnet/AutoDetectEntitlements/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AutoDetectEntitlements/Makefile
+++ b/tests/dotnet/AutoDetectEntitlements/Makefile
@@ -1,0 +1,2 @@
+TOP=../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/AutoDetectEntitlements/iOS/AutoDetectEntitlements.csproj
+++ b/tests/dotnet/AutoDetectEntitlements/iOS/AutoDetectEntitlements.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AutoDetectEntitlements/iOS/Entitlements.plist
+++ b/tests/dotnet/AutoDetectEntitlements/iOS/Entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- This is an invalid XML file -->
+	<!-- This way the test runs faster (if the file is included in the build) -->
+	<InvalidTag>
+</dict>
+</plist>

--- a/tests/dotnet/AutoDetectEntitlements/iOS/Makefile
+++ b/tests/dotnet/AutoDetectEntitlements/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AutoDetectEntitlements/macOS/AutoDetectEntitlements.csproj
+++ b/tests/dotnet/AutoDetectEntitlements/macOS/AutoDetectEntitlements.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AutoDetectEntitlements/macOS/Entitlements.plist
+++ b/tests/dotnet/AutoDetectEntitlements/macOS/Entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- This is an invalid XML file -->
+	<!-- This way the test runs faster (if the file is included in the build) -->
+	<InvalidTag>
+</dict>
+</plist>

--- a/tests/dotnet/AutoDetectEntitlements/macOS/Makefile
+++ b/tests/dotnet/AutoDetectEntitlements/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AutoDetectEntitlements/shared.csproj
+++ b/tests/dotnet/AutoDetectEntitlements/shared.csproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<ApplicationId>AutoDetectEntitlements</ApplicationId>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/AutoDetectEntitlements/shared.mk
+++ b/tests/dotnet/AutoDetectEntitlements/shared.mk
@@ -1,0 +1,3 @@
+TOP=../../../..
+TESTNAME=AutoDetectEntitlements
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/AutoDetectEntitlements/tvOS/AutoDetectEntitlements.csproj
+++ b/tests/dotnet/AutoDetectEntitlements/tvOS/AutoDetectEntitlements.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AutoDetectEntitlements/tvOS/Entitlements.plist
+++ b/tests/dotnet/AutoDetectEntitlements/tvOS/Entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- This is an invalid XML file -->
+	<!-- This way the test runs faster (if the file is included in the build) -->
+	<InvalidTag>
+</dict>
+</plist>

--- a/tests/dotnet/AutoDetectEntitlements/tvOS/Makefile
+++ b/tests/dotnet/AutoDetectEntitlements/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -960,5 +960,28 @@ namespace Xamarin.Tests {
 
 			DotNet.AssertBuild (project_path, properties);
 		}
+
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", true)]
+		[TestCase (ApplePlatform.iOS, "ios-arm64", false)]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64", true)]
+		public void AutoDetectEntitlements (ApplePlatform platform, string runtimeIdentifiers, bool exclude)
+		{
+			var project = "AutoDetectEntitlements";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			if (exclude) {
+				properties ["EnableDefaultCodesignEntitlements"] = "false";
+				DotNet.AssertBuild (project_path, properties);
+			} else {
+				var rv = DotNet.AssertBuildFailure (project_path, properties);
+				var errors = BinLog.GetBuildLogErrors (rv.BinLogPath).ToList ();
+				Assert.That (errors [0].Message, Does.Contain ("Error loading Entitlements.plist template 'Entitlements.plist'"), "Message");
+			}
+		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tests/DotnetTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/DotnetTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 using Xamarin.Tests;
@@ -52,6 +53,15 @@ namespace Xamarin.iOS.Tasks {
 		{
 			Configuration.AssertDotNetAvailable ();
 
+			Dictionary<string, string> properties = null;
+
+			if (Platform == "iPhoneSimulator") {
+				properties = new Dictionary<string, string>
+				{
+					{ "EnableDefaultCodesignEntitlements", "false" },
+				};
+			}
+
 			tfi = "Xamarin.iOS";
 			switch (project) {
 			case "MyMetalGame":
@@ -67,7 +77,7 @@ namespace Xamarin.iOS.Tasks {
 			ClearTestDirectory ();
 
 			Mode = ExecutionMode.DotNet;
-			BuildProject (project, clean: false, expectedErrorCount: expectedErrorCount);
+			BuildProject (project, clean: false, expectedErrorCount: expectedErrorCount, properties: properties);
 			var dotnet_bundle = AppBundlePath;
 
 			Mode = ExecutionMode.MSBuild;
@@ -80,7 +90,7 @@ namespace Xamarin.iOS.Tasks {
 				NugetRestore (Path.Combine (net461, "MyExtensionWithPackageReference", "MyExtensionWithPackageReference.csproj"));
 				break;
 			}
-			BuildProject (project, nuget_restore: true, expectedErrorCount: expectedErrorCount);
+			BuildProject (project, nuget_restore: true, expectedErrorCount: expectedErrorCount, properties: properties);
 			var net461_bundle = AppBundlePath;
 
 			if (expectedErrorCount == 0)

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -18,7 +19,7 @@ namespace Xamarin.iOS.Tasks
 		{
 		}
 
-		public ProjectPaths BuildProject (string appName, int expectedErrorCount = 0, bool clean = true, bool nuget_restore = false, bool is_library = false)
+		public ProjectPaths BuildProject (string appName, int expectedErrorCount = 0, bool clean = true, bool nuget_restore = false, bool is_library = false, Dictionary<string, string> properties = null)
 		{
 			var mtouchPaths = SetupProjectPaths (appName);
 			var csproj = mtouchPaths.ProjectCSProjPath;
@@ -31,7 +32,7 @@ namespace Xamarin.iOS.Tasks
 				NugetRestore (csproj);
 
 			if (clean) {
-				RunTarget (mtouchPaths, "Clean", Mode);
+				RunTarget (mtouchPaths, "Clean", Mode, properties: properties);
 				Assert.IsFalse (Directory.Exists (AppBundlePath), "App bundle exists after cleanup: {0} ", AppBundlePath);
 				Assert.IsFalse (Directory.Exists (AppBundlePath + ".dSYM"), "App bundle .dSYM exists after cleanup: {0} ", AppBundlePath + ".dSYM");
 				Assert.IsFalse (Directory.Exists (AppBundlePath + ".mSYM"), "App bundle .mSYM exists after cleanup: {0} ", AppBundlePath + ".mSYM");
@@ -53,7 +54,7 @@ namespace Xamarin.iOS.Tasks
 				}
 			}
 
-			RunTarget (mtouchPaths, "Build", Mode, expectedErrorCount);
+			RunTarget (mtouchPaths, "Build", Mode, expectedErrorCount, properties: properties);
 
 			if (expectedErrorCount > 0 || is_library)
 				return mtouchPaths;


### PR DESCRIPTION
Also provide a way out by setting EnableDefaultCodesignEntitlements=false.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1595888.