### PR TITLE
[introspection] No need to skip NSUrl implementing the QLPreviewItem protocol.

### DIFF
--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -563,10 +563,6 @@ namespace Introspection {
 				if (type.Name == "HMChipServiceRequestHandler") // Apple removed this class
 					return true;
 				break;
-			case "QLPreviewItem":
-				if (type.Name == "NSUrl")
-					return true;
-				break;
 			}
 			return false;
 		}


### PR DESCRIPTION
It seems Apple reversed this breaking change.

Ref: https://github.com/xamarin/xamarin-macios/issues/15232