### PR TITLE
[xcode14.1][HomeKit] Brings back HMAccessorySetupManager

### DIFF
--- a/src/HomeKit/HMCompat.cs
+++ b/src/HomeKit/HMCompat.cs
@@ -101,7 +101,6 @@ namespace HomeKit {
 
 	} /* class HMChipServiceHome */
 
-	[Obsolete ("This class is removed.")]
 	public partial class HMAccessorySetupManager {
 
 #pragma warning disable CS0618 // HMChipServiceTopology and HMErrorHandler is obsolete
@@ -113,21 +112,10 @@ namespace HomeKit {
 
 #if !XAMCORE_5_0
 #if __IOS__ && !__MACCATALYST__
-#if NET
-	[EditorBrowsable (EditorBrowsableState.Never)]
-	[Obsolete ("This class is removed.")]
-#endif
-	public unsafe partial class HMAccessorySetupManager : NSObject {
-		public override NativeHandle ClassHandle => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
-
-		public HMAccessorySetupManager () : base (NSObjectFlag.Empty) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
-		protected HMAccessorySetupManager (NSObjectFlag t) : base (t) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
-		protected internal HMAccessorySetupManager (NativeHandle handle) : base (handle) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
+	public unsafe partial class HMAccessorySetupManager {
 
 		public virtual void AddAndSetUpAccessories (HMMatterTopology topology, Action<NSError> completion) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
 		public virtual Task AddAndSetUpAccessoriesAsync (HMMatterTopology topology) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
-		public virtual void PerformAccessorySetup (HMAccessorySetupRequest request, Action<HMAccessorySetupResult, NSError> completion) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
-		public virtual Task<HMAccessorySetupResult> PerformAccessorySetupAsync (HMAccessorySetupRequest request) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
 		public virtual void PerformMatterEcosystemAccessorySetup (HMAccessorySetupRequest request, HMMatterTopology topology, Action<NSError> completion) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
 		public virtual Task PerformMatterEcosystemAccessorySetupAsync (HMAccessorySetupRequest request, HMMatterTopology topology) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
 	}

--- a/src/HomeKit/HMCompat.cs
+++ b/src/HomeKit/HMCompat.cs
@@ -104,7 +104,12 @@ namespace HomeKit {
 	public partial class HMAccessorySetupManager {
 
 #pragma warning disable CS0618 // HMChipServiceTopology and HMErrorHandler is obsolete
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete (Constants.RemovedFromHomeKit)]
 		public virtual void AddAndSetUpAccessories (HMChipServiceTopology topology, HMErrorHandler completion) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete (Constants.RemovedFromHomeKit)]
 		public virtual Task AddAndSetUpAccessoriesAsync (HMChipServiceTopology topology) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
 #pragma warning restore CS0618 // HMChipServiceTopology and HMErrorHandler is obsolete
 	}	
@@ -114,9 +119,20 @@ namespace HomeKit {
 #if __IOS__ && !__MACCATALYST__
 	public unsafe partial class HMAccessorySetupManager {
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete (Constants.RemovedFromHomeKit)]
 		public virtual void AddAndSetUpAccessories (HMMatterTopology topology, Action<NSError> completion) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete (Constants.RemovedFromHomeKit)]
 		public virtual Task AddAndSetUpAccessoriesAsync (HMMatterTopology topology) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete (Constants.RemovedFromHomeKit)]
 		public virtual void PerformMatterEcosystemAccessorySetup (HMAccessorySetupRequest request, HMMatterTopology topology, Action<NSError> completion) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete (Constants.RemovedFromHomeKit)]
 		public virtual Task PerformMatterEcosystemAccessorySetupAsync (HMAccessorySetupRequest request, HMMatterTopology topology) => throw new InvalidOperationException (Constants.RemovedFromHomeKit);
 	}
 

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -1971,4 +1971,13 @@ namespace HomeKit {
 		NSUuid [] AccessoryUniqueIdentifiers { get; }
 	}
 
+	[iOS (15,2), NoWatch, NoTV, NoMacCatalyst]
+	[BaseType (typeof (NSObject))]
+	interface HMAccessorySetupManager {
+		[Async]
+		[iOS (15,4)]
+		[Export ("performAccessorySetupUsingRequest:completionHandler:")]
+		void PerformAccessorySetup (HMAccessorySetupRequest request, Action<HMAccessorySetupResult, NSError> completion);
+	}
+
 }

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -251,9 +251,6 @@ namespace Introspection {
 					return true;
 				break;
 #endif
-			case "HMAccessorySetupManager":
-				// Selector fails submission test in Xcode 14.0 timeframe
-				return true;
 			}
 			return base.Skip (type);
 		}

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-HomeKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-HomeKit.ignore
@@ -1,8 +1,3 @@
-# These performMatterEcosystemAccessorySetupUsingRequest:topology:completionHandler: now fails submission tests
-# And the type was stubbed away as it was not usable
-!missing-selector! HMAccessorySetupManager::performAccessorySetupUsingRequest:completionHandler: not bound
-!missing-type! HMAccessorySetupManager not bound
-
 # CHIP is not bound yet and will be only when is stable
 !missing-selector! HMAccessorySetupRequest::matterPayload not bound
 !missing-selector! HMAccessorySetupRequest::setMatterPayload: not bound

--- a/tests/xtro-sharpie/iOS-HomeKit.ignore
+++ b/tests/xtro-sharpie/iOS-HomeKit.ignore
@@ -1,11 +1,6 @@
 # This is deprecated in Xcode 13.3 and its companion member is deprecated on 15.4
 !deprecated-attribute-wrong! HMHome::addAndSetupAccessoriesWithPayload:completionHandler: has 15.4 not 15.0 on [Deprecated] attribute
 
-# These performMatterEcosystemAccessorySetupUsingRequest:topology:completionHandler: now fails submission tests
-# And the type was stubbed away as it was not usable
-!missing-selector! HMAccessorySetupManager::performAccessorySetupUsingRequest:completionHandler: not bound
-!missing-type! HMAccessorySetupManager not bound
-
 # CHIP is not bound yet and will be only when is stable
 !missing-selector! HMAccessorySetupRequest::matterPayload not bound
 !missing-selector! HMAccessorySetupRequest::setMatterPayload: not bound


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#16415

HMAccessorySetupManager was removed by mistake when we had to remove matter related objects due to submission tests.

We have kept the Matter APIs removed and just enabled PerformAccessorySetup Submission tests are happy using Xcode 14.1 RC1
https://gist.github.com/dalexsoto/243b0da224c613e9afc9706c54f882a1