### PR TITLE
[release/6.0.4xx][msbuild] Take the .NET version into account when computing the illink.dll location.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -316,8 +316,6 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 			<_RemoteILLinkPath>$(ILLinkTasksAssembly.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)').Replace('net472', 'net$(BundledNETCoreAppTargetFrameworkVersion)').Replace('$([System.IO.Path]::GetFileName('$(ILLinkTasksAssembly)'))', 'illink.dll'))</_RemoteILLinkPath>
 		</PropertyGroup>
 
-		<Error Condition="!Exists('$(_RemoteILLinkPath)')" Text="Could not find the path to illink.dll ('$(_RemoteILLinkPath)' does not exist)" />
-
 		<!-- Include Debug symbols as input so those are copied to the server -->
 		<ItemGroup>
 			<!-- @(_PDBToLink) comes from the _ComputeManagedAssemblyToLink target, which is a dependency of this target and is included in Microsoft.NET.ILLink.targets -->

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -312,9 +312,11 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 		Outputs="$(_LinkSemaphore)">
 
 		<PropertyGroup>
-			<!-- We need to use net5.0 because when building from VS it sets MSBuildRuntimeType to Core and will pick net472 (which doesn't contain the illink assembly) -->
-			<_RemoteILLinkPath>$(ILLinkTasksAssembly.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)').Replace('net472', 'net6.0').Replace('$([System.IO.Path]::GetFileName('$(ILLinkTasksAssembly)'))', 'illink.dll'))</_RemoteILLinkPath>
+			<!-- We need to use netX.Y because when building from VS it sets MSBuildRuntimeType to Core and will pick net472 (which doesn't contain the illink assembly) -->
+			<_RemoteILLinkPath>$(ILLinkTasksAssembly.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)').Replace('net472', 'net$(BundledNETCoreAppTargetFrameworkVersion)').Replace('$([System.IO.Path]::GetFileName('$(ILLinkTasksAssembly)'))', 'illink.dll'))</_RemoteILLinkPath>
 		</PropertyGroup>
+
+		<Error Condition="!Exists('$(_RemoteILLinkPath)')" Text="Could not find the path to illink.dll ('$(_RemoteILLinkPath)' does not exist)" />
 
 		<!-- Include Debug symbols as input so those are copied to the server -->
 		<ItemGroup>


### PR DESCRIPTION
We use illink.dll from the executing .NET version: if we're building with .NET
7, then we're using illink from .NET 7. This means we can't hard-code 'net6.0'
when computing the path to illink.dll for remote builds.

Backport of #15876.

Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1611403.