### PR TITLE
[tools] We still need to build mtouch+mmp for .NET.

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,14 +3,9 @@ TOP=..
 include $(TOP)/Make.config
 
 ifdef INCLUDE_MAC
-ifdef INCLUDE_XAMARIN_LEGACY
 SUBDIRS+=mmp
 endif
-endif
 
-ifdef INCLUDE_XAMARIN_LEGACY
-SUBDIRS += mtouch
-endif
 
 ifdef INCLUDE_XAMARIN_LEGACY
 SUBDIRS += xibuild


### PR DESCRIPTION
Because we use mtouch and mmp to build the partial static registrar code for .NET.

Eventually we'll look into generating the partial static registrar some other
way, but that's for another time.