### PR TITLE
[release/7.0.1xx-xcode14-rc2] [msbuild] Add a public 'CompileImageAssetsDependsOn' property. Fixes #16065.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -792,6 +792,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<PropertyGroup>
 		<_CompileImageAssetsDependsOn>
+			$(CompileImageAssetsDependsOn);
 			$(_CompileImageAssetsDependsOn);
 			_DetectAppManifest;
 			_DetectSdkLocations;


### PR DESCRIPTION
Add a public 'CompileImageAssetsDependsOn' property, so that MAUI can inject tasks that
must be completed before we compile image assets:

```xml
<PropertyGroup>
	<CompileImageAssetsDependsOn>
		$(CompileImageAssetsDependsOn);
		ResizetizeCollectItems;
	</CompileImageAssetsDependsOn>
</PropertyGroup>
```

Fixes https://github.com/xamarin/xamarin-macios/issues/16065.


Backport of #16089
