### PR TITLE
Ensure we restore the temp csproj to compute AOT compiler path

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompilerTaskBase.cs
@@ -45,7 +45,7 @@ namespace Xamarin.MacDev.Tasks {
 		string ComputeAotCompilerPath ()
 		{
 			var projectPath = Path.GetTempFileName ();
-			
+
 			File.Delete (projectPath);
 			projectPath += ".csproj";
 
@@ -65,10 +65,10 @@ namespace Xamarin.MacDev.Tasks {
 			File.WriteAllText (projectPath, csproj);
 
 			var dotnetPath = Environment.GetEnvironmentVariable ("DOTNET_HOST_PATH");
-			
+
 			if (string.IsNullOrEmpty (dotnetPath)) {
 				dotnetPath = "dotnet";
-			}	
+			}
 
 			var environment = default (Dictionary<string, string>);
 			var customHome = Environment.GetEnvironmentVariable ("DOTNET_CUSTOM_HOME");
@@ -103,7 +103,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (File.Exists (configFile)) {
 				arguments.Add ("/p:RestoreConfigFile=" + configFile);
 			}
-			
+
 			arguments.Add ("/bl:" + binlog);
 			arguments.Add (projectPath);
 
@@ -146,7 +146,7 @@ namespace Xamarin.MacDev.Tasks {
 			}
 		}
 
-		string GetTempBinLog()
+		string GetTempBinLog ()
 		{
 			var binlog = Path.GetTempFileName ();
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompilerTaskBase.cs
@@ -2,10 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
 using Microsoft.Build.Framework;
-
 using Xamarin.Localization.MSBuild;
+using Threading = System.Threading.Tasks;
 
 namespace Xamarin.MacDev.Tasks {
 	public abstract class FindAotCompilerTaskBase : XamarinTask {
@@ -46,13 +45,10 @@ namespace Xamarin.MacDev.Tasks {
 		string ComputeAotCompilerPath ()
 		{
 			var projectPath = Path.GetTempFileName ();
-			var outputFile = Path.GetTempFileName ();
-			var binlog = Path.GetTempFileName ();
-
+			
 			File.Delete (projectPath);
 			projectPath += ".csproj";
-			File.Delete (binlog);
-			binlog += ".binlog";
+
 			var csproj = $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -68,17 +64,11 @@ namespace Xamarin.MacDev.Tasks {
 ";
 			File.WriteAllText (projectPath, csproj);
 
-			var executable = Environment.GetEnvironmentVariable ("DOTNET_HOST_PATH");
-			if (string.IsNullOrEmpty (executable))
-				executable = "dotnet";
-
-			var arguments = new List<string> ();
-			arguments.Add ("build");
-			arguments.Add ("/p:OutputFilePath=" + outputFile);
-			arguments.Add ("/p:RuntimeIdentifier=" + RuntimeIdentifier);
-			arguments.Add ("/t:ComputeAotCompilerPath");
-			arguments.Add ("/bl:" + binlog);
-			arguments.Add (projectPath);
+			var dotnetPath = Environment.GetEnvironmentVariable ("DOTNET_HOST_PATH");
+			
+			if (string.IsNullOrEmpty (dotnetPath)) {
+				dotnetPath = "dotnet";
+			}	
 
 			var environment = default (Dictionary<string, string>);
 			var customHome = Environment.GetEnvironmentVariable ("DOTNET_CUSTOM_HOME");
@@ -88,20 +78,82 @@ namespace Xamarin.MacDev.Tasks {
 			}
 
 			try {
-				ExecuteAsync (executable, arguments, environment: environment).Wait ();
+				ExecuteRestoreAsync (dotnetPath, projectPath, environment).Wait ();
+
+				return ExecuteBuildAsync (dotnetPath, projectPath, environment).Result;
+			} finally {
+				if (KeepTemporaryOutput) {
+					Log.LogMessage (MessageImportance.Normal, $"Temporary project for the FindAotCompiler task: {projectPath}");
+				} else {
+					File.Delete (projectPath);
+				}
+			}
+		}
+
+		async Threading.Task ExecuteRestoreAsync (string dotnetPath, string projectPath, Dictionary<string, string> environment)
+		{
+			var binlog = GetTempBinLog ();
+			var arguments = new List<string> ();
+
+			arguments.Add ("restore");
+
+			var dotnetDir = Path.GetDirectoryName (dotnetPath);
+			var configFile = Path.Combine (dotnetDir, "NuGet.config");
+
+			if (File.Exists (configFile)) {
+				arguments.Add ("/p:RestoreConfigFile=" + configFile);
+			}
+			
+			arguments.Add ("/bl:" + binlog);
+			arguments.Add (projectPath);
+
+			try {
+				await ExecuteAsync (dotnetPath, arguments, environment: environment);
+			} finally {
+				if (KeepTemporaryOutput) {
+					Log.LogMessage (MessageImportance.Normal, $"Temporary restore log for the FindAotCompiler task: {binlog}");
+				} else {
+					File.Delete (binlog);
+				}
+			}
+		}
+
+		async Threading.Task<string> ExecuteBuildAsync (string dotnetPath, string projectPath, Dictionary<string, string> environment)
+		{
+			var outputFile = Path.GetTempFileName ();
+			var binlog = GetTempBinLog ();
+			var arguments = new List<string> ();
+
+			arguments.Add ("build");
+			arguments.Add ("/p:OutputFilePath=" + outputFile);
+			arguments.Add ("/p:RuntimeIdentifier=" + RuntimeIdentifier);
+			arguments.Add ("/t:ComputeAotCompilerPath");
+			arguments.Add ("/bl:" + binlog);
+			arguments.Add (projectPath);
+
+			try {
+				await ExecuteAsync (dotnetPath, arguments, environment: environment);
+
 				return File.ReadAllText (outputFile).Trim ();
 			} finally {
 				if (KeepTemporaryOutput) {
-					Log.LogMessage (MessageImportance.Normal, "Temporary files for the FindAotCompiler task:");
-					Log.LogMessage (MessageImportance.Normal, $"    Project file: {projectPath}");
-					Log.LogMessage (MessageImportance.Normal, $"    Output file: {outputFile}");
-					Log.LogMessage (MessageImportance.Normal, $"    Binary log: {binlog}");
+					Log.LogMessage (MessageImportance.Normal, $"Temporary output for the FindAotCompiler task: {outputFile}");
+					Log.LogMessage (MessageImportance.Normal, $"Temporary build log for the FindAotCompiler task: {binlog}");
 				} else {
-					File.Delete (projectPath);
 					File.Delete (outputFile);
 					File.Delete (binlog);
 				}
 			}
+		}
+
+		string GetTempBinLog()
+		{
+			var binlog = Path.GetTempFileName ();
+
+			File.Delete (binlog);
+			binlog += ".binlog";
+
+			return binlog;
 		}
 	}
 }


### PR DESCRIPTION
The build command doesn't support a parameter to specify a NuGet.config, so we need to restore the temp project first, so we pass the NuGet.config file to use the sources from, in case it exists (e.g: the NuGet.config from the XMA dotnet path).

This is useful to support auhtorized NuGet feeds

Fixes Bug #1611102 - [XVS][MAUI] Failed to build .NET MAUI (net6.0) with iOS Simulator: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1611102