### PR TITLE
[DevOps] Use the project URI to calculate the project.

### DIFF
--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -184,6 +184,25 @@ function New-GitHubStatusesObject {
     return [GitHubStatuses]::new($Org, $Repo, $Token)
 }
 
+function New-GitHubStatusesObjectFromUrl {
+    param (
+
+        [ValidateNotNullOrEmpty ()]
+        [string]
+        $Url,
+
+        [ValidateNotNullOrEmpty ()]
+        [string]
+        $Token
+    )
+
+    $orgRepo = $Url.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    return [GitHubStatuses]::new($org, $repo, $Token)
+}
+
+
 class GitHubComment {
     [string] $Id
     [string] $Author
@@ -564,6 +583,32 @@ function New-GitHubCommentsObject {
         return [GitHubComments]::new($Org, $Repo, $Token)
     }
 }
+
+<# 
+    .SYNOPSIS
+        Creates a new GitHubComments object from a repo url so that can be used to create comments for the build.
+#>
+function New-GitHubCommentsObjectFromUrl {
+    param (
+
+        [ValidateNotNullOrEmpty ()]
+        [string]
+        $Url,
+
+        [ValidateNotNullOrEmpty ()]
+        [string]
+        $Token,
+
+        [string]
+        $Hash
+
+    )
+    Write-Debug "New-GitHubCommentsObjectFromUrl ('$Url', '$Token', '$Hash')"
+    $orgRepo = $Url.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+    return New-GitHubCommentsObject -Org $org -Repo $repo -Token $Token -Hash $Hash
+}
+
 
 <#
     .SYNOPSIS
@@ -1003,4 +1048,6 @@ Export-ModuleMember -Function Convert-Markdown
 
 # new future API that uses objects.
 Export-ModuleMember -Function New-GitHubCommentsObject
+Export-ModuleMember -Function New-GitHubCommentsObjectFromUrl
 Export-ModuleMember -Function New-GitHubStatusesObject
+Export-ModuleMember -Function New-GitHubStatusesObjectFromUrl

--- a/tools/devops/automation/templates/build/api-diff-process-results.yml
+++ b/tools/devops/automation/templates/build/api-diff-process-results.yml
@@ -74,11 +74,7 @@ steps:
       $converted = $inputContents + "`n`nUnable to convert markdown: $_`n`n"
     }
 
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
-
-    $githubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
+    $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
     $result = $githubComments.NewCommentFromMessage("", "", $converted)
   displayName: 'Publish GitHub comment for change detection'
   timeoutInMinutes: 10

--- a/tools/devops/automation/templates/build/api-diff-process-results.yml
+++ b/tools/devops/automation/templates/build/api-diff-process-results.yml
@@ -73,7 +73,6 @@ steps:
     } catch {
       $converted = $inputContents + "`n`nUnable to convert markdown: $_`n`n"
     }
-
     $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
     $result = $githubComments.NewCommentFromMessage("", "", $converted)
   displayName: 'Publish GitHub comment for change detection'

--- a/tools/devops/automation/templates/build/api-diff-process-results.yml
+++ b/tools/devops/automation/templates/build/api-diff-process-results.yml
@@ -73,7 +73,12 @@ steps:
     } catch {
       $converted = $inputContents + "`n`nUnable to convert markdown: $_`n`n"
     }
-    $githubComments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
+
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $githubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
     $result = $githubComments.NewCommentFromMessage("", "", $converted)
   displayName: 'Publish GitHub comment for change detection'
   timeoutInMinutes: 10

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -250,7 +250,6 @@ steps:
 # to write a comment.
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
- 
     $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token) -Hash $Env:GIT_HASH
     $githubComments.NewCommentFromMessage("Build failed", ":fire:", "Build failed for the job '$(System.JobDisplayName)'")
   condition: failed()

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -251,7 +251,11 @@ steps:
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
 
-    $githubComments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token) -Hash $Env:GIT_HASH
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $githubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $(GitHub.Token) -Hash $Env:GIT_HASH
     $githubComments.NewCommentFromMessage("Build failed", ":fire:", "Build failed for the job '$(System.JobDisplayName)'")
   condition: failed()
   displayName: 'Report build failure'

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -250,12 +250,8 @@ steps:
 # to write a comment.
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
-
-    $githubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $(GitHub.Token) -Hash $Env:GIT_HASH
+ 
+    $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token) -Hash $Env:GIT_HASH
     $githubComments.NewCommentFromMessage("Build failed", ":fire:", "Build failed for the job '$(System.JobDisplayName)'")
   condition: failed()
   displayName: 'Report build failure'

