### PR TITLE
[7.0.1xx-rc2] Disable iOS, tvOS and watchOS in this branch.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -290,10 +290,10 @@ MIN_TVOS_SIMULATOR_VERSION=12.4
 # These are the simulator package ids for the versions above
 EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK12_4 com.apple.pkg.AppleTVSimulatorSDK12_4 com.apple.pkg.WatchSimulatorSDK6_0
 
-INCLUDE_IOS=1
+INCLUDE_IOS=
 INCLUDE_MAC=1
-INCLUDE_WATCH=1
-INCLUDE_TVOS=1
+INCLUDE_WATCH=
+INCLUDE_TVOS=
 INCLUDE_MACCATALYST=1
 INCLUDE_DEVICE=1
 INCLUDE_DOTNET_WATCHOS=

--- a/Makefile
+++ b/Makefile
@@ -101,9 +101,9 @@ package:
 	mkdir -p ../package
 	$(MAKE) -C $(MACCORE_PATH) package
 	# copy .pkg, .zip and *updateinfo to the packages directory to be uploaded to storage
-	$(CP) $(MACCORE_PATH)/release/*.pkg ../package
-	$(CP) $(MACCORE_PATH)/release/*.zip ../package
-	$(CP) $(MACCORE_PATH)/release/*updateinfo ../package
+	-$(CP) $(MACCORE_PATH)/release/*.pkg ../package
+	-$(CP) $(MACCORE_PATH)/release/*.zip ../package
+	-$(CP) $(MACCORE_PATH)/release/*updateinfo ../package
 
 dotnet-install-system:
 	$(Q) $(MAKE) -C dotnet install-system

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -9,10 +9,6 @@ endif
 endif
 
 ifdef INCLUDE_XAMARIN_LEGACY
-SUBDIRS += mtouch
-endif
-
-ifdef INCLUDE_XAMARIN_LEGACY
 SUBDIRS += xibuild
 endif
 

--- a/tools/devops/automation/scripts/bash/build-nugets.sh
+++ b/tools/devops/automation/scripts/bash/build-nugets.sh
@@ -19,6 +19,6 @@ cp -c "$DOTNET_NUPKG_DIR"/SignList.targets ../package/
 
 DOTNET_PKG_DIR=$(make -C tools/devops print-abspath-variable VARIABLE=DOTNET_PKG_DIR | grep "^DOTNET_PKG_DIR=" | sed -e 's/^DOTNET_PKG_DIR=//')
 make -C dotnet package -j
-cp -c "$DOTNET_PKG_DIR"/*.pkg ../package/
-cp -c "$DOTNET_PKG_DIR"/*.msi ../package/
-cp -c "$DOTNET_PKG_DIR"/*.zip ../package/
+cp -c "$DOTNET_PKG_DIR"/*.pkg ../package/ || true
+cp -c "$DOTNET_PKG_DIR"/*.msi ../package/ || true
+cp -c "$DOTNET_PKG_DIR"/*.zip ../package/ || true


### PR DESCRIPTION
We're building iOS and tvOS in the corresponding xcode14 branch, which means
we only have to build for macOS and Mac Catalyst in this branch.

Also fix an issue where we built mtouch even if all mobile platforms were
disabled.