### PR TITLE
[tests] Update the cecil tests to run on .NET assemblies.

### DIFF
--- a/tests/cecil-tests/EnumTest.cs
+++ b/tests/cecil-tests/EnumTest.cs
@@ -12,7 +12,8 @@ namespace Cecil.Tests {
 	[TestFixture]
 	public class EnumTest {
 
-		[TestCaseSource (typeof (Helper), "PlatformAssemblies")]
+		[TestCaseSource (typeof (Helper), nameof (Helper.PlatformAssemblies))]
+		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformAssemblies))]
 		// https://github.com/xamarin/xamarin-macios/issues/9724
 		public void NoAvailabilityOnError (string assemblyPath)
 		{

--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -163,6 +163,9 @@ namespace Cecil.Tests {
 
 		public static IEnumerable PlatformAssemblies {
 			get {
+				if (!Configuration.include_legacy_xamarin)
+					yield break;
+
 				if (Configuration.include_ios) {
 					// we want to process 32/64 bits individually since their content can differ
 					yield return new TestCaseData (Path.Combine (Configuration.MonoTouchRootDirectory, "lib", "32bits", "iOS", "Xamarin.iOS.dll"));

--- a/tests/cecil-tests/MarshalAsTest.cs
+++ b/tests/cecil-tests/MarshalAsTest.cs
@@ -83,6 +83,11 @@ namespace Cecil.Tests {
 			var rv = true;
 
 			var type = tr.Resolve ();
+
+			// System.Runtime.InteropServices.NFloat is in a custom assembly in .NET 6, so add a special case.
+			if (type is null && tr.FullName == "System.Runtime.InteropServices.NFloat")
+				return true;
+
 			if (type.IsEnum)
 				return true;
 

--- a/tests/cecil-tests/MarshalAsTest.cs
+++ b/tests/cecil-tests/MarshalAsTest.cs
@@ -16,6 +16,7 @@ namespace Cecil.Tests {
 	[TestFixture]
 	public class MarshalAsTest {
 		[TestCaseSource (typeof (Helper), nameof (Helper.PlatformAssemblies))]
+		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformAssemblies))]
 		public void TestAssembly (string assemblyPath)
 		{
 			var assembly = Helper.GetAssembly (assemblyPath);

--- a/tests/cecil-tests/Test.cs
+++ b/tests/cecil-tests/Test.cs
@@ -15,6 +15,7 @@ namespace Cecil.Tests {
 	public class Test {
 
 		[TestCaseSource (typeof (Helper), nameof (Helper.PlatformAssemblies))]
+		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformImplementationAssemblies))]
 		// ref: https://github.com/xamarin/xamarin-macios/pull/7760
 		public void IdentifyBackingFieldAssignation (string assemblyPath)
 		{
@@ -50,6 +51,7 @@ namespace Cecil.Tests {
 		}
 
 		[TestCaseSource (typeof (Helper),  nameof (Helper.PlatformAssemblies))]
+		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformImplementationAssemblies))]
 		// ref: https://github.com/xamarin/xamarin-macios/issues/8249
 		public void EnsureUIThreadOnInit (string assemblyPath)
 		{
@@ -84,6 +86,7 @@ namespace Cecil.Tests {
 		}
 
 		[TestCaseSource (typeof (Helper), nameof (Helper.PlatformAssemblies))]
+		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformAssemblies))]
 		public void NoSystemConsoleReference (string assemblyPath)
 		{
 			if (Path.GetFileName (assemblyPath) == "Xamarin.Mac.dll")
@@ -126,6 +129,7 @@ namespace Cecil.Tests {
 		};
 
 		[TestCaseSource (typeof (Helper), nameof (Helper.PlatformAssemblies))]
+		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformAssemblies))]
 		public void NoBannedApi (string assemblyPath)
 		{
 			var assembly = Helper.GetAssembly (assemblyPath);
@@ -151,6 +155,7 @@ namespace Cecil.Tests {
 		}
 
 		[TestCaseSource (typeof (Helper), nameof (Helper.PlatformAssemblies))]
+		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformAssemblies))]
 		// ref: https://github.com/xamarin/xamarin-macios/issues/4835
 		public void Unavailable (string assemblyPath)
 		{
@@ -159,16 +164,22 @@ namespace Cecil.Tests {
 			var platform = PlatformName.None;
 			switch (assembly.Name.Name) {
 			case "Xamarin.Mac":
+			case "Microsoft.macOS":
 				platform = PlatformName.MacOSX;
 				break;
 			case "Xamarin.iOS":
+			case "Microsoft.iOS":
 				platform = PlatformName.iOS;
 				break;
 			case "Xamarin.WatchOS":
 				platform = PlatformName.WatchOS;
 				break;
 			case "Xamarin.TVOS":
+			case "Microsoft.tvOS":
 				platform = PlatformName.TvOS;
+				break;
+			case "Microsoft.MacCatalyst":
+				platform = PlatformName.MacCatalyst;
 				break;
 			}
 			Assert.That (platform, Is.Not.EqualTo (PlatformName.None), "None");

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -47,6 +47,7 @@ namespace Xamarin.Tests
 		public static bool include_maccatalyst;
 		public static bool include_device;
 		public static bool include_dotnet;
+		public static bool include_legacy_xamarin;
 
 		static Version xcode_version;
 		public static Version XcodeVersion {
@@ -295,6 +296,7 @@ namespace Xamarin.Tests
 			include_maccatalyst = !string.IsNullOrEmpty (GetVariable ("INCLUDE_MACCATALYST", ""));
 			include_device = !string.IsNullOrEmpty (GetVariable ("INCLUDE_DEVICE", ""));
 			include_dotnet = !string.IsNullOrEmpty (GetVariable ("ENABLE_DOTNET", ""));
+			include_legacy_xamarin = !string.IsNullOrEmpty (GetVariable ("INCLUDE_LEGACY_XAMARIN", ""));
 			DotNetBclDir = GetVariable ("DOTNET_BCL_DIR", null);
 			DotNetCscCommand = GetVariable ("DOTNET_CSC_COMMAND", null)?.Trim ('\'');
 			DotNetExecutable = GetVariable ("DOTNET", null);


### PR DESCRIPTION
And not legacy assemblies if the legacy build is disabled.