### PR TITLE
Unset the prerelease identifier.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -118,8 +118,8 @@ endif
 ## change *first*, otherwise we'll produce builds with the same version from
 ## two different branches (which is very, very bad).
 ##
-NUGET_HARDCODED_PRERELEASE_IDENTIFIER=net7.0-xcode14.1
-NUGET_HARDCODED_PRERELEASE_BRANCH=net7.0-xcode14.1
+# NUGET_HARDCODED_PRERELEASE_IDENTIFIER=net7.0-xcode14.1
+# NUGET_HARDCODED_PRERELEASE_BRANCH=net7.0-xcode14.1
 
 # compute the alphanumeric version of branch names
 NUGET_RELEASE_BRANCH_ALPHANUMERIC:=$(shell export LANG=C; printf "%s" "$(NUGET_RELEASE_BRANCH)" | tr -c '[a-zA-Z0-9-]' '-')


### PR DESCRIPTION
There's no release coming from main, so unset the prerelease identifier.