### PR TITLE
[tools] Enable the PushToTalk framework in the simulator.

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -454,7 +454,7 @@ public class Frameworks : Dictionary<string, Framework> {
 
 				{ "AVRouting", "AVRouting", 16,0},
 				{ "BackgroundAssets", "BackgroundAssets", 16,0},
-				{ "PushToTalk", "PushToTalk", new Version (16,0), NotAvailableInSimulator},
+				{ "PushToTalk", "PushToTalk", new Version (16,0), new Version (16, 2) /* available to build with, although it's unusable */},
 				{ "SharedWithYou", "SharedWithYou", 16, 0 },
 				{ "SharedWithYouCore", "SharedWithYouCore", 16, 0 },
 


### PR DESCRIPTION
Apple provides the headers to target PushToTalk (so using PushToTalk in code
builds just fine for the simulator in Xcode), but it doesn't work at runtime.

I believe it's better to allow the same thing in our bindings, for two reasons:

* Apple prints out a helpful error message at runtime, instead of our rather
  incomprehensible build error.
* Apple might implement simulator support in the future, in which case we
  won't need to do anything else.