### PR TITLE
[mtouch] Automatically disable bitcode if using Xcode 14+. Fixes #15210.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1115,6 +1115,33 @@ public class B : A {}
 		}
 
 		[Test]
+		[TestCase (Profile.tvOS, MTouchBitcode.ASMOnly, "arm64+llvm")]
+		[TestCase (Profile.tvOS, MTouchBitcode.Full, "arm64+llvm")]
+		[TestCase (Profile.tvOS, MTouchBitcode.Marker, "arm64+llvm")]
+		[TestCase (Profile.iOS, MTouchBitcode.ASMOnly, "arm64+llvm")]
+		[TestCase (Profile.iOS, MTouchBitcode.Full, "arm64+llvm")]
+		[TestCase (Profile.iOS, MTouchBitcode.Marker, "arm64+llvm")]
+		[TestCase (Profile.watchOS, MTouchBitcode.ASMOnly, "arm64_32+llvm")]
+		[TestCase (Profile.watchOS, MTouchBitcode.Full, "arm64_32+llvm")]
+		[TestCase (Profile.watchOS, MTouchBitcode.Marker, "arm64_32+llvm")]
+		public void MT0186 (Profile profile, MTouchBitcode mode, string abi)
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.Profile = profile;
+				if (profile == Profile.watchOS) {
+					mtouch.CreateTemporaryWatchKitExtension ();
+				} else {
+					mtouch.CreateTemporaryApp ();
+				}
+				mtouch.Abi = abi;
+				mtouch.Bitcode = mode;
+				mtouch.WarnAsError = new int[] { 186 };
+				Assert.AreEqual (1, mtouch.Execute (MTouchAction.BuildDev));
+				mtouch.AssertError (186, "Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the 'MtouchEnableBitcode' property from the project file.");
+			}
+		}
+
+		[Test]
 		public void MT0095_SharedCode ()
 		{
 			using (var exttool = new MTouchTool ()) {

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -874,6 +874,11 @@ namespace Xamarin.Bundler {
 				ErrorHelper.Warning (3007, Errors.MX3007);
 			}
 
+			if (Driver.XcodeVersion.Major >= 14 && BitCodeMode != BitCodeMode.None) {
+				ErrorHelper.Warning (186, Errors.MX0186 /* Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the 'MtouchEnableBitcode' property from the project file. */);
+				BitCodeMode = BitCodeMode.None;
+			}
+
 			Optimizations.Initialize (this, out var messages);
 			ErrorHelper.Show (messages);
 			if (Driver.Verbosity > 3)

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -644,7 +644,7 @@ namespace Xamarin.Bundler {
 				// interpreter can use some extra code (e.g. SRE) that is not shipped in the default (AOT) profile
 				EnableRepl = true;
 			} else {
-				if (Platform == ApplePlatform.WatchOS && IsArchEnabled (Abi.ARM64_32) && BitCodeMode != BitCodeMode.LLVMOnly) {
+				if (Platform == ApplePlatform.WatchOS && IsArchEnabled (Abi.ARM64_32) && BitCodeMode != BitCodeMode.LLVMOnly && Driver.XcodeVersion.Major < 14) {
 					if (IsArchEnabled (Abi.ARMv7k)) {
 						throw ErrorHelper.CreateError (145, Errors.MT0145);
 					} else {
@@ -661,7 +661,7 @@ namespace Xamarin.Bundler {
 			if (!IsLLVM && (EnableAsmOnlyBitCode || EnableLLVMOnlyBitCode))
 				throw ErrorHelper.CreateError (3008, Errors.MT3008);
 
-			if (IsLLVM && Platform == ApplePlatform.WatchOS && BitCodeMode != BitCodeMode.LLVMOnly) {
+			if (IsLLVM && Platform == ApplePlatform.WatchOS && BitCodeMode != BitCodeMode.LLVMOnly && Driver.XcodeVersion.Major < 14) {
 				ErrorHelper.Warning (111, Errors.MT0111);
 				BitCodeMode = BitCodeMode.LLVMOnly;
 			}
@@ -842,7 +842,7 @@ namespace Xamarin.Bundler {
 				}
 			}
 
-			if (IsDeviceBuild) {
+			if (IsDeviceBuild && Driver.XcodeVersion.Major < 14) {
 				switch (BitCodeMode) {
 				case BitCodeMode.ASMOnly:
 					if (Platform == ApplePlatform.WatchOS)

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -3794,6 +3794,15 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the &apos;MtouchEnableBitcode&apos; property from the project file..
+        /// </summary>
+        public static string MX0186 {
+            get {
+                return ResourceManager.GetString("MX0186", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not copy the assembly &apos;{0}&apos; to &apos;{1}&apos;: {2}
         ///		.
         /// </summary>

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -935,6 +935,10 @@
 		<value>The option '{0}' cannot take the value '{1}' when using CoreCLR.</value>
 	</data>
 
+	<data name="MX0186" xml:space="preserve">
+		<value>Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the 'MtouchEnableBitcode' property from the project file.</value>
+	</data>
+
 	<data name="MX1009" xml:space="preserve">
 		<value>Could not copy the assembly '{0}' to '{1}': {2}
 		</value>


### PR DESCRIPTION
Apple has deprecated bitcode, and will apparently reject app submissions
containing bitcode starting with Xcode 14. So automatically disable bitcode if
building using Xcode 14+ (and show a warning so that app developers can remove
the 'MtouchEnableBitcode' property from their project files).

Fixes https://github.com/xamarin/xamarin-macios/issues/15210.