### PR TITLE
[release/6.0.4xx-xcode14] [illink] Ensure we replace the dotnet SDK path in the _ExtraTrimmerArgs for remote builds

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -317,6 +317,8 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 
 			<!-- The .NET 7 linker sets _TrimmerDefaultAction instead of TrimmerDefaultAction, so copy that value if it's set (and TrimmerDefaultAction is not set) -->
 			<TrimmerDefaultAction Condition="'$(TrimmerDefaultAction)' == ''">$(_TrimmerDefaultAction)</TrimmerDefaultAction>
+
+			<_RemoteExtraTrimmerArgs Condition="'$(_ExtraTrimmerArgs)' != ''">$(_ExtraTrimmerArgs.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)'))</_RemoteExtraTrimmerArgs>
 		</PropertyGroup>
 
 		<!-- Include Debug symbols as input so those are copied to the server -->
@@ -356,7 +358,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 				RootDescriptorFiles="@(TrimmerRootDescriptor)"
 				OutputDirectory="$(IntermediateLinkDir)"
 				DumpDependencies="$(_TrimmerDumpDependencies)"
-				ExtraArgs="$(_ExtraTrimmerArgs)"
+				ExtraArgs="$(_RemoteExtraTrimmerArgs)"
 				ToolExe="$(_DotNetHostFileName)"
 				ToolPath="$(_DotNetHostDirectory)"
 				ILLinkPath="$(_RemoteILLinkPath)"


### PR DESCRIPTION
.gs for remote builds

From net7, the original ILLInk targets are adding a new link attribute pointing to a supressions file inside the ILLink tasks folder, e.g: '--link-attributes "C:\Program Files\dotnet\sdk\7.0.100-rc.2.22477.23\Sdks\Microsoft.NET.ILLink.Tasks\build\6.0_suppressions.xml"'.

For remote builds, we need to replace the original dotnet folder with the XMA dotnet folder in the Mac, so in our override targets we replace this value before passing it to the ILLink task


Backport of #16294
