### PR TITLE
[xtro] Improve assembly resolution to not load incorrect assemblies.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,5 +8,7 @@
     <MicrosoftNETCoreAppRefPackageVersion>7.0.3</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>7.0.2</MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
+    <!-- custom variables -->
+    <DOTNET_TFM>net7.0</DOTNET_TFM>
   </PropertyGroup>
 </Project>

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -40,6 +40,7 @@ bin/Debug/xtro-sharpie.exe xtro-report/bin/Debug/xtro-report.exe xtro-sanity/bin
 	$(Q) touch $@
 
 XIOS ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/iOS/Xamarin.iOS.dll
+XIOS_LIBDIR ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS
 XIOS_GL ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll
 XIOS_ARCH = arm64
 XIOS_PCH = iphoneos$(IOS_SDK_VERSION)-$(XIOS_ARCH).pch
@@ -53,6 +54,7 @@ $(XIOS_PCH): .stamp-check-sharpie
 
 
 XWATCHOS ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/32bits/watchOS/Xamarin.WatchOS.dll
+XWATCHOS_LIBDIR ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.WatchOS
 
 XWATCHOS_ARCH = armv7
 XWATCHOS_PCH = watchos$(WATCH_SDK_VERSION)-$(XWATCHOS_ARCH).pch
@@ -62,6 +64,7 @@ $(XWATCHOS_PCH): .stamp-check-sharpie
 		-exclude RealityKit \
 
 XTVOS ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/tvOS/Xamarin.TVOS.dll
+XTVOS_LIBDIR ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.TVOS/
 XTVOS_GL ?= $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
 XTVOS_ARCH = arm64
 XTVOS_PCH = appletvos$(TVOS_SDK_VERSION)-$(XTVOS_ARCH).pch
@@ -72,6 +75,7 @@ $(XTVOS_PCH): .stamp-check-sharpie
 		-exclude RealityKit \
 
 XMACOS ?= $(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/64bits/mobile/Xamarin.Mac.dll
+XMACOS_LIBDIR ?= $(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/Xamarin.Mac
 XMACOS_ARCH = x86_64
 XMACOS_PCH = macosx$(MACOS_SDK_VERSION)-$(XMACOS_ARCH).pch
 XMACOS_RID = osx-x64
@@ -209,7 +213,7 @@ report-short:
 define DotNetClassify
 .stamp-dotnet-classify-$(1): bin/Debug/xtro-sharpie.exe $$(X$(2)_PCH) $$(X$(2)_DOTNET)
 	rm -f $$(DOTNET_ANNOTATIONS_DIR)/$(1)-*.raw
-	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $$(DOTNET_ANNOTATIONS_DIR) $$(X$(2)_PCH) $$(X$(2)_DOTNET)
+	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $$(DOTNET_ANNOTATIONS_DIR) --lib $(DOTNET_BCL_DIR) $$(X$(2)_PCH) $$(X$(2)_DOTNET)
 	touch $$@
 
 dotnet-classify-$(1): .stamp-dotnet-classify-$(1)
@@ -222,7 +226,7 @@ INCLUDED_PLATFORMS+=iOS
 CLASSIFY+=.stamp-classify-ios
 .stamp-classify-ios: bin/Debug/xtro-sharpie.exe $(XIOS_PCH) $(XIOS) $(XIOS_GL)
 	rm -f $(ANNOTATIONS_DIR)/iOS-*.raw
-	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XIOS_PCH) $(XIOS) $(XIOS_GL)
+	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) --lib $(XIOS_LIBDIR) $(XIOS_PCH) $(XIOS) $(XIOS_GL)
 	$(Q) touch $@
 endif
 
@@ -231,7 +235,7 @@ INCLUDED_PLATFORMS+=tvOS
 CLASSIFY+=.stamp-classify-tvos
 .stamp-classify-tvos: bin/Debug/xtro-sharpie.exe $(XTVOS_PCH) $(XTVOS) $(XTVOS_GL)
 	rm -f $(ANNOTATIONS_DIR)/tvOS-*.raw
-	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XTVOS_PCH) $(XTVOS) $(XTVOS_GL)
+	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) --lib $(XTVOS_LIBDIR) $(XTVOS_PCH) $(XTVOS) $(XTVOS_GL)
 	$(Q) touch $@
 endif
 
