### PR TITLE
[actions] Update the single-platform test branch every Saturday.

### DIFF
--- a/.github/workflows/update-single-platform-branches.yml
+++ b/.github/workflows/update-single-platform-branches.yml
@@ -1,0 +1,24 @@
+name: Update single-platform release tests branches
+
+on:
+  # run every saturday (at noon UTC), so the builds occur during the weekend during lower CI load
+  schedule:
+  - cron:  '0 12 * * 6'
+
+jobs:
+  updateSinglePlatformBranches:
+    name: Merge main into single-platform release test branches
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: 'Update branches'
+        run: |
+          set -ex
+          for platform in iOS tvOS MacCatalyst macOS; do
+            git checkout -b release/release-test-only-dotnet-$platform origin/release/release-test-only-dotnet-$platform
+            git merge origin/main
+            git push
+          done


### PR DESCRIPTION
We have four branches that test releasing a single platform:

    release/release-test-only-dotnet-$platform

In these branches, only the given platform is enabled (these are also
.NET-only branches), with the idea that we're testing the build and publish of
a single platform. These branches have a 'release/' prefix, so that the go
through as much as possible of our release pipeline.

Hopefully by testing and making sure the following builds and publishes correctly:

* All platforms (the default for our build)
* Each platform by itself

Building and publishing more than one (but less than all four) platforms also
work.

This PR will automatically update these four branches from main every
Saturday, so that we'll be able to find and fix any problems that occur before
release date.