### PR TITLE
[Runtime] Fix comparing a pointer to a UTF8 string with a managed string with embedded nulls.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1946,6 +1946,8 @@ namespace ObjCRuntime {
 					}
 					if (b != (short) str [i])
 						return false;
+					if (b == 0)
+						return false;
 				}
 				return c [str.Length] == 0;
 			}


### PR DESCRIPTION
A managed string can contain embedded nulls, while a native UTF8 string won't,
which means that we can't depend on finding a different character between the
two strings to determine whether we've reached the end of the native UTF8
string or not.