### PR TITLE
[HealthKit] Remove HKSeriesBuilder compliance of NSSecureCoding.

### DIFF
--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -3501,7 +3501,7 @@ namespace HealthKit {
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface HKSeriesBuilder
-#if !MONOMAC
+#if !MONOMAC && !XAMCORE_5_0
 		: NSSecureCoding
 #endif
 {


### PR DESCRIPTION
There's no trace of this in the headers, so I assume it's something that
happened in a beta and then got removed, and we didn't notice to update our
bindings.