### PR TITLE
[src/generator/tests] Verify that availability attributes don't include useless version information. Fixes #11029.

### DIFF
--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -1411,7 +1411,7 @@ namespace Security {
 		[SupportedOSPlatform ("ios13.0")]
 		[SupportedOSPlatform ("tvos13.0")]
 		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
+		[SupportedOSPlatform ("maccatalyst")]
 #else
 		[iOS (13, 0)]
 		[TV (13, 0)]

--- a/src/UIKit/NSLayoutManager.cs
+++ b/src/UIKit/NSLayoutManager.cs
@@ -113,7 +113,7 @@ namespace UIKit {
 		[SupportedOSPlatform ("tvos13.0")]
 		[SupportedOSPlatform ("macos10.15")]
 		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
+		[SupportedOSPlatform ("maccatalyst")]
 #else
 		[Watch (6, 0)]
 		[TV (13, 0)]

--- a/src/XKit/Types.cs
+++ b/src/XKit/Types.cs
@@ -39,7 +39,7 @@ namespace UIKit {
 #if NET
 	[SupportedOSPlatform ("tvos11.0")]
 	[SupportedOSPlatform ("ios11.0")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
+	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos10.15")]
 #else
 	[Watch (4, 0)]

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -959,6 +959,13 @@ public abstract class AvailabilityBaseAttribute : Attribute {
 
 	void GenerateSupported (StringBuilder builder)
 	{
+#if BGENERATOR
+		// If the version is less than or equal to the min version for the platform in question,
+		// the version is redundant, so just skip it.
+		if (Version is not null && Version <= Xamarin.SdkVersions.GetMinVersion (Generator.AsApplePlatform (Platform)))
+			Version = null;
+#endif
+
 		builder.Append ("[SupportedOSPlatform (\"");
 		GeneratePlatformNameAndVersion (builder);
 		builder.AppendLine ("\")]");

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3397,6 +3397,26 @@ public partial class Generator : IMemberGatherer {
 #endif
 	}
 
+	public static ApplePlatform AsApplePlatform (PlatformName platform)
+	{
+		switch (platform) {
+		case PlatformName.iOS:
+			return ApplePlatform.iOS;
+		case PlatformName.TvOS:
+			return ApplePlatform.TVOS;
+		case PlatformName.MacCatalyst:
+			return ApplePlatform.MacCatalyst;
+		case PlatformName.MacOSX:
+			return ApplePlatform.MacOSX;
+		case PlatformName.WatchOS:
+			return ApplePlatform.WatchOS;
+		case PlatformName.None:
+			return ApplePlatform.None;
+		default:
+			throw new ArgumentOutOfRangeException (nameof (platform), platform, $"Unknown platform: {platform}");
+		}
+	}
+
 	static AvailabilityBaseAttribute CloneFromOtherPlatform (AvailabilityBaseAttribute attr, PlatformName platform)
 	{
 		if (attr.Version is null) {
@@ -3416,14 +3436,18 @@ public partial class Generator : IMemberGatherer {
 			// Due to the absurd API of Version, you can not pass a -1 to the revision constructor
 			// nor can you coerse to 0, as that will fail with "16.0.0 <= 16.0" => false in the registrar
 			// So determine if the revision is -1, and use the 2 or 3 param ctor...
-			if (attr.Version.Revision == -1) {
+			var version = attr.Version;
+			var minimum = Xamarin.SdkVersions.GetMinVersion (AsApplePlatform (platform));
+			if (version < minimum)
+				version = minimum;
+			if (version.Revision == -1) {
 				switch (attr.AvailabilityKind) {
 				case AvailabilityKind.Introduced:
-					return new IntroducedAttribute (platform, attr.Version.Major, attr.Version.Minor, message: attr.Message);
+					return new IntroducedAttribute (platform, version.Major, version.Minor, message: attr.Message);
 				case AvailabilityKind.Deprecated:
-					return new DeprecatedAttribute (platform, attr.Version.Major, attr.Version.Minor, message: attr.Message);
+					return new DeprecatedAttribute (platform, version.Major, version.Minor, message: attr.Message);
 				case AvailabilityKind.Obsoleted:
-					return new ObsoletedAttribute (platform, attr.Version.Major, attr.Version.Minor, message: attr.Message);
+					return new ObsoletedAttribute (platform, version.Major, version.Minor, message: attr.Message);
 				case AvailabilityKind.Unavailable:
 					return new UnavailableAttribute (platform, message: attr.Message);
 				default:
@@ -3432,11 +3456,11 @@ public partial class Generator : IMemberGatherer {
 			} else {
 				switch (attr.AvailabilityKind) {
 				case AvailabilityKind.Introduced:
-					return new IntroducedAttribute (platform, attr.Version.Major, attr.Version.Minor, attr.Version.Revision, message: attr.Message);
+					return new IntroducedAttribute (platform, version.Major, version.Minor, version.Revision, message: attr.Message);
 				case AvailabilityKind.Deprecated:
-					return new DeprecatedAttribute (platform, attr.Version.Major, attr.Version.Minor, attr.Version.Revision, message: attr.Message);
+					return new DeprecatedAttribute (platform, version.Major, version.Minor, version.Revision, message: attr.Message);
 				case AvailabilityKind.Obsoleted:
-					return new ObsoletedAttribute (platform, attr.Version.Major, attr.Version.Minor, attr.Version.Revision, message: attr.Message);
+					return new ObsoletedAttribute (platform, version.Major, version.Minor, version.Revision, message: attr.Message);
 				case AvailabilityKind.Unavailable:
 					return new UnavailableAttribute (platform, message: attr.Message);
 				default:

--- a/tests/cecil-tests/ApiAvailabilityTest.cs
+++ b/tests/cecil-tests/ApiAvailabilityTest.cs
@@ -372,12 +372,12 @@ namespace Cecil.Tests {
 
 				// Verify that any SupportedOSPlatform attributes don't specify a version that is
 				// either earlier than our minimum deployment target, or later than the current OS version.
-				if (apiSupportedVersion is not null) {
+				if (apiSupportedVersion is not null && !(api is AssemblyDefinition)) {
 					var minimum = Xamarin.SdkVersions.GetMinVersion (platform);
 					var maximum = Xamarin.SdkVersions.GetVersion (platform);
-					// FIXME: This is a big change to fix, and should be fixed in a different PR.
-					//if (apiSupportedVersion <= minimum)
-					//	failures.Add ($"[FAIL] {apiSupportedVersion} <= {minimum} (Min) on '{api.AsFullName ()}'.");
+
+					if (apiSupportedVersion <= minimum)
+						failures.Add ($"[FAIL] {apiSupportedVersion} <= {minimum} (Min) on '{api.AsFullName ()}'.");
 					if (apiSupportedVersion > maximum)
 						failures.Add ($"[FAIL] {apiSupportedVersion} > {maximum} (Max) on '{api.AsFullName ()}'.");
 				}


### PR DESCRIPTION
* Change the generator to not write the version in SupportedOSPlatform
  attributes unless it's greater than min OS version.
* Fix a few redundant Mac Catalyst availability versions.
* Uncomment the test to verify that availability attributes don't include
  useless version information.

Fixes https://github.com/xamarin/xamarin-macios/issues/11029.