### PR TITLE
[release/7.0.1xx-rc2] [msbuild] Make DetectSigningIdentity.CodesignEntitlements an ITaskItem property.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSigningIdentityTaskBase.cs
@@ -106,7 +106,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public string CodesignProvision { get; set; }
 
-		public string CodesignEntitlements { get; set; }
+		public ITaskItem CodesignEntitlements { get; set; }
 
 		public string CodesignRequireProvisioningProfile { get; set; }
 
@@ -180,13 +180,13 @@ namespace Xamarin.MacDev.Tasks
 		bool HasEntitlements {
 			get {
 				if (!hasEntitlements.HasValue) {
-					if (string.IsNullOrEmpty (CodesignEntitlements)) {
+					if (string.IsNullOrEmpty (CodesignEntitlements?.ItemSpec)) {
 						// If no CodesignEntitlements was specified, we don't have any entitlements
 						hasEntitlements = false;
 					} else {
 						if (IsDotNet) {
 							// .NET: Check the file to see if there are any entitlements inside
-							var entitlements = PDictionary.FromFile (CodesignEntitlements);
+							var entitlements = PDictionary.FromFile (CodesignEntitlements.ItemSpec);
 							hasEntitlements = entitlements.Count > 0;
 						} else {
 							// Legacy Xamarin: to preserve backwards compat, consider the presence of a file enough to say we have entitlements.

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
@@ -113,7 +113,7 @@ namespace Xamarin.MacDev.Tasks {
 			File.WriteAllText (entitlementsPath, testCase.Entitlements);
 
 			var task = CreateTask (dir, simulator: testCase.IsSimulator);
-			task.CodesignEntitlements = entitlementsPath;
+			task.CodesignEntitlements = new TaskItem (entitlementsPath);
 			task.SdkIsSimulator = testCase.IsSimulator;
 			if (testCase.CodesignRequireProvisioningProfile.HasValue)
 				task.CodesignRequireProvisioningProfile = testCase.CodesignRequireProvisioningProfile.Value.ToString ();


### PR DESCRIPTION
This way XVS will copy the corresponding file to the mac during a build.

Fixes this error:

    Target Name=_DetectSigningIdentity Project=C:\Users\admin\source\repos\iOSApp4\iOSApp4\iOSApp4.csproj
        DetectSigningIdentity
            Assembly = C:\Program Files\dotnet\packs\Microsoft.iOS.Sdk\16.0.515\tools\msbuild\iOS\..\iOS\Xamarin.iOS.Tasks.dll
            Parameters
                AppBundleName = iOSApp4
                BundleIdentifier = com.companyname.iOSApp4
                CodesignEntitlements = Entitlements.plist
                RequireCodeSigning = False
                SdkIsSimulator = True
                SdkPlatform = iPhoneSimulator
                SessionId = ...
                TargetFrameworkMoniker = .NETCoreApp,Version=v6.0,Profile=ios
            DetectSigningIdentity: 2022-09-28T04:17:13.3947732-07:00 - Started
            DetectSigningIdentity: 2022-09-28T04:17:13.3947732-07:00 - Initializing
            [xma][info]: Trying to get a Build Connection for Session '...': Xamarin.Messaging.Build.Client.BuildConnection...., Lifetime: AppDomain
            DetectSigningIdentity: 2022-09-28T04:17:13.3947732-07:00 - Initialized
            DetectSigningIdentity: 2022-09-28T04:17:13.3957722-07:00 - There's no available inputs to copy to the Mac
            DetectSigningIdentity: 2022-09-28T04:17:13.3957722-07:00 - Serializing intputs
            DetectSigningIdentity: 2022-09-28T04:17:13.4077719-07:00 - Executing
            [xma][info]: Starting remote task execution for 'iOSApp4': Xamarin.MacDev.Tasks.DetectSigningIdentity
            [xma][info]: Sending Request Xamarin.Messaging.Build.Contracts.ExecuteTaskMessage to topic xvs/build/execute-task/iOSApp4/01e0050002fDetectSigningIdentity
            [xma][err]: An error occurred on the receiver while executing a post for topic xvs/build/execute-task/iOSApp4/01e0050002fDetectSigningIdentity and client build01e0050ee064bdc5af5fe8d051898268699b25ed1eeec849023e711753e8d82d6484admin
            [xma][info]: An error occurred while executing the operation. The Build Server connection is active and running so no retries will be attempted.
            Errors
                C:\Program Files\dotnet\packs\Microsoft.iOS.Sdk\16.0.515\tools\msbuild\iOS\Xamarin.Shared.targets(1699,3): MessagingRemoteException: An error occurred on client Build while executing a reply for topic xvs/build/execute-task/iOSApp4/01e0050002fDetectSigningIdentity
    FileNotFoundException: Could not find file "/Users/vstester/Library/Caches/Xamarin/mtbs/builds/iOSApp4/.../Entitlements.plist"
     [C:\Users\admin\source\repos\iOSApp4\iOSApp4\iOSApp4.csproj]
            DetectSigningIdentity: 2022-09-28T04:17:13.4631033-07:00 - Finished

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1635214.


Backport of #16174
