### PR TITLE
[dotnet] Add class library project templates for tvOS, macOS and Mac Catalyst.

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/.template.config/template.json
@@ -1,0 +1,19 @@
+﻿{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS", "Mac Catalyst" ],
+  "identity": "Microsoft.MacCatalyst.MacCatalystLib",
+  "name": "Mac Catalyst Class Library",
+  "description": "A project for creating a .NET Mac Catalyst class library",
+  "shortName": "maccatalystlib",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "MacCatalystLib1",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "MacCatalystLib1.csproj" }
+  ],
+  "defaultName": "MacCatalystLib1"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/Class1.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/Class1.cs
@@ -1,0 +1,4 @@
+namespace MacCatalystLib1;
+
+public class Class1 {
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/MacCatalystLib1.csproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/MacCatalystLib1.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MacCatalystLib1</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/.template.config/template.json
@@ -1,0 +1,19 @@
+﻿{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS" ],
+  "identity": "Microsoft.macOS.macOSLib",
+  "name": "macOS Class Library",
+  "description": "A project for creating a .NET macOS class library",
+  "shortName": "macoslib",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "macOSLib1",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "macOSLib1.csproj" }
+  ],
+  "defaultName": "macOSLib1"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/Class1.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/Class1.cs
@@ -1,0 +1,4 @@
+namespace macOSLib1;
+
+public class Class1 {
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/macOSLib1.csproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/macOSLib1.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-macos</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">macOSLib1</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/.template.config/template.json
@@ -1,0 +1,19 @@
+﻿{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "tvOS", "Mobile" ],
+  "identity": "Microsoft.tvOS.tvOSLib",
+  "name": "tvOS Class Library",
+  "description": "A project for creating a .NET tvOS class library",
+  "shortName": "tvoslib",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "tvOSLib1",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "tvOSLib1.csproj" }
+  ],
+  "defaultName": "tvOSLib1"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/Class1.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/Class1.cs
@@ -1,0 +1,4 @@
+namespace tvOSLib1;
+
+public class Class1 {
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/tvOSLib1.csproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/tvOSLib1.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-tvos</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">tvOSLib1</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet/UnitTests/TemplateTest.cs
+++ b/tests/dotnet/UnitTests/TemplateTest.cs
@@ -7,14 +7,12 @@ namespace Xamarin.Tests {
 		public struct TemplateInfo {
 			public readonly ApplePlatform Platform;
 			public readonly string Template;
-			public readonly bool ValidateSuccessfulBuild;
 			public readonly bool Execute;
 
-			public TemplateInfo (ApplePlatform platform, string template, bool validateSuccessfulBuild = true, bool execute = false)
+			public TemplateInfo (ApplePlatform platform, string template, bool execute = false)
 			{
 				Platform = platform;
 				Template = template;
-				ValidateSuccessfulBuild = validateSuccessfulBuild;
 				Execute = execute;
 			}
 		}
@@ -24,11 +22,17 @@ namespace Xamarin.Tests {
 			new TemplateInfo (ApplePlatform.iOS, "ios-tabbed"),
 			new TemplateInfo (ApplePlatform.iOS, "ioslib"),
 			new TemplateInfo (ApplePlatform.iOS, "iosbinding"),
+
 			new TemplateInfo (ApplePlatform.TVOS, "tvos"),
+			new TemplateInfo (ApplePlatform.TVOS, "tvoslib"),
 			new TemplateInfo (ApplePlatform.TVOS, "tvosbinding"),
+
 			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalyst", execute: true),
+			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalystlib"),
 			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalystbinding"),
+
 			new TemplateInfo (ApplePlatform.MacOSX, "macos", execute: true),
+			new TemplateInfo (ApplePlatform.MacOSX, "macoslib"),
 			new TemplateInfo (ApplePlatform.MacOSX, "macosbinding"),
 		};
 
@@ -76,12 +80,8 @@ namespace Xamarin.Tests {
 
 		[Test]
 		[TestCaseSource (nameof (Templates))]
-		public void CreateAndBuildTemplate (TemplateInfo info)
+		public void CreateAndBuildProjectTemplate (TemplateInfo info)
 		{
-			if (!info.ValidateSuccessfulBuild) {
-				return;
-			}
-
 			Configuration.IgnoreIfIgnoredPlatform (info.Platform);
 			var tmpDir = Cache.CreateTemporaryDirectory ();
 			var outputDir = Path.Combine (tmpDir, info.Template);


### PR DESCRIPTION
These new project templates won't show up in VSMac until the new templates are
added to VSMac.

Ref: https://github.com/xamarin/vsmac-xamarin-extensions/blob/61afbd1cd188150e82861c21cee0eb355b39c574/Xamarin.Addins.Core/Xamarin.Ide.Templating/TemplateDescriptionProvider.cs#L207-L216

Also update the corresponding template tests.

This PR might be easier to review commit-by-commit due to the large number of generated localization files.