### PR TITLE
[devops] Make the binlog artifact name unique.

### DIFF
--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -226,6 +226,6 @@ steps:
           displayName: 'Publish Artifact: All binlogs'
           inputs:
             targetPath: $(Build.ArtifactStagingDirectory)/all-binlogs
-            artifactName: all-binlogs-$(Build.BuildId)
+            artifactName: all-binlogs-$(Build.BuildId)-$(System.JobAttempt)
           continueOnError: true
           condition: succeededOrFailed()

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -363,7 +363,7 @@ steps:
   displayName: 'Publish Artifact: All binlogs'
   inputs:
     targetPath: $(Build.ArtifactStagingDirectory)/all-binlogs
-    artifactName: all-binlogs-test-${{ parameters.testPrefix }}-$(Build.BuildId)
+    artifactName: all-binlogs-test-${{ parameters.testPrefix }}-$(Build.BuildId)-$(System.JobAttempt)
   continueOnError: true
   condition: succeededOrFailed()
 


### PR DESCRIPTION
Make the binlog artifact name unique across build attempts, so that uploading the binlog archive doesn't fail in subsequent build attempts:

> ##[error]Artifact all-binlogs-test-simulator_cecil-6594281 already exists for build 6594281.