### PR TITLE
[release/7.0.1xx-xcode14-rc2] Make package signing work with some platforms disabled.

### DIFF
--- a/tools/devops/Makefile
+++ b/tools/devops/Makefile
@@ -59,4 +59,7 @@ print-abspath-variable:
 print-variable:
 	@echo $(VARIABLE)=$($(VARIABLE))
 
+print-variable-value-to-file:
+	@echo $($(VARIABLE)) > "$(FILE)"
+
 provisioning: build-provisioning.csx device-tests-provisioning.csx provision-xcode.csx

--- a/tools/devops/automation/scripts/bash/configure-platforms.sh
+++ b/tools/devops/automation/scripts/bash/configure-platforms.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -eux
+
+set -o pipefail
+IFS=$'\n\t '
+
+FILE=$(pwd)/tmp.txt
+
+make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable-value-to-file FILE="$FILE" VARIABLE=DOTNET_PLATFORMS
+DOTNET_PLATFORMS=$(cat "$FILE")
+
+make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable-value-to-file FILE="$FILE" VARIABLE=ALL_DOTNET_PLATFORMS
+ALL_DOTNET_PLATFORMS=$(cat "$FILE")
+
+make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable-value-to-file FILE="$FILE" VARIABLE=ENABLE_DOTNET
+ENABLE_DOTNET=$(cat "$FILE")
+
+
+make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable-value-to-file FILE="$FILE" VARIABLE=INCLUDE_XAMARIN_LEGACY
+INCLUDE_XAMARIN_LEGACY=$(cat "$FILE")
+
+make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable-value-to-file FILE="$FILE" VARIABLE=INCLUDE_IOS
+INCLUDE_IOS=$(cat "$FILE")
+
+make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable-value-to-file FILE="$FILE" VARIABLE=INCLUDE_TVOS
+INCLUDE_TVOS=$(cat "$FILE")
+
+make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable-value-to-file FILE="$FILE" VARIABLE=INCLUDE_WATCH
+INCLUDE_WATCH=$(cat "$FILE")
+
+make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable-value-to-file FILE="$FILE" VARIABLE=INCLUDE_MAC
+INCLUDE_MAC=$(cat "$FILE")
+
+rm -f "$FILE"
+
+# print it out, so turn off echoing since that confuses Azure DevOps
+set +x
+
+echo "##vso[task.setvariable variable=ENABLE_DOTNET;isOutput=true]$ENABLE_DOTNET"
+echo "##vso[task.setvariable variable=DOTNET_PLATFORMS;isOutput=true]$DOTNET_PLATFORMS"
+DISABLED_DOTNET_PLATFORMS=" $ALL_DOTNET_PLATFORMS "
+for platform in $DOTNET_PLATFORMS; do
+	PLATFORM_UPPER=$(echo "$platform" | tr '[:lower:]' '[:upper:]')
+	echo "##vso[task.setvariable variable=INCLUDE_DOTNET_$PLATFORM_UPPER;isOutput=true]1"
+	DISABLED_DOTNET_PLATFORMS=${DISABLED_DOTNET_PLATFORMS/ $platform / }
+done
+for platform in $DISABLED_DOTNET_PLATFORMS; do
+	PLATFORM_UPPER=$(echo "$platform" | tr '[:lower:]' '[:upper:]')
+	echo "##vso[task.setvariable variable=INCLUDE_DOTNET_$PLATFORM_UPPER;isOutput=true]"
+done
+
+echo "##vso[task.setvariable variable=INCLUDE_XAMARIN_LEGACY;isOutput=true]$INCLUDE_XAMARIN_LEGACY"
+echo "##vso[task.setvariable variable=INCLUDE_LEGACY_IOS;isOutput=true]$INCLUDE_IOS"
+echo "##vso[task.setvariable variable=INCLUDE_LEGACY_TVOS;isOutput=true]$INCLUDE_TVOS"
+echo "##vso[task.setvariable variable=INCLUDE_LEGACY_WATCH;isOutput=true]$INCLUDE_WATCH"
+echo "##vso[task.setvariable variable=INCLUDE_LEGACY_MAC;isOutput=true]$INCLUDE_MAC"
+
+set -x

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -16,6 +16,13 @@ steps:
   parameters:
     isPR: false # always use the latests set of scripts merged with main
 
+- bash: ./xamarin-macios/tools/devops/automation/scripts/bash/configure-platforms.sh
+  name: configure_platforms
+  displayName: 'Configure platforms'
+  env:
+    ${{ if eq(parameters.enableDotnet, true) }}:
+      ENABLE_DOTNET: "True"
+
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MaciosCI.psd1
 

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -35,6 +35,7 @@ steps:
 - ${{ each pkg in parameters.packages }}:
   - task: DownloadPipelineArtifact@2
     displayName: Download notarized build ${{ pkg.name }}
