### PR TITLE
[devops] Add more post-build pipeline branches.

### DIFF
--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -13,6 +13,8 @@ resources:
       - main
       - release/*
       - net7.0
+      - net8.0
+      - release-test/* # this is for testing the release pipeline on branches without GitHub's branch protection (so we can automate tests without requiring commits to go through pull requests, etc.).
       stages:
       - prepare_release
 


### PR DESCRIPTION
* Add net8.0, because that's coming soon.
* Add release-test/\*, because we want to run some automated tests on various
  release configurations, and all the release/\* branches are branch-protected,
  which means CI can't commit any such branch without going through a pull
  request (which needs to be approved, etc.), and that's not very automated at
  all. So add a branch pattern to the post-build pipeline that isn't
  branch-protected.