### PR TITLE
[devops] Increase bash compatibility and clean variables a bit.

### DIFF
--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -73,10 +73,10 @@ jobs:
       AgentPoolComputed: $(CIBuildPool)
     ${{ if eq(parameters.pool, 'pr') }}:
       AgentPoolComputed: $(PRBuildPool)
-    PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
+    PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
     # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
     BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
-    XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness-labels'] ]
+    XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness_labels'] ]
   pool:
     name: $(AgentPoolComputed)
     demands:

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -103,30 +103,24 @@ jobs:
     # add all the variables that have been parsed by the configuration step. Could we have a less verbose way??
     #
     # build-package
-    # run-internal-tests
     # skip-packages
     # skip-nugets
     # skip-signing
-    # skip-external-tests
-    # trigger-device-tests
     # run-sample-tests
     # skip-packaged-xamarin-mac-tests
-    BuildPackage: $[ dependencies.configure.outputs['labels.build-package'] ]
-    RunInternalTests: $[ dependencies.configure.outputs['labels.run-internal-tests'] ]
-    SkipPackages: $[ dependencies.configure.outputs['labels.skip-packages'] ]
-    SkipNugets: $[ dependencies.configure.outputs['labels.skip-nugets'] ]
-    SkipSigning: $[ dependencies.configure.outputs['labels.skip-signing'] ]
-    SkipExternalTests: $[ dependencies.configure.outputs['labels.skip-external-tests'] ]
-    TriggerDeviceTests: $[ dependencies.configure.outputs['labels.trigger-device-tests'] ]
-    RunSampleTests: $[ dependencies.configure.outputs['labels.run-sample-tests'] ]
-    SkipPackagedXamarinMacTests: $[ dependencies.configure.outputs['labels.skip-packaged-xamarin-mac-tests'] ]
-    SkipApiComparison: $[ dependencies.configure.outputs['labels.skip-api-comparison'] ]
+    BuildPackage: $[ dependencies.configure.outputs['labels.build_package'] ]
+    SkipPackages: $[ dependencies.configure.outputs['labels.skip_packages'] ]
+    SkipNugets: $[ dependencies.configure.outputs['labels.skip_nugets'] ]
+    SkipSigning: $[ dependencies.configure.outputs['labels.skip_signing'] ]
+    RunSampleTests: $[ dependencies.configure.outputs['labels.run_sample_tests'] ]
+    SkipPackagedXamarinMacTests: $[ dependencies.configure.outputs['labels.skip_packaged_xamarin_mac_tests'] ]
+    SkipApiComparison: $[ dependencies.configure.outputs['labels.skip_api_comparison'] ]
     # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
-    PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
+    PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
     # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
     BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
     BUILD_REVISION: $[ variables['Build.SourceVersion'] ]
-    XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness-labels'] ]
+    XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness_labels'] ]
   pool:
     name: $(AgentPoolComputed)
     demands:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -113,12 +113,6 @@ steps:
         $configVars.Add("BuildPkgs", "True")
       }
 
-      # if we want to have device tests, we do need the pkgs so that we can fwd them to the device tests
-      if ($Env:TriggerDeviceTests -eq "True") {
-        $configVars.Add("BuildPkgs", "True")
-        $configVars.Add("RunDeviceTests", "True")
-      }
-
       if ($Env:SkipNugets -eq "True") {
         $configVars.Add("BuildNugets", "False")
       } else {
@@ -131,12 +125,6 @@ steps:
         $configVars.Add("SignPkgs", "True")
       }
 
-      if ($Env:SkipExternalTests -eq "True") {
-        $configVars.Add("RunExternalTests", "False")
-      } else {
-        $configVars.Add("RunExternalTests", "True")
-      }
-
       if ($Env:SkipPackagedXamarinMacTests -eq "True") {
         $configVars.Add("RunMacTests", "False")
       } else {
@@ -144,7 +132,6 @@ steps:
       }
 
       $configVars.Add("RunSampleTests", $Env:RunSampleTests)
