### PR TITLE
[release/7.0.1xx-rc1] Revert "[tests] Update expected error message texts."

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -487,10 +487,10 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		[TestCase (ApplePlatform.iOS, "win10-x86", "Error getting pack version: Pack 'Microsoft.NETCore.App.Runtime.Mono.win-x86' was not present in workload manifests.")]
-		[TestCase (ApplePlatform.TVOS, "win10-x64", "Error getting pack version: Pack 'Microsoft.NETCore.App.Runtime.Mono.win-x64' was not present in workload manifests.")]
+		[TestCase (ApplePlatform.iOS, "win10-x86", null)]
+		[TestCase (ApplePlatform.TVOS, "win10-x64", null)]
 		[TestCase (ApplePlatform.MacOSX, "win10-arm", null)]
-		[TestCase (ApplePlatform.MacCatalyst, "win10-arm64", "Error getting pack version: Pack 'Microsoft.NETCore.App.Runtime.Mono.win-arm64' was not present in workload manifests.")]
+		[TestCase (ApplePlatform.MacCatalyst, "win10-arm64", "Unable to find package Microsoft.NETCore.App.Runtime.Mono.win-arm64. No packages exist with this id in source[(]s[)]:.*")]
 		public void InvalidRuntimeIdentifier_Restore (ApplePlatform platform, string runtimeIdentifier, string? failureMessagePattern)
 		{
 			var project = "MySimpleApp";


### PR DESCRIPTION
This reverts commit dd2f4742123adcb83c7a5a8985baa6b9041d782d.

The dotnet/runtime changes that required these changes apparently aren't in RC 1.