### PR TITLE
[AVFoundation] Fix the AVAudioFormat.StreamDescription binding. Fixes #8892.

### DIFF
--- a/src/AVFoundation/AVAudioFormat.cs
+++ b/src/AVFoundation/AVAudioFormat.cs
@@ -11,6 +11,7 @@
 #pragma warning disable 0661
 // In both of these cases, the NSObject Equals/GetHashCode implementation works fine, so we can ignore these warnings.
 
+using AudioToolbox;
 using Foundation;
 using ObjCRuntime;
 using System;
@@ -33,6 +34,31 @@ namespace AVFoundation {
 		public static bool operator != (AVAudioFormat a, AVAudioFormat b)
 		{
 			return !(a == b);
+		}
+
+		[Export ("StreamDescription")]
+#if NET
+		[SupportedOSPlatform ("ios8.0")]
+		[SupportedOSPlatform ("macos10.10")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst8.0")]
+#endif
+		public virtual AudioStreamBasicDescription StreamDescription {
+#if NET
+			[SupportedOSPlatform ("ios8.0")]
+			[SupportedOSPlatform ("macos10.10")]
+			[SupportedOSPlatform ("tvos")]
+			[SupportedOSPlatform ("maccatalyst8.0")]
+#endif
+			get {
+				var ptr = _StreamDescription;
+				if (ptr == IntPtr.Zero)
+					return default (AudioStreamBasicDescription);
+				unsafe {
+					AudioStreamBasicDescription *p = (AudioStreamBasicDescription *) ptr;
+					return *p;
+				}
+			}
 		}
 	}
 }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1274,8 +1274,9 @@ namespace AVFoundation {
 		[Export ("interleaved")]
 		bool Interleaved { [Bind ("isInterleaved")] get; }
 
+		[Internal]
 		[Export ("streamDescription")]
-		AudioStreamBasicDescription StreamDescription { get; }
+		IntPtr _StreamDescription { get; }
 
 		[Export ("channelLayout"), NullAllowed]
 		AVAudioChannelLayout ChannelLayout { get; }

--- a/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
@@ -3,6 +3,9 @@
 // 		Whitney Schmidt (whschm@microsoft.com)
 // Copyright 2020 Microsoft Corp.
 
+using System;
+
+using AudioToolbox;
 using Foundation;
 using AVFoundation;
 using NUnit.Framework;
@@ -58,6 +61,21 @@ namespace MonoTouchFixtures.AVFoundation {
 				Assert.IsFalse (null != nullFormat, "null != nullFormat");
 			}
 
+		}
+
+		[Test]
+		public void StreamDescription ()
+		{
+			var format = new AVAudioFormat (AVAudioCommonFormat.PCMFloat32, 44100.0, 2, true);
+			var desc = format.StreamDescription;
+			Assert.AreEqual (AudioFormatType.LinearPCM, desc.Format, "Format");
+			Assert.AreEqual (AudioFormatFlags.LinearPCMIsFloat | AudioFormatFlags.LinearPCMIsPacked, desc.FormatFlags, "FormatFlags");
+			Assert.AreEqual (8, desc.BytesPerPacket, "BytesPerPacket");
+			Assert.AreEqual (1, desc.FramesPerPacket, "FramesPerPacket");
+			Assert.AreEqual (8, desc.BytesPerFrame, "BytesPerFrame");
+			Assert.AreEqual (2, desc.ChannelsPerFrame, "ChannelsPerFrame");
+			Assert.AreEqual (32, desc.BitsPerChannel, "BitsPerChannel");
+			Assert.AreEqual (0, desc.Reserved, "Reserved");
 		}
 	}
 }


### PR DESCRIPTION
The property returns a pointer to a struct, not the struct itself.

Fixes https://github.com/xamarin/xamarin-macios/issues/8892.