### PR TITLE
[main] [release/6.0.4xx-xcode14] [apidiff] Don't compare to legacy platforms that aren't included in the build. Fixes #16011.

### DIFF
--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -506,7 +506,19 @@ ifdef ENABLE_DOTNET
 update-dotnet: $(DOTNET_REFS)
 endif
 
-update-refs: $(WATCHOS_REFS) $(TVOS_REFS) $(IOS_REFS) $(MAC_REFS)
+ifdef INCLUDE_IOS
+update-refs: $(IOS_REFS)
+endif
+ifdef INCLUDE_TVOS
+update-refs: $(TVOS_REFS)
+endif
+ifdef INCLUDE_WATCH
+update-refs: $(WATCHOS_REFS)
+endif
+ifdef INCLUDE_MAC
+update-refs: $(MAC_REFS)
+endif
+
 ifdef ENABLE_DOTNET
 update-refs: $(DOTNET_REFS)
 endif

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -61,8 +61,8 @@ IOS_ASSEMBLIES     = $(foreach file,$(MONO_ASSEMBLIES),Xamarin.iOS/$(file))    $
 MAC_ASSEMBLIES     = $(foreach file,$(MONO_ASSEMBLIES),Xamarin.Mac/$(file))     $(MAC_SRC_ASSEMBLIES)
 WATCHOS_ASSEMBLIES = $(foreach file,$(filter-out Mono.Data.Tds Mono.Security,$(MONO_ASSEMBLIES)),Xamarin.WatchOS/$(file)) $(WATCHOS_SRC_ASSEMBLIES)
 TVOS_ASSEMBLIES    = $(foreach file,$(MONO_ASSEMBLIES),Xamarin.TVOS/$(file))    $(TVOS_SRC_ASSEMBLIES)
-DOTNET_LEGACY_ASSEMBLIES = Microsoft.iOS.Ref/ref/$(DOTNET_TFM)/Microsoft.iOS Microsoft.tvOS.Ref/ref/$(DOTNET_TFM)/Microsoft.tvOS \
-	Microsoft.macOS.Ref/ref/$(DOTNET_TFM)/Microsoft.macOS
+DOTNET_LEGACY_PLATFORMS = $(filter-out MacCatalyst,$(DOTNET_PLATFORMS))
+DOTNET_LEGACY_ASSEMBLIES = $(foreach platform,$(DOTNET_LEGACY_PLATFORMS),Microsoft.$(platform).Ref/ref/$(DOTNET_TFM)/Microsoft.$(platform))
 DOTNET_ASSEMBLIES = $(foreach platform,$(DOTNET_PLATFORMS),Microsoft.$(platform).Ref/ref/$(DOTNET_TFM)/Microsoft.$(platform))
 
 IOS_ARCH_ASSEMBLIES = native-32/Xamarin.iOS native-64/Xamarin.iOS


### PR DESCRIPTION
Don't try to compare legacy vs .NET for platforms that aren't included in the build, because this happens:

> make: *** No rule to make target 'output/diff/dotnet/legacy-diff/Microsoft.macOS.Ref/ref/net6.0/Microsoft.macOS.html', needed by 'output/api-diff.html'.  Stop.

We do this by not hardcoding the list of legacy platforms, but instead starting with DOTNET_PLATFORMS variable (which won't contain platforms that aren't included in the build), and then removing any .NET-only platforms (i.e. Mac Catalyst).

Also fix the `update-refs` target to not try to update refs for platforms that aren't enabled.

Fixes https://github.com/xamarin/xamarin-macios/issues/16011.


Backport of #16029
