### PR TITLE
initial 8-bit ascii selector support

### DIFF
--- a/src/ObjCRuntime/Selector.cs
+++ b/src/ObjCRuntime/Selector.cs
@@ -145,7 +145,7 @@ namespace ObjCRuntime {
 		[DllImport (Messaging.LIBOBJC_DYLIB, EntryPoint="sel_registerName")]
 		public extern static /* SEL */ IntPtr GetHandle (/* const char* */ string name);
 
-		public static NativeHandle GetHandle (ReadOnlySpan<byte> name)
+		public static NativeHandle GetHandle8 (ReadOnlySpan<byte> name)
 		{
 			unsafe {
 				fixed (byte *ptr = name) {

--- a/src/ObjCRuntime/Selector.cs
+++ b/src/ObjCRuntime/Selector.cs
@@ -145,6 +145,17 @@ namespace ObjCRuntime {
 		[DllImport (Messaging.LIBOBJC_DYLIB, EntryPoint="sel_registerName")]
 		public extern static /* SEL */ IntPtr GetHandle (/* const char* */ string name);
 
+		public static NativeHandle GetHandle (ReadOnlySpan<byte> name)
+		{
+			unsafe {
+				fixed (byte *ptr = name) {
+					return GetHandle (ptr);
+				}
+			}
+		}
+
+		[DllImport (Messaging.LIBOBJC_DYLIB, EntryPoint="sel_registerName")]
+		unsafe extern static /* SEL */ IntPtr GetHandle (byte* name);
 		// objc/objc.h
 		[DllImport (Messaging.LIBOBJC_DYLIB)]
 		[return: MarshalAs (UnmanagedType.U1)]

--- a/src/UIKit/UIControl.cs
+++ b/src/UIKit/UIControl.cs
@@ -75,7 +75,7 @@ namespace UIKit {
 			if (!t.TryGetValue (events, out ep)) {
 				ep = new UIControlEventProxy (this, notification);
 				t [events] = ep;
-				AddTarget (ep, Selector.GetHandle (new ReadOnlySpan<byte> (UIControlEventProxy.BridgeSelector8)), events);
+				AddTarget (ep, Selector.GetHandle8 (new ReadOnlySpan<byte> (UIControlEventProxy.BridgeSelector8)), events);
 			} else {
 				ep.Counter++;
 			}
@@ -103,7 +103,7 @@ namespace UIKit {
 			if (ep.Counter > 1)
 				return;
 
-			RemoveTarget (ep, Selector.GetHandle (new ReadOnlySpan<byte> (UIControlEventProxy.BridgeSelector8)), events);
+			RemoveTarget (ep, Selector.GetHandle8 (new ReadOnlySpan<byte> (UIControlEventProxy.BridgeSelector8)), events);
 			t.Remove (events);
 			ep.Dispose ();
 			if (t.Count == 0)

--- a/src/UIKit/UIControl.cs
+++ b/src/UIKit/UIControl.cs
@@ -22,6 +22,11 @@ namespace UIKit {
 		UIControl source;
 		internal int Counter = 1;
 		internal const string BridgeSelector = "BridgeSelector";
+		internal static byte [] BridgeSelector8 = new byte [] {
+			(byte)'B', (byte)'r', (byte)'i', (byte)'d', (byte)'g', (byte)'e', (byte)'S', (byte)'e',
+			(byte)'l', (byte)'e', (byte)'c', (byte)'t', (byte)'o', (byte)'r', 0
+		};
+
 
 		public UIControlEventProxy (UIControl source, EventHandler eh)
 		{
@@ -70,7 +75,7 @@ namespace UIKit {
 			if (!t.TryGetValue (events, out ep)) {
 				ep = new UIControlEventProxy (this, notification);
 				t [events] = ep;
-				AddTarget (ep, Selector.GetHandle (UIControlEventProxy.BridgeSelector), events);
+				AddTarget (ep, Selector.GetHandle (new ReadOnlySpan<byte> (UIControlEventProxy.BridgeSelector8)), events);
 			} else {
 				ep.Counter++;
 			}
@@ -98,7 +103,7 @@ namespace UIKit {
 			if (ep.Counter > 1)
 				return;
 
-			RemoveTarget (ep, Selector.GetHandle (UIControlEventProxy.BridgeSelector), events);
+			RemoveTarget (ep, Selector.GetHandle (new ReadOnlySpan<byte> (UIControlEventProxy.BridgeSelector8)), events);
 			t.Remove (events);
 			ep.Dispose ();
 			if (t.Count == 0)


### PR DESCRIPTION
What's going on:
We use UTF-16 selectors which are 16-bit characters. ObjC uses C string selectors which are 8 bit null terminated ascii.
16 bit selectors will use 2x the storage and for each invoke to `sel_registerName` which cause a new string to be allocated and the input string will be converted to 8-bit ascii. We can do better.

This change represents a proof of concept of using 8 bit selectors only. How?

- Implemented an overload of `Selector.GetHandle` which takes a `ReadOnlySpan<byte>`
- Added a fake overload of the `GetHandle` pinvoke that takes a `byte*` instead of `string`.
- Changed `UIControl` to use this overload.
- To generate the selector in `UIControl`, I used this code:
```
if (args.Length != 2) {
        Console.WriteLine ("Usage: vert varname string");
        return;
}

var varname = args [0];
var str = args [1];

Console.WriteLine ($"static byte [] {varname} = new byte [] {{");
for (var i=0; i < str.Count (); i++) {
        if (i > 0) Console.Write (',');
        if (i % 8 == 0) {
                Console.Write ("\n\t");
        } else {
                Console.Write (' ');
        }
        Console.Write ($"(byte)'{str [i]}'");
}
Console.WriteLine (", 0\n};");
```
and finally, for testing, I ran this code:
```
public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
        {
                // create a new window instance based on the screen size
                Window = new UIWindow (UIScreen.MainScreen.Bounds);

                // create a UIViewController with a single UILabel
                var vc = new UIViewController ();

                actionB = new UIButton (new CGRect (0, 0, 300, 150));
                actionB.SetTitle ("Click Me", UIControlState.Normal);
                Console.WriteLine ("adding target.");
                actionB.AddTarget (Handler, UIControlEvent.TouchUpInside);
                Console.WriteLine ("added target.");
                feedbackB = new UIButton (new CGRect (0, 200, 300, 150));
                feedbackB.SetTitle ("0", UIControlState.Normal);
                vc.View!.AddSubview (actionB);
                vc.View!.AddSubview (feedbackB);

                Window.RootViewController = vc;

                // make the window visible
                Window.MakeKeyAndVisible ();

                return true;
        }
```
on an iOS simulator I verified that (1) the code path in UIControl was getting hit and (2) that calling code worked as expected.

This is just the start - since everything is going to be built on top of this, I want this PR to get a lot of scrutiny.
The planned next steps are:
- change the generator to generate static byte arrays instead of strings
- change the existing manual bindings to use static byte arrays
- consider refactoring Selector instances to not use strings - this might not be a huge win. Don't know.
- when C# 11 is available, use the string form `"someString\0" u8` instead of byte arrays
- add an `Export8` or `ExportAscii` attribute that takes a byte array and refactor to use that

Ref: #10462.
