### PR TITLE
[xcode14.1] [CoreMidi] Fixed MidiPacket.Bytes IndexOutOfRangeException. Fixes #16979.

### DIFF
--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -851,7 +851,7 @@ namespace CoreMidi {
 
 		public IntPtr Bytes {
 			get {
-				if (bytes is null)
+				if (bytes is null || bytes.Length < 1)
 					return byteptr;
 				unsafe {
 					fixed (byte *p = &bytes [start]){


### PR DESCRIPTION
Closes #16979

The only `MidiPacket` constructor ever used internally is the one accepting an `IntPtr` argument. Therefore `bytes` will always have the default empty array value. Because of this, in the `Bytes` get accessor `bytes` is not null, but empty and indexing into `bytes` on line 848 throws the exception. The other option would have been to remove the empty array default value that was added in #15098, but the length check seemed like the safer, although maybe slightly less performant, option.


Backport of #16992
