### PR TITLE
[release] Only try to copy files to the package directory if they exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,11 @@ package release:
 	$(Q) $(MAKE) -C $(TOP)/release release
 	# copy .pkg, .zip and *updateinfo to the packages directory to be uploaded to storage
 	$(Q) mkdir -p ../package
-	$(Q) $(CP) $(TOP)/release/*.pkg ../package
-	$(Q) $(CP) $(TOP)/release/*.zip ../package
-	$(Q) $(CP) $(TOP)/release/*updateinfo ../package
+	$(Q) echo "Output from 'make release':"
+	$(Q) ls -la $(TOP)/release | sed 's/^/    /'
+	$(Q) if test -n "$$(shopt -s nullglob; echo $(TOP)/release/*.pkg)"; then $(CP) $(TOP)/release/*.pkg ../package; fi
+	$(Q) if test -n "$$(shopt -s nullglob; echo $(TOP)/release/*.zip)"; then $(CP) $(TOP)/release/*.zip ../package; fi
+	$(Q) if test -n "$$(shopt -s nullglob; echo $(TOP)/release/*updateinfo)"; then $(CP) $(TOP)/release/*updateinfo ../package; fi
 	$(Q) echo "Packages:"
 	$(Q) ls -la ../package | sed 's/^/    /'
 


### PR DESCRIPTION
This is important when not building all platforms, because not all types of
files are produced for every platform.