### PR TITLE
[release/7.0.2xx] Fix libs reidentification deployed in a subdirectory

### DIFF
--- a/builds/create-csproj-for-all-packagereferences.sh
+++ b/builds/create-csproj-for-all-packagereferences.sh
@@ -48,6 +48,7 @@ sed -i '' 's/""/"/g' "$TMPPATH"
 
 # Remove packages that we build locally
 sed -i '' '/Xamarin.Tests.FrameworksInRuntimesNativeDirectory/d' "$TMPPATH"
+sed -i '' '/Xamarin.Tests.DynamicLibrariesInRuntimesNativeDirectory/d' "$TMPPATH"
 
 # Get only the name and version of each package, and write that back in a PackageDownload item
 sed -i '' 's@.*<PackageReference.*Include="\([a-zA-Z0-9._-]*\)".*Version="\([a-zA-Z0-9._-]*\)".*>.*@\t\t<PackageDownload Include="\1" Version="[\2]" />@g' "$TMPPATH"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -710,7 +710,9 @@
 		<ItemGroup>
 			<!-- Support a 'CopyToAppBundle' metadata that can be set to 'false' to avoid copying a framework to the app bundle -->
 			<_DynamicLibraryToPublish Include="@(_FileNativeReference)" Condition="'%(_FileNativeReference.Kind)' == 'Dynamic' And '%(_FileNativeReference.CopyToAppBundle)' != 'false'">
-				<RelativePath>$(_DylibPublishDir)\%(Filename)%(Extension)</RelativePath>
+				<!-- Rewrite the relative path so that everything ends up in the app bundle -->
+				<RelativePath Condition="'%(_FileNativeReference.RelativePath)' == ''">$(_DylibPublishDir)\%(Filename)%(Extension)</RelativePath>
+				<RelativePath Condition="'%(_FileNativeReference.RelativePath)' != ''">$(_RelativeAppBundlePath)\%(_FileNativeReference.RelativePath)</RelativePath>
 				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
 			</_DynamicLibraryToPublish>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1182,13 +1182,22 @@
 	<Target Name="_ComputeDynamicLibrariesToReidentify">
 		<PropertyGroup>
 			<_ExecutablePathPrefix Condition="'$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS'">@executable_path/</_ExecutablePathPrefix>
-			<_ExecutablePathPrefix Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">@executable_path/../$(_CustomBundleName)/</_ExecutablePathPrefix>
+			<_ExecutablePathPrefix Condition="'$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst'">@executable_path/../../</_ExecutablePathPrefix>
 		</PropertyGroup>
 		<ItemGroup>
+			<!-- Create the ComputedRelativePath metadata from RelativePath -->
 			<_DynamicLibraryToReidentify Include="@(_FileNativeReference)" Condition="'%(Extension)' == '.dylib'">
-				<DynamicLibraryId>$(_ExecutablePathPrefix)%(Filename)%(Extension)</DynamicLibraryId>
 				<SourceItemGroup>_FileNativeReference</SourceItemGroup>
