### PR TITLE
[devops] Skip a few steps if something goes wrong.

### DIFF
--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -97,7 +97,6 @@ steps:
   displayName: 'Check HD Free Space'
   timeoutInMinutes: 5
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/
-  condition: succeededOrFailed() # we do not care about the previous step
 
 # if we got to this point, it means that we do have at least 50 Gb to run the test, should
 # be more than enough, else the above script would have stopped the pipeline

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -44,14 +44,12 @@ steps:
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MaciosCI.psd1
     Set-MLaunchVerbosity -Verbosity 10
   displayName: 'Make mlaunch verbose'
-  condition: succeededOrFailed() # we do not care about the previous step
 
 # Re-start the daemon used to find the devices in the bot.
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MaciosCI.psd1
     Optimize-DeviceDiscovery
   displayName: 'Fix device discovery (reset launchctl)'
-  condition: succeededOrFailed() # making mlaunch verbose should be a non blocker
 
 - bash: |
     make -C src build/generator-frameworks.g.cs


### PR DESCRIPTION
There's no need to:

* Check for HD space.
* Make mlaunch verbose.
* Reset launchctl.

if something else already went wrong in a test run.