### PR TITLE
[devops] Make sure no errors are ignored during signing.

### DIFF
--- a/tools/devops/automation/templates/sign-and-notarized/sign-and-notarized.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/sign-and-notarized.yml
@@ -62,6 +62,7 @@ steps:
 
 - ${{ if and(eq(parameters.skipESRP, false), eq(parameters.isPR, false)) }}:
   - bash: |
+      set -exo pipefail
       security unlock-keychain -p $PRODUCTSIGN_KEYCHAIN_PASSWORD builder.keychain
       if [[ "$SYSTEM_DEBUG" == "true" ]]; then
         export ESRP_TEMP="$WORKING_DIR/esrp"


### PR DESCRIPTION
Make sure bash doesn't ignore any errors during signing. This makes it easier
to diagnose signing failures, because they don't show up in weird ways later.