### PR TITLE
[dotnet] Add [SupportedOSPlatformGuard] attributes to UIDevice.CheckSystemVersion. Fixes #16250.

### DIFF
--- a/src/UIKit/UIDevice.cs
+++ b/src/UIKit/UIDevice.cs
@@ -12,6 +12,11 @@ namespace UIKit {
 #endif
 	partial class UIDevice {
 
+#if NET
+		[SupportedOSPlatformGuard ("ios")]
+		[SupportedOSPlatformGuard ("tvos")]
+		[SupportedOSPlatformGuard ("maccatalyst")]
+#endif
 		public bool CheckSystemVersion (int major, int minor)
 		{
 #if WATCH


### PR DESCRIPTION
This requires the fix for https://github.com/dotnet/roslyn-analyzers/issues/6204
to be shipped in .NET 7 first. This will likely happen in .NET 7.0.200, which we'll
likely ship from main, thus I'm merging this into main.

Fixes https://github.com/xamarin/xamarin-macios/issues/16250.