### PR TITLE
[tests] Ignore any NuGet failures in PackageReferenceTests.SatellitesFromNuget. Fixes #xamarin/maccore@2612.

### DIFF
--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -510,11 +510,16 @@ namespace TestCase
 			return string.Format ("System.IO.File.Create(\"{0}\").Dispose();",  Path.Combine (tmpDir, guid.ToString ()));
 		}
 
+		public static bool TryNugetRestore (string project, out StringBuilder output)
+		{
+			output = new StringBuilder ();
+			var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new [] { $"--", "/t:Restore", project}, stdout: output, stderr: output, environmentVariables: Configuration.GetBuildEnvironment (ApplePlatform.MacOSX));
+			return rv == 0;
+		}
+
 		public static void NugetRestore (string project)
 		{
-			var output = new StringBuilder ();
-			var rv = ExecutionHelper.Execute (Configuration.XIBuildPath, new [] { $"--", "/t:Restore", project}, stdout: output, stderr: output, environmentVariables: Configuration.GetBuildEnvironment (ApplePlatform.MacOSX));
-			if (rv != 0) {
+			if (!TryNugetRestore (project, out var output)) {
 				Console.WriteLine ("nuget restore failed:");
 				Console.WriteLine (output);
 				Assert.Fail ($"'nuget restore' failed for {project}");

--- a/tests/mmptest/src/PackageReferenceTests.cs
+++ b/tests/mmptest/src/PackageReferenceTests.cs
@@ -45,7 +45,8 @@ namespace Xamarin.MMP.Tests
 				TI.AddGUIDTestCode (config);
 
 				string project = TI.GenerateUnifiedExecutableProject (config);
-				TI.NugetRestore (project);
+				if (!TI.TryNugetRestore (project, out var _))
+					Assert.Ignore ("NuGet restore failed, probably due to network hiccups."); // https://github.com/xamarin/maccore/issues/2612
 				TI.BuildProject (project);
 
 				var appDir = Path.Combine (tmpDir, "bin", "Debug", full ? "XM45Example.app" : "UnifiedExample.app");


### PR DESCRIPTION
NuGet seems to struggle with the network on the bots for this particular test,
so ignore the test if there are any nuget failures.

Fixes https://github.com/xamarin/maccore/issues/2612.