### PR TITLE
Bump to dotnet/runtime/release/7.0@608da95f.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -600,6 +600,7 @@ endif
 $(TOP)/dotnet.config: $(TOP)/eng/Versions.props
 	$(Q) grep MicrosoftDotnetSdkInternalPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftDotnetSdkInternalPackageVersion>//g' -e 's/[ \t]*/DOTNET_VERSION=/' >> $@.tmp
 	$(Q) grep MicrosoftNETCoreAppRefPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftNETCoreAppRefPackageVersion>//g' -e 's/[ \t]*/BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION=/' >> $@.tmp
+	$(Q) grep MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>//g' -e 's/[ \t]*/EMSCRIPTEN_MANIFEST_PACKAGE_VERSION=/' >> $@.tmp
 	$(Q) mv $@.tmp $@
 
 DOTNET_DESTDIR ?= $(TOP)/_build
@@ -639,6 +640,10 @@ endif
 
 # We must do the same for our version band: the last two digits must be set to 0.
 MANIFEST_VERSION_BAND=7.0.100
+# The toolchain can either be hardcoded to something like 6.0.200, or set to MANIFEST_VERSION_BAND.
+# Typically it should be MANIFEST_VERSION_BAND, but it usually takes a while after MANIFEST_VERSION_BAND is bumped
+# for this to follow suit, in which case we can keep things working by hardcoding the previous version band.
+TOOLCHAIN_MANIFEST_VERSION_BAND=$(MANIFEST_VERSION_BAND)
 
 # The location of csc changes depending on whether we're using a preview or a stable/service release :/
 DOTNET_CSC_PATH_PREVIEW=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION)/Roslyn/bincore/csc.dll

--- a/NuGet.config
+++ b/NuGet.config
@@ -10,12 +10,10 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-emsdk -->
-    <add key="darc-pub-dotnet-emsdk-3f6c45a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-3f6c45a2/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-pub-dotnet-runtime-531f715" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-531f715f/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
@@ -26,6 +24,9 @@
     <add key="macios-dependencies" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/macios-dependencies/nuget/v3/index.json" />
     <add key="xamarin-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
     <add key="local-tests-feed" value="tests/.nuget/packages" />
+    <!-- These feeds are from main (6.0.4xx runtime branch) to get 6.0.9 versions of numerous .NET 6 packages. It should be possible to remove this after a while. -->
+    <add key="darc-pub-dotnet-emsdk-3f6c45a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-3f6c45a2/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-531f715" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-531f715f/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -131,6 +131,17 @@ DOWNLOAD_DOTNET_VERSION=$(BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION)
 endif
 endif
 
