### PR TITLE
[devops] Set BUILD_REVISION globally.

### DIFF
--- a/tools/devops/automation/scripts/GitHub.Tests.ps1
+++ b/tools/devops/automation/scripts/GitHub.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'New-GitHubComment' {
                 "BUILD_BUILDID" = "BUILD_BUILDID";
                 "SYSTEM_JOBNAME" = "SYSTEM_JOBNAME";
                 "SYSTEM_STAGEDISPLAYNAME" = "SYSTEM_STAGEDISPLAYNAME"
-                "BUILD_REVISION" = "BUILD_REVISION";
+                "BUILD_SOURCEVERSION" = "BUILD_SOURCEVERSION";
                 "GITHUB_TOKEN" = "GITHUB_TOKEN";
                 "BUILD_DEFINITIONNAME" = "BUILD_DEFINITIONNAME"
             }
@@ -39,7 +39,7 @@ Describe 'New-GitHubComment' {
             # assert the call and compare the expected parameters to the received ones
             Assert-MockCalled -CommandName Invoke-RestMethod -Times 1 -Scope It -ParameterFilter {
                 # validate each of the params and the payload
-                if ($Uri -ne "https://api.github.com/repos/xamarin/xamarin-macios/commits/BUILD_REVISION/comments") {
+                if ($Uri -ne "https://api.github.com/repos/xamarin/xamarin-macios/commits/BUILD_SOURCEVERSION/comments") {
                     return $False
                 }
                 if ($Headers.Authorization -ne ("token {0}" -f $envVariables["GITHUB_TOKEN"])) {
@@ -85,7 +85,7 @@ Describe 'New-GitHubComment' {
                 "BUILD_BUILDID" = "BUILD_BUILDID";
                 "SYSTEM_JOBNAME" = "SYSTEM_JOBNAME";
                 "SYSTEM_STAGEDISPLAYNAME" = "SYSTEM_STAGEDISPLAYNAME"
-                "BUILD_REVISION" = "BUILD_REVISION";
+                "BUILD_SOURCEVERSION" = "BUILD_SOURCEVERSION";
                 "GITHUB_TOKEN" = "GITHUB_TOKEN";
                 "BUILD_DEFINITIONNAME" = "BUILD_DEFINITIONNAME"
             }

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -659,7 +659,7 @@ function Get-XamarinStorageIndexUrl {
         * SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: The uri of the vsts collection. Needed to be able to calculate the target url.
         * SYSTEM_TEAMPROJECT: The team project executing the build. Needed to be able to calculate the target url.
         * BUILD_BUILDID: The current build id. Needed to be able to calculate the target url.
-        * BUILD_REVISION: The revision of the current build. Needed to know the commit whose status to change.
+        * BUILD_SOURCEVERSION: The revision of the current build. Needed to know the commit whose status to change.
         * GITHUB_TOKEN: OAuth or PAT token to interact with the GitHub API.
 #>
 function New-GitHubComment {
@@ -684,7 +684,7 @@ function New-GitHubComment {
         "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI" = $Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI;
         "SYSTEM_TEAMPROJECT" = $Env:SYSTEM_TEAMPROJECT;
         "BUILD_DEFINITIONNAME" = $Env:BUILD_DEFINITIONNAME;
-        "BUILD_REVISION" = $Env:BUILD_REVISION;
+        "BUILD_SOURCEVERSION" = $Env:BUILD_SOURCEVERSION;
         "BUILD_REASON" = $Env:BUILD_REASON;
         "BUILD_SOURCEBRANCH" = $Env:BUILD_SOURCEBRANCH;
         "GITHUB_TOKEN" = $Env:GITHUB_TOKEN;
@@ -720,7 +720,7 @@ function New-GitHubComment {
         $changeId = $buildSourceBranch.Replace("refs/pull/", "").Replace("/merge", "")
         $url = "https://api.github.com/repos/xamarin/xamarin-macios/issues/$changeId/comments"
     } else {
-        $url = "https://api.github.com/repos/xamarin/xamarin-macios/commits/$Env:BUILD_REVISION/comments"
+        $url = "https://api.github.com/repos/xamarin/xamarin-macios/commits/$Env:BUILD_SOURCEVERSION/comments"
     }
 
     # github has a max size for the comments to be added in a PR, it can be the case that because we failed so much, that we

--- a/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
+++ b/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
@@ -53,7 +53,6 @@ steps:
   name: detectChanges
   continueOnError: true # this isn't fatal, the github comment will show how bad this really is
   env:
-    BUILD_REVISION: 'devops' # doesn't matter the exact value, any value is understood as "we're in CI"
     PR_ID: ${{ parameters.prID }} # reusing jenkins vars, to be fixed
     AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
 

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -127,7 +127,6 @@ jobs:
     PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
     # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
     BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
-    BUILD_REVISION: $[ variables['Build.SourceVersion'] ]
     XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness_labels'] ]
     RUN_MAC_TESTS: $[ dependencies.configure.outputs['decisions.RUN_MAC_TESTS'] ]
   pool:

--- a/tools/devops/automation/templates/common/setup.yml
+++ b/tools/devops/automation/templates/common/setup.yml
@@ -15,8 +15,6 @@ steps:
 
 - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/clean-bot.sh
   displayName: 'Clean bot'
-  env:
-    BUILD_REVISION: 'jenkins'
   continueOnError: true
   timeoutInMinutes: 60
 

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -45,7 +45,6 @@ steps:
     $statuses.SetStatus("pending", "Tests on macOS ${{ parameters.statusContext }} have started.", "${{ parameters.statusContext }}")
   displayName: "Initialize state"
   env:
-    BUILD_REVISION: $(Build.SourceVersion)
     CONTEXT: ${{ parameters.statusContext }}
     GITHUB_TOKEN: $(GitHub.Token)
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -98,8 +97,6 @@ steps:
 
 - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/clean-bot.sh
   displayName: 'Clean bot'
-  env:
-    BUILD_REVISION: 'jenkins'
   continueOnError: true
   timeoutInMinutes: 60
 
@@ -116,7 +113,6 @@ steps:
       exit 1
     }
   env:
-    BUILD_REVISION: $(Build.SourceVersion)
     CONTEXT: ${{ parameters.statusContext }}
     GITHUB_TOKEN: $(GitHub.Token)
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -255,7 +251,6 @@ steps:
   timeoutInMinutes: 60
   env:
     CONTEXT: ${{ parameters.statusContext }}
-    BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     MONO_DEBUG: no-gdb-backtrace
@@ -286,7 +281,6 @@ steps:
   continueOnError: true
   env:
     CONTEXT: ${{ parameters.statusContext }}
-    BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     TEST_BOT: $(Agent.Name)

--- a/tools/devops/automation/templates/sign-and-notarized/artifact-github-comment.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/artifact-github-comment.yml
@@ -32,7 +32,6 @@ steps:
     $result = $gihubComments.NewCommentFromObject("Artifacts", ":books:", $artifact)
     Write-Host $result
   env:
-    BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
     ACCESSTOKEN: $(System.AccessToken)
     ${{ if eq(parameters.repositoryAlias, 'self') }}:

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -257,7 +257,6 @@ steps:
     Write-Host "Setting SBOM.PackagesPath: ${pkgsPath}"
     Write-Host "##vso[task.setvariable variable=SBOM.PackagesPath]$pkgsPath"
   env:
-    BUILD_REVISION: $(Build.SourceVersion)
     GITHUB_TOKEN: $(GitHub.Token)
     ACCESSTOKEN: $(System.AccessToken)
     AZURE_CONTAINER: ${{ parameters.azureContainer }}

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -90,7 +90,6 @@ steps:
       $statuses.SetStatus("pending", "Device tests on VSTS have been started.", "${{ parameters.statusContext }}")
     }
   env:
-    BUILD_REVISION: $(Build.SourceVersion)
     CONTEXT: ${{ parameters.statusContext }}
     GITHUB_TOKEN: $(GitHub.Token)
     ACCESSTOKEN: $(System.AccessToken)

--- a/tools/devops/automation/templates/tests/publish-html.yml
+++ b/tools/devops/automation/templates/tests/publish-html.yml
@@ -89,7 +89,6 @@ steps:
       }
   env:
     LABELS: ${{ join(';', parameters.simTestsConfigurations) }}
-    BUILD_REVISION: $(Build.SourceVersion)
     CONTEXT: ${{ parameters.statusContext }}
     DEVICE_PREFIX: ${{ parameters.testPrefix }}
     GITHUB_TOKEN: $(GitHub.Token)

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -193,7 +193,6 @@ steps:
     TESTS_EXTRA_ARGUMENTS: ${{ parameters.testsLabels }}
     USE_XAMARIN_STORAGE: ${{ parameters.useXamarinStorage }}
     USE_TCP_TUNNEL: 'true'
-    BUILD_REVISION: $(Build.SourceVersion)
     PARAMETERS_TESTPREFIX: '${{ parameters.testPrefix }}'
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios
   displayName: 'Run tests'

--- a/tools/devops/automation/templates/variables.yml
+++ b/tools/devops/automation/templates/variables.yml
@@ -39,3 +39,6 @@ variables:
   value: 'bosstoragemirror'
 - name: azureContainer
   value: 'wrench'
+- name: BUILD_REVISION
+  value: azure-devops-$(Build.SourceVersion)
+


### PR DESCRIPTION
A lot of code in our repo uses the presence of the BUILD_REVISION environment
variable to determine whether we're running in CI or not, so just set the
variable globally once so that it's always set - that way we never forget to
set it.

Note that the exact value of the variable doesn't matter, only that it's set.
Also change one place in the yaml that was depending on the contents of the
BUILD_REVISION to use the Azure Devops variable BUILD_SOURCEVERSION instead
(like we do everywhere else in our yaml code).