### PR TITLE
[release/7.0.1xx-rc2] [UIKit] Change UITextInput.SelectedTextRange to not be ArgumentSemantic.Copy. Fixes #15677.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -6936,7 +6936,9 @@ namespace UIKit {
 	interface UITextInput : UIKeyInput {
 		[Abstract]
 		[NullAllowed] // by default this property is null
-		[Export ("selectedTextRange", ArgumentSemantic.Copy)]
+		// This is declared as ArgumentSemantic.Copy, but UITextRange doesn't conform to NSCopying.
+		// Also declaring it as ArgumentSemantic.Copy makes UIKIt crash: https://github.com/xamarin/xamarin-macios/issues/15677
+		[Export ("selectedTextRange")]
 		UITextRange SelectedTextRange { get; set;  }
 
 		[Abstract]


### PR DESCRIPTION
When a property is declared as ArgumentSemantic.Copy, we'll copy the input value in property setters.

Unfortunately this makes UIKit crash, because for
UITextField.SelectedTextRange UIKit might use a custom UITextRange subclass,
with a broken 'copy' implementation (doesn't copy all the fields), that
subsequently makes the app crash.

On the other hand, UITextRange doesn't conform to NSCopying, and as such is in
theory not necessarily copyable, and thus I believe the bug is really that the
property is declared as a 'copy' property.

Fixes https://github.com/xamarin/xamarin-macios/issues/15677.


Backport of #16201
