### PR TITLE
[release/7.0.1xx-rc2] [dotnet] Don't try to ILStrip assemblies unless we're connected to a Mac.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -755,7 +755,11 @@
 			<_AssemblyDirsToCreate Include="@(_AssembliesToBeStripped->'%(OutputPath)%(Directory)'->Distinct())"/>
 		</ItemGroup>
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="@(_AssemblyDirsToCreate)" />
-		<Xamarin.MacDev.Tasks.ILStrip Assemblies="@(_AssembliesToBeStripped)" SessionId="$(BuildSessionId)">
+		<Xamarin.MacDev.Tasks.ILStrip
+			Assemblies="@(_AssembliesToBeStripped)"
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			>
 			<Output TaskParameter="StrippedAssemblies" ItemName="_StrippedAssemblies" />
 		</Xamarin.MacDev.Tasks.ILStrip>
 		<ItemGroup>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -387,20 +387,23 @@ namespace Xamarin.Tests {
 		[Test]
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64", false)]
 		[TestCase (ApplePlatform.iOS, "ios-arm64", true)]
+		[TestCase (ApplePlatform.iOS, "ios-arm64", true, null, "Release")]
 		[TestCase (ApplePlatform.iOS, "ios-arm64", true, "PublishTrimmed=true;UseInterpreter=true")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64", false)]
-		public void IsNotMacBuild (ApplePlatform platform, string runtimeIdentifiers, bool isDeviceBuild, string? extraProperties = null)
+		public void IsNotMacBuild (ApplePlatform platform, string runtimeIdentifiers, bool isDeviceBuild, string? extraProperties = null, string configuration = "Debug")
 		{
 			var project = "MySimpleApp";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 			if (isDeviceBuild)
 				Configuration.AssertDeviceAvailable ();
 
-			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 			Clean (project_path);
 			var properties = GetDefaultProperties (runtimeIdentifiers);
 			properties ["IsMacEnabled"] = "false";
+			if (!string.IsNullOrEmpty (configuration))
+				properties ["Configuration"] = configuration;
 			if (extraProperties is not null) {
 				foreach (var assignment in extraProperties.Split (';')) {
 					var split = assignment.Split ('=');


### PR DESCRIPTION
Fixes this error:

	targets/Xamarin.Shared.Sdk.targets(754,3): error MSB4018: The "Xamarin.MacDev.Tasks.ILStrip" task failed unexpectedly.
	targets/Xamarin.Shared.Sdk.targets(754,3): error MSB4018: System.ArgumentException: 'Assemblies' is required. (Parameter 'Assemblies')
	targets/Xamarin.Shared.Sdk.targets(754,3): error MSB4018:    at ILStrip.Execute()
	targets/Xamarin.Shared.Sdk.targets(754,3): error MSB4018:    at ILStripTasks.ILStripBase.Execute() in /Users/rolf/work/maccore/main/xamarin-macios/msbuild/Xamarin.iOS.Tasks/Tasks/ILStripBase.cs:line 18
	targets/Xamarin.Shared.Sdk.targets(754,3): error MSB4018:    at Xamarin.MacDev.Tasks.ILStrip.Execute() in /Users/rolf/work/maccore/main/xamarin-macios/msbuild/Xamarin.iOS.Tasks/Tasks/ILStrip.cs:line 16
	targets/Xamarin.Shared.Sdk.targets(754,3): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
	targets/Xamarin.Shared.Sdk.targets(754,3): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
     0 Warning(s)
     1 Error(s)


Backport of #16160
