### PR TITLE
[monotouch-test] Ignore certificate chain errors on bots. Fixes #xamarin/maccore@2626.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -111,11 +111,21 @@ partial class TestRuntime {
 		return new Version (major, minor, build);
 	}
 
+	static bool? is_in_ci;
+	public static bool IsInCI {
+		get {
+			if (!is_in_ci.HasValue) {
+				var in_ci = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_REVISION"));
+				in_ci |= !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION")); // set by Azure DevOps
+				is_in_ci = in_ci;
+			}
+			return is_in_ci.Value;
+		}
+	}
+
 	public static void IgnoreInCI (string message)
 	{
-		var in_ci = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_REVISION"));
-		in_ci |= !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION")); // set by Azure DevOps
-		if (!in_ci) {
+		if (!IsInCI) {
 			Console.WriteLine ($"Not ignoring test ('{message}'), because not running in CI. BUILD_REVISION={Environment.GetEnvironmentVariable ("BUILD_REVISION")} BUILD_SOURCEVERSION={Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION")}");
 			return;
 		}

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -604,6 +604,8 @@ namespace MonoTests.System.Net.Http {
 					callbackWasExecuted = true;
 					try {
 						Assert.IsNotNull (certificate);
+						if (errors == SslPolicyErrors.RemoteCertificateChainErrors && TestRuntime.IsInCI)
+							return;
 						Assert.AreEqual (SslPolicyErrors.None, errors);
 					} catch (Exception e) {
 						ex2 = e;

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -605,7 +605,7 @@ namespace MonoTests.System.Net.Http {
 					try {
 						Assert.IsNotNull (certificate);
 						if (errors == SslPolicyErrors.RemoteCertificateChainErrors && TestRuntime.IsInCI)
-							return;
+							return false;
 						Assert.AreEqual (SslPolicyErrors.None, errors);
 					} catch (Exception e) {
 						ex2 = e;


### PR DESCRIPTION
Ignore certificate chain errors on bots in MessageHandlerTest.RejectSslCertificatesWithCustomValidationCallbackNSUrlSessionHandler.

Fixes https://github.com/xamarin/maccore/issues/2626.