### PR TITLE
[msbuild] Fix a few duplicate compile items warnings.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
+++ b/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
@@ -9,11 +9,7 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Update="MSBStrings.Designer.cs">
-      <DependentUpon>MSBStrings.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
+    <Compile Remove="MSBStrings.Designer.cs" />
     <EmbeddedResource Include="MSBStrings.resx">
       <Type>Resx</Type>
       <Generator>PublicResXFileCodeGenerator</Generator>

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -34,9 +34,6 @@
     <Compile Include="..\..\tools\common\FileCopier.cs">
         <Link>FileCopier.cs</Link>
     </Compile>
-    <Compile Include="..\..\tools\mtouch\errors.Designer.cs">
-      <Link>errors.Designer.cs</Link>
-    </Compile>
     <Compile Include="..\..\tools\common\TargetFramework.cs">
       <Link>TargetFramework.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes:

	CSC : warning CS2002: Source file 'xamarin-macios/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs' specified multiple times [xamarin-macios/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj]
    CSC : warning CS2002: Source file 'xamarin-macios/tools/mtouch/Errors.Designer.cs' specified multiple times [xamarin-macios/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj]