### PR TITLE
[release/6.0.4xx-xcode14.1] [dotnet/tools] Don't disable compact unwind info. Fixes #16546.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1152,11 +1152,6 @@
 			<_LinkNativeExecutableInputs Include="@(_XamarinMainLibraries)" />
 			<_LinkNativeExecutableInputs Include="@(_FileNativeReference)" />
 		</ItemGroup>
-
-		<ItemGroup Condition="'$(_XamarinRuntime)' == 'MonoVM' And $([MSBuild]::VersionGreaterThanOrEquals('$(_XcodeVersion)','14.0'))">
-			<_MainLinkerFlags Include="-Wl,-no_compact_unwind" />
-			<_MainLinkerFlags Include="-Wl,-keep_dwarf_unwind" />
-		</ItemGroup>
 	</Target>
 
 	<!-- Any .dylibs we link with might have an incorrect identity (see https://github.com/xamarin/xamarin-macios/issues/13999),

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -141,13 +141,6 @@ namespace Xamarin.Utils {
 			}
 			AddOtherFlag ("-lz");
 			AddOtherFlag ("-liconv");
-
-			if (Driver.XcodeVersion.Major >= 14 && Application.BitCodeMode == BitCodeMode.None) {
-				// This solves a warning:
-				//     ld: warning: could not create compact unwind for _BrotliBuildHistogramsWithContext: registers 27 not saved contiguously in frame
-				AddOtherFlag ("-Wl,-no_compact_unwind");
-				AddOtherFlag ("-Wl,-keep_dwarf_unwind");
-			}
 		}
 
 		public void LinkWithXamarin ()


### PR DESCRIPTION
Don't disable compact unwind info in the native linker, it may break C++
exception handling.

We originally disabled compact unwind info to fix a warning from the native
linker, this will have to be solved another way (in any case extra build
warnings is preferrable compared to an app crashing at runtime due to broken
C++ exception handling).

This partially reverts c05e774612a95bf3830509d55a25784d3805344e.

Fixes https://github.com/xamarin/xamarin-macios/issues/16546.


Backport of #16623



Backport of #16624
