### PR TITLE
[xcode14.1] [Foundation] Handle re-entrancy in NSObject_Disposer.Drain. Fixes #16587.

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -980,6 +980,11 @@ namespace Foundation {
 				}
 				if (!call_drain)
 					return;
+				ScheduleDrain ();
+			}
+
+			static void ScheduleDrain ()
+			{
 #if NET
 				Messaging.void_objc_msgSend_NativeHandle_NativeHandle_bool (class_ptr, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), Selector.GetHandle ("drain:"), NativeHandle.Zero, false);
 #else
@@ -991,11 +996,23 @@ namespace Foundation {
 #endif
 			}
 			
+			static bool draining;
+
 			[Export ("drain:")]
 			static  void Drain (NSObject ctx) {
 				List<NSObject> drainList;
 				
 				lock (lock_obj) {
+					// This function isn't re-entrant safe, so protect against it. The only possibility I can
+					// see where this function would be re-entrant, is if in the call to ReleaseManagedRef below,
+					// the native dealloc method for a type ended up executing the run loop, and that runloop
+					// processed a drain request, ending up in this method (again).
+					if (draining) {
+						ScheduleDrain ();
+						return;
+					}
+					draining = true;
+
 					drainList = handles;
 					if (handles == drainList1)
 						handles = drainList2;
@@ -1006,6 +1023,10 @@ namespace Foundation {
 				foreach (NSObject x in drainList)
 					x.ReleaseManagedRef ();
 				drainList.Clear();
+
+				lock (lock_obj) {
+					draining = false;
+				}
 			}
 		}
 			


### PR DESCRIPTION
NSObject_Disposer.Drain isn't reentry-safe, and there's a rather impressive (and not in a good way) case where this can happen: if a native dealloc method ends up processing the main thread's runloop somehow.

The fix makes the Drain function detect reentrancy, and just re-schedule a call to itself on the run loop. I believe should be safe - either the dealloc method will process the runloop again a few times, in which case we'll just re-schedule the drain call every time, until the dealloc method finishes processing the runloop, and then the next drain call will actually drain.

Fixes https://github.com/xamarin/xamarin-macios/issues/16587.

Backport of #17014.