### PR TITLE
[CFNetwork] Add nullability to forgotten files.

### DIFF
--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -257,7 +257,7 @@ namespace CoreServices {
 			/* CFHTTPAuthenticationRef */ IntPtr auth, /* CFString */ IntPtr username, /* CFString */ IntPtr password,
 			/* CFStreamError* */ out CFStreamError error);
 
-		public void ApplyCredentials (CFHTTPAuthentication auth, NetworkCredential credential)
+		public void ApplyCredentials (CFHTTPAuthentication? auth, NetworkCredential credential)
 		{
 			if (auth is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (auth));

--- a/src/CFNetwork/Content.cs
+++ b/src/CFNetwork/Content.cs
@@ -37,6 +37,8 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Foundation;
 
+#nullable enable
+
 namespace CFNetwork {
 
 	class Content : StreamContent {
@@ -61,9 +63,7 @@ namespace CFNetwork {
 		protected override void Dispose (bool disposing)
 		{
 			if (disposing) {
-				if (responseStream != null)
-					responseStream.Dispose ();
-				responseStream = null;
+				responseStream.Dispose ();
 			}
 		}
 

--- a/src/CFNetwork/WebRequestStream.cs
+++ b/src/CFNetwork/WebRequestStream.cs
@@ -37,13 +37,15 @@ using CoreFoundation;
 using CoreServices;
 using Foundation;
 
+#nullable enable
+
 namespace CFNetwork {
 
 	class WebRequestStream {
 		Stream stream;
 		CFReadStream readStream;
 		CFWriteStream writeStream;
-		TaskCompletionSource<object> openTcs;
+		TaskCompletionSource<object?> openTcs;
 		CancellationTokenSource cts;
 
 		byte [] buffer;
@@ -61,7 +63,7 @@ namespace CFNetwork {
 			buffer = new byte [BufferSize];
 			cts = CancellationTokenSource.CreateLinkedTokenSource (cancellationToken);
 
-			openTcs = new TaskCompletionSource<object> ();
+			openTcs = new TaskCompletionSource<object?> ();
 
 			cts.Token.Register (() => Close ());
 

--- a/src/CFNetwork/WorkerThread.cs
+++ b/src/CFNetwork/WorkerThread.cs
@@ -38,14 +38,16 @@ using System.Diagnostics;
 using Foundation;
 using CoreFoundation;
 
+#nullable enable
+
 using CFRunLoopModeString = global::Foundation.NSString;
 
 namespace CFNetwork {
 
 	public class WorkerThread {
-		CFRunLoop loop;
-		Source source;
-		Context context;
+		CFRunLoop? loop;
+		Source? source;
+		Context? context;
 		CancellationTokenSource cts;
 		ManualResetEventSlim readyEvent;
 		ConcurrentQueue<Event> eventQueue = new ConcurrentQueue<Event> ();
@@ -88,8 +90,9 @@ namespace CFNetwork {
 		public void Stop ()
 		{
 			cts.Cancel ();
-			loop.RemoveSource (source, CFRunLoop.ModeDefault);
-			loop.Stop ();
+			if (source is not null)
+				loop?.RemoveSource (source, CFRunLoop.ModeDefault);
+			loop?.Stop ();
 		}
 
 		protected void PostNoResult (Action callback)
@@ -100,8 +103,8 @@ namespace CFNetwork {
 				return null;
 			};
 			eventQueue.Enqueue (ev);
-			source.Signal ();
-			loop.WakeUp ();
+			source?.Signal ();
+			loop?.WakeUp ();
 		}
 
 		public Task Post (Action callback)
@@ -116,11 +119,11 @@ namespace CFNetwork {
 				callback (c);
 				return null;
 			};
-			ev.Tcs = new TaskCompletionSource<object> ();
+			ev.Tcs = new TaskCompletionSource<object?> ();
 			ev.Cts = CancellationTokenSource.CreateLinkedTokenSource (cts.Token, cancellationToken);
 			eventQueue.Enqueue (ev);
-			source.Signal ();
-			loop.WakeUp ();
+			source?.Signal ();
+			loop?.WakeUp ();
 
 			try {
 				await ev.Tcs.Task;
@@ -129,25 +132,25 @@ namespace CFNetwork {
 			}
 		}
 
-		public Task<T> Post<T> (Func<T> callback)
+		public Task<T?> Post<T> (Func<T> callback)
 		{
 			return Post (c => callback (), CancellationToken.None);
 		}
 
-		public async Task<T> Post<T> (Func<CancellationToken, T> callback,
+		public async Task<T?> Post<T> (Func<CancellationToken, T> callback,
 									  CancellationToken cancellationToken)
 		{
 			var ev = new Event ();
 			ev.Callback = c => callback (c);
-			ev.Tcs = new TaskCompletionSource<object> ();
+			ev.Tcs = new TaskCompletionSource<object?> ();
 			ev.Cts = CancellationTokenSource.CreateLinkedTokenSource (cts.Token, cancellationToken);
 			eventQueue.Enqueue (ev);
-			source.Signal ();
-			loop.WakeUp ();
+			source?.Signal ();
+			loop?.WakeUp ();
 
 			try {
 				var result = await ev.Tcs.Task;
-				if (result != null)
+				if (result is not null)
 					return (T) result;
 				else
 					return default (T);
@@ -162,7 +165,7 @@ namespace CFNetwork {
 			if (!eventQueue.TryDequeue (out ev))
 				return;
 
-			if ((ev.Cts != null) && ev.Cts.IsCancellationRequested) {
+			if ((ev.Cts is not null) && ev.Cts.IsCancellationRequested) {
 				ev.Tcs.SetCanceled ();
 				return;
 			}
@@ -171,20 +174,20 @@ namespace CFNetwork {
 
 			try {
 				var result = ev.Callback (effectiveCts.Token);
-				if (ev.Tcs != null)
+				if (ev.Tcs is not null)
 					ev.Tcs.SetResult (result);
 			} catch (TaskCanceledException) {
-				if (ev.Tcs != null)
+				if (ev.Tcs is not null)
 					ev.Tcs.SetCanceled ();
 			} catch (Exception ex) {
-				if (ev.Tcs != null)
+				if (ev.Tcs is not null)
 					ev.Tcs.SetException (ex);
 			}
 		}
 
 		struct Event {
-			public Func<CancellationToken, object> Callback;
-			public TaskCompletionSource<object> Tcs;
+			public Func<CancellationToken, object?> Callback;
+			public TaskCompletionSource<object?> Tcs;
 			public CancellationTokenSource Cts;
 		}
 


### PR DESCRIPTION
Add nullability to the files. Although this files won't be present in the new dotnet versions, it is good to add them for classic. Also, if we move all files to have nullability enabled we should be able to pass it as a flag and remove the need to use '#nullable enable' which people can forget.