### PR TITLE
[generator] Fix warnings in api definitions.

### DIFF
--- a/src/PassKit/PKEnums.cs
+++ b/src/PassKit/PKEnums.cs
@@ -189,10 +189,12 @@ namespace PassKit {
 		[Mac (12,0), iOS (15,0), Watch (8,0)]
 		Continue = 16,
 #if !NET
+#pragma warning disable 0618 // warning CS0618: 'PKPaymentButtonType.[field]' is obsolete: 'Use '[replacement]'.'
 		[iOS (12,0)]
 		Book2 = Checkout,
 		[iOS (12,0)]
 		Checkout2 = Book,
+#pragma warning restore
 #endif // !NET
 	}
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -5338,22 +5338,30 @@ namespace AppKit {
 	, NSEditor // Conflict over if CommitEditing is a property or a method. NSViewController has it right so can't "fix" NSEditor to match existing API
 #endif
 	{
+#pragma warning disable 0108 // warning CS0108: 'NSController.DiscardEditing()' hides inherited member 'NSEditor.DiscardEditing()'. Use the new keyword if hiding was intended.
 		[Export ("discardEditing")]
 		void DiscardEditing ();
+#pragma warning restore
 
 		[Export ("commitEditingWithDelegate:didCommitSelector:contextInfo:")]
 #if NET
+#pragma warning disable 0108 // warning CS0108: 'NSController.CommitEditing(NSObject, Selector, nint)' hides inherited member 'NSEditor.CommitEditing(NSObject, Selector, nint)'. Use the new keyword if hiding was intended.
 		void CommitEditing ([NullAllowed] NSObject delegate1, [NullAllowed] Selector didCommitSelector, IntPtr contextInfo);
+#pragma warning restore
 #else
 		void CommitEditingWithDelegate ([NullAllowed] NSObject delegate1, [NullAllowed] Selector didCommitSelector, IntPtr contextInfo);
 #endif
 
 #if NET
+#pragma warning disable 0108 // warning CS0108: 'NSController.ObjectDidBeginEditing(INSEditor)' hides inherited member 'NSEditorRegistration.ObjectDidBeginEditing(INSEditor)'. Use the new keyword if hiding was intended.
 		[Export ("objectDidBeginEditing:")]
 		void ObjectDidBeginEditing (INSEditor editor);
+#pragma warning restore
 
+#pragma warning disable 0108 // warning CS0108: 'NSController.ObjectDidEndEditing(INSEditor)' hides inherited member 'NSEditorRegistration.ObjectDidEndEditing(INSEditor)'. Use the new keyword if hiding was intended.
 		[Export ("objectDidEndEditing:")]
 		void ObjectDidEndEditing (INSEditor editor);
+#pragma warning restore
 #else
 		[Export ("objectDidBeginEditing:")]
 		void ObjectDidBeginEditing (NSObject editor);
@@ -5364,7 +5372,9 @@ namespace AppKit {
 
 		[Export ("commitEditing")]
 #if NET
+#pragma warning disable 0108 // warning CS0108: 'NSController.CommitEditing()' hides inherited member 'NSEditor.CommitEditing()'. Use the new keyword if hiding was intended.
 		bool CommitEditing ();
+#pragma warning restore
 #else
 		bool CommitEditing { get; }
 #endif
@@ -5970,8 +5980,10 @@ namespace AppKit {
 		// Found in NSUserInterfaceValidations protocol with INSValidatedUserInterfaceItem param but bound originally with NSObject
 		// Adding protocol gave warning 0108 which is unfixable without API break 
 #if NET
+#pragma warning disable 0108 // warning CS0108: 'NSDocument.ValidateUserInterfaceItem(INSValidatedUserInterfaceItem)' hides inherited member 'NSUserInterfaceValidations.ValidateUserInterfaceItem(INSValidatedUserInterfaceItem)'. Use the new keyword if hiding was intended.
 		[Export ("validateUserInterfaceItem:")]
 		bool ValidateUserInterfaceItem (INSValidatedUserInterfaceItem anItem);
+#pragma warning restore
 #else
 		[Export ("validateUserInterfaceItem:")]
 		bool ValidateUserInterfaceItem (NSObject /* must implement NSValidatedUserInterfaceItem */ anItem);
@@ -6110,7 +6122,7 @@ namespace AppKit {
 		// Should be removed but radar://42781537 - Classes fail to conformsToProtocol despite header declaration
 		[Mac (10,10)]
 		[Export ("restoreUserActivityState:")]
-		void RestoreUserActivityState (NSUserActivity userActivity);
+		new void RestoreUserActivityState (NSUserActivity userActivity);
 #endif
 
 		[Mac (10,12)]
@@ -6256,8 +6268,10 @@ namespace AppKit {
 		// Found in NSUserInterfaceValidations protocol with INSValidatedUserInterfaceItem param but bound originally with NSObject
 		// Adding protocol gave warning 0108 which is unfixable without API break 
 #if NET
+#pragma warning disable 0108 // warning CS0108: 'NSDocumentController.ValidateUserInterfaceItem(INSValidatedUserInterfaceItem)' hides inherited member 'NSUserInterfaceValidations.ValidateUserInterfaceItem(INSValidatedUserInterfaceItem)'. Use the new keyword if hiding was intended.
 		[Export ("validateUserInterfaceItem:")]
 		bool ValidateUserInterfaceItem (INSValidatedUserInterfaceItem anItem);
+#pragma warning restore
 #else
 		[Export ("validateUserInterfaceItem:")]
 		bool ValidateUserInterfaceItem (NSObject /* must implement NSValidatedUserInterfaceItem */ anItem);
@@ -13125,7 +13139,7 @@ namespace AppKit {
 		// Should be removed but radar://42781537 - Classes fail to conformsToProtocol despite header declaration
 		[Mac (10,10)]
 		[Export ("restoreUserActivityState:")]
-		void RestoreUserActivityState (NSUserActivity userActivity);
+		new void RestoreUserActivityState (NSUserActivity userActivity);
 #endif
 
 		[Mac (10,10,3)]
@@ -19496,11 +19510,15 @@ namespace AppKit {
 		[Protocolize]
 		NSTextViewDelegate Delegate { get; set; }
 
+#pragma warning disable 0109 // warning CS0109: The member 'NSTextView.Editable' does not hide an accessible member. The new keyword is not required.
 		[Export ("editable")]
 		new bool Editable { [Bind ("isEditable")]get; set; }
+#pragma warning restore
 
+#pragma warning disable 0109 // warning CS0109: The member 'NSTextView.Selectable' does not hide an accessible member. The new keyword is not required.
 		[Export ("selectable")]
 		new bool Selectable { [Bind ("isSelectable")]get; set; }
+#pragma warning restore
 
 		[Export ("richText")]
 		bool RichText { [Bind ("isRichText")]get; set; }
@@ -27477,8 +27495,10 @@ namespace AppKit {
 		[Export ("downloadedFontDescriptors", ArgumentSemantic.Copy)]
 		NSFontDescriptor[] DownloadedFontDescriptors { get; }
 
+#pragma warning disable 0108 // warning CS0108: 'NSFontAssetRequest.Progress' hides inherited member 'NSProgressReporting.Progress'. Use the new keyword if hiding was intended.
 		[Export ("progress", ArgumentSemantic.Strong)]
 		NSProgress Progress { get; }
+#pragma warning restore
 
 		[Export ("downloadFontAssetsWithCompletionHandler:")]
 		void DownloadFontAssets (DownloadFontAssetsRequestCompletionHandler completionHandler);

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -4924,11 +4924,15 @@ namespace AVFoundation {
 		[return: Release]
 		CMFormatDescription CopyCurrentSampleFormatDescription ();
 
+#pragma warning disable 0618 // warning CS0618: 'AVSampleCursorSyncInfo' is obsolete: 'This API is not available on this platform.'
 		[Export ("currentSampleSyncInfo")]
 		AVSampleCursorSyncInfo CurrentSampleSyncInfo { get; }
+#pragma warning restore
 
+#pragma warning disable 0618 // warning CS0618: 'AVSampleCursorSyncInfo' is obsolete: 'This API is not available on this platform.'
 		[Export ("currentSampleDependencyInfo")]
 		AVSampleCursorSyncInfo CurrentSampleDependencyInfo { get; }
+#pragma warning restore
 
 		[Mac (10,11)]
 		[Export ("samplesRequiredForDecoderRefresh")]
@@ -4938,17 +4942,23 @@ namespace AVFoundation {
 		[Export ("currentChunkStorageURL")]
 		NSUrl CurrentChunkStorageUrl { get; }
 
+#pragma warning disable 0618 // warning CS0618: 'AVSampleCursorStorageRange' is obsolete: 'This API is not available on this platform.'
 		[Export ("currentChunkStorageRange")]
 		AVSampleCursorStorageRange CurrentChunkStorageRange { get; }
+#pragma warning restore
 
+#pragma warning disable 0618 // warning CS0618: 'AVSampleCursorChunkInfo' is obsolete: 'This API is not available on this platform.'
 		[Export ("currentChunkInfo")]
 		AVSampleCursorChunkInfo CurrentChunkInfo { get; }
+#pragma warning restore
 
 		[Export ("currentSampleIndexInChunk")]
 		long CurrentSampleIndexInChunk { get; }
 
+#pragma warning disable 0618 // warning CS0618: 'AVSampleCursorStorageRange' is obsolete: 'This API is not available on this platform.'
 		[Export ("currentSampleStorageRange")]
 		AVSampleCursorStorageRange CurrentSampleStorageRange { get; }
+#pragma warning restore
 
 #if MONOMAC
 		[NoiOS][NoWatch][NoTV]

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -636,6 +636,9 @@ public class BindingTouch : IDisposable {
 
 		if (Driver.RunCommand (compile_command [0], arguments, null, out var compile_output, true, Driver.Verbosity) != 0)
 			throw ErrorHelper.CreateError (errorCode, $"{compiler} {StringUtils.FormatArguments (arguments)}\n{compile_output}".Replace ("\n", "\n\t"));
+		var output = string.Join (Environment.NewLine, compile_output.ToString ().Split (new char [] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
+		if (!string.IsNullOrEmpty (output))
+			Console.WriteLine (output);
 	}
 
 	static string GetWorkDir ()

--- a/src/carplay.cs
+++ b/src/carplay.cs
@@ -1592,6 +1592,9 @@ namespace CarPlay {
 
 		[Field ("CPMaximumNumberOfGridImages")]
 		nuint MaximumNumberOfGridImages { get; }
+
+		[NullAllowed, Export ("text")]
+		new string Text { get; set; }
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]
@@ -1655,6 +1658,9 @@ namespace CarPlay {
 
 		[Field ("CPMaximumMessageItemImageSize")]
 		CGSize MaximumMessageItemImageSize { get; }
+
+		[NullAllowed, Export ("text")]
+		new string Text { get; set; }
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]

--- a/src/carplay.cs
+++ b/src/carplay.cs
@@ -506,9 +506,6 @@ namespace CarPlay {
 		[Export ("initWithText:detailText:image:accessoryImage:accessoryType:")]
 		NativeHandle Constructor ([NullAllowed] string text, [NullAllowed] string detailText, [NullAllowed] UIImage image, [NullAllowed] UIImage accessoryImage, CPListItemAccessoryType accessoryType);
 
-		[NullAllowed, Export ("text")]
-		new string Text { get; }
-
 		[NullAllowed, Export ("detailText")]
 		string DetailText { get; }
 
@@ -518,9 +515,6 @@ namespace CarPlay {
 		[Deprecated (PlatformName.iOS, 14, 0)]
 		[Export ("showsDisclosureIndicator")]
 		bool ShowsDisclosureIndicator { get; }
-
-		[NullAllowed, Export ("userInfo", ArgumentSemantic.Strong)]
-		new NSObject UserInfo { get; set; }
 
 		[iOS (14, 0)]
 		[Export ("explicitContent")]
@@ -566,14 +560,6 @@ namespace CarPlay {
 		[iOS (14,0)]
 		[Export ("setText:")]
 		void SetText (string text);
-
-		[NullAllowed, iOS (14, 0)]
-		[Export ("handler", ArgumentSemantic.Copy)]
-		new CPSelectableListItemHandler Handler { get; set; }
-
-		[iOS (15, 0), MacCatalyst (15,0)]
-		[Export ("enabled")]
-		bool Enabled { [Bind ("isEnabled")] get; set; }
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (12,0)]
@@ -1600,26 +1586,12 @@ namespace CarPlay {
 		[NullAllowed, Export ("listImageRowHandler", ArgumentSemantic.Copy)]
 		CPListImageRowItemHandler ListImageRowHandler { get; set; }
 
-		[Export ("handler", ArgumentSemantic.Copy)]
-		[NullAllowed]
-		new CPSelectableListItemHandler Handler { get; set; }
-
 		[Static]
 		[Export ("maximumImageSize")]
 		CGSize MaximumImageSize { get; }
 
 		[Field ("CPMaximumNumberOfGridImages")]
 		nuint MaximumNumberOfGridImages { get; }
-
-		[NullAllowed, Export ("text")]
-		new string Text { get; set; }
-
-		[NullAllowed, Export ("userInfo", ArgumentSemantic.Strong)]
-		new NSObject UserInfo { get; set; }
-
-		[iOS (15, 0), MacCatalyst (15,0)]
-		[Export ("enabled")]
-		bool Enabled { [Bind ("isEnabled")] get; set; }
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]
@@ -1683,16 +1655,6 @@ namespace CarPlay {
 
 		[Field ("CPMaximumMessageItemImageSize")]
 		CGSize MaximumMessageItemImageSize { get; }
-
-		[NullAllowed, Export ("text")]
-		new string Text { get; set; }
-
-		[NullAllowed, Export ("userInfo", ArgumentSemantic.Strong)]
-		new NSObject UserInfo { get; set; }
-
-		[iOS (15, 0), MacCatalyst (15,0)]
-		[Export ("enabled")]
-		bool Enabled { [Bind ("isEnabled")] get; set; }
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (14,0)]

--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -1586,7 +1586,9 @@ namespace Contacts {
 
 #if !NET
 	[iOS (9,0), Mac (10,11)]
+#pragma warning disable 0618 // warning CS0618: 'CategoryAttribute.CategoryAttribute(bool)' is obsolete: 'Inline the static members in this category in the category's class (and remove this obsolete once fixed)'
 	[Category (allowStaticMembers: true)]
+#pragma warning disable
 	[BaseType (typeof (CNContainer))]
 	interface CNContainer_PredicatesExtension {
 
@@ -1682,7 +1684,9 @@ namespace Contacts {
 
 #if !NET
 	[iOS (9,0), Mac (10,11)]
+#pragma warning disable 0618 // warning CS0618: 'CategoryAttribute.CategoryAttribute(bool)' is obsolete: 'Inline the static members in this category in the category's class (and remove this obsolete once fixed)'
 	[Category (allowStaticMembers: true)]
+#pragma warning disable
 	[BaseType (typeof (CNGroup))]
 	interface CNGroup_PredicatesExtension {
 

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -1046,17 +1046,21 @@ namespace CoreData
 		[Export ("save:")]
 		bool Save (out NSError error);
 
+#pragma warning disable 0109 // warning CS0109: The member 'NSManagedObjectContext.Lock()' does not hide an accessible member. The new keyword is not required.
 		[NoWatch][NoTV]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'PerformAndWait' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'PerformAndWait' instead.")]
 		[Export ("lock")]
 		new void Lock ();
+#pragma warning restore
 
+#pragma warning disable 0109 // warning CS0109: The member 'NSManagedObjectContext.Unlock()' does not hide an accessible member. The new keyword is not required.
 		[NoWatch][NoTV]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'PerformAndWait' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'PerformAndWait' instead.")]
 		[Export ("unlock")]
 		new void Unlock ();
+#pragma warning restore
 
 		[NoWatch][NoTV]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'Perform' instead.")]
@@ -2059,17 +2063,21 @@ namespace CoreData
 		[return: NullAllowed]
 		NSManagedObjectID ManagedObjectIDForURIRepresentation (NSUrl url);
 
+#pragma warning disable 0109 // warning CS0109: The member 'NSManagedObjectContext.Lock()' does not hide an accessible member. The new keyword is not required.
 		[NoWatch][NoTV]
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'PerformAndWait' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'PerformAndWait' instead.")]
 		[Export ("lock")]
 		new void Lock ();
+#pragma warning restore
 
+#pragma warning disable 0109 // warning CS0109: The member 'NSManagedObjectContext.Unlock()' does not hide an accessible member. The new keyword is not required.
 		[NoWatch][NoTV]
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'PerformAndWait' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'PerformAndWait' instead.")]
 		[Export ("unlock")]
 		new void Unlock ();
+#pragma warning restore
 
 		[NoWatch][NoTV]
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'Perform' instead.")]

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -1728,7 +1728,7 @@ namespace CoreImage {
 		[Static]
 		[Wrap ("FromData (data, options.GetDictionary ())")]
 		[return: NullAllowed]
-		CIImage FromData (NSData data, [NullAllowed] CIImageInitializationOptionsWithMetadata? options);
+		CIImage FromData (NSData data, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
 
 		[Static]
 		[iOS(9,0)]
@@ -1795,7 +1795,7 @@ namespace CoreImage {
 		[Mac (10,13)]
 		[Static]
 		[Wrap ("FromSurface (surface, options.GetDictionary ())")]
-		CIImage FromSurface (IOSurface.IOSurface surface, CIImageInitializationOptions? options);
+		CIImage FromSurface (IOSurface.IOSurface surface, CIImageInitializationOptions options);
 
 		[Static]
 		[Export ("imageWithColor:")]

--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -2417,9 +2417,13 @@ namespace GameController {
 	[Mac (13,0), iOS (16,0), MacCatalyst (16,0), NoWatch, TV (16,0)]
 	[Protocol]
 	interface GCDevicePhysicalInput : GCDevicePhysicalInputState {
+#if !XAMCORE_5_0
+#pragma warning disable 0108 // warning CS0108: 'GCDevicePhysicalInput.Device' hides inherited member 'GCDevicePhysicalInputState.Device'. Use the new keyword if hiding was intended.
 		[Abstract]
 		[NullAllowed, Export ("device", ArgumentSemantic.Weak)]
 		IGCDevice Device { get; }
+#pragma warning restore
+#endif
 
 		[Abstract]
 		[NullAllowed, Export ("elementValueDidChangeHandler", ArgumentSemantic.Copy)]

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -4205,7 +4205,9 @@ namespace HealthKit {
 
 		[iOS (15,4)]
 		[Export ("initWithRecordTypes:sourceTypes:predicate:resultsHandler:")]
+#pragma warning disable 8632 // warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 		IntPtr Constructor (string [] recordTypes, [BindAs (typeof (HKVerifiableClinicalRecordSourceType []))] NSString [] sourceTypes, [NullAllowed] NSPredicate predicate, Action<HKVerifiableClinicalRecordQuery, HKVerifiableClinicalRecord []?, NSError?> resultsHandler);
+#pragma warning restore
 	}
 
 	[NoWatch, iOS (15,0), Mac (13,0)]

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -1888,8 +1888,10 @@ namespace MapKit {
 		[NullAllowed]
 		string URLTemplate { get; }
 
+#pragma warning disable 0109 // warning CS0109: The member 'MKTileOverlay.CanReplaceMapContent' does not hide an accessible member. The new keyword is not required.
 		[Export ("canReplaceMapContent")]
 		new bool CanReplaceMapContent { get; set; }
+#pragma warning restore
 
 		[Export ("URLForTilePath:")]
 		NSUrl URLForTilePath (MKTileOverlayPath path);

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -1624,7 +1624,9 @@ namespace Metal {
 		[Abstract]
 #endif
 		[Export ("accelerationStructureSizesWithDescriptor:")]
+#pragma warning disable 0618 // warning CS0618: 'MTLAccelerationStructureSizes' is obsolete: 'This API is not available on this platform.'
 		MTLAccelerationStructureSizes CreateAccelerationStructureSizes (MTLAccelerationStructureDescriptor descriptor);
+#pragma warning restore
 
 		[Mac (11,0), iOS (14,0), NoTV]
 #if NET

--- a/src/notificationcenter.cs
+++ b/src/notificationcenter.cs
@@ -79,7 +79,9 @@ namespace NotificationCenter {
 	[Internal]
 	[Category]
 #else
+#pragma warning disable 0618 // warning CS0618: 'CategoryAttribute.CategoryAttribute(bool)' is obsolete: 'Inline the static members in this category in the category's class (and remove this obsolete once fixed)'
 	[Category (allowStaticMembers: true)] // Classic isn't internal so we need this
+#pragma warning restore
 #endif
 	interface UIVibrancyEffect_NotificationCenter {
 		[Internal]

--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -1451,7 +1451,9 @@ namespace PdfKit {
 		[NoiOS]
 		[Export ("printOperationForPrintInfo:scalingMode:autoRotate:")]
 		[return: NullAllowed]
+#pragma warning disable 0618 // 'PdfPrintScalingMode' is obsolete: 'This type is not available on iOS.'
 		NSPrintOperation GetPrintOperation ([NullAllowed] NSPrintInfo printInfo, PdfPrintScalingMode scaleMode, bool doRotate);
+#pragma warning restore
 	}
 
 	[iOS (11,0)]
@@ -2017,7 +2019,9 @@ namespace PdfKit {
 
 		[NoiOS]
 		[Export ("printWithInfo:autoRotate:pageScaling:")]
+#pragma warning disable // 0618: 'PdfPrintScalingMode' is obsolete: 'This type is not available on iOS.'
 		void Print (NSPrintInfo printInfo, bool doRotate, PdfPrintScalingMode scaleMode);
+#pragma warning restore
 
 		[Export ("pageForPoint:nearest:")]
 		[return: NullAllowed]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -1970,7 +1970,7 @@ namespace SceneKit {
 		SCNHitTestResult [] HitTest (SCNVector3 pointA, SCNVector3 pointB, [NullAllowed] NSDictionary options);
 
 		[Wrap ("HitTest (pointA, pointB, options.GetDictionary ())")]
-		SCNHitTestResult [] HitTest (SCNVector3 pointA, SCNVector3 pointB, SCNHitTestOptions? options);
+		SCNHitTestResult [] HitTest (SCNVector3 pointA, SCNVector3 pointB, [NullAllowed] SCNHitTestOptions options);
 
 		[Mac (10,10)]
 		[Export ("eulerAngles")]

--- a/src/sharedwithyou.cs
+++ b/src/sharedwithyou.cs
@@ -367,9 +367,6 @@ namespace SharedWithYou {
 
 		[Export ("initWithHighlight:trigger:")]
 		NativeHandle Constructor (SWHighlight highlight, SWHighlightChangeEventTrigger trigger);
-
-		[Export ("highlightURL", ArgumentSemantic.Copy)]
-		NSUrl HighlightUrl { get; }
 	}
 
 	[NoWatch, NoTV, Mac (13,0), iOS (16,0), MacCatalyst (16,0)]

--- a/src/soundanalysis.cs
+++ b/src/soundanalysis.cs
@@ -203,8 +203,6 @@ namespace SoundAnalysis {
 
 #if NET
 		[BindAs (typeof (CMTime[]))]
-#else
-		[return: BindAs (typeof (CMTime[]))]
 #endif
 		[Export ("enumeratedDurations", ArgumentSemantic.Strong)]
 		NSValue[] EnumeratedDurations { get; }

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -289,7 +289,9 @@ namespace UIKit {
 
 #if !XAMCORE_3_0
 	[NoWatch]
+#pragma warning disable 0618 // warning CS0618: 'CategoryAttribute.CategoryAttribute(bool)' is obsolete: 'Inline the static members in this category in the category's class (and remove this obsolete once fixed)'
 	[Category (allowStaticMembers: true)] // Classic isn't internal so we need this
+#pragma warning restore
 	[BaseType (typeof (NSAttributedString))]
 	interface NSAttributedStringAttachmentConveniences {
 		[Internal]
@@ -11483,9 +11485,11 @@ namespace UIKit {
 
 		// from UIResponder (UIActivityItemsConfiguration)
 
+#pragma warning disable 0109 // warning CS0109: The member 'UIResponder.ActivityItemsConfiguration' does not hide an accessible member. The new keyword is not required.
 		[NoWatch, NoTV, iOS (13, 0)]
 		[NullAllowed, Export ("activityItemsConfiguration", ArgumentSemantic.Strong)]
 		new IUIActivityItemsConfigurationReading ActivityItemsConfiguration { get; set; }
+#pragma warning restore
 
 		// from UIResponder (UICaptureTextFromCameraSupporting)
 		[TV (15,0), iOS (15,0), MacCatalyst (15,0)]
@@ -11498,11 +11502,13 @@ namespace UIKit {
 		[return: NullAllowed]
 		NSTouchBar CreateTouchBar ();
 
+#pragma warning disable 0108 // warning CS0108: 'NSFontAssetRequest.Progress' hides inherited member 'NSProgressReporting.Progress'. Use the new keyword if hiding was intended.
 		[MacCatalyst (13, 0)]
 		[NoWatch, NoTV, NoiOS]
 		[Export ("touchBar", ArgumentSemantic.Strong)]
 		[NullAllowed]
-		new NSTouchBar TouchBar { get; set; }
+		NSTouchBar TouchBar { get; set; }
+#pragma warning restore
 	}
 	
 	[NoWatch]

--- a/src/usernotifications.cs
+++ b/src/usernotifications.cs
@@ -194,10 +194,12 @@ namespace UserNotifications {
 
 		// Additional enum values to fix reordering - to be at the end of the enum
 #if !XAMCORE_5_0
+#pragma warning disable 0618 // warning CS0618: 'UNNotificationInterruptionLevel.[field]' is obsolete: 'Use '[replacement]'.'
 		Active2 = Critical,
 		Critical2 = TimeSensitive,
 		Passive2 = Active,
 		TimeSensitive2 = Passive,
+#pragma warning restore
 #endif // !XAMCORE_5_0
 	}
 

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -2061,16 +2061,20 @@ namespace UIKit {
 		[Export ("hidden")]
 		bool Hidden { [Bind ("isHidden")] get; set; }
 
+#pragma warning disable 0109 // warning CS0109: The member 'NSCollectionLayoutVisibleItem.Center' does not hide an accessible member. The new keyword is not required.
 		// Inherited from UIDynamicItem for !MONOMAC
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
 		[Abstract]
 		[Export ("center", ArgumentSemantic.Assign)]
 		new CGPoint Center { get; set; }
+#pragma warning restore
 
+#pragma warning disable 0109 // warning CS0109: The member 'NSCollectionLayoutVisibleItem.Bounds' does not hide an accessible member. The new keyword is not required.
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
 		[Abstract]
 		[Export ("bounds")]
 		new CGRect Bounds { get; }
+#pragma warning restore
 
 		[NoMac]
 		[Abstract]

--- a/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
+++ b/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
@@ -84,7 +84,7 @@ namespace MonoTouchFixtures.AudioUnit {
 		}
 
 		[Test]
-		public unsafe void TestSizeOf()
+		public unsafe void TestSizeOf ()
 		{
 			Assert.AreEqual (sizeof (AudioFormat), Marshal.SizeOf (typeof (AudioFormat)));
 			Assert.AreEqual (sizeof (AudioValueRange), Marshal.SizeOf (typeof (AudioValueRange)));


### PR DESCRIPTION
Fixes these warnings:

    appkit.cs(13128,8): warning CS0108: 'NSResponder.RestoreUserActivityState(NSUserActivity)' hides inherited member 'NSUserActivityRestoring.RestoreUserActivityState(NSUserActivity)'. Use the new keyword if hiding was intended.
	appkit.cs(19500,12): warning CS0109: The member 'NSTextView.Editable' does not hide an accessible member. The new keyword is not required.
	appkit.cs(19503,12): warning CS0109: The member 'NSTextView.Selectable' does not hide an accessible member. The new keyword is not required.
	appkit.cs(27481,14): warning CS0108: 'NSFontAssetRequest.Progress' hides inherited member 'NSProgressReporting.Progress'. Use the new keyword if hiding was intended.
	appkit.cs(5342,8): warning CS0108: 'NSController.DiscardEditing()' hides inherited member 'NSEditor.DiscardEditing()'. Use the new keyword if hiding was intended.
	appkit.cs(5346,8): warning CS0108: 'NSController.CommitEditing(NSObject, Selector, nint)' hides inherited member 'NSEditor.CommitEditing(NSObject, Selector, nint)'. Use the new keyword if hiding was intended.
	appkit.cs(5353,8): warning CS0108: 'NSController.ObjectDidBeginEditing(INSEditor)' hides inherited member 'NSEditorRegistration.ObjectDidBeginEditing(INSEditor)'. Use the new keyword if hiding was intended.
	appkit.cs(5356,8): warning CS0108: 'NSController.ObjectDidEndEditing(INSEditor)' hides inherited member 'NSEditorRegistration.ObjectDidEndEditing(INSEditor)'. Use the new keyword if hiding was intended.
	appkit.cs(5367,8): warning CS0108: 'NSController.CommitEditing()' hides inherited member 'NSEditor.CommitEditing()'. Use the new keyword if hiding was intended.
	appkit.cs(5974,8): warning CS0108: 'NSDocument.ValidateUserInterfaceItem(INSValidatedUserInterfaceItem)' hides inherited member 'NSUserInterfaceValidations.ValidateUserInterfaceItem(INSValidatedUserInterfaceItem)'. Use the new keyword if hiding was intended.
	appkit.cs(6113,8): warning CS0108: 'NSDocument.RestoreUserActivityState(NSUserActivity)' hides inherited member 'NSUserActivityRestoring.RestoreUserActivityState(NSUserActivity)'. Use the new keyword if hiding was intended.
	appkit.cs(6260,8): warning CS0108: 'NSDocumentController.ValidateUserInterfaceItem(INSValidatedUserInterfaceItem)' hides inherited member 'NSUserInterfaceValidations.ValidateUserInterfaceItem(INSValidatedUserInterfaceItem)'. Use the new keyword if hiding was intended.
	avfoundation.cs(4928,3): warning CS0618: 'AVSampleCursorSyncInfo' is obsolete: 'This API is not available on this platform.'
	avfoundation.cs(4931,3): warning CS0618: 'AVSampleCursorSyncInfo' is obsolete: 'This API is not available on this platform.'
	avfoundation.cs(4942,3): warning CS0618: 'AVSampleCursorStorageRange' is obsolete: 'This API is not available on this platform.'
	avfoundation.cs(4945,3): warning CS0618: 'AVSampleCursorChunkInfo' is obsolete: 'This API is not available on this platform.'
	avfoundation.cs(4951,3): warning CS0618: 'AVSampleCursorStorageRange' is obsolete: 'This API is not available on this platform.'
	carplay.cs(1622,8): warning CS0108: 'CPListImageRowItem.Enabled' hides inherited member 'CPListTemplateItem.Enabled'. Use the new keyword if hiding was intended.
	carplay.cs(1695,8): warning CS0108: 'CPMessageListItem.Enabled' hides inherited member 'CPListTemplateItem.Enabled'. Use the new keyword if hiding was intended.
	carplay.cs(576,8): warning CS0108: 'CPListItem.Enabled' hides inherited member 'CPListTemplateItem.Enabled'. Use the new keyword if hiding was intended.
	contacts.cs(1589,3): warning CS0618: 'CategoryAttribute.CategoryAttribute(bool)' is obsolete: 'Inline the static members in this category in the category's class (and remove this obsolete once fixed)'
	contacts.cs(1685,3): warning CS0618: 'CategoryAttribute.CategoryAttribute(bool)' is obsolete: 'Inline the static members in this category in the category's class (and remove this obsolete once fixed)'
	coredata.cs(1053,12): warning CS0109: The member 'NSManagedObjectContext.Lock()' does not hide an accessible member. The new keyword is not required.
	coredata.cs(1059,12): warning CS0109: The member 'NSManagedObjectContext.Unlock()' does not hide an accessible member. The new keyword is not required.
	coredata.cs(2066,12): warning CS0109: The member 'NSPersistentStoreCoordinator.Lock()' does not hide an accessible member. The new keyword is not required.
	coredata.cs(2072,12): warning CS0109: The member 'NSPersistentStoreCoordinator.Unlock()' does not hide an accessible member. The new keyword is not required.
	coreimage.cs(1731,88): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
	coreimage.cs(1798,81): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
	foundation.cs(459,21): error CS0246: The type or namespace name 'NSTextBlock' could not be found (are you missing a using directive or an assembly reference?)
	foundation.cs(463,21): error CS0246: The type or namespace name 'NSTextTable' could not be found (are you missing a using directive or an assembly reference?)
	gamecontroller.cs(2422,13): warning CS0108: 'GCDevicePhysicalInput.Device' hides inherited member 'GCDevicePhysicalInputState.Device'. Use the new keyword if hiding was intended.
	healthkit.cs(4208,237): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
	healthkit.cs(4208,247): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
	mapkit.cs(1892,12): warning CS0109: The member 'MKTileOverlay.CanReplaceMapContent' does not hide an accessible member. The new keyword is not required.
	metal.cs(1627,3): warning CS0618: 'MTLAccelerationStructureSizes' is obsolete: 'This API is not available on this platform.'
	notificationcenter.cs(82,3): warning CS0618: 'CategoryAttribute.CategoryAttribute(bool)' is obsolete: 'Inline the static members in this category in the category's class (and remove this obsolete once fixed)'
	PassKit/PKEnums.cs(193,11): warning CS0618: 'PKPaymentButtonType.Checkout' is obsolete: 'Use 'Checkout2'.'
	PassKit/PKEnums.cs(195,15): warning CS0618: 'PKPaymentButtonType.Book' is obsolete: 'Use 'Book2'.'
	pdfkit.cs(1454,76): warning CS0618: 'PdfPrintScalingMode' is obsolete: 'This type is not available on iOS.'
	pdfkit.cs(2020,53): warning CS0618: 'PdfPrintScalingMode' is obsolete: 'This type is not available on iOS.'
	scenekit.cs(1973,87): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
	sharedwithyou.cs(372,9): warning CS0108: 'SWHighlightChangeEvent.HighlightUrl' hides inherited member 'SWHighlightEvent.HighlightUrl'. Use the new keyword if hiding was intended.
	soundanalysis.cs(207,4): warning CS0657: 'return' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
	uikit.cs(11490,44): warning CS0109: The member 'UIResponder.ActivityItemsConfiguration' does not hide an accessible member. The new keyword is not required.
	uikit.cs(11505,18): warning CS0109: The member 'UIResponder.TouchBar' does not hide an accessible member. The new keyword is not required.
	uikit.cs(11509,14): warning CS0108: 'UIResponder.TouchBar' hides inherited member 'NSTouchBarProvider.TouchBar'. Use the new keyword if hiding was intended.
	uikit.cs(292,3): warning CS0618: 'CategoryAttribute.CategoryAttribute(bool)' is obsolete: 'Inline the static members in this category in the category's class (and remove this obsolete once fixed)'
	usernotifications.cs(197,13): warning CS0618: 'UNNotificationInterruptionLevel.Critical' is obsolete: 'Use 'Critical2'.'
	usernotifications.cs(198,15): warning CS0618: 'UNNotificationInterruptionLevel.TimeSensitive' is obsolete: 'Use 'TimeSensitive2'.'
	usernotifications.cs(199,14): warning CS0618: 'UNNotificationInterruptionLevel.Active' is obsolete: 'Use 'Active2'.'
	usernotifications.cs(200,20): warning CS0618: 'UNNotificationInterruptionLevel.Passive' is obsolete: 'Use 'Passive2'.'
	xkit.cs(2068,15): warning CS0109: The member 'NSCollectionLayoutVisibleItem.Center' does not hide an accessible member. The new keyword is not required.
	xkit.cs(2073,14): warning CS0109: The member 'NSCollectionLayoutVisibleItem.Bounds' does not hide an accessible member. The new keyword is not required.