### PR TITLE
[devops] Fix crash report collection when there's nothing to collect.

### DIFF
--- a/tools/devops/automation/scripts/bash/collect-and-upload-crash-reports.sh
+++ b/tools/devops/automation/scripts/bash/collect-and-upload-crash-reports.sh
@@ -1,10 +1,14 @@
 #!/bin/bash -ex
 
-env | sort
+if test -z "$SYSTEM_DEFAULTWORKINGDIRECTORY"; then
+  SYSTEM_DEFAULTWORKINGDIRECTORY=$(pwd)
+fi
 
 if ! test -d "$HOME/Library/Logs/DiagnosticReports"; then
-  true # directory doesn't exist: nothing to do
-elif test -n "$(ls -A $HOME/Library/Logs/DiagnosticReports)"; then
+  echo "No crash report directory found" # nothing to do
+elif [[ "$(find "$HOME/Library/Logs/DiagnosticReports" -type f | wc -l)" -eq 0 ]]; then
+  echo "No crash reports found"  # nothing to do
+else
   zip -9rj "$SYSTEM_DEFAULTWORKINGDIRECTORY/crash-reports.zip" "$HOME/Library/Logs/DiagnosticReports"
   if test -f "$SYSTEM_DEFAULTWORKINGDIRECTORY/crash-reports.zip"; then
     set +x


### PR DESCRIPTION
Fix crash report collection to not try to zip up the
~/Library/Logs/DiagnosticReports directory if there's nothing in it, because
it creates a warning in Azure DevOps:

    + zip -9rj /Users/builder/azdo/_work/2/s/crash-reports.zip /Users/builder/Library/Logs/DiagnosticReports
    zip error: Nothing to do! (try: zip -9rj /Users/builder/azdo/_work/2/s/crash-reports.zip . -i /Users/builder/Library/Logs/DiagnosticReports)
    ##[error]Bash exited with code '12'.

Also remove some debug spew, and make it possible to create a crash report
collection locally by writing the zip file to the current directory if
SYSTEM_DEFAULTWORKINGDIRECTORY isn't set.