### PR TITLE
[actions] Use a non-protected branch for release branch testing.

### DIFF
--- a/.github/workflows/update-single-platform-branches.yml
+++ b/.github/workflows/update-single-platform-branches.yml
@@ -24,7 +24,7 @@ jobs:
           git config user.email "github-actions-single-platform-branch-updater@xamarin.com"
           git config user.name "GitHub Actions Single Platform Branch Updater"
           for platform in iOS tvOS MacCatalyst macOS; do
-            git checkout -b release/release-test-only-dotnet-$platform origin/release/release-test-only-dotnet-$platform
+            git checkout -b release-test/only-dotnet-$platform origin/release-test/only-dotnet-$platform
             git merge origin/main
             git push
           done


### PR DESCRIPTION
See also: #16286