### PR TITLE
[release/7.0.1xx] [tests] Ignore ExceptionsTest.ManagedExceptionPassthrough on ARM64 desktop.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -167,6 +167,15 @@ partial class TestRuntime
 			NUnit.Framework.Assert.Ignore (message);
 #endif
 	}
+
+	public static void AssertNotARM64Desktop (string message = "This test does not run on an ARM64 desktop.")
+	{
+#if __MACOS__ || __MACCATALYST__
+		if (IsARM64)
+			NUnit.Framework.Assert.Ignore (message);
+#endif
+	}
+
 	public static void AssertIfSimulatorThenARM64 ()
 	{
 #if !__MACOS__ && !__MACCATALYST__

--- a/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
@@ -143,6 +143,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 #if !DEBUG && !__WATCHOS__
 			Assert.Ignore ("This test only works in debug mode in the simulator.");
 #endif
+
+			TestRuntime.AssertNotARM64Desktop ("Exception handling doesn't work on ARM64 desktop: https://github.com/xamarin/xamarin-macios/issues/16264");
+
 			var hasDebugger = global::System.Diagnostics.Debugger.IsAttached;
 
 			InstallHandlers ();


### PR DESCRIPTION
Ignore ExceptionsTest.ManagedExceptionPassthrough on ARM64 desktop until we
fix the underlying bug.

Ref: https://github.com/xamarin/xamarin-macios/issues/16264


Backport of #16384
