### PR TITLE
[release/7.0.1xx] Updated Xamarin.Messaging to 1.9.5

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.9.0</MessagingVersion>
+		<MessagingVersion>1.9.5</MessagingVersion>
 		<HotRestartVersion>1.0.93</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
This should bring the fix to correctly build iOS applications with references to class libraries


Backport of #17363
