### PR TITLE
[Foundation] Hide NSTask.LaunchFromPath from intellisense for Mac Catalyst.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -15466,6 +15466,7 @@ namespace Foundation {
 #else
 #if MACCATALYST
 		[Obsolete ("Do not use; this method is not available on Mac Catalyst.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
 #endif // MACCATALYST
 #endif // XAMCORE_5_0
 		[Export ("launchedTaskWithLaunchPath:arguments:")]


### PR DESCRIPTION
Since it doesn't work anyway, there's no reason to show it.