### PR TITLE
[builds] Improve curl commands to retry harder in case of failures.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -1,5 +1,17 @@
 include $(TOP)/mk/subdirs.mk
 
+# Common cURL command:
+# --fail: return an exit code if the connection succeeded, but returned an HTTP error code.
+# --location: follow redirects
+# --connect-timeout: if a connection doesn't happen within 15 seconds, then fail (and potentially retry). This is lower than the default to not get stuck waiting for a long time in case something goes wrong (but instead retry).
+# --verbose / --silent: no explanation needed.
+# --show-error: show an error to the terminal even if asked to be --silent.
+CURL = curl --fail --location --connect-timeout 15 $(if $(V),--verbose,--silent) --show-error
+# --retry: retry download 20 times
+# --retry-delay: wait 2 seconds between each retry attempt
+# --retry-all-errors: ignore the definition of insanity and retry even for errors that seem like you'd get the same result (such as 404). This isn't the real purpose, because this will also retry errors that will get a different result (such as connection failures / resets), which apparently --retry doesn't cover.
+CURL_RETRY = $(CURL) --retry 20 --retry-delay 2 --retry-all-errors
+
 # calculate commit distance and store it in a file so that we don't have to re-calculate it every time make is executed.
 
 -include $(TOP)/Make.config.inc
@@ -15,13 +27,13 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 	@if which ccache > /dev/null 2>&1; then printf "ENABLE_CCACHE=1\nexport CCACHE_BASEDIR=$(abspath $(TOP)/..)\n" >> $@; echo "Found ccache on the system, enabling it"; fi
 	@if test -d $(TOP)/../maccore; then printf "ENABLE_XAMARIN=1\n" >> $@; echo "Detected the maccore repository, automatically enabled the Xamarin build"; fi
 	@# Build from source if we're on CI and packages aren't available.
-	@if ! curl -s -f --head "$(MONO_IOS_URL)" &> /dev/null; then \
+	@if ! $(CURL_RETRY) --head "$(MONO_IOS_URL)" &> /dev/null; then \
 		echo "$(COLOR_GRAY)*** The mono archive for iOS ($(MONO_IOS_URL)) can't be downloaded:$(COLOR_CLEAR)"; \
 		echo "$$ curl -s --head '$(MONO_IOS_URL)'" | sed 's/^/    /'; \
 		curl -s --head "$(MONO_IOS_URL)" | sed 's/^/    /'; \
 		MONO_DOWNLOAD_FAIL=1; \
 	fi; \
-	if ! curl -s -f --head "$(MONO_MAC_URL)" &> /dev/null; then \
+	if ! $(CURL_RETRY) --head "$(MONO_MAC_URL)" &> /dev/null; then \
 		echo "$(COLOR_GRAY)*** The mono archive for macOS ($(MONO_MAC_URL)) can't be downloaded:$(COLOR_CLEAR)"; \
 		echo "$$ curl -s --head '$(MONO_MAC_URL)'" | sed 's/^/    /'; \
 		curl -s --head "$(MONO_MAC_URL)" | sed 's/^/    /'; \

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -45,7 +45,7 @@ $(DOWNLOADS):
 		$(CP) ~/Library/Caches/xamarin-macios/$(notdir $@) $@.tmp; \
 	else \
 		EC=0; \
-		curl -f -L -S --retry 20 --retry-delay 2 --connect-timeout 15 $(if $(V),-v,-s) $(MONO_URL) --output $@.tmp || EC=$$?; \
+		$(CURL_RETRY) $(MONO_URL) --output $@.tmp || EC=$$?; \
 		if [[ x$$EC == x22 ]]; then \
 			MSG="Could not download the archive %s because the URL doesn't exist. This can happen if bumping mono very soon after the corresponding commit was pushed to mono (i.e. the archive hasn't been built yet). If so, please wait a bit and try again."; \
 			printf "$(COLOR_RED)*** $$MSG$(COLOR_CLEAR)\n" "$(notdir $@)"; \
@@ -89,13 +89,13 @@ print-dotnet-pkg-urls: dotnet-install.sh
 	$(Q) rm -f $@-found-it.stamp
 	$(Q) for url in $$(./dotnet-install.sh --version "$(DOTNET_VERSION)" --architecture $(DOTNET_ARCH) --no-path $$DOTNET_INSTALL_EXTRA_ARGS --dry-run | grep URL.*primary: | sed 's/.*primary: //'); do \
 		pkg=$${url/tar.gz/pkg}; \
-		if curl -LI --fail "$$pkg" >/dev/null 2>&1; then echo "$$pkg"; touch $@-found-it.stamp; break; fi; \
+		if $(CURL) -I "$$pkg" >/dev/null 2>&1; then echo "$$pkg"; touch $@-found-it.stamp; break; fi; \
 	done
 	$(Q) if ! test -f $@-found-it.stamp; then echo "No working urls were found."; exit 1; fi
 	$(Q) rm -f $@-found-it.stamp
 
 dotnet-install.sh: Makefile
-	$(Q) curl --retry 20 --retry-delay 2 --connect-timeout 15 -S -L $(if $(V),-v,-s) https://dot.net/v1/dotnet-install.sh --output $@.tmp
+	$(Q) $(CURL_RETRY) https://dot.net/v1/dotnet-install.sh --output $@.tmp
 	$(Q) chmod +x $@.tmp
 	$(Q) mv $@.tmp $@
 


### PR DESCRIPTION
* Use a variable for the curl command to avoid duplicating all the retry logic.
* Pass --retry-all-failures to curl to retry harder.

Hopefully fixes these errors:

    curl: (56) LibreSSL SSL_read: error:02FFF036:system library:func(4095):Connection reset by peer, errno 54
    make: *** [downloads/ios-release-Darwin-2a19f878dab8d2e62123e0bf29453de553f5402a.7z] Error 56