### PR TITLE
[Foundation] Merge multiple partial NSAttributedString definitions.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -661,6 +661,65 @@ namespace Foundation
 		[Export ("attributedStringByInflectingString")]
 		NSAttributedString AttributedStringByInflectingString { get; }
 
+		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
+		[Export ("boundingRectWithSize:options:")]
+		CGRect BoundingRectWithSize (CGSize size, NSStringDrawingOptions options);
+
+#if MONOMAC
+		[Field ("NSTextLayoutSectionOrientation", "AppKit")]
+#else
+		[Field ("NSTextLayoutSectionOrientation", "UIKit")]
+#endif
+		[iOS (7,0)]
+		NSString TextLayoutSectionOrientation { get; }
+
+#if MONOMAC
+		[Field ("NSTextLayoutSectionRange", "AppKit")]
+#else
+		[Field ("NSTextLayoutSectionRange", "UIKit")]
+#endif
+		[iOS (7,0)]
+		NSString TextLayoutSectionRange { get; }
+
+#if MONOMAC
+		[Field ("NSTextLayoutSectionsAttribute", "AppKit")]
+#else
+		[Field ("NSTextLayoutSectionsAttribute", "UIKit")]
+#endif
+		[iOS (7,0)]
+		NSString TextLayoutSectionsAttribute { get; }
+
+		[NoiOS, NoWatch, NoTV]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
+		[Field ("NSUnderlineByWordMask", "AppKit")]
+		nint UnderlineByWordMaskAttributeName { get; }
+
+#if MONOMAC
+		[Field ("NSTextScalingDocumentAttribute", "AppKit")]
+#else
+		[Field ("NSTextScalingDocumentAttribute", "UIKit")]
+#endif
+		[Mac (10,15)]
+		[iOS (13,0), TV (13,0), Watch (6,0)]
+		NSString TextScalingDocumentAttribute { get; }
+
+#if MONOMAC
+		[Field ("NSSourceTextScalingDocumentAttribute", "AppKit")]
+#else
+		[Field ("NSSourceTextScalingDocumentAttribute", "UIKit")]
+#endif
+		[Mac (10,15)]
+		[iOS (13,0), TV (13,0), Watch (6,0)]
+		NSString SourceTextScalingDocumentAttribute { get; }
+
+#if MONOMAC
+		[Field ("NSCocoaVersionDocumentAttribute", "AppKit")]
+#else
+		[Field ("NSCocoaVersionDocumentAttribute", "UIKit")]
+#endif
+		[Mac (10,15)]
+		[iOS (13,0), TV (13,0), Watch (6,0)]
+		NSString CocoaVersionDocumentAttribute { get; }
 	}
 
 	// we follow the API found in swift
@@ -13976,65 +14035,6 @@ namespace Foundation
 		NSImage ImageForResource (string name);
 	}
 
-	partial interface NSAttributedString {
-
-#if MONOMAC
-		[Field ("NSTextLayoutSectionOrientation", "AppKit")]
-#else
-		[Field ("NSTextLayoutSectionOrientation", "UIKit")]
-#endif
-		[iOS (7,0)]
-		NSString TextLayoutSectionOrientation { get; }
-
-#if MONOMAC
-		[Field ("NSTextLayoutSectionRange", "AppKit")]
-#else
-		[Field ("NSTextLayoutSectionRange", "UIKit")]
-#endif
-		[iOS (7,0)]
-		NSString TextLayoutSectionRange { get; }
-
-#if MONOMAC
-		[Field ("NSTextLayoutSectionsAttribute", "AppKit")]
-#else
-		[Field ("NSTextLayoutSectionsAttribute", "UIKit")]
-#endif
-		[iOS (7,0)]
-		NSString TextLayoutSectionsAttribute { get; }
-
-		[NoiOS, NoWatch, NoTV]
-		[Deprecated (PlatformName.MacOSX, 10, 11)]
-		[Field ("NSUnderlineByWordMask", "AppKit")]
-		nint UnderlineByWordMaskAttributeName { get; }
-
-#if MONOMAC
-		[Field ("NSTextScalingDocumentAttribute", "AppKit")]
-#else
-		[Field ("NSTextScalingDocumentAttribute", "UIKit")]
-#endif
-		[Mac (10,15)]
-		[iOS (13,0), TV (13,0), Watch (6,0)]
-		NSString TextScalingDocumentAttribute { get; }
-
-#if MONOMAC
-		[Field ("NSSourceTextScalingDocumentAttribute", "AppKit")]
-#else
-		[Field ("NSSourceTextScalingDocumentAttribute", "UIKit")]
-#endif
-		[Mac (10,15)]
-		[iOS (13,0), TV (13,0), Watch (6,0)]
-		NSString SourceTextScalingDocumentAttribute { get; }
-
-#if MONOMAC
-		[Field ("NSCocoaVersionDocumentAttribute", "AppKit")]
-#else
-		[Field ("NSCocoaVersionDocumentAttribute", "UIKit")]
-#endif
-		[Mac (10,15)]
-		[iOS (13,0), TV (13,0), Watch (6,0)]
-		NSString CocoaVersionDocumentAttribute { get; }
-	}
-
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSDateInterval : NSCopying, NSSecureCoding {
@@ -14191,13 +14191,6 @@ namespace Foundation
 		[NullAllowed]
 		[Export ("primaryPresentedItemURL")]
 		NSUrl PrimaryPresentedItemUrl { get; }
-	}
-
-	[NoiOS][NoMacCatalyst][NoWatch][NoTV]
-	partial interface NSAttributedString {
-		[NoiOS][NoMacCatalyst][NoWatch][NoTV]
-		[Export ("boundingRectWithSize:options:")]
-		CGRect BoundingRectWithSize (CGSize size, NSStringDrawingOptions options);
 	}
 
 	[NoiOS][NoMacCatalyst][NoWatch][NoTV]


### PR DESCRIPTION
It just ends up being confusing and difficult to get a full picture of the type's
API definition if it's spread over multiple places.