### PR TITLE
[xcode14.1] [AVFoundation] Fix capitalization issue

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1833,8 +1833,14 @@ namespace AVFoundation {
 		[Protocolize]
 		AVAudioRecorderDelegate Delegate { get; set;  }
 	
-		[Export ("currentTime")]
+#if !XAMCORE_5_0
+		[Obsolete ("Use the 'CurrentTime' property instead.")]
+		[Wrap ("CurrentTime", IsVirtual = true)]
 		double currentTime { get; }
+#endif
+
+		[Export ("currentTime")]
+		double CurrentTime { get; }
 	
 		[Export ("meteringEnabled")]
 		bool MeteringEnabled { [Bind ("isMeteringEnabled")] get; set;  }


### PR DESCRIPTION
currentTime property incorrectly capitalized in AVAudioRecorder type Fixes #16458


Backport of #16461