+.stamp-install-custom-dotnet-runtime-workloads:
+ifeq ($(SKIP_CUSTOM_DOTNET_RUNTIME_INSTALL),1)
+	$(Q) echo "Skipped custom .NET runtime install"
+else
+	$(Q) mv ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain.net7
+	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.mono.toolchain.net7.manifest-$(TOOLCHAIN_MANIFEST_VERSION_BAND)/$(DOWNLOAD_DOTNET_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain.net7/
+	$(Q) mv ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten.net7
+	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.emscripten.net7.manifest-$(TOOLCHAIN_MANIFEST_VERSION_BAND)/$(EMSCRIPTEN_MANIFEST_PACKAGE_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten.net7/
+	$(Q) touch $@
+endif
+
 .stamp-download-dotnet-packages: $(TOP)/Make.config downloads/$(DOTNET_INSTALL_NAME)
 	$(Q_GEN) cd package-download && $(DOTNET) \
 		build \
@@ -144,10 +155,7 @@ endif
 		/p:ToolChainManifestVersionBand="$(TOOLCHAIN_MANIFEST_VERSION_BAND)" \
 		/bl \
 		$(DOTNET_BUILD_VERBOSITY)
-	$(Q) mv ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain.net7
-	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.mono.toolchain.net7.manifest-$(TOOLCHAIN_MANIFEST_VERSION_BAND)/$(DOWNLOAD_DOTNET_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain.net7/
-	$(Q) mv ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten.net7
-	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.emscripten.net7.manifest-$(TOOLCHAIN_MANIFEST_VERSION_BAND)/$(EMSCRIPTEN_MANIFEST_PACKAGE_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten.net7/
+	$(MAKE) .stamp-install-custom-dotnet-runtime-workloads
 	$(Q) touch $@
 
 .stamp-install-t4: $(TOP)/.config/dotnet-tools.json .stamp-download-dotnet-packages

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -141,8 +141,13 @@ endif
 		/p:PackageRuntimeIdentifiersCoreCLR="$(DOTNET_CORECLR_RUNTIME_IDENTIFIERS)" \
 		/p:CustomDotNetVersion="$(DOWNLOAD_DOTNET_VERSION)" \
 		/p:DotNetManifestVersionBand="$(DOTNET_MANIFEST_VERSION_BAND)" \
+		/p:ToolChainManifestVersionBand="$(TOOLCHAIN_MANIFEST_VERSION_BAND)" \
 		/bl \
 		$(DOTNET_BUILD_VERBOSITY)
+	$(Q) mv ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain.net7
+	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.mono.toolchain.net7.manifest-$(TOOLCHAIN_MANIFEST_VERSION_BAND)/$(DOWNLOAD_DOTNET_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain.net7/
+	$(Q) mv ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten.net7
+	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.emscripten.net7.manifest-$(TOOLCHAIN_MANIFEST_VERSION_BAND)/$(EMSCRIPTEN_MANIFEST_PACKAGE_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten.net7/
 	$(Q) touch $@
 
 .stamp-install-t4: $(TOP)/.config/dotnet-tools.json .stamp-download-dotnet-packages

--- a/builds/package-download/download-packages.proj
+++ b/builds/package-download/download-packages.proj
@@ -18,6 +18,12 @@
 
     <!-- download the reference assemblies -->
     <PackageDownload Include="microsoft.netcore.app.ref" Version="[$(ActualPackageVersion)]" />
+
+    <!-- and get the mono workload as well -->
+    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(ToolChainManifestVersionBand)" Version="[$(ActualPackageVersion)]" />
+
+    <!-- and get the emscripten workload as well -->
+    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net7.Manifest-$(ToolChainManifestVersionBand)" Version="[$(MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion)]" />
   </ItemGroup>
 
   <!-- target to write out the BundledNETCorePlatformsPackageVersion to a file -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -395,7 +395,6 @@
 			<_MonoComponent Include="hot_reload" Condition="'$(MtouchInterpreter)' == 'true'" />
 			<_MonoComponent Include="debugger" Condition="'$(_BundlerDebug)' == 'true'" />
 			<_MonoComponent Include="diagnostics_tracing" Condition="'$(_BundlerDebug)' == 'true'" />
-			<_MonoComponent Include="marshal-ilgen" />
 		</ItemGroup>
 	</Target>
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,14 +8,18 @@
       <Uri>https://github.com/dotnet/linker</Uri>
       <Sha>313671b195b1b36d56a8888a9a0e12edaac52c57</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.1.22422.12" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.2.22451.3">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>ef077d0b58ffddcf54fa73bd85dace6b999b8992</Sha>
+      <Sha>608da95fedbb4686789cdd98102a94f341a41fb8</Sha>
     </Dependency>
     <!-- This is required for our test apps to build; in some cases Microsoft.AspNetCore.App is pulled in, and when building test apps the build needs to be able to resolve that -->
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="7.0.0-rc.2.22424.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>0e0cb263176b2ff6f048aa48c7870986c37d894d</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.0-rc.2.22430.5" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+      <Sha>8d8d2122b16c81df4b158fe43995f958e8fe115e</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,8 @@
     <MicrosoftNETILLinkTasksPackageVersion>7.0.100-1.22423.4</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETILStripTasksPackageVersion>6.0.0-rc.2.21468.3</MicrosoftNETILStripTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.1.22422.12</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.2.22451.3</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>7.0.0-rc.2.22430.5</MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
   </PropertyGroup>
 </Project>

--- a/tools/devops/automation/scripts/bash/install-workloads.sh
+++ b/tools/devops/automation/scripts/bash/install-workloads.sh
@@ -5,6 +5,9 @@ IFS=$'\n\t '
 
 env | sort
 
+make global.json
+make -C builds dotnet
+
 var=$(make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable VARIABLE=DOTNET)
 DOTNET=${var#*=}
 echo "Using dotnet found at $DOTNET"

--- a/tools/devops/automation/scripts/bash/install-workloads.sh
+++ b/tools/devops/automation/scripts/bash/install-workloads.sh
@@ -6,7 +6,7 @@ IFS=$'\n\t '
 env | sort
 
 make global.json
-make -C builds dotnet
+make -C builds dotnet SKIP_CUSTOM_DOTNET_RUNTIME_INSTALL=1
 
 var=$(make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable VARIABLE=DOTNET)
 DOTNET=${var#*=}

--- a/tools/devops/automation/scripts/bash/install-workloads.sh
+++ b/tools/devops/automation/scripts/bash/install-workloads.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -eux
+
+set -o pipefail
+IFS=$'\n\t '
+
+env | sort
+
+var=$(make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable VARIABLE=DOTNET)
+DOTNET=${var#*=}
+echo "Using dotnet found at $DOTNET"
+
+var=$(make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable VARIABLE=DOTNET_PLATFORMS)
+DOTNET_PLATFORMS=${var#*=}
+echo "Dotnet platforms are '$DOTNET_PLATFORMS'"
+
+var=$(make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-abspath-variable VARIABLE=DOTNET_NUPKG_DIR)
+DOTNET_NUPKG_DIR=${var#*=}
+echo "Using nuget dir $DOTNET_NUPKG_DIR"
+
+ROLLBACK_PATH="$BUILD_SOURCESDIRECTORY/artifacts/WorkloadRollback/WorkloadRollback.json"
+
+echo "Rollback file contents:"
+cat "$ROLLBACK_PATH"
+
+mkdir -p "$DOTNET_NUPKG_DIR"
+ls -R "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package"
+cp "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package/"*.nupkg "$DOTNET_NUPKG_DIR"
+cp "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package/"*.pkg "$DOTNET_NUPKG_DIR"
+cp "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package/"*.zip "$DOTNET_NUPKG_DIR"
+ls -R "$DOTNET_NUPKG_DIR"
+
+NUGET_SOURCES=$(grep https://pkgs.dev.azure.com ./NuGet.config | sed -e 's/.*value="//'  -e 's/".*//')
+SOURCES=()
+for source in $NUGET_SOURCES; do
+  SOURCES+=(--source)
+  SOURCES+=($source)
+done
+
+PLATFORMS=()
+for platform in $DOTNET_PLATFORMS; do
+  CURRENT=$(echo "$platform" | tr "[:upper:]" "[:lower:]")
+  PLATFORMS+=("$CURRENT")
+done
+
+for platform in $DOTNET_PLATFORMS; do
+  unzip -l "$DOTNET_NUPKG_DIR"/Microsoft."$platform".Bundle.*.zip
+  unzip "$DOTNET_NUPKG_DIR"/Microsoft."$platform".Bundle.*.zip -d tmpdir
+  rsync -av tmpdir/dotnet/sdk-manifests/* "$BUILD_SOURCESDIRECTORY"/xamarin-macios/builds/downloads/dotnet-*/sdk-manifests/
+done
+find "$BUILD_SOURCESDIRECTORY"/xamarin-macios/builds/downloads/dotnet-*
+
+$DOTNET workload install --from-rollback-file "$ROLLBACK_PATH" --source "$DOTNET_NUPKG_DIR" "${SOURCES[@]}" --verbosity diag "${PLATFORMS[@]}"
+
+var=$(make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable VARIABLE=DOTNET_DIR)
+DOTNET_DIR=${var#*=}
+ls -lR "$DOTNET_DIR"

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -100,59 +100,7 @@ steps:
     Write-Host "##vso[task.setvariable variable=MACCATALYST_WORKLOAD_VERSION;]$catalystVersion"
   displayName: 'Set workload versions for xtro'
 
-- bash: |
-    set -x
-    set -e
-
-    var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=DOTNET)
-    DOTNET=${var#*=}
-    echo "Using dotnet found at $DOTNET"
-
-    var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=DOTNET_PLATFORMS)
-    DOTNET_PLATFORMS=${var#*=}
-    echo "Dotnet platforms are '$DOTNET_PLATFORMS'"
-
-    var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-abspath-variable VARIABLE=DOTNET_NUPKG_DIR)
-    DOTNET_NUPKG_DIR=${var#*=}
-    echo "Using nuget dir $DOTNET_NUPKG_DIR"
-
-    ROLLBACK_PATH="$(Build.SourcesDirectory)/artifacts/WorkloadRollback/WorkloadRollback.json"
-
-    echo "Rollback file contents:" 
-    echo "$(cat $ROLLBACK_PATH)"
-
-    mkdir -p $DOTNET_NUPKG_DIR
-    ls -R $(Build.SourcesDirectory)/artifacts/not-signed-package
-    cp $(Build.SourcesDirectory)/artifacts/not-signed-package/*.nupkg $DOTNET_NUPKG_DIR
-    cp $(Build.SourcesDirectory)/artifacts/not-signed-package/*.pkg $DOTNET_NUPKG_DIR
-    cp $(Build.SourcesDirectory)/artifacts/not-signed-package/*.zip $DOTNET_NUPKG_DIR
-    ls -R $DOTNET_NUPKG_DIR
-
-    NUGET_SOURCES=$(grep https://pkgs.dev.azure.com ./NuGet.config | sed -e 's/.*value="//'  -e 's/".*//')
-    SOURCES=""
-    for source in $NUGET_SOURCES; do
-      SOURCES="$SOURCES --source $source"
-    done
-
-    PLATFORMS=""
-    for platform in $DOTNET_PLATFORMS; do
-      CURRENT=$(echo $platform | tr A-Z a-z)
-      PLATFORMS="$PLATFORMS $CURRENT"
-    done
-
-    for platform in $DOTNET_PLATFORMS; do
-      unzip -l $DOTNET_NUPKG_DIR/Microsoft.$platform.Bundle.*.zip
-      unzip $DOTNET_NUPKG_DIR/Microsoft.$platform.Bundle.*.zip -d tmpdir
-      rsync -av tmpdir/dotnet/sdk-manifests/* $(Build.SourcesDirectory)/xamarin-macios/builds/downloads/dotnet-*/sdk-manifests/
-    done
-    find $(Build.SourcesDirectory)/xamarin-macios/builds/downloads/dotnet-*
-
-    $DOTNET workload install --from-rollback-file $ROLLBACK_PATH --source $DOTNET_NUPKG_DIR $SOURCES --verbosity diag $PLATFORMS
-
-    var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=DOTNET_DIR)
-    DOTNET_DIR=${var#*=}
-    ls -lR $DOTNET_DIR
-
+- bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/install-workloads.sh
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios
   displayName: 'Install dotnet workloads'
 

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -69,16 +69,6 @@ steps:
     allowFailedBuilds: true
     path: $(Build.SourcesDirectory)/artifacts
 
-- bash: |
-    set -x
-    set -e
-
-    make global.json
-    make -C builds dotnet
-  workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios
-  displayName: Bootstrap dotnet
-  timeoutInMinutes: 30
-
 - pwsh: |
     $workloadPath = "$(Build.SourcesDirectory)/artifacts/WorkloadRollback/WorkloadRollback.json"
     $versionData = Get-Content $workloadPath | ConvertFrom-Json
@@ -103,6 +93,7 @@ steps:
 - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/install-workloads.sh
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios
   displayName: 'Install dotnet workloads'
+  timeoutInMinutes: 45
 
 - bash: |
     set -x


### PR DESCRIPTION
Stop relying on dotnet/installer to provide dotnet/runtime bumps.

Ref: https://github.com/xamarin/xamarin-android/pull/7319