### PR TITLE
[MapKit] Move MKOverlayView.MKRoadWidthAtZoomScale to MKOverlayRenderer.

### DIFF
--- a/src/MapKit/MKOverlayRenderer.cs
+++ b/src/MapKit/MKOverlayRenderer.cs
@@ -16,9 +16,6 @@ namespace MapKit {
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
-#else
-		[TV (9, 2)]
-		[Mac (10, 9)]
 #endif
 		[DllImport (Constants.MapKitLibrary)]
 		public static extern nfloat MKRoadWidthAtZoomScale (/* MKZoomScale */ nfloat zoomScale);

--- a/src/MapKit/MKOverlayRenderer.cs
+++ b/src/MapKit/MKOverlayRenderer.cs
@@ -1,0 +1,28 @@
+#if !WATCH
+
+using System;
+using System.Runtime.InteropServices;
+using Foundation;
+using ObjCRuntime;
+using MapKit;
+
+#nullable enable
+
+namespace MapKit {
+	public partial class MKOverlayRenderer {
+
+#if NET
+		[SupportedOSPlatform ("tvos9.2")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("maccatalyst")]
+#else
+		[TV (9, 2)]
+		[Mac (10, 9)]
+#endif
+		[DllImport (Constants.MapKitLibrary)]
+		public static extern nfloat MKRoadWidthAtZoomScale (/* MKZoomScale */ nfloat zoomScale);
+	}
+}
+
+#endif // !WATCH

--- a/src/MapKit/MKOverlayView.cs
+++ b/src/MapKit/MKOverlayView.cs
@@ -2,6 +2,7 @@
 // 
 //
 
+#if !XAMCORE_5_0
 #if !WATCH
 
 using System;
@@ -20,9 +21,12 @@ namespace MapKit {
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
-		[UnsupportedOSPlatform ("ios7.0")]
-		[ObsoletedOSPlatform ("ios7.0", "Use 'MKOverlayRenderer' instead.")]
+		[ObsoletedOSPlatform ("ios", "Use 'MKOverlayRenderer.MKRoadWidthAtZoomScale' instead.")]
+		[ObsoletedOSPlatform ("macos", "Use 'MKOverlayRenderer.MKRoadWidthAtZoomScale' instead.")]
+		[ObsoletedOSPlatform ("tvos", "Use 'MKOverlayRenderer.MKRoadWidthAtZoomScale' instead.")]
+		[ObsoletedOSPlatform ("maccatalyst", "Use 'MKOverlayRenderer.MKRoadWidthAtZoomScale' instead.")]
 #else
+		[Obsolete ("Use 'MKOverlayRenderer.MKRoadWidthAtZoomScale' instead.")]
 		[TV (9, 2)]
 		[Mac (10, 9)]
 #endif
@@ -32,3 +36,4 @@ namespace MapKit {
 }
 
 #endif
+#endif // !XAMCORE_5_0

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1099,6 +1099,7 @@ MAPKIT_SOURCES = \
 	MapKit/MKMapCameraZoomRange.cs \
 	MapKit/MKMapItem.cs \
 	MapKit/MKMultiPoint.cs \
+	MapKit/MKOverlayRenderer.cs \
 	MapKit/MKOverlayView.cs \
 	MapKit/MKPointOfInterestFilter.cs \
 	MapKit/MKPolygon.cs \


### PR DESCRIPTION
MKRoadWidthAtZoomScale is a P/Invoke we decided to put in the MKOverlayView
class a long time ago.

This is problematic, because the P/Invoke is available on more platforms than
MKOverlayView (and the MKOverlayView class is deprecated, while the P/Invoke
is not), which it impossible to get the availability attributes right.

So instead move the P/Invoke to the MKOverlayRenderer class (but keep the old
code around until XAMCORE_5_0 for backwards compat reasons). The
MKOverlayRenderer class is the replacement for the deprecated MKOverlayView
class, and it's also available on all the platforms the P/Invoke is available,
so the availability attributes are now trivial.