### PR TITLE
[release/6.0.4xx-xcode14] [apidiff] Change to use dl.internalx.com with a GitHub PAT for API reference downloads.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -1,5 +1,17 @@
 include $(TOP)/mk/subdirs.mk
 
+# Common cURL command:
+# --fail: return an exit code if the connection succeeded, but returned an HTTP error code.
+# --location: follow redirects
+# --connect-timeout: if a connection doesn't happen within 15 seconds, then fail (and potentially retry). This is lower than the default to not get stuck waiting for a long time in case something goes wrong (but instead retry).
+# --verbose / --silent: no explanation needed.
+# --show-error: show an error to the terminal even if asked to be --silent.
+CURL = curl --fail --location --connect-timeout 15 $(if $(V),--verbose,--silent) --show-error
+# --retry: retry download 20 times
+# --retry-delay: wait 2 seconds between each retry attempt
+# --retry-all-errors: ignore the definition of insanity and retry even for errors that seem like you'd get the same result (such as 404). This isn't the real purpose, because this will also retry errors that will get a different result (such as connection failures / resets), which apparently --retry doesn't cover.
+CURL_RETRY = $(CURL) --retry 20 --retry-delay 2 --retry-all-errors
+
 # calculate commit distance and store it in a file so that we don't have to re-calculate it every time make is executed.
 
 -include $(TOP)/Make.config.inc
@@ -15,13 +27,13 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 	@if which ccache > /dev/null 2>&1; then printf "ENABLE_CCACHE=1\nexport CCACHE_BASEDIR=$(abspath $(TOP)/..)\n" >> $@; echo "Found ccache on the system, enabling it"; fi
 	@if test -d $(TOP)/../maccore; then printf "ENABLE_XAMARIN=1\n" >> $@; echo "Detected the maccore repository, automatically enabled the Xamarin build"; fi
 	@# Build from source if we're on CI and packages aren't available.
-	@if ! curl -s -f --head "$(MONO_IOS_URL)" &> /dev/null; then \
+	@if ! $(CURL_RETRY) --head "$(MONO_IOS_URL)" &> /dev/null; then \
 		echo "$(COLOR_GRAY)*** The mono archive for iOS ($(MONO_IOS_URL)) can't be downloaded:$(COLOR_CLEAR)"; \
 		echo "$$ curl -s --head '$(MONO_IOS_URL)'" | sed 's/^/    /'; \
 		curl -s --head "$(MONO_IOS_URL)" | sed 's/^/    /'; \
 		MONO_DOWNLOAD_FAIL=1; \
 	fi; \
-	if ! curl -s -f --head "$(MONO_MAC_URL)" &> /dev/null; then \
+	if ! $(CURL_RETRY) --head "$(MONO_MAC_URL)" &> /dev/null; then \
 		echo "$(COLOR_GRAY)*** The mono archive for macOS ($(MONO_MAC_URL)) can't be downloaded:$(COLOR_CLEAR)"; \
 		echo "$$ curl -s --head '$(MONO_MAC_URL)'" | sed 's/^/    /'; \
 		curl -s --head "$(MONO_MAC_URL)" | sed 's/^/    /'; \

