### PR TITLE
[Foundation] Remove support for '[NSAttributedString initWithFileURL:options:documentAttributes:error:]'.

### DIFF
--- a/src/Foundation/NSAttributedString.iOS.cs
+++ b/src/Foundation/NSAttributedString.iOS.cs
@@ -55,20 +55,6 @@ namespace Foundation {
 		public NSAttributedString (NSData data, ref NSError error)
 		: this (data, new NSDictionary (), out ignore, ref error) { }
 
-#if IOS // not TVOS or WATCH
-		// use the best selector based on the OS version
-		public NSAttributedString (NSUrl url, NSDictionary? options, out NSDictionary resultDocumentAttributes, ref NSError error)
-		{
-			if (SystemVersion.CheckiOS (9,0))
-				Handle = InitWithURL (url, options, out resultDocumentAttributes, ref error);
-			else
-				Handle = InitWithFileURL (url, options, out resultDocumentAttributes, ref error);
-
-			if (Handle == IntPtr.Zero)
-				throw new ArgumentException ();
-		}
-#endif
-
 	}
 #endif
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -333,34 +333,9 @@ namespace Foundation
 		NativeHandle Constructor (string str);
 
 #if !MONOMAC
-
-#if IOS
-		// New API in iOS9 with same signature as an older alternative.
-		// We expose only the *new* one for the new platforms as the old
-		// one was moved to `NSDeprecatedKitAdditions (NSAttributedString)`
-		[NoMac][NoWatch][NoTV]
-		[iOS (9,0)]
-		[Internal]
-		[Export ("initWithURL:options:documentAttributes:error:")]
-		IntPtr InitWithURL (NSUrl url, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
-
-		// but we still need to allow the API to work before iOS 9.0
-		// and to compleify matters the old one was deprecated in 9.0
-		[NoMac][NoWatch][NoTV]
-		[iOS (7,0)]
-		[Internal]
-		[Deprecated (PlatformName.iOS, 9, 0)]
-		[Export ("initWithFileURL:options:documentAttributes:error:")]
-		IntPtr InitWithFileURL (NSUrl url, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
-#elif TVOS || WATCH
-		[NoMac]
-		[iOS (9,0)]
-		[Export ("initWithURL:options:documentAttributes:error:")]
-		NativeHandle Constructor (NSUrl url, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
-#endif
 		[NoMac]
 		[iOS (7,0)]
-		[Wrap ("this (url, options.GetDictionary (), out resultDocumentAttributes, ref error)")]
+		[Wrap ("this (url, options.GetDictionary ()!, out resultDocumentAttributes, ref error)")]
 		NativeHandle Constructor (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
 		[NoMac]
@@ -370,7 +345,7 @@ namespace Foundation
 
 		[NoMac]
 		[iOS (7,0)]
-		[Wrap ("this (data, options.GetDictionary (), out resultDocumentAttributes, ref error)")]
+		[Wrap ("this (data, options.GetDictionary ()!, out resultDocumentAttributes, ref error)")]
 		NativeHandle Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
 		[NoMac]
@@ -407,6 +382,13 @@ namespace Foundation
 		[Export ("enumerateAttribute:inRange:options:usingBlock:")]
 		void EnumerateAttribute (NSString attributeName, NSRange inRange, NSAttributedStringEnumeration options, NSAttributedStringCallback callback);
 
+		[Export ("initWithURL:options:documentAttributes:error:")]
+#if !(__MACOS__ || XAMCORE_5_0)
+		NativeHandle Constructor (NSUrl url, NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
+#else
+		NativeHandle Constructor (NSUrl url, NSDictionary options, out NSDictionary resultDocumentAttributes, out NSError error);
+#endif
+
 #if MONOMAC
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
 		[Export ("initWithData:options:documentAttributes:error:")]
@@ -425,15 +407,11 @@ namespace Foundation
 		void DrawString (CGRect rect, NSStringDrawingOptions options);	
 
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
-		[Export ("initWithURL:options:documentAttributes:error:")]
-		NativeHandle Constructor (NSUrl url, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, out NSError error);
-
-		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
-		[Wrap ("this (url, options.GetDictionary (), out resultDocumentAttributes, out error)")]
+		[Wrap ("this (url, options.GetDictionary ()!, out resultDocumentAttributes, out error)")]
 		NativeHandle Constructor (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, out NSError error);
 
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
-		[Wrap ("this (data, options.GetDictionary (), out resultDocumentAttributes, out error)")]
+		[Wrap ("this (data, options.GetDictionary ()!, out resultDocumentAttributes, out error)")]
 		NativeHandle Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, out NSError error);
 
 		[NoiOS][NoMacCatalyst][NoWatch][NoTV]

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
@@ -60,7 +60,6 @@
 !extra-null-allowed! 'System.Boolean UIKit.NSLayoutManagerDelegate::ShouldSetLineFragmentRect(UIKit.NSLayoutManager,CoreGraphics.CGRect&,CoreGraphics.CGRect&,System.Runtime.InteropServices.NFloat&,UIKit.NSTextContainer,Foundation.NSRange)' has a extraneous [NullAllowed] on parameter #2
 !extra-null-allowed! 'System.Boolean UIKit.NSLayoutManagerDelegate::ShouldSetLineFragmentRect(UIKit.NSLayoutManager,CoreGraphics.CGRect&,CoreGraphics.CGRect&,System.Runtime.InteropServices.NFloat&,UIKit.NSTextContainer,Foundation.NSRange)' has a extraneous [NullAllowed] on parameter #3
 !extra-null-allowed! 'System.Boolean UIKit.UIApplication::CanOpenUrl(Foundation.NSUrl)' has a extraneous [NullAllowed] on parameter #0
-!extra-null-allowed! 'System.IntPtr Foundation.NSAttributedString::InitWithURL(Foundation.NSUrl,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSData,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIAccessibilityCustomAction::.ctor(Foundation.NSAttributedString,UIKit.UIAccessibilityCustomActionHandler)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIAccessibilityCustomAction::.ctor(System.String,UIKit.UIAccessibilityCustomActionHandler)' has a extraneous [NullAllowed] on parameter #1

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -268,7 +268,6 @@
 !extra-null-allowed! 'System.Void AppKit.NSView::WillRemoveSubview(AppKit.NSView)' has a extraneous [NullAllowed] on parameter #0
 !extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSData,Foundation.NSDictionary,Foundation.NSDictionary&)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSData,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
-!extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSUrl,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
 
 # Initial result from new rule missing-null-allowed
 !missing-null-allowed! 'AppKit.INSPasteboardWriting AppKit.NSCollectionViewDelegate::PasteboardWriterForItem(AppKit.NSCollectionView,System.UIntPtr)' is missing an [NullAllowed] on return type

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
@@ -102,7 +102,6 @@
 !extra-null-allowed! 'System.Boolean UIKit.NSLayoutManagerDelegate::ShouldSetLineFragmentRect(UIKit.NSLayoutManager,CoreGraphics.CGRect&,CoreGraphics.CGRect&,System.Runtime.InteropServices.NFloat&,UIKit.NSTextContainer,Foundation.NSRange)' has a extraneous [NullAllowed] on parameter #3
 !extra-null-allowed! 'System.Boolean UIKit.UIApplication::CanOpenUrl(Foundation.NSUrl)' has a extraneous [NullAllowed] on parameter #0
 !extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSData,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
-!extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSUrl,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIAccessibilityCustomAction::.ctor(Foundation.NSAttributedString,UIKit.UIAccessibilityCustomActionHandler)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIAccessibilityCustomAction::.ctor(System.String,UIKit.UIAccessibilityCustomActionHandler)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIAccessibilityCustomAction::set_Name(System.String)' has a extraneous [NullAllowed] on parameter #0

--- a/tests/xtro-sharpie/iOS-UIKit.ignore
+++ b/tests/xtro-sharpie/iOS-UIKit.ignore
@@ -82,7 +82,6 @@
 !extra-null-allowed! 'System.Boolean UIKit.NSLayoutManagerDelegate::ShouldSetLineFragmentRect(UIKit.NSLayoutManager,CoreGraphics.CGRect&,CoreGraphics.CGRect&,System.nfloat&,UIKit.NSTextContainer,Foundation.NSRange)' has a extraneous [NullAllowed] on parameter #2
 !extra-null-allowed! 'System.Boolean UIKit.NSLayoutManagerDelegate::ShouldSetLineFragmentRect(UIKit.NSLayoutManager,CoreGraphics.CGRect&,CoreGraphics.CGRect&,System.nfloat&,UIKit.NSTextContainer,Foundation.NSRange)' has a extraneous [NullAllowed] on parameter #3
 !extra-null-allowed! 'System.Boolean UIKit.UIApplication::CanOpenUrl(Foundation.NSUrl)' has a extraneous [NullAllowed] on parameter #0
-!extra-null-allowed! 'System.IntPtr Foundation.NSAttributedString::InitWithURL(Foundation.NSUrl,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSData,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIAccessibilityCustomAction::.ctor(Foundation.NSAttributedString,UIKit.UIAccessibilityCustomActionHandler)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIAccessibilityCustomAction::.ctor(System.String,UIKit.UIAccessibilityCustomActionHandler)' has a extraneous [NullAllowed] on parameter #1

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -368,7 +368,6 @@
 !extra-null-allowed! 'System.Void AppKit.NSView::WillRemoveSubview(AppKit.NSView)' has a extraneous [NullAllowed] on parameter #0
 !extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSData,Foundation.NSDictionary,Foundation.NSDictionary&)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSData,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
-!extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSUrl,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
 
 # Initial result from new rule missing-null-allowed
 !missing-null-allowed! 'AppKit.INSPasteboardWriting AppKit.NSCollectionViewDelegate::PasteboardWriterForItem(AppKit.NSCollectionView,System.nuint)' is missing an [NullAllowed] on return type

--- a/tests/xtro-sharpie/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/tvOS-UIKit.ignore
@@ -114,7 +114,6 @@
 !extra-null-allowed! 'System.Boolean UIKit.NSLayoutManagerDelegate::ShouldSetLineFragmentRect(UIKit.NSLayoutManager,CoreGraphics.CGRect&,CoreGraphics.CGRect&,System.nfloat&,UIKit.NSTextContainer,Foundation.NSRange)' has a extraneous [NullAllowed] on parameter #3
 !extra-null-allowed! 'System.Boolean UIKit.UIApplication::CanOpenUrl(Foundation.NSUrl)' has a extraneous [NullAllowed] on parameter #0
 !extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSData,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
-!extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSUrl,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIAccessibilityCustomAction::.ctor(Foundation.NSAttributedString,UIKit.UIAccessibilityCustomActionHandler)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIAccessibilityCustomAction::.ctor(System.String,UIKit.UIAccessibilityCustomActionHandler)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIAccessibilityCustomAction::set_Name(System.String)' has a extraneous [NullAllowed] on parameter #0

--- a/tests/xtro-sharpie/watchOS-UIKit.ignore
+++ b/tests/xtro-sharpie/watchOS-UIKit.ignore
@@ -26,7 +26,6 @@
 
 # Initial result from new rule extra-null-allowed
 !extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSData,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
-!extra-null-allowed! 'System.Void Foundation.NSAttributedString::.ctor(Foundation.NSUrl,Foundation.NSDictionary,Foundation.NSDictionary&,Foundation.NSError&)' has a extraneous [NullAllowed] on parameter #1
 !extra-null-allowed! 'System.Void UIKit.UIBezierPath::set_CGPath(CoreGraphics.CGPath)' has a extraneous [NullAllowed] on parameter #0
 
 # Initial result from new rule missing-null-allowed


### PR DESCRIPTION
The 'initWithFileURL:options:documentAttributes:error:' was deprecated in iOS
9, and a new alternative (initWithURL:options:documentAttributes:error:) was
added. At the time, we implemented automatic detection of the current OS, and
would choose one version or the other depending on which was available.

We won't support anything below iOS 9 anymore, which means that keeping the
backwards-compatible constructor is useless, so just remove the corresponding
code and expose the new alternative directly.

On another note, this constructor uses a 'ref NSError' argument instead of an
'out NSError' on mobile platforms (likely due to the generator not having
proper 'out' parameter support when this constructor was implemented), so
improve to use 'out' parameters in XAMCORE_5_0 (and macOS, where it already
uses 'out' parameters).

Ref: https://github.com/xamarin/xamarin-macios/issues/15216