@@ -240,7 +244,7 @@ INCLUDED_PLATFORMS+=watchOS
 CLASSIFY+=.stamp-classify-watchos
 .stamp-classify-watchos: bin/Debug/xtro-sharpie.exe $(XWATCHOS_PCH) $(XWATCHOS)
 	rm -f $(ANNOTATIONS_DIR)/watchOS-*.raw
-	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XWATCHOS_PCH) $(XWATCHOS)
+	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) --lib $(XWATCHOS_LIBDIR) $(XWATCHOS_PCH) $(XWATCHOS)
 	$(Q) touch $@
 endif
 
@@ -249,7 +253,7 @@ INCLUDED_PLATFORMS+=macOS
 CLASSIFY+=.stamp-classify-macos
 .stamp-classify-macos: bin/Debug/xtro-sharpie.exe $(XMACOS_PCH) $(XMACOS)
 	rm -f $(ANNOTATIONS_DIR)/macOS-*.raw
-	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) $(XMACOS_PCH) $(XMACOS)
+	$(MONO) bin/Debug/xtro-sharpie.exe --output-directory $(ANNOTATIONS_DIR) --lib $(XMACOS_LIBDIR) $(XMACOS_PCH) $(XMACOS)
 	$(Q) touch $@
 endif
 

--- a/tests/xtro-sharpie/Program.cs
+++ b/tests/xtro-sharpie/Program.cs
@@ -11,13 +11,15 @@ namespace Extrospection {
 		static int Main (string [] arguments)
 		{
 			var outputDirectory = string.Empty;
+			var searchDirectories = new List<string> ();
 			var options = new OptionSet {
 				{ "output-directory=", (v) => outputDirectory = v },
+				{ "lib=", (v) => searchDirectories.Add (v) },
 			};
 			var args = options.Parse (arguments);
 
 			if (args.Count < 2) {
-				Console.Error.WriteLine ("Usage: mono64 xtro-sharpie.exe pch-file dll-file [dll2-file]");
+				Console.Error.WriteLine ("Usage: xtro-sharpie.exe [--output-directory=<output directory>] [--lib=<assembly search directory>] pch-file dll-file [dll2-file]");
 				return 1;
 			}
 
@@ -25,7 +27,7 @@ namespace Extrospection {
 				var assemblies = new List<string> ();
 				for (int i = 1; i < args.Count; i++)
 					assemblies.Add (args [i]);
-				new Runner ().Execute (args [0], assemblies, outputDirectory);
+				new Runner ().Execute (args [0], assemblies, outputDirectory, searchDirectories);
 				return 0;
 			} catch (Exception e) {
 				Console.WriteLine (e);

--- a/tests/xtro-sharpie/Runner.cs
+++ b/tests/xtro-sharpie/Runner.cs
@@ -15,7 +15,7 @@ namespace Extrospection {
 		{
 		}
 
-		public void Execute (string pchFile, IEnumerable<string> assemblyNames, string outputDirectory = "")
+		public void Execute (string pchFile, IEnumerable<string> assemblyNames, string outputDirectory, IEnumerable<string> searchDirectories)
 		{
 			var managed_reader = new AssemblyReader () {
 				new MapNamesVisitor (), // must come first to map managed and native names.
@@ -47,7 +47,7 @@ namespace Extrospection {
 				else if (name.EndsWith (".MacCatalyst", StringComparison.Ordinal))
 					Helpers.Platform = Platforms.MacCatalyst;
 				Helpers.IsDotNet = assemblyName.Contains ("/runtimes/");
-				managed_reader.Load (assemblyName);
+				managed_reader.Load (assemblyName, searchDirectories);
 			}
 			managed_reader.Process ();
 
@@ -66,18 +66,78 @@ namespace Extrospection {
 		}
 	}
 
+	class AssemblyResolver : IAssemblyResolver, IDisposable {
+		Dictionary<string, AssemblyDefinition> cache = new Dictionary<string, AssemblyDefinition>(StringComparer.Ordinal);
+		HashSet<string> directories = new HashSet<string> ();
+
+		public AssemblyDefinition Resolve (AssemblyNameReference name)
+		{
+			return Resolve (name, new ReaderParameters ());
+		}
+
+		AssemblyDefinition SearchDirectories (AssemblyNameReference name, ReaderParameters parameters)
+		{
+			var extensions = new string [] { ".dll", ".exe" };
+			var paths = directories
+				.SelectMany (dir => extensions.Select (ext => Path.Combine (dir, name.Name + ext)))
+				.Where (File.Exists)
+				.ToArray ();
+
+			if (paths.Length == 0)
+				throw new Exception ($"Unable to resolve the assembly {name.FullName} because it wasn't found in any of the search directories:\n\t{string.Join ("\n\t", directories)}");
+
+			if (paths.Length > 1)
+				throw new Exception ($"Unable to resolve the assembly {name.FullName} because multiple candidates were found:\n\t{string.Join ("\n\t", paths)}\nIn the search directories:\n\t{string.Join ("\n\t", directories)}");
+
+			var path = paths [0];
+			if (parameters.AssemblyResolver is null)
+				parameters.AssemblyResolver = this;
+			return AssemblyDefinition.ReadAssembly (path, parameters);
+		}
+
+		public AssemblyDefinition Load (string path)
+		{
+			var parameters = new ReaderParameters () {
+				AssemblyResolver = this,
+			};
+			var rv = AssemblyDefinition.ReadAssembly (path, parameters);
+			cache [rv.Name.FullName] = rv;
+			return rv;
+		}
+
+		public AssemblyDefinition Resolve (AssemblyNameReference name, ReaderParameters parameters)
+		{
+			var key = name.FullName;
+			if (cache.TryGetValue (key, out var assembly))
+				return assembly;
+
+			assembly = SearchDirectories (name, parameters);
+			cache [key] = assembly;
+			return assembly;
+		}
+
+		public void AddSearchDirectory (params string [] values)
+		{
+			foreach (var value in values)
+				directories.Add (value.TrimEnd ('/'));
+		}
+
+		public void Dispose ()
+		{
+			// Nothing to do.
+		}
+	}
+
 	class AssemblyReader : IEnumerable<BaseVisitor> {
 
 		HashSet<AssemblyDefinition> assemblies = new HashSet<AssemblyDefinition> ();
-		DefaultAssemblyResolver resolver = new DefaultAssemblyResolver ();
+		AssemblyResolver resolver = new AssemblyResolver ();
 
-		public void Load (string filename)
+		public void Load (string filename, IEnumerable<string> searchDirectories)
 		{
+			resolver.AddSearchDirectory (searchDirectories.ToArray ());
 			resolver.AddSearchDirectory (Path.GetDirectoryName (filename));
-			ReaderParameters rp = new ReaderParameters () {
-				AssemblyResolver = resolver
-			};
-			assemblies.Add (AssemblyDefinition.ReadAssembly (filename, rp));
+			assemblies.Add (resolver.Load (filename));
 		}
 
 		public void Process ()

--- a/tests/xtro-sharpie/Runner.cs
+++ b/tests/xtro-sharpie/Runner.cs
@@ -67,7 +67,7 @@ namespace Extrospection {
 	}
 
 	class AssemblyResolver : IAssemblyResolver, IDisposable {
-		Dictionary<string, AssemblyDefinition> cache = new Dictionary<string, AssemblyDefinition>(StringComparer.Ordinal);
+		Dictionary<string, AssemblyDefinition> cache = new Dictionary<string, AssemblyDefinition> (StringComparer.Ordinal);
 		HashSet<string> directories = new HashSet<string> ();
 
 		public AssemblyDefinition Resolve (AssemblyNameReference name)

--- a/tests/xtro-sharpie/xtro-sharpie.csproj
+++ b/tests/xtro-sharpie/xtro-sharpie.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="../../eng/Versions.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -56,22 +57,22 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'iOS (.NET)' ">
     <StartAction>Project</StartAction>
-    <StartArguments>$(iOS_PCH) --output-directory api-annotations-dotnet $(iOS_DLL)</StartArguments>
+    <StartArguments>$(iOS_PCH) --output-directory api-annotations-dotnet --lib ../../packages/microsoft.netcore.app.ref/$(MicrosoftNETCoreAppRefPackageVersion)/ref/$(DOTNET_TFM) $(iOS_DLL)</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'tvOS (.NET)' ">
     <StartAction>Project</StartAction>
-    <StartArguments>$(tvOS_PCH) --output-directory api-annotations-dotnet $(tvOS_DLL)</StartArguments>
+    <StartArguments>$(tvOS_PCH) --output-directory api-annotations-dotnet --lib ../../packages/microsoft.netcore.app.ref/$(MicrosoftNETCoreAppRefPackageVersion)/ref/$(DOTNET_TFM) $(tvOS_DLL)</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'macOS (.NET)' ">
     <StartAction>Project</StartAction>
-    <StartArguments>$(macOS_PCH) --output-directory api-annotations-dotnet $(macOS_DLL)</StartArguments>
+    <StartArguments>$(macOS_PCH) --output-directory api-annotations-dotnet --lib ../../packages/microsoft.netcore.app.ref/$(MicrosoftNETCoreAppRefPackageVersion)/ref/$(DOTNET_TFM) $(macOS_DLL)</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'MacCatalyst (.NET)' ">
     <StartAction>Project</StartAction>
-    <StartArguments>$(MacCatalyst_PCH) --output-directory api-annotations-dotnet $(MacCatalyst_DLL)</StartArguments>
+    <StartArguments>$(MacCatalyst_PCH) --output-directory api-annotations-dotnet --lib ../../packages/microsoft.netcore.app.ref/$(MicrosoftNETCoreAppRefPackageVersion)/ref/$(DOTNET_TFM) $(MacCatalyst_DLL)</StartArguments>
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Add support to xtro-sharpie for where to look for referenced assemblies, and
adjust assembly resolution to only look in those directories.

This makes sure xtro-sharpie loads the expected references, and fixes a
problem where the (broken) assembly resolution wouldn't find a .NET assembly
because it doesn't exist in legacy Xamarin (where it would look by default).

Fixes this problem that showed up in a different PR (due to new .NET API
referencing the System.Runtime.Loader assembly, which doesn't exist in legacy
Xamarin):

    mono64 --debug bin/Debug/xtro-sharpie.exe --output-directory api-annotations-dotnet appletvos16.1-arm64.pch ../../_build/Microsoft.tvOS.Runtime.tvos-arm64/runtimes/tvos-arm64/lib/net7.0/Microsoft.tvOS.dll
    Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: 'System.Runtime.Loader, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
      at Mono.Cecil.BaseAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference name, Mono.Cecil.ReaderParameters parameters) [0x000ff] in C:\src\cecil\Mono.Cecil\BaseAssemblyResolver.cs:172
      at Mono.Cecil.BaseAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference name) [0x00000] in C:\src\cecil\Mono.Cecil\BaseAssemblyResolver.cs:117
      at Mono.Cecil.DefaultAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference name) [0x0001d] in C:\src\cecil\Mono.Cecil\DefaultAssemblyResolver.cs:33
      at Mono.Cecil.MetadataResolver.Resolve (Mono.Cecil.TypeReference type) [0x0003a] in C:\src\cecil\Mono.Cecil\MetadataResolver.cs:110
      at Mono.Cecil.ModuleDefinition.Resolve (Mono.Cecil.TypeReference type) [0x00000] in C:\src\cecil\Mono.Cecil\ModuleDefinition.cs:748
      at Mono.Cecil.TypeReference.Resolve () [0x0000f] in C:\src\cecil\Mono.Cecil\TypeReference.cs:280
      at Extrospection.Helpers.GetName (Mono.Cecil.MethodDefinition self) [0x00051] in /Users/rolf/work/maccore/whatever/xamarin-macios/tests/xtro-sharpie/Helpers.cs:332
      at Extrospection.DesignatedInitializerCheck.VisitManagedMethod (Mono.Cecil.MethodDefinition method) [0x00001] in /Users/rolf/work/maccore/whatever/xamarin-macios/tests/xtro-sharpie/DesignatedInitializerCheck.cs:43
      at Extrospection.AssemblyReader.ProcessType (Extrospection.BaseVisitor v, Mono.Cecil.TypeDefinition type) [0x0002b] in /Users/rolf/work/maccore/whatever/xamarin-macios/tests/xtro-sharpie/Runner.cs:104
      at Extrospection.AssemblyReader.Process () [0x0008e] in /Users/rolf/work/maccore/whatever/xamarin-macios/tests/xtro-sharpie/Runner.cs:93
      at Extrospection.Runner.Execute (System.String pchFile, System.Collections.Generic.IEnumerable`1[T] assemblyNames, System.String outputDirectory) [0x001af] in /Users/rolf/work/maccore/whatever/xamarin-macios/tests/xtro-sharpie/Runner.cs:52
      at Extrospection.MainClass.Main (System.String[] arguments) [0x0008f] in /Users/rolf/work/maccore/whatever/xamarin-macios/tests/xtro-sharpie/Program.cs:28
    make: *** [.stamp-dotnet-classify-tvOS] Error 1