### PR TITLE
[dotnet-linker] Only enable ForceLoad for native binding libraries if that's actually requested in the binding library. Fixes #16861.

### DIFF
--- a/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
+++ b/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Linker {
 					var item = new MSBuildItem {
 						Include = arg,
 						Metadata = new Dictionary<string, string> {
-							{ "ForceLoad", "true" },
+							{ "ForceLoad", asm.ForceLoad ? "true" : "false" },
 							{ "Assembly", asm.Identity },
 						},
 					};


### PR DESCRIPTION
We don't want to pass -force_load unncessarily to the native linker, because
that defeats -dead_strip and makes apps bigger than necessary. So make sure to
honor the correct value for native libraries from binding libraries.

Fixes https://github.com/xamarin/xamarin-macios/issues/16861.