### PR TITLE
[msbuild] Ignore MSB3246 in a few places.

### DIFF
--- a/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>Build</AssemblyName>
     <NoWarn>$(NoWarn);NU1603</NoWarn> <!-- Xamarin.Messaging.Build.Common 1.6.24 depends on Merq (>= 1.1.0) but Merq 1.1.0 was not found. An approximate best match of Merq 1.1.4 was resolved. -->
+    <NoWarn>$(NoWarn);MSB3277</NoWarn> <!-- warning MSB3277: Found conflicts between different versions of "System.IO.Compression" that could not be resolved. -->
   </PropertyGroup>
 
   <PropertyGroup Label="Messaging">

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -10,6 +10,7 @@
     <LangVersion>latest</LangVersion>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <NoWarn>$(NoWarn);NU1603</NoWarn> <!-- Xamarin.Messaging.Build.Common 1.6.24 depends on Merq (>= 1.1.0) but Merq 1.1.0 was not found. An approximate best match of Merq 1.1.4 was resolved. -->
+    <NoWarn>$(NoWarn);MSB3277</NoWarn> <!-- warning MSB3277: Found conflicts between different versions of "System.Reflection.Metadata" that could not be resolved. -->
   </PropertyGroup>
 
   <Import Project="..\..\eng\Versions.props" />


### PR DESCRIPTION
Fixes:

    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277: Found conflicts between different versions of "System.Reflection.Metadata" that could not be resolved. [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277: There was a conflict between "System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a". [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:     "System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was chosen because it was primary and "System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was not. [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:     References which depend on "System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [xamarin-macios/packages/system.reflection.metadata/1.6.0/lib/netstandard2.0/System.Reflection.Metadata.dll]. [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:         xamarin-macios/packages/system.reflection.metadata/1.6.0/lib/netstandard2.0/System.Reflection.Metadata.dll [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:           Project file item includes which caused reference "xamarin-macios/packages/system.reflection.metadata/1.6.0/lib/netstandard2.0/System.Reflection.Metadata.dll". [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:             xamarin-macios/packages/system.reflection.metadata/1.6.0/lib/netstandard2.0/System.Reflection.Metadata.dll [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:     References which depend on "System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" []. [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:         xamarin-macios/packages/microsoft.net.illink.tasks/6.0.200-1.22219.3/tools/net472/ILLink.Tasks.dll [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:           Project file item includes which caused reference "xamarin-macios/packages/microsoft.net.illink.tasks/6.0.200-1.22219.3/tools/net472/ILLink.Tasks.dll". [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:             ILLink.Tasks [xamarin-macios/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277: Found conflicts between different versions of "System.IO.Compression" that could not be resolved. [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277: There was a conflict between "System.IO.Compression, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" and "System.IO.Compression, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089". [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:     "System.IO.Compression, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" was chosen because it was primary and "System.IO.Compression, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" was not. [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:     References which depend on "System.IO.Compression, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" [xamarin-macios/packages/netstandard.library/2.0.3/build/netstandard2.0/ref/System.IO.Compression.dll]. [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:         xamarin-macios/packages/netstandard.library/2.0.3/build/netstandard2.0/ref/System.IO.Compression.dll [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:           Project file item includes which caused reference "xamarin-macios/packages/netstandard.library/2.0.3/build/netstandard2.0/ref/System.IO.Compression.dll". [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:             xamarin-macios/packages/netstandard.library/2.0.3/build/netstandard2.0/ref/System.IO.Compression.dll [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:     References which depend on "System.IO.Compression, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" []. [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:         /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Build.dll [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:           Project file item includes which caused reference "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Build.dll". [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:             Microsoft.Build [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:             Xamarin.iOS.Tasks [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:         /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Build.Tasks.Core.dll [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:           Project file item includes which caused reference "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Build.Tasks.Core.dll". [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:             Microsoft.Build.Tasks.Core [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:             Xamarin.iOS.Tasks [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277: Found conflicts between different versions of "System.Net.Http" that could not be resolved. [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277: There was a conflict between "System.Net.Http, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a". [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:     "System.Net.Http, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was chosen because it was primary and "System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was not. [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:     References which depend on "System.Net.Http, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [xamarin-macios/packages/netstandard.library/2.0.3/build/netstandard2.0/ref/System.Net.Http.dll]. [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:         xamarin-macios/packages/netstandard.library/2.0.3/build/netstandard2.0/ref/System.Net.Http.dll [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:           Project file item includes which caused reference "xamarin-macios/packages/netstandard.library/2.0.3/build/netstandard2.0/ref/System.Net.Http.dll". [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:             xamarin-macios/packages/netstandard.library/2.0.3/build/netstandard2.0/ref/System.Net.Http.dll [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:     References which depend on "System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" []. [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:         /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Build.Tasks.Core.dll [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:           Project file item includes which caused reference "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Build.Tasks.Core.dll". [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:             Microsoft.Build.Tasks.Core [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3277:             Xamarin.iOS.Tasks [xamarin-macios/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj]