### PR TITLE
[workload] Remove missed net7 pack declarations

### DIFF
--- a/dotnet/generate-workloadmanifest-json.csharp
+++ b/dotnet/generate-workloadmanifest-json.csharp
@@ -40,10 +40,8 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 		writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.net7\",");
 		writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.net6\",");
 	}
-	writer.WriteLine ($"				\"Microsoft.{platform}.Ref.net7\",");
 	writer.WriteLine ($"				\"Microsoft.{platform}.Ref\",");
 	foreach (var rid in runtimeIdentifiers) {
-		writer.WriteLine ($"				\"Microsoft.{platform}.Runtime.{rid}.net7\",");
 		writer.WriteLine ($"				\"Microsoft.{platform}.Runtime.{rid}\",");
 	}
 	writer.WriteLine ($"				\"Microsoft.{platform}.Templates.net7\"");


### PR DESCRIPTION
Commit 53766eba attempted to remove all references to the `Ref` and
`Runtime` packs that had a `.net7` alias, however one instance in the
workload manifest was missed.