### PR TITLE
[6.0.4xx-xcode14.1] Make this a release branch.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -102,7 +102,7 @@ endif
 
 ## If this branch is a release branch, set NUGET_RELEASE_BRANCH to the exact branch name (so that any other branches won't become release branches just by branching off from a release branch).
 ## Example: release/6.0.3xx
-# NUGET_RELEASE_BRANCH=release/6.0.4xx-xcode14.1
+NUGET_RELEASE_BRANCH=release/6.0.4xx-xcode14.1
 
 ## If this is a pre-release (alpha, beta, rc, xcode, etc.) branch, set NUGET_HARDCODED_PRERELASE_BRANCH to the exact branch name. Also set NUGET_HARDCODED_PRELEASE_IDENTIFIER to the prerelease identifier to use.
 ## Example:
@@ -118,8 +118,8 @@ endif
 ## change *first*, otherwise we'll produce builds with the same version from
 ## two different branches (which is very, very bad).
 ##
-NUGET_HARDCODED_PRERELEASE_IDENTIFIER=xcode14.1
-NUGET_HARDCODED_PRERELEASE_BRANCH=release/6.0.4xx-xcode14.1
+# NUGET_HARDCODED_PRERELEASE_IDENTIFIER=xcode14.1
+# NUGET_HARDCODED_PRERELEASE_BRANCH=release/6.0.4xx-xcode14.1
 
 # compute the alphanumeric version of branch names
 NUGET_RELEASE_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(NUGET_RELEASE_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')


### PR DESCRIPTION
Current release versions in this branch:

	Microsoft.iOS 16.1.179+sha.2107639a131
	Microsoft.tvOS 16.1.179+sha.2107639a131
	Microsoft.MacCatalyst 16.1.179+sha.2107639a131
	Microsoft.macOS 13.0.734+sha.2107639a131

Compare with the net7.0-xcode14.1 branch version numbers (from #16430):

    Microsoft.iOS 16.1.1419-net7.0-xcode14.1+sha.51ad25e7b64
    Microsoft.tvOS 16.1.1419-net7.0-xcode14.1+sha.51ad25e7b64
    Microsoft.MacCatalyst 16.1.1419-net7.0-xcode14.1+sha.51ad25e7b64
    Microsoft.macOS 13.0.1974-net7.0-xcode14.1+sha.51ad25e7b64

the buffer is >1000 commits.