### PR TITLE
[dotnet] First change for blitability of pinvokes with strings

### DIFF
--- a/src/ObjCRuntime/NativeString.cs
+++ b/src/ObjCRuntime/NativeString.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace ObjCRuntime {
+	internal struct NativeString : IDisposable {
+		IntPtr ptr;
+		public NativeString (string str)
+		{
+			ptr = Marshal.StringToHGlobalAuto (str);
+		}
+
+		public void Dispose ()
+		{
+			if (ptr != IntPtr.Zero) {
+				Marshal.FreeHGlobal (ptr);
+				ptr = IntPtr.Zero;
+			}
+		}
+
+		public static implicit operator IntPtr (NativeString str) => str.ptr;
+	}
+}

--- a/src/SystemConfiguration/NetworkReachability.cs
+++ b/src/SystemConfiguration/NetworkReachability.cs
@@ -105,7 +105,7 @@ namespace SystemConfiguration {
 
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		extern static /* SCNetworkReachabilityRef __nullable */ IntPtr SCNetworkReachabilityCreateWithName (
-			/* CFAllocatorRef __nullable */ IntPtr allocator, /* const char* __nonnull */ string address);
+			/* CFAllocatorRef __nullable */ IntPtr allocator, /* const char* __nonnull */ IntPtr address);
 
 		[DllImport (Constants.SystemConfigurationLibrary)]
 		extern static /* SCNetworkReachabilityRef __nullable */ IntPtr SCNetworkReachabilityCreateWithAddress (
@@ -156,7 +156,8 @@ namespace SystemConfiguration {
 			if (address is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (address));
 
-			return CheckFailure (SCNetworkReachabilityCreateWithName (IntPtr.Zero, address));
+			using var addressStr = new NativeString (address);
+			return CheckFailure (SCNetworkReachabilityCreateWithName (IntPtr.Zero, addressStr));
 		}
 
 		public NetworkReachability (string address)

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1914,6 +1914,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/NativeAttribute.cs \
 	ObjCRuntime/NativeHandle.cs \
 	ObjCRuntime/NativeNameAttribute.cs \
+	ObjCRuntime/NativeString.cs \
 	ObjCRuntime/NFloat.cs \
 	ObjCRuntime/ObsoleteConstants.cs \
 	ObjCRuntime/PlatformAvailability.cs \


### PR DESCRIPTION
This is the first in a series or changes for making pinvokes that take strings contain all blitable types.

NativeString.cs is being used to do the conversion. Be aware that we're abusing `IDisposable` to act like C++'s RAII, but it makes the usage cleaner.