### PR TITLE
[runtime] Use the built-in support in MonoVM for autorelease pools on threadpool threads. Fixes #11788.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -255,6 +255,7 @@
 			"MonoProfileThreadFunc", "end"
 		) {
 			XamarinRuntime = RuntimeMode.MonoVM,
+			Mode = DotNetMode.OnlyLegacy,
 		},
 
 		new Export ("void", "mono_profiler_install_gc",

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -235,6 +235,7 @@ xamarin_get_runtime_class ()
  * and create a pool that spans the thread's entire lifetime.
  */
 
+#if !DOTNET
 static CFMutableDictionaryRef xamarin_thread_hash = NULL;
 static pthread_mutex_t thread_hash_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -296,14 +297,18 @@ thread_end (MonoProfiler *prof, uintptr_t tid)
 	// COOP: no managed memory access: any mode.
 	xamarin_thread_finish (NULL);
 }
+#endif // !DOTNET
 
 void
 xamarin_install_nsautoreleasepool_hooks ()
 {
+	// No need to do anything here for CoreCLR.
+#if !DOTNET
 	// COOP: executed at startup (and no managed memory access): any mode.
 	xamarin_thread_hash = CFDictionaryCreateMutable (kCFAllocatorDefault, 0, NULL, NULL);
 
 	mono_profiler_install_thread (thread_start, thread_end);
+#endif // !DOTNET
 }
 
 void


### PR DESCRIPTION
MonoVM in .NET 6+ supports automatic autorelease pools on threadpool threads
just like CoreCLR does, so we can remove our custom mono profiler hooks to
accomplish this.

Fixes https://github.com/xamarin/xamarin-macios/issues/11788.