### PR TITLE
[net7.0-xcode14.1] Make the buffer bigger between .NET 6 and .NET 7 nugets for Xcode 14.1

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -3,7 +3,7 @@ include $(TOP)/mk/subdirs.mk
 # calculate commit distance and store it in a file so that we don't have to re-calculate it every time make is executed.
 
 # Hardcode this for now to have a higher version number than the current stable release.
-NUGET_VERSION_COMMIT_DISTANCE_START=500
+NUGET_VERSION_COMMIT_DISTANCE_START=1000
 
 -include $(TOP)/Make.config.inc
 $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk


### PR DESCRIPTION
Current versions in this branch:

    Microsoft.iOS 16.1.1419-net7.0-xcode14.1+sha.51ad25e7b64
    Microsoft.tvOS 16.1.1419-net7.0-xcode14.1+sha.51ad25e7b64
    Microsoft.MacCatalyst 16.1.1419-net7.0-xcode14.1+sha.51ad25e7b64
    Microsoft.macOS 13.0.1974-net7.0-xcode14.1+sha.51ad25e7b64

Compare with the `release/6.0.4xx-xcode14.1` branch version numbers (from #16431):

	Microsoft.iOS 16.1.179+sha.2107639a131
	Microsoft.tvOS 16.1.179+sha.2107639a131
	Microsoft.MacCatalyst 16.1.179+sha.2107639a131
	Microsoft.macOS 13.0.734+sha.2107639a131

the buffer is >1000 commits.