### PR TITLE
[msbuild] Fix dirty working copy with Errors.designer.cs.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/.gitignore
+++ b/msbuild/Xamarin.MacDev.Tasks/.gitignore
@@ -1,0 +1,2 @@
+Errors.designer.cs
+

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -69,12 +69,29 @@
 
   <ItemGroup>
     <EmbeddedResource Include="../../tools/mtouch/Errors.resx">
+
+    <!--
+
+      The Xamarin.MacDev.Tasks.sln solution is build with dotnet, while other
+      projects are still built with msbuild. This becomes a problem when
+      generating Errors.designer.cs, because depending on the runtime the
+      output is different.
+
+      This means that the Errors.designer.cs will sometimes randomly change
+      (depending on which project re-generated the file), leaving the file
+      modified in git. This is quite annoying, but it also breaks the api
+      comparison, which depends on the build not leaving modified files
+      behind. So for now, we generate Errors.designer.cs separately
+      for Xamarin.MacDev.Tasks.sln to not conflict with the mtouch version.
+
+    -->
+
       <Type>Resx</Type>
       <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>../../tools/mtouch/Errors.Designer.cs</LastGenOutput>
+      <LastGenOutput>Errors.designer.cs</LastGenOutput>
       <CustomToolNamespace>Xamarin.Bundler</CustomToolNamespace>
       <ManifestResourceName>Xamarin.Bundler.Errors</ManifestResourceName>
-      <StronglyTypedFileName>../../tools/mtouch/Errors.Designer.cs</StronglyTypedFileName>
+      <StronglyTypedFileName>Errors.designer.cs</StronglyTypedFileName>
       <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
       <StronglyTypedNamespace>Xamarin.Bundler</StronglyTypedNamespace>
       <StronglyTypedClassName>Errors</StronglyTypedClassName>

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -113,8 +113,8 @@
     <Compile Include="..\..\tools\common\MachO.cs">
       <Link>MachO.cs</Link>
     </Compile>
-    <Compile Include="..\..\tools\mtouch\Errors.Designer.cs">
-      <Link>Errors.Designer.cs</Link>
+    <Compile Include="..\..\tools\mtouch\Errors.designer.cs">
+      <Link>Errors.designer.cs</Link>
     </Compile>
     <Compile Include="src\NativeExtensionEmbedding.cs" />
     <Compile Include="..\common\BinLog.cs">

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -220,7 +220,7 @@
     <EmbeddedResource Include="..\mtouch\Errors.resx">
       <Link>tools\mtouch\Errors.resx</Link>
       <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Errors.Designer.cs</LastGenOutput>
+      <LastGenOutput>Errors.designer.cs</LastGenOutput>
       <CustomToolNamespace>Xamarin.Bundler</CustomToolNamespace>
       <ManifestResourceName>Xamarin.Bundler.Errors</ManifestResourceName>
     </EmbeddedResource>

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -453,8 +453,8 @@
       <Link>tools\linker\CustomSymbolWriter.cs</Link>
     </Compile>
     <Compile Include="Target.mmp.cs" />
-    <Compile Include="..\mtouch\Errors.Designer.cs">
-      <Link>tools\mtouch\Errors.Designer.cs</Link>
+    <Compile Include="..\mtouch\Errors.designer.cs">
+      <Link>tools\mtouch\Errors.designer.cs</Link>
       <DependentUpon>Errors.resx</DependentUpon>
     </Compile>
     <Compile Include="..\linker\ScanTypeReferenceStep.cs">
@@ -502,7 +502,7 @@
     <EmbeddedResource Include="..\mtouch\Errors.resx">
       <Link>tools\mtouch\Errors.resx</Link>
       <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Errors.Designer.cs</LastGenOutput>
+      <LastGenOutput>Errors.designer.cs</LastGenOutput>
       <CustomToolNamespace>Xamarin.Bundler</CustomToolNamespace>
       <ManifestResourceName>Xamarin.Bundler.Errors</ManifestResourceName>
     </EmbeddedResource>

--- a/tools/mtouch/README.md
+++ b/tools/mtouch/README.md
@@ -4,7 +4,7 @@ Messages for new mtouch error codes live in `Errors.resx`.
 
 * You can now make changes to `Errors.resx` in the Visual Studio for Mac IDE or from any text editor.
 
-* If you make changes in the IDE, you should see changes automatically copy into Errors.Designer.cs. Be sure to rebuild the project after making your changes.
+* If you make changes in the IDE, you should see changes automatically copy into Errors.designer.cs. Be sure to rebuild the project after making your changes.
 
 * If you make changes from a text editor, be sure to run `make` inside the xamarin-macios/tools/mtouch directory.
 

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -519,10 +519,10 @@
     <EmbeddedResource Include="Errors.resx">
       <Type>Resx</Type>
       <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Errors.Designer.cs</LastGenOutput>
+      <LastGenOutput>Errors.designer.cs</LastGenOutput>
       <CustomToolNamespace>Xamarin.Bundler</CustomToolNamespace>
       <ManifestResourceName>Xamarin.Bundler.Errors</ManifestResourceName>
-      <StronglyTypedFileName>Errors.Designer.cs</StronglyTypedFileName>
+      <StronglyTypedFileName>Errors.designer.cs</StronglyTypedFileName>
       <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
       <StronglyTypedNamespace>Xamarin.Bundler</StronglyTypedNamespace>
       <StronglyTypedClassName>Errors</StronglyTypedClassName>

--- a/tools/nnyeah/nnyeah/nnyeah.csproj
+++ b/tools/nnyeah/nnyeah/nnyeah.csproj
@@ -26,11 +26,11 @@
   <ItemGroup>
     <EmbeddedResource Update="Errors.resx">
       <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Errors.Designer.cs</LastGenOutput>
+      <LastGenOutput>Errors.designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Compile Update="Errors.Designer.cs">
+    <Compile Update="Errors.designer.cs">
       <DependentUpon>Errors.resx</DependentUpon>
     </Compile>
   </ItemGroup>


### PR DESCRIPTION
The Xamarin.MacDev.Tasks.sln solution is built with dotnet, while other projects
are still built with msbuild. This becomes a problem when generating Errors.designer.cs,
because depending on the runtime the output is different.

This means that the Errors.designer.cs will sometimes randomly change (depending
on which project re-generated the file), leaving the file modified in git. This is
quite annoying, but it also breaks the api comparison, which depends on the build
not leaving modified files behind. So for now, we generate Errors.designer.cs separately
for Xamarin.MacDev.Tasks.sln to not conflict with the mtouch version.

Also fix capitalization in numerous places to be consistent (it's Errors.designer.cs,
not Errors.Designer.cs).