### PR TITLE
[Localization] Change the Cron Job to trigger weekend scheduled build

### DIFF
--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -74,14 +74,13 @@ stages:
           repositoryAlias: self
           commit: HEAD
 
-    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-      - job: translations
-        displayName: 'Loc translations'
-        pool:
-          vmImage: windows-latest
-        steps:
-        - template:  templates/loc-translations.yml
-          parameters:
-            isPR: false
-            repositoryAlias: self
-            commit: HEAD
+    - job: translations
+      displayName: 'Loc translations'
+      pool:
+        vmImage: windows-latest
+      steps:
+      - template:  templates/loc-translations.yml
+        parameters:
+          isPR: false
+          repositoryAlias: self
+          commit: HEAD

--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -11,33 +11,7 @@ parameters:
   type: boolean
   default: true
 
-- name: stageDisplayNamePrefix
-  type: string
-  default: ''
-
-- name: dependsOn
-  type: string
-  default: ''
-
-- name: dependsOnResult
-  type: string
-  default: ''
-
-- name: isPR
-  type: boolean
-  default: false
-
-- name: repositoryAlias
-  type: string
-  default: self
-
-- name: commit
-  type: string
-  default: HEAD
-
 variables:
-- name: System.Debug
-  value: true
 - template: templates/variables.yml
 
 resources:
@@ -87,10 +61,7 @@ stages:
 
 - ${{ if eq(parameters.runGovernanceTests, true) }}:
   - stage: governance_checks
-    displayName: '${{ parameters.stageDisplayNamePrefix }}Governance Checks'
-    dependsOn: ${{ parameters.dependsOn }}
-    ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
-      condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
+    displayName: 'Governance Checks'
     jobs:
     - job: governance
       displayName: 'Governance Checks'
@@ -99,9 +70,9 @@ stages:
       steps:
       - template: templates/governance-checks.yml
         parameters:
-          isPR: ${{ parameters.isPR }}
-          repositoryAlias: ${{ parameters.repositoryAlias }}
-          commit: ${{ parameters.commit }}
+          isPR: false
+          repositoryAlias: self
+          commit: HEAD
 
     - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
       - job: translations
@@ -111,6 +82,6 @@ stages:
         steps:
         - template:  templates/loc-translations.yml
           parameters:
-            isPR: ${{ parameters.isPR }}
-            repositoryAlias: ${{ parameters.repositoryAlias }}
-            commit: ${{ parameters.commit }}
+            isPR: false
+            repositoryAlias: self
+            commit: HEAD

--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -7,124 +7,38 @@
 #
 parameters:
 
-- name: provisionatorChannel
-  displayName: Provisionator channel to use 
-  type: string
-  default: 'latest'
-
-- name: pool
-  type: string
-  displayName: Bot pool to use
-  default: automatic
-  values:
-  - pr
-  - ci
-  - automatic
-
-- name: runTests
-  displayName: Run Simulator Tests
-  type: boolean
-  default: true
-
-- name: runDeviceTests
-  displayName: Run Device Tests 
-  type: boolean
-  default: false
-
-- name: runOldMacOSTests
-  displayName: Run Tests on older macOS versions 
-  type: boolean
-  default: true
-
-- name: runWindowsIntegration
-  displayName: Run Windows integration tests
-  type: boolean
-  default: true
-
 - name: runGovernanceTests
-  displayName: Run Governance Checks
   type: boolean
   default: true
 
-- name: runSamples
-  displayName: Run Samples
+- name: stageDisplayNamePrefix
+  type: string
+  default: ''
+
+- name: dependsOn
+  type: string
+  default: ''
+
+- name: dependsOnResult
+  type: string
+  default: ''
+
+- name: isPR
   type: boolean
   default: false
-  
-- name: enableDotnet
-  displayName: Build Dotnet 
-  type: boolean
-  default: true
 
-- name: enableAPIDiff
-  displayName: Enable API diff generation
-  type: boolean
-  default: true
+- name: repositoryAlias
+  type: string
+  default: self
 
-- name: forceInsertion
-  displayName: Force Insertion 
-  type: boolean
-  default: false 
+- name: commit
+  type: string
+  default: HEAD
 
