### PR TITLE
[tests] Add dependency so that we don't try to write a file in a directory that doesn't exist.

### DIFF
--- a/tests/test-libraries/frameworks/Makefile
+++ b/tests/test-libraries/frameworks/Makefile
@@ -137,7 +137,7 @@ endif
 	$$(Q_ZIP) cd .libs/$(3)/$(1).resources && $(ZIP) -r $$(abspath .libs/$(3)/$(1).resources.zip) .
 
 ## a binding resource package needs an adjacent assembly to be considered a binding resource package, so create a dummy assembly.
-.libs/$(3)/$(1).dll:
+.libs/$(3)/$(1).dll: .libs/$(3)
 	$$(Q) printf "Fake assembly named $(3)\n" > $$@
 
 $(3)_BINDING_RESOURCE_PACKAGE_TARGETS += \


### PR DESCRIPTION
Fixes this:

    Making all in frameworks
    /bin/sh: .libs/tvos-arm64/FrameworksInRuntimesNativeDirectory1.dll: No such file or directory
    make[2]: *** [.libs/tvos-arm64/FrameworksInRuntimesNativeDirectory1.dll] Error 1