### PR TITLE
[release/7.0.1xx-xcode14-rc2] [ci] Only try to sign nested zips if they exist

### DIFF
--- a/dotnet/Workloads/SignList.targets
+++ b/dotnet/Workloads/SignList.targets
@@ -16,20 +16,23 @@
     <Unzip
         SourceFiles="@(_NestedBrokerZip)"
         DestinationFolder="@(_NestedBrokerZip -> '$(_NestedZipExtractionDir)%(Filename)')"
+        Condition="'@(_NestedBrokerZip->Count())' != '0'"
     />
-    <Delete Files="@(_NestedBrokerZip)" />
+    <Delete Files="@(_NestedBrokerZip)" Condition="'@(_NestedBrokerZip->Count())' != '0'" />
 
     <Unzip
         SourceFiles="@(_NestedBuildZip)"
         DestinationFolder="@(_NestedBuildZip -> '$(_NestedZipExtractionDir)%(Filename)')"
+        Condition="'@(_NestedBuildZip->Count())' != '0'"
     />
-    <Delete Files="@(_NestedBuildZip)" />
+    <Delete Files="@(_NestedBuildZip)" Condition="'@(_NestedBuildZip->Count())' != '0'" />
 
     <Unzip
         SourceFiles="@(_NestediOSAppZip)"
         DestinationFolder="@(_NestediOSAppZip -> '$(_NestedZipExtractionDir)%(Filename)')"
+        Condition="'@(_NestediOSAppZip->Count())' != '0'"
     />
-    <Delete Files="@(_NestediOSAppZip)" />
+    <Delete Files="@(_NestediOSAppZip)" Condition="'@(_NestediOSAppZip->Count())' != '0'" />
   </Target>
 
   <Target Name="_ZipNestedZips"
@@ -38,14 +41,17 @@
     <ZipDirectory
         SourceDirectory="@(_NestedBrokerZip -> '$(_NestedZipExtractionDir)%(Filename)')"
         DestinationFile="@(_NestedBrokerZip)"
+        Condition="'@(_NestedBrokerZip->Count())' != '0'"
     />
     <ZipDirectory
         SourceDirectory="@(_NestedBuildZip -> '$(_NestedZipExtractionDir)%(Filename)')"
         DestinationFile="@(_NestedBuildZip)"
+        Condition="'@(_NestedBuildZip->Count())' != '0'"
     />
     <ZipDirectory
         SourceDirectory="@(_NestediOSAppZip -> '$(_NestedZipExtractionDir)%(Filename)')"
         DestinationFile="@(_NestediOSAppZip)"
+        Condition="'@(_NestediOSAppZip->Count())' != '0'"
     />
     <RemoveDir Directories="$(_NestedZipExtractionDir)" />
   </Target>


### PR DESCRIPTION
Recent signing attempts on branches that are building a limited set of Apple platforms are failing:

    Target "_UnzipNestedZips: (TargetId:3)" in file "D:\a\_work\_temp\artifact-signing\extracted\SignList.targets" from project "D:\a\_work\_temp\artifact-signing\SignFiles.proj" (target "_CalculateItemsToSign" depends on it):
    Set Property: _NestedZipExtractionDir=D:\a\_work\_temp\artifact-signing\extracted\nested\
    Using "RemoveDir" task from assembly "Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
    Task "RemoveDir" (TaskId:2)
      Task Parameter:Directories=D:\a\_work\_temp\artifact-signing\extracted\nested\ (TaskId:2)
      Directory "D:\a\_work\_temp\artifact-signing\extracted\nested\" doesn't exist. Skipping. (TaskId:2)
    Done executing task "RemoveDir". (TaskId:2)
    Using "Unzip" task from assembly "Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
    Task "Unzip" (TaskId:3)
    D:\a\_work\_temp\artifact-signing\extracted\SignList.targets(16,5): Error MSB4044: The "Unzip" task was not given a value for the required parameter "DestinationFolder".

We should only attempt to extract and sign content in `Broker.zip`, `Build.zip`, and `Xamarin.PreBuilt.iOS.app.zip` if the zip exists.


Backport of #16141
