### PR TITLE
[xcode14.1] Updated Xamarin.Messaging to 1.8.26

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.8.25</MessagingVersion>
+		<MessagingVersion>1.8.26</MessagingVersion>
 		<HotRestartVersion>1.0.93</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Brings an important fix for the Build Session Id generation


Backport of #16464
