### PR TITLE
[main] Fix native watchOS app bundling when using newer Xcode 14 watchOS project. Fixes #16142.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ValidateAppBundleTaskBase.cs
@@ -115,7 +115,7 @@ namespace Xamarin.iOS.Tasks {
 				break;
 			}
 		}
-		
+
 		void ValidateWatchApp (string path, string mainBundleIdentifier, string mainShortVersionString, string mainVersion)
 		{
 			var name = Path.GetFileNameWithoutExtension (path);


### PR DESCRIPTION
I've made some small edits to the ValidateWatchApp method to allow for a native watchOS app that was created in Xcode 14 that uses a single project instead of an extension to be bundled into a Xamarin app. 

Should fix #16142 and progress on #10070


Backport of #16690
