### PR TITLE
[NearbyInteraction] Remove NISession.SetARSession from Mac Catalyst.

### DIFF
--- a/src/NearbyInteraction/NICompat.cs
+++ b/src/NearbyInteraction/NICompat.cs
@@ -4,6 +4,8 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 //
 
+#if !XAMCORE_5_0
+
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
@@ -29,19 +31,24 @@ using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 #nullable enable
 namespace NearbyInteraction {
 
-#if WATCH
 	public partial class NISession {
 
-#if !NET
+#if WATCH
 		[Obsolete ("This method was removed and will always throw a InvalidOperationException.")]
-#endif
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		public virtual void SetARSession (ARSession session) => throw new InvalidOperationException (Constants.ApiRemovedGeneral);
 
-#if !NET
 		[Obsolete ("This method was removed and will always throw a InvalidOperationException.")]
-#endif
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		public virtual MatrixFloat4x4 GetWorldTransform (NINearbyObject @object) => throw new InvalidOperationException (Constants.ApiRemovedGeneral);
+#endif // WATCH
 
-	}
+#if __MACCATALYST__
+		[Obsolete ("This method was removed and will always throw a InvalidOperationException.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public virtual void SetARSession (NSObject session) => throw new InvalidOperationException (Constants.ApiRemovedGeneral);
 #endif
+	}
 }
+
+#endif // !XAMCORE_5_0

--- a/src/NearbyInteraction/NICompat.cs
+++ b/src/NearbyInteraction/NICompat.cs
@@ -31,6 +31,7 @@ using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 #nullable enable
 namespace NearbyInteraction {
 
+#if !__MACOS__ && !__TVOS__
 	public partial class NISession {
 
 #if WATCH
@@ -49,6 +50,7 @@ namespace NearbyInteraction {
 		public virtual void SetARSession (NSObject session) => throw new InvalidOperationException (Constants.ApiRemovedGeneral);
 #endif
 	}
+#endif // !__MACOS__ && !__TVOS__
 }
 
 #endif // !XAMCORE_5_0

--- a/src/nearbyinteraction.cs
+++ b/src/nearbyinteraction.cs
@@ -125,7 +125,8 @@ namespace NearbyInteraction {
 		[Export ("invalidate")]
 		void Invalidate ();
 
-		[NoWatch, NoTV, NoMac, iOS (16, 0), MacCatalyst (16, 0)]
+		[NoMacCatalyst] // We don't have ARKit bindings for Mac Catalyst (because ARKit doesn't work on Mac Catalyst), so we can't bind this method.
+		[NoWatch, NoTV, NoMac, iOS (16, 0)]
 		[Export ("setARSession:")]
 		void SetARSession (ARSession session);
 


### PR DESCRIPTION
ARKit is in a weird spot on Mac Catalyst: it exists, but it doesn't do
anything. Since it doesn't actually work, we don't have bindings for ARKit.

This means that while the method '[NISession setARSession:]' technically
exists on Mac Catalyst, we can't bind it properly, since the type of the
parameter (ARSession) isn't available in our bindings for Mac Catalyst.

Due to how we hack around the lack of ARSession in our source code, we ended
up binding the method with an NSObject argument instead. This is still wrong,
so here I'm removing that method from the API.

But of course, removing that API is a breaking change, so until then the
method is obsoleted and hidden, and only removed in XAMCORE_5_0.

Also hide a few other obsoleted API in NISession, and remove those as well in
XAMCORE_5_0.