### PR TITLE
[release/6.0.4xx-xcode14.1] Bump Xamarin.MacDev.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "external/Xamarin.MacDev"]
     path = external/Xamarin.MacDev
     url = ../../xamarin/Xamarin.MacDev
-    branch = main
+    branch = net6.0
 [submodule "external/MonoTouch.Dialog"]
     path = external/MonoTouch.Dialog
     url = ../../migueldeicaza/MonoTouch.Dialog


### PR DESCRIPTION
Bump Xamarin.MacDev to get a fix for .NET 8: the value of
Environment.SpecialFolder.Personal will change.

New commits in xamarin/Xamarin.MacDev:

* xamarin/Xamarin.MacDev@616d0a5 [net6.0] Use Environment.SpecialFolder.UserProfile, not SpecialFolder.Personal.

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/0717ac3c249595b48860904ce77000a6115affbe..616d0a561e604b6ff2057651bb46767643f02b3f