### PR TITLE
[release/7.0.1xx-xcode14.2] Bump the hardcoded start for the MSI stable commit distance calculation.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -16,7 +16,7 @@ CURL_RETRY = $(CURL) --retry 20 --retry-delay 2 --retry-all-errors
 
 # Hardcode this for now to have a higher version number than the current stable release.
 NUGET_VERSION_COMMIT_DISTANCE_START=1000
-NUGET_VERSION_STABLE_COMMIT_DISTANCE_START=0
+NUGET_VERSION_STABLE_COMMIT_DISTANCE_START=30
 
 -include $(TOP)/Make.config.inc
 $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk


### PR DESCRIPTION
This is necessary because Xcode 14.2 does not ship with an updated SDK for
tvOS, which means that the MSI for tvOS from this branch needs to have a
higher version numer than the tvOS MSI from the release/7.0.1xx-xcode14.1
branch - and that's accomplished by hardcoding a starting point.

Should fix this error:

> ##[error]VALIDATEMANIFEST : error : PackageDiffVersionsAreMonotonicallyIncreasing failed : Package versions should never decrease (16.1.3.0 is less than the baseline version 16.1.21.0). : [manifest=VisualStudioPreview/17.5.0-pre.3.0+33305.110.main][item=tvos,version=16.1.3.0]