### PR TITLE
[ci] Add support to net6.0 for multi-targeting in VS

### DIFF
--- a/dotnet/Workloads/Microsoft.NET.Sdk.MacCatalyst/WorkloadManifest.targets
+++ b/dotnet/Workloads/Microsoft.NET.Sdk.MacCatalyst/WorkloadManifest.targets
@@ -1,5 +1,5 @@
 <Project>
-	<Import Project="Sdk.props" Sdk="Microsoft.MacCatalyst.Sdk" Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst'" />
+	<Import Project="Sdk.props" Sdk="Microsoft.MacCatalyst.Sdk.net6" Condition="'$(TargetPlatformIdentifier)' == 'MacCatalyst'" />
 
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
 		<SdkSupportedTargetPlatformIdentifier Include="maccatalyst" DisplayName="Mac Catalyst" />

--- a/dotnet/Workloads/Microsoft.NET.Sdk.iOS/WorkloadManifest.targets
+++ b/dotnet/Workloads/Microsoft.NET.Sdk.iOS/WorkloadManifest.targets
@@ -1,6 +1,6 @@
 <Project>
-	<Import Project="Sdk.props" Sdk="Microsoft.iOS.Sdk" Condition="'$(TargetPlatformIdentifier)' == 'iOS'" />
-	<Import Project="Sdk.props" Sdk="Microsoft.iOS.Windows.Sdk.Aliased" Condition=" '$(TargetPlatformIdentifier)' == 'iOS' and $([MSBuild]::IsOSPlatform('windows'))" />
+	<Import Project="Sdk.props" Sdk="Microsoft.iOS.Sdk.net6" Condition="'$(TargetPlatformIdentifier)' == 'iOS'" />
+	<Import Project="Sdk.props" Sdk="Microsoft.iOS.Windows.Sdk.Aliased.net6" Condition=" '$(TargetPlatformIdentifier)' == 'iOS' and $([MSBuild]::IsOSPlatform('windows'))" />
 
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
 		<SdkSupportedTargetPlatformIdentifier Include="ios" DisplayName="iOS" />

--- a/dotnet/Workloads/Microsoft.NET.Sdk.macOS/WorkloadManifest.targets
+++ b/dotnet/Workloads/Microsoft.NET.Sdk.macOS/WorkloadManifest.targets
@@ -1,5 +1,5 @@
 <Project>
-	<Import Project="Sdk.props" Sdk="Microsoft.macOS.Sdk" Condition="'$(TargetPlatformIdentifier)' == 'macOS'" />
+	<Import Project="Sdk.props" Sdk="Microsoft.macOS.Sdk.net6" Condition="'$(TargetPlatformIdentifier)' == 'macOS'" />
 
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
 		<SdkSupportedTargetPlatformIdentifier Include="macos" DisplayName="macOS" />

--- a/dotnet/Workloads/Microsoft.NET.Sdk.tvOS/WorkloadManifest.targets
+++ b/dotnet/Workloads/Microsoft.NET.Sdk.tvOS/WorkloadManifest.targets
@@ -1,5 +1,5 @@
 <Project>
-	<Import Project="Sdk.props" Sdk="Microsoft.tvOS.Sdk" Condition="'$(TargetPlatformIdentifier)' == 'tvOS'" />
+	<Import Project="Sdk.props" Sdk="Microsoft.tvOS.Sdk.net6" Condition="'$(TargetPlatformIdentifier)' == 'tvOS'" />
 
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
 		<SdkSupportedTargetPlatformIdentifier Include="tvos" DisplayName="tvOS" />

--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -29,5 +29,10 @@
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg" Version="@MACCATALYST_WORKLOAD_VERSION@" />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.macOS.Manifest*.nupkg" Version="@MACOS_WORKLOAD_VERSION@" />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.tvOS.Manifest*.nupkg" Version="@TVOS_WORKLOAD_VERSION@" />
+    <MultiTargetPackNames Include="Microsoft.iOS.Sdk" />
+    <MultiTargetPackNames Include="Microsoft.iOS.Windows.Sdk" />
+    <MultiTargetPackNames Include="Microsoft.MacCatalyst.Sdk" />
+    <MultiTargetPackNames Include="Microsoft.macOS.Sdk" />
+    <MultiTargetPackNames Include="Microsoft.tvOS.Sdk" />
   </ItemGroup>
 </Project>

