### PR TITLE
[msbuild] Fix creating Build.zip.

### DIFF
--- a/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
@@ -5,6 +5,8 @@
     <AssemblyName>Build</AssemblyName>
     <NoWarn>$(NoWarn);NU1603</NoWarn> <!-- Xamarin.Messaging.Build.Common 1.6.24 depends on Merq (>= 1.1.0) but Merq 1.1.0 was not found. An approximate best match of Merq 1.1.4 was resolved. -->
     <NoWarn>$(NoWarn);MSB3277</NoWarn> <!-- warning MSB3277: Found conflicts between different versions of "System.IO.Compression" that could not be resolved. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <MonoMSBuildBinPath>/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin</MonoMSBuildBinPath>
   </PropertyGroup>
 
   <PropertyGroup Label="Messaging">
@@ -21,16 +23,16 @@
 
   <ItemGroup>
       <Reference Include="Microsoft.Build">
-          <HintPath>$(MSBuildBinPath)/Microsoft.Build.dll</HintPath>
+          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.dll</HintPath>
       </Reference>
       <Reference Include="Microsoft.Build.Framework">
-          <HintPath>$(MSBuildBinPath)/Microsoft.Build.Framework.dll</HintPath>
+          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.Framework.dll</HintPath>
       </Reference>
       <Reference Include="Microsoft.Build.Tasks.Core">
-          <HintPath>$(MSBuildBinPath)/Microsoft.Build.Tasks.Core.dll</HintPath>
+          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.Tasks.Core.dll</HintPath>
       </Reference>
       <Reference Include="Microsoft.Build.Utilities.Core">
-          <HintPath>$(MSBuildBinPath)/Microsoft.Build.Utilities.Core.dll</HintPath>
+          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.Utilities.Core.dll</HintPath>
       </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
We recently switched from building the msbuild tasks with 'msbuild' to use
'dotnet build' instead.

One difference between the two methods is that 'dotnet build' doesn't copy
referenced assemblies to the output path.

This turns out to be a problem because we zip up the output from the
Xamarin.Messaging.Build project, and expect it to contain everything required
to load the Xamarin.Messaging.Build assembly (this zip file is shipped with
our VS (Windows) support, and during remote execution copied to the connected
mac and then the build from Windows will load the assembly on the Mac in order
to do stuff on the Mac).

Another problem is that we include MSBuild assemblies from the
'$(MSBuildBinPath)' location, which is now different (we used to pick up
Mono's MSBuild assemblies, and that changed when we started building with
.NET).

In other words: because the Build.zip file stopped containing all the required
files to load Xamarin.Messaging.Build.dll, remote builds from VS stopped
working.

Ref: https://github.com/xamarin/xamarin-macios/pull/16418

Here we attempt to fix this by:

* Setting 'CopyLocalLockFileAssemblies=true'. This will copy referenced
  assemblies to the output directory.
* Explicitly referencing Mono's MSBuild assemblies instead of relying upon
  finding them in '$(MSBuildBinPath)'. At this point I believe it's fine to
  hardcode Mono's path, since it's unlikely we'll get any new Mono updates.