### PR TITLE
Do not copy files to build server for a Delete.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 
 namespace Microsoft.Build.Tasks {

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
@@ -1,7 +1,7 @@
 using Xamarin.Messaging.Build.Client;
 
 namespace Microsoft.Build.Tasks {
-	public class Delete : DeleteBase {
+	public class Delete : DeleteBase, ITaskCallback {
 		public override bool Execute ()
 		{
 			var result = base.Execute ();
@@ -27,5 +27,7 @@ namespace Microsoft.Build.Tasks {
 		}
 
 		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+
+		public bool ShouldCreateOutputFile (ITaskItem item) => false;
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
@@ -29,5 +29,7 @@ namespace Microsoft.Build.Tasks {
 		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
 
 		public bool ShouldCreateOutputFile (ITaskItem item) => false;
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Delete.cs
@@ -25,5 +25,7 @@ namespace Microsoft.Build.Tasks {
 
 			return result;
 		}
+
+		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
 	}
 }


### PR DESCRIPTION
The `Delete` task should not need to copy any files to the remote server.
Lets try to set this up by implementing the `ShouldCopyToBuildServer` method.

This should help reduce build times if it works.