### PR TITLE
[AVFoundation] Improve the callback in AVAssetImageGenerator.GenerateCGImagesAsynchronously.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -105,7 +105,12 @@ namespace AVFoundation {
 	interface MTAudioProcessingTap {}
 #endif
 
+#if XAMCORE_5_0
+	delegate void AVAssetImageGeneratorCompletionHandler (CMTime requestedTime, CGImage imageRef, CMTime actualTime, AVAssetImageGeneratorResult result, NSError error);
+#else
 	delegate void AVAssetImageGeneratorCompletionHandler (CMTime requestedTime, IntPtr imageRef, CMTime actualTime, AVAssetImageGeneratorResult result, NSError error);
+	delegate void AVAssetImageGeneratorCompletionHandler2 (CMTime requestedTime, CGImage imageRef, CMTime actualTime, AVAssetImageGeneratorResult result, NSError error);
+#endif
 	delegate void AVCompletion (bool finished);
 	delegate void AVRequestAccessStatus (bool accessGranted);
 	delegate AVAudioBuffer AVAudioConverterInputHandler (uint inNumberOfPackets, out AVAudioConverterInputStatus outStatus);
@@ -3742,6 +3747,12 @@ namespace AVFoundation {
 
 		[Export ("generateCGImagesAsynchronouslyForTimes:completionHandler:")]
 		void GenerateCGImagesAsynchronously (NSValue[] cmTimesRequestedTimes, AVAssetImageGeneratorCompletionHandler handler);
+
+#if !XAMCORE_5_0
+		[Sealed]
+		[Export ("generateCGImagesAsynchronouslyForTimes:completionHandler:")]
+		void GenerateCGImagesAsynchronously (NSValue[] cmTimesRequestedTimes, AVAssetImageGeneratorCompletionHandler2 handler);
+#endif
 
 		[Export ("cancelAllCGImageGeneration")]
 		void CancelAllCGImageGeneration ();


### PR DESCRIPTION
Add an overload to AVAssetImageGenerator.GenerateCGImagesAsynchronously that
takes a callback we call with a managed CGImage instance instead of a CGImage handle.

This makes the API a bit easier to use.

Ref: https://github.com/xamarin/xamarin-macios/issues/16314