### PR TITLE
[tests] Move code to avoid unreachable code warning.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1315,9 +1315,9 @@ partial class TestRuntime {
 #else
 			if (TestRuntime.CheckMacSystemVersion (10, 10))
 				return; // Crossing fingers that this won't hang.
-#endif
 			NUnit.Framework.Assert.Ignore ("This test requires permission to access events, but there's no API to request access without potentially showing dialogs.");
 			break;
+#endif
 		case EKAuthorizationStatus.Denied:
 			if (assert_granted)
 				NUnit.Framework.Assert.Ignore ("This test requires permission to access events.");


### PR DESCRIPTION
Fixes this warning:

> xamarin-macios/tests/common/TestRuntime.cs(1321,4): warning CS0162: Unreachable code detected