### PR TITLE
[MediaPlayer] Adjust availability attributes for MPMediaItem/MPMediaEntity.

### DIFF
--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -42,7 +42,6 @@ using NativeHandle = System.IntPtr;
 #endif
 
 namespace MediaPlayer {
-	[Mac (10, 12, 2)] // type exists only to expose fields
 	[BaseType (typeof (NSObject))]
 #if !MONOMAC
 #if NET
@@ -54,8 +53,9 @@ namespace MediaPlayer {
 	[TV (14, 0)]
 	interface MPMediaEntity : NSSecureCoding {
 #else
+	[Mac (10, 12, 2)] // type exists only to expose fields
 	interface MPMediaItem : NSSecureCoding {
-#endif
+#endif // !MONOMAC
 		[Static]
 		[Export ("canFilterByProperty:")]
 		bool CanFilterByProperty (NSString property);


### PR DESCRIPTION
The API for MPMediaItem/MPMediaEntity varies wildly between platforms (for
historical reasons), so move availability attributes around a bit so that they
match reality a bit better: MPMediaEntity is not available on macOS, only
MPMediaItem is.