-      $configVars.Add("RunInternalTests", $Env:RunInternalTests)
 
     } else {
       # set the defaults, all the things! o/
@@ -154,17 +141,8 @@ steps:
       $configVars.Add("SignPkgs", "True")
 
       # tests, run all of them, internal, external, mac but not sample tests
-      $configVars.Add("RunInternalTests", "True")
-      $configVars.Add("RunExternalTests", "True")
       $configVars.Add("RunMacTests", "True")
       $configVars.Add("RunSampleTests", "False")
-
-      # if a developer decided to trigger one without device tests, allow it
-      if ($Env:RUN_DEVICE_TESTS -eq "true") {
-        $configVars.Add("RunDeviceTests", "True")
-      } else {
-        $configVars.Add("RunDeviceTests", "False")
-      }
     }
     # write debugging and process of the vars
     foreach($key in $configVars.Keys) {
@@ -175,8 +153,6 @@ steps:
   name: configuration
   displayName: "Parse PR labels"
   timeoutInMinutes: 5
-  env:
-    RUN_DEVICE_TESTS: '${{ parameters.runDeviceTests }}'
 
 - ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
   - task: PowerShell@2

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -70,7 +70,7 @@ steps:
 
       # add a var with the change id, which can be later consumed by some of the old scripts from
       # jenkins
-      Write-Host "##vso[task.setvariable variable=pr-number;isOutput=true]$changeId"
+      Write-Host "##vso[task.setvariable variable=pr_number;isOutput=true]$changeId"
 
       $prInfo = Get-GitHubPRInfo -ChangeId $changeId
       Write-Host $prInfo
@@ -90,17 +90,14 @@ steps:
       $ref = $prInfo.base.ref
       $tags.Add("$ref")
 
-      Write-Host "##vso[task.setvariable variable=xharness-labels;isOutput=true]$xharnessLabels"
+      Write-Host "##vso[task.setvariable variable=xharness_labels;isOutput=true]$xharnessLabels"
 
       # set output variables based on the git labels
       $labelsOfInterest = @(
         "build-package",
-        "run-internal-tests",
         "skip-packages",
         "skip-nugets",
         "skip-signing",
-        "skip-external-tests",
-        "trigger-device-tests",
         "run-sample-tests",
         "skip-packaged-xamarin-mac-tests",
         "skip-api-comparison",
@@ -109,7 +106,9 @@ steps:
 
       foreach ($l in $labelsOfInterest) {
         $labelPresent = 1 -eq ($prInfo.labels | Where-Object { $_.name -eq "$l"}).Count
-        Write-Host "##vso[task.setvariable variable=$l;isOutput=true]$labelPresent"
+        # We need to replace dashes with underscores, because bash can't access an environment variable with a dash in the name.
+        $lbl = $l.Replace('-', '_')
+        Write-Host "##vso[task.setvariable variable=$lbl;isOutput=true]$labelPresent"
       }
 
       Write-Host "##vso[task.setvariable variable=prBuild;isOutput=true]True"

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -74,7 +74,7 @@ stages:
         vmImage: ${{ parameters.macPool }}
 
     variables:
-      PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
+      PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
       GIT_HASH: $[ stageDependencies.build_packages.build.outputs['fix_commit.GIT_HASH'] ]
 
     steps:

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -127,7 +127,7 @@ jobs:
   variables:
     Parameters.outputStorageUri: ''
     NUGETS_PUBLISHED: $[ stageDependencies.sign_notarize_dotnet.sign_notarize_dotnet.outputs['nugetPublishing.NUGETS_PUBLISHED'] ] # not a typo, stage and job have the same name
-    SKIP_NUGETS: $[ dependencies.configure.outputs['labels.skip-nugets'] ]
+    SKIP_NUGETS: $[ dependencies.configure.outputs['labels.skip_nugets'] ]
 
   pool:
     vmImage: 'windows-latest'
@@ -148,8 +148,7 @@ jobs:
   - upload_azure_blob
   condition: succeededOrFailed()
   variables:
-    PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
-    BUILD_PACKAGE: $[ dependencies.configure.outputs['labels.build-package'] ]
+    PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
     TESTS_BOT: $[ stageDependencies.build_packages.build.outputs['build.TESTS_BOT'] ]  # we build in a diff bot than the ones used for the comments
     GIT_HASH: $[ stageDependencies.build_packages.build.outputs['fix_commit.GIT_HASH'] ]
   pool:

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -107,7 +107,7 @@ stages:
   - ${{ each label in parameters.simTestsConfigurations }}:
     - job: "tests_${{ replace(label, '-', '_') }}"
       ${{ if eq(parameters.parseLabels, true) }}:
-        condition: ne(dependencies.configure.outputs['labels.skip-all-tests'], 'True')
+        condition: ne(dependencies.configure.outputs['labels.skip_all_tests'], 'True')
       dependsOn:
       - ${{ if eq(parameters.parseLabels, true) }}:
         - configure
@@ -116,10 +116,10 @@ stages:
 
       variables:
         # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
-        PR_ID: $[ dependencies.configure.outputs['labels.pr-number'] ]
+        PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
         # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
         BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
-        XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness-labels'] ]
+        XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness_labels'] ]
         ${{ if eq(parameters.testPool, '') }}:
           AgentPoolComputed: $(PRBuildPool)
         ${{ else }}:
@@ -152,7 +152,7 @@ stages:
 
   - job: publish_test_results
     ${{ if eq(parameters.parseLabels, true) }}:
-      condition: and(ne(dependencies.configure.outputs['labels.skip-all-tests'], 'True'),  succeededOrFailed())
+      condition: and(ne(dependencies.configure.outputs['labels.skip_all_tests'], 'True'),  succeededOrFailed())
     ${{ else }}:
       condition: succeededOrFailed()
     displayName: 'GitHub comment - Publish results'
@@ -183,7 +183,7 @@ stages:
 
   - job: publish_skipped_tests
     ${{ if eq(parameters.parseLabels, true) }}:
-      condition: eq(dependencies.configure.outputs['labels.skip-all-tests'], 'True')
+      condition: eq(dependencies.configure.outputs['labels.skip_all_tests'], 'True')
     ${{ else }}:
       condition: false
     displayName: 'GitHub comment - Skipped tests'


### PR DESCRIPTION
Remove support/logic for the following labels:

* run-internal-tests
* skip-external-tests
* trigger-device-tests

because they didn't actually do anything.

Also use underscores instead of dashes in output variables, because these
variables are also exported as environment variables, and environment variable
names can't contain dashes (bash can't access them).