### PR TITLE
[DevOps] Rename the yaml-templates resources to match the MAUI repo.

### DIFF
--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -132,7 +132,7 @@ resources:
     checkoutOptions:
       submodules: true
 
-  - repository: templates
+  - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
     ref: refs/heads/main

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -132,7 +132,7 @@ resources:
     checkoutOptions:
       submodules: true
 
-  - repository: templates
+  - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
     ref: refs/heads/main

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -117,7 +117,7 @@ resources:
     checkoutOptions:
       submodules: true
 
-  - repository: templates
+  - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
     ref: refs/heads/main

--- a/tools/devops/automation/publish-pr-html-results.yml
+++ b/tools/devops/automation/publish-pr-html-results.yml
@@ -11,7 +11,7 @@ resources:
     checkoutOptions:
       submodules: false  # no need
 
-  - repository: templates
+  - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
     ref: refs/heads/main

--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -51,7 +51,7 @@ jobs:
     - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
 
     # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-    - template: azure-devops-pools/agent-pool-selector.yml@templates
+    - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
       parameters:
         agentPoolPR: $(PRBuildPool)
         agentPoolPRUrl: $(PRBuildPoolUrl)

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -63,7 +63,7 @@ jobs:
     - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
 
     # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-    - template: azure-devops-pools/agent-pool-selector.yml@templates
+    - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
       parameters:
         agentPoolPR: $(PRBuildPool)
         agentPoolPRUrl: $(PRBuildPoolUrl)

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -41,7 +41,7 @@ steps:
   parameters:
     keyringPass: ${{ parameters.keyringPass }}
 
-- template: install-certificates.yml@templates
+- template: install-certificates.yml@yaml-templates
   parameters:
     DeveloperIdApplication: $(developer-id-application)
     DeveloperIdInstaller: $(developer-id-installer)

--- a/tools/devops/automation/templates/common/checkout.yml
+++ b/tools/devops/automation/templates/common/checkout.yml
@@ -40,7 +40,7 @@ steps:
   clean: true
   persistCredentials: true  # hugely important, else there are some scripts that check a single file from maccore that will fail
 
-- checkout: templates
+- checkout: yaml-templates
   clean: true
 
 - checkout: release-scripts

--- a/tools/devops/automation/templates/common/setup.yml
+++ b/tools/devops/automation/templates/common/setup.yml
@@ -6,7 +6,7 @@ parameters:
   type: string
 
 steps:
-- template: agent-cleanser/v1.yml@templates   # Uninstalls mono, Xamarin.Mac (if installed) plus cleanses the Provisionator Xcode cache and kills processes at the end
+- template: agent-cleanser/v1.yml@yaml-templates # Uninstalls mono, Xamarin.Mac (if installed) plus cleanses the Provisionator Xcode cache and kills processes at the end
   parameters:
     CleanseProcesses: true
 

--- a/tools/devops/automation/templates/common/teardown.yml
+++ b/tools/devops/automation/templates/common/teardown.yml
@@ -18,12 +18,12 @@ steps:
   displayName: "Remove artifacts"
   condition: always()
 
-- template: uninstall-certificates/v1.yml@templates
+- template: uninstall-certificates/v1.yml@yaml-templates
   parameters:
     HostedMacKeychainPassword: ${{ parameters.keyringPass }}
 
 # this will always be executed, is the default condition in the template
-- template: uninstall-certificates/v1.yml@templates
+- template: uninstall-certificates/v1.yml@yaml-templates
   parameters:
     HostedMacKeychainPassword: ${{ parameters.keyringPass }}
 

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -21,7 +21,7 @@ steps:
   parameters:
     isPR: ${{ parameters.isPR }}
 
-- template: agent-cleanser/v1.yml@templates   # Uninstalls mono, Xamarin.Mac (if installed) plus cleanses the Provisionator Xcode cache and kills processes at the end
+- template: agent-cleanser/v1.yml@yaml-templates # Uninstalls mono, Xamarin.Mac (if installed) plus cleanses the Provisionator Xcode cache and kills processes at the end
   parameters:
     CleanseProcesses: true
 

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -18,14 +18,14 @@ stages:
 
   jobs:
   # Check - "xamarin-macios (Prepare Release Sign NuGets)"
-  - template: sign-artifacts/jobs/v2.yml@templates
+  - template: sign-artifacts/jobs/v2.yml@yaml-templates
     parameters:
       artifactName: dotnet-signed
       signType: Real
       usePipelineArtifactTasks: true
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v3.yml@templates
+  - template: nuget-msi-convert/job/v3.yml@yaml-templates
     parameters:
       yamlResourceName: templates
       dependsOn: signing
@@ -115,7 +115,7 @@ stages:
 
 # Check - "xamarin-macios (VS Insertion Wait For Approval)"
 # Check - "xamarin-macios (VS Insertion Create VS Drop and Open PR)"
-- template: vs-insertion/stage/v1.yml@templates
+- template: vs-insertion/stage/v1.yml@yaml-templates
   parameters:
     dependsOn: prepare_release
     symbolArtifactName: nuget-signed

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -55,7 +55,7 @@ jobs:
     clean: true
     persistCredentials: true  # hugely important, else there are some scripts that check a single file from maccore that will fail
 
-  - checkout: templates
+  - checkout: yaml-templates
     clean: true
 
   - checkout: release-scripts
@@ -91,7 +91,7 @@ jobs:
       displayName: 'Move pkg ${{ pkg.name }} to its final destination'
       condition: ne('', variables['${{ pkg.conditionVariable }}'])
 
-  - template: generate-workspace-info.yml@templates
+  - template: generate-workspace-info.yml@yaml-templates
     parameters:
       GitHubToken: $(GitHub.Token)
       ArtifactDirectory: $(Build.SourcesDirectory)/package-internal

--- a/tools/devops/automation/templates/sign-and-notarized/setup.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/setup.yml
@@ -23,7 +23,7 @@ steps:
   clean: true
   persistCredentials: true  # hugely important, else there are some scripts that check a single file from maccore that will fail
 
-- checkout: templates
+- checkout: yaml-templates
   clean: true
 
 - checkout: release-scripts

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -43,7 +43,7 @@ steps:
   displayName: "Build manifest"
 
 # Important needed for the next step
-- template: generate-workspace-info.yml@templates
+- template: generate-workspace-info.yml@yaml-templates
   parameters:
     GitHubToken: $(GitHub.Token)
     ArtifactDirectory: $(Build.SourcesDirectory)/package-internal

--- a/tools/devops/automation/vs-insertion.yml
+++ b/tools/devops/automation/vs-insertion.yml
@@ -9,7 +9,7 @@ resources:
     checkoutOptions:
       submodules: false  # no need
 
-  - repository: templates
+  - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
     ref: refs/heads/main
@@ -59,7 +59,7 @@ jobs:
   - group: Xamarin-Secrets
   pool: VSEng-ReleasePool-1ES
   steps:
-  - template: vs-insertion/jobs/create_insert_drop/v1.yml@templates
+  - template: vs-insertion/jobs/create_insert_drop/v1.yml@yaml-templates
     parameters:
       symbolArtifactName: nuget-signed
       symbolConversionFilters: '*mlaunch.app*'


### PR DESCRIPTION
In an attempt to unify the build of all the SDKs we need to be rename all shared resources between the CIs to all use the same name.

This commit renames the resource to use the pattern used by MAUI.

Partial fix for https://github.com/xamarin/sdk-insertions/issues/39