### PR TITLE
[release/6.0.4xx-xcode14] [msbuild] Hot Restart fixes

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -163,9 +163,8 @@
 			<_FilesToHotRestartContent Include="@(_FilesToHotRestartContent -> '%(RootDir)%(Directory)%(Filename).pdb')"
 													 Condition="Exists('%(RootDir)%(Directory)%(Filename).pdb')" />
 
-			<!-- TODO: We stopped filtering assemblies until we fix the net6 build -->
-			<!-- <_FilesToHotRestartContent Include="@(ReferenceCopyLocalPaths -> Distinct())" Condition="Exists('$(HotRestartAppBundlePath)\%(Filename)%(Extension)') == 'false'"/> -->
-			<_FilesToHotRestartContent Include="@(ReferenceCopyLocalPaths -> Distinct())"/>
+			<_FilesToHotRestartContent Include="@(ReferenceCopyLocalPaths -> Distinct())" 
+				Condition="Exists('$(HotRestartAppBundlePath)\%(Filename)%(Extension)') == 'false' And '%(Extension)' != '.a' And '%(Extension)' != '.dylib' And '%(Extension)' != '.dat'"/>
 		</ItemGroup>
 	</Target>
 

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -38,7 +38,7 @@
 		<CollectBundleResources
 			OptimizePropertyLists="$(OptimizePropertyLists)"
 			OptimizePNGs="$(OptimizePNGs)"
-			BundleResources="@(Content);@(BundleResource)"
+			BundleResources="@(Content);@(BundleResource);@(MauiAsset)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(IPhoneResourcePrefix)">
 


### PR DESCRIPTION
Adds missing css files needed on Maui Blazor apps and avoids copying unnecessary files into the bundle (overdue task since the .NET migration).


Backport of #15979
