### PR TITLE
[tests] Make the helper makefiles for .NET tests more helpful.

### DIFF
--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -30,6 +30,7 @@
 		<NativeLibName>macos-fat</NativeLibName>
 		<SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">10.14</SupportedOSPlatformVersion>
 		<CompilerResponseFile>$(MSBuildThisFileDirectory)\..\..\src\build\dotnet\macos-defines-dotnet.rsp</CompilerResponseFile>
+		<RuntimeIdentifiers Condition="'$(UniversalBuild)' == 'true'">osx-x64;osx-arm64</RuntimeIdentifiers>
 		<RuntimeIdentifiers Condition="'$(Configuration)' == 'Release' And '$(SingleArchReleaseBuild)' == 'true'">osx-x64</RuntimeIdentifiers>
 	</PropertyGroup>
 
@@ -39,6 +40,7 @@
 		<NativeLibName>maccatalyst-fat</NativeLibName>
 		<SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">13.3</SupportedOSPlatformVersion>
 		<CompilerResponseFile>$(MSBuildThisFileDirectory)\..\..\src\build\dotnet\maccatalyst-defines-dotnet.rsp</CompilerResponseFile>
+		<RuntimeIdentifiers Condition="'$(UniversalBuild)' == 'true'">maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
 		<RuntimeIdentifiers Condition="'$(Configuration)' == 'Release' And '$(SingleArchReleaseBuild)' == 'true'">maccatalyst-x64</RuntimeIdentifiers>
 	</PropertyGroup>
 

--- a/tests/common/shared-dotnet.mk
+++ b/tests/common/shared-dotnet.mk
@@ -1,6 +1,54 @@
-
 include $(TOP)/Make.config
 include $(TOP)/mk/colors.mk
+
+#
+# The targets here are available for .NET projects in the following directories: tests/<test>/dotnet/<platform>
+#
+# Targets:
+#
+# ➡️ build
+#
+#         Builds the project.
+#
+# ➡️ run
+#
+#         Runs the project using 'dotnet run' - this is the only way (in this
+#         makefile) to run mobile projects (they'll run in the simulator by
+#         default). This also works for desktop platforms, but you won't see
+#         stdout/stderr, which is kind of annoying.
+#
+# ➡️ run-bare
+#
+#         Runs the executable. This doesn't work for mobile platforms, but is
+#         usually the best option for desktop platforms, since it will
+#         print stdout/stderr from the test app to the terminal.
+#
+# ➡️ reload
+#
+#         Rebuilds all of xamarin-macios, and cleans up some stuff, so that
+#         everything should be ready to try again.
+#
+#         ⚠️ This target may hang for reasons I haven't been able to figure ⚠️
+#         ⚠️ out yet, in which case just cancel (Ctrl-C) and try again      ⚠️
+#
+# Options:
+#
+# ➡️ UNIVERSAL=1: build a universal app instead of whatever the default is.
+# ➡️ RUNTIMEIDENTIFIERS=...: list the runtime identifiers to build for.
+# ➡️ CONFIG=configuration: the configuration to use (defaults to Debug)
+#
+# Example to run monotouch-test on Mac Catalyst:
+#
+#     $ cd tests/monotouch-test/dotnet/MacCactalyst
+#     $ make build
+#     $ make run-bare
+#
+# After a change (anywhere in the repo), run reload first to rebuild:
+#
+#    $ make reload
+#    $ make build
+#    $ make run-bare
+#
 
 unexport MSBUILD_EXE_PATH
 
@@ -18,6 +66,59 @@ ifeq ($(CONFIG),)
 CONFIG=Debug
 else
 CONFIG_ARGUMENT=/p:Configuration=$(CONFIG)
