### PR TITLE
[Foundation] Improve null-checking in MonoTouchException.AppendNativeStackTrace.

### DIFF
--- a/src/Foundation/MonoTouchException.cs
+++ b/src/Foundation/MonoTouchException.cs
@@ -49,8 +49,9 @@ namespace Foundation {
 
 		void AppendNativeStackTrace (StringBuilder sb)
 		{
-			if (native_exc is not null) {
-				foreach (var symbol in native_exc.CallStackSymbols)
+			var callStackSymbols = native_exc?.CallStackSymbols;
+			if (callStackSymbols is not null) {
+				foreach (var symbol in callStackSymbols)
 					sb.Append ('\t').AppendLine (symbol);
 			}
 		}


### PR DESCRIPTION
Hopefully fixes this problem:

    Unhandled managed exception: Failed to print exception: System.NullReferenceException: Object reference not set to an instance of an object
      at Foundation.MonoTouchException.AppendNativeStackTrace (System.Text.StringBuilder sb) [0x0002f] in /Library/Frameworks/Xamarin.iOS.framework/Versions/16.0.0.72/src/Xamarin.iOS/Foundation/MonoTouchException.cs:51
      at Foundation.MonoTouchException.get_Message () [0x00039] in /Library/Frameworks/Xamarin.iOS.framework/Versions/16.0.0.72/src/Xamarin.iOS/Foundation/MonoTouchException.cs:43
      at ObjCRuntime.Runtime.PrintException (System.Exception exc, System.Boolean isInnerException, System.Text.StringBuilder sb) [0x0000f] in /Library/Frameworks/Xamarin.iOS.framework/Versions/16.0.0.72/src/Xamarin.iOS/ObjCRuntime/Runtime.cs:528
      at ObjCRuntime.Runtime.PrintAllExceptions (System.IntPtr exception_gchandle) [0x0003b] in /Library/Frameworks/Xamarin.iOS.framework/Versions/16.0.0.72/src/Xamarin.iOS/ObjCRuntime/Runtime.cs:545