### PR TITLE
[net7.0] [devops] Don't fail building nugets if we dno't have files of every possible extension.

### DIFF
--- a/tools/devops/automation/scripts/bash/build-nugets.sh
+++ b/tools/devops/automation/scripts/bash/build-nugets.sh
@@ -19,6 +19,6 @@ cp -c "$DOTNET_NUPKG_DIR"/SignList.targets ../package/
 
 DOTNET_PKG_DIR=$(make -C tools/devops print-abspath-variable VARIABLE=DOTNET_PKG_DIR | grep "^DOTNET_PKG_DIR=" | sed -e 's/^DOTNET_PKG_DIR=//')
 make -C dotnet package -j
-cp -c "$DOTNET_PKG_DIR"/*.pkg ../package/
-cp -c "$DOTNET_PKG_DIR"/*.msi ../package/
-cp -c "$DOTNET_PKG_DIR"/*.zip ../package/
+cp -c "$DOTNET_PKG_DIR"/*.pkg ../package/ || true
+cp -c "$DOTNET_PKG_DIR"/*.msi ../package/ || true
+cp -c "$DOTNET_PKG_DIR"/*.zip ../package/ || true


### PR DESCRIPTION
Depending on the enabled platforms, we might not have files with all the listed extensions.