### PR TITLE
[CI] Move the upload to a hosted image.

### DIFF
--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -24,10 +24,6 @@ parameters:
 - name: azureContainer
   type: string
 
-- name: windowsPool
-  type: string
-  default: "VSEng-VSMac-Xamarin-Shared"
-
 jobs:
 - job: configure
   displayName: 'Configure build'
@@ -160,9 +156,7 @@ jobs:
     SKIP_NUGETS: $[ dependencies.configure.outputs['labels.skip_nugets'] ]
 
   pool:
-    name: ${{ parameters.windowsPool }}
-    demands:
-    - agent.os -equals Windows_NT
+    vmImage: windows-latest
     workspace:
       clean: all
   steps:

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -48,7 +48,15 @@ steps:
 - task: DownloadPipelineArtifact@2
   displayName: Download packages
   inputs:
-    patterns: '**'
+    patterns:
+      - '**'
+      - '!*binlogs*'  # ignore binlogs, they use space and are not needed
+      - '!*DropMetadata*/**' # same with the drop metadata
+      - '!*HtmlReport*/**' # same the html test results if preset
+      - '!*TestSummary*/**' # same the md test results if preset
+      - '!*agent-logs*/**' # same the agent logs
+      - '!mac-test-package/**' # same the mac test packages
+      - '!crash-reports*/**' # same the crash reports
     allowFailedBuilds: true
     path: $(Build.SourcesDirectory)/artifacts
 

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -48,15 +48,7 @@ steps:
 - task: DownloadPipelineArtifact@2
   displayName: Download packages
   inputs:
-    patterns:
-      - '**'
-      - '!*binlogs*'  # ignore binlogs, they use space and are not needed
-      - '!*DropMetadata*/**' # same with the drop metadata
-      - '!*HtmlReport*/**' # same the html test results if preset
-      - '!*TestSummary*/**' # same the md test results if preset
-      - '!*agent-logs*/**' # same the agent logs
-      - '!mac-test-package/**' # same the mac test packages
-      - '!crash-reports*/**' # same the crash reports
+    patterns: '!(*binlogs*|*DropMetadata*/**|*HtmlReport*/**|*TestSummary*/**|*agent-logs*/**|mac-test-package/**|crash-reports*/**)' # downlod all except some data we re not interested in 
     allowFailedBuilds: true
     path: $(Build.SourcesDirectory)/artifacts
 

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -82,7 +82,6 @@ steps:
     storage: ${{ parameters.azureStorage }}
     ContainerName: ${{ parameters.azureContainer }}
     BlobPrefix: $(Build.SourceBranchName)/$(Build.SourceVersion)/$(Build.BuildId)/package  # ideally, we would use a variable for this
-    AdditionalArgumentsForBlobCopy: "/SetContentType /Y $(AzCopyFullCopyArg)"
     outputStorageContainerSasToken: PackageSasToken
 
 - task: AzureFileCopy@3
@@ -94,7 +93,6 @@ steps:
     storage: ${{ parameters.azureStorage }}
     ContainerName: ${{ parameters.azureContainer }}
     BlobPrefix: jenkins/$(Build.SourceBranchName)/$(Build.SourceVersion)
-    AdditionalArgumentsForBlobCopy: "/SetContentType /Y $(AzCopyFullCopyArg)"
     outputStorageContainerSasToken: PackageSasToken
 
 - task: AzureFileCopy@3
@@ -106,7 +104,6 @@ steps:
     storage: ${{ parameters.azureStorage }}
     ContainerName: ${{ parameters.azureContainer }}
     BlobPrefix: jenkins/$(Build.SourceBranchName)/latest
-    AdditionalArgumentsForBlobCopy: "/SetContentType /Y $(AzCopyFullCopyArg)"
     outputStorageContainerSasToken: PackageSasToken
 
 - task: AzureFileCopy@3
@@ -118,7 +115,6 @@ steps:
     storage: ${{ parameters.azureStorage }}
     ContainerName: ${{ parameters.azureContainer }}
     BlobPrefix: jenkins/$(Build.SourceVersion)
-    AdditionalArgumentsForBlobCopy: "/SetContentType /Y $(AzCopyFullCopyArg)"
     outputStorageContainerSasToken: PackageSasToken
 
 - pwsh: |


### PR DESCRIPTION
We have noticed that the azure upload steps fail when they are executed in a on prem windows machine. The infra team does not know what this is happening. To work around it we are taking the following stes:

- Move the upload to a hosted image, which does work.
- Donot download all artefacts, since hosted images only have a 10 gb hdd. We download all but the not needed files using negative match patterns.