### PR TITLE
[tests] Enable tests for interfaces being linked away. Fixes #9566.

### DIFF
--- a/tests/linker/ios/link all/InterfacesTest.cs
+++ b/tests/linker/ios/link all/InterfacesTest.cs
@@ -94,7 +94,9 @@ namespace LinkAll.Interfaces {
 		}
 
 		[Test]
+#if !NET
 		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/9566")]
+#endif
 		public void Issue9566 ()
 		{
 			var ifaces = (I[]) (object) new B[0];


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/9566.