### PR TITLE
[dotnet/msbuild] Only compile entitlements once for universal builds. Fixes #15632.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -172,6 +172,7 @@
 		<BuildDependsOn Condition="'$(RuntimeIdentifiers)' == '' And '$(_IsMultiRidBuild)' != 'true'">
 			_ComputePublishTrimmed;
 			BuildOnlySettings;
+			_CompileEntitlements;
 			_CollectBundleResources;
 			_PackLibraryResources;
 			_UnpackLibraryResources;
@@ -197,8 +198,8 @@
 		<!-- outer build for multi-rid build -->
 		<BuildDependsOn Condition="'$(RuntimeIdentifiers)' != ''">
 			_CollectBundleResources;
-			_RunRidSpecificBuild;
 			_CompileEntitlements;
+			_RunRidSpecificBuild;
 			_DetectAppManifest;
 			_ReadAppManifest;
 			_WriteAppManifest;
@@ -221,7 +222,6 @@
 			_CreatePkgInfo;
 			_SmeltMetal;
 			_TemperMetal;
-			_CompileEntitlements;
 			_DetectAppManifest;
 			_ReadAppManifest;
 			_WriteAppManifest;
@@ -330,6 +330,7 @@
 				_ProcessedColladaAssetsPath=$(_ProcessedColladaAssetsPath);
 				_ProcessedTextureAtlasesPath=$(_ProcessedTextureAtlasesPath);
 				_ProcessedCoreMLModelsPath=$(_ProcessedCoreMLModelsPath);
+				_CompiledEntitlementsPath=$(_CompiledEntitlementsPath);
 			</_RidSpecificProperties>
 		</PropertyGroup>
 
@@ -1579,7 +1580,7 @@
 			<_CreateDumpExecutableToSign Include="@(_CreateDumpExecutable -> '$(_DylibPublishDir)%(RelativePath)')" KeepMetadata="false">
 				<CodesignAllocate>$(_CodesignAllocate)</CodesignAllocate>
 				<CodesignDisableTimestamp Condition="'$(_BundlerDebug)' == 'true'">true</CodesignDisableTimestamp>
-				<CodesignEntitlements>$(IntermediateOutputPath)Entitlements.xcent</CodesignEntitlements>
+				<CodesignEntitlements>$(_CompiledEntitlementsPath)</CodesignEntitlements>
 				<CodesignExtraArgs>$(CodesignExtraArgs)</CodesignExtraArgs>
 				<CodesignKeychain>$(CodesignKeychain)</CodesignKeychain>
 				<CodesignResourceRules>$(_PreparedResourceRules)</CodesignResourceRules>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -644,7 +644,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_CompileEntitlements"
 		Condition="'$(_RequireCodeSigning)' == 'true' Or '$(CodesignEntitlements)' != ''"
 		DependsOnTargets="$(_CompileEntitlementsDependsOn)"
-		Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
+		Outputs="$(_CompiledEntitlementsPath)">
 		<!-- Automatically add the 'allow-jit' entitlement for desktop release builds in .NET -->
 		<ItemGroup Condition="'$(Configuration)' == 'Release' And ('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst') And '$(UsingAppleNETSdk)' == 'true'">
 			<!-- We need to compare the result of AnyHaveMetadataValue to 'true', because if it's empty, the return value is not a boolean, it's an empty string -->
@@ -658,7 +658,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			BundleIdentifier="$(_BundleIdentifier)"
 			CustomEntitlements="@(CustomEntitlements)"
 			Entitlements="$(CodesignEntitlements)"
-			CompiledEntitlements="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent"
+			CompiledEntitlements="$(_CompiledEntitlementsPath)"
 			IsAppExtension="$(IsAppExtension)"
 			ProvisioningProfile="$(_ProvisioningProfile)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
@@ -685,6 +685,10 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<GetFullPath SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(_CompiledCodesignEntitlements)' != ''" RelativePath="$(_CompiledCodesignEntitlements)">
 			<Output TaskParameter="FullPath" PropertyName="_CompiledCodesignEntitlements" />
 		</GetFullPath>
+
+		<ItemGroup>
+			<FileWrites Include="$(_CompiledEntitlementsPath)" />
+		</ItemGroup>
 	</Target>
 
 	<!-- Compilation of InterfaceDefinition assets (*.xib, *.storyboard) -->
@@ -1132,6 +1136,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<_ProcessedColladaAssetsPath Condition="'$(_ProcessedColladaAssetsPath)' == ''">$(DeviceSpecificIntermediateOutputPath)collada\_ProcessedColladaAssetsPath.items</_ProcessedColladaAssetsPath>
 			<_ProcessedTextureAtlasesPath Condition="'$(_ProcessedTextureAtlasesPath)' == ''">$(DeviceSpecificIntermediateOutputPath)atlas\_ProcessedTextureAtlasesPath.items</_ProcessedTextureAtlasesPath>
 			<_ProcessedCoreMLModelsPath Condition="'$(_ProcessedCoreMLModelsPath)' == ''">$(DeviceSpecificIntermediateOutputPath)coremlc\_ProcessedCoreMLModelsPath.items</_ProcessedCoreMLModelsPath>
+			<_CompiledEntitlementsPath Condition="'$(_CompiledEntitlementsPath)' == ''">$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent</_CompiledEntitlementsPath>
 			<_SaveProcessedItems Condition="'$(RuntimeIdentifiers)' != '' And '$(UsingAppleNETSdk)' == 'true'">true</_SaveProcessedItems>
 		</PropertyGroup>
 	</Target>

