### PR TITLE
[dotnet] CoreGraphics convert strings in pinvokes

### DIFF
--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -860,7 +860,7 @@ namespace CoreGraphics {
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSelectFont (/* CGContextRef */ IntPtr c,
-			/* const char* __nullable */ string? name, /* CGFloat */ nfloat size, CGTextEncoding textEncoding);
+			/* const char* __nullable */ IntPtr name, /* CGFloat */ nfloat size, CGTextEncoding textEncoding);
 
 #if NET
 		[SupportedOSPlatform ("ios")]
@@ -875,7 +875,8 @@ namespace CoreGraphics {
 #endif
 		public void SelectFont (string? name, nfloat size, CGTextEncoding textEncoding)
 		{
-			CGContextSelectFont (Handle, name, size, textEncoding);
+			using var namePtr = new TransientString (name);
+			CGContextSelectFont (Handle, namePtr, size, textEncoding);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
@@ -904,7 +905,7 @@ namespace CoreGraphics {
 		[Deprecated (PlatformName.MacOSX, 10, 9)]
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ string? s, /* size_t */ nint length);
+		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ IntPtr s, /* size_t */ nint length);
 
 #if NET
 		[SupportedOSPlatform ("ios")]
@@ -923,7 +924,8 @@ namespace CoreGraphics {
 				count = 0;
 			else if (count > str.Length)
 				throw new ArgumentException (nameof (count));
-			CGContextShowText (Handle, str, count);
+			using var strPtr = new TransientString (str);
+			CGContextShowText (Handle, strPtr, count);
 		}
 
 #if NET
@@ -939,7 +941,8 @@ namespace CoreGraphics {
 #endif
 		public void ShowText (string? str)
 		{
-			CGContextShowText (Handle, str, str is null ? 0 : str.Length);
+			using var strPtr = new TransientString (str);
+			CGContextShowText (Handle, strPtr, str is null ? 0 : str.Length);
 		}
 
 #if NET
@@ -1005,7 +1008,7 @@ namespace CoreGraphics {
 #endif
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowTextAtPoint (/* CGContextRef __nullable */ IntPtr c, /* CGFloat */ nfloat x,
-			/* CGFloat */ nfloat y, /* const char* __nullable */ string? str, /* size_t */ nint length);
+			/* CGFloat */ nfloat y, /* const char* __nullable */ IntPtr str, /* size_t */ nint length);
 
 #if NET
 		[SupportedOSPlatform ("ios")]
@@ -1020,7 +1023,8 @@ namespace CoreGraphics {
 #endif
 		public void ShowTextAtPoint (nfloat x, nfloat y, string? str, int length)
 		{
-			CGContextShowTextAtPoint (Handle, x, y, str, length);
+			using var strPtr = new TransientString (str);
+			CGContextShowTextAtPoint (Handle, x, y, strPtr, length);
 		}
 
 #if NET
@@ -1036,7 +1040,8 @@ namespace CoreGraphics {
 #endif
 		public void ShowTextAtPoint (nfloat x, nfloat y, string? str)
 		{
-			CGContextShowTextAtPoint (Handle, x, y, str, str is null ? 0 : str.Length);
+			using var strPtr = new TransientString (str);
+			CGContextShowTextAtPoint (Handle, x, y, strPtr, str is null ? 0 : str.Length);
 		}
 
 #if NET

--- a/src/CoreGraphics/CGDataProvider.cs
+++ b/src/CoreGraphics/CGDataProvider.cs
@@ -82,14 +82,15 @@ namespace CoreGraphics {
 
 #if !COREBUILD
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGDataProviderRef */ IntPtr CGDataProviderCreateWithFilename (/* const char* */ string filename);
+		extern static /* CGDataProviderRef */ IntPtr CGDataProviderCreateWithFilename (/* const char* */ IntPtr filename);
 
 		static public CGDataProvider? FromFile (string file)
 		{
 			if (file is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (file));
 
-			var handle = CGDataProviderCreateWithFilename (file);
+			using var filePtr = new TransientString (file);
+			var handle = CGDataProviderCreateWithFilename (filePtr);
 			if (handle == IntPtr.Zero)
 				return null;
 
@@ -101,7 +102,8 @@ namespace CoreGraphics {
 			if (file is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (file));
 
-			var handle = CGDataProviderCreateWithFilename (file);
+			using var filePtr = new TransientString (file);
+			var handle = CGDataProviderCreateWithFilename (filePtr);
 			if (handle == IntPtr.Zero)
 				throw new ArgumentException ("Could not create provider from the specified file");
 			return handle;

--- a/src/CoreGraphics/CGPDFContentStream.cs
+++ b/src/CoreGraphics/CGPDFContentStream.cs
@@ -95,7 +95,7 @@ namespace CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGPDFObjectRef */ IntPtr CGPDFContentStreamGetResource (/* CGPDFContentStreamRef */ IntPtr cs, /* const char* */ string category, /* const char* */ string name);
+		extern static /* CGPDFObjectRef */ IntPtr CGPDFContentStreamGetResource (/* CGPDFContentStreamRef */ IntPtr cs, /* const char* */ IntPtr category, /* const char* */ IntPtr name);
 
 		public CGPDFObject? GetResource (string category, string name)
 		{
@@ -104,7 +104,9 @@ namespace CoreGraphics {
 			if (name is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
-			var h = CGPDFContentStreamGetResource (Handle, category, name);
+			using var categoryPtr = new TransientString (category);
+			using var namePtr = new TransientString (name);
+			var h = CGPDFContentStreamGetResource (Handle, categoryPtr, namePtr);
 			return (h == IntPtr.Zero) ? null : new CGPDFObject (h);
 		}
 	}

--- a/src/CoreGraphics/CGPDFDictionary.cs
+++ b/src/CoreGraphics/CGPDFDictionary.cs
@@ -78,89 +78,100 @@ namespace CoreGraphics {
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		extern static bool CGPDFDictionaryGetBoolean (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFBoolean* */ [MarshalAs (UnmanagedType.I1)] out bool value);
+		extern static bool CGPDFDictionaryGetBoolean (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ IntPtr key, /* CGPDFBoolean* */ [MarshalAs (UnmanagedType.I1)] out bool value);
 
 		public bool GetBoolean (string key, out bool result)
 		{
 			if (key is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
-			return CGPDFDictionaryGetBoolean (Handle, key, out result);
+			using var keyPtr = new TransientString (key);
+			return CGPDFDictionaryGetBoolean (Handle, keyPtr, out result);
 		}
 
 		// CGPDFInteger -> long int so 32/64 bits -> CGPDFObject.h
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		extern static bool CGPDFDictionaryGetInteger (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFInteger* */ out nint value);
+		extern static bool CGPDFDictionaryGetInteger (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ IntPtr key, /* CGPDFInteger* */ out nint value);
 
 		public bool GetInt (string key, out nint result)
 		{
 			if (key is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
-			return CGPDFDictionaryGetInteger (Handle, key, out result);
+			using var keyPtr = new TransientString (key);
+			return CGPDFDictionaryGetInteger (Handle, keyPtr, out result);
 		}
 
 		// CGPDFReal -> CGFloat -> CGPDFObject.h
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		extern static bool CGPDFDictionaryGetNumber (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFReal* */ out nfloat value);
+		extern static bool CGPDFDictionaryGetNumber (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ IntPtr key, /* CGPDFReal* */ out nfloat value);
 
 		public bool GetFloat (string key, out nfloat result)
 		{
 			if (key is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
-			return CGPDFDictionaryGetNumber (Handle, key, out result);
+
+			using var keyPtr = new TransientString (key);
+			return CGPDFDictionaryGetNumber (Handle, keyPtr, out result);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		extern static bool CGPDFDictionaryGetName (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* const char ** */ out IntPtr value);
+		extern static bool CGPDFDictionaryGetName (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ IntPtr key, /* const char ** */ out IntPtr value);
 
 		public bool GetName (string key, out string? result)
 		{
 			if (key is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
-			var r = CGPDFDictionaryGetName (Handle, key, out var res);
+			using var keyPtr = new TransientString (key);
+			var r = CGPDFDictionaryGetName (Handle, keyPtr, out var res);
 			result = r ? Marshal.PtrToStringAnsi (res) : null;
 			return r;
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		extern static bool CGPDFDictionaryGetDictionary (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFDictionaryRef* */ out IntPtr result);
+		extern static bool CGPDFDictionaryGetDictionary (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ IntPtr key, /* CGPDFDictionaryRef* */ out IntPtr result);
 
 		public bool GetDictionary (string key, out CGPDFDictionary? result)
 		{
 			if (key is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
-			var r = CGPDFDictionaryGetDictionary (Handle, key, out var res);
+
+			using var keyPtr = new TransientString (key);
+			var r = CGPDFDictionaryGetDictionary (Handle, keyPtr, out var res);
 			result = r ? new CGPDFDictionary (res) : null;
 			return r;
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		extern static bool CGPDFDictionaryGetStream (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFStreamRef* */ out IntPtr value);
+		extern static bool CGPDFDictionaryGetStream (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ IntPtr key, /* CGPDFStreamRef* */ out IntPtr value);
 
 		public bool GetStream (string key, out CGPDFStream? result)
 		{
 			if (key is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
-			var r = CGPDFDictionaryGetStream (Handle, key, out var ptr);
+			
+			using var keyPtr = new TransientString (key);
+			var r = CGPDFDictionaryGetStream (Handle, keyPtr, out var ptr);
 			result = r ? new CGPDFStream (ptr) : null;
 			return r;
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		extern static bool CGPDFDictionaryGetArray (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFArrayRef* */ out IntPtr value);
+		extern static bool CGPDFDictionaryGetArray (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ IntPtr key, /* CGPDFArrayRef* */ out IntPtr value);
 
 		public bool GetArray (string key, out CGPDFArray? array)
 		{
 			if (key is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
-			var r = CGPDFDictionaryGetArray (Handle, key, out var ptr);
+
+			using var keyPtr = new TransientString (key);
+			var r = CGPDFDictionaryGetArray (Handle, keyPtr, out var ptr);
 			array = r ? new CGPDFArray (ptr) : null;
 			return r;
 		}
@@ -246,13 +257,15 @@ namespace CoreGraphics {
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		extern static bool CGPDFDictionaryGetString (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ string key, /* CGPDFStringRef* */ out IntPtr value);
+		extern static bool CGPDFDictionaryGetString (/* CGPDFDictionaryRef */ IntPtr dict, /* const char* */ IntPtr key, /* CGPDFStringRef* */ out IntPtr value);
 
 		public bool GetString (string key, out string? result)
 		{
 			if (key is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
-			var r = CGPDFDictionaryGetString (Handle, key, out var res);
+
+			using var keyPtr = new TransientString (key);
+			var r = CGPDFDictionaryGetString (Handle, keyPtr, out var res);
 			result = r ? CGPDFString.ToString (res) : null;
 			return r;
 		}

--- a/src/CoreGraphics/CGPDFDictionary.cs
+++ b/src/CoreGraphics/CGPDFDictionary.cs
@@ -154,7 +154,7 @@ namespace CoreGraphics {
 		{
 			if (key is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
-			
+
 			using var keyPtr = new TransientString (key);
 			var r = CGPDFDictionaryGetStream (Handle, keyPtr, out var ptr);
 			result = r ? new CGPDFStream (ptr) : null;

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -151,11 +151,12 @@ namespace CoreGraphics {
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		extern static bool CGPDFDocumentUnlockWithPassword (/* CGPDFDocumentRef */ IntPtr document, /* const char* */ string password);
+		extern static bool CGPDFDocumentUnlockWithPassword (/* CGPDFDocumentRef */ IntPtr document, /* const char* */ IntPtr password);
 
 		public bool Unlock (string password)
 		{
-			return CGPDFDocumentUnlockWithPassword (Handle, password);
+			using var passwordPtr = new TransientString (password);
+			return CGPDFDocumentUnlockWithPassword (Handle, passwordPtr);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]

--- a/src/CoreGraphics/CGPDFOperatorTable.cs
+++ b/src/CoreGraphics/CGPDFOperatorTable.cs
@@ -76,7 +76,7 @@ namespace CoreGraphics {
 		// We need this P/Invoke for legacy AOT scenarios (since we have public API taking a 'Action<IntPtr, IntPtr>', and with this particular native function we can't wrap the delegate)
 		// Unfortunately CoreCLR doesn't support generic Action delegates in P/Invokes: https://github.com/dotnet/runtime/issues/32963
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGPDFOperatorTableSetCallback (/* CGPDFOperatorTableRef */ IntPtr table, /* const char */ string name, /* CGPDFOperatorCallback */ Action<IntPtr, IntPtr>? callback);
+		extern static void CGPDFOperatorTableSetCallback (/* CGPDFOperatorTableRef */ IntPtr table, /* const char */ IntPtr name, /* CGPDFOperatorCallback */ Action<IntPtr, IntPtr>? callback);
 #endif
 
 #if NET
@@ -84,14 +84,14 @@ namespace CoreGraphics {
 		// The good part about this signature is that it enforces at compile time that 'callback' is callable from native code in a FullAOT scenario.
 		// The bad part is that it's unsafe code (and callers must be in unsafe mode as well).
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		unsafe extern static void CGPDFOperatorTableSetCallback (/* CGPDFOperatorTableRef */ IntPtr table, /* const char */ string name, /* CGPDFOperatorCallback */ delegate* unmanaged<IntPtr, IntPtr, void> callback);
+		unsafe extern static void CGPDFOperatorTableSetCallback (/* CGPDFOperatorTableRef */ IntPtr table, /* const char */ IntPtr name, /* CGPDFOperatorCallback */ delegate* unmanaged<IntPtr, IntPtr, void> callback);
 #endif
 
 #if MONOMAC && !NET
 		// This signature can work everywhere, but we can't enforce at compile time that 'callback' is a delegate to a static function (which is required for FullAOT scenarios),
 		// so limit it to non-FullAOT platforms (macOS)
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static void CGPDFOperatorTableSetCallback (/* CGPDFOperatorTableRef */ IntPtr table, /* const char */ string name, /* CGPDFOperatorCallback */ CGPDFOperatorCallback? callback);
+		extern static void CGPDFOperatorTableSetCallback (/* CGPDFOperatorTableRef */ IntPtr table, /* const char */ IntPtr name, /* CGPDFOperatorCallback */ CGPDFOperatorCallback? callback);
 
 		// this won't work with AOT since the callback must be decorated with [MonoPInvokeCallback]
 		public void SetCallback (string name, Action<CGPDFScanner?,object?>? callback)
@@ -99,10 +99,11 @@ namespace CoreGraphics {
 			if (name is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
+			using var namePtr = new TransientString (name);
 			if (callback is null)
-				CGPDFOperatorTableSetCallback (Handle, name, (CGPDFOperatorCallback?) null);
+				CGPDFOperatorTableSetCallback (Handle, namePtr, (CGPDFOperatorCallback?) null);
 			else
-				CGPDFOperatorTableSetCallback (Handle, name, new CGPDFOperatorCallback (delegate (IntPtr reserved, IntPtr gchandle) {
+				CGPDFOperatorTableSetCallback (Handle, namePtr, new CGPDFOperatorCallback (delegate (IntPtr reserved, IntPtr gchandle) {
 					// we could do 'new CGPDFScanner (reserved, true)' but we would not get `UserInfo` (managed state) back
 					// we could GCHandle `userInfo` but that would (even more) diverge both code bases :(
 					var scanner = GetScannerFromInfo (gchandle);
@@ -120,7 +121,8 @@ namespace CoreGraphics {
 			if (name is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
-			CGPDFOperatorTableSetCallback (Handle, name, callback);
+			using var namePtr = new TransientString (name);
+			CGPDFOperatorTableSetCallback (Handle, namePtr, callback);
 		}
 #endif // !NET
 
@@ -131,7 +133,8 @@ namespace CoreGraphics {
 			if (name is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
 
-			CGPDFOperatorTableSetCallback (Handle, name, callback);
+			using var namePtr = new TransientString (name);
+			CGPDFOperatorTableSetCallback (Handle, namePtr, callback);
 		}
 #endif
 


### PR DESCRIPTION
converted all pinvokes in CoreGraphics to use `IntPtr` instead of `string`.