### PR TITLE
[tests] Use a different identifier than '%...%' for replacement text.

### DIFF
--- a/tests/common/mac/ApiDefinition.cs
+++ b/tests/common/mac/ApiDefinition.cs
@@ -63,5 +63,5 @@ namespace ExampleBinding
 	//
 	// For more information, see http://developer.xamarin.com/guides/ios/advanced_topics/binding_objective-c/
 	//
-%CODE%
+REPLACE_CODE_REPLACE
 }

--- a/tests/common/mac/BindingProjectWithNoTag.csproj
+++ b/tests/common/mac/BindingProjectWithNoTag.csproj
@@ -20,7 +20,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-%CODE%
+REPLACE_CODE_REPLACE
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/common/mac/Component1.fs
+++ b/tests/common/mac/Component1.fs
@@ -2,4 +2,4 @@ namespace FSharpXM45Library
 type Class1() = 
     member this.X = "F#"
 
-%CODE%
+REPLACE_CODE_REPLACE

--- a/tests/common/mac/MobileBinding.csproj
+++ b/tests/common/mac/MobileBinding.csproj
@@ -22,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-%CODE%
+REPLACE_CODE_REPLACE
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/common/mac/MyClass.cs
+++ b/tests/common/mac/MyClass.cs
@@ -10,4 +10,4 @@ namespace Library
 	}
 }
 
-%CODE%
+REPLACE_CODE_REPLACE

--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -239,7 +239,7 @@ namespace Xamarin.MMP.Tests
 
 		static string ProjectTextReplacement (UnifiedTestConfig config, string text)
 		{
-			 text = text.Replace ("%CODE%", config.CSProjConfig)
+			text = text.Replace ("REPLACE_CODE_REPLACE", config.CSProjConfig)
 					   .Replace ("%REFERENCES%", config.References)
 					   .Replace ("%REFERENCES_BEFORE_PLATFORM%", config.ReferencesBeforePlatform)
 					   .Replace ("%NAME%", config.AssemblyName ?? Path.GetFileNameWithoutExtension (config.ProjectName))
@@ -304,8 +304,8 @@ namespace Xamarin.MMP.Tests
 		public static string GenerateBindingLibraryProject (UnifiedTestConfig config)
 		{
 			string sourceDir = FindSourceDirectory ();
-			CopyFileWithSubstitutions (Path.Combine (sourceDir, "ApiDefinition.cs"), Path.Combine (config.TmpDir, "ApiDefinition.cs"), text => text.Replace ("%CODE%", config.APIDefinitionConfig));
-			CopyFileWithSubstitutions (Path.Combine (sourceDir, "StructsAndEnums.cs"), Path.Combine (config.TmpDir, "StructsAndEnums.cs"), text => text.Replace ("%CODE%", config.StructsAndEnumsConfig));
+			CopyFileWithSubstitutions (Path.Combine (sourceDir, "ApiDefinition.cs"), Path.Combine (config.TmpDir, "ApiDefinition.cs"), text => text.Replace ("REPLACE_CODE_REPLACE", config.APIDefinitionConfig));
+			CopyFileWithSubstitutions (Path.Combine (sourceDir, "StructsAndEnums.cs"), Path.Combine (config.TmpDir, "StructsAndEnums.cs"), text => text.Replace ("REPLACE_CODE_REPLACE", config.StructsAndEnumsConfig));
 
 			string linkWithName = null;
 			if (config.LinkWithName != null) {
@@ -331,7 +331,7 @@ namespace Xamarin.MMP.Tests
 			string projectSuffix = config.FSharp ? ".fsproj" : ".csproj";
 
 			CopyFileWithSubstitutions (Path.Combine (sourceDir, sourceFileName), Path.Combine (config.TmpDir, sourceFileName), text => {
-				return text.Replace ("%CODE%", config.TestCode);
+				return text.Replace ("REPLACE_CODE_REPLACE", config.TestCode);
 			});
 
 			return CopyFileWithSubstitutions (Path.Combine (sourceDir, config.ProjectName + projectSuffix), Path.Combine (config.TmpDir, config.ProjectName + projectSuffix), text => {
@@ -474,7 +474,7 @@ module main =
     [<EntryPoint>]
     let main args =
         NSApplication.Init ()
-        %CODE%
+        REPLACE_CODE_REPLACE
         0";
 
 			const string MainTemplate = @"
@@ -490,12 +490,12 @@ namespace TestCase
 		static void Main (string[] args)
 		{
 			NSApplication.Init ();
-			%CODE%
+			REPLACE_CODE_REPLACE
 		}
 	}
 }";
 			string currentTemplate = fsharp ? FSharpMainTemplate : MainTemplate;
-			string testCase = currentTemplate.Replace ("%CODE%", content).Replace ("%DECL%", decl);
+			string testCase = currentTemplate.Replace ("REPLACE_CODE_REPLACE", content).Replace ("%DECL%", decl);
 			using (StreamWriter s = new StreamWriter (location))
 				s.Write(testCase);
 		}

--- a/tests/common/mac/StructsAndEnums.cs
+++ b/tests/common/mac/StructsAndEnums.cs
@@ -2,5 +2,5 @@ using System;
 
 namespace ExampleBinding
 {
-	%CODE%
+	REPLACE_CODE_REPLACE
 }

--- a/tests/common/mac/SystemMonoExample.csproj
+++ b/tests/common/mac/SystemMonoExample.csproj
@@ -24,7 +24,7 @@
     <Optimize>false</Optimize>
     <DebugSymbols>true</DebugSymbols>
    <Profiling>false</Profiling>
-%CODE%
+REPLACE_CODE_REPLACE
    </PropertyGroup>
    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <EnableCodeSigning>false</EnableCodeSigning>
@@ -34,7 +34,7 @@
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
     <DebugSymbols>true</DebugSymbols>
-%CODE%
+REPLACE_CODE_REPLACE
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/common/mac/Today/TodayViewController.cs
+++ b/tests/common/mac/Today/TodayViewController.cs
@@ -17,7 +17,7 @@ namespace TodayExtensionTest
 		public override void ViewDidLoad ()
 		{
 			base.ViewDidLoad ();
-%TESTCODE%
+			REPLACE_CODE_REPLACE
 			// Do any additional setup after loading the view.
 		}
 

--- a/tests/common/mac/UnifiedExample.csproj
+++ b/tests/common/mac/UnifiedExample.csproj
@@ -24,7 +24,7 @@
     <UseRefCounting>true</UseRefCounting>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
-%CODE%
+REPLACE_CODE_REPLACE
     </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -39,7 +39,7 @@
     <UseSGen>true</UseSGen>
     <UseRefCounting>true</UseRefCounting>
     <LinkMode>SdkOnly</LinkMode>
-%CODE%
+REPLACE_CODE_REPLACE
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/common/mac/UnifiedLibrary.csproj
+++ b/tests/common/mac/UnifiedLibrary.csproj
@@ -29,7 +29,7 @@
     <CreatePackage>false</CreatePackage>
     <EnableCodeSigning>false</EnableCodeSigning>
     <EnablePackageSigning>false</EnablePackageSigning>
-%CODE%
+REPLACE_CODE_REPLACE
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/common/mac/XM45Binding.csproj
+++ b/tests/common/mac/XM45Binding.csproj
@@ -21,7 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-%CODE%
+REPLACE_CODE_REPLACE
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/common/mac/XM45Example.csproj
+++ b/tests/common/mac/XM45Example.csproj
@@ -23,7 +23,7 @@
     <EnablePackageSigning>false</EnablePackageSigning>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
-%CODE%
+REPLACE_CODE_REPLACE
     <Profiling>false</Profiling>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -35,7 +35,7 @@
     <EnableCodeSigning>false</EnableCodeSigning>
     <CreatePackage>false</CreatePackage>
     <EnablePackageSigning>false</EnablePackageSigning>
-%CODE%
+REPLACE_CODE_REPLACE
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/mac/XM45Library.csproj
+++ b/tests/common/mac/XM45Library.csproj
@@ -19,7 +19,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-%CODE%
+REPLACE_CODE_REPLACE
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/mmptest/src/ExtensionTests.cs
+++ b/tests/mmptest/src/ExtensionTests.cs
@@ -24,7 +24,7 @@ namespace Xamarin.MMP.Tests
 				string project = Path.Combine (tmpDir, "Today/TodayExtensionTest.csproj");
 				string main = Path.Combine (tmpDir, "Today/TodayViewController.cs");
 				TI.CopyFileWithSubstitutions (project, project, s => s.Replace ("%ITEMGROUP%", ""));
-				TI.CopyFileWithSubstitutions (main, main, s => s.Replace ("%TESTCODE%", ""));
+				TI.CopyFileWithSubstitutions (main, main, s => s.Replace ("REPLACE_CODE_REPLACE", ""));
 				TI.BuildProject (project);
 			});
 		}

