### PR TITLE
[tests] Fix conditional logic for .NET 7+.

### DIFF
--- a/tests/linker/ios/link sdk/CryptoTest.cs
+++ b/tests/linker/ios/link sdk/CryptoTest.cs
@@ -31,7 +31,7 @@ namespace LinkSdk {
 			// located inside System.Core.dll - IOW the linker needs to be aware of this
 			Aes aes = Aes.Create ();
 			Assert.NotNull (aes, "Aes");
-#if NET7_0
+#if NET7_0_OR_GREATER
 			const string prefix = "System.Security.Cryptography, ";
 #elif NET
 			const string prefix = "System.Security.Cryptography.Algorithms, ";


### PR DESCRIPTION
Fixes this test in .NET 8:

    AesCreate: System.Security.Cryptography.Algorithms,
        Expected: String starting with "System.Security.Cryptography.Algorithms, "
        But was: "System.Security.Cryptography, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"