### PR TITLE
[devops] Update according to renamed label.

### DIFF
--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -333,7 +333,8 @@ class BuildConfiguration {
             "skip-nugets",
             "skip-signing",
             "run-sample-tests",
-            "skip-packaged-xamarin-mac-tests",
+            "skip-packaged-macos-tests",
+            "run-packaged-macos-tests",
             "skip-api-comparison",
             "skip-all-tests"
           )


### PR DESCRIPTION
Also add 'run-packaged-macos-tests' to the labels we care about.

This fixes an issue where the label combination
'skip-all-tests,run-packaged-macos-tests' would not run any tests.