### PR TITLE
[dotnet] Make sure to create a directory before we try to put files into it.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -74,6 +74,7 @@ DIRECTORIES += \
 	$(TMP_PKG_DIR) \
 	$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Windows.Sdk/Sdk) \
 	$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(DOTNET_DESTDIR)/Microsoft.$(platform).Windows.Sdk/targets) \
+	$(foreach platform,$(DOTNET_PLATFORMS),Workloads/Microsoft.NET.Sdk.$(platform)) \
 
 $(DIRECTORIES):
 	$(Q) mkdir -p $@
@@ -167,13 +168,12 @@ endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call SharedAfterTargetsTemplate,$(platform),$(NET6_$(platform)_NUGET_VERSION_NO_METADATA))))
 
 define WorkloadTargets
-Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.json: Makefile $(TOP)/Make.config.inc $(TOP)/.git/HEAD $(TOP)/.git/index Makefile generate-workloadmanifest-json.csharp
-	$$(Q) mkdir -p Workloads/Microsoft.NET.Sdk.$(1)/
+Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.json: Makefile $(TOP)/Make.config.inc $(TOP)/.git/HEAD $(TOP)/.git/index Makefile generate-workloadmanifest-json.csharp | Workloads/Microsoft.NET.Sdk.$(1)
 	$$(Q) rm -f $$@.tmp
 	$$(Q_GEN) ./generate-workloadmanifest-json.csharp "$(1)" "$(3)" "$(4)" "$$(DOTNET_$(5)_RUNTIME_IDENTIFIERS)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)"
 	$$(Q) mv $$@.tmp $$@
 
-Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.targets: Workloads/WorkloadManifest.$(1).template.targets Makefile $(TOP)/Make.config.inc $(TOP)/.git/HEAD $(TOP)/.git/index
+Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.targets: Workloads/WorkloadManifest.$(1).template.targets Makefile $(TOP)/Make.config.inc $(TOP)/.git/HEAD $(TOP)/.git/index | Workloads/Microsoft.NET.Sdk.$(1)
 	$$(Q_GEN) sed \
 		-e "s/@NUGET_VERSION_NO_METADATA@/$3/g" \
 		$$< > $$@.tmp


### PR DESCRIPTION
Fixes this random build error:

    /bin/sh: Workloads/Microsoft.NET.Sdk.macOS/WorkloadManifest.targets.tmp: No such file or directory
    make[1]: *** [Workloads/Microsoft.NET.Sdk.macOS/WorkloadManifest.targets] Error 1
    make[1]: *** Waiting for unfinished jobs....