### PR TITLE
[msbuild] Don't process assemblies over and over again in the UnpackLibraryResources target. Fixes #16377.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1788,9 +1788,10 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</PropertyGroup>
 		<ItemGroup>
 			<_UnpackLibraryResourceItems Include="@(ReferencePath);@(ReferenceDependencyPaths)">
-				<StampFile>%(Identity)</StampFile>
+				<StampFile>%(Identity).stamp</StampFile>
 			</_UnpackLibraryResourceItems>
 		</ItemGroup>
+		<MakeDir Directories="$(_StampDirectory)" />
 	</Target>
 
 	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_CollectBundleResources;_PrepareUnpackLibraryResources"
@@ -1806,6 +1807,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ReferencedLibraries="@(_UnpackLibraryResourceItems)">
 			<Output TaskParameter="BundleResourcesWithLogicalNames" ItemName="_BundleResourceWithLogicalName" />
 		</UnpackLibraryResources>
+		<ItemGroup>
+			<FileWrites Include="$(_StampDirectory)*.stamp" />
+		</ItemGroup>
 	</Target>
 
 	<Target Name="_ParseBundlerArguments">

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1808,7 +1808,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<Output TaskParameter="BundleResourcesWithLogicalNames" ItemName="_BundleResourceWithLogicalName" />
 		</UnpackLibraryResources>
 		<ItemGroup>
-			<FileWrites Include="$(_StampDirectory)*.stamp" />
+			<FileWrites Include="@(_UnpackLibraryResourceItems->'$(_StampDirectory)%(StampFile)')" />
 		</ItemGroup>
 	</Target>
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1812,10 +1812,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true'"
 			Files="@(_UnpackLibraryResourceItems->'$(_StampDirectory)%(StampFile)')"
 			AlwaysCreate="True"
-		/>
-		<ItemGroup>
-			<FileWrites Include="@(_UnpackLibraryResourceItems->'$(_StampDirectory)%(StampFile)')" />
-		</ItemGroup>
+		>
+			<Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
+		</Touch>
 	</Target>
 
 	<Target Name="_ParseBundlerArguments">

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1782,7 +1782,20 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</PackLibraryResources>
 	</Target>
 
-	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_CollectBundleResources">
+	<Target Name="_PrepareUnpackLibraryResources">
+		<PropertyGroup>
+			<_StampDirectory>$(IntermediateOutputPath)resourcestamps</_StampDirectory>
+		</PropertyGroup>
+		<ItemGroup>
+			<_UnpackLibraryResourceItems Include="@(ReferencePath);@(ReferenceDependencyPaths)">
+				<StampFile>%(Identity)</StampFile>
+			</_UnpackLibraryResourceItems>
+		</ItemGroup>
+	</Target>
+
+	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_CollectBundleResources;_PrepareUnpackLibraryResources"
+		Inputs="@(_UnpackLibraryResourceItems)"
+		Outputs="@(_UnpackLibraryResourceItems->'$(_StampDirectory)%(StampFile)')">
 		<UnpackLibraryResources
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
@@ -1790,7 +1803,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			NoOverwrite="@(_BundleResourceWithLogicalName)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			TargetFrameworkDirectory="$(TargetFrameworkDirectory)"
-			ReferencedLibraries="@(ReferencePath);@(ReferenceDependencyPaths)">
+			ReferencedLibraries="@(_UnpackLibraryResourceItems)">
 			<Output TaskParameter="BundleResourcesWithLogicalNames" ItemName="_BundleResourceWithLogicalName" />
 		</UnpackLibraryResources>
 	</Target>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1788,7 +1788,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</PropertyGroup>
 		<ItemGroup>
 			<_UnpackLibraryResourceItems Include="@(ReferencePath);@(ReferenceDependencyPaths)">
-				<StampFile>%(Identity).stamp</StampFile>
+				<StampFile>%(FileName).stamp</StampFile>
 			</_UnpackLibraryResourceItems>
 		</ItemGroup>
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_StampDirectory)" />

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1784,7 +1784,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="_PrepareUnpackLibraryResources">
 		<PropertyGroup>
-			<_StampDirectory>$(IntermediateOutputPath)resourcestamps</_StampDirectory>
+			<_StampDirectory>$(IntermediateOutputPath)resourcestamps\</_StampDirectory>
 		</PropertyGroup>
 		<ItemGroup>
 			<_UnpackLibraryResourceItems Include="@(ReferencePath);@(ReferenceDependencyPaths)">

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1791,7 +1791,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<StampFile>%(Identity).stamp</StampFile>
 			</_UnpackLibraryResourceItems>
 		</ItemGroup>
-		<MakeDir Directories="$(_StampDirectory)" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_StampDirectory)" />
 	</Target>
 
 	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_CollectBundleResources;_PrepareUnpackLibraryResources"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1791,12 +1791,12 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<StampFile>%(FileName).stamp</StampFile>
 			</_UnpackLibraryResourceItems>
 		</ItemGroup>
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_StampDirectory)" />
 	</Target>
 
 	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_CollectBundleResources;_PrepareUnpackLibraryResources"
 		Inputs="@(_UnpackLibraryResourceItems)"
 		Outputs="@(_UnpackLibraryResourceItems->'$(_StampDirectory)%(StampFile)')">
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_StampDirectory)" />
 		<UnpackLibraryResources
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1807,6 +1807,12 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ReferencedLibraries="@(_UnpackLibraryResourceItems)">
 			<Output TaskParameter="BundleResourcesWithLogicalNames" ItemName="_BundleResourceWithLogicalName" />
 		</UnpackLibraryResources>
+		<Touch
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			Files="@(_UnpackLibraryResourceItems->'$(_StampDirectory)%(StampFile)')"
+			AlwaysCreate="True"
+		/>
 		<ItemGroup>
 			<FileWrites Include="@(_UnpackLibraryResourceItems->'$(_StampDirectory)%(StampFile)')" />
 		</ItemGroup>


### PR DESCRIPTION
Fixes #16377 

MSbuild has the ability to run `Target` partially. However in order to make sure we can use this, both the `Inputs` and `Outputs` need to have a 1-1 mapping. MSBuild will then use this mapping to figure out which files have actually changed.
Then it will call the Target with only those files. 

In Xamarin.Android we make use of stamp files to provide this 1-1 mapping. We have a `pre` Target which will calculate an ItemGroup which will include a StampFile piece of metadata. We then use this new ItemGroup for both the `Inputs` and `Outputs`, thus meeting the 1-1 requirement. 

This PR updates the `_UnpackLibraryResources` to run partially. This will hopefully reduce the build time on incremental builds. 