### PR TITLE
[devops] Only install XI/XM package if corresponding build is enabled.

### DIFF
--- a/tools/devops/Makefile
+++ b/tools/devops/Makefile
@@ -8,7 +8,12 @@ device-tests-provisioning.csx: device-tests-provisioning.csx.in Makefile $(TOP)/
 		-e 's#@MONO_PACKAGE@#$(MIN_MONO_URL)#g' \
 		-e 's#@VS_PACKAGE@#$(MIN_VISUAL_STUDIO_URL)#g' \
 		-e 's#@MIN_SHARPIE_URL@#$(MIN_SHARPIE_URL)#g' \
+		-e 's#@INCLUDE_MAC@#$(INCLUDE_MAC)#g' \
+		-e 's#@INCLUDE_IOS@#$(INCLUDE_IOS)#g' \
+		-e 's#@INCLUDE_XAMARIN_LEGACY@#$(INCLUDE_XAMARIN_LEGACY)#g' \
 		$< > $@;
+		@echo "Generated $@:"
+		@cat $@
 
 build-provisioning.csx: build-provisioning.csx.in Makefile $(TOP)/Make.config
 	$(Q_GEN) sed \
@@ -17,19 +22,28 @@ build-provisioning.csx: build-provisioning.csx.in Makefile $(TOP)/Make.config
 		-e 's#@VS_PACKAGE@#$(MIN_VISUAL_STUDIO_URL)#g' \
 		-e 's#@MIN_SHARPIE_URL@#$(MIN_SHARPIE_URL)#g' \
 		$< > $@;
+		@echo "Generated $@:"
+		@cat $@
 
 mac-tests-provisioning.csx: mac-tests-provisioning.csx.in Makefile $(TOP)/Make.config
 	$(Q_GEN) sed \
 		-e 's#@XM_PACKAGE@#$(XM_PACKAGE)#g' \
 		-e 's#@MONO_PACKAGE@#$(MIN_MONO_URL)#g' \
 		-e 's#@VS_PACKAGE@#$(MIN_VISUAL_STUDIO_URL)#g' \
+		-e 's#@INCLUDE_MAC@#$(INCLUDE_MAC)#g' \
+		-e 's#@INCLUDE_IOS@#$(INCLUDE_IOS)#g' \
+		-e 's#@INCLUDE_XAMARIN_LEGACY@#$(INCLUDE_XAMARIN_LEGACY)#g' \
 		$< > $@;
+		@echo "Generated $@:"
+		@cat $@
 
 provision-xcode.csx: provision-xcode.csx.in Makefile $(TOP)/Make.config
 	$(Q_GEN) sed \
 		-e 's#@XCODE_XIP_NAME@#$(notdir $(XCODE_URL))#g' \
 		-e 's#@XCODE_ROOT_PATH@#$(XCODE_DEVELOPER_ROOT)#g' \
 		$< > $@;
+		@echo "Generated $@:"
+		@cat $@
 
 LocProject.json: LocProject.json.in Makefile $(TOP)/Make.config
 	$(Q_GEN) sed \

--- a/tools/devops/device-tests-provisioning.csx.in
+++ b/tools/devops/device-tests-provisioning.csx.in
@@ -10,9 +10,12 @@ using static Xamarin.Provisioning.ProvisioningScript;
 Xcode ("@XCODE_XIP_NAME@").XcodeSelect (allowUntrusted: true);
 
 // provisionator knows how to deal with this items
-Item ("@MONO_PACKAGE@");
-Item ("@VS_PACKAGE@");
-Item ("@XI_PACKAGE@");
+if (!string.IsNullOrEmpty ("@INCLUDE_XAMARIN_LEGACY@")) {
+	Item ("@MONO_PACKAGE@");
+	Item ("@VS_PACKAGE@");
+	if (!string.IsNullOrEmpty ("@INCLUDE_IOS@"))
+		Item ("@XI_PACKAGE@");
+}
 Item ("@MIN_SHARPIE_URL@");
 
 BrewPackages ("p7zip");

--- a/tools/devops/mac-tests-provisioning.csx.in
+++ b/tools/devops/mac-tests-provisioning.csx.in
@@ -7,9 +7,12 @@ using System.Linq;
 using static Xamarin.Provisioning.ProvisioningScript;
 
 // provisionator knows how to deal with this items
-Item ("@MONO_PACKAGE@");
-Item ("@VS_PACKAGE@");
-Item ("@XM_PACKAGE@");
+if (!string.IsNullOrEmpty ("@INCLUDE_XAMARIN_LEGACY@")) {
+	Item ("@MONO_PACKAGE@");
+	Item ("@VS_PACKAGE@");
+	if (!string.IsNullOrEmpty ("@INCLUDE_MAC@"))
+		Item ("@XM_PACKAGE@");
+}
 
 BrewPackages ("p7zip");
 


### PR DESCRIPTION
Only install the XI and/or XM package if the corresponding part of the build is enabled.

Also don't install either if the legacy Xamarin build is disabled.