### PR TITLE
Add 'None' build action to ObjC binding items

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -16,10 +16,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Exclude api definitions from files included by default -->
+    <!-- Exclude api definitions and core sources from the compilation file list, but let them without build action so they're not hidden in the IDE. We'll re-add them later (this way we make sure they only show up once in the Compile item group) -->
     <Compile Remove="@(ObjcBindingApiDefinition)" />
-    <!-- Exclude core sources as well, we re-add them later (this way we make sure they only show up once in the Compile item group) -->
+	<None Include="@(ObjcBindingApiDefinition)" />
     <Compile Remove="@(ObjcBindingCoreSource)" />
+    <None Include="@(ObjcBindingCoreSource)" />
   </ItemGroup>
 
   <!-- Architecture -->


### PR DESCRIPTION
Besides excluding the API definition and core source files from the compilation list, we also need to re-add them as 'None' items so they're still shown in the IDE

Fix related to: https://github.com/xamarin/xamarin-macios/issues/15690