+    condition: ne('', variables['${{ pkg.conditionVariable }}'])
     inputs:
       artifact: 'classic-${{ pkg.name }}-signed'
       allowFailedBuilds: true
@@ -48,6 +49,7 @@ steps:
       ls -lR $FULL_PATH
       cp -a "$FULL_PATH/." "$(Build.SourcesDirectory)/package"
     displayName: 'Move pkg ${{ pkg.name }} to its final destination'
+    condition: ne('', variables['${{ pkg.conditionVariable }}'])
 
 - template: generate-workspace-info.yml@templates
   parameters:

--- a/tools/devops/automation/templates/sign-and-notarized/prepare-pkg-stage.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/prepare-pkg-stage.yml
@@ -25,31 +25,37 @@ parameters:
       job: 'xamarin_ios_sign_notarize',
       name: 'Xamarin.iOS',
       pattern: 'xamarin.ios-*',
+      conditionVariable: "INCLUDE_LEGACY_IOS",
     },
     {
       job: 'xamarin_mac_sing_notarie',
       name: 'Xamarin.Mac',
       pattern: 'xamarin.mac-*',
+      conditionVariable: "INCLUDE_LEGACY_MAC",
     },
     {
       job: 'microsoft_ios_sign_notarize',
       name: 'Microsoft.iOS',
       pattern: 'Microsoft.iOS.Bundle*.pkg',
+      conditionVariable: "INCLUDE_DOTNET_IOS",
     },
     {
       job: 'microsoft_tvos_sign_notarize',
       name: 'Microsoft.tvOS',
       pattern: 'Microsoft.tvOS.Bundle*.pkg',
+      conditionVariable: "INCLUDE_DOTNET_TVOS",
     },
     {
       job: 'microsoft_mac_sign_notarize',
       name: 'Microsoft.macOS',
       pattern: 'Microsoft.macOS.Bundle*.pkg',
+      conditionVariable: "INCLUDE_DOTNET_MACOS",
     },
     {
       job: 'microsoft_maccatalyst_sign_notarize',
       name: 'Microsoft.MacCatalyst',
       pattern: 'Microsoft.MacCatalyst.Bundle*.pkg',
+      conditionVariable: "INCLUDE_DOTNET_MACCATALYST",
     },
   ]
 
@@ -71,6 +77,7 @@ jobs:
     dependsOn:
     - configure
     displayName: 'Sign & Notarize ${{ pkg.name }}'
+    condition: ne(dependencies.configure.outputs['configure_platforms.${{ pkg.conditionVariable }}'],'')
     timeoutInMinutes: 1000
     pool:
       vmImage: internal-macos-11
@@ -105,16 +112,21 @@ jobs:
 
 - job: funnel_job
   dependsOn:
+  - configure
   - ${{ if eq(parameters.enableDotnet, true) }}:
     - sign_notarize_dotnet
   - ${{ each pkg in parameters.packages }}:
     - ${{ pkg.job }}
   displayName: 'Collect signed artifacts'
+  condition: and(not(failed()), not(canceled())) # default is succeded(), but that fails if there are any skipped jobs, so change the condition to !failed && !cancelled
   timeoutInMinutes: 1000
   pool:
     vmImage: internal-macos-11
   workspace:
     clean: all
+  variables:
+    ${{ each pkg in parameters.packages }}:
+      ${{ pkg.conditionVariable }}: $[ dependencies.configure.outputs['configure_platforms.${{ pkg.conditionVariable }}'] ]
 
   steps:
   - template: funnel.yml
@@ -130,7 +142,7 @@ jobs:
   timeoutInMinutes: 1000
   dependsOn:
   - funnel_job
-  condition: succeeded()
+  condition: and(not(failed()), not(canceled())) # default is succeded(), but that fails if there are any skipped jobs, so change the condition to !failed && !cancelled
 
   variables:
     Parameters.outputStorageUri: ''


### PR DESCRIPTION
Change package signing so that we only try to sign packages for platforms that aren't disabled.

This makes the 'Prepare packages' job green in Azure Devops.

The 'Prepare Release' job still fails in the 'Convert NuGet to MSI' step (for
the branch I've been working on), because the package names are too long for
MSIs. This should be resolved for a proper release branch (i.e. when this PR
is merged), because package names are much shorter in a release branch.

Example results: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6711641&view=results

Backport of #16028.


Backport of #16039
