### PR TITLE
[xtro] Fix targets file and print out full path to the html report.

### DIFF
--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -196,11 +196,11 @@ report: report/index.html
 endif
 
 ifdef ENABLE_DOTNET
-dotnet-report/index.html: xtro-report/bin/Debug/xtro-report.exe .stamp-dotnet-classify
+report-dotnet/index.html: xtro-report/bin/Debug/xtro-report.exe .stamp-dotnet-classify
 	rm -rf report-dotnet
 	$(MONO) xtro-report/bin/Debug/xtro-report.exe $(DOTNET_ANNOTATIONS_DIR) report-dotnet
 
-dotnet-report: dotnet-report/index.html
+dotnet-report: report-dotnet/index.html
 endif
 
 report-short:

--- a/tests/xtro-sharpie/xtro-report/Reporter.cs
+++ b/tests/xtro-sharpie/xtro-report/Reporter.cs
@@ -270,7 +270,7 @@ namespace Extrospection {
 			log.Flush ();
 
 			Console.WriteLine ($"@MonkeyWrench: SetSummary: {errors} unclassified found.");
-			Console.WriteLine ($"Created {indexPath}");
+			Console.WriteLine ($"Created {Path.GetFullPath (indexPath)}");
 
 			return errors == 0 ? 0 : 1;
 		}


### PR DESCRIPTION
There was a typo in the target name for creating the html report for .NET
('report-dotnet' vs 'dotnet-report').

Also print out the full path the html report when it's created, makes it much
easier to open the file from the command line because I can c&p the entire
path.