### PR TITLE
[tests] Hardcode the SupportedOSPlatformVersion for the .NET 6 tests.

### DIFF
--- a/tests/dotnet/Net6_0SimpleApp/MacCatalyst/Net6_0SimpleApp.csproj
+++ b/tests/dotnet/Net6_0SimpleApp/MacCatalyst/Net6_0SimpleApp.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/Net6_0SimpleApp/iOS/Net6_0SimpleApp.csproj
+++ b/tests/dotnet/Net6_0SimpleApp/iOS/Net6_0SimpleApp.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0-ios</TargetFramework>
+		<SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/Net6_0SimpleApp/macOS/Net6_0SimpleApp.csproj
+++ b/tests/dotnet/Net6_0SimpleApp/macOS/Net6_0SimpleApp.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0-macos</TargetFramework>
+		<SupportedOSPlatformVersion>10.15</SupportedOSPlatformVersion>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>

--- a/tests/dotnet/Net6_0SimpleApp/tvOS/Net6_0SimpleApp.csproj
+++ b/tests/dotnet/Net6_0SimpleApp/tvOS/Net6_0SimpleApp.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0-tvos</TargetFramework>
+		<SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 	<Import Project="..\shared.csproj" />
 </Project>


### PR DESCRIPTION
.NET 6 doesn't define the minimum supported OS version property, which means
we can't use the existing logic to automatically determine the min OS version
to use as the default SupportedOSPlatformVersion in the .NET 6, so hardcode
the value.