### PR TITLE
[release/6.0.4xx-xcode14.2] [dotnet] Ensure any trimmer components are restored properly.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -39,6 +39,14 @@
 		<!-- Ref: https://github.com/xamarin/xamarin-macios/issues/16193 -->
 		<!-- Ref: https://github.com/dotnet/sdk/issues/28419 -->
 		<GenerateSatelliteAssembliesForCore Condition="'$(GenerateSatelliteAssembliesForCore)' == ''">true</GenerateSatelliteAssembliesForCore>
+
+		<!-- This will ensure any trimmer components are restored by the framework reference logic. As such it must happen before Microsoft.NET.Publish.targets is included.
+			Ref:
+			* https://github.com/dotnet/sdk/pull/29441
+			* https://github.com/dotnet/sdk/blob/c5a58bc6c3eb2b236b314e6d17a89a537459890c/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L20-L21
+			* https://github.com/dotnet/sdk/blob/c5a58bc6c3eb2b236b314e6d17a89a537459890c/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets#L102
+		-->
+		<_IsTrimmingEnabled>true</_IsTrimmingEnabled>
 	</PropertyGroup>
 
 	<!-- Set the default RuntimeIdentifier if not already specified. -->


### PR DESCRIPTION
.NET 8 will load the ILLink component based on the target framework of the
project file - so if .NET 8 is building a net7.0-ios app, the build will
restore and use the ILLink component from .NET 7.

There is a problem however:

* The inclusion of the ILLink component is dpendent on the PublishTrimmed
  property - if PublishTrimmed is true, then the ILLink component is restored
  (which makes sense, why restore it if it's not going to be used?).
* We always PublishTrimmed, because the linker must always be executed for our
  projects. So far so good - we can just always enable PublishTrimmed, right?
* Nope, when building on Windows, we only enable PublishTrimmed when connected
  to a Mac, because that's where the ILLink target must be executed (and if
  we're not connected to a Mac, we can't run the ILLink target, and things
  fall apart - so just disable PublishTrimmed in that, since it won't work
  anyway).
* Early on in the build we have no idea if we're connected to a Mac or not,
  which means we can only enable PublishTrimmed in a target, and not as an
  early-on default value. This is *way* to late for the ILLink component,
  which needs PublishTrimmed set quite early in the build process.
* Fortunately, the ILLink inclusion is actually gated on a different variable
  (_IsTrimmingEnabled) - which is initialized from PublishTrimmed if it's not
  set. So the way out here is to set _IsTrimmingEnabled early enough, and now
  the ILLink component is included and restored.
* The additional hurdle is that we need to set _IsTrimmingEnabled in our .NET
  6 and .NET 7 workloads as well, it's not enough to set it in our .NET 8
  workload (which isn't even loaded when building an earlier TFM).


Backport of #17227
