### PR TITLE
[devops] Add some debug code to figure out a random error.

### DIFF
--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -170,6 +170,7 @@ steps:
 
 # sometimes the make that creates the pkgs fails.
 - bash: |
+    set -ex
     if ! test -f $(Build.SourcesDirectory)/artifacts/tmp/mac-test-package/mac-test-package.7z; then
       echo "No test package could be found for tests on macOS $CONTEXT" > "$GITHUB_FAILURE_COMMENT_FILE"
       exit 1


### PR DESCRIPTION
The 'Expand tests.' step sometimes fails with:

> ##[error]Bash exited with code '1'.

Which is very unhelpful. Make bash more verbose to see if we can figure out what's going wrong.