### PR TITLE
[dotnet] Disable warning about using a preview version of .NET.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -204,6 +204,8 @@ export MD_APPLE_SDK_ROOT=$(abspath $(XCODE_DEVELOPER_ROOT)/../..)
 
 # We don't need to be told there are workload updates
 export DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=true
+# We don't need to be told we're using preview packages (we pretty much always are).
+export SuppressNETCoreSdkPreviewMessage=true
 
 # Mono version embedded in XI/XM (NEEDED_MONO_VERSION/BRANCH) are specified in mk/mono.mk
 include $(TOP)/mk/mono.mk


### PR DESCRIPTION
We're pretty much always using a preview version of .NET, so this gets old
fast.