### PR TITLE
[src] Remove availability attributes on error enums.

### DIFF
--- a/src/CoreLocation/CLEnums.cs
+++ b/src/CoreLocation/CLEnums.cs
@@ -69,7 +69,6 @@ namespace CoreLocation {
 		PromptDeclined = 18,
 
 		// ios16
-		[NoMac, iOS (16, 1), MacCatalyst (16, 1), Watch (9, 1), TV (16, 1)]
 		HistoricalLocationError,
 	}
 

--- a/src/watchkit.cs
+++ b/src/watchkit.cs
@@ -1584,9 +1584,7 @@ namespace WatchKit {
 		BARDisabled = 6,
 		NotApprovedToStartSession = 7,
 		NotApprovedToSchedule = 8,
-		[Watch (9,0)]
 		MustBeActiveToPrompt = 9,
-		[Watch (9,0)]
 		UnsupportedSessionType = 10,
 	}
 


### PR DESCRIPTION
Fixes these test failures:

    1) Failed : Cecil.Tests.EnumTest.NoAvailabilityOnError("/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/32bits/iOS/Xamarin.iOS.dll")
       CoreLocation.CLError.HistoricalLocationError
       Expected: <empty>
       But was:  < "CoreLocation.CLError.HistoricalLocationError" >
       at Cecil.Tests.EnumTest.NoAvailabilityOnError (System.String assemblyPath) [0x00067] in /Users/builder/azdo/_work/3/s/xamarin-macios/tests/cecil-tests/EnumTest.cs:29

    2) Failed : Cecil.Tests.EnumTest.NoAvailabilityOnError("/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/iOS/Xamarin.iOS.dll")
       CoreLocation.CLError.HistoricalLocationError
       Expected: <empty>
       But was:  < "CoreLocation.CLError.HistoricalLocationError" >
       at Cecil.Tests.EnumTest.NoAvailabilityOnError (System.String assemblyPath) [0x00067] in /Users/builder/azdo/_work/3/s/xamarin-macios/tests/cecil-tests/EnumTest.cs:29

    3) Failed : Cecil.Tests.EnumTest.NoAvailabilityOnError("/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/32bits/watchOS/Xamarin.WatchOS.dll")
       WatchKit.WKExtendedRuntimeSessionErrorCode.MustBeActiveToPrompt, WatchKit.WKExtendedRuntimeSessionErrorCode.UnsupportedSessionType, CoreLocation.CLError.HistoricalLocationError
       Expected: <empty>
       But was:  < "WatchKit.WKExtendedRuntimeSessionErrorCode.MustBeActiveToPrompt", "WatchKit.WKExtendedRuntimeSessionErrorCode.UnsupportedSessionType", "CoreLocation.CLError.HistoricalLocationError" >
       at Cecil.Tests.EnumTest.NoAvailabilityOnError (System.String assemblyPath) [0x00067] in /Users/builder/azdo/_work/3/s/xamarin-macios/tests/cecil-tests/EnumTest.cs:29

    4) Failed : Cecil.Tests.EnumTest.NoAvailabilityOnError("/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/tvOS/Xamarin.TVOS.dll")
       CoreLocation.CLError.HistoricalLocationError
       Expected: <empty>
       But was:  < "CoreLocation.CLError.HistoricalLocationError" >
       at Cecil.Tests.EnumTest.NoAvailabilityOnError (System.String assemblyPath) [0x00067] in /Users/builder/azdo/_work/3/s/xamarin-macios/tests/cecil-tests/EnumTest.cs:29

    5) Failed : Cecil.Tests.EnumTest.NoAvailabilityOnError("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/Xamarin.Mac/Xamarin.Mac.dll")
       CoreLocation.CLError.HistoricalLocationError
       Expected: <empty>
       But was:  < "CoreLocation.CLError.HistoricalLocationError" >
       at Cecil.Tests.EnumTest.NoAvailabilityOnError (System.String assemblyPath) [0x00067] in /Users/builder/azdo/_work/3/s/xamarin-macios/tests/cecil-tests/EnumTest.cs:29

    6) Failed : Cecil.Tests.EnumTest.NoAvailabilityOnError("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/Xamarin.Mac.dll")
       CoreLocation.CLError.HistoricalLocationError
       Expected: <empty>
       But was:  < "CoreLocation.CLError.HistoricalLocationError" >
       at Cecil.Tests.EnumTest.NoAvailabilityOnError (System.String assemblyPath) [0x00067] in /Users/builder/azdo/_work/3/s/xamarin-macios/tests/cecil-tests/EnumTest.cs:29