### PR TITLE
[tests] Assert that we don't have any private IntPtr constructors in cecil-tests.

### DIFF
--- a/tests/cecil-tests/ConstructorTest.cs
+++ b/tests/cecil-tests/ConstructorTest.cs
@@ -280,8 +280,8 @@ namespace Cecil.Tests {
 								Console.WriteLine ($"{GetLocation (intptrCtor)}{msg}");
 								failures.Add (msg);
 							} else {
-								var msg = $"{type}: private (IntPtr) constructor found. It should probably not exist.";
-								Console.WriteLine ($"{GetLocation (intptrCtor)}{msg}");
+								var msg = $"{type}: private (IntPtr) constructor found. It should probably not exist. If it should, add an exception to this test.";
+								failures.Add ($"{GetLocation (intptrCtor)}{msg}");
 							}
 						}
 


### PR DESCRIPTION
This depends on #16977 being merged first.