### PR TITLE
[AppKit] Bind an NSWindow(IntPtr) constructor in the API definition.

### DIFF
--- a/src/AppKit/NSWindow.cs
+++ b/src/AppKit/NSWindow.cs
@@ -59,6 +59,7 @@ namespace AppKit {
 			}
 		}
 
+#if !NET
 		static IntPtr selInitWithWindowRef = Selector.GetHandle ("initWithWindowRef:");
 
 		// Do not actually export because NSObjectFlag is not exportable.
@@ -74,10 +75,15 @@ namespace AppKit {
 			}
 			InitializeReleasedWhenClosed ();
 		}
+#endif
 
 		static public NSWindow FromWindowRef (IntPtr windowRef)
 		{
+#if NET
+			return new NSWindow (windowRef);
+#else
 			return new NSWindow (windowRef, NSObjectFlag.Empty);
+#endif
 		}
 
 		void InitializeReleasedWhenClosed ()

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -20649,6 +20649,12 @@ namespace AppKit {
 		[PostSnippet ("InitializeReleasedWhenClosed ();", Optimizable = true)]
 		NativeHandle Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation, NSScreen screen);
 
+#if NET
+		[Export ("initWithWindowRef:")]
+		[PostSnippet ("InitializeReleasedWhenClosed ();", Optimizable = true)]
+		NativeHandle Constructor (IntPtr windowRef);
+#endif
+
 		[Export ("title")]
 		string Title { get; set; }
 

--- a/tests/cecil-tests/ConstructorTest.cs
+++ b/tests/cecil-tests/ConstructorTest.cs
@@ -255,6 +255,7 @@ namespace Cecil.Tests {
 						case "NSConditionLock": // has a nint (i.e. IntPtr) constructor (condition) - not a mistake
 						case "NSScrubberProportionalLayout": // has a nint (i.e. IntPtr) constructor (numberOfVisibleItems) - not a mistake
 						case "NSIndexSet": // has a nuint (i.e. UIntPtr) constructor (index) - not a mistake
+						case "NSWindow": // has an actual IntPtr constructor (initWithWindowRef:) - not a mistake
 							continue;
 						}
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -1697,7 +1697,6 @@
 !missing-selector! NSWindow::handleSaveScriptCommand: not bound
 !missing-selector! NSWindow::hasCloseBox not bound
 !missing-selector! NSWindow::hasTitleBar not bound
-!missing-selector! NSWindow::initWithWindowRef: not bound
 !missing-selector! NSWindow::isFloatingPanel not bound
 !missing-selector! NSWindow::isMiniaturizable not bound
 !missing-selector! NSWindow::isModalPanel not bound


### PR DESCRIPTION
This simplifies our manual bindings a little bit.