### PR TITLE
[Foundation] Add NSArray.ToArray and implement IEnumerable<NSObject>.

### DIFF
--- a/src/Foundation/NSArray.cs
+++ b/src/Foundation/NSArray.cs
@@ -37,7 +37,7 @@ using NativeHandle = System.IntPtr;
 
 namespace Foundation {
 
-	public partial class NSArray {
+	public partial class NSArray : IEnumerable<NSObject> {
 
 		//
 		// Creates an array with the elements;   If the value passed is null, it
@@ -428,6 +428,29 @@ namespace Foundation {
 			} catch {
 				return null;
 			}
+		}
+
+		public TKey[] ToArray<TKey> () where TKey: class, INativeObject
+		{
+			var rv = new TKey [GetCount (Handle)];
+			for (var i = 0; i < rv.Length; i++)
+				rv [i] = GetItem<TKey> ((nuint) i);
+			return rv;
+		}
+
+		public NSObject[] ToArray ()
+		{
+			return ToArray<NSObject> ();
+		}
+
+		IEnumerator<NSObject> IEnumerable<NSObject>.GetEnumerator ()
+		{
+			return new NSFastEnumerator<NSObject> (this);
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			return new NSFastEnumerator<NSObject> (this);
 		}
 	}
 }

--- a/src/Foundation/NSArray_1.cs
+++ b/src/Foundation/NSArray_1.cs
@@ -89,5 +89,10 @@ namespace Foundation {
 				return GetItem<TKey> ((nuint)idx);
 			}
 		}
+
+		public new TKey[] ToArray ()
+		{
+			return base.ToArray<TKey> ();
+		}
 	}
 }

--- a/tests/monotouch-test/Foundation/ArrayTest.cs
+++ b/tests/monotouch-test/Foundation/ArrayTest.cs
@@ -8,6 +8,7 @@
 //
 
 using System;
+using System.Linq;
 using Foundation;
 using ObjCRuntime;
 using Security;
@@ -121,6 +122,38 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.That (a.Count, Is.EqualTo ((nuint) 0), "Count");
 				// and a valid native instance (or some other API might fail)
 				Assert.That (a.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+			}
+		}
+
+		[Test]
+		public void ToArray ()
+		{
+			using (var a = NSArray.FromStrings (new string [1] { "abc" })) {
+				var arr = a.ToArray ();
+				Assert.AreEqual (1, arr.Length, "Length");
+				Assert.AreEqual ("abc", arr [0].ToString (), "Value");
+			}
+		}
+
+		[Test]
+		public void ToArray_T ()
+		{
+			using (var a = NSArray.FromStrings (new string [1] { "abc" })) {
+				var arr = a.ToArray<NSString> ();
+				Assert.AreEqual (1, arr.Length, "Length");
+				Assert.AreEqual ("abc", arr [0].ToString (), "Value");
+			}
+		}
+
+		[Test]
+		public void Enumerator ()
+		{
+			using (var a = NSArray.FromStrings (new string [1] { "abc" })) {
+				foreach (var item in a)
+					Assert.AreEqual ("abc", item.ToString (), "Value");
+				var list = a.ToList ();
+				Assert.AreEqual (1, list.Count (), "Length");
+				Assert.AreEqual ("abc", list [0].ToString (), "Value");
 			}
 		}
 	}

--- a/tests/monotouch-test/Foundation/NSArray1Test.cs
+++ b/tests/monotouch-test/Foundation/NSArray1Test.cs
@@ -93,5 +93,29 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.AreSame (str3, arr [2], "NSArray indexer");
 			}
 		}
+
+		[Test]
+		public void ToArray ()
+		{
+			using (var a = NSArray<NSString>.FromNSObjects ((NSString) "abc")) {
+				var arr = a.ToArray ();
+				NSString element = arr [0];
+				Assert.AreEqual (1, arr.Length, "Length");
+				Assert.AreEqual ("abc", arr [0].ToString (), "Value");
+				Assert.AreEqual ("abc", (string) element, "Value element");
+			}
+		}
+
+		[Test]
+		public void ToArray_T ()
+		{
+			using (var a = NSArray<NSString>.FromNSObjects ((NSString) "abc")) {
+				var arr = a.ToArray ();
+				NSString element = arr [0];
+				Assert.AreEqual (1, arr.Length, "Length");
+				Assert.AreEqual ("abc", arr [0].ToString (), "Value");
+				Assert.AreEqual ("abc", (string) element, "Value element");
+			}
+		}
 	}
 }


### PR DESCRIPTION
For NSArray, implement:

* A ToArray () method that returns an NSArray[].
* A ToArray<T> () method that returns a T[].
* The IEnumerable<NSObject> interface.

For NSArray<T>, implement:

* A ToArray () method that returns a T[].

This should make NSArray much better to work with from managed code.