### PR TITLE
[devops] Don't fail if the build didn't produce any *.msi files.

### DIFF
--- a/tools/devops/automation/scripts/bash/build-nugets.sh
+++ b/tools/devops/automation/scripts/bash/build-nugets.sh
@@ -20,4 +20,4 @@ cp -c "$DOTNET_NUPKG_DIR"/SignList.targets ../package/
 DOTNET_PKG_DIR=$(make -C tools/devops print-abspath-variable VARIABLE=DOTNET_PKG_DIR | grep "^DOTNET_PKG_DIR=" | sed -e 's/^DOTNET_PKG_DIR=//')
 make -C dotnet package -j
 cp -c "$DOTNET_PKG_DIR"/*.pkg ../package/
-cp -c "$DOTNET_PKG_DIR"/*.msi ../package/
+cp -c "$DOTNET_PKG_DIR"/*.msi ../package/ || true


### PR DESCRIPTION
We won't produce any *.msi files when building for macOS only for instance.