### PR TITLE
[msbuild] Only require a provisioning profile if we have non-empty entitlements.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -136,16 +136,6 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		-->
 		<CodesignEntitlements Condition="'$(UsingAppleNETSdk)' == 'true' And '$(CodesignEntitlements)' == '' And Exists('Entitlements.plist') And '$(EnableDefaultCodesignEntitlements)' != 'false'">Entitlements.plist</CodesignEntitlements>
 
-		<!-- _RequireProvisioningProfile -->
-		<!-- Default: false -->
-		<!-- macOS: true if a provisioning profile is used -->
-		<!-- iOS/tvOS/watchOS: true if building for device or if a custom entitlements file is used -->
-		<!-- Mac Catalyst: true if a provisioning profile is used -->
-		<_RequireProvisioningProfile Condition="'$(_RequireProvisioningProfile)' == '' And '$(_PlatformName)' == 'macOS' And '$(CodesignProvision)' != ''">true</_RequireProvisioningProfile>
-		<_RequireProvisioningProfile Condition="'$(_RequireProvisioningProfile)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And ('$(ComputedPlatform)' == 'iPhone' Or '$(CodesignEntitlements)' != '')">true</_RequireProvisioningProfile>
-		<_RequireProvisioningProfile Condition="'$(_RequireProvisioningProfile)' == '' And '$(_PlatformName)' == 'MacCatalyst' And '$(CodesignProvision)' != ''">true</_RequireProvisioningProfile>
-		<_RequireProvisioningProfile Condition="'$(_RequireProvisioningProfile)' == ''">false</_RequireProvisioningProfile>
-
 		<!-- If we should automatically try to detect the app manifest (Info.plist) from any None, BundleResource or Content items -->
 		<!-- It might be desirable to turn off the automatic detection if the current logic detects Info.plist that aren't the app manifest -->
 		<!-- One example would be when including native frameworks in the app bundle - frameworks have an Info.plist that might be picked up -->

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1698,12 +1698,14 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="$(_DetectSigningIdentityDependsOn)">
 		<DetectSigningIdentity
 			SessionId="$(BuildSessionId)"
+			CodesignProvision="$(CodesignProvision)"
+			CodesignEntitlements="$(CodesignEntitlements)"
+			CodesignRequireProvisioningProfile="$(CodesignRequireProvisioningProfile)"
 			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleName="$(_AppBundleName)"
 			BundleIdentifier="$(_BundleIdentifier)"
 			Keychain="$(CodesignKeychain)"
 			RequireCodeSigning="$(_RequireCodeSigning)"
