### PR TITLE
[mtouch] Generate own constants file.

### DIFF
--- a/tests/mtouch/Makefile
+++ b/tests/mtouch/Makefile
@@ -35,6 +35,9 @@ bin/Debug/mtouchtests.dll: $(mtouchtests_dependencies)
 	$(SYSTEM_XIBUILD) -- mtouchtests.csproj /r $(XBUILD_VERBOSITY) /bl
 	$(Q) rm -f .failed-stamp
 
+$(abspath $(TOP)/tools/mtouch/Constants.cs):
+	$(Q) $(MAKE) $(notdir $@) -C $(dir $@)
+
 build: bin/Debug/mtouchtests.dll
 
 test.config: $(TOP)/Make.config Makefile

--- a/tools/mtouch/.gitignore
+++ b/tools/mtouch/.gitignore
@@ -1,3 +1,4 @@
+Constants.cs
 *.a
 *.dylib
 *.dSYM

--- a/tools/mtouch/Constants.cs.in
+++ b/tools/mtouch/Constants.cs.in
@@ -1,0 +1,6 @@
+namespace Xamarin.Bundler {
+	public static partial class Constants {
+		public const string Version = "@VERSION@";
+		internal const string Revision = "@REVISION@";
+	}
+}

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -223,6 +223,11 @@ mtouch.csproj.inc: export BUILD_VERBOSITY=$(MSBUILD_VERBOSITY)
 $(MTOUCH_DIR)/mtouch.exe: $(mtouch_dependencies)
 	$(Q_GEN) $(SYSTEM_MSBUILD) $(TOP)/Xamarin.iOS.sln "/t:mtouch" $(XBUILD_VERBOSITY) /p:Configuration=$(MTOUCH_CONF)
 
+Constants.cs: Constants.cs.in Makefile $(TOP)/Make.config.inc
+	$(Q_GEN) sed \
+		-e "s/@VERSION@/$(IOS_PACKAGE_VERSION_MAJOR).$(IOS_PACKAGE_VERSION_MINOR).$(IOS_PACKAGE_VERSION_REV)/g" \
+		-e 's/@REVISION@/$(IOS_COMMIT_DISTANCE) ($(CURRENT_BRANCH_SED_ESCAPED): $(CURRENT_HASH))/g' \
+		$< > $@
 #
 # Partial static registrar libraries
 #

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -53,9 +53,7 @@
     <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\Mono.Options\Mono.Options\Options.cs">
       <Link>mono-archive\Options.cs</Link>
     </Compile>
-    <Compile Include="..\..\src\build\ios\Constants.cs">
-      <Link>src\build\ios\Constants.cs</Link>
-    </Compile>
+    <Compile Include="Constants.cs" />
     <Compile Include="..\..\src\ObjCRuntime\Constants.cs">
       <Link>src\ObjCRuntime\Constants.cs</Link>
     </Compile>


### PR DESCRIPTION
Generate own constants file, instead of relying on platform-specific files in
src/, which may or may not exist depending on the enabled platforms.