### PR TITLE
[6.0.4xx] [dotnet] Don't include iOS and tvOS in vs-workload.props anymore.

### DIFF
--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <TargetName>Microsoft.NET.Sdk.MaciOS.Workload</TargetName>
+    <TargetName>Microsoft.NET.Sdk.MacCatalyst.macOS.Workload</TargetName>
     <ManifestBuildVersion>@IOS_WORKLOAD_VERSION@</ManifestBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->
-    <ShortNames Include="@PACK_VERSION_LONG@">
-      <Replacement>@PACK_VERSION_SHORT@</Replacement>
-    </ShortNames>
     <ShortNames Include="@MACOS_PACK_VERSION_LONG@">
       <Replacement>@MACOS_PACK_VERSION_SHORT@</Replacement>
     </ShortNames>
@@ -18,21 +15,11 @@
     <ShortNames Include="Microsoft.NET.Sdk.MacCatalyst.Manifest">
       <Replacement>Microsoft.MacCatalyst.Manifest</Replacement>
     </ShortNames>
-    <ShortNames Include="Microsoft.tvOS.Runtime.tvossimulator">
-      <Replacement>Microsoft.tvOS.Runtime</Replacement>
-    </ShortNames>
-    <ComponentResources Include="ios" Version="@IOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for iOS" Description=".NET SDK Workload for building iOS applications."/>
     <ComponentResources Include="maccatalyst" Version="@MACCATALYST_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Mac Catalyst" Description=".NET SDK Workload for building macOS applications with Mac Catalyst."/>
     <ComponentResources Include="macos" Version="@MACOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for macOS" Description=".NET SDK Workload for building macOS applications."/>
-    <ComponentResources Include="tvos" Version="@TVOS_WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for tvOS" Description=".NET SDK Workload for building tvOS applications."/>
-    <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.iOS.Manifest*.nupkg" Version="@IOS_WORKLOAD_VERSION@" />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.MacCatalyst.Manifest*.nupkg" Version="@MACCATALYST_WORKLOAD_VERSION@" />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.macOS.Manifest*.nupkg" Version="@MACOS_WORKLOAD_VERSION@" />
-    <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.tvOS.Manifest*.nupkg" Version="@TVOS_WORKLOAD_VERSION@" />
-    <MultiTargetPackNames Include="Microsoft.iOS.Sdk" />
-    <MultiTargetPackNames Include="Microsoft.iOS.Windows.Sdk" />
     <MultiTargetPackNames Include="Microsoft.MacCatalyst.Sdk" />
     <MultiTargetPackNames Include="Microsoft.macOS.Sdk" />
-    <MultiTargetPackNames Include="Microsoft.tvOS.Sdk" />
   </ItemGroup>
 </Project>

--- a/dotnet/Workloads/vs-workload.template.props
+++ b/dotnet/Workloads/vs-workload.template.props
@@ -6,6 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->
+    <ShortNames Include="@PACK_VERSION_LONG@">
+      <Replacement>@PACK_VERSION_SHORT@</Replacement>
+    </ShortNames>
     <ShortNames Include="@MACOS_PACK_VERSION_LONG@">
       <Replacement>@MACOS_PACK_VERSION_SHORT@</Replacement>
     </ShortNames>


### PR DESCRIPTION
The iOS and tvOS workloads are/will be included in the release/6.0.4xx-xcode14
branch.