+endif
+
+ifeq ($(PLATFORM),)
+PLATFORM=$(notdir $(CURDIR))
+endif
+
+ifeq ($(RUNTIMEIDENTIFIERS),)
+ifeq ($(PLATFORM),iOS)
+RUNTIMEIDENTIFIERS=ios-arm64
+else ifeq ($(PLATFORM),tvOS)
+RUNTIMEIDENTIFIERS=tvos-arm64
+else ifeq ($(PLATFORM),MacCatalyst)
+ifeq ($(CONFIG),Release)
+RUNTIMEIDENTIFIERS=maccatalyst-x64;maccatalyst-arm64
+else ifneq ($(UNIVERSAL),)
+RUNTIMEIDENTIFIERS=maccatalyst-x64;maccatalyst-arm64
+else
+RUNTIMEIDENTIFIERS=maccatalyst-x64
+endif
+else ifeq ($(PLATFORM),macOS)
+ifeq ($(CONFIG),Release)
+RUNTIMEIDENTIFIERS=osx-x64;osx-arm64
+else ifneq ($(UNIVERSAL),)
+RUNTIMEIDENTIFIERS=osx-x64;osx-arm64
+else
+RUNTIMEIDENTIFIERS=osx-x64
+endif
+else
+RUNTIMEIDENTIFIERS=unknown-platform-$(PLATFORM)
+endif
+endif
+
+ifneq ($(UNIVERSAL),)
+UNIVERSAL_ARGUMENT=/p:UniversalBuild=true
+endif
+
+ifeq ($(findstring ;,$(RUNTIMEIDENTIFIERS)),;)
+PATH_RID=
+else
+PATH_RID=$(RUNTIMEIDENTIFIERS)/
+endif
+
+
+ifeq ($(PLATFORM),iOS)
+EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-ios/$(PATH_RID)$(TESTNAME).app/$(TESTNAME)"
+else ifeq ($(PLATFORM),tvOS)
+EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-tvos/$(PATH_RID)$(TESTNAME).app/$(TESTNAME)"
+else ifeq ($(PLATFORM),MacCatalyst)
+EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-maccatalyst/$(PATH_RID)$(TESTNAME).app/Contents/MacOS/$(TESTNAME)"
+else ifeq ($(PLATFORM),macOS)
+EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-macos/$(PATH_RID)$(TESTNAME).app/Contents/MacOS/$(TESTNAME)"
+else
+EXECUTABLE=unknown-platform-$(PLATFORM)
 endif
 
 prepare:
@@ -38,13 +139,16 @@ reload-and-run:
 	$(Q) $(MAKE) run
 
 build: prepare
-	$(Q) $(DOTNET) build "/bl:$(abspath $@-$(BINLOG_TIMESTAMP).binlog)" *.?sproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS) $(CONFIG_ARGUMENT)
+	$(Q) $(DOTNET) build "/bl:$(abspath $@-$(BINLOG_TIMESTAMP).binlog)" *.?sproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS) $(CONFIG_ARGUMENT) $(UNIVERSAL_ARGUMENT)
 
 run: prepare
-	$(Q) $(DOTNET) build "/bl:$(abspath $@-$(BINLOG_TIMESTAMP).binlog)" *.?sproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS) $(CONFIG_ARGUMENT) -t:Run
+	$(Q) $(DOTNET) build "/bl:$(abspath $@-$(BINLOG_TIMESTAMP).binlog)" *.?sproj $(MSBUILD_VERBOSITY) $(BUILD_ARGUMENTS) $(CONFIG_ARGUMENT) $(UNIVERSAL_ARGUMENT) -t:Run
 
 run-bare:
-	$(Q) "$(abspath .)"/bin/$(CONFIG)/$(TEST_TFM)-*/*/"$(TESTNAME)".app/Contents/MacOS/"$(TESTNAME)" --autostart --autoexit
+	$(Q) "$(EXECUTABLE)" --autostart --autoexit
+
+print-executable:
+	@echo $(EXECUTABLE)
 
 run-remote:
 	$(Q) test -n "$(REMOTE_HOST)" || ( echo "Must specify the remote machine by setting the REMOTE_HOST environment variable"; exit 1 )


### PR DESCRIPTION
Make the helper makefiles for .NET tests more helpful by adding support for
universal apps, and also document the most relevant targets.