### PR TITLE
[xtro] Fix processing common files when not all platforms are selected.

### DIFF
--- a/tools/common/ApplePlatform.cs
+++ b/tools/common/ApplePlatform.cs
@@ -52,5 +52,23 @@ namespace Xamarin.Utils {
 				return "Unknown";
 			}
 		}
+
+		public static ApplePlatform Parse (string platform)
+		{
+			switch (platform.ToLowerInvariant ()) {
+			case "ios":
+				return ApplePlatform.iOS;
+			case "tvos":
+				return ApplePlatform.TVOS;
+			case "macos":
+				return ApplePlatform.MacOSX;
+			case "watchos":
+				return ApplePlatform.WatchOS;
+			case "maccatalyst":
+				return ApplePlatform.MacCatalyst;
+			default:
+				throw new System.InvalidOperationException ($"Unknown platform: {platform}");
+			}
+		}
 	}
 }


### PR DESCRIPTION
We can't process a common-fx.ignore file for a given framework if that
framework isn't included in any of the platforms we're building for.

Example: we can't process common-AppKit.ignore when only iOS is enabled,
because none of the errors listed in common-AppKit.ignore will be reported for
an iOS build.