### PR TITLE
[main] [mtouch] Automatically disable bitcode if using Xcode 14+. Fixes #15210.

### DIFF
--- a/tests/common/BundlerTool.cs
+++ b/tests/common/BundlerTool.cs
@@ -326,7 +326,7 @@ namespace Xamarin.Tests
 			if (rv == 0)
 				return;
 			var errors = Messages.Where ((v) => v.IsError).ToList ();
-			Assert.Fail ($"Expected execution to succeed, but exit code was {rv}, and there were {errors.Count} error(s): {message}\n\t" +
+			Assert.Fail ($"Expected execution to succeed, but exit code was {rv}, and there were {errors.Count} error(s).\nCommand: {ToolPath} {StringUtils.FormatArguments (ToolArguments)}\nMessage: {message}\n\t" +
 				     string.Join ("\n\t", errors.Select ((v) => v.ToString ())));
 		}
 

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1118,12 +1118,6 @@ public class B : A {}
 		[TestCase (Profile.tvOS, MTouchBitcode.ASMOnly, "arm64+llvm")]
 		[TestCase (Profile.tvOS, MTouchBitcode.Full, "arm64+llvm")]
 		[TestCase (Profile.tvOS, MTouchBitcode.Marker, "arm64+llvm")]
-		[TestCase (Profile.iOS, MTouchBitcode.ASMOnly, "arm64+llvm")]
-		[TestCase (Profile.iOS, MTouchBitcode.Full, "arm64+llvm")]
-		[TestCase (Profile.iOS, MTouchBitcode.Marker, "arm64+llvm")]
-		[TestCase (Profile.watchOS, MTouchBitcode.ASMOnly, "arm64_32+llvm")]
-		[TestCase (Profile.watchOS, MTouchBitcode.Full, "arm64_32+llvm")]
-		[TestCase (Profile.watchOS, MTouchBitcode.Marker, "arm64_32+llvm")]
 		public void MT0186 (Profile profile, MTouchBitcode mode, string abi)
 		{
 			using (var mtouch = new MTouchTool ()) {

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1115,6 +1115,33 @@ public class B : A {}
 		}
 
 		[Test]
+		[TestCase (Profile.tvOS, MTouchBitcode.ASMOnly, "arm64+llvm")]
+		[TestCase (Profile.tvOS, MTouchBitcode.Full, "arm64+llvm")]
+		[TestCase (Profile.tvOS, MTouchBitcode.Marker, "arm64+llvm")]
+		[TestCase (Profile.iOS, MTouchBitcode.ASMOnly, "arm64+llvm")]
+		[TestCase (Profile.iOS, MTouchBitcode.Full, "arm64+llvm")]
+		[TestCase (Profile.iOS, MTouchBitcode.Marker, "arm64+llvm")]
+		[TestCase (Profile.watchOS, MTouchBitcode.ASMOnly, "arm64_32+llvm")]
+		[TestCase (Profile.watchOS, MTouchBitcode.Full, "arm64_32+llvm")]
+		[TestCase (Profile.watchOS, MTouchBitcode.Marker, "arm64_32+llvm")]
+		public void MT0186 (Profile profile, MTouchBitcode mode, string abi)
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.Profile = profile;
+				if (profile == Profile.watchOS) {
+					mtouch.CreateTemporaryWatchKitExtension ();
+				} else {
+					mtouch.CreateTemporaryApp ();
+				}
+				mtouch.Abi = abi;
+				mtouch.Bitcode = mode;
+				mtouch.WarnAsError = new int[] { 186 };
+				Assert.AreEqual (1, mtouch.Execute (MTouchAction.BuildDev));
+				mtouch.AssertError (186, "Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the 'MtouchEnableBitcode' property from the project file.");
+			}
+		}
+
+		[Test]
 		public void MT0095_SharedCode ()
 		{
 			using (var exttool = new MTouchTool ()) {

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1130,8 +1130,12 @@ public class B : A {}
 				mtouch.Abi = abi;
 				mtouch.Bitcode = mode;
 				mtouch.WarnAsError = new int[] { 186 };
-				Assert.AreEqual (1, mtouch.Execute (MTouchAction.BuildDev));
-				mtouch.AssertError (186, "Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the 'MtouchEnableBitcode' property from the project file.");
+				if (Configuration.XcodeVersion.Major >= 14) {
+					Assert.AreEqual (1, mtouch.Execute (MTouchAction.BuildDev));
+					mtouch.AssertError (186, "Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the 'MtouchEnableBitcode' property from the project file.");
+				} else {
+					Assert.AreEqual (0, mtouch.Execute (MTouchAction.BuildDev));
+				}
 			}
 		}
 

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -874,6 +874,11 @@ namespace Xamarin.Bundler {
 				ErrorHelper.Warning (3007, Errors.MX3007);
 			}
 
