### PR TITLE
[actions] Add GitHub action to automatically format code.

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -1,0 +1,73 @@
+name: Autoformat code
+on: pull_request
+
+#
+# The autoformat action is a 2-parter:
+# Part 1 (this file):
+#     * This is done in a safe context with no secrets (target: pull_request)
+#     * We clone the repo and check out the pull request
+#     * We run 'dotnet format' to format incorrectly formatted code (this is the potentially unsafe action, since who knows what kind of attach vector 'dotnet format' is)
+#     * We see if any code was formatted, and create a commit with those changes.
+#     * We preare a patch for the commit, and store it as an artifact.
+# Part 2 (autoformat2.yml):
+#     * This is done in a context with more powers (most importantly it can push to forks)
+#     * We get the πatch artifact from part 1
+#     * We push the commit, and add a label to the PR.
+#
+# Ref:
+#     https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#     https://github.com/actions/checkout/issues/455
+#
+
+jobs:
+  autoformat-code:
+    name: Autoformat code
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'actions-enable-autoformat')
+
+    steps:
+    - name: 'Checkout repo'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: 'Autoformat'
+      id: autoformat
+      run: |
+        set -exo pipefail
+
+        SRC_DIR=$(pwd)
+        cd ..
+        dotnet format "$SRC_DIR/tools/xibuild/xibuild.csproj"
+        # add more projects here...
+        cd "$SRC_DIR"
+
+        if git diff --exit-code >/dev/null; then
+          echo "No code formatting occurred"
+          exit 0
+        fi
+
+        git add -- .
+        git config --global user.email "github-actions-autoformatter@xamarin.com"
+        git config --global user.name "GitHub Actions Autoformatter"
+        git checkout "$GITHUB_HEAD_REF"
+        git commit -m "Auto-format source code"
+
+        mkdir -p autoformat
+        echo ${{ github.event.number }} > ./autoformat/PR
+        git format-patch HEAD^..HEAD --stdout > ./autoformat/autoformat.patch
+        #cat ./autoformat/autoformat.patch
+
+        echo "::set-output name=autoformatted::true"
+
+    - name: 'Debug'
+      run: echo "Yay? ${{ steps.autoformat.outputs.autoformatted }}"
+
+    - name: 'Upload patch'
+      uses: actions/upload-artifact@v2
+      if: steps.autoformat.outputs.autoformatted == 'true'
+      with:
+        name: autoformat
+        path: autoformat/

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -62,9 +62,6 @@ jobs:
 
         echo "::set-output name=autoformatted::true"
 
-    - name: 'Debug'
-      run: echo "Yay? ${{ steps.autoformat.outputs.autoformatted }}"
-
     - name: 'Upload patch'
       uses: actions/upload-artifact@v2
       if: steps.autoformat.outputs.autoformatted == 'true'

--- a/.github/workflows/autoformat2.yml
+++ b/.github/workflows/autoformat2.yml
@@ -1,0 +1,69 @@
+name: Autoformat code part 2
+on:
+  workflow_run:
+    workflows: ["Autoformat code"]
+    types:
+      - completed
+
+# See autoformat.yml for a description of what happens here.
+
+jobs:
+  push-and-notify:
+    name: Push autoformatted code and notify user
+    runs-on: ubuntu-latest
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'actions-enable-autoformat') &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+    - name: 'Download artifacts'
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             run_id: ${{github.event.workflow_run.id }},
+          });
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "autoformat"
+          })[0];
+          var download = await github.actions.downloadArtifact({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             artifact_id: matchArtifact.id,
+             archive_format: 'zip',
+          });
+          var fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/autoformat.zip', Buffer.from(download.data));
+
+    - run: unzip autoformat.zip
+
+    - name: 'Checkout repo'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: 'Get autoformatted commit and push it'
+      run: |
+        git checkout "$GITHUB_HEAD_REF"
+        git am < autoformat/autoformat.patch
+        git show
+        #git push
+
+    - name: 'Yell at user'
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          let fs = require('fs');
+          let issue_number = Number(fs.readFileSync('./PR'));
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issue_number,
+            body: '# :warning: Your code has been automatically reformatted. :warning:\n\nIf this is not desired, add the `actions-skip-autoformat` label, and revert the reformatting commit.'
+          });


### PR DESCRIPTION
Implement a GitHub action to automatically format our source code.

This is implemented in two steps:

1. A restricted action is used to check if the code has any formatting issues, and if so, creates a patch to fix the code.
2. Another action is used to commit and push the patch (and add a comment to the PR notifying the submitter about the problems found).

This is because the first action will call 'dotnet format', which might be insecure in that it can execute code from the repository. This is not safe in a context that is allowed to push commits (because there are secrets in the environment) - so anyone could create a PR that would be executed as a part of 'dotnet format' and then look for our secrets and make them public. The restricted action's environment does not have any secrets, and it's thus safe to execute random code.

The second action will only execute if the corresponding file is in main, so this PR need to be merged before this can be fully implemented, and as such I've made the autoformatting opt-in (by adding the `actions-enable-autoformat` label). Once everything is confirmed to work properly, it will become opt-out instead.

Also, for now only a very simple project is autoformatted (xibuild.csproj), but the
idea is to fix source code incrementally, and add to the list of projects/code
we autoformat.