### PR TITLE
[dotnet] security string pinvokes

### DIFF
--- a/src/ObjCRuntime/TransientString.cs
+++ b/src/ObjCRuntime/TransientString.cs
@@ -23,7 +23,22 @@ namespace ObjCRuntime {
 			
 		public TransientString (string? str, Encoding encoding = Encoding.Auto)
 		{
-			ptr = (Encode (encoding)) (str);
+			switch (encoding) {
+			case Encoding.Auto:
+				ptr = Marshal.StringToHGlobalAuto (str);
+				break;
+			case Encoding.BStr:
+				ptr = Marshal.StringToBSTR (str);
+				break;
+			case Encoding.Ansi:
+				ptr = Marshal.StringToHGlobalAnsi (str);
+				break;
+			case Encoding.Unicode:
+				ptr = Marshal.StringToHGlobalUni (str);
+				break;
+			default:
+				throw new ArgumentOutOfRangeException (nameof (encoding));
+			}
 		}
 
 		public void Dispose ()
@@ -33,16 +48,6 @@ namespace ObjCRuntime {
 				ptr = IntPtr.Zero;
 			}
 		}
-
-		static Func<string?, IntPtr> Encode (Encoding encoding) => encoding switch 
-		{
-			Encoding.Auto => Marshal.StringToHGlobalAuto,
-			Encoding.BStr => Marshal.StringToBSTR,
-			Encoding.Ansi => Marshal.StringToHGlobalAnsi,
-			Encoding.Unicode => Marshal.StringToHGlobalUni,
-			_ => throw new ArgumentOutOfRangeException (nameof (encoding))
-		};
-		
 
 		public static implicit operator IntPtr (TransientString str) => str.ptr;
 	}

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -337,17 +337,18 @@ namespace Security {
 		}
 
 		[DllImport (Constants.SecurityLibrary)]
-		static extern /* OS_dispatch_data */ IntPtr sec_protocol_metadata_create_secret (/* OS_sec_protocol_metadata */ IntPtr metadata, /* size_t */ nuint label_len, /* const char*/ [MarshalAs (UnmanagedType.LPStr)] string label, /* size_t */ nuint exporter_length);
+		static extern /* OS_dispatch_data */ IntPtr sec_protocol_metadata_create_secret (/* OS_sec_protocol_metadata */ IntPtr metadata, /* size_t */ nuint label_len, /* const char*/ IntPtr label, /* size_t */ nuint exporter_length);
 
 		public DispatchData? CreateSecret (string label, nuint exporterLength)
 		{
 			if (label is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (label));
-			return CreateDispatchData (sec_protocol_metadata_create_secret (GetCheckedHandle (), (nuint) label.Length, label, exporterLength));
+			using var labelPtr = new TransientString (label, TransientString.Encoding.Ansi);
+			return CreateDispatchData (sec_protocol_metadata_create_secret (GetCheckedHandle (), (nuint) label.Length, labelPtr, exporterLength));
 		}
 
 		[DllImport (Constants.SecurityLibrary)]
-		static unsafe extern /* OS_dispatch_data */ IntPtr sec_protocol_metadata_create_secret_with_context (/* OS_sec_protocol_metadata */ IntPtr metadata, /* size_t */ nuint label_len, /* const char*/ [MarshalAs (UnmanagedType.LPStr)] string label, /* size_t */  nuint context_len, byte* context, /* size_t */ nuint exporter_length);
+		static unsafe extern /* OS_dispatch_data */ IntPtr sec_protocol_metadata_create_secret_with_context (/* OS_sec_protocol_metadata */ IntPtr metadata, /* size_t */ nuint label_len, /* const char*/ IntPtr label, /* size_t */  nuint context_len, byte* context, /* size_t */ nuint exporter_length);
 
 		public unsafe DispatchData? CreateSecret (string label, byte [] context, nuint exporterLength)
 		{
@@ -355,8 +356,9 @@ namespace Security {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (label));
 			if (context is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (context));
-			fixed (byte* p = context)
-				return CreateDispatchData (sec_protocol_metadata_create_secret_with_context (GetCheckedHandle (), (nuint) label.Length, label, (nuint) context.Length, p, exporterLength));
+			using var labelPtr = new TransientString (label, TransientString.Encoding.Ansi);
+			fixed (byte* p = context) 
+				return CreateDispatchData (sec_protocol_metadata_create_secret_with_context (GetCheckedHandle (), (nuint) label.Length, labelPtr, (nuint) context.Length, p, exporterLength));
 		}
 
 		// API returning `OS_dispatch_data` can also return `null` and

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1914,7 +1914,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/NativeAttribute.cs \
 	ObjCRuntime/NativeHandle.cs \
 	ObjCRuntime/NativeNameAttribute.cs \
-	ObjCRuntime/NativeString.cs \
+	ObjCRuntime/TransientString.cs \
 	ObjCRuntime/NFloat.cs \
 	ObjCRuntime/ObsoleteConstants.cs \
 	ObjCRuntime/PlatformAvailability.cs \


### PR DESCRIPTION
- Renamed NativeString.cs -> TransientString.cs
- Added an encoding parameter for available Marshal methods
- Added encoding in the ctor
- Handled security strings