### PR TITLE
[Foundation] Add a 'None' option to NSKeyValueObservingOptions.

### DIFF
--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -487,7 +487,12 @@ namespace Foundation {
 	[Flags]
 	[Native]
 	public enum NSKeyValueObservingOptions : ulong {
-		New = 1, Old = 2, OldNew = 3, Initial = 4, Prior = 8,
+		None = 0,
+		New = 1,
+		Old = 2,
+		OldNew = 3,
+		Initial = 4,
+		Prior = 8,
 	}
 
 	[Native]


### PR DESCRIPTION
It's a [Flags] enum, so it makes sense to have an option to have no flags.