### PR TITLE
[AudioUnit] Make AudioUnitParameterType.AUDCFilterDecayTime obsolete on Mac Catalyst.

### DIFF
--- a/src/AudioUnit/AUEnums.cs
+++ b/src/AudioUnit/AUEnums.cs
@@ -565,8 +565,11 @@ namespace AudioUnit {
 		AULowShelfCutoffFrequency = 0,
 		AULowShelfGain = 1,
 
+#if !XAMCORE_5_0 // I can't find this value in the headers anymore
 		[Obsoleted (PlatformName.iOS, 7, 0)]
+		[Obsoleted (PlatformName.MacCatalyst, 13, 1)]
 		AUDCFilterDecayTime = 0,
+#endif
 
 		// AUParametricEQ
 		ParametricEQCenterFreq = 0,


### PR DESCRIPTION
Mark this field as obsolete on Mac Catalyst to match iOS, but also completely
remove it in XAMCORE_5_0, since I can't find it in the headers anymore
anyways.