### PR TITLE
[release/6.0.4xx-xcode14.1] [build] Add support for Visual Studio on win-arm64.

### DIFF
--- a/dotnet/generate-vs-workload.csharp
+++ b/dotnet/generate-vs-workload.csharp
@@ -87,7 +87,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	foreach (var entry in platforms) {
 		var platform = entry.Item1;
 		var version = entry.Item2;
-		writer.WriteLine ($"    <WorkloadPackages Include=\"$(NuGetPackagePath)\\Microsoft.NET.Sdk.{platform}.Manifest*.nupkg\" Version=\"{version}\" />");
+		writer.WriteLine ($"    <WorkloadPackages Include=\"$(NuGetPackagePath)\\Microsoft.NET.Sdk.{platform}.Manifest*.nupkg\" Version=\"{version}\" SupportsMachineArch=\"true\" />");
 	}
 	foreach (var entry in platforms) {
 		var platform = entry.Item1;


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/204
Context: https://github.com/xamarin/xamarin-android/pull/7471

Updates the VSMAN files generated for our .NET workload to support Visual Studio on windows-arm64.

Backport of ##16935.