### PR TITLE
[autoformat] Update to cope with breaking changes in actions/github-script.

### DIFF
--- a/.github/workflows/autoformat2.yml
+++ b/.github/workflows/autoformat2.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/github-script@v6.3.1
       with:
         script: |
-          var artifacts = await github.actions.listWorkflowRunArtifacts({
+          var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
              owner: context.repo.owner,
              repo: context.repo.repo,
              run_id: ${{github.event.workflow_run.id }},
@@ -28,7 +28,7 @@ jobs:
           var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
             return artifact.name == "autoformat"
           })[0];
-          var download = await github.actions.downloadArtifact({
+          var download = await github.rest.actions.downloadArtifact({
              owner: context.repo.owner,
              repo: context.repo.repo,
              artifact_id: matchArtifact.id,


### PR DESCRIPTION
actions/github-script was recently updated from 3.1.0 to 6.3.1 (69de14c668b776631fc5c829c02403738c848e65), but unfortunately there were breaking changes:

* https://github.com/actions/github-script#breaking-changes
* https://github.com/actions/github-script/issues/242#issuecomment-1049167283

This would manifest as:

    TypeError: Cannot read properties of undefined (reading 'listWorkflowRunArtifacts')
    Error: Unhandled error: TypeError: Cannot read properties of undefined (reading 'listWorkflowRunArtifacts')
        at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6.3.1/dist/index.js:13340:16), <anonymous>:3:38)
        at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6.3.1/dist/index.js:13341:12)
        at main (/home/runner/work/_actions/actions/github-script/v6.3.1/dist/index.js:13436:26)
        at Module.858 (/home/runner/work/_actions/actions/github-script/v6.3.1/dist/index.js:13413:1)
        at __webpack_require__ (/home/runner/work/_actions/actions/github-script/v6.3.1/dist/index.js:24:31)
        at startup (/home/runner/work/_actions/actions/github-script/v6.3.1/dist/index.js:43:19)
        at /home/runner/work/_actions/actions/github-script/v6.3.1/dist/index.js:49:18
        at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v6.3.1/dist/index.js:52:10)
        at Module._compile (node:internal/modules/cjs/loader:1101:14)
        at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)

So update our code to to use the new way to do things.