### PR TITLE
[net7.0-xcode14] Disable objc_msgSend stubs in clang. Fixes #16223.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -370,7 +370,11 @@ endif
 
 SIMULATOR_SDK=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(IOS_SDK_VERSION).sdk
 
-OBJC_CFLAGS=-ObjC++ -std=c++14 -fno-exceptions -stdlib=libc++
+# Clang will by default emit objc_msgSend stubs in Xcode 14, which ld from earlier Xcodes doesn't understand.
+# We disable this by passing -fno-objc-msgsend-selector-stubs to clang.
+# We can probably remove this flag once we require developers to use Xcode 14.
+# Ref: https://github.com/xamarin/xamarin-macios/issues/16223
+OBJC_CFLAGS=-ObjC++ -std=c++14 -fno-exceptions -stdlib=libc++ -fno-objc-msgsend-selector-stubs
 
 COMMON_SIMULATOR_CFLAGS=-mios-simulator-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(SIMULATOR_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES)
 SIMULATOR86_CFLAGS=$(COMMON_SIMULATOR_CFLAGS) -arch i386


### PR DESCRIPTION
Clang will by default emit objc_msgSend stubs in Xcode 14, which ld from
earlier Xcodes doesn't understand. We disable this by passing
-fno-objc-msgsend-selector-stubs to clang.

Ref: https://developer.apple.com/videos/play/wwdc2022/110363/
Ref: https://www.wwdcnotes.com/notes/wwdc22/110363/
Ref: https://github.com/llvm/llvm-project/issues/56034

Fixes https://github.com/xamarin/xamarin-macios/issues/16223.


Backport of #16231
