### PR TITLE
[dotnet] Adjust stable MSI versioning.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -4,6 +4,7 @@ include $(TOP)/mk/subdirs.mk
 
 # Hardcode this for now to have a higher version number than the current stable release.
 NUGET_VERSION_COMMIT_DISTANCE_START=1000
+NUGET_VERSION_STABLE_COMMIT_DISTANCE_START=0
 
 -include $(TOP)/Make.config.inc
 $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
@@ -26,6 +27,7 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 	@printf "WATCHOS_NUGET_COMMIT_DISTANCE:=$(shell printf "%03d" "$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep WATCHOS_NUGET_OS_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed -e 's/ //g' -e "s/^/$(NUGET_VERSION_COMMIT_DISTANCE_START)+/" | bc)")\\n" >> $@
 	@printf "MACOS_NUGET_COMMIT_DISTANCE:=$(shell printf "%03d" "$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MACOS_NUGET_OS_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed -e 's/ //g' -e "s/^/$(NUGET_VERSION_COMMIT_DISTANCE_START)+/" | bc)")\\n" >> $@
 	@printf "MACCATALYST_NUGET_COMMIT_DISTANCE:=$(shell printf "%03d" "$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MACCATALYST_NUGET_OS_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed -e 's/ //g' -e "s/^/$(NUGET_VERSION_COMMIT_DISTANCE_START)+/" | bc)")\\n" >> $@
+	@printf "NUGET_STABLE_COMMIT_DISTANCE:=$(shell LANG=C; export LANG; git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -L '/^[#[:blank:]]*NUGET_RELEASE_BRANCH=/,+1' -- ./Make.config HEAD | sed 's/ .*//' `..HEAD --oneline | wc -l | sed -e 's/ //g' -e "s/^/$(NUGET_VERSION_STABLE_COMMIT_DISTANCE_START)+/" | bc)\\n" >> $@
 	@#
 	@if which ccache > /dev/null 2>&1; then printf "ENABLE_CCACHE=1\nexport CCACHE_BASEDIR=$(abspath $(TOP)/..)\n" >> $@; echo "Found ccache on the system, enabling it"; fi
 	@if test -d $(TOP)/../maccore; then printf "ENABLE_XAMARIN=1\n" >> $@; echo "Detected the maccore repository, automatically enabled the Xamarin build"; fi

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -192,12 +192,21 @@ LOCAL_WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/LICENSE
 endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform),$(shell echo $(platform) | tr A-Z a-z),$($(platform)_NUGET_VERSION_NO_METADATA),$(NET6_$(platform)_NUGET_VERSION_NO_METADATA),$(shell echo $(platform) | tr a-z A-Z))))
 
+# We use a different versioning for stable releases (which is determined by the NUGET_PRERELEASE_IDENTIFIER variable being empty):
+# We reset the commit distance (to the commits since NUGET_PRERELEASE_IDENTIFIER changed - which must have changed for a branch to become a stable branch)
+# We use the commit distance as the third number in the version, instead of the fourth.
+ifeq ($(NUGET_PRERELEASE_IDENTIFIER),)
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).$(NUGET_STABLE_COMMIT_DISTANCE)))
+else
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).0.$($(shell echo $(platform) | tr a-z A-Z)_NUGET_COMMIT_DISTANCE)))
+endif
+
 $(DOTNET_NUPKG_DIR)/vs-workload.props: Makefile generate-vs-workload.csharp
 	$(Q) rm -f $@.tmp
 	$(Q_GEN) ./generate-vs-workload.csharp \
-		$(foreach platform,$(DOTNET_PLATFORMS),--platform $(platform) $($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).0.$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_COMMIT_DISTANCE)) \
+		$(foreach platform,$(DOTNET_PLATFORMS),--platform $(platform) $($(platform)_MSI_VERSION)) \
 		$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),--windows-platform $(platform)) \
-		$(foreach platform,$(DOTNET_PLATFORMS),--shorten $($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION_NO_METADATA)=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).0.$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_COMMIT_DISTANCE)) \
+		$(foreach platform,$(DOTNET_PLATFORMS),--shorten $($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION_NO_METADATA)=$($(platform)_MSI_VERSION)) \
 		--shorten Microsoft.MacCatalyst.Runtime.maccatalyst=Microsoft.MacCatalyst.Runtime \
 		--shorten Microsoft.NET.Sdk.MacCatalyst.Manifest=Microsoft.MacCatalyst.Manifest \
 		--shorten Microsoft.tvOS.Runtime.tvossimulator=Microsoft.tvOS.Runtime \


### PR DESCRIPTION
Stable MSIs are versioned like non-stable MSIs, except that:

* We define the commit distance as the number of commits since the branch
  bacame a release branch (and started using stable branding). Technically
  this is the number of commits since the `NUGET_RELEASE_BRANCH` variable
  changed (which will be incorrect for non-stable branches, but in that case
  we shouldn't use this number in those scenarios).
* We use the above-mentioned commit distance as the third number in the MSI
  version (as opposed to the fourth number in non-stable branches.)

Note: we detect if we're building a stable release by checking if the
`NUGET_PRERELEASE_IDENTIFIER` is empty (we can't use `NUGET_RELEASE_BRANCH`,
because this variable will be set for PRs to the release branch, while
`NUGET_PRERELEASE_IDENTIFIER` will only be empty for CI builds from a stable
branch).