### PR TITLE
[Foundation] Share custom constructor code between iOS and macOS for NSAttributedString.

### DIFF
--- a/src/Foundation/NSAttributedString.cs
+++ b/src/Foundation/NSAttributedString.cs
@@ -31,12 +31,48 @@ using System;
 using CoreFoundation;
 using CoreText;
 using ObjCRuntime;
+#if MONOMAC || __MACCATALYST__
+using AppKit;
+#endif
 #if !MONOMAC
 using UIKit;
 #endif
 
 namespace Foundation {
 	public partial class NSAttributedString {
+
+#if __MACOS__ || XAMCORE_5_0
+		public NSAttributedString (NSUrl url, NSAttributedStringDocumentAttributes documentAttributes, out NSError error)
+		: this (url, documentAttributes, out var _, out error) {}
+
+		public NSAttributedString (NSData data, NSAttributedStringDocumentAttributes documentAttributes, out NSError error)
+		: this (data, documentAttributes, out var _, out error) {}
+
+		public NSAttributedString (NSUrl url, out NSError error)
+		: this (url, new NSDictionary (), out var _, out error) {}
+
+		public NSAttributedString (NSData data, out NSError error)
+		: this (data, new NSDictionary (), out var _, out error) {}
+#else
+		public NSAttributedString (NSUrl url, NSAttributedStringDocumentAttributes documentAttributes, ref NSError error)
+		: this (url, documentAttributes, out var _, ref error) {}
+
+		public NSAttributedString (NSData data, NSAttributedStringDocumentAttributes documentAttributes, ref NSError error)
+		: this (data, documentAttributes, out var _, ref error) {}
+
+		public NSAttributedString (NSUrl url, ref NSError error)
+		: this (url, new NSDictionary (), out var _, ref error) {}
+
+		public NSAttributedString (NSData data, ref NSError error)
+		: this (data, new NSDictionary (), out var _, ref error) {}
+#endif
+
+#if __MACOS__
+		public NSAttributedString (string str, NSStringAttributes? attributes)
+			: this (str, attributes?.Dictionary)
+		{
+		}
+#endif // __MACOS__
 
 		public string? Value {
 			get {

--- a/src/Foundation/NSAttributedString.cs
+++ b/src/Foundation/NSAttributedString.cs
@@ -55,16 +55,16 @@ namespace Foundation {
 		: this (data, new NSDictionary (), out var _, out error) {}
 #else
 		public NSAttributedString (NSUrl url, NSAttributedStringDocumentAttributes documentAttributes, ref NSError error)
-		: this (url, documentAttributes, out var _, ref error) {}
+		: this (url, documentAttributes, out var _, ref error) { }
 
 		public NSAttributedString (NSData data, NSAttributedStringDocumentAttributes documentAttributes, ref NSError error)
-		: this (data, documentAttributes, out var _, ref error) {}
+		: this (data, documentAttributes, out var _, ref error) { }
 
 		public NSAttributedString (NSUrl url, ref NSError error)
-		: this (url, new NSDictionary (), out var _, ref error) {}
+		: this (url, new NSDictionary (), out var _, ref error) { }
 
 		public NSAttributedString (NSData data, ref NSError error)
-		: this (data, new NSDictionary (), out var _, ref error) {}
+		: this (data, new NSDictionary (), out var _, ref error) { }
 #endif
 
 #if __MACOS__

--- a/src/Foundation/NSAttributedString.iOS.cs
+++ b/src/Foundation/NSAttributedString.iOS.cs
@@ -39,23 +39,6 @@ using UIKit;
 
 namespace Foundation {
 
-#if !MONOMAC && !COREBUILD
-	public partial class NSAttributedString {
-		public NSAttributedString (NSUrl url, NSAttributedStringDocumentAttributes documentAttributes, ref NSError error)
-		: this (url, documentAttributes, out _, ref error) { }
-
-		public NSAttributedString (NSData data, NSAttributedStringDocumentAttributes documentAttributes, ref NSError error)
-		: this (data, documentAttributes, out _, ref error) { }
-
-		public NSAttributedString (NSUrl url, ref NSError error)
-		: this (url, new NSDictionary (), out _, ref error) { }
-
-		public NSAttributedString (NSData data, ref NSError error)
-		: this (data, new NSDictionary (), out _, ref error) { }
-
-	}
-#endif
-
 	public partial class NSAttributedStringDocumentAttributes : DictionaryContainer {
 #if !MONOMAC && !COREBUILD
 		public NSAttributedStringDocumentAttributes () : base (new NSMutableDictionary ()) { }

--- a/src/Foundation/NSAttributedString.mac.cs
+++ b/src/Foundation/NSAttributedString.mac.cs
@@ -20,11 +20,6 @@ namespace Foundation
 {
 	public partial class NSAttributedString
 	{
-		public NSAttributedString (string str, NSStringAttributes? attributes)
-			: this (str, attributes?.Dictionary)
-		{
-		}
-
 		public NSAttributedString (string str,
 			NSFont? font = null,
 			NSColor? foregroundColor = null,


### PR DESCRIPTION
This also makes the set of constructors for NSAttributedString identical
between all platforms.

Ref: https://github.com/xamarin/xamarin-macios/issues/14489