### PR TITLE
[workloads] Fix iOS.Windows.Sdk.Aliased.net6 pack name

### DIFF
--- a/dotnet/targets/WorkloadManifest.iOS.template.json
+++ b/dotnet/targets/WorkloadManifest.iOS.template.json
@@ -27,7 +27,7 @@
 				"any": "Microsoft.@PLATFORM@.Sdk"
 			}
 		},
-		"Microsoft.@PLATFORM@.Windows.Sdk.Aliased": {
+		"Microsoft.@PLATFORM@.Windows.Sdk.Aliased.net6": {
 			"kind": "sdk",
 			"version": "@VERSION@",
 			"alias-to": {


### PR DESCRIPTION
Commit 246aa834 missed a manifest pack entry when renaming packs to
include a `.net6` suffix, producing an invalid manifest and causing MSI
conversion to fail.  Fix this by making sure to use  the `.net6` suffix
everywhere.

Failing build context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6627063&view=logs&j=b4ea4e02-2fcb-5a4a-1d1d-96cc58456a90&t=1ef5c69d-aeda-5369-a23d-e57771ac0882&l=119