### PR TITLE
[dotnet] sanitized pinvokes that use string

### DIFF
--- a/src/CoreFoundation/CFMutableString.cs
+++ b/src/CoreFoundation/CFMutableString.cs
@@ -55,7 +55,7 @@ namespace CoreFoundation {
 				throw new ArgumentException (nameof (maxLength));
 			Handle = CFStringCreateMutable (IntPtr.Zero, maxLength);
 			if (@string is not null) {
-				using var stringPtr = new TransientString (@string);
+				using var stringPtr = new TransientString (@string, TransientString.Encoding.Unicode);
 				CFStringAppendCharacters (Handle, stringPtr, @string.Length);
 			}
 		}
@@ -81,7 +81,7 @@ namespace CoreFoundation {
 			if (@string is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (@string));
 			str = null; // destroy any cached value
-			using var stringPtr = new TransientString (@string);
+			using var stringPtr = new TransientString (@string, TransientString.Encoding.Unicode);
 			CFStringAppendCharacters (Handle, stringPtr, @string.Length);
 		}
 

--- a/src/CoreFoundation/CFMutableString.cs
+++ b/src/CoreFoundation/CFMutableString.cs
@@ -54,8 +54,10 @@ namespace CoreFoundation {
 			if (maxLength < 0)
 				throw new ArgumentException (nameof (maxLength));
 			Handle = CFStringCreateMutable (IntPtr.Zero, maxLength);
-			if (@string is not null)
-				CFStringAppendCharacters (Handle, @string, @string.Length);
+			if (@string is not null) {
+				using var stringPtr = new TransientString (@string);
+				CFStringAppendCharacters (Handle, stringPtr, @string.Length);
+			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -72,14 +74,15 @@ namespace CoreFoundation {
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary, CharSet = CharSet.Unicode)]
-		static extern void CFStringAppendCharacters (/* CFMutableStringRef* */ IntPtr theString, string chars, nint numChars);
+		static extern void CFStringAppendCharacters (/* CFMutableStringRef* */ IntPtr theString, IntPtr chars, nint numChars);
 
 		public void Append (string @string)
 		{
 			if (@string is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (@string));
 			str = null; // destroy any cached value
-			CFStringAppendCharacters (Handle, @string, @string.Length);
+			using var stringPtr = new TransientString (@string);
+			CFStringAppendCharacters (Handle, stringPtr, @string.Length);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -130,7 +130,7 @@ namespace CoreFoundation {
 		protected CFString () { }
 
 		[DllImport (Constants.CoreFoundationLibrary, CharSet = CharSet.Unicode)]
-		extern static IntPtr CFStringCreateWithCharacters (IntPtr allocator, string str, nint count);
+		extern static IntPtr CFStringCreateWithCharacters (IntPtr allocator, IntPtr str, nint count);
 
 		[DllImport (Constants.CoreFoundationLibrary, CharSet = CharSet.Unicode)]
 		extern static nint CFStringGetLength (IntPtr handle);
@@ -146,7 +146,8 @@ namespace CoreFoundation {
 			if (value is null)
 				return NativeHandle.Zero;
 
-			return CFStringCreateWithCharacters (IntPtr.Zero, value, value.Length);
+			using var valuePtr = new TransientString (value);
+			return CFStringCreateWithCharacters (IntPtr.Zero, valuePtr, value.Length);
 		}
 
 		public static void ReleaseNative (NativeHandle handle)
@@ -160,7 +161,8 @@ namespace CoreFoundation {
 			if (str is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (str));
 
-			Handle = CFStringCreateWithCharacters (IntPtr.Zero, str, str.Length);
+			using var strPtr = new TransientString (str);
+			Handle = CFStringCreateWithCharacters (IntPtr.Zero, strPtr, str.Length);
 			this.str = str;
 		}
 

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -146,7 +146,7 @@ namespace CoreFoundation {
 			if (value is null)
 				return NativeHandle.Zero;
 
-			using var valuePtr = new TransientString (value);
+			using var valuePtr = new TransientString (value, TransientString.Encoding.Unicode);
 			return CFStringCreateWithCharacters (IntPtr.Zero, valuePtr, value.Length);
 		}
 
@@ -161,7 +161,7 @@ namespace CoreFoundation {
 			if (str is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (str));
 
-			using var strPtr = new TransientString (str);
+			using var strPtr = new TransientString (str, TransientString.Encoding.Unicode);
 			Handle = CFStringCreateWithCharacters (IntPtr.Zero, strPtr, str.Length);
 			this.str = str;
 		}

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -216,7 +216,7 @@ namespace CoreFoundation {
 #endif
 
 		public DispatchQueue (string label)
-			: base (dispatch_queue_create (label, IntPtr.Zero), true)
+			: base (dispatch_queue_create_wrapper (label, IntPtr.Zero), true)
 		{
 			if (Handle == IntPtr.Zero)
 				throw new Exception ("Error creating dispatch queue");
@@ -232,7 +232,7 @@ namespace CoreFoundation {
 		}
 
 		public DispatchQueue (string label, bool concurrent)
-			: base (dispatch_queue_create (label, concurrent ? ConcurrentQueue : IntPtr.Zero), true)
+			: base (dispatch_queue_create_wrapper (label, concurrent ? ConcurrentQueue : IntPtr.Zero), true)
 		{
 			if (Handle == IntPtr.Zero)
 				throw new Exception ("Error creating dispatch queue");
@@ -250,7 +250,7 @@ namespace CoreFoundation {
 		[Watch (3, 0)]
 #endif
 		public DispatchQueue (string label, Attributes attributes, DispatchQueue? target = null)
-			: base (dispatch_queue_create_with_target (label, attributes?.Create () ?? IntPtr.Zero, target.GetHandle ()), true)
+			: base (dispatch_queue_create_with_target_wrapper (label, attributes?.Create () ?? IntPtr.Zero, target.GetHandle ()), true)
 		{
 		}
 
@@ -556,6 +556,11 @@ namespace CoreFoundation {
 			}
 		}
 
+		static IntPtr dispatch_queue_create_wrapper (string label, IntPtr attr)
+		{
+			using var labelPtr = new TransientString (label);
+			return dispatch_queue_create (labelPtr, attr);
+		}
 		//
 		// Native methods
 		//
@@ -573,8 +578,14 @@ namespace CoreFoundation {
 		[TV (10, 0)]
 		[Watch (3, 0)]
 #endif
+		static IntPtr dispatch_queue_create_with_target_wrapper (string label, IntPtr attr, IntPtr target)
+		{
+			using var labelPtr = new TransientString (label);
+			return dispatch_queue_create_with_target (labelPtr, attr, target);
+		}
+
 		[DllImport (Constants.libcLibrary, EntryPoint = "dispatch_queue_create_with_target$V2")]
-		extern static IntPtr dispatch_queue_create_with_target (string label, IntPtr attr, IntPtr target);
+		extern static IntPtr dispatch_queue_create_with_target (IntPtr label, IntPtr attr, IntPtr target);
 
 		[DllImport (Constants.libcLibrary)]
 		extern static void dispatch_async_f (IntPtr queue, IntPtr context, dispatch_callback_t dispatch);

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -216,7 +216,7 @@ namespace CoreFoundation {
 #endif
 
 		public DispatchQueue (string label)
-			: base (dispatch_queue_create_wrapper (label, IntPtr.Zero), true)
+			: base (dispatch_queue_create (label, IntPtr.Zero), true)
 		{
 			if (Handle == IntPtr.Zero)
 				throw new Exception ("Error creating dispatch queue");
@@ -232,7 +232,7 @@ namespace CoreFoundation {
 		}
 
 		public DispatchQueue (string label, bool concurrent)
-			: base (dispatch_queue_create_wrapper (label, concurrent ? ConcurrentQueue : IntPtr.Zero), true)
+			: base (dispatch_queue_create (label, concurrent ? ConcurrentQueue : IntPtr.Zero), true)
 		{
 			if (Handle == IntPtr.Zero)
 				throw new Exception ("Error creating dispatch queue");
@@ -250,7 +250,7 @@ namespace CoreFoundation {
 		[Watch (3, 0)]
 #endif
 		public DispatchQueue (string label, Attributes attributes, DispatchQueue? target = null)
-			: base (dispatch_queue_create_with_target_wrapper (label, attributes?.Create () ?? IntPtr.Zero, target.GetHandle ()), true)
+			: base (dispatch_queue_create_with_target (label, attributes?.Create () ?? IntPtr.Zero, target.GetHandle ()), true)
 		{
 		}
 
@@ -556,7 +556,7 @@ namespace CoreFoundation {
 			}
 		}
 
-		static IntPtr dispatch_queue_create_wrapper (string label, IntPtr attr)
+		static IntPtr dispatch_queue_create (string label, IntPtr attr)
 		{
 			using var labelPtr = new TransientString (label);
 			return dispatch_queue_create (labelPtr, attr);
@@ -578,7 +578,7 @@ namespace CoreFoundation {
 		[TV (10, 0)]
 		[Watch (3, 0)]
 #endif
-		static IntPtr dispatch_queue_create_with_target_wrapper (string label, IntPtr attr, IntPtr target)
+		static IntPtr dispatch_queue_create_with_target (string label, IntPtr attr, IntPtr target)
 		{
 			using var labelPtr = new TransientString (label);
 			return dispatch_queue_create_with_target (labelPtr, attr, target);

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -565,7 +565,7 @@ namespace CoreFoundation {
 		// Native methods
 		//
 		[DllImport (Constants.libcLibrary)]
-		extern static IntPtr dispatch_queue_create (string label, IntPtr attr);
+		extern static IntPtr dispatch_queue_create (IntPtr label, IntPtr attr);
 
 #if NET
 		[SupportedOSPlatform ("macos")]

--- a/src/CoreFoundation/DispatchSource.cs
+++ b/src/CoreFoundation/DispatchSource.cs
@@ -575,7 +575,7 @@ namespace CoreFoundation {
 
 			const int O_EVTONLY = 0x8000;
 			[DllImport (Constants.libcLibrary, SetLastError = true)]
-			extern static int open (string path, int flags);
+			extern static int open (IntPtr path, int flags);
 
 			[DllImport (Constants.libcLibrary)]
 			internal extern static int close (int fd);
@@ -585,7 +585,8 @@ namespace CoreFoundation {
 				if (path is null)
 					ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (path));
 
-				fd = open (path, O_EVTONLY);
+				using var pathPtr = new TransientString (path);
+				fd = open (pathPtr, O_EVTONLY);
 				if (fd == -1)
 					throw new IOException ("Failure to open the file", Marshal.GetLastWin32Error ());
 				if (type_vnode == IntPtr.Zero)

--- a/src/CoreFoundation/OSLog.cs
+++ b/src/CoreFoundation/OSLog.cs
@@ -84,7 +84,7 @@ namespace CoreFoundation {
 		extern static void os_release (IntPtr handle);
 
 		[DllImport ("__Internal")]
-		extern static void xamarin_os_log (IntPtr logHandle, OSLogLevel level, string message);
+		extern static void xamarin_os_log (IntPtr logHandle, OSLogLevel level, IntPtr message);
 
 		[Preserve (Conditional = true)]
 		internal OSLog (NativeHandle handle, bool owns)
@@ -112,7 +112,8 @@ namespace CoreFoundation {
 			if (message is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (message));
 
-			xamarin_os_log (Handle, level, message);
+			using var messagePtr = new TransientString (message);
+			xamarin_os_log (Handle, level, messagePtr);
 		}
 	}
 }


### PR DESCRIPTION
sanitized the pinvokes that use string.
Note: I did *not* address the pinvokes that take callback functions - that will be addressed in a later PR.