### PR TITLE
[tools] Always weak link the SensorKit framework. Fixes #9938.

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -428,7 +428,7 @@ public class Frameworks : Dictionary<string, Framework> {
 				{ "MLCompute", "MLCompute", new Version (14,0), NotAvailableInSimulator },
 				{ "NearbyInteraction", "NearbyInteraction", 14,0 },
 				{ "ScreenTime", "ScreenTime", 14,0 },
-				{ "SensorKit", "SensorKit", 14,0 },
+				{ "SensorKit", "SensorKit", new Version (14, 0), null, true }, /* not always present on device, e.g. any iPad, so must be weak linked; https://github.com/xamarin/xamarin-macios/issues/9938 */
 				{ "UniformTypeIdentifiers", "UniformTypeIdentifiers", 14,0 },
 
 				{ "AdServices", "AdServices", 14,3 },


### PR DESCRIPTION
The SensorKit framework isn't available on all devices (for instance iPads),
and as such we can't link with it strongly.

This seems to be a bug in Apple's toolchain, because Xcode runs into the same
problem if you try to use an app referencing SensorKit on an iPad.

Fixes https://github.com/xamarin/xamarin-macios/issues/9938.