### PR TITLE
[apidiff] Fix when to compare Microsoft.iOS.dll vs Microsoft.MacCatalyst.dll.

### DIFF
--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -20,8 +20,15 @@ endif
 ifndef SKIP_XAMARIN_VS_DOTNET
 INCLUDE_XAMARIN_VS_DOTNET=1
 endif
+
+ifdef ENABLE_DOTNET
+ifdef INCLUDE_IOS
+ifdef INCLUDE_MACCATALYST
 ifndef SKIP_IOS_VS_MACCATALYST
 INCLUDE_IOS_VS_MACCATALYST=1
+endif
+endif
+endif
 endif
 
 MONO_API_INFO = $(API_TOOLS_PATH)/mono-api-info/bin/Debug/net6.0/mono-api-info.dll
@@ -192,14 +199,10 @@ ifdef INCLUDE_TVOS
 API_DIFF_DEPENDENCIES += $(OUTPUT_DIR)/tvos-api-diff.html
 endif
 endif
-ifdef INCLUDE_MACCATALYST
-ifdef ENABLE_DOTNET
+endif # INCLUDE_IOS
 ifdef INCLUDE_IOS_VS_MACCATALYST
 API_DIFF_DEPENDENCIES += $(OUTPUT_DIR)/diff/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/$(DOTNET_TFM)/Microsoft.iOS.MacCatalyst.html
-endif
-endif
-endif
-endif # INCLUDE_IOS
+endif # INCLUDE_IOS_VS_MACCATALYST
 ifdef ENABLE_DOTNET
 API_DIFF_DEPENDENCIES += $(foreach assembly,$(DOTNET_ASSEMBLIES),$(OUTPUT_DIR)/diff/dotnet/$(assembly).html)
 ifdef INCLUDE_XAMARIN_VS_DOTNET
@@ -260,12 +263,8 @@ ifdef ENABLE_DOTNET
 	$(Q) $(foreach platform,$(DOTNET_PLATFORMS),$(call ApiDiffReportHtml,$(platform),$@))
 
 	@# .NET: Microsoft.iOS vs Microsoft.MacCatalyst
-ifdef INCLUDE_IOS
-ifdef INCLUDE_MACCATALYST
 ifdef INCLUDE_IOS_VS_MACCATALYST
 	$(Q) echo "<li>Microsoft.iOS vs Microsoft.MacCatalyst: <a href='diff/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/$(DOTNET_TFM)/Microsoft.iOS.MacCatalyst.html'>html</a> <a href='diff/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/$(DOTNET_TFM)/Microsoft.iOS.MacCatalyst.md'>markdown</a></li>" >> $@
-endif
-endif
 endif
 	$(Q) echo "</ul>" >> $@
 
@@ -346,13 +345,9 @@ ifdef ENABLE_DOTNET
 	$(Q) $(foreach platform,$(DOTNET_PLATFORMS),$(call ApiDiffReportMarkdown,$(platform),$@))
 
 	@# .NET: Microsoft.iOS vs Microsoft.MacCatalyst
-ifdef INCLUDE_IOS
-ifdef INCLUDE_MACCATALYST
 ifdef INCLUDE_IOS_VS_MACCATALYST
 	$(Q) echo "* Microsoft.iOS vs Microsoft.MacCatalyst: [vsdrops](diff/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/$(DOTNET_TFM)/Microsoft.iOS.MacCatalyst.html) [gist](diff/dotnet/iOS-MacCatalyst-diff/Microsoft.iOS.Ref/ref/$(DOTNET_TFM)/Microsoft.iOS.MacCatalyst.md)" >> $@
 endif # INCLUDE_IOS_VS_MACCATALYST
-endif # INCLUDE_MACCATALYST
-endif # INCLUDE_IOS
 	$(Q) echo "" >> $@
 	$(Q) echo "</details>" >> "$@"
 	$(Q) echo "" >> $@


### PR DESCRIPTION
We can only compare Microsoft.iOS.dll and Microsoft.MacCatalyst.dll when all of the following are true:

* .NET is enabled.
* iOS is enabled.
* Mac Catalyst is enabled.

So adjust (and simplify a bit) our logic accordingly.