### PR TITLE
[tests] Use .NET to build cecil-tests.

### DIFF
--- a/tests/cecil-tests/Makefile
+++ b/tests/cecil-tests/Makefile
@@ -5,7 +5,7 @@ include $(TOP)/Make.config
 all-local::
 
 build:
-	$(SYSTEM_MSBUILD) /r
+	$(Q) $(DOTNET) build $(DOTNET_BUILD_VERBOSITY) /bl
 
 run-tests: build
 	$(TOP)/tools/nunit3-console-3.11.1 $(abspath $(TOP)/tests/cecil-tests/bin/Debug/net472/cecil-tests.dll) $(TEST_NAME) -labels=After


### PR DESCRIPTION
Use .NET to build cecil-tests, using the appropriate verbosity, and creating a
binlog as well.