### PR TITLE
[devops] Add the job attempt to the api diff container name.

### DIFF
--- a/tools/devops/automation/templates/build/api-diff-process-results.yml
+++ b/tools/devops/automation/templates/build/api-diff-process-results.yml
@@ -48,7 +48,7 @@ steps:
   continueOnError: true # don't let any failures here stop us
   inputs:
     dropServiceURI: 'https://devdiv.artifacts.visualstudio.com/DefaultCollection'
-    dropMetadataContainerName: 'DropMetadata-ChangeDetection'
+    dropMetadataContainerName: 'DropMetadata-ChangeDetection-$(System.JobAttempt)'
     buildNumber: 'xamarin-macios/detected-changes/$(Build.BuildNumber)/$(Build.BuildId)-$(System.JobAttempt)'
     sourcePath: '$(System.DefaultWorkingDirectory)/change-detection/results/'
     detailedLog: true


### PR DESCRIPTION
This way the api diff job can be re-run and not fail because the artifact
already exists:

> ##[error]Artifact 'DropMetadata-ChangeDetection' already exists. If the build is producing multiple Drops, the Drop Metadata Container Name should be unique for each Drop.