### PR TITLE
[build] Improve generated manifest MSI versions

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -170,9 +170,9 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform)
 $(DOTNET_NUPKG_DIR)/vs-workload.props: Makefile generate-vs-workload.csharp
 	$(Q) rm -f $@.tmp
 	$(Q_GEN) ./generate-vs-workload.csharp \
-		$(foreach platform,$(DOTNET_PLATFORMS),--platform $(platform) $($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION).$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_COMMIT_DISTANCE)) \
+		$(foreach platform,$(DOTNET_PLATFORMS),--platform $(platform) $($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).0.$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_COMMIT_DISTANCE)) \
 		$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),--windows-platform $(platform)) \
-		$(foreach platform,$(DOTNET_PLATFORMS),--shorten $($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION_NO_METADATA)=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION).$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_COMMIT_DISTANCE)) \
+		$(foreach platform,$(DOTNET_PLATFORMS),--shorten $($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION_NO_METADATA)=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).0.$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_COMMIT_DISTANCE)) \
 		--shorten Microsoft.MacCatalyst.Runtime.maccatalyst=Microsoft.MacCatalyst.Runtime \
 		--shorten Microsoft.NET.Sdk.MacCatalyst.Manifest=Microsoft.MacCatalyst.Manifest \
 		--shorten Microsoft.tvOS.Runtime.tvossimulator=Microsoft.tvOS.Runtime \


### PR DESCRIPTION
Attempt to improve consistency in generated workload manifest MSI versions by more closely following the four digit versioning schema used by Android and MAUI.  This change should only affect preview versioned workload manifests, as stable manifest MSIs will now use the three digit NuGet package version as the MSI version.

The previous version passed to the MSI version generation task in arcade contained the commit distance twice, and now the commit distance is only used in the fourth version part.

Before:
Version="15.4.1167.1167"

After:
Version="15.4.0.1167"

Compared to Android/MAUI:
Version="33.0.0.151"
Version="7.0.0.6683"

With these changes the arcade task should weigh the time delta between builds more heavily, which should produce MSI versions that increment more consistently and by smaller amounts.