### PR TITLE
[msbuild] Fix processing static libraries in binding sidecars.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.Designer.cs
@@ -2726,5 +2726,14 @@ namespace Xamarin.Localization.MSBuild {
                 return ResourceManager.GetString("W7100", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unexpected extension &apos;{0}&apos; for native reference &apos;{1}&apos; in manifest &apos;{2}&apos;..
+        /// </summary>
+        public static string W7105 {
+            get {
+                return ResourceManager.GetString("W7105", resourceCulture);
+            }
+        }
     }
 }

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1450,4 +1450,13 @@
                 * 'Remove', 'Boolean', 'String', 'StringArray'
         </comment>
     </data>
+
+    <data name="W7105" xml:space="preserve">
+        <value>Unexpected extension '{0}' for native reference '{1}' in manifest '{2}'.</value>
+        <comment>
+            {0}: file extension
+            {1}: path to a file
+            {2}: path to a file
+        </comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferencesBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferencesBase.cs
@@ -167,7 +167,12 @@ namespace Xamarin.MacDev.Tasks {
 					t = new TaskItem (Path.Combine (resources, name));
 					t.SetMetadata ("Kind", "Dynamic");
 					break;
+				case ".a": // static library
+					t = new TaskItem (Path.Combine (resources, name));
+					t.SetMetadata ("Kind", "Static");
+					break;
 				default:
+					Log.LogWarning (MSBStrings.W7105 /* Unexpected extension '{0}' for native reference '{1}' in manifest '{2}'. */, Path.GetExtension (name), name, manifest);
 					t = r;
 					break;
 				}


### PR DESCRIPTION
Fixes an issue where we'd end up trying to link with the managed assembly instead:

> ld: warning: ignoring file .../bin/Debug/net6.0-ios/MyBinding.dll, building for iOS Simulator-x86_64 but attempting to link with file built for unknown-unsupported file format ( 0x4D 0x5A 0x90 0x00 0x03 0x00 0x00 0x00 0x04 0x00 0x00 0x00 0xFF 0xFF 0x00 0x00 )

Also add a warning if we run into other types of libraries in the future to
make it easier to diagnose.