### PR TITLE
[tests] We do not need qa-dependencies.zip anymore.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -54,7 +54,7 @@ endif
 #
 
 package-tests:
-	$(MAKE) qa-test-dependencies.zip mac-test-package.zip
+	$(MAKE) mac-test-package.zip
 
 test.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.Details.xml
 	@rm -f $@
@@ -208,50 +208,6 @@ test-install-sources:
 	cd $(NUNIT_MSBUILD_DIR) && $(SYSTEM_XIBUILD) -t -- ../nunit-console.exe ../../../../tools/install-source/InstallSourcesTests/bin/Release/InstallSourcesTests.dll -xml=TestResults_InstallSourcesTests.xml -labels $(TEST_FIXTURE) || touch .failed-stamp
 	@[[ -z "$$BUILD_REPOSITORY" ]] || ( xsltproc $(TOP)/tests/HtmlTransform.xslt $(NUNIT_MSBUILD_DIR)/TestResults_InstallSourcesTests.xml > $(TOP)/tests/index.html && echo "@MonkeyWrench: AddFile: $$PWD/index.html" )
 	@if test -e $(NUNIT_MSBUILD_DIR)/.failed-stamp; then rm $(NUNIT_MSBUILD_DIR)/.failed-stamp; exit 1; fi
-
-
-ifdef ENABLE_XAMARIN
-ifdef INCLUDE_IOS
-qa-test-dependencies.zip:
-	@$(MAKE) build-test-libraries
-	@# Make sure we start from a clean slate
-	$(Q) rm -rf $@ $@.tmpdir
-ifdef INCLUDE_TVOS
-	@# TVOS
-	$(Q) mkdir -p $@.tmpdir/tvos $@.tmpdir/tvsimulator
-	$(Q) $(CP) $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.TVOS/MonoTouch.Dialog-1.dll* $@.tmpdir/tvos
-	$(Q) $(CP) $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.TVOS/MonoTouch.NUnitLite.dll* $@.tmpdir/tvos
-	$(Q) $(CP) $(TOP)/tests/test-libraries/.libs/tvos/libtest.a $@.tmpdir/tvos
-	$(Q) $(CP) $(TOP)/tests/test-libraries/.libs/tvos/libtest.dylib $@.tmpdir/tvos
-	$(Q) $(CP) -a $(TOP)/tests/test-libraries/.libs/tvos/XTest.framework $@.tmpdir/tvos
-	$(Q) $(CP) $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.TVOS/MonoTouch.Dialog-1.dll* $@.tmpdir/tvsimulator
-	$(Q) $(CP) $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.TVOS/MonoTouch.NUnitLite.dll* $@.tmpdir/tvsimulator
-	$(Q) $(CP) $(TOP)/tests/test-libraries/.libs/tvsimulator/libtest.a $@.tmpdir/tvsimulator
-	$(Q) $(CP) $(TOP)/tests/test-libraries/.libs/tvsimulator/libtest.dylib $@.tmpdir/tvsimulator
-	$(Q) $(CP) -a $(TOP)/tests/test-libraries/.libs/tvsimulator/XTest.framework $@.tmpdir/tvsimulator
-endif
-	@# iOS
-	$(Q) mkdir -p $@.tmpdir/iphoneos $@.tmpdir/iphonesimulator
-	$(Q) $(CP) $(TOP)/tests/test-libraries/.libs/iphoneos/libtest.a $@.tmpdir/iphoneos
-	$(Q) $(CP) $(TOP)/tests/test-libraries/.libs/iphoneos/libtest.dylib $@.tmpdir/iphoneos
-	$(Q) $(CP) -a $(TOP)/tests/test-libraries/.libs/iphoneos/XTest.framework $@.tmpdir/iphoneos
-	$(Q) $(CP) $(TOP)/tests/test-libraries/.libs/iphonesimulator/libtest.a $@.tmpdir/iphonesimulator
-	$(Q) $(CP) $(TOP)/tests/test-libraries/.libs/iphonesimulator/libtest.dylib $@.tmpdir/iphonesimulator
-	$(Q) $(CP) -a $(TOP)/tests/test-libraries/.libs/iphonesimulator/XTest.framework $@.tmpdir/iphonesimulator
-	$(Q) printf '#!/bin/bash -e\n\n/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch "$$@"\n' > $@.tmpdir/mlaunch
-	$(Q) chmod +x $@.tmpdir/mlaunch
-	@# Generate zip
-	$(Q_GEN) cd $@.tmpdir && zip -9r $(abspath $@) .
-	@# Cleanup
-	$(Q) rm -rf $@.tmpdir
-else
-qa-test-dependencies.zip:
-	@echo Not enabled
-endif
-else
-qa-test-dependencies.zip:
-	@echo Xamarin build not enabled
-endif
 
 ifdef INCLUDE_MAC
 mac-test-package.zip:


### PR DESCRIPTION
This was used in the old Xamarin days.