### PR TITLE
[release/7.0.1xx-xcode14] Updated Xamarin.Messaging to 1.8.25

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.8.6</MessagingVersion>
+		<MessagingVersion>1.8.25</MessagingVersion>
 		<HotRestartVersion>1.0.93</HotRestartVersion>
 	</PropertyGroup>
 </Project>

--- a/msbuild/Messaging/Xamarin.Messaging.Build/BuildAgent.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/BuildAgent.cs
@@ -10,10 +10,10 @@ namespace Xamarin.Messaging.Build {
 
 		public BuildAgent (ITopicGenerator topicGenerator, string version = null, string versionInfo = null) : base (topicGenerator)
 		{
-			buildAgentInfo = new BuildAgentInfo ();
-
 			Version = string.IsNullOrEmpty (version) ? GetVersion () : version;
 			VersionInfo = string.IsNullOrEmpty (versionInfo) ? GetInformationalVersion () : versionInfo;
+
+			buildAgentInfo = new BuildAgentInfo (Version);
 		}
 
 		public override string Name => buildAgentInfo.Name;
@@ -21,6 +21,13 @@ namespace Xamarin.Messaging.Build {
 		public override string Version { get; }
 
 		public override string VersionInfo { get; }
+
+		protected override Task OnStartingAsync ()
+		{
+			topicGenerator.AddReplacement ("{AgentVersion}", Version);
+
+			return Task.CompletedTask;
+		}
 
 		protected override Task InitializeAsync ()
 		{

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Build.Tasks {
 			}
 
 			var client = BuildConnection
-				.GetAsync (SessionId, BuildEngine4)
+				.GetAsync (BuildEngine4)
 				.Result
 				.Client;
 

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Exec.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Exec.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Tasks {
 		{
 			try {
 				var client = BuildConnection
-					.GetAsync (SessionId, BuildEngine4)
+					.GetAsync (BuildEngine4)
 					.Result
 					.Client;
 				var sshCommands = client
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Tasks {
 		public override void Cancel ()
 		{
 			if (this.ShouldExecuteRemotely (SessionId))
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 			base.Cancel ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/RemoveDir.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/RemoveDir.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.Tasks {
 			}
 
 			var client = BuildConnection
-				.GetAsync (SessionId, BuildEngine4)
+				.GetAsync (BuildEngine4)
 				.Result
 				.Client;
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ACTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ACTool.cs
@@ -15,7 +15,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ALToolUpload.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ALToolUpload.cs
@@ -16,7 +16,7 @@ namespace Xamarin.MacDev.Tasks {
 		public override void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 			base.Cancel ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ALToolValidate.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ALToolValidate.cs
@@ -16,7 +16,7 @@ namespace Xamarin.MacDev.Tasks {
 		public override void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 			base.Cancel ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompile.cs
@@ -29,7 +29,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ArTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ArTool.cs
@@ -22,7 +22,7 @@ namespace Xamarin.MacDev.Tasks {
 		public override void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 			base.Cancel ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
@@ -18,7 +18,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/BTouch.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/BTouch.cs
@@ -60,7 +60,7 @@ namespace Xamarin.MacDev.Tasks {
 			base.Cancel ();
 
 			if (!string.IsNullOrEmpty (SessionId))
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		async System.Threading.Tasks.Task GetGeneratedSourcesAsync (TaskRunner taskRunner)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
@@ -22,7 +22,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CodesignVerify.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CodesignVerify.cs
@@ -13,7 +13,7 @@ namespace Xamarin.MacDev.Tasks {
 		public override void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 			base.Cancel ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectBundleResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectBundleResources.cs
@@ -24,7 +24,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
@@ -35,7 +35,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs
@@ -39,7 +39,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
@@ -39,7 +39,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileSceneKitAssets.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileSceneKitAssets.cs
@@ -20,7 +20,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		void FixUpRootedPaths (ITaskItem [] sceneKitAssets)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeBundleResourceOutputPaths.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeBundleResourceOutputPaths.cs
@@ -26,7 +26,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		void RemoveDuplicates ()

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeCodesignItems.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeCodesignItems.cs
@@ -26,7 +26,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeRemoteGeneratorProperties.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeRemoteGeneratorProperties.cs
@@ -24,7 +24,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		public bool ShouldCopyToBuildServer (ITaskItem item)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CoreMLCompiler.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CoreMLCompiler.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateAssetPackManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateAssetPackManifest.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackage.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackage.cs
@@ -44,7 +44,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		IEnumerable<TaskItem> GetItemsFromNativeReference (string folderPath)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateDebugConfiguration.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateDebugConfiguration.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateDebugSettings.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateDebugSettings.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreatePkgInfo.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreatePkgInfo.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectDebugNetworkConfiguration.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectDebugNetworkConfiguration.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocations.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocations.cs
@@ -24,7 +24,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSigningIdentity.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSigningIdentity.cs
@@ -24,7 +24,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Ditto.cs
@@ -25,7 +25,7 @@ namespace Xamarin.MacDev.Tasks {
 			base.Cancel ();
 
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied ()

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompiler.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompiler.cs
@@ -22,7 +22,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		public bool ShouldCopyToBuildServer (ITaskItem item)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetDirectories.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetDirectories.cs
@@ -22,7 +22,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFileSystemEntries.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFileSystemEntries.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFiles.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFiles.cs
@@ -22,7 +22,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFullPath.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFullPath.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetNativeExecutableName.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetNativeExecutableName.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/IBTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/IBTool.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/MergeAppBundles.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/MergeAppBundles.cs
@@ -13,7 +13,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (!string.IsNullOrEmpty (SessionId))
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Metal.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Metal.cs
@@ -13,7 +13,7 @@ namespace Xamarin.MacDev.Tasks {
 		public override void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 			base.Cancel ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/MetalLib.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/MetalLib.cs
@@ -24,7 +24,7 @@ namespace Xamarin.MacDev.Tasks {
 			base.Cancel ();
 
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/OptimizeImage.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/OptimizeImage.cs
@@ -24,7 +24,7 @@ namespace Xamarin.MacDev.Tasks {
 			base.Cancel ();
 
 			if (!string.IsNullOrEmpty (SessionId))
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/OptimizePropertyList.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/OptimizePropertyList.cs
@@ -24,7 +24,7 @@ namespace Xamarin.MacDev.Tasks {
 			base.Cancel ();
 
 			if (!string.IsNullOrEmpty (SessionId))
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PackLibraryResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PackLibraryResources.cs
@@ -46,7 +46,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		public bool ShouldCopyToBuildServer (ITaskItem item) => false;

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareNativeReferences.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareNativeReferences.cs
@@ -49,7 +49,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		IEnumerable<TaskItem> GetItemsFromNativeReference (string folderPath)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareResourceRules.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareResourceRules.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ScnTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ScnTool.cs
@@ -13,7 +13,7 @@ namespace Xamarin.MacDev.Tasks {
 		public override void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 			base.Execute ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/SmartCopy.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/SmartCopy.cs
@@ -21,7 +21,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		public bool ShouldCopyToBuildServer (ITaskItem item) => false;

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/SpotlightIndexer.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/SpotlightIndexer.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public override void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 			base.Execute ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/TextureAtlas.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/TextureAtlas.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs
@@ -36,7 +36,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		public bool ShouldCopyToBuildServer (ITaskItem item)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/WriteAppManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/WriteAppManifest.cs
@@ -24,7 +24,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Zip.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Zip.cs
@@ -16,7 +16,7 @@ namespace Xamarin.MacDev.Tasks {
 		public override void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 			base.Cancel ();
 		}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CollectAssetPacks.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CollectAssetPacks.cs
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CollectITunesArtwork.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CollectITunesArtwork.cs
@@ -22,7 +22,7 @@ namespace Xamarin.iOS.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CollectITunesSourceFiles.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CollectITunesSourceFiles.cs
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CompileITunesMetadata.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CompileITunesMetadata.cs
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CopyArchiveFiles.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CopyArchiveFiles.cs
@@ -56,12 +56,12 @@ namespace Xamarin.iOS.Tasks {
 			}
 		}
 
-		public void Cancel () => BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+		public void Cancel () => BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 		async System.Threading.Tasks.Task<IBuildClient> GetBuildClientAsync ()
 		{
 			var connection = await BuildConnection
-				.GetAsync (SessionId, BuildEngine4)
+				.GetAsync (BuildEngine4)
 				.ConfigureAwait (continueOnCapturedContext: false);
 
 			return connection.Client;

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CreateAssetPack.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CreateAssetPack.cs
@@ -13,7 +13,7 @@ namespace Xamarin.iOS.Tasks {
 		public override void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 			base.Cancel ();
 		}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/FindWatchOS2AppBundle.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/FindWatchOS2AppBundle.cs
@@ -18,7 +18,7 @@ namespace Xamarin.iOS.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/GetMlaunchArguments.cs
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ILLink.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ILLink.cs
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.Tasks {
 		public override void Cancel ()
 		{
 			if (this.ShouldExecuteRemotely (SessionId))
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 			else
 				base.Cancel ();
 		}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/MTouch.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/MTouch.cs
@@ -69,7 +69,7 @@ namespace Xamarin.iOS.Tasks {
 			base.Cancel ();
 
 			if (!string.IsNullOrEmpty (SessionId))
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
 		IEnumerable<ITaskItem> GetConfigFiles (IEnumerable<ITaskItem> references)

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/PrepareObjCBindingNativeFrameworks.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/PrepareObjCBindingNativeFrameworks.cs
@@ -42,7 +42,7 @@ namespace Xamarin.iOS.Tasks {
 					yield return item;
 		}
 
-		public void Cancel () => BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+		public void Cancel () => BuildConnection.CancelAsync (BuildEngine4).Wait ();
 
 		IEnumerable<TaskItem> GetItemsFromNativeReference (string folderPath)
 		{

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ResolveNativeWatchApp.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ResolveNativeWatchApp.cs
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ResolveUniversalTypeIdentifiers.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ResolveUniversalTypeIdentifiers.cs
@@ -26,7 +26,7 @@ namespace Xamarin.iOS.Tasks {
 				LogTaskProperty ("ProjectDir", ProjectDir);
 				LogTaskProperty ("SessionId", SessionId);
 
-				var connection = BuildConnection.GetAsync (SessionId, BuildEngine4).Result;
+				var connection = BuildConnection.GetAsync (BuildEngine4).Result;
 				var buildClient = connection.Client as BuildClient;
 
 				if (!connection.IsConnected || buildClient == null) {

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ValidateAppBundleTask.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ValidateAppBundleTask.cs
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/VerifyXcodeVersion.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/VerifyXcodeVersion.cs
@@ -16,7 +16,7 @@ namespace Xamarin.iOS.Tasks {
 		async Threading.Task<bool> ExecuteAsync ()
 		{
 			try {
-				var connection = await BuildConnection.GetAsync (SessionId, BuildEngine4).ConfigureAwait (continueOnCapturedContext: false);
+				var connection = await BuildConnection.GetAsync (BuildEngine4).ConfigureAwait (continueOnCapturedContext: false);
 				var buildClient = connection.Client as BuildClient;
 
 				if (!connection.IsConnected || buildClient == null) {

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/WriteAssetPackManifest.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/WriteAssetPackManifest.cs
@@ -14,7 +14,7 @@ namespace Xamarin.iOS.Tasks {
 		public void Cancel ()
 		{
 			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (SessionId, BuildEngine4).Wait ();
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }


### PR DESCRIPTION
Also adapted Build Agent and MSBuild Tasks to the new Messaging changes

This brings important changes in Xamarin.Messaging to fix an SSH incompatibility with macOS Ventura and also to fix some issues with the iOS remote build with multi targeting dotnet scenarios and also scenarios mixing dotnet and traditional Xamarin projects in the same VS session


Backport of #16419
