### PR TITLE
[msbuild] Fix the FindAotCompiler task for .NET 7.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindAotCompilerTaskBase.cs
@@ -20,7 +20,7 @@ namespace Xamarin.MacDev.Tasks {
 
 		public override bool Execute ()
 		{
-			if (MonoAotCrossCompiler?.Length > 0) {
+			if (MonoAotCrossCompiler?.Length > 0 && string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("XAMARIN_FORCE_AOT_COMPILER_PATH_COMPUTATION"))) {
 				var aotCompilerItem = MonoAotCrossCompiler.SingleOrDefault (v => v.GetMetadata ("RuntimeIdentifier") == RuntimeIdentifier);
 
 				if (aotCompilerItem == null) {
@@ -51,7 +51,7 @@ namespace Xamarin.MacDev.Tasks {
 			var csproj = $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
-		<TargetFramework>net6.0-{PlatformName}</TargetFramework>
+		<TargetFramework>net{TargetFramework.Version}-{PlatformName}</TargetFramework>
 	</PropertyGroup>
 	<Target Name=""ComputeAotCompilerPath"">
 		<PropertyGroup>


### PR DESCRIPTION
Compute the .NET version to use when generating the project file to compute
the AOT compiler.

Also include a way to always force the computation, even on macOS (this eases
testing).

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1597624.