### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/tools/governance/cgmanifest.json
+++ b/tools/governance/cgmanifest.json
@@ -1,64 +1,65 @@
 {
-   "Registrations": [
-       {
-           "Component": {
-               "Type": "git",
-               "Git": {
-                   "RepositoryUrl": "https://github.com/spouliot/Touch.Unit.git",
-                   "CommitHash": "89afaf7e05a942c87231cf5601b3a5b59640e218"
-               }
-           },
-           "DevelopmentDependency": true
-       },
-       {
-           "Component": {
-               "Type": "git",
-               "Git": {
-                   "RepositoryUrl": "https://github.com/xamarin/Xamarin.MacDev",
-                   "CommitHash": "7ea83265099f904eaeb487a7b6a579e9e77d9433"
-               }
-           },
-           "DevelopmentDependency": false
-       },
-       {
-           "Component": {
-               "Type": "git",
-               "Git": {
-                   "RepositoryUrl": "https://github.com/mono/guiunit.git",
-                   "CommitHash": "9affe4813987b009022ab7b10e55f81f4a37344c"
-               }
-           },
-           "DevelopmentDependency": true
-       },
-       {
-           "Component": {
-               "Type": "git",
-               "Git": {
-                   "RepositoryUrl": "https://github.com/xamarin/macios-binaries",
-                   "CommitHash": "d33e206ce7978d2ec0019989a1add727c87ea1cf"
-               }
-           },
-           "DevelopmentDependency": false
-       },
-       {
-           "Component": {
-               "Type": "git",
-               "Git": {
-                   "RepositoryUrl": "https://github.com/mono/opentk.git",
-                   "CommitHash": "396bc90c7ac2e7ce442840a5e8bd91e5e79b381e"
-               }
-           },
-           "DevelopmentDependency": false
-       },
-       {
-           "Component": {
-               "Type": "git",
-               "Git": {
-                   "RepositoryUrl": "https://github.com/mono/mono",
-                   "CommitHash": "8c085a99b32e99ae2f0a6b3de61541fefb4d3389"
-               }
-           },
-           "DevelopmentDependency": false
-       }
-   ]
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/spouliot/Touch.Unit.git",
+          "CommitHash": "89afaf7e05a942c87231cf5601b3a5b59640e218"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/xamarin/Xamarin.MacDev",
+          "CommitHash": "7ea83265099f904eaeb487a7b6a579e9e77d9433"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/mono/guiunit.git",
+          "CommitHash": "9affe4813987b009022ab7b10e55f81f4a37344c"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/xamarin/macios-binaries",
+          "CommitHash": "d33e206ce7978d2ec0019989a1add727c87ea1cf"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/mono/opentk.git",
+          "CommitHash": "396bc90c7ac2e7ce442840a5e8bd91e5e79b381e"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/mono/mono",
+          "CommitHash": "8c085a99b32e99ae2f0a6b3de61541fefb4d3389"
+        }
+      },
+      "DevelopmentDependency": false
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.