### PR TITLE
[devops] Reset dependencies before adding provisioning profiles.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -194,6 +194,15 @@ steps:
   displayName: "Configure build"
   timeoutInMinutes: 5
 
+# Make sure we have the right maccore hash checked out before we try to add
+# the provisioning profiles.
+- bash: |
+    set -ex
+    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset
+  name: resetDependencies
+  dispayName: 'Reset dependencies'
+  timeoutInMinutes: 10
+
 # We'll need these profiles to build the hot restart prebuilt app during the build
 # (it's built for device, and thus needs a certificate available so that the app can be signed).
 # We do this again before running the tests further below.
@@ -220,7 +229,6 @@ steps:
     set -x
     set -e
     echo "##vso[task.setvariable variable=TESTS_BOT;isOutput=true]$AGENT_NAME"
-    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset
     MAKE_FLAGS=""
 
     if [[ "$SYSTEM_DEBUG" == "true" ]]; then

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -200,7 +200,7 @@ steps:
     set -ex
     time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset
   name: resetDependencies
-  dispayName: 'Reset dependencies'
+  displayName: 'Reset dependencies'
   timeoutInMinutes: 10
 
 # We'll need these profiles to build the hot restart prebuilt app during the build


### PR DESCRIPTION
This makes sure we're at the right maccore hash before adding provisioning
profile (in particular we want to be at the hash where the PR branch is at,
not the tip of main (which is the default)).