### PR TITLE
Handle frameworks and binding packages in Hot Restart

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.props
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.props
@@ -12,6 +12,8 @@
 		<HotRestartContentStampDir>$(HotRestartSignedAppOutputDir)$(_AppBundleName).stamp\</HotRestartContentStampDir>
 		<HotRestartIPAPath>$(HotRestartSignedAppOutputDir)$(_AppBundleName).ipa</HotRestartIPAPath>
 
+		<HotRestartPackageResourcesDir>$(TEMP)\Xamarin\HotRestart\Resources\</HotRestartPackageResourcesDir>
+
 		<UnpackHotRestartFrameworks Condition="'$(UnpackHotRestartFrameworks)' == ''">true</UnpackHotRestartFrameworks>
 
 		<_IsHotRestartDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)HOTRESTART($|;)'))</_IsHotRestartDefined>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -8,6 +8,7 @@
 	<UsingTask TaskName="Xamarin.iOS.HotRestart.Tasks.DetectSigningIdentity" AssemblyFile="Xamarin.iOS.Tasks.Windows.dll" />
 	<UsingTask TaskName="Xamarin.iOS.HotRestart.Tasks.PrepareAppBundle" AssemblyFile="Xamarin.iOS.Tasks.Windows.dll" />
 	<UsingTask TaskName="Xamarin.iOS.HotRestart.Tasks.UnpackFrameworks" AssemblyFile="Xamarin.iOS.Tasks.Windows.dll" />
+	<UsingTask TaskName="Xamarin.iOS.Tasks.Windows.Unzip" AssemblyFile="Xamarin.iOS.Tasks.Windows.dll" />
 	
 	<Import Project="Xamarin.iOS.HotRestart.props" />
 
@@ -86,7 +87,34 @@
 		</Touch>
 	</Target>
 
-	<Target Name="_CollectHotRestartFrameworks" >
+	<!-- Also include frameworks from packages -->
+	<Target Name="_CollectHotRestartFrameworksFromPackages"
+		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsHotRestartBuild)' == 'true' And '$(UnpackHotRestartFrameworks)' == 'true'" >
+
+		<ItemGroup>
+			<_PackageResourcesDirs Include="@(AssembliesWithFrameworks -> '%(RootDir)%(Directory)%(FileName).resources')"
+				Condition="Exists('%(RootDir)%(Directory)%(FileName).resources')" />
+			<_PackageResourcesZips Include="@(AssembliesWithFrameworks -> '%(RootDir)%(Directory)%(FileName).resources.zip')"
+				Condition="Exists('%(RootDir)%(Directory)%(FileName).resources.zip')" />
+		</ItemGroup>
+
+		<Unzip ZipFilePath="@(_PackageResourcesZips)"
+			ExtractionPath="$(HotRestartPackageResourcesDir)%(NuGetPackageId)\%(NuGetPackageVersion)"
+			Condition="'@(_PackageResourcesZips)' != '' And !Exists('$(HotRestartPackageResourcesDir)%(NuGetPackageId)\%(NuGetPackageVersion)')" />
+
+		<ItemGroup Condition="'@(_PackageResourcesZips)' != ''">
+			<_PackageResourcesDirs Include="@(_PackageResourcesZips -> '$(HotRestartPackageResourcesDir)%(NuGetPackageId)\%(NuGetPackageVersion)')" />
+		</ItemGroup>
+
+		<ItemGroup Condition="'@(_PackageResourcesDirs)' != ''">
+			<_PackageResourcesFrameworkFiles Include="%(_PackageResourcesDirs.Identity)\*.framework\*" />
+			<_PackageResourcesFrameworkFiles Include="%(_PackageResourcesDirs.Identity)\**\*.xcframework\ios-arm64\*.framework\*" />
+			<_HotRestartFrameworksFromPackages Include="@(_PackageResourcesFrameworkFiles -> '%(RootDir)%(Directory)')" KeepDuplicates="false" />
+			<_HotRestartFrameworks Include="@(_HotRestartFrameworksFromPackages)" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="_CollectHotRestartFrameworks">
 		<ItemGroup>
 			<_HotRestartFrameworks Include="@(None -> '%(RootDir)%(Directory)')" Condition="$([System.String]::new('%(Directory)').EndsWith('.framework\'))" KeepDuplicates="false" />
 			<_HotRestartFrameworks Include="@(_UnpackedFramework);@(NativeReference)" KeepDuplicates="false" />

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Zip.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Zip.cs
@@ -2,8 +2,10 @@ using System;
 using System.IO;
 using System.IO.Compression;
 
