### PR TITLE
[devops] Only run tests on other macOS versions in certain scenarios.

### DIFF
--- a/tools/devops/automation/scripts/bash/configure-decisions.sh
+++ b/tools/devops/automation/scripts/bash/configure-decisions.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -eux
+
+set -o pipefail
+IFS=$'\n\t'
+
+# Some debug spew...
+env -0 | sort -z | tr '\0' '\n' || true
+
+function AddOutputVariable () {
+	set +x
+	echo "Setting the variable $1=$2"
+	echo "##vso[task.setvariable variable=$1;isOutput=true]$2"
+	set -x
+}
+
+# Run mac tests if any desktop platform is enabled, and they've not been disabled.
+if [[ "${LABELS_SKIP_PACKAGED_MACOS_TESTS:-}" == "True" ]]; then
+	# They've been skipped: don't run them
+	RUN_MAC_TESTS=false
+elif [[ "${LABELS_RUN_PACKAGED_MACOS_TESTS:-}" == "True" ]]; then
+	# They've been explicitly enabled: run them
+	RUN_MAC_TESTS=true
+elif [[ "${LABELS_SKIP_ALL_TESTS:-}" == "True" ]]; then
+	# All tests have been skipped
+	RUN_MAC_TESTS=false
+elif [[ "${INCLUDE_DOTNET_MACOS:-}" != "" ]]; then
+	# Run mac tests if a .NET desktop platform is enabled
+	RUN_MAC_TESTS=true
+elif [[ "${INCLUDE_LEGACY_MAC:-}" != "" ]]; then
+	# Run mac tests if a legacy desktop platform is enabled
+	RUN_MAC_TESTS=true
+else
+	# Otherwise don't run mac tests
+	RUN_MAC_TESTS=false
+fi
+AddOutputVariable RUN_MAC_TESTS "$RUN_MAC_TESTS"

--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -139,7 +139,7 @@ steps:
 
       name: macTestPkg
       displayName: 'Package macOS tests'
-      condition: and(succeeded(), contains(variables['configuration.RunMacTests'], 'True'))
+      condition: and(succeeded(), contains(variables['RUN_MAC_TESTS'], 'true'))
       continueOnError: true # not a terrible blocking issue
       timeoutInMinutes: 60
 

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -107,13 +107,11 @@ jobs:
     # skip-nugets
     # skip-signing
     # run-sample-tests
-    # skip-packaged-xamarin-mac-tests
     BuildPackage: $[ dependencies.configure.outputs['labels.build_package'] ]
     SkipPackages: $[ dependencies.configure.outputs['labels.skip_packages'] ]
     SkipNugets: $[ dependencies.configure.outputs['labels.skip_nugets'] ]
     SkipSigning: $[ dependencies.configure.outputs['labels.skip_signing'] ]
     RunSampleTests: $[ dependencies.configure.outputs['labels.run_sample_tests'] ]
-    SkipPackagedXamarinMacTests: $[ dependencies.configure.outputs['labels.skip_packaged_xamarin_mac_tests'] ]
     SkipApiComparison: $[ dependencies.configure.outputs['labels.skip_api_comparison'] ]
     # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
     PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
@@ -121,6 +119,7 @@ jobs:
     BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
     BUILD_REVISION: $[ variables['Build.SourceVersion'] ]
     XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness_labels'] ]
+    RUN_MAC_TESTS: $[ dependencies.configure.outputs['decisions.RUN_MAC_TESTS'] ]
   pool:
     name: $(AgentPoolComputed)
     demands:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -122,12 +122,6 @@ steps:
         $configVars.Add("SignPkgs", "True")
       }
 
-      if ($Env:SkipPackagedXamarinMacTests -eq "True") {
-        $configVars.Add("RunMacTests", "False")
-      } else {
-        $configVars.Add("RunMacTests", "True")
-      }
-
       $configVars.Add("RunSampleTests", $Env:RunSampleTests)
 
     } else {
@@ -138,7 +132,6 @@ steps:
       $configVars.Add("SignPkgs", "True")
 
       # tests, run all of them, internal, external, mac but not sample tests
-      $configVars.Add("RunMacTests", "True")
       $configVars.Add("RunSampleTests", "False")
     }
     # write debugging and process of the vars

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -99,7 +99,8 @@ steps:
         "skip-nugets",
         "skip-signing",
         "run-sample-tests",
-        "skip-packaged-xamarin-mac-tests",
+        "skip-packaged-macos-tests",
+        "run-packaged-macos-tests",
         "skip-api-comparison",
         "skip-all-tests"
       )
@@ -140,6 +141,10 @@ steps:
       ENABLE_DOTNET: "True"
   name: labels
   displayName: 'Configure build'
+
+- bash: ./xamarin-macios/tools/devops/automation/scripts/bash/configure-decisions.sh
+  name: decisions
+  displayName: 'Make decisions'
 
 # upload config to be consumed later
 - ${{ if eq(parameters.uploadArtifacts, true) }}:

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -36,9 +36,7 @@ stages:
   displayName: ${{ parameters.displayName }}
   dependsOn:
   - build_packages
-  # we need to have the pkgs built and the device sets to be ran, that is decided via the labels or type of build during the build_packages stage
-  condition: succeeded()
-
+  condition: and(succeeded(), eq(dependencies.build_packages.outputs['configure.decisions.RUN_MAC_TESTS'], 'true'))
   variables:
     GITHUB_FAILURE_COMMENT_FILE: $(System.DefaultWorkingDirectory)/github-comment-file.md
 


### PR DESCRIPTION
* Don't run these tests if neither macOS nor Mac Catalyst is enabled.
* Honor `skip-all-tests` to skip these tests.
* Change the `skip-packaged-xamarin-mac-tests` label to `skip-packaged-macos-tests` since Xamarin.Mac is disappearing soon.
* Add a `run-packaged-macos-tests` to mirror `skip-packaged-macos-tests` (this is useful when using `skip-all-tests` to only run these tests).