### PR TITLE
[NetworkExtension] Updated completionHandler of handleAppMessage

### DIFF
--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -1103,6 +1103,9 @@ namespace NetworkExtension {
 		[NullAllowed, Export ("proxySettings", ArgumentSemantic.Copy)]
 		NEProxySettings ProxySettings { get; set; }
 	}
+
+	[iOS(9, 0)][Mac(10, 11)]
+	delegate void NETunnelAppMessageHandler ([NullAllowed] NSData data);
 		
 	[iOS (9,0)][Mac (10,11)]
 	[BaseType (typeof(NEProvider))]
@@ -1111,8 +1114,8 @@ namespace NetworkExtension {
 	{
 		[Export ("handleAppMessage:completionHandler:")]
 		[Async]
-		void HandleAppMessage (NSData messageData, [NullAllowed] Action<NSData?> completionHandler);
-	
+		void HandleAppMessage (NSData messageData, [NullAllowed] NETunnelAppMessageHandler completionHandler);
+
 		[Export ("setTunnelNetworkSettings:completionHandler:")]
 		[Async]
 		void SetTunnelNetworkSettings ([NullAllowed] NETunnelNetworkSettings tunnelNetworkSettings, [NullAllowed] Action<NSError> completionHandler);

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -21,6 +21,8 @@ using NEHotspotHelperCommandType = Foundation.NSObject;
 using NEHotspotHelperConfidence = Foundation.NSObject;
 #endif
 
+#nullable enable
+
 namespace NetworkExtension {
 
 	// Just to satisfy the core dll contract, the right type will be used on the generated file
@@ -1109,7 +1111,7 @@ namespace NetworkExtension {
 	{
 		[Export ("handleAppMessage:completionHandler:")]
 		[Async]
-		void HandleAppMessage (NSData messageData, [NullAllowed] Action<NSData> completionHandler);
+		void HandleAppMessage (NSData messageData, [NullAllowed] Action<NSData?> completionHandler);
 	
 		[Export ("setTunnelNetworkSettings:completionHandler:")]
 		[Async]


### PR DESCRIPTION
HandleAppMessage as it appears in /src/build/Mac/full/NetworkExtension/NETunnelProvider.g.cs after running generator:

Export ("handleAppMessage:completionHandler:")]
[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
public unsafe virtual void HandleAppMessage (
    NSData messageData,       [BlockProxy(typeof(ObjCRuntime.Trampolines.NIDActionArity1V37))]global::System.Action<NSData>? completionHandler)

Fixes #16789