### PR TITLE
[dotnet] Create an MSBuild property for the current min OS version.

### DIFF
--- a/dotnet/generate-target-platforms.csharp
+++ b/dotnet/generate-target-platforms.csharp
@@ -45,6 +45,9 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ("\t<ItemGroup>");
 	writer.WriteLine ($"\t\t<SdkSupportedTargetPlatformVersion Condition=\"'$(TargetPlatformIdentifier)' == '{platform}'\" Include=\"@({platform}SdkSupportedTargetPlatformVersion)\" />");
 	writer.WriteLine ("\t</ItemGroup>");
+	writer.WriteLine ("\t<PropertyGroup>");
+	writer.WriteLine ($"\t\t<{platform}MinSupportedOSPlatformVersion>{minSdkVersionString}</{platform}MinSupportedOSPlatformVersion>");
+	writer.WriteLine ("\t</PropertyGroup>");
 	writer.WriteLine ("</Project>");
 }
 

--- a/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net7.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ProvisioningType>automatic</ProvisioningType>

--- a/tests/common/TestProjects/AppWithExtraArgumentThatOverrides/AppWithExtraArgumentThatOverrides.dotnet.csproj
+++ b/tests/common/TestProjects/AppWithExtraArgumentThatOverrides/AppWithExtraArgumentThatOverrides.dotnet.csproj
@@ -5,7 +5,7 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <MtouchLink>None</MtouchLink>
-    <SupportedOSPlatformVersion>11.4</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/common/TestProjects/Bug60536/Bug60536.dotnet.csproj
+++ b/tests/common/TestProjects/Bug60536/Bug60536.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.3</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/My Spaced App/My Spaced App.dotnet.csproj
+++ b/tests/common/TestProjects/My Spaced App/My Spaced App.dotnet.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>MySpacedApp</AssemblyName>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyActionExtension/MyActionExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyActionExtension/MyActionExtension.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyAppWithPackageReference/MyAppWithPackageReference.dotnet.csproj
+++ b/tests/common/TestProjects/MyAppWithPackageReference/MyAppWithPackageReference.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyCoreMLApp/MyCoreMLApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyCoreMLApp/MyCoreMLApp.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(macOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyDocumentPickerExtension/MyDocumentPickerExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyDocumentPickerExtension/MyDocumentPickerExtension.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.dotnet.csproj
+++ b/tests/common/TestProjects/MyExtensionWithPackageReference/MyExtensionWithPackageReference.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyIBToolLinkTest/MyIBToolLinkTest.dotnet.csproj
+++ b/tests/common/TestProjects/MyIBToolLinkTest/MyIBToolLinkTest.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyKeyboardExtension/MyKeyboardExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyKeyboardExtension/MyKeyboardExtension.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
-    <SupportedOSPlatformVersion>9.3</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyLinkedAssets/MyLinkedAssets.dotnet.csproj
+++ b/tests/common/TestProjects/MyLinkedAssets/MyLinkedAssets.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.2</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <!-- No automatic inclusion since these files are outside of the project directory -->

--- a/tests/common/TestProjects/MyMasterDetailApp/MyMasterDetailApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyMasterDetailApp/MyMasterDetailApp.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyMetalGame/MyMetalGame.dotnet.csproj
+++ b/tests/common/TestProjects/MyMetalGame/MyMetalGame.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyOpenGLApp/MyOpenGLApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyOpenGLApp/MyOpenGLApp.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>8.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyPhotoEditingExtension/MyPhotoEditingExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyPhotoEditingExtension/MyPhotoEditingExtension.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyReleaseBuild/MyReleaseBuild.dotnet.csproj
+++ b/tests/common/TestProjects/MyReleaseBuild/MyReleaseBuild.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MySceneKitApp/MySceneKitApp.dotnet.csproj
+++ b/tests/common/TestProjects/MySceneKitApp/MySceneKitApp.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyShareExtension/MyShareExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyShareExtension/MyShareExtension.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MySingleView/MySingleView.dotnet.csproj
+++ b/tests/common/TestProjects/MySingleView/MySingleView.dotnet.csproj
@@ -6,7 +6,7 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <DefaultItemExcludes>$(DefaultItemExcludes);MyLibrary\**</DefaultItemExcludes>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MySpriteKitGame/MySpriteKitGame.dotnet.csproj
+++ b/tests/common/TestProjects/MySpriteKitGame/MySpriteKitGame.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyTVApp/MyTVApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyTVApp/MyTVApp.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <RuntimeIdentifier>tvossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(tvOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyTVMetalGame/MyTVMetalGame.dotnet.csproj
+++ b/tests/common/TestProjects/MyTVMetalGame/MyTVMetalGame.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>tvossimulator-x64</RuntimeIdentifier>
-    <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(tvOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyTVServicesExtension/MyTVServicesExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyTVServicesExtension/MyTVServicesExtension.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <RuntimeIdentifier>tvossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(tvOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyTabbedApplication/MyTabbedApplication.dotnet.csproj
+++ b/tests/common/TestProjects/MyTabbedApplication/MyTabbedApplication.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyTodayExtension/MyTodayExtension.dotnet.csproj
+++ b/tests/common/TestProjects/MyTodayExtension/MyTodayExtension.dotnet.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <IsAppExtension>true</IsAppExtension>
-    <SupportedOSPlatformVersion>8.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/common/TestProjects/MyWatch2Container/MyWatch2Container.dotnet.csproj
+++ b/tests/common/TestProjects/MyWatch2Container/MyWatch2Container.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyWebViewApp/MyWebViewApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyWebViewApp/MyWebViewApp.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/TestProjects/MyXamarinFormsApp/MyXamarinFormsApp.dotnet.csproj
+++ b/tests/common/TestProjects/MyXamarinFormsApp/MyXamarinFormsApp.dotnet.csproj
@@ -5,7 +5,7 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/common/TestProjects/MyiOSAppWithBinding/MyiOSAppWithBinding.dotnet.csproj
+++ b/tests/common/TestProjects/MyiOSAppWithBinding/MyiOSAppWithBinding.dotnet.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -8,7 +8,7 @@
 		<AssetTargetFallback>xamarinios10;$(AssetTargetFallback)</AssetTargetFallback>
 		<NativeLibName>ios-fat</NativeLibName>
 		<!-- We need this because we'd otherwise default to the latest OS version we support, and we'll want to execute on earlier versions -->
-		<SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">10.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
 		<CompilerResponseFile>$(MSBuildThisFileDirectory)\..\..\src\build\dotnet\ios-defines-dotnet.rsp</CompilerResponseFile>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(_PlatformName)' == 'iOS'">
@@ -18,7 +18,7 @@
 	<PropertyGroup Condition="$(TargetFramework.EndsWith('-tvos'))">
 		<AssetTargetFallback>xamarintvos10;$(AssetTargetFallback)</AssetTargetFallback>
 		<NativeLibName>tvos-fat</NativeLibName>
-		<SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">10.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(tvOSMinSupportedOSPlatformVersion</SupportedOSPlatformVersion>
 		<CompilerResponseFile>$(MSBuildThisFileDirectory)\..\..\src\build\dotnet\tvos-defines-dotnet.rsp</CompilerResponseFile>
 	</PropertyGroup>
 	<ItemGroup Condition="$(TargetFramework.EndsWith('-tvos'))">
@@ -28,7 +28,7 @@
 	<PropertyGroup Condition="$(TargetFramework.EndsWith('-macos'))">
 		<DefineConstants>$(DefineConstants);MONOMAC</DefineConstants>
 		<NativeLibName>macos-fat</NativeLibName>
-		<SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">10.14</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(macOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
 		<CompilerResponseFile>$(MSBuildThisFileDirectory)\..\..\src\build\dotnet\macos-defines-dotnet.rsp</CompilerResponseFile>
 		<RuntimeIdentifiers Condition="'$(Configuration)' == 'Release' And '$(SingleArchReleaseBuild)' == 'true'">osx-x64</RuntimeIdentifiers>
 	</PropertyGroup>
@@ -37,7 +37,7 @@
 	<PropertyGroup Condition="$(TargetFramework.EndsWith('-maccatalyst'))">
 		<AssetTargetFallback>xamarinios10;$(AssetTargetFallback)</AssetTargetFallback>
 		<NativeLibName>maccatalyst-fat</NativeLibName>
-		<SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">13.3</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(MacCatalystMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
 		<CompilerResponseFile>$(MSBuildThisFileDirectory)\..\..\src\build\dotnet\maccatalyst-defines-dotnet.rsp</CompilerResponseFile>
 		<RuntimeIdentifiers Condition="'$(Configuration)' == 'Release' And '$(SingleArchReleaseBuild)' == 'true'">maccatalyst-x64</RuntimeIdentifiers>
 	</PropertyGroup>

--- a/tests/dotnet/MyCatalystApp/MyCatalystApp.csproj
+++ b/tests/dotnet/MyCatalystApp/MyCatalystApp.csproj
@@ -8,6 +8,6 @@
 		<ApplicationTitle>MyCatalystApp</ApplicationTitle>
 		<ApplicationId>com.xamarin.mycatalystapp</ApplicationId>
 		<ApplicationVersion>3.14</ApplicationVersion>
-		<SupportedOSPlatformVersion>13.1</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>$(MacCatalystMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
 	</PropertyGroup>
 </Project>

--- a/tests/dotnet/MyCocoaApp/MyCocoaApp.csproj
+++ b/tests/dotnet/MyCocoaApp/MyCocoaApp.csproj
@@ -3,6 +3,6 @@
 	<PropertyGroup>
 		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 		<OutputType>Exe</OutputType>
-		<SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>$(macOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
 	</PropertyGroup>
 </Project>

--- a/tests/dotnet/MySingleView/MySingleView.csproj
+++ b/tests/dotnet/MySingleView/MySingleView.csproj
@@ -7,6 +7,6 @@
 		<ApplicationTitle>MySingleTitle</ApplicationTitle>
 		<ApplicationId>com.xamarin.mysingletitle</ApplicationId>
 		<ApplicationVersion>3.14</ApplicationVersion>
-		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
 	</PropertyGroup>
 </Project>

--- a/tests/dotnet/MyTVApp/MyTVApp.csproj
+++ b/tests/dotnet/MyTVApp/MyTVApp.csproj
@@ -3,6 +3,6 @@
 	<PropertyGroup>
 		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
 		<OutputType>Exe</OutputType>
-		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>$(tvOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
 	</PropertyGroup>
 </Project>

--- a/tests/dotnet/size-comparison/MySingleView/dotnet/MySingleView.csproj
+++ b/tests/dotnet/size-comparison/MySingleView/dotnet/MySingleView.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 		<RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
 		<OutputType>Exe</OutputType>
-		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>$(iOSMinSupportedOSPlatformVersion)</SupportedOSPlatformVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="../AppDelegate.cs" />


### PR DESCRIPTION
Create an MSBuild property for the minimum OS version
(`SupportedOSPlatformVersion`) we support for a given platform (named
`[platform]MinSupportedOSPlatformVersion`), and use it in most tests instead
of hardcoding the min OS version (which would otherwise have to be updated
every time we bump the min OS version).