--- a/tests/mmptest/src/PackageReferenceTests.cs
+++ b/tests/mmptest/src/PackageReferenceTests.cs
@@ -64,7 +64,7 @@ namespace Xamarin.MMP.Tests
 				string main = Path.Combine (tmpDir, "Today/TodayViewController.cs");
 
 				TI.CopyFileWithSubstitutions (project, project, s => s.Replace ("%ITEMGROUP%", PackageReference));
-				TI.CopyFileWithSubstitutions (main, main, s => s.Replace ("%TESTCODE%", TestCode));
+				TI.CopyFileWithSubstitutions (main, main, s => s.Replace ("REPLACE_CODE_REPLACE", TestCode));
 
 				TI.NugetRestore (project);
 				var buildResult = TI.BuildProject (Path.Combine (tmpDir, "Today/TodayExtensionTest.csproj"));

--- a/tests/mmptest/src/XM45Example.csproj
+++ b/tests/mmptest/src/XM45Example.csproj
@@ -23,7 +23,7 @@
     <UseRefCounting>false</UseRefCounting>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
-%CODE%
+REPLACE_CODE_REPLACE
   <Profiling>false</Profiling></PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
When the autoformatter runs into the '%...%' pattern in *.cs files, it will
re-format the text (to '% ... %'), but that breaks our text replacement logic.
So instead use a valid C# identifier as a replacement token, in which case the
autoformatter won't confuse our replacement logic.