### PR TITLE
[net7.0-xcode14.1] Update all provisionator call sites to use AUTH_TOKEN_GITHUB_COM

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -60,6 +60,8 @@ steps:
   inputs:
     provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/provision-brew-packages.csx
     provisioning_extra_args: '-vvvv'
+  env:
+    AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
   timeoutInMinutes: 30
   enabled: true
   continueOnError: true # brew installation can be temperamental, and things usually work even if the installation fail.
@@ -73,6 +75,8 @@ steps:
   inputs:
     provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/build-provisioning.csx
     provisioning_extra_args: '-vvvv'
+  env:
+    AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
   timeoutInMinutes: 250
 
 # Use the env variables that were set by the label parsing in the configure step

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -118,6 +118,8 @@ steps:
   inputs:
     provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/provision-brew-packages.csx
     provisioning_extra_args: '-vvvv'
+  env:
+    AUTH_TOKEN_GITHUB_COM: $(GitHub.Token)
   timeoutInMinutes: 30
   enabled: false
 
@@ -151,6 +153,8 @@ steps:
   inputs:
     provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/mac-tests-provisioning.csx
     provisioning_extra_args: '-vvvv'
+  env:
+    AUTH_TOKEN_GITHUB_COM: $(GitHub.Token)
   timeoutInMinutes: 250
 
 # Executed ONLY if we want to clear the provisionator cache.

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -161,6 +161,8 @@ steps:
   inputs:
     provisioning_script: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/device-tests-provisioning.csx
     provisioning_extra_args: '-vvvv'
+  env:
+    AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
   timeoutInMinutes: 250
 
 - bash: |
@@ -173,6 +175,8 @@ steps:
   inputs:
     provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/mac-tests-provisioning.csx
     provisioning_extra_args: '-vvvv'
+  env:
+    AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
   timeoutInMinutes: 250
 
 - bash: |


### PR DESCRIPTION
This introduces changes to ensure that the Github token is available at all provisionator invocations so that when we need to flip to using dl.internalx.com, there are no breakages.


Backport of #16511
