### PR TITLE
[msbuild] Fix a compile warning about file being added twice.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -65,6 +65,7 @@
     <Compile Include="..\Versions.dotnet.g.cs">
       <Link>Versions.dotnet.g.cs</Link>
     </Compile>
+    <Compile Remove="Errors.designer.cs" /> <!-- The 'CoreResGen' target will add it again from the EmbeddedResource item, this avoids a warning about the file being compiled twice -->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes:

> CSC : warning CS2002: Source file 'xamarin-macios/msbuild/Xamarin.MacDev.Tasks/Errors.designer.cs' specified multiple times