### PR TITLE
[tests] Remove a few duplicated package references.

### DIFF
--- a/tests/bindings-test/dotnet/shared.csproj
+++ b/tests/bindings-test/dotnet/shared.csproj
@@ -15,10 +15,6 @@
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
 
   <ItemGroup>
-    <PackageReference Include="NUnitLite" Version="3.12.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ObjcBindingApiDefinition Include="$(BindingsTestDirectory)\ApiDefinition.cs" />
     <ObjcBindingApiDefinition Include="$(RootTestsDirectory)\generator\tests\ref-out-parameters.cs" />
     <ObjcBindingApiDefinition Include="$(BindingsTestDirectory)\ApiDefinition.generated.cs" />

--- a/tests/bindings-test2/dotnet/shared.csproj
+++ b/tests/bindings-test2/dotnet/shared.csproj
@@ -15,7 +15,6 @@
   <Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
 
   <ItemGroup>
-    <PackageReference Include="NUnitLite" Version="3.12.0" />
     <ProjectReference Include="$(RootTestsDirectory)\bindings-test\dotnet\$(_PlatformName)\bindings-test.csproj" />
   </ItemGroup>
 

--- a/tests/fsharplibrary/dotnet/shared.fsproj
+++ b/tests/fsharplibrary/dotnet/shared.fsproj
@@ -13,7 +13,6 @@
 	<Import Project="$(RootTestsDirectory)/common/shared-dotnet.csproj" />
 
 	<ItemGroup>
-		<PackageReference Include="NUnitLite" Version="3.12.0" />
 		<PackageReference Include="FSharp.Core" Version="6.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
The NUnitLite package is already included in the shared-dotnet.csproj file,
which these projects import.