### PR TITLE
[DevOps] Checkout the yaml repos to fix an issue with the working dir.

### DIFF
--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -117,7 +117,7 @@ steps:
         Write-Host "Build task not found at $execPath!"
     }
 
-    $maciosPath="$Env:BUILD_SOURCESDIRECTORY"
+    $maciosPath="$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios"
 
     Write-Host "Exect path is $execPath"
     Write-Host "Macios path is $maciosPath"

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -32,6 +32,9 @@ steps:
     persistCredentials: true
     path: s/xamarin-macios
 
+- checkout: yaml-templates
+  clean: true
+
 # Download the Html Report that was added by the tests job.
 - task: DownloadPipelineArtifact@2
   displayName: Download packages
@@ -138,7 +141,7 @@ steps:
   continueOnError: true
 
 - pwsh: |
-    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\tools\devops\automation\scripts\MaciosCI.psd1
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
     $statuses = New-GitHubStatusesObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token)
 
     Dir "$(Build.SourcesDirectory)\\artifacts\\package"

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -32,6 +32,8 @@ steps:
     persistCredentials: true
     path: s/xamarin-macios
 
+# checkout an extra repo to ensure that we have the same tree structure in the working directory in all pipelines.
+# if you delete this checkout the unified pipeline will have issues.
 - checkout: yaml-templates
   clean: true
 


### PR DESCRIPTION
Azure pipelines has this terrible design in which the path of the checkout is different depending if you checkout a single repo or several.

In this case, we have no issues on macios because we do know we have not been checkout with anyother repo in the upload step, that is not the case when working on the unified pipeline. Rather than adding some complicated logic, we are going to be checking out the yaml templates so that we have the same working directory structure.