-- name: skipESRP
-  displayName: Skip ESRP
-  type: boolean
-  default: false # only to be used when testing the CI and we do not need a signed pkg
-
-- name: simTestsConfigurations
-  displayName: Simulator test configurations to run
-  type: object
-  default: []
-
-- name: deviceTestsConfigurations
-  displayName: Device test configurations to run
-  type: object
-  default: [
-    {
-      testPrefix: 'iOS64',
-      stageName: 'ios64b_device',
-      displayName: 'iOS64 Device Tests',
-      testPool: 'VSEng-Xamarin-Mac-Devices',
-      useXamarinStorage: false,
-      testsLabels: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
-      statusContext: 'VSTS: device tests iOS',
-      makeTarget: 'vsts-device-tests',
-      extraBotDemands: [
-        'ios',
-      ]
-    },
-    {
-      testPrefix: 'tvos',
-      stageName: 'tvos_device',
-      displayName: 'tvOS Device Tests',
-      testPool: 'VSEng-Xamarin-Mac-Devices',
-      useXamarinStorage: false,
-      testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
-      statusContext: 'VSTS: device tests tvOS',
-      makeTarget: 'vsts-device-tests',
-      extraBotDemands: [
-        'tvos',
-      ]
-    }]
-
-- name: macTestsConfigurations
-  displayName: macOS test configurations to run
-  type: object
-  default: [
-    {
-      stageName: 'mac_11_5_m1',
-      displayName: 'M1 - Mac Big Sur (11.5)',
-      macPool: 'VSEng-VSMac-Xamarin-Shared',
-      useImage: false,
-      statusContext: 'M1 - Mac Big Sur (11.5)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals BigSur",
-        "macOS.Architecture -equals arm64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    }]
+variables:
+- name: System.Debug
+  value: true
+- template: templates/variables.yml
 
 resources:
   repositories:
@@ -156,11 +70,6 @@ resources:
     ref: refs/heads/only_codesign
     endpoint: xamarin
 
-variables:
-- template: templates/variables.yml
-- name: MicrobuildConnector
-  value: ''
-
 trigger: none
 
 schedules:
@@ -175,29 +84,33 @@ schedules:
   always: true
 
 stages:
-- template: templates/main-stage.yml
-  parameters:
-    xcodeChannel: Stable
-    isPR: false
-    provisionatorChannel: ${{ parameters.provisionatorChannel }}
-    pool: ${{ parameters.pool }}
-    runTests: ${{ parameters.runTests }}
-    runDeviceTests: ${{ parameters.runDeviceTests }}
-    runOldMacOSTests: ${{ parameters.runOldMacOSTests }}
-    runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
-    runGovernanceTests: ${{ parameters.runGovernanceTests }}
-    runSamples: ${{ parameters.runSamples }}
-    enableDotnet: ${{ parameters.enableDotnet }}
-    enableAPIDiff: ${{ parameters.enableAPIDiff }}
-    forceInsertion: ${{ parameters.forceInsertion }}
-    skipESRP: ${{ parameters.skipESRP }}
-    ${{ if ne(length(parameters.simTestsConfigurations), 0)}}:
-      simTestsConfigurations: ${{ parameters.simTestsConfigurations }}
-    deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}
-    macTestsConfigurations: ${{ parameters.macTestsConfigurations }}
-    azureStorage: ${{ variables['azureStorage'] }}
-    azureContainer: ${{ variables['azureContainer'] }}
-    signingSetupSteps:
-    - template: ./templates/sign-and-notarized/setup.yml
-      parameters:
-        isPR: false
+
+- ${{ if eq(parameters.runGovernanceTests, true) }}:
+  - stage: governance_checks
+    displayName: '${{ parameters.stageDisplayNamePrefix }}Governance Checks'
+    dependsOn: ${{ parameters.dependsOn }}
+    ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
+      condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
+    jobs:
+    - job: governance
+      displayName: 'Governance Checks'
+      pool:
+        vmImage: windows-latest
+      steps:
+      - template: templates/governance-checks.yml
+        parameters:
+          isPR: ${{ parameters.isPR }}
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+
+    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+      - job: translations
+        displayName: 'Loc translations'
+        pool:
+          vmImage: windows-latest
+        steps:
+        - template:  templates/loc-translations.yml
+          parameters:
+            isPR: ${{ parameters.isPR }}
+            repositoryAlias: ${{ parameters.repositoryAlias }}
+            commit: ${{ parameters.commit }}


### PR DESCRIPTION
I have been testing these changes inside the xamarin-macios-translations pipeline.
The last run was green (found [here](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6984912&view=results)). I had to use some placeholder code for the actual calls for the OneLocBuild task that will communicate with the Loc Team but it reached those points as expected!

This PR also rips out calls to the main-stage.yml template to only use the stages necessary for the OneLocBuild run over the weekend!

I think these changes are set to see if the main branch can trigger the OneLocBuild Task over the weekend build!