### PR TITLE
[tests] Remove duplicated Import to fix build warning.

### DIFF
--- a/tests/framework-test/dotnet/shared.csproj
+++ b/tests/framework-test/dotnet/shared.csproj
@@ -39,6 +39,4 @@
       <Link>ApplePlatform.cs</Link>
     </Compile>
   </ItemGroup>
-
-  <Import Project="$(RootTestsDirectory)\nunit.framework.targets" />
 </Project>


### PR DESCRIPTION
Fixes:

    xamarin-macios/tests/framework-test/dotnet/shared.csproj(43,3): warning MSB4011: "xamarin-macios/tests/nunit.framework.targets" cannot be imported again. It was already imported at "xamarin-macios/tests/common/shared-dotnet.csproj (69,2)". This is most likely a build authoring error. This subsequent import will be ignored.