### PR TITLE
 [ci] Add support to net7.0 for multi-targeting in VS

### DIFF
--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -29,5 +29,10 @@
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg" Version="@MACCATALYST_WORKLOAD_VERSION@" />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.macOS.Manifest*.nupkg" Version="@MACOS_WORKLOAD_VERSION@" />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.tvOS.Manifest*.nupkg" Version="@TVOS_WORKLOAD_VERSION@" />
+    <MultiTargetPackNames Include="Microsoft.iOS.Sdk" />
+    <MultiTargetPackNames Include="Microsoft.iOS.Windows.Sdk" />
+    <MultiTargetPackNames Include="Microsoft.MacCatalyst.Sdk" />
+    <MultiTargetPackNames Include="Microsoft.macOS.Sdk" />
+    <MultiTargetPackNames Include="Microsoft.tvOS.Sdk" />
   </ItemGroup>
 </Project>

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -25,7 +25,7 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v2.yml@templates
+  - template: nuget-msi-convert/job/v3.yml@templates
     parameters:
       yamlResourceName: templates
       dependsOn: signing
@@ -99,6 +99,19 @@ stages:
             inputs:
               artifactName: vsdrop-signed
               downloadPath: $(Build.SourcesDirectory)/vs-insertion
+
+    - template: templates/common/upload-vs-insertion-artifacts.yml@sdk-insertions
+      parameters:
+        githubToken: $(GitHub.Token)
+        githubContext: $(MultiTargetVSDropCommitStatusName)
+        blobName: $(MultiTargetVSDropCommitStatusName)
+        packagePrefix: xamarin-macios
+        artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+        downloadSteps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: vsdrop-multitarget-signed
+              downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
 # Check - "xamarin-macios (VS Insertion Wait For Approval)"
 # Check - "xamarin-macios (VS Insertion Create VS Drop and Open PR)"


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/180
Context: https://github.com/xamarin/yaml-templates/pull/195
Context: https://github.com/xamarin/yaml-templates/pull/199
Context: https://github.com/xamarin/xamarin-macios/pull/15761

Updates the build to use the latest MSI generation template. The v3
template uses the latest changes from arcade which include a large
refactoring, support for multi-targeting, and support for workload pack
group MSIs.

The build will now produce two different VS Drop artifacts.  The MSI and
VSMAN files generated for SDK packs have been split out into a new
`vsdrop-multitarget-signed` artifact, allowing us to include multiple
versions of the SDK packs in VS.