### PR TITLE
[msbuild] Make sure '_AppBundlePath' is always relative. Fixes #15130.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2683,7 +2683,10 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<AppBundleDir>$(_AppContainerDir)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
 		</PropertyGroup>
 		<PropertyGroup>
-			<_AppBundlePath>$(AppBundleDir)\</_AppBundlePath>
+			<!-- Ensure _AppBundlePath is a relative path (relative to the project directory) and contains a trailing slash -->
+			<_AppBundlePath>$(AppBundleDir)</_AppBundlePath>
+			<_AppBundlePath Condition="$([System.IO.Path]::IsPathRooted('$(AppBundleDir)'))">$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)','$(AppBundleDir)'))</_AppBundlePath>
+			<_AppBundlePath>$([MSBuild]::EnsureTrailingSlash('$(_AppBundlePath)'))</_AppBundlePath>
 			<_AppResourcesRelativePath Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">Contents\Resources\</_AppResourcesRelativePath>
 			<_AppResourcesRelativePath Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS'"></_AppResourcesRelativePath>
 			<_AppResourcesPath>$(_AppBundlePath)$(_AppResourcesRelativePath)</_AppResourcesPath>


### PR DESCRIPTION
_AppBundlePath is relative by default, but if AppBundleDir is set to an
absolute path (or the root path used to compute AppBundleDir is an absolute
path), then we must ensure _AppBundlePath is still a relative path, because
our code depends on this.

Note that there are no tests for this, because:

* The problem is that our code concatenates a path + _AppBundlePath.
* This works fine on macOS, because it still looks like a valid path.
* It does not work fine on Windows, because the resulting path ends up with a
  drive letter in the middle.
* We currently don't have any tests on Windows.

Fixes https://github.com/xamarin/xamarin-macios/issues/15130.