### PR TITLE
[Foundation] Unify NSAttributedStringDocumentReadingOptionKeys and NSAttributedStringDocumentReadingOptionKey.

### DIFF
--- a/src/Foundation/NSAttributedStringDocumentAttributes.cs
+++ b/src/Foundation/NSAttributedStringDocumentAttributes.cs
@@ -268,10 +268,10 @@ namespace Foundation {
 #endif
 		public NSUrl? ReadAccessUrl {
 			get {
-				return GetNativeValue<NSUrl> (NSAttributedStringDocumentReadingOptionKeys.ReadAccessUrlKey);
+				return GetNativeValue<NSUrl> (NSAttributedStringDocumentReadingOptionKey.NSReadAccessURLDocumentOption);
 			}
 			set {
-				SetNativeValue (NSAttributedStringDocumentReadingOptionKeys.ReadAccessUrlKey, value);
+				SetNativeValue (NSAttributedStringDocumentReadingOptionKey.NSReadAccessURLDocumentOption, value);
 			}
 		}
 #endif // !TVOS && !WATCH

--- a/src/Foundation/NSAttributedStringDocumentAttributes.cs
+++ b/src/Foundation/NSAttributedStringDocumentAttributes.cs
@@ -268,10 +268,10 @@ namespace Foundation {
 #endif
 		public NSUrl? ReadAccessUrl {
 			get {
-				return GetNativeValue<NSUrl> (NSAttributedStringDocumentReadingOptionKey.NSReadAccessURLDocumentOption);
+				return GetNativeValue<NSUrl> (NSAttributedStringDocumentReadingOptionKey.NSReadAccessUrlDocumentOption);
 			}
 			set {
-				SetNativeValue (NSAttributedStringDocumentReadingOptionKey.NSReadAccessURLDocumentOption, value);
+				SetNativeValue (NSAttributedStringDocumentReadingOptionKey.NSReadAccessUrlDocumentOption, value);
 			}
 		}
 #endif // !TVOS && !WATCH

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -869,16 +869,6 @@ namespace Foundation {
 	[Mac (10, 15), iOS (13, 0)]
 	delegate void NSAttributedStringCompletionHandler ([NullAllowed] NSAttributedString attributedString, [NullAllowed] NSDictionary<NSString, NSObject> attributes, [NullAllowed] NSError error);
 
-	[NoWatch]
-	[NoTV] // really inside WebKit
-	[Mac (10, 15), iOS (13, 0)]
-	[Static]
-	[Internal]
-	interface NSAttributedStringDocumentReadingOptionKeys {
-		[Field ("NSReadAccessURLDocumentOption", "WebKit")]
-		NSString ReadAccessUrlKey { get; }
-	}
-
 	[BaseType (typeof (NSObject),
 		   Delegates = new string [] { "WeakDelegate" },
 		   Events = new Type [] { typeof (NSCacheDelegate) })]

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -4414,6 +4414,6 @@ namespace UIKit {
 		[NoWatch, NoTV]
 		[Mac (10, 15), iOS (13, 0)]
 		[Field ("NSReadAccessURLDocumentOption", "WebKit")]
-		NSString NSReadAccessURLDocumentOption { get; }
+		NSString NSReadAccessUrlDocumentOption { get; }
 	}
 }

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -4387,27 +4387,33 @@ namespace UIKit {
 	interface NSAttributedStringDocumentReadingOptionKey {
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
-		[Internal, Field ("NSWebPreferencesDocumentOption")]
+		[Field ("NSWebPreferencesDocumentOption")]
 		NSString NSWebPreferencesDocumentOption { get; }
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
-		[Internal, Field ("NSWebResourceLoadDelegateDocumentOption")]
+		[Field ("NSWebResourceLoadDelegateDocumentOption")]
 		NSString NSWebResourceLoadDelegateDocumentOption { get; }
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
-		[Internal, Field ("NSBaseURLDocumentOption")]
+		[Field ("NSBaseURLDocumentOption")]
 		NSString NSBaseURLDocumentOption { get; }
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
-		[Internal, Field ("NSTextEncodingNameDocumentOption")]
+		[Field ("NSTextEncodingNameDocumentOption")]
 		NSString NSTextEncodingNameDocumentOption { get; }
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
-		[Internal, Field ("NSTextSizeMultiplierDocumentOption")]
+		[Field ("NSTextSizeMultiplierDocumentOption")]
 		NSString NSTextSizeMultiplierDocumentOption { get; }
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
-		[Internal, Field ("NSTimeoutDocumentOption")]
+		[Field ("NSTimeoutDocumentOption")]
 		NSString NSTimeoutDocumentOption { get; }
+
+		// This field is really inside WebKit
+		[NoWatch, NoTV]
+		[Mac (10, 15), iOS (13, 0)]
+		[Field ("NSReadAccessURLDocumentOption", "WebKit")]
+		NSString NSReadAccessURLDocumentOption { get; }
 	}
 }


### PR DESCRIPTION
Move the remaining field in NSAttributedStringDocumentReadingOptionKeys into
NSAttributedStringDocumentReadingOptionKey to share more code, and update code
accordingly.

Also remove redundant [Internal] attributes on
NSAttributedStringDocumentReadingOptionKey fields, because the type itself is
[Internal].

This has no effect on public API, because it's all internal.