### PR TITLE
[devops] Don't try to publish test results unless there are any tests results.

### DIFF
--- a/tools/devops/automation/templates/common/upload-vsts-tests.yml
+++ b/tools/devops/automation/templates/common/upload-vsts-tests.yml
@@ -25,10 +25,16 @@ steps:
       testPrefix: ${{ parameters.testPrefix }}
 
 - bash: |
-    find . -name 'vsts-*.xml'
-    find . -name 'vsts-*.xml' -ls -exec cat {} \;
+    set -ex
+    find . -name 'vsts-*.xml' || true
+    find . -name 'vsts-*.xml' -ls -exec cat {} \; || true
+    VSTS_XML_FILES=$(find . -name 'vsts-*.xml' | wc -l | sed 's/ //g')
+    set +x
+    echo "##vso[task.setvariable variable=VSTS_XML_FILES]$VSTS_XML_FILES"
+    set -x
   continueOnError: true
   condition: succeededOrFailed()
+  displayName: 'List NUnit test results'
 
   # Upload test results to vsts.
   - task: PublishTestResults@2
@@ -38,4 +44,4 @@ steps:
       testResultsFiles: '**/vsts-*.xml'
       failTaskOnFailedTests: true
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: and(ne($(VSTS_XML_FILES),0),succeededOrFailed())

--- a/tools/devops/automation/templates/common/upload-vsts-tests.yml
+++ b/tools/devops/automation/templates/common/upload-vsts-tests.yml
@@ -45,4 +45,4 @@ steps:
       testResultsFiles: '**/vsts-*.xml'
       failTaskOnFailedTests: true
     continueOnError: true
-    condition: and(ne($[VSTS_XML_FILES],0),succeededOrFailed())
+    condition: and(ne(variables['VSTS_XML_FILES'], 0), succeededOrFailed())

--- a/tools/devops/automation/templates/common/upload-vsts-tests.yml
+++ b/tools/devops/automation/templates/common/upload-vsts-tests.yml
@@ -24,19 +24,6 @@ steps:
     parameters:
       testPrefix: ${{ parameters.testPrefix }}
 
-- bash: |
-    set -ex
-    find . -name 'vsts-*.xml' || true
-    find . -name 'vsts-*.xml' -ls -exec cat {} \; || true
-    VSTS_XML_FILES=$(find . -name 'vsts-*.xml' | wc -l | sed 's/ //g')
-    set +x
-    echo "##vso[task.setvariable variable=VSTS_XML_FILES]$VSTS_XML_FILES"
-    set -x
-  name: ListNUnitTestResults
-  continueOnError: true
-  condition: succeededOrFailed()
-  displayName: 'List NUnit test results'
-
   # Upload test results to vsts.
   - task: PublishTestResults@2
     displayName: 'Publish NUnit Device Test Results'
@@ -45,4 +32,4 @@ steps:
       testResultsFiles: '**/vsts-*.xml'
       failTaskOnFailedTests: true
     continueOnError: true
-    condition: and(ne(variables['VSTS_XML_FILES'], 0), succeededOrFailed())
+    condition: succeededOrFailed()

--- a/tools/devops/automation/templates/common/upload-vsts-tests.yml
+++ b/tools/devops/automation/templates/common/upload-vsts-tests.yml
@@ -32,6 +32,7 @@ steps:
     set +x
     echo "##vso[task.setvariable variable=VSTS_XML_FILES]$VSTS_XML_FILES"
     set -x
+  name: ListNUnitTestResults
   continueOnError: true
   condition: succeededOrFailed()
   displayName: 'List NUnit test results'
@@ -44,4 +45,4 @@ steps:
       testResultsFiles: '**/vsts-*.xml'
       failTaskOnFailedTests: true
     continueOnError: true
-    condition: and(ne($(VSTS_XML_FILES),0),succeededOrFailed())
+    condition: and(ne($[VSTS_XML_FILES],0),succeededOrFailed())

--- a/tools/devops/automation/templates/common/upload-vsts-tests.yml
+++ b/tools/devops/automation/templates/common/upload-vsts-tests.yml
@@ -24,6 +24,12 @@ steps:
     parameters:
       testPrefix: ${{ parameters.testPrefix }}
 
