### PR TITLE
[7.0.1xx-rc2] [devops] Only upload 'macOS' and 'Mac Catalyst' packages to the 'not-signed-package' artifact.

### DIFF
--- a/tools/devops/automation/scripts/bash/install-workloads.sh
+++ b/tools/devops/automation/scripts/bash/install-workloads.sh
@@ -30,6 +30,10 @@ ls -R "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package"
 cp "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package/"*.nupkg "$DOTNET_NUPKG_DIR"
 cp "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package/"*.pkg "$DOTNET_NUPKG_DIR"
 cp "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package/"*.zip "$DOTNET_NUPKG_DIR"
+ls -R "$BUILD_SOURCESDIRECTORY/artifacts/packages-to-not-publish"
+cp "$BUILD_SOURCESDIRECTORY/artifacts/packages-to-not-publish/"*.nupkg "$DOTNET_NUPKG_DIR"
+cp "$BUILD_SOURCESDIRECTORY/artifacts/packages-to-not-publish/"*.pkg "$DOTNET_NUPKG_DIR"
+cp "$BUILD_SOURCESDIRECTORY/artifacts/packages-to-not-publish/"*.zip "$DOTNET_NUPKG_DIR"
 ls -R "$DOTNET_NUPKG_DIR"
 
 NUGET_SOURCES=$(grep https://pkgs.dev.azure.com ./NuGet.config | sed -e 's/.*value="//'  -e 's/".*//')

--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -130,12 +130,34 @@ steps:
           artifactName: PkgsVersions
         continueOnError: true
 
+      # separate macOS and Mac Catalyst packages from the rest
+      - bash: |
+          set -ex
+          rm -rf "$(Build.SourcesDirectory)/packages-to-publish"
+          # Copy all the packages
+          cp -r "$(Build.SourcesDirectory)/package" "$(Build.SourcesDirectory)/packages-to-publish"
+          # Move iOS and tvOS packages to a separate artifact
+          ls -laR "$(Build.SourcesDirectory)/packages-to-publish"
+          mkdir -p "$(Build.SourcesDirectory)/packages-to-not-publish/notarized"
+          mv "$(Build.SourcesDirectory)/packages-to-publish"/*[.]iOS[.]*           "$(Build.SourcesDirectory)/packages-to-not-publish/" || true
+          mv "$(Build.SourcesDirectory)/packages-to-publish/notarized"/*[.]iOS[.]* "$(Build.SourcesDirectory)/packages-to-not-publish/notarized/" || true
+          mv "$(Build.SourcesDirectory)/packages-to-publish"/*[.]tvOS[.]*           "$(Build.SourcesDirectory)/packages-to-not-publish/" || true
+          mv "$(Build.SourcesDirectory)/packages-to-publish/notarized/"*[.]tvOS[.]* "$(Build.SourcesDirectory)/packages-to-not-publish/notarized/" || true
+          ls -laR "$(Build.SourcesDirectory)/packages-to-not-publish"
+
       # upload each of the pkgs into the pipeline artifacts
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Build Artifacts'
         inputs:
-          targetPath: $(Build.SourcesDirectory)/package
+          targetPath: $(Build.SourcesDirectory)/package-to-publish
           artifactName: not-signed-package
+        continueOnError: true
+
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish Build Artifacts (To Not Publish)'
+        inputs:
+          targetPath: $(Build.SourcesDirectory)/packages-to-not-publish
+          artifactName: packages-to-not-publish
         continueOnError: true
 
       # funny enough we need these profiles to build the mac tests


### PR DESCRIPTION
Only upload 'macOS' and 'Mac Catalyst' packages to the 'not-signed-package'
artifact in this branch, so that the VS insertion logic won't try to insert
the iOS and tvOS workloads, since those will come from a different branch
(`release/7.0.1xx-xcode14-rc2`).