### PR TITLE
[dotnet] Add numerous item templates. Fixes #15836.

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "MacCatalystApplication | MacCatalystAppExtension | MacCatalystBinding | MacCatalystClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "Mac Catalyst" ]
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/template.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS", "Mac Catalyst" ],
+  "name": "Mac Catalyst Controller",
+  "description": "A MacCatalyst Controller class",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.MacCatalyst.Controller",
+  "shortName": "maccatalyst-controller",
+  "sourceName": "Controller1",
+  "primaryOutputs": [
+    { "path": "Controller1.cs" }
+  ],
+  "defaultName": "Controller1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "MacCatalystApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/Controller1.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/Controller1.cs
@@ -1,0 +1,15 @@
+namespace MacCatalystApp1;
+
+[Register ("Controller1")]
+public class Controller1 : UIViewController {
+	public override void ViewDidLoad ()
+	{
+		View = new UIView {
+			BackgroundColor = UIColor.Blue,
+		};
+
+		base.ViewDidLoad ();
+
+		// Perform any additional setup after loading the view
+	}
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "MacCatalystApplication | MacCatalystAppExtension | MacCatalystBinding | MacCatalystClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "Mac Catalyst" ]
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst Storyboard",
+  "description": "A MacCatalyst Storyboard"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/template.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS", "Mac Catalyst" ],
+  "name": "Mac Catalyst Storyboard",
+  "description": "A MacCatalyst Storyboard",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.MacCatalyst.Storyboard",
+  "shortName": "maccatalyst-storyboard",
+  "sourceName": "Storyboard1",
+  "primaryOutputs": [
+    { "path": "Stortboard1.storyboard" }
+  ],
+  "defaultName": "Storyboard1"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/Storyboard1.storyboard
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/Storyboard1.storyboard
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "MacCatalystApplication | MacCatalystAppExtension | MacCatalystBinding | MacCatalystClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "Mac Catalyst" ]
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View",
+  "description": "A MacCatalyst View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/template.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS", "Mac Catalyst" ],
+  "name": "Mac Catalyst View",
+  "description": "A MacCatalyst View",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.MacCatalyst.View",
+  "shortName": "maccatalyst-view",
+  "sourceName": "View1",
+  "primaryOutputs": [
+    { "path": "View1.cs" }
+  ],
+  "defaultName": "View1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "MacCatalystApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/View1.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/View1.cs
@@ -1,0 +1,5 @@
+namespace MacCatalystApp1;
+
+[Register ("View1")]
+public class View1 : UIView {
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json.schemastore.org/ide.host",
+    "appliesTo": "MacCatalystApplication | MacCatalystAppExtension | MacCatalystBinding | MacCatalystClassLibary",
+    "defaultItemExtension": "cs",
+    "itemHierarchyPaths": [ "Mac Catalyst" ]
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Mac Catalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "MacCatalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/template.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS", "Mac Catalyst" ],
+  "name": "Mac Catalyst View Controller",
+  "description": "A MacCatalyst View Controller class and xib",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.MacCatalyst.ViewController",
+  "shortName": "maccatalyst-viewcontroller",
+  "sourceName": "ViewController1",
+  "primaryOutputs": [
+    { "path": "ViewController1.cs" },
+    { "path": "ViewController1.designer.cs" },
+    { "path": "ViewController1.xib" }
+  ],
+  "defaultName": "ViewController1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "MacCatalystApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/View1.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/View1.cs
@@ -1,0 +1,5 @@
+namespace MacCatalystApp1;
+
+[Register ("View1")]
+public class View1 : UIView {
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/ViewController1.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/ViewController1.cs
@@ -1,0 +1,20 @@
+namespace MacCatalystApp1;
+
+public partial class ViewController1 : UIViewController
+{
+	public ViewController1 () : base (nameof (ViewController1), null)
+	{
+	}
+
+	public override void ViewDidLoad ()
+	{
+		base.ViewDidLoad ();
+		// Perform any additional setup after loading the view, typically from a nib.
+	}
+
+	public override void DidReceiveMemoryWarning ()
+	{
+		base.DidReceiveMemoryWarning ();
+		// Release any cached data, images, etc that aren't in use.
+	}
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/ViewController1.designer.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/ViewController1.designer.cs
@@ -1,0 +1,17 @@
+// WARNING
+//
+// This file has been generated automatically by Visual Studio from the outlets and
+// actions declared in your storyboard file.
+// Manual changes to this file will not be maintained.
+//
+using System.CodeDom.Compiler;
+
+namespace MacCatalystApp1;
+
+[Register ("ViewController1")]
+partial class ViewController1
+{
+	void ReleaseDesignerOutlets ()
+	{
+	}
+}

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/ViewController1.xib
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/ViewController1.xib
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ViewController1">
+            <connections>
+                <outlet property="view" destination="2" id="RRd-Eg-VrN"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="2">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+        </view>
+    </objects>
+</document>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-controller/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "IOSApplication | IOSAppExtension | IOSBinding | IOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "iOS" ]
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "IOSApplication | IOSAppExtension | IOSBinding | IOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "iOS" ]
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "iOS Storyboard template",
+  "description": "An iOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/.template.config/template.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "iOS", "Mobile" ],
+  "name": "iOS Storyboard",
+  "description": "An iOS Storyboard",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.iOS.Storyboard",
+  "shortName": "ios-storyboard",
+  "sourceName": "Storyboard1",
+  "primaryOutputs": [
+    { "path": "Stortboard1.storyboard" }
+  ],
+  "defaultName": "Storyboard1"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/Storyboard1.storyboard
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-storyboard/Storyboard1.storyboard
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/FirstViewController.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/FirstViewController.cs
@@ -5,6 +5,8 @@ using ObjCRuntime;
 public partial class FirstViewController : UIViewController {
 	protected FirstViewController (NativeHandle handle) : base (handle)
 	{
+		// This constructor is required if the view controller is loaded from a xib or a storyboard.
+		// Do not put any initialization here, use ViewDidLoad instead.
 	}
 
 	public override void ViewDidLoad ()

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/SecondViewController.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/SecondViewController.cs
@@ -5,6 +5,8 @@ using ObjCRuntime;
 public partial class SecondViewController : UIViewController {
 	protected SecondViewController (NativeHandle handle) : base (handle)
 	{
+		// This constructor is required if the view controller is loaded from a xib or a storyboard.
+		// Do not put any initialization here, use ViewDidLoad instead.
 	}
 
 	public override void ViewDidLoad ()

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "IOSApplication | IOSAppExtension | IOSBinding | IOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "iOS" ]
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View",
+  "description": "An iOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View template",
+  "description": "An iOS View class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/.template.config/template.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "iOS", "Mobile" ],
+  "name": "iOS View",
+  "description": "An iOS View",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.iOS.View",
+  "shortName": "ios-view",
+  "sourceName": "View1",
+  "primaryOutputs": [
+    { "path": "View1.cs" }
+  ],
+  "defaultName": "View1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "iOSApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-view/View1.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-view/View1.cs
@@ -1,0 +1,5 @@
+namespace iOSApp1;
+
+[Register ("View1")]
+public class View1 : UIView {
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "IOSApplication | IOSAppExtension | IOSBinding | IOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "iOS" ]
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "iOS View Controller template",
+  "description": "An iOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/.template.config/template.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "iOS", "Mobile" ],
+  "name": "iOS View Controller",
+  "description": "An iOS View Controller class and xib",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.iOS.ViewController",
+  "shortName": "ios-viewcontroller",
+  "sourceName": "ViewController1",
+  "primaryOutputs": [
+    { "path": "ViewController1.cs" },
+    { "path": "ViewController1.designer.cs" },
+    { "path": "ViewController1.xib" }
+  ],
+  "defaultName": "ViewController1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "iOSApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/View1.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/View1.cs
@@ -1,0 +1,5 @@
+namespace iOSApp1;
+
+[Register ("View1")]
+public class View1 : UIView {
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/ViewController1.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/ViewController1.cs
@@ -1,0 +1,20 @@
+namespace iOSApp1;
+
+public partial class ViewController1 : UIViewController
+{
+	public ViewController1 () : base (nameof (ViewController1), null)
+	{
+	}
+
+	public override void ViewDidLoad ()
+	{
+		base.ViewDidLoad ();
+		// Perform any additional setup after loading the view, typically from a nib.
+	}
+
+	public override void DidReceiveMemoryWarning ()
+	{
+		base.DidReceiveMemoryWarning ();
+		// Release any cached data, images, etc that aren't in use.
+	}
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/ViewController1.designer.cs
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/ViewController1.designer.cs
@@ -1,0 +1,17 @@
+// WARNING
+//
+// This file has been generated automatically by Visual Studio from the outlets and
+// actions declared in your storyboard file.
+// Manual changes to this file will not be maintained.
+//
+using System.CodeDom.Compiler;
+
+namespace iOSApp1;
+
+[Register ("ViewController1")]
+partial class ViewController1
+{
+	void ReleaseDesignerOutlets ()
+	{
+	}
+}

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/ViewController1.xib
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-viewcontroller/ViewController1.xib
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ViewController1">
+            <connections>
+                <outlet property="view" destination="2" id="RRd-Eg-VrN"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="2">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+        </view>
+    </objects>
+</document>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "MacOSApplication | MacOSAppExtension | MacOSBinding | MacOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "macOS" ]
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS View Controller with UI implemented in code",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Controller",
+  "description": "A macOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/template.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS" ],
+  "name": "macOS Controller",
+  "description": "A macOS View Controller with UI implemented in code",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.macOS.Controller",
+  "shortName": "macos-controller",
+  "sourceName": "Controller1",
+  "primaryOutputs": [
+    { "path": "Controller1.cs" }
+  ],
+  "defaultName": "Controller1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "macOSApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/Controller1.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/Controller1.cs
@@ -1,0 +1,25 @@
+using ObjCRuntime;
+
+namespace macOSApp1;
+
+[Register ("Controller1")]
+public class Controller1 : NSViewController {
+	public Controller1 ()
+	{
+	}
+
+	protected Controller1 (NativeHandle handle) : base (handle)
+	{
+		// This constructor is required if the view controller is loaded from a xib or a storyboard.
+		// Do not put any initialization here, use ViewDidLoad instead.
+	}
+
+	public override void ViewDidLoad ()
+	{
+		base.ViewDidLoad ();
+
+		// Perform any additional setup after loading the view
+		View.WantsLayer = true;
+		View.Layer!.BackgroundColor = NSColor.Blue.CGColor;
+	}
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "MacOSApplication | MacOSAppExtension | MacOSBinding | MacOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "macOS" ]
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/template.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS" ],
+  "name": "macOS Storyboard",
+  "description": "A macOS Storyboard",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.macOS.Storyboard",
+  "shortName": "macos-storyboard",
+  "sourceName": "Storyboard1",
+  "primaryOutputs": [
+    { "path": "Stortboard1.storyboard" }
+  ],
+  "defaultName": "Storyboard1"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/Storyboard1.storyboard
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/Storyboard1.storyboard
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="bU7-R8-ocO">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="PEd-7d-5j0">
+            <objects>
+                <viewController id="bU7-R8-ocO" sceneMemberID="viewController">
+                    <view key="view" id="tOy-S4-hL0">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="9uD-mB-xHs" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="68" y="131"/>
+        </scene>
+    </scenes>
+</document>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "MacOSApplication | MacOSAppExtension | MacOSBinding | MacOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "macOS" ]
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View with UI implemented in Xcode's Interface Builder (XIB file)",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View",
+  "description": "A macOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/template.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS" ],
+  "name": "macOS View",
+  "description": "A macOS View with UI implemented in Xcode's Interface Builder (XIB file)",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.macOS.View",
+  "shortName": "macos-view",
+  "sourceName": "View1",
+  "primaryOutputs": [
+    { "path": "View1.cs" },
+    { "path": "View1.designer.cs" },
+    { "path": "View1.xib" }
+  ],
+  "defaultName": "View1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "macOSApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/View1.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/View1.cs
@@ -1,0 +1,11 @@
+namespace macOSApp1;
+
+[Register ("View1")]
+public class View1 : NSView {
+	public View1 ()
+	{
+		// Set a light blue background color
+		WantsLayer = true;
+		Layer!.BackgroundColor = NSColor.FromRgb (51, 171, 249).CGColor;
+	}
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/View1.xib
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/View1.xib
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="c22-O7-iKe" customClass="View1">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <point key="canvasLocation" x="68" y="154"/>
+        </customView>
+    </objects>
+</document>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "MacOSApplication | MacOSAppExtension | MacOSBinding | MacOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "macOS" ]
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller with UI implemented in Xcode's Interface Builder (XIB file)",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/template.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "macOS" ],
+  "name": "macOS View Controller",
+  "description": "A macOS View Controller with UI implemented in Xcode's Interface Builder (XIB file)",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.macOS.ViewController",
+  "shortName": "macos-viewcontroller",
+  "sourceName": "ViewController1",
+  "primaryOutputs": [
+    { "path": "ViewController1.cs" },
+    { "path": "ViewController1.designer.cs" },
+    { "path": "ViewController1.xib" }
+  ],
+  "defaultName": "ViewController1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "macOSApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/ViewController1.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/ViewController1.cs
@@ -1,0 +1,25 @@
+using ObjCRuntime;
+
+namespace macOSApp1;
+
+public partial class ViewController1 : NSViewController
+{
+	public ViewController1 () : base (nameof (ViewController1), null)
+	{
+	}
+
+	protected ViewController1 (NativeHandle handle) : base (handle)
+	{
+		// This constructor is required if the view controller is loaded from a xib or a storyboard.
+		// Do not put any initialization here, use ViewDidLoad instead.
+	}
+
+	public override void ViewDidLoad ()
+	{
+		base.ViewDidLoad ();
+
+		// Perform any additional setup after loading the view
+		View.WantsLayer = true;
+		View.Layer!.BackgroundColor = NSColor.Blue.CGColor;
+	}
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/ViewController1.designer.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/ViewController1.designer.cs
@@ -1,0 +1,17 @@
+// WARNING
+//
+// This file has been generated automatically by Visual Studio from the outlets and
+// actions declared in your storyboard file.
+// Manual changes to this file will not be maintained.
+//
+using System.CodeDom.Compiler;
+
+namespace macOSApp1;
+
+[Register ("ViewController1")]
+partial class ViewController1
+{
+	void ReleaseDesignerOutlets ()
+	{
+	}
+}

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/ViewController1.xib
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/ViewController1.xib
@@ -1,0 +1,21 @@
+﻿<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment version="101400" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="ViewController1">
+            <connections>
+                <outlet property="view" destination="c22-O7-iKe" id="onT-l6-8o0"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="c22-O7-iKe">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <point key="canvasLocation" x="14" y="154"/>
+        </customView>
+    </objects>
+</document>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/ViewController.cs
@@ -5,6 +5,8 @@ namespace macOSApp1;
 public partial class ViewController : NSViewController {
 	protected ViewController (NativeHandle handle) : base (handle)
 	{
+		// This constructor is required if the view controller is loaded from a xib or a storyboard.
+		// Do not put any initialization here, use ViewDidLoad instead.
 	}
 
 	public override void ViewDidLoad ()

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "TvOSApplication | TvOSAppExtension | TvOSBinding | TvOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "tvOS" ]
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/.template.config/template.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "tvOS", "Mobile" ],
+  "name": "tvOS Controller",
+  "description": "A tvOS Controller class",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.tvOS.Controller",
+  "shortName": "tvos-controller",
+  "sourceName": "Controller1",
+  "primaryOutputs": [
+    { "path": "Controller1.cs" }
+  ],
+  "defaultName": "Controller1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "tvOSApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/Controller1.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-controller/Controller1.cs
@@ -1,0 +1,15 @@
+namespace tvOSApp1;
+
+[Register ("Controller1")]
+public class Controller1 : UIViewController {
+	public override void ViewDidLoad ()
+	{
+		View = new UIView {
+			BackgroundColor = UIColor.Green,
+		};
+
+		base.ViewDidLoad ();
+
+		// Perform any additional setup after loading the view
+	}
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "TvOSApplication | TvOSAppExtension | TvOSBinding | TvOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "tvOS" ]
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/.template.config/template.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "tvOS", "Mobile" ],
+  "name": "tvOS Storyboard",
+  "description": "A tvOS Storyboard",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.tvOS.Storyboard",
+  "shortName": "tvos-storyboard",
+  "sourceName": "Storyboard1",
+  "primaryOutputs": [
+    { "path": "Stortboard1.storyboard" }
+  ],
+  "defaultName": "Storyboard1"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/Storyboard1.storyboard
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-storyboard/Storyboard1.storyboard
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "TvOSApplication | TvOSAppExtension | TvOSBinding | TvOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "tvOS" ]
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/.template.config/template.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "tvOS", "Mobile" ],
+  "name": "tvOS View",
+  "description": "A tvOS View",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.tvOS.View",
+  "shortName": "tvos-view",
+  "sourceName": "View1",
+  "primaryOutputs": [
+    { "path": "View1.cs" }
+  ],
+  "defaultName": "View1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "tvOSApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/View1.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-view/View1.cs
@@ -1,0 +1,5 @@
+namespace tvOSApp1;
+
+[Register ("View1")]
+public class View1 : UIView {
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/ide.host.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "appliesTo": "TvOSApplication | TvOSAppExtension | TvOSBinding | TvOSClassLibary",
+  "defaultItemExtension": "cs",
+  "itemHierarchyPaths": [ "tvOS" ]
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.cs.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.de.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.en.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.fr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.it.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.ja.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.ko.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.pl.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.pt-BR.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.ru.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.tr.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.zh-Hans.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.zh-Hant.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/.template.config/template.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "tvOS", "Mobile" ],
+  "name": "tvOS View Controller",
+  "description": "A tvOS View Controller class and xib",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "identity": "Microsoft.tvOS.ViewController",
+  "shortName": "tvos-viewcontroller",
+  "sourceName": "ViewController1",
+  "primaryOutputs": [
+    { "path": "ViewController1.cs" },
+    { "path": "ViewController1.designer.cs" },
+    { "path": "ViewController1.xib" }
+  ],
+  "defaultName": "ViewController1",
+  "symbols": {
+    "namespace": {
+      "description": "namespace for the generated code",
+      "replaces": "tvOSApp1",
+      "type": "parameter"
+    }
+  }
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/View1.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/View1.cs
@@ -1,0 +1,5 @@
+namespace tvOSApp1;
+
+[Register ("View1")]
+public class View1 : UIView {
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/ViewController1.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/ViewController1.cs
@@ -1,0 +1,20 @@
+namespace tvOSApp1;
+
+public partial class ViewController1 : UIViewController
+{
+	public ViewController1 () : base (nameof (ViewController1), null)
+	{
+	}
+
+	public override void ViewDidLoad ()
+	{
+		base.ViewDidLoad ();
+		// Perform any additional setup after loading the view, typically from a nib.
+	}
+
+	public override void DidReceiveMemoryWarning ()
+	{
+		base.DidReceiveMemoryWarning ();
+		// Release any cached data, images, etc that aren't in use.
+	}
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/ViewController1.designer.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/ViewController1.designer.cs
@@ -1,0 +1,17 @@
+// WARNING
+//
+// This file has been generated automatically by Visual Studio from the outlets and
+// actions declared in your storyboard file.
+// Manual changes to this file will not be maintained.
+//
+using System.CodeDom.Compiler;
+
+namespace tvOSApp1;
+
+[Register ("ViewController1")]
+partial class ViewController1
+{
+	void ReleaseDesignerOutlets ()
+	{
+	}
+}

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/ViewController1.xib
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos-viewcontroller/ViewController1.xib
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.AppleTV.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ViewController1">
+            <connections>
+                <outlet property="view" destination="2" id="RRd-Eg-VrN"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="2">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+        </view>
+    </objects>
+</document>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.cs
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/ViewController.cs
@@ -5,5 +5,7 @@ namespace tvOSApp1;
 public partial class ViewController : UIViewController {
 	protected ViewController (NativeHandle handle) : base (handle)
 	{
+		// This constructor is required if the view controller is loaded from a xib or a storyboard.
+		// Do not put any initialization here, use ViewDidLoad instead.
 	}
 }

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -79,13 +79,17 @@ namespace Xamarin.Tests {
 			return Execute ("build", project, properties, false);
 		}
 
-		public static ExecutionResult AssertNew (string outputDirectory, string template)
+		public static ExecutionResult AssertNew (string outputDirectory, string template, string? name = null)
 		{
 			Directory.CreateDirectory (outputDirectory);
 
 			var args = new List<string> ();
 			args.Add ("new");
 			args.Add (template);
+			if (!string.IsNullOrEmpty (name)) {
+				args.Add ("--name");
+				args.Add (name);
+			}
 
 			var env = new Dictionary<string, string> ();
 			env ["MSBuildSDKsPath"] = null;

--- a/tests/dotnet/UnitTests/TemplateTest.cs
+++ b/tests/dotnet/UnitTests/TemplateTest.cs
@@ -21,18 +21,17 @@ namespace Xamarin.Tests {
 			static TemplateType ParseConfig (ApplePlatform platform, string template)
 			{
 				// read the template's configuration to figure out if it's a project template, and if not, skip it
-				var dir = Path.Combine(Configuration.SourceRoot, "dotnet", "Templates", $"Microsoft.{platform.AsString()}.Templates");
-				var jsonPath = Path.Combine(dir, template, ".template.config", "template.json");
-				var options = new JsonSerializerOptions
-				{
+				var dir = Path.Combine (Configuration.SourceRoot, "dotnet", "Templates", $"Microsoft.{platform.AsString ()}.Templates");
+				var jsonPath = Path.Combine (dir, template, ".template.config", "template.json");
+				var options = new JsonSerializerOptions {
 					PropertyNameCaseInsensitive = true,
 					IncludeFields = true,
 					AllowTrailingCommas = false, // for max compat
 				};
 				try {
-					var json = JsonSerializer.Deserialize<TemplateConfig>(File.ReadAllText(jsonPath), options);
+					var json = JsonSerializer.Deserialize<TemplateConfig> (File.ReadAllText (jsonPath), options);
 					var type = json.Tags.Type;
-					return Enum.Parse<TemplateType>(type, true);
+					return Enum.Parse<TemplateType> (type, true);
 				} catch (Exception e) {
 					throw new Exception ($"Failed to parse {jsonPath}", e);
 				}
@@ -44,13 +43,12 @@ namespace Xamarin.Tests {
 			}
 		}
 
-		public enum TemplateType
-		{
+		public enum TemplateType {
 			Project,
 			Item,
 		}
 
-		public static TemplateInfo[] Templates = {
+		public static TemplateInfo [] Templates = {
 			/* project templates */
 			new TemplateInfo (ApplePlatform.iOS, "ios"),
 			new TemplateInfo (ApplePlatform.iOS, "ios-tabbed"),
@@ -91,7 +89,7 @@ namespace Xamarin.Tests {
 			new TemplateInfo (ApplePlatform.MacOSX, "macos-viewcontroller"),
 		};
 
-		public static TemplateInfo[] GetProjectTemplates ()
+		public static TemplateInfo [] GetProjectTemplates ()
 		{
 			return Templates.Where (v => v.TemplateType == TemplateType.Project).ToArray ();
 		}
@@ -205,36 +203,36 @@ namespace Xamarin.Tests {
 
 			var csproj = Path.Combine (outputDir, info.Template + ".csproj");
 			var rv = DotNet.AssertBuild (csproj);
-			var warnings = BinLog.GetBuildLogWarnings(rv.BinLogPath).Select(v => v.Message);
-			Assert.That(warnings, Is.Empty, $"Build warnings:\n\t{string.Join("\n\t", warnings)}");
+			var warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).Select (v => v.Message);
+			Assert.That (warnings, Is.Empty, $"Build warnings:\n\t{string.Join ("\n\t", warnings)}");
 
 			if (info.Execute) {
-				var runtimeIdentifiers = GetDefaultRuntimeIdentifier(platform);
+				var runtimeIdentifiers = GetDefaultRuntimeIdentifier (platform);
 
-				Assert.IsTrue(CanExecute(info.Platform, runtimeIdentifiers), "Must be executable to execute!");
+				Assert.IsTrue (CanExecute (info.Platform, runtimeIdentifiers), "Must be executable to execute!");
 
 				// First add some code to exit the template if it launches successfully.
-				var mainFile = Path.Combine(outputDir, "Main.cs");
-				var mainContents = File.ReadAllText(mainFile);
+				var mainFile = Path.Combine (outputDir, "Main.cs");
+				var mainContents = File.ReadAllText (mainFile);
 				var exitSampleWithSuccess = @"NSTimer.CreateScheduledTimer (1, (v) => {
 	Console.WriteLine (Environment.GetEnvironmentVariable (""MAGIC_WORD""));
 	Environment.Exit (0);
 			});
 			";
-				var modifiedMainContents = mainContents.Replace("// This is the main entry point of the application.", exitSampleWithSuccess);
-				Assert.AreNotEqual(modifiedMainContents, mainContents, "Failed to modify the main content");
-				File.WriteAllText(mainFile, modifiedMainContents);
+				var modifiedMainContents = mainContents.Replace ("// This is the main entry point of the application.", exitSampleWithSuccess);
+				Assert.AreNotEqual (modifiedMainContents, mainContents, "Failed to modify the main content");
+				File.WriteAllText (mainFile, modifiedMainContents);
 
 				// Build the sample
-				rv = DotNet.AssertBuild(csproj);
+				rv = DotNet.AssertBuild (csproj);
 
 				// There should still not be any warnings
-				warnings = BinLog.GetBuildLogWarnings(rv.BinLogPath).Select(v => v.Message);
-				Assert.That(warnings, Is.Empty, $"Build warnings (2):\n\t{string.Join("\n\t", warnings)}");
+				warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).Select (v => v.Message);
+				Assert.That (warnings, Is.Empty, $"Build warnings (2):\n\t{string.Join ("\n\t", warnings)}");
 
-				var appPath = GetAppPath(csproj, platform, runtimeIdentifiers);
-				var appExecutable = GetNativeExecutable(platform, appPath);
-				ExecuteWithMagicWordAndAssert(appExecutable);
+				var appPath = GetAppPath (csproj, platform, runtimeIdentifiers);
+				var appExecutable = GetNativeExecutable (platform, appPath);
+				ExecuteWithMagicWordAndAssert (appExecutable);
 			}
 		}
 	}

--- a/tests/dotnet/UnitTests/TemplateTest.cs
+++ b/tests/dotnet/UnitTests/TemplateTest.cs
@@ -8,16 +8,50 @@ namespace Xamarin.Tests {
 			public readonly ApplePlatform Platform;
 			public readonly string Template;
 			public readonly bool Execute;
+			public readonly TemplateType TemplateType;
 
 			public TemplateInfo (ApplePlatform platform, string template, bool execute = false)
 			{
 				Platform = platform;
 				Template = template;
 				Execute = execute;
+				TemplateType = ParseConfig (Platform, template);
+			}
+
+			static TemplateType ParseConfig (ApplePlatform platform, string template)
+			{
+				// read the template's configuration to figure out if it's a project template, and if not, skip it
+				var dir = Path.Combine(Configuration.SourceRoot, "dotnet", "Templates", $"Microsoft.{platform.AsString()}.Templates");
+				var jsonPath = Path.Combine(dir, template, ".template.config", "template.json");
+				var options = new JsonSerializerOptions
+				{
+					PropertyNameCaseInsensitive = true,
+					IncludeFields = true,
+					AllowTrailingCommas = false, // for max compat
+				};
+				try {
+					var json = JsonSerializer.Deserialize<TemplateConfig>(File.ReadAllText(jsonPath), options);
+					var type = json.Tags.Type;
+					return Enum.Parse<TemplateType>(type, true);
+				} catch (Exception e) {
+					throw new Exception ($"Failed to parse {jsonPath}", e);
+				}
+			}
+
+			public override string ToString ()
+			{
+				return Template;
 			}
 		}
 
-		public static TemplateInfo [] Templates = {
+		public enum TemplateType
+		{
+			Project,
+			Item,
+		}
+
+		public static TemplateInfo[] Templates = {
+			/* project templates */
 			new TemplateInfo (ApplePlatform.iOS, "ios"),
 			new TemplateInfo (ApplePlatform.iOS, "ios-tabbed"),
 			new TemplateInfo (ApplePlatform.iOS, "ioslib"),
@@ -34,7 +68,33 @@ namespace Xamarin.Tests {
 			new TemplateInfo (ApplePlatform.MacOSX, "macos", execute: true),
 			new TemplateInfo (ApplePlatform.MacOSX, "macoslib"),
 			new TemplateInfo (ApplePlatform.MacOSX, "macosbinding"),
+
+			/* item templates */
+			new TemplateInfo (ApplePlatform.iOS, "ios-controller"),
+			new TemplateInfo (ApplePlatform.iOS, "ios-storyboard"),
+			new TemplateInfo (ApplePlatform.iOS, "ios-view"),
+			new TemplateInfo (ApplePlatform.iOS, "ios-viewcontroller"),
+
+			new TemplateInfo (ApplePlatform.TVOS, "tvos-controller"),
+			new TemplateInfo (ApplePlatform.TVOS, "tvos-storyboard"),
+			new TemplateInfo (ApplePlatform.TVOS, "tvos-view"),
+			new TemplateInfo (ApplePlatform.TVOS, "tvos-viewcontroller"),
+
+			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalyst-controller"),
+			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalyst-storyboard"),
+			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalyst-view"),
+			new TemplateInfo (ApplePlatform.MacCatalyst, "maccatalyst-viewcontroller"),
+
+			new TemplateInfo (ApplePlatform.MacOSX, "macos-controller"),
+			new TemplateInfo (ApplePlatform.MacOSX, "macos-storyboard"),
+			new TemplateInfo (ApplePlatform.MacOSX, "macos-view"),
+			new TemplateInfo (ApplePlatform.MacOSX, "macos-viewcontroller"),
 		};
+
+		public static TemplateInfo[] GetProjectTemplates ()
+		{
+			return Templates.Where (v => v.TemplateType == TemplateType.Project).ToArray ();
+		}
 
 		public class TemplateConfig {
 			public string Name;
@@ -66,20 +126,18 @@ namespace Xamarin.Tests {
 				// read the template's configuration to figure out if it's a project template, and if not, skip it
 				foreach (var templateDir in templateDirectories) {
 					var jsonPath = Path.Combine (templateDir, ".template.config", "template.json");
+					Assert.That (jsonPath, Does.Exist, "Config file must exist");
 					if (!File.Exists (jsonPath))
 						continue;
-					var json = JsonSerializer.Deserialize<TemplateConfig> (File.ReadAllText (jsonPath), options);
-					if (json.Tags.Type != "project")
-						continue;
 
-					allTemplates.Add (json.ShortName);
+					allTemplates.Add (Path.GetFileName (templateDir));
 				}
 			}
 			Assert.That (allListedTemplates, Is.EquivalentTo (allTemplates), "The listed templates here and the templates on disk don't match");
 		}
 
 		[Test]
-		[TestCaseSource (nameof (Templates))]
+		[TestCaseSource (nameof (GetProjectTemplates))]
 		public void CreateAndBuildProjectTemplate (TemplateInfo info)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (info.Platform);
@@ -119,6 +177,64 @@ namespace Xamarin.Tests {
 				var appPath = GetAppPath (csproj, platform, runtimeIdentifiers);
 				var appExecutable = GetNativeExecutable (platform, appPath);
 				ExecuteWithMagicWordAndAssert (appExecutable);
+			}
+		}
+
+		[Test]
+		[TestCase (ApplePlatform.iOS)]
+		[TestCase (ApplePlatform.TVOS)]
+		[TestCase (ApplePlatform.MacCatalyst)]
+		[TestCase (ApplePlatform.MacOSX)]
+		public void CreateAndBuildItemTemplates (ApplePlatform platform)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			// We create a new project from the basic project template, and then we add all the
+			// item templates for the given platforms. This is faster than testing the item templates
+			// one-by-one.
+
+			var info = Templates.Single (v => string.Equals (v.Template, platform.AsString (), StringComparison.OrdinalIgnoreCase));
+			var itemTemplates = Templates.Where (v => v.TemplateType == TemplateType.Item && v.Platform == platform);
+
+			var tmpDir = Cache.CreateTemporaryDirectory ();
+			var outputDir = Path.Combine (tmpDir, info.Template);
+			DotNet.AssertNew (outputDir, info.Template);
+
+			foreach (var item in itemTemplates)
+				DotNet.AssertNew (outputDir, item.Template, "item_" + item.Template);
+
+			var csproj = Path.Combine (outputDir, info.Template + ".csproj");
+			var rv = DotNet.AssertBuild (csproj);
+			var warnings = BinLog.GetBuildLogWarnings(rv.BinLogPath).Select(v => v.Message);
+			Assert.That(warnings, Is.Empty, $"Build warnings:\n\t{string.Join("\n\t", warnings)}");
+
+			if (info.Execute) {
+				var runtimeIdentifiers = GetDefaultRuntimeIdentifier(platform);
+
+				Assert.IsTrue(CanExecute(info.Platform, runtimeIdentifiers), "Must be executable to execute!");
+
+				// First add some code to exit the template if it launches successfully.
+				var mainFile = Path.Combine(outputDir, "Main.cs");
+				var mainContents = File.ReadAllText(mainFile);
+				var exitSampleWithSuccess = @"NSTimer.CreateScheduledTimer (1, (v) => {
+	Console.WriteLine (Environment.GetEnvironmentVariable (""MAGIC_WORD""));
+	Environment.Exit (0);
+			});
+			";
+				var modifiedMainContents = mainContents.Replace("// This is the main entry point of the application.", exitSampleWithSuccess);
+				Assert.AreNotEqual(modifiedMainContents, mainContents, "Failed to modify the main content");
+				File.WriteAllText(mainFile, modifiedMainContents);
+
+				// Build the sample
+				rv = DotNet.AssertBuild(csproj);
+
+				// There should still not be any warnings
+				warnings = BinLog.GetBuildLogWarnings(rv.BinLogPath).Select(v => v.Message);
+				Assert.That(warnings, Is.Empty, $"Build warnings (2):\n\t{string.Join("\n\t", warnings)}");
+
+				var appPath = GetAppPath(csproj, platform, runtimeIdentifiers);
+				var appExecutable = GetNativeExecutable(platform, appPath);
+				ExecuteWithMagicWordAndAssert(appExecutable);
 			}
 		}
 	}


### PR DESCRIPTION
Add the following item templates for all platforms:

* Controller (View Controller with UI written in code)
* View
* View Controller (View Controller with UI written in XIB)
* Storyboard

Item templates won't show up in VSMac until this is released:
https://github.com/xamarin/vsmac/pull/9133.

Fixes https://github.com/xamarin/xamarin-macios/issues/15836.

Also update the template tests accordingly.

This PR might be easier to review commit-by-commit due to the large number of generated localization files.