### PR TITLE
[dotnet] blitable network pinvokes

### DIFF
--- a/src/Network/NWAdvertiseDescriptor.cs
+++ b/src/Network/NWAdvertiseDescriptor.cs
@@ -55,7 +55,13 @@ namespace Network {
 		[Watch (9, 0)]
 #endif
 		[DllImport (Constants.NetworkLibrary)]
-		static extern OS_nw_advertise_descriptor nw_advertise_descriptor_create_application_service (string application_service_name);
+		static extern OS_nw_advertise_descriptor nw_advertise_descriptor_create_application_service (IntPtr application_service_name);
+
+		static OS_nw_advertise_descriptor nw_advertise_descriptor_create_application_service (string application_service_name)
+		{
+			using var namePtr = new TransientString (application_service_name);
+			return nw_advertise_descriptor_create_application_service (namePtr);
+		}
 
 #if NET
 		[SupportedOSPlatform ("tvos16.0")]
@@ -103,7 +109,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern IntPtr nw_advertise_descriptor_create_bonjour_service (string name, string type, string? domain);
+		static extern IntPtr nw_advertise_descriptor_create_bonjour_service (IntPtr name, IntPtr type, IntPtr domain);
 
 		public static NWAdvertiseDescriptor? CreateBonjourService (string name, string type, string? domain = null)
 		{
@@ -113,21 +119,25 @@ namespace Network {
 			if (type is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (type));
 
-			var x = nw_advertise_descriptor_create_bonjour_service (name, type, domain);
+			using var namePtr = new TransientString (name);
+			using var typePtr = new TransientString (type);
+			using var domainPtr = new TransientString (domain);
+			var x = nw_advertise_descriptor_create_bonjour_service (namePtr, typePtr, domainPtr);
 			if (x == IntPtr.Zero)
 				return null;
 			return new NWAdvertiseDescriptor (x, owns: true);
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_advertise_descriptor_set_txt_record (IntPtr handle, string txtRecord, nuint txtLen);
+		static extern void nw_advertise_descriptor_set_txt_record (IntPtr handle, IntPtr txtRecord, nuint txtLen);
 
 		public void SetTxtRecord (string txt)
 		{
 			if (txt is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (txt));
 			var n = System.Text.Encoding.UTF8.GetByteCount (txt);
-			nw_advertise_descriptor_set_txt_record (GetCheckedHandle (), txt, (nuint) n);
+			using var txtPtr = new TransientString (txt);
+			nw_advertise_descriptor_set_txt_record (GetCheckedHandle (), txtPtr, (nuint) n);
 		}
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWBrowserDescriptor.cs
+++ b/src/Network/NWBrowserDescriptor.cs
@@ -40,7 +40,7 @@ namespace Network {
 		internal NWBrowserDescriptor (NativeHandle handle, bool owns) : base (handle, owns) { }
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern OS_nw_browse_descriptor nw_browse_descriptor_create_bonjour_service (string type, string? domain);
+		static extern OS_nw_browse_descriptor nw_browse_descriptor_create_bonjour_service (IntPtr type, IntPtr domain);
 
 #if NET
 		[SupportedOSPlatform ("tvos16.0")]
@@ -54,7 +54,7 @@ namespace Network {
 		[Watch (9, 0)]
 #endif
 		[DllImport (Constants.NetworkLibrary)]
-		static extern OS_nw_browse_descriptor nw_browse_descriptor_create_application_service (string application_service_name);
+		static extern OS_nw_browse_descriptor nw_browse_descriptor_create_application_service (IntPtr application_service_name);
 
 #if NET
 		[SupportedOSPlatform ("tvos16.0")]
@@ -72,7 +72,8 @@ namespace Network {
 			if (applicationServiceName is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (applicationServiceName));
 
-			return new NWBrowserDescriptor (nw_browse_descriptor_create_application_service (applicationServiceName), owns: true);
+			using var applicationServiceNamePtr = new TransientString (applicationServiceName);
+			return new NWBrowserDescriptor (nw_browse_descriptor_create_application_service (applicationServiceNamePtr), owns: true);
 		}
 
 #if NET
@@ -113,7 +114,9 @@ namespace Network {
 			if (type is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (type));
 
-			return new NWBrowserDescriptor (nw_browse_descriptor_create_bonjour_service (type, domain), owns: true);
+			using var typePtr = new TransientString (type);
+			using var domainPtr = new TransientString (domain);
+			return new NWBrowserDescriptor (nw_browse_descriptor_create_bonjour_service (typePtr, domainPtr), owns: true);
 		}
 
 		public static NWBrowserDescriptor CreateBonjourService (string type) => CreateBonjourService (type, null);

--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -529,7 +529,7 @@ namespace Network {
 			SendIdempotent (d, context, isComplete);
 		}
 
-		[DllImport (Constants.NetworkLibrary)]
+		[DllImport (Constants.NetworkLibrary, EntryPoint = "nw_connection_copy_description")]
 		extern static IntPtr nw_connection_copy_description_ptr (IntPtr handle);
 
 		static string nw_connection_copy_description (IntPtr handle)

--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -530,7 +530,13 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		extern static string nw_connection_copy_description (IntPtr handle);
+		extern static IntPtr nw_connection_copy_description_ptr (IntPtr handle);
+
+		static string nw_connection_copy_description (IntPtr handle)
+		{
+			var ptr = nw_connection_copy_description_ptr (handle);
+			return TransientString.ToStringAndFree (ptr)!;
+		}
 
 		public string Description => nw_connection_copy_description (GetCheckedHandle ());
 

--- a/src/Network/NWContentContext.cs
+++ b/src/Network/NWContentContext.cs
@@ -68,13 +68,14 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		extern static IntPtr nw_content_context_create (string contextIdentifier);
+		extern static IntPtr nw_content_context_create (IntPtr contextIdentifier);
 
 		public NWContentContext (string contextIdentifier)
 		{
 			if (contextIdentifier is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (contextIdentifier));
-			InitializeHandle (nw_content_context_create (contextIdentifier));
+			using var contextIdentifierPtr = new TransientString (contextIdentifier);
+			InitializeHandle (nw_content_context_create (contextIdentifierPtr));
 		}
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWEndpoint.cs
+++ b/src/Network/NWEndpoint.cs
@@ -51,7 +51,7 @@ namespace Network {
 		public NWEndpointType Type => nw_endpoint_get_type (GetCheckedHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
-		extern static OS_nw_endpoint nw_endpoint_create_host (string hostname, string port);
+		extern static OS_nw_endpoint nw_endpoint_create_host (IntPtr hostname, IntPtr port);
 
 		public static NWEndpoint? Create (string hostname, string port)
 		{
@@ -59,7 +59,9 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (hostname));
 			if (port is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (port));
-			var handle = nw_endpoint_create_host (hostname, port);
+			using var hostnamePtr = new TransientString (hostname);
+			using var portPtr = new TransientString (port);
+			var handle = nw_endpoint_create_host (hostnamePtr, portPtr);
 			if (handle == IntPtr.Zero)
 				return null;
 			return new NWEndpoint (handle, owns: true);
@@ -71,7 +73,13 @@ namespace Network {
 		public string? Hostname => Marshal.PtrToStringAnsi (nw_endpoint_get_hostname (GetCheckedHandle ()));
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern string nw_endpoint_copy_port_string (OS_nw_endpoint endpoint);
+		static extern IntPtr nw_endpoint_copy_port_string_ptr (OS_nw_endpoint endpoint);
+
+		static string nw_endpoint_copy_port_string (OS_nw_endpoint endpoint)
+		{
+			var ptr = nw_endpoint_copy_port_string_ptr (endpoint);
+			return TransientString.ToStringAndFree (ptr)!;
+		}
 
 		public string Port => nw_endpoint_copy_port_string (GetCheckedHandle ());
 
@@ -88,7 +96,13 @@ namespace Network {
 		// type to begin with.
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern string nw_endpoint_copy_address_string (OS_nw_endpoint endpoint);
+		static extern IntPtr nw_endpoint_copy_address_string_ptr (OS_nw_endpoint endpoint);
+
+		static string nw_endpoint_copy_address_string (OS_nw_endpoint endpoint)
+		{
+			var ptr = nw_endpoint_copy_address_string_ptr (endpoint);
+			return TransientString.ToStringAndFree (ptr)!;
+		}
 
 		public string Address => nw_endpoint_copy_address_string (GetCheckedHandle ());
 
@@ -100,13 +114,16 @@ namespace Network {
 
 		// TODO: same
 		[DllImport (Constants.NetworkLibrary)]
-		static extern unsafe OS_nw_endpoint nw_endpoint_create_bonjour_service (string name, string type, string domain);
+		static extern unsafe OS_nw_endpoint nw_endpoint_create_bonjour_service (IntPtr name, IntPtr type, IntPtr domain);
 
 		public static NWEndpoint? CreateBonjourService (string name, string serviceType, string domain)
 		{
 			if (serviceType is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (serviceType));
-			var x = nw_endpoint_create_bonjour_service (name, serviceType, domain);
+			using var namePtr = new TransientString (name);
+			using var serviceTypePtr = new TransientString (serviceType);
+			using var domainPtr = new TransientString (domain);
+			var x = nw_endpoint_create_bonjour_service (namePtr, serviceTypePtr, domainPtr);
 			if (x == IntPtr.Zero)
 				return null;
 			return new NWEndpoint (x, owns: true);
@@ -138,7 +155,7 @@ namespace Network {
 		[iOS (13, 0)]
 #endif
 		[DllImport (Constants.NetworkLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-		static extern OS_nw_endpoint nw_endpoint_create_url (string url);
+		static extern OS_nw_endpoint nw_endpoint_create_url (IntPtr url);
 
 #if NET
 		[SupportedOSPlatform ("tvos13.0")]
@@ -154,7 +171,8 @@ namespace Network {
 		{
 			if (url is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (url));
-			var handle = nw_endpoint_create_url (url);
+			using var urlPtr = new TransientString (url);
+			var handle = nw_endpoint_create_url (urlPtr);
 			if (handle == IntPtr.Zero)
 				return null;
 			return new NWEndpoint (handle, owns: true);

--- a/src/Network/NWEndpoint.cs
+++ b/src/Network/NWEndpoint.cs
@@ -72,7 +72,7 @@ namespace Network {
 
 		public string? Hostname => Marshal.PtrToStringAnsi (nw_endpoint_get_hostname (GetCheckedHandle ()));
 
-		[DllImport (Constants.NetworkLibrary)]
+		[DllImport (Constants.NetworkLibrary, EntryPoint = "nw_endpoint_copy_port_string")]
 		static extern IntPtr nw_endpoint_copy_port_string_ptr (OS_nw_endpoint endpoint);
 
 		static string nw_endpoint_copy_port_string (OS_nw_endpoint endpoint)
@@ -95,7 +95,7 @@ namespace Network {
 		// address family would have to be mapped, and it does not look like a very useful
 		// type to begin with.
 
-		[DllImport (Constants.NetworkLibrary)]
+		[DllImport (Constants.NetworkLibrary, EntryPoint = "nw_endpoint_copy_address_string")]
 		static extern IntPtr nw_endpoint_copy_address_string_ptr (OS_nw_endpoint endpoint);
 
 		static string nw_endpoint_copy_address_string (OS_nw_endpoint endpoint)

--- a/src/Network/NWFramerMessage.cs
+++ b/src/Network/NWFramerMessage.cs
@@ -59,7 +59,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_framer_message_set_value (OS_nw_protocol_metadata message, string key, IntPtr value, ref BlockLiteral dispose_value);
+		static extern void nw_framer_message_set_value (OS_nw_protocol_metadata message, IntPtr key, IntPtr value, ref BlockLiteral dispose_value);
 		delegate void nw_framer_message_set_value_t (IntPtr block, IntPtr data);
 		static nw_framer_message_set_value_t static_SetDataHandler = TrampolineSetDataHandler;
 
@@ -88,7 +88,8 @@ namespace Network {
 			BlockLiteral block_handler = new BlockLiteral ();
 			block_handler.SetupBlockUnsafe (static_SetDataHandler, callback);
 			try {
-				nw_framer_message_set_value (GetCheckedHandle (), key, pinned.AddrOfPinnedObject (), ref block_handler);
+				using var keyPtr = new TransientString (key);
+				nw_framer_message_set_value (GetCheckedHandle (), keyPtr, pinned.AddrOfPinnedObject (), ref block_handler);
 			} finally {
 				block_handler.CleanupBlock ();
 			}
@@ -96,7 +97,7 @@ namespace Network {
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool nw_framer_message_access_value (OS_nw_protocol_metadata message, string key, ref BlockLiteral access_value);
+		static extern bool nw_framer_message_access_value (OS_nw_protocol_metadata message, IntPtr key, ref BlockLiteral access_value);
 		delegate bool nw_framer_message_access_value_t (IntPtr block, IntPtr data);
 		static nw_framer_message_access_value_t static_AccessValueHandler = TrampolineAccessValueHandler;
 
@@ -130,7 +131,8 @@ namespace Network {
 			block_handler.SetupBlockUnsafe (static_AccessValueHandler, callback);
 			try {
 				// the callback is inlined!!!
-				var found = nw_framer_message_access_value (GetCheckedHandle (), key, ref block_handler);
+				using var keyPtr = new TransientString (key);
+				var found = nw_framer_message_access_value (GetCheckedHandle (), keyPtr, ref block_handler);
 				if (found) {
 					unsafe {
 						outData = new ReadOnlySpan<byte> ((void*) outPointer, dataLength);
@@ -145,13 +147,25 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_framer_message_set_object_value (OS_nw_protocol_metadata message, string key, IntPtr value);
+		static extern void nw_framer_message_set_object_value (OS_nw_protocol_metadata message, IntPtr key, IntPtr value);
+
+		static void nw_framer_message_set_object_value (OS_nw_protocol_metadata message, string key, IntPtr value)
+		{
+			using var keyPtr = new TransientString (key);
+			nw_framer_message_set_object_value (message, keyPtr, value);
+		}
 
 		public void SetObject (string key, NSObject value)
 			=> nw_framer_message_set_object_value (GetCheckedHandle (), key, value.GetHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern IntPtr nw_framer_message_copy_object_value (OS_nw_protocol_metadata message, string key);
+		static extern IntPtr nw_framer_message_copy_object_value (OS_nw_protocol_metadata message, IntPtr key);
+
+		static IntPtr nw_framer_message_copy_object_value (OS_nw_protocol_metadata message, string key)
+		{
+			using var keyPtr = new TransientString (key);
+			return nw_framer_message_copy_object_value (message, keyPtr);
+		}
 
 		public T? GetObject<T> (string key) where T : NSObject
 			=> Runtime.GetNSObject<T> (nw_framer_message_copy_object_value (GetCheckedHandle (), key), owns: true);

--- a/src/Network/NWListener.cs
+++ b/src/Network/NWListener.cs
@@ -47,7 +47,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		extern static IntPtr nw_listener_create_with_port (string port, IntPtr nwparameters);
+		extern static IntPtr nw_listener_create_with_port (IntPtr port, IntPtr nwparameters);
 
 		public static NWListener? Create (string port, NWParameters parameters)
 		{
@@ -58,7 +58,8 @@ namespace Network {
 			if (port is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (port));
 
-			handle = nw_listener_create_with_port (port, parameters.Handle);
+			using var portPtr = new TransientString (port);
+			handle = nw_listener_create_with_port (portPtr, parameters.Handle);
 			if (handle == IntPtr.Zero)
 				return null;
 			return new NWListener (handle, owns: true);

--- a/src/Network/NWPrivacyContext.cs
+++ b/src/Network/NWPrivacyContext.cs
@@ -38,7 +38,13 @@ namespace Network {
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern unsafe OS_nw_privacy_context nw_privacy_context_create (string description);
+		static extern unsafe OS_nw_privacy_context nw_privacy_context_create (IntPtr description);
+
+		static unsafe OS_nw_privacy_context nw_privacy_context_create (string description)
+		{
+			using var descriptionPtr = new TransientString (description);
+			return nw_privacy_context_create (descriptionPtr);
+		}
 
 		public NWPrivacyContext (string description)
 			: base (nw_privacy_context_create (description), true) { }

--- a/src/Network/NWProtocolDefinition.cs
+++ b/src/Network/NWProtocolDefinition.cs
@@ -140,7 +140,7 @@ namespace Network {
 		[iOS (13, 0)]
 #endif
 		[DllImport (Constants.NetworkLibrary)]
-		static extern unsafe OS_nw_protocol_definition nw_framer_create_definition (string identifier, NWFramerCreateFlags flags, ref BlockLiteral start_handler);
+		static extern unsafe OS_nw_protocol_definition nw_framer_create_definition (IntPtr identifier, NWFramerCreateFlags flags, ref BlockLiteral start_handler);
 		delegate NWFramerStartResult nw_framer_create_definition_t (IntPtr block, IntPtr framer);
 		static nw_framer_create_definition_t static_CreateFramerHandler = TrampolineCreateFramerHandler;
 
@@ -172,7 +172,8 @@ namespace Network {
 			BlockLiteral block_handler = new BlockLiteral ();
 			block_handler.SetupBlockUnsafe (static_CreateFramerHandler, startCallback);
 			try {
-				return new NWProtocolDefinition (nw_framer_create_definition (identifier, flags, ref block_handler), owns: true);
+				using var identifierPtr = new TransientString (identifier);
+				return new NWProtocolDefinition (nw_framer_create_definition (identifierPtr, flags, ref block_handler), owns: true);
 			} finally {
 				block_handler.CleanupBlock ();
 			}

--- a/src/Network/NWProtocolFramerOptions.cs
+++ b/src/Network/NWProtocolFramerOptions.cs
@@ -45,17 +45,24 @@ namespace Network {
 		internal NSProtocolFramerOptions (NativeHandle handle, bool owns) : base (handle, owns) { }
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_framer_options_set_object_value (OS_nw_protocol_options options, string key, NativeHandle value);
+		static extern void nw_framer_options_set_object_value (OS_nw_protocol_options options, IntPtr key, NativeHandle value);
+
+		static void nw_framer_options_set_object_value (OS_nw_protocol_options options, string key, NativeHandle value)
+		{
+			using var keyPtr = new TransientString (key);
+			nw_framer_options_set_object_value (options, keyPtr, value);
+		}
 
 		public void SetValue<T> (string key, T? value) where T : NSObject
 			=> nw_framer_options_set_object_value (GetCheckedHandle (), key, value.GetHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern NativeHandle nw_framer_options_copy_object_value (OS_nw_protocol_options options, string key);
+		static extern NativeHandle nw_framer_options_copy_object_value (OS_nw_protocol_options options, IntPtr key);
 
 		public T? GetValue<T> (string key) where T : NSObject
 		{
-			var value = nw_framer_options_copy_object_value (GetCheckedHandle (), key);
+			using var keyPtr = new TransientString (key);
+			var value = nw_framer_options_copy_object_value (GetCheckedHandle (), keyPtr);
 			return Runtime.GetNSObject<T> (value, owns: true);
 		}
 

--- a/src/Network/NWProtocolQuicOptions.cs
+++ b/src/Network/NWProtocolQuicOptions.cs
@@ -37,8 +37,13 @@ namespace Network {
 		public NWProtocolQuicOptions () : this (nw_quic_create_options (), owns: true) { }
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_quic_add_tls_application_protocol (OS_nw_protocol_options options, string applicationProtocol);
+		static extern void nw_quic_add_tls_application_protocol (OS_nw_protocol_options options, IntPtr applicationProtocol);
 
+		static void nw_quic_add_tls_application_protocol (OS_nw_protocol_options options, string applicationProtocol)
+		{
+			using var applicationProtocolPtr = new TransientString (applicationProtocol);
+			nw_quic_add_tls_application_protocol (options, applicationProtocolPtr);
+		}
 		public void AddTlsApplicationProtocol (string applicationProtocol)
 			=> nw_quic_add_tls_application_protocol (GetCheckedHandle (), applicationProtocol);
 

--- a/src/Network/NWQuicMetadata.cs
+++ b/src/Network/NWQuicMetadata.cs
@@ -54,7 +54,7 @@ namespace Network {
 			set => nw_quic_set_keepalive_interval (GetCheckedHandle (), value);
 		}
 
-		[DllImport (Constants.NetworkLibrary)]
+		[DllImport (Constants.NetworkLibrary, EntryPoint = "nw_quic_get_application_error_reason")]
 		static extern IntPtr nw_quic_get_application_error_reason_ptr (OS_nw_protocol_metadata metadata);
 
 		static string nw_quic_get_application_error_reason (OS_nw_protocol_metadata metadata)

--- a/src/Network/NWQuicMetadata.cs
+++ b/src/Network/NWQuicMetadata.cs
@@ -55,7 +55,13 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern string nw_quic_get_application_error_reason (OS_nw_protocol_metadata metadata);
+		static extern IntPtr nw_quic_get_application_error_reason_ptr (OS_nw_protocol_metadata metadata);
+
+		static string nw_quic_get_application_error_reason (OS_nw_protocol_metadata metadata)
+		{
+			var ptr = nw_quic_get_application_error_reason_ptr (metadata);
+			return TransientString.ToStringAndFree (ptr)!;
+		}
 
 		public string? ApplicationErrorReason
 			=> nw_quic_get_application_error_reason (GetCheckedHandle ());
@@ -67,7 +73,13 @@ namespace Network {
 			nw_quic_get_application_error (GetCheckedHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_quic_set_application_error (OS_nw_protocol_metadata metadata, ulong application_error, string? reason);
+		static extern void nw_quic_set_application_error (OS_nw_protocol_metadata metadata, ulong application_error, IntPtr reason);
+
+		static void nw_quic_set_application_error (OS_nw_protocol_metadata metadata, ulong application_error, string? reason)
+		{
+			using var reasonPtr = new TransientString (reason);
+			nw_quic_set_application_error (metadata, application_error, reasonPtr);
+		}
 
 		public (ulong error, string? reason) ApplicationError {
 			get => (ApplicationErrorCode, ApplicationErrorReason);

--- a/src/Network/NWTxtRecord.cs
+++ b/src/Network/NWTxtRecord.cs
@@ -75,25 +75,33 @@ namespace Network {
 		public NWTxtRecord Clone () => new NWTxtRecord (nw_txt_record_copy (GetCheckedHandle ()), owns: true);
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern NWTxtRecordFindKey nw_txt_record_find_key (IntPtr handle, string key);
+		static extern NWTxtRecordFindKey nw_txt_record_find_key (IntPtr handle, IntPtr key);
+
+		static NWTxtRecordFindKey nw_txt_record_find_key (IntPtr handle, string key)
+		{
+			using var keyPtr = new TransientString (key);
+			return nw_txt_record_find_key (handle, keyPtr);
+		}
 
 		public NWTxtRecordFindKey FindKey (string key) => nw_txt_record_find_key (GetCheckedHandle (), key);
 
 		[DllImport (Constants.NetworkLibrary)]
-		unsafe static extern byte nw_txt_record_set_key (IntPtr handle, string key, IntPtr value, nuint valueLen);
+		unsafe static extern byte nw_txt_record_set_key (IntPtr handle, IntPtr key, IntPtr value, nuint valueLen);
 
 		public bool Add (string key, ReadOnlySpan<byte> value)
 		{
 			unsafe {
+				using var keyPtr = new TransientString (key);
 				fixed (byte* mh = value)
-					return nw_txt_record_set_key (GetCheckedHandle (), key, (IntPtr) mh, (nuint) value.Length) != 0;
+					return nw_txt_record_set_key (GetCheckedHandle (), keyPtr, (IntPtr) mh, (nuint) value.Length) != 0;
 			}
 		}
 
 		public bool Add (string key)
 		{
 			unsafe {
-				return nw_txt_record_set_key (GetCheckedHandle (), key, IntPtr.Zero, 0) != 0;
+				using var keyPtr = new TransientString (key);
+				return nw_txt_record_set_key (GetCheckedHandle (), keyPtr, IntPtr.Zero, 0) != 0;
 			}
 		}
 
@@ -101,7 +109,13 @@ namespace Network {
 			=> Add (key, value is null ? null : Encoding.UTF8.GetBytes (value));
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern byte nw_txt_record_remove_key (IntPtr handle, string key);
+		static extern byte nw_txt_record_remove_key (IntPtr handle, IntPtr key);
+
+		static byte nw_txt_record_remove_key (IntPtr handle, string key)
+		{
+			using var keyPtr = new TransientString (key);
+			return nw_txt_record_remove_key (handle, keyPtr);
+		}
 
 		public bool Remove (string key) => nw_txt_record_remove_key (GetCheckedHandle (), key) != 0;
 
@@ -203,7 +217,7 @@ namespace Network {
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern unsafe bool nw_txt_record_access_key (OS_nw_txt_record txt_record, string key, ref BlockLiteral access_value);
+		static extern unsafe bool nw_txt_record_access_key (OS_nw_txt_record txt_record, IntPtr key, ref BlockLiteral access_value);
 
 		unsafe delegate void nw_txt_record_access_key_t (IntPtr block, string key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
 		unsafe static nw_txt_record_access_key_t static_AccessKeyHandler = TrampolineAccessKeyHandler;
@@ -233,7 +247,8 @@ namespace Network {
 			BlockLiteral block_handler = new BlockLiteral ();
 			block_handler.SetupBlockUnsafe (static_AccessKeyHandler, handler);
 			try {
-				return nw_txt_record_access_key (GetCheckedHandle (), key, ref block_handler);
+				using var keyPtr = new TransientString (key);
+				return nw_txt_record_access_key (GetCheckedHandle (), keyPtr, ref block_handler);
 			} finally {
 				block_handler.CleanupBlock ();
 			}

--- a/src/Network/NWWebSocketOptions.cs
+++ b/src/Network/NWWebSocketOptions.cs
@@ -50,23 +50,26 @@ namespace Network {
 		public NWWebSocketOptions (NWWebSocketVersion version) : base (nw_ws_create_options (version), true) { }
 
 		[DllImport (Constants.NetworkLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-		static extern void nw_ws_options_add_additional_header (OS_nw_protocol_options options, string name, string value);
+		static extern void nw_ws_options_add_additional_header (OS_nw_protocol_options options, IntPtr name, IntPtr value);
 
 		public void SetHeader (string header, string value)
 		{
 			if (header is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (header));
-			nw_ws_options_add_additional_header (GetCheckedHandle (), header, value);
+			using var headerPtr = new TransientString (header);
+			using var valuePtr = new TransientString (value);
+			nw_ws_options_add_additional_header (GetCheckedHandle (), headerPtr, valuePtr);
 		}
 
 		[DllImport (Constants.NetworkLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-		static extern void nw_ws_options_add_subprotocol (OS_nw_protocol_options options, string subprotocol);
+		static extern void nw_ws_options_add_subprotocol (OS_nw_protocol_options options, IntPtr subprotocol);
 
 		public void AddSubprotocol (string subprotocol)
 		{
 			if (subprotocol is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (subprotocol));
-			nw_ws_options_add_subprotocol (GetCheckedHandle (), subprotocol);
+			using var subprotocolPtr = new TransientString (subprotocol);
+			nw_ws_options_add_subprotocol (GetCheckedHandle (), subprotocolPtr);
 		}
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWWebSocketResponse.cs
+++ b/src/Network/NWWebSocketResponse.cs
@@ -41,13 +41,25 @@ namespace Network {
 		internal NWWebSocketResponse (NativeHandle handle, bool owns) : base (handle, owns) { }
 
 		[DllImport (Constants.NetworkLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-		static extern unsafe OS_nw_ws_response nw_ws_response_create (NWWebSocketResponseStatus status, string selected_subprotocol);
+		static extern unsafe OS_nw_ws_response nw_ws_response_create (NWWebSocketResponseStatus status, IntPtr selected_subprotocol);
+
+		static unsafe OS_nw_ws_response nw_ws_response_create (NWWebSocketResponseStatus status, string selected_subprotocol)
+		{
+			using var selected_subprotocolPtr = new TransientString (selected_subprotocol);
+			return nw_ws_response_create (status, selected_subprotocolPtr);
+		}
 
 		public NWWebSocketResponse (NWWebSocketResponseStatus status, string subprotocol)
 			=> InitializeHandle (nw_ws_response_create (status, subprotocol));
 
 		[DllImport (Constants.NetworkLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-		static extern string nw_ws_response_get_selected_subprotocol (OS_nw_ws_response response);
+		static extern IntPtr nw_ws_response_get_selected_subprotocol_ptr (OS_nw_ws_response response);
+
+		static string nw_ws_response_get_selected_subprotocol (OS_nw_ws_response response)
+		{
+			var ptr = nw_ws_response_get_selected_subprotocol_ptr (response);
+			return TransientString.ToStringAndFree (ptr)!;
+		}
 
 		public string SelectedSubprotocol => nw_ws_response_get_selected_subprotocol (GetCheckedHandle ());
 
@@ -88,7 +100,14 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-		static extern void nw_ws_response_add_additional_header (OS_nw_ws_response response, string name, string value);
+		static extern void nw_ws_response_add_additional_header (OS_nw_ws_response response, IntPtr name, IntPtr value);
+
+		static void nw_ws_response_add_additional_header (OS_nw_ws_response response, string name, string value)
+		{
+			using var namePtr = new TransientString (name);
+			using var valuePtr = new TransientString (value);
+			nw_ws_response_add_additional_header (response, name, value);
+		}
 
 		public void SetHeader (string header, string value) => nw_ws_response_add_additional_header (GetCheckedHandle (), header, value);
 	}

--- a/src/Network/NWWebSocketResponse.cs
+++ b/src/Network/NWWebSocketResponse.cs
@@ -52,13 +52,13 @@ namespace Network {
 		public NWWebSocketResponse (NWWebSocketResponseStatus status, string subprotocol)
 			=> InitializeHandle (nw_ws_response_create (status, subprotocol));
 
-		[DllImport (Constants.NetworkLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (Constants.NetworkLibrary, EntryPoint = "nw_ws_response_get_selected_subprotocol", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr nw_ws_response_get_selected_subprotocol_ptr (OS_nw_ws_response response);
 
 		static string nw_ws_response_get_selected_subprotocol (OS_nw_ws_response response)
 		{
 			var ptr = nw_ws_response_get_selected_subprotocol_ptr (response);
-			return TransientString.ToStringAndFree (ptr)!;
+			return TransientString.ToStringAndFree (ptr, TransientString.Encoding.Ansi)!;
 		}
 
 		public string SelectedSubprotocol => nw_ws_response_get_selected_subprotocol (GetCheckedHandle ());

--- a/src/ObjCRuntime/TransientString.cs
+++ b/src/ObjCRuntime/TransientString.cs
@@ -52,9 +52,6 @@ namespace ObjCRuntime {
 		public static implicit operator IntPtr (TransientString str) => str.ptr;
 
 
-		[DllImport ("/usr/lib/libc.dylib")]
-		static extern void free (IntPtr ptr);
-
 		public static string? ToStringAndFree (IntPtr ptr, Encoding encoding = Encoding.Auto)
 		{
 			string? result = null;
@@ -74,8 +71,7 @@ namespace ObjCRuntime {
 			default:
 				throw new ArgumentOutOfRangeException (nameof (encoding));
 			}
-			if (ptr != IntPtr.Zero)
-				free (ptr);
+			Marshal.FreeHGlobal (ptr);
 			return result;
 		}
 	}

--- a/src/ObjCRuntime/TransientString.cs
+++ b/src/ObjCRuntime/TransientString.cs
@@ -50,5 +50,33 @@ namespace ObjCRuntime {
 		}
 
 		public static implicit operator IntPtr (TransientString str) => str.ptr;
+
+
+		[DllImport ("/usr/lib/libc.dylib")]
+		static extern void free (IntPtr ptr);
+
+		public static string? ToStringAndFree (IntPtr ptr, Encoding encoding = Encoding.Auto)
+		{
+			string? result = null;
+			switch (encoding) {
+			case Encoding.Auto:
+				result = Marshal.PtrToStringAuto (ptr);
+				break;
+			case Encoding.BStr:
+				result = Marshal.PtrToStringBSTR (ptr);
+				break;
+			case Encoding.Ansi:
+				result = Marshal.PtrToStringAnsi (ptr);
+				break;
+			case Encoding.Unicode:
+				result = Marshal.PtrToStringUni (ptr);
+				break;
+			default:
+				throw new ArgumentOutOfRangeException (nameof (encoding));
+			}
+			if (ptr != IntPtr.Zero)
+				free (ptr);
+			return result;
+		}
 	}
 }


### PR DESCRIPTION
fix all pinvokes in the Network package that use strings

Guiding principle for this PR: be unobtrusive

This meant making the changes as minor as possible
- if the pinvoke gets called once and doesn't return `string`, change the `string` args to `IntPtr` and inline the `string` -> `TransientString` conversion.
- if the pinvoke is used in an expression method body (`public int SomeFunc (string s) => SomePInvoke (s);`), then I wrote a wrapper function for it that keeps the original signature
- if the function returns a string, I renamed the pinvoke with `Ptr` or `_ptr` on the end, changed it to return `IntPtr`, then wrote an adapter that uses calls is, allocates a new string and frees the original using `TransientString.ToStringAndFree` 