### PR TITLE
[workloads] Fix manifest.json platform replacement

### DIFF
--- a/dotnet/generate-workloadmanifest-json.csharp
+++ b/dotnet/generate-workloadmanifest-json.csharp
@@ -75,7 +75,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"			}}");
 	writer.WriteLine ($"		}},");
 	if (hasWindows) {
-		writer.WriteLine ($"		\"Microsoft.@PLATFORM@.Windows.Sdk.Aliased.net7\": {{");
+		writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.net7\": {{");
 		writer.WriteLine ($"			\"kind\": \"sdk\",");
 		writer.WriteLine ($"			\"version\": \"{version}\",");
 		writer.WriteLine ($"			\"alias-to\": {{");


### PR DESCRIPTION
Fixes a string replacement related typo in the generated pack name for
`Microsoft.@PLATFORM@.Windows.Sdk.Aliased.net7`.