### PR TITLE
[tools] Split tools/common/SdkVersions.cs in two files.

### DIFF
--- a/tests/mtouch/Makefile
+++ b/tests/mtouch/Makefile
@@ -38,6 +38,9 @@ bin/Debug/mtouchtests.dll: $(mtouchtests_dependencies)
 $(abspath $(TOP)/tools/mtouch/Constants.cs):
 	$(Q) $(MAKE) $(notdir $@) -C $(dir $@)
 
+$(TOP)/tools/common/ProductConstants.cs:
+	$(Q) $(MAKE) -C $(TOP)/tools/mtouch ../common/ProductConstants.cs
+
 build: bin/Debug/mtouchtests.dll
 
 test.config: $(TOP)/Make.config Makefile

--- a/tests/mtouch/mtouchtests.csproj
+++ b/tests/mtouch/mtouchtests.csproj
@@ -79,6 +79,9 @@
     <Compile Include="..\..\tools\common\SdkVersions.cs">
       <Link>SdkVersions.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\ProductConstants.cs">
+      <Link>ProductConstants.cs</Link>
+    </Compile>
     <Compile Include="ErrorTest.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="Compat.cs" />

--- a/tools/common/.gitignore
+++ b/tools/common/.gitignore
@@ -1,1 +1,2 @@
-SdkVersions.cs
+SdkVersions.cs.tmp
+ProductConstants.cs

--- a/tools/common/Make.common
+++ b/tools/common/Make.common
@@ -1,3 +1,5 @@
+# We check in SdkVersions.cs so that it's easier to use this file when building tests on Windows.
+
 ../common/SdkVersions.cs: ../common/SdkVersions.cs.in Makefile $(TOP)/Make.config
 	$(Q_GEN) sed \
 		-e 's/@IOS_SDK_VERSION@/$(IOS_SDK_VERSION)/g' -e 's/@WATCHOS_SDK_VERSION@/$(WATCH_SDK_VERSION)/' -e 's/@TVOS_SDK_VERSION@/$(TVOS_SDK_VERSION)/' -e 's/@MACOS_SDK_VERSION@/$(MACOS_SDK_VERSION)/' \
@@ -54,4 +56,19 @@
 		-e "s/@DEFAULT_TARGET_PLATFORM_VERSION_MACCATALYST@/$(DEFAULT_TARGET_PLATFORM_VERSION_MACCATALYST)/g" \
 		\
 		-e "s/@PRODUCT_HASH@/$(CURRENT_HASH_LONG)/g" \
-		$< > $@ 
+		$< > $@.tmp
+	$(Q) if ! diff $@ $@.tmp >/dev/null; then $(CP) $@.tmp $@; echo "The file $(TOP)/tools/common/SdkVersions.cs has been automatically re-generated; please commit the changes."; fi
+
+../common/ProductConstants.cs: ../common/ProductConstants.cs.in Makefile $(TOP)/Make.config
+	$(Q_GEN) sed \
+		-e "s/@IOS_VERSION@/$(IOS_PACKAGE_VERSION_MAJOR).$(IOS_PACKAGE_VERSION_MINOR).$(IOS_PACKAGE_VERSION_REV)/g" \
+		-e "s/@TVOS_VERSION@/$(IOS_PACKAGE_VERSION_MAJOR).$(IOS_PACKAGE_VERSION_MINOR).$(IOS_PACKAGE_VERSION_REV)/g" \
+		-e "s/@WATCHOS_VERSION@/$(IOS_PACKAGE_VERSION_MAJOR).$(IOS_PACKAGE_VERSION_MINOR).$(IOS_PACKAGE_VERSION_REV)/g" \
+		-e "s/@MACOS_VERSION@/$(MAC_PACKAGE_VERSION_MAJOR).$(MAC_PACKAGE_VERSION_MINOR).$(MAC_PACKAGE_VERSION_REV)/g" \
+		\
+		$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),-e 's/@$(platform)_REVISION@/$($(platform)_COMMIT_DISTANCE) ($(CURRENT_BRANCH_SED_ESCAPED): $(CURRENT_HASH))/g')  \
+		$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),-e 's/@$(platform)_NUGET_VERSION@/$($(platform)_NUGET_VERSION)/g')  \
+		$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),-e "s/@$(platform)_NUGET_REVISION@/$(NUGET_PRERELEASE_IDENTIFIER)$($(platform)_NUGET_COMMIT_DISTANCE)+$(NUGET_BUILD_METADATA)/g")  \
+		\
+		-e "s/@PRODUCT_HASH@/$(CURRENT_HASH_LONG)/g" \
+		$< > $@

