### PR TITLE
[msbuild] Merge the Mmp and MmpTaskBase classes.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Tasks/Mmp.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/Mmp.cs
@@ -1,4 +1,0 @@
-namespace Xamarin.Mac.Tasks {
-	public class Mmp : MmpTaskBase {
-	}
-}

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/MmpTaskBase.cs
@@ -19,7 +19,7 @@ using Xamarin.Utils;
 using Xamarin.Localization.MSBuild;
 
 namespace Xamarin.Mac.Tasks {
-	public abstract class MmpTaskBase : BundlerToolTaskBase {
+	public class Mmp : BundlerToolTaskBase {
 		protected override string ToolName {
 			get { return "mmp"; }
 		}


### PR DESCRIPTION
We no longer need two have overridable logic for remote builds, so the
non-abstract task class and the abstract base class can be merged.

First out is the Mmp task.