--- a/Make.config
+++ b/Make.config
@@ -36,12 +36,12 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/d17-3/87f98a75edaa6757fd6ff5170d297615830fb41b/6466144/package/bundle.zip
-APIDIFF_REFERENCES_Mac=https://bosstoragemirror.blob.core.windows.net/wrench/d17-3/87f98a75edaa6757fd6ff5170d297615830fb41b/6466144/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_iOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx/e45c10c68e85a6c6bb10542dff5fcaac3f8dade3/6506533/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_tvOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx/e45c10c68e85a6c6bb10542dff5fcaac3f8dade3/6506533/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_macOS=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx/e45c10c68e85a6c6bb10542dff5fcaac3f8dade3/6506533/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_MacCatalyst=https://bosstoragemirror.blob.core.windows.net/wrench/6.0.4xx/e45c10c68e85a6c6bb10542dff5fcaac3f8dade3/6506533/package/bundle.zip
+APIDIFF_REFERENCES_iOS=https://dl.internalx.com/wrench/d17-3/87f98a75edaa6757fd6ff5170d297615830fb41b/6466144/package/bundle.zip
+APIDIFF_REFERENCES_Mac=https://dl.internalx.com/wrench/d17-3/87f98a75edaa6757fd6ff5170d297615830fb41b/6466144/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_iOS=https://dl.internalx.com/wrench/6.0.4xx/e45c10c68e85a6c6bb10542dff5fcaac3f8dade3/6506533/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_tvOS=https://dl.internalx.com/wrench/6.0.4xx/e45c10c68e85a6c6bb10542dff5fcaac3f8dade3/6506533/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_macOS=https://dl.internalx.com/wrench/6.0.4xx/e45c10c68e85a6c6bb10542dff5fcaac3f8dade3/6506533/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_MacCatalyst=https://dl.internalx.com/wrench/6.0.4xx/e45c10c68e85a6c6bb10542dff5fcaac3f8dade3/6506533/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -45,7 +45,7 @@ $(DOWNLOADS):
 		$(CP) ~/Library/Caches/xamarin-macios/$(notdir $@) $@.tmp; \
 	else \
 		EC=0; \
-		curl -f -L $(if $(V),-v,-s) $(MONO_URL) --output $@.tmp || EC=$$?; \
+		$(CURL_RETRY) $(MONO_URL) --output $@.tmp || EC=$$?; \
 		if [[ x$$EC == x22 ]]; then \
 			MSG="Could not download the archive %s because the URL doesn't exist. This can happen if bumping mono very soon after the corresponding commit was pushed to mono (i.e. the archive hasn't been built yet). If so, please wait a bit and try again."; \
 			printf "$(COLOR_RED)*** $$MSG$(COLOR_CLEAR)\n" "$(notdir $@)"; \
@@ -89,13 +89,13 @@ print-dotnet-pkg-urls: dotnet-install.sh
 	$(Q) rm -f $@-found-it.stamp
 	$(Q) for url in $$(./dotnet-install.sh --version "$(DOTNET_VERSION)" --architecture $(DOTNET_ARCH) --no-path $$DOTNET_INSTALL_EXTRA_ARGS --dry-run | grep URL.*primary: | sed 's/.*primary: //'); do \
 		pkg=$${url/tar.gz/pkg}; \
-		if curl -LI --fail "$$pkg" >/dev/null 2>&1; then echo "$$pkg"; touch $@-found-it.stamp; break; fi; \
+		if $(CURL) -I "$$pkg" >/dev/null 2>&1; then echo "$$pkg"; touch $@-found-it.stamp; break; fi; \
 	done
 	$(Q) if ! test -f $@-found-it.stamp; then echo "No working urls were found."; exit 1; fi
 	$(Q) rm -f $@-found-it.stamp
 
 dotnet-install.sh: Makefile
-	$(Q) curl --retry 20 --retry-delay 2 --connect-timeout 15 -S -L $(if $(V),-v,-s) https://dot.net/v1/dotnet-install.sh --output $@.tmp
+	$(Q) $(CURL_RETRY) https://dot.net/v1/dotnet-install.sh --output $@.tmp
 	$(Q) chmod +x $@.tmp
 	$(Q) mv $@.tmp $@
 

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -1,6 +1,7 @@
 TOP = ../..
 
 include $(TOP)/Make.config
+include $(TOP)/mk/colors.mk
 
 ifdef SKIP_NEW_APIS #Requires https://github.com/mono/mono/commit/4c6a463678f3f0bfa599caeb66de72c7217fa95d
 NEW_REGEX = "-n:.?"
