### PR TITLE
[Foundation] [NSTask launchedTaskWithLaunchPath:arguments:] is not available on Mac Catalyst.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -15461,6 +15461,13 @@ namespace Foundation {
 
 		[Static]
 		[Deprecated (PlatformName.MacOSX, 10, 15)]
+#if XAMCORE_5_0
+		[NoMacCatalyst]
+#else
+#if MACCATALYST
+		[Obsolete ("Do not use; this method is not available on Mac Catalyst.")]
+#endif // MACCATALYST
+#endif // XAMCORE_5_0
 		[Export ("launchedTaskWithLaunchPath:arguments:")]
 		NSTask LaunchFromPath (string path, string [] arguments);
 


### PR DESCRIPTION
But we can't just remove it, so obsolete it until we can.