### PR TITLE
[dotnet] CoreFont delegates

### DIFF
--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -196,13 +196,24 @@ namespace CoreText {
 			return CFArray.ArrayFromHandleFunc (cfArrayRef, fd => new CTFontDescriptor (fd, false), true)!;
 		}
 
+#if NET
+		[DllImport (Constants.CoreTextLibrary)]
+		static unsafe extern IntPtr CTFontCollectionCreateMatchingFontDescriptorsSortedWithCallback (
+				IntPtr collection, delegate* unmanaged<IntPtr, IntPtr, IntPtr, CFIndex> sortCallback, 
+				IntPtr refCon);
+#else
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCollectionCreateMatchingFontDescriptorsSortedWithCallback (
 				IntPtr collection, CTFontCollectionSortDescriptorsCallback sortCallback, IntPtr refCon);
+#endif
 
 		delegate CFIndex CTFontCollectionSortDescriptorsCallback (IntPtr first, IntPtr second, IntPtr refCon);
 
+#if NET
+		[UnmanagedCallersOnly]
+#else
 		[MonoPInvokeCallback (typeof (CTFontCollectionSortDescriptorsCallback))]
+#endif
 		static CFIndex CompareDescriptors (IntPtr first, IntPtr second, IntPtr context)
 		{
 			GCHandle c = GCHandle.FromIntPtr (context);
@@ -217,10 +228,20 @@ namespace CoreText {
 		{
 			GCHandle comparison = GCHandle.Alloc (comparer);
 			try {
-				var cfArrayRef = CTFontCollectionCreateMatchingFontDescriptorsSortedWithCallback (
+				IntPtr cfArrayRef;
+#if NET
+				unsafe {
+					cfArrayRef = CTFontCollectionCreateMatchingFontDescriptorsSortedWithCallback (
+						Handle,
+						&CompareDescriptors,
+						GCHandle.ToIntPtr (comparison));
+				}
+#else
+				cfArrayRef = CTFontCollectionCreateMatchingFontDescriptorsSortedWithCallback (
 						Handle,
 						new CTFontCollectionSortDescriptorsCallback (CompareDescriptors),
 						GCHandle.ToIntPtr (comparison));
+#endif
 				if (cfArrayRef == IntPtr.Zero)
 					return Array.Empty<CTFontDescriptor> ();
 				return CFArray.ArrayFromHandleFunc (cfArrayRef, fd => new CTFontDescriptor (fd, false), true)!;

--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -205,9 +205,9 @@ namespace CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCollectionCreateMatchingFontDescriptorsSortedWithCallback (
 				IntPtr collection, CTFontCollectionSortDescriptorsCallback sortCallback, IntPtr refCon);
-#endif
 
 		delegate CFIndex CTFontCollectionSortDescriptorsCallback (IntPtr first, IntPtr second, IntPtr refCon);
+#endif
 
 #if NET
 		[UnmanagedCallersOnly]

--- a/src/CoreText/CTFontDescriptor.cs
+++ b/src/CoreText/CTFontDescriptor.cs
@@ -740,10 +740,17 @@ namespace CoreText {
 #else
 		[Mac (10, 9)]
 #endif
+#if NET
+		[DllImport (Constants.CoreTextLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		static unsafe extern bool CTFontDescriptorMatchFontDescriptorsWithProgressHandler (IntPtr descriptors, IntPtr mandatoryAttributes,
+			delegate* unmanaged<CTFontDescriptorMatchingState, IntPtr, bool> progressHandler);
+#else
 		[DllImport (Constants.CoreTextLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CTFontDescriptorMatchFontDescriptorsWithProgressHandler (IntPtr descriptors, IntPtr mandatoryAttributes,
 			Func<CTFontDescriptorMatchingState, IntPtr, bool> progressHandler);
+#endif
 
 #if NET
 		[SupportedOSPlatform ("macos")]

--- a/src/CoreText/CTRunDelegate.cs
+++ b/src/CoreText/CTRunDelegate.cs
@@ -46,6 +46,16 @@ namespace CoreText {
 	delegate void CTRunDelegateDeallocateCallback (IntPtr refCon);
 	delegate nfloat CTRunDelegateGetCallback (IntPtr refCon);
 
+#if NET
+	[StructLayout (LayoutKind.Sequential)]
+	struct CTRunDelegateCallbacks {
+		public /* CFIndex */ nint version;
+		public unsafe delegate* unmanaged<IntPtr, void> dealloc;
+		public unsafe delegate* unmanaged<IntPtr, nfloat> getAscent;
+		public unsafe delegate* unmanaged<IntPtr, nfloat> getDescent;
+		public unsafe delegate* unmanaged<IntPtr, nfloat> getWidth;
+	}
+#else
 	[StructLayout (LayoutKind.Sequential)]
 	struct CTRunDelegateCallbacks {
 		public /* CFIndex */ nint version;
@@ -54,6 +64,7 @@ namespace CoreText {
 		public CTRunDelegateGetCallback getDescent;
 		public CTRunDelegateGetCallback getWidth;
 	}
+#endif
 	#endregion
 
 #if NET
@@ -128,6 +139,17 @@ namespace CoreText {
 		internal CTRunDelegateCallbacks GetCallbacks ()
 		{
 			if (!callbacks.HasValue) {
+#if NET
+				unsafe {
+					callbacks = new CTRunDelegateCallbacks () {
+						version = 1,
+						dealloc = &Deallocate,
+						getAscent = &GetAscent,
+						getDescent = &GetDescent,
+						getWidth = &GetWidth,
+					};
+				}
+#else
 				callbacks = new CTRunDelegateCallbacks () {
 					version = 1, // kCTRunDelegateVersion1
 					dealloc = Deallocate,
@@ -135,11 +157,16 @@ namespace CoreText {
 					getDescent = GetDescent,
 					getWidth = GetWidth,
 				};
+#endif
 			}
 			return callbacks.Value;
 		}
 
+#if NET
+		[UnmanagedCallersOnly]
+#else
 		[MonoPInvokeCallback (typeof (CTRunDelegateDeallocateCallback))]
+#endif
 		static void Deallocate (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);
@@ -160,7 +187,11 @@ namespace CoreText {
 			return c.Target as CTRunDelegateOperations;
 		}
 
+#if NET
+		[UnmanagedCallersOnly]
+#else
 		[MonoPInvokeCallback (typeof (CTRunDelegateGetCallback))]
+#endif
 		static nfloat GetAscent (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);
@@ -169,7 +200,11 @@ namespace CoreText {
 			return (nfloat) self.GetAscent ();
 		}
 
+#if NET
+		[UnmanagedCallersOnly]
+#else
 		[MonoPInvokeCallback (typeof (CTRunDelegateGetCallback))]
+#endif
 		static nfloat GetDescent (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);
@@ -178,7 +213,11 @@ namespace CoreText {
 			return (nfloat) self.GetDescent ();
 		}
 
+#if NET
+		[UnmanagedCallersOnly]
+#else
 		[MonoPInvokeCallback (typeof (CTRunDelegateGetCallback))]
+#endif
 		static nfloat GetWidth (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);


### PR DESCRIPTION
For these set of changes, I'm converting a delegate type to `delegate* unmanaged<....>` and where necessary adding in the `[UnmanagedCallersOnly]` attribute.