### PR TITLE
[tests] Re-enable tests that were disabled in Xcode 12 beta 1. Fixes #9531.

### DIFF
--- a/tests/monotouch-test/ARKit/AREnvironmentProbeAnchorTest.cs
+++ b/tests/monotouch-test/ARKit/AREnvironmentProbeAnchorTest.cs
@@ -43,9 +43,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			var probeAnchor = new AREnvironmentProbeAnchor (MatrixFloat4x4.Identity, new VectorFloat3 (1, 1, 1));
 			Assert.AreEqual (MatrixFloat4x4.Identity, probeAnchor.Transform, "Transform");
-			// broken since xcode 12 beta 1 on simulator (only)
-			if ((Runtime.Arch == Arch.DEVICE) || !TestRuntime.CheckXcodeVersion (12, 0))
-				Assert.AreEqual (new VectorFloat3 (1, 1, 1), probeAnchor.Extent, "Extent");
+			Assert.AreEqual (new VectorFloat3 (1, 1, 1), probeAnchor.Extent, "Extent");
 		}
 
 		[Test]
@@ -53,9 +51,7 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			var probeAnchorWithName = new AREnvironmentProbeAnchor ("My Anchor", MatrixFloat4x4.Identity, new VectorFloat3 (1, 1, 1));
 			Assert.AreEqual (MatrixFloat4x4.Identity, probeAnchorWithName.Transform, "Transform");
-			// broken since xcode 12 beta 1 on simulator (only)
-			if ((Runtime.Arch == Arch.DEVICE) || !TestRuntime.CheckXcodeVersion (12, 0))
-				Assert.AreEqual (new VectorFloat3 (1, 1, 1), probeAnchorWithName.Extent, "Extent");
+			Assert.AreEqual (new VectorFloat3 (1, 1, 1), probeAnchorWithName.Extent, "Extent");
 		}
 	}
 }

--- a/tests/monotouch-test/ARKit/ARReferenceObjectTest.cs
+++ b/tests/monotouch-test/ARKit/ARReferenceObjectTest.cs
@@ -41,8 +41,6 @@ namespace MonoTouchFixtures.ARKit {
 		[Test]
 		public void MarshallingTest ()
 		{
-			if ((Runtime.Arch == Arch.SIMULATOR) && TestRuntime.CheckXcodeVersion (12, 0))
-				Assert.Ignore ("broken with beta 1 - can't instantiate the object");
 			var model3 = new ARReferenceObject (NSUrl.FromFilename ("Model3.arobject"), out NSError error);
 			Assert.AreEqual ("Model3", model3.Name, "Name");
 			Assert.NotNull (model3.Center, "Center");


### PR DESCRIPTION
Looks like these tests are working in the simulator now.

Fixes https://github.com/xamarin/xamarin-macios/issues/9531.