### PR TITLE
Switch maccore to track main and bump.

### DIFF
--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -91,3 +91,10 @@ reset: check-versions
 
 reset-versions: reset-versions-impl
 	$(Q) ! test -f $(THISDIR)/.stamp-reset-maccore || ( echo "$(COLOR_GRAY)Checking again since maccore changed$(COLOR_CLEAR)" && $(MAKE) reset-versions-impl )
+
+README := $(abspath $(TOP)/mk/xamarin.mk)
+bump-current-maccore: P=MACCORE
+bump-current-%:
+	@sed  -i '' -e "s,NEEDED_$(P)_VERSION.*,NEEDED_$(P)_VERSION := $(shell cd $($(P)_PATH) && git log -1 --pretty=format:%H),g" $(README)
+	@sed  -i '' -e "s,NEEDED_$(P)_BRANCH.*,NEEDED_$(P)_BRANCH := $(shell cd $($(P)_PATH) && git rev-parse --abbrev-ref HEAD),g" $(README)
+	@sed  -i '' -e "s,^\\($(P)_MODULE.*:=\\).*\\(git.*$\\),\\1 $(shell cd $($(P)_PATH) && git config remote.$(shell cd $($(P)_PATH) && git config branch.$(shell cd $($(P)_PATH) && git rev-parse --abbrev-ref HEAD).remote).url)," $(README)

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,8 +7,8 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 0837e7caffb2e42efcd183cb1d71998fb6022e2c
-NEEDED_MACCORE_BRANCH := xcode14
+NEEDED_MACCORE_VERSION := 893e01ae00872bcf0458ca094a9beb3f6fda3709
+NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore
 MACCORE_MODULE    := git@github.com:xamarin/maccore.git


### PR DESCRIPTION
Also add copy make target to bump the current maccore hash from maccore.

New commits in xamarin/maccore:

* xamarin/maccore@893e01ae00 Update provisionator bootstrap
* xamarin/maccore@7fa40752e4 Merge xcode14 into main.
* xamarin/maccore@140923bddf Merge remote-tracking branch 'xamarin/xcode14' into merge-xcode14-into-main
* xamarin/maccore@4e3eab455c Use Environment.SpecialFolder.UserProfile, not SpecialFolder.Personal.
* xamarin/maccore@9a347bd708 [certificates] Update la_dev_apple.p12, la_distr_apple.p12 and la_mac_installer_distr.p12
* xamarin/maccore@bcdd779e58 [devops] Install Mono too.
* xamarin/maccore@75a03ccbfc [xcode14] Merge main into xcode14
* xamarin/maccore@7690a80a2f [submission] Fix submission test makefile
* xamarin/maccore@813beaf11a Don't build mlaunch from the parent/root makefile anymore.
* xamarin/maccore@695f55471d [analysis] Make sure to create directories before copying files into them.
* xamarin/maccore@29a6536838 [mlaunch] Fix computing the current source branch in CI.
* xamarin/maccore@8c281e0c8f [mlaunch] Build & package without using xamarin-macios.
* xamarin/maccore@3e5c67a1ea [devops] Provision Xcode and Xamarin.Mac on the bots.

Diff: https://github.com/xamarin/maccore/compare/0837e7caffb2e42efcd183cb1d71998fb6022e2c..893e01ae00872bcf0458ca094a9beb3f6fda3709