### PR TITLE
[CloudKit] Update availability attributes for CKShareParticipantType.

### DIFF
--- a/src/CloudKit/Enums.cs
+++ b/src/CloudKit/Enums.cs
@@ -207,7 +207,13 @@ namespace CloudKit {
 	}
 
 	[Watch (3, 0)]
-	[iOS (10, 10), Mac (10, 12)]
+	[iOS (10, 0)]
+	[Mac (10, 12)]
+	[TV (10, 0)]
+	[Deprecated (PlatformName.TvOS, 12, 0, message: "Use 'CKShareParticipantRole' instead.")]
+	[Deprecated (PlatformName.iOS, 12, 0, message: "Use 'CKShareParticipantRole' instead.")]
+	[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use 'CKShareParticipantRole' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'CKShareParticipantRole' instead.")]
 	[Native]
 	public enum CKShareParticipantType : long {
 		Unknown = 0,


### PR DESCRIPTION
* The iOS attribute is incorrect (iOS 10.10 doesn't exist), so fix that
  according to headers (should be iOS 10.0).
* When looking at the header, I realized the enum is deprecated, so fix that
  too.