### PR TITLE
[test] Adjust ProjectTest.AppWithGenericLibraryReference to not fail when only macOS is enabled.

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -872,7 +872,11 @@ namespace Xamarin.Tests {
 		{
 			var project = "AppWithGenericLibraryReference";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
-			Configuration.IgnoreIfIgnoredPlatform (ApplePlatform.MacOSX); // This test requires macOS as well, for all other platforms.
+			if (platform == ApplePlatform.MacOSX) {
+				Configuration.IgnoreIfIgnoredPlatform (ApplePlatform.iOS); // This test requires iOS as well when testing macOS
+			} else {
+				Configuration.IgnoreIfIgnoredPlatform (ApplePlatform.MacOSX); // This test requires macOS as well (for all other platforms except macOS).
+			}
 
 			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
 			Clean (project_path);


### PR DESCRIPTION
This test requires another platform to be enabled in addition to the current
platform being tested: that other platform is iOS when testing macOS, and
macOS for all other platforms.

This can be seen in the target frameworks for the referenced library projects:

    MacCatalyst/Library.csproj:     <TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)-macos;netstandard2.1</TargetFrameworks>
    iOS/Library.csproj:             <TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)-macos;netstandard2.1</TargetFrameworks>
    macOS/Library.csproj:           <TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)-ios;netstandard2.1</TargetFrameworks>
    tvOS/Library.csproj:            <TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)-macos;netstandard2.1</TargetFrameworks>