### PR TITLE
[tests] Don't build packaged macOS tests in parallel in CI.

### DIFF
--- a/tests/package-mac-tests.sh
+++ b/tests/package-mac-tests.sh
@@ -58,7 +58,11 @@ if test -n "$INCLUDE_XAMARIN_LEGACY"; then
 fi
 TEST_SUITES+=(build-monotouch-test)
 
-make -f packaged-macos-tests.mk "${TEST_SUITES[@]}" -j
+if test -n "$BUILD_REVISION"; then
+	MAKE_FLAGS=-j
+fi
+
+make -f packaged-macos-tests.mk "${TEST_SUITES[@]}" $MAKE_FLAGS
 
 if test -n "$INCLUDE_XAMARIN_LEGACY"; then
 	for app in */bin/x86/*/*.app linker/mac/*/bin/x86/*/*.app linker/mac/*/generated-projects/*/bin/x86/*/*.app introspection/Mac/bin/x86/*/*.app; do


### PR DESCRIPTION
The random build failure it causes aren't worth it for the speed gain.