### PR TITLE
Added try catches to the methods in AVAudioPlayer to prevent Initiali…

### DIFF
--- a/src/AVFoundation/AVAudioPlayer.cs
+++ b/src/AVFoundation/AVAudioPlayer.cs
@@ -38,24 +38,35 @@ namespace AVFoundation {
 				IntPtr errhandle;
 				IntPtr ptrtohandle = (IntPtr) (&errhandle);
 
-				var ap = new AVAudioPlayer (url, ptrtohandle);
-				if (ap.Handle == IntPtr.Zero) {
-					error = Runtime.GetNSObject<NSError> (errhandle);
+				try {
+					var ap = new AVAudioPlayer(url, ptrtohandle);
+					if (ap.Handle == IntPtr.Zero) {
+						error = Runtime.GetNSObject<NSError>(errhandle);
+						return null;
+					}
+					else
+						error = null;
+
+					return ap;
+				} catch {
+					error = Runtime.GetNSObject<NSError>(errhandle);
 					return null;
-				} else
-					error = null;
-				return ap;
+				}
 			}
 		}
 
 		public static AVAudioPlayer? FromUrl (NSUrl url)
 		{
 			unsafe {
-				var ap = new AVAudioPlayer (url, IntPtr.Zero);
-				if (ap.Handle == IntPtr.Zero)
-					return null;
+				try {
+					var ap = new AVAudioPlayer(url, IntPtr.Zero);
+					if (ap.Handle == IntPtr.Zero)
+						return null;
 
-				return ap;
+					return ap;
+				} catch {
+					return null;
+				}
 			}
 		}
 
@@ -63,26 +74,37 @@ namespace AVFoundation {
 		{
 			unsafe {
 				IntPtr errhandle;
-				IntPtr ptrtohandle = (IntPtr) (&errhandle);
+				IntPtr ptrtohandle = (IntPtr)(&errhandle);
 
-				var ap = new AVAudioPlayer (data, ptrtohandle);
-				if (ap.Handle == IntPtr.Zero) {
-					error = Runtime.GetNSObject<NSError> (errhandle);
+				try {
+					var ap = new AVAudioPlayer(data, ptrtohandle);
+					if (ap.Handle == IntPtr.Zero) {
+						error = Runtime.GetNSObject<NSError>(errhandle);
+						return null;
+					}
+					else
+						error = null;
+
+					return ap;
+				} catch {
+					error = Runtime.GetNSObject<NSError>(errhandle);
 					return null;
-				} else
-					error = null;
-				return ap;
+				}
 			}
 		}
 
 		public static AVAudioPlayer? FromData (NSData data)
 		{
 			unsafe {
-				var ap = new AVAudioPlayer (data, IntPtr.Zero);
-				if (ap.Handle == IntPtr.Zero)
-					return null;
+				try {
+					var ap = new AVAudioPlayer(data, IntPtr.Zero);
+					if (ap.Handle == IntPtr.Zero)
+						return null;
 
-				return ap;
+					return ap;
+				} catch {
+					return null;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Was able to reproduce issue by creating a new Xamarin project and using an invalid NURL like in the issue. What happens is an exception is thrown by InitializeHandle (line 631 of NSObject2.cs) because the handle passed to it is null. I am unsure about this, but wonder if GetHandle's return of only an IntPtr instead of NativeHandle (in Selector.cs) is somehow causing an issue.

The desired behavior by user was to not have an exception thrown but to return null and assign the error to the out NSError parameter. The error code seems, on a quick Google search, with being unable to access a specified file.
"error	{The operation couldn’t be completed. (OSStatus error 2003334207.)}"
Trivia: apparently that error code is a 4 character ASCII for "wht?"

I'm not sure if additional work needs to be done to the binding itself, since the user also indicated that this exception was thrown even with a _valid_ NSURL.

I also adjusted the other methods in this class to have try/catch as well, in case this issue popped up again.

Fixes #16229