### PR TITLE
[msbuild] Only sign the app bundle if codesigning is enabled. Fixes #16197.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1923,7 +1923,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	-->
 	<Target
 		Name="_CodesignVerify"
-		Condition="'$(_CodesignAppBundleCondition)' == 'true'"
+		Condition="'$(_CodesignAppBundleCondition)' == 'true' And '$(_RequireCodeSigning)' == 'true'"
 		DependsOnTargets="_CodesignAppBundle"
 		>
 		<CodesignVerify
@@ -2049,9 +2049,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				We only run the CodesignAppBundle target on the outer-most executable project
 			    * Not on app extensions
 			    * Not on watch apps
+			    * Not if explicitly disabled by setting EnableCodeSigning=false
 			-->
-			<_CodesignAppBundleCondition Condition="'$(_CodesignAppBundleCondition)' == ''">$(_RequireCodeSigning)</_CodesignAppBundleCondition>
-			<_CodesignAppBundleCondition Condition="'$(_CodesignAppBundleCondition)' == '' And '$(IsAppExtension)' != 'true' And '$(IsWatchApp)' != 'true' And '$(_CanOutputAppBundle)' == 'true'">true</_CodesignAppBundleCondition>
+			<_CodesignAppBundleCondition Condition="'$(_CodesignAppBundleCondition)' == '' And '$(IsAppExtension)' != 'true' And '$(IsWatchApp)' != 'true' And '$(_CanOutputAppBundle)' == 'true' And '$(EnableCodeSigning)' != 'false'">true</_CodesignAppBundleCondition>
 			<_CodesignAppBundleCondition Condition="'$(_CodesignAppBundleCondition)' == ''">false</_CodesignAppBundleCondition>
 		</PropertyGroup>
 	</Target>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1923,7 +1923,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	-->
 	<Target
 		Name="_CodesignVerify"
-		Condition="'$(_CodesignAppBundleCondition)' == 'true' And '$(_RequireCodeSigning)' == 'true'"
+		Condition="'$(_CodesignAppBundleCondition)' == 'true'"
 		DependsOnTargets="_CodesignAppBundle"
 		>
 		<CodesignVerify
@@ -2050,6 +2050,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			    * Not on app extensions
 			    * Not on watch apps
 			-->
+			<_CodesignAppBundleCondition Condition="'$(_CodesignAppBundleCondition)' == ''">$(_RequireCodeSigning)</_CodesignAppBundleCondition>
 			<_CodesignAppBundleCondition Condition="'$(_CodesignAppBundleCondition)' == '' And '$(IsAppExtension)' != 'true' And '$(IsWatchApp)' != 'true' And '$(_CanOutputAppBundle)' == 'true'">true</_CodesignAppBundleCondition>
 			<_CodesignAppBundleCondition Condition="'$(_CodesignAppBundleCondition)' == ''">false</_CodesignAppBundleCondition>
 		</PropertyGroup>


### PR DESCRIPTION
Only sign the app bundle if codesigning is enabled.

This fixes a bug where we'd still try to sign an app bundle, even if the user
disabled code signing by setting EnableCodeSigning=false, if the default logic
was to sign the app bundle.

Fixes https://github.com/xamarin/xamarin-macios/issues/16197.