### PR TITLE
[msbuild] Fix watchOS submissions with Xcode 14. Fixes #16499.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.WatchOS.App.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.WatchOS.App.Common.targets
@@ -71,9 +71,16 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 	<Target Name="_CompileToNative" DependsOnTargets="$(_CompileToNativeDependsOn)"
 		Inputs="$(_NativeWatchApp)"
 		Outputs="$(_NativeExecutable);$(_AppBundlePath)_WatchKitStub\WK">
+
+		<PropertyGroup>
+			<!-- Remove any arm64e slices -->
+			<WKDittoArchitectures Condition="'$(WKDittoArchitectures)' == ''">--arch arm64_32 --arch arm64 --arch armv7k</WKDittoArchitectures>
+		</PropertyGroup>
+
 		<Ditto
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)'"
+			AdditionalArguments="$(WKDittoArchitectures)"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(_NativeWatchApp)"
@@ -85,6 +92,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<Ditto
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)'"
+			AdditionalArguments="$(WKDittoArchitectures)"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(_NativeWatchApp)"


### PR DESCRIPTION
We have to remove any arm64e slices from the WK binary we copy from Apple's
SDK into the Watch app, as explained in Apple's forums.

Ref: https://developer.apple.com/forums/thread/714224
Fixes https://github.com/xamarin/xamarin-macios/issues/16120.
Fixes https://github.com/xamarin/xamarin-macios/issues/16499.