### PR TITLE
[LaunchServices] Updates for Xcode14 Beta 4

### DIFF
--- a/src/CoreServices/LaunchServices.cs
+++ b/src/CoreServices/LaunchServices.cs
@@ -52,6 +52,12 @@ namespace CoreServices
 	public enum LSResult
 	{
 		Success = 0,
+#if NET
+		[SupportedOSPlatform ("macos13.0")]
+#else
+		[Mac (13,0)]
+#endif
+		MalformedLocErr = -10400,
 		AppInTrash = -10660,
 		ExecutableIncorrectFormat = -10661,
 		AttributeNotFound = -10662,


### PR DESCRIPTION
Because LaunchServices is only included as a manual binding inside CoreServices, it does not seem that we have everything bound inside the LaunchServices Xcode headers.

Beta 1 and 2 diff files preserved here: https://gist.github.com/tj-devel709/49de4b471559eb9504b4b67b0db2b389

Beta 1 has changes introducing MacCatalyst in 2 already existing classes that are not bound by us. Beta 2 has a new enum value that this PR includes.