### PR TITLE
[runtime] Store assemblies' MVID in the generated static registrar code.

### DIFF
--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -56,8 +56,8 @@ typedef struct {
 } MTProperty;
 
 // This structure completely describes everything required to resolve a metadata token
-typedef struct MTFullTokenReference {
-	const char *assembly_name; /* the name of the assembly */
+typedef struct __attribute__((packed)) {
+	uint32_t assembly_index; /* index into the 'assemblies' array in the registration map */
 	uint32_t module_token;
 	uint32_t token;
 } MTFullTokenReference;
@@ -99,10 +99,15 @@ typedef struct __attribute__((packed)) {
 	const __unsafe_unretained Protocol * const * protocols; // the corresponding native protocols
 } MTProtocolMap;
 
+typedef struct __attribute__((packed)) {
+	const char *name;
+	const char *mvid;
+} MTAssembly;
+
 struct MTRegistrationMap;
 
 struct MTRegistrationMap {
-	const char **assembly;
+	const MTAssembly *assemblies;
 	MTClassMap *map;
 	const MTFullTokenReference *full_token_references;
 	// There are some managed types that are not registered because their ObjC

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -55,9 +55,9 @@ namespace ObjCRuntime {
 
 #pragma warning disable 649 // Field 'X' is never assigned to, and will always have its default value
 		internal unsafe struct MTRegistrationMap {
-			public IntPtr assembly;
+			public MTAssembly *assemblies;
 			public MTClassMap *map;
-			public IntPtr full_token_references; /* array of MTFullTokenReference */
+			public MTFullTokenReference *full_token_references;
 			public MTManagedClassMap* skipped_map;
 			public MTProtocolWrapperMap* protocol_wrapper_map;
 			public MTProtocolMap protocol_map;
@@ -76,6 +76,13 @@ namespace ObjCRuntime {
 			None = 0,
 			CustomType = 1,
 			UserType = 2,
+		}
+
+		[StructLayout (LayoutKind.Sequential, Pack = 1)]
+		internal unsafe struct MTFullTokenReference {
+			public uint assembly_index;
+			public uint module_token;
+			public uint token;
 		}
 
 		[StructLayout (LayoutKind.Sequential, Pack = 1)]
@@ -102,6 +109,12 @@ namespace ObjCRuntime {
 		internal unsafe struct MTProtocolMap {
 			public uint* protocol_tokens;
 			public IntPtr* protocols;
+		}
+
+		[StructLayout (LayoutKind.Sequential, Pack = 1)]
+		internal unsafe struct MTAssembly {
+			public IntPtr name;
+			public IntPtr mvid;
 		}
 
 		/* Keep Delegates, Trampolines and InitializationOptions in sync with monotouch-glue.m */

--- a/tests/dotnet/MyRegistrarApp/AppDelegate.cs
+++ b/tests/dotnet/MyRegistrarApp/AppDelegate.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace MySimpleApp
+{
+	public class Program
+	{
+		static int Main (string[] args)
+		{
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+#if INCLUDED_ADDITIONAL_CODE
+			GC.KeepAlive (typeof (AdditionalClass));
+#endif
+
+			return StaticRegistrarValidationTest ();
+		}
+
+		static int StaticRegistrarValidationTest ()
+		{
+			try {
+				using var obj = new SomeObj ();
+				obj.Whatever ();
+				xamarin_IntPtr_objc_msgSend_IntPtr_ref_IntPtr_exception (obj.Handle, Selector.GetHandle ("whatever"), IntPtr.Zero, IntPtr.Zero, out var gchandle);
+				Console.WriteLine ($"GCH: {gchandle}");
+				if (gchandle != IntPtr.Zero) {
+					var gch = GCHandle.FromIntPtr (gchandle);
+					var exc = (Exception) gch.Target;
+					gch.Free ();
+					throw exc;
+				}
+				return 1; // We're not supposed to get here
+			} catch (Exception e) {
+				Console.WriteLine ($"E: {e}");
+				if (e.Message.Contains ("The assembly MyRegistrarApp has been modified since the app was built, invalidating the generated static registrar code."))
+					return 0;
+				return 2;
+			}
+		}
+
+		[DllImport ("__Internal")]
+		static extern IntPtr xamarin_IntPtr_objc_msgSend_IntPtr_ref_IntPtr_exception (IntPtr handle, IntPtr selector, IntPtr p0, IntPtr p1, out IntPtr gchandle);
+	}
+
+	public class SomeObj : NSObject
+	{
+		[Export ("whatever")]
+		public IntPtr Whatever ()
+		{
+			return new IntPtr (0xdeadf00d);
+		}
+	}
+
+	public class DeadClass {} // Some code for the linker to remove
+
+#if INCLUDED_ADDITIONAL_CODE
+	public class AdditionalClass {
+	}
+#endif
+}

--- a/tests/dotnet/MyRegistrarApp/MacCatalyst/Makefile
+++ b/tests/dotnet/MyRegistrarApp/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/MyRegistrarApp/MacCatalyst/MyRegistrarApp.csproj
+++ b/tests/dotnet/MyRegistrarApp/MacCatalyst/MyRegistrarApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/MyRegistrarApp/Makefile
+++ b/tests/dotnet/MyRegistrarApp/Makefile
@@ -1,0 +1,2 @@
+TOP=../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/MyRegistrarApp/iOS/Makefile
+++ b/tests/dotnet/MyRegistrarApp/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/MyRegistrarApp/iOS/MyRegistrarApp.csproj
+++ b/tests/dotnet/MyRegistrarApp/iOS/MyRegistrarApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/MyRegistrarApp/macOS/Makefile
+++ b/tests/dotnet/MyRegistrarApp/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/MyRegistrarApp/macOS/MyRegistrarApp.csproj
+++ b/tests/dotnet/MyRegistrarApp/macOS/MyRegistrarApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/MyRegistrarApp/shared.csproj
+++ b/tests/dotnet/MyRegistrarApp/shared.csproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>MyRegistrarApp</ApplicationTitle>
+		<ApplicationId>com.xamarin.myregistrarapp</ApplicationId>
+
+		<ExcludeNUnitLiteReference>true</ExcludeNUnitLiteReference>
+		<ExcludeTouchUnitReference>true</ExcludeTouchUnitReference>
+
+		<DefineConstants>$(DefineConstants);$(AdditionalDefineConstants)</DefineConstants>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/MyRegistrarApp/shared.mk
+++ b/tests/dotnet/MyRegistrarApp/shared.mk
@@ -1,0 +1,3 @@
+TOP=../../../..
+TESTNAME=MyRegistrarApp
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/MyRegistrarApp/tvOS/Makefile
+++ b/tests/dotnet/MyRegistrarApp/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/MyRegistrarApp/tvOS/MyRegistrarApp.csproj
+++ b/tests/dotnet/MyRegistrarApp/tvOS/MyRegistrarApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+  </PropertyGroup>
+  <Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/UnitTests/RegistrarTest.cs
+++ b/tests/dotnet/UnitTests/RegistrarTest.cs
@@ -1,0 +1,50 @@
+namespace Xamarin.Tests {
+	[TestFixture]
+	public class RegistrarTest : TestBaseClass
+	{
+		[TestCase (ApplePlatform.MacCatalyst, true)]
+		[TestCase (ApplePlatform.MacOSX, true)]
+		[TestCase (ApplePlatform.iOS, false)]
+		[TestCase (ApplePlatform.TVOS, false)]
+		public void InvalidStaticRegistrarValidation (ApplePlatform platform, bool validated)
+		{
+			var project = "MyRegistrarApp";
+			var configuration = "Debug";
+			var runtimeIdentifiers = GetDefaultRuntimeIdentifier (platform);
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var projectPath = GetProjectPath (project, platform: platform);
+			Clean (projectPath);
+			var properties = GetDefaultProperties ();
+			properties ["Registrar"] = "static";
+			// enable the linker (so that the main assembly is modified)
+			properties ["LinkMode"] = "full";
+			properties ["MtouchLink"] = "full";
+
+			DotNet.AssertBuild (projectPath, properties);
+
+			var appDir = GetAppPath (projectPath, platform, runtimeIdentifiers, configuration);
+			var asmDir = Path.Combine (appDir, GetRelativeAssemblyDirectory (platform));
+
+			var appExecutable = Path.Combine (asmDir, project + ".dll");
+
+			// Save the first version of the main assembly in memory
+			var firstAssembly = File.ReadAllBytes (appExecutable);
+
+			// Build again, including additional code
+			properties ["AdditionalDefineConstants"] = "INCLUDED_ADDITIONAL_CODE";
+			DotNet.AssertBuild (projectPath, properties);
+
+			// Revert to the original version of the main assembly
+			File.WriteAllBytes (appExecutable, firstAssembly);
+
+			if (validated) {
+				ExecuteProjectWithMagicWordAndAssert (projectPath, platform, runtimeIdentifiers);
+			} else if (CanExecute (platform, runtimeIdentifiers)) {
+				var rv = base.Execute (GetNativeExecutable (platform, appDir), out var output, out _);
+				Assert.AreEqual (1, rv.ExitCode, "Expected no validation");
+			}
+		}
+	}
+}
+

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2118,7 +2118,7 @@ namespace Registrar {
 
 		AutoIndentStringBuilder full_token_references = new AutoIndentStringBuilder ();
 		uint full_token_reference_count;
-		List<string> registered_assemblies = new List<string> ();
+		List<(AssemblyDefinition Assembly, string Name)> registered_assemblies = new List<(AssemblyDefinition Assembly, string Name)> ();
 
 		bool IsPlatformType (TypeReference type)
 		{
@@ -2837,9 +2837,9 @@ namespace Registrar {
 
 			if (string.IsNullOrEmpty (single_assembly)) {
 				foreach (var assembly in GetAssemblies ())
-					registered_assemblies.Add (GetAssemblyName (assembly));
+					registered_assemblies.Add (new (assembly, GetAssemblyName (assembly)));
 			} else {
-				registered_assemblies.Add (single_assembly);
+				registered_assemblies.Add (new (GetAssemblies ().Single (v => GetAssemblyName (v) == single_assembly), single_assembly));
 			}
 
 			foreach (var @class in allTypes) {
@@ -3138,22 +3138,24 @@ namespace Registrar {
 				map.AppendLine ();
 			}
 
-			map.AppendLine ("static const char *__xamarin_registration_assemblies []= {");
+			map.AppendLine ("static const MTAssembly __xamarin_registration_assemblies [] = {");
 			int count = 0;
 			foreach (var assembly in registered_assemblies) {
 				count++;
 				if (count > 1)
 					map.AppendLine (", ");
-				map.Append ("\"");
-				map.Append (assembly);
-				map.Append ("\"");
+				map.Append ("{ \"");
+				map.Append (assembly.Name);
+				map.Append ("\", \"");
+				map.Append (assembly.Assembly.MainModule.Mvid.ToString ());
+				map.Append ("\" }");
 			}
 			map.AppendLine ();
 			map.AppendLine ("};");
 			map.AppendLine ();
 
 			if (full_token_reference_count > 0) {
-				map.AppendLine ("static const struct MTFullTokenReference __xamarin_token_references [] = {");
+				map.AppendLine ("static const MTFullTokenReference __xamarin_token_references [] = {");
 				map.AppendLine (full_token_references);
 				map.AppendLine ("};");
 				map.AppendLine ();
@@ -4841,7 +4843,13 @@ namespace Registrar {
 			default:
 				throw ErrorHelper.CreateError (99, Errors.MX0099, $"unsupported tokentype ({member.MetadataToken.TokenType}) for {member.FullName}");
 			}
-			full_token_references.AppendFormat ("\t\t{{ /* #{3} = 0x{4:X} */ \"{0}\", 0x{1:X}, 0x{2:X} }},\n", GetAssemblyName (member.Module.Assembly), member.Module.MetadataToken.ToUInt32 (), member.MetadataToken.ToUInt32 (), full_token_reference_count, rv);
+			var assemblyIndex = registered_assemblies.FindIndex (v => v.Assembly == member.Module.Assembly);
+			var assemblyName = registered_assemblies [assemblyIndex].Name;
+			var moduleToken = member.Module.MetadataToken.ToUInt32 ();
+			var moduleName = member.Module.Name;
+			var memberToken = member.MetadataToken.ToUInt32 ();
+			var memberName = member.FullName;
+			full_token_references.Append ($"\t\t{{ /* #{full_token_reference_count} = 0x{rv:X} */ {assemblyIndex} /* {assemblyName} */, 0x{moduleToken:X} /* {moduleName} */, 0x{memberToken:X} /* {memberName} */ }},\n");
 			return rv;
 		}
 
@@ -4873,7 +4881,7 @@ namespace Registrar {
 
 			/* The assembly must be a registered one, and only within the first 128 assemblies */
 			var assembly_name = GetAssemblyName (member.Module.Assembly);
-			var index = registered_assemblies.IndexOf (assembly_name);
+			var index = registered_assemblies.FindIndex (v => v.Name == assembly_name);
 			if (index < 0 || index > 127)
 				return CreateFullTokenReference (member);
 

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2171,4 +2171,16 @@
 			1: exception info
 		</comment>
 	</data>
+
+	<data name="MX8043" xml:space="preserve">
+		<value>An exception occurred while validating the static registrar code for {0}: {1}</value>
+		<comment>
+			0: name of an assembly
+			1: exception info
+		</comment>
+	</data>
+
+	<data name="MX8044" xml:space="preserve">
+		<value>The assembly {0} has been modified since the app was built, invalidating the generated static registrar code. The MVID for the loaded assembly is {1}, while the MVID for the assembly the generated static registrar code corresponds to is {2}.</value>
+	</data>
 </root>


### PR DESCRIPTION
This will increase app size a little bit: the space for the MVID + 4 bytes for each
assembly, but we'll be able to validate and show a helpful error message if the generated
static registrar code does not match the assembly loaded at runtime.

It's also a step toward per-assembly static registration (ref: #12067).