### PR TITLE
[dotnet] handle arrays to make blittable

### DIFF
--- a/src/CoreGraphics/CGColor.cs
+++ b/src/CoreGraphics/CGColor.cs
@@ -75,7 +75,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGColorRef */ IntPtr CGColorCreate (/* CGColorSpaceRef */ IntPtr space, /* CGFloat */ nfloat [] components);
+		extern unsafe static /* CGColorRef */ IntPtr CGColorCreate (/* CGColorSpaceRef */ IntPtr space, /* CGFloat */ nfloat* components);
 
 		static IntPtr Create (CGColorSpace colorspace, nfloat [] components)
 		{
@@ -83,7 +83,11 @@ namespace CoreGraphics {
 				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (components));
 			var colorspace_handle = colorspace.GetNonNullHandle (nameof (colorspace));
 
-			return CGColorCreate (colorspace_handle, components);
+			unsafe {
+				fixed (nfloat* componentsPtr = components) {
+					return CGColorCreate (colorspace_handle, componentsPtr);
+				}
+			}
 		}
 
 		public CGColor (CGColorSpace colorspace, nfloat [] components)
@@ -167,7 +171,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGColorRef */ IntPtr CGColorCreateWithPattern (/* CGColorSpaceRef */ IntPtr space, /* CGPatternRef */ IntPtr pattern, /* const CGFloat[] */ nfloat [] components);
+		extern unsafe static /* CGColorRef */ IntPtr CGColorCreateWithPattern (/* CGColorSpaceRef */ IntPtr space, /* CGPatternRef */ IntPtr pattern, /* const CGFloat[] */ nfloat* components);
 
 		static IntPtr Create (CGColorSpace colorspace, CGPattern pattern, nfloat [] components)
 		{
@@ -176,10 +180,14 @@ namespace CoreGraphics {
 			var colorspace_handle = colorspace.GetNonNullHandle (nameof (colorspace));
 			var pattern_handle = pattern.GetNonNullHandle (nameof (pattern));
 
-			var handle = CGColorCreateWithPattern (colorspace_handle, pattern_handle, components);
-			if (handle == IntPtr.Zero)
-				throw new ArgumentException ();
-			return handle;
+			unsafe {
+				fixed (nfloat* componentsPtr = components) {
+					var handle = CGColorCreateWithPattern (colorspace_handle, pattern_handle, componentsPtr);
+					if (handle == IntPtr.Zero)
+						throw new ArgumentException ();
+					return handle;
+				}
+			}
 		}
 
 		public CGColor (CGColorSpace colorspace, CGPattern pattern, nfloat [] components)

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -180,7 +180,7 @@ namespace CoreGraphics {
 #endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateCalibratedGray (/* const CGFloat[3] */ nfloat [] whitepoint, /* const CGFloat[3] */ nfloat []? blackpoint, /* CGFloat */ nfloat gamma);
+		extern unsafe static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateCalibratedGray (/* const CGFloat[3] */ nfloat* whitepoint, /* const CGFloat[3] */ nfloat*  blackpoint, /* CGFloat */ nfloat gamma);
 
 		public static CGColorSpace? CreateCalibratedGray (nfloat [] whitepoint, nfloat []? blackpoint, nfloat gamma)
 		{
@@ -191,13 +191,17 @@ namespace CoreGraphics {
 			if (blackpoint is not null && blackpoint.Length != 3)
 				throw new ArgumentException ("Must be null or have exactly 3 values", nameof (blackpoint));
 
-			var ptr = CGColorSpaceCreateCalibratedGray (whitepoint, blackpoint, gamma);
-			return FromHandle (ptr, true);
+			unsafe {
+				fixed (nfloat* whitepointPtr = whitepoint, blackpointPtr = blackpoint) {
+					var ptr = CGColorSpaceCreateCalibratedGray (whitepointPtr, blackpointPtr, gamma);
+					return FromHandle (ptr, true);
+				}
+			}
 		}
 
 		// 3, 3, 3, 9
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateCalibratedRGB (/* const CGFloat[3] */ nfloat [] whitePoint, /* const CGFloat[3] */ nfloat []? blackPoint, /* const CGFloat[3] */ nfloat []? gamma, /* const CGFloat[9] */ nfloat []? matrix);
+		extern static unsafe /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateCalibratedRGB (/* const CGFloat[3] */ nfloat* whitePoint, /* const CGFloat[3] */ nfloat* blackPoint, /* const CGFloat[3] */ nfloat* gamma, /* const CGFloat[9] */ nfloat* matrix);
 
 		public static CGColorSpace? CreateCalibratedRGB (nfloat [] whitepoint, nfloat []? blackpoint, nfloat []? gamma, nfloat []? matrix)
 		{
@@ -212,12 +216,16 @@ namespace CoreGraphics {
 			if (matrix is not null && matrix.Length != 9)
 				throw new ArgumentException ("Must be null or have exactly 9 values", nameof (matrix));
 
-			var ptr = CGColorSpaceCreateCalibratedRGB (whitepoint, blackpoint, gamma, matrix);
-			return FromHandle (ptr, true);
+			unsafe {
+				fixed (nfloat* whitepointPtr = whitepoint, blackpointPtr = blackpoint, gammaPtr = gamma, matrixPtr = matrix) {
+					var ptr = CGColorSpaceCreateCalibratedRGB (whitepointPtr, blackpointPtr, gammaPtr, matrixPtr);
+					return FromHandle (ptr, true);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGColorSpaceRef __nullable */ IntPtr CGColorSpaceCreateLab (nfloat [] whitepoint, nfloat []? blackpoint, nfloat []? range);
+		extern static unsafe /* CGColorSpaceRef __nullable */ IntPtr CGColorSpaceCreateLab (nfloat* whitepoint, nfloat* blackpoint, nfloat* range);
 
 		// Available since the beginning of time
 		public static CGColorSpace? CreateLab (nfloat [] whitepoint, nfloat []? blackpoint, nfloat []? range)
@@ -231,8 +239,12 @@ namespace CoreGraphics {
 			if (range is not null && range.Length != 4)
 				throw new ArgumentException ("Must be null or have exactly 4 values", nameof (range));
 
-			var ptr = CGColorSpaceCreateLab (whitepoint, blackpoint, range);
-			return FromHandle (ptr, true);
+			unsafe {
+				fixed (nfloat* whitepointPtr = whitepoint, blackpointPtr = blackpoint, rangePtr = range) {
+					var ptr = CGColorSpaceCreateLab (whitepointPtr, blackpointPtr, rangePtr);
+					return FromHandle (ptr, true);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -579,8 +591,8 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateICCBased (/* size_t */ nint nComponents,
-			/* const CGFloat* __nullable */ nfloat []? range,
+		extern static unsafe /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateICCBased (/* size_t */ nint nComponents,
+			/* const CGFloat* __nullable */ nfloat* range,
 			/* CGDataProviderRef __nullable */ IntPtr profile,
 			/* CGColorSpaceRef __nullable */ IntPtr alternate);
 
@@ -591,8 +603,12 @@ namespace CoreGraphics {
 #endif
 		{
 			nint nComponents = range is null ? 0 : range.Length / 2;
-			var ptr = CGColorSpaceCreateICCBased (nComponents, range, profile.GetHandle (), alternate.GetHandle ());
-			return FromHandle (ptr, true);
+			unsafe {
+				fixed (nfloat* rangePtr = range) {
+					var ptr = CGColorSpaceCreateICCBased (nComponents, rangePtr, profile.GetHandle (), alternate.GetHandle ());
+					return FromHandle (ptr, true);
+				}
+			}
 		}
 
 #if NET

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -180,7 +180,7 @@ namespace CoreGraphics {
 #endif
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern unsafe static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateCalibratedGray (/* const CGFloat[3] */ nfloat* whitepoint, /* const CGFloat[3] */ nfloat*  blackpoint, /* CGFloat */ nfloat gamma);
+		extern unsafe static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateCalibratedGray (/* const CGFloat[3] */ nfloat* whitepoint, /* const CGFloat[3] */ nfloat* blackpoint, /* CGFloat */ nfloat gamma);
 
 		public static CGColorSpace? CreateCalibratedGray (nfloat [] whitepoint, nfloat []? blackpoint, nfloat gamma)
 		{

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -164,12 +164,16 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetLineDash (/* CGContextRef */ IntPtr c, /* CGFloat */ nfloat phase, /* CGFloat[] */ nfloat []? lengths, /* size_t */ nint count);
+		extern static unsafe void CGContextSetLineDash (/* CGContextRef */ IntPtr c, /* CGFloat */ nfloat phase, /* CGFloat[] */ nfloat* lengths, /* size_t */ nint count);
 
 		public void SetLineDash (nfloat phase, nfloat []? lengths)
 		{
 			int n = lengths is null ? 0 : lengths.Length;
-			CGContextSetLineDash (Handle, phase, lengths, n);
+			unsafe {
+				fixed (nfloat* lengthsPtr = lengths) {
+					CGContextSetLineDash (Handle, phase, lengthsPtr, n);
+				}
+			}
 		}
 
 		public void SetLineDash (nfloat phase, nfloat []? lengths, int n)
@@ -178,7 +182,11 @@ namespace CoreGraphics {
 				n = 0;
 			else if (n < 0 || n > lengths.Length)
 				throw new ArgumentException (nameof (n));
-			CGContextSetLineDash (Handle, phase, lengths, n);
+			unsafe {
+				fixed (nfloat* lengthsPtr = lengths) {
+					CGContextSetLineDash (Handle, phase, lengthsPtr, n);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -583,39 +591,55 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetFillColor (/* CGContextRef */ IntPtr context,
-			/* const CGFloat * __nullable */ nfloat []? components);
+		extern static unsafe void CGContextSetFillColor (/* CGContextRef */ IntPtr context,
+			/* const CGFloat * __nullable */ nfloat* components);
 
 		public void SetFillColor (nfloat []? components)
 		{
-			CGContextSetFillColor (Handle, components);
+			unsafe {
+				fixed (nfloat* componentsPtr = components) {
+					CGContextSetFillColor (Handle, componentsPtr);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetStrokeColor (/* CGContextRef */ IntPtr context,
-			/* const CGFloat * __nullable */ nfloat []? components);
+		extern static unsafe void CGContextSetStrokeColor (/* CGContextRef */ IntPtr context,
+			/* const CGFloat * __nullable */ nfloat* components);
 
 		public void SetStrokeColor (nfloat []? components)
 		{
-			CGContextSetStrokeColor (Handle, components);
+			unsafe {
+				fixed (nfloat* componentsPtr = components) {
+					CGContextSetStrokeColor (Handle, componentsPtr);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetFillPattern (/* CGContextRef */ IntPtr context,
-			/* CGPatternRef __nullable */ IntPtr pattern, /* const CGFloat * __nullable */ nfloat []? components);
+		extern static unsafe void CGContextSetFillPattern (/* CGContextRef */ IntPtr context,
+			/* CGPatternRef __nullable */ IntPtr pattern, /* const CGFloat * __nullable */ nfloat* components);
 
 		public void SetFillPattern (CGPattern pattern, nfloat []? components)
 		{
-			CGContextSetFillPattern (Handle, pattern.GetHandle (), components);
+			unsafe {
+				fixed (nfloat* componentsPtr = components) {
+					CGContextSetFillPattern (Handle, pattern.GetHandle (), componentsPtr);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextSetStrokePattern (/* CGContextRef */ IntPtr context,
-			/* CGPatternRef __nullable */ IntPtr pattern, /* const CGFloat * __nullable */ nfloat []? components);
+		extern static unsafe void CGContextSetStrokePattern (/* CGContextRef */ IntPtr context,
+			/* CGPatternRef __nullable */ IntPtr pattern, /* const CGFloat * __nullable */ nfloat* components);
 
 		public void SetStrokePattern (CGPattern? pattern, nfloat []? components)
 		{
-			CGContextSetStrokePattern (Handle, pattern.GetHandle (), components);
+			unsafe {
+				fixed (nfloat* componentsPtr = components) {
+					CGContextSetStrokePattern (Handle, pattern.GetHandle (), componentsPtr);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]

--- a/src/CoreGraphics/CGFunction.cs
+++ b/src/CoreGraphics/CGFunction.cs
@@ -122,7 +122,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static IntPtr CGFunctionCreate (/* void* */ IntPtr data, /* size_t */ nint domainDimension, /* CGFloat* */ nfloat []? domain, nint rangeDimension, /* CGFloat* */ nfloat []? range, ref CGFunctionCallbacks callbacks);
+		extern static unsafe IntPtr CGFunctionCreate (/* void* */ IntPtr data, /* size_t */ nint domainDimension, /* CGFloat* */ nfloat* domain, nint rangeDimension, /* CGFloat* */ nfloat* range, ref CGFunctionCallbacks callbacks);
 
 		unsafe public delegate void CGFunctionEvaluate (nfloat* data, nfloat* outData);
 
@@ -143,8 +143,12 @@ namespace CoreGraphics {
 			this.evaluate = callback;
 
 			var gch = GCHandle.Alloc (this);
-			var handle = CGFunctionCreate (GCHandle.ToIntPtr (gch), domain is not null ? domain.Length / 2 : 0, domain, range is not null ? range.Length / 2 : 0, range, ref cbacks);
-			InitializeHandle (handle);
+			unsafe {
+				fixed (nfloat* domainPtr = domain, rangePtr = range) {
+					var handle = CGFunctionCreate (GCHandle.ToIntPtr (gch), domain is not null ? domain.Length / 2 : 0, domainPtr, range is not null ? range.Length / 2 : 0, rangePtr, ref cbacks);
+					InitializeHandle (handle);
+				}
+			}
 		}
 #if NET
 		[UnmanagedCallersOnly]

--- a/src/CoreGraphics/CGGradient.cs
+++ b/src/CoreGraphics/CGGradient.cs
@@ -81,9 +81,9 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGGradientRef __nullable */ IntPtr CGGradientCreateWithColorComponents (
-			/* CGColorSpaceRef __nullable */ IntPtr colorspace, /* const CGFloat* __nullable */ nfloat []? components,
-			/* const CGFloat* __nullable */ nfloat []? locations, /* size_t */ nint count);
+		extern static unsafe /* CGGradientRef __nullable */ IntPtr CGGradientCreateWithColorComponents (
+			/* CGColorSpaceRef __nullable */ IntPtr colorspace, /* const CGFloat* __nullable */ nfloat* components,
+			/* const CGFloat* __nullable */ nfloat* locations, /* size_t */ nint count);
 
 		static IntPtr Create (CGColorSpace colorspace, nfloat [] components, nfloat []? locations)
 		{
@@ -94,7 +94,11 @@ namespace CoreGraphics {
 			if (components is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (components));
 
-			return CGGradientCreateWithColorComponents (colorspace.GetCheckedHandle (), components, locations, components.Length / (colorspace.Components + 1));
+			unsafe {
+				fixed (nfloat* componentsPtr = components, locationsPtr = locations) {
+					return CGGradientCreateWithColorComponents (colorspace.GetCheckedHandle (), componentsPtr, locationsPtr, components.Length / (colorspace.Components + 1));
+				}
+			}
 		}
 
 		public CGGradient (CGColorSpace colorspace, nfloat [] components, nfloat []? locations)
@@ -111,7 +115,11 @@ namespace CoreGraphics {
 			if (components is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (components));
 
-			return CGGradientCreateWithColorComponents (colorspace.GetCheckedHandle (), components, null, components.Length / (colorspace.Components + 1));
+			unsafe {
+				fixed (nfloat* componentsPtr = components) {
+					return CGGradientCreateWithColorComponents (colorspace.GetCheckedHandle (), componentsPtr, null, components.Length / (colorspace.Components + 1));
+				}
+			}
 		}
 
 		public CGGradient (CGColorSpace colorspace, nfloat [] components)
@@ -120,9 +128,9 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGGradientRef __nullable */ IntPtr CGGradientCreateWithColors (
+		extern static unsafe /* CGGradientRef __nullable */ IntPtr CGGradientCreateWithColors (
 			/* CGColorSpaceRef __nullable */ IntPtr space, /* CFArrayRef __nullable */ IntPtr colors,
-			/* const CGFloat* __nullable */ nfloat []? locations);
+			/* const CGFloat* __nullable */ nfloat* locations);
 
 		static IntPtr Create (CGColorSpace? colorspace, CGColor [] colors, nfloat []? locations)
 		{
@@ -131,8 +139,13 @@ namespace CoreGraphics {
 			if (colors is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (colors));
 
-			using (var array = CFArray.FromNativeObjects (colors))
-				return CGGradientCreateWithColors (colorspace.GetHandle (), array.Handle, locations);
+			using (var array = CFArray.FromNativeObjects (colors)) {
+				unsafe {
+					fixed (nfloat* locationsPtr = locations) {
+						return CGGradientCreateWithColors (colorspace.GetHandle (), array.Handle, locationsPtr);
+					}
+				}
+			}
 		}
 
 		public CGGradient (CGColorSpace colorspace, CGColor [] colors, nfloat []? locations)
@@ -145,8 +158,11 @@ namespace CoreGraphics {
 			if (colors is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (colors));
 
-			using (var array = CFArray.FromNativeObjects (colors))
-				return CGGradientCreateWithColors (colorspace.GetHandle (), array.Handle, null);
+			using (var array = CFArray.FromNativeObjects (colors)) {
+				unsafe {
+					return CGGradientCreateWithColors (colorspace.GetHandle (), array.Handle, null);
+				}
+			}
 		}
 
 		public CGGradient (CGColorSpace? colorspace, CGColor [] colors)

--- a/src/CoreGraphics/CGImage.cs
+++ b/src/CoreGraphics/CGImage.cs
@@ -176,10 +176,10 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGImageRef */ IntPtr CGImageCreate (/* size_t */ nint width, /* size_t */ nint height,
+		extern static unsafe /* CGImageRef */ IntPtr CGImageCreate (/* size_t */ nint width, /* size_t */ nint height,
 			/* size_t */ nint bitsPerComponent, /* size_t */ nint bitsPerPixel, /* size_t */ nint bytesPerRow,
 			/* CGColorSpaceRef */ IntPtr space, CGBitmapFlags bitmapInfo, /* CGDataProviderRef */ IntPtr provider,
-			/* CGFloat[] */ nfloat []? decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate, CGColorRenderingIntent intent);
+			/* CGFloat[] */ nfloat* decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate, CGColorRenderingIntent intent);
 
 		static IntPtr Create (int width, int height, int bitsPerComponent, int bitsPerPixel, int bytesPerRow,
 				CGColorSpace? colorSpace, CGBitmapFlags bitmapFlags, CGDataProvider? provider,
@@ -196,9 +196,13 @@ namespace CoreGraphics {
 			if (bytesPerRow < 0)
 				throw new ArgumentException (nameof (bytesPerRow));
 
-			return CGImageCreate (width, height, bitsPerComponent, bitsPerPixel, bytesPerRow,
+			unsafe {
+				fixed (nfloat* decodePtr = decode) {
+					return CGImageCreate (width, height, bitsPerComponent, bitsPerPixel, bytesPerRow,
 						colorSpace.GetHandle (), bitmapFlags, provider.GetHandle (),
-						decode, shouldInterpolate, intent);
+						decodePtr, shouldInterpolate, intent);
+				}
+			}
 		}
 
 		public CGImage (int width, int height, int bitsPerComponent, int bitsPerPixel, int bytesPerRow,
@@ -223,9 +227,13 @@ namespace CoreGraphics {
 			if (bytesPerRow < 0)
 				throw new ArgumentException (nameof (bytesPerRow));
 
-			return CGImageCreate (width, height, bitsPerComponent, bitsPerPixel, bytesPerRow,
+			unsafe {
+				fixed (nfloat* decodePtr = decode) {
+					return CGImageCreate (width, height, bitsPerComponent, bitsPerPixel, bytesPerRow,
 						colorSpace.GetHandle (), (CGBitmapFlags) alphaInfo, provider.GetHandle (),
-						decode, shouldInterpolate, intent);
+						decodePtr, shouldInterpolate, intent);
+				}
+			}
 		}
 
 		public CGImage (int width, int height, int bitsPerComponent, int bitsPerPixel, int bytesPerRow,
@@ -292,29 +300,37 @@ namespace CoreGraphics {
 
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGImageRef */ IntPtr CGImageCreateWithJPEGDataProvider (/* CGDataProviderRef */ IntPtr source,
-			/* CGFloat[] */ nfloat []? decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate, CGColorRenderingIntent intent);
+		extern static unsafe /* CGImageRef */ IntPtr CGImageCreateWithJPEGDataProvider (/* CGDataProviderRef */ IntPtr source,
+			/* CGFloat[] */ nfloat* decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate, CGColorRenderingIntent intent);
 
 		public static CGImage? FromJPEG (CGDataProvider? provider, nfloat []? decode, bool shouldInterpolate, CGColorRenderingIntent intent)
 		{
-			var handle = CGImageCreateWithJPEGDataProvider (provider.GetHandle (), decode, shouldInterpolate, intent);
-			return FromHandle (handle, true);
+			unsafe {
+				fixed (nfloat* decodePtr = decode) {
+					var handle = CGImageCreateWithJPEGDataProvider (provider.GetHandle (), decodePtr, shouldInterpolate, intent);
+					return FromHandle (handle, true);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGImageRef */ IntPtr CGImageCreateWithPNGDataProvider (/* CGDataProviderRef */ IntPtr source,
-			/* CGFloat[] */ nfloat []? decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate, CGColorRenderingIntent intent);
+		extern static unsafe /* CGImageRef */ IntPtr CGImageCreateWithPNGDataProvider (/* CGDataProviderRef */ IntPtr source,
+			/* CGFloat[] */ nfloat* decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate, CGColorRenderingIntent intent);
 
 		public static CGImage? FromPNG (CGDataProvider provider, nfloat []? decode, bool shouldInterpolate, CGColorRenderingIntent intent)
 		{
-			var handle = CGImageCreateWithPNGDataProvider (provider.GetHandle (), decode, shouldInterpolate, intent);
-			return FromHandle (handle, true);
+			unsafe {
+				fixed (nfloat* decodePtr = decode) {
+					var handle = CGImageCreateWithPNGDataProvider (provider.GetHandle (), decodePtr, shouldInterpolate, intent);
+					return FromHandle (handle, true);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGImageRef */ IntPtr CGImageMaskCreate (/* size */ nint width, /* size */ nint height,
+		extern static unsafe /* CGImageRef */ IntPtr CGImageMaskCreate (/* size */ nint width, /* size */ nint height,
 			/* size */ nint bitsPerComponent, /* size */ nint bitsPerPixel, /* size */ nint bytesPerRow,
-			/* CGDataProviderRef */ IntPtr provider, /* CGFloat[] */ nfloat []? decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate);
+			/* CGDataProviderRef */ IntPtr provider, /* CGFloat[] */ nfloat* decode, [MarshalAs (UnmanagedType.I1)] bool shouldInterpolate);
 
 		public static CGImage? CreateMask (int width, int height, int bitsPerComponent, int bitsPerPixel, int bytesPerRow, CGDataProvider? provider, nfloat []? decode, bool shouldInterpolate)
 		{
@@ -326,21 +342,29 @@ namespace CoreGraphics {
 				throw new ArgumentException (nameof (bitsPerPixel));
 			if (bytesPerRow < 0)
 				throw new ArgumentException (nameof (bytesPerRow));
+			unsafe {
+				fixed (nfloat* decodePtr = decode) {
 
-			var handle = CGImageMaskCreate (width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, provider.GetHandle (), decode, shouldInterpolate);
-			return FromHandle (handle, true);
+					var handle = CGImageMaskCreate (width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, provider.GetHandle (), decodePtr, shouldInterpolate);
+					return FromHandle (handle, true);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGImageRef */ IntPtr CGImageCreateWithMaskingColors (/* CGImageRef */ IntPtr image, /* CGFloat[] */ nfloat []? components);
+		extern static unsafe /* CGImageRef */ IntPtr CGImageCreateWithMaskingColors (/* CGImageRef */ IntPtr image, /* CGFloat[] */ nfloat* components);
 
 		public CGImage? WithMaskingColors (nfloat []? components)
 		{
 			var N = 2 * ColorSpace!.Components;
 			if (components is not null && components.Length != N)
 				throw new ArgumentException ("The argument 'components' must have 2N values, where N is the number of components in the color space of the image.", nameof (components));
-			var handle = CGImageCreateWithMaskingColors (Handle, components);
-			return FromHandle (handle, true);
+			unsafe {
+				fixed (nfloat* componentsPtr = components) {
+					var handle = CGImageCreateWithMaskingColors (Handle, componentsPtr);
+					return FromHandle (handle, true);
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -722,7 +722,7 @@ namespace CoreGraphics {
 			/* CGPathRef */ IntPtr path,
 			/* const CGAffineTransform * */ CGAffineTransform* transform,
 			/* CGFloat */ nfloat phase,
-			/* CGFloat */ nfloat [] lengths,
+			/* CGFloat */ nfloat* lengths,
 			/* size_t */ nint count);
 
 		public CGPath CopyByDashingPath (CGAffineTransform transform, nfloat [] lengths)
@@ -732,7 +732,9 @@ namespace CoreGraphics {
 
 		public unsafe CGPath CopyByDashingPath (CGAffineTransform transform, nfloat [] lengths, nfloat phase)
 		{
-			return MakeMutable (CGPathCreateCopyByDashingPath (Handle, &transform, phase, lengths, lengths is null ? 0 : lengths.Length), true);
+			fixed (nfloat* lengthsPtr = lengths) {
+				return MakeMutable (CGPathCreateCopyByDashingPath (Handle, &transform, phase, lengthsPtr, lengths is null ? 0 : lengths.Length), true);
+			}
 		}
 
 		public CGPath CopyByDashingPath (nfloat [] lengths)
@@ -742,8 +744,10 @@ namespace CoreGraphics {
 
 		public unsafe CGPath CopyByDashingPath (nfloat [] lengths, nfloat phase)
 		{
-			var path = CGPathCreateCopyByDashingPath (Handle, null, phase, lengths, lengths is null ? 0 : lengths.Length);
-			return MakeMutable (path, true);
+			fixed (nfloat* lengthsPtr = lengths) {
+				var path = CGPathCreateCopyByDashingPath (Handle, null, phase, lengthsPtr, lengths is null ? 0 : lengths.Length);
+				return MakeMutable (path, true);
+			}
 		}
 
 		public unsafe CGPath Copy ()

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -2551,13 +2551,17 @@ namespace CoreText {
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern nint CTFontGetLigatureCaretPositions (IntPtr handle, CGGlyph glyph, [Out] nfloat [] positions, nint max);
+		static extern unsafe nint CTFontGetLigatureCaretPositions (IntPtr handle, CGGlyph glyph, [Out] nfloat* positions, nint max);
 
 		public nint GetLigatureCaretPositions (CGGlyph glyph, nfloat [] positions)
 		{
 			if (positions is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (positions));
-			return CTFontGetLigatureCaretPositions (Handle, glyph, positions, positions.Length);
+			unsafe {
+				fixed (nfloat* positionsPtr = positions) {
+					return CTFontGetLigatureCaretPositions (Handle, glyph, positionsPtr, positions.Length);
+				}
+			}
 		}
 		#endregion
 


### PR DESCRIPTION
manual marshaling arrays for blitability

In short, all pinvokes that took arrays have been changed pointers to the array type that we're using. Consequently, the pinvoke becomes `unsafe` and the calling code needs an `unsafe`/`fixed` block. Not as pretty, but straightforward.

This cuts out about 20 failures in the blitability pinvoke test.