### PR TITLE
[main] [6.0.4xx] [msbuild] Use _TrimmerDefaultAction if TrimmerDefaultAction isn't set.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -314,6 +314,9 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 		<PropertyGroup>
 			<!-- We need to use netX.Y because when building from VS it sets MSBuildRuntimeType to Core and will pick net472 (which doesn't contain the illink assembly) -->
 			<_RemoteILLinkPath>$(ILLinkTasksAssembly.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)').Replace('net472', 'net$(BundledNETCoreAppTargetFrameworkVersion)').Replace('$([System.IO.Path]::GetFileName('$(ILLinkTasksAssembly)'))', 'illink.dll'))</_RemoteILLinkPath>
+
+			<!-- The .NET 7 linker sets _TrimmerDefaultAction instead of TrimmerDefaultAction, so copy that value if it's set (and TrimmerDefaultAction is not set) -->
+			<TrimmerDefaultAction Condition="'$(TrimmerDefaultAction)' == ''">$(_TrimmerDefaultAction)</TrimmerDefaultAction>
 		</PropertyGroup>
 
 		<!-- Include Debug symbols as input so those are copied to the server -->


### PR DESCRIPTION
The .NET 7 linker targets will set _TrimmerDefaultAction instead of
TrimmerDefaultAction, so if TrimmerDefaultAction isn't set (which it will be
for .NET 6), then use _TrimmerDefaultAction (which should be set for .NET 7).

Unfortunately for .NET 8 it seems I've misplaced my crystal ball, so we'll
have to wait a bit to see what happens then.

Ref: https://github.com/xamarin/xamarin-macios/issues/16125.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1621047.


Backport of #16126
