### PR TITLE
[dotnet] Hardcode 'true' as the default value for GenerateSatelliteAssembliesForCore. Fixes #16193.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -34,6 +34,11 @@
 
 		<!-- Do we need a RuntimeIdentifier? For apps and app extensions we do -->
 		<_RuntimeIdentifierIsRequired Condition="'$(OutputType)' == 'Exe' Or '$(IsAppExtension)' == 'true'">true</_RuntimeIdentifierIsRequired>
+
+		<!-- The logic to compute the default value for GenerateSatelliteAssembliesForCore is wrong when building inside Visual Studio (Windows), so make sure it defaults to the correct value -->
+		<!-- Ref: https://github.com/xamarin/xamarin-macios/issues/16193 -->
+		<!-- Ref: https://github.com/dotnet/sdk/issues/28419 -->
+		<GenerateSatelliteAssembliesForCore Condition="'$(GenerateSatelliteAssembliesForCore)' == ''">true</GenerateSatelliteAssembliesForCore>
 	</PropertyGroup>
 
 	<!-- Set the default RuntimeIdentifier if not already specified. -->


### PR DESCRIPTION
Hardcode 'true' as the default value for GenerateSatelliteAssembliesForCore,
because .NET gets it wrong when building from inside VS (Windows).

When building using either VSMac or the command line (either from Windows or
Mac), the `MSBuildRuntimeType` property is set to `Core`, and as a result, the
default value for `GenerateSatelliteAssembliesForCore` is `true`:

```xml
<GenerateSatelliteAssembliesForCore Condition=" '$(GenerateSatelliteAssembliesForCore)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">true</GenerateSatelliteAssembliesForCore>
```

See: https://github.com/dotnet/sdk/blob/00100960bf06cb595daba647673cd0329be896f4/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L41

This is the correct behavior.

However, when building from inside Visual Studio (for Windows), the
`MSBuildRuntimeType` property is set to `Full`, and thus
`GenerateSatelliteAssembliesForCore` is not set to `true`, and we end up
executing al.exe to generate satellite assemblies, which is wrong (al.exe
complains that 'arm64' is an invalid platform).

Fix this by always defaulting `GenerateSatelliteAssembliesForCore` to `true`,
independent on where we're executing.

Ref: https://github.com/dotnet/sdk/issues/28419.

Fixes https://github.com/xamarin/xamarin-macios/issues/16193.