### PR TITLE
[Foundation] Create a new NSAttributedStringDocument type to match Apple's headers.

### DIFF
--- a/src/Foundation/NSAttributedString.iOS.cs
+++ b/src/Foundation/NSAttributedString.iOS.cs
@@ -69,13 +69,13 @@ namespace Foundation {
 		public NSDocumentType DocumentType {
 			get {
 				var s = GetNSStringValue (UIStringAttributeKey.NSDocumentTypeDocumentAttribute);
-				if (s == UIStringAttributeKey.NSPlainTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSPlainTextDocumentType)
 					return NSDocumentType.PlainText;
-				if (s == UIStringAttributeKey.NSRTFDTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSRtfdTextDocumentType)
 					return NSDocumentType.RTFD;
-				if (s == UIStringAttributeKey.NSRTFTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSRtfTextDocumentType)
 					return NSDocumentType.RTF;
-				if (s == UIStringAttributeKey.NSHTMLTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSHtmlTextDocumentType)
 					return NSDocumentType.HTML;
 				return NSDocumentType.Unknown;
 			}
@@ -83,16 +83,16 @@ namespace Foundation {
 			set {
 				switch (value) {
 				case NSDocumentType.PlainText:
-					SetStringValue (UIStringAttributeKey.NSDocumentTypeDocumentAttribute, UIStringAttributeKey.NSPlainTextDocumentType);
+					SetStringValue (UIStringAttributeKey.NSDocumentTypeDocumentAttribute, NSAttributedStringDocumentType.NSPlainTextDocumentType);
 					break;
 				case NSDocumentType.RTFD:
-					SetStringValue (UIStringAttributeKey.NSDocumentTypeDocumentAttribute, UIStringAttributeKey.NSRTFDTextDocumentType);
+					SetStringValue (UIStringAttributeKey.NSDocumentTypeDocumentAttribute, NSAttributedStringDocumentType.NSRtfdTextDocumentType);
 					break;
 				case NSDocumentType.RTF:
-					SetStringValue (UIStringAttributeKey.NSDocumentTypeDocumentAttribute, UIStringAttributeKey.NSRTFTextDocumentType);
+					SetStringValue (UIStringAttributeKey.NSDocumentTypeDocumentAttribute, NSAttributedStringDocumentType.NSRtfTextDocumentType);
 					break;
 				case NSDocumentType.HTML:
-					SetStringValue (UIStringAttributeKey.NSDocumentTypeDocumentAttribute, UIStringAttributeKey.NSHTMLTextDocumentType);
+					SetStringValue (UIStringAttributeKey.NSDocumentTypeDocumentAttribute, NSAttributedStringDocumentType.NSHtmlTextDocumentType);
 					break;
 				}
 			}

--- a/src/Foundation/NSAttributedString.mac.cs
+++ b/src/Foundation/NSAttributedString.mac.cs
@@ -194,25 +194,25 @@ namespace Foundation
 			get {
 				var s = GetNSStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption);
 
-				if (s == NSStringAttributeKey.NSPlainTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSPlainTextDocumentType)
 					return NSDocumentType.PlainText;
-				if (s == NSStringAttributeKey.NSRtfTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSRtfTextDocumentType)
 					return NSDocumentType.RTF;
-				if (s == NSStringAttributeKey.NSRtfdTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSRtfdTextDocumentType)
 					return NSDocumentType.RTFD;
-				if (s == NSStringAttributeKey.NSMacSimpleTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSMacSimpleTextDocumentType)
 					return NSDocumentType.MacSimpleText;
-				if (s == NSStringAttributeKey.NSHTMLTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSHtmlTextDocumentType)
 					return NSDocumentType.HTML;
-				if (s == NSStringAttributeKey.NSDocFormatTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSDocFormatTextDocumentType)
 					return NSDocumentType.DocFormat;
-				if (s == NSStringAttributeKey.NSWordMLTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSWordMLTextDocumentType)
 					return NSDocumentType.WordML;
-				if (s == NSStringAttributeKey.NSWebArchiveTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSWebArchiveTextDocumentType)
 					return NSDocumentType.WebArchive;
-				if (s == NSStringAttributeKey.NSOfficeOpenXMLTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSOfficeOpenXMLTextDocumentType)
 					return NSDocumentType.OfficeOpenXml;
-				if (s == NSStringAttributeKey.NSOpenDocumentTextDocumentType)
+				if (s == NSAttributedStringDocumentType.NSOpenDocumentTextDocumentType)
 					return NSDocumentType.OpenDocument;
 				return NSDocumentType.Unknown;
 			}
@@ -220,34 +220,34 @@ namespace Foundation
 			set {
 				switch (value){
 				case NSDocumentType.PlainText:
-					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSStringAttributeKey.NSPlainTextDocumentType);
+					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSAttributedStringDocumentType.NSPlainTextDocumentType);
 					break;
 				case NSDocumentType.RTFD:
-					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSStringAttributeKey.NSRtfdTextDocumentType);
+					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSAttributedStringDocumentType.NSRtfdTextDocumentType);
 					break;
 				case NSDocumentType.RTF:
-					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSStringAttributeKey.NSRtfTextDocumentType);
+					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSAttributedStringDocumentType.NSRtfTextDocumentType);
 					break;
 				case NSDocumentType.HTML:
-					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSStringAttributeKey.NSHTMLTextDocumentType);
+					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSAttributedStringDocumentType.NSHtmlTextDocumentType);
 					break;
 				case NSDocumentType.MacSimpleText:
-					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSStringAttributeKey.NSMacSimpleTextDocumentType);
+					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSAttributedStringDocumentType.NSMacSimpleTextDocumentType);
 					break;
 				case NSDocumentType.DocFormat:
