### PR TITLE
[msbuild] Remove MS7068 so allow creating binding projects without native libraries. Fixes #15489.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -1796,16 +1796,6 @@ namespace Xamarin.Localization.MSBuild {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t create a binding resource package unless there are native references in the binding project.
-        ///        .
-        /// </summary>
-        public static string E7068 {
-            get {
-                return ResourceManager.GetString("E7068", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+..
         /// </summary>
         public static string E7069 {

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1239,10 +1239,7 @@
         </value>
     </data>
     
-    <data name="E7068" xml:space="preserve">
-        <value>Can't create a binding resource package unless there are native references in the binding project.
-        </value>
-    </data>
+    <!-- E7068: not in use anymore -->
     
     <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ does not support watchOS 1 apps. Please migrate your project to watchOS 2+.</value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -997,10 +997,6 @@
         <value>Nastavení: Položka {0} neexistuje.
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>Pokud ve vazebním projektu neexistují nativní odkazy, nedá se vytvořit balíček prostředků vazby.
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ nepodporuje aplikace watchOS 1. Migrujte projekt na watchOS 2+.</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -997,10 +997,6 @@
         <value>Festlegen: Eintrag "{0}" ist nicht vorhanden.
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>Ein Bindungsressourcenpaket kann nur erstellt werden, wenn im Bindungsprojektsystem native Verweise vorhanden sind.
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ unterstützt keine Apps für watchOS 1. Migrieren Sie Ihr Projekt zu watchOS 2 +.</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -997,10 +997,6 @@
         <value>Establecer: la entrada, "{0}", no existe.
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>No se puede crear un paquete de recursos de enlace, a menos que haya referencias nativas en el proyecto de enlace.
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ no es compatible con las aplicaciones watchOS 1. Migra tu proyecto a watchOS 2+.</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -997,10 +997,6 @@
         <value>Set : l'entrée "{0}" n'existe pas
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>Impossible de créer un paquet de ressources de liaison, sauf s'il existe des références natives dans le projet de liaison.
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ ne prend pas en charge les applications Watchos 1. Effectuez la migration de votre projet vers Watchos 2+.</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -997,10 +997,6 @@
         <value>Impostazione: la voce "{0}" non esiste
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>Non è possibile creare un pacchetto di risorse di binding a meno che nel progetto di binding non siano presenti riferimenti nativi.
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ non supporta le app watchOS 1. Eseguire la migrazione del progetto a watchOS 2+.</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -997,10 +997,6 @@
         <value>設定: エントリ "{0}" が存在しません
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>バインド プロジェクトにネイティブ参照がある場合を除いて、バインド リソース パッケージは作成できません。
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14 以降では watchOS 1 アプリがサポートされていません。プロジェクトを watchOS 2 以降に移行してください。</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -997,10 +997,6 @@
         <value>설정: '{0}' 항목이 없음
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>바인딩 프로젝트에 네이티브 참조가 없으면 바인딩 리소스 패키지를 생성할 수 없습니다.
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14 이상은 watchOS 1 앱을 지원하지 않습니다. 프로젝트를 watchOS 2 이상으로 마이그레이션하세요.</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -997,10 +997,6 @@
         <value>Ustawianie: wpis („{0}”) nie istnieje
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>Nie można utworzyć pakietu zasobów powiązania, chyba że istnieją odwołania natywne w projekcie powiązania.
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ nie obsługuje aplikacji systemu watchOS 1. Dokonaj migracji projektu do systemu watchOS 2+.</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -997,10 +997,6 @@
         <value>Configurar: A Entrada, "{0}", Não Existe
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>Não é possível criar um pacote de recursos de associação, a menos que haja referências nativas no projeto de associação.
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>O Xamarin.iOS 14+ não oferece suporte a aplicativos watchOS 1. Migre seu projeto para watchOS 2.</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -997,10 +997,6 @@
         <value>Задание: запись "{0}" не существует.
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>Создание пакета ресурсов привязки возможно, только если в проекте привязки есть собственные ссылки.
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ не поддерживает приложения watchOS 1. Перенесите свой проект на watchOS 2+.</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -997,10 +997,6 @@
         <value>Ayarla: "{0}" Girişi Yok
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>Bağlama projesinde yerel başvurular olmadığı sürece, bağlama kaynak paketi oluşturulamaz.
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ uzantısı watchOS 1 uygulamalarını desteklemiyor. Lütfen projenizi watchOS 2+ sürümüne geçirin.</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -997,10 +997,6 @@
         <value>设置: 不存在条目“{0}”
 </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>除非绑定项目中存在本机引用，否则无法创建绑定资源包。
-</value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ 不支持 watchOS 1 应用。请将你的项目迁移到 watchOS 2+。</value>
     </data>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -997,10 +997,6 @@
         <value>設定: 項目 "{0}" 不存在
         </value>
     </data>
-  <data name="E7068" xml:space="preserve">
-        <value>除非繫結專案中具有原生參考，否則無法建立繫結資源套件。
-        </value>
-    </data>
   <data name="E7069" xml:space="preserve">
         <value>Xamarin.iOS 14+ 不支援 watchOS 1 應用程式。請將您的專案遷移到 watchOS 2+。</value>
     </data>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs
@@ -32,10 +32,9 @@ namespace Xamarin.MacDev.Tasks {
 
 		public override bool Execute ()
 		{
-			// LinkWith must be migrated for NoBindingEmbedding styled binding projects
 			if (NativeReferences.Length == 0) {
-				Log.LogError (7068, null, MSBStrings.E7068);
-				return false;
+				// Nothing to do here
+				return true;
 			}
 
 			var compress = false;

--- a/tests/dotnet/UnitTests/TemplateTest.cs
+++ b/tests/dotnet/UnitTests/TemplateTest.cs
@@ -23,13 +23,13 @@ namespace Xamarin.Tests {
 			new TemplateInfo (ApplePlatform.iOS, "ios"),
 			new TemplateInfo (ApplePlatform.iOS, "ios-tabbed"),
 			new TemplateInfo (ApplePlatform.iOS, "ioslib"),
-			new TemplateInfo (ApplePlatform.iOS, "iosbinding", false), // Bindings can not build without a native library assigned
+			new TemplateInfo (ApplePlatform.iOS, "iosbinding"),
 			new TemplateInfo (ApplePlatform.TVOS, "tvos"),
-			new TemplateInfo (ApplePlatform.TVOS, "tvosbinding", false), // Bindings can not build without a native library assigned
+			new TemplateInfo (ApplePlatform.TVOS, "tvosbinding"),
 			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalyst", execute: true),
-			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalystbinding", false), // Bindings can not build without a native library assigned
+			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalystbinding"),
 			new TemplateInfo (ApplePlatform.MacOSX, "macos", execute: true),
-			new TemplateInfo (ApplePlatform.MacOSX, "macosbinding", false), // Bindings can not build without a native library assigned
+			new TemplateInfo (ApplePlatform.MacOSX, "macosbinding"),
 		};
 
 		public class TemplateConfig {

--- a/tests/mmptest/src/BindingProjectNoEmbeddingTests.cs
+++ b/tests/mmptest/src/BindingProjectNoEmbeddingTests.cs
@@ -71,8 +71,7 @@ namespace Xamarin.MMP.Tests
 
 				projects.Item1.LinkWithName = "SimpleClassDylib.dylib";
 
-				var buildResult = BindingProjectTests.SetupAndBuildBindingProject (projects.Item1, false, shouldFail: true);
-				buildResult.Messages.AssertError (7068, "Can't create a binding resource package unless there are native references in the binding project.\n        ");
+				BindingProjectTests.SetupAndBuildBindingProject (projects.Item1, false);
 			});
 		}
 

--- a/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
@@ -58,12 +58,6 @@ namespace Xamarin.iOS.Tasks
 			Assert.True (File.Exists (finalFrameworkPath), $"{finalFrameworkPath} file was not part of bundle?");
 		}
 
-		// [Test] MISSING_TEST - No LinkWith only projects
-		public void DoesNotSupportLinkWith ()
-		{
-			Assert.Fail ();
-		}
-
 		[TestCase (true)]
 		// [TestCase (false)] MISSING_TEST - Framework only tests
 		public void ShouldNotUnnecessarilyRebuildBindingProject (bool framework)


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/15489.
