### PR TITLE
[net7.0] [api-diff] Add api-diff.md to the all-markdowns target.

### DIFF
--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -317,6 +317,8 @@ define ApiDiffReportMarkdown
 
 endef
 
+all-markdowns:: $(OUTPUT_DIR)/api-diff.md
+
 $(OUTPUT_DIR)/api-diff.md: $(API_DIFF_DEPENDENCIES)
 ifdef INCLUDE_XAMARIN_LEGACY
 	$(Q) if $(foreach html,$(wildcard $(OUTPUT_DIR)/*-api-diff.html),! test -s "$(html)" &&) true; then \


### PR DESCRIPTION



Backport of #16380
