### PR TITLE
[runtime] Use a custom native -> managed trampoline for calling NSObject.InvokeConformsToProtocol from the generated static registrar code.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -678,6 +678,13 @@
 			WrappedManagedFunction = "AttemptRetainNSObject",
 			OnlyDynamicUsage = false,
 		},
+
+		new XDelegate ("bool", "bool", "xamarin_invoke_conforms_to_protocol",
+			"id", "IntPtr", "obj",
+			"Protocol *", "IntPtr", "protocol"
+		) {
+			WrappedManagedFunction = "InvokeConformsToProtocol",
+		},
 	};
 	delegates.CalculateLengths ();
 #><#+

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2143,6 +2143,14 @@ namespace ObjCRuntime {
 		static extern IntPtr xamarin_get_original_working_directory_path ();
 #endif // NET || !__MACOS__
 
+		static bool InvokeConformsToProtocol (IntPtr handle, IntPtr protocol)
+		{
+			var obj = Runtime.GetNSObject (handle);
+			if (obj is null)
+				return false;
+			return obj.ConformsToProtocol (protocol);
+		}
+
 	}
 	
 	internal class IntPtrEqualityComparer : IEqualityComparer<IntPtr>

--- a/tests/api-shared/ObjCRuntime/RegistrarTest.cs
+++ b/tests/api-shared/ObjCRuntime/RegistrarTest.cs
@@ -32,7 +32,7 @@ namespace XamarinTests.ObjCRuntime {
 			try {
 				ptr = Messaging.IntPtr_objc_msgSend (Class.GetHandle (typeof (IntPtrCtorTestClass)), Selector.GetHandle ("alloc"));
 				ptr = Messaging.IntPtr_objc_msgSend (ptr, Selector.GetHandle ("init"));
-				var ex = Assert.Throws<RuntimeException> (() => Messaging.bool_objc_msgSend_IntPtr (ptr, Selector.GetHandle ("conformsToProtocol:"), IntPtr.Zero));
+				var ex = Assert.Throws<RuntimeException> (() => Messaging.bool_objc_msgSend_IntPtr (ptr, Selector.GetHandle ("testMethod:"), IntPtr.Zero));
 				var lines = new List<string> ();
 #if NET
 				lines.Add (string.Format ("Failed to marshal the Objective-C object 0x{0} (type: IntPtrCtorTestClass). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'XamarinTests.ObjCRuntime.RegistrarSharedTest+IntPtrCtorTestClass' does not have a constructor that takes one NativeHandle argument).", ptr.ToString ("x")));
@@ -40,8 +40,8 @@ namespace XamarinTests.ObjCRuntime {
 				lines.Add (string.Format ("Failed to marshal the Objective-C object 0x{0} (type: IntPtrCtorTestClass). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'XamarinTests.ObjCRuntime.RegistrarSharedTest+IntPtrCtorTestClass' does not have a constructor that takes one IntPtr argument).", ptr.ToString ("x")));
 #endif
 				lines.Add ("Additional information:");
-				lines.Add ("Selector: conformsToProtocol:");
-				lines.Add ("InvokeConformsToProtocol");
+				lines.Add ("Selector: testMethod:");
+				lines.Add ("TestMethod");
 				foreach (var line in lines)
 					Assert.That (ex.ToString (), Does.Contain (line), "#message");
 			} finally {
@@ -55,6 +55,11 @@ namespace XamarinTests.ObjCRuntime {
 			public IntPtrCtorTestClass (int foo)
 			{
 				Console.WriteLine ("foo1");
+			}
+
+			[Export ("testMethod:")]
+			public void TestMethod (IntPtrCtorTestClass p)
+			{
 			}
 		}
 	}

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3350,7 +3350,10 @@ namespace Registrar {
 				if (customConformsToProtocol) {
 					sb.AppendLine ("-(BOOL) conformsToProtocol: (void *) protocol");
 					sb.AppendLine ("{");
-					sb.AppendLine ("return xamarin_invoke_conforms_to_protocol (self, (Protocol *) protocol);");
+					sb.AppendLine ("GCHandle exception_gchandle;");
+					sb.AppendLine ("BOOL rv = xamarin_invoke_conforms_to_protocol (self, (Protocol *) protocol, &exception_gchandle);");
+					sb.AppendLine ("xamarin_process_managed_exception_gchandle (exception_gchandle);");
+					sb.AppendLine ("return rv;");
 					sb.AppendLine ("}");
 					return;
 				}

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3340,6 +3340,22 @@ namespace Registrar {
 				return;
 			}
 
+			var customConformsToProtocol = method.Selector == "conformsToProtocol:" && method.Method.DeclaringType.Is ("Foundation", "NSObject") && method.Method.Name == "InvokeConformsToProtocol" && method.Parameters.Length == 1;
+			if (customConformsToProtocol) {
+				if (Driver.IsDotNet) {
+					customConformsToProtocol &= method.Parameters [0].Is ("ObjCRuntime", "NativeHandle");
+				} else {
+					customConformsToProtocol &= method.Parameters [0].Is ("System", "IntPtr");
+				}
+				if (customConformsToProtocol) {
+					sb.AppendLine ("-(BOOL) conformsToProtocol: (void *) protocol");
+					sb.AppendLine ("{");
+					sb.AppendLine ("return xamarin_invoke_conforms_to_protocol (self, (Protocol *) protocol);");
+					sb.AppendLine ("}");
+					return;
+				}
+			}
+
 			var rettype = string.Empty;
 			var returntype = method.ReturnType;
 			var isStatic = method.IsStatic;


### PR DESCRIPTION
This avoids one case where we we embed metadata tokens to a different assembly
in the generated static registrar code.

This is required for supporting per-assembly static registration
(https://github.com/xamarin/xamarin-macios/issues/12067).