### PR TITLE
[release/7.0.2xx] Bump to MSBuild.StructuredLogger v2.1.758.

### DIFF
--- a/tests/bgen/bgen-tests.csproj
+++ b/tests/bgen/bgen-tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/UnitTests/DotNetUnitTests.csproj
+++ b/tests/dotnet/UnitTests/DotNetUnitTests.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
 		<PackageReference Include="Mono.Cecil" Version="0.11.4" />
-		<PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />
+		<PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
 		<PackageReference Include="System.Text.Json" Version="5.0.2" />
 	</ItemGroup>
 

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ErrorTests.cs" />

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -42,7 +42,7 @@
       <HintPath Condition="$(TESTS_USE_SYSTEM) != ''">\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\lib\mmp\mmp.exe</HintPath>
     </Reference>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\mtouch\Cache.cs">

--- a/tests/mtouch/mtouchtests.csproj
+++ b/tests/mtouch/mtouchtests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
     <Reference Include="Mono.Cecil">
       <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.dll</HintPath>
     </Reference>


### PR DESCRIPTION
To get new log format:

> System.NotSupportedException : Unsupported log file format. Latest supported version is 14, the log file has version 15.


Backport of #17229