-namespace Xamarin.iOS.Tasks.Windows {
-	internal static class Zip {
+namespace Xamarin.iOS.Tasks.Windows
+{
+	internal static class Zip
+	{
 		internal static void Extract (string sourceFileName, string destinationPath)
 		{
 			// We use a temp dir because the extraction dir should not exist for the ZipFile API to work
@@ -21,7 +23,7 @@ namespace Xamarin.iOS.Tasks.Windows {
 			Directory.Delete (tempExtractionPath, recursive: true);
 		}
 
-		static void CopyDirectory (string source, string destination)
+		private static void CopyDirectory (string source, string destination)
 		{
 			var sourceDirectoryInfo = new DirectoryInfo (source);
 
@@ -35,6 +37,61 @@ namespace Xamarin.iOS.Tasks.Windows {
 				CopyDirectory (dir.FullName, Path.Combine (destination, dir.Name));
 			}
 		}
+
+		private static void ExtractWithSymlinksToDirectory(string sourceFileName, string destinationDirectoryName)
+		{
+			// Do the normal extraction first
+			using var source = ZipFile.OpenRead(sourceFileName);
+			source.ExtractToDirectory(destinationDirectoryName);
+
+			// Read all the symbolic links contained in the zip
+			var links = ReadSymbolicLinks(source, destinationDirectoryName).ToList();
+			
+			// Pass 1 - Delete the fake link files
+			foreach (var link in links)
+			{
+				File.Delete(link.Key);
+			}
+			
+			// Pass 2 - Create directory symbolic links
+			foreach (var link in links)
+			{
+				// Initially, we will assume all links are directory links because there's no way to tell otherwise.
+				Directory.CreateSymbolicLink(link.Key, link.Value);
+			}
+			
+			// Pass 3 - Create file symbolic links
+			foreach (var link in links)
+			{
+				// If the target directory doesn't exist, then we'll delete the link and recreate it as a file link.
+				if (!Directory.Exists(Path.Combine(link.Key, "..", link.Value)))
+				{
+					Directory.Delete(link.Key);
+					File.CreateSymbolicLink(link.Key, link.Value);
+				}
+			}
+		}
+
+		private static IEnumerable<KeyValuePair<string, string>> ReadSymbolicLinks(ZipArchive archive, string baseDirectory = ".")
+		{
+			foreach (var entry in archive.Entries.Where(IsSymbolicLink))
+			{
+				var path = Path.Combine(baseDirectory, entry.FullName.Replace('/', Path.DirectorySeparatorChar));
+				
+				using var stream = entry.Open();
+				using var reader = new StreamReader(stream);
+				var link = reader.ReadToEnd().Replace('/', Path.DirectorySeparatorChar);
+				
+				yield return new KeyValuePair<string, string>(path, link);
+			}
+		}
+
+		// References:
+		// https://www.gnu.org/software/libc/manual/html_node/Testing-File-Type.html
+		// https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Stat.cs
+		private const int S_IFMT = 0xF000;
+		private const int S_IFLNK = 0xA000;
+		
+		private static bool IsSymbolicLink(ZipArchiveEntry entry) => ((entry.ExternalAttributes >> 16) & S_IFMT) == S_IFLNK;
 	}
 }
-


### PR DESCRIPTION
- Supports either regular framework or xcframework files coming from nuget packages
- Updates the `Unzip` task to properly create symbolic links, which may occur within resource zips containing xcframeworks

Fixes #16571

@rolfbjarne