### PR TITLE
[tests] Remove ignore due to custom code that's been gone for almost two years.

### DIFF
--- a/tests/cecil-tests/Test.cs
+++ b/tests/cecil-tests/Test.cs
@@ -90,9 +90,6 @@ namespace Cecil.Tests {
 		public void NoSystemConsoleReference (AssemblyInfo info)
 		{
 			var assembly = info.Assembly;
-			if (assembly.Name.Name == "Xamarin.Mac")
-				Assert.Ignore ("Xamarin.Mac has a workaround for Sierra bug w/NSLog");
-
 			// this has a quite noticeable impact on (small) app size
 			if (assembly.MainModule.TryGetTypeReference ("System.Console", out var _))
 				Assert.Fail ($"{assembly} has a reference to `System.Console`. Please use `Runtime.NSLog` inside the platform assemblies");


### PR DESCRIPTION
We had custom code with Console.WriteLine for macOS 10.12 for a while, but that was removed here:

a93bcdec341ddb3812d26b9c6acfb5c0ec2898c9

So there's no need to skip the test that verifies we don't call Console.WriteLine anymore.