### PR TITLE
[release/6.0.4xx-xcode14.1] [dotnet] Always use a four part VS component version

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -173,7 +173,7 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform)
 # We reset the commit distance (to the commits since NUGET_PRERELEASE_IDENTIFIER changed - which must have changed for a branch to become a stable branch)
 # We use the commit distance as the third number in the version, instead of the fourth.
 ifeq ($(NUGET_PRERELEASE_IDENTIFIER),)
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).$(NUGET_STABLE_COMMIT_DISTANCE)))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).$(NUGET_STABLE_COMMIT_DISTANCE).0))
 else
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).0.$($(shell echo $(platform) | tr a-z A-Z)_NUGET_COMMIT_DISTANCE)))
 endif


### PR DESCRIPTION
The `%(Version)` metadata declared in `vs-workload.props` should always
be a four part version, this was missed when reviewing commit https://github.com/xamarin/xamarin-macios/commit/9f1dc519ea2211df8a4440336c3e867455bc4691.
Fix this by adding a trailing `.0` to stable branded packages.

For "Preview" branded manifest packs, the fourth part of the version
should be the commit distance (e.g. 16.1.0.5).

For "Stable" branded manifest packs, the third part of the version
should be the commit distance (e.g. 16.1.5.0).

See the following for more info on `vs-workload.props` versioning:
https://github.com/xamarin/sdk-insertions/wiki/How-to-create-a-new-insertion#msi-generation-and-vs-versioning-requirements


Backport of #16633
