### PR TITLE
[generator] Unify generation/copying of Obsolete attributes.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -5170,7 +5170,7 @@ namespace AVFoundation {
 
 #if !NET
 		[Field ("AVMetadataFormatQuickTimeUserData")]
-		[Obsolete ("Use 'AVMetadataFormat' enum values")]
+		[Obsolete ("Use 'AVMetadataFormat' enum values.")]
 		NSString FormatQuickTimeUserData { get; }
 #endif
 		
@@ -5353,7 +5353,7 @@ namespace AVFoundation {
 #if !NET
 		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadataFormatISOUserData")]
-		[Obsolete ("Use 'AVMetadataFormat' enum values")]
+		[Obsolete ("Use 'AVMetadataFormat' enum values.")]
 		NSString KFormatISOUserData { get; }
 #endif
 
@@ -5501,7 +5501,7 @@ namespace AVFoundation {
 		
 #if !NET
 		[Field ("AVMetadataFormatiTunesMetadata")]
-		[Obsolete ("Use 'AVMetadataFormat' enum values")]
+		[Obsolete ("Use 'AVMetadataFormat' enum values.")]
 		NSString FormatiTunesMetadata { get; }
 #endif
 		
@@ -5655,7 +5655,7 @@ namespace AVFoundation {
 		
 #if !NET
 		[Field ("AVMetadataFormatID3Metadata")]
-		[Obsolete ("Use 'AVMetadataFormat' enum values")]
+		[Obsolete ("Use 'AVMetadataFormat' enum values.")]
 		NSString FormatID3Metadata { get; }
 #endif
 
@@ -5976,7 +5976,7 @@ namespace AVFoundation {
 #if !NET
 		[iOS (8,0)][Mac (10,10)]
 		[Field ("AVMetadataFormatHLSMetadata")]
-		[Obsolete ("Use 'AVMetadataFormat' enum values")]
+		[Obsolete ("Use 'AVMetadataFormat' enum values.")]
 		NSString FormatHlsMetadata { get; }
 #endif
 

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -192,27 +192,27 @@ namespace CoreGraphics {
 		NSString ExtendedLinearGray { get; }
 
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
-		[Obsolete ("Now accessible as GenericCmyk")]
+		[Obsolete ("Now accessible as GenericCmyk.")]
 		[Field ("kCGColorSpaceGenericCMYK")]
 		NSString GenericCMYK { get; }
 
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
-		[Obsolete ("Now accessible as AdobeRgb1998")]
+		[Obsolete ("Now accessible as AdobeRgb1998.")]
 		[Field ("kCGColorSpaceAdobeRGB1998")]
 		NSString AdobeRGB1998 { get; }
 
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
-		[Obsolete ("Now accessible as Srgb")]
+		[Obsolete ("Now accessible as Srgb.")]
 		[Field ("kCGColorSpaceSRGB")]
 		NSString SRGB { get; }
 
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
-		[Obsolete ("Now accessible as GenericRgb")]
+		[Obsolete ("Now accessible as GenericRgb.")]
 		[Field ("kCGColorSpaceGenericRGB")]
 		NSString GenericRGB { get; }
 
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
-		[Obsolete ("Now accessible as GenericRgb")]
+		[Obsolete ("Now accessible as GenericRgb.")]
 		[Field ("kCGColorSpaceGenericRGBLinear")]
 		NSString GenericRGBLinear { get; }
 

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -35,12 +35,6 @@ public partial class Generator {
 		}
 	}
 
-	void CopyObsolete (ICustomAttributeProvider provider)
-	{
-		foreach (var oa in AttributeManager.GetCustomAttributes<ObsoleteAttribute> (provider))
-			print ("[Obsolete (\"{0}\", {1})]", oa.Message, oa.IsError ? "true" : "false");
-	}
-
 	void CopyNativeName (ICustomAttributeProvider provider)
 	{
 		foreach (var oa in AttributeManager.GetCustomAttributes<NativeNameAttribute> (provider))
@@ -85,7 +79,7 @@ public partial class Generator {
 			sb.Append ("]");
 			print (sb.ToString ());
 		}
-		CopyObsolete (type);
+		PrintObsoleteAttributes (type);
 		CopyNativeName (type);
 
 		var unique_constants = new HashSet<string> ();
@@ -100,7 +94,7 @@ public partial class Generator {
 			if (f.IsSpecialName)
 				continue;
 			PrintPlatformAttributes (f, is_enum: true);
-			CopyObsolete (f);
+			PrintObsoleteAttributes (f);
 			print ("{0} = {1},", f.Name, f.GetRawConstantValue ());
 			var fa = AttributeManager.GetCustomAttribute<FieldAttribute> (f);
 			if (fa == null)


### PR DESCRIPTION
Unify generation/copying of Obsolete attributes from api definitions to generated code.

This reduces code dupliation a bit, but it will also result in more
"[EditorBrowsable (Never)]" attributes (which we weren't generating in a few
cases).

In addition we're now copying Obsolete attributes for smart fields to the
generated code.