### PR TITLE
[net7.0-xcode14.1] [tests] Handle managed exceptions in a networking callback.

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -604,13 +604,18 @@ namespace MonoTests.System.Net.Http
 			bool callbackWasExecuted = false;
 			bool done = false;
 			Exception ex = null;
+			Exception ex2 = null;
 			HttpResponseMessage result = null;
 
 			var handler = new NSUrlSessionHandler {
 				ServerCertificateCustomValidationCallback = (sender, certificate, chain, errors) => {
 					callbackWasExecuted = true;
-					Assert.IsNotNull (certificate);
-					Assert.AreEqual (SslPolicyErrors.None, errors);
+					try {
+						Assert.IsNotNull (certificate);
+						Assert.AreEqual (SslPolicyErrors.None, errors);
+					} catch (Exception e) {
+						ex2 = e;
+					}
 					return false;
 				}
 			};
@@ -635,6 +640,7 @@ namespace MonoTests.System.Net.Http
 				Assert.IsInstanceOf (typeof (HttpRequestException), ex, "Exception type");
 				Assert.IsNotNull (ex.InnerException, "InnerException");
 				Assert.IsInstanceOf (typeof (WebException), ex.InnerException, "InnerException type");
+				Assert.IsNull (ex2, "Callback asserts");
 			}
 		}
 #endif


### PR DESCRIPTION
Fixes a problem where any exception would crash the process, because the
callback was executed on a background thread, and there was no other managed
frame catching the managed exception:

    MonoTests.System.Net.Http.MessageHandlerTest.RejectSslCertificatesWithCustomValidationCallbackNSUrlSessionHandler
    2022-10-21 07:02:23.557 monotouchtest[91107:28076542] *** Terminating app due to uncaught exception 'NUnit.Framework.AssertionException', reason: '  Expected: None
      But was:  RemoteCertificateChainErrors
     (NUnit.Framework.AssertionException)
       at NUnit.Framework.Assert.ReportFailure(String message)
       at NUnit.Framework.Assert.ReportFailure(ConstraintResult result, String message, Object[] args)
       at NUnit.Framework.Assert.AreEqual(Object expected, Object actual)
       at MonoTests.System.Net.Http.MessageHandlerTest.<>c__DisplayClass14_0.<RejectSslCertificatesWithCustomValidationCallbackNSUrlSessionHandler>b__2(HttpRequestMessage sender, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors errors) in /Users/builder/azdo/_work/2/s/xamarin-macios/tests/monotouch-test/System.Net.Http/MessageHandlers.cs:line 613
       at Foundation.NSUrlSessionHandler.ServerCertificateCustomValidationCallbackHelper.Invoke(HttpRequestMessage request, SecTrust secTrust)
       at Foundation.NSUrlSessionHandler.TryInvokeServerCertificateCustomValidationCallback(HttpRequestMessage request, SecTrust secTrust, Boolean& trusted)
       at Foundation.NSUrlSessionHandler.NSUrlSessionHandlerDelegate.DidReceiveChallenge(NSUrlSession session, NSUrlSessionTask task, NSUrlAuthenticationChallenge challenge, Action`2 completionHandler)
    --- End of stack trace from previous location ---
       at ObjCRuntime.Runtime.InvokeMethod(MethodBase method, Object instance, IntPtr native_parameters)
       at ObjCRuntime.Runtime.InvokeMethod(MonoObject* methodobj, MonoObject* instanceobj, IntPtr native_parameters)
       at ObjCRuntime.Runtime.bridge_runtime_invoke_method(MonoObject* method, MonoObject* instance, IntPtr parameters, IntPtr& exception_gchandle)
    '
    *** First throw call stack:
    (
    	0   CoreFoundation                      0x00007ff81dba97c3 __exceptionPreprocess + 242
    	1   libobjc.A.dylib                     0x00007ff81d909bc3 objc_exception_throw + 48
    	2   monotouchtest                       0x000000010426e524 xamarin_process_managed_exception + 820
    	3   monotouchtest                       0x00000001042fec76 _ZL32native_to_managed_trampoline_183P11objc_objectP13objc_selectorPP11_MonoObjectS0_S0_S0_S0_j + 1302
    	4   monotouchtest                       0x00000001042fe750 -[Foundation_NSUrlSessionHandler_NSUrlSessionHandlerDelegate URLSession:task:didReceiveChallenge:completionHandler:] + 80
    	5   CFNetwork                           0x00007ff8225d3635 _CFHostIsDomainTopLevelForCertificatePolicy + 13206
    	6   libdispatch.dylib                   0x00007ff81d8af0cc _dispatch_call_block_and_release + 12
    	7   libdispatch.dylib                   0x00007ff81d8b0317 _dispatch_client_callout + 8
    	8   libdispatch.dylib                   0x00007ff81d8b6317 _dispatch_lane_serial_drain + 672
    	9   libdispatch.dylib                   0x00007ff81d8b6e30 _dispatch_lane_invoke + 417
    	10  libdispatch.dylib                   0x00007ff81d8c0eee _dispatch_workloop_worker_thread + 753
    	11  libsystem_pthread.dylib             0x00007ff81da63fd0 _pthread_wqthread + 326
    	12  libsystem_pthread.dylib             0x00007ff81da62f57 start_wqthread + 15


Backport of #16414