-					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSStringAttributeKey.NSDocFormatTextDocumentType);
+					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSAttributedStringDocumentType.NSDocFormatTextDocumentType);
 					break;
 				case NSDocumentType.WordML:
-					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSStringAttributeKey.NSWordMLTextDocumentType);
+					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSAttributedStringDocumentType.NSWordMLTextDocumentType);
 					break;
 				case NSDocumentType.WebArchive:
-					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSStringAttributeKey.NSWebArchiveTextDocumentType);
+					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSAttributedStringDocumentType.NSWebArchiveTextDocumentType);
 					break;
 				case NSDocumentType.OfficeOpenXml:
-					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSStringAttributeKey.NSOfficeOpenXMLTextDocumentType);
+					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSAttributedStringDocumentType.NSOfficeOpenXMLTextDocumentType);
 					break;
 				case NSDocumentType.OpenDocument:
-					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSStringAttributeKey.NSOpenDocumentTextDocumentType);
+					SetStringValue (NSStringAttributeKey.NSDocumentTypeDocumentOption, NSAttributedStringDocumentType.NSOpenDocumentTextDocumentType);
 					break;
 				}
 			}

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -15577,36 +15577,6 @@ namespace AppKit {
 		[Internal, Field ("NSFileTypeDocumentOption")]
 		NSString NSFileTypeDocumentOption { get; }
 
-		[Internal, Field ("NSPlainTextDocumentType")]
-		NSString NSPlainTextDocumentType { get; }
-
-		[Internal, Field ("NSRTFTextDocumentType")]
-		NSString NSRtfTextDocumentType { get; }
-
-		[Internal, Field ("NSRTFDTextDocumentType")]
-		NSString NSRtfdTextDocumentType { get; }
-
-		[Internal, Field ("NSMacSimpleTextDocumentType")]
-		NSString NSMacSimpleTextDocumentType { get; }
-
-		[Internal, Field ("NSHTMLTextDocumentType")]
-		NSString NSHTMLTextDocumentType { get; }
-
-		[Internal, Field ("NSDocFormatTextDocumentType")]
-		NSString NSDocFormatTextDocumentType { get; }
-
-		[Internal, Field ("NSWordMLTextDocumentType")]
-		NSString NSWordMLTextDocumentType { get; }
-
-		[Internal, Field ("NSWebArchiveTextDocumentType")]
-		NSString NSWebArchiveTextDocumentType { get; }
-
-		[Internal, Field ("NSOfficeOpenXMLTextDocumentType")]
-		NSString NSOfficeOpenXMLTextDocumentType { get; }
-
-		[Internal, Field ("NSOpenDocumentTextDocumentType")]
-		NSString NSOpenDocumentTextDocumentType { get; }
-
 		[Mac (10,11)]
 		[Internal, Field ("NSDefaultAttributesDocumentAttribute")]
 		NSString NSDefaultAttributesDocumentAttribute { get; }

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -12839,29 +12839,9 @@ namespace UIKit {
 		[Internal, Field ("NSTextEffectLetterpressStyle")]
 		NSString NSTextEffectLetterpressStyle { get; }
 
-	//
-	// Document Types
-	//
 		[iOS (7,0)]
 		[Internal, Field ("NSDocumentTypeDocumentAttribute")]
 		NSString NSDocumentTypeDocumentAttribute { get; }
-
-		[iOS (7,0)]
-		[Internal, Field ("NSPlainTextDocumentType")]
-		NSString NSPlainTextDocumentType { get; }
-		
-		[iOS (7,0)]
-		[Internal, Field ("NSRTFDTextDocumentType")]
-		NSString NSRTFDTextDocumentType { get; }
-		
-		[iOS (7,0)]
-		[Internal, Field ("NSRTFTextDocumentType")]
-		NSString NSRTFTextDocumentType { get; }
-
-		[iOS (7,0)]
-		[Internal, Field ("NSHTMLTextDocumentType")]
-		NSString NSHTMLTextDocumentType { get; }
-
 	//
 	//
 	//

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -4170,4 +4170,43 @@ namespace UIKit {
 		NSTextListElement ParentElement { get; }
 	}
 
+	[Static]
+	[Internal]
+	interface NSAttributedStringDocumentType {
+		[Field ("NSPlainTextDocumentType")]
+		NSString NSPlainTextDocumentType { get; }
+
+		[Field ("NSRTFDTextDocumentType")]
+		NSString NSRtfdTextDocumentType { get; }
+
+		[Field ("NSRTFTextDocumentType")]
+		NSString NSRtfTextDocumentType { get; }
+
+		[Field ("NSHTMLTextDocumentType")]
+		NSString NSHtmlTextDocumentType { get; }
+
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		[Field ("NSMacSimpleTextDocumentType")]
+		NSString NSMacSimpleTextDocumentType { get; }
+
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		[Field ("NSDocFormatTextDocumentType")]
+		NSString NSDocFormatTextDocumentType { get; }
+
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		[Field ("NSWordMLTextDocumentType")]
+		NSString NSWordMLTextDocumentType { get; }
+
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		[Field ("NSWebArchiveTextDocumentType")]
+		NSString NSWebArchiveTextDocumentType { get; }
+
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		[Field ("NSOfficeOpenXMLTextDocumentType")]
+		NSString NSOfficeOpenXMLTextDocumentType { get; }
+
+		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
+		[Field ("NSOpenDocumentTextDocumentType")]
+		NSString NSOpenDocumentTextDocumentType { get; }
+	}
 }


### PR DESCRIPTION
This also allows us to unify the code between all platforms.

There are no changes in the public API, because I'm only changing internal types.

Ref: #14489.