### PR TITLE
[tests] Improve AsyncTests.Bug12221 to not fail on 403 errors on the bots.

### DIFF
--- a/tests/bindings-test/iOS/bindings-test.csproj
+++ b/tests/bindings-test/iOS/bindings-test.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="Xamarin.iOS" />
     <PackageReference Include="NUnitLite" Version="3.12.0" />
   </ItemGroup>

--- a/tests/bindings-test/macOS/bindings-test.csproj
+++ b/tests/bindings-test/macOS/bindings-test.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -1388,6 +1389,11 @@ partial class TestRuntime {
 		IgnoreInCIfHttpStatusCodes (ex, HttpStatusCode.BadGateway, HttpStatusCode.GatewayTimeout, HttpStatusCode.ServiceUnavailable);
 	}
 
+	public static void IgnoreInCIIfForbidden (Exception ex)
+	{
+		IgnoreInCIfHttpStatusCodes (ex, HttpStatusCode.BadGateway, HttpStatusCode.GatewayTimeout, HttpStatusCode.ServiceUnavailable, HttpStatusCode.Forbidden);
+	}
+
 	public static void IgnoreInCIIfBadNetwork (HttpStatusCode status)
 	{
 		IgnoreInCIfHttpStatusCodes (status, HttpStatusCode.BadGateway, HttpStatusCode.GatewayTimeout, HttpStatusCode.ServiceUnavailable);
@@ -1415,6 +1421,16 @@ partial class TestRuntime {
 	static bool TryGetHttpStatusCode (Exception ex, out HttpStatusCode status)
 	{
 		status = (HttpStatusCode) 0;
+
+#if NET // HttpRequestException.StatusCode only exists in .NET 5+
+		if (ex is HttpRequestException hre) {
+			if (hre.StatusCode.HasValue) {
+				status = hre.StatusCode.Value;
+				return true;
+			}
+			return false;
+		}
+#endif
 
 		var we = ex as WebException;
 		if (we is null)

--- a/tests/linker/ios/link sdk/AsyncTest.cs
+++ b/tests/linker/ios/link sdk/AsyncTest.cs
@@ -22,7 +22,12 @@ namespace LinkSdk {
 #if __WATCHOS__
 			Assert.Ignore ("WatchOS doesn't support BSD sockets, which our network stack currently requires.");
 #endif
-			LoadCategories ().Wait ();
+			try {
+				LoadCategories ().GetAwaiter ().GetResult ();
+			} catch (HttpRequestException hre) {
+				TestRuntime.IgnoreInCIIfForbidden (hre); // Ignore any 403 errors.
+				throw;
+			}
 		}
 	}
 }

--- a/tests/linker/ios/link sdk/AsyncTest.cs
+++ b/tests/linker/ios/link sdk/AsyncTest.cs
@@ -24,6 +24,9 @@ namespace LinkSdk {
 #endif
 			try {
 				LoadCategories ().GetAwaiter ().GetResult ();
+			} catch (TaskCanceledException tce) {
+				TestRuntime.IgnoreInCI ("Ignore any download timeouts");
+				throw;
 			} catch (HttpRequestException hre) {
 				TestRuntime.IgnoreInCIIfForbidden (hre); // Ignore any 403 errors.
 				throw;


### PR DESCRIPTION
Fixes:

    [FAIL] Bug12221 : System.AggregateException : One or more errors occurred. (Response status code does not indicate success: 403 (Forbidden).)
    ----> System.Net.Http.HttpRequestException : Response status code does not indicate success: 403 (Forbidden).
          at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean )
          at System.Threading.Tasks.Task.Wait(Int32 , CancellationToken )
          at System.Threading.Tasks.Task.Wait()
          at LinkSdk.AsyncTests.Bug12221() in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/linker/ios/link sdk/AsyncTest.cs:line 25
          at System.Reflection.MethodInvoker.InterpretedInvoke(Object , Span`1 , BindingFlags )
       --HttpRequestException
          at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
          at System.Net.Http.HttpClient.GetStringAsyncCore(HttpRequestMessage , CancellationToken )
          at LinkSdk.AsyncTests.<>c.<<LoadCategories>b__0_0>d.MoveNext() in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/linker/ios/link sdk/AsyncTest.cs:line 16

One important detail is the change from calling 'Wait ()' to calling
'GetAwaiter ().GetResult ()': this is to avoid the AggregateException in the
stack trace above.

Fixes https://github.com/xamarin/maccore/issues/2570.