--- a/tools/common/ProductConstants.cs.in
+++ b/tools/common/ProductConstants.cs.in
@@ -1,0 +1,35 @@
+using System;
+
+#if MTOUCH || MMP || BUNDLER
+using Xamarin.Bundler;
+using Xamarin.Utils;
+#endif
+
+#if MTOUCH
+using MonoTouch;
+#endif
+
+namespace Xamarin {
+	sealed class ProductConstants {
+		public string Version;
+		public string Revision;
+		public const string Hash = "@PRODUCT_HASH@";
+
+		ProductConstants (string version, string revision)
+		{
+			Version = version;
+			Revision = revision;
+		}
+#if BUNDLER
+		public readonly static ProductConstants iOS = new ProductConstants ("@IOS_NUGET_VERSION@", "@IOS_NUGET_REVISION@");
+		public readonly static ProductConstants tvOS = new ProductConstants ("@TVOS_NUGET_VERSION@", "@TVOS_NUGET_REVISION@");
+		public readonly static ProductConstants watchOS = new ProductConstants ("@WATCHOS_NUGET_VERSION@", "@WATCHOS_NUGET_REVISION@");
+		public readonly static ProductConstants macOS = new ProductConstants ("@MACOS_NUGET_VERSION@", "@MACOS_NUGET_REVISION@");
+#else
+		public readonly static ProductConstants iOS = new ProductConstants ("@IOS_VERSION@", "@IOS_REVISION@");
+		public readonly static ProductConstants tvOS = new ProductConstants ("@TVOS_VERSION@", "@TVOS_REVISION@");
+		public readonly static ProductConstants watchOS = new ProductConstants ("@WATCHOS_VERSION@", "@WATCHOS_REVISION@");
+		public readonly static ProductConstants macOS = new ProductConstants ("@MACOS_VERSION@", "@MACOS_REVISION@");
+#endif
+	}
+}

