### PR TITLE
[actions] Checkout all branches when updating single platform release branches.

### DIFF
--- a/.github/workflows/update-single-platform-branches.yml
+++ b/.github/workflows/update-single-platform-branches.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: 'Update branches'
         run: |


### PR DESCRIPTION
Because we want to update branches other than main.