### PR TITLE
[devops] Make publishing binlogs nonfatal.

### DIFF
--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -76,3 +76,4 @@ jobs:
       targetPath: $(Build.ArtifactStagingDirectory)\post-build-binlogs
       artifactName: post-build-binlogs
     condition: succeededOrFailed()
+    continueOnError: true


### PR DESCRIPTION
We don't need the binlogs in order to produce a successful build (only to
diagnose a failing build).