--- a/tools/common/SdkVersions.cs
+++ b/tools/common/SdkVersions.cs
@@ -51,33 +51,33 @@ namespace Xamarin {
 		public const string DefaultTargetPlatformVersionmacOS = "13.0";
 		public const string DefaultTargetPlatformVersionMacCatalyst = "16.1";
 
-		public static Version OSXVersion { get { return new Version (OSX); }}
-		public static Version iOSVersion { get { return new Version (iOS); }}
-		public static Version WatchOSVersion { get { return new Version (WatchOS); }}
-		public static Version TVOSVersion { get { return new Version (TVOS); }}
-		public static Version MacCatalystVersion { get { return new Version (MacCatalyst); }}
+		public static Version OSXVersion { get { return new Version (OSX); } }
+		public static Version iOSVersion { get { return new Version (iOS); } }
+		public static Version WatchOSVersion { get { return new Version (WatchOS); } }
+		public static Version TVOSVersion { get { return new Version (TVOS); } }
+		public static Version MacCatalystVersion { get { return new Version (MacCatalyst); } }
 
-		public static Version iOSTargetVersion { get { return new Version (MaxiOSDeploymentTarget); }}
-		public static Version WatchOSTargetVersion { get { return new Version (MaxWatchDeploymentTarget); }}
-		public static Version TVOSTargetVersion { get { return new Version (MaxTVOSDeploymentTarget); }}
+		public static Version iOSTargetVersion { get { return new Version (MaxiOSDeploymentTarget); } }
+		public static Version WatchOSTargetVersion { get { return new Version (MaxWatchDeploymentTarget); } }
+		public static Version TVOSTargetVersion { get { return new Version (MaxTVOSDeploymentTarget); } }
 
-		public static Version MinOSXVersion { get { return new Version (MinOSX); }}
-		public static Version MiniOSVersion { get { return new Version (MiniOS); }}
-		public static Version MinWatchOSVersion { get { return new Version (MinWatchOS); }}
-		public static Version MinTVOSVersion { get { return new Version (MinTVOS); }}
-		public static Version MinMacCatalystVersion { get { return new Version (MinMacCatalyst); }}
+		public static Version MinOSXVersion { get { return new Version (MinOSX); } }
+		public static Version MiniOSVersion { get { return new Version (MiniOS); } }
+		public static Version MinWatchOSVersion { get { return new Version (MinWatchOS); } }
+		public static Version MinTVOSVersion { get { return new Version (MinTVOS); } }
+		public static Version MinMacCatalystVersion { get { return new Version (MinMacCatalyst); } }
 
-		public static Version MiniOSSimulatorVersion { get { return new Version (MiniOSSimulator); }}
-		public static Version MinWatchOSSimulatorVersion { get { return new Version (MinWatchOSSimulator); }}
-		public static Version MinWatchOSCompanionSimulatorVersion { get { return new Version (MinWatchOSCompanionSimulator); }}
-		public static Version MinTVOSSimulatorVersion { get { return new Version (MinTVOSSimulator); }}
+		public static Version MiniOSSimulatorVersion { get { return new Version (MiniOSSimulator); } }
+		public static Version MinWatchOSSimulatorVersion { get { return new Version (MinWatchOSSimulator); } }
+		public static Version MinWatchOSCompanionSimulatorVersion { get { return new Version (MinWatchOSCompanionSimulator); } }
+		public static Version MinTVOSSimulatorVersion { get { return new Version (MinTVOSSimulator); } }
 
-		public static Version MaxiOSSimulatorVersion { get { return new Version (MaxiOSSimulator); }}
-		public static Version MaxWatchOSSimulatorVersion { get { return new Version (MaxWatchOSSimulator); }}
-		public static Version MaxWatchOSCompanionSimulatorVersion { get { return new Version (MaxWatchOSCompanionSimulator); }}
-		public static Version MaxTVOSSimulatorVersion { get { return new Version (MaxTVOSSimulator); }}
+		public static Version MaxiOSSimulatorVersion { get { return new Version (MaxiOSSimulator); } }
+		public static Version MaxWatchOSSimulatorVersion { get { return new Version (MaxWatchOSSimulator); } }
+		public static Version MaxWatchOSCompanionSimulatorVersion { get { return new Version (MaxWatchOSCompanionSimulator); } }
+		public static Version MaxTVOSSimulatorVersion { get { return new Version (MaxTVOSSimulator); } }
 
-		public static Version XcodeVersion { get { return new Version (Xcode); }}
+		public static Version XcodeVersion { get { return new Version (Xcode); } }
 
 #if MTOUCH || MMP || BUNDLER
 		public static Version GetVersion (Application app)
@@ -123,7 +123,7 @@ namespace Xamarin {
 #if MMP
 	static class MonoVersions {
 		public static string MinimumMono = "6.4.0.94";
-		public static Version MinimumMonoVersion { get { return new Version (MinimumMono); }}
+		public static Version MinimumMonoVersion { get { return new Version (MinimumMono); } }
 	}
 #endif
 }

--- a/tools/common/SdkVersions.cs
+++ b/tools/common/SdkVersions.cs
@@ -9,6 +9,8 @@ using Xamarin.Utils;
 using MonoTouch;
 #endif
 
+#nullable enable
+
 namespace Xamarin {
 	static class SdkVersions {
 		public const string Xcode = "14.1";

--- a/tools/common/SdkVersions.cs
+++ b/tools/common/SdkVersions.cs
@@ -9,49 +9,47 @@ using Xamarin.Utils;
 using MonoTouch;
 #endif
 
-#nullable enable
-
 namespace Xamarin {
 	static class SdkVersions {
-		public const string Xcode = "@XCODE_VERSION@";
-		public const string OSX = "@MACOS_SDK_VERSION@";
-		public const string iOS = "@IOS_SDK_VERSION@";
-		public const string WatchOS = "@WATCHOS_SDK_VERSION@";
-		public const string TVOS = "@TVOS_SDK_VERSION@";
-		public const string MacCatalyst = "@MACCATALYST_SDK_VERSION@";
+		public const string Xcode = "14.1";
+		public const string OSX = "13.0";
+		public const string iOS = "16.1";
+		public const string WatchOS = "9.1";
+		public const string TVOS = "16.1";
+		public const string MacCatalyst = "16.1";
 
 #if NET
-		public const string MinOSX = "@DOTNET_MIN_MACOS_SDK_VERSION@";
-		public const string MiniOS = "@DOTNET_MIN_IOS_SDK_VERSION@";
+		public const string MinOSX = "10.14";
+		public const string MiniOS = "10.0";
 		public const string MinWatchOS = "99.99"; // TODO not supported, many changes required to remove it
-		public const string MinTVOS = "@DOTNET_MIN_TVOS_SDK_VERSION@";
-		public const string MinMacCatalyst = "@DOTNET_MIN_MACCATALYST_SDK_VERSION@";
+		public const string MinTVOS = "10.0";
+		public const string MinMacCatalyst = "13.1";
 #else
-		public const string MinOSX = "@MIN_MACOS_SDK_VERSION@";
-		public const string MiniOS = "@MIN_IOS_SDK_VERSION@";
-		public const string MinWatchOS = "@MIN_WATCHOS_SDK_VERSION@";
-		public const string MinTVOS = "@MIN_TVOS_SDK_VERSION@";
-		public const string MinMacCatalyst = "@MIN_MACCATALYST_SDK_VERSION@";
+		public const string MinOSX = "10.9";
+		public const string MiniOS = "7.0";
+		public const string MinWatchOS = "2.0";
+		public const string MinTVOS = "9.0";
+		public const string MinMacCatalyst = "13.1";
 #endif
 
-		public const string MiniOSSimulator = "@MIN_IOS_SIMULATOR_VERSION@";
-		public const string MinWatchOSSimulator = "@MIN_WATCHOS_SIMULATOR_VERSION@";
-		public const string MinWatchOSCompanionSimulator = "@MIN_WATCHOS_COMPANION_SIMULATOR_VERSION@";
-		public const string MinTVOSSimulator = "@MIN_TVOS_SIMULATOR_VERSION@";
+		public const string MiniOSSimulator = "12.4";
+		public const string MinWatchOSSimulator = "7.0";
+		public const string MinWatchOSCompanionSimulator = "14.5";
+		public const string MinTVOSSimulator = "12.4";
 
-		public const string MaxiOSSimulator = "@MAX_IOS_SIMULATOR_VERSION@";
-		public const string MaxWatchOSSimulator = "@MAX_WATCH_SIMULATOR_VERSION@";
-		public const string MaxWatchOSCompanionSimulator = "@MAX_IOS_SIMULATOR_VERSION@";
-		public const string MaxTVOSSimulator = "@MAX_TVOS_SIMULATOR_VERSION@";
+		public const string MaxiOSSimulator = "16.1";
+		public const string MaxWatchOSSimulator = "9.1";
+		public const string MaxWatchOSCompanionSimulator = "16.1";
+		public const string MaxTVOSSimulator = "16.1";
 
-		public const string MaxiOSDeploymentTarget = "@MAX_IOS_DEPLOYMENT_TARGET@";
-		public const string MaxWatchDeploymentTarget = "@MAX_WATCH_DEPLOYMENT_TARGET@";
-		public const string MaxTVOSDeploymentTarget = "@MAX_TVOS_DEPLOYMENT_TARGET@";
+		public const string MaxiOSDeploymentTarget = "16.1";
+		public const string MaxWatchDeploymentTarget = "9.1";
+		public const string MaxTVOSDeploymentTarget = "16.1";
 
-		public const string DefaultTargetPlatformVersioniOS = "@DEFAULT_TARGET_PLATFORM_VERSION_IOS@";
-		public const string DefaultTargetPlatformVersiontvOS = "@DEFAULT_TARGET_PLATFORM_VERSION_TVOS@";
-		public const string DefaultTargetPlatformVersionmacOS = "@DEFAULT_TARGET_PLATFORM_VERSION_MACOS@";
-		public const string DefaultTargetPlatformVersionMacCatalyst = "@DEFAULT_TARGET_PLATFORM_VERSION_MACCATALYST@";
+		public const string DefaultTargetPlatformVersioniOS = "16.1";
+		public const string DefaultTargetPlatformVersiontvOS = "16.1";
+		public const string DefaultTargetPlatformVersionmacOS = "13.0";
+		public const string DefaultTargetPlatformVersionMacCatalyst = "16.1";
 
 		public static Version OSXVersion { get { return new Version (OSX); }}
 		public static Version iOSVersion { get { return new Version (iOS); }}
@@ -124,7 +122,7 @@ namespace Xamarin {
 
 #if MMP
 	static class MonoVersions {
-		public static string MinimumMono = "@MIN_XM_MONO_VERSION@";
+		public static string MinimumMono = "6.4.0.94";
 		public static Version MinimumMonoVersion { get { return new Version (MinimumMono); }}
 	}
 #endif

--- a/tools/common/SdkVersions.cs.in
+++ b/tools/common/SdkVersions.cs.in
@@ -53,33 +53,33 @@ namespace Xamarin {
 		public const string DefaultTargetPlatformVersionmacOS = "@DEFAULT_TARGET_PLATFORM_VERSION_MACOS@";
 		public const string DefaultTargetPlatformVersionMacCatalyst = "@DEFAULT_TARGET_PLATFORM_VERSION_MACCATALYST@";
 
-		public static Version OSXVersion { get { return new Version (OSX); }}
-		public static Version iOSVersion { get { return new Version (iOS); }}
-		public static Version WatchOSVersion { get { return new Version (WatchOS); }}
-		public static Version TVOSVersion { get { return new Version (TVOS); }}
-		public static Version MacCatalystVersion { get { return new Version (MacCatalyst); }}
+		public static Version OSXVersion { get { return new Version (OSX); } }
+		public static Version iOSVersion { get { return new Version (iOS); } }
+		public static Version WatchOSVersion { get { return new Version (WatchOS); } }
+		public static Version TVOSVersion { get { return new Version (TVOS); } }
+		public static Version MacCatalystVersion { get { return new Version (MacCatalyst); } }
 
-		public static Version iOSTargetVersion { get { return new Version (MaxiOSDeploymentTarget); }}
-		public static Version WatchOSTargetVersion { get { return new Version (MaxWatchDeploymentTarget); }}
-		public static Version TVOSTargetVersion { get { return new Version (MaxTVOSDeploymentTarget); }}
+		public static Version iOSTargetVersion { get { return new Version (MaxiOSDeploymentTarget); } }
+		public static Version WatchOSTargetVersion { get { return new Version (MaxWatchDeploymentTarget); } }
+		public static Version TVOSTargetVersion { get { return new Version (MaxTVOSDeploymentTarget); } }
 
-		public static Version MinOSXVersion { get { return new Version (MinOSX); }}
-		public static Version MiniOSVersion { get { return new Version (MiniOS); }}
-		public static Version MinWatchOSVersion { get { return new Version (MinWatchOS); }}
-		public static Version MinTVOSVersion { get { return new Version (MinTVOS); }}
-		public static Version MinMacCatalystVersion { get { return new Version (MinMacCatalyst); }}
+		public static Version MinOSXVersion { get { return new Version (MinOSX); } }
+		public static Version MiniOSVersion { get { return new Version (MiniOS); } }
+		public static Version MinWatchOSVersion { get { return new Version (MinWatchOS); } }
+		public static Version MinTVOSVersion { get { return new Version (MinTVOS); } }
+		public static Version MinMacCatalystVersion { get { return new Version (MinMacCatalyst); } }
 
-		public static Version MiniOSSimulatorVersion { get { return new Version (MiniOSSimulator); }}
-		public static Version MinWatchOSSimulatorVersion { get { return new Version (MinWatchOSSimulator); }}
-		public static Version MinWatchOSCompanionSimulatorVersion { get { return new Version (MinWatchOSCompanionSimulator); }}
-		public static Version MinTVOSSimulatorVersion { get { return new Version (MinTVOSSimulator); }}
+		public static Version MiniOSSimulatorVersion { get { return new Version (MiniOSSimulator); } }
+		public static Version MinWatchOSSimulatorVersion { get { return new Version (MinWatchOSSimulator); } }
+		public static Version MinWatchOSCompanionSimulatorVersion { get { return new Version (MinWatchOSCompanionSimulator); } }
+		public static Version MinTVOSSimulatorVersion { get { return new Version (MinTVOSSimulator); } }
 
-		public static Version MaxiOSSimulatorVersion { get { return new Version (MaxiOSSimulator); }}
-		public static Version MaxWatchOSSimulatorVersion { get { return new Version (MaxWatchOSSimulator); }}
-		public static Version MaxWatchOSCompanionSimulatorVersion { get { return new Version (MaxWatchOSCompanionSimulator); }}
-		public static Version MaxTVOSSimulatorVersion { get { return new Version (MaxTVOSSimulator); }}
+		public static Version MaxiOSSimulatorVersion { get { return new Version (MaxiOSSimulator); } }
+		public static Version MaxWatchOSSimulatorVersion { get { return new Version (MaxWatchOSSimulator); } }
+		public static Version MaxWatchOSCompanionSimulatorVersion { get { return new Version (MaxWatchOSCompanionSimulator); } }
+		public static Version MaxTVOSSimulatorVersion { get { return new Version (MaxTVOSSimulator); } }
 
-		public static Version XcodeVersion { get { return new Version (Xcode); }}
+		public static Version XcodeVersion { get { return new Version (Xcode); } }
 
 #if MTOUCH || MMP || BUNDLER
 		public static Version GetVersion (Application app)
@@ -125,7 +125,7 @@ namespace Xamarin {
 #if MMP
 	static class MonoVersions {
 		public static string MinimumMono = "@MIN_XM_MONO_VERSION@";
-		public static Version MinimumMonoVersion { get { return new Version (MinimumMono); }}
+		public static Version MinimumMonoVersion { get { return new Version (MinimumMono); } }
 	}
 #endif
 }

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -77,6 +77,9 @@
     <Compile Include="..\common\SdkVersions.cs">
       <Link>external\tools\common\SdkVersions.cs</Link>
     </Compile>
+    <Compile Include="..\common\ProductConstants.cs">
+      <Link>external\tools\common\ProductConstants.cs</Link>
+    </Compile>
     <Compile Include="..\common\Symbols.cs">
       <Link>external\tools\common\Symbols.cs</Link>
     </Compile>
@@ -277,7 +280,7 @@
       <ManifestResourceName>Xamarin.Bundler.Errors.zh-Hant</ManifestResourceName>
     </EmbeddedResource>
   </ItemGroup>
-  <Target Name="BuildSdkVersions" Inputs="../common/SdkVersions.cs.in;../common/Make.common" Outputs="../common/SdkVersions.cs">
-    <Exec Command="make ../common/SdkVersions.cs" />
+  <Target Name="BuildSdkVersions" Inputs="../common/SdkVersions.cs.in;../common/ProductConstants.cs.in" Outputs="../common/SdkVersions.cs;../common/ProductConstants.cs">
+    <Exec Command="make ../common/SdkVersions.cs ../common/ProductConstants.cs" />
   </Target>
 </Project>

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -57,6 +57,9 @@
     <Compile Include="..\common\SdkVersions.cs">
       <Link>tools\common\SdkVersions.cs</Link>
     </Compile>
+    <Compile Include="..\common\ProductConstants.cs">
+      <Link>tools\common\ProductConstants.cs</Link>
+    </Compile>
     <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\external\linker\src\tuner\Mono.Tuner\ApplyPreserveAttributeBase.cs">
       <Link>mono-archive\Mono.Tuner\ApplyPreserveAttributeBase.cs</Link>
     </Compile>
@@ -565,7 +568,7 @@
       <Link>docs\website\mmp-errors.md</Link>
     </None>
   </ItemGroup>
-  <Target Name="BuildSdkVersions" Inputs="../common/SdkVersions.cs.in" Outputs="../common/SdkVersions.cs">
-    <Exec Command="make ../common/SdkVersions.cs" />
+  <Target Name="BuildSdkVersions" Inputs="../common/SdkVersions.cs.in;../common/ProductConstants.cs.in" Outputs="../common/SdkVersions.cs;../common/ProductConstants.cs">
+    <Exec Command="make ../common/SdkVersions.cs ../common/ProductConstants.cs" />
   </Target>
 </Project>

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -46,6 +46,9 @@
     <Compile Include="..\common\SdkVersions.cs">
       <Link>tools\common\SdkVersions.cs</Link>
     </Compile>
+    <Compile Include="..\common\ProductConstants.cs">
+      <Link>tools\common\ProductConstants.cs</Link>
+    </Compile>
     <Compile Include="Stripper.cs" />
     <Compile Include="Target.mtouch.cs" />
     <Compile Include="Tuning.mtouch.cs" />
@@ -582,8 +585,8 @@
       <ManifestResourceName>Xamarin.Bundler.Errors.zh-Hant</ManifestResourceName>
     </EmbeddedResource>
   </ItemGroup>
-  <Target Name="BuildSdkVersions" Inputs="../common/SdkVersions.cs.in" Outputs="../common/SdkVersions.cs">
-    <Exec Command="make ../common/SdkVersions.cs" />
+  <Target Name="BuildSdkVersions" Inputs="../common/SdkVersions.cs.in;../common/ProductConstants.cs.in" Outputs="../common/SdkVersions.cs;../common/ProductConstants.cs">
+    <Exec Command="make ../common/SdkVersions.cs ../common/ProductConstants.cs" />
   </Target>
   <Target Name="AfterBuild">
     <!-- This makes sure that just building the csproj will install the updated mtouch.exe, so that tests get it without having to 'make mtouch' manually -->


### PR DESCRIPTION
We need parts of tools/common/SdkVersions.cs when building tests on Windows.
In order to simplify our Windows-life, we're going to check in the generated
SdkVersions.cs file, that way it won't have to be re-generated on Windows (the
logic is very make-based, and not easily executed on Windows).

However, parts of SdkVersions.cs would change every commit, which would make
the above solution rather annoying. So split out those parts into a new file
(ProductConstants.cs), which is still generated during the build (and not
checked in).