### PR TITLE
[Localization] Set OneLocBuild Task to not delete Lego Branch

### DIFF
--- a/tools/devops/automation/templates/loc-translations.yml
+++ b/tools/devops/automation/templates/loc-translations.yml
@@ -89,6 +89,7 @@ steps:
     prSourceBranchPrefix: 'locfiles'
     repoType: gitHub
     gitHubPatVariable: '$(GitHub.Token)'
+    isDeletePrSourceBranchSelected: false
 
 - task: PublishBuildArtifacts@1
   continueOnError: true


### PR DESCRIPTION
In our localization process, the Loc team builds the translations (in the not-user-readable .lcl files) and merges them into the 'Localization' branch from a 'Lego/...' branch. After this happens, our 'Get Localization Translations' github action takes that commits and creates a PR into main with those changes. It is really important that this github action works because we will later delete the 'Localization' branch and create a new one from the 'main' branch so that the branches stay in sync. 

There worked fine, but there is now a 'isDeletePrSourceBranchSelected' input to the OneLocBuild task that defaults to true that deletes the 'Lego/...' branch right after the commit to 'Localization' is made. Due to this, the github action cannot bring the commit to 'main' because the 'Lego/...' branch no longer exists.

The hope is that setting this input to false will successfully not delete the 'Lego/...' branch allowing the rest of the flow to be uninterrupted.