@@ -393,17 +394,31 @@ APIDIFF_URLS=$(APIDIFF_REFERENCES_iOS) $(APIDIFF_REFERENCES_Mac) $(foreach platf
 APIDIFF_UNIQUE_URLS=$(sort $(APIDIFF_URLS))
 APIDIFF_UNIQUE_HASHES=$(foreach url,$(APIDIFF_UNIQUE_URLS),$(word 5,$(subst /, ,$(url))))
 
+AUTH_TOKEN_GITHUB_COM_FILE=$(HOME)/.config/AUTH_TOKEN_GITHUB_COM
+ifeq ($(AUTH_TOKEN_GITHUB_COM),)
+ifeq ($(AUTH_TOKEN_GITHUB_COM_FILE),$(shell ls -1 $(AUTH_TOKEN_GITHUB_COM_FILE 2>/dev/null)))
+AUTH_TOKEN_GITHUB_COM:=$(shell cat $(AUTH_TOKEN_GITHUB_COM_FILE))
+endif
+endif
+
+check-token:
+	@if test -z "$(AUTH_TOKEN_GITHUB_COM)"; then echo "$(COLOR_RED)Can't download API references because the environment variable $(COLOR_BLUE)AUTH_TOKEN_GITHUB_COM$(COLOR_RED) isn't set. Please see the README.md file for more information.$(COLOR_CLEAR)"; exit 1; fi
+
+.PHONY: check-token
+
 define DownloadBundle
 BUNDLE_ZIP_$(1)=$(APIDIFF_DIR)/bundle-$(1).zip
 BUNDLE_ZIP_$(1)_URL=$(shell echo $(APIDIFF_UNIQUE_URLS) | tr ' ' '\n' | grep '/$(1)/')
 $$(BUNDLE_ZIP_$(1)):
+	$(Q) mkdir -p $$(dir $$@)
 	@# download to a temporary filename so interrupted downloads won't prevent re-downloads.
 	@echo "Downloading $$(BUNDLE_ZIP_$(1)_URL)..."
 	$$(Q) if test -f ~/Library/Caches/xamarin-macios/$$(notdir $$@); then \
 		echo "Found a cached version of $$(notdir $$@) in ~/Library/Caches/xamarin-macios/$$(notdir $$@)."; \
 		$$(CP) ~/Library/Caches/xamarin-macios/$$(notdir $$@) $$@.tmp; \
 	else \
-		curl -f -L $$(if $$(V),-v,-s) "$$(BUNDLE_ZIP_$(1)_URL)" --output $$@.tmp; \
+		$(MAKE) check-token || exit 1; \
+		$(CURL_RETRY) -H "Authorization: token $(AUTH_TOKEN_GITHUB_COM)" "$$(BUNDLE_ZIP_$(1)_URL)" --output $$@.tmp; \
 		if [[ "x$$$$MACIOS_CACHE_DOWNLOADS" != "x" ]]; then \
 			mkdir -p ~/Library/Caches/xamarin-macios/; \
 			$$(CP) $$@.tmp ~/Library/Caches/xamarin-macios/"$$(notdir $$@)"; \

--- a/tools/apidiff/README.md
+++ b/tools/apidiff/README.md
@@ -2,8 +2,11 @@
 
 Inside `Make.config` update the `APIDIFF_REFERENCES=` line to point to the `bundle.zip` URL of the currently stable version. E.g.
 
+The links from our CI will be from `bosstoragemirror.blob.core.windows.net`, but
+replace the domain name with `dl.internalx.com`, so the URL looks like this:
+
 ```
-APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d15-9/2dc06c712629feeb179ed112a590d9922caac6e7/53/package/bundle.zip
+APIDIFF_REFERENCES=https://dl.internalx.com/wrench/jenkins/d15-9/2dc06c712629feeb179ed112a590d9922caac6e7/53/package/bundle.zip
 ```
 
 # New Revisions
@@ -13,3 +16,20 @@ On the bots each revision rebuilds every assemblies. Each of them will be compar
 This can be done manually with `make`. The `.\diff\` directory will contain the diffs in HTML format.
 
 The helper `make merge` target creates a single `api-diff.html` file (from all the `diff\*.html` files) that be used for the documentation web site.
+
+# GitHub token
+
+It's required to provide a [GitHub PAT][GitHubPAT], with scope `read:user` and
+`read:org`, in order to download the API reference files. The PAT can be created
+[here][CreatePAT].
+
+This can be provided in two ways:
+
+1. Create a file named `~/.config/AUTH_TOKEN_GITHUB_COM`, and add the PAT to
+   this file (the file must contain only the PAT, and nothing else). This is the
+   recommended way.
+2. Export the PAT as the `AUTH_TOKEN_GITHUB_COM` environment variable.
+
+[GitHubPAT]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+[CreatePAT]: https://github.com/settings/tokens
+

--- a/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
+++ b/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
@@ -45,6 +45,7 @@ steps:
   env:
     BUILD_REVISION: 'devops' # doesn't matter the exact value, any value is understood as "we're in CI"
     PR_ID: ${{ parameters.prID }} # reusing jenkins vars, to be fixed
+    AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
 
 # publish the resulting artifact
 - task: PublishPipelineArtifact@1

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -144,7 +144,7 @@ stages:
         runTests: ${{ and(parameters.runTests, ne(variables['Build.Reason'], 'Schedule'))}}
         runDeviceTests: ${{ and(parameters.runDeviceTests, ne(variables['Build.Reason'], 'Schedule')) }}
         keyringPass: $(pass--lab--mac--builder--keychain)
-        gitHubToken: ${{ variables['GitHub.Token'] }}
+        gitHubToken: $(Github.Token)
         xqaCertPass: $(xqa--certificates--password)
         enableDotnet: ${{ parameters.enableDotnet }}
         skipESRP: ${{ parameters.skipESRP }}
@@ -174,7 +174,7 @@ stages:
           isPR: ${{ parameters.isPR }}
           vsdropsPrefix: ${{ variables.vsdropsPrefix }}
           keyringPass: $(pass--lab--mac--builder--keychain)
-          gitHubToken: ${{ variables['GitHub.Token'] }}
+          gitHubToken: $(Github.Token)
           xqaCertPass: $(xqa--certificates--password)
           enableDotnet: ${{ parameters.enableDotnet }}
           pool: ${{ parameters.pool }}
@@ -203,7 +203,7 @@ stages:
     makeTarget: 'jenkins'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
     keyringPass: $(pass--lab--mac--builder--keychain)
-    gitHubToken: ${{ variables['GitHub.Token'] }}
+    gitHubToken: $(Github.Token)
     xqaCertPass: $(xqa--certificates--password)
     enableDotnet: ${{ parameters.enableDotnet }}
     condition: ${{ parameters.runTests }}
@@ -227,7 +227,7 @@ stages:
           makeTarget: ${{ config.makeTarget }} 
           vsdropsPrefix: ${{ variables.vsdropsPrefix }}
           keyringPass: $(pass-XamarinQA-bot-login) 
-          gitHubToken: ${{ variables['GitHub.Token'] }}
+          gitHubToken: $(Github.Token)
           xqaCertPass: $(xqa--certificates--password)
           enableDotnet: ${{ parameters.enableDotnet }}
           condition: ${{ parameters.runDeviceTests }}
@@ -273,7 +273,7 @@ stages:
       extraBotDemands: ['xismoke-32']
       vsdropsPrefix: ${{ variables.vsdropsPrefix }}
       keyringPass: $(pass--lab--mac--builder--keychain)
-      gitHubToken: ${{ variables['GitHub.Token'] }}
+      gitHubToken: $(Github.Token)
       xqaCertPass: $(xqa--certificates--password)
       enableDotnet: ${{ parameters.enableDotnet }}
 


### PR DESCRIPTION
Update the download of API references to:

* Use `dl.internalx.com` links instead of `bosstoragemirror.blob.core.windows.net`
  links (the relative path stays the same).
* Require a GitHub PAT in order to download from dl.internalx.com. This PAT
  can either be provided through a file (recommended for local use) or through
  the environment.
* Document these changes.

Also backport #16394, which these changes require.

Backport of #16548.