### PR TITLE
[xcode14.1] Bump API references to Xcode 14 stable release for iOS, tvOS and watchOS.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -36,10 +36,10 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/d17-3/87f98a75edaa6757fd6ff5170d297615830fb41b/6466144/package/bundle.zip
+APIDIFF_REFERENCES_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx-xcode14/6756a11462d8aa6e73d4a320712b276caba159c1/6718459/package/bundle.zip
 APIDIFF_REFERENCES_Mac=https://bosstoragemirror.blob.core.windows.net/wrench/d17-3/87f98a75edaa6757fd6ff5170d297615830fb41b/6466144/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx/4bd34d034c8c5a4e092c8bd3c8868153d94277b4/6656178/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_tvOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx/4bd34d034c8c5a4e092c8bd3c8868153d94277b4/6656178/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx-xcode14/6756a11462d8aa6e73d4a320712b276caba159c1/6718459/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_tvOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx-xcode14/6756a11462d8aa6e73d4a320712b276caba159c1/6718459/package/bundle.zip
 APIDIFF_REFERENCES_DOTNET_macOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx/4bd34d034c8c5a4e092c8bd3c8868153d94277b4/6656178/package/bundle.zip
 APIDIFF_REFERENCES_DOTNET_MacCatalyst=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx/4bd34d034c8c5a4e092c8bd3c8868153d94277b4/6656178/package/bundle.zip
 


### PR DESCRIPTION



Backport of #16150
