### PR TITLE
[devops] Don't create legacy iOS/Mac symlinks unless legacy build is enabled.

### DIFF
--- a/tools/devops/automation/scripts/bash/create-legacy-ios-mac-sdk-symlinks.sh
+++ b/tools/devops/automation/scripts/bash/create-legacy-ios-mac-sdk-symlinks.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -ex
+
+include_xamarin_legacy=$(make -C tools/devops print-variable VARIABLE=INCLUDE_XAMARIN_LEGACY)
+include_xamarin_legacy=${include_xamarin_legacy#*=}
+if test -z "$include_xamarin_legacy"; then
+	echo "Not creating symlinks because legaxy Xamarin is disabled."
+	exit
+fi
+
+if test -d /Library/Frameworks/Xamarin.Mac.framework/Versions/Current; then
+  mac_var=$(make -C tools/devops print-variable VARIABLE=MAC_DESTDIR MAC_DESTDIR=)
+  MAC_DESTDIR=${mac_var#*=}
+  XM_DEST_DIR="$MAC_DESTDIR/Library/Frameworks/Xamarin.Mac.framework/Versions/"
+  mkdir -p "$XM_DEST_DIR"
+  ln -s /Library/Frameworks/Xamarin.Mac.framework/Versions/Current "$XM_DEST_DIR/git"
+  ls -laR "$XM_DEST_DIR"
+fi
+
+if test -d /Library/Frameworks/Xamarin.iOS.framework/Versions/Current; then
+  ios_var=$(make -C tools/devops print-variable VARIABLE=IOS_DESTDIR IOS_DESTDIR=)
+  IOS_DESTDIR=${ios_var#*=}
+  XI_DEST_DIR="$IOS_DESTDIR/Library/Frameworks/Xamarin.iOS.framework/Versions/"
+  mkdir -p "$XI_DEST_DIR"
+  ln -s /Library/Frameworks/Xamarin.iOS.framework/Versions/Current "$XI_DEST_DIR/git"
+  ls -laR "$XI_DEST_DIR"
+fi

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -175,21 +175,7 @@ steps:
     ls -R /Library/Frameworks/Xamarin.Mac.framework
   displayName: "Show installed Frameworks"
 
-- bash: |
-    set -e
-    set -x
-    mac_var=$(make -C tools/devops print-variable VARIABLE=MAC_DESTDIR MAC_DESTDIR=)
-    ios_var=$(make -C tools/devops print-variable VARIABLE=IOS_DESTDIR IOS_DESTDIR=)
-    MAC_DESTDIR=${mac_var#*=}
-    IOS_DESTDIR=${ios_var#*=}
-    XM_DEST_DIR="$MAC_DESTDIR/Library/Frameworks/Xamarin.Mac.framework/Versions/"
-    XI_DEST_DIR="$IOS_DESTDIR/Library/Frameworks/Xamarin.iOS.framework/Versions/"
-    mkdir -p "$XM_DEST_DIR"
-    mkdir -p "$XI_DEST_DIR"
-    ln -s /Library/Frameworks/Xamarin.Mac.framework/Versions/Current "$XM_DEST_DIR/git"
-    ln -s /Library/Frameworks/Xamarin.iOS.framework/Versions/Current "$XI_DEST_DIR/git"
-    ls -laR "$XM_DEST_DIR"
-    ls -laR "$XI_DEST_DIR"
+- bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/create-legacy-ios-mac-sdk-symlinks.sh
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios/
   displayName: Create legacy iOS/Mac SDK symlinks
 


### PR DESCRIPTION
* Move the bash in the yml file to a separate script file to ease reading, writing & debugging.
* Don't install any symlinks if legacy Xamarin isn't enabled.
* Only install the iOS / macOS symlink if the corresponding build is enabled.