### PR TITLE
Use test channel of build-tasks

### DIFF
--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -120,7 +120,7 @@ resources:
   - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/bond/build-tasks-channel
     endpoint: xamarin
 
   - repository: sdk-insertions

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -62,6 +62,7 @@ steps:
 # Important needed for the next step
 - template: generate-workspace-info.yml@yaml-templates
   parameters:
+    BuildTasksChannel: 'test'
     GitHubToken: $(GitHub.Token)
     ArtifactDirectory: $(Build.SourcesDirectory)/package-internal
 


### PR DESCRIPTION
Checking to see if the test-signed version of the build-tasks package solves the virus scanning issue