--- a/dotnet/targets/WorkloadManifest.MacCatalyst.template.json
+++ b/dotnet/targets/WorkloadManifest.MacCatalyst.template.json
@@ -4,7 +4,7 @@
 		"@PLATFORM_LOWERCASE@": {
 			"description": ".NET SDK Workload for building macOS applications with @PLATFORM@.",
 			"packs": [
-				"Microsoft.@PLATFORM@.Sdk",
+				"Microsoft.@PLATFORM@.Sdk.net6",
 				"Microsoft.@PLATFORM@.Ref",
 				"Microsoft.@PLATFORM@.Runtime.maccatalyst-arm64",
 				"Microsoft.@PLATFORM@.Runtime.maccatalyst-x64",
@@ -16,9 +16,12 @@
 		}
 	},
 	"packs": {
-		"Microsoft.@PLATFORM@.Sdk": {
+		"Microsoft.@PLATFORM@.Sdk.net6": {
 			"kind": "sdk",
-			"version": "@VERSION@"
+			"version": "@VERSION@",
+			"alias-to": {
+				"any": "Microsoft.@PLATFORM@.Sdk"
+			}
 		},
 		"Microsoft.@PLATFORM@.Ref": {
 			"kind": "framework",

--- a/dotnet/targets/WorkloadManifest.iOS.template.json
+++ b/dotnet/targets/WorkloadManifest.iOS.template.json
@@ -4,8 +4,8 @@
 		"@PLATFORM_LOWERCASE@": {
 			"description": ".NET SDK Workload for building @PLATFORM@ applications.",
 			"packs": [
-				"Microsoft.@PLATFORM@.Sdk",
-				"Microsoft.@PLATFORM@.Windows.Sdk.Aliased",
+				"Microsoft.@PLATFORM@.Sdk.net6",
+				"Microsoft.@PLATFORM@.Windows.Sdk.Aliased.net6",
 				"Microsoft.@PLATFORM@.Ref",
 				"Microsoft.@PLATFORM@.Runtime.ios-arm",
 				"Microsoft.@PLATFORM@.Runtime.ios-arm64",
@@ -20,9 +20,12 @@
 		}
 	},
 	"packs": {
-		"Microsoft.@PLATFORM@.Sdk": {
+		"Microsoft.@PLATFORM@.Sdk.net6": {
 			"kind": "sdk",
-			"version": "@VERSION@"
+			"version": "@VERSION@",
+			"alias-to": {
+				"any": "Microsoft.@PLATFORM@.Sdk"
+			}
 		},
 		"Microsoft.@PLATFORM@.Windows.Sdk.Aliased": {
 			"kind": "sdk",

--- a/dotnet/targets/WorkloadManifest.macOS.template.json
+++ b/dotnet/targets/WorkloadManifest.macOS.template.json
@@ -4,7 +4,7 @@
 		"@PLATFORM_LOWERCASE@": {
 			"description": ".NET SDK Workload for building @PLATFORM@ applications.",
 			"packs": [
-				"Microsoft.@PLATFORM@.Sdk",
+				"Microsoft.@PLATFORM@.Sdk.net6",
 				"Microsoft.@PLATFORM@.Ref",
 				"Microsoft.@PLATFORM@.Runtime.osx-arm64",
 				"Microsoft.@PLATFORM@.Runtime.osx-x64",
@@ -16,9 +16,12 @@
 		}
 	},
 	"packs": {
-		"Microsoft.@PLATFORM@.Sdk": {
+		"Microsoft.@PLATFORM@.Sdk.net6": {
 			"kind": "sdk",
-			"version": "@VERSION@"
+			"version": "@VERSION@",
+			"alias-to": {
+				"any": "Microsoft.@PLATFORM@.Sdk"
+			}
 		},
 		"Microsoft.@PLATFORM@.Ref": {
 			"kind": "framework",

--- a/dotnet/targets/WorkloadManifest.tvOS.template.json
+++ b/dotnet/targets/WorkloadManifest.tvOS.template.json
@@ -4,7 +4,7 @@
 		"@PLATFORM_LOWERCASE@": {
 			"description": ".NET SDK Workload for building @PLATFORM@ applications.",
 			"packs": [
-				"Microsoft.@PLATFORM@.Sdk",
+				"Microsoft.@PLATFORM@.Sdk.net6",
 				"Microsoft.@PLATFORM@.Ref",
 				"Microsoft.@PLATFORM@.Runtime.tvos-arm64",
 				"Microsoft.@PLATFORM@.Runtime.tvossimulator-x64",
@@ -17,9 +17,12 @@
 		}
 	},
 	"packs": {
-		"Microsoft.@PLATFORM@.Sdk": {
+		"Microsoft.@PLATFORM@.Sdk.net6": {
 			"kind": "sdk",
-			"version": "@VERSION@"
+			"version": "@VERSION@",
+			"alias-to": {
+				"any": "Microsoft.@PLATFORM@.Sdk"
+			}
 		},
 		"Microsoft.@PLATFORM@.Ref": {
 			"kind": "framework",

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -22,7 +22,7 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v2.yml@templates
+  - template: nuget-msi-convert/job/v3.yml@templates
     parameters:
       yamlResourceName: templates
       dependsOn: signing
@@ -96,6 +96,19 @@ stages:
             inputs:
               artifactName: vsdrop-signed
               downloadPath: $(Build.SourcesDirectory)/vs-insertion
+
+    - template: templates/common/upload-vs-insertion-artifacts.yml@sdk-insertions
+      parameters:
+        githubToken: $(GitHub.Token)
+        githubContext: $(MultiTargetVSDropCommitStatusName)
+        blobName: $(MultiTargetVSDropCommitStatusName)
+        packagePrefix: xamarin-macios
+        artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+        downloadSteps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: vsdrop-multitarget-signed
+              downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
 # Check - "xamarin-macios (VS Insertion Wait For Approval)"
 # Check - "xamarin-macios (VS Insertion Create VS Drop and Open PR)"


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/180
Context: https://github.com/xamarin/yaml-templates/pull/195
Context: https://github.com/xamarin/yaml-templates/pull/199
Context: https://github.com/xamarin/xamarin-macios/pull/15761

Updates the build to use the latest MSI generation template. The v3
template uses the latest changes from arcade which include a large
refactoring, support for multi-targeting, and support for workload pack
group MSIs.

The build will now produce two different VS Drop artifacts.  The MSI and
VSMAN files generated for SDK packs have been split out into a new
`vsdrop-multitarget-signed` artifact, allowing us to include multiple
versions of the SDK packs in VS.

All of the SDK packs have been renamed to include a `.net6` suffix to
match the pack aliases that will be referenced in the .NET 7 manifests.