### PR TITLE
[dotnet] Fix workload name for aliased windows sdk pack.

### DIFF
--- a/dotnet/targets/WorkloadManifest.iOS.template.json
+++ b/dotnet/targets/WorkloadManifest.iOS.template.json
@@ -27,7 +27,7 @@
 				"any": "Microsoft.@PLATFORM@.Sdk"
 			}
 		},
-		"Microsoft.@PLATFORM@.Windows.Sdk.Aliased": {
+		"Microsoft.@PLATFORM@.Windows.Sdk.Aliased.net6": {
 			"kind": "sdk",
 			"version": "@VERSION@",
 			"alias-to": {


### PR DESCRIPTION
This regressed in 246aa834431275dfa363ff98bc687616acc81dde, where the name
changed in the workload list at the top of the file, but the actual workload
wasn't renamed accordingly.