### PR TITLE
Use Environment.SpecialFolder.UserProfile, not SpecialFolder.Personal.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ArchiveTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ArchiveTaskBase.cs
@@ -64,7 +64,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected string XcodeArchivesDir {
 			get {
-				var home = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+				var home = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 
 				return Path.Combine (home, "Library", "Developer", "Xcode", "Archives");
 			}

--- a/tests/monotouch-test/Foundation/FileManagerTest.cs
+++ b/tests/monotouch-test/Foundation/FileManagerTest.cs
@@ -95,7 +95,7 @@ namespace MonoTouchFixtures.Foundation {
 		{
 			Assert.False (NSFileManager.GetSkipBackupAttribute (NSBundle.MainBundle.ExecutableUrl.ToString ()), "MainBundle");
 
-			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), $"DoNotBackupMe-NSFileManager-{Process.GetCurrentProcess ().Id}");
+			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), $"DoNotBackupMe-NSFileManager-{Process.GetCurrentProcess ().Id}");
 			try {
 				File.WriteAllText (filename, "not worth a bit");
 				

--- a/tests/monotouch-test/Foundation/UrlTest.cs
+++ b/tests/monotouch-test/Foundation/UrlTest.cs
@@ -49,7 +49,7 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.That (value, Is.TypeOf (typeof (NSNumber)), "NSNumber");
 			Assert.That ((int) (value as NSNumber), Is.EqualTo (0), "0");
 			
-			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), $"DoNotBackupMe-NSUrl-{Process.GetCurrentProcess ().Id}");
+			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), $"DoNotBackupMe-NSUrl-{Process.GetCurrentProcess ().Id}");
 			try {
 				File.WriteAllText (filename, "not worth a bit");
 				using (NSUrl url = NSUrl.FromFilename (filename)) {

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -321,7 +321,7 @@ namespace Xamarin.Bundler {
 		static int GetDefaultVerbosity ()
 		{
 			var v = 0;
-			var fn = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), $".{NAME}-verbosity");
+			var fn = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), $".{NAME}-verbosity");
 			if (File.Exists (fn)) {
 				v = (int) new FileInfo (fn).Length;
 				if (v == 0)

--- a/tools/devops/mac-tests-provisioning.csx.in
+++ b/tools/devops/mac-tests-provisioning.csx.in
@@ -16,7 +16,7 @@ if (!string.IsNullOrEmpty ("@INCLUDE_XAMARIN_LEGACY@")) {
 
 BrewPackages ("p7zip");
 
-var appleSdkOverride = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "Library", "Preferences", "Xamarin", "Settings.plist");
+var appleSdkOverride = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Preferences", "Xamarin", "Settings.plist");
 Item ("Override Apple SDK Settings")
 	.Condition (item => !File.Exists (appleSdkOverride) || GetSettingValue (appleSdkOverride, "AppleSdkRoot") != GetSelectedXcodePath ())
 	.Action (item => {


### PR DESCRIPTION
Context: dotnet/runtime#68610
Context: https://github.com/xamarin/xamarin-android-tools/commit/0be567a9

In Mono and .NET prior to .NET 8, the
[`System.Environment.SpecialFolder`][0]`.Personal` enum value would refer to
`$HOME` on Unix platforms.

This will be changing in .NET 8, such that
`Environment.SpecialFolder.Personal` will instead refer to
`$XDG_DOCUMENTS_DIR` (if set) or `$HOME/Documents`.  This is for "semantic
compatibility" with .NET on Windows.

Replace usage of `Environment.SpecialFolder.Personal` with
`Environment.SpecialFolder.UserProfile`, so that our code continues to work as
expected under .NET 8.

[0]: https://docs.microsoft.com/en-us/dotnet/api/system.environment.specialfolder?view=net-6.0