### PR TITLE
[release/6.0.4xx-xcode14.1] [tests] Ignore PassLibraryTest.PassLibraryTest on bots if PKPassLibrary.GetPasses returns null. Fixes #xamarin/maccore@2598.

### DIFF
--- a/tests/monotouch-test/PassKit/PassLibraryTest.cs
+++ b/tests/monotouch-test/PassKit/PassLibraryTest.cs
@@ -42,7 +42,7 @@ namespace MonoTouchFixtures.PassKit {
 			if (passes is null)
 				TestRuntime.IgnoreInCI ("GetPasses () seems to randomly return null on our bots.");
 			// If the following assert fails for you locally, please investigate! See https://github.com/xamarin/maccore/issues/2598.
-			Assert.NotNull (passes, "GetPasses");
+			Assert.NotNull (passes, "GetPasses - if this assert fails for you locally, please investigate! See https://github.com/xamarin/maccore/issues/2598.");
 
 			using (var url = PassTest.GetBoardingPassUrl ()) {
 #if __MACCATALYST__

--- a/tests/monotouch-test/PassKit/PassLibraryTest.cs
+++ b/tests/monotouch-test/PassKit/PassLibraryTest.cs
@@ -38,7 +38,11 @@ namespace MonoTouchFixtures.PassKit {
 
 			var library = new PKPassLibrary ();
 			// not null (but empty by default) and there's no API to add them
-			Assert.NotNull (library.GetPasses (), "GetPasses");
+			var passes = library.GetPasses ();
+			if (passes is null)
+				TestRuntime.IgnoreInCI ("GetPasses () seems to randomly return null on our bots.");
+			// If the following assert fails for you locally, please investigate! See https://github.com/xamarin/maccore/issues/2598.
+			Assert.NotNull (passes, "GetPasses");
 
 			using (var url = PassTest.GetBoardingPassUrl ()) {
 #if __MACCATALYST__


### PR DESCRIPTION
PKPassLibrary.GetPasses randomly returns null for no apparent rhyme or reason
on our bots, so just ignore the test in that case.

Maybe if someone can reproduce locally one day we'll be able to investigate
and figure out what's happening.

Fixes https://github.com/xamarin/maccore/issues/2598.


Backport of #16738
