### PR TITLE
[tools] Exclude Driver.Concurrency from .NET.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -433,7 +433,9 @@ namespace Xamarin.Bundler {
 			}
 		}
 
+#if !NET
 		public static int Concurrency => Driver.Concurrency;
+#endif
 		public Version DeploymentTarget;
 		public Version SdkVersion; // for Mac Catalyst this is the iOS version
 		public Version NativeSdkVersion; // this is the same as SdkVersion, except that for Mac Catalyst it's the macOS SDK version.

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -299,12 +299,14 @@ namespace Xamarin.Bundler {
 		}
 #endif // !NET
 
+#if !NET
 		static int Jobs;
 		public static int Concurrency {
 			get {
 				return Jobs == 0 ? Environment.ProcessorCount : Jobs;
 			}
 		}
+#endif
 
 		public static int Verbosity {
 			get { return ErrorHelper.Verbosity; }


### PR DESCRIPTION
Fixes this compiler warning:

    tools/common/Driver.cs(302,14): warning CS0649: Field 'Driver.Jobs' is never assigned to, and will always have its default value 0