### PR TITLE
[generator] Don't generate accessors with No* availability attributes on them.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -6600,12 +6600,12 @@ public partial class Generator : IMemberGatherer {
 		generate_getter = false;
 		generate_setter = false;
 		if (pi.CanRead) {
-		        getter = pi.GetGetMethod ();
-		        generate_getter = !getter.IsUnavailable (this);
+			getter = pi.GetGetMethod ();
+			generate_getter = !getter.IsUnavailable (this);
 		}
 		if (pi.CanWrite) {
-		        setter = pi.GetSetMethod ();
-		        generate_setter = !setter.IsUnavailable (this);
+			setter = pi.GetSetMethod ();
+			generate_setter = !setter.IsUnavailable (this);
 		}
 	}
 

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -1020,6 +1020,42 @@ namespace GeneratorTests {
 			Assert.IsNotNull (pinvoke, "PInvoke");
 		}
 
+		[Test]
+		[TestCase (Profile.iOS)]
+		public void NoAvailabilityForAccessors (Profile profile)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (profile.AsPlatform ());
+			var bgen = new BGenTool ();
+			bgen.Profile = profile;
+			bgen.AddTestApiDefinition ("tests/no-availability-for-accessors.cs");
+			bgen.CreateTemporaryBinding ();
+			bgen.AssertExecute ("build");
+
+			bgen.AssertMethod ("NS.Whatever", "get_PropA");
+			bgen.AssertNoMethod ("NS.Whatever", "set_PropA", parameterTypes: "Foundation.NSObject");
+			bgen.AssertMethod ("NS.Whatever", "set_PropB", parameterTypes: "Foundation.NSObject");
+			bgen.AssertNoMethod ("NS.Whatever", "get_PropB");
+			bgen.AssertMethod ("NS.Whatever", "get_IPropA");
+			bgen.AssertNoMethod ("NS.Whatever", "set_IPropA", parameterTypes: "Foundation.NSObject");
+			bgen.AssertMethod ("NS.Whatever", "set_IPropB", parameterTypes: "Foundation.NSObject");
+			bgen.AssertNoMethod ("NS.Whatever", "get_IPropB");
+			bgen.AssertMethod ("NS.Whatever", "get_IPropAOpt");
+			bgen.AssertNoMethod ("NS.Whatever", "set_IPropAOpt", parameterTypes: "Foundation.NSObject");
+			bgen.AssertMethod ("NS.Whatever", "set_IPropBOpt", parameterTypes: "Foundation.NSObject");
+			bgen.AssertNoMethod ("NS.Whatever", "get_IPropBOpt");
+			bgen.AssertPublicMethodCount ("NS.Whatever", 9); // 6 accessors + 2 constructors + ClassHandle getter
+
+			bgen.AssertMethod ("NS.IIProtocol", "get_IPropA");
+			bgen.AssertNoMethod ("NS.IIProtocol", "set_IPropA", parameterTypes: "Foundation.NSObject");
+			bgen.AssertMethod ("NS.IIProtocol", "set_IPropB", parameterTypes: "Foundation.NSObject");
+			bgen.AssertNoMethod ("NS.IIProtocol", "get_IPropB");
+			bgen.AssertPublicMethodCount ("NS.IIProtocol", 2);
+			
+			bgen.AssertMethod ("NS.IProtocol_Extensions", "GetIPropAOpt", parameterTypes: "NS.IIProtocol");
+			bgen.AssertMethod ("NS.IProtocol_Extensions", "SetIPropBOpt", parameterTypes: new string [] { "NS.IIProtocol", "Foundation.NSObject" });
+			bgen.AssertPublicMethodCount ("NS.IProtocol_Extensions", 2);
+		}
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -1050,7 +1050,7 @@ namespace GeneratorTests {
 			bgen.AssertMethod ("NS.IIProtocol", "set_IPropB", parameterTypes: "Foundation.NSObject");
 			bgen.AssertNoMethod ("NS.IIProtocol", "get_IPropB");
 			bgen.AssertPublicMethodCount ("NS.IIProtocol", 2);
-			
+
 			bgen.AssertMethod ("NS.IProtocol_Extensions", "GetIPropAOpt", parameterTypes: "NS.IIProtocol");
 			bgen.AssertMethod ("NS.IProtocol_Extensions", "SetIPropBOpt", parameterTypes: new string [] { "NS.IIProtocol", "Foundation.NSObject" });
 			bgen.AssertPublicMethodCount ("NS.IProtocol_Extensions", 2);

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -304,14 +304,15 @@ namespace Xamarin.Tests {
 		{
 			LoadAssembly ();
 
-			var t = assembly.MainModule.Types.FirstOrDefault ((v) => v.FullName == typename);
-			var actual = t.Methods.Count ((v) => {
+			var t = assembly.MainModule.Types.First ((v) => v.FullName == typename);
+			var actual = t.Methods.Where ((v) => {
 				if (v.IsPrivate || v.IsFamily || v.IsFamilyAndAssembly)
 					return false;
 				return true;
 			});
-			if (actual != count)
-				Assert.Fail ($"Expected {count} publicly accessible method(s) in {typename}, found {actual} publicly accessible method(s). {message}");
+			if (actual.Count () != count) {
+				Assert.Fail ($"Expected {count} publicly accessible method(s) in {typename}, found {actual} publicly accessible method(s): {message}\n\t{string.Join ("\n\t", actual.Select (v => v.FullName).OrderBy (v => v))}");
+			}
 		}
 
 		public void AssertType (string fullname, TypeAttributes? attributes = null, string message = null)
@@ -326,6 +327,11 @@ namespace Xamarin.Tests {
 				Assert.AreEqual (attributes.Value, t.Attributes, $"Incorrect attributes for type {fullname}.");
 		}
 
+		public void AssertMethod (string typename, string method, params string [] parameterTypes)
+		{
+			AssertMethod (typename, method, null, null, parameterTypes);
+		}
+
 		public void AssertMethod (string typename, string method, string returnType = null, params string [] parameterTypes)
 		{
 			AssertMethod (typename, method, null, returnType, parameterTypes);
@@ -333,9 +339,29 @@ namespace Xamarin.Tests {
 
 		public void AssertMethod (string typename, string method, MethodAttributes? attributes = null, string returnType = null, params string [] parameterTypes)
 		{
-			LoadAssembly ();
+			var m = FindMethod (typename, method, returnType, parameterTypes);
+			if (m is null) {
+				Assert.Fail ($"No method '{method}' with signature '{string.Join ("', '", parameterTypes)}' on the type '{typename}' was found.");
+				return;
+			}
+			if (attributes.HasValue)
+				Assert.AreEqual (attributes.Value, m.Attributes, "Attributes for {0}", m.FullName);
+		}
 
-			var t = assembly.MainModule.Types.First ((v) => v.FullName == typename);
+		public void AssertNoMethod (string typename, string method, string returnType = null, params string [] parameterTypes)
+		{
+			var m = FindMethod (typename, method, returnType, parameterTypes);
+			if (m is not null)
+				Assert.Fail ($"Unexpectedly found method '{method}' with signature '{string.Join ("', '", parameterTypes)}' on the type '{typename}'.");
+		}
+
+		MethodDefinition FindMethod (string typename, string method, string returnType, params string [] parameterTypes)
+		{
+			var assembly = LoadAssembly ();
+			var t = assembly.MainModule.Types.FirstOrDefault ((v) => v.FullName == typename);
+			if (t is null)
+				return null;
+
 			var m = t.Methods.FirstOrDefault ((v) => {
 				if (v.Name != method)
 					return false;
@@ -346,13 +372,10 @@ namespace Xamarin.Tests {
 						return false;
 				return true;
 			});
-			if (m == null)
-				Assert.Fail ($"No method '{method}' with signature '{string.Join ("', '", parameterTypes)}' was found.");
-			if (attributes.HasValue)
-				Assert.AreEqual (attributes.Value, m.Attributes, "Attributes for {0}", m.FullName);
+			return m;
 		}
 
-		void LoadAssembly ()
+		AssemblyDefinition LoadAssembly ()
 		{
 			if (assembly is null) {
 				var parameters = new ReaderParameters ();
@@ -362,6 +385,7 @@ namespace Xamarin.Tests {
 				parameters.AssemblyResolver = resolver;
 				assembly = AssemblyDefinition.ReadAssembly (Out ?? (Path.Combine (TmpDirectory, Path.GetFileNameWithoutExtension (ApiDefinitions [0]).Replace ('-', '_') + ".dll")), parameters);
 			}
+			return assembly;
 		}
 
 		void EnsureTempDir ()

--- a/tests/generator/tests/no-availability-for-accessors.cs
+++ b/tests/generator/tests/no-availability-for-accessors.cs
@@ -1,0 +1,56 @@
+using System;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	[BaseType (typeof (NSObject))]
+	interface Whatever : IProtocol {
+		[Export ("propA")]
+		NSObject PropA {
+			get;
+			[NoiOS]
+			set;
+		}
+
+		[Export ("propB")]
+		NSObject PropB {
+			[NoiOS]
+			get;
+			set;
+		}
+	}
+
+	[Protocol]
+	interface IProtocol {
+		[Abstract]
+		[Export ("iPropA")]
+		NSObject IPropA {
+			get;
+			[NoiOS]
+			set;
+		}
+
+		[Abstract]
+		[Export ("iPropB")]
+		NSObject IPropB {
+			[NoiOS]
+			get;
+			set;
+		}
+
+		[Export ("iPropAOpt")]
+		NSObject IPropAOpt {
+			get;
+			[NoiOS]
+			set;
+		}
+
+		[Export ("iPropBOpt")]
+		NSObject IPropBOpt {
+			[NoiOS]
+			get;
+			set;
+		}
+	}
+}


### PR DESCRIPTION
Previously API definitions like this:

    string Property {
    	get;
    	[NoiOS]
    	set;
    }

would generate a setter for every platform, even iOS.

This is rather unexpected, so fix the generator to honor No* attributes on
property getters and setters.