### PR TITLE
[compare-commits] Fix undefined array access when running on bots.

### DIFF
--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -203,7 +203,7 @@ if test -z "${BUILD_REVISION:-}"; then
 	GIT_COLOR_P=(-c "color.status=always")
 else
 	GIT_COLOR=
-	GIT_COLOR_P=()
+	GIT_COLOR_P=(-c "color.status=auto")
 fi
 
 GENERATOR_DIFF_FILE=


### PR DESCRIPTION
Fix undefined array access due to empty bash array when running on bots by
always creating a non-empty array (of color arguments to git).