### PR TITLE
[release/7.0.1xx-xcode14.2] Bump API references to the Xcode 14.1 release.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -65,12 +65,12 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES_iOS=https://dl.internalx.com/wrench/6.0.4xx-xcode14/6756a11462d8aa6e73d4a320712b276caba159c1/6718459/package/bundle.zip
-APIDIFF_REFERENCES_Mac=https://dl.internalx.com/wrench/d17-3/87f98a75edaa6757fd6ff5170d297615830fb41b/6466144/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_iOS=https://dl.internalx.com/wrench/6.0.4xx-xcode14/6756a11462d8aa6e73d4a320712b276caba159c1/6718459/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_tvOS=https://dl.internalx.com/wrench/6.0.4xx-xcode14/6756a11462d8aa6e73d4a320712b276caba159c1/6718459/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_macOS=https://dl.internalx.com/wrench/6.0.4xx/4bd34d034c8c5a4e092c8bd3c8868153d94277b4/6656178/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_MacCatalyst=https://dl.internalx.com/wrench/6.0.4xx/4bd34d034c8c5a4e092c8bd3c8868153d94277b4/6656178/package/bundle.zip
+APIDIFF_REFERENCES_iOS=https://dl.internalx.com/wrench/xcode14.1/aaa923d79ee5f5247db226bc70edb47cc6e84787/6931415/package/bundle.zip
+APIDIFF_REFERENCES_Mac=https://dl.internalx.com/wrench/xcode14.1/aaa923d79ee5f5247db226bc70edb47cc6e84787/6931415/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_iOS=https://dl.internalx.com/wrench/7.0.1xx/a6cb1adc6dfd3248d389ff2cf73d2753a40672e5/6938165/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_tvOS=https://dl.internalx.com/wrench/7.0.1xx/a6cb1adc6dfd3248d389ff2cf73d2753a40672e5/6938165/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_macOS=https://dl.internalx.com/wrench/7.0.1xx/a6cb1adc6dfd3248d389ff2cf73d2753a40672e5/6938165/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_MacCatalyst=https://dl.internalx.com/wrench/7.0.1xx/a6cb1adc6dfd3248d389ff2cf73d2753a40672e5/6938165/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -37,11 +37,11 @@ export HTML_NO_BREAKING_CHANGES_MESSAGE=No breaking changes
 export MARKDOWN_BREAKING_CHANGES_MESSAGE=:heavy_exclamation_mark: Breaking changes :heavy_exclamation_mark:
 export MARKDOWN_NO_BREAKING_CHANGES_MESSAGE=No breaking changes
 
-# Change the below to net7.0 once we have reference assemblies from net7.0 (i.e. once net7.0 goes stable).
-DOTNET_TFM_REFERENCE_iOS=net6.0
-DOTNET_TFM_REFERENCE_tvOS=net6.0
-DOTNET_TFM_REFERENCE_macOS=net6.0
-DOTNET_TFM_REFERENCE_MacCatalyst=net6.0
+# Change the below to net8.0 once we have reference assemblies from net8.0 (i.e. once net8.0 goes stable).
+DOTNET_TFM_REFERENCE_iOS=net7.0
+DOTNET_TFM_REFERENCE_tvOS=net7.0
+DOTNET_TFM_REFERENCE_macOS=net7.0
+DOTNET_TFM_REFERENCE_MacCatalyst=net7.0
 
 # I18N are excluded - but otherwise if should be like ../../builds/Makefile + what XI adds
 # in the order to the api-diff.html merged file


### PR DESCRIPTION
Backport of #16710