+- bash: |
+    find . -name 'vsts-*.xml'
+    find . -name 'vsts-*.xml' -ls -exec cat {} \;
+  continueOnError: true
+  condition: succeededOrFailed()
+
   # Upload test results to vsts.
   - task: PublishTestResults@2
     displayName: 'Publish NUnit Device Test Results'

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -271,10 +271,16 @@ steps:
   condition: succeededOrFailed()
 
 - bash: |
-    find . -name 'vsts-*.xml'
-    find . -name 'vsts-*.xml' -ls -exec cat {} \;
+    set -ex
+    find . -name 'vsts-*.xml' || true
+    find . -name 'vsts-*.xml' -ls -exec cat {} \; || true
+    VSTS_XML_FILES=$(find . -name 'vsts-*.xml' | wc -l | sed 's/ //g')
+    set +x
+    echo "##vso[task.setvariable variable=VSTS_XML_FILES]$VSTS_XML_FILES"
+    set -x
   continueOnError: true
   condition: succeededOrFailed()
+  displayName: 'List NUnit test results'
 
 # Upload test results to vsts.
 - task: PublishTestResults@2
@@ -284,7 +290,7 @@ steps:
     testResultsFiles: '**/vsts-*.xml'
     failTaskOnFailedTests: true
   continueOnError: true
-  condition: succeededOrFailed()
+  condition: and(ne($(VSTS_XML_FILES),0),succeededOrFailed())
 
 # Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
 - task: ArchiveFiles@1

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -278,10 +278,10 @@ steps:
     set +x
     echo "##vso[task.setvariable variable=VSTS_XML_FILES]$VSTS_XML_FILES"
     set -x
-  name: ListNUnitTestResults
+  name: CountNUnitTestResults
   continueOnError: true
   condition: succeededOrFailed()
-  displayName: 'List NUnit test results'
+  displayName: 'Count NUnit test results'
 
 # Upload test results to vsts.
 - task: PublishTestResults@2
@@ -289,7 +289,6 @@ steps:
   inputs:
     testResultsFormat: NUnit
     testResultsFiles: '**/vsts-*.xml'
-    failTaskOnFailedTests: true
   continueOnError: true
   condition: and(ne(variables['VSTS_XML_FILES'], 0), succeededOrFailed())
 

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -270,6 +270,12 @@ steps:
   continueOnError: true
   condition: succeededOrFailed()
 
+- bash: |
+    find . -name 'vsts-*.xml'
+    find . -name 'vsts-*.xml' -ls -exec cat {} \;
+  continueOnError: true
+  condition: succeededOrFailed()
+
 # Upload test results to vsts.
 - task: PublishTestResults@2
   displayName: 'Publish NUnit Device Test Results'

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -278,6 +278,7 @@ steps:
     set +x
     echo "##vso[task.setvariable variable=VSTS_XML_FILES]$VSTS_XML_FILES"
     set -x
+  name: ListNUnitTestResults
   continueOnError: true
   condition: succeededOrFailed()
   displayName: 'List NUnit test results'
@@ -290,7 +291,7 @@ steps:
     testResultsFiles: '**/vsts-*.xml'
     failTaskOnFailedTests: true
   continueOnError: true
-  condition: and(ne($(VSTS_XML_FILES),0),succeededOrFailed())
+  condition: and(ne($[VSTS_XML_FILES],0),succeededOrFailed())
 
 # Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
 - task: ArchiveFiles@1

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -291,7 +291,7 @@ steps:
     testResultsFiles: '**/vsts-*.xml'
     failTaskOnFailedTests: true
   continueOnError: true
-  condition: and(ne($[VSTS_XML_FILES],0),succeededOrFailed())
+  condition: and(ne(variables['VSTS_XML_FILES'], 0), succeededOrFailed())
 
 # Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
 - task: ArchiveFiles@1


### PR DESCRIPTION
Don't try to publish test results unless there are any tests results.

Fixes this [horribly/amusingly incorrect error][1] in the publish task:

    ##[error]Error: Failed find: ENOENT: no such file or directory, lstat '/System/Library/Frameworks/iTunesLibrary.framework/Versions/Versions'
    ##[section]Finishing: Publish NUnit Device Test Results

Also stop failing the task on failing tests, because we already have another task that fail if there are failing tests (the task that runs the tests).

[1]: https://github.com/microsoft/azure-pipelines-tasks/issues/16786