### PR TITLE
[autoformat] Autoformat after a PR race.

### DIFF
--- a/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
+++ b/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
@@ -84,7 +84,7 @@ namespace MonoTouchFixtures.AudioUnit {
 		}
 
 		[Test]
-		public unsafe void TestSizeOf()
+		public unsafe void TestSizeOf ()
 		{
 			Assert.AreEqual (sizeof (AudioFormat), Marshal.SizeOf (typeof (AudioFormat)));
 			Assert.AreEqual (sizeof (AudioValueRange), Marshal.SizeOf (typeof (AudioValueRange)));


### PR DESCRIPTION
There was a PR race:

1. I created a PR to autoformat monotouch-test code.
2. Another PR added incorrectly formatted code to monotouch-test.
3. The first PR was merged, everything was fine.
4. The second PR was merged (it was green) - but its code hadn't been
   autoformatted.
5. Now there's incorrectly formatted code in the repo, which will show up in
   every new PR.