### PR TITLE
[xharness] Packaged macOS tests are a thing now.

### DIFF
--- a/tests/xharness/TestLabel.cs
+++ b/tests/xharness/TestLabel.cs
@@ -74,6 +74,8 @@ namespace Xharness {
 		Xcframework = 1 << 26,
 		[Label ("xtro")]
 		Xtro = 1 << 27,
+		[Label ("packaged-macos")]
+		Xtro = 1 << 28,
 		[Label ("all")]
 		All = Int64.MaxValue,
 	}

--- a/tests/xharness/TestLabel.cs
+++ b/tests/xharness/TestLabel.cs
@@ -75,7 +75,7 @@ namespace Xharness {
 		[Label ("xtro")]
 		Xtro = 1 << 27,
 		[Label ("packaged-macos")]
-		Xtro = 1 << 28,
+		PackagedMacOS = 1 << 28,
 		[Label ("all")]
 		All = Int64.MaxValue,
 	}


### PR DESCRIPTION
While this value isn't used directly in xharness, we can add a
'skip-packaged-macos-tests' label for a PR, which xharness will try to match
with a test label, so the test label must exist, otherwise all tests will
fail.