### PR TITLE
Bump to dotnet/runtime/release/7.0-rc1@06aceb70.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -595,6 +595,7 @@ endif
 $(TOP)/dotnet.config: $(TOP)/eng/Versions.props
 	$(Q) grep MicrosoftDotnetSdkInternalPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftDotnetSdkInternalPackageVersion>//g' -e 's/[ \t]*/DOTNET_VERSION=/' >> $@.tmp
 	$(Q) grep MicrosoftNETCoreAppRefPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftNETCoreAppRefPackageVersion>//g' -e 's/[ \t]*/BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION=/' >> $@.tmp
+	$(Q) grep MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>//g' -e 's/[ \t]*/EMSCRIPTEN_MANIFEST_PACKAGE_VERSION=/' >> $@.tmp
 	$(Q) mv $@.tmp $@
 
 DOTNET_DESTDIR ?= $(TOP)/_build
@@ -634,6 +635,10 @@ endif
 
 # We must do the same for our version band: the last two digits must be set to 0.
 MANIFEST_VERSION_BAND=7.0.100
+# The toolchain can either be hardcoded to something like 6.0.200, or set to MANIFEST_VERSION_BAND.
+# Typically it should be MANIFEST_VERSION_BAND, but it usually takes a while after MANIFEST_VERSION_BAND is bumped
+# for this to follow suit, in which case we can keep things working by hardcoding the previous version band.
+TOOLCHAIN_MANIFEST_VERSION_BAND=$(MANIFEST_VERSION_BAND)
 
 # The location of csc changes depending on whether we're using a preview or a stable/service release :/
 DOTNET_CSC_PATH_PREVIEW=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION)/Roslyn/bincore/csc.dll

--- a/NuGet.config
+++ b/NuGet.config
@@ -24,7 +24,6 @@
     <add key="macios-dependencies" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/macios-dependencies/nuget/v3/index.json" />
     <add key="xamarin-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
     <add key="local-tests-feed" value="tests/.nuget/packages" />
-
     <!-- These feeds are from main (6.0.4xx runtime branch) to get 6.0.9 versions of numerous .NET 6 packages. It should be possible to remove this after a while. -->
     <add key="darc-pub-dotnet-emsdk-3f6c45a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-3f6c45a2/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-runtime-531f715" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-531f715f/nuget/v3/index.json" />

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -141,8 +141,11 @@ endif
 		/p:PackageRuntimeIdentifiersCoreCLR="$(DOTNET_CORECLR_RUNTIME_IDENTIFIERS)" \
 		/p:CustomDotNetVersion="$(DOWNLOAD_DOTNET_VERSION)" \
 		/p:DotNetManifestVersionBand="$(DOTNET_MANIFEST_VERSION_BAND)" \
+		/p:ToolChainManifestVersionBand="$(TOOLCHAIN_MANIFEST_VERSION_BAND)" \
 		/bl \
 		$(DOTNET_BUILD_VERBOSITY)
+	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.mono.toolchain.net7.manifest-$(TOOLCHAIN_MANIFEST_VERSION_BAND)/$(DOWNLOAD_DOTNET_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain.net7/
+	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.emscripten.net7.manifest-$(TOOLCHAIN_MANIFEST_VERSION_BAND)/$(EMSCRIPTEN_MANIFEST_PACKAGE_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten.net7/
 	$(Q) touch $@
 
 .stamp-install-t4: $(TOP)/.config/dotnet-tools.json .stamp-download-dotnet-packages

--- a/builds/package-download/download-packages.proj
+++ b/builds/package-download/download-packages.proj
@@ -18,6 +18,12 @@
 
     <!-- download the reference assemblies -->
     <PackageDownload Include="microsoft.netcore.app.ref" Version="[$(ActualPackageVersion)]" />
+
+    <!-- and get the mono workload as well -->
+    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(ToolChainManifestVersionBand)" Version="[$(ActualPackageVersion)]" />
+
+    <!-- and get the emscripten workload as well -->
+    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net7.Manifest-$(ToolChainManifestVersionBand)" Version="[$(MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion)]" />
   </ItemGroup>
 
   <!-- target to write out the BundledNETCorePlatformsPackageVersion to a file -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -395,7 +395,6 @@
 			<_MonoComponent Include="hot_reload" Condition="'$(MtouchInterpreter)' == 'true'" />
 			<_MonoComponent Include="debugger" Condition="'$(_BundlerDebug)' == 'true'" />
 			<_MonoComponent Include="diagnostics_tracing" Condition="'$(_BundlerDebug)' == 'true'" />
-			<_MonoComponent Include="marshal-ilgen" />
 		</ItemGroup>
 	</Target>
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,6 +17,10 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>63fb7a86b560452a4ba8291f0234aef47cf2843f</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.0-rc.1.22424.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+      <Sha>5ef661392ae7b1595b683df83d63e3a0365fc126</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.21212.6">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
       <Uri>https://github.com/dotnet/linker</Uri>
       <Sha>313671b195b1b36d56a8888a9a0e12edaac52c57</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.1.22423.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.1.22426.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>516f061b83daa17416a99cdef982cad7ef1ab0db</Sha>
+      <Sha>06aceb7015f3bd2ff019ef5920d2354eb2ea2c92</Sha>
     </Dependency>
     <!-- This is required for our test apps to build; in some cases Microsoft.AspNetCore.App is pulled in, and when building test apps the build needs to be able to resolve that -->
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="7.0.0-rc.1.22423.7" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <MicrosoftNETILLinkTasksPackageVersion>7.0.100-1.22423.4</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETILStripTasksPackageVersion>6.0.0-rc.2.21468.3</MicrosoftNETILStripTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.1.22423.4</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.1.22426.10</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,6 +6,7 @@
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETILStripTasksPackageVersion>6.0.0-rc.2.21468.3</MicrosoftNETILStripTasksPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.1.22426.10</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>7.0.0-rc.1.22424.1</MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
   </PropertyGroup>
 </Project>

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -744,9 +744,7 @@ namespace Xamarin.Bundler {
 			if (app.UseInterpreter) {
 				sw.WriteLine ("extern \"C\" { void mono_ee_interp_init (const char *); }");
 				sw.WriteLine ("extern \"C\" { void mono_icall_table_init (void); }");
-#if !NET
 				sw.WriteLine ("extern \"C\" { void mono_marshal_ilgen_init (void); }");
-#endif
 				sw.WriteLine ("extern \"C\" { void mono_method_builder_ilgen_init (void); }");
 				sw.WriteLine ("extern \"C\" { void mono_sgen_mono_ilgen_init (void); }");
 			}
@@ -771,9 +769,7 @@ namespace Xamarin.Bundler {
 				sw.WriteLine ("\tmono_jit_set_aot_mode (MONO_AOT_MODE_LLVMONLY);");
 			else if (app.UseInterpreter) {
 				sw.WriteLine ("\tmono_icall_table_init ();");
-#if !NET
 				sw.WriteLine ("\tmono_marshal_ilgen_init ();");
-#endif
 				sw.WriteLine ("\tmono_method_builder_ilgen_init ();");
 				sw.WriteLine ("\tmono_sgen_mono_ilgen_init ();");
 #if !NET


### PR DESCRIPTION
Stop relying on dotnet/installer to provide dotnet/runtime bumps.

Ref: https://github.com/xamarin/xamarin-android/pull/7319