### PR TITLE
[tools] Try to fix #xamarin/maccore@2637 by making sure a file's timestamp changes.

### DIFF
--- a/tools/common/Make.common
+++ b/tools/common/Make.common
@@ -58,6 +58,7 @@
 		-e "s/@PRODUCT_HASH@/$(CURRENT_HASH_LONG)/g" \
 		$< > $@.tmp
 	$(Q) if ! diff $@ $@.tmp >/dev/null; then $(CP) $@.tmp $@; echo "The file $(TOP)/tools/common/SdkVersions.cs has been automatically re-generated; please commit the changes."; fi
+	$(Q) touch $@
 
 ../common/ProductConstants.cs: ../common/ProductConstants.in.cs Makefile $(TOP)/Make.config
 	$(Q_GEN) sed \


### PR DESCRIPTION
Try to fix #xamarin/maccore@2637 by making sure a file's timestamp changes
after make runs the corresponding target.

Otherwise it seems make may run into some sort of infinite loop.

Ref: https://github.com/xamarin/maccore/issues/2637