### PR TITLE
[DevOps] Use the checkout template for the unified pipeline to work.

### DIFF
--- a/tools/devops/automation/templates/common/checkout.yml
+++ b/tools/devops/automation/templates/common/checkout.yml
@@ -6,11 +6,11 @@ parameters:
   type: boolean
 
 steps:
-- checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-  clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
-  submodules: recursive
-  path: s/xamarin-macios
-
+- template: sdk-unified/steps/checkout/v1.yml@templates
+  parameters:
+    clean: true
+    submodules: recursive
+    path: s/xamarin-macios
 
 - ${{ if parameters.isPR }}:
   - pwsh: |

--- a/tools/devops/automation/templates/loc-translations.yml
+++ b/tools/devops/automation/templates/loc-translations.yml
@@ -5,10 +5,11 @@ parameters:
 
 steps:
 
-- checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-  clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
-  submodules: recursive
-  path: s/xamarin-macios
+- template: sdk-unified/steps/checkout/v1.yml@templates
+  parameters:
+    clean: true
+    submodules: recursive
+    path: s/xamarin-macios
 
 - ${{ if parameters.isPR }}:
   - pwsh: |

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -46,10 +46,12 @@ jobs:
   steps:
 
   # DO NOT USE THE checkout.yml template. The reason is that the template changes the hash which results in a problem with the artifacts scripts
-  - checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-    clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
-    submodules: recursive
-    path: s/xamarin-macios
+  #
+  - template: sdk-unified/steps/checkout/v1.yml@templates
+    parameters:
+      clean: true
+      submodules: recursive
+      path: s/xamarin-macios
 
   - checkout: maccore
     clean: true

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -46,7 +46,6 @@ jobs:
   steps:
 
   # DO NOT USE THE checkout.yml template. The reason is that the template changes the hash which results in a problem with the artifacts scripts
-  #
   - template: sdk-unified/steps/checkout/v1.yml@templates
     parameters:
       clean: true

--- a/tools/devops/automation/templates/sign-and-notarized/setup.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/setup.yml
@@ -14,10 +14,11 @@ parameters:
 steps:
 
 # DO NOT USE THE checkout.yml template. The reason is that the template changes the hash which results in a problem with the artifacts scripts
-- checkout: self          # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-  clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
-  submodules: recursive
-  path: s/xamarin-macios
+- template:  sdk-unified/steps/checkout/v1.yml@templates
+  parameters:
+    clean: true
+    submodules: recursive
+    path: s/xamarin-macios
 
 - checkout: maccore
   clean: true

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -16,9 +16,11 @@ parameters:
 steps:
 # Do not use the templates/common/checkout.yaml for this job else the azure upload tool will fail because 
 # it cannot find the correct branch to be used. 
-- checkout: self
-  persistCredentials: true
-  path: s/xamarin-macios
+- template:  sdk-unified/steps/checkout/v1.yml@templates
+  parameters:
+    clean: true
+    persistCredentials: true
+    path: s/xamarin-macios
 
 # Download the Html Report that was added by the tests job.
 - task: DownloadPipelineArtifact@2

--- a/tools/devops/automation/templates/windows/reserve-mac.yml
+++ b/tools/devops/automation/templates/windows/reserve-mac.yml
@@ -5,8 +5,10 @@ parameters:
   default: "VSEng-VSMac-Xamarin-Shared"
 
 steps:
-- checkout: self
-  path: s/xamarin-macios
+- template:  sdk-unified/steps/checkout/v1.yml@templates
+  parameters:
+    clean: true
+    path: s/xamarin-macios
 
 - checkout: maccore
   persistCredentials: true  # hugely important, else there are some scripts that check a single file from maccore that will fail


### PR DESCRIPTION
Move to use a template to perform the checkout. The new template allows to perform the checkout using a resource alias, which later can be used to use the template outside this repo. 

Partial fix for https://github.com/xamarin/sdk-insertions/issues/41