### PR TITLE
[registrar] Deduplicate the code to compute the initialization method name for the generated static registrar code.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -1029,9 +1029,9 @@ namespace Xamarin.Bundler {
 #endif
 			var registrar = new Registrar.StaticRegistrar (this);
 			if (RootAssemblies.Count == 1)
-				registrar.GenerateSingleAssembly (resolver, resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m, Path.GetFileNameWithoutExtension (RootAssembly));
+				registrar.GenerateSingleAssembly (resolver, resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m, Path.GetFileNameWithoutExtension (RootAssembly), out var _);
 			else
-				registrar.Generate (resolver, resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m);
+				registrar.Generate (resolver, resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m, out var _);
 		}
 
 		public IEnumerable<Abi> Abis {

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2785,7 +2785,16 @@ namespace Registrar {
 			skipped_types.Add (new SkippedType { Skipped = type, Actual = registered_type });
 		}
 
-		void Specialize (AutoIndentStringBuilder sb)
+		public string GetInitializationMethodName (string single_assembly)
+		{
+			if (!string.IsNullOrEmpty (single_assembly)) {
+				return "xamarin_create_classes_" + single_assembly.Replace ('.', '_').Replace ('-', '_');
+			} else {
+				return "xamarin_create_classes";
+			}
+		}
+
+		void Specialize (AutoIndentStringBuilder sb, out string initialization_method)
 		{
 			List<Exception> exceptions = new List<Exception> ();
 			List<ObjCMember> skip = new List<ObjCMember> ();
@@ -2809,11 +2818,9 @@ namespace Registrar {
 			}
 
 			map.AppendLine ("static MTClassMap __xamarin_class_map [] = {");
-			if (string.IsNullOrEmpty (single_assembly)) {
-				map_init.AppendLine ("void xamarin_create_classes () {");
-			} else {
-				map_init.AppendLine ("void xamarin_create_classes_{0} () {{", single_assembly.Replace ('.', '_').Replace ('-', '_'));
-			}
+
+			initialization_method = GetInitializationMethodName (single_assembly);
+			map_init.AppendLine ($"void {initialization_method} () {{");
 
 			// Select the types that needs to be registered.
 			var allTypes = new List<ObjCType> ();
@@ -5079,18 +5086,18 @@ namespace Registrar {
 			pinfo.EntryPoint = wrapperName;
 		}
 
-		public void GenerateSingleAssembly (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, string assembly)
+		public void GenerateSingleAssembly (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, string assembly, out string initialization_method)
 		{
 			single_assembly = assembly;
-			Generate (resolver, assemblies, header_path, source_path);
+			Generate (resolver, assemblies, header_path, source_path, out initialization_method);
 		}
 
-		public void Generate (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path)
+		public void Generate (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, out string initialization_method)
 		{
-			Generate (null, assemblies, header_path, source_path);
+			Generate (null, assemblies, header_path, source_path, out initialization_method);
 		}
 
-		public void Generate (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path)
+		public void Generate (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, out string initialization_method)
 		{
 			this.resolver = resolver;
 
@@ -5104,10 +5111,10 @@ namespace Registrar {
 				RegisterAssembly (assembly);
 			}
 
-			Generate (header_path, source_path);
+			Generate (header_path, source_path, out initialization_method);
 		}
 
-		void Generate (string header_path, string source_path)
+		void Generate (string header_path, string source_path, out string initialization_method)
 		{
 			var sb = new AutoIndentStringBuilder ();
 			header = new AutoIndentStringBuilder ();
@@ -5142,7 +5149,7 @@ namespace Registrar {
 			if (App.Embeddinator)
 				methods.WriteLine ("void xamarin_embeddinator_initialize ();");
 
-			Specialize (sb);
+			Specialize (sb, out initialization_method);
 
 			methods.WriteLine ();
 			methods.AppendLine ();

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -622,7 +622,7 @@ namespace Xamarin.Bundler {
 			sw.WriteLine ("#include <xamarin/xamarin.h>");
 #if !NET
 			if (App.Registrar == RegistrarMode.PartialStatic)
-				sw.WriteLine ("extern \"C\" void xamarin_create_classes_Xamarin_Mac ();");
+				sw.WriteLine ($"extern \"C\" void {StaticRegistrar.GetInitializationMethodName ("Xamarin.Mac")} ();");
 #endif
 			sw.WriteLine ();
 			sw.WriteLine ();
@@ -643,13 +643,6 @@ namespace Xamarin.Bundler {
 			if (App.DisableOmitFramePointer ?? App.EnableDebug)
 				sw.WriteLine ("\txamarin_disable_omit_fp = true;");
 			sw.WriteLine ();
-
-#if !NET
-			if (App.Registrar == RegistrarMode.Static)
-				sw.WriteLine ("\txamarin_create_classes ();");
-			else if (App.Registrar == RegistrarMode.PartialStatic)
-				sw.WriteLine ("\txamarin_create_classes_Xamarin_Mac ();");
-#endif
 
 			if (App.EnableDebug)
 				sw.WriteLine ("\txamarin_debug_mode = TRUE;");

--- a/tools/dotnet-linker/Steps/RegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/RegistrarStep.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Linker {
 				break;
 			case RegistrarMode.PartialStatic:
 				// The method name is created in StaticRegistrar.Specialize.
-				var method = "xamarin_create_classes_" + Path.GetFileNameWithoutExtension (Configuration.PlatformAssembly.Replace ('.', '_').Replace ('-', '_'));
+				var method = Configuration.Target.StaticRegistrar.GetInitializationMethodName (Configuration.PlatformAssembly);
 				Configuration.RegistrationMethods.Add (method);
 				Configuration.CompilerFlags.AddLinkWith (Configuration.PartialStaticRegistrarLibrary);
 				break;
@@ -36,7 +36,7 @@ namespace Xamarin.Linker {
 					if (Annotations.GetAction (assembly) != Mono.Linker.AssemblyAction.Delete)
 						bundled_assemblies.Add (assembly);
 				}
-				Configuration.Target.StaticRegistrar.Generate (bundled_assemblies, header, code);
+				Configuration.Target.StaticRegistrar.Generate (bundled_assemblies, header, code, out var initialization_method);
 
 				var items = new List<MSBuildItem> ();
 				foreach (var abi in Configuration.Abis) {
@@ -50,7 +50,7 @@ namespace Xamarin.Linker {
 				}
 
 				Configuration.WriteOutputForMSBuild ("_RegistrarFile", items);
-				Configuration.RegistrationMethods.Add ("xamarin_create_classes");
+				Configuration.RegistrationMethods.Add (initialization_method);
 				break;
 			case RegistrarMode.Default: // We should have resolved 'Default' to an actual mode by now.
 			default:

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -102,6 +102,7 @@ namespace Xamarin.Bundler {
 		public Target Target;
 		public string RegistrarCodePath;
 		public string RegistrarHeaderPath;
+		public List<string> RegistrationMethods;
 
 		public override IEnumerable<string> Inputs {
 			get {
@@ -119,7 +120,8 @@ namespace Xamarin.Bundler {
 
 		protected override void Execute ()
 		{
-			Target.StaticRegistrar.Generate (Target.Assemblies.Select ((a) => a.AssemblyDefinition), RegistrarHeaderPath, RegistrarCodePath);
+			Target.StaticRegistrar.Generate (Target.Assemblies.Select ((a) => a.AssemblyDefinition), RegistrarHeaderPath, RegistrarCodePath, out var initialization_name);
+			RegistrationMethods.Add (initialization_name);
 		}
 	}
 

--- a/tools/mtouch/Target.mtouch.cs
+++ b/tools/mtouch/Target.mtouch.cs
@@ -1265,6 +1265,7 @@ namespace Xamarin.Bundler {
 					Target = this,
 					RegistrarCodePath = registrar_m,
 					RegistrarHeaderPath = registrar_h,
+					RegistrationMethods = registration_methods,
 				};
 
 				foreach (var abi in GetArchitectures (AssemblyBuildTarget.StaticObject)) {
@@ -1298,33 +1299,30 @@ namespace Xamarin.Bundler {
 
 					LinkWithTaskOutput (registrar_task);
 				}
-
-				registration_methods.Add ("xamarin_create_classes");
 			}
 
 			if (App.Registrar == RegistrarMode.Dynamic && App.LinkMode == LinkMode.None) {
 				string method;
 				string library;
+				string libraryName;
 				switch (App.Platform) {
 				case ApplePlatform.iOS:
-					method = "xamarin_create_classes_Xamarin_iOS";
-					library = "Xamarin.iOS.registrar.a";
+					libraryName = "Xamarin.iOS";
 					break;
 				case ApplePlatform.WatchOS:
-					method = "xamarin_create_classes_Xamarin_WatchOS";
-					library = "Xamarin.WatchOS.registrar.a";
+					libraryName = "Xamarin.WatchOS";
 					break;
 				case ApplePlatform.TVOS:
-					method = "xamarin_create_classes_Xamarin_TVOS";
-					library = "Xamarin.TVOS.registrar.a";
+					libraryName = "Xamarin.TVOS";
 					break;
 				case ApplePlatform.MacCatalyst:
-					method = "xamarin_create_classes_Xamarin_MacCatalyst";
-					library = "Xamarin.MacCatalyst.registrar.a";
+					libraryName = "Xamarin.MacCatalyst";
 					break;
 				default:
 					throw ErrorHelper.CreateError (71, Errors.MX0071, App.Platform, App.ProductName);
 				}
+				method = StaticRegistrar.GetInitializationMethodName (libraryName);
+				library = libraryName + ".registrar.a";
 
 				var lib = Path.Combine (Driver.GetProductSdkLibDirectory (App), library);
 				if (File.Exists (lib)) {

--- a/tools/mtouch/Target.mtouch.cs
+++ b/tools/mtouch/Target.mtouch.cs
@@ -1257,11 +1257,12 @@ namespace Xamarin.Bundler {
 			List<string> registration_methods = new List<string> ();
 
 			// The static registrar.
+			RunRegistrarTask run_registrar_task = null;
 			if (App.Registrar == RegistrarMode.Static) {
 				var registrar_m = Path.Combine (ArchDirectory, "registrar.m");
 				var registrar_h = Path.Combine (ArchDirectory, "registrar.h");
 
-				var run_registrar_task = new RunRegistrarTask {
+				run_registrar_task = new RunRegistrarTask {
 					Target = this,
 					RegistrarCodePath = registrar_m,
 					RegistrarHeaderPath = registrar_h,
@@ -1343,6 +1344,8 @@ namespace Xamarin.Bundler {
 					MainM = main_m,
 					RegistrationMethods = registration_methods,
 				};
+				if (run_registrar_task is not null)
+					generate_main_task.AddDependency (run_registrar_task);
 				var main_o = Path.Combine (App.Cache.Location, arch, "main.o");
 				var main_task = new CompileMainTask {
 					Target = this,


### PR DESCRIPTION
This is a step towards having a registration map (and initialization method) for each assembly.

Ref: https://github.com/xamarin/xamarin-macios/issues/11309