+			if (Driver.XcodeVersion.Major >= 14 && BitCodeMode != BitCodeMode.None) {
+				ErrorHelper.Warning (186, Errors.MX0186 /* Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the 'MtouchEnableBitcode' property from the project file. */);
+				BitCodeMode = BitCodeMode.None;
+			}
+
 			Optimizations.Initialize (this, out var messages);
 			ErrorHelper.Show (messages);
 			if (Driver.Verbosity > 3)

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -874,7 +874,8 @@ namespace Xamarin.Bundler {
 				ErrorHelper.Warning (3007, Errors.MX3007);
 			}
 
-			if (Driver.XcodeVersion.Major >= 14 && BitCodeMode != BitCodeMode.None) {
+			if (Driver.XcodeVersion.Major >= 14 && BitCodeMode != BitCodeMode.None && Platform == ApplePlatform.TVOS) {
+				// We currently have to leave watchOS alone, because the process is to first build bitcode, then compile bitcode into native code, and finally remove the bitcode from the executable (this is likely fixable, but looks like it's a larger effort involving the runtime team).
 				ErrorHelper.Warning (186, Errors.MX0186 /* Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the 'MtouchEnableBitcode' property from the project file. */);
 				BitCodeMode = BitCodeMode.None;
 			}

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -644,7 +644,7 @@ namespace Xamarin.Bundler {
 				// interpreter can use some extra code (e.g. SRE) that is not shipped in the default (AOT) profile
 				EnableRepl = true;
 			} else {
-				if (Platform == ApplePlatform.WatchOS && IsArchEnabled (Abi.ARM64_32) && BitCodeMode != BitCodeMode.LLVMOnly) {
+				if (Platform == ApplePlatform.WatchOS && IsArchEnabled (Abi.ARM64_32) && BitCodeMode != BitCodeMode.LLVMOnly && Driver.XcodeVersion.Major < 14) {
 					if (IsArchEnabled (Abi.ARMv7k)) {
 						throw ErrorHelper.CreateError (145, Errors.MT0145);
 					} else {
@@ -661,7 +661,7 @@ namespace Xamarin.Bundler {
 			if (!IsLLVM && (EnableAsmOnlyBitCode || EnableLLVMOnlyBitCode))
 				throw ErrorHelper.CreateError (3008, Errors.MT3008);
 
-			if (IsLLVM && Platform == ApplePlatform.WatchOS && BitCodeMode != BitCodeMode.LLVMOnly) {
+			if (IsLLVM && Platform == ApplePlatform.WatchOS && BitCodeMode != BitCodeMode.LLVMOnly && Driver.XcodeVersion.Major < 14) {
 				ErrorHelper.Warning (111, Errors.MT0111);
 				BitCodeMode = BitCodeMode.LLVMOnly;
 			}
@@ -842,7 +842,7 @@ namespace Xamarin.Bundler {
 				}
 			}
 
-			if (IsDeviceBuild) {
+			if (IsDeviceBuild && Driver.XcodeVersion.Major < 14) {
 				switch (BitCodeMode) {
 				case BitCodeMode.ASMOnly:
 					if (Platform == ApplePlatform.WatchOS)

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -644,7 +644,7 @@ namespace Xamarin.Bundler {
 				// interpreter can use some extra code (e.g. SRE) that is not shipped in the default (AOT) profile
 				EnableRepl = true;
 			} else {
-				if (Platform == ApplePlatform.WatchOS && IsArchEnabled (Abi.ARM64_32) && BitCodeMode != BitCodeMode.LLVMOnly && Driver.XcodeVersion.Major < 14) {
+				if (Platform == ApplePlatform.WatchOS && IsArchEnabled (Abi.ARM64_32) && BitCodeMode != BitCodeMode.LLVMOnly) {
 					if (IsArchEnabled (Abi.ARMv7k)) {
 						throw ErrorHelper.CreateError (145, Errors.MT0145);
 					} else {
@@ -661,7 +661,7 @@ namespace Xamarin.Bundler {
 			if (!IsLLVM && (EnableAsmOnlyBitCode || EnableLLVMOnlyBitCode))
 				throw ErrorHelper.CreateError (3008, Errors.MT3008);
 
-			if (IsLLVM && Platform == ApplePlatform.WatchOS && BitCodeMode != BitCodeMode.LLVMOnly && Driver.XcodeVersion.Major < 14) {
+			if (IsLLVM && Platform == ApplePlatform.WatchOS && BitCodeMode != BitCodeMode.LLVMOnly) {
 				ErrorHelper.Warning (111, Errors.MT0111);
 				BitCodeMode = BitCodeMode.LLVMOnly;
 			}

--- a/tools/mtouch/Application.mtouch.cs
+++ b/tools/mtouch/Application.mtouch.cs
@@ -842,7 +842,7 @@ namespace Xamarin.Bundler {
 				}
 			}
 
-			if (IsDeviceBuild && Driver.XcodeVersion.Major < 14) {
+			if (IsDeviceBuild) {
 				switch (BitCodeMode) {
 				case BitCodeMode.ASMOnly:
 					if (Platform == ApplePlatform.WatchOS)
@@ -853,6 +853,8 @@ namespace Xamarin.Bundler {
 					break;
 				case BitCodeMode.None:
 					// If neither llvmonly nor asmonly is enabled, enable markeronly.
+					if (Driver.XcodeVersion.Major >= 14)
+						break;
 					if (Platform == ApplePlatform.TVOS || Platform == ApplePlatform.WatchOS)
 						BitCodeMode = BitCodeMode.MarkerOnly;
 					break;
@@ -1236,7 +1238,12 @@ namespace Xamarin.Bundler {
 		{
 			var sb = new List<string> ();
 			sb.Add (macho_file);
-			switch (BitCodeMode) {
+
+			var mode = BitCodeMode;
+			if (Driver.XcodeVersion.Major >= 14)
+				mode = BitCodeMode.None;
+
+			switch (mode) {
 			case BitCodeMode.ASMOnly:
 			case BitCodeMode.LLVMOnly:
 				// do nothing, since we don't know neither if bitcode is needed (if we're publishing) or if native code is needed (not publishing).

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -315,6 +315,9 @@ namespace Xamarin.Bundler
 						}
 					}
 				}
+
+				if (code == 0 && Driver.XcodeVersion.Major >= 14 && Target.App.BitCodeMode != BitCodeMode.None)
+					Target.App.StripBitcode (OutputFile);
 			} catch (System.ComponentModel.Win32Exception wex) {
 				/* This means we failed to execute the linker, not that the linker itself returned with a failure */
 				if (wex.NativeErrorCode == 7 /* E2BIG = Too many arguments */ ) {
@@ -350,6 +353,9 @@ namespace Xamarin.Bundler
 			// we can't trust the native linker to pick the right (non private) framework when an older TargetVersion is used
 			if (CompilerFlags.WeakFrameworks.Count > 0)
 				Target.AdjustDylibs (OutputFile);
+			// Remove bitcode from the binary
+			if (Driver.XcodeVersion.Major >= 14 && App.BitCodeMode != BitCodeMode.None)
+				App.StripBitcode (OutputFile);
 		}
 
 		protected override void CompilationFailed (int exitCode)

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -3794,6 +3794,15 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the &apos;MtouchEnableBitcode&apos; property from the project file..
+        /// </summary>
+        public static string MX0186 {
+            get {
+                return ResourceManager.GetString("MX0186", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not copy the assembly &apos;{0}&apos; to &apos;{1}&apos;: {2}
         ///		.
         /// </summary>

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -935,6 +935,10 @@
 		<value>The option '{0}' cannot take the value '{1}' when using CoreCLR.</value>
 	</data>
 
+	<data name="MX0186" xml:space="preserve">
+		<value>Bitcode is enabled, but bitcode is not supported in Xcode 14+ and has been disabled. Please disable bitcode by removing the 'MtouchEnableBitcode' property from the project file.</value>
+	</data>
+
 	<data name="MX1009" xml:space="preserve">
 		<value>Could not copy the assembly '{0}' to '{1}': {2}
 		</value>

--- a/tools/mtouch/Target.mtouch.cs
+++ b/tools/mtouch/Target.mtouch.cs
@@ -1420,7 +1420,7 @@ namespace Xamarin.Bundler
 			}
 
 			var bitcode = App.EnableBitCode;
-			if (bitcode)
+			if (bitcode && Driver.XcodeVersion.Major < 14)
 				linker_flags.AddOtherFlag (App.EnableMarkerOnlyBitCode ? "-fembed-bitcode-marker" : "-fembed-bitcode");
 			
 			if (!App.EnablePie.HasValue)

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -790,7 +790,7 @@ namespace Xamarin.Bundler
 			switch (app.Platform) {
 				case ApplePlatform.TVOS:
 				case ApplePlatform.WatchOS:
-					if (Driver.XcodeVersion.Major >= 14 && app.IsLLVM)
+					if (Driver.XcodeVersion.Major >= 14)
 						app.EnableCxx = true;
 					break;
 			}

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -787,6 +787,14 @@ namespace Xamarin.Bundler
 			// we try again with clang.
 			//
 
+			switch (app.Platform) {
+				case ApplePlatform.TVOS:
+				case ApplePlatform.WatchOS:
+					if (Driver.XcodeVersion.Major >= 14 && app.IsLLVM)
+						app.EnableCxx = true;
+					break;
+			}
+
 			if (string.IsNullOrEmpty (app.Compiler)) {
 				// by default we use `gcc` before iOS7 SDK, falling back to `clang`. Otherwise we go directly to `clang`
 				// so we don't get bite by the fact that Xcode5 has a gcc compiler (which calls `clang`, even if not 100% 


### PR DESCRIPTION
Apple has deprecated bitcode, and will apparently reject app submissions
containing bitcode starting with Xcode 14. So automatically disable bitcode if
building using Xcode 14+ (and show a warning so that app developers can remove
the 'MtouchEnableBitcode' property from their project files).

Fixes https://github.com/xamarin/xamarin-macios/issues/15210.


Backport of #15804