--- a/tests/common/BinLog.cs
+++ b/tests/common/BinLog.cs
@@ -24,6 +24,43 @@ namespace Xamarin.Tests {
 		public string? File;
 		public string? ProjectFile;
 		public string? Message;
+
+		public override string ToString ()
+		{
+			var rv = new StringBuilder ();
+
+			if (!string.IsNullOrEmpty (File)) {
+				rv.Append (File);
+				if (LineNumber > 0) {
+					rv.Append ('(');
+					rv.Append (LineNumber.ToString ());
+					if (EndLineNumber > 0) {
+						rv.Append (',');
+						rv.Append (EndLineNumber.ToString ());
+					}
+					rv.Append ("): ");
+				}
+			}
+			switch (Type) {
+			case BuildLogEventType.Error:
+				rv.Append ("error");
+				break;
+			case BuildLogEventType.Warning:
+				rv.Append ("warning");
+				break;
+			case BuildLogEventType.Message:
+				rv.Append ("message");
+				break;
+			}
+			if (!string.IsNullOrEmpty (Code)) {
+				rv.Append (' ');
+				rv.Append (Code);
+			}
+			rv.Append (": ");
+			if (!string.IsNullOrEmpty (Message))
+				rv.Append (Message);
+			return rv.ToString ();
+		}
 	}
 
 	public enum BuildLogEventType {

--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -66,7 +66,7 @@
 	</ItemGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)/../ComputeRegistrarConstant.targets" />
-	<Import Project="$(MSBuildThisFileDirectory)/../nunit.framework.targets" />
+	<Import Project="$(MSBuildThisFileDirectory)/../nunit.framework.targets" Condition="'$(ExcludeNUnitLiteReference)' != 'true'" />
 
 	<Import Project="$(GeneratedProjectFile)" Condition="'$(GeneratedProjectFile)' != ''" />
 </Project>

--- a/tests/dotnet/UnitTests/Extensions.cs
+++ b/tests/dotnet/UnitTests/Extensions.cs
@@ -1,0 +1,17 @@
+using System;
+
+#nullable enable
+
+namespace Xamarin.Tests {
+	public static class Extensions
+	{
+		public static void AssertNoWarnings (this ExecutionResult result)
+		{
+			var warnings = BinLog.GetBuildLogWarnings (result.BinLogPath).ToArray ();
+			if (!warnings.Any ())
+				return;
+
+			Assert.Fail ($"No warnings expected, but got:\n\t{string.Join ("\n\t", warnings.Select (v => v.ToString ()))}");
+		}
+	}
+}

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1159,6 +1159,25 @@ namespace Xamarin.Tests {
 			}
 		}
 
+		// [TestCase (ApplePlatform.MacCatalyst, null, "Release")]
+		[TestCase (ApplePlatform.MacOSX, null, "Release")]
+		public void NoWarnCodesign (ApplePlatform platform, string runtimeIdentifiers, string configuration)
+		{
+			var project = "Entitlements";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
+			Clean (project_path);
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["Configuration"] = configuration;
+			properties ["EnableCodeSigning"] = "true";
+			properties ["ExcludeNUnitLiteReference"] = "true";
+			properties ["ExcludeTouchUnitReference"] = "true";
+			var rv = DotNet.AssertBuild (project_path, properties);
+			rv.AssertNoWarnings ();
+		}
+
 		[Test]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
 		public void BuildAndExecuteAppWithNativeDynamicLibrariesInPackageReference (ApplePlatform platform, string runtimeIdentifier)

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -66,12 +66,12 @@ namespace Xamarin.Tests {
 		{
 			var rv = GetProjectPath (project, subdir, platform);
 			if (string.IsNullOrEmpty (runtimeIdentifiers))
-				runtimeIdentifiers = GetDefaultRuntimeIdentifier (platform);
+				runtimeIdentifiers = GetDefaultRuntimeIdentifier (platform, configuration);
 			var appPathRuntimeIdentifier = runtimeIdentifiers.IndexOf (';') >= 0 ? "" : runtimeIdentifiers;
 			return Path.Combine (Path.GetDirectoryName (rv)!, "bin", configuration, platform.ToFramework (netVersion), appPathRuntimeIdentifier);
 		}
 
-		protected string GetDefaultRuntimeIdentifier (ApplePlatform platform)
+		protected string GetDefaultRuntimeIdentifier (ApplePlatform platform, string configuration = "Debug")
 		{
 			switch (platform) {
 			case ApplePlatform.iOS:
@@ -79,9 +79,9 @@ namespace Xamarin.Tests {
 			case ApplePlatform.TVOS:
 				return "tvossimulator-x64";
 			case ApplePlatform.MacOSX:
-				return "osx-x64";
+				return "Release".Equals (configuration, StringComparison.OrdinalIgnoreCase) ? "osx-x64;osx-arm64" : "osx-x64";
 			case ApplePlatform.MacCatalyst:
-				return "maccatalyst-x64";
+				return "Release".Equals (configuration, StringComparison.OrdinalIgnoreCase) ? "maccatalyst-x64;maccatalyst-arm64" : "maccatalyst-x64";
 			default:
 				throw new ArgumentOutOfRangeException ($"Unknown platform: {platform}");
 			}


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/15632.