### PR TITLE
[msbuild] Compute _AppContainerDir from AppBundleDir if AppBundleDir is set by the developer. Fixes #15014.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2682,6 +2682,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<_AppContainerDir Condition="'$(IsAppDistribution)' == 'true'">$(ArchivePath)\Products\Applications\</_AppContainerDir>
 			<AppBundleDir>$(_AppContainerDir)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
 		</PropertyGroup>
+		<PropertyGroup Condition="'$(_AppContainerDir)' == ''">
+			 <_AppContainerDir>$([System.IO.Path]::GetDirectoryName($(AppBundleDir)))/</_AppContainerDir>
+		</PropertyGroup>
 		<PropertyGroup>
 			<_AppBundlePath>$(AppBundleDir)\</_AppBundlePath>
 			<_AppResourcesRelativePath Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">Contents\Resources\</_AppResourcesRelativePath>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -982,5 +982,19 @@ namespace Xamarin.Tests {
 				Assert.That (errors [0].Message, Does.Contain ("Error loading Entitlements.plist template 'Entitlements.plist'"), "Message");
 			}
 		}
+
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
+		public void CustomAppBundleDir (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			var customAppBundleDir = Path.Combine (Cache.CreateTemporaryDirectory (), project + ".app");
+			properties ["AppBundleDir"] = customAppBundleDir;
+			var result = DotNet.AssertBuild (project_path, properties);
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/15014.