### PR TITLE
[tests] Re-enable tests that were disabled in Xcode 12 beta 1. Fixes #9531.

### DIFF
--- a/tests/monotouch-test/ARKit/AREnvironmentProbeAnchorTest.cs
+++ b/tests/monotouch-test/ARKit/AREnvironmentProbeAnchorTest.cs
@@ -43,8 +43,8 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			var probeAnchor = new AREnvironmentProbeAnchor (MatrixFloat4x4.Identity, new VectorFloat3 (1, 1, 1));
 			Assert.AreEqual (MatrixFloat4x4.Identity, probeAnchor.Transform, "Transform");
-			// broken since xcode 12 beta 1 on simulator (only)
-			if ((Runtime.Arch == Arch.DEVICE) || !TestRuntime.CheckXcodeVersion (12, 0))
+			// broken since Xcode 12 on simulator (only), fixed in simulator in Xcode 14
+			if ((Runtime.Arch == Arch.DEVICE) || !TestRuntime.CheckXcodeVersion (12, 0) || TestRuntime.CheckXcodeVersion (14, 0))
 				Assert.AreEqual (new VectorFloat3 (1, 1, 1), probeAnchor.Extent, "Extent");
 		}
 
@@ -53,8 +53,8 @@ namespace MonoTouchFixtures.ARKit {
 		{
 			var probeAnchorWithName = new AREnvironmentProbeAnchor ("My Anchor", MatrixFloat4x4.Identity, new VectorFloat3 (1, 1, 1));
 			Assert.AreEqual (MatrixFloat4x4.Identity, probeAnchorWithName.Transform, "Transform");
-			// broken since xcode 12 beta 1 on simulator (only)
-			if ((Runtime.Arch == Arch.DEVICE) || !TestRuntime.CheckXcodeVersion (12, 0))
+			// broken since Xcode 12 on simulator (only), fixed in simulator in Xcode 14
+			if ((Runtime.Arch == Arch.DEVICE) || !TestRuntime.CheckXcodeVersion (12, 0) || TestRuntime.CheckXcodeVersion (14, 0))
 				Assert.AreEqual (new VectorFloat3 (1, 1, 1), probeAnchorWithName.Extent, "Extent");
 		}
 	}

--- a/tests/monotouch-test/ARKit/ARReferenceObjectTest.cs
+++ b/tests/monotouch-test/ARKit/ARReferenceObjectTest.cs
@@ -41,9 +41,10 @@ namespace MonoTouchFixtures.ARKit {
 		[Test]
 		public void MarshallingTest ()
 		{
-			if ((Runtime.Arch == Arch.SIMULATOR) && TestRuntime.CheckXcodeVersion (12, 0))
-				Assert.Ignore ("broken with beta 1 - can't instantiate the object");
+			TestRuntime.AssertNotSimulator (); // The Objective-C constructor is just stubbed out to return NULL in the simulator, so this test only works on device.
+
 			var model3 = new ARReferenceObject (NSUrl.FromFilename ("Model3.arobject"), out NSError error);
+			Assert.IsNull (error, "Error");
 			Assert.AreEqual ("Model3", model3.Name, "Name");
 			Assert.NotNull (model3.Center, "Center");
 			Assert.NotNull (model3.Extent, "Extent");


### PR DESCRIPTION
Looks like some of these tests are working in the simulator now.

I also confirmed that ARReferenceObjectTest.MarshallingTest test should be
ignored in the simulator by verifying that Xcode gets the same behavior we do
(i.e. it doesn't work).

Fixes https://github.com/xamarin/xamarin-macios/issues/9531.