-			RequireProvisioningProfile="$(_RequireProvisioningProfile)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkPlatform="$(_SdkPlatform)"
 			ProvisioningProfile="$(CodesignProvision)"

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -193,6 +193,9 @@ namespace Xamarin.Tests {
 						return false; // the .NET runtime will deal with selecting the http handler, no need for us to do anything
 					case "runtimeconfig.bin":
 						return false; // this file is present for .NET apps, but not legacy apps.
+					case "embedded.mobileprovision":
+					case "CodeResources":
+						return false; // sometimes we don't sign in .NET when we do in legacy (if there's an empty Entitlements.plist file)
 					}
 
 					var components = v.Split ('/');

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
@@ -123,7 +123,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (testCase.Required) {
 				Assert.That (task.DetectedAppId, Is.Not.Null.And.Not.Empty, "DetectedAppId");
 				Assert.AreEqual ("-", task.DetectedCodeSigningKey, "DetectedCodeSigningKey");
-				Assert.AreEqual ("Development", task.DetectedDistributionType, "DetectedDistributionType");
+				Assert.That (task.DetectedDistributionType, Is.EqualTo ("Development").Or.EqualTo ("AppStore"), "DetectedDistributionType");
 				Assert.That (task.DetectedProvisioningProfile, Is.Not.Null.And.Not.Empty, "DetectedProvisioningProfile");
 			} else {
 				Assert.IsNull (task.DetectedAppId, "DetectedAppId");

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
@@ -1,0 +1,137 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Utilities;
+using NUnit.Framework;
+
+using Xamarin.iOS.Tasks;
+using Xamarin.MacDev;
+using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
+
+namespace Xamarin.MacDev.Tasks {
+	[TestFixture]
+	public class DetectSigningIdentityTaskTests : TestBase {
+		DetectSigningIdentity CreateTask (string? tmpdir = null, ApplePlatform platform = ApplePlatform.iOS, bool simulator = true, bool isDotNet = true)
+		{
+			if (string.IsNullOrEmpty (tmpdir))
+				tmpdir = Cache.CreateTemporaryDirectory ();
+
+			var task = CreateTask<DetectSigningIdentity> ();
+			task.AppBundleName = "AssemblyName";
+			task.SdkPlatform = PlatformFrameworkHelper.GetSdkPlatform (platform, simulator);
+			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform, isDotNet).ToString ();
+
+			return task;
+		}
+
+		[Test]
+		public void Default ()
+		{
+			var dir = Cache.CreateTemporaryDirectory ();
+			var task = CreateTask (dir);
+
+			ExecuteTask (task);
+
+			Assert.IsNull (task.DetectedAppId, "DetectedAppId");
+			Assert.AreEqual ("-", task.DetectedCodeSigningKey, "DetectedCodeSigningKey");
+			Assert.AreEqual ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate", task.DetectedCodesignAllocate, "DetectedCodesignAllocate");
+			Assert.AreEqual ("Any", task.DetectedDistributionType, "DetectedDistributionType");
+			Assert.IsNull (task.DetectedProvisioningProfile, "DetectedProvisioningProfile");
+		}
+
+		const string EmptyEntitlements1 = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
+<plist version=""1.0"">
+<dict>
+</dict>
+</plist>";
+
+		const string EmptyEntitlements2 = @"<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
+<plist version=""1.0"">
+<dict>
+</dict>
+</plist>";
+
+		const string EmptyEntitlements3 = @"<plist version=""1.0"">
+<dict>
+</dict>
+</plist>";
+
+		const string EmptyEntitlements4 = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
+<plist version=""1.0"">
+<dict>
+<!-- comment here! -->
+</dict>
+</plist>";
+
+		const string NonEmptyEntitlements1 = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
+<plist version=""1.0"">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+</dict>
+</plist>";
+
+		public class EntitlementTestCase
+		{
+			public string Name = string.Empty;
+			public string Entitlements = string.Empty;
+			public bool Required;
+			public bool IsSimulator;
+			public bool? CodesignRequireProvisioningProfile;
+
+			public override string ToString ()
+			{
+				return Name;
+			}
+		}
+
+		static EntitlementTestCase[] GetEntitlementsTestCases ()
+		{
+			return new EntitlementTestCase[]
+			{
+				new EntitlementTestCase { Name = nameof (EmptyEntitlements1), Entitlements = EmptyEntitlements1, Required = false, IsSimulator = true },
+				new EntitlementTestCase { Name = nameof (EmptyEntitlements2), Entitlements = EmptyEntitlements2, Required = false, IsSimulator = true },
+				new EntitlementTestCase { Name = nameof (EmptyEntitlements3), Entitlements = EmptyEntitlements3, Required = false, IsSimulator = true },
+				new EntitlementTestCase { Name = nameof (EmptyEntitlements4), Entitlements = EmptyEntitlements4, Required = false, IsSimulator = true },
+				new EntitlementTestCase { Name = nameof (NonEmptyEntitlements1), Entitlements = NonEmptyEntitlements1, Required = true, IsSimulator = true },
+				new EntitlementTestCase { Name = nameof (EmptyEntitlements1) + "_Required", Entitlements = EmptyEntitlements1, Required = true, IsSimulator = true, CodesignRequireProvisioningProfile = true },
+				new EntitlementTestCase { Name = nameof (NonEmptyEntitlements1) + "_NotRequired", Entitlements = NonEmptyEntitlements1, Required = false, IsSimulator = true, CodesignRequireProvisioningProfile = false },
+			};
+		}
+
+		[Test]
+		[TestCaseSource (nameof (GetEntitlementsTestCases))]
+		public void EmptyEntitlements (EntitlementTestCase testCase)
+		{
+			var dir = Cache.CreateTemporaryDirectory ();
+			var entitlementsPath = Path.Combine (dir, "Entitlements.plist");
+			File.WriteAllText (entitlementsPath, testCase.Entitlements);
+
+			var task = CreateTask (dir, simulator: testCase.IsSimulator);
+			task.CodesignEntitlements = entitlementsPath;
+			task.SdkIsSimulator = testCase.IsSimulator;
+			if (testCase.CodesignRequireProvisioningProfile.HasValue)
+				task.CodesignRequireProvisioningProfile = testCase.CodesignRequireProvisioningProfile.Value.ToString ();
+
+			ExecuteTask (task);
+
+			if (testCase.Required) {
+				Assert.That (task.DetectedAppId, Is.Not.Null.And.No.Empty, "DetectedAppId");
+				Assert.AreEqual ("-", task.DetectedCodeSigningKey, "DetectedCodeSigningKey");
+				Assert.AreEqual ("Development", task.DetectedDistributionType, "DetectedDistributionType");
+				Assert.That (task.DetectedProvisioningProfile, Is.Not.Null.And.Not.Empty, "DetectedProvisioningProfile");
+			} else {
+				Assert.IsNull (task.DetectedAppId, "DetectedAppId");
+				Assert.IsNull (task.DetectedCodeSigningKey, "DetectedCodeSigningKey");
+				Assert.AreEqual ("Any", task.DetectedDistributionType, "DetectedDistributionType");
+				Assert.IsNull (task.DetectedProvisioningProfile, "DetectedProvisioningProfile");
+			}
+			Assert.AreEqual ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate", task.DetectedCodesignAllocate, "DetectedCodesignAllocate");
+		}
+	}
+}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
@@ -121,7 +121,7 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			if (testCase.Required) {
-				Assert.That (task.DetectedAppId, Is.Not.Null.And.No.Empty, "DetectedAppId");
+				Assert.That (task.DetectedAppId, Is.Not.Null.And.Not.Empty, "DetectedAppId");
 				Assert.AreEqual ("-", task.DetectedCodeSigningKey, "DetectedCodeSigningKey");
 				Assert.AreEqual ("Development", task.DetectedDistributionType, "DetectedDistributionType");
 				Assert.That (task.DetectedProvisioningProfile, Is.Not.Null.And.Not.Empty, "DetectedProvisioningProfile");


### PR DESCRIPTION
This is the behavior in legacy Xamarin (for mobile projects): if a project
contains a CodesignEntitlements=Entitlements.plist property, we require a
provisioning profile (and failing the build if none is found).

In .NET, the expected behavior is that if a file is in the project directory,
it should be detected automatically and handled accordingly. We didn't do this
for the initial release of .NET, but we implemented it later
(https://github.com/xamarin/xamarin-macios/pull/15729).

However, this turned out to be complicated, because many templates provide an
Entitlements.plist file, and now suddenly just the presence of such a file
would require a provisioning profile, which also means setting up the whole
rigmarole of Apple's certificates and provisioning profiles (and even
potentially getting a paid Apple Developer account).

This usually worked well in legacy Xamarin, because in templates only the
Release configuration would set the CodesignEntitlements=Entitlements.plist
property, and thus we'd only require a provisioning profile for release builds
(and the Entitlements.plist file would be ignored for Debug builds).

Here we change the default behavior when building for .NET so that we only
require a provisioning profile if the Entitlements.plist file is empty (i.e.
doesn't request any entitlements).

I've also implemented an override, where setting the
CodesignRequireProvisioningProfile=true property will override our default
logic.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1613459.