### PR TITLE
[msbuild] Automatically add the 'com.apple.security.cs.allow-jit' entitlement for desktop release builds. Fixes #15745.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -2040,6 +2040,33 @@ namespace Xamarin.Localization.MSBuild {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid value &apos;{0}&apos; for the entitlement &apos;{1}&apos; of type &apos;{2}&apos; specified in the CustomEntitlements item group. Expected no value at all..
+        /// </summary>
+        public static string E7102 {
+            get {
+                return ResourceManager.GetString("E7102", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid value &apos;{0}&apos; for the entitlement &apos;{1}&apos; of type &apos;{2}&apos; specified in the CustomEntitlements item group. Expected &apos;true&apos; or &apos;false&apos;..
+        /// </summary>
+        public static string E7103 {
+            get {
+                return ResourceManager.GetString("E7103", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unknown type &apos;{0}&apos; for the entitlement &apos;{1}&apos; specified in the CustomEntitlements item group. Expected &apos;Remove&apos;, &apos;Boolean&apos;, &apos;String&apos;, or &apos;StringArray&apos;..
+        /// </summary>
+        public static string E7104 {
+            get {
+                return ResourceManager.GetString("E7104", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid framework: {0}.
         /// </summary>
         public static string InvalidFramework {

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1428,4 +1428,29 @@
     <data name="E7101" xml:space="preserve">
         <value>Unknown property '{0}' with value '{1}'.</value>
     </data>
+
+    <data name="E7102" xml:space="preserve">
+        <value>Invalid value '{0}' for the entitlement '{1}' of type '{2}' specified in the CustomEntitlements item group. Expected no value at all.</value>
+        <comment>
+            Don't translate: CustomEntitlements (name of option in project file)
+        </comment>
+    </data>
+
+    <data name="E7103" xml:space="preserve">
+        <value>Invalid value '{0}' for the entitlement '{1}' of type '{2}' specified in the CustomEntitlements item group. Expected 'true' or 'false'.</value>
+        <comment>
+            Don't translate:
+                * CustomEntitlements (name of option in project file)
+                * 'true', 'false'
+        </comment>
+    </data>
+
+    <data name="E7104" xml:space="preserve">
+        <value>Unknown type '{0}' for the entitlement '{1}' specified in the CustomEntitlements item group. Expected 'Remove', 'Boolean', 'String', or 'StringArray'.</value>
+        <comment>
+            Don't translate:
+                * CustomEntitlements (name of option in project file)
+                * 'Remove', 'Boolean', 'String', 'StringArray'
+        </comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -645,12 +645,18 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		Condition="'$(_RequireCodeSigning)' == 'true' Or '$(CodesignEntitlements)' != ''"
 		DependsOnTargets="$(_CompileEntitlementsDependsOn)"
 		Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
+		<!-- Automatically add the 'allow-jit' entitlement for desktop release builds in .NET -->
+		<ItemGroup Condition="'$(Configuration)' == 'Release' And ('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst') And '$(UsingAppleNETSdk)' == 'true'">
+			<!-- We need to compare the result of AnyHaveMetadataValue to 'true', because if it's empty, the return value is not a boolean, it's an empty string -->
+			<CustomEntitlements Condition="'@(CustomEntitlements->AnyHaveMetadataValue('Identity','com.apple.security.cs.allow-jit'))' != 'true'" Include="com.apple.security.cs.allow-jit" Type="Boolean" Value="true" />
+		</ItemGroup>
 		<CompileEntitlements
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			AppIdentifier="$(_AppIdentifier)"
 			BundleIdentifier="$(_BundleIdentifier)"
+			CustomEntitlements="@(CustomEntitlements)"
 			Entitlements="$(CodesignEntitlements)"
 			CompiledEntitlements="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent"
 			IsAppExtension="$(IsAppExtension)"

--- a/tests/dotnet/Entitlements/AppDelegate.cs
+++ b/tests/dotnet/Entitlements/AppDelegate.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace MySimpleApp
+{
+	public class Program
+	{
+		static int Main (string[] args)
+		{
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return args.Length;
+		}
+	}
+}

--- a/tests/dotnet/Entitlements/MacCatalyst/Entitlements.csproj
+++ b/tests/dotnet/Entitlements/MacCatalyst/Entitlements.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/Entitlements/MacCatalyst/Entitlements.plist
+++ b/tests/dotnet/Entitlements/MacCatalyst/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/dotnet/Entitlements/MacCatalyst/Makefile
+++ b/tests/dotnet/Entitlements/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/Entitlements/Makefile
+++ b/tests/dotnet/Entitlements/Makefile
@@ -1,0 +1,2 @@
+TOP=../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/Entitlements/iOS/Entitlements.csproj
+++ b/tests/dotnet/Entitlements/iOS/Entitlements.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/Entitlements/iOS/Entitlements.plist
+++ b/tests/dotnet/Entitlements/iOS/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/dotnet/Entitlements/iOS/Makefile
+++ b/tests/dotnet/Entitlements/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/Entitlements/macOS/Entitlements.csproj
+++ b/tests/dotnet/Entitlements/macOS/Entitlements.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/Entitlements/macOS/Entitlements.plist
+++ b/tests/dotnet/Entitlements/macOS/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/dotnet/Entitlements/macOS/Makefile
+++ b/tests/dotnet/Entitlements/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/Entitlements/shared.csproj
+++ b/tests/dotnet/Entitlements/shared.csproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<ApplicationId>Entitlements</ApplicationId>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/Entitlements/shared.mk
+++ b/tests/dotnet/Entitlements/shared.mk
@@ -1,0 +1,3 @@
+TOP=../../../..
+TESTNAME=AutoDetectEntitlements
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/Entitlements/tvOS/Entitlements.csproj
+++ b/tests/dotnet/Entitlements/tvOS/Entitlements.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/Entitlements/tvOS/Entitlements.plist
+++ b/tests/dotnet/Entitlements/tvOS/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/dotnet/Entitlements/tvOS/Makefile
+++ b/tests/dotnet/Entitlements/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -996,5 +996,30 @@ namespace Xamarin.Tests {
 			properties ["AppBundleDir"] = customAppBundleDir;
 			var result = DotNet.AssertBuild (project_path, properties);
 		}
+
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", "Release")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64", "Debug")]
+		public void AutoAllowJitEntitlements (ApplePlatform platform, string runtimeIdentifiers, string configuration)
+		{
+			var project = "Entitlements";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
+			Clean (project_path);
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["Configuration"] = configuration;
+			DotNet.AssertBuild (project_path, properties);
+
+			var executable = GetNativeExecutable (platform, appPath);
+			var foundEntitlements = TryGetEntitlements (executable, out var entitlements);
+			if (configuration == "Release") {
+				Assert.IsTrue (foundEntitlements, "Found in Release");
+				Assert.IsTrue (entitlements!.Get<PBoolean>("com.apple.security.cs.allow-jit")?.Value, "Jit Allowed");
+			} else {
+				var jitNotAllowed = !foundEntitlements || !entitlements!.ContainsKey ("com.apple.security.cs.allow-jit");
+				Assert.True (jitNotAllowed, "Jit Not Allowed");
+			}
+		}
 	}
 }


### PR DESCRIPTION
* Add support for specifying custom entitlements with an MSBuild item group.
* Use this new support to automatically add the 'com.apple.security.cs.allow-jit'
  entitlement to .NET desktop apps when building for release, since all apps that
  go through notarization will need it in order to be able to use the JIT.

It's possible to override the default behavior by adding something like this to the project file:

    <ItemGroup>
        <CustomEntitlements Include="com.apple.security.cs.allow-jit" Type="Remove" />
    </ItemGroup>

Fixes https://github.com/xamarin/xamarin-macios/issues/15745.