### PR TITLE
[src] Remove a lot of redundant availability attributes.

### DIFF
--- a/src/AVFoundation/AVAudioSettings.cs
+++ b/src/AVFoundation/AVAudioSettings.cs
@@ -175,8 +175,6 @@ namespace AVFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public AVAudioBitRateStrategy? BitRateStrategy {
 			set {
@@ -220,8 +218,6 @@ namespace AVFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public AVSampleRateConverterAlgorithm? SampleRateConverterAlgorithm {
 			get {
@@ -255,8 +251,6 @@ namespace AVFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public AVAudioQuality? EncoderAudioQualityForVBR {
 			get {

--- a/src/AVFoundation/AVVideoSettings.cs
+++ b/src/AVFoundation/AVVideoSettings.cs
@@ -219,8 +219,6 @@ namespace AVFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public double? MaxKeyFrameIntervalDuration {
 			get {
@@ -237,8 +235,6 @@ namespace AVFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 		[UnsupportedOSPlatform ("macos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public bool? AllowFrameReordering {
 			get {
@@ -254,8 +250,6 @@ namespace AVFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 		[UnsupportedOSPlatform ("macos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public AVVideoH264EntropyMode? EntropyEncoding {
 			get {
@@ -297,8 +291,6 @@ namespace AVFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 		[UnsupportedOSPlatform ("macos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public float? ExpectedSourceFrameRate {
 			get {
@@ -315,8 +307,6 @@ namespace AVFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 		[UnsupportedOSPlatform ("macos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public float? AverageNonDroppableFrameRate {
 			get {

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -482,7 +482,6 @@ namespace AVFoundation {
 		NotDetermined, Restricted, Denied, Authorized
 	}
 
-	[iOS (7, 0)]
 	[Mac (10, 14)]
 	[Native]
 	// NSInteger - AVSpeechSynthesis.h
@@ -929,10 +928,8 @@ namespace AVFoundation {
 		PresetHevc3840x2160 = 12,
 	}
 
-	[TV (9, 0)]
 	[NoWatch]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	public enum AVOutputSettingsPreset {
 		[Field ("AVOutputSettingsPreset640x480")]
 		Preset640x480 = 0,

--- a/src/AddressBook/ABPerson.cs
+++ b/src/AddressBook/ABPerson.cs
@@ -696,8 +696,6 @@ namespace AddressBook {
 		[UnsupportedOSPlatform ("ios9.0")]
 		[ObsoletedOSPlatform ("maccatalyst14.0", "Use the 'Contacts' API instead.")]
 		[ObsoletedOSPlatform ("ios9.0", "Use the 'Contacts' API instead.")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static ABPersonCompositeNameFormat ABPersonGetCompositeNameFormatForRecord (IntPtr record);
@@ -709,8 +707,6 @@ namespace AddressBook {
 		[UnsupportedOSPlatform ("ios9.0")]
 		[ObsoletedOSPlatform ("maccatalyst14.0", "Use the 'Contacts' API instead.")]
 		[ObsoletedOSPlatform ("ios9.0", "Use the 'Contacts' API instead.")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static ABPersonCompositeNameFormat GetCompositeNameFormat (ABRecord? record)
 		{
@@ -724,8 +720,6 @@ namespace AddressBook {
 		[UnsupportedOSPlatform ("ios9.0")]
 		[ObsoletedOSPlatform ("maccatalyst14.0", "Use the 'Contacts' API instead.")]
 		[ObsoletedOSPlatform ("ios9.0", "Use the 'Contacts' API instead.")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABPersonCopyCompositeNameDelimiterForRecord (IntPtr record);
@@ -737,8 +731,6 @@ namespace AddressBook {
 		[UnsupportedOSPlatform ("ios9.0")]
 		[ObsoletedOSPlatform ("maccatalyst14.0", "Use the 'Contacts' API instead.")]
 		[ObsoletedOSPlatform ("ios9.0", "Use the 'Contacts' API instead.")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static string? GetCompositeNameDelimiter (ABRecord? record)
 		{

--- a/src/AudioToolbox/AudioToolbox.cs
+++ b/src/AudioToolbox/AudioToolbox.cs
@@ -69,8 +69,6 @@ namespace AudioToolbox {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)] // 10.5
 #endif
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static OSStatus CopyNameFromSoundBank (/* CFURLRef */ IntPtr inURL, /* CFStringRef */ ref IntPtr outName);
@@ -80,8 +78,6 @@ namespace AudioToolbox {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)] // 10.5
 #endif
 		public static string? GetName (NSUrl url)
 		{
@@ -104,7 +100,6 @@ namespace AudioToolbox {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.AudioToolboxLibrary)]
@@ -116,7 +111,6 @@ namespace AudioToolbox {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public static InstrumentInfo []? GetInstrumentInfo (NSUrl url)

--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -399,7 +399,6 @@ namespace AudioUnit {
 		[ObsoletedOSPlatform ("tvos14.0")]
 		[ObsoletedOSPlatform ("ios14.0")]
 #else
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 14, 0)]
 		[Deprecated (PlatformName.TvOS, 14, 0)]
 #endif
@@ -416,7 +415,6 @@ namespace AudioUnit {
 		[ObsoletedOSPlatform ("tvos14.0", "Use 'CopyIcon' instead.")]
 		[ObsoletedOSPlatform ("ios14.0", "Use 'CopyIcon' instead.")]
 #else
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use 'CopyIcon' instead.")]
 		[Deprecated (PlatformName.TvOS, 14, 0, message: "Use 'CopyIcon' instead.")]
 #endif
@@ -438,7 +436,6 @@ namespace AudioUnit {
 		[ObsoletedOSPlatform ("maccatalyst14.0")]
 		[ObsoletedOSPlatform ("ios13.0")]
 #else
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0)]
 		[Deprecated (PlatformName.TvOS, 13, 0)]
 		[MacCatalyst (14, 0)]
@@ -459,7 +456,6 @@ namespace AudioUnit {
 		[ObsoletedOSPlatform ("maccatalyst14.0", "Use 'AudioUnit' instead.")]
 		[ObsoletedOSPlatform ("ios13.0", "Use 'AudioUnit' instead.")]
 #else
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'AudioUnit' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'AudioUnit' instead.")]
 		[MacCatalyst (14, 0)]

--- a/src/AudioUnit/AudioComponentDescription.cs
+++ b/src/AudioUnit/AudioComponentDescription.cs
@@ -54,8 +54,6 @@ namespace AudioUnit {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		MIDIProcessor = 0x61756d69, // 'aumi'
 #if NET
@@ -73,32 +71,24 @@ namespace AudioUnit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		RemoteEffect = 0x61757278, // 'aurx',
 #if NET
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		RemoteGenerator = 0x61757267, // 'aurg',
 #if NET
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		RemoteInstrument = 0x61757269, // 'auri',
 #if NET
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		RemoteMusicEffect = 0x6174726d, // 'aurm'
 #endif

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -765,7 +765,6 @@ namespace AudioUnit {
 		[ObsoletedOSPlatform ("maccatalyst14.0")]
 		[ObsoletedOSPlatform ("ios13.0")]
 #else
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0)]
 		[Deprecated (PlatformName.TvOS, 13, 0)]
 		[MacCatalyst (14, 0)]
@@ -786,7 +785,6 @@ namespace AudioUnit {
 		[ObsoletedOSPlatform ("maccatalyst14.0", "Use 'AudioUnit' instead.")]
 		[ObsoletedOSPlatform ("ios13.0", "Use 'AudioUnit' instead.")]
 #else
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'AudioUnit' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'AudioUnit' instead.")]
 		[MacCatalyst (14, 0)]
@@ -818,7 +816,6 @@ namespace AudioUnit {
 		[ObsoletedOSPlatform ("maccatalyst14.0")]
 		[ObsoletedOSPlatform ("ios13.0")]
 #else
-		[iOS (7, 0)]
 		[MacCatalyst (14, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0)]
 		[Deprecated (PlatformName.TvOS, 13, 0)]
@@ -839,7 +836,6 @@ namespace AudioUnit {
 		[ObsoletedOSPlatform ("maccatalyst14.0", "Use 'AudioUnit' instead.")]
 		[ObsoletedOSPlatform ("ios13.0", "Use 'AudioUnit' instead.")]
 #else
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'AudioUnit' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'AudioUnit' instead.")]
 		[MacCatalyst (14, 0)]

--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -300,7 +300,6 @@ namespace CoreServices {
 			[ObsoletedOSPlatform ("ios12.0", "Not available anymore.")]
 #else
 			[Mac (10, 9)]
-			[iOS (7, 0)]
 			[Deprecated (PlatformName.iOS, 12, 0, message: "Not available anymore.")]
 			[Deprecated (PlatformName.TvOS, 12, 0, message: "Not available anymore.")]
 			[Deprecated (PlatformName.MacOSX, 10, 14, message: "Not available anymore.")]

--- a/src/Compression/Enums.cs
+++ b/src/Compression/Enums.cs
@@ -7,7 +7,7 @@ namespace Compression {
 
 	// this enum as per the headers is an int NOT an NSInteger
 #if !NET
-	[iOS (9, 0), TV (9, 0), Mac (10, 11)]
+	[iOS (9, 0), Mac (10, 11)]
 #endif
 	public enum CompressionAlgorithm {
 		LZ4 = 0x100,

--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -812,7 +812,6 @@ namespace CoreFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -824,7 +823,6 @@ namespace CoreFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -836,7 +834,6 @@ namespace CoreFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -848,7 +845,6 @@ namespace CoreFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -860,7 +856,6 @@ namespace CoreFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public DispatchQueue ReadDispatchQueue {
@@ -878,7 +873,6 @@ namespace CoreFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public DispatchQueue WriteDispatchQueue {

--- a/src/CoreFoundation/CFUrl.cs
+++ b/src/CoreFoundation/CFUrl.cs
@@ -140,7 +140,6 @@ namespace CoreFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -153,7 +152,6 @@ namespace CoreFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public bool IsFileReference {

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -269,8 +269,6 @@ namespace CoreFoundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static string? CurrentQueueLabel {
 			get {

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -627,7 +627,6 @@ namespace CoreGraphics {
 		[ObsoletedOSPlatform ("tvos11.0", "Use 'GetICCData' instead.")]
 		[ObsoletedOSPlatform ("ios11.0", "Use 'GetICCData' instead.")]
 #else
-		[iOS (7, 0)] // note: pre-release docs/headers says iOS6 and later, available on OSX since 10.5
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'GetICCData' instead.")]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'GetICCData' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'GetICCData' instead.")]

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -817,7 +817,6 @@ namespace CoreGraphics {
 		[SupportedOSPlatform ("tvos")]
 #else
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 #endif
 		static unsafe public CGPath FromRoundedRect (CGRect rectangle, nfloat cornerWidth, nfloat cornerHeight)
 		{
@@ -831,7 +830,6 @@ namespace CoreGraphics {
 		[SupportedOSPlatform ("tvos")]
 #else
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 #endif
 		static public unsafe CGPath FromRoundedRect (CGRect rectangle, nfloat cornerWidth, nfloat cornerHeight, CGAffineTransform transform)
 		{
@@ -848,7 +846,6 @@ namespace CoreGraphics {
 		[SupportedOSPlatform ("tvos")]
 #else
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 #endif
 		public unsafe void AddRoundedRect (CGAffineTransform transform, CGRect rect, nfloat cornerWidth, nfloat cornerHeight)
 		{
@@ -862,7 +859,6 @@ namespace CoreGraphics {
 		[SupportedOSPlatform ("tvos")]
 #else
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 #endif
 		public unsafe void AddRoundedRect (CGRect rect, nfloat cornerWidth, nfloat cornerHeight)
 		{

--- a/src/CoreImage/CIContext.cs
+++ b/src/CoreImage/CIContext.cs
@@ -125,8 +125,6 @@ namespace CoreImage {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public bool? OutputPremultiplied {
 			get {

--- a/src/CoreMedia/CMFormatDescription.cs
+++ b/src/CoreMedia/CMFormatDescription.cs
@@ -377,7 +377,6 @@ namespace CoreMedia {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.CoreMediaLibrary)]
@@ -395,7 +394,6 @@ namespace CoreMedia {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public static CMVideoFormatDescription? FromH264ParameterSets (List<byte []> parameterSets, int nalUnitHeaderLength, out CMFormatDescriptionError error)
@@ -440,7 +438,6 @@ namespace CoreMedia {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.CoreMediaLibrary)]
@@ -458,7 +455,6 @@ namespace CoreMedia {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public byte []? GetH264ParameterSet (nuint index, out nuint parameterSetCount, out int nalUnitHeaderLength, out CMFormatDescriptionError error)

--- a/src/CoreMedia/CMSampleBuffer.cs
+++ b/src/CoreMedia/CMSampleBuffer.cs
@@ -656,7 +656,6 @@ namespace CoreMedia {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.CoreMediaLibrary)]
@@ -668,7 +667,6 @@ namespace CoreMedia {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public CMSampleBufferError CopyPCMDataIntoAudioBufferList (int frameOffset, int numFrames, AudioBuffers bufferList)

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -600,7 +600,6 @@ namespace CoreMedia {
 		[ObsoletedOSPlatform ("macos10.10")]
 		[ObsoletedOSPlatform ("ios8.0")]
 #else
-		[TV (9, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0)]
 		[Deprecated (PlatformName.TvOS, 9, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
@@ -619,7 +618,6 @@ namespace CoreMedia {
 		[ObsoletedOSPlatform ("macos10.10")]
 		[ObsoletedOSPlatform ("ios8.0")]
 #else
-		[TV (9, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0)]
 		[Deprecated (PlatformName.TvOS, 9, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
@@ -643,7 +641,6 @@ namespace CoreMedia {
 		[ObsoletedOSPlatform ("macos10.10")]
 		[ObsoletedOSPlatform ("ios8.0")]
 #else
-		[TV (9, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0)]
 		[Deprecated (PlatformName.TvOS, 9, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
@@ -662,7 +659,6 @@ namespace CoreMedia {
 		[ObsoletedOSPlatform ("macos10.10")]
 		[ObsoletedOSPlatform ("ios8.0")]
 #else
-		[TV (9, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0)]
 		[Deprecated (PlatformName.TvOS, 9, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -1804,8 +1804,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)] // documented as 3.2 but it's wrong (see unit tests)
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCreateWithNameAndOptions (IntPtr name, nfloat size, IntPtr matrix, nuint options);
@@ -1830,8 +1828,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)] // documented as 3.2 but it's wrong (see unit tests)
 #endif
 		public CTFont (string name, nfloat size, CTFontOptions options)
 			: base (Create (name, size, options), true)
@@ -1843,8 +1839,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)] // documented as 3.2 but it's wrong (see unit tests)
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCreateWithNameAndOptions (IntPtr name, nfloat size, ref CGAffineTransform matrix, nuint options);
@@ -1869,8 +1863,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)] // documented as 3.2 but it's wrong (see unit tests)
 #endif
 		public CTFont (string name, nfloat size, ref CGAffineTransform matrix, CTFontOptions options)
 			: base (Create (name, size, ref matrix, options), true)
@@ -1882,8 +1874,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)] // documented as 3.2 but it's wrong (see unit tests)
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCreateWithFontDescriptorAndOptions (IntPtr descriptor, nfloat size, IntPtr matrix, nuint options);
@@ -1903,8 +1893,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)] // documented as 3.2 but it's wrong (see unit tests)
 #endif
 		public CTFont (CTFontDescriptor descriptor, nfloat size, CTFontOptions options)
 			: base (Create (descriptor, size, options), true)
@@ -1916,8 +1904,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)] // documented as 3.2 but it's wrong (see unit tests)
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCreateWithFontDescriptorAndOptions (IntPtr descriptor, nfloat size, ref CGAffineTransform matrix, nuint options);
@@ -1937,8 +1923,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)] // documented as 3.2 but it's wrong (see unit tests)
 #endif
 		public CTFont (CTFontDescriptor descriptor, nfloat size, CTFontOptions options, ref CGAffineTransform matrix)
 			: base (Create (descriptor, size, options, ref matrix), true)

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -434,8 +434,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern /* CFArrayRef */ IntPtr CTFontManagerCreateFontDescriptorsFromURL (/* CFURLRef */ IntPtr fileURL);
@@ -445,8 +443,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static CTFontDescriptor [] GetFonts (NSUrl url)
 		{
@@ -532,8 +528,6 @@ namespace CoreText {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		static NSString? RegisteredFontsChangedNotification {
 			get {
@@ -698,7 +692,6 @@ namespace CoreText {
 		}
 #endif
 
-		// [Watch (2,0), TV (9,0), Mac (10,7), iOS (7,0)]
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern unsafe /* CTFontDescriptorRef _Nullable */ IntPtr CTFontManagerCreateFontDescriptorFromData (/* CFDataRef */ IntPtr data);
 

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -11,8 +11,6 @@ using System.Runtime.InteropServices;
 using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
-#if NET
-#endif
 
 using CFDictionaryRef = System.IntPtr;
 using CVPixelBufferRef = System.IntPtr;

--- a/src/CoreVideo/CVPixelFormatType.cs
+++ b/src/CoreVideo/CVPixelFormatType.cs
@@ -29,8 +29,6 @@
 using System;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
-#if NET
-#endif
 
 #nullable enable
 

--- a/src/CoreWlan/Enums.cs
+++ b/src/CoreWlan/Enums.cs
@@ -5,8 +5,6 @@ using Foundation;
 using CoreFoundation;
 using ObjCRuntime;
 using System;
-#if NET
-#endif
 
 namespace CoreWlan {
 

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -852,9 +852,7 @@ namespace Foundation {
 	public enum NSUnderlineStyle : long {
 		None = 0x00,
 		Single = 0x01,
-		[iOS (7, 0)]
 		Thick = 0x02,
-		[iOS (7, 0)]
 		Double = 0x09,
 		PatternSolid = 0x0000,
 		PatternDot = 0x0100,
@@ -943,27 +941,20 @@ namespace Foundation {
 		WrapCalendarComponents = 1 << 0,
 
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		MatchStrictly = 1 << 1,
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		SearchBackwards = 1 << 2,
 
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		MatchPreviousTimePreservingSmallerUnits = 1 << 8,
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		MatchNextTimePreservingSmallerUnits = 1 << 9,
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		MatchNextTime = 1 << 10,
 
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		MatchFirst = 1 << 12,
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		MatchLast = 1 << 13,
 	}
 
@@ -1001,7 +992,6 @@ namespace Foundation {
 		Stable = 1 << 4
 	}
 
-	[iOS (7, 0)]
 	[Flags]
 	[Native]
 	public enum NSDataBase64DecodingOptions : ulong {
@@ -1009,7 +999,6 @@ namespace Foundation {
 		IgnoreUnknownCharacters = 1
 	}
 
-	[iOS (7, 0)]
 	[Flags]
 	[Native]
 	public enum NSDataBase64EncodingOptions : ulong {
@@ -1021,7 +1010,6 @@ namespace Foundation {
 	}
 
 #if !XAMCORE_3_0
-	[iOS (7, 0)]
 	[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'NSWritingDirectionFormatType'.")]
 	[Flags]
 	[Native]

--- a/src/Foundation/Enums.cs
+++ b/src/Foundation/Enums.cs
@@ -4,7 +4,6 @@ using ObjCRuntime;
 namespace Foundation {
 
 	// Utility enum, ObjC uses NSString
-	[iOS (7, 0)]
 	public enum NSDocumentType {
 		Unknown = -1,
 		PlainText,
@@ -27,7 +26,6 @@ namespace Foundation {
 
 	// Utility enum, ObjC uses NSString
 	[NoMac]
-	[iOS (7, 0)]
 	public enum NSDocumentViewMode {
 		Normal,
 		PageLayout
@@ -63,7 +61,6 @@ namespace Foundation {
 	}
 
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	public enum NSItemDownloadingStatus {
 		[Field (null)]
 		Unknown = -1,

--- a/src/Foundation/NSMetadataItem.cs
+++ b/src/Foundation/NSMetadataItem.cs
@@ -155,7 +155,6 @@ namespace Foundation {
 		[UnsupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 #if NET
@@ -244,7 +243,6 @@ namespace Foundation {
 		[UnsupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public NSError? UbiquitousItemDownloadingError {
@@ -259,7 +257,6 @@ namespace Foundation {
 		[UnsupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public NSError? UbiquitousItemUploadingError {

--- a/src/Foundation/NSUserDefaults.cs
+++ b/src/Foundation/NSUserDefaults.cs
@@ -32,8 +32,6 @@ namespace Foundation {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public NSUserDefaults (string name, NSUserDefaultsType type)
 		{

--- a/src/GLKit/GLTextureLoader.cs
+++ b/src/GLKit/GLTextureLoader.cs
@@ -218,8 +218,6 @@ namespace GLKit {
 		[ObsoletedOSPlatform ("tvos12.0", "Use 'Metal' instead.")]
 		[ObsoletedOSPlatform ("macos10.14", "Use 'Metal' instead.")]
 		[ObsoletedOSPlatform ("ios12.0", "Use 'Metal' instead.")]
-#else
-		[iOS (7, 0)]
 #endif
 		public bool? SRGB {
 			get {

--- a/src/GameController/GCExtendedGamepadSnapshot.cs
+++ b/src/GameController/GCExtendedGamepadSnapshot.cs
@@ -30,7 +30,6 @@ namespace GameController {
 	[ObsoletedOSPlatform ("tvos12.2", "Use 'GCExtendedGamepadSnapshotData' instead.")]
 	[ObsoletedOSPlatform ("ios12.2", "Use 'GCExtendedGamepadSnapshotData' instead.")]
 #else
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[Deprecated (PlatformName.iOS, 12, 2, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 14, 4, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]

--- a/src/GameController/GCGamepadSnapshot.cs
+++ b/src/GameController/GCGamepadSnapshot.cs
@@ -32,7 +32,6 @@ namespace GameController {
 	[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCExtendedGamepad' instead.")]
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCExtendedGamepad' instead.")]
 	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCExtendedGamepad' instead.")]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 #endif
 	[StructLayout (LayoutKind.Sequential, Pack = 1)]

--- a/src/GameKit/GameKit.cs
+++ b/src/GameKit/GameKit.cs
@@ -295,7 +295,6 @@ namespace GameKit {
 	}
 
 	// uint8_t -> GKTurnBasedMatch.h
-	[iOS (7, 0)]
 	public enum GKTurnBasedExchangeStatus : sbyte {
 		Unknown,
 		Active,

--- a/src/HealthKit/Enums.cs
+++ b/src/HealthKit/Enums.cs
@@ -5,7 +5,6 @@ using System;
 
 namespace HealthKit {
 	// NSInteger -> HKDefines.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -17,7 +16,6 @@ namespace HealthKit {
 	}
 
 	// NSInteger -> HKDefines.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -28,7 +26,6 @@ namespace HealthKit {
 	}
 
 	// NSInteger -> HKDefines.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -41,7 +38,6 @@ namespace HealthKit {
 	}
 
 	// NSInteger -> HKDefines.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -58,7 +54,6 @@ namespace HealthKit {
 	}
 
 	// NSInteger -> HKMetadata.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -78,7 +73,6 @@ namespace HealthKit {
 	}
 
 	// NSInteger -> HKMetadata.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -93,7 +87,6 @@ namespace HealthKit {
 	}
 
 	// NSInteger -> HKObjectType.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -111,7 +104,6 @@ namespace HealthKit {
 	}
 
 	// NSInteger -> HKObjectType.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -129,7 +121,6 @@ namespace HealthKit {
 	}
 
 	// NSUInteger -> HKQuery.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -141,7 +132,6 @@ namespace HealthKit {
 	}
 
 	// NSUInteger -> HKStatistics.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -160,7 +150,6 @@ namespace HealthKit {
 	}
 
 	// NSInteger -> HKUnit.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -183,7 +172,6 @@ namespace HealthKit {
 	}
 
 	[Native]
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	public enum HKWorkoutActivityType : ulong {
@@ -307,7 +295,6 @@ namespace HealthKit {
 	}
 
 	[Native]
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	public enum HKWorkoutEventType : long {
@@ -327,7 +314,6 @@ namespace HealthKit {
 		PauseOrResumeRequest,
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -335,7 +321,6 @@ namespace HealthKit {
 		NotApplicable = 0
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -348,7 +333,6 @@ namespace HealthKit {
 		EggWhite
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -363,7 +347,6 @@ namespace HealthKit {
 		None,
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -380,7 +363,6 @@ namespace HealthKit {
 		EstrogenSurge = 4,
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[Native]
@@ -397,7 +379,6 @@ namespace HealthKit {
 		LoudEnvironment = 1,
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[Native]

--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -1412,7 +1412,7 @@ namespace HomeKit {
 	}
 
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
-	[Watch (2, 0), TV (10, 0), NoMac, iOS (8, 0)]
+	[TV (10, 0), NoMac, iOS (8, 0)]
 	[Native]
 	public enum HMCharacteristicValueTargetDoorState : long {
 		Open = 0,
@@ -1420,7 +1420,7 @@ namespace HomeKit {
 	}
 
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
-	[Watch (2, 0), TV (10, 0), NoMac, iOS (8, 0)]
+	[TV (10, 0), NoMac, iOS (8, 0)]
 	[Native]
 	public enum HMCharacteristicValueCurrentHeatingCooling : long {
 		Off = 0,
@@ -1429,7 +1429,7 @@ namespace HomeKit {
 	}
 
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
-	[Watch (2, 0), TV (10, 0), NoMac, iOS (8, 0)]
+	[TV (10, 0), NoMac, iOS (8, 0)]
 	[Native]
 	public enum HMCharacteristicValueTargetLockMechanismState : long {
 		Unsecured = 0,

--- a/src/ImageIO/CGImageDestination.cs
+++ b/src/ImageIO/CGImageDestination.cs
@@ -63,8 +63,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public CGImageMetadata? Metadata { get; set; }
 
@@ -73,8 +71,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public bool MergeMetadata { get; set; }
 
@@ -83,8 +79,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public bool ShouldExcludeXMP { get; set; }
 
@@ -104,8 +98,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public DateTime? DateTime { get; set; }
 
@@ -114,8 +106,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public int? Orientation { get; set; }
 
@@ -329,8 +319,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.ImageIOLibrary)]
 		extern static void CGImageDestinationAddImageAndMetadata (/* CGImageDestinationRef __nonnull */ IntPtr idst,
@@ -342,8 +330,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		public void AddImageAndMetadata (CGImage image, CGImageMetadata meta, NSDictionary? options)
@@ -358,8 +344,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public void AddImageAndMetadata (CGImage image, CGImageMetadata meta, CGImageDestinationOptions? options)
 		{
@@ -372,8 +356,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.ImageIOLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
@@ -386,8 +368,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		public bool CopyImageSource (CGImageSource image, NSDictionary? options, out NSError? error)
@@ -404,8 +384,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public bool CopyImageSource (CGImageSource image, CGCopyImageSourceOptions? options, out NSError? error)
 		{

--- a/src/ImageIO/CGImageMetadata.cs
+++ b/src/ImageIO/CGImageMetadata.cs
@@ -27,8 +27,6 @@ namespace ImageIO {
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("tvos")]
-#else
-	[iOS (7, 0)]
 #endif
 	public partial class CGImageMetadataEnumerateOptions {
 
@@ -54,8 +52,6 @@ namespace ImageIO {
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("tvos")]
-#else
-	[iOS (7, 0)]
 #endif
 	public partial class CGImageMetadata : NativeObject {
 #if !NET

--- a/src/ImageIO/CGImageMetadataTag.cs
+++ b/src/ImageIO/CGImageMetadataTag.cs
@@ -28,8 +28,6 @@ namespace ImageIO {
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("tvos")]
-#else
-	[iOS (7, 0)]
 #endif
 	public class CGImageMetadataTag : NativeObject {
 

--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -71,7 +71,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public bool ShouldCacheImmediately { get; set; }

--- a/src/ImageIO/CGImageSource.iOS.cs
+++ b/src/ImageIO/CGImageSource.iOS.cs
@@ -31,8 +31,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 		[UnsupportedOSPlatform ("macos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		public CGImageMetadata? CopyMetadata (nint index, NSDictionary? options)
@@ -46,8 +44,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 		[UnsupportedOSPlatform ("macos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public CGImageMetadata? CopyMetadata (nint index, CGImageOptions? options)
 		{
@@ -61,8 +57,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 		[UnsupportedOSPlatform ("macos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.ImageIOLibrary)]
 		extern static void CGImageSourceRemoveCacheAtIndex (/* CGImageSourceRef __nonnull */ IntPtr isrc,
@@ -73,8 +67,6 @@ namespace ImageIO {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 		[UnsupportedOSPlatform ("macos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public void RemoveCache (nint index)
 		{

--- a/src/ImageIO/CGMutableImageMetadata.cs
+++ b/src/ImageIO/CGMutableImageMetadata.cs
@@ -23,8 +23,6 @@ namespace ImageIO {
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("tvos")]
-#else
-	[iOS (7, 0)]
 #endif
 	public class CGMutableImageMetadata : CGImageMetadata {
 

--- a/src/ImageIO/Enums.cs
+++ b/src/ImageIO/Enums.cs
@@ -15,7 +15,6 @@ namespace ImageIO {
 
 	// untyped enum -> CGImageMetadata.h
 	// note: not used in any API
-	[iOS (7, 0)]
 	[ErrorDomain ("kCFErrorDomainCGImageMetadata")]
 	public enum CGImageMetadataErrors {
 		Unknown = 0,
@@ -26,7 +25,6 @@ namespace ImageIO {
 	}
 
 	// untyped enum -> CGImageMetadata.h
-	[iOS (7, 0)]
 	public enum CGImageMetadataType {
 		Invalid = -1,
 		Default = 0,

--- a/src/MapKit/MKEnums.cs
+++ b/src/MapKit/MKEnums.cs
@@ -23,7 +23,6 @@ namespace MapKit {
 	[NoWatch]
 	[Native]
 	[TV (9, 2)]
-	[iOS (7, 0)]
 	public enum MKDirectionsTransportType : ulong {
 		Automobile = 1 << 0,
 		Walking = 1 << 1,
@@ -50,7 +49,6 @@ namespace MapKit {
 	// NSUInteger -> MKDistanceFormatter.h
 	[Native]
 	[TV (9, 2)]
-	[iOS (7, 0)]
 	public enum MKDistanceFormatterUnits : ulong {
 		Default,
 		Metric,
@@ -61,7 +59,6 @@ namespace MapKit {
 	// NSUInteger -> MKDistanceFormatter.h
 	[Native]
 	[TV (9, 2)]
-	[iOS (7, 0)]
 	public enum MKDistanceFormatterUnitStyle : ulong {
 		Default = 0,
 		Abbreviated,
@@ -72,7 +69,6 @@ namespace MapKit {
 	[TV (9, 2)]
 	[NoWatch]
 	[Native]
-	[iOS (7, 0)]
 	public enum MKOverlayLevel : long {
 		AboveRoads = 0,
 		AboveLabels,

--- a/src/MapKit/MKMapItem.cs
+++ b/src/MapKit/MKMapItem.cs
@@ -56,8 +56,6 @@ namespace MapKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public MKMapCamera? Camera { get; set; }
 #endif

--- a/src/MediaAccessibility/MAEnums.cs
+++ b/src/MediaAccessibility/MAEnums.cs
@@ -18,7 +18,6 @@ using Foundation;
 namespace MediaAccessibility {
 
 	[Native]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	public enum MACaptionAppearanceDomain : long {
 		Default = 0,
@@ -26,7 +25,6 @@ namespace MediaAccessibility {
 	}
 
 	[Native]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	public enum MACaptionAppearanceDisplayType : long {
 		ForcedOnly = 0,
@@ -35,7 +33,6 @@ namespace MediaAccessibility {
 	}
 
 	[Native]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	public enum MACaptionAppearanceBehavior : long {
 		UseValue = 0,
@@ -43,7 +40,6 @@ namespace MediaAccessibility {
 	}
 
 	[Native]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	public enum MACaptionAppearanceFontStyle : long {
 		Default = 0,
@@ -57,7 +53,6 @@ namespace MediaAccessibility {
 	}
 
 	[Native]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	public enum MACaptionAppearanceTextEdgeStyle : long {
 		Undefined = 0,

--- a/src/MediaAccessibility/MediaAccessibility.cs
+++ b/src/MediaAccessibility/MediaAccessibility.cs
@@ -25,7 +25,6 @@ namespace MediaAccessibility {
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("tvos")]
 #else
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 #endif
 	public static partial class MACaptionAppearance {

--- a/src/MediaPlayer/MPMoviePlayerController.cs
+++ b/src/MediaPlayer/MPMoviePlayerController.cs
@@ -18,7 +18,6 @@ namespace MediaPlayer {
 		// the resulting syntax does not look good in user code so we provide a better looking API
 		// https://trello.com/c/iQpXOxCd/227-category-and-static-methods-selectors
 		// note: we cannot reuse the same method name - as it would break compilation of existing apps
-		[iOS (7,0)]
 		[Obsoleted (PlatformName.iOS, 15,0, PlatformArchitecture.None, Constants.iAdRemoved)]
 		static public void PrepareForPrerollAds ()
 		{

--- a/src/MediaPlayer/MediaPlayer.cs
+++ b/src/MediaPlayer/MediaPlayer.cs
@@ -128,7 +128,6 @@ namespace MediaPlayer {
 		MusicVideo = 1 << 11,
 		[Mac (10, 12, 2)]
 		VideoITunesU = 1 << 12,
-		[iOS (7, 0)]
 		[Mac (10, 12, 2)]
 		HomeVideo = 1 << 13,
 		[Mac (10, 12, 2)]

--- a/src/Metal/MTLEnums.cs
+++ b/src/Metal/MTLEnums.cs
@@ -472,7 +472,7 @@ namespace Metal {
 		[iOS (9, 0)]
 		Depth32Float_Stencil8 = 260,
 
-		[NoWatch, iOS (9, 0), TV (9, 0)]
+		[NoWatch, iOS (9, 0)]
 		X32_Stencil8 = 261,
 
 		[Mac (10, 12)]
@@ -897,12 +897,10 @@ namespace Metal {
 		macOS_GPUFamily2_v1 = 10005,
 
 #if !NET
-		[TV (9, 0)]
 		[Obsolete ("Use 'tvOS_GPUFamily1_v1' instead.")]
 		TVOS_GPUFamily1_v1 = 30000,
 #endif
 
-		[TV (9, 0)]
 		tvOS_GPUFamily1_v1 = 30000,
 
 		[NoiOS, TV (10, 0), NoWatch, NoMac]

--- a/src/MultipeerConnectivity/Enums.cs
+++ b/src/MultipeerConnectivity/Enums.cs
@@ -13,7 +13,6 @@ namespace MultipeerConnectivity {
 
 	// NSInteger -> MCSession.h
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Native]
 	public enum MCSessionSendDataMode : long {
 		Reliable,
@@ -22,7 +21,6 @@ namespace MultipeerConnectivity {
 
 	// NSInteger -> MCSession.h
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Native]
 	public enum MCSessionState : long {
 		NotConnected,
@@ -32,7 +30,6 @@ namespace MultipeerConnectivity {
 
 	// NSInteger -> MCSession.h
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Native]
 	public enum MCEncryptionPreference : long {
 		Optional = 0,
@@ -42,7 +39,6 @@ namespace MultipeerConnectivity {
 
 	// NSInteger -> MCError.h
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Native ("MCErrorCode")]
 	[ErrorDomain ("MCErrorDomain")]
 	public enum MCError : long {

--- a/src/PassKit/PKEnums.cs
+++ b/src/PassKit/PKEnums.cs
@@ -34,7 +34,6 @@ namespace PassKit {
 	}
 
 	// NSInteger -> PKPassLibrary.h
-	[iOS (7, 0)]
 	[Mac (11, 0)]
 	[Native]
 	public enum PKPassLibraryAddPassesStatus : long {

--- a/src/SafariServices/SSEnums.cs
+++ b/src/SafariServices/SSEnums.cs
@@ -17,7 +17,6 @@ namespace SafariServices {
 
 	// NSInteger -> SSReadingList.h
 	[NoMac]
-	[iOS (7, 0)]
 	[MacCatalyst (14, 0)]
 	[Native ("SSReadingListErrorCode")]
 	[ErrorDomain ("SSReadingListErrorDomain")]

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -32,7 +32,6 @@
 
 #if !NET
 #define NATIVE_APPLE_CERTIFICATE
-#else
 #endif
 
 using System;
@@ -335,7 +334,7 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 #else
-		[iOS (10, 3)] // [Mac (10,5)]
+		[iOS (10, 3)] // 
 		[TV (10, 3)]
 		[Watch (3, 3)]
 #endif
@@ -365,7 +364,7 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 #else
-		[iOS (10, 3)] // [Mac (10,5)]
+		[iOS (10, 3)] // 
 		[TV (10, 3)]
 		[Watch (3, 3)]
 #endif

--- a/src/Security/Enums.cs
+++ b/src/Security/Enums.cs
@@ -499,7 +499,6 @@ namespace Security {
 
 	// untyped enum in Security.framework/Headers/SecPolicy.h but the API use CFOptionFlags
 	// which is defined as in CFBase.h (do not trust Apple web documentation)
-	[iOS (7, 0)]
 	[Flags]
 	[Native]
 	public enum SecRevocation : ulong {

--- a/src/Security/SecPolicy.cs
+++ b/src/Security/SecPolicy.cs
@@ -24,8 +24,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
 		extern static IntPtr /* __nullable CFDictionaryRef */ SecPolicyCopyProperties (IntPtr /* SecPolicyRef */ policyRef);
@@ -35,8 +33,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public NSDictionary? GetProperties ()
 		{
@@ -62,7 +58,6 @@ namespace Security {
 		[SupportedOSPlatform ("tvos")]
 #else
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 #endif
 		static public SecPolicy? CreateRevocationPolicy (SecRevocation revocationFlags)
 		{
@@ -77,7 +72,6 @@ namespace Security {
 		[SupportedOSPlatform ("tvos")]
 #else
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
 		extern static IntPtr /* __nullable SecPolicyRef */ SecPolicyCreateWithProperties (IntPtr /* CFTypeRef */ policyIdentifier, IntPtr /* CFDictionaryRef */ properties);
@@ -89,7 +83,6 @@ namespace Security {
 		[SupportedOSPlatform ("tvos")]
 #else
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 #endif
 		static public SecPolicy CreatePolicy (NSString policyIdentifier, NSDictionary properties)
 		{

--- a/src/Security/SecTrust.cs
+++ b/src/Security/SecTrust.cs
@@ -40,8 +40,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
 		extern static SecStatusCode /* OSStatus */ SecTrustCopyPolicies (IntPtr /* SecTrustRef */ trust, ref IntPtr /* CFArrayRef* */ policies);
@@ -51,8 +49,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public SecPolicy [] GetPolicies ()
 		{
@@ -105,7 +101,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
@@ -117,7 +112,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
@@ -129,7 +123,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public bool NetworkFetchAllowed {
@@ -152,8 +145,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
 		extern static SecStatusCode /* OSStatus */ SecTrustCopyCustomAnchorCertificates (IntPtr /* SecTrustRef */ trust, out IntPtr /* CFArrayRef* */ anchors);
@@ -163,8 +154,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public SecCertificate [] GetCustomAnchorCertificates ()
 		{
@@ -187,7 +176,6 @@ namespace Security {
 		[ObsoletedOSPlatform ("tvos13.0", "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
 		[ObsoletedOSPlatform ("ios13.0", "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
 #else
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
@@ -221,7 +209,6 @@ namespace Security {
 		[ObsoletedOSPlatform ("tvos13.0", "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
 		[ObsoletedOSPlatform ("ios13.0", "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
 #else
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
 		[Deprecated (PlatformName.WatchOS, 6, 0, message: "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
@@ -306,8 +293,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
 		extern static SecStatusCode /* OSStatus */ SecTrustGetTrustResult (IntPtr /* SecTrustRef */ trust, out SecTrustResult /* SecTrustResultType */ result);
@@ -317,8 +302,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public SecTrustResult GetTrustResult ()
 		{
@@ -368,7 +351,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
@@ -380,7 +362,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		public NSDictionary GetResult ()
@@ -394,7 +375,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
 #else
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
@@ -421,8 +401,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public void SetOCSPResponse (NSData ocspResponse)
 		{
@@ -437,8 +415,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public void SetOCSPResponse (IEnumerable<NSData> ocspResponses)
 		{
@@ -454,8 +430,6 @@ namespace Security {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public void SetOCSPResponse (NSArray ocspResponses)
 		{

--- a/src/Security/SecureTransport.cs
+++ b/src/Security/SecureTransport.cs
@@ -180,7 +180,6 @@ namespace Security {
 		BreakOnCertRequested,
 		BreakOnClientAuth,
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		FalseStart,
 

--- a/src/TVServices/TVEnums.cs
+++ b/src/TVServices/TVEnums.cs
@@ -11,7 +11,6 @@ using ObjCRuntime;
 
 namespace TVServices {
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVContentItemImageShape : long {
 		None = 0,
@@ -23,7 +22,6 @@ namespace TVServices {
 		ExtraWide
 	}
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVTopShelfContentStyle : long {
 		Inset = 1,

--- a/src/UIKit/UIAccessibility.cs
+++ b/src/UIKit/UIAccessibility.cs
@@ -189,8 +189,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.UIKitLibrary)]
 		extern static /* UIBezierPath* */ IntPtr UIAccessibilityConvertPathToScreenCoordinates (/* UIBezierPath* */ IntPtr path, /* UIView* */ IntPtr view);
@@ -199,8 +197,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIBezierPath ConvertPathToScreenCoordinates (UIBezierPath path, UIView view)
 		{
@@ -217,8 +213,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.UIKitLibrary)]
 		extern static CGRect UIAccessibilityConvertFrameToScreenCoordinates (CGRect rect, /* UIView* */ IntPtr view);
@@ -227,8 +221,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static CGRect ConvertFrameToScreenCoordinates (CGRect rect, UIView view)
 		{
@@ -243,8 +235,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.UIKitLibrary)]
 		extern unsafe static void UIAccessibilityRequestGuidedAccessSession (/* BOOL */ [MarshalAs (UnmanagedType.I1)] bool enable, /* void(^completionHandler)(BOOL didSucceed) */ void* completionHandler);
@@ -253,8 +243,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void RequestGuidedAccessSession (bool enable, Action<bool> completionHandler)
@@ -275,8 +263,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static Task<bool> RequestGuidedAccessSessionAsync (bool enable)
 		{

--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -289,7 +289,6 @@ namespace UIKit {
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'UIBarMetrics.Compat' instead.")]
 		LandscapePhone = Compact,
 
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'UIBarMetrics.CompactPrompt' instead.")]
 		LandscapePhonePrompt = CompactPrompt
 	}
@@ -694,7 +693,6 @@ namespace UIKit {
 		DetailDisclosureButton,
 		Checkmark,
 		[NoTV]
-		[iOS (7, 0)]
 		DetailButton
 	}
 
@@ -1460,7 +1458,6 @@ namespace UIKit {
 
 	// NSUInteger -> UIView.h
 	[Native]
-	[iOS (7, 0)]
 	[NoWatch]
 	public enum UIViewKeyframeAnimationOptions : ulong {
 		LayoutSubviews = UIViewAnimationOptions.LayoutSubviews,
@@ -1517,7 +1514,6 @@ namespace UIKit {
 	// NSUInteger -> UISearchBar.h
 	[Native]
 	[NoWatch]
-	[iOS (7, 0)]
 	public enum UISearchBarStyle : ulong {
 		Default,
 		Prominent,
@@ -1527,7 +1523,6 @@ namespace UIKit {
 	// NSInteger -> UIInputView.h
 	[Native]
 	[NoWatch]
-	[iOS (7, 0)]
 	public enum UIInputViewStyle : long {
 		Default,
 		Keyboard
@@ -3075,7 +3070,6 @@ namespace UIKit {
 	// NSInteger -> UIGuidedAccessRestrictions.h
 	[Native]
 	[NoWatch]
-	[iOS (7, 0)]
 	public enum UIGuidedAccessRestrictionState : long {
 		Allow,
 		Deny,

--- a/src/UIKit/UIFont.cs
+++ b/src/UIKit/UIFont.cs
@@ -53,8 +53,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont PreferredHeadline {
 			get {
@@ -66,8 +64,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont PreferredBody {
 			get {
@@ -79,8 +75,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont PreferredSubheadline {
 			get {
@@ -92,8 +86,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont PreferredFootnote {
 			get {
@@ -105,8 +97,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont PreferredCaption1 {
 			get {
@@ -118,8 +108,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont PreferredCaption2 {
 			get {
@@ -272,8 +260,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont GetPreferredFontForTextStyle (NSString uiFontTextStyle)
 		{
@@ -285,8 +271,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont GetPreferredFontForTextStyle (UIFontTextStyle uiFontTextStyle)
 		{
@@ -298,8 +282,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont GetPreferredFontForTextStyle (NSString uiFontTextStyle, UITraitCollection traitCollection)
 		{
@@ -311,8 +293,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont GetPreferredFontForTextStyle (UIFontTextStyle uiFontTextStyle, UITraitCollection traitCollection)
 		{
@@ -324,8 +304,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIFont FromDescriptor (UIFontDescriptor descriptor, nfloat pointSize)
 		{

--- a/src/UIKit/UIGuidedAccessRestriction.cs
+++ b/src/UIKit/UIGuidedAccessRestriction.cs
@@ -24,8 +24,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		[DllImport (Constants.UIKitLibrary)]
 		extern static /* UIGuidedAccessRestrictionState */ nint UIGuidedAccessRestrictionStateForIdentifier (/* NSString */ IntPtr restrictionIdentifier);
@@ -34,8 +32,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public static UIGuidedAccessRestrictionState GetState (string restrictionIdentifier)
 		{

--- a/src/UIKit/UIStringAttributes.cs
+++ b/src/UIKit/UIStringAttributes.cs
@@ -159,8 +159,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public NSString WeakTextEffect {
 			get {
@@ -175,8 +173,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public NSTextEffect TextEffect {
 			get {
@@ -201,8 +197,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public NSTextAttachment TextAttachment {
 			get {
@@ -218,8 +212,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public NSUrl Link {
 			get {
@@ -234,8 +226,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public float? BaselineOffset {
 			get {
@@ -250,8 +240,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public UIColor StrikethroughColor {
 			get {
@@ -266,8 +254,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public UIColor UnderlineColor {
 			get {
@@ -283,8 +269,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public float? Obliqueness {
 			get {
@@ -299,8 +283,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public float? Expansion {
 			get {
@@ -315,8 +297,6 @@ namespace UIKit {
 		[SupportedOSPlatform ("ios7.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
-#else
-		[iOS (7, 0)]
 #endif
 		public NSNumber [] WritingDirectionInt {
 			get {

--- a/src/WatchKit/WKDefs.cs
+++ b/src/WatchKit/WKDefs.cs
@@ -110,7 +110,7 @@ namespace WatchKit {
 		Failed
 	}
 
-	[Watch (2, 0), NoiOS]
+	[NoiOS]
 	[Native]
 	public enum WKAudioRecorderPreset : long {
 		NarrowBandSpeech,
@@ -126,7 +126,7 @@ namespace WatchKit {
 		Destructive
 	}
 
-	[Watch (2, 0), NoiOS]
+	[NoiOS]
 	[Native]
 	public enum WKAlertControllerStyle : long {
 		Alert,
@@ -134,7 +134,7 @@ namespace WatchKit {
 		ActionSheet
 	}
 
-	[Watch (2, 0), NoiOS]
+	[NoiOS]
 	[Native]
 	public enum WKVideoGravity : long {
 		Aspect,

--- a/src/XKit/XKitCompat.cs
+++ b/src/XKit/XKitCompat.cs
@@ -21,9 +21,6 @@ namespace UIKit {
 
 #if !COREBUILD
 
-#if !NET
-	[iOS (7, 0)]
-#endif
 	public partial class NSLayoutManager {
 		[Obsolete ("Always throws 'NotSupportedException' (not a public API).")]
 		public virtual void ReplaceTextStorage (NSTextStorage newTextStorage)

--- a/src/accounts.cs
+++ b/src/accounts.cs
@@ -45,7 +45,6 @@ namespace Accounts {
 		NSString ErrorDomain { get; }
 #endif
 
-		[iOS (7, 0)]
 		[NoMac]
 		[Export ("userFullName")]
 		string UserFullName { get; }
@@ -152,7 +151,6 @@ namespace Accounts {
 
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use Tencent Weibo SDK instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use Tencent Weibo SDK instead.")]
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Field ("ACAccountTypeIdentifierTencentWeibo")]
 		NSString TencentWeibo { get; }
@@ -197,7 +195,6 @@ namespace Accounts {
 
 	[Deprecated (PlatformName.iOS, 11, 0, message: "Use Tencent Weibo SDK instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use Tencent Weibo SDK instead.")]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[Static]
 	interface ACTencentWeiboKey {

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -117,7 +117,6 @@ namespace AVFoundation {
 	delegate AVAudioBuffer AVAudioConverterInputHandler (uint inNumberOfPackets, out AVAudioConverterInputStatus outStatus);
 
 	[NoWatch]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface AVAsynchronousVideoCompositionRequest : NSCopying {
@@ -486,7 +485,7 @@ namespace AVFoundation {
 		[Field ("AVMetadataFormatID3Metadata")]
 		FormatID3Metadata = 2,
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVMetadataFormatISOUserData")]
 		FormatISOUserData = 3,
 
@@ -531,19 +530,19 @@ namespace AVFoundation {
 		[Field ("AVFileTypeAMR")]
 		Amr = 9,
 
-		[iOS (7, 0), Mac (10, 11)]
+		[Mac (10, 11)]
 		[Field ("AVFileType3GPP2")]
 		ThreeGpp2 = 10,
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVFileTypeMPEGLayer3")]
 		MpegLayer3 = 11,
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVFileTypeSunAU")]
 		SunAU = 12,
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVFileTypeAC3")]
 		AC3 = 13,
 
@@ -626,19 +625,19 @@ namespace AVFoundation {
 		[Field ("AVFileTypeAMR")]
 		NSString Amr { get; }
 
-		[iOS (7, 0), Mac (10, 11)]
+		[Mac (10, 11)]
 		[Field ("AVFileType3GPP2")]
 		NSString ThreeGpp2 { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVFileTypeMPEGLayer3")]
 		NSString MpegLayer3 { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVFileTypeSunAU")]
 		NSString SunAU { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVFileTypeAC3")]
 		NSString AC3 { get; }
 
@@ -662,7 +661,6 @@ namespace AVFoundation {
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
-	[iOS (7, 0)] // And OSX 10.7
 	[DisableDefaultCtor] // crash -> immutable and you can get them but not set them (i.e. no point in creating them)
 	[BaseType (typeof (NSObject))]
 	interface AVFrameRateRange {
@@ -687,7 +685,7 @@ namespace AVFoundation {
 		[Field ("AVVideoCodecKey")]
 		NSString CodecKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVVideoMaxKeyFrameIntervalDurationKey")]
 		NSString MaxKeyFrameIntervalDurationKey { get; }
 
@@ -695,12 +693,10 @@ namespace AVFoundation {
 		[Field ("AVVideoAppleProRAWBitDepthKey")]
 		NSString AppleProRawBitDepthKey { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Field ("AVVideoAllowFrameReorderingKey")]
 		NSString AllowFrameReorderingKey { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Field ("AVVideoAverageNonDroppableFrameRateKey")]
 		NSString AverageNonDroppableFrameRateKey { get; }
@@ -710,34 +706,28 @@ namespace AVFoundation {
 		[Field ("AVVideoEncoderSpecificationKey")]
 		NSString EncoderSpecificationKey { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Field ("AVVideoExpectedSourceFrameRateKey")]
 		NSString ExpectedSourceFrameRateKey { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Field ("AVVideoH264EntropyModeCABAC")]
 		NSString H264EntropyModeCABAC { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Field ("AVVideoH264EntropyModeCAVLC")]
 		NSString H264EntropyModeCAVLC { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Field ("AVVideoH264EntropyModeKey")]
 		NSString H264EntropyModeKey { get; }
 
-		[TV (9, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'AVVideoCodecType' enum instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'AVVideoCodecType' enum instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'AVVideoCodecType' enum instead.")]
 		[Field ("AVVideoCodecH264")]
 		NSString CodecH264 { get; }
 
-		[TV (9, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'AVVideoCodecType' enum instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'AVVideoCodecType' enum instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'AVVideoCodecType' enum instead.")]
@@ -809,15 +799,15 @@ namespace AVFoundation {
 		[Field ("AVVideoProfileLevelH264High41")]
 		NSString ProfileLevelH264High41 { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264BaselineAutoLevel")]
 		NSString ProfileLevelH264BaselineAutoLevel { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264MainAutoLevel")]
 		NSString ProfileLevelH264MainAutoLevel { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264HighAutoLevel")]
 		NSString ProfileLevelH264HighAutoLevel { get; }
 
@@ -1692,10 +1682,10 @@ namespace AVFoundation {
 		[Export ("channelAssignments", ArgumentSemantic.Copy), NullAllowed]
 		AVAudioSessionChannelDescription [] ChannelAssignments { get; set; }
 
-		[iOS (7, 0), Mac (10, 9), Export ("initWithData:fileTypeHint:error:")]
+		[Mac (10, 9), Export ("initWithData:fileTypeHint:error:")]
 		NativeHandle Constructor (NSData data, [NullAllowed] string fileTypeHint, out NSError outError);
 
-		[iOS (7, 0), Mac (10, 9), Export ("initWithContentsOfURL:fileTypeHint:error:")]
+		[Mac (10, 9), Export ("initWithContentsOfURL:fileTypeHint:error:")]
 		NativeHandle Constructor (NSUrl url, [NullAllowed] string fileTypeHint, out NSError outError);
 
 		[iOS (10, 0), TV (10, 0), Mac (10, 12)]
@@ -2212,7 +2202,7 @@ namespace AVFoundation {
 		[Notification]
 		NSString MediaServicesWereResetNotification { get; }
 
-		[iOS (7, 0), Notification, Field ("AVAudioSessionMediaServicesWereLostNotification")]
+		[Notification, Field ("AVAudioSessionMediaServicesWereLostNotification")]
 		NSString MediaServicesWereLostNotification { get; }
 
 		[NoMac]
@@ -2224,7 +2214,6 @@ namespace AVFoundation {
 		NSString ModeMoviePlayback { get; }
 
 		[NoMac]
-		[iOS (7, 0)]
 		[Field ("AVAudioSessionModeVideoChat")]
 		NSString ModeVideoChat { get; }
 
@@ -2282,7 +2271,6 @@ namespace AVFoundation {
 		NSString PortUsbAudio { get; }
 
 		[NoMac]
-		[iOS (7, 0)]
 		[Field ("AVAudioSessionPortBluetoothLE")]
 		NSString PortBluetoothLE { get; }
 
@@ -2315,11 +2303,9 @@ namespace AVFoundation {
 		[Field ("AVAudioSessionPortVirtual")]
 		NSString PortVirtual { get; }
 
-		[iOS (7, 0)]
 		[UnifiedInternal, Field ("AVAudioSessionLocationUpper")]
 		NSString LocationUpper { get; }
 
-		[iOS (7, 0)]
 		[UnifiedInternal, Field ("AVAudioSessionLocationLower")]
 		NSString LocationLower { get; }
 
@@ -2351,63 +2337,54 @@ namespace AVFoundation {
 
 		[NoTV, NoMac]
 		[Watch (4, 0)]
-		[iOS (7, 0)]
 		[Export ("requestRecordPermission:")]
 		void RequestRecordPermission (AVPermissionGranted responseCallback);
 
-		[NoWatch, iOS (7, 0), NoMac]
+		[NoWatch, NoMac]
 		[Export ("setPreferredInput:error:")]
 		bool SetPreferredInput ([NullAllowed] AVAudioSessionPortDescription inPort, out NSError outError);
 
-		[NoWatch, iOS (7, 0), NoMac]
+		[NoWatch, NoMac]
 		[Export ("preferredInput", ArgumentSemantic.Copy), NullAllowed]
 		AVAudioSessionPortDescription PreferredInput { get; }
 
-		[iOS (7, 0), NoMac]
+		[NoMac]
 		[NullAllowed, Export ("availableInputs")]
 		AVAudioSessionPortDescription [] AvailableInputs { get; }
 
 		[NoWatch, NoMac]
-		[iOS (7, 0)]
 		[Export ("setPreferredInputNumberOfChannels:error:")]
 		bool SetPreferredInputNumberOfChannels (nint count, out NSError outError);
 
 		[NoWatch, NoMac]
-		[iOS (7, 0)]
 		[Export ("preferredInputNumberOfChannels")]
 		nint GetPreferredInputNumberOfChannels ();
 
 		[NoWatch, NoMac]
-		[iOS (7, 0)]
 		[Export ("setPreferredOutputNumberOfChannels:error:")]
 		bool SetPreferredOutputNumberOfChannels (nint count, out NSError outError);
 
 		[NoWatch, NoMac]
-		[iOS (7, 0)]
 		[Export ("preferredOutputNumberOfChannels")]
 		nint GetPreferredOutputNumberOfChannels ();
 
-		[iOS (7, 0), NoMac]
+		[NoMac]
 		[Export ("maximumInputNumberOfChannels")]
 		nint MaximumInputNumberOfChannels { get; }
 
-		[iOS (7, 0), NoMac]
+		[NoMac]
 		[Export ("maximumOutputNumberOfChannels")]
 		nint MaximumOutputNumberOfChannels { get; }
 
-		[iOS (7, 0)]
 		[UnifiedInternal, Field ("AVAudioSessionOrientationTop")]
 		NSString OrientationTop { get; }
 
-		[iOS (7, 0)]
 		[UnifiedInternal, Field ("AVAudioSessionOrientationBottom")]
 		NSString OrientationBottom { get; }
 
-		[iOS (7, 0)]
 		[UnifiedInternal, Field ("AVAudioSessionOrientationFront")]
 		NSString OrientationFront { get; }
 
-		[iOS (7, 0)]
 		[UnifiedInternal, Field ("AVAudioSessionOrientationBack")]
 		NSString OrientationBack { get; }
 
@@ -2419,15 +2396,12 @@ namespace AVFoundation {
 		[Field ("AVAudioSessionOrientationRight")]
 		NSString OrientationRight { get; }
 
-		[iOS (7, 0)]
 		[UnifiedInternal, Field ("AVAudioSessionPolarPatternOmnidirectional")]
 		NSString PolarPatternOmnidirectional { get; }
 
-		[iOS (7, 0)]
 		[UnifiedInternal, Field ("AVAudioSessionPolarPatternCardioid")]
 		NSString PolarPatternCardioid { get; }
 
-		[iOS (7, 0)]
 		[UnifiedInternal, Field ("AVAudioSessionPolarPatternSubcardioid")]
 		NSString PolarPatternSubcardioid { get; }
 
@@ -2524,33 +2498,27 @@ namespace AVFoundation {
 		[Export ("dataSourceName")]
 		string DataSourceName { get; }
 
-		[iOS (7, 0)]
 		[Export ("location", ArgumentSemantic.Copy), NullAllowed]
 		[Internal]
 		NSString Location_ { get; }
 
-		[iOS (7, 0)]
 		[Export ("orientation", ArgumentSemantic.Copy), NullAllowed]
 		[Internal]
 		NSString Orientation_ { get; }
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[UnifiedInternal, Export ("supportedPolarPatterns"), NullAllowed]
 		NSString [] SupportedPolarPatterns { get; }
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[UnifiedInternal, Export ("selectedPolarPattern", ArgumentSemantic.Copy), NullAllowed]
 		NSString SelectedPolarPattern { get; }
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[UnifiedInternal, Export ("preferredPolarPattern", ArgumentSemantic.Copy), NullAllowed]
 		NSString PreferredPolarPattern { get; }
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[UnifiedInternal, Export ("setPreferredPolarPattern:error:")]
 		bool SetPreferredPolarPattern ([NullAllowed] NSString pattern, out NSError outError);
 
@@ -2621,7 +2589,6 @@ namespace AVFoundation {
 		[Export ("channelNumber")]
 		nint ChannelNumber { get; }
 
-		[iOS (7, 0)]
 		[Export ("channelLabel")]
 		int /* AudioChannelLabel = UInt32 */ ChannelLabel { get; }
 	}
@@ -2646,7 +2613,6 @@ namespace AVFoundation {
 		[Export ("channels"), NullAllowed]
 		AVAudioSessionChannelDescription [] Channels { get; }
 
-		[iOS (7, 0)]
 		[Export ("dataSources"), NullAllowed]
 #if NET
 		AVAudioSessionDataSourceDescription [] DataSources { get; }
@@ -2655,17 +2621,14 @@ namespace AVFoundation {
 #endif
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[Export ("selectedDataSource", ArgumentSemantic.Copy), NullAllowed]
 		AVAudioSessionDataSourceDescription SelectedDataSource { get; }
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[Export ("preferredDataSource", ArgumentSemantic.Copy), NullAllowed]
 		AVAudioSessionDataSourceDescription PreferredDataSource { get; }
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[Export ("setPreferredDataSource:error:")]
 		bool SetPreferredDataSource ([NullAllowed] AVAudioSessionDataSourceDescription dataSource, out NSError outError);
 
@@ -3200,7 +3163,6 @@ namespace AVFoundation {
 		[Export ("chapterMetadataGroupsBestMatchingPreferredLanguages:")]
 		AVTimedMetadataGroup [] GetChapterMetadataGroupsBestMatchingPreferredLanguages (string [] languages);
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Export ("trackGroups", ArgumentSemantic.Copy)]
 		AVAssetTrackGroup [] TrackGroups { get; }
@@ -3813,7 +3775,6 @@ namespace AVFoundation {
 		AVAsset Asset { get; }
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
 		[Protocolize]
@@ -3959,7 +3920,6 @@ namespace AVFoundation {
 		[Export ("outputSettings"), NullAllowed]
 		NSDictionary OutputSettings { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		// DOC: this is a AVAudioTimePitch value
@@ -4000,7 +3960,6 @@ namespace AVFoundation {
 		[Wrap ("AudioSettings"), NullAllowed]
 		AudioSettings Settings { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		// This is an AVAudioTimePitch constant
@@ -4042,7 +4001,7 @@ namespace AVFoundation {
 		CVPixelBufferAttributes UncompressedVideoSettings { get; }
 
 		[NoWatch]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
 		[Protocolize]
 		AVVideoCompositing CustomVideoCompositor { get; }
@@ -4081,7 +4040,7 @@ namespace AVFoundation {
 		bool ShouldWaitForLoadingOfRequestedResource (AVAssetResourceLoader resourceLoader, AVAssetResourceLoadingRequest loadingRequest);
 
 		[NoWatch]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("resourceLoader:didCancelLoadingRequest:")]
 		void DidCancelLoadingRequest (AVAssetResourceLoader resourceLoader, AVAssetResourceLoadingRequest loadingRequest);
 
@@ -4101,7 +4060,7 @@ namespace AVFoundation {
 		bool ShouldWaitForRenewalOfRequestedResource (AVAssetResourceLoader resourceLoader, AVAssetResourceRenewalRequest renewalRequest);
 	}
 
-	[iOS (7, 0), Mac (10, 9), NoWatch]
+	[Mac (10, 9), NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash at 'description' - not meant to be used callable (it's used from a property getter)
 	interface AVAssetResourceLoadingDataRequest {
@@ -4132,7 +4091,6 @@ namespace AVFoundation {
 		// note: we cannot use [Bind] here as it would break compatibility with iOS 6.x
 		// `isFinished` was only added in iOS 7.0 SDK and cannot be called in earlier versions
 		[Export ("isFinished")]
-		[iOS (7, 0)] // on iOS 6 it was `finished` but it's now rejected by Apple
 		bool Finished { get; }
 
 		[Export ("finishLoadingWithResponse:data:redirect:")]
@@ -4165,27 +4123,21 @@ namespace AVFoundation {
 		[Field ("AVAssetResourceLoadingRequestStreamingContentKeyRequestRequiresPersistentKey")]
 		NSString StreamingContentKeyRequestRequiresPersistentKey { get; }
 
-		[iOS (7, 0)]
 		[Export ("isCancelled")]
 		bool IsCancelled { get; }
 
-		[iOS (7, 0)]
 		[Export ("contentInformationRequest"), NullAllowed]
 		AVAssetResourceLoadingContentInformationRequest ContentInformationRequest { get; }
 
-		[iOS (7, 0)]
 		[Export ("dataRequest"), NullAllowed]
 		AVAssetResourceLoadingDataRequest DataRequest { get; }
 
-		[iOS (7, 0)]
 		[Export ("response", ArgumentSemantic.Copy), NullAllowed]
 		NSUrlResponse Response { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("redirect", ArgumentSemantic.Copy), NullAllowed]
 		NSUrlRequest Redirect { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("finishLoading")]
 		void FinishLoading ();
 
@@ -4201,7 +4153,7 @@ namespace AVFoundation {
 	}
 
 
-	[iOS (7, 0), Mac (10, 9), NoWatch]
+	[Mac (10, 9), NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // no valid handle, the instance is received (not created) -> see doc
 	interface AVAssetResourceLoadingContentInformationRequest {
@@ -4345,16 +4297,14 @@ namespace AVFoundation {
 		int /* CMTimeScale = int32_t */ MovieTimeScale { get; set; }
 
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		[Export ("canAddInputGroup:")]
 		bool CanAddInputGroup (AVAssetWriterInputGroup inputGroup);
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Export ("addInputGroup:")]
 		void AddInputGroup (AVAssetWriterInputGroup inputGroup);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("inputGroups")]
 		AVAssetWriterInputGroup [] InputGroups { get; }
 
@@ -4479,31 +4429,31 @@ namespace AVFoundation {
 		[Export ("mediaTimeScale")]
 		int /* CMTimeScale = int32_t */ MediaTimeScale { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("languageCode", ArgumentSemantic.Copy), NullAllowed]
 		string LanguageCode { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("extendedLanguageTag", ArgumentSemantic.Copy), NullAllowed]
 		string ExtendedLanguageTag { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("naturalSize")]
 		CGSize NaturalSize { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("preferredVolume")]
 		float PreferredVolume { get; set; } // defined as 'float'
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("marksOutputTrackAsEnabled")]
 		bool MarksOutputTrackAsEnabled { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("canAddTrackAssociationWithTrackOfInput:type:")]
 		bool CanAddTrackAssociationWithTrackOfInput (AVAssetWriterInput input, NSString trackAssociationType);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("addTrackAssociationWithTrackOfInput:type:")]
 		void AddTrackAssociationWithTrackOfInput (AVAssetWriterInput input, NSString trackAssociationType);
 
@@ -4585,7 +4535,7 @@ namespace AVFoundation {
 
 	[NoWatch]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetWriterInputGroup initWithInputs:defaultInput:] invalid parameter not satisfying: inputs != ((void*)0)
-	[iOS (7, 0), Mac (10, 9), BaseType (typeof (AVMediaSelectionGroup))]
+	[Mac (10, 9), BaseType (typeof (AVMediaSelectionGroup))]
 	interface AVAssetWriterInputGroup {
 
 		[Static, Export ("assetWriterInputGroupWithInputs:defaultInput:")]
@@ -4832,16 +4782,15 @@ namespace AVFoundation {
 		[Export ("isPlayable")]
 		bool Playable { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("availableTrackAssociationTypes")]
 		NSString [] AvailableTrackAssociationTypes { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("minFrameDuration")]
 		CMTime MinFrameDuration { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("associatedTracksOfType:")]
 		AVAssetTrack [] GetAssociatedTracks (NSString avAssetTrackTrackAssociationType);
 
@@ -5004,7 +4953,7 @@ namespace AVFoundation {
 		NSDictionary CurrentSampleDependencyAttachments { get; }
 	}
 
-	[iOS (7, 0), Mac (10, 9), Watch (6, 0)]
+	[Mac (10, 9), Watch (6, 0)]
 	[Category, BaseType (typeof (AVAssetTrack))]
 	interface AVAssetTrackTrackAssociation {
 		[Field ("AVTrackAssociationTypeAudioFallback")]
@@ -5028,7 +4977,7 @@ namespace AVFoundation {
 		NSString MetadataReferent { get; }
 	}
 
-	[iOS (7, 0), Mac (10, 9), Watch (6, 0)]
+	[Mac (10, 9), Watch (6, 0)]
 	[BaseType (typeof (NSObject))]
 	interface AVAssetTrackGroup : NSCopying {
 		[Export ("trackIDs", ArgumentSemantic.Copy)]
@@ -5108,15 +5057,15 @@ namespace AVFoundation {
 		[Export ("propertyList")]
 		NSObject PropertyList { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("displayName")]
 		string DisplayName { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("displayNameWithLocale:")]
 		string GetDisplayName (NSLocale locale);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("extendedLanguageTag"), NullAllowed]
 		string ExtendedLanguageTag { get; }
 	}
@@ -5354,42 +5303,42 @@ namespace AVFoundation {
 		[Field ("AVMetadata3GPUserDataKeyDescription")]
 		NSString K3GPUserDataKeyDescription { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyCollection")]
 		NSString K3GPUserDataKeyCollection { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyUserRating")]
 		NSString K3GPUserDataKeyUserRating { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyThumbnail")]
 		NSString K3GPUserDataKeyThumbnail { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyAlbumAndTrack")]
 		NSString K3GPUserDataKeyAlbumAndTrack { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyKeywordList")]
 		NSString K3GPUserDataKeyKeywordList { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyMediaClassification")]
 		NSString K3GPUserDataKeyMediaClassification { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyMediaRating")]
 		NSString K3GPUserDataKeyMediaRating { get; }
 
 #if !NET
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVMetadataFormatISOUserData")]
 		[Obsolete ("Use 'AVMetadataFormat' enum values.")]
 		NSString KFormatISOUserData { get; }
 #endif
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVMetadataKeySpaceISOUserData")]
 		NSString KKeySpaceISOUserData { get; }
 
@@ -7008,7 +6957,7 @@ namespace AVFoundation {
 		[Export ("metadataItemsFromArray:withKey:keySpace:")]
 		AVMetadataItem [] FilterWithKey (AVMetadataItem [] metadataItems, [NullAllowed] NSObject key, [NullAllowed] string keySpace);
 
-		[iOS (7, 0), Mac (10, 9), NoWatch] // headers say it is the watch, but the AVMetadataItemFilter is not
+		[Mac (10, 9), NoWatch] // headers say it is the watch, but the AVMetadataItemFilter is not
 		[Static, Export ("metadataItemsFromArray:filteredByMetadataItemFilter:")]
 		AVMetadataItem [] FilterWithItemFilter (AVMetadataItem [] metadataItems, AVMetadataItemFilter metadataItemFilter);
 
@@ -7089,7 +7038,7 @@ namespace AVFoundation {
 		void Respond (NSError error);
 	}
 
-	[iOS (7, 0), Mac (10, 9), Watch (8, 0)]
+	[Mac (10, 9), Watch (8, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // for binary compatibility this is added in AVMetadataItemFilter.cs w/[Obsolete]
 	interface AVMetadataItemFilter {
@@ -7120,43 +7069,43 @@ namespace AVFoundation {
 		[Field ("AVMetadataObjectTypeFace")]
 		NSString TypeFace { get; }
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeAztecCode")]
 		NSString TypeAztecCode { get; }
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeCode128Code")]
 		NSString TypeCode128Code { get; }
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeCode39Code")]
 		NSString TypeCode39Code { get; }
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeCode39Mod43Code")]
 		NSString TypeCode39Mod43Code { get; }
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeCode93Code")]
 		NSString TypeCode93Code { get; }
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeEAN13Code")]
 		NSString TypeEAN13Code { get; }
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeEAN8Code")]
 		NSString TypeEAN8Code { get; }
 
 		[Field ("AVMetadataObjectTypePDF417Code")]
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		NSString TypePDF417Code { get; }
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeQRCode")]
 		NSString TypeQRCode { get; }
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Field ("AVMetadataObjectTypeUPCECode")]
 		NSString TypeUPCECode { get; }
 
@@ -7204,52 +7153,52 @@ namespace AVFoundation {
 		[Field ("AVMetadataObjectTypeFace")]
 		Face = 1 << 0,
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[NoWatch]
 		[Field ("AVMetadataObjectTypeAztecCode")]
 		AztecCode = 1 << 1,
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[NoWatch]
 		[Field ("AVMetadataObjectTypeCode128Code")]
 		Code128Code = 1 << 2,
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[NoWatch]
 		[Field ("AVMetadataObjectTypeCode39Code")]
 		Code39Code = 1 << 3,
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[NoWatch]
 		[Field ("AVMetadataObjectTypeCode39Mod43Code")]
 		Code39Mod43Code = 1 << 4,
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[NoWatch]
 		[Field ("AVMetadataObjectTypeCode93Code")]
 		Code93Code = 1 << 5,
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[NoWatch]
 		[Field ("AVMetadataObjectTypeEAN13Code")]
 		EAN13Code = 1 << 6,
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[NoWatch]
 		[Field ("AVMetadataObjectTypeEAN8Code")]
 		EAN8Code = 1 << 7,
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[NoWatch]
 		[Field ("AVMetadataObjectTypePDF417Code")]
 		PDF417Code = 1 << 8,
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[NoWatch]
 		[Field ("AVMetadataObjectTypeQRCode")]
 		QRCode = 1 << 9,
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[NoWatch]
 		[Field ("AVMetadataObjectTypeUPCECode")]
 		UPCECode = 1 << 10,
@@ -7341,7 +7290,7 @@ namespace AVFoundation {
 
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
-	[iOS (7, 0), Mac (10, 15)]
+	[Mac (10, 15)]
 	[BaseType (typeof (AVMetadataObject))]
 	interface AVMetadataMachineReadableCodeObject {
 		[Export ("corners", ArgumentSemantic.Copy)]
@@ -8427,20 +8376,19 @@ namespace AVFoundation {
 		[Async]
 		void DetermineCompatibleFileTypes (Action<string []> compatibleFileTypesHandler);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("metadataItemFilter", ArgumentSemantic.Retain), NullAllowed]
 		AVMetadataItemFilter MetadataItemFilter { get; set; }
 
 		[NoWatch]
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		[NullAllowed, Export ("customVideoCompositor", ArgumentSemantic.Copy)]
 		[Protocolize]
 		AVVideoCompositing CustomVideoCompositor { get; }
 
 		// DOC: Use the values from AVAudioTimePitchAlgorithm class.
 		[Mac (10, 9)]
-		[iOS (7, 0), Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
+		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		NSString AudioTimePitchAlgorithm { get; set; }
 
 		[iOS (8, 0), Mac (10, 10)]
@@ -8464,7 +8412,7 @@ namespace AVFoundation {
 		void EstimateOutputFileLength (Action<long, NSError> handler);
 	}
 
-	[iOS (7, 0), Watch (6, 0)]
+	[Watch (6, 0)]
 	[Static]
 	interface AVAudioTimePitchAlgorithm {
 		[NoMac]
@@ -8515,7 +8463,7 @@ namespace AVFoundation {
 		[Export ("audioTapProcessor", ArgumentSemantic.Retain)]
 		MTAudioProcessingTap AudioTapProcessor { get; [NotImplemented] set; }
 
-		[iOS (7, 0), Mac (10, 11)]
+		[Mac (10, 11)]
 		[NullAllowed] // by default this property is null
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		NSString AudioTimePitchAlgorithm { get; [NotImplemented] set; }
@@ -8547,7 +8495,7 @@ namespace AVFoundation {
 		[Override]
 		MTAudioProcessingTap AudioTapProcessor { get; set; }
 
-		[iOS (7, 0), Mac (10, 10)]
+		[Mac (10, 10)]
 		[NullAllowed] // by default this property is null
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		[Override]
@@ -8555,7 +8503,6 @@ namespace AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (7, 0)]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	interface AVVideoCompositing {
@@ -8628,7 +8575,7 @@ namespace AVFoundation {
 		[Static, Export ("videoCompositionWithPropertiesOfAsset:")]
 		AVVideoComposition FromAssetProperties (AVAsset asset);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("customVideoCompositorClass", ArgumentSemantic.Copy), NullAllowed]
 		Class CustomVideoCompositorClass { get; [NotImplemented] set; }
 
@@ -8657,7 +8604,7 @@ namespace AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (7, 0), Mac (10, 9)]
+	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionRenderContext {
 		[Export ("size", ArgumentSemantic.Copy)]
@@ -8743,7 +8690,7 @@ namespace AVFoundation {
 		AVMutableVideoComposition Create (AVAsset asset, AVVideoCompositionInstruction prototypeInstruction);
 
 		[NullAllowed]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("customVideoCompositorClass", ArgumentSemantic.Retain)]
 		[Override]
 		Class CustomVideoCompositorClass { get; set; }
@@ -8799,15 +8746,15 @@ namespace AVFoundation {
 
 		// These are there because it adopts the protocol *of the same name*
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("containsTweening")]
 		bool ContainsTweening { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[NullAllowed, Export ("requiredSourceTrackIDs")]
 		NSNumber [] RequiredSourceTrackIDs { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("passthroughTrackID")]
 		int PassthroughTrackID { get; } /* CMPersistentTrackID = int32_t */
 
@@ -8858,7 +8805,7 @@ namespace AVFoundation {
 		[Export ("getOpacityRampForTime:startOpacity:endOpacity:timeRange:")]
 		bool GetOpacityRamp (CMTime time, ref float /* defined as 'float*' */ startOpacity, ref float /* defined as 'float*' */ endOpacity, ref CMTimeRange timeRange);
 
-		[iOS (7, 0), Mac (10, 9), Export ("getCropRectangleRampForTime:startCropRectangle:endCropRectangle:timeRange:")]
+		[Mac (10, 9), Export ("getCropRectangleRampForTime:startCropRectangle:endCropRectangle:timeRange:")]
 		bool GetCrop (CMTime time, ref CGRect startCropRectangle, ref CGRect endCropRectangle, ref CMTimeRange timeRange);
 	}
 
@@ -8888,11 +8835,11 @@ namespace AVFoundation {
 		[Export ("setOpacity:atTime:")]
 		void SetOpacity (float /* defined as 'float' */ opacity, CMTime time);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("setCropRectangleRampFromStartCropRectangle:toEndCropRectangle:timeRange:")]
 		void SetCrop (CGRect startCropRectangle, CGRect endCropRectangle, CMTimeRange timeRange);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("setCropRectangle:atTime:")]
 		void SetCrop (CGRect cropRectangle, CMTime time);
 	}
@@ -8908,7 +8855,7 @@ namespace AVFoundation {
 		[Export ("videoCompositionCoreAnimationToolWithPostProcessingAsVideoLayer:inLayer:")]
 		AVVideoCompositionCoreAnimationTool FromLayer (CALayer videoLayer, CALayer animationLayer);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Static, Export ("videoCompositionCoreAnimationToolWithPostProcessingAsVideoLayers:inLayer:")]
 		AVVideoCompositionCoreAnimationTool FromComposedVideoFrames (CALayer [] videoLayers, CALayer inAnimationlayer);
 	}
@@ -9039,7 +8986,6 @@ namespace AVFoundation {
 		NSString Preset352x288 { get; }
 
 		[NoMac]
-		[iOS (7, 0)]
 		[Field ("AVCaptureSessionPresetInputPriority")]
 		NSString PresetInputPriority { get; }
 
@@ -9082,13 +9028,11 @@ namespace AVFoundation {
 		NSString InterruptionReasonKey { get; }
 
 		[NoMac]
-		[iOS (7, 0)]
 		[MacCatalyst (14, 0)]
 		[Export ("usesApplicationAudioSession")]
 		bool UsesApplicationAudioSession { get; set; }
 
 		[NoMac]
-		[iOS (7, 0)]
 		[Export ("automaticallyConfiguresApplicationAudioSession")]
 		bool AutomaticallyConfiguresApplicationAudioSession { get; set; }
 
@@ -9109,7 +9053,6 @@ namespace AVFoundation {
 		[Deprecated (PlatformName.MacOSX, 12, 3, message: "Use 'SynchronizationClock' instead.")]
 		[Deprecated (PlatformName.iOS, 15, 4, message: "Use 'SynchronizationClock' instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 15, 4, message: "Use 'SynchronizationClock' instead.")]
-		[iOS (7, 0)]
 		[Export ("masterClock"), NullAllowed]
 		CMClock MasterClock { get; }
 
@@ -9325,7 +9268,7 @@ namespace AVFoundation {
 		[Export ("input")]
 		AVCaptureInput Input { get; }
 
-		[iOS (7, 0), Mac (10, 9), Export ("clock", ArgumentSemantic.Copy), NullAllowed]
+		[Mac (10, 9), Export ("clock", ArgumentSemantic.Copy), NullAllowed]
 		CMClock Clock { get; }
 
 		[BindAs (typeof (AVCaptureDeviceType))]
@@ -9501,11 +9444,11 @@ namespace AVFoundation {
 		[return: NullAllowed]
 		AVCaptureConnection ConnectionFromMediaType (NSString avMediaType);
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Export ("metadataOutputRectOfInterestForRect:")]
 		CGRect GetMetadataOutputRectOfInterestForRect (CGRect rectInOutputCoordinates);
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Export ("rectForMetadataOutputRectOfInterest:")]
 		CGRect GetRectForMetadataOutputRectOfInterest (CGRect rectInMetadataOutputCoordinates);
 
@@ -9611,11 +9554,11 @@ namespace AVFoundation {
 		[return: NullAllowed]
 		AVMetadataObject GetTransformedMetadataObject (AVMetadataObject metadataObject);
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Export ("metadataOutputRectOfInterestForRect:")]
 		CGRect MapToMetadataOutputCoordinates (CGRect rectInLayerCoordinates);
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Export ("rectForMetadataOutputRectOfInterest:")]
 		CGRect MapToLayerCoordinates (CGRect rectInMetadataOutputCoordinates);
 
@@ -9685,7 +9628,7 @@ namespace AVFoundation {
 		[Export ("availableVideoCodecTypes")]
 		NSString [] AvailableVideoCodecTypes { get; }
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Export ("recommendedVideoSettingsForAssetWriterWithOutputFileType:")]
 		[return: NullAllowed]
 		NSDictionary GetRecommendedVideoSettingsForAssetWriter (string outputFileType);
@@ -9757,7 +9700,7 @@ namespace AVFoundation {
 		void SetSampleBufferDelegateQueue ([NullAllowed] AVCaptureAudioDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackDispatchQueue);
 #endif
 
-		[iOS (7, 0), Mac (10, 15)]
+		[Mac (10, 15)]
 		[Export ("recommendedAudioSettingsForAssetWriterWithOutputFileType:")]
 		[return: NullAllowed]
 		NSDictionary GetRecommendedAudioSettingsForAssetWriter (string outputFileType);
@@ -9934,7 +9877,6 @@ namespace AVFoundation {
 		[Export ("setMetadataObjectsDelegate:queue:")]
 		void SetDelegate ([NullAllowed][Protocolize] AVCaptureMetadataOutputObjectsDelegate objectsDelegate, [NullAllowed] DispatchQueue objectsCallbackQueue);
 
-		[iOS (7, 0)]
 		[Export ("rectOfInterest", ArgumentSemantic.Copy)]
 		CGRect RectOfInterest { get; set; }
 
@@ -10631,21 +10573,18 @@ namespace AVFoundation {
 		[NoMac]
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
 		[Deprecated (PlatformName.MacCatalyst, 14, 0)]
-		[iOS (7, 0)]
 		[Export ("automaticallyEnablesStillImageStabilizationWhenAvailable")]
 		bool AutomaticallyEnablesStillImageStabilizationWhenAvailable { get; set; }
 
 		[NoMac]
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
 		[Deprecated (PlatformName.MacCatalyst, 14, 0)]
-		[iOS (7, 0)]
 		[Export ("stillImageStabilizationActive")]
 		bool IsStillImageStabilizationActive { [Bind ("isStillImageStabilizationActive")] get; }
 
 		[NoMac]
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
 		[Deprecated (PlatformName.MacCatalyst, 14, 0)]
-		[iOS (7, 0)]
 		[Export ("stillImageStabilizationSupported")]
 		bool IsStillImageStabilizationSupported { [Bind ("isStillImageStabilizationSupported")] get; }
 
@@ -10754,7 +10693,7 @@ namespace AVFoundation {
 		BuiltInLiDarDepthCamera,
 	}
 
-	[NoTV, iOS (7, 0), Mac (10, 14), NoWatch] // matches API that uses it.
+	[NoTV, Mac (10, 14), NoWatch] // matches API that uses it.
 	enum AVAuthorizationMediaType {
 		Video,
 		Audio,
@@ -10990,35 +10929,35 @@ namespace AVFoundation {
 		[Export ("automaticallyEnablesLowLightBoostWhenAvailable")]
 		bool AutomaticallyEnablesLowLightBoostWhenAvailable { get; set; }
 
-		[iOS (7, 0), NoWatch, NoMac]
+		[NoWatch, NoMac]
 		[Export ("videoZoomFactor")]
 		nfloat VideoZoomFactor { get; set; }
 
-		[iOS (7, 0), NoWatch, NoMac]
+		[NoWatch, NoMac]
 		[Export ("rampToVideoZoomFactor:withRate:")]
 		void RampToVideoZoom (nfloat factor, float /* float, not CGFloat */ rate);
 
-		[iOS (7, 0), NoWatch, NoMac]
+		[NoWatch, NoMac]
 		[Export ("rampingVideoZoom")]
 		bool RampingVideoZoom { [Bind ("isRampingVideoZoom")] get; }
 
-		[iOS (7, 0), NoWatch, NoMac]
+		[NoWatch, NoMac]
 		[Export ("cancelVideoZoomRamp")]
 		void CancelVideoZoomRamp ();
 
-		[iOS (7, 0), NoWatch, NoMac]
+		[NoWatch, NoMac]
 		[Export ("autoFocusRangeRestrictionSupported")]
 		bool AutoFocusRangeRestrictionSupported { [Bind ("isAutoFocusRangeRestrictionSupported")] get; }
 
-		[iOS (7, 0), NoWatch, NoMac]
+		[NoWatch, NoMac]
 		[Export ("autoFocusRangeRestriction")]
 		AVCaptureAutoFocusRangeRestriction AutoFocusRangeRestriction { get; set; }
 
-		[iOS (7, 0), NoWatch, NoMac]
+		[NoWatch, NoMac]
 		[Export ("smoothAutoFocusSupported")]
 		bool SmoothAutoFocusSupported { [Bind ("isSmoothAutoFocusSupported")] get; }
 
-		[iOS (7, 0), NoWatch, NoMac]
+		[NoWatch, NoMac]
 		[Export ("smoothAutoFocusEnabled")]
 		bool SmoothAutoFocusEnabled { [Bind ("isSmoothAutoFocusEnabled")] get; set; }
 
@@ -11031,14 +10970,13 @@ namespace AVFoundation {
 		bool FaceDrivenAutoFocusEnabled { [Bind ("isFaceDrivenAutoFocusEnabled")] get; set; }
 
 		// Either AVMediaTypeVideo or AVMediaTypeAudio.
-		[iOS (7, 0), NoWatch]
+		[NoWatch]
 		[Static]
 		[Wrap ("RequestAccessForMediaType (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant ()! : AVMediaTypes.Audio.GetConstant ()!, completion)")]
 		[Async]
 		void RequestAccessForMediaType (AVAuthorizationMediaType mediaType, AVRequestAccessStatus completion);
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[Mac (10, 14)]
 		[Static, Export ("requestAccessForMediaType:completionHandler:")]
 		[Async]
@@ -11046,23 +10984,21 @@ namespace AVFoundation {
 
 		// Calling this method with any media type other than AVMediaTypeVideo or AVMediaTypeAudio raises an exception.
 		[NoWatch]
-		[iOS (7, 0)]
 		[Mac (10, 14)]
 		[Static]
 		[Wrap ("GetAuthorizationStatus (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant ()! : AVMediaTypes.Audio.GetConstant ()!)")]
 		AVAuthorizationStatus GetAuthorizationStatus (AVAuthorizationMediaType mediaType);
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[Mac (10, 14)]
 		[Static, Export ("authorizationStatusForMediaType:")]
 		AVAuthorizationStatus GetAuthorizationStatus (NSString avMediaTypeToken);
 
-		[iOS (7, 0), NoWatch]
+		[NoWatch]
 		[Export ("activeFormat", ArgumentSemantic.Retain)]
 		AVCaptureDeviceFormat ActiveFormat { get; set; }
 
-		[iOS (7, 0), NoWatch]
+		[NoWatch]
 		[Export ("formats")]
 		AVCaptureDeviceFormat [] Formats { get; }
 
@@ -11129,13 +11065,11 @@ namespace AVFoundation {
 		AVCaptureDeviceTransportControlsPlaybackMode TransportControlsPlaybackMode { get; }
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Export ("activeVideoMinFrameDuration", ArgumentSemantic.Copy)]
 		CMTime ActiveVideoMinFrameDuration { get; set; }
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Export ("activeVideoMaxFrameDuration", ArgumentSemantic.Copy)]
 		CMTime ActiveVideoMaxFrameDuration { get; set; }
@@ -11494,7 +11428,6 @@ namespace AVFoundation {
 	[Introduced (PlatformName.MacCatalyst, 14, 0)]
 	[NoWatch]
 	[NoTV]
-	[iOS (7, 0)]
 	[DisableDefaultCtor] // crash -> immutable, it can be set but it should be selected from tha available formats (not a custom one)
 	[BaseType (typeof (NSObject))]
 	interface AVCaptureDeviceFormat {
@@ -11890,26 +11823,21 @@ namespace AVFoundation {
 		[Export ("externalPlaybackVideoGravity", ArgumentSemantic.Copy)]
 		NSString WeakExternalPlaybackVideoGravity { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("volume")]
 		float Volume { get; set; } // defined as 'float'
 
-		[iOS (7, 0)]
 		[Export ("muted")]
 		bool Muted { [Bind ("isMuted")] get; set; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Export ("appliesMediaSelectionCriteriaAutomatically")]
 		bool AppliesMediaSelectionCriteriaAutomatically { get; set; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[return: NullAllowed]
 		[Export ("mediaSelectionCriteriaForMediaCharacteristic:")]
 		AVPlayerMediaSelectionCriteria MediaSelectionCriteriaForMediaCharacteristic (NSString avMediaCharacteristic);
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Export ("setMediaSelectionCriteria:forMediaCharacteristic:")]
 		void SetMediaSelectionCriteria ([NullAllowed] AVPlayerMediaSelectionCriteria criteria, NSString avMediaCharacteristic);
@@ -11996,7 +11924,7 @@ namespace AVFoundation {
 		AVPlayerPlaybackCoordinator PlaybackCoordinator { get; }
 	}
 
-	[iOS (7, 0), Mac (10, 9), Watch (6, 0)]
+	[Mac (10, 9), Watch (6, 0)]
 	[BaseType (typeof (NSObject))]
 	interface AVPlayerMediaSelectionCriteria {
 		[Export ("preferredLanguages"), NullAllowed]
@@ -12369,30 +12297,30 @@ namespace AVFoundation {
 		[Notification]
 		NSString NewErrorLogEntryNotification { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Static, Export ("playerItemWithAsset:automaticallyLoadedAssetKeys:")]
 		AVPlayerItem FromAsset ([NullAllowed] AVAsset asset, [NullAllowed] NSString [] automaticallyLoadedAssetKeys);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[DesignatedInitializer]
 		[Export ("initWithAsset:automaticallyLoadedAssetKeys:")]
 		NativeHandle Constructor (AVAsset asset, [NullAllowed] params NSString [] automaticallyLoadedAssetKeys);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("automaticallyLoadedAssetKeys", ArgumentSemantic.Copy)]
 		NSString [] AutomaticallyLoadedAssetKeys { get; }
 
-		[iOS (7, 0), Mac (10, 9), NoWatch]
+		[Mac (10, 9), NoWatch]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
 		[Protocolize]
 		AVVideoCompositing CustomVideoCompositor { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		// DOC: Mention this is an AVAudioTimePitch constant
 		NSString AudioTimePitchAlgorithm { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("selectMediaOptionAutomaticallyInMediaSelectionGroup:")]
 		void SelectMediaOptionAutomaticallyInMediaSelectionGroup (AVMediaSelectionGroup mediaSelectionGroup);
 
@@ -12411,13 +12339,11 @@ namespace AVFoundation {
 		[NoiOS]
 		[NoMac]
 		[NoWatch]
-		[TV (9, 0)]
 		[Export ("navigationMarkerGroups", ArgumentSemantic.Copy)]
 		AVNavigationMarkersGroup [] NavigationMarkerGroups { get; set; }
 
 		[NoMac]
 		[NoWatch]
-		[TV (9, 0)]
 		[iOS (13, 0)]
 		[Export ("externalMetadata", ArgumentSemantic.Copy)]
 		AVMetadataItem [] ExternalMetadata { get; set; }
@@ -12426,7 +12352,6 @@ namespace AVFoundation {
 		[NoMacCatalyst]
 		[NoMac]
 		[NoWatch]
-		[TV (9, 0)]
 		[Export ("interstitialTimeRanges", ArgumentSemantic.Copy)]
 		AVInterstitialTimeRange [] InterstitialTimeRanges { get; set; }
 		#endregion
@@ -12915,7 +12840,6 @@ namespace AVFoundation {
 	}
 
 	[Watch (6, 0)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -12924,7 +12848,7 @@ namespace AVFoundation {
 		void OutputSequenceWasFlushed (AVPlayerItemOutput output);
 	}
 
-	[iOS (7, 0), Watch (6, 0)]
+	[Watch (6, 0)]
 	[BaseType (typeof (AVPlayerItemOutputPushDelegate))]
 	[Model]
 	[Protocol]
@@ -12934,7 +12858,7 @@ namespace AVFoundation {
 		void DidOutputAttributedStrings (AVPlayerItemLegibleOutput output, NSAttributedString [] strings, CMSampleBuffer [] nativeSamples, CMTime itemTime);
 	}
 
-	[iOS (7, 0), Mac (10, 9), NoWatch]
+	[Mac (10, 9), NoWatch]
 	[BaseType (typeof (AVPlayerItemOutput))]
 	interface AVPlayerItemLegibleOutput {
 		[Export ("initWithMediaSubtypesForNativeRepresentation:")]
@@ -13035,7 +12959,7 @@ namespace AVFoundation {
 		[Export ("observedBitrate")]
 		double ObservedBitrate { get; }
 
-		[iOS (8, 0), TV (9, 0), Mac (10, 10)]
+		[iOS (8, 0), Mac (10, 10)]
 		[Export ("indicatedBitrate")]
 		double IndicatedBitrate { get; }
 
@@ -13058,11 +12982,11 @@ namespace AVFoundation {
 		[Export ("numberOfMediaRequests")]
 		nint NumberOfMediaRequests { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("startupTime")]
 		double StartupTime { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("downloadOverdue")]
 		nint DownloadOverdue { get; }
 
@@ -13071,7 +12995,7 @@ namespace AVFoundation {
 		[Deprecated (PlatformName.TvOS, 15, 0, message: "Use 'ObservedBitrateStandardDeviation' instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 15, 0, message: "Use 'ObservedBitrateStandardDeviation' instead.")]
 		[Deprecated (PlatformName.WatchOS, 8, 0, message: "Use 'ObservedBitrateStandardDeviation' instead.")]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("observedMaxBitrate")]
 		double ObservedMaxBitrate { get; }
 
@@ -13080,27 +13004,27 @@ namespace AVFoundation {
 		[Deprecated (PlatformName.TvOS, 15, 0, message: "Use 'ObservedBitrateStandardDeviation' instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 15, 0, message: "Use 'ObservedBitrateStandardDeviation' instead.")]
 		[Deprecated (PlatformName.WatchOS, 8, 0, message: "Use 'ObservedBitrateStandardDeviation' instead.")]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("observedMinBitrate")]
 		double ObservedMinBitrate { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("observedBitrateStandardDeviation")]
 		double ObservedBitrateStandardDeviation { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("playbackType", ArgumentSemantic.Copy), NullAllowed]
 		string PlaybackType { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("mediaRequestsWWAN")]
 		nint MediaRequestsWWAN { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("switchBitrate")]
 		double SwitchBitrate { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("transferDuration")]
 		double TransferDuration { get; }
 
@@ -13190,7 +13114,7 @@ namespace AVFoundation {
 		[Export ("isReadyForDisplay")]
 		bool ReadyForDisplay { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("videoRect")]
 		CGRect VideoRect { get; }
 
@@ -13241,7 +13165,7 @@ namespace AVFoundation {
 		[NullAllowed, Export ("assetTrack")]
 		AVAssetTrack AssetTrack { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("currentVideoFrameRate")]
 		float CurrentVideoFrameRate { get; } // defined as 'float'
 
@@ -13479,7 +13403,7 @@ namespace AVFoundation {
 		[Field ("AVEncoderBitRatePerChannelKey")]
 		NSString AVEncoderBitRatePerChannelKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVEncoderBitRateStrategyKey"), Internal]
 		NSString AVEncoderBitRateStrategyKey { get; }
 
@@ -13495,27 +13419,27 @@ namespace AVFoundation {
 		[Field ("AVChannelLayoutKey")]
 		NSString AVChannelLayoutKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_Constant"), Internal]
 		NSString _Constant { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_LongTermAverage"), Internal]
 		NSString _LongTermAverage { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_VariableConstrained"), Internal]
 		NSString _VariableConstrained { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_Variable"), Internal]
 		NSString _Variable { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVSampleRateConverterAlgorithm_Normal"), Internal]
 		NSString AVSampleRateConverterAlgorithm_Normal { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVSampleRateConverterAlgorithm_Mastering"), Internal]
 		NSString AVSampleRateConverterAlgorithm_Mastering { get; }
 
@@ -13523,7 +13447,7 @@ namespace AVFoundation {
 		[Field ("AVSampleRateConverterAlgorithm_MinimumPhase")]
 		NSString AVSampleRateConverterAlgorithm_MinimumPhase { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("AVEncoderAudioQualityForVBRKey"), Internal]
 		NSString AVEncoderAudioQualityForVBRKey { get; }
 	}
@@ -13637,7 +13561,6 @@ namespace AVFoundation {
 
 	[Mac (10, 15)]
 	[Watch (3, 0)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	interface AVSpeechSynthesisVoice : NSSecureCoding {
 
@@ -13690,7 +13613,6 @@ namespace AVFoundation {
 
 	[Mac (10, 15)]
 	[Watch (3, 0)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	interface AVSpeechUtterance : NSCopying, NSSecureCoding {
 
@@ -13754,7 +13676,6 @@ namespace AVFoundation {
 
 	[Mac (10, 15)]
 	[Watch (3, 0)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject), Delegates = new string [] { "WeakDelegate" }, Events = new Type [] { typeof (AVSpeechSynthesizerDelegate) })]
 	interface AVSpeechSynthesizer {
 
@@ -14035,7 +13956,6 @@ namespace AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]

--- a/src/avkit.cs
+++ b/src/avkit.cs
@@ -227,20 +227,18 @@ namespace AVKit {
 		NSObject WeakDelegate { get; set; }
 
 		[NoMac]
-		[TV (9, 0), iOS (14, 0)]
+		[iOS (14, 0)]
 		[Export ("requiresLinearPlayback")]
 		bool RequiresLinearPlayback { get; set; }
 
 		#region AVPlayerViewControllerSubtitleOptions
 		[NoiOS]
 		[NoMac]
-		[TV (9, 0)]
 		[NullAllowed, Export ("allowedSubtitleOptionLanguages", ArgumentSemantic.Copy)]
 		string [] AllowedSubtitleOptionLanguages { get; set; }
 
 		[NoiOS]
 		[NoMac]
-		[TV (9, 0)]
 		[Export ("requiresFullSubtitles")]
 		bool RequiresFullSubtitles { get; set; }
 		#endregion
@@ -372,7 +370,6 @@ namespace AVKit {
 		[NoMac]
 		[NoMacCatalyst]
 		[NoWatch]
-		[TV (9, 0)]
 		[Export ("playerViewController:didPresentInterstitialTimeRange:")]
 		void DidPresentInterstitialTimeRange (AVPlayerViewController playerViewController, AVInterstitialTimeRange interstitial);
 
@@ -398,25 +395,21 @@ namespace AVKit {
 		[NoMac]
 		[NoWatch]
 		[NoMacCatalyst]
-		[TV (9, 0)]
 		[Export ("playerViewController:willPresentInterstitialTimeRange:")]
 		void WillPresentInterstitialTimeRange (AVPlayerViewController playerViewController, AVInterstitialTimeRange interstitial);
 
 		[NoiOS]
 		[NoMac]
-		[TV (9, 0)]
 		[Export ("playerViewController:willResumePlaybackAfterUserNavigatedFromTime:toTime:")]
 		void WillResumePlaybackAfterUserNavigatedFromTime (AVPlayerViewController playerViewController, CMTime oldTime, CMTime targetTime);
 
 		[NoiOS]
 		[NoMac]
-		[TV (9, 0)]
 		[Export ("playerViewController:didSelectMediaSelectionOption:inMediaSelectionGroup:")]
 		void DidSelectMediaSelectionOption (AVPlayerViewController playerViewController, [NullAllowed] AVMediaSelectionOption mediaSelectionOption, AVMediaSelectionGroup mediaSelectionGroup);
 
 		[NoiOS]
 		[NoMac]
-		[TV (9, 0)]
 		[Export ("playerViewController:didSelectExternalSubtitleOptionLanguage:")]
 		void DidSelectExternalSubtitleOptionLanguage (AVPlayerViewController playerViewController, string language);
 
@@ -688,7 +681,6 @@ namespace AVKit {
 	[NoMac]
 	[NoMacCatalyst]
 	[NoWatch]
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	interface AVInterstitialTimeRange : NSCopying, NSSecureCoding {
 		[Export ("initWithTimeRange:")]
@@ -701,7 +693,6 @@ namespace AVKit {
 
 	[NoiOS]
 	[NoMac]
-	[TV (9, 0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
 	interface AVNavigationMarkersGroup {

--- a/src/cfnetwork.cs
+++ b/src/cfnetwork.cs
@@ -117,7 +117,6 @@ namespace CoreServices {
 		// iOS headers says it's iOS 7.0 only (but comments talks about OSX)
 		// yet both 7.0+ and 10.9 returns null
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		[Internal]
 		[Field ("kCFHTTPAuthenticationSchemeOAuth1", "CFNetwork")]
 		IntPtr _AuthenticationSchemeOAuth1 { get; }

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -629,11 +629,11 @@ namespace CoreAnimation {
 		[Export ("drawsAsynchronously")]
 		bool DrawsAsynchronously { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("allowsEdgeAntialiasing")]
 		bool AllowsEdgeAntialiasing { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("allowsGroupOpacity")]
 		bool AllowsGroupOpacity { get; set; }
 
@@ -1906,7 +1906,7 @@ namespace CoreAnimation {
 	// 'initWithType:', 'behaviorWithType:' and 'behaviorTypes' API now cause rejection
 	// https://trello.com/c/J8BDDUV9/86-33590997-coreanimation-quartzcore-api-removals
 #if !NET
-	[iOS (7, 0), Mac (10, 9)]
+	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface CAEmitterBehavior : NSSecureCoding {
 

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -138,12 +138,12 @@ namespace CoreBluetooth {
 		NativeHandle Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue);
 
 		[DesignatedInitializer]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("initWithDelegate:queue:options:")]
 		[PostGet ("WeakDelegate")]
 		NativeHandle Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Wrap ("this (centralDelegate, queue, options.GetDictionary ())")]
 		NativeHandle Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, CBCentralInitOptions options);
 
@@ -190,35 +190,31 @@ namespace CoreBluetooth {
 		NSString OptionStartDelayKey { get; }
 
 		[Field ("CBCentralManagerOptionRestoreIdentifierKey")]
-		[iOS (7, 0)]
 		[Mac (10, 13)]
 		NSString OptionRestoreIdentifierKey { get; }
 
 		[Field ("CBCentralManagerRestoredStatePeripheralsKey")]
-		[iOS (7, 0)]
 		[Mac (10, 13)]
 		NSString RestoredStatePeripheralsKey { get; }
 
 		[Field ("CBCentralManagerRestoredStateScanServicesKey")]
-		[iOS (7, 0)]
 		[Mac (10, 13)]
 		NSString RestoredStateScanServicesKey { get; }
 
 		[Field ("CBCentralManagerRestoredStateScanOptionsKey")]
-		[iOS (7, 0)]
 		[Mac (10, 13)]
 		NSString RestoredStateScanOptionsKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("retrievePeripheralsWithIdentifiers:")]
 		CBPeripheral [] RetrievePeripheralsWithIdentifiers ([Params] NSUuid [] identifiers);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("retrieveConnectedPeripheralsWithServices:")]
 		CBPeripheral [] RetrieveConnectedPeripherals ([Params] CBUUID [] serviceUUIDs);
 
 		[Field ("CBCentralManagerOptionShowPowerAlertKey")]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		NSString OptionShowPowerAlertKey { get; }
 
 		[iOS (16, 0), NoMac, TV (16, 0), MacCatalyst (16, 0), Watch (9, 0)]
@@ -226,7 +222,7 @@ namespace CoreBluetooth {
 		NSString OptionDeviceAccessForMedia { get; }
 
 		[Field ("CBCentralManagerScanOptionSolicitedServiceUUIDsKey")]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		NSString ScanOptionSolicitedServiceUUIDsKey { get; }
 
 		[iOS (9, 0)]
@@ -284,11 +280,11 @@ namespace CoreBluetooth {
 		[Field ("CBAdvertisementDataTxPowerLevelKey")]
 		NSString TxPowerLevelKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("CBAdvertisementDataIsConnectable")]
 		NSString IsConnectableKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("CBAdvertisementDataSolicitedServiceUUIDsKey")]
 		NSString SolicitedServiceUuidsKey { get; }
 	}
@@ -308,17 +304,14 @@ namespace CoreBluetooth {
 	[Watch (4, 0)]
 	[Static, Internal]
 	interface RestoredStateKeys {
-		[iOS (7, 0)]
 		[Mac (10, 13)]
 		[Field ("CBCentralManagerRestoredStatePeripheralsKey")]
 		NSString PeripheralsKey { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 13)]
 		[Field ("CBCentralManagerRestoredStateScanServicesKey")]
 		NSString ScanServicesKey { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 13)]
 		[Field ("CBCentralManagerRestoredStateScanOptionsKey")]
 		NSString ScanOptionsKey { get; }
@@ -401,11 +394,11 @@ namespace CoreBluetooth {
 		[Field ("CBAdvertisementDataOverflowServiceUUIDsKey")]
 		NSString DataOverflowServiceUUIDsKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("CBAdvertisementDataIsConnectable")]
 		NSString IsConnectable { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("CBAdvertisementDataSolicitedServiceUUIDsKey")]
 		NSString DataSolicitedServiceUUIDsKey { get; }
 
@@ -471,7 +464,7 @@ namespace CoreBluetooth {
 		[Override]
 		CBDescriptor [] Descriptors { get; set; }
 
-		[iOS (7, 0), Export ("subscribedCentrals")]
+		[Export ("subscribedCentrals")]
 		[NullAllowed]
 		CBCentral [] SubscribedCentrals { get; }
 	}
@@ -575,7 +568,7 @@ namespace CoreBluetooth {
 		[Export ("maximumWriteValueLengthForType:")]
 		nuint GetMaximumWriteValueLength (CBCharacteristicWriteType type);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("state")]
 		CBPeripheralState State { get; }
 
@@ -656,7 +649,6 @@ namespace CoreBluetooth {
 		[Export ("peripheralDidUpdateName:")]
 		void UpdatedName (CBPeripheral peripheral);
 
-		[iOS (7, 0)]
 		[Export ("peripheral:didModifyServices:"), EventArgs ("CBPeripheralServices")]
 		void ModifiedServices (CBPeripheral peripheral, CBService [] services);
 
@@ -747,7 +739,7 @@ namespace CoreBluetooth {
 		CBUUID FromCFUUID (IntPtr theUUID);
 
 		[Static]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("UUIDWithNSUUID:")]
 		CBUUID FromNSUuid (NSUuid theUUID);
 
@@ -884,7 +876,6 @@ namespace CoreBluetooth {
 		NSUuid Identifier { get; }
 
 		// Introduced with iOS7, but does not have NS_AVAILABLE
-		[iOS (7, 0)]
 		[Export ("maximumUpdateValueLength")]
 		nuint MaximumUpdateValueLength { get; }
 	}
@@ -907,7 +898,6 @@ namespace CoreBluetooth {
 		[NoTV]
 		[NoWatch]
 		[DesignatedInitializer]
-		[iOS (7, 0)]
 		[Export ("initWithDelegate:queue:options:")]
 		[PostGet ("WeakDelegate")]
 		NativeHandle Constructor ([NullAllowed][Protocolize] CBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
@@ -964,26 +954,21 @@ namespace CoreBluetooth {
 		void UnpublishL2CapChannel (ushort psm);
 
 		[Field ("CBPeripheralManagerOptionShowPowerAlertKey")]
-		[iOS (7, 0)]
 		NSString OptionShowPowerAlertKey { get; }
 
 		[Field ("CBPeripheralManagerOptionRestoreIdentifierKey")]
-		[iOS (7, 0)]
 		NSString OptionRestoreIdentifierKey { get; }
 
 		[Field ("CBPeripheralManagerRestoredStateServicesKey")]
-		[iOS (7, 0)]
 		NSString RestoredStateServicesKey { get; }
 
 		[Field ("CBPeripheralManagerRestoredStateAdvertisementDataKey")]
-		[iOS (7, 0)]
 		NSString RestoredStateAdvertisementDataKey { get; }
 
 #if !NET
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'CBManager.Authorization' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'CBManager.Authorization' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'CBManager.Authorization' instead.")]
-		[iOS (7, 0)]
 		[Static]
 		[Export ("authorizationStatus")]
 		CBPeripheralManagerAuthorizationStatus AuthorizationStatus { get; }
@@ -1063,7 +1048,6 @@ namespace CoreBluetooth {
 		IntPtr _UUID { get; }
 #endif
 
-		[iOS (7, 0)]
 		[Export ("identifier")]
 		NSUuid Identifier { get; }
 	}

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -61,7 +61,6 @@ namespace CoreData {
 	[NoWatch]
 	[NoTV]
 	[Native] // NUInteger -> NSPersistentStoreCoordinator.h
-	[iOS (7, 0)]
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Please see the release notes and Core Data documentation.")]
 	[Mac (10, 9)]
 	[Deprecated (PlatformName.MacOSX, 10, 12, message: "Please see the release notes and Core Data documentation.")]
@@ -915,7 +914,7 @@ namespace CoreData {
 
 		// headers say this is introduced in 7.0,10.9 but Xcode 7 API diff
 		// indicates it's new in 9.0,10.11... going by the header value...
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("hasPersistentChangedValues")]
 		bool HasPersistentChangedValues { get; }
 
@@ -1982,7 +1981,6 @@ namespace CoreData {
 		[return: NullAllowed]
 		NSDictionary MetadataForPersistentStoreOfType ([NullAllowed] NSString storeType, NSUrl url, out NSError error);
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Static, Export ("metadataForPersistentStoreOfType:URL:options:error:")]
 		[return: NullAllowed]
@@ -1993,7 +1991,6 @@ namespace CoreData {
 		[Static, Export ("setMetadata:forPersistentStoreOfType:URL:error:")]
 		bool SetMetadata ([NullAllowed] NSDictionary metadata, [NullAllowed] NSString storeType, NSUrl url, out NSError error);
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Static, Export ("setMetadata:forPersistentStoreOfType:URL:options:error:")]
 		bool SetMetadata ([NullAllowed] NSDictionary<NSString, NSObject> metadata, string storeType, NSUrl url, [NullAllowed] NSDictionary options, out NSError error);
@@ -2225,46 +2222,46 @@ namespace CoreData {
 
 		[NoWatch]
 		[NoTV]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSPersistentStoreUbiquitousPeerTokenOption")]
 		NSString PersistentStoreUbiquitousPeerTokenOption { get; }
 
 		[NoWatch]
 		[NoTV]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Static]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Please see the release notes and Core Data documentation.")]
 		[Deprecated (PlatformName.MacOSX, 10, 12, message: "Please see the release notes and Core Data documentation.")]
 		[Export ("removeUbiquitousContentAndPersistentStoreAtURL:options:error:")]
 		bool RemoveUbiquitousContentAndPersistentStore (NSUrl storeUrl, [NullAllowed] NSDictionary options, out NSError error);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Notification (typeof (NSPersistentStoreCoordinatorStoreChangeEventArgs))]
 		[Field ("NSPersistentStoreCoordinatorStoresWillChangeNotification")]
 		NSString StoresWillChangeNotification { get; }
 
 		[NoWatch]
 		[NoTV]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSPersistentStoreRebuildFromUbiquitousContentOption")]
 		NSString RebuildFromUbiquitousContentOption { get; }
 
 		[NoWatch]
 		[NoTV]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSPersistentStoreRemoveUbiquitousMetadataOption")]
 		NSString RemoveUbiquitousMetadataOption { get; }
 
 		[NoWatch]
 		[NoTV]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSPersistentStoreUbiquitousContainerIdentifierKey")]
 		[Obsolete ("Use 'UbiquitousContainerIdentifierKey' instead.")]
 		NSString eUbiquitousContainerIdentifierKey { get; }
 
 		[NoWatch]
 		[NoTV]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSPersistentStoreUbiquitousContainerIdentifierKey")]
 		NSString UbiquitousContainerIdentifierKey { get; }
 
@@ -2309,7 +2306,6 @@ namespace CoreData {
 		[NoWatch]
 		[NoTV]
 		[Export ("NSPersistentStoreUbiquitousTransitionTypeKey")]
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Please see the release notes and Core Data documentation.")]
 		NSPersistentStoreUbiquitousTransitionType EventType { get; }
 	}

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -436,7 +436,6 @@ namespace CoreImage {
 		[Export ("workingFormat")]
 		CIFormat WorkingFormat { get; }
 
-		[iOS (7, 0)]
 		[Internal]
 		[Field ("kCIContextOutputPremultiplied", "+CoreImage")]
 		NSString OutputPremultiplied { get; }
@@ -690,9 +689,7 @@ namespace CoreImage {
 		void RegisterFilterName (string name, NSObject constructorObject, NSDictionary classAttributes);
 #else
 		[iOS (9, 0)]
-		[Mac (10, 4)]
 		[MacCatalyst (13, 1)]
-		[TV (9, 0)]
 		[NoWatch]
 		[Static]
 		[Export ("registerFilterName:constructor:classAttributes:")]
@@ -1244,63 +1241,48 @@ namespace CoreImage {
 		[Field ("kCIInputShadingImageKey", "+CoreImage")]
 		NSString ShadingImage { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputTimeKey", "+CoreImage")]
 		NSString Time { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputTransformKey", "+CoreImage")]
 		NSString Transform { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputScaleKey", "+CoreImage")]
 		NSString Scale { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputAspectRatioKey", "+CoreImage")]
 		NSString AspectRatio { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputCenterKey", "+CoreImage")]
 		NSString Center { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputRadiusKey", "+CoreImage")]
 		NSString Radius { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputAngleKey", "+CoreImage")]
 		NSString Angle { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputWidthKey", "+CoreImage")]
 		NSString Width { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputSharpnessKey", "+CoreImage")]
 		NSString Sharpness { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputIntensityKey", "+CoreImage")]
 		NSString Intensity { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputEVKey", "+CoreImage")]
 		NSString EV { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputSaturationKey", "+CoreImage")]
 		NSString Saturation { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputColorKey", "+CoreImage")]
 		NSString Color { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputBrightnessKey", "+CoreImage")]
 		NSString Brightness { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputContrastKey", "+CoreImage")]
 		NSString Contrast { get; }
 
@@ -1313,15 +1295,12 @@ namespace CoreImage {
 		[Field ("kCIInputWeightsKey", "+CoreImage")]
 		NSString WeightsKey { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputMaskImageKey", "+CoreImage")]
 		NSString MaskImage { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputTargetImageKey", "+CoreImage")]
 		NSString TargetImage { get; }
 
-		[iOS (7, 0)]
 		[Field ("kCIInputExtentKey", "+CoreImage")]
 		NSString Extent { get; }
 
@@ -2048,16 +2027,12 @@ namespace CoreImage {
 		NativeHandle Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
 #else
 		[iOS (9, 0)]
-		[Mac (10, 4)]
 		[MacCatalyst (13, 1)]
-		[TV (9, 0)]
 		[Export ("initWithCVImageBuffer:options:")]
 		NativeHandle Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary<NSString, NSObject> dict);
 
 		[iOS (9, 0)]
-		[Mac (10, 4)]
 		[MacCatalyst (13, 1)]
-		[TV (9, 0)]
 		[Internal] // This overload is needed for our strong dictionary support (but only for Unified, since for Classic the generic version is transformed to this signature)
 		[Sealed]
 		[Export ("initWithCVImageBuffer:options:")]
@@ -2797,7 +2772,6 @@ namespace CoreImage {
 		[NoiOS]
 		[NoWatch]
 		[NoTV]
-		[Mac (10, 4)]
 		[MacCatalyst (13, 1)]
 		[Export ("setROISelector:")]
 		void SetRegionOfInterestSelector (Selector aMethod);
@@ -3120,11 +3094,11 @@ namespace CoreImage {
 		[Field ("CIDetectorMaxFeatureCount"), Internal]
 		NSString MaxFeatureCount { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("CIDetectorEyeBlink"), Internal]
 		NSString EyeBlink { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("CIDetectorSmile"), Internal]
 		NSString Smile { get; }
 
@@ -3218,27 +3192,27 @@ namespace CoreImage {
 		[Export ("trackingFrameCount", ArgumentSemantic.Assign)]
 		int TrackingFrameCount { get; } /* int, not NSInteger */
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("bounds", ArgumentSemantic.Assign)]
 		CGRect Bounds { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("faceAngle", ArgumentSemantic.Assign)]
 		float FaceAngle { get; } /* float, not CGFloat */
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("hasFaceAngle", ArgumentSemantic.Assign)]
 		bool HasFaceAngle { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("hasSmile", ArgumentSemantic.Assign)]
 		bool HasSmile { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("leftEyeClosed", ArgumentSemantic.Assign)]
 		bool LeftEyeClosed { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("rightEyeClosed", ArgumentSemantic.Assign)]
 		bool RightEyeClosed { get; }
 	}
@@ -3489,7 +3463,6 @@ namespace CoreImage {
 		[CoreImageFilterProperty ("outputImageNonMPS")]
 		CIImage OutputImageNonMps { get; }
 
-		[Mac (10, 5)]
 		[NoiOS]
 		[NoTV]
 		[NoWatch]
@@ -3619,7 +3592,6 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIBlendWithMask))]
 	interface CIBlendWithAlphaMask {
@@ -3876,7 +3848,6 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIFilter))]
 	interface CIColorClamp : CIColorClampProtocol {
@@ -3900,7 +3871,6 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter (DefaultCtorVisibility = MethodAttributes.Public, StringCtorVisibility = MethodAttributes.Public)]
-	[iOS (7, 0)]        // not part of the attributes dictionary -> [NoiOS] is generated
 	[Mac (10, 9)]   // not part of the attributes dictionary -> [NoMac] is generated
 	[BaseType (typeof (CIFilter))]
 	interface CIColorCrossPolynomial : CIColorCrossPolynomialProtocol {
@@ -3912,7 +3882,6 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIColorCube))]
 	interface CIColorCubeWithColorSpace : CIColorCubeWithColorSpaceProtocol {
@@ -3944,7 +3913,6 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIColorCrossPolynomial))]
 	interface CIColorPolynomial : CIColorPolynomialProtocol {
@@ -4000,14 +3968,12 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIConvolutionCore))]
 	interface CIConvolution3X3 {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIConvolutionCore))]
 	interface CIConvolution5X5 {
@@ -4021,14 +3987,12 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIConvolutionCore))]
 	interface CIConvolution9Horizontal {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIConvolutionCore))]
 	interface CIConvolution9Vertical {
@@ -4622,7 +4586,6 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (CIFilter))]
 	interface CILinearToSRGBToneCurve : CILinearToSrgbToneCurveProtocol {
@@ -4857,7 +4820,6 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter (StringCtorVisibility = MethodAttributes.Public)]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[Abstract]
 	[BaseType (typeof (CIFilter))]
@@ -4865,56 +4827,48 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIPhotoEffect))]
 	interface CIPhotoEffectChrome {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIPhotoEffect))]
 	interface CIPhotoEffectFade {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIPhotoEffect))]
 	interface CIPhotoEffectInstant {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIPhotoEffect))]
 	interface CIPhotoEffectMono {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIPhotoEffect))]
 	interface CIPhotoEffectNoir {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIPhotoEffect))]
 	interface CIPhotoEffectProcess {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIPhotoEffect))]
 	interface CIPhotoEffectTonal {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIPhotoEffect))]
 	interface CIPhotoEffectTransfer {
@@ -4981,7 +4935,6 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CICodeGenerator))]
 	interface CIQRCodeGenerator : CIQRCodeGeneratorProtocol {
@@ -5130,7 +5083,6 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (CIFilter))]
 	interface CISRGBToneCurveToLinear : CISrgbToneCurveToLinearProtocol {
@@ -5366,7 +5318,6 @@ namespace CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (CIFilter))]
 	interface CIVignetteEffect : CIVignetteEffectProtocol {

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -34,7 +34,6 @@ namespace CoreLocation {
 
 	[NoTV]
 	[NoWatch]
-	[iOS (7, 0)]
 	[Native] // NSInteger -> CLRegion.h
 	public enum CLRegionState : long {
 		Unknown,
@@ -45,7 +44,6 @@ namespace CoreLocation {
 	[Mac (10, 15)]
 	[NoTV]
 	[NoWatch]
-	[iOS (7, 0)]
 	[Native] // NSInteger -> CLRegion.h
 	public enum CLProximity : long {
 		Unknown,
@@ -393,14 +391,14 @@ namespace CoreLocation {
 		[NoWatch]
 		[NoTV]
 		[Mac (10, 10)]
-		[iOS (7, 0), Static, Export ("isMonitoringAvailableForClass:")]
+		[Static, Export ("isMonitoringAvailableForClass:")]
 		bool IsMonitoringAvailable (Class regionClass);
 
 		[NoWatch]
 		[NoTV]
 		[NoMac]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'RangedBeaconConstraints' instead.")]
-		[iOS (7, 0), Export ("rangedRegions", ArgumentSemantic.Copy)]
+		[Export ("rangedRegions", ArgumentSemantic.Copy)]
 		NSSet RangedRegions { get; }
 
 		[NoWatch, NoTV, Mac (11, 0), iOS (13, 0)]
@@ -410,7 +408,7 @@ namespace CoreLocation {
 		[Mac (10, 10)]
 		[NoWatch]
 		[NoTV]
-		[iOS (7, 0), Export ("requestStateForRegion:")]
+		[Export ("requestStateForRegion:")]
 		void RequestState (CLRegion region);
 
 		[NoWatch]
@@ -418,7 +416,7 @@ namespace CoreLocation {
 		[NoMac]
 		[NoMacCatalyst]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'StartRangingBeacons(CLBeaconIdentityConstraint)' instead.")]
-		[iOS (7, 0), Export ("startRangingBeaconsInRegion:")]
+		[Export ("startRangingBeaconsInRegion:")]
 		void StartRangingBeacons (CLBeaconRegion region);
 
 		[NoWatch, NoTV, Mac (11, 0), iOS (13, 0)]
@@ -430,7 +428,7 @@ namespace CoreLocation {
 		[NoMac]
 		[NoMacCatalyst]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'StopRangingBeacons(CLBeaconIdentityConstraint)' instead.")]
-		[iOS (7, 0), Export ("stopRangingBeaconsInRegion:")]
+		[Export ("stopRangingBeaconsInRegion:")]
 		void StopRangingBeacons (CLBeaconRegion region);
 
 		[NoWatch, NoTV, Mac (11, 0), iOS (13, 0)]
@@ -439,7 +437,7 @@ namespace CoreLocation {
 
 		[NoWatch]
 		[NoTV]
-		[iOS (7, 0), Mac (11, 0)]
+		[Mac (11, 0)]
 		[Static]
 		[Export ("isRangingAvailable")]
 		bool IsRangingAvailable { get; }
@@ -564,14 +562,14 @@ namespace CoreLocation {
 		[NoWatch]
 		[NoTV]
 		[Mac (10, 10)]
-		[iOS (7, 0), Export ("locationManager:didDetermineState:forRegion:"), EventArgs ("CLRegionStateDetermined")]
+		[Export ("locationManager:didDetermineState:forRegion:"), EventArgs ("CLRegionStateDetermined")]
 		void DidDetermineState (CLLocationManager manager, CLRegionState state, CLRegion region);
 
 		[NoWatch]
 		[NoTV]
 		[NoMac]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'DidRangeBeaconsSatisfyingConstraint' instead.")]
-		[iOS (7, 0), Export ("locationManager:didRangeBeacons:inRegion:"), EventArgs ("CLRegionBeaconsRanged")]
+		[Export ("locationManager:didRangeBeacons:inRegion:"), EventArgs ("CLRegionBeaconsRanged")]
 		void DidRangeBeacons (CLLocationManager manager, CLBeacon [] beacons, CLBeaconRegion region);
 
 		[NoWatch, NoTV, Mac (11, 0), iOS (13, 0)]
@@ -583,7 +581,7 @@ namespace CoreLocation {
 		[NoTV]
 		[NoMac]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'DidFailRangingBeacons' instead.")]
-		[iOS (7, 0), Export ("locationManager:rangingBeaconsDidFailForRegion:withError:"), EventArgs ("CLRegionBeaconsFailed")]
+		[Export ("locationManager:rangingBeaconsDidFailForRegion:withError:"), EventArgs ("CLRegionBeaconsFailed")]
 		void RangingBeaconsDidFailForRegion (CLLocationManager manager, CLBeaconRegion region, NSError error);
 
 		[NoWatch, NoTV, Mac (11, 0), iOS (13, 0)]
@@ -671,11 +669,11 @@ namespace CoreLocation {
 		[Export ("containsCoordinate:")]
 		bool Contains (CLLocationCoordinate2D coordinate);
 
-		[iOS (7, 0), Export ("notifyOnEntry", ArgumentSemantic.Assign)]
+		[Export ("notifyOnEntry", ArgumentSemantic.Assign)]
 		[Mac (10, 10)]
 		bool NotifyOnEntry { get; set; }
 
-		[iOS (7, 0), Export ("notifyOnExit", ArgumentSemantic.Assign)]
+		[Export ("notifyOnExit", ArgumentSemantic.Assign)]
 		[Mac (10, 10)]
 		bool NotifyOnExit { get; set; }
 	}
@@ -748,7 +746,7 @@ namespace CoreLocation {
 	}
 
 	[Mac (10, 10)]
-	[iOS (7, 0), BaseType (typeof (CLRegion))]
+	[BaseType (typeof (CLRegion))]
 #if MONOMAC
 	[DisableDefaultCtor]
 #endif
@@ -770,7 +768,7 @@ namespace CoreLocation {
 	[NoWatch]
 	[Mac (11, 0)]
 	[NoTV]
-	[iOS (7, 0), BaseType (typeof (CLRegion))]
+	[BaseType (typeof (CLRegion))]
 	[DisableDefaultCtor] // nil-Handle on iOS8 if 'init' is used
 	partial interface CLBeaconRegion {
 
@@ -838,7 +836,7 @@ namespace CoreLocation {
 	[NoWatch]
 	[Mac (11, 0)]
 	[NoTV]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	partial interface CLBeacon : NSCopying, NSSecureCoding {
 
 		[NoMac]

--- a/src/coremotion.cs
+++ b/src/coremotion.cs
@@ -231,16 +231,13 @@ namespace CoreMotion {
 	delegate void CMMagnetometerHandler (CMMagnetometerData magnetometerData, NSError error);
 
 	[NoWatch]
-	[iOS (7, 0)]
 	delegate void CMStepQueryHandler (nint numberOfSteps, NSError error);
 
 	[NoWatch]
-	[iOS (7, 0)]
 	delegate void CMStepUpdateHandler (nint numberOfSteps, NSDate timestamp, NSError error);
 
 	[NoMac]
 	[NoWatch]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'CMPedometer' instead.")]
 	interface CMStepCounter {
@@ -362,15 +359,12 @@ namespace CoreMotion {
 	}
 
 	[NoMac]
-	[iOS (7, 0)]
 	delegate void CMMotionActivityHandler (CMMotionActivity activity);
 
 	[NoMac]
-	[iOS (7, 0)]
 	delegate void CMMotionActivityQueryHandler (CMMotionActivity [] activities, NSError error);
 
 	[NoMac]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	interface CMMotionActivityManager {
 
@@ -395,7 +389,6 @@ namespace CoreMotion {
 	}
 
 	[NoMac]
-	[iOS (7, 0)]
 	[BaseType (typeof (CMLogItem))]
 	[DisableDefaultCtor] // <quote>You do not create instances of this class yourself.</quote>
 	interface CMMotionActivity : NSCopying, NSSecureCoding {

--- a/src/corespotlight.cs
+++ b/src/corespotlight.cs
@@ -244,7 +244,6 @@ namespace CoreSpotlight {
 		bool MultiValued { [Bind ("isMultiValued")] get; }
 	}
 
-	[TV (9, 0)] // Headers don't say, documentation says no, however everything works just fine in Xcode (and no warnings).
 	[iOS (9, 0)]
 	[Mac (10, 13)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]

--- a/src/coretelephony.cs
+++ b/src/coretelephony.cs
@@ -29,7 +29,6 @@ namespace CoreTelephony {
 
 	[MacCatalyst (14, 0)]
 	[Static]
-	[iOS (7, 0)]
 	interface CTRadioAccessTechnology {
 		[Field ("CTRadioAccessTechnologyGPRS")]
 		NSString GPRS { get; }
@@ -103,7 +102,7 @@ namespace CoreTelephony {
 		Action<CTCarrier> CellularProviderUpdatedEventHandler { get; set; }
 
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use 'ServiceCurrentRadioAccessTechnology' instead.")]
-		[iOS (7, 0), Export ("currentRadioAccessTechnology")]
+		[Export ("currentRadioAccessTechnology")]
 		[NullAllowed]
 		NSString CurrentRadioAccessTechnology { get; }
 
@@ -194,7 +193,6 @@ namespace CoreTelephony {
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
-	[iOS (7, 0)]
 	partial interface CTSubscriber {
 		[Export ("carrierToken")]
 		[NullAllowed]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -658,8 +658,6 @@ namespace Foundation {
 		CGRect GetBoundingRect (CGSize size, NSStringDrawingOptions options, [NullAllowed] NSStringDrawingContext context);
 
 		[MacCatalyst (13, 1)]
-		[TV (9, 0)]
-		[Mac (10, 0)]
 		[iOS (6, 0)]
 		[Export ("size")]
 		CGSize Size { get; }
@@ -778,7 +776,6 @@ namespace Foundation {
 #else
 		[Field ("NSTextLayoutSectionOrientation", "UIKit")]
 #endif
-		[iOS (7, 0)]
 		NSString TextLayoutSectionOrientation { get; }
 
 #if MONOMAC
@@ -786,7 +783,6 @@ namespace Foundation {
 #else
 		[Field ("NSTextLayoutSectionRange", "UIKit")]
 #endif
-		[iOS (7, 0)]
 		NSString TextLayoutSectionRange { get; }
 
 #if !XAMCORE_5_0
@@ -795,7 +791,6 @@ namespace Foundation {
 #else
 		[Field ("NSTextLayoutSectionsAttribute", "UIKit")]
 #endif
-		[iOS (7, 0)]
 		NSString TextLayoutSectionsAttribute { get; }
 #endif // !XAMCORE_5_0
 
@@ -1872,27 +1867,27 @@ namespace Foundation {
 		[Export ("rangeOfData:options:range:")]
 		NSRange Find (NSData dataToFind, NSDataSearchOptions searchOptions, NSRange searchRange);
 
-		[iOS (7, 0), Mac (10, 9)] // 10.9
+		[Mac (10, 9)] // 10.9
 		[Export ("initWithBase64EncodedString:options:")]
 		NativeHandle Constructor (string base64String, NSDataBase64DecodingOptions options);
 
-		[iOS (7, 0), Mac (10, 9)] // 10.9
+		[Mac (10, 9)] // 10.9
 		[Export ("initWithBase64EncodedData:options:")]
 		NativeHandle Constructor (NSData base64Data, NSDataBase64DecodingOptions options);
 
-		[iOS (7, 0), Mac (10, 9)] // 10.9
+		[Mac (10, 9)] // 10.9
 		[Export ("base64EncodedDataWithOptions:")]
 		NSData GetBase64EncodedData (NSDataBase64EncodingOptions options);
 
-		[iOS (7, 0), Mac (10, 9)] // 10.9
+		[Mac (10, 9)] // 10.9
 		[Export ("base64EncodedStringWithOptions:")]
 		string GetBase64EncodedString (NSDataBase64EncodingOptions options);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("enumerateByteRangesUsingBlock:")]
 		void EnumerateByteRange (NSDataByteRangeEnumerator enumerator);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("initWithBytesNoCopy:length:deallocator:")]
 		NativeHandle Constructor (IntPtr bytes, nuint length, [NullAllowed] Action<IntPtr, nuint> deallocator);
 
@@ -2190,7 +2185,7 @@ namespace Foundation {
 		[Export ("setLocalizedDateFormatFromTemplate:")]
 		void SetLocalizedDateFormatFromTemplate (string dateFormatTemplate);
 
-		[Watch (2, 0), TV (9, 0), Mac (10, 10), iOS (8, 0)]
+		[Mac (10, 10), iOS (8, 0)]
 		[Export ("formattingContext", ArgumentSemantic.Assign)]
 		NSFormattingContext FormattingContext { get; set; }
 	}
@@ -2852,7 +2847,7 @@ namespace Foundation {
 		[Export ("classNameForClass:")]
 		string GetClassName (Class kls);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSKeyedArchiveRootObjectKey")]
 		NSString RootObjectKey { get; }
 
@@ -3176,17 +3171,14 @@ namespace Foundation {
 		[Field ("NSMetadataUbiquitousItemIsUploadingKey")]
 		NSString UbiquitousItemIsUploadingKey { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Field ("NSMetadataUbiquitousItemDownloadingStatusKey")]
 		NSString UbiquitousItemDownloadingStatusKey { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Field ("NSMetadataUbiquitousItemDownloadingErrorKey")]
 		NSString UbiquitousItemDownloadingErrorKey { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Field ("NSMetadataUbiquitousItemUploadingErrorKey")]
 		NSString UbiquitousItemUploadingErrorKey { get; }
@@ -3825,22 +3817,22 @@ namespace Foundation {
 		[Field ("NSMetadataUbiquitousSharedItemPermissionsReadWrite")]
 		NSString UbiquitousSharedItemPermissionsReadWrite { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[NullAllowed] // by default this property is null
 		[Export ("searchItems", ArgumentSemantic.Copy)]
 		// DOC: object is a mixture of NSString, NSMetadataItem, NSUrl
 		NSObject [] SearchItems { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[NullAllowed] // by default this property is null
 		[Export ("operationQueue", ArgumentSemantic.Retain)]
 		NSOperationQueue OperationQueue { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("enumerateResultsUsingBlock:")]
 		void EnumerateResultsUsingBlock (NSMetadataQueryEnumerationCallback callback);
 
-		[iOS (7, 0), Mac (10, 9), Export ("enumerateResultsWithOptions:usingBlock:")]
+		[Mac (10, 9), Export ("enumerateResultsWithOptions:usingBlock:")]
 		void EnumerateResultsWithOptions (NSEnumerationOptions opts, NSMetadataQueryEnumerationCallback block);
 
 		//
@@ -4068,7 +4060,6 @@ namespace Foundation {
 
 		[NoMac]
 		[NoTV]
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'ReadFromUrl' instead.")]
 		[Export ("readFromFileURL:options:documentAttributes:error:")]
 		bool ReadFromFile (NSUrl url, NSDictionary options, ref NSDictionary returnOptions, ref NSError error);
@@ -4080,7 +4071,6 @@ namespace Foundation {
 		bool ReadFromFile (NSUrl url, NSAttributedStringDocumentAttributes options, ref NSDictionary returnOptions, ref NSError error);
 
 		[NoMac]
-		[iOS (7, 0)]
 		[Export ("readFromData:options:documentAttributes:error:")]
 		bool ReadFromData (NSData data, NSDictionary options, ref NSDictionary returnOptions, ref NSError error);
 
@@ -4595,7 +4585,6 @@ namespace Foundation {
 #if false
 		// FIXME that value is present in the header (7.0 DP 6) files but returns NULL (i.e. unusable)
 		// we're also missing other NSURLError* fields (which we should add)
-		[iOS (7,0)]
 		[Field ("NSURLErrorBackgroundTaskCancelledReasonKey")]
 		NSString NSUrlErrorBackgroundTaskCancelledReasonKey { get; }
 #endif
@@ -4692,7 +4681,7 @@ namespace Foundation {
 		[Static, Export ("expressionForBlock:arguments:")]
 		NSExpression FromFunction (NSExpressionCallbackHandler target, NSExpression [] parameters);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Static]
 		[Export ("expressionForAnyKey")]
 		NSExpression FromAnyKey ();
@@ -4702,7 +4691,7 @@ namespace Foundation {
 		[Export ("expressionForConditional:trueExpression:falseExpression:")]
 		NSExpression FromConditional (NSPredicate predicate, NSExpression trueExpression, NSExpression falseExpression);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("allowEvaluation")]
 		void AllowEvaluation ();
 
@@ -5167,7 +5156,6 @@ namespace Foundation {
 		[Static]
 		NSLocaleLanguageDirection GetLineDirection (string isoLanguageCode);
 
-		[iOS (7, 0)] // already in OSX 10.6
 		[Static]
 		[Export ("localeWithLocaleIdentifier:")]
 		NSLocale FromLocaleIdentifier (string ident);
@@ -5532,7 +5520,7 @@ namespace Foundation {
 		[Export ("reversedSortDescriptor")]
 		NSObject ReversedSortDescriptor { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("allowEvaluation")]
 		void AllowEvaluation ();
 	}
@@ -5617,7 +5605,7 @@ namespace Foundation {
 		[Export ("userInfo")]
 		NSObject UserInfo { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("tolerance")]
 		double Tolerance { get; set; }
 	}
@@ -5812,7 +5800,7 @@ namespace Foundation {
 	}
 
 	[iOS (8, 0)]
-	[Mac (10, 10), Watch (2, 0), TV (9, 0)] // .objc_class_name_NSUserActivity", referenced from '' not found
+	[Mac (10, 10)] // .objc_class_name_NSUserActivity", referenced from '' not found
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // xcode 8 beta 4 marks it as API_DEPRECATED
 	partial interface NSUserActivity
@@ -5984,7 +5972,7 @@ namespace Foundation {
 	}
 
 	[iOS (8, 0)]
-	[Mac (10, 10), Watch (3, 0), TV (9, 0)] // same as NSUserActivity
+	[Mac (10, 10), Watch (3, 0)] // same as NSUserActivity
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	partial interface NSUserActivityDelegate {
@@ -6020,7 +6008,7 @@ namespace Foundation {
 		IntPtr InitWithUserName (string username);
 
 		[Internal]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("initWithSuiteName:")]
 		IntPtr InitWithSuiteName (string suiteName);
 
@@ -6308,32 +6296,32 @@ namespace Foundation {
 		[Export ("URLByDeletingPathExtension")]
 		NSUrl RemovePathExtension ();
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("getFileSystemRepresentation:maxLength:")]
 		bool GetFileSystemRepresentation (IntPtr buffer, nint maxBufferLength);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("fileSystemRepresentation")]
 		IntPtr GetFileSystemRepresentationAsUtf8Ptr { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("removeCachedResourceValueForKey:")]
 		void RemoveCachedResourceValueForKey (NSString key);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("removeAllCachedResourceValues")]
 		void RemoveAllCachedResourceValues ();
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("setTemporaryResourceValue:forKey:")]
 		void SetTemporaryResourceValue (NSObject value, NSString key);
 
 		[DesignatedInitializer]
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("initFileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
 		NativeHandle Constructor (IntPtr ptrUtf8path, bool isDir, [NullAllowed] NSUrl baseURL);
 
-		[iOS (7, 0), Mac (10, 9), Static, Export ("fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
+		[Mac (10, 9), Static, Export ("fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
 		NSUrl FromUTF8Pointer (IntPtr ptrUtf8path, bool isDir, [NullAllowed] NSUrl baseURL);
 
 		/* These methods come from NURL_AppKitAdditions */
@@ -6750,27 +6738,27 @@ namespace Foundation {
 		[Field ("NSURLPathKey")]
 		NSString PathKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusKey")]
 		NSString UbiquitousItemDownloadingStatusKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingErrorKey")]
 		NSString UbiquitousItemDownloadingErrorKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemUploadingErrorKey")]
 		NSString UbiquitousItemUploadingErrorKey { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusNotDownloaded")]
 		NSString UbiquitousItemDownloadingStatusNotDownloaded { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusDownloaded")]
 		NSString UbiquitousItemDownloadingStatusDownloaded { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusCurrent")]
 		NSString UbiquitousItemDownloadingStatusCurrent { get; }
 
@@ -6983,22 +6971,22 @@ namespace Foundation {
 
 	[Category, BaseType (typeof (NSCharacterSet))]
 	partial interface NSUrlUtilities_NSCharacterSet {
-		[iOS (7, 0), Static, Export ("URLUserAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[Static, Export ("URLUserAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlUserAllowedCharacterSet { get; }
 
-		[iOS (7, 0), Static, Export ("URLPasswordAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[Static, Export ("URLPasswordAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlPasswordAllowedCharacterSet { get; }
 
-		[iOS (7, 0), Static, Export ("URLHostAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[Static, Export ("URLHostAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlHostAllowedCharacterSet { get; }
 
-		[iOS (7, 0), Static, Export ("URLPathAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[Static, Export ("URLPathAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlPathAllowedCharacterSet { get; }
 
-		[iOS (7, 0), Static, Export ("URLQueryAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[Static, Export ("URLQueryAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlQueryAllowedCharacterSet { get; }
 
-		[iOS (7, 0), Static, Export ("URLFragmentAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[Static, Export ("URLFragmentAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlFragmentAllowedCharacterSet { get; }
 	}
 
@@ -7061,7 +7049,7 @@ namespace Foundation {
 		void RemoveCachedResponse (NSUrlSessionDataTask dataTask);
 	}
 
-	[iOS (7, 0), Mac (10, 9)]
+	[Mac (10, 9)]
 	[BaseType (typeof (NSObject), Name = "NSURLComponents")]
 	partial interface NSUrlComponents : NSCopying {
 		[Export ("initWithURL:resolvingAgainstBaseURL:")]
@@ -7475,11 +7463,11 @@ namespace Foundation {
 		[Export ("setDefaultCredential:forProtectionSpace:")]
 		void SetDefaultCredential (NSUrlCredential credential, NSUrlProtectionSpace forProtectionSpace);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("removeCredential:forProtectionSpace:options:")]
 		void RemoveCredential (NSUrlCredential credential, NSUrlProtectionSpace forProtectionSpace, NSDictionary options);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSURLCredentialStorageRemoveSynchronizableCredentials")]
 		NSString RemoveSynchronizableCredentials { get; }
 
@@ -7539,7 +7527,6 @@ namespace Foundation {
 	// but Apple has flagged these as not allowing null.
 	//
 	// Leaving the null allowed for now.
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (NSObject), Name = "NSURLSession")]
 	[DisableDefaultCtorAttribute]
@@ -7768,7 +7755,6 @@ namespace Foundation {
 		void StopSecureConnection ();
 	}
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (NSObject), Name = "NSURLSessionTask")]
 	[DisableDefaultCtor]
@@ -7873,7 +7859,6 @@ namespace Foundation {
 	// All of the NSUrlSession APIs are either 10.10, or 10.9 and 64-bit only
 	// "NSURLSession is not available for i386 targets before Mac OS X 10.10."
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (NSUrlSessionTask), Name = "NSURLSessionDataTask")]
 	[DisableDefaultCtor]
@@ -7886,7 +7871,6 @@ namespace Foundation {
 		NativeHandle Constructor ();
 	}
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (NSUrlSessionDataTask), Name = "NSURLSessionUploadTask")]
 	[DisableDefaultCtor]
@@ -7899,7 +7883,6 @@ namespace Foundation {
 		NativeHandle Constructor ();
 	}
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (NSUrlSessionTask), Name = "NSURLSessionDownloadTask")]
 	[DisableDefaultCtor]
@@ -7951,7 +7934,6 @@ namespace Foundation {
 		int HttpsProxyPort { get; set; }
 	}
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (NSObject), Name = "NSURLSessionConfiguration")]
 	[DisableDefaultCtorAttribute]
@@ -8095,7 +8077,6 @@ namespace Foundation {
 		bool RequiresDnsSecValidation { get; set; }
 	}
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[Model, BaseType (typeof (NSObject), Name = "NSURLSessionDelegate")]
 	[Protocol]
@@ -8113,7 +8094,6 @@ namespace Foundation {
 
 	public interface INSUrlSessionTaskDelegate { }
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[Model]
 	[BaseType (typeof (NSUrlSessionDelegate), Name = "NSURLSessionTaskDelegate")]
@@ -8155,7 +8135,6 @@ namespace Foundation {
 		void DidCreateTask (NSUrlSession session, NSUrlSessionTask task);
 	}
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[Model]
 	[BaseType (typeof (NSUrlSessionTaskDelegate), Name = "NSURLSessionDataDelegate")]
@@ -8178,7 +8157,6 @@ namespace Foundation {
 		void DidBecomeStreamTask (NSUrlSession session, NSUrlSessionDataTask dataTask, NSUrlSessionStreamTask streamTask);
 	}
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[Model]
 	[BaseType (typeof (NSUrlSessionTaskDelegate), Name = "NSURLSessionDownloadDelegate")]
@@ -9195,11 +9173,9 @@ namespace Foundation {
 
 	[Category, BaseType (typeof (NSString))]
 	partial interface NSUrlUtilities_NSString {
-		[iOS (7, 0)]
 		[Export ("stringByAddingPercentEncodingWithAllowedCharacters:")]
 		NSString CreateStringByAddingPercentEncoding (NSCharacterSet allowedCharacters);
 
-		[iOS (7, 0)]
 		[Export ("stringByRemovingPercentEncoding")]
 		NSString CreateStringByRemovingPercentEncoding ();
 
@@ -9842,7 +9818,6 @@ namespace Foundation {
 		[Export ("queuePriority")]
 		NSOperationQueuePriority QueuePriority { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("asynchronous")]
 		bool Asynchronous { [Bind ("isAsynchronous")] get; }
 
@@ -10694,7 +10669,6 @@ namespace Foundation {
 		[Export ("localizations")]
 		string [] Localizations { get; }
 
-		[iOS (7, 0)]
 		[Export ("appStoreReceiptURL")]
 		NSUrl AppStoreReceiptUrl { get; }
 
@@ -10811,7 +10785,6 @@ namespace Foundation {
 		void _GetIndexes (IntPtr target);
 
 		[Mac (10, 9)]
-		[iOS (7, 0)]
 		[Export ("getIndexes:range:")]
 		[Internal]
 		void _GetIndexes (IntPtr target, NSRange positionRange);
@@ -11438,7 +11411,7 @@ namespace Foundation {
 		[Export ("stopMonitoring")]
 		void StopMonitoring ();
 
-		[iOS (7, 0), Mac (10, 10)]
+		[Mac (10, 10)]
 		[Export ("includesPeerToPeer")]
 		bool IncludesPeerToPeer { get; set; }
 	}
@@ -11471,7 +11444,6 @@ namespace Foundation {
 		[Export ("netService:didUpdateTXTRecordData:"), EventArgs ("NSNetServiceData")]
 		void UpdatedTxtRecordData (NSNetService sender, NSData data);
 
-		[iOS (7, 0)]
 		[Export ("netService:didAcceptConnectionWithInputStream:outputStream:"), EventArgs ("NSNetServiceConnection")]
 		void DidAcceptConnection (NSNetService sender, NSInputStream inputStream, NSOutputStream outputStream);
 	}
@@ -11525,7 +11497,7 @@ namespace Foundation {
 		[Export ("stop")]
 		void Stop ();
 
-		[iOS (7, 0), Mac (10, 10)]
+		[Mac (10, 10)]
 		[Export ("includesPeerToPeer")]
 		bool IncludesPeerToPeer { get; set; }
 	}
@@ -11818,7 +11790,6 @@ namespace Foundation {
 		[Static]
 		NSValue FromCGPoint (CGPoint point);
 
-		[Mac (10, 0)]
 		[MacCatalyst (15, 0)]
 #if MONOMAC
 		[Export ("rectValue")]
@@ -11827,7 +11798,6 @@ namespace Foundation {
 #endif
 		CGRect CGRectValue { get; }
 
-		[Mac (10, 0)]
 		[MacCatalyst (15, 0)]
 #if MONOMAC
 		[Export ("sizeValue")]
@@ -11836,7 +11806,6 @@ namespace Foundation {
 #endif
 		CGSize CGSizeValue { get; }
 
-		[Mac (10, 0)]
 		[MacCatalyst (15, 0)]
 #if MONOMAC
 		[Export ("pointValue")]
@@ -12815,15 +12784,15 @@ namespace Foundation {
 		[Export ("systemUptime")]
 		double SystemUptime { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("beginActivityWithOptions:reason:")]
 		NSObject BeginActivity (NSActivityOptions options, string reason);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("endActivity:")]
 		void EndActivity (NSObject activity);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("performActivityWithOptions:reason:usingBlock:")]
 		void PerformActivity (NSActivityOptions options, string reason, Action runCode);
 
@@ -12929,7 +12898,7 @@ namespace Foundation {
 		string GetFullUserName ();
 	}
 
-	[iOS (7, 0), Mac (10, 9)]
+	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	partial interface NSProgress {
 
@@ -13587,7 +13556,6 @@ namespace Foundation {
 		[Notification]
 		NSString UbiquityIdentityDidChangeNotification { get; }
 
-		[iOS (7, 0)]
 		[Export ("containerURLForSecurityApplicationGroupIdentifier:")]
 		NSUrl GetContainerUrl (string securityApplicationGroupIdentifier);
 
@@ -14024,7 +13992,7 @@ namespace Foundation {
 		[Export ("predicateFromMetadataQueryString:")]
 		NSPredicate FromMetadataQueryString (string query);
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("allowEvaluation")]
 		void AllowEvaluation ();
 	}
@@ -14352,7 +14320,6 @@ namespace Foundation {
 		string ReplacementString { get; }
 
 		[Export ("alternativeStrings")]
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		string [] AlternativeStrings { get; }
 
@@ -14432,7 +14399,6 @@ namespace Foundation {
 
 		[Static]
 		[Export ("correctionCheckingResultWithRange:replacementString:alternativeStrings:")]
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		NSTextCheckingResult CorrectionCheckingResult (NSRange range, string replacementString, string [] alternativeStrings);
 
@@ -17155,8 +17121,6 @@ namespace Foundation {
 
 		[Mac (10, 11)]
 		[iOS (9, 0)]
-		[Watch (2, 0)]
-		[TV (9, 0)]
 		[Export ("synchronousRemoteObjectProxyWithErrorHandler:"), Internal]
 		IntPtr _CreateSynchronousRemoteObjectProxy ([BlockCallback] Action<NSError> errorHandler);
 

--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -34,9 +34,7 @@ using NativeHandle = System.IntPtr;
 
 namespace GameController {
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // The GCControllerElement class is never instantiated directly.
 	partial interface GCControllerElement {
@@ -88,7 +86,6 @@ namespace GameController {
 
 	delegate void GCControllerAxisValueChangedHandler (GCControllerAxisInput axis, float /* float, not CGFloat */ value);
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (GCControllerElement))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
@@ -111,7 +108,7 @@ namespace GameController {
 	delegate void GCControllerButtonValueChanged (GCControllerButtonInput button, float /* float, not CGFloat */ buttonValue, bool pressed);
 	delegate void GCControllerButtonTouchedChanged (GCControllerButtonInput button, float value, bool pressed, bool touched);
 
-	[iOS (7, 0), Mac (10, 9)]
+	[Mac (10, 9)]
 	[BaseType (typeof (GCControllerElement))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
 	partial interface GCControllerButtonInput {
@@ -163,7 +160,6 @@ namespace GameController {
 
 	delegate void GCControllerDirectionPadValueChangedHandler (GCControllerDirectionPad dpad, float /* float, not CGFloat */ xValue, float /* float, not CGFloat */ yValue);
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (GCControllerElement))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
@@ -202,7 +198,6 @@ namespace GameController {
 	[Deprecated (PlatformName.MacOSX, 10, 12, message: "Use 'GCExtendedGamepad' instead.")]
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'GCExtendedGamepad' instead.")]
 	[Deprecated (PlatformName.TvOS, 10, 0, message: "Use 'GCExtendedGamepad' instead.")]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (GCPhysicalInputProfile))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
@@ -243,7 +238,6 @@ namespace GameController {
 	[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCExtendedGamepad' instead.")]
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCExtendedGamepad' instead.")]
 	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCExtendedGamepad' instead.")]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (GCGamepad))]
 	[DisableDefaultCtor]
@@ -261,7 +255,6 @@ namespace GameController {
 
 	delegate void GCExtendedGamepadValueChangedHandler (GCExtendedGamepad gamepad, GCControllerElement element);
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (GCPhysicalInputProfile))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
@@ -339,7 +332,6 @@ namespace GameController {
 		GCControllerButtonInput ButtonHome { get; }
 	}
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.GetExtendedGamepadController()' instead.")]
 	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetExtendedGamepadController()' instead.")]
@@ -365,7 +357,7 @@ namespace GameController {
 		GCExtendedGamepadSnapshotDataVersion DataVersion { get; }
 	}
 
-	[iOS (7, 0), Mac (10, 9)]
+	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	partial interface GCController : GCDevice {
 
@@ -606,12 +598,10 @@ namespace GameController {
 
 	[Mac (10, 11)]
 	[iOS (10, 0)]
-	[TV (9, 0)]
 	delegate void GCMicroGamepadValueChangedHandler (GCMicroGamepad gamepad, GCControllerElement element);
 
 	[Mac (10, 11)]
 	[iOS (10, 0)]
-	[TV (9, 0)]
 	[BaseType (typeof (GCPhysicalInputProfile))]
 	[DisableDefaultCtor]
 	interface GCMicroGamepad {
@@ -656,7 +646,6 @@ namespace GameController {
 	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.Capture()' instead.")]
 	[Mac (10, 12)]
 	[iOS (10, 0)]
-	[TV (9, 0)]
 	[BaseType (typeof (GCMicroGamepad))]
 	interface GCMicroGamepadSnapshot {
 		[Export ("snapshotData", ArgumentSemantic.Copy)]
@@ -678,7 +667,6 @@ namespace GameController {
 
 	[Mac (10, 12)]
 	[iOS (10, 0)]
-	[TV (9, 0)]
 	[BaseType (typeof (UIViewController))]
 	interface GCEventViewController {
 

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -357,7 +357,6 @@ namespace GameKit {
 		[Deprecated (PlatformName.TvOS, 14, 0, message: "Use 'LoadEntries' instead.")]
 		[Deprecated (PlatformName.MacOSX, 11, 0, message: "Use 'LoadEntries' instead.")]
 		[Deprecated (PlatformName.WatchOS, 7, 0, message: "Use 'LoadEntries' instead.")]
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[NullAllowed]
 		[Export ("identifier", ArgumentSemantic.Copy)]
@@ -365,7 +364,6 @@ namespace GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("loadImageWithCompletionHandler:")]
 		[Async]
@@ -441,7 +439,6 @@ namespace GameKit {
 	}
 
 	[Watch (3, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	interface GKLeaderboardSet : NSCoding, NSSecureCoding {
@@ -618,13 +615,11 @@ namespace GameKit {
 		NativeHandle Constructor (string identifier, GKPlayer player);
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use the overload that takes a 'GKPlayer' instead.")]
 		[Export ("initWithLeaderboardIdentifier:forPlayer:")]
 		NativeHandle Constructor (string identifier, string playerID);
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Internal]
 		[Export ("initWithLeaderboardIdentifier:")]
@@ -682,14 +677,12 @@ namespace GameKit {
 		[Async]
 		void ReportScores (GKScore [] scores, [NullAllowed] Action<NSError> completionHandler);
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[NullAllowed] // by default this property is null
 		[Export ("leaderboardIdentifier", ArgumentSemantic.Copy)]
 		string LeaderboardIdentifier { get; set; }
 
 		[NoWatch]
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("reportScores:withEligibleChallenges:withCompletionHandler:"), Static]
 		[Async]
@@ -708,7 +701,6 @@ namespace GameKit {
 		[NoTV]
 		[NoWatch]
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Pass 'GKPlayers' to 'ChallengeComposeController (GKPlayer [] players, string message, ...)' instead.")]
-		[iOS (7, 0)]
 		[Export ("challengeComposeControllerWithPlayers:message:completionHandler:")]
 		[return: NullAllowed]
 		UIViewController ChallengeComposeController ([NullAllowed] string [] playerIDs, [NullAllowed] string message, [NullAllowed] GKChallengeComposeHandler completionHandler);
@@ -847,13 +839,11 @@ namespace GameKit {
 		[Export ("presentFriendRequestCreatorFromWindow:error:")]
 		bool PresentFriendRequestCreator ([NullAllowed] NSWindow window, [NullAllowed] out NSError error);
 
-		[iOS (7, 0)]
 		[Mac (10, 10)] // Mismarked in header, 17613142
 		[Export ("loadDefaultLeaderboardIdentifierWithCompletionHandler:")]
 		[Async]
 		void LoadDefaultLeaderboardIdentifier ([NullAllowed] Action<string, NSError> completionHandler);
 
-		[iOS (7, 0)]
 		[Mac (10, 10)] // Mismarked in header, 17613142
 		[Export ("setDefaultLeaderboardIdentifier:completionHandler:")]
 		[Async]
@@ -875,15 +865,15 @@ namespace GameKit {
 		[Async]
 		void SetDefaultLeaderboardCategoryID ([NullAllowed] string categoryID, [NullAllowed] Action<NSError> completionHandler);
 
-		[iOS (7, 0), Mac (10, 10)]
+		[Mac (10, 10)]
 		[Export ("registerListener:")]
 		void RegisterListener ([Protocolize] GKLocalPlayerListener listener);
 
-		[iOS (7, 0), Mac (10, 10)]
+		[Mac (10, 10)]
 		[Export ("unregisterListener:")]
 		void UnregisterListener ([Protocolize] GKLocalPlayerListener listener);
 
-		[iOS (7, 0), Mac (10, 10)]
+		[Mac (10, 10)]
 		[Export ("unregisterAllListeners")]
 		void UnregisterAllListeners ();
 
@@ -891,7 +881,7 @@ namespace GameKit {
 		[Deprecated (PlatformName.TvOS, 13, 4, message: "Use 'FetchItemsForIdentityVerificationSignature' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 15, 4, message: "Use 'FetchItemsForIdentityVerificationSignature' instead.")]
 		[Deprecated (PlatformName.WatchOS, 6, 2, message: "Use 'FetchItemsForIdentityVerificationSignature' instead.")]
-		[iOS (7, 0), Mac (10, 10)]
+		[Mac (10, 10)]
 		[Async (ResultTypeName = "GKIdentityVerificationSignatureResult")]
 		[Export ("generateIdentityVerificationSignatureWithCompletionHandler:")]
 		void GenerateIdentityVerificationSignature ([NullAllowed] GKIdentityVerificationSignatureHandler completionHandler);
@@ -1530,7 +1520,6 @@ namespace GameKit {
 		NativeHandle Constructor ([NullAllowed] string identifier);
 
 		[NoMac]
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'ctor (string identifier, GKPlayer player)' instead.")]
 		[Export ("initWithIdentifier:forPlayer:")]
 		NativeHandle Constructor ([NullAllowed] string identifier, string playerId);
@@ -1568,7 +1557,6 @@ namespace GameKit {
 
 		[NoMac]
 		[NoTV]
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'Player' instead.")]
 		[NullAllowed, Export ("playerID", ArgumentSemantic.Copy)]
 		string PlayerID {
@@ -1576,7 +1564,7 @@ namespace GameKit {
 		}
 
 		[NoWatch]
-		[iOS (7, 0), Mac (10, 10)]
+		[Mac (10, 10)]
 		[Export ("reportAchievements:withEligibleChallenges:withCompletionHandler:"), Static]
 		[Async]
 		void ReportAchievements (GKAchievement [] achievements, GKChallenge [] challenges, [NullAllowed] Action<NSError> completionHandler);
@@ -1606,7 +1594,6 @@ namespace GameKit {
 		[NoMac]
 		[NoTV]
 		[NoWatch]
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0)]
 		[Export ("challengeComposeControllerWithPlayers:message:completionHandler:")]
 		[return: NullAllowed]
@@ -2011,35 +1998,29 @@ namespace GameKit {
 		[Field ("GKTurnTimeoutNone"), Static]
 		double NoTimeout { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("exchanges", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		GKTurnBasedExchange [] Exchanges { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("activeExchanges", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		GKTurnBasedExchange [] ActiveExchanges { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("completedExchanges", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		GKTurnBasedExchange [] CompletedExchanges { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("exchangeDataMaximumSize")]
 		nuint ExhangeDataMaximumSize { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("exchangeMaxInitiatedExchangesPerPlayer")]
 		nuint ExchangeMaxInitiatedExchangesPerPlayer { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("setLocalizableMessageWithKey:arguments:")]
 		void SetMessage (string localizableMessage, [NullAllowed] params NSObject [] arguments);
@@ -2047,25 +2028,21 @@ namespace GameKit {
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use 'EndMatchInTurn (NSData, GKLeaderboardScore[], NSObject[], Action<NSError>)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 11, 0, message: "Use 'EndMatchInTurn (NSData, GKLeaderboardScore[], NSObject[], Action<NSError>)' instead.")]
 		[Deprecated (PlatformName.TvOS, 14, 0, message: "Use 'EndMatchInTurn (NSData, GKLeaderboardScore[], NSObject[], Action<NSError>)' instead.")]
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("endMatchInTurnWithMatchData:scores:achievements:completionHandler:")]
 		[Async]
 		void EndMatchInTurn (NSData matchData, [NullAllowed] GKScore [] scores, [NullAllowed] GKAchievement [] achievements, [NullAllowed] Action<NSError> completionHandler);
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("saveMergedMatchData:withResolvedExchanges:completionHandler:")]
 		[Async]
 		void SaveMergedMatchData (NSData matchData, GKTurnBasedExchange [] exchanges, [NullAllowed] Action<NSError> completionHandler);
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("sendExchangeToParticipants:data:localizableMessageKey:arguments:timeout:completionHandler:")]
 		[Async]
 		void SendExchange (GKTurnBasedParticipant [] participants, NSData data, string localizableMessage, NSObject [] arguments, double timeout, [NullAllowed] Action<GKTurnBasedExchange, NSError> completionHandler);
 
-		[iOS (7, 0)]
 		[Mac (10, 10)]
 		[Export ("sendReminderToParticipants:localizableMessageKey:arguments:completionHandler:")]
 		[Async]
@@ -2264,7 +2241,6 @@ namespace GameKit {
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use '.ctor (GKGameCenterViewControllerState)' instead.")]
 		[Deprecated (PlatformName.TvOS, 14, 0, message: "Use '.ctor (GKGameCenterViewControllerState)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 11, 0, message: "Use '.ctor (GKGameCenterViewControllerState)' instead.")]
-		[TV (9, 0)]
 		[Export ("viewState", ArgumentSemantic.Assign)]
 		GKGameCenterViewControllerState ViewState { get; set; }
 
@@ -2284,8 +2260,6 @@ namespace GameKit {
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use '.ctor (GKLeaderboard, GKLeaderboardPlayerScope)' instead.")]
 		[Deprecated (PlatformName.TvOS, 14, 0, message: "Use '.ctor (GKLeaderboard, GKLeaderboardPlayerScope)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 11, 0, message: "Use '.ctor (GKLeaderboard, GKLeaderboardPlayerScope)' instead.")]
-		[TV (9, 0)]
-		[iOS (7, 0)]
 		[Mac (10, 10)] // Marked 10.9 in header, apple 17612948
 		[NullAllowed] // by default this property is null
 		[Export ("leaderboardIdentifier", ArgumentSemantic.Strong)]
@@ -2353,7 +2327,7 @@ namespace GameKit {
 		void RemotePlayerCompletedChallenge (GKChallenge challenge);
 	}
 
-	[iOS (7, 0), Mac (10, 10)]
+	[Mac (10, 10)]
 	[Watch (3, 0)]
 	[BaseType (typeof (NSObject))]
 	interface GKTurnBasedExchange {
@@ -2411,7 +2385,7 @@ namespace GameKit {
 		double TimeoutNone { get; }
 	}
 
-	[iOS (7, 0), Mac (10, 10)]
+	[Mac (10, 10)]
 	[Watch (3, 0)]
 	[BaseType (typeof (NSObject))]
 	interface GKTurnBasedExchangeReply {
@@ -2433,7 +2407,7 @@ namespace GameKit {
 		NSDate ReplyDate { get; }
 	}
 
-	[iOS (7, 0), Mac (10, 10)]
+	[Mac (10, 10)]
 	[Watch (3, 0)]
 	[Model, Protocol, BaseType (typeof (NSObject))]
 	interface GKLocalPlayerListener : GKTurnBasedEventListener
@@ -2447,7 +2421,7 @@ namespace GameKit {
 	}
 
 	[NoWatch]
-	[iOS (7, 0), Mac (10, 10)]
+	[Mac (10, 10)]
 	[Model, Protocol, BaseType (typeof (NSObject))]
 	interface GKChallengeListener {
 		[Export ("player:wantsToPlayChallenge:")]
@@ -2464,11 +2438,10 @@ namespace GameKit {
 	}
 
 	[NoWatch]
-	[iOS (7, 0), Mac (10, 10)]
+	[Mac (10, 10)]
 	[Protocol, Model, BaseType (typeof (NSObject))]
 	interface GKInviteEventListener {
 		[Mac (10, 10)]
-		[iOS (7, 0)]
 		[Export ("player:didAcceptInvite:")]
 		void DidAcceptInvite (GKPlayer player, GKInvite invite);
 
@@ -2483,7 +2456,7 @@ namespace GameKit {
 		void DidRequestMatch (GKPlayer player, GKPlayer [] recipientPlayers);
 	}
 
-	[iOS (7, 0), Mac (10, 10)]
+	[Mac (10, 10)]
 	[Watch (3, 0)]
 	[Model, Protocol, BaseType (typeof (NSObject))]
 	interface GKTurnBasedEventListener {

--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -489,7 +489,6 @@ namespace GameplayKit {
 
 		[Mac (10, 11, 2)]
 		[iOS (9, 1)]
-		[TV (9, 0)]
 		[Export ("unapplyGameModelUpdate:")]
 		void UnapplyGameModelUpdate (IGKGameModelUpdate gameModelUpdate);
 	}
@@ -1366,7 +1365,6 @@ namespace GameplayKit {
 
 	[NoMac]
 	[iOS (9, 1)]
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	interface GKHybridStrategist : GKStrategist {
 		[Export ("budget")]
@@ -1380,7 +1378,6 @@ namespace GameplayKit {
 	}
 
 	[iOS (9, 1)]
-	[TV (9, 0)]
 	[Protocol]
 	interface GKStrategist {
 		[Abstract]
@@ -1396,7 +1393,7 @@ namespace GameplayKit {
 		IGKGameModelUpdate GetBestMoveForActivePlayer ();
 	}
 
-	[iOS (9, 1), TV (9, 0), Mac (10, 12)]
+	[iOS (9, 1), Mac (10, 12)]
 	[BaseType (typeof (NSObject))]
 	interface GKMonteCarloStrategist : GKStrategist {
 		[Export ("budget")]

--- a/src/glkit.cs
+++ b/src/glkit.cs
@@ -576,7 +576,6 @@ namespace GLKit {
 		[Field ("GLKTextureLoaderGrayscaleAsAlpha")]
 		NSString GrayscaleAsAlpha { get; }
 
-		[iOS (7, 0)]
 		[Field ("GLKTextureLoaderSRGB")]
 		NSString SRGB { get; }
 

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -31,7 +31,6 @@ namespace HealthKit {
 	}
 
 	// NSInteger -> HKDefines.h
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[ErrorDomain ("HKErrorDomain")]
@@ -52,7 +51,6 @@ namespace HealthKit {
 	}
 
 	[iOS (10, 0)]
-	[Watch (2, 0)]
 	[Mac (13, 0)]
 	[Native]
 	public enum HKWorkoutSessionLocationType : long {
@@ -62,7 +60,6 @@ namespace HealthKit {
 	}
 
 	[NoiOS]
-	[Watch (2, 0)]
 	[Mac (13, 0)]
 	[Native]
 	public enum HKWorkoutSessionState : long {
@@ -178,7 +175,6 @@ namespace HealthKit {
 
 	delegate void HKWorkoutRouteBuilderDataHandler (HKWorkoutRouteQuery query, CLLocation [] routeData, bool done, NSError error);
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKQuery))]
@@ -214,7 +210,6 @@ namespace HealthKit {
 		HKAnchoredObjectUpdateHandler UpdateHandler { get; set; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Static]
@@ -421,7 +416,6 @@ namespace HealthKit {
 		NSString ValidationError { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
@@ -500,7 +494,6 @@ namespace HealthKit {
 		string CustodianName { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKSample))]
@@ -534,7 +527,6 @@ namespace HealthKit {
 
 	delegate void HKCorrelationQueryResultHandler (HKCorrelationQuery query, HKCorrelation [] correlations, NSError error);
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKQuery))]
@@ -550,7 +542,6 @@ namespace HealthKit {
 		NSDictionary SamplePredicates { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKSampleType))]
@@ -563,7 +554,6 @@ namespace HealthKit {
 	delegate void HKHealthStoreRecoverActiveWorkoutSessionHandler (HKWorkoutSession session, NSError error);
 	delegate void HKHealthStoreCompletionHandler (bool success, NSError error);
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (NSObject))]
@@ -752,7 +742,6 @@ namespace HealthKit {
 
 	delegate void HKStoreSampleAddedCallback (bool success, NSError error);
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (NSObject))]
@@ -761,7 +750,6 @@ namespace HealthKit {
 		HKBiologicalSex BiologicalSex { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (NSObject))]
@@ -929,7 +917,6 @@ namespace HealthKit {
 		HKQuantity HeartRateEventThreshold { get; set; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[Static]
@@ -1168,7 +1155,6 @@ namespace HealthKit {
 		NSString UserMotionContext { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 #if NET
@@ -1199,7 +1185,6 @@ namespace HealthKit {
 		HKDevice Device { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 #if NET
@@ -1318,7 +1303,6 @@ namespace HealthKit {
 
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKObjectType))]
@@ -1327,7 +1311,6 @@ namespace HealthKit {
 
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKSampleType
@@ -1364,7 +1347,6 @@ namespace HealthKit {
 
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKSampleType))]
@@ -1381,7 +1363,6 @@ namespace HealthKit {
 
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKSampleType))]
@@ -1399,7 +1380,6 @@ namespace HealthKit {
 	[Watch (8, 0), iOS (15, 0)]
 	delegate void HKObserverQueryDescriptorUpdateHandler (HKObserverQuery query, NSSet<HKSampleType> samples, [BlockCallback] Action completion, NSError error);
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKQuery))]
@@ -1416,7 +1396,6 @@ namespace HealthKit {
 		NativeHandle Constructor (HKQueryDescriptor [] queryDescriptors, HKObserverQueryDescriptorUpdateHandler updateHandler);
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
@@ -1436,7 +1415,6 @@ namespace HealthKit {
 		NSComparisonResult Compare (HKQuantity quantity);
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKSample))]
@@ -1471,7 +1449,6 @@ namespace HealthKit {
 		nint Count { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
@@ -1707,7 +1684,6 @@ namespace HealthKit {
 		NSPredicate GetPredicateForWorkouts (NSPredicate activityPredicate);
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKObject))]
@@ -1741,7 +1717,6 @@ namespace HealthKit {
 
 	delegate void HKSampleQueryResultsHandler (HKSampleQuery query, HKSample [] results, NSError error);
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKQuery))]
@@ -1766,7 +1741,6 @@ namespace HealthKit {
 		NativeHandle Constructor (HKQueryDescriptor [] queryDescriptors, nint limit, NSSortDescriptor [] sortDescriptors, HKSampleQueryResultsHandler resultsHandler);
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
@@ -1785,7 +1759,6 @@ namespace HealthKit {
 
 	delegate void HKSourceQueryCompletionHandler (HKSourceQuery query, NSSet sources, NSError error);
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKQuery))]
@@ -1796,7 +1769,6 @@ namespace HealthKit {
 		NativeHandle Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate objectPredicate, HKSourceQueryCompletionHandler completionHandler);
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
@@ -1876,7 +1848,6 @@ namespace HealthKit {
 
 	delegate void HKStatisticsCollectionEnumerator (HKStatistics result, bool stop);
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
@@ -1901,7 +1872,6 @@ namespace HealthKit {
 	delegate void HKStatisticsCollectionQueryStatisticsUpdateHandler (HKStatisticsCollectionQuery query, HKStatistics statistics, HKStatisticsCollection collection, NSError error);
 
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKQuery))]
@@ -1929,7 +1899,6 @@ namespace HealthKit {
 
 	delegate void HKStatisticsQueryHandler (HKStatisticsQuery query, HKStatistics result, NSError error);
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKQuery))]
@@ -1940,7 +1909,6 @@ namespace HealthKit {
 		NativeHandle Constructor (HKQuantityType quantityType, [NullAllowed] NSPredicate quantitySamplePredicate, HKStatisticsOptions options, HKStatisticsQueryHandler handler);
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	enum HKQuantityTypeIdentifier {
@@ -2297,7 +2265,6 @@ namespace HealthKit {
 		WaterTemperature,
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	enum HKCorrelationTypeIdentifier {
@@ -2314,7 +2281,6 @@ namespace HealthKit {
 		HeartbeatSeries,
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	enum HKCategoryTypeIdentifier {
@@ -2584,7 +2550,6 @@ namespace HealthKit {
 		ProlongedMenstrualPeriods,
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	enum HKCharacteristicTypeIdentifier {
@@ -2612,7 +2577,6 @@ namespace HealthKit {
 		ActivityMoveMode,
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
@@ -2946,7 +2910,6 @@ namespace HealthKit {
 		HKUnit DegreeAngle { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKSample))]
@@ -3078,7 +3041,6 @@ namespace HealthKit {
 		HKStatistics GetStatistics (HKQuantityType quantityType);
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (NSObject))]
@@ -3135,7 +3097,6 @@ namespace HealthKit {
 		NSDateInterval DateInterval { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (8, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (HKSampleType))]
@@ -3145,7 +3106,6 @@ namespace HealthKit {
 		NSString Identifier { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (NSObject))]
@@ -3163,7 +3123,6 @@ namespace HealthKit {
 		HKMetadata Metadata { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (NSObject))]
@@ -3219,7 +3178,6 @@ namespace HealthKit {
 		NativeHandle Constructor (HKDocumentType documentType, [NullAllowed] NSPredicate predicate, nuint limit, [NullAllowed] NSSortDescriptor [] sortDescriptors, bool includeDocumentData, Action<HKDocumentQuery, HKDocumentSample [], bool, NSError> resultsHandler);
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[Static]
@@ -3249,7 +3207,6 @@ namespace HealthKit {
 		NSString UdiDeviceIdentifier { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (NSObject))]
@@ -3265,7 +3222,6 @@ namespace HealthKit {
 		HKWheelchairUse WheelchairUse { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (NSObject))]
@@ -3313,7 +3269,6 @@ namespace HealthKit {
 		//NSOperatingSystemVersion AnyOperatingSystem { get; }
 	}
 
-	[Watch (2, 0)]
 	[iOS (9, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (NSObject))]
@@ -3326,7 +3281,6 @@ namespace HealthKit {
 
 
 	[NoiOS]
-	[Watch (2, 0)]
 	[Mac (13, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3415,7 +3369,6 @@ namespace HealthKit {
 	}
 
 	[NoiOS]
-	[Watch (2, 0)]
 	[Mac (13, 0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -1275,22 +1275,22 @@ namespace ImageIO {
 		[Field ("kCGImagePropertyMakerCanonAspectRatioInfo")]
 		NSString MakerCanonAspectRatioInfo { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("kCGImagePropertyExifISOSpeed")]
 		NSString ExifISOSpeed { get; }
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("kCGImagePropertyExifISOSpeedLatitudeyyy")]
 		NSString ExifISOSpeedLatitudeYyy { get; }
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("kCGImagePropertyExifISOSpeedLatitudezzz")]
 		NSString ExifISOSpeedLatitudeZzz { get; }
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("kCGImagePropertyExifRecommendedExposureIndex")]
 		NSString ExifRecommendedExposureIndex { get; }
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("kCGImagePropertyExifSensitivityType")]
 		NSString ExifSensitivityType { get; }
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Field ("kCGImagePropertyExifStandardOutputSensitivity")]
 		NSString ExifStandardOutputSensitivity { get; }
 
@@ -1316,7 +1316,6 @@ namespace ImageIO {
 		NSString ExifOffsetTimeDigitized { get; }
 
 		[NoMac]
-		[iOS (7, 0)]
 		[Field ("kCGImagePropertyMakerAppleDictionary")]
 		NSString MakerAppleDictionary { get; }
 
@@ -2758,7 +2757,6 @@ namespace ImageIO {
 		NSString HeifDictionary { get; }
 	}
 
-	[iOS (7, 0)]
 	[Static]
 	interface CGImageMetadataTagNamespaces {
 		[Field ("kCGImageMetadataNamespaceExif")]
@@ -2787,7 +2785,6 @@ namespace ImageIO {
 		NSString IPTCExtension { get; }
 	}
 
-	[iOS (7, 0)]
 	[Static]
 	interface CGImageMetadataTagPrefixes {
 		[Field ("kCGImageMetadataPrefixExif")]
@@ -2816,7 +2813,6 @@ namespace ImageIO {
 		NSString IPTCExtension { get; }
 	}
 
-	[iOS (7, 0)]
 	interface CGImageMetadata {
 		[Field ("kCFErrorDomainCGImageMetadata")]
 		NSString ErrorDomain { get; }
@@ -2832,7 +2828,6 @@ namespace ImageIO {
 		[Field ("kCGImageSourceShouldCache")]
 		IntPtr kShouldCache { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Internal]
 		[Field ("kCGImageSourceShouldCacheImmediately")]
@@ -3073,17 +3068,14 @@ namespace ImageIO {
 	[Partial]
 	interface CGCopyImageSourceOptions {
 
-		[iOS (7, 0)]
 		[Internal]
 		[Field ("kCGImageDestinationMetadata")]
 		IntPtr kMetadata { get; }
 
-		[iOS (7, 0)]
 		[Internal]
 		[Field ("kCGImageDestinationMergeMetadata")]
 		IntPtr kMergeMetadata { get; }
 
-		[iOS (7, 0)]
 		[Internal]
 		[Field ("kCGImageMetadataShouldExcludeXMP")]
 		IntPtr kShouldExcludeXMP { get; }
@@ -3094,12 +3086,10 @@ namespace ImageIO {
 		[Field ("kCGImageMetadataShouldExcludeGPS")]
 		IntPtr kShouldExcludeGPS { get; }
 
-		[iOS (7, 0)]
 		[Internal]
 		[Field ("kCGImageDestinationDateTime")]
 		IntPtr kDateTime { get; }
 
-		[iOS (7, 0)]
 		[Internal]
 		[Field ("kCGImageDestinationOrientation")]
 		IntPtr kOrientation { get; }

--- a/src/javascriptcore.cs
+++ b/src/javascriptcore.cs
@@ -19,7 +19,7 @@ namespace JavaScriptCore {
 
 	delegate void JSContextExceptionHandler (JSContext context, JSValue exception);
 
-	[Mac (10, 9), iOS (7, 0)]
+	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	partial interface JSContext {
@@ -93,7 +93,7 @@ namespace JavaScriptCore {
 	[TV (13, 0)]
 	delegate void JSPromiseCreationExecutor (JSValue resolve, JSValue rejected);
 
-	[Mac (10, 9), iOS (7, 0)]
+	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // invalid (null) Handle is returned
 	partial interface JSValue {
@@ -319,7 +319,7 @@ namespace JavaScriptCore {
 		bool IsSymbol { get; }
 	}
 
-	[Mac (10, 9), iOS (7, 0)]
+	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_3_0
 	[DisableDefaultCtor]
@@ -339,7 +339,7 @@ namespace JavaScriptCore {
 		JSValue Value { get; }
 	}
 
-	[Mac (10, 9), iOS (7, 0)]
+	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	partial interface JSVirtualMachine {
@@ -354,7 +354,7 @@ namespace JavaScriptCore {
 		void RemoveManagedReference (NSObject obj, NSObject owner);
 	}
 
-	[Mac (10, 9), iOS (7, 0)]
+	[Mac (10, 9)]
 	[Static]
 	interface JSPropertyDescriptorKeys {
 
@@ -377,7 +377,7 @@ namespace JavaScriptCore {
 		NSString Set { get; }
 	}
 
-	[Mac (10, 9), iOS (7, 0)]
+	[Mac (10, 9)]
 #if NET
 	[Protocol, Model]
 #else

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -107,7 +107,7 @@ namespace MapKit {
 		// optional, not implemented by MKPolygon, MKPolyline and MKCircle
 		// implemented by MKTileOverlay (and defined there)
 		[OptionalImplementation]
-		[iOS (7, 0), Export ("canReplaceMapContent")]
+		[Export ("canReplaceMapContent")]
 		bool CanReplaceMapContent { get; }
 	}
 
@@ -290,11 +290,11 @@ namespace MapKit {
 	interface MKDirectionsRequest {
 		[NullAllowed] // by default this property is null
 		[Export ("destination")]
-		MKMapItem Destination { get; [iOS (7, 0)] set; }
+		MKMapItem Destination { get; set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("source")]
-		MKMapItem Source { get; [iOS (7, 0)] set; }
+		MKMapItem Source { get; set; }
 
 		[Export ("initWithContentsOfURL:")]
 		NativeHandle Constructor (NSUrl url);
@@ -303,18 +303,18 @@ namespace MapKit {
 		[Export ("isDirectionsRequestURL:")]
 		bool IsDirectionsRequestUrl (NSUrl url);
 
-		[iOS (7, 0), Export ("transportType")]
+		[Export ("transportType")]
 		MKDirectionsTransportType TransportType { get; set; }
 
-		[iOS (7, 0), Export ("requestsAlternateRoutes")]
+		[Export ("requestsAlternateRoutes")]
 		bool RequestsAlternateRoutes { get; set; }
 
 		[NullAllowed] // by default this property is null
-		[iOS (7, 0), Export ("departureDate", ArgumentSemantic.Copy)]
+		[Export ("departureDate", ArgumentSemantic.Copy)]
 		NSDate DepartureDate { get; set; }
 
 		[NullAllowed] // by default this property is null
-		[iOS (7, 0), Export ("arrivalDate", ArgumentSemantic.Copy)]
+		[Export ("arrivalDate", ArgumentSemantic.Copy)]
 		NSDate ArrivalDate { get; set; }
 
 		[Mac (13, 0), iOS (16, 0), MacCatalyst (16, 0), NoWatch, TV (16, 0)]
@@ -639,54 +639,52 @@ namespace MapKit {
 		[Export ("setUserTrackingMode:animated:")]
 		void SetUserTrackingMode (MKUserTrackingMode trackingMode, bool animated);
 
-		[iOS (7, 0), Export ("camera", ArgumentSemantic.Copy)]
+		[Export ("camera", ArgumentSemantic.Copy)]
 		MKMapCamera Camera { get; set; }
 
-		[iOS (7, 0), Export ("setCamera:animated:")]
+		[Export ("setCamera:animated:")]
 		void SetCamera (MKMapCamera camera, bool animated);
 
 		[NoTV]
-		[iOS (7, 0), Export ("rotateEnabled")]
+		[Export ("rotateEnabled")]
 		bool RotateEnabled { [Bind ("isRotateEnabled")] get; set; }
 
 		[NoTV]
-		[iOS (7, 0), Export ("pitchEnabled")]
+		[Export ("pitchEnabled")]
 		bool PitchEnabled { [Bind ("isPitchEnabled")] get; set; }
 
-		[iOS (7, 0), Export ("showAnnotations:animated:")]
+		[Export ("showAnnotations:animated:")]
 		void ShowAnnotations (IMKAnnotation [] annotations, bool animated);
 
-		[iOS (7, 0), Export ("addOverlay:level:")]
+		[Export ("addOverlay:level:")]
 		[PostGet ("Overlays")]
 		void AddOverlay (IMKOverlay overlay, MKOverlayLevel level);
 
-		[iOS (7, 0), Export ("addOverlays:level:")]
+		[Export ("addOverlays:level:")]
 		[PostGet ("Overlays")]
 		void AddOverlays (IMKOverlay [] overlays, MKOverlayLevel level);
 
-		[iOS (7, 0), Export ("exchangeOverlay:withOverlay:")]
+		[Export ("exchangeOverlay:withOverlay:")]
 		[PostGet ("Overlays")]
 		void ExchangeOverlay (IMKOverlay overlay1, IMKOverlay overlay2);
 
-		[iOS (7, 0), Export ("insertOverlay:atIndex:level:")]
+		[Export ("insertOverlay:atIndex:level:")]
 		[PostGet ("Overlays")]
 		void InsertOverlay (IMKOverlay overlay, nuint index, MKOverlayLevel level);
 
-		[iOS (7, 0), Export ("overlaysInLevel:")]
+		[Export ("overlaysInLevel:")]
 		IMKOverlay [] OverlaysInLevel (MKOverlayLevel level);
 
-		[iOS (7, 0), Export ("rendererForOverlay:")]
+		[Export ("rendererForOverlay:")]
 		[return: NullAllowed]
 		MKOverlayRenderer RendererForOverlay (IMKOverlay overlay);
 
 		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'PointOfInterestFilter' instead.")]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'PointOfInterestFilter' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'PointOfInterestFilter' instead.")]
-		[iOS (7, 0)]
 		[Export ("showsPointsOfInterest")]
 		bool ShowsPointsOfInterest { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("showsBuildings")]
 		bool ShowsBuildings { get; set; }
 
@@ -834,16 +832,16 @@ namespace MapKit {
 		[Export ("mapView:didChangeUserTrackingMode:animated:"), EventArgs ("MMapViewUserTracking")]
 		void DidChangeUserTrackingMode (MKMapView mapView, MKUserTrackingMode mode, bool animated);
 
-		[iOS (7, 0), Export ("mapView:rendererForOverlay:"), DelegateName ("MKRendererForOverlayDelegate"), DefaultValue (null)]
+		[Export ("mapView:rendererForOverlay:"), DelegateName ("MKRendererForOverlayDelegate"), DefaultValue (null)]
 		MKOverlayRenderer OverlayRenderer (MKMapView mapView, IMKOverlay overlay);
 
-		[iOS (7, 0), Export ("mapView:didAddOverlayRenderers:"), EventArgs ("MKDidAddOverlayRenderers")]
+		[Export ("mapView:didAddOverlayRenderers:"), EventArgs ("MKDidAddOverlayRenderers")]
 		void DidAddOverlayRenderers (MKMapView mapView, MKOverlayRenderer [] renderers);
 
-		[iOS (7, 0), Export ("mapViewWillStartRenderingMap:")]
+		[Export ("mapViewWillStartRenderingMap:")]
 		void WillStartRenderingMap (MKMapView mapView);
 
-		[iOS (7, 0), Export ("mapViewDidFinishRenderingMap:fullyRendered:"), EventArgs ("MKDidFinishRenderingMap")]
+		[Export ("mapViewDidFinishRenderingMap:fullyRendered:"), EventArgs ("MKDidFinishRenderingMap")]
 		void DidFinishRenderingMap (MKMapView mapView, bool fullyRendered);
 
 		[TV (11, 0)]
@@ -1416,7 +1414,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (MKOverlayPathRenderer))]
+	[BaseType (typeof (MKOverlayPathRenderer))]
 	[Mac (10, 9)]
 	partial interface MKCircleRenderer {
 
@@ -1439,7 +1437,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	[Mac (10, 9)]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Cannot initialize MKDirections with nil request
 	partial interface MKDirections {
@@ -1469,7 +1467,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	[Mac (10, 9)]
 	partial interface MKETAResponse {
 		[Export ("source")]
@@ -1501,7 +1499,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	[Mac (10, 9)]
 	partial interface MKDirectionsResponse {
 
@@ -1517,7 +1515,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	[Mac (10, 9)]
 	partial interface MKRoute {
 
@@ -1553,7 +1551,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	[Mac (10, 9)]
 	partial interface MKRouteStep {
 
@@ -1575,7 +1573,7 @@ namespace MapKit {
 	}
 
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSFormatter))]
+	[BaseType (typeof (NSFormatter))]
 	[Mac (10, 9)]
 	partial interface MKDistanceFormatter {
 
@@ -1598,7 +1596,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (MKPolyline))]
+	[BaseType (typeof (MKPolyline))]
 	[Mac (10, 9)]
 	partial interface MKGeodesicPolyline {
 
@@ -1613,7 +1611,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	[Mac (10, 9)]
 	partial interface MKMapCamera : NSCopying, NSSecureCoding {
 
@@ -1656,7 +1654,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	[Mac (10, 9)]
 	partial interface MKMapSnapshot {
 
@@ -1680,7 +1678,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	[Mac (10, 9)]
 	partial interface MKMapSnapshotOptions : NSCopying {
 
@@ -1733,7 +1731,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	[Mac (10, 9)]
 	partial interface MKMapSnapshotter {
 
@@ -1760,7 +1758,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (MKOverlayRenderer))]
+	[BaseType (typeof (MKOverlayRenderer))]
 	[Mac (10, 9)]
 	[ThreadSafe]
 	partial interface MKOverlayPathRenderer {
@@ -1824,7 +1822,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	[Mac (10, 9)]
 	partial interface MKOverlayRenderer {
 
@@ -1880,7 +1878,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (MKOverlayPathRenderer))]
+	[BaseType (typeof (MKOverlayPathRenderer))]
 	[Mac (10, 9)]
 	partial interface MKPolygonRenderer {
 
@@ -1903,7 +1901,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (MKOverlayPathRenderer))]
+	[BaseType (typeof (MKOverlayPathRenderer))]
 	[Mac (10, 9)]
 	partial interface MKPolylineRenderer {
 
@@ -1944,7 +1942,7 @@ namespace MapKit {
 	[ThreadSafe]
 	[TV (9, 2)]
 	[Mac (10, 9)]
-	[iOS (7, 0), BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	partial interface MKTileOverlay : MKOverlay {
 		[DesignatedInitializer]
 		[Export ("initWithURLTemplate:")]
@@ -1985,7 +1983,7 @@ namespace MapKit {
 
 	[NoWatch]
 	[TV (9, 2)]
-	[iOS (7, 0), BaseType (typeof (MKOverlayRenderer))]
+	[BaseType (typeof (MKOverlayRenderer))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: Expected a MKTileOverlay but got (null)
 	[DisableDefaultCtor] // throw in iOS8 beta 1 ^
 	[Mac (10, 9)]

--- a/src/mediaaccessibility.cs
+++ b/src/mediaaccessibility.cs
@@ -8,7 +8,7 @@ namespace MediaAccessibility {
 #if NET
 	[Static]
 	interface MACaptionAppearance {
-		[iOS (7,0)][Mac (10,9)]
+		[Mac (10,9)]
 		[Notification]
 		[Field ("kMACaptionAppearanceSettingsChangedNotification")]
 		NSString SettingsChangedNotification { get; }
@@ -26,7 +26,6 @@ namespace MediaAccessibility {
 
 	[Static]
 	interface MAMediaCharacteristic {
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Field ("MAMediaCharacteristicDescribesMusicAndSoundForAccessibility")]
 		NSString DescribesMusicAndSoundForAccessibility { get; }
@@ -36,7 +35,6 @@ namespace MediaAccessibility {
 		[Field ("MAMediaCharacteristicDescribesVideoForAccessibility")]
 		NSString DescribesVideoForAccessibility { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Field ("MAMediaCharacteristicTranscribesSpokenDialogForAccessibility")]
 		NSString TranscribesSpokenDialogForAccessibility { get; }

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -190,7 +190,6 @@ namespace MediaPlayer {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ArtworkProperty { get; }
 
-		[iOS (7, 0)]
 		[Field ("MPMediaItemPropertyIsExplicit")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString IsExplicitProperty { get; }
@@ -456,16 +455,13 @@ namespace MediaPlayer {
 		[Export ("valueForProperty:")]
 		NSObject ValueForProperty (string property);
 
-		[iOS (7, 0)]
 		[Export ("persistentID")]
 		ulong PersistentID { get; }
 
-		[iOS (7, 0)]
 		[Export ("name")]
 		[NullAllowed]
 		string Name { get; }
 
-		[iOS (7, 0)]
 		[Export ("playlistAttributes")]
 		MPMediaPlaylistAttribute PlaylistAttributes { get; }
 
@@ -1381,30 +1377,25 @@ namespace MediaPlayer {
 		[Export ("routeButtonRectForBounds:")]
 		CGRect GetRouteButtonRect (CGRect bounds);
 
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'AVRouteDetector.MultipleRoutesDetected' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'AVRouteDetector.MultipleRoutesDetected' instead.")]
 		[Export ("wirelessRoutesAvailable")]
 		bool AreWirelessRoutesAvailable { [Bind ("areWirelessRoutesAvailable")] get; }
 
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'AVPlayer.ExternalPlaybackActive' instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'AVPlayer.ExternalPlaybackActive' instead.")]
 		[Export ("wirelessRouteActive")]
 		bool IsWirelessRouteActive { [Bind ("isWirelessRouteActive")] get; }
 
-		[iOS (7, 0)]
 		[NullAllowed] // by default this property is null
 		[Export ("volumeWarningSliderImage", ArgumentSemantic.Retain)]
 		UIImage VolumeWarningSliderImage { get; set; }
 
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'AVRouteDetector.MultipleRoutesDetectedDidChange' instead.")]
 		[Notification]
 		[Field ("MPVolumeViewWirelessRoutesAvailableDidChangeNotification")]
 		NSString WirelessRoutesAvailableDidChangeNotification { get; }
 
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'AVPlayer.ExternalPlaybackActive' KVO instead.")]
 		[Notification]
 		[Field ("MPVolumeViewWirelessRouteActiveDidChangeNotification")]
@@ -2026,7 +2017,6 @@ namespace MediaPlayer {
 		bool IsAutomaticLegibleLanguageOption { get; }
 
 		[iOS (9, 1)]
-		[TV (9, 0)]
 		[Export ("isAutomaticAudibleLanguageOption")]
 		bool IsAutomaticAudibleLanguageOption { get; }
 	}
@@ -2292,7 +2282,6 @@ namespace MediaPlayer {
 	}
 
 	[iOS (9, 0)]
-	[TV (9, 0)]
 	[Mac (10, 12, 1)]
 	[Watch (6, 0)]
 	[Category]
@@ -2304,7 +2293,6 @@ namespace MediaPlayer {
 	}
 
 	[iOS (9, 0)]
-	[TV (9, 0)]
 	[Mac (10, 12, 1)]
 	[Watch (6, 0)]
 	[Category]

--- a/src/messageui.cs
+++ b/src/messageui.cs
@@ -91,27 +91,22 @@ namespace MessageUI {
 		[Export ("canSendText")]
 		bool CanSendText { get; }
 
-		[iOS (7, 0)]
 		[Static]
 		[Export ("canSendAttachments")]
 		bool CanSendAttachments { get; }
 
-		[iOS (7, 0)]
 		[Static]
 		[Export ("canSendSubject")]
 		bool CanSendSubject { get; }
 
-		[iOS (7, 0)]
 		[Static]
 		[Export ("isSupportedAttachmentUTI:")]
 		bool IsSupportedAttachment (string uti);
 
-		[iOS (7, 0)]
 		[NullAllowed]
 		[Export ("subject", ArgumentSemantic.Copy)]
 		string Subject { get; set; }
 
-		[iOS (7, 0)]
 		[return: NullAllowed]
 		[Export ("attachments")]
 		NSDictionary [] GetAttachments ();
@@ -120,11 +115,9 @@ namespace MessageUI {
 		[NullAllowed, Export ("message", ArgumentSemantic.Copy)]
 		MSMessage Message { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("addAttachmentURL:withAlternateFilename:")]
 		bool AddAttachment (NSUrl attachmentURL, [NullAllowed] string alternateFilename);
 
-		[iOS (7, 0)]
 		[Export ("addAttachmentData:typeIdentifier:filename:")]
 		bool AddAttachment (NSData attachmentData, string uti, string filename);
 
@@ -132,7 +125,6 @@ namespace MessageUI {
 		[Export ("insertCollaborationItemProvider:")]
 		bool InsertCollaboration (NSItemProvider itemProvider);
 
-		[iOS (7, 0)]
 		[Export ("disableUserAttachments")]
 		void DisableUserAttachments ();
 
@@ -143,11 +135,9 @@ namespace MessageUI {
 		[Field ("MFMessageComposeViewControllerTextMessageAvailabilityKey")]
 		NSString TextMessageAvailabilityKey { get; }
 
-		[iOS (7, 0)]
 		[Field ("MFMessageComposeViewControllerAttachmentAlternateFilename")]
 		NSString AttachmentAlternateFilename { get; }
 
-		[iOS (7, 0)]
 		[Field ("MFMessageComposeViewControllerAttachmentURL")]
 		NSString AttachmentURL { get; }
 	}

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -3923,7 +3923,6 @@ namespace Metal {
 	interface IMTLHeap { }
 	[iOS (8, 0)]
 	[Mac (10, 11)]
-	[TV (9, 0)]
 	[MacCatalyst (13, 1)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
 	partial interface MTLResource {

--- a/src/mobilecoreservices.cs
+++ b/src/mobilecoreservices.cs
@@ -534,7 +534,6 @@ namespace MobileCoreServices {
 
 		[Watch (2, 2)]
 		[iOS (9, 1)]
-		[TV (9, 0)]
 		[NoMac]
 		[Field ("kUTTypeLivePhoto", "+CoreServices")]
 		NSString LivePhoto { get; }

--- a/src/multipeerconnectivity.cs
+++ b/src/multipeerconnectivity.cs
@@ -25,7 +25,6 @@ using NativeHandle = System.IntPtr;
 namespace MultipeerConnectivity {
 
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: -[MCPeerID init]: unrecognized selector sent to instance 0x7d721090
@@ -42,7 +41,6 @@ namespace MultipeerConnectivity {
 	delegate void MCSessionNearbyConnectionDataForPeerCompletionHandler (NSData connectionData, NSError error);
 
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash when calling `description` selector
@@ -115,7 +113,6 @@ namespace MultipeerConnectivity {
 	}
 
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -146,7 +143,6 @@ namespace MultipeerConnectivity {
 	}
 
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCNearbyServiceAdvertiser init]: unrecognized selector sent to instance 0x19195e50
@@ -183,7 +179,6 @@ namespace MultipeerConnectivity {
 	delegate void MCNearbyServiceAdvertiserInvitationHandler (bool accept, [NullAllowed] MCSession session);
 
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -199,7 +194,6 @@ namespace MultipeerConnectivity {
 	}
 
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCNearbyServiceBrowser init]: unrecognized selector sent to instance 0x15519a70
@@ -233,7 +227,6 @@ namespace MultipeerConnectivity {
 	}
 
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -256,7 +249,6 @@ namespace MultipeerConnectivity {
 
 	[Mac (10, 10)]
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[BaseType (typeof (UIViewController))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCPeerPickerViewController initWithNibName:bundle:]: unrecognized selector sent to instance 0x15517b90
 	partial interface MCBrowserViewController : MCNearbyServiceBrowserDelegate {
@@ -295,7 +287,6 @@ namespace MultipeerConnectivity {
 	}
 
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -317,7 +308,6 @@ namespace MultipeerConnectivity {
 	}
 
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: -[MCAdvertiserAssistant init]: unrecognized selector sent to instance 0x7ea7fa40
@@ -352,7 +342,6 @@ namespace MultipeerConnectivity {
 	}
 
 	[TV (10, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
 	[Model]

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -96,7 +96,6 @@ namespace PassKit {
 		[Export ("replacePassWithPass:")]
 		bool Replace (PKPass pass);
 
-		[iOS (7, 0)]
 		[Export ("addPasses:withCompletionHandler:")]
 		[Async]
 		void AddPasses (PKPass [] passes, [NullAllowed] Action<PKPassLibraryAddPassesStatus> completion);
@@ -693,7 +692,6 @@ namespace PassKit {
 		[Export ("initWithPass:")]
 		NativeHandle Constructor (PKPass pass);
 
-		[iOS (7, 0)]
 		[Export ("initWithPasses:")]
 		NativeHandle Constructor (PKPass [] pass);
 
@@ -885,7 +883,6 @@ namespace PassKit {
 		NSString ErrorDomain { get; }
 #endif
 
-		[iOS (7, 0)]
 		[NullAllowed, Export ("userInfo", ArgumentSemantic.Copy)]
 		NSDictionary UserInfo { get; }
 

--- a/src/safariservices.cs
+++ b/src/safariservices.cs
@@ -60,7 +60,6 @@ namespace SafariServices {
 	}
 
 	[NoMac]
-	[iOS (7, 0)]
 	[Introduced (PlatformName.MacCatalyst, 13, 4)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Misuse of SSReadingList interface. Use class method defaultReadingList.

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -228,7 +228,6 @@ namespace SceneKit {
 
 		[Abstract]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'SCNAnimationPlayer.Paused' instead.")]
-		[TV (9, 0)]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'SCNAnimationPlayer.Paused' instead.")]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'SCNAnimationPlayer.Paused' instead.")]
 		[Mac (10, 9)]
@@ -3023,7 +3022,6 @@ namespace SceneKit {
 	[Watch (3, 0)]
 	[iOS (8, 0)]
 	[MacCatalyst (13, 0)]
-	[TV (9, 0)]
 	[Mac (10, 8)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]

--- a/src/security.cs
+++ b/src/security.cs
@@ -15,7 +15,6 @@ using CoreFoundation;
 namespace Security {
 
 	[Static]
-	[iOS (7, 0)]
 	interface SecPolicyIdentifier {
 		// they are CFString -> https://github.com/Apple-FOSS-Mirror/libsecurity_keychain/blob/master/lib/SecPolicy.cpp
 
@@ -77,7 +76,6 @@ namespace Security {
 	}
 
 	[Static]
-	[iOS (7, 0)]
 	interface SecPolicyPropertyKey {
 		[Field ("kSecPolicyOid")]
 		NSString Oid { get; }
@@ -109,7 +107,6 @@ namespace Security {
 
 
 	[Static]
-	[iOS (7, 0)]
 	interface SecTrustPropertyKey {
 		[Field ("kSecPropertyTypeTitle")]
 		NSString Title { get; }
@@ -119,7 +116,7 @@ namespace Security {
 	}
 
 	[Static]
-	[iOS (7, 0), Mac (10, 9)]
+	[Mac (10, 9)]
 	interface SecTrustResultKey {
 		[Field ("kSecTrustEvaluationDate")]
 		NSString EvaluationDate { get; }
@@ -518,12 +515,10 @@ namespace Security {
 		[Field ("kSecAttrAccessible")]
 		IntPtr Accessible { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Field ("kSecAttrSynchronizableAny")]
 		IntPtr SynchronizableAny { get; }
 
-		[iOS (7, 0)]
 		[Mac (10, 9)]
 		[Field ("kSecAttrSynchronizable")]
 		IntPtr Synchronizable { get; }

--- a/src/social.cs
+++ b/src/social.cs
@@ -53,7 +53,6 @@ namespace Social {
 
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use Tencent Weibo SDK instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use Tencent Weibo SDK instead.")]
-		[iOS (7, 0)]
 		[Field ("SLServiceTypeTencentWeibo")]
 		[Mac (10, 9)]
 		NSString TencentWeibo { get; }

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -151,7 +151,6 @@ namespace SpriteKit {
 	[DisableDefaultCtor] // DesignatedInitializer below
 	[Mac (10, 9)]
 	[Watch (3, 0)]
-	[iOS (7, 0)]
 	[MacCatalyst (13, 1)]
 #if MONOMAC
 	[BaseType (typeof (NSResponder))]
@@ -322,7 +321,6 @@ namespace SpriteKit {
 		bool IntersectsNode (SKNode node);
 
 		[iOS (8, 3)]
-		[TV (9, 0)]
 		[Mac (10, 11)]
 		[Export ("isEqualToNode:")]
 		bool IsEqual (SKNode node);
@@ -427,7 +425,6 @@ namespace SpriteKit {
 	[NoMac]
 	[MacCatalyst (13, 1)]
 	[NoWatch]
-	[iOS (7, 0)]
 	[Category, BaseType (typeof (UITouch))]
 	partial interface SKNodeTouches_UITouch {
 
@@ -440,7 +437,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKEffectNode : SKWarpable {
 
@@ -569,7 +565,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKEffectNode))]
 	interface SKScene
 #if !WATCH
@@ -737,7 +732,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKSpriteNode : SKWarpable {
 
@@ -845,7 +839,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	partial interface SKKeyframeSequence : NSSecureCoding, NSCopying {
 
@@ -897,7 +890,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKEmitterNode {
 
@@ -1088,7 +1080,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKShapeNode {
 
@@ -1269,7 +1260,6 @@ namespace SpriteKit {
 	}
 
 	[Watch (3, 0)]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKLabelNode {
@@ -1362,7 +1352,6 @@ namespace SpriteKit {
 
 	[Watch (4, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKVideoNode {
 
@@ -1471,7 +1460,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKCropNode {
 
@@ -1482,7 +1470,6 @@ namespace SpriteKit {
 
 	[NoWatch]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (UIView))]
 #if XAMCORE_3_0
 	[DisableDefaultCtor]
@@ -1601,7 +1588,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	partial interface SKTransition : NSCopying {
@@ -1658,7 +1644,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	partial interface SKTexture : NSSecureCoding, NSCopying {
@@ -1765,7 +1750,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	partial interface SKTextureAtlas : NSSecureCoding {
 
@@ -2246,7 +2230,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // <quote>To create an action, call the class method for the action you are interested in. </quote>
 	partial interface SKAction : NSSecureCoding, NSCopying {
@@ -2698,7 +2681,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[DisableDefaultCtor] // see https://bugzilla.xamarin.com/show_bug.cgi?id=14502
 	[BaseType (typeof (NSObject))]
 	partial interface SKPhysicsBody : NSSecureCoding, NSCopying {
@@ -2841,7 +2823,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // <quote>An SKPhysicsContact object is created automatically by Scene Kit</quote>
 	partial interface SKPhysicsContact {
@@ -2866,7 +2847,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -2884,7 +2864,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject),
 		   Delegates = new string [] { "WeakContactDelegate" },
 		   Events = new Type [] { typeof (SKPhysicsContactDelegate) })]
@@ -2945,7 +2924,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	[Abstract] // <quote>You never instantiate objects of this class directly</quote>
 	partial interface SKPhysicsJoint : NSSecureCoding {
@@ -2967,7 +2945,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKPhysicsJoint))]
 	[DisableDefaultCtor] // impossible to set the `anchor` using the default ctor (see #14511) 
 	partial interface SKPhysicsJointPin {
@@ -2994,7 +2971,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKPhysicsJoint))]
 	[DisableDefaultCtor] // impossible to set the `anchorA` and `anchorB` using the default ctor (see #14511) 
 	partial interface SKPhysicsJointSpring {
@@ -3011,7 +2987,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKPhysicsJoint))]
 	[DisableDefaultCtor] // https://bugzilla.xamarin.com/show_bug.cgi?id=14511
 	partial interface SKPhysicsJointFixed {
@@ -3022,7 +2997,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKPhysicsJoint))]
 	[DisableDefaultCtor] // impossible to set the `anchor` and `axis` using the default ctor (see #14511) 
 	partial interface SKPhysicsJointSliding {
@@ -3042,7 +3016,6 @@ namespace SpriteKit {
 
 	[Watch (3, 0)]
 	[Mac (10, 9)]
-	[iOS (7, 0)]
 	[BaseType (typeof (SKPhysicsJoint))]
 	[DisableDefaultCtor] // impossible to set the `anchorA` and `anchorB` using the default ctor (see #14511) 
 	partial interface SKPhysicsJointLimit {

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -165,7 +165,7 @@ namespace StoreKit {
 		[Export ("quantity")]
 		nint Quantity { get; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[NullAllowed]
 		[Export ("applicationUsername", ArgumentSemantic.Copy)]
 		string ApplicationUsername { get; }
@@ -210,7 +210,7 @@ namespace StoreKit {
 		[Override]
 		NSData RequestData { get; set; }
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[NullAllowed] // by default this property is null
 		[Export ("applicationUsername", ArgumentSemantic.Copy)]
 		[New]
@@ -244,7 +244,7 @@ namespace StoreKit {
 		[Export ("restoreCompletedTransactions")]
 		void RestoreCompletedTransactions ();
 
-		[iOS (7, 0), Mac (10, 9)]
+		[Mac (10, 9)]
 		[Export ("restoreCompletedTransactionsWithApplicationUsername:")]
 		void RestoreCompletedTransactions ([NullAllowed] string username);
 
@@ -524,7 +524,6 @@ namespace StoreKit {
 	}
 
 	[Watch (6, 2)]
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (SKRequest))]
 	interface SKReceiptRefreshRequest {
@@ -543,7 +542,6 @@ namespace StoreKit {
 		SKReceiptProperties ReceiptProperties { get; }
 	}
 
-	[iOS (7, 0)]
 	[Mac (10, 9)]
 	[Watch (6, 2)]
 	[Static, Internal]

--- a/src/tvmlkit.cs
+++ b/src/tvmlkit.cs
@@ -15,7 +15,6 @@ using NativeHandle = System.IntPtr;
 
 namespace TVMLKit {
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVColorType : long {
 		None,
@@ -24,7 +23,6 @@ namespace TVMLKit {
 		LinearGradientLeftToRight
 	}
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVElementAlignment : long {
 		Undefined,
@@ -37,7 +35,6 @@ namespace TVMLKit {
 		Trailing,
 	}
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVElementContentAlignment : long {
 		Undefined,
@@ -46,7 +43,6 @@ namespace TVMLKit {
 		Bottom
 	}
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVElementPosition : long {
 		Undefined,
@@ -75,7 +71,6 @@ namespace TVMLKit {
 		BottomTrailing,
 	}
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVElementEventType : long {
 		Play = 1,
@@ -85,7 +80,6 @@ namespace TVMLKit {
 		Change
 	}
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVElementUpdateType : long {
 		None,
@@ -103,14 +97,12 @@ namespace TVMLKit {
 #endif
 	}
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVElementResettableProperty : long {
 		UpdateType,
 		AutoHighlightIdentifier
 	}
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVImageType : long {
 		Image,
@@ -119,7 +111,6 @@ namespace TVMLKit {
 		Hero
 	}
 
-	[TV (9, 0)]
 	[Native]
 	[ErrorDomain ("TVMLKitErrorDomain")]
 	public enum TVMLKitError : long {
@@ -129,7 +120,6 @@ namespace TVMLKit {
 		Last
 	}
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVViewElementStyleType : long {
 		Integer = 1,
@@ -142,7 +132,6 @@ namespace TVMLKit {
 		EdgeInsets
 	}
 
-	[TV (9, 0)]
 	[Native]
 	public enum TVTextElementStyle : long {
 		None,
@@ -209,7 +198,6 @@ namespace TVMLKit {
 		Music,
 	}
 
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	interface TVApplicationControllerContext : NSCopying {
 		[Export ("javaScriptApplicationURL", ArgumentSemantic.Copy)]
@@ -226,7 +214,6 @@ namespace TVMLKit {
 		bool SupportsPictureInPicturePlayback { get; set; }
 	}
 
-	[TV (9, 0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	interface TVApplicationControllerDelegate {
@@ -281,7 +268,6 @@ namespace TVMLKit {
 		void Stop ();
 	}
 
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	interface TVColor : NSCopying {
 		[Export ("colorType")]
@@ -298,7 +284,6 @@ namespace TVMLKit {
 	}
 
 #if false // TVMLKit/TVElementTypes.h was removed from Xcode 7.1 beta 3 (mistake?)
-	[TV (9,0)]
 	[Static]
 	interface TVAttributeKey {
 		// FIXME: does it fit here ?
@@ -396,7 +381,6 @@ namespace TVMLKit {
 		NSString TVAttributeSiriData { get; }
 	}
 
-	[TV (9,0)]
 	[Static]
 	interface TVElementKey {
 		[Field ("TVElementKeyActivityIndicator")]
@@ -692,7 +676,6 @@ namespace TVMLKit {
 	}
 
 	// FIXME: enum'ify ?
-	[TV (9,0)]
 	[Static]
 	interface TVKeyboardType {
 		[Field ("TVKeyboardTypeEmailAddress")]
@@ -706,7 +689,6 @@ namespace TVMLKit {
 	}
 #endif
 
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	interface TVElementFactory {
 		// FIXME: provide System.Type overload
@@ -715,7 +697,6 @@ namespace TVMLKit {
 		void RegisterViewElementClass (Class elementClass, string elementName);
 	}
 
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	interface TVViewElementStyle : NSCopying {
 		// FIXME: badly named, unsure of return value
@@ -804,7 +785,6 @@ namespace TVMLKit {
 		TVColor TintColor { get; }
 	}
 
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	interface TVViewElement : NSCopying {
 		[Export ("elementIdentifier")]
@@ -856,7 +836,6 @@ namespace TVMLKit {
 		NSDictionary<NSString, NSObject> ElementData { get; }
 	}
 
-	[TV (9, 0)]
 	[BaseType (typeof (TVViewElement))]
 	interface TVImageElement {
 		[NullAllowed, Export ("URL")]
@@ -869,7 +848,6 @@ namespace TVMLKit {
 		TVImageType ImageType { get; }
 	}
 
-	[TV (9, 0)]
 	[Protocol]
 	interface TVInterfaceCreating {
 		[Export ("viewForElement:existingView:")]
@@ -902,7 +880,6 @@ namespace TVMLKit {
 
 	interface ITVInterfaceCreating { }
 
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	interface TVInterfaceFactory : TVInterfaceCreating {
 		[Static]
@@ -913,7 +890,6 @@ namespace TVMLKit {
 		ITVInterfaceCreating ExtendedInterfaceCreator { get; set; }
 	}
 
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	interface TVStyleFactory {
 		[Static]
@@ -921,7 +897,6 @@ namespace TVMLKit {
 		void RegisterStyle (string styleName, TVViewElementStyleType type, bool inherited);
 	}
 
-	[TV (9, 0)]
 	[BaseType (typeof (TVViewElement))]
 	interface TVTextElement {
 		[NullAllowed, Export ("attributedText")]

--- a/src/tvservices.cs
+++ b/src/tvservices.cs
@@ -12,7 +12,6 @@ using NativeHandle = System.IntPtr;
 
 namespace TVServices {
 
-	[TV (9, 0)]
 	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'TVTopShelfContentProvider' instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -28,7 +27,6 @@ namespace TVServices {
 		NativeHandle Constructor (string identifier, [NullAllowed] TVContentIdentifier container);
 	}
 
-	[TV (9, 0)]
 	[BaseType (typeof (NSObject))]
 	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'TVTopShelfItem' instead.")]
 	[DisableDefaultCtor]
@@ -90,7 +88,6 @@ namespace TVServices {
 		void SetImageUrl ([NullAllowed] NSUrl aUrl, TVContentItemImageTrait traits);
 	}
 
-	[TV (9, 0)]
 	[Protocol]
 	interface TVTopShelfProvider {
 		[Abstract]
@@ -102,7 +99,6 @@ namespace TVServices {
 		TVContentItem [] TopShelfItems { get; }
 	}
 
-	[TV (9, 0)]
 	[Static]
 	interface TVTopShelfItems {
 		[Notification]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -486,13 +486,11 @@ namespace UIKit {
 
 	[Category, BaseType (typeof (NSMutableAttributedString))]
 	interface NSMutableAttributedStringKitAdditions {
-		[iOS (7, 0)]
 		[Export ("fixAttributesInRange:")]
 		void FixAttributesInRange (NSRange range);
 	}
 
 	[NoWatch]
-	[iOS (7, 0)] // Yup, it is declared as appearing in 7.0, even if it shipped with 8.0
 	[Category, BaseType (typeof (NSLayoutConstraint))]
 	interface NSIdentifier {
 		[Export ("identifier")]
@@ -778,24 +776,19 @@ namespace UIKit {
 		[Field ("UIAccessibilityPageScrolledNotification")]
 		int PageScrolledNotification { get; } // This is int, not nint
 
-		[iOS (7, 0)]
 		[NullAllowed] // by default this property is null
 		[Export ("accessibilityPath", ArgumentSemantic.Copy)]
 		UIBezierPath AccessibilityPath { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("accessibilityActivate")]
 		bool AccessibilityActivate ();
 
-		[iOS (7, 0)]
 		[Field ("UIAccessibilitySpeechAttributePunctuation")]
 		NSString SpeechAttributePunctuation { get; }
 
-		[iOS (7, 0)]
 		[Field ("UIAccessibilitySpeechAttributeLanguage")]
 		NSString SpeechAttributeLanguage { get; }
 
-		[iOS (7, 0)]
 		[Field ("UIAccessibilitySpeechAttributePitch")]
 		NSString SpeechAttributePitch { get; }
 
@@ -886,7 +879,7 @@ namespace UIKit {
 
 		// FIXME: we only used this on a few types before, none of them available on tvOS
 		// but a new member was added to the platform... 
-		[TV (9, 0), NoWatch, NoiOS]
+		[NoWatch, NoiOS]
 		[NullAllowed, Export ("accessibilityHeaderElements", ArgumentSemantic.Copy)]
 		NSObject [] AccessibilityHeaderElements { get; set; }
 
@@ -1465,7 +1458,6 @@ namespace UIKit {
 		[Export ("activityDidFinish:")]
 		void Finished (bool completed);
 
-		[iOS (7, 0)]
 		[Export ("activityCategory"), Static]
 		UIActivityCategory Category { get; }
 	}
@@ -1500,23 +1492,18 @@ namespace UIKit {
 		[Field ("UIActivityTypeSaveToCameraRoll")]
 		NSString SaveToCameraRoll { get; }
 
-		[iOS (7, 0)]
 		[Field ("UIActivityTypeAddToReadingList")]
 		NSString AddToReadingList { get; }
 
-		[iOS (7, 0)]
 		[Field ("UIActivityTypePostToFlickr")]
 		NSString PostToFlickr { get; }
 
-		[iOS (7, 0)]
 		[Field ("UIActivityTypePostToVimeo")]
 		NSString PostToVimeo { get; }
 
-		[iOS (7, 0)]
 		[Field ("UIActivityTypePostToTencentWeibo")]
 		NSString PostToTencentWeibo { get; }
 
-		[iOS (7, 0)]
 		[Field ("UIActivityTypeAirDrop")]
 		NSString AirDrop { get; }
 
@@ -1591,15 +1578,12 @@ namespace UIKit {
 		[Export ("activityViewController:itemForActivityType:")]
 		NSObject GetItemForActivity (UIActivityViewController activityViewController, [NullAllowed] NSString activityType);
 
-		[iOS (7, 0)]
 		[Export ("activityViewController:dataTypeIdentifierForActivityType:")]
 		string GetDataTypeIdentifierForActivity (UIActivityViewController activityViewController, [NullAllowed] NSString activityType);
 
-		[iOS (7, 0)]
 		[Export ("activityViewController:subjectForActivityType:")]
 		string GetSubjectForActivity (UIActivityViewController activityViewController, [NullAllowed] NSString activityType);
 
-		[iOS (7, 0)]
 		[Export ("activityViewController:thumbnailImageForActivityType:suggestedSize:")]
 		UIImage GetThumbnailImageForActivity (UIActivityViewController activityViewController, [NullAllowed] NSString activityType, CGSize suggestedSize);
 
@@ -1874,7 +1858,7 @@ namespace UIKit {
 
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -1900,7 +1884,7 @@ namespace UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	interface UIObjectRestoration {
 #if false
 		// a bit hard to support *static* as part of an interface / extension methods
@@ -2482,11 +2466,9 @@ namespace UIKit {
 		[Field ("UIApplicationLaunchOptionsNewsstandDownloadsKey")]
 		NSString LaunchOptionsNewsstandDownloadsKey { get; }
 
-		[iOS (7, 0)]
 		[Field ("UIApplicationLaunchOptionsBluetoothCentralsKey")]
 		NSString LaunchOptionsBluetoothCentralsKey { get; }
 
-		[iOS (7, 0)]
 		[Field ("UIApplicationLaunchOptionsBluetoothPeripheralsKey")]
 		NSString LaunchOptionsBluetoothPeripheralsKey { get; }
 
@@ -2528,40 +2510,33 @@ namespace UIKit {
 		//
 		// 7.0
 		//
-		[iOS (7, 0)]
 		[Field ("UIContentSizeCategoryDidChangeNotification")]
 		[Notification (typeof (UIContentSizeCategoryChangedEventArgs))]
 		NSString ContentSizeCategoryChangedNotification { get; }
 
 		[ThreadSafe]
-		[iOS (7, 0)]
 		[RequiresSuper]
 		[Export ("beginBackgroundTaskWithName:expirationHandler:")]
 		nint BeginBackgroundTask (string taskName, Action expirationHandler);
 
 		[TV (11, 0)]
-		[iOS (7, 0)]
 		[Field ("UIApplicationBackgroundFetchIntervalMinimum")]
 		double BackgroundFetchIntervalMinimum { get; }
 
 		[TV (11, 0)]
-		[iOS (7, 0)]
 		[Field ("UIApplicationBackgroundFetchIntervalNever")]
 		double BackgroundFetchIntervalNever { get; }
 
 		[TV (11, 0)]
-		[iOS (7, 0)]
 		[Export ("setMinimumBackgroundFetchInterval:")]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use a 'BGAppRefreshTask' from 'BackgroundTasks' framework.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use a 'BGAppRefreshTask' from 'BackgroundTasks' framework.")]
 		void SetMinimumBackgroundFetchInterval (double minimumBackgroundFetchInterval);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		[iOS (7, 0)]
 		[Export ("preferredContentSizeCategory")]
 		NSString PreferredContentSizeCategory { get; }
 
-		[iOS (7, 0)]
 		[Wrap ("UIContentSizeCategoryExtensions.GetValue (SharedApplication.PreferredContentSizeCategory)")]
 		UIContentSizeCategory GetPreferredContentSizeCategory ();
 
@@ -2590,36 +2565,29 @@ namespace UIKit {
 		void RequestSceneSessionRefresh (UISceneSession sceneSession);
 
 		// from @interface UIApplication (UIStateRestoration)
-		[iOS (7, 0)]
 		[Export ("ignoreSnapshotOnNextApplicationLaunch")]
 		void IgnoreSnapshotOnNextApplicationLaunch ();
 
 		// from @interface UIApplication (UIStateRestoration)
 		[Export ("registerObjectForStateRestoration:restorationIdentifier:")]
-		[iOS (7, 0)]
 		[Static]
 		void RegisterObjectForStateRestoration (IUIStateRestoring uistateRestoringObject, string restorationIdentifier);
 
-		[iOS (7, 0)]
 		[Field ("UIApplicationStateRestorationTimestampKey")]
 		NSString StateRestorationTimestampKey { get; }
 
-		[iOS (7, 0)]
 		[Field ("UIApplicationStateRestorationSystemVersionKey")]
 		NSString StateRestorationSystemVersionKey { get; }
 
 		[TV (11, 0)]
-		[iOS (7, 0)]
 		[Export ("backgroundRefreshStatus")]
 		UIBackgroundRefreshStatus BackgroundRefreshStatus { get; }
 
 		[TV (11, 0)]
-		[iOS (7, 0)]
 		[Notification]
 		[Field ("UIApplicationBackgroundRefreshStatusDidChangeNotification")]
 		NSString BackgroundRefreshStatusDidChangeNotification { get; }
 
-		[iOS (7, 0)]
 		[Notification]
 		[Field ("UIApplicationUserDidTakeScreenshotNotification")]
 		NSString UserDidTakeScreenshotNotification { get; }
@@ -2794,7 +2762,7 @@ namespace UIKit {
 		NSObject TargetContentIdentifier { get; set; }
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[BaseType (typeof (UIDynamicBehavior))]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: init is undefined for objects of type UIAttachmentBehavior
 	interface UIAttachmentBehavior {
@@ -2880,7 +2848,6 @@ namespace UIKit {
 		NSString WeakNewValue { get; }
 	}
 
-	[iOS (7, 0)]
 	[Static]
 	[NoWatch]
 	public enum UIContentSizeCategory {
@@ -3357,16 +3324,13 @@ namespace UIKit {
 		bool AccessibilityPerformMagicTap ();
 
 		[TV (10, 0)]
-		[iOS (7, 0)]
 		[Export ("application:didReceiveRemoteNotification:fetchCompletionHandler:")]
 		void DidReceiveRemoteNotification (UIApplication application, NSDictionary userInfo, Action<UIBackgroundFetchResult> completionHandler);
 
-		[iOS (7, 0)]
 		[Export ("application:handleEventsForBackgroundURLSession:completionHandler:")]
 		void HandleEventsForBackgroundUrl (UIApplication application, string sessionIdentifier, Action completionHandler);
 
 		[TV (11, 0)]
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use a 'BGAppRefreshTask' from 'BackgroundTasks' framework.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use a 'BGAppRefreshTask' from 'BackgroundTasks' framework.")]
 		[Export ("application:performFetchWithCompletionHandler:")]
@@ -3987,22 +3951,18 @@ namespace UIKit {
 		//
 		// 7.0
 		//
-		[iOS (7, 0)]
 		[Export ("startInteractiveTransitionToCollectionViewLayout:completion:")]
 		[Async (ResultTypeName = "UICollectionViewTransitionResult")]
 		UICollectionViewTransitionLayout StartInteractiveTransition (UICollectionViewLayout newCollectionViewLayout,
 										 [NullAllowed] UICollectionViewLayoutInteractiveTransitionCompletion completion);
 
-		[iOS (7, 0)]
 		[Export ("setCollectionViewLayout:animated:completion:")]
 		[Async]
 		void SetCollectionViewLayout (UICollectionViewLayout layout, bool animated, [NullAllowed] UICompletionHandler completion);
 
-		[iOS (7, 0)]
 		[Export ("finishInteractiveTransition")]
 		void FinishInteractiveTransition ();
 
-		[iOS (7, 0)]
 		[Export ("cancelInteractiveTransition")]
 		void CancelInteractiveTransition ();
 
@@ -4241,7 +4201,6 @@ namespace UIKit {
 		[Export ("collectionView:performAction:forItemAtIndexPath:withSender:")]
 		void PerformAction (UICollectionView collectionView, Selector action, NSIndexPath indexPath, NSObject sender);
 
-		[iOS (7, 0)]
 		[Export ("collectionView:transitionLayoutForOldLayout:newLayout:")]
 		UICollectionViewTransitionLayout TransitionLayout (UICollectionView collectionView, UICollectionViewLayout fromLayout, UICollectionViewLayout toLayout);
 
@@ -4449,11 +4408,9 @@ namespace UIKit {
 		[Export ("initWithCollectionViewLayout:")]
 		NativeHandle Constructor (UICollectionViewLayout layout);
 
-		[iOS (7, 0)]
 		[Export ("collectionViewLayout")]
 		UICollectionViewLayout Layout { get; }
 
-		[iOS (7, 0)]
 		[Export ("useLayoutToLayoutNavigationTransitions", ArgumentSemantic.Assign)]
 		bool UseLayoutToLayoutNavigationTransitions { get; set; }
 
@@ -4627,47 +4584,36 @@ namespace UIKit {
 		[Static, Export ("layoutAttributesClass")]
 		Class LayoutAttributesClass { get; }
 
-		[iOS (7, 0)]
 		[Static, Export ("invalidationContextClass")]
 		Class InvalidationContextClass ();
 
-		[iOS (7, 0)]
 		[Export ("invalidationContextForBoundsChange:")]
 		UICollectionViewLayoutInvalidationContext GetInvalidationContextForBoundsChange (CGRect newBounds);
 
-		[iOS (7, 0)]
 		[Export ("indexPathsToDeleteForSupplementaryViewOfKind:")]
 		NSIndexPath [] GetIndexPathsToDeleteForSupplementaryView (NSString kind);
 
-		[iOS (7, 0)]
 		[Export ("indexPathsToDeleteForDecorationViewOfKind:")]
 		NSIndexPath [] GetIndexPathsToDeleteForDecorationViewOfKind (NSString kind);
 
-		[iOS (7, 0)]
 		[Export ("indexPathsToInsertForSupplementaryViewOfKind:")]
 		NSIndexPath [] GetIndexPathsToInsertForSupplementaryView (NSString kind);
 
-		[iOS (7, 0)]
 		[Export ("indexPathsToInsertForDecorationViewOfKind:")]
 		NSIndexPath [] GetIndexPathsToInsertForDecorationView (NSString kind);
 
-		[iOS (7, 0)]
 		[Export ("invalidateLayoutWithContext:")]
 		void InvalidateLayout (UICollectionViewLayoutInvalidationContext context);
 
-		[iOS (7, 0)]
 		[Export ("finalizeLayoutTransition")]
 		void FinalizeLayoutTransition ();
 
-		[iOS (7, 0)]
 		[Export ("prepareForTransitionFromLayout:")]
 		void PrepareForTransitionFromLayout (UICollectionViewLayout oldLayout);
 
-		[iOS (7, 0)]
 		[Export ("prepareForTransitionToLayout:")]
 		void PrepareForTransitionToLayout (UICollectionViewLayout newLayout);
 
-		[iOS (7, 0)]
 		[Export ("targetContentOffsetForProposedContentOffset:")]
 		CGPoint TargetContentOffsetForProposedContentOffset (CGPoint proposedContentOffset);
 
@@ -4743,17 +4689,15 @@ namespace UIKit {
 		[Export ("layoutAttributesForSupplementaryViewOfKind:withIndexPath:")]
 		UICollectionViewLayoutAttributes CreateForSupplementaryView (NSString kind, NSIndexPath indexPath);
 
-		[iOS (7, 0)]
 		[Export ("bounds")]
 		new CGRect Bounds { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("transform")]
 		new CGAffineTransform Transform { get; set; }
 
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UICollectionViewLayoutInvalidationContext {
 		[Export ("invalidateDataSourceCounts")]
@@ -4807,7 +4751,7 @@ namespace UIKit {
 		CGPoint InteractiveMovementTarget { get; }
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[BaseType (typeof (UICollectionViewLayoutInvalidationContext))]
 	partial interface UICollectionViewFlowLayoutInvalidationContext {
 		[Export ("invalidateFlowLayoutDelegateMetrics")]
@@ -4817,7 +4761,7 @@ namespace UIKit {
 		bool InvalidateFlowLayoutAttributes { get; set; }
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[BaseType (typeof (UICollectionViewLayout))]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: -[UICollectionViewTransitionLayout init] is not a valid initializer - use -initWithCurrentLayout:nextLayout: instead
 	interface UICollectionViewTransitionLayout : NSCoding {
@@ -5181,104 +5125,104 @@ namespace UIKit {
 
 #if !NET
 		[Obsolete ("Use 'SystemRed' instead.")]
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemRedColor")]
 		UIColor SystemRedColor { get; }
 #endif
 
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemRedColor")]
 		UIColor SystemRed { get; }
 
 #if !NET
 		[Obsolete ("Use 'SystemGreen' instead.")]
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemGreenColor")]
 		UIColor SystemGreenColor { get; }
 #endif
 
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemGreenColor")]
 		UIColor SystemGreen { get; }
 
 #if !NET
 		[Obsolete ("Use 'SystemBlue' instead.")]
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemBlueColor")]
 		UIColor SystemBlueColor { get; }
 #endif
 
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemBlueColor")]
 		UIColor SystemBlue { get; }
 
 #if !NET
 		[Obsolete ("Use 'SystemOrange' instead.")]
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemOrangeColor")]
 		UIColor SystemOrangeColor { get; }
 #endif
 
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemOrangeColor")]
 		UIColor SystemOrange { get; }
 
 #if !NET
 		[Obsolete ("Use 'SystemYellow' instead.")]
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemYellowColor")]
 		UIColor SystemYellowColor { get; }
 #endif
 
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemYellowColor")]
 		UIColor SystemYellow { get; }
 
 #if !NET
 		[Obsolete ("Use 'SystemPink' instead.")]
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemPinkColor")]
 		UIColor SystemPinkColor { get; }
 #endif
 
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemPinkColor")]
 		UIColor SystemPink { get; }
 
 #if !NET
 		[Obsolete ("Use 'SystemPurple' instead.")]
-		[TV (9, 0), NoWatch, iOS (9, 0)]
+		[NoWatch, iOS (9, 0)]
 		[Static]
 		[Export ("systemPurpleColor")]
 		UIColor SystemPurpleColor { get; }
 #endif
 
-		[TV (9, 0), NoWatch, iOS (9, 0)]
+		[NoWatch, iOS (9, 0)]
 		[Static]
 		[Export ("systemPurpleColor")]
 		UIColor SystemPurple { get; }
 
 #if !NET
 		[Obsolete ("Use 'SystemTeal' instead.")]
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemTealColor")]
 		UIColor SystemTealColor { get; }
 #endif
 
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemTealColor")]
 		UIColor SystemTeal { get; }
@@ -5337,13 +5281,13 @@ namespace UIKit {
 
 #if !NET
 		[Obsolete ("Use 'SystemGray' instead.")]
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemGrayColor")]
 		UIColor SystemGrayColor { get; }
 #endif
 
-		[TV (9, 0), NoWatch, iOS (7, 0)]
+		[NoWatch]
 		[Static]
 		[Export ("systemGrayColor")]
 		UIColor SystemGray { get; }
@@ -5667,7 +5611,7 @@ namespace UIKit {
 		string AccessibilityName { get; }
 	}
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (UIDynamicBehavior),
 		   Delegates = new string [] { "CollisionDelegate" },
 		   Events = new Type [] { typeof (UICollisionBehaviorDelegate) })]
@@ -5722,7 +5666,7 @@ namespace UIKit {
 		void RemoveAllBoundaries ();
 	}
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
 	[Model]
@@ -5885,7 +5829,7 @@ namespace UIKit {
 		void DidPause (UIDynamicAnimator animator);
 	}
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIDynamicAnimator {
 		[DesignatedInitializer]
@@ -5946,7 +5890,7 @@ namespace UIKit {
 
 	}
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (UIDynamicBehavior))]
 	interface UIDynamicItemBehavior {
 		[DesignatedInitializer]
@@ -6003,7 +5947,7 @@ namespace UIKit {
 		bool Anchored { [Bind ("isAnchored")] get; set; }
 	}
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
 	[Model]
@@ -6042,7 +5986,7 @@ namespace UIKit {
 
 	interface IUIDynamicItem { }
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	interface UIDynamicBehavior {
 		[Export ("childBehaviors", ArgumentSemantic.Copy)]
@@ -6288,16 +6232,13 @@ namespace UIKit {
 		[Export ("fontNamesForFamilyName:")]
 		string [] FontNamesForFamilyName (string familyName);
 
-		[iOS (7, 0)]
 		[Export ("fontDescriptor")]
 		UIFontDescriptor FontDescriptor { get; }
 
-		[iOS (7, 0)]
 		[Static, Export ("fontWithDescriptor:size:")]
 		[Internal] // bug 25511
 		IntPtr _FromDescriptor (UIFontDescriptor descriptor, nfloat pointSize);
 
-		[iOS (7, 0)]
 		[Static, Export ("preferredFontForTextStyle:")]
 		[Internal] // bug 25511
 		IntPtr _GetPreferredFontForTextStyle (NSString uiFontTextStyle);
@@ -6318,27 +6259,21 @@ namespace UIKit {
 	}
 
 	public enum UIFontTextStyle {
-		[iOS (7, 0)]
 		[Field ("UIFontTextStyleHeadline")]
 		Headline,
 
-		[iOS (7, 0)]
 		[Field ("UIFontTextStyleBody")]
 		Body,
 
-		[iOS (7, 0)]
 		[Field ("UIFontTextStyleSubheadline")]
 		Subheadline,
 
-		[iOS (7, 0)]
 		[Field ("UIFontTextStyleFootnote")]
 		Footnote,
 
-		[iOS (7, 0)]
 		[Field ("UIFontTextStyleCaption1")]
 		Caption1,
 
-		[iOS (7, 0)]
 		[Field ("UIFontTextStyleCaption2")]
 		Caption2,
 
@@ -6364,7 +6299,6 @@ namespace UIKit {
 		LargeTitle,
 	}
 
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
 	partial interface UIFontDescriptor : NSSecureCoding, NSCopying {
@@ -6638,11 +6572,9 @@ namespace UIKit {
 		[Export ("touchesCancelled:withEvent:")]
 		void TouchesCancelled (NSSet touches, UIEvent evt);
 
-		[iOS (7, 0)]
 		[Export ("shouldRequireFailureOfGestureRecognizer:")]
 		bool ShouldRequireFailureOfGestureRecognizer (UIGestureRecognizer otherGestureRecognizer);
 
-		[iOS (7, 0)]
 		[Export ("shouldBeRequiredToFailByGestureRecognizer:")]
 		bool ShouldBeRequiredToFailByGestureRecognizer (UIGestureRecognizer otherGestureRecognizer);
 
@@ -6701,11 +6633,9 @@ namespace UIKit {
 		[Export ("gestureRecognizerShouldBegin:"), DelegateName ("UIGestureProbe"), DefaultValue (true)]
 		bool ShouldBegin (UIGestureRecognizer recognizer);
 
-		[iOS (7, 0)]
 		[Export ("gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:"), DelegateName ("UIGesturesProbe"), DefaultValue (false)]
 		bool ShouldBeRequiredToFailBy (UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer);
 
-		[iOS (7, 0)]
 		[Export ("gestureRecognizer:shouldRequireFailureOfGestureRecognizer:"), DelegateName ("UIGesturesProbe"), DefaultValue (false)]
 		bool ShouldRequireFailureOf (UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer);
 
@@ -6914,7 +6844,7 @@ namespace UIKit {
 	}
 
 	[BaseType (typeof (UIDynamicBehavior))]
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	interface UIGravityBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
@@ -7118,7 +7048,7 @@ namespace UIKit {
 		NSString IsLocalUserInfoKey { get; }
 	}
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (UICommand))]
 	[DesignatedDefaultCtor]
 	interface UIKeyCommand {
@@ -7814,7 +7744,6 @@ namespace UIKit {
 	}
 
 	[NoWatch, NoTV]
-	[iOS (7, 0)]
 	[BaseType (typeof (UIPanGestureRecognizer))]
 	interface UIScreenEdgePanGestureRecognizer {
 
@@ -8058,12 +7987,10 @@ namespace UIKit {
 
 		[Export ("renderingMode")]
 		[ThreadSafe]
-		[iOS (7, 0)]
 		UIImageRenderingMode RenderingMode { get; }
 
 		[Export ("imageWithRenderingMode:")]
 		[ThreadSafe]
-		[iOS (7, 0)]
 		UIImage ImageWithRenderingMode (UIImageRenderingMode renderingMode);
 
 		[Export ("CGImage")]
@@ -8921,20 +8848,19 @@ namespace UIKit {
 		UIToolTipInteraction ToolTipInteraction { get; }
 	}
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
 	interface UIBarPositioning {
 		[Abstract]
-		[iOS (7, 0)]
 		[Export ("barPosition")]
 		UIBarPosition BarPosition { get; }
 	}
 
 	interface IUIBarPositioning { }
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -9492,12 +9418,10 @@ namespace UIKit {
 		[Export ("isAnimating")]
 		bool IsAnimating { get; }
 
-		[TV (9, 0)]
 		[NoiOS] // UIKIT_AVAILABLE_TVOS_ONLY
 		[Export ("adjustsImageWhenAncestorFocused")]
 		bool AdjustsImageWhenAncestorFocused { get; set; }
 
-		[TV (9, 0)]
 		[NoiOS] // UIKIT_AVAILABLE_TVOS_ONLY
 		[Export ("focusedFrameGuide")]
 		UILayoutGuide FocusedFrameGuide { get; }
@@ -10135,21 +10059,18 @@ namespace UIKit {
 		//
 		// 7.0
 		//
-		[iOS (7, 0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("barTintColor", ArgumentSemantic.Retain)]
 		UIColor BarTintColor { get; set; }
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("backIndicatorImage", ArgumentSemantic.Retain)]
 		UIImage BackIndicatorImage { get; set; }
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("backIndicatorTransitionMaskImage", ArgumentSemantic.Retain)]
@@ -10175,12 +10096,10 @@ namespace UIKit {
 		[NullAllowed, Export ("compactScrollEdgeAppearance", ArgumentSemantic.Copy)]
 		UINavigationBarAppearance CompactScrollEdgeAppearance { get; set; }
 
-		[iOS (7, 0)]
 		[Appearance]
 		[Export ("setBackgroundImage:forBarPosition:barMetrics:")]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIBarPosition barPosition, UIBarMetrics barMetrics);
 
-		[iOS (7, 0)]
 		[Appearance]
 		[Export ("backgroundImageForBarPosition:barMetrics:")]
 		UIImage GetBackgroundImage (UIBarPosition barPosition, UIBarMetrics barMetrics);
@@ -10509,7 +10428,6 @@ namespace UIKit {
 		nfloat HideShowBarDuration { get; }
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("interactivePopGestureRecognizer", ArgumentSemantic.Copy)]
 		UIGestureRecognizer InteractivePopGestureRecognizer { get; }
 
@@ -10561,26 +10479,22 @@ namespace UIKit {
 		void DidShowViewController (UINavigationController navigationController, [Transient] UIViewController viewController, bool animated);
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("navigationControllerSupportedInterfaceOrientations:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UINavigationController,UIInterfaceOrientationMask>")]
 		UIInterfaceOrientationMask SupportedInterfaceOrientations (UINavigationController navigationController);
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("navigationControllerPreferredInterfaceOrientationForPresentation:")]
 		[DelegateName ("Func<UINavigationController,UIInterfaceOrientation>")]
 		[NoDefaultValue]
 		UIInterfaceOrientation GetPreferredInterfaceOrientation (UINavigationController navigationController);
 
-		[iOS (7, 0)]
 		[Export ("navigationController:interactionControllerForAnimationController:")]
 		[DelegateName ("Func<UINavigationController,IUIViewControllerAnimatedTransitioning,IUIViewControllerInteractiveTransitioning>")]
 		[NoDefaultValue]
 		IUIViewControllerInteractiveTransitioning GetInteractionControllerForAnimationController (UINavigationController navigationController, IUIViewControllerAnimatedTransitioning animationController);
 
-		[iOS (7, 0)]
 		[Export ("navigationController:animationControllerForOperation:fromViewController:toViewController:")]
 		[DelegateName ("Func<UINavigationController,UINavigationControllerOperation,UIViewController,UIViewController,IUIViewControllerAnimatedTransitioning>")]
 		[NoDefaultValue]
@@ -10764,14 +10678,12 @@ namespace UIKit {
 		void WillTransition (UIPageViewController pageViewController, UIViewController [] pendingViewControllers);
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("pageViewControllerSupportedInterfaceOrientations:")]
 		[DelegateName ("Func<UIPageViewController,UIInterfaceOrientationMask>")]
 		[DefaultValue (UIInterfaceOrientationMask.All)]
 		UIInterfaceOrientationMask SupportedInterfaceOrientations (UIPageViewController pageViewController);
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("pageViewControllerPreferredInterfaceOrientationForPresentation:")]
 		[DelegateName ("Func<UIPageViewController,UIInterfaceOrientation>")]
 		[DefaultValue (UIInterfaceOrientation.Portrait)]
@@ -11368,7 +11280,7 @@ namespace UIKit {
 		NSProgress ObservedProgress { get; set; }
 	}
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (UIDynamicBehavior))]
 	partial interface UIPushBehavior {
 		[DesignatedInitializer]
@@ -11412,7 +11324,7 @@ namespace UIKit {
 
 	}
 
-	[NoWatch, iOS (7, 0)]
+	[NoWatch]
 	[BaseType (typeof (UIDynamicBehavior))]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: init is undefined for objects of type UISnapBehavior
 	partial interface UISnapBehavior {
@@ -11528,15 +11440,12 @@ namespace UIKit {
 		// 7.0
 		//
 
-		[iOS (7, 0)]
 		[Export ("keyCommands")]
 		UIKeyCommand [] KeyCommands { get; }
 
-		[iOS (7, 0)]
 		[Static, Export ("clearTextInputContextIdentifier:")]
 		void ClearTextInputContextIdentifier (NSString identifier);
 
-		[iOS (7, 0)]
 		[Export ("targetForAction:withSender:")]
 		NSObject GetTargetForAction (Selector action, [NullAllowed] NSObject sender);
 
@@ -11548,11 +11457,9 @@ namespace UIKit {
 		[Export ("validateCommand:")]
 		void ValidateCommand (UICommand command);
 
-		[iOS (7, 0)]
 		[Export ("textInputContextIdentifier")]
 		NSString TextInputContextIdentifier { get; }
 
-		[iOS (7, 0)]
 		[Export ("textInputMode")]
 		UITextInputMode TextInputMode { get; }
 
@@ -11828,7 +11735,6 @@ namespace UIKit {
 		[Notification]
 		NSString CapturedDidChangeNotification { get; }
 
-		[iOS (7, 0)]
 		[return: NullAllowed]
 		[Export ("snapshotViewAfterScreenUpdates:")]
 		UIView SnapshotView (bool afterScreenUpdates);
@@ -12062,13 +11968,11 @@ namespace UIKit {
 		[Field ("UIScrollViewDecelerationRateFast")]
 		nfloat DecelerationRateFast { get; }
 
-		[iOS (7, 0)]
 		[Export ("keyboardDismissMode")]
 		UIScrollViewKeyboardDismissMode KeyboardDismissMode { get; set; }
 
 		[NoWatch]
 		[iOS (11, 0)]
-		[TV (9, 0)]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Configuring the 'PanGestureRecognizer' for indirect scrolling automatically supports directional presses now, so this property is no longer useful.")]
 		[Export ("directionalPressGestureRecognizer")]
 		UIGestureRecognizer DirectionalPressGestureRecognizer { get; }
@@ -12290,22 +12194,19 @@ namespace UIKit {
 		[NullAllowed]
 		UIView InputAccessoryView { get; set; }
 
-		[iOS (7, 0)]
 		[Appearance]
 		[Export ("setBackgroundImage:forBarPosition:barMetrics:")]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIBarPosition barPosition, UIBarMetrics barMetrics);
 
-		[iOS (7, 0)]
 		[Export ("backgroundImageForBarPosition:barMetrics:")]
 		[Appearance]
 		UIImage BackgroundImageForBarPosition (UIBarPosition barPosition, UIBarMetrics barMetrics);
 
-		[iOS (7, 0), Export ("barTintColor", ArgumentSemantic.Retain)]
+		[Export ("barTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor BarTintColor { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("searchBarStyle")]
 		UISearchBarStyle SearchBarStyle { get; set; }
 
@@ -12366,7 +12267,6 @@ namespace UIKit {
 	}
 
 	[NoWatch, iOS (9, 1)]
-	[TV (9, 0)]
 	[BaseType (typeof (UIViewController))]
 	interface UISearchContainerViewController {
 		// inlined
@@ -12558,11 +12458,9 @@ namespace UIKit {
 		[Export ("searchResultsTitle", ArgumentSemantic.Copy)]
 		string SearchResultsTitle { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("displaysSearchBarInNavigationBar", ArgumentSemantic.Assign)]
 		bool DisplaysSearchBarInNavigationBar { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("navigationItem")]
 		UINavigationItem NavigationItem { get; }
 	}
@@ -12918,39 +12816,30 @@ namespace UIKit {
 		[Field ("NSVerticalGlyphFormAttributeName")]
 		NSString VerticalGlyphForm { get; }
 
-		[iOS (7, 0)]
 		[Field ("NSTextEffectAttributeName")]
 		NSString TextEffect { get; }
 
-		[iOS (7, 0)]
 		[Field ("NSAttachmentAttributeName")]
 		NSString Attachment { get; }
 
-		[iOS (7, 0)]
 		[Field ("NSLinkAttributeName")]
 		NSString Link { get; }
 
-		[iOS (7, 0)]
 		[Field ("NSBaselineOffsetAttributeName")]
 		NSString BaselineOffset { get; }
 
-		[iOS (7, 0)]
 		[Field ("NSUnderlineColorAttributeName")]
 		NSString UnderlineColor { get; }
 
-		[iOS (7, 0)]
 		[Field ("NSStrikethroughColorAttributeName")]
 		NSString StrikethroughColor { get; }
 
-		[iOS (7, 0)]
 		[Field ("NSObliquenessAttributeName")]
 		NSString Obliqueness { get; }
 
-		[iOS (7, 0)]
 		[Field ("NSExpansionAttributeName")]
 		NSString Expansion { get; }
 
-		[iOS (7, 0)]
 		[Field ("NSWritingDirectionAttributeName")]
 		NSString WritingDirection { get; }
 
@@ -12963,7 +12852,6 @@ namespace UIKit {
 		// These are internal, if we choose to expose these, we should
 		// put them on a better named class
 		//
-		[iOS (7, 0)]
 		[Internal, Field ("NSTextEffectLetterpressStyle")]
 		NSString NSTextEffectLetterpressStyle { get; }
 
@@ -13090,7 +12978,6 @@ namespace UIKit {
 		[NullAllowed]
 		UIImage ShadowImage { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("barTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
@@ -13098,27 +12985,22 @@ namespace UIKit {
 
 		[Appearance]
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("itemPositioning")]
 		UITabBarItemPositioning ItemPositioning { get; set; }
 
 		[Appearance]
-		[iOS (7, 0)]
 		[Export ("itemWidth")]
 		nfloat ItemWidth { get; set; }
 
 		[Appearance]
-		[iOS (7, 0)]
 		[Export ("itemSpacing")]
 		nfloat ItemSpacing { get; set; }
 
 		[Appearance]
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("barStyle")]
 		UIBarStyle BarStyle { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("translucent")]
 		bool Translucent { [Bind ("isTranslucent")] get; set; }
 
@@ -13243,24 +13125,24 @@ namespace UIKit {
 		void FinishedCustomizingViewControllers (UITabBarController tabBarController, UIViewController [] viewControllers, bool changed);
 
 		[NoTV]
-		[iOS (7, 0), Export ("tabBarControllerSupportedInterfaceOrientations:")]
+		[Export ("tabBarControllerSupportedInterfaceOrientations:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UITabBarController,UIInterfaceOrientationMask>")]
 		UIInterfaceOrientationMask SupportedInterfaceOrientations (UITabBarController tabBarController);
 
 		[NoTV]
-		[iOS (7, 0), Export ("tabBarControllerPreferredInterfaceOrientationForPresentation:")]
+		[Export ("tabBarControllerPreferredInterfaceOrientationForPresentation:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UITabBarController,UIInterfaceOrientation>")]
 		UIInterfaceOrientation GetPreferredInterfaceOrientation (UITabBarController tabBarController);
 
-		[iOS (7, 0), Export ("tabBarController:interactionControllerForAnimationController:")]
+		[Export ("tabBarController:interactionControllerForAnimationController:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UITabBarController,IUIViewControllerAnimatedTransitioning,IUIViewControllerInteractiveTransitioning>")]
 		IUIViewControllerInteractiveTransitioning GetInteractionControllerForAnimationController (UITabBarController tabBarController,
 													 IUIViewControllerAnimatedTransitioning animationController);
 
-		[iOS (7, 0), Export ("tabBarController:animationControllerForTransitionFromViewController:toViewController:")]
+		[Export ("tabBarController:animationControllerForTransitionFromViewController:toViewController:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UITabBarController,UIViewController,UIViewController,IUIViewControllerAnimatedTransitioning>")]
 		IUIViewControllerAnimatedTransitioning GetAnimationControllerForTransition (UITabBarController tabBarController,
@@ -13330,13 +13212,11 @@ namespace UIKit {
 		[Appearance]
 		UIOffset TitlePositionAdjustment { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("initWithTitle:image:selectedImage:")]
 		[PostGet ("Image")]
 		[PostGet ("SelectedImage")]
 		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] UIImage image, [NullAllowed] UIImage selectedImage);
 
-		[iOS (7, 0)]
 		[Export ("selectedImage", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		UIImage SelectedImage { get; set; }
@@ -13628,25 +13508,20 @@ namespace UIKit {
 		//
 		// 7.0
 		//
-		[iOS (7, 0)]
 		[Export ("estimatedRowHeight", ArgumentSemantic.Assign)]
 		nfloat EstimatedRowHeight { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("estimatedSectionHeaderHeight", ArgumentSemantic.Assign)]
 		nfloat EstimatedSectionHeaderHeight { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("estimatedSectionFooterHeight", ArgumentSemantic.Assign)]
 		nfloat EstimatedSectionFooterHeight { get; set; }
 
-		[iOS (7, 0)]
 		[Appearance]
 		[NullAllowed] // by default this property is null
 		[Export ("sectionIndexBackgroundColor", ArgumentSemantic.Retain)]
 		UIColor SectionIndexBackgroundColor { get; set; }
 
-		[iOS (7, 0)]
 		[Appearance]
 		[Export ("separatorInset")]
 		UIEdgeInsets SeparatorInset { get; set; }
@@ -13912,15 +13787,12 @@ namespace UIKit {
 		[Export ("tableView:didUnhighlightRowAtIndexPath:")]
 		void RowUnhighlighted (UITableView tableView, NSIndexPath rowIndexPath);
 
-		[iOS (7, 0)]
 		[Export ("tableView:estimatedHeightForRowAtIndexPath:")]
 		nfloat EstimatedHeight (UITableView tableView, NSIndexPath indexPath);
 
-		[iOS (7, 0)]
 		[Export ("tableView:estimatedHeightForHeaderInSection:")]
 		nfloat EstimatedHeightForHeader (UITableView tableView, nint section);
 
-		[iOS (7, 0)]
 		[Export ("tableView:estimatedHeightForFooterInSection:")]
 		nfloat EstimatedHeightForFooter (UITableView tableView, nint section);
 
@@ -14162,7 +14034,6 @@ namespace UIKit {
 
 		[Appearance]
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("separatorInset")]
 		UIEdgeInsets SeparatorInset { get; set; }
 
@@ -14366,15 +14237,12 @@ namespace UIKit {
 		[Export ("tableView:didUnhighlightRowAtIndexPath:")]
 		void RowUnhighlighted (UITableView tableView, NSIndexPath rowIndexPath);
 
-		[iOS (7, 0)]
 		[Export ("tableView:estimatedHeightForRowAtIndexPath:")]
 		nfloat EstimatedHeight (UITableView tableView, NSIndexPath indexPath);
 
-		[iOS (7, 0)]
 		[Export ("tableView:estimatedHeightForHeaderInSection:")]
 		nfloat EstimatedHeightForHeader (UITableView tableView, nint section);
 
-		[iOS (7, 0)]
 		[Export ("tableView:estimatedHeightForFooterInSection:")]
 		nfloat EstimatedHeightForFooter (UITableView tableView, nint section);
 
@@ -14728,7 +14596,6 @@ namespace UIKit {
 		[Export ("typingAttributes", ArgumentSemantic.Copy)]
 		NSDictionary TypingAttributes { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("defaultTextAttributes", ArgumentSemantic.Copy), NullAllowed]
 		NSDictionary WeakDefaultTextAttributes { get; set; }
 
@@ -14883,33 +14750,26 @@ namespace UIKit {
 			set;
 		}
 
-		[iOS (7, 0)]
 		[Export ("selectable")]
 		bool Selectable { [Bind ("isSelectable")] get; set; }
 
 		[DesignatedInitializer]
-		[iOS (7, 0)]
 		[Export ("initWithFrame:textContainer:")]
 		[PostGet ("TextContainer")]
 		NativeHandle Constructor (CGRect frame, [NullAllowed] NSTextContainer textContainer);
 
-		[iOS (7, 0)]
 		[Export ("textContainer", ArgumentSemantic.Copy)]
 		NSTextContainer TextContainer { get; }
 
-		[iOS (7, 0)]
 		[Export ("textContainerInset", ArgumentSemantic.Assign)]
 		UIEdgeInsets TextContainerInset { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("layoutManager", ArgumentSemantic.Copy)]
 		NSLayoutManager LayoutManager { get; }
 
-		[iOS (7, 0)]
 		[Export ("textStorage", ArgumentSemantic.Retain)]
 		NSTextStorage TextStorage { get; }
 
-		[iOS (7, 0)]
 		[Export ("linkTextAttributes", ArgumentSemantic.Copy)]
 		NSDictionary WeakLinkTextAttributes { get; set; }
 
@@ -14969,13 +14829,11 @@ namespace UIKit {
 		[Export ("textViewDidChangeSelection:"), EventArgs ("UITextView")]
 		void SelectionChanged (UITextView textView);
 
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use the 'ShouldInteractWithUrl' overload that takes 'UITextItemInteraction' instead.")]
 		[Deprecated (PlatformName.TvOS, 10, 0, message: "Use the 'ShouldInteractWithUrl' overload that takes 'UITextItemInteraction' instead.")]
 		[Export ("textView:shouldInteractWithURL:inRange:"), DelegateName ("Func<UITextView,NSUrl,NSRange,bool>"), DefaultValue ("true")]
 		bool ShouldInteractWithUrl (UITextView textView, NSUrl URL, NSRange characterRange);
 
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use the 'ShouldInteractWithTextAttachment' overload that takes 'UITextItemInteraction' instead.")]
 		[Deprecated (PlatformName.TvOS, 10, 0, message: "Use the 'ShouldInteractWithTextAttachment' overload that takes 'UITextItemInteraction' instead.")]
 		[Export ("textView:shouldInteractWithTextAttachment:inRange:"), DelegateName ("Func<UITextView,NSTextAttachment,NSRange,bool>"), DefaultValue ("true")]
@@ -15045,13 +14903,11 @@ namespace UIKit {
 		[Export ("shadowImageForToolbarPosition:")]
 		UIImage GetShadowImage (UIToolbarPosition topOrBottom);
 
-		[iOS (7, 0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("barTintColor", ArgumentSemantic.Retain)]
 		UIColor BarTintColor { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
@@ -15647,22 +15503,17 @@ namespace UIKit {
 		[NullAllowed]
 		[Export ("tintColor")]
 		[Appearance]
-		[iOS (7, 0)]
 		UIColor TintColor { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("tintAdjustmentMode")]
 		UIViewTintAdjustmentMode TintAdjustmentMode { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("tintColorDidChange")]
 		void TintColorDidChange ();
 
-		[iOS (7, 0)]
 		[Static, Export ("performWithoutAnimation:")]
 		void PerformWithoutAnimation (Action actionsWithoutAnimation);
 
-		[iOS (7, 0)]
 		[Static, Export ("performSystemAnimation:onViews:options:animations:completion:")]
 		[Async]
 		void PerformSystemAnimation (UISystemAnimation animation, UIView [] views, UIViewAnimationOptions options, [NullAllowed] Action parallelAnimations, [NullAllowed] UICompletionHandler completion);
@@ -15672,44 +15523,35 @@ namespace UIKit {
 		[Export ("modifyAnimationsWithRepeatCount:autoreverses:animations:")]
 		void ModifyAnimations (nfloat count, bool autoreverses, Action animations);
 
-		[iOS (7, 0)]
 		[Static, Export ("animateKeyframesWithDuration:delay:options:animations:completion:")]
 		[Async]
 		void AnimateKeyframes (double duration, double delay, UIViewKeyframeAnimationOptions options, Action animations, [NullAllowed] UICompletionHandler completion);
 
-		[iOS (7, 0)]
 		[Static, Export ("addKeyframeWithRelativeStartTime:relativeDuration:animations:")]
 		void AddKeyframeWithRelativeStartTime (double frameStartTime, double frameDuration, Action animations);
 
-		[iOS (7, 0)]
 		[Export ("addMotionEffect:")]
 		[PostGet ("MotionEffects")]
 		void AddMotionEffect (UIMotionEffect effect);
 
-		[iOS (7, 0)]
 		[Export ("removeMotionEffect:")]
 		[PostGet ("MotionEffects")]
 		void RemoveMotionEffect (UIMotionEffect effect);
 
-		[iOS (7, 0)]
 		[NullAllowed] // by default this property is null
 		[Export ("motionEffects", ArgumentSemantic.Copy)]
 		UIMotionEffect [] MotionEffects { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("snapshotViewAfterScreenUpdates:")]
 		UIView SnapshotView (bool afterScreenUpdates);
 
-		[iOS (7, 0)]
 		[Export ("resizableSnapshotViewFromRect:afterScreenUpdates:withCapInsets:")]
 		[return: NullAllowed]
 		UIView ResizableSnapshotView (CGRect rect, bool afterScreenUpdates, UIEdgeInsets capInsets);
 
-		[iOS (7, 0)]
 		[Export ("drawViewHierarchyInRect:afterScreenUpdates:")]
 		bool DrawViewHierarchy (CGRect rect, bool afterScreenUpdates);
 
-		[iOS (7, 0)]
 		[Static]
 		[Export ("animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:")]
 		[Async]
@@ -16372,15 +16214,12 @@ namespace UIKit {
 		[Export ("shouldAutorotate")]
 		bool ShouldAutorotate ();
 
-		[iOS (7, 0)]
 		[Export ("edgesForExtendedLayout", ArgumentSemantic.Assign)]
 		UIRectEdge EdgesForExtendedLayout { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("extendedLayoutIncludesOpaqueBars", ArgumentSemantic.Assign)]
 		bool ExtendedLayoutIncludesOpaqueBars { get; set; }
 
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'UIScrollView.ContentInsetAdjustmentBehavior' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'UIScrollView.ContentInsetAdjustmentBehavior' instead.")]
 		[Export ("automaticallyAdjustsScrollViewInsets", ArgumentSemantic.Assign)]
@@ -16395,58 +16234,47 @@ namespace UIKit {
 		[return: NullAllowed]
 		UIScrollView GetContentScrollView (NSDirectionalRectEdge edge);
 
-		[iOS (7, 0)]
 		[Export ("preferredContentSize", ArgumentSemantic.Copy)]
 		new CGSize PreferredContentSize { get; set; }
 
 		[NoTV]
 		[NoWatch]
-		[iOS (7, 0)]
 		[Export ("preferredStatusBarStyle")]
 		UIStatusBarStyle PreferredStatusBarStyle ();
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("prefersStatusBarHidden")]
 		bool PrefersStatusBarHidden ();
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("setNeedsStatusBarAppearanceUpdate")]
 		void SetNeedsStatusBarAppearanceUpdate ();
 
-		[iOS (7, 0)]
 		[Export ("applicationFinishedRestoringState")]
 		void ApplicationFinishedRestoringState ();
 
-		[iOS (7, 0)]
 		[Export ("transitioningDelegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakTransitioningDelegate { get; set; }
 
-		[iOS (7, 0)]
 		[Wrap ("WeakTransitioningDelegate")]
 		[Protocolize]
 		UIViewControllerTransitioningDelegate TransitioningDelegate { get; set; }
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("childViewControllerForStatusBarStyle")]
 		[return: NullAllowed]
 		UIViewController ChildViewControllerForStatusBarStyle ();
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("childViewControllerForStatusBarHidden")]
 		[return: NullAllowed]
 		UIViewController ChildViewControllerForStatusBarHidden ();
 
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'UIView.SafeAreaLayoutGuide.TopAnchor' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'UIView.SafeAreaLayoutGuide.TopAnchor' instead.")]
 		[Export ("topLayoutGuide")]
 		IUILayoutSupport TopLayoutGuide { get; }
 
-		[iOS (7, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'UIView.SafeAreaLayoutGuide.BottomAnchor' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'UIView.SafeAreaLayoutGuide.BottomAnchor' instead.")]
 		[Export ("bottomLayoutGuide")]
@@ -16454,12 +16282,10 @@ namespace UIKit {
 
 		[NoTV]
 		[NoWatch]
-		[iOS (7, 0)]
 		[Export ("preferredStatusBarUpdateAnimation")]
 		UIStatusBarAnimation PreferredStatusBarUpdateAnimation { get; }
 
 		[NoTV]
-		[iOS (7, 0)]
 		[Export ("modalPresentationCapturesStatusBarAppearance", ArgumentSemantic.Assign)]
 		bool ModalPresentationCapturesStatusBarAppearance { get; set; }
 
@@ -16698,7 +16524,7 @@ namespace UIKit {
 		void SetNeedsUpdateOfSupportedInterfaceOrientations ();
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[Protocol, Model, BaseType (typeof (NSObject))]
 	partial interface UIViewControllerContextTransitioning {
 		[Abstract]
@@ -16936,7 +16762,7 @@ namespace UIKit {
 
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[Static]
 	partial interface UITransitionContext {
 		[Field ("UITransitionContextFromViewControllerKey")]
@@ -16954,7 +16780,7 @@ namespace UIKit {
 		NSString ToViewKey { get; }
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	partial interface UIViewControllerAnimatedTransitioning {
@@ -16975,7 +16801,7 @@ namespace UIKit {
 	}
 	interface IUIViewControllerAnimatedTransitioning { }
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	partial interface UIViewControllerInteractiveTransitioning {
@@ -17016,7 +16842,7 @@ namespace UIKit {
 		UIPresentationController GetPresentationControllerForPresentedViewController (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController, UIViewController sourceViewController);
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	partial interface UIPercentDrivenInteractiveTransition : UIViewControllerInteractiveTransitioning {
 		[Export ("duration")]
@@ -17059,7 +16885,7 @@ namespace UIKit {
 	// This protocol is only for consumption (there is no API to set a transition coordinator context,
 	// you'll be provided an existing one), so we do not provide a model to subclass.
 	//
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[Protocol]
 	partial interface UIViewControllerTransitionCoordinatorContext {
 		[Abstract]
@@ -17130,7 +16956,7 @@ namespace UIKit {
 	// This protocol is only for consumption (there is no API to set a transition coordinator,
 	// only get an existing one), so we do not provide a model to subclass.
 	//
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[Protocol]
 	partial interface UIViewControllerTransitionCoordinator : UIViewControllerTransitionCoordinatorContext {
 		[Abstract]
@@ -17240,23 +17066,18 @@ namespace UIKit {
 		[Export ("keyboardDisplayRequiresUserAction")]
 		bool KeyboardDisplayRequiresUserAction { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("paginationMode")]
 		UIWebPaginationMode PaginationMode { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("paginationBreakingMode")]
 		UIWebPaginationBreakingMode PaginationBreakingMode { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("pageLength")]
 		nfloat PageLength { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("gapBetweenPages")]
 		nfloat GapBetweenPages { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("pageCount")]
 		nint PageCount { get; }
 
@@ -17578,12 +17399,10 @@ namespace UIKit {
 	[Protocol]
 	interface UISplitViewControllerDelegate {
 		[NoTV]
-		[iOS (7, 0)]  // While introduced in 7.0, it was not made public, it was only publicized in iOS 8 and made retroactively supported
 		[Export ("splitViewControllerSupportedInterfaceOrientations:"), DelegateName ("Func<UISplitViewController,UIInterfaceOrientationMask>"), DefaultValue (UIInterfaceOrientationMask.All)]
 		UIInterfaceOrientationMask SupportedInterfaceOrientations (UISplitViewController splitViewController);
 
 		[NoTV]
-		[iOS (7, 0)]  // While introduced in 7.0, it was not made public, it was only publicized in iOS 8 and made retroactively supported
 		[Export ("splitViewControllerPreferredInterfaceOrientationForPresentation:"), DelegateName ("Func<UISplitViewController,UIInterfaceOrientation>"), DefaultValue (UIInterfaceOrientation.Unknown)]
 		UIInterfaceOrientation GetPreferredInterfaceOrientationForPresentation (UISplitViewController splitViewController);
 
@@ -17931,7 +17750,6 @@ namespace UIKit {
 		[Export ("popoverBackgroundViewClass", ArgumentSemantic.Retain)]
 		IntPtr PopoverBackgroundViewClass { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("backgroundColor", ArgumentSemantic.Copy)]
 		UIColor BackgroundColor { get; set; }
 	}
@@ -17949,7 +17767,7 @@ namespace UIKit {
 		[Export ("popoverControllerShouldDismissPopover:"), DelegateName ("UIPopoverControllerCondition"), DefaultValue ("true")]
 		bool ShouldDismiss (UIPopoverController popoverController);
 
-		[iOS (7, 0), Export ("popoverController:willRepositionPopoverToRect:inView:"), EventArgs ("UIPopoverControllerReposition")]
+		[Export ("popoverController:willRepositionPopoverToRect:inView:"), EventArgs ("UIPopoverControllerReposition")]
 		void WillReposition (UIPopoverController popoverController, ref CGRect rect, ref UIView view);
 	}
 
@@ -18306,7 +18124,7 @@ namespace UIKit {
 		[Export ("printInteractionControllerDidFinishJob:"), EventArgs ("UIPrintInteraction")]
 		void DidFinishJob (UIPrintInteractionController printInteractionController);
 
-		[iOS (7, 0), Export ("printInteractionController:cutLengthForPaper:")]
+		[Export ("printInteractionController:cutLengthForPaper:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UIPrintInteractionController,UIPrintPaper,nfloat>")]
 		nfloat CutLengthForPaper (UIPrintInteractionController printInteractionController, UIPrintPaper paper);
@@ -18388,7 +18206,7 @@ namespace UIKit {
 		[Async (ResultTypeName = "UIPrintInteractionResult")]
 		bool PresentFromRectInView (CGRect rect, UIView view, bool animated, [NullAllowed] UIPrintInteractionCompletionHandler completion);
 
-		[iOS (7, 0), Export ("showsNumberOfCopies")]
+		[Export ("showsNumberOfCopies")]
 		bool ShowsNumberOfCopies { get; set; }
 
 
@@ -18520,11 +18338,9 @@ namespace UIKit {
 		[Export ("initWithText:")]
 		NativeHandle Constructor ([NullAllowed] string text);
 
-		[iOS (7, 0)]
 		[Export ("initWithAttributedText:")]
 		NativeHandle Constructor ([NullAllowed] NSAttributedString text);
 
-		[iOS (7, 0)]
 		[NullAllowed]
 		[Export ("attributedText", ArgumentSemantic.Copy)]
 		NSAttributedString AttributedText { get; set; }
@@ -18584,7 +18400,7 @@ namespace UIKit {
 		NativeHandle Constructor ([NullAllowed] string text);
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[DesignatedDefaultCtor]
 	interface UIMotionEffect : NSCoding, NSCopying {
@@ -18592,7 +18408,7 @@ namespace UIKit {
 		NSDictionary ComputeKeyPathsAndRelativeValues (UIOffset viewerOffset);
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[BaseType (typeof (UIMotionEffect))]
 	interface UIInterpolatingMotionEffect : NSCoding {
 		[DesignatedInitializer]
@@ -18614,7 +18430,7 @@ namespace UIKit {
 		NSObject MaximumRelativeValue { get; set; }
 	}
 
-	[iOS (7, 0), NoWatch]
+	[NoWatch]
 	[BaseType (typeof (UIMotionEffect))]
 	interface UIMotionEffectGroup {
 		[NullAllowed] // by default this property is null
@@ -18725,33 +18541,26 @@ namespace UIKit {
 
 	[Category, BaseType (typeof (NSString))]
 	interface NSStringDrawing {
-		[iOS (7, 0)]
 		[Export ("sizeWithAttributes:")]
 		CGSize WeakGetSizeUsingAttributes ([NullAllowed] NSDictionary attributes);
 
-		[iOS (7, 0)]
 		[Wrap ("WeakGetSizeUsingAttributes (This, attributes.GetDictionary ())")]
 		CGSize GetSizeUsingAttributes (UIStringAttributes attributes);
 
-		[iOS (7, 0)]
 		[Export ("drawAtPoint:withAttributes:")]
 		void WeakDrawString (CGPoint point, [NullAllowed] NSDictionary attributes);
 
-		[iOS (7, 0)]
 		[Wrap ("WeakDrawString (This, point, attributes.GetDictionary ())")]
 		void DrawString (CGPoint point, UIStringAttributes attributes);
 
-		[iOS (7, 0)]
 		[Export ("drawInRect:withAttributes:")]
 		void WeakDrawString (CGRect rect, [NullAllowed] NSDictionary attributes);
 
-		[iOS (7, 0)]
 		[Wrap ("WeakDrawString (This, rect, attributes.GetDictionary ())")]
 		void DrawString (CGRect rect, UIStringAttributes attributes);
 	}
 
 	[NoWatch]
-	[iOS (7, 0)]
 	[BaseType (typeof (UIView))]
 	interface UIInputView : NSCoding {
 		[DesignatedInitializer]
@@ -18941,7 +18750,6 @@ namespace UIKit {
 	}
 
 	[NoWatch]
-	[iOS (7, 0)]
 	[Protocol]
 	[Model]
 	[BaseType (typeof (NSObject))]
@@ -19098,7 +18906,6 @@ namespace UIKit {
 #else
 #if !NET // No longer present in watchOS 7.0
 		// note: defined twice, where watchOS is defined it says it's not in iOS, the other one (for iOS 9) says it's not in tvOS
-		[Watch (2,0)]
 		[Field ("UIUserNotificationActionResponseTypedTextKey")]
 		NSString ResponseTypedTextKey { get; }
 #endif // !NET
@@ -19350,7 +19157,6 @@ namespace UIKit {
 	}
 
 	[NoWatch]
-	[iOS (7, 0)]
 	[Protocol]
 	interface UIGuidedAccessRestrictionDelegate {
 		[Abstract]

--- a/src/watchkit.cs
+++ b/src/watchkit.cs
@@ -192,12 +192,10 @@ namespace WatchKit {
 		[Export ("dismissMediaPlayerController")]
 		void DismissMediaPlayerController ();
 
-		[Watch (2, 0)]
 		[Export ("presentAudioRecorderControllerWithOutputURL:preset:options:completion:")]
 		[Async]
 		void PresentAudioRecorderController (NSUrl outputUrl, WKAudioRecorderPreset preset, [NullAllowed] NSDictionary options, Action<bool, NSError> completion);
 
-		[Watch (2, 0)]
 		[Export ("dismissAudioRecorderController")]
 		void DismissAudioRecorderController ();
 
@@ -321,7 +319,6 @@ namespace WatchKit {
 		void PerformDismissAction ();
 
 		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use 'PerformDismissAction' instead.")]
-		[Watch (2, 0)]
 		[Export ("dismissController")]
 		void DismissController ();
 
@@ -395,7 +392,6 @@ namespace WatchKit {
 		[Export ("setAccessibilityIdentifier:")]
 		void SetAccessibilityIdentifier ([NullAllowed] string accessibilityIdentifier);
 
-		[Watch (2, 0)]
 		[Notification]
 		[Field ("WKAccessibilityVoiceOverStatusChanged")]
 		NSString VoiceOverStatusChanged { get; }
@@ -444,23 +440,18 @@ namespace WatchKit {
 		[Export ("removeAllCachedImages")]
 		void RemoveAllCachedImages ();
 
-		[Watch (2, 0)]
 		[Export ("systemVersion")]
 		string SystemVersion { get; }
 
-		[Watch (2, 0)]
 		[Export ("name")]
 		string Name { get; }
 
-		[Watch (2, 0)]
 		[Export ("model")]
 		string Model { get; }
 
-		[Watch (2, 0)]
 		[Export ("localizedModel")]
 		string LocalizedModel { get; }
 
-		[Watch (2, 0)]
 		[Export ("systemName")]
 		string SystemName { get; }
 
@@ -468,7 +459,6 @@ namespace WatchKit {
 		[Export ("waterResistanceRating")]
 		WKWaterResistanceRating WaterResistanceRating { get; }
 
-		[Watch (2, 0)]
 		[Export ("playHaptic:")]
 		void PlayHaptic (WKHapticType type);
 
@@ -919,17 +909,14 @@ namespace WatchKit {
 		void SetCurrentTime (double time);
 #endif
 
-		[Watch (2, 0)]
 		[Notification]
 		[Field ("WKAudioFilePlayerItemTimeJumpedNotification")]
 		NSString TimeJumpedNotification { get; }
 
-		[Watch (2, 0)]
 		[Notification]
 		[Field ("WKAudioFilePlayerItemDidPlayToEndTimeNotification")]
 		NSString DidPlayToEndTimeNotification { get; }
 
-		[Watch (2, 0)]
 		[Notification]
 		[Field ("WKAudioFilePlayerItemFailedToPlayToEndTimeNotification")]
 		NSString FailedToPlayToEndTimeNotification { get; }
@@ -1226,7 +1213,6 @@ namespace WatchKit {
 
 	// to be made [Internal] once #34656 is fixed
 	[Static]
-	[Watch (2, 0)]
 	[NoiOS]
 	interface WKMediaPlayerControllerOptionsKeys {
 		[Field ("WKMediaPlayerControllerOptionsAutoplayKey")]
@@ -1244,7 +1230,6 @@ namespace WatchKit {
 
 	// to be made [Internal] once #34656 is fixed
 	[Static]
-	[Watch (2, 0)]
 	[NoiOS]
 	interface WKAudioRecorderControllerOptionsKey {
 		[Field ("WKAudioRecorderControllerOptionsActionTitleKey")]

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -149,8 +149,6 @@ namespace UIKit {
 	[Native]
 	[NoWatch]
 	[iOS (6, 0)]
-	[Mac (10, 7)]
-	[TV (9, 0)]
 	[MacCatalyst (13, 0)]
 	public enum NSLayoutAttribute : long {
 		NoAttribute = 0,
@@ -202,8 +200,6 @@ namespace UIKit {
 	[NoWatch]
 	[MacCatalyst (13, 0)]
 	[iOS (6, 0)]
-	[Mac (10, 7)]
-	[TV (9, 0)]
 	public enum NSLayoutFormatOptions : ulong {
 		None = 0,
 
@@ -306,9 +302,6 @@ namespace UIKit {
 
 	[MacCatalyst (13, 1)]
 	[NoWatch] // Header is not present in watchOS SDK.
-	[iOS (7, 0)]
-	[TV (9, 0)]
-	[Mac (10, 7)]
 	[DesignatedDefaultCtor]
 	[BaseType (typeof (NSObject))]
 	partial interface NSLayoutManager : NSSecureCoding {
@@ -1453,12 +1446,9 @@ namespace UIKit {
 	interface INSLayoutManagerDelegate { }
 
 	[NoWatch] // Header not present in watchOS SDK.
-	[iOS (7, 0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[Mac (10, 0)]
-	[TV (9, 0)]
 	[MacCatalyst (13, 1)]
 	interface NSLayoutManagerDelegate {
 		[Export ("layoutManagerDidInvalidateLayout:")]
@@ -1468,7 +1458,6 @@ namespace UIKit {
 		void DidInvalidatedLayout (NSLayoutManager sender);
 #endif
 
-		[iOS (7, 0)]
 		[Export ("layoutManager:didCompleteLayoutForTextContainer:atEnd:")]
 #if NET || !MONOMAC
 		void DidCompleteLayout (NSLayoutManager layoutManager, [NullAllowed] NSTextContainer textContainer, bool layoutFinishedFlag);
@@ -1664,8 +1653,6 @@ namespace UIKit {
 	[ThreadSafe]
 	[BaseType (typeof (NSObject))]
 	[iOS (6, 0)]
-	[Mac (10, 0)]
-	[TV (9, 0)]
 	[MacCatalyst (13, 1)]
 	interface NSParagraphStyle : NSSecureCoding, NSMutableCopying {
 		[Export ("lineSpacing")]
@@ -1733,11 +1720,9 @@ namespace UIKit {
 		NSParagraphStyle DefaultParagraphStyle { get; [NotImplemented] set; }
 #endif
 
-		[iOS (7, 0)]
 		[Export ("defaultTabInterval")]
 		nfloat DefaultTabInterval { get; [NotImplemented] set; }
 
-		[iOS (7, 0)]
 		[Export ("tabStops", ArgumentSemantic.Copy)]
 		[NullAllowed]
 		NSTextTab [] TabStops { get; [NotImplemented] set; }
@@ -1775,8 +1760,6 @@ namespace UIKit {
 	[ThreadSafe]
 	[BaseType (typeof (NSParagraphStyle))]
 	[iOS (6, 0)]
-	[Mac (10, 0)]
-	[TV (9, 0)]
 	[MacCatalyst (13, 1)]
 	interface NSMutableParagraphStyle {
 		[Export ("lineSpacing")]
@@ -1835,12 +1818,10 @@ namespace UIKit {
 		[Export ("usesDefaultHyphenation")]
 		bool UsesDefaultHyphenation { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("defaultTabInterval")]
 		[Override]
 		nfloat DefaultTabInterval { get; set; }
 
-		[iOS (7, 0)]
 		[Export ("tabStops", ArgumentSemantic.Copy)]
 		[Override]
 		[NullAllowed]
@@ -2386,8 +2367,6 @@ namespace UIKit {
 	}
 
 	[iOS (6, 0)]
-	[Mac (10, 7)]
-	[TV (9, 0)]
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -2474,7 +2453,6 @@ namespace UIKit {
 
 	[Watch (9, 0)]
 	[Introduced (PlatformName.iOS)]
-	[TV (9, 0)]
 	[Mac (10, 11)]
 	[MacCatalyst (13, 0)]
 	[Model]
@@ -2497,9 +2475,6 @@ namespace UIKit {
 		CGRect GetAttachmentBounds ([NullAllowed] NSTextContainer textContainer, CGRect proposedLineFragment, CGPoint glyphPosition, nuint characterIndex);
 	}
 
-	[iOS (7, 0)]
-	[Mac (10, 0)]
-	[TV (9, 0)]
 	[MacCatalyst (13, 1)]
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
@@ -2603,7 +2578,6 @@ namespace UIKit {
 
 	[NoWatch]
 	[MacCatalyst (13, 0)]
-	[iOS (7, 0)]
 	[BaseType (typeof (NSMutableAttributedString), Delegates = new string [] { "Delegate" }, Events = new Type [] { typeof (NSTextStorageDelegate) })]
 	partial interface NSTextStorage : NSSecureCoding {
 		[Export ("initWithString:")]
@@ -2681,14 +2655,12 @@ namespace UIKit {
 		[Export ("ensureAttributesAreFixedInRange:")]
 		void EnsureAttributesAreFixed (NSRange range);
 
-		[iOS (7, 0)]
 		[Notification, Field ("NSTextStorageWillProcessEditingNotification")]
 #if !MONOMAC || NET
 		[Internal]
 #endif
 		NSString WillProcessEditingNotification { get; }
 
-		[iOS (7, 0)]
 		[Notification, Field ("NSTextStorageDidProcessEditingNotification")]
 #if !MONOMAC || NET
 		[Internal]
@@ -2704,9 +2676,6 @@ namespace UIKit {
 	interface INSTextStorageDelegate { }
 
 	[NoWatch]
-	[iOS (7, 0)]
-	[Mac (10, 6)]
-	[TV (9, 0)]
 	[MacCatalyst (13, 0)]
 	[Model]
 	[BaseType (typeof (NSObject))]
@@ -2997,7 +2966,7 @@ namespace UIKit {
 		string ElementKind { get; }
 	}
 
-	[iOS (9, 0), Watch (2, 0)]
+	[iOS (9, 0)]
 	[MacCatalyst (13, 0)]
 	[Mac (10, 11)]
 	[BaseType (typeof (NSObject))]
@@ -3046,9 +3015,6 @@ namespace UIKit {
 		NSColor ShadowColor { get; set; }
 	}
 
-	[iOS (7, 0)]
-	[Mac (10, 0)]
-	[TV (9, 0)]
 	[MacCatalyst (13, 0)]
 	[BaseType (typeof (NSObject))]
 	interface NSTextTab : NSSecureCoding, NSCopying {
@@ -3089,10 +3055,7 @@ namespace UIKit {
 		NSString ColumnTerminatorsAttributeName { get; }
 	}
 
-	[Mac (10, 7)]
-	[iOS (7, 0)]
 	[MacCatalyst (13, 0)]
-	[TV (9, 0)]
 	[NoWatch]
 	[Protocol]
 	// no [Model] since it's not exposed in any API
@@ -3110,9 +3073,6 @@ namespace UIKit {
 	}
 
 	[NoWatch]
-	[iOS (7, 0)]
-	[Mac (10, 0)]
-	[TV (9, 0)]
 	[MacCatalyst (13, 0)]
 	[BaseType (typeof (NSObject))]
 	partial interface NSTextContainer : NSTextLayoutOrientationProvider, NSSecureCoding {
@@ -3209,28 +3169,24 @@ namespace UIKit {
 	[ThreadSafe]
 	[Category, BaseType (typeof (NSString))]
 	interface NSExtendedStringDrawing {
-		[iOS (7, 0)]
 		[TV (7, 0)]
 		[MacCatalyst (13, 1)]
 		[Mac (10, 11)]
 		[Export ("drawWithRect:options:attributes:context:")]
 		void WeakDrawString (CGRect rect, NSStringDrawingOptions options, [NullAllowed] NSDictionary attributes, [NullAllowed] NSStringDrawingContext context);
 
-		[iOS (7, 0)]
 		[TV (7, 0)]
 		[MacCatalyst (13, 1)]
 		[Mac (10, 11)]
 		[Wrap ("WeakDrawString (This, rect, options, attributes.GetDictionary (), context)")]
 		void DrawString (CGRect rect, NSStringDrawingOptions options, StringAttributes attributes, [NullAllowed] NSStringDrawingContext context);
 
-		[iOS (7, 0)]
 		[TV (7, 0)]
 		[MacCatalyst (13, 1)]
 		[Mac (10, 11)]
 		[Export ("boundingRectWithSize:options:attributes:context:")]
 		CGRect WeakGetBoundingRect (CGSize size, NSStringDrawingOptions options, [NullAllowed] NSDictionary attributes, [NullAllowed] NSStringDrawingContext context);
 
-		[iOS (7, 0)]
 		[TV (7, 0)]
 		[MacCatalyst (13, 1)]
 		[Mac (10, 11)]
@@ -4154,7 +4110,7 @@ namespace UIKit {
 		NSTextRange GetAdjustedRange (NSTextRange textRange, bool forEditingTextSelection);
 	}
 
-	[TV (9, 0), NoWatch, Mac (10, 0), iOS (7, 0), MacCatalyst (13, 0)]
+	[NoWatch, MacCatalyst (13, 0)]
 	[BaseType (typeof (NSObject))]
 	interface NSTextList : NSCoding, NSCopying, NSSecureCoding {
 		[Export ("initWithMarkerFormat:options:")]


### PR DESCRIPTION
Remove a lot of redundant availability attributes when the version is lower or equal
to the lowest we support.

This was mostly done using a script: https://gist.github.com/rolfbjarne/86b85f843904bab2bddb7ce7cecb09af