### PR TITLE
[Localization] Add the test-cron branch to the schedule and other params

### DIFF
--- a/tests/monotouch-test/CoreFoundation/SocketTest.cs
+++ b/tests/monotouch-test/CoreFoundation/SocketTest.cs
@@ -27,7 +27,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class CFSocketTest {
-		static readonly byte[] dataToSend = { 0, 1, 2, 3 };
+		static readonly byte [] dataToSend = { 0, 1, 2, 3 };
 
 		[Test]
 		public void RetainCount ()
@@ -81,8 +81,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 			var gchandles = new Tuple<GCHandle, GCHandle> [socketCount];
 			var mainLoop = CFRunLoop.Current;
 			Exception ex = null;
-			var thread = new Thread ((v) =>
-			{
+			var thread = new Thread ((v) => {
 				try {
 					for (var i = 0; i < socketCount; i++) {
 						var received = new ManualResetEvent (false);

--- a/tests/monotouch-test/CoreFoundation/SocketTest.cs
+++ b/tests/monotouch-test/CoreFoundation/SocketTest.cs
@@ -27,7 +27,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class CFSocketTest {
-		static readonly byte [] dataToSend = { 0, 1, 2, 3 };
+		static readonly byte[] dataToSend = { 0, 1, 2, 3 };
 
 		[Test]
 		public void RetainCount ()
@@ -81,7 +81,8 @@ namespace MonoTouchFixtures.CoreFoundation {
 			var gchandles = new Tuple<GCHandle, GCHandle> [socketCount];
 			var mainLoop = CFRunLoop.Current;
 			Exception ex = null;
-			var thread = new Thread ((v) => {
+			var thread = new Thread ((v) =>
+			{
 				try {
 					for (var i = 0; i < socketCount; i++) {
 						var received = new ManualResetEvent (false);

--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -157,9 +157,11 @@ resources:
     endpoint: xamarin
 
 variables:
+- ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
+  - template: templates/vsts-variables.yml
 - template: templates/variables.yml
 - name: MicrobuildConnector
-  value: ''
+  value: 'MicroBuild Signing Task (DevDiv)'
 
 trigger: none
 
@@ -167,11 +169,12 @@ schedules:
 
 # the translations team wants a green build, we can do that on sundays even if 
 # the code did not change and without the device tests.
-- cron: "0 12 * * 0"
-  displayName: Weekly Translations build (Sunday @ noon)
+- cron: "0 22 * * *"
+  displayName: Translations build
   branches:
     include:
     - main
+    - test-cron
   always: true
 
 stages:

--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -157,11 +157,9 @@ resources:
     endpoint: xamarin
 
 variables:
-- ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
-  - template: templates/vsts-variables.yml
 - template: templates/variables.yml
 - name: MicrobuildConnector
-  value: 'MicroBuild Signing Task (DevDiv)'
+  value: ''
 
 trigger: none
 

--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -169,7 +169,7 @@ schedules:
 
 # the translations team wants a green build, we can do that on sundays even if 
 # the code did not change and without the device tests.
-- cron: "0 22 * * *"
+- cron: "0 12 * * 0"
   displayName: Translations build
   branches:
     include:

--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -167,7 +167,7 @@ schedules:
 
 # the translations team wants a green build, we can do that on sundays even if 
 # the code did not change and without the device tests.
-- cron: "0 12 * * 0"
+- cron: "51 14 * * *"
   displayName: Weekly Translations build (Sunday @ noon)
   branches:
     include:

--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -170,7 +170,7 @@ schedules:
 # the translations team wants a green build, we can do that on sundays even if 
 # the code did not change and without the device tests.
 - cron: "0 12 * * 0"
-  displayName: Translations build
+  displayName: Weekly Translations build (Sunday @ noon)
   branches:
     include:
     - main


### PR DESCRIPTION
Adding the test-cron branch to the xamarin-macios-localization pipeline so that we can change the times on that branch. 

This PR needs to land in the main branch because the pipeline points to this yaml file in the main branch so the needed parameters need to be here