### PR TITLE
[build] Improve VS component versions

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -155,12 +155,12 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform)
 $(DOTNET_NUPKG_DIR)/vs-workload.props: Workloads/vs-workload.template.props
 	$(Q) rm -f $@.tmp
 	$(Q_GEN) sed \
-		$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),-e "s/@$(platform)_WORKLOAD_VERSION@/$($(platform)_NUGET_VERSION).$($(platform)_NUGET_COMMIT_DISTANCE)/g") \
+		$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),-e "s/@$(platform)_WORKLOAD_VERSION@/$($(platform)_NUGET_OS_VERSION).0.$($(platform)_NUGET_COMMIT_DISTANCE)/g") \
 		$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),-e "s/@$(platform)_MSI_VERSION@/$($(platform)_MSI_VERSION)/g") \
 		-e "s/@PACK_VERSION_LONG@/$(IOS_NUGET_VERSION_NO_METADATA)/g" \
-		-e "s/@PACK_VERSION_SHORT@/$(IOS_NUGET_VERSION).$(IOS_NUGET_COMMIT_DISTANCE)/g" \
+		-e "s/@PACK_VERSION_SHORT@/$(IOS_NUGET_OS_VERSION).0.$(IOS_NUGET_COMMIT_DISTANCE)/g" \
 		-e "s/@MACOS_PACK_VERSION_LONG@/$(MACOS_NUGET_VERSION_NO_METADATA)/g" \
-		-e "s/@MACOS_PACK_VERSION_SHORT@/$(MACOS_NUGET_VERSION).$(MACOS_NUGET_COMMIT_DISTANCE)/g" \
+		-e "s/@MACOS_PACK_VERSION_SHORT@/$(MACOS_NUGET_OS_VERSION).0.$(MACOS_NUGET_COMMIT_DISTANCE)/g" \
 		$< > $@.tmp
 	$(Q) mv $@.tmp $@
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/commit/85799ee55bedd2bd61089b5af4049dee5380911d
Context: https://github.com/xamarin/sdk-insertions/wiki/How-to-create-a-new-insertion#msi-generation-and-vs-versioning-requirements

Attempt to improve consistency in VS component versions by more closely
following the four digit versioning schema used by Android and MAUI.

The previous component version contained the commit distance twice, and
now the commit distance is only used in the fourth version part.

Before:
Version="15.4.1167.1167"

After:
Version="15.4.0.1167"

Compared to Android/MAUI:
Version="33.0.0.151"
Version="7.0.0.6683"