### PR TITLE
[ObjCRuntime] Fix double dots in exception message.

### DIFF
--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -703,7 +703,7 @@ namespace ObjCRuntime {
 				// This will re-throw the original exception and preserve the stacktrace.
 				ExceptionDispatchInfo.Capture (ex).Throw ();
 			} catch (Exception e) {
-				throw ErrorHelper.CreateError (8042, e, Errors.MX8042 /* An exception occurred while trying to invoke the function {0}: {1}. */, GetMethodFullName (method), e.Message);
+				throw ErrorHelper.CreateError (8042, e, Errors.MX8042 /* An exception occurred while trying to invoke the function {0}: {1} */, GetMethodFullName (method), e.Message);
 			}
 
 			// Copy any byref parameters back out again

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -4115,7 +4115,7 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An exception occurred while trying to invoke the function {0}: {1}..
+        ///   Looks up a localized string similar to An exception occurred while trying to invoke the function {0}: {1}.
         /// </summary>
         public static string MX8042 {
             get {

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2169,7 +2169,7 @@
 	</data>
 
 	<data name="MX8042" xml:space="preserve">
-		<value>An exception occurred while trying to invoke the function {0}: {1}.</value>
+		<value>An exception occurred while trying to invoke the function {0}: {1}</value>
 		<comment>
 			0: name of function
 			1: exception info


### PR DESCRIPTION
Don't add a dot after showing another exception message, because that another
exception message might also add a dot.

Example:

> An exception occurred while trying to invoke the function System.Void VisualStudioMac.AppDelegate.DidFinishLaunching (Foundation.NSNotification): Object of type 'CoreLocation.CLLocationManager' cannot be converted to type 'Foundation.NSNotification'..