### PR TITLE
[DevOps] Allow to pass extra dependencies for the build stage.

### DIFF
--- a/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
+++ b/tests/monotouch-test/AudioUnit/AudioUnitTest.cs
@@ -84,7 +84,7 @@ namespace MonoTouchFixtures.AudioUnit {
 		}
 
 		[Test]
-		public unsafe void TestSizeOf()
+		public unsafe void TestSizeOf ()
 		{
 			Assert.AreEqual (sizeof (AudioFormat), Marshal.SizeOf (typeof (AudioFormat)));
 			Assert.AreEqual (sizeof (AudioValueRange), Marshal.SizeOf (typeof (AudioValueRange)));

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -176,11 +176,7 @@ stages:
 - ${{ if eq(parameters.runGovernanceTests, true) }}:
   - stage: governance_checks
     displayName: '${{ parameters.stageDisplayNamePrefix }}Governance Checks'
-    ${{ if ne(parameters.dependsOn, '')}}:
-      dependsOn:
-      - ${{ parameters.dependsOn }}
-    ${{ else }}:
-      dependsOn: []
+    dependsOn: ${{ parameters.dependsOn }}
     ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
       condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
     jobs:
@@ -223,11 +219,7 @@ stages:
 
 - stage: build_packages
   displayName: '${{ parameters.stageDisplayNamePrefix }}Build'
-  ${{ if ne(parameters.dependsOn, '')}}:
-    dependsOn:
-    - ${{ parameters.dependsOn }}
-  ${{ else }}:
-    dependsOn: []
+  dependsOn: ${{ parameters.dependsOn }}
   ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
     condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
   jobs:
@@ -311,11 +303,7 @@ stages:
 - ${{ if eq(parameters.enableAPIDiff, true) }}:
   - stage: generate_api_diff
     displayName: '${{ parameters.stageDisplayNamePrefix }}API diff'
-    ${{ if ne(parameters.dependsOn, '')}}:
-      dependsOn:
-      - ${{ parameters.dependsOn }}
-    ${{ else }}:
-      dependsOn: []
+    dependsOn: ${{ parameters.dependsOn }}
     ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
       condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
     jobs:

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -163,12 +163,26 @@ parameters:
   type: string
   default: ''
 
+- name: dependsOn
+  type: string
+  default: ''
+
+- name: dependsOnResult
+  type: string
+  default: ''
+
 stages:
 
 - ${{ if eq(parameters.runGovernanceTests, true) }}:
   - stage: governance_checks
     displayName: '${{ parameters.stageDisplayNamePrefix }}Governance Checks'
-    dependsOn: []
+    ${{ if ne(parameters.dependsOn, '')}}:
+      dependsOn:
+      - ${{ parameters.dependsOn }}
+    ${{ else }}:
+      dependsOn: []
+    ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
+      condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
     jobs:
     - job: governance
       displayName: 'Governance Checks'
@@ -209,7 +223,13 @@ stages:
 
 - stage: build_packages
   displayName: '${{ parameters.stageDisplayNamePrefix }}Build'
-  dependsOn: []
+  ${{ if ne(parameters.dependsOn, '')}}:
+    dependsOn:
+    - ${{ parameters.dependsOn }}
+  ${{ else }}:
+    dependsOn: []
+  ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
+    condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
   jobs:
   - template: ./build/build-stage.yml
     parameters:
@@ -291,7 +311,13 @@ stages:
 - ${{ if eq(parameters.enableAPIDiff, true) }}:
   - stage: generate_api_diff
     displayName: '${{ parameters.stageDisplayNamePrefix }}API diff'
-    dependsOn: []
+    ${{ if ne(parameters.dependsOn, '')}}:
+      dependsOn:
+      - ${{ parameters.dependsOn }}
+    ${{ else }}:
+      dependsOn: []
+    ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
+      condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
     jobs:
     - template: ./build/api-diff-stage.yml
       parameters:


### PR DESCRIPTION
Allow to add a dependency before our build. This is used in the unified pipeline to try to download the binaries if it can rather than building from scratch.