### PR TITLE
[Foundation] Make NSAttributedStringDocumentType a strongly-typed enum.

### DIFF
--- a/src/Foundation/Enums.cs
+++ b/src/Foundation/Enums.cs
@@ -3,6 +3,7 @@ using ObjCRuntime;
 
 namespace Foundation {
 
+#if !XAMCORE_5_0
 	// Utility enum, ObjC uses NSString
 	public enum NSDocumentType {
 		Unknown = -1,
@@ -23,6 +24,7 @@ namespace Foundation {
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		OpenDocument,
 	}
+#endif // !XAMCORE_5_0
 
 	// Utility enum, ObjC uses NSString
 	public enum NSDocumentViewMode {

--- a/src/Foundation/NSAttributedStringDocumentAttributes.cs
+++ b/src/Foundation/NSAttributedStringDocumentAttributes.cs
@@ -87,78 +87,27 @@ namespace Foundation {
 			}
 		}
 
-		public NSDocumentType DocumentType {
+#if XAMCORE_5_0
+		public NSAttributedStringDocumentType DocumentType {
 			get {
-				var s = WeakDocumentType;
 
-				if (s == NSAttributedStringDocumentType.NSPlainTextDocumentType)
-					return NSDocumentType.PlainText;
-				if (s == NSAttributedStringDocumentType.NSRtfdTextDocumentType)
-					return NSDocumentType.RTFD;
-				if (s == NSAttributedStringDocumentType.NSRtfTextDocumentType)
-					return NSDocumentType.RTF;
-				if (s == NSAttributedStringDocumentType.NSHtmlTextDocumentType)
-					return NSDocumentType.HTML;
-
-#if __MACOS__
-				if (s == NSAttributedStringDocumentType.NSMacSimpleTextDocumentType)
-					return NSDocumentType.MacSimpleText;
-				if (s == NSAttributedStringDocumentType.NSDocFormatTextDocumentType)
-					return NSDocumentType.DocFormat;
-				if (s == NSAttributedStringDocumentType.NSWordMLTextDocumentType)
-					return NSDocumentType.WordML;
-				if (s == NSAttributedStringDocumentType.NSWebArchiveTextDocumentType)
-					return NSDocumentType.WebArchive;
-				if (s == NSAttributedStringDocumentType.NSOfficeOpenXMLTextDocumentType)
-					return NSDocumentType.OfficeOpenXml;
-				if (s == NSAttributedStringDocumentType.NSOpenDocumentTextDocumentType)
-					return NSDocumentType.OpenDocument;
-#endif // __MACOS__
-
-				return NSDocumentType.Unknown;
+				return NSAttributedStringDocumentTypeExtensions.GetValue (WeakDocumentType);
 			}
-
 			set {
-				NSString? documentType = null;
-				switch (value) {
-				case NSDocumentType.PlainText:
-					documentType = NSAttributedStringDocumentType.NSPlainTextDocumentType;
-					break;
-				case NSDocumentType.RTFD:
-					documentType = NSAttributedStringDocumentType.NSRtfdTextDocumentType;
-					break;
-				case NSDocumentType.RTF:
-					documentType = NSAttributedStringDocumentType.NSRtfTextDocumentType;
-					break;
-				case NSDocumentType.HTML:
-					documentType = NSAttributedStringDocumentType.NSHtmlTextDocumentType;
-					break;
-#if __MACOS__
-				case NSDocumentType.MacSimpleText:
-					documentType = NSAttributedStringDocumentType.NSMacSimpleTextDocumentType;
-					break;
-				case NSDocumentType.DocFormat:
-					documentType = NSAttributedStringDocumentType.NSDocFormatTextDocumentType;
-					break;
-				case NSDocumentType.WordML:
-					documentType = NSAttributedStringDocumentType.NSWordMLTextDocumentType;
-					break;
-				case NSDocumentType.WebArchive:
-					documentType = NSAttributedStringDocumentType.NSWebArchiveTextDocumentType;
-					break;
-				case NSDocumentType.OfficeOpenXml:
-					documentType = NSAttributedStringDocumentType.NSOfficeOpenXMLTextDocumentType;
-					break;
-				case NSDocumentType.OpenDocument:
-					documentType = NSAttributedStringDocumentType.NSOpenDocumentTextDocumentType;
-					break;
-#endif // __MACOS__
-				}
-
-				if (documentType is not null)
-					WeakDocumentType = documentType;
+				WeakDocumentType = value.GetConstant ();
 			}
 		}
+#else
+		public NSDocumentType DocumentType {
+			get {
+
+				return (NSDocumentType) NSAttributedStringDocumentTypeExtensions.GetValue (WeakDocumentType);
+			}
+			set {
+				WeakDocumentType = ((NSAttributedStringDocumentType) value).GetConstant ();
+			}
+		}
+#endif // !XAMCORE_5_0
 
 		public NSDictionary? WeakDefaultAttributes {
 			get {

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -87,7 +87,9 @@ public partial class Generator {
 		Tuple<FieldInfo, FieldAttribute> null_field = null;
 		Tuple<FieldInfo, FieldAttribute> default_symbol = null;
 		var underlying_type = GetCSharpTypeName (TypeManager.GetUnderlyingEnumType (type));
-		print ("{0} enum {1} : {2} {{", AttributeManager.HasAttribute<InternalAttribute> (type) ? "internal" : "public", type.Name, underlying_type);
+		var is_internal = AttributeManager.HasAttribute<InternalAttribute> (type);
+		var visibility = is_internal ? "internal" : "public";
+		print ("{0} enum {1} : {2} {{", visibility, type.Name, underlying_type);
 		indent++;
 		foreach (var f in type.GetFields ()) {
 			// skip value__ field 
@@ -126,7 +128,7 @@ public partial class Generator {
 			// the *Extensions has the same version requirement as the enum itself
 			PrintPlatformAttributes (type);
 			print_generated_code ();
-			print ("static public partial class {0}Extensions {{", type.Name);
+			print ("static {1} partial class {0}Extensions {{", type.Name, visibility);
 			indent++;
 
 			var field = fields.FirstOrDefault ();

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -4196,44 +4196,49 @@ namespace UIKit {
 		NSTextListElement ParentElement { get; }
 	}
 
-	[Static]
+#if !XAMCORE_5_0
 	[Internal]
-	interface NSAttributedStringDocumentType {
+#endif
+	enum NSAttributedStringDocumentType {
+		[DefaultEnumValue]
+		[Field (null)]
+		Unknown = NSDocumentType.Unknown,
+
 		[Field ("NSPlainTextDocumentType")]
-		NSString NSPlainTextDocumentType { get; }
+		Plain = NSDocumentType.PlainText,
 
 		[Field ("NSRTFDTextDocumentType")]
-		NSString NSRtfdTextDocumentType { get; }
+		Rtfd = NSDocumentType.RTFD,
 
 		[Field ("NSRTFTextDocumentType")]
-		NSString NSRtfTextDocumentType { get; }
+		Rtf = NSDocumentType.RTF,
 
 		[Field ("NSHTMLTextDocumentType")]
-		NSString NSHtmlTextDocumentType { get; }
+		Html = NSDocumentType.HTML,
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		[Field ("NSMacSimpleTextDocumentType")]
-		NSString NSMacSimpleTextDocumentType { get; }
+		MacSimple = NSDocumentType.MacSimpleText,
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		[Field ("NSDocFormatTextDocumentType")]
-		NSString NSDocFormatTextDocumentType { get; }
+		DocFormat = NSDocumentType.DocFormat,
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		[Field ("NSWordMLTextDocumentType")]
-		NSString NSWordMLTextDocumentType { get; }
+		WordML = NSDocumentType.WordML,
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		[Field ("NSWebArchiveTextDocumentType")]
-		NSString NSWebArchiveTextDocumentType { get; }
+		WebArchive = NSDocumentType.WebArchive,
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		[Field ("NSOfficeOpenXMLTextDocumentType")]
-		NSString NSOfficeOpenXMLTextDocumentType { get; }
+		OfficeOpenXml = NSDocumentType.OfficeOpenXml,
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 		[Field ("NSOpenDocumentTextDocumentType")]
-		NSString NSOpenDocumentTextDocumentType { get; }
+		OpenDocument = NSDocumentType.OpenDocument,
 	}
 
 	[Static]


### PR DESCRIPTION
This simplifies our code somewhat, and in XAMCORE_5_0 we can simplify even more.

Ref: https://github.com/xamarin/xamarin-macios/issues/14489