### PR TITLE
[Foundation] There's no reason to conditionally exclude code for macOS when the member has a NoMac attribute.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -10980,10 +10980,8 @@ namespace Foundation {
 		[Export ("preferredPresentationSize")]
 		CGSize PreferredPresentationSize {
 			get;
-#if !MONOMAC
 			[NoMac]
 			set;
-#endif
 		}
 
 		[NoiOS, NoTV, NoWatch, NoMacCatalyst]


### PR DESCRIPTION
This ensures that all platform assemblies know that the member doesn't exist
on macOS.