### PR TITLE
[release/7.0.1xx] [msbuild] Build the solution using .NET instead of msbuild.

### DIFF
--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -535,8 +535,7 @@ all-local:: $(MSBUILD_PRODUCTS) .stamp-test-xml
 
 .build-stamp: export SYSTEM_MONO:=$(SYSTEM_MONO)
 .build-stamp: $(ALL_SOURCES)
-	$(Q) $(SYSTEM_MONO) /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore $(NUGET_VERBOSITY)
-	$(Q) $(SYSTEM_MSBUILD) "/bl:$@.binlog" $(XBUILD_VERBOSITY)
+	$(Q) $(DOTNET) build "/bl:$@.binlog" $(XBUILD_VERBOSITY)
 	$(Q) touch $@
 
 # make all the target assemblies build when any of the sources have changed

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
@@ -5,6 +5,8 @@
     <AssemblyName>Build</AssemblyName>
     <NoWarn>$(NoWarn);NU1603</NoWarn> <!-- Xamarin.Messaging.Build.Common 1.6.24 depends on Merq (>= 1.1.0) but Merq 1.1.0 was not found. An approximate best match of Merq 1.1.4 was resolved. -->
     <NoWarn>$(NoWarn);MSB3277</NoWarn> <!-- warning MSB3277: Found conflicts between different versions of "System.IO.Compression" that could not be resolved. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <MonoMSBuildBinPath>/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin</MonoMSBuildBinPath>
   </PropertyGroup>
 
   <PropertyGroup Label="Messaging">
@@ -21,16 +23,16 @@
 
   <ItemGroup>
       <Reference Include="Microsoft.Build">
-          <HintPath>$(MSBuildBinPath)/Microsoft.Build.dll</HintPath>
+          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.dll</HintPath>
       </Reference>
       <Reference Include="Microsoft.Build.Framework">
-          <HintPath>$(MSBuildBinPath)/Microsoft.Build.Framework.dll</HintPath>
+          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.Framework.dll</HintPath>
       </Reference>
       <Reference Include="Microsoft.Build.Tasks.Core">
-          <HintPath>$(MSBuildBinPath)/Microsoft.Build.Tasks.Core.dll</HintPath>
+          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.Tasks.Core.dll</HintPath>
       </Reference>
       <Reference Include="Microsoft.Build.Utilities.Core">
-          <HintPath>$(MSBuildBinPath)/Microsoft.Build.Utilities.Core.dll</HintPath>
+          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.Utilities.Core.dll</HintPath>
       </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
Mono has a networking bug that NuGet often triggers, leading to build failures like this:


      [...]
      GET https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/825db618-e3eb-4426-ba54-b1d6e6c944d8/nuget/v3/flat2/system.threading.tasks.extensions/index.json
      GET https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/49e5305d-d845-4a14-9d69-6f5dbfb9570c/nuget/v3/flat2/system.threading.tasks.extensions/index.json
      GET https://pkgs.dev.azure.com/xamarin/6fd3d886-57a5-4e31-8db7-52a1b47c07a8/_packaging/bcd6855c-070e-4cb7-a698-ac197b93cd87/nuget/v3/flat2/system.threading.tasks.extensions/index.json
      NotFound https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d6ecda8-a4ca-4c13-8c0c-939b925b1f31/nuget/v3/flat2/system.runtime.serialization.primitives/index.json 263ms
    Retrying 'FindPackagesByIdAsync' for source 'https://pkgs.dev.azure.com/xamarin/6fd3d886-57a5-4e31-8db7-52a1b47c07a8/_packaging/bcd6855c-070e-4cb7-a698-ac197b93cd87/nuget/v3/flat2/system.threading.tasks.extensions/index.json'.
    Cannot access a disposed object.
    Object name: 'System.Net.Sockets.Socket'.
      GET https://pkgs.dev.azure.com/xamarin/6fd3d886-57a5-4e31-8db7-52a1b47c07a8/_packaging/bcd6855c-070e-4cb7-a698-ac197b93cd87/nuget/v3/flat2/system.threading.tasks.extensions/index.json
    Retrying 'FindPackagesByIdAsync' for source 'https://pkgs.dev.azure.com/xamarin/6fd3d886-57a5-4e31-8db7-52a1b47c07a8/_packaging/bcd6855c-070e-4cb7-a698-ac197b93cd87/nuget/v3/flat2/system.threading.tasks.extensions/index.json'.
    Cannot access a disposed object.
    Object name: 'System.Net.Sockets.Socket'.
      GET https://pkgs.dev.azure.com/xamarin/6fd3d886-57a5-4e31-8db7-52a1b47c07a8/_packaging/bcd6855c-070e-4cb7-a698-ac197b93cd87/nuget/v3/flat2/system.threading.tasks.extensions/index.json
      OK https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.serialization.primitives/index.json 261ms
      NotFound https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/2a281e02-c7a8-4a75-8582-3407d441de57/nuget/v3/flat2/system.runtime.serialization.primitives/index.json 272ms
      [...]

This is very annoying when it happens on our bots, because we have to retry
the build until it works.

I initially tried to fix this by simplify building the msbuild solution with
.NET, and while that worked (the random network errors in NuGet disappeared),
another issue surfaced (ref: #16418).

This other issue was fixed in main (#16445), but on the release branches the
original fix was reverted instead, since that was the safest approach (better
to have random network errors on the bots than ship a something that doesn't
work 100% of the time).

However, due to the number of release branches we currently have (and they're
unlikely to decrease in number any time soon), the random network errors on
the bots are getting more and more disruptive, so let's try the fix again on
our release branches.

Ref: #16445, #16428.