--- a/tools/devops/automation/templates/common/clean.yml
+++ b/tools/devops/automation/templates/common/clean.yml
@@ -18,7 +18,12 @@ steps:
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MaciosCI.psd1
-    $comments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $comments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $(GitHub.Token)
     $ciComment = "${{ parameters.commentToHide }}"
 
     $prId = "$(Build.SourceBranch)".Replace("refs/pull/", "").Replace("/merge", "")

--- a/tools/devops/automation/templates/common/clean.yml
+++ b/tools/devops/automation/templates/common/clean.yml
@@ -19,11 +19,7 @@ steps:
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MaciosCI.psd1
 
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
-
-    $comments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $(GitHub.Token)
+    $comments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
     $ciComment = "${{ parameters.commentToHide }}"
 
     $prId = "$(Build.SourceBranch)".Replace("refs/pull/", "").Replace("/merge", "")

--- a/tools/devops/automation/templates/common/status.yml
+++ b/tools/devops/automation/templates/common/status.yml
@@ -41,11 +41,8 @@ steps:
 - pwsh: |
     Import-Module .\\MaciosCI.psd1
     # calcualte the repo we are using, rather than using a parameter, we can use the URI from github, for example: https://github.com/xamarin/sdk-insertions
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
 
-    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token "${{ parameters.githubToken }}"
+    $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token "${{ parameters.githubToken }}"
     $statuses.SetStatus("${{ parameters.status }}", "${{ parameters.description }}", "${{ parameters.context }}", "${{ parameters.targetUrl }}")
   displayName: ${{ parameters.displayName }}
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts

--- a/tools/devops/automation/templates/common/status.yml
+++ b/tools/devops/automation/templates/common/status.yml
@@ -2,14 +2,6 @@
 
 parameters: 
 
-- name: org
-  type: string
-  default: "xamarin"
-
-- name: repo
-  type: string
-  default: "xamarin-macios"
-
 - name: githubToken
   type: string
 
@@ -48,7 +40,12 @@ steps:
 
 - pwsh: |
     Import-Module .\\MaciosCI.psd1
-    $statuses = New-GitHubStatusesObject -Org "${{ parameters.org }}" -Repo "${{ parameters.repo }}" -Token "${{ parameters.githubToken }}"
+    # calcualte the repo we are using, rather than using a parameter, we can use the URI from github, for example: https://github.com/xamarin/sdk-insertions
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token "${{ parameters.githubToken }}"
     $statuses.SetStatus("${{ parameters.status }}", "${{ parameters.description }}", "${{ parameters.context }}", "${{ parameters.targetUrl }}")
   displayName: ${{ parameters.displayName }}
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -29,7 +29,6 @@ steps:
 # if something goes wrong before we successfully complete the tests (in which case we delete the file).
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-
     $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
 
     Set-Content -Path "$Env:GITHUB_FAILURE_COMMENT_FILE" -Value "Tests on macOS ${{ parameters.statusContext }} failed for unknown reasons."
@@ -195,7 +194,6 @@ steps:
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-
     $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
 
     Write-Host "Found tests"
@@ -263,10 +261,8 @@ steps:
 # Make sure to report any errors
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-
     $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token) -Hash $Env:GIT_HASH
     $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
