### PR TITLE
[tests] NWPathMonitors must be cancelled.

### DIFF
--- a/tests/monotouch-test/Network/NWPathMonitorTest.cs
+++ b/tests/monotouch-test/Network/NWPathMonitorTest.cs
@@ -13,14 +13,10 @@ namespace monotouchtest.Network {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class NWPathMonitorTest {
-
-		NWPathMonitor monitor;
-
 		[SetUp]
 		public void SetUp ()
 		{
 			TestRuntime.AssertXcodeVersion (10, 0);
-			monitor = new NWPathMonitor ();
 		}
 
 		[Test]
@@ -30,6 +26,7 @@ namespace monotouchtest.Network {
 
 			NWPath finalPath = null;
 			bool isPathUpdated = false;
+			using var monitor = new NWPathMonitor ();
 
 			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), async () => {
 
@@ -54,6 +51,7 @@ namespace monotouchtest.Network {
 		[Test]
 		public void PathIsAlwaysUpdatedWithNewHandlerTest ()
 		{
+			using var monitor = new NWPathMonitor ();
 			NWPath oldPath = monitor.CurrentPath;
 			NWPath newPath = monitor.CurrentPath;
 			bool isOldPathSet = false;
@@ -102,16 +100,10 @@ namespace monotouchtest.Network {
 			Assert.False (Object.ReferenceEquals (oldPath, newPath), "different instances");
 		}
 
-		[TearDown]
-		public void TearDown ()
-		{
-			monitor?.Dispose ();
-		}
-
-
 		[Test]
 		public void ProhibitInterfaceTypeTest ()
 		{
+			using var monitor = new NWPathMonitor ();
 			TestRuntime.AssertXcodeVersion (13, 0);
 			Assert.DoesNotThrow (() => {
 				monitor.ProhibitInterfaceType (NWInterfaceType.Wifi);

--- a/tests/monotouch-test/Network/NWPathMonitorTest.cs
+++ b/tests/monotouch-test/Network/NWPathMonitorTest.cs
@@ -37,6 +37,7 @@ namespace monotouchtest.Network {
 					if (path != null) {
 						finalPath = monitor.CurrentPath;
 						isPathUpdated = true;
+						monitor.Cancel ();
 					}
 
 				});
@@ -66,6 +67,7 @@ namespace monotouchtest.Network {
 						oldPath = monitor.CurrentPath;
 						isOldPathSet = true;
 						cbEvent.Set ();
+						monitor.Cancel ();
 					}
 				});
 
@@ -82,6 +84,7 @@ namespace monotouchtest.Network {
 					if (path != null) {
 						newPath = monitor.CurrentPath;
 						isNewPathSet = true;
+						monitor.Cancel ();
 					}
 
 				});

--- a/tests/monotouch-test/Network/NWPathMonitorTest.cs
+++ b/tests/monotouch-test/Network/NWPathMonitorTest.cs
@@ -64,7 +64,7 @@ namespace monotouchtest.Network {
 				}
 			});
 			monitor.Start ();
-			TestRuntime.RunAsync (DateTime.Now.AddSeconds (3), () => {}, () => oldPath is not null);
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (3), () => { }, () => oldPath is not null);
 
 			// Set a different handler
 			monitor.SnapshotHandler = ((path) => {
@@ -73,7 +73,7 @@ namespace monotouchtest.Network {
 				}
 			});
 			monitor.Start ();
-			TestRuntime.RunAsync (DateTime.Now.AddSeconds (3), () => {}, () => newPath is not null);
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (3), () => { }, () => newPath is not null);
 			monitor.Cancel ();
 
 			Assert.IsNotNull (oldPath, "oldPath set (no timeout)");


### PR DESCRIPTION
Otherwise the process may crash later on:

    apitest.KernelNotificationTest

    =================================================================
    	Native Crash Reporting
    =================================================================
    Got a term while executing native code. This usually indicates
    a fatal error in the mono runtime or one of the native libraries
    used by your application.
    =================================================================

    =================================================================
    	Native stacktrace:
    =================================================================
    	0x1050093d6 - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : mono_dump_native_crash_info
    	0x104ffcf3e - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : mono_handle_native_crash
    	0x1050106c6 - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : mono_crashing_signal_handler
    	0x7ff818795dfd - /usr/lib/system/libsystem_platform.dylib : _sigtramp
    	0x0 - Unknown
    	0x7ff81c88c9f8 - /usr/lib/libnetwork.dylib : nw_path_shared_necp_fd
    	0x7ff81c99e796 - /usr/lib/libnetwork.dylib : -[NWConcrete_nw_path_evaluator dealloc]
    	0x7ff81c9bb93e - /usr/lib/libnetwork.dylib : __nw_dictionary_dispose_block_invoke
    	0x7ff8184bc5a3 - /usr/lib/system/libxpc.dylib : _xpc_dictionary_apply_apply
    	0x7ff8184b97e9 - /usr/lib/system/libxpc.dylib : _xpc_dictionary_apply_node_f
    	0x7ff8184bc4cd - /usr/lib/system/libxpc.dylib : xpc_dictionary_apply
    	0x7ff81c98c7eb - /usr/lib/libnetwork.dylib : -[OS_nw_dictionary dealloc]
    	0x7ff81cfa5ab5 - /usr/lib/libnetwork.dylib : nw_path_release_globals
    	0x7ff81c9edba6 - /usr/lib/libnetwork.dylib : nw_settings_child_has_forked
    	0x7ff818783103 - /usr/lib/system/libsystem_pthread.dylib : _pthread_atfork_child_handlers
    	0x7ff81867482d - /usr/lib/system/libsystem_c.dylib : fork
    	0x1051b37a3 - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : process_create
    	0x1051b224a - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal
    	0x1050e4111 - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal_raw
    	0x10d4f2437 - Unknown
    	0x10d4f1e4b - Unknown
    	0x10d4f188b - Unknown
    	0x10d4f17b3 - Unknown
    	0x10d4f1363 - Unknown
    	0x10d4f11bb - Unknown
    	0x10d4efc53 - Unknown
    	0x10d4ee121 - Unknown
    	0x105013d23 - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : mono_jit_runtime_invoke
    	0x1051483f8 - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : mono_runtime_invoke_checked
    	0x1051510cf - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : mono_runtime_try_invoke_array
    	0x1050d7127 - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : ves_icall_InternalInvoke
    	0x1050e9b57 - /Users/rolf/work/maccore/msbuild/xamarin-macios/tests/xammac_tests/bin/x86/Debug/xammac_tests.app/Contents/MacOS/xammac_tests : ves_icall_InternalInvoke_raw