### PR TITLE
Add automatic support for not building iOS 32-bit stuff when min iOS version is >= 11.0

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -279,6 +279,12 @@ ENABLE_DOTNET=1
 # disable source code install by default (it's enabled for CI builds)
 ENABLE_INSTALL_SOURCE=
 
+ifeq ($(shell test $(shell echo $(MIN_IOS_SDK_VERSION) | sed 's/[.].*//') -ge 11; echo $$?),0)
+IOS_SUPPORTS_32BIT_ARCHITECTURES=
+else
+IOS_SUPPORTS_32BIT_ARCHITECTURES=1
+endif
+
 -include $(TOP)/Make.config.local
 -include $(TOP)/configure.inc
 
@@ -651,16 +657,24 @@ ALL_DOTNET_PLATFORMS=iOS macOS tvOS MacCatalyst
 DOTNET_PLATFORMS=
 ifdef INCLUDE_IOS
 DOTNET_PLATFORMS+=iOS
+
+# 32-bit architectures
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
 ifdef INCLUDE_DEVICE
-DOTNET_IOS_RUNTIME_IDENTIFIERS=ios-arm ios-arm64 iossimulator-x86 iossimulator-x64 iossimulator-arm64
-DOTNET_IOS_RUNTIME_IDENTIFIERS_32=ios-arm iossimulator-x86
-DOTNET_IOS_RUNTIME_IDENTIFIERS_64=ios-arm64 iossimulator-x64 iossimulator-arm64
-else
-DOTNET_IOS_RUNTIME_IDENTIFIERS=iossimulator-x86 iossimulator-x64 iossimulator-arm64
-DOTNET_IOS_RUNTIME_IDENTIFIERS_32=iossimulator-x86
-DOTNET_IOS_RUNTIME_IDENTIFIERS_64=iossimulator-x64 iossimulator-arm64
-endif
-endif
+DOTNET_IOS_RUNTIME_IDENTIFIERS_32=ios-arm
+endif # INCLUDE_DEVICE
+DOTNET_IOS_RUNTIME_IDENTIFIERS_32+=iossimulator-x86
+endif # IOS_SUPPORTS_32BIT_ARCHITECTURES
+
+# 64-bit architectures
+ifdef INCLUDE_DEVICE
+DOTNET_IOS_RUNTIME_IDENTIFIERS_64=ios-arm64
+endif # INCLUDE_DEVICE
+DOTNET_IOS_RUNTIME_IDENTIFIERS_64+=iossimulator-x64 iossimulator-arm64
+
+# All of them
+DOTNET_IOS_RUNTIME_IDENTIFIERS=$(DOTNET_IOS_RUNTIME_IDENTIFIERS_32) $(DOTNET_IOS_RUNTIME_IDENTIFIERS_64)
+endif # INCLUDE_IOS
 
 ifdef INCLUDE_TVOS
 DOTNET_PLATFORMS+=tvOS

--- a/dotnet/generate-workloadmanifest-json.csharp
+++ b/dotnet/generate-workloadmanifest-json.csharp
@@ -20,9 +20,9 @@ var argumentIndex = 2;
 var platform = args [argumentIndex++];
 var version = args [argumentIndex++];
 var net6Version = args [argumentIndex++];
