### PR TITLE
[Foundation] Fix NSDate's explicit conversion operators with DateTime.

### DIFF
--- a/src/Foundation/NSDate.cs
+++ b/src/Foundation/NSDate.cs
@@ -38,30 +38,90 @@ using ObjCRuntime;
 namespace Foundation {
 
 	public partial class NSDate {
-		const double NANOSECS_PER_MILLISEC = 1000000.0;
+		const int NANOSECS_PER_TICKS = 100;
+		const int NANOSECS_PER_MICROSEC = 1000;
+		const int NANOSECS_PER_MILLISEC = 1000000;
 
 		static readonly NSCalendar calendar = new NSCalendar (NSCalendarType.Gregorian) { TimeZone = NSTimeZone.FromName ("UTC") };
 
-		// now explicit since data can be lost for small/large values of DateTime
+		// Converting NSDate -> DateTime limits precision. The exact amount
+		// depends on the date (the further in the future the bigger the
+		// loss), but at DateTime.MaxValue it's around 91.5 microseconds.
+
+		// DateTime and NSDate computes time differently: basically they disagree on how many seconds or ticks have passed
+		// since a given date.
+		// Example: DateTime.MinValue is "January 1, 0001", but if you ask DateTime how many seconds ago that was, and give that
+		// number to NSDate, you get a date a couple of days later.
+		// So instead convert between NSDate and DateTime by getting the date and time components.
+		//
+		// Also note that converting NSDate -> DateTime limits precision. The
+		// exact amount depends on the date (the further in the future the
+		// bigger the loss), but at DateTime.MaxValue it's around 91.5
+		// microseconds.
 		public static explicit operator DateTime (NSDate d)
 		{
-			double secs = d.SecondsSinceReferenceDate;
-			if ((secs < -63114076800) || (secs > 252423993599.9994)) // we round to the nearest .001 in the conversion from ns to ms
-				throw new ArgumentOutOfRangeException (nameof (d), d, $"{nameof (d)} is outside the range of NSDate {secs} seconds");
-
-			// For 64 bit, convert to components representation since we cannot rely on secondsSinceReferenceDate
-			var units = NSCalendarUnit.Year | NSCalendarUnit.Month | NSCalendarUnit.Day | NSCalendarUnit.Hour |
+			var units = NSCalendarUnit.Era | NSCalendarUnit.Year | NSCalendarUnit.Month | NSCalendarUnit.Day | NSCalendarUnit.Hour |
 				NSCalendarUnit.Minute | NSCalendarUnit.Second | NSCalendarUnit.Nanosecond | NSCalendarUnit.Calendar;
+
 			using var calComponents = calendar.Components (units, d);
-			return new DateTime (
+
+			// DateTime doesn't support dates starting with year 10.000.
+			// Except for the year 10.000 on the dot: we convert it to DateTime.MaxValue.
+			//
+			// DateTime.MaxValue is actually one tick before year 10.000. This
+			// means that when we convert DateTime.MaxValue to NSDate, we
+			// actually end up with a date in year 10.000 due to precision
+			// differences. In order to be able to roundtrip a
+			// DateTime.MaxValue value, we hardcode the corresponding
+			// NSDate.SecondsSinceReferenceDate here.
+			if (calComponents.Year >= 10000) {
+				if (d.SecondsSinceReferenceDate == 252423993600)
+					return DateTime.SpecifyKind (DateTime.MaxValue, DateTimeKind.Utc);
+				throw new ArgumentOutOfRangeException (nameof (d), d, $"The date is outside the range of DateTime: {d.SecondsSinceReferenceDate}");
+			}
+
+			// DateTime doesn't support BC dates (AD dates have Era = 1)
+			if (calComponents.Era != 1)
+				throw new ArgumentOutOfRangeException (nameof (d), d, "The date is outside the range of DateTime.");
+
+			// NSCalendar gives us the number of nanoseconds corresponding
+			// with the fractional second. DateTime's constructor wants
+			// milliseconds and microseconds separately, where microseconds is
+			// the fractional number of milliseconds. That doesn't count for
+			// any remaining ticks, so add that at the end manually. This
+			// means we need to do some math here, to split the sub-second
+			// number of nanoseconds into milliseconds, microseconds and
+			// ticks.
+			var nanosecondsLeft = calComponents.Nanosecond;
+			var milliseconds = nanosecondsLeft / NANOSECS_PER_MILLISEC;
+			nanosecondsLeft -= milliseconds * NANOSECS_PER_MILLISEC;
+			var microseconds = nanosecondsLeft / NANOSECS_PER_MICROSEC;
+			nanosecondsLeft -= microseconds * NANOSECS_PER_MICROSEC;
+			var ticks = nanosecondsLeft / NANOSECS_PER_TICKS;
+
+			var rv = new DateTime (
 				(int) calComponents.Year,
 				(int) calComponents.Month,
 				(int) calComponents.Day,
 				(int) calComponents.Hour,
 				(int) calComponents.Minute,
 				(int) calComponents.Second,
-				Convert.ToInt32 (calComponents.Nanosecond / NANOSECS_PER_MILLISEC),
+				(int) milliseconds,
+#if NET
+				(int) microseconds,
+#endif
 				DateTimeKind.Utc);
+
+#if NET
+			if (ticks > 0)
+				rv = rv.AddTicks (ticks);
+#else
+			if (microseconds > 0 || ticks > 0)
+				rv = rv.AddTicks (ticks + 10 * (int) microseconds);
+#endif
+
+
+			return rv;
 		}
 
 		// now explicit since data can be lost for DateTimeKind.Unspecified
@@ -72,7 +132,9 @@ namespace Foundation {
 
 			var dtUnv = dt.ToUniversalTime ();
 
-			// Convert to components representation since we cannot rely on secondsSinceReferenceDate
+			// Compute the sub-second fraction of nanoseconds.
+			var subsecondTicks = dtUnv.Ticks % TimeSpan.TicksPerSecond;
+			var nanoseconds = subsecondTicks * NANOSECS_PER_TICKS;
 			using var dateComponents = new NSDateComponents ();
 			dateComponents.Day = dtUnv.Day;
 			dateComponents.Month = dtUnv.Month;
@@ -80,11 +142,11 @@ namespace Foundation {
 			dateComponents.Hour = dtUnv.Hour;
 			dateComponents.Minute = dtUnv.Minute;
 			dateComponents.Second = dtUnv.Second;
-			dateComponents.Nanosecond = (int) (dtUnv.Millisecond * NANOSECS_PER_MILLISEC);
+			dateComponents.Nanosecond = (int) nanoseconds;
 
 			var retDate = calendar.DateFromComponents (dateComponents);
 			if (retDate is null)
-				throw new ArgumentOutOfRangeException (nameof (dt), dt, $"{nameof (dt)} is outside the range of NSDate");
+				throw new ArgumentOutOfRangeException (nameof (dt), dt, $"The date is outside the range of NSDate");
 
 			return retDate;
 		}

--- a/tests/monotouch-test/Asserts.cs
+++ b/tests/monotouch-test/Asserts.cs
@@ -1019,4 +1019,25 @@ public static class Asserts {
 		}
 		Assert.Fail ($"{message}\nExpected: {e_sb}\nActual:   {a_sb}\n          {d_sb}");
 	}
+
+	public static void AreEqual (DateTime expected, DateTime actual, string message)
+	{
+		if (expected == actual)
+			return;
+
+		var diff = expected - actual;
+		Assert.Fail ($"{message}\n\tExpected DateTime: {expected} (Ticks: {expected.Ticks})\n\tActual DateTime: {actual} (Ticks: {actual.Ticks})\n\tDifference is: {diff} = {diff.TotalMilliseconds} ms = {diff.TotalSeconds} s");
+	}
+
+	public static void AreEqual (DateTime expected, DateTime actual, TimeSpan tolerance, string message)
+	{
+		if (expected == actual)
+			return;
+
+		var diff = expected - actual;
+		if (Math.Abs (diff.Ticks) < tolerance.Ticks)
+			return;
+
+		Assert.Fail ($"{message}\n\tExpected DateTime: {expected} (Ticks: {expected.Ticks})\n\tActual DateTime: {actual} (Ticks: {actual.Ticks})\n\tDifference is: {diff} = {diff.TotalMilliseconds} ms = {diff.TotalSeconds} s\n\tTolerance is: {tolerance} = {tolerance.TotalMilliseconds} ms = {tolerance.TotalSeconds} s");
+	}
 }


### PR DESCRIPTION
We recently tried to fix NSDate's conversion operators with DateTime
(3c65ab17569baf9f9acd8b6e2ded19aeb4fdfe7b), but unfortunately a corner case
was missed.

The new approach in the above-mentioned commit would get the individual
date/time components for a given date and use the appropriate constructor for
the other type to re-construct the date/time in question.

However, one case was missed: when converting from NSDate to DateTime, we'd
get a fractional number of milliseconds. This fractional number could be
something like 999.99 milliseconds, and when converting that to the int the
DateTime constructor expected for the number of milliseconds, then DateTime
would throw an exception, because the number of milliseconds could only be
between 0 and 999.

I've solved this by not using floating-point math in the computations. We're
now getting the number of nanoseconds from the NSDate (which is a natural
number, and represents the total number of nanoseconds less than a whole
second), and then converting that to the number of milliseconds, microseconds
and ticks that can be used with DateTime using integral math. Unfortunately
DateTime doesn't have a constructor that takes the remaining number of ticks
after all the other fields have been provided, but that can be added
afterwards.

I've also made a few other improvements:

* Improve the validation for the NSDate -> DateTime conversion to detect BC
  dates by using the NSDate's Era component (to throw because DateTime only
  supports AC dates). Also don't allow a tick later than year 10.000 (DateTime
  only supports up to a tick before year 10.000) - but explicitly support
  exactly year 10.000, and convert it to DateTime.MaxValue (this is because
  due to precision errors NSDate can't actually express 'a tick before year
  10.000', it ends up being rounded up to year 10.000 exactly). This means
  there are no more magical values in the range validation checks.
* Increase precision in the DateTime -> NSDate conversion by starting with the
  sub-second amount of ticks from the DateTime instance (instead of the number
  of milliseconds). This allows us to compute the nanoseconds NSDate expects
  with much higher precision.
* More tests!

Fixes this test:

    MonoTouchFixtures.Foundation.DateTest.DateTimeToNSDate : 2 ms
        [FAIL] Precision32022 : System.ArgumentOutOfRangeException : Valid values are between 0 and 999, inclusive.
            Parameter name: millisecond
            at System.DateTime..ctor (System.Int32 year, System.Int32 month, System.Int32 day, System.Int32 hour, System.Int32 minute, System.Int32 second, System.Int32 millisecond, System.DateTimeKind kind) [0x0002d] in <4d40c65adfc14d7fb19bad9310f3eb2a>:0
            at Foundation.NSDate.op_Explicit (Foundation.NSDate d) [0x000b8] in <9cb1e1018c034b75ba5f4ed7b83ba2f2>:0
            at MonoTouchFixtures.Foundation.DateTest.Precision32022 () [0x0000c] in <c44b5df5f7b84b69b737e9fd61bddaed>:0
            at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
            at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <4d40c65adfc14d7fb19bad9310f3eb2a>:0

Fixes https://github.com/xamarin/maccore/issues/2632.

Date and time is difficult.

Ref: https://gist.github.com/timvisee/fcda9bbdff88d45cc9061606b4b923ca
Ref: the rest of internet...