### PR TITLE
[tools] Fix MT1302 to show the correct path to the assembly.

### DIFF
--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -390,7 +390,6 @@ namespace Xamarin.Bundler {
 					}
 				} else {
 					Driver.Log (3, $"The assembly {FullPath} does not have any resources.");
-
 				}
 			} else {
 				if (!Directory.Exists (path))

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -382,7 +382,16 @@ namespace Xamarin.Bundler {
 			}
 
 			if (!File.Exists (zipPath)) {
-				ErrorHelper.Warning (1302, Errors.MT1302, metadata.LibraryName, zipPath);
+				ErrorHelper.Warning (1302, Errors.MT1302, metadata.LibraryName, FullPath);
+				if (assembly.MainModule.HasResources) {
+					Driver.Log (3, $"The assembly {FullPath} has {assembly.MainModule.Resources.Count} resources:");
+					foreach (var res in assembly.MainModule.Resources) {
+						Driver.Log (3, $"    {res.ResourceType}: {res.Name}");
+					}
+				} else {
+					Driver.Log (3, $"The assembly {FullPath} does not have any resources.");
+
+				}
 			} else {
 				if (!Directory.Exists (path))
 					Directory.CreateDirectory (path);


### PR DESCRIPTION
We used to show this:

> ILLINK warning MT1302: Could not extract the native library 'StaticLibrary.a' from '~/Downloads/BindingTest/obj/Debug/net7.0-ios/iossimulator-x64/linker-cache/StaticLibrary.a'. Please ensure the native library was properly embedded in the managed assembly (if the assembly was built using a binding project, the native library must be included in the project, and its Build Action must be 'ObjcBindingNativeLibrary').

now we show the assembly:

> ILLINK warning MT1302: Could not extract the native library 'StaticLibrary.a' from '~/Downloads/BindingTest/obj/Debug/net7.0-ios/iossimulator-x64/linker-cache/BindingLibrary.dll'. Please ensure the native library was properly embedded in the managed assembly (if the assembly was built using a binding project, the native library must be included in the project, and its Build Action must be 'ObjcBindingNativeLibrary').

Also increase diagnostics for this failure scenario to list all the resources
in the given assembly.