### PR TITLE
[actions] Get the head repository using the correct syntax.

### DIFF
--- a/.github/workflows/autoformat2.yml
+++ b/.github/workflows/autoformat2.yml
@@ -50,7 +50,7 @@ jobs:
       if: steps.unzip_artifacts.outputs.autoformatted == 'true'
       with:
         fetch-depth: 0
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        repository: ${{ github.event.workflow_run.head_repository.full_name }}
         ref: ${{ github.event.workflow_run.head_branch }}
 
     - name: 'Get autoformatted commit and push it'


### PR DESCRIPTION
Get the head repository using the correct syntax when trying to publish
autoformatted changes. This action is a 'workflow_run' action, and not a
'pull_request' action, and as such we must look in the 'workflow_run' object
for the data we need.

This will hopefully make the action able to publish results back to a fork.