### PR TITLE
[dotnet] Shorten prerelease identifier to make package names shorter.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -118,7 +118,9 @@ endif
 ## change *first*, otherwise we'll produce builds with the same version from
 ## two different branches (which is very, very bad).
 ##
-NUGET_HARDCODED_PRERELEASE_IDENTIFIER=net8.0-preview.1
+## Note that the prerelease identifier should be as short as possible, because otherwise
+## the resulting package name can become too long for MSIs.
+NUGET_HARDCODED_PRERELEASE_IDENTIFIER=net8-p1
 NUGET_HARDCODED_PRERELEASE_BRANCH=net8.0
 
 # compute the alphanumeric version of branch names


### PR DESCRIPTION
MSIs has a limit:

> Relative package path exceeds the maximum length (182): Microsoft.MacCatalyst.Manifest-8.0.100-alpha.1,version=128.67.51819,chip=x86,productarch=neutral\Microsoft.NET.Sdk.MacCatalyst.Manifest-8.0.100-alpha.1.16.1.555-net8.0-preview.1-x86.msi

So use a shorter prerelease identifier to try to not reach this limit.