### PR TITLE
[main] Fixed Build Agent

### DIFF
--- a/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>Build</AssemblyName>
     <NoWarn>$(NoWarn);NU1603</NoWarn> <!-- Xamarin.Messaging.Build.Common 1.6.24 depends on Merq (>= 1.1.0) but Merq 1.1.0 was not found. An approximate best match of Merq 1.1.4 was resolved. -->


### PR DESCRIPTION
The Build Agent is a console app so it can't target netstandard. Changing it back to net472 for now


Backport of #16083
