### PR TITLE
Add Accent Color to ACTool task

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ACToolTaskBase.cs
@@ -17,6 +17,8 @@ namespace Xamarin.MacDev.Tasks {
 
 		#region Inputs
 
+		public string AccentColor { get; set; }
+
 		public string DeviceModel { get; set; }
 
 		public string DeviceOSVersion { get; set; }
@@ -85,6 +87,13 @@ namespace Xamarin.MacDev.Tasks {
 					if (IsMessagesExtension)
 						args.Add ("--product-type com.apple.product-type.app-extension.messages");
 				}
+			}
+
+			if (!string.IsNullOrEmpty(AccentColor)) {
+				args.Add("--accent-color", AccentColor);
+			}
+			else {
+				args.Add("--accent-color", "AccentColor");
 			}
 
 			if (!string.IsNullOrEmpty (XSLaunchImageAssets)) {

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -872,6 +872,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true' And '@(ImageAsset)' != ''"
 			ToolExe="$(ACToolExe)"
 			ToolPath="$(ACToolPath)"
+			AccentColor="$(AccentColor)"
 			BundleIdentifier="$(_BundleIdentifier)"
 			CLKComplicationGroup="$(_CLKComplicationGroup)"
 			DeviceModel="$(TargetDeviceModel)"


### PR DESCRIPTION
This PR addresses https://github.com/xamarin/xamarin-macios/issues/10275

`actool` can set an application's "Global" color set, overwriting the system defaults. XCode sets this as "AccentColor," but when we call it directly, we don't pass in anything. This means a user cannot overwrite this setting themselves unless they rewrite the ACTool task.

This PR adds the default "AccentColor" to the ACTool task, and an override parameter of "AccentColor."

![image](https://user-images.githubusercontent.com/898335/202905945-8bdb78ec-1a5e-408f-9db2-f35d58ae46f8.png)

![image](https://user-images.githubusercontent.com/898335/202905967-77c715db-a4ba-4211-9f21-1bb2473b0697.png)

To use this:

- Create a new Asset Catalog or use the default.
- Add a new ColorSet.
- Either use `AccentColor` or enter a new name and enter in the name as a parameter in your csproj.

You should now see the colors reflected in the application.