### PR TITLE
[6.0.4xx] [devops] Only upload 'macOS' and 'Mac Catalyst' packages to the 'package' artifact.

### DIFF
--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -108,11 +108,23 @@ steps:
         name: workload_file
         displayName: 'Generate "WorkloadRollback.json'
 
+      # separate macOS and Mac Catalyst packages from the rest
+      - bash: |
+          set -ex
+          rm -rf "$(Build.SourcesDirectory)/package-to-publish"
+          # Copy all the packages
+          cp -r "$(Build.SourcesDirectory)/package" "$(Build.SourcesDirectory)/package-to-publish"
+          # Remove iOS and tvOS packages
+          ls -laR "$(Build.SourcesDirectory)/package-to-publish"
+          rm -f "$(Build.SourcesDirectory)/package-to-publish"/*[.]iOS[.]*  "$(Build.SourcesDirectory)/package-to-publish/notarized"/*[.]iOS[.]*
+          rm -f "$(Build.SourcesDirectory)/package-to-publish"/*[.]tvOS[.]* "$(Build.SourcesDirectory)/package-to-publish/notarized/"*[.]tvOS[.]*
+          ls -laR "$(Build.SourcesDirectory)/package-to-publish"
+
       # upload each of the pkgs into the pipeline artifacts
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Build Artifacts'
         inputs:
-          targetPath: $(Build.SourcesDirectory)/package
+          targetPath: $(Build.SourcesDirectory)/package-to-publish
           artifactName: package
         continueOnError: true
 

--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -111,21 +111,32 @@ steps:
       # separate macOS and Mac Catalyst packages from the rest
       - bash: |
           set -ex
-          rm -rf "$(Build.SourcesDirectory)/package-to-publish"
+          rm -rf "$(Build.SourcesDirectory)/packages-to-publish"
           # Copy all the packages
-          cp -r "$(Build.SourcesDirectory)/package" "$(Build.SourcesDirectory)/package-to-publish"
-          # Remove iOS and tvOS packages
-          ls -laR "$(Build.SourcesDirectory)/package-to-publish"
-          rm -f "$(Build.SourcesDirectory)/package-to-publish"/*[.]iOS[.]*  "$(Build.SourcesDirectory)/package-to-publish/notarized"/*[.]iOS[.]*
-          rm -f "$(Build.SourcesDirectory)/package-to-publish"/*[.]tvOS[.]* "$(Build.SourcesDirectory)/package-to-publish/notarized/"*[.]tvOS[.]*
-          ls -laR "$(Build.SourcesDirectory)/package-to-publish"
+          cp -r "$(Build.SourcesDirectory)/package" "$(Build.SourcesDirectory)/packages-to-publish"
+          # Move iOS and tvOS packages to a separate artifact
+          ls -laR "$(Build.SourcesDirectory)/packages-to-publish"
+          mkdir -p "$(Build.SourcesDirectory)/packages-to-not-publish/notarized"
+          mv "$(Build.SourcesDirectory)/packages-to-publish"/*[.]iOS[.]*           "$(Build.SourcesDirectory)/packages-to-not-publish/"
+          mv "$(Build.SourcesDirectory)/packages-to-publish/notarized"/*[.]iOS[.]* "$(Build.SourcesDirectory)/packages-to-not-publish/notarized/"
+          mv "$(Build.SourcesDirectory)/packages-to-publish"/*[.]tvOS[.]*           "$(Build.SourcesDirectory)/packages-to-not-publish/"
+          mv "$(Build.SourcesDirectory)/packages-to-publish/notarized/"*[.]tvOS[.]* "$(Build.SourcesDirectory)/packages-to-not-publish/notarized/"
+          ls -laR "$(Build.SourcesDirectory)/packages-to-not-publish"
 
       # upload each of the pkgs into the pipeline artifacts
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Build Artifacts'
         inputs:
-          targetPath: $(Build.SourcesDirectory)/package-to-publish
+          targetPath: $(Build.SourcesDirectory)/packages-to-publish
           artifactName: package
+        continueOnError: true
+
+      # upload each of the pkgs into the pipeline artifacts
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish Build Artifacts'
+        inputs:
+          targetPath: $(Build.SourcesDirectory)/packages-to-not-publish
+          artifactName: packages-to-not-publish
         continueOnError: true
 
       - task: PublishPipelineArtifact@1

--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -117,10 +117,10 @@ steps:
           # Move iOS and tvOS packages to a separate artifact
           ls -laR "$(Build.SourcesDirectory)/packages-to-publish"
           mkdir -p "$(Build.SourcesDirectory)/packages-to-not-publish/notarized"
-          mv "$(Build.SourcesDirectory)/packages-to-publish"/*[.]iOS[.]*           "$(Build.SourcesDirectory)/packages-to-not-publish/"
-          mv "$(Build.SourcesDirectory)/packages-to-publish/notarized"/*[.]iOS[.]* "$(Build.SourcesDirectory)/packages-to-not-publish/notarized/"
-          mv "$(Build.SourcesDirectory)/packages-to-publish"/*[.]tvOS[.]*           "$(Build.SourcesDirectory)/packages-to-not-publish/"
-          mv "$(Build.SourcesDirectory)/packages-to-publish/notarized/"*[.]tvOS[.]* "$(Build.SourcesDirectory)/packages-to-not-publish/notarized/"
+          mv "$(Build.SourcesDirectory)/packages-to-publish"/*[.]iOS[.]*           "$(Build.SourcesDirectory)/packages-to-not-publish/" || true
+          mv "$(Build.SourcesDirectory)/packages-to-publish/notarized"/*[.]iOS[.]* "$(Build.SourcesDirectory)/packages-to-not-publish/notarized/" || true
+          mv "$(Build.SourcesDirectory)/packages-to-publish"/*[.]tvOS[.]*           "$(Build.SourcesDirectory)/packages-to-not-publish/" || true
+          mv "$(Build.SourcesDirectory)/packages-to-publish/notarized/"*[.]tvOS[.]* "$(Build.SourcesDirectory)/packages-to-not-publish/notarized/" || true
           ls -laR "$(Build.SourcesDirectory)/packages-to-not-publish"
 
       # upload each of the pkgs into the pipeline artifacts

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -128,6 +128,9 @@ steps:
     ls -R $(Build.SourcesDirectory)/artifacts/package
     cp $(Build.SourcesDirectory)/artifacts/package/*.nupkg $DOTNET_NUPKG_DIR
     cp $(Build.SourcesDirectory)/artifacts/package/*.pkg $DOTNET_NUPKG_DIR
+    ls -R $(Build.SourcesDirectory)/artifacts/packages-to-not-publish
+    cp $(Build.SourcesDirectory)/artifacts/packages-to-not-publish/*.nupkg $DOTNET_NUPKG_DIR
+    cp $(Build.SourcesDirectory)/artifacts/packages-to-not-publish/*.pkg $DOTNET_NUPKG_DIR
     ls -R $DOTNET_NUPKG_DIR
 
     NUGET_SOURCES=$(grep https://pkgs.dev.azure.com ./NuGet.config | sed -e 's/.*value="//'  -e 's/".*//')


### PR DESCRIPTION
Only upload 'macOS' and 'Mac Catalyst' packages to the 'package' artifact in this branch, so that the VS insertion logic won't try to insert the iOS and tvOS workloads, since those will come from a different branch (`release/6.0.4xx-xcode14`).