### PR TITLE
[dotnet] Don't try to collect RID-specific items to codesign unless we're connected to (or building on) a Mac.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1299,7 +1299,7 @@
 		<ReadItemsFromFile
 			SessionId="$(BuildSessionId)"
 			File="%(_RidSpecificCodesignItemsPath.Identity)"
-			Condition="@(_RidSpecificCodesignItemsPath->Count()) &gt; 0"
+			Condition="@(_RidSpecificCodesignItemsPath->Count()) &gt; 0 And '$(IsMacEnabled)' == 'true'"
 		>
 			<Output TaskParameter="Items" ItemName="_RidSpecificCodesignItems" />
 		</ReadItemsFromFile>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -385,19 +385,21 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		[TestCase ("iossimulator-x64", false)]
-		[TestCase ("ios-arm64", true)]
-		[TestCase ("ios-arm64", true, "PublishTrimmed=true;UseInterpreter=true")]
-		public void IsNotMacBuild (string runtimeIdentifier, bool isDeviceBuild, string? extraProperties = null)
+		[TestCase (ApplePlatform.iOS, "iossimulator-x64", false)]
+		[TestCase (ApplePlatform.iOS, "ios-arm64", true)]
+		[TestCase (ApplePlatform.iOS, "ios-arm64", true, "PublishTrimmed=true;UseInterpreter=true")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64", false)]
+		public void IsNotMacBuild (ApplePlatform platform, string runtimeIdentifiers, bool isDeviceBuild, string? extraProperties = null)
 		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
 			if (isDeviceBuild)
 				Configuration.AssertDeviceAvailable ();
 
-			var platform = ApplePlatform.iOS;
-			var project_path = GetProjectPath ("MySingleView", runtimeIdentifiers: runtimeIdentifier, platform: platform, out var appPath);
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 			Clean (project_path);
-			var properties = GetDefaultProperties (runtimeIdentifier);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
 			properties ["IsMacEnabled"] = "false";
 			if (extraProperties is not null) {
 				foreach (var assignment in extraProperties.Split (';')) {
@@ -407,10 +409,16 @@ namespace Xamarin.Tests {
 			}
 			var result = DotNet.AssertBuild (project_path, properties);
 			AssertThatLinkerDidNotExecute (result);
-			var appExecutable = Path.Combine (appPath, Path.GetFileName (project_path));
-			Assert.That (appPath, Does.Exist, "There is an .app");
-			Assert.That (appExecutable, Does.Not.Empty, "There is no executable");
-			Assert.That (Path.Combine (appPath, "Xamarin.iOS.dll"), Does.Not.Exist, "Xamarin.iOS.dll is in the bundle");
+			switch (platform) {
+			case ApplePlatform.iOS:
+				var appExecutable = Path.Combine (appPath, Path.GetFileName (project_path));
+				Assert.That (appPath, Does.Exist, "There is an .app");
+				Assert.That (appExecutable, Does.Not.Empty, "There is no executable");
+				Assert.That (Path.Combine (appPath, Configuration.GetBaseLibraryName (platform, true)), Does.Not.Exist, "Platform assembly is in the bundle");
+				break;
+			case ApplePlatform.MacCatalyst:
+				break;
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes this problem when building universal Mac Catalyst apps on Windows:

    Target Name=_CollectRidSpecificCodesignItems Project=D:\a\_work\1\s\src\Graphics\samples\GraphicsTester.Skia.Mac\GraphicsTester.Skia.Mac.csproj
        ReadItemsFromFile
            Assembly = D:\a\_work\1\s\bin\dotnet\packs\Microsoft.MacCatalyst.Sdk\15.4.1173-rc.2\tools\msbuild\iOS\..\iOS\Xamarin.iOS.Tasks.dll
            Parameters
                File = obj\Release\net7.0-macos\codesignitems-osx-x64.items
            Errors
                D:\a\_work\1\s\bin\dotnet\packs\Microsoft.macOS.Sdk\12.3.1173-rc.2\targets\Xamarin.Shared.Sdk.targets(1303,3): error MSB4018: The "ReadItemsFromFile" task failed unexpectedly.
    System.IO.FileNotFoundException: Could not find file 'D:\a\_work\1\s\src\Graphics\samples\GraphicsTester.Skia.Mac\obj\Release\net7.0-macos\codesignitems-osx-x64.items'.
    File name: 'D:\a\_work\1\s\src\Graphics\samples\GraphicsTester.Skia.Mac\obj\Release\net7.0-macos\codesignitems-osx-x64.items'
       at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
       at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
       at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
       at System.Xml.XmlDownloadManager.GetStream(Uri uri, ICredentials credentials, IWebProxy proxy)
       at System.Xml.XmlTextReaderImpl.FinishInitUriString()
       at System.Xml.XmlReaderSettings.CreateReader(String inputUri, XmlParserContext inputContext)
       at System.Xml.Linq.XDocument.Load(String uri, LoadOptions options)
       at Xamarin.MacDev.Tasks.ReadItemsFromFileBase.Execute() in /Users/builder/azdo/_work/1/s/xamarin-macios/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadItemsFromFileBase.cs:line 39
       at Xamarin.MacDev.Tasks.ReadItemsFromFile.Execute() in /Users/builder/azdo/_work/1/s/xamarin-macios/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadItemsFromFile.cs:line 15
       at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
       at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [D:\a\_work\1\s\src\Graphics\samples\GraphicsTester.Skia.Mac\GraphicsTester.Skia.Mac.csproj]