### PR TITLE
[devops] Enable legacy xamarin tests by default.

### DIFF
--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -198,7 +198,7 @@ stages:
     displayName: 'Simulator tests'
     testPool: '' # use the default
     useXamarinStorage: false
-    testsLabels: '--label=skip-all-tests,run-ios-64-tests,run-ios-simulator-tests,run-tvos-tests,run-watchos-tests,run-mac-tests,run-maccatalyst-tests,run-dotnet-tests,run-system-permission-tests'
+    testsLabels: '--label=skip-all-tests,run-ios-64-tests,run-ios-simulator-tests,run-tvos-tests,run-watchos-tests,run-mac-tests,run-maccatalyst-tests,run-dotnet-tests,run-system-permission-tests,run-xamarin-legacy-tests'
     statusContext: 'VSTS: simulator tests'
     makeTarget: 'jenkins'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}


### PR DESCRIPTION
Now that it's possible to disable legacy xamarin tests, we must also enable
them after using 'skip-all-tests' if we want to run legacy tests.

Otherwise we end up only executing .NET tests:
https://github.com/xamarin/xamarin-macios/commit/f592de721ddfd5fd487a77a7ffa10687b741d04a#commitcomment-84832124