-    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
     
     if (Test-Path -Path "$Env:GITHUB_FAILURE_COMMENT_FILE" -PathType Leaf)  {
       $statuses.SetStatus("error", "Tests on macOS ${{ parameters.statusContext }} failed.", "${{ parameters.statusContext }}")

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -29,11 +29,8 @@ steps:
 # if something goes wrong before we successfully complete the tests (in which case we delete the file).
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
 
-    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
+    $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
 
     Set-Content -Path "$Env:GITHUB_FAILURE_COMMENT_FILE" -Value "Tests on macOS ${{ parameters.statusContext }} failed for unknown reasons."
     $statuses.SetStatus("pending", "Tests on macOS ${{ parameters.statusContext }} have started.", "${{ parameters.statusContext }}")
@@ -198,11 +195,8 @@ steps:
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
 
-    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
+    $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
 
     Write-Host "Found tests"
     $testsPath = "$(Build.SourcesDirectory)/artifacts/mac-test-package/tests"
@@ -269,11 +263,9 @@ steps:
 # Make sure to report any errors
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
 
-    $githubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $(GitHub.Token) -Hash $Env:GIT_HASH
+    $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token) -Hash $Env:GIT_HASH
+    $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
     $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
     
     if (Test-Path -Path "$Env:GITHUB_FAILURE_COMMENT_FILE" -PathType Leaf)  {

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -29,7 +29,11 @@ steps:
 # if something goes wrong before we successfully complete the tests (in which case we delete the file).
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-    $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
 
     Set-Content -Path "$Env:GITHUB_FAILURE_COMMENT_FILE" -Value "Tests on macOS ${{ parameters.statusContext }} failed for unknown reasons."
     $statuses.SetStatus("pending", "Tests on macOS ${{ parameters.statusContext }} have started.", "${{ parameters.statusContext }}")
@@ -194,7 +198,11 @@ steps:
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-    $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
 
     Write-Host "Found tests"
     $testsPath = "$(Build.SourcesDirectory)/artifacts/mac-test-package/tests"
@@ -261,8 +269,12 @@ steps:
 # Make sure to report any errors
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-    $githubComments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token) -Hash $Env:GIT_HASH
-    $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $githubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $(GitHub.Token) -Hash $Env:GIT_HASH
+    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
     
     if (Test-Path -Path "$Env:GITHUB_FAILURE_COMMENT_FILE" -PathType Leaf)  {
       $statuses.SetStatus("error", "Tests on macOS ${{ parameters.statusContext }} failed.", "${{ parameters.statusContext }}")

--- a/tools/devops/automation/templates/sign-and-notarized/artifact-github-comment.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/artifact-github-comment.yml
@@ -18,7 +18,6 @@ steps:
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $artifact = New-ArtifactsFromJsonFile -Path "$Env:ARTIFACTS_JSON_PATH"
-
     $gihubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
     $result = $gihubComments.NewCommentFromObject("Artifacts", ":books:", $artifact)
     Write-Host $result

--- a/tools/devops/automation/templates/sign-and-notarized/artifact-github-comment.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/artifact-github-comment.yml
@@ -18,7 +18,12 @@ steps:
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $artifact = New-ArtifactsFromJsonFile -Path "$Env:ARTIFACTS_JSON_PATH"
-    $gihubComments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
+
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $gihubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
     $result = $gihubComments.NewCommentFromObject("Artifacts", ":books:", $artifact)
     Write-Host $result
   env:

--- a/tools/devops/automation/templates/sign-and-notarized/artifact-github-comment.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/artifact-github-comment.yml
@@ -19,11 +19,7 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $artifact = New-ArtifactsFromJsonFile -Path "$Env:ARTIFACTS_JSON_PATH"
 
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
-
-    $gihubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
+    $gihubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH
     $result = $gihubComments.NewCommentFromObject("Artifacts", ":books:", $artifact)
     Write-Host $result
   env:

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -129,7 +129,11 @@ steps:
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\tools\devops\automation\scripts\MaciosCI.psd1
-    $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
 
     Dir "$(Build.SourcesDirectory)\\artifacts\\package"
 

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -129,11 +129,7 @@ steps:
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\tools\devops\automation\scripts\MaciosCI.psd1
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
-
-    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
+    $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
 
     Dir "$(Build.SourcesDirectory)\\artifacts\\package"
 

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -70,11 +70,8 @@ steps:
 # 3. Cancel the pipeline and do not execute any of the following steps.
 - pwsh: | 
     Import-Module ./MaciosCI.psd1
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
 
-    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
+    $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
 
     if ( -not (Test-HDFreeSpace -Size 20)) {
       $statuses.SetStatus("error", "Not enough free space in the host.", "${{ parameters.statusContext }}")

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -70,7 +70,11 @@ steps:
 # 3. Cancel the pipeline and do not execute any of the following steps.
 - pwsh: | 
     Import-Module ./MaciosCI.psd1
-    $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
 
     if ( -not (Test-HDFreeSpace -Size 20)) {
       $statuses.SetStatus("error", "Not enough free space in the host.", "${{ parameters.statusContext }}")

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -70,7 +70,6 @@ steps:
 # 3. Cancel the pipeline and do not execute any of the following steps.
 - pwsh: | 
     Import-Module ./MaciosCI.psd1
-
     $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
 
     if ( -not (Test-HDFreeSpace -Size 20)) {

--- a/tools/devops/automation/templates/tests/publish-html.yml
+++ b/tools/devops/automation/templates/tests/publish-html.yml
@@ -72,11 +72,7 @@ steps:
           $emoji = ":fire:"
         }
 
-        $uri = $(Build.Repository.Uri)
-        $orgRepo = $uri.Replace("https://github.com/", "")
-        $org, $repo = $orgRepo -split "/",2
-
-        $gihubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH -Debug
+        $gihubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH -Debug
         $result = $gihubComments.NewCommentFromObject("Test results", $emoji, $parallelResults)
       } catch {
         New-GitHubComment -Header "Failed to compute test summaries on $Env:CONTEXT" -Emoji ":fire:" -Description "Failed to compute test summaries: $_."

--- a/tools/devops/automation/templates/tests/publish-html.yml
+++ b/tools/devops/automation/templates/tests/publish-html.yml
@@ -72,7 +72,11 @@ steps:
           $emoji = ":fire:"
         }
 
-        $gihubComments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH -Debug
+        $uri = $(Build.Repository.Uri)
+        $orgRepo = $uri.Replace("https://github.com/", "")
+        $org, $repo = $orgRepo -split "/",2
+
+        $gihubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH -Debug
         $result = $gihubComments.NewCommentFromObject("Test results", $emoji, $parallelResults)
       } catch {
         New-GitHubComment -Header "Failed to compute test summaries on $Env:CONTEXT" -Emoji ":fire:" -Description "Failed to compute test summaries: $_."

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -236,11 +236,7 @@ steps:
     $testAttempt = [int]"$(System.JobAttempt)"
     $testResult = New-TestResults -Path $testResultsPath -Status "$(runTests.TESTS_JOBSTATUS)" -Context "${{ parameters.statusContext }}" -Attempt $testAttempt
 
-    $uri = $(Build.Repository.Uri)
-    $orgRepo = $uri.Replace("https://github.com/", "")
-    $org, $repo = $orgRepo -split "/",2
-
-    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
+    $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
     $statuses.SetStatus($testResult.GetStatus())
   displayName: "Set tests status."
   continueOnError: true

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -236,7 +236,11 @@ steps:
     $testAttempt = [int]"$(System.JobAttempt)"
     $testResult = New-TestResults -Path $testResultsPath -Status "$(runTests.TESTS_JOBSTATUS)" -Context "${{ parameters.statusContext }}" -Attempt $testAttempt
 
-    $statuses = New-GitHubStatusesObject -Org "xamarin" -Repo "xamarin-macios" -Token $(GitHub.Token)
+    $uri = $(Build.Repository.Uri)
+    $orgRepo = $uri.Replace("https://github.com/", "")
+    $org, $repo = $orgRepo -split "/",2
+
+    $statuses = New-GitHubStatusesObject -Org $org -Repo $repo -Token $(GitHub.Token)
     $statuses.SetStatus($testResult.GetStatus())
   displayName: "Set tests status."
   continueOnError: true

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -205,7 +205,11 @@ stages:
     - pwsh: |
         Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
 
-        $gihubComments = New-GitHubCommentsObject -Org "xamarin" -Repo "xamarin-macios" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH -Debug
+        $uri = $(Build.Repository.Uri)
+        $orgRepo = $uri.Replace("https://github.com/", "")
+        $org, $repo = $orgRepo -split "/",2
+
+        $gihubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH -Debug
         $sb = [System.Text.StringBuilder]::new()
         $sb.AppendLine("All tests have been skipped because the label 'skip-all-tests' was set.")
         $result = $gihubComments.NewCommentFromMessage("Test results", ":seedling:", $sb.ToString())

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -205,11 +205,7 @@ stages:
     - pwsh: |
         Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
 
-        $uri = $(Build.Repository.Uri)
-        $orgRepo = $uri.Replace("https://github.com/", "")
-        $org, $repo = $orgRepo -split "/",2
-
-        $gihubComments = New-GitHubCommentsObject -Org $org -Repo $repo -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH -Debug
+        $gihubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $Env:GITHUB_TOKEN -Hash $Env:GIT_HASH -Debug
         $sb = [System.Text.StringBuilder]::new()
         $sb.AppendLine("All tests have been skipped because the label 'skip-all-tests' was set.")
         $result = $gihubComments.NewCommentFromMessage("Test results", ":seedling:", $sb.ToString())


### PR DESCRIPTION
The template can be run by a diff pipeline, that means that the project and the commit wont point to xmarin/xamarin-macios. We use the URI to calculate the org and the repo to be passed to the pwh objects.

Fixes https://github.com/xamarin/sdk-insertions/issues/43