### PR TITLE
[devops] Augment the install-workloads.sh script to make it easier to run locally.

### DIFF
--- a/tools/devops/automation/scripts/bash/install-workloads.sh
+++ b/tools/devops/automation/scripts/bash/install-workloads.sh
@@ -5,6 +5,39 @@ IFS=$'\n\t '
 
 env | sort
 
+# This script can be executed locally by downloading the 'WorkloadRollback'
+# and 'not-signed-package' artifacts from an Azure DevOps build, and then
+# extracting the files into the xamarin-macios/../artifacts directory.
+
+# If BUILD_SOURCESDIRECTORY is not set, it's likely we're executing locally.
+# In which case we can figure out where we are from the current git checkout
+# (and also set BUILD_SOURCESDIRECTORY accordingly, since the rest of the
+# script needs it).
+if test -z "${BUILD_SOURCESDIRECTORY:-}"; then
+  BUILD_SOURCESDIRECTORY="$(git rev-parse --show-toplevel)/.."
+fi
+# Don't assume we're in the right directory (makes it easier to run the script
+# locally).
+cd "$BUILD_SOURCESDIRECTORY/xamarin-macios"
+
+# Validate a few things
+ARTIFACTS_PATH=$BUILD_SOURCESDIRECTORY/artifacts
+if ! test -d "$ARTIFACTS_PATH"; then
+  echo "The path to the artifects ($ARTIFACTS_PATH) does not exist!"
+  exit 1
+elif [[ $(find "$ARTIFACTS_PATH/not-signed-package" -type f -name '*.nupkg' -or -name '*.pkg' -or -name '*.zip' | wc -l) -lt 1 ]]; then
+  echo "No artifacts found in $ARTIFACTS_PATH/not-signed-package"
+  echo "If you're running this locally, download the 'not-signed-package' artifact and extract it into $ARTIFACTS_PATH/not-signed-package"
+  exit 1
+fi
+
+ROLLBACK_PATH="$ARTIFACTS_PATH/WorkloadRollback/WorkloadRollback.json"
+if ! test -f "$ROLLBACK_PATH"; then
+  echo "The rollback file $ROLLBACK_PATH does not exist!"
+  exit 1
+fi
+
+#  Start working
 make global.json
 make -C builds dotnet CUSTOM_DOTNET_RUNTIME_INSTALL=1
 
@@ -20,16 +53,14 @@ var=$(make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-abspat
 DOTNET_NUPKG_DIR=${var#*=}
 echo "Using nuget dir $DOTNET_NUPKG_DIR"
 
-ROLLBACK_PATH="$BUILD_SOURCESDIRECTORY/artifacts/WorkloadRollback/WorkloadRollback.json"
-
 echo "Rollback file contents:"
 cat "$ROLLBACK_PATH"
 
 mkdir -p "$DOTNET_NUPKG_DIR"
-ls -R "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package"
-cp "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package/"*.nupkg "$DOTNET_NUPKG_DIR"
-cp "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package/"*.pkg "$DOTNET_NUPKG_DIR"
-cp "$BUILD_SOURCESDIRECTORY/artifacts/not-signed-package/"*.zip "$DOTNET_NUPKG_DIR"
+ls -R "$ARTIFACTS_PATH/not-signed-package"
+cp "$ARTIFACTS_PATH/not-signed-package/"*.nupkg "$DOTNET_NUPKG_DIR"
+cp "$ARTIFACTS_PATH/not-signed-package/"*.pkg "$DOTNET_NUPKG_DIR"
+cp "$ARTIFACTS_PATH/not-signed-package/"*.zip "$DOTNET_NUPKG_DIR"
 ls -R "$DOTNET_NUPKG_DIR"
 
 NUGET_SOURCES=$(grep https://pkgs.dev.azure.com ./NuGet.config | sed -e 's/.*value="//'  -e 's/".*//')


### PR DESCRIPTION
It's often desired to run the install-workloads.sh script locally, in order to
diagnose problems with it.

So improve it a bit by:

* Adding a few comments explaining things.
* Don't assume we're in the correct directory.
* Figure out BUILD_SOURCESDIRECTORY if it's not already set.
* Validate a bit and show more helpful errors.

Hopefully future me will be grateful!