### PR TITLE
[devops] Stop testing on macOS 10.15.

### DIFF
--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -112,17 +112,6 @@ parameters:
   type: object
   default: [
     {
-      stageName: 'mac_10_15',
-      displayName: 'Mac Catalina (10.15)',
-      macPool: 'macOS-10.15',
-      useImage: true,
-      statusContext: 'Mac Catalina (10.15)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "Agent.OSVersion -equals '10.15'"
-      ]
-    },
-    {
       stageName: 'mac_11_5_m1',
       displayName: 'M1 - Mac Big Sur (11.5)',
       macPool: 'VSEng-VSMac-Xamarin-Shared',

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -112,17 +112,6 @@ parameters:
   type: object
   default: [
     {
-      stageName: 'mac_10_15',
-      displayName: 'Mac Catalina (10.15)',
-      macPool: 'macOS-10.15',
-      useImage: true,
-      statusContext: 'Mac Catalina (10.15)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "Agent.OSVersion -equals '10.15'"
-      ]
-    },
-    {
       stageName: 'mac_11_5_m1',
       displayName: 'M1 - Mac Big Sur (11.5)',
       macPool: 'VSEng-VSMac-Xamarin-Shared',

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -97,17 +97,6 @@ parameters:
   type: object
   default: [
     {
-      stageName: 'mac_10_15',
-      displayName: 'Mac Catalina (10.15)',
-      macPool: 'macOS-10.15',
-      useImage: true,
-      statusContext: 'Mac Catalina (10.15)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "Agent.OSVersion -equals '10.15'"
-      ]
-    },
-    {
       stageName: 'mac_11_5_m1',
       displayName: 'M1 - Mac Big Sur (11.5)',
       macPool: 'VSEng-VSMac-Xamarin-Shared',


### PR DESCRIPTION
The 10.15 bots are going away in a few months, and in any case macOS 10.15 is
not supported by Apple anymore, so stop testing on macOS 10.15.