-var runtimeIdentifiers = args [argumentIndex++].Split (' ');
+var runtimeIdentifiers = args [argumentIndex++].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 var outputPath = args [argumentIndex++];
-var windowsPlatforms = args [argumentIndex++].Split (' ');
+var windowsPlatforms = args [argumentIndex++].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 var hasWindows = Array.IndexOf (windowsPlatforms, platform) >= 0;
 
 var platformLowerCase = platform.ToLowerInvariant ();

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -32,6 +32,13 @@ SHARED_FILES = $(SHARED_SOURCES) $(SHARED_HEADERS) $(SHARED_I386_SOURCES) $(SHAR
 
 EXTRA_DEPENDENCIES = $(SHARED_HEADERS) $(TOP)/Make.config $(TOP)/mk/mono.mk
 
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
+IOS_SIMULATOR_ARCHITECTURES=x86
+IOS_DEVICE_ARCHITECTURES=armv7 armv7s
+endif
+IOS_SIMULATOR_ARCHITECTURES+=x86_64
+IOS_DEVICE_ARCHITECTURES+=arm64
+
 coreclrhost.h: Makefile
 	$(Q_CURL) curl -L --fail --output "$@.tmp" https://raw.githubusercontent.com/dotnet/runtime/6c8f9fff6adcf6c661072646dbdafabed5267ec5/src/coreclr/hosts/inc/coreclrhost.h
 	$(Q) mv "$@.tmp" "$@"
@@ -153,9 +160,9 @@ endef
 # 3: architectures
 ifdef INCLUDE_IOS
 ifdef INCLUDE_DEVICE
-$(eval $(call FrameworkTemplate,iphoneos,IPHONEOS,armv7 armv7s arm64))
+$(eval $(call FrameworkTemplate,iphoneos,IPHONEOS,$(IOS_DEVICE_ARCHITECTURES)))
 endif
-$(eval $(call FrameworkTemplate,iphonesimulator,IOSSIMULATOR,x86 x86_64))
+$(eval $(call FrameworkTemplate,iphonesimulator,IOSSIMULATOR,$(IOS_SIMULATOR_ARCHITECTURES)))
 endif
 
 ifdef INCLUDE_WATCH
@@ -221,9 +228,9 @@ endef
 # 3: architectures
 ifdef INCLUDE_IOS
 ifdef INCLUDE_DEVICE
-$(eval $(call PlatformTemplate,iphoneos,IPHONEOS,armv7 armv7s arm64))
+$(eval $(call PlatformTemplate,iphoneos,IPHONEOS,$(IOS_DEVICE_ARCHITECTURES)))
 endif
-$(eval $(call PlatformTemplate,iphonesimulator,IOSSIMULATOR,x86 x86_64))
+$(eval $(call PlatformTemplate,iphonesimulator,IOSSIMULATOR,$(IOS_SIMULATOR_ARCHITECTURES)))
 endif
 ifdef INCLUDE_MACCATALYST
 $(eval $(call PlatformTemplate,maccatalyst,MACCATALYST,x86_64))

--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -145,7 +145,10 @@ xamarin_start_wwan (const char *uri)
 	CFURLRef url = CFURLCreateWithString (kCFAllocatorDefault, host, nil);
 	
 	CFHTTPMessageRef message = CFHTTPMessageCreateRequest (kCFAllocatorDefault, get, url, kCFHTTPVersion1_1);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 	CFReadStreamRef stream = CFReadStreamCreateForHTTPRequest (kCFAllocatorDefault, message);
+#pragma clang diagnostic pop
 	
 	CFReadStreamScheduleWithRunLoop (stream, CFRunLoopGetCurrent (), kCFRunLoopCommonModes);
 	

--- a/src/Makefile
+++ b/src/Makefile
@@ -375,10 +375,15 @@ IOS_TARGETS += \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.iOS/OpenTK-1.0.dll          \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.iOS/OpenTK-1.0.pdb          \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.iOS/OpenTK-1.0.dll.config   \
-	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/32bits/iOS/Xamarin.iOS.dll               \
-	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/32bits/iOS/Xamarin.iOS.pdb               \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/64bits/iOS/Xamarin.iOS.dll               \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/64bits/iOS/Xamarin.iOS.pdb               \
+
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
+IOS_TARGETS += \
+	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/32bits/iOS/Xamarin.iOS.dll               \
+	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/32bits/iOS/Xamarin.iOS.pdb               \
+
+endif
 
 DOTNET_TARGETS += \
 	$(IOS_DOTNET_BUILD_DIR)/32/Microsoft.iOS.dll \

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -176,14 +176,21 @@ $$($(1)_DIRECTORIES):
 
 endef
 
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
+IOS_SIMULATOR_ARCHITECTURES=x86
+IOS_DEVICE_ARCHITECTURES=armv7 armv7s
+endif
+IOS_SIMULATOR_ARCHITECTURES+=x86_64 arm64
+IOS_DEVICE_ARCHITECTURES+=arm64
+
 # 1: platform infix
 # 2: platform variable
 # 3: architectures
 # 4: platform name
 # 5: min version
 # 6: os
-$(eval $(call Template,iphonesimulator,IOSSIMULATOR,x86 x86_64 arm64,iPhoneSimulator,-mios-simulator-version-min=8.0 -isysroot $(SIMULATOR_SDK)))
-$(eval $(call Template,iphoneos,IPHONEOS,armv7 armv7s arm64,iPhoneOS,-miphoneos-version-min=8.0 -isysroot $(DEVICE_SDK)))
+$(eval $(call Template,iphonesimulator,IOSSIMULATOR,$(IOS_SIMULATOR_ARCHITECTURES),iPhoneSimulator,-mios-simulator-version-min=8.0 -isysroot $(SIMULATOR_SDK)))
+$(eval $(call Template,iphoneos,IPHONEOS,$(IOS_DEVICE_ARCHITECTURES),iPhoneOS,-miphoneos-version-min=8.0 -isysroot $(DEVICE_SDK)))
 ifdef INCLUDE_TVOS
 $(eval $(call Template,tvsimulator,TVSIMULATOR,x86_64 arm64,AppleTVSimulator,-mtvos-simulator-version-min=9.0 -isysroot $(SIMULATORTV_SDK)))
 $(eval $(call Template,tvos,TVOS,arm64,AppleTVOS,-mtvos-version-min=9.0 -fembed-bitcode -isysroot $(DEVICETV_SDK)))
@@ -211,9 +218,11 @@ $(5)_TARGETS += .libs/$(4)/libtest.$(1).a
 all-local:: $$($(5)_TARGETS)
 endef
 
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
 $(eval $(call LibTemplate,armv7+7s,.libs/iphoneos/libtest.armv7.o,.libs/iphoneos/libtest.armv7s.o,ios-fat,IOS))
 $(eval $(call LibTemplate,armv7+x86,.libs/iphoneos/libtest.armv7.o,.libs/iphonesimulator/libtest.x86.o,ios-fat,IOS))
 $(eval $(call LibTemplate,armv7s+x86,.libs/iphoneos/libtest.armv7s.o,.libs/iphonesimulator/libtest.x86.o,ios-fat,IOS))
+endif
 
 ifdef INCLUDE_TVOS
 $(eval $(call LibTemplate,arm64+x86_64,.libs/tvos/libtest.arm64.o,.libs/tvsimulator/libtest.x86_64.o,tvos-fat,TVOS))

--- a/tests/test-libraries/frameworks/Makefile
+++ b/tests/test-libraries/frameworks/Makefile
@@ -47,8 +47,13 @@ maccatalyst_INFO_PLIST_INFIX=/Versions/A/Resources
 maccatalyst_BINARY_INFIX=/Versions/A
 
 # For XCFrameworks, we have to lipo some of the RID-specific frameworks together (the ones with multiple RIDs below)
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
 iphonesimulator_XC_RUNTIMEIDENTIFIERS=iossimulator-x86 iossimulator-x64  iossimulator-arm64
 iphoneos_XC_RUNTIMEIDENTIFIERS=ios-arm ios-arm64
+else
+iphonesimulator_XC_RUNTIMEIDENTIFIERS=iossimulator-x64 iossimulator-arm64
+iphoneos_XC_RUNTIMEIDENTIFIERS=ios-arm64
+endif
 tvsimulator_XC_RUNTIMEIDENTIFIERS=tvossimulator-x64 tvossimulator-arm64
 tvos_XC_RUNTIMEIDENTIFIERS=tvos-arm64
 mac_XC_RUNTIMEIDENTIFIERS=osx-x64 osx-arm64

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -5,7 +5,11 @@ include $(TOP)/Make.config
 # in system headers show up.
 export CCACHE_CPP2=1
 
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
 SIMLAUNCHERS = simlauncher32-sgen simlauncher64-sgen
+else
+SIMLAUNCHERS = simlauncher64-sgen
+endif
 
 UNREFERENCED_SYMBOLS = 							\
 	_xamarin_dyn_objc_msgSend 					\
@@ -258,11 +262,15 @@ define RunRegistrar
 .SECONDARY: Xamarin.$(5).registrar.$(1).$(2).m Xamarin.$(5).registrar.$(1).$(2).h Xamarin.$(5).registrar.$(1).$(2).a
 .SECONDARY: .libs/Microsoft.$(8).registrar.$(2).m .libs/Microsoft.$(8).registrar.$(2).h .libs/Microsoft.$(8).registrar.$(2).a
 endef
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
 $(eval $(call RunRegistrar,ios,i386,32,$(IOS_SDK_VERSION),iOS,$(SIMULATOR86_CFLAGS),$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/SDKs/MonoTouch.iphonesimulator.sdk/include,$(MONOTOUCH_MONO_PATH),iOS,iossimulator-x86))
+endif
 $(eval $(call RunRegistrar,ios,x86_64,64,$(IOS_SDK_VERSION),iOS,$(SIMULATOR64_CFLAGS),$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/SDKs/MonoTouch.iphonesimulator.sdk/include,$(MONOTOUCH_MONO_PATH),iOS,iossimulator-x64))
 $(eval $(call RunRegistrar,ios,arm64,64,$(IOS_SDK_VERSION),iOS,$(SIMULATOR_ARM64_CFLAGS),$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/SDKs/MonoTouch.iphonesimulator.sdk/include,$(MONOTOUCH_MONO_PATH),iOS,iossimulator-arm64))
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
 $(eval $(call RunRegistrar,ios,armv7,32,$(IOS_SDK_VERSION),iOS,$(DEVICE7_CFLAGS),$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/SDKs/MonoTouch.iphoneos.sdk/include,$(MONOTOUCH_MONO_PATH),iOS,armv7))
 $(eval $(call RunRegistrar,ios,armv7s,32,$(IOS_SDK_VERSION),iOS,$(DEVICE7S_CFLAGS),$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/SDKs/MonoTouch.iphoneos.sdk/include,$(MONOTOUCH_MONO_PATH),iOS,armv7s))
+endif
 $(eval $(call RunRegistrar,ios,arm64,64,$(IOS_SDK_VERSION),iOS,$(DEVICE64_CFLAGS),$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/SDKs/MonoTouch.iphoneos.sdk/include,$(MONOTOUCH_MONO_PATH),iOS,ios-arm64))
 $(eval $(call RunRegistrar,tvos,x86_64,64,$(TVOS_SDK_VERSION),TVOS,$(SIMULATORTV_CFLAGS),$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/include,$(MONOTOUCH_TV_MONO_PATH),tvOS,tvossimulator-x64))
 $(eval $(call RunRegistrar,tvos,arm64,64,$(TVOS_SDK_VERSION),TVOS,$(SIMULATORTV_ARM64_CFLAGS),$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/include,$(MONOTOUCH_TV_MONO_PATH),tvOS,tvossimulator-arm64))
@@ -274,10 +282,18 @@ $(eval $(call RunRegistrar,watchos,arm64_32,32,$(WATCH_SDK_VERSION),WatchOS,$(DE
 $(eval $(call RunRegistrar,maccatalyst,x86_64,64,$(MACCATALYST_SDK_VERSION),MacCatalyst,$(MACCATALYST_X86_64_CFLAGS),$(IOS_DESTDIR)$(XAMARIN_MACCATALYST_SDK)/include,$(MONOTOUCH_MACCATALYST_MONO_PATH),MacCatalyst,maccatalyst-x64))
 $(eval $(call RunRegistrar,maccatalyst,arm64,64,$(MACCATALYST_SDK_VERSION),MacCatalyst,$(MACCATALYST_ARM64_CFLAGS),$(IOS_DESTDIR)$(XAMARIN_MACCATALYST_SDK)/include,$(MONOTOUCH_MACCATALYST_MONO_PATH),MacCatalyst,maccatalyst-arm64))
 
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
 %.registrar.ios.simulator.a:     %.registrar.ios.i386.a %.registrar.ios.x86_64.a
+else
+%.registrar.ios.simulator.a:     %.registrar.ios.x86_64.a
+endif
 	$(Q_LIPO) $(DEVICE_BIN_PATH)/lipo -create -output $@ $^
 
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
 %.registrar.ios.device.a:        %.registrar.ios.arm64.a %.registrar.ios.armv7.a %.registrar.ios.armv7s.a
+else
+%.registrar.ios.device.a:        %.registrar.ios.arm64.a
+endif
 	$(Q_LIPO) $(DEVICE_BIN_PATH)/lipo -create -output $@ $^
 
 %.registrar.watchos.device.a:    %.registrar.watchos.armv7k.a %.registrar.watchos.arm64_32.a
@@ -420,7 +436,11 @@ verify-sorted-resx:
 	fi
 
 ifdef INCLUDE_XAMARIN_LEGACY
+ifdef IOS_SUPPORTS_32BIT_ARCHITECTURES
 package-introspection-dependencies.zip: simlauncher32-sgen simlauncher64-sgen
+else
+package-introspection-dependencies.zip: simlauncher64-sgen
+endif
 	$(Q) mkdir -p $@.tmpdir
 	$(Q) $(CP) -a simlauncher*-sgen*  $@.tmpdir
 	$(Q_GEN) cd $@.tmpdir && zip -9r $(abspath $@) .


### PR DESCRIPTION
There are no changes for 32-bit watchOS, because watchOS support is likely to
go away completely anyways.