### PR TITLE
[release/7.0.1xx] Bump Xamarin.MacDev.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "external/Xamarin.MacDev"]
     path = external/Xamarin.MacDev
     url = ../../xamarin/Xamarin.MacDev
-    branch = main
+    branch = net7.0
 [submodule "external/MonoTouch.Dialog"]
     path = external/MonoTouch.Dialog
     url = ../../migueldeicaza/MonoTouch.Dialog


### PR DESCRIPTION
Bump Xamarin.MacDev to get a fix for .NET 8: the value of
Environment.SpecialFolder.Personal will change.

New commits in xamarin/Xamarin.MacDev:

* xamarin/Xamarin.MacDev@fc05c31 [net7.0] Use Environment.SpecialFolder.UserProfile, not SpecialFolder.Personal.

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/0717ac3c249595b48860904ce77000a6115affbe..fc05c313e7fb09db30b3182fd8adc3a562a593c6