### PR TITLE
[devops] Improve check for crash reports before collecting them.

### DIFF
--- a/tools/devops/automation/scripts/bash/collect-and-upload-crash-reports.sh
+++ b/tools/devops/automation/scripts/bash/collect-and-upload-crash-reports.sh
@@ -2,7 +2,9 @@
 
 env | sort
 
-if test -d "$HOME/Library/Logs/DiagnosticReports"; then
+if ! test -d "$HOME/Library/Logs/DiagnosticReports"; then
+  true # directory doesn't exist: nothing to do
+elif test -n "$(ls -A $HOME/Library/Logs/DiagnosticReports)"; then
   zip -9rj "$SYSTEM_DEFAULTWORKINGDIRECTORY/crash-reports.zip" "$HOME/Library/Logs/DiagnosticReports"
   if test -f "$SYSTEM_DEFAULTWORKINGDIRECTORY/crash-reports.zip"; then
     set +x


### PR DESCRIPTION
Otherwise this happens if the directory is empty:

    + test -d /Users/runner/Library/Logs/DiagnosticReports
    + zip -9rj /Users/runner/work/1/s/crash-reports.zip /Users/runner/Library/Logs/DiagnosticReports

    zip error: Nothing to do! (try: zip -9rj /Users/runner/work/1/s/crash-reports.zip . -i /Users/runner/Library/Logs/DiagnosticReports)