### PR TITLE
Make it easy to figure out which versions we're building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,15 +38,23 @@ ifdef INCLUDE_IOS
 endif
 endif
 	@./system-dependencies.sh
-	@echo "Building the packages:"
-	@echo "    Xamarin.iOS $(IOS_PACKAGE_VERSION)"
-	@echo "    Xamarin.Mac $(MAC_PACKAGE_VERSION)"
-	@echo "and the NuGets:"
-	@echo "    Xamarin.iOS $(IOS_NUGET_VERSION_FULL)"
-	@echo "    Xamarin.tvOS $(TVOS_NUGET_VERSION_FULL)"
-	@echo "    Xamarin.watchOS $(WATCHOS_NUGET_VERSION_FULL)"
-	@echo "    Xamarin.macOS $(MACOS_NUGET_VERSION_FULL)"
-	@echo "    Xamarin.MacCatalyst $(MACCATALYST_NUGET_VERSION_FULL)"
+	$(Q) $(MAKE) show-versions
+
+show-versions:
+	@echo "Building:"
+ifdef INCLUDE_XAMARIN_LEGACY
+	@echo "    The legacy package(s):"
+ifdef INCLUDE_IOS
+	@echo "        Xamarin.iOS $(IOS_PACKAGE_VERSION)"
+endif
+ifdef INCLUDE_MAC
+	@echo "        Xamarin.Mac $(MAC_PACKAGE_VERSION)"
+endif
+endif
+ifdef ENABLE_DOTNET
+	@echo "    The .NET NuGet(s):"
+	@$(foreach platform,$(DOTNET_PLATFORMS),echo "        Microsoft.$(platform) $($(shell echo $(platform) | tr 'a-z' 'A-Z')_NUGET_VERSION_FULL)";)
+endif
 
 check-permissions:
 ifdef INCLUDE_MAC


### PR DESCRIPTION
Just do `make show-versions`:

    $ make show-versions
    Building:
        The legacy package(s):
            Xamarin.iOS 15.13.0.132
            Xamarin.Mac 8.13.0.132
        The .NET NuGet(s):
            Microsoft.iOS 15.4.436-ci.show-versions+sha.405ff7c275
            Microsoft.tvOS 15.4.436-ci.show-versions+sha.405ff7c275
            Microsoft.MacCatalyst 15.4.436-ci.show-versions+sha.405ff7c275
            Microsoft.macOS 12.3.436-ci.show-versions+sha.405ff7c275