### PR TITLE
[tests] Don't run watchOS tests for .NET.

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS.cs
@@ -5,7 +5,6 @@ using Xamarin.Tests;
 using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks {
-	[TestFixture (true)]
 	[TestFixture (false)]
 	public abstract class GeneratePlistTaskTests_watchOS : GeneratePlistTaskTests_Core {
 		protected override ApplePlatform Platform => ApplePlatform.WatchOS;

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS_WatchKitApp.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS_WatchKitApp.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
 
 namespace Xamarin.MacDev.Tasks {
-	[TestFixture (true)]
 	[TestFixture (false)]
 	public class GeneratePlistTaskTests_watchOS_WatchKitApp : GeneratePlistTaskTests_watchOS {
 		public GeneratePlistTaskTests_watchOS_WatchKitApp (bool isDotNet)

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS_WatchKitExtension.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_watchOS_WatchKitExtension.cs
@@ -3,7 +3,6 @@ using NUnit.Framework;
 using Xamarin.MacDev;
 
 namespace Xamarin.MacDev.Tasks {
-	[TestFixture (true)]
 	[TestFixture (false)]
 	public class GeneratePlistTaskTests_watchOS_WatchKitExtension : GeneratePlistTaskTests_watchOS {
 		public GeneratePlistTaskTests_watchOS_WatchKitExtension (bool isDotNet)


### PR DESCRIPTION
Fixes these tests:

```
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).BuildMachineOSBuild: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).BundleDevelopmentRegion: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).BundleExecutable: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).BundleIdentifier: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).BundleInfoDictionaryVersion: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).BundleName: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).BundlePackageType: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).BundleSignature: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).BundleSupportedPlatforms: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).BundleVersion: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).DeviceFamily: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).MinimumOSVersion: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).MissingBundleIdentifier: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).MissingDisplayName: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).NormalPlist: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).NoWatchCompanion: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).PlistMissing: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).VerifyAllDT: System.InvalidOperationException : Invalid platform: WatchOS
* Xamarin.MacDev.Tasks.GeneratePlistTaskTests_watchOS_WatchKitExtension(True).XamarinVersion: System.InvalidOperationException : Invalid platform: WatchOS
```