-				<ReidentifiedPath>$(_IntermediateNativeLibraryDir)/%(Filename)%(Extension)</ReidentifiedPath>
+				<ComputedRelativePath>%(_FileNativeReference.RelativePath)</ComputedRelativePath>
+			</_DynamicLibraryToReidentify>
+			<!-- Set ComputedRelativePath from Filename and Extension if not set (i.e. RelativePath didn't exist on the item) -->
+			<_DynamicLibraryToReidentify Update="@(_DynamicLibraryToReidentify)" Condition="'%(SourceItemGroup)' == '_FileNativeReference' And '%(_DynamicLibraryToReidentify.ComputedRelativePath)' == ''">
+				<ComputedRelativePath>Contents/$(_CustomBundleName)/%(Filename)%(Extension)</ComputedRelativePath>
+			</_DynamicLibraryToReidentify>
+			<!-- Compute DynamicLibraryId and ReidentifiedPath -->
+			<_DynamicLibraryToReidentify Update="@(_DynamicLibraryToReidentify)" Condition="'%(SourceItemGroup)' == '_FileNativeReference'">
+				<DynamicLibraryId Condition="'%(_DynamicLibraryToReidentify.DynamicLibraryId)' == ''">$([System.String]::Copy('$(_ExecutablePathPrefix)%(_DynamicLibraryToReidentify.ComputedRelativePath)').Replace('\', '/'))</DynamicLibraryId>
+				<ReidentifiedPath Condition="'%(_DynamicLibraryToReidentify.ReidentifiedPath)' == ''">$(_IntermediateNativeLibraryDir)/%(_DynamicLibraryToReidentify.ComputedRelativePath)</ReidentifiedPath>
 			</_DynamicLibraryToReidentify>
 		</ItemGroup>
 	</Target>

--- a/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/AppDelegate.cs
+++ b/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/AppDelegate.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace NativeDynamicLibraryReferencesApp {
+	public class Program {
+		[DllImport ("libtest.dylib")]
+		static extern int theUltimateAnswer ();
+
+		static int Main (string [] args)
+		{
+			Console.WriteLine ($"Dynamic library: {theUltimateAnswer ()}");
+
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/MacCatalyst/AppWithNativeDynamicLibrariesInPackageReference.csproj
+++ b/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/MacCatalyst/AppWithNativeDynamicLibrariesInPackageReference.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+		<FatName>ios-fat</FatName>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/Makefile
+++ b/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/Makefile
@@ -1,0 +1,2 @@
+TOP=../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/macOS/AppWithNativeDynamicLibrariesInPackageReference.csproj
+++ b/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/macOS/AppWithNativeDynamicLibrariesInPackageReference.csproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+		<RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+		<FatName>macos-fat</FatName>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/shared.csproj
+++ b/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/shared.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<ApplicationTitle>AppWithNativeDynamicLibrariesInPackageReference</ApplicationTitle>
+		<ApplicationId>com.xamarin.appwithnativedynamiclibrariesinpackagereference</ApplicationId>
+		<ApplicationVersion>1.0</ApplicationVersion>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<PackageReference Include="Xamarin.Tests.DynamicLibrariesInRuntimesNativeDirectory" Version="1.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/test-libraries/nugets/DynamicLibrariesInRuntimesNativeDirectory/DynamicLibrariesInRuntimesNativeDirectory.csproj
+++ b/tests/test-libraries/nugets/DynamicLibrariesInRuntimesNativeDirectory/DynamicLibrariesInRuntimesNativeDirectory.csproj
@@ -1,0 +1,69 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>Xamarin.Tests.DynamicLibrariesInRuntimesNativeDirectory</PackageId>
+    <PackageVersion>1.0.0</PackageVersion>
+    <RepositoryUrl>https://github.com/xamarin/xamarin-macios</RepositoryUrl>
+    <RepositoryBranch>main</RepositoryBranch>
+    <Authors>Microsoft</Authors>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/xamarin/xamarin-macios</PackageProjectUrl>
+    <RootTestDirectory>../../..</RootTestDirectory>
+    <TestFrameworksDirectory>$(RootTestDirectory)/test-libraries/frameworks</TestFrameworksDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Dynamic library in native directory -->
+    <Content Include="$(RootTestDirectory)\test-libraries\.libs\macos\libtest.x86_64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>runtimes/osx-x64/native/libtest.dylib</PackagePath>
+    </Content>
+    <Content Include="$(RootTestDirectory)\test-libraries\.libs\macos\libtest.arm64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>runtimes/osx-arm64/native/libtest.dylib</PackagePath>
+    </Content>
+    <Content Include="$(RootTestDirectory)\test-libraries\.libs\maccatalyst\libtest.x86_64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>runtimes/maccatalyst-x64/native/libtest.dylib</PackagePath>
+    </Content>
+    <Content Include="$(RootTestDirectory)\test-libraries\.libs\maccatalyst\libtest.arm64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>runtimes/maccatalyst-arm64/native/libtest.dylib</PackagePath>
+    </Content>
+    <!-- Dynamic library in native subdirectory -->
+    <Content Include="$(RootTestDirectory)\test-libraries\.libs\macos\libtest.x86_64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>bin/osx-x64/libtest.dylib</PackagePath>
+    </Content>
+    <Content Include="$(RootTestDirectory)\test-libraries\.libs\macos\libtest.arm64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>bin/osx-arm64/libtest.dylib</PackagePath>
+    </Content>
+    <Content Include="$(RootTestDirectory)\test-libraries\.libs\maccatalyst\libtest.x86_64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>bin/maccatalyst-x64/libtest.dylib</PackagePath>
+    </Content>
+    <Content Include="$(RootTestDirectory)\test-libraries\.libs\maccatalyst\libtest.arm64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>bin/maccatalyst-arm64/libtest.dylib</PackagePath>
+    </Content>
+    <Content Include="$(RootTestDirectory)\test-libraries\.libs\maccatalyst\libtest.arm64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>bin/maccatalyst-arm64/libtest2.dylib</PackagePath>
+    </Content>
+    <!-- Targets file -->
+    <Content Include="$(MSBuildThisFileDirectory)\Xamarin.Tests.DynamicLibrariesInRuntimesNativeDirectory.targets">
+      <Pack>true</Pack>
+      <PackagePath>build/Xamarin.Tests.DynamicLibrariesInRuntimesNativeDirectory.targets</PackagePath>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/tests/test-libraries/nugets/DynamicLibrariesInRuntimesNativeDirectory/Makefile
+++ b/tests/test-libraries/nugets/DynamicLibrariesInRuntimesNativeDirectory/Makefile
@@ -1,0 +1,27 @@
+TOP=../../../..
+include $(TOP)/Make.config
+
+unexport MSBUILD_EXE_PATH
+
+.libs:
+	$(Q) mkdir -p $@
+
+PACKAGE_ID=$(shell grep PackageId DynamicLibrariesInRuntimesNativeDirectory.csproj | sed 's_.*<PackageId>\(.*\)</PackageId>.*_\1_')
+PACKAGE_VERSION=$(shell grep '<PackageVersion>' DynamicLibrariesInRuntimesNativeDirectory.csproj | sed 's_.*<PackageVersion>\(.*\)</PackageVersion>.*_\1_')
+
+# Test case for dynamic libraries
+.libs/DynamicLibrariesInRuntimesNativeDirectory.nupkg: export DOTNET_PLATFORMS:=$(shell echo $(DOTNET_PLATFORMS) | tr ' ' ';')
+.libs/DynamicLibrariesInRuntimesNativeDirectory.nupkg: DynamicLibrariesInRuntimesNativeDirectory.csproj $(wildcard *.cs) | .libs
+	$(Q) mkdir -p $(abspath $(NUGET_TEST_FEED))
+	$(Q_GEN) $(DOTNET) pack /bl $(DOTNET_PACK_VERBOSITY) $<
+	$(Q) $(CP) bin/Debug/Xamarin.Tests.DynamicLibrariesInRuntimesNativeDirectory.$(PACKAGE_VERSION).nupkg $@
+
+INSTALLED_PACKAGE=$(NUGET_TEST_FEED)/xamarin.tests.DynamicLibrariesInRuntimesNativeDirectory/$(PACKAGE_VERSION)/xamarin.tests.DynamicLibrariesInRuntimesNativeDirectory.$(PACKAGE_VERSION).nupkg
+
+$(INSTALLED_PACKAGE): .libs/DynamicLibrariesInRuntimesNativeDirectory.nupkg
+	if test -d $(NUGET_TEST_FEED)/$(PACKAGE_ID)/$(PACKAGE_VERSION); then nuget delete $(PACKAGE_ID) $(PACKAGE_VERSION) -source $(abspath $(NUGET_TEST_FEED)) -NonInteractive || true; fi
+	rm -Rf $(TOP)/tests/dotnet/packages/xamarin.tests.DynamicLibrariesInRuntimesNativeDirectory
+	mkdir -p $(abspath $(NUGET_TEST_FEED))
+	nuget add "$<" -source $(abspath $(NUGET_TEST_FEED)) -NonInteractive
+
+all-local:: $(INSTALLED_PACKAGE)

--- a/tests/test-libraries/nugets/DynamicLibrariesInRuntimesNativeDirectory/Xamarin.Tests.DynamicLibrariesInRuntimesNativeDirectory.targets
+++ b/tests/test-libraries/nugets/DynamicLibrariesInRuntimesNativeDirectory/Xamarin.Tests.DynamicLibrariesInRuntimesNativeDirectory.targets
@@ -1,0 +1,11 @@
+<Project>
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)..\bin\$(RuntimeIdentifier)\libtest.dylib">
+            <Visible>false</Visible>
+            <Link>$(OutputDirectory)\subdir\%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+            <PublishState>Included</PublishState>
+        </None>
+    </ItemGroup>
+</Project>

--- a/tests/test-libraries/nugets/Makefile
+++ b/tests/test-libraries/nugets/Makefile
@@ -1,4 +1,4 @@
 TOP=../../..
-SUBDIRS=FrameworksInRuntimesNativeDirectory
+SUBDIRS=FrameworksInRuntimesNativeDirectory DynamicLibrariesInRuntimesNativeDirectory
 
 include $(TOP)/Make.config


### PR DESCRIPTION
Dynamic libraries might be deployed in subdirectories such as libclrjit.dylib from the nuget package cefglue.common:
Contents/MonoBundle/CefGlueBrowserProcess/libclrjit.dylib

The library ID for that library should be:
@executable_path/../MonoBundle/CefGlueBrowserProcess/libclrjit.dylib

Instead of:
@executable_path/../MonoBundle/libclrjit.dylib

Beside the library ID being wrong, when it's combined with the nuget package microsoft.netcore.app.runtime.osx-x64 providing a library with the same name, both uses the same `ReidentifiedPath`, which can cause a failure in the InstallNameTool tasks that are run in parallel operating on the same temporary file.

The following patch uses the `RelativePath` for the tempory file used by `InstallNameTool` so that there are no clashes with other files with the same name deployed in other directories. It also uses the `RelativePath` to create the correct library id:
@executable_path/../../Contents/MonoBundle/CefGlueBrowserProcess/libclrjit.dylib

Partially fixes https://github.com/xamarin/xamarin-macios/issues/15173 for this scenario


Backport of #16706
