### PR TITLE
[msbuild] Put all the MSBuild tests in the same namespace.

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/FrameworkListTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/FrameworkListTest.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using Xamarin.Tests;
 using System.Linq;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class FrameworkListTests

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CollectITunesArtworkTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CollectITunesArtworkTaskTests.cs
@@ -5,7 +5,9 @@ using Microsoft.Build.Utilities;
 
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+using Xamarin.iOS.Tasks;
+
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture]
 	public class CollectITunesArtworkTaskTests : TestBase {
 		string AppPath => Path.GetDirectoryName (GetType ().Assembly.Location);

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
@@ -9,7 +9,7 @@ using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
 using Xamarin.Utils;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture]
 	public class CompileAppManifestTaskTests : TestBase {
 		CompileAppManifest CreateTask (string? tmpdir = null, ApplePlatform platform = ApplePlatform.iOS)

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 using Xamarin.MacDev.Tasks;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public abstract class GeneratePlistTaskTests_Core : TestBase

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using NUnit.Framework;
 using Xamarin.MacDev;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class GeneratePlistTaskTests_iOS : GeneratePlistTaskTests_Core

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS_AppExtension.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS_AppExtension.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
 using Xamarin.MacDev;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class GeneratePlistTaskTests_iOS_AppExtension : GeneratePlistTaskTests_iOS

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_tvOS.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_tvOS.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
 using Xamarin.MacDev;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class GeneratePlistTaskTests_tvOS : GeneratePlistTaskTests_Core

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
 using Xamarin.MacDev;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public abstract class GeneratePlistTaskTests_watchOS: GeneratePlistTaskTests_Core

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS_WatchKitApp.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS_WatchKitApp.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class GeneratePlistTaskTests_watchOS_WatchKitApp : GeneratePlistTaskTests_watchOS

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS_WatchKitExtension.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS_WatchKitExtension.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using NUnit.Framework;
 using Xamarin.MacDev;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class GeneratePlistTaskTests_watchOS_WatchKitExtension : GeneratePlistTaskTests_watchOS

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetBundleNameTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetBundleNameTaskTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 
 using Xamarin.MacDev.Tasks;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class GetBundleNameTaskTests : TestBase

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -13,7 +13,7 @@ using Xamarin.MacDev.Tasks;
 using Xamarin.Tests;
 using Xamarin.Utils;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class IBToolTaskTests : TestBase

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationStringTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationStringTest.cs
@@ -11,9 +11,10 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using Xamarin.iOS.Tasks;
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture]
 	public class LocalizationStringTest : TestBase {
 		[TestCase ("cs-CZ", "došlo k chybě: neznámý formát image")]

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MTouchTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MTouchTaskTests.cs
@@ -6,9 +6,11 @@ using System.Linq;
 using Microsoft.Build.Utilities;
 
 using NUnit.Framework;
+
+using Xamarin.iOS.Tasks;
 using Xamarin.MacDev;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	class CustomMTouchTask : MTouch
 	{

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ParseBundlerArgumentsTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ParseBundlerArgumentsTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 
 using Xamarin.MacDev.Tasks;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class ParseBundlerArgumentsTests : TestBase

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/PropertyListEditorTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/PropertyListEditorTaskTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class PropertyListEditorTaskTests : TestBase

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/Logger.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/Logger.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 using Microsoft.Build.Framework;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	public class Logger : ILogger
 	{

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestBase.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	public abstract class TestBase
 	{

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestEngine.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestEngine.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Logging;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 
 	public class TestEngine : IBuildEngine, IBuildEngine2, IBuildEngine3, IBuildEngine4

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/UtilityTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/UtilityTests.cs
@@ -10,7 +10,7 @@ using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
 using Xamarin.Utils;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class UtilityTests

--- a/tests/msbuild/Xamarin.MacDev.Tests/DotnetTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/DotnetTest.cs
@@ -6,7 +6,7 @@ using Xamarin.Tests;
 
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 
 	// This test builds test projects using both MSBuild (old-style) and .NET (new-style), and
 	// compares the resulting .app directories.

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/BindingProject.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/BindingProject.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 using System.IO;
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/BindingReferences.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/BindingReferences.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	public class BindingReferences : TestBase {
 
 		[Test]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Bug60536.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Bug60536.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.Evaluation;
 
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class Bug60536 : ProjectTest

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/CodesignAppBundle.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/CodesignAppBundle.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 
 using Xamarin.MacDev;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone", "Debug")]
 	[TestFixture ("iPhone", "Release")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/CompileSceneKitAssetsTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/CompileSceneKitAssetsTest.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	// [TestFixture ("iPhone")] // Skip this to speed things up a bit.
 	[TestFixture ("iPhoneSimulator")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/CoreMLCompiler.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/CoreMLCompiler.cs
@@ -8,7 +8,7 @@ using Xamarin.Tests;
 
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/EmbeddedExtension.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/EmbeddedExtension.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class EmbeddedExtension : ProjectTest {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/Action.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/Action.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class ActionTests : ExtensionTestBase

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/CustomKeyboard.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/CustomKeyboard.cs
@@ -2,7 +2,7 @@ using System;
 using NUnit.Framework;
 using System.Linq;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class CustomKeyboardTests : ExtensionTestBase {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/DocumentPicker.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/DocumentPicker.cs
@@ -1,7 +1,7 @@
 using System;
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class DocumentPickerTests : ExtensionTestBase {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	public class ExtensionTestBase : TestBase {
 		public ExtensionTestBase () { }

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/PhotoEditing.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/PhotoEditing.cs
@@ -1,7 +1,7 @@
 using System;
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class PhotoEditingTests : ExtensionTestBase {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/Share.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/Share.cs
@@ -1,7 +1,7 @@
 using System;
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhoneSimulator")]
 	[TestFixture ("iPhone")]
 	public class ShareTests : ExtensionTestBase {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/Today.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/Today.cs
@@ -1,7 +1,7 @@
 using System;
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class TodayTests : ExtensionTestBase {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/WatchKit.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/WatchKit.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class WatchKit : ExtensionTestBase {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/WatchKit2.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/Extensions/WatchKit2.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class WatchKit2 : ExtensionTestBase {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/IBToolLinking.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/IBToolLinking.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/LinkedAssets.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/LinkedAssets.cs
@@ -2,7 +2,7 @@ using System.IO;
 
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/NativeReferences.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/NativeReferences.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class NativeReferencesTests : ProjectTest {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 using Xamarin.Tests;
 using Xamarin.Utils;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectReference.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectReference.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectTest.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	public class ProjectTest : TestBase {
 		public ProjectTest (string platform)

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectWithFrameworks.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectWithFrameworks.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class ProjectWithFrameworksTests : ExtensionTestBase {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectWithSpaces.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ProjectWithSpaces.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ReleaseBuild.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ReleaseBuild.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone")]
 	public class ReleaseBuild : ProjectTest

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ResponseFileArguments.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/ResponseFileArguments.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	public class ResponseFileArguments : ProjectTest
 	{

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/SystemMemoryReference.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/SystemMemoryReference.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class SystemMemoryReferenceTests : ProjectTest {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/TVOS/TVApp.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/TVOS/TVApp.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/TVOS/TVMetalGameTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/TVOS/TVMetalGameTests.cs
@@ -2,7 +2,7 @@ using System;
 
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks {
+namespace Xamarin.MacDev.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
 	public class TVMetalGameTests : ProjectTest {

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/XIProject.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/XIProject.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	class XIProject : IDisposable {
 		public string OriginalProjectDirectory { get; private set; }

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/XamarinForms.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/XamarinForms.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using NUnit.Framework;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]

--- a/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
@@ -8,7 +8,7 @@ using Xamarin.MacDev;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class TargetTests : TestBase

--- a/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/ValidateAppBundleTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/ValidateAppBundleTaskTests.cs
@@ -8,7 +8,7 @@ using Xamarin.MacDev;
 
 using Xamarin.Tests;
 
-namespace Xamarin.iOS.Tasks
+namespace Xamarin.MacDev.Tasks
 {
 	[TestFixture]
 	public class ValidateAppBundleTaskTests : ExtensionTestBase


### PR DESCRIPTION
I always have to look through all the namespaces to figure out where a
specific test is, so this simplifies things a bit.

It's also where the tasks themselves are headed at some point.