### PR TITLE
[release/6.0.4xx-xcode14] [tests] Adjust test for tvOS and watchOS.

### DIFF
--- a/tests/monotouch-test/Security/RecordTest.cs
+++ b/tests/monotouch-test/Security/RecordTest.cs
@@ -160,7 +160,11 @@ namespace MonoTouchFixtures.Security {
 
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				return;
+#if __TVOS__ || __WATCHOS__
+			Assert.That (rec.AuthenticationUI, Is.EqualTo (SecAuthenticationUI.Fail), "AuthenticationUI-get");
+#else
 			Assert.That (rec.AuthenticationUI, Is.EqualTo (SecAuthenticationUI.NotSet), "AuthenticationUI-get");
+#endif
 			rec.AuthenticationUI = SecAuthenticationUI.Allow;
 			Assert.That (rec.AuthenticationUI, Is.EqualTo (SecAuthenticationUI.Allow), "AuthenticationUI-set");
 		}


### PR DESCRIPTION
Probably regressed after 61e8ce443f2e9472d25c8670aead43bee18fe934.

Fixes https://github.com/xamarin/maccore/issues/2618.


Backport of #15939
