### PR TITLE
[generator] Fix an issue where we'd not copy attributes from inlined protocols.

### DIFF
--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -44,6 +44,13 @@ using Xamarin.Utils;
 
 public class BindingTouch : IDisposable {
 	TargetFramework? target_framework;
+#if NET
+	public static ApplePlatform [] AllPlatforms = new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst };
+	public static PlatformName [] AllPlatformNames = new PlatformName [] { PlatformName.iOS, PlatformName.MacOSX, PlatformName.TvOS, PlatformName.MacCatalyst };
+#else
+	public static ApplePlatform [] AllPlatforms = new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.WatchOS };
+	public static PlatformName [] AllPlatformNames = new PlatformName [] { PlatformName.iOS, PlatformName.MacOSX, PlatformName.TvOS, PlatformName.WatchOS };
+#endif
 	public PlatformName CurrentPlatform;
 	public bool BindThirdPartyLibrary = true;
 	public bool skipSystemDrawing;

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -1793,6 +1793,9 @@ namespace Metal {
 	partial interface MTLTexture : MTLResource {
 		[iOS (8, 0)]
 		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
+		[Deprecated (PlatformName.TvOS, 10, 0)]
+		[Deprecated (PlatformName.MacCatalyst, 13, 1)]
 		[Abstract, Export ("rootResource")]
 		IMTLResource RootResource { get; }
 

--- a/tests/cecil-tests/ApiAvailabilityTest.cs
+++ b/tests/cecil-tests/ApiAvailabilityTest.cs
@@ -202,7 +202,6 @@ namespace Cecil.Tests {
 			"MediaPlayer.MPVolumeSettings.AlertHide()",
 			"MediaPlayer.MPVolumeSettings.AlertIsVisible()",
 			"MediaPlayer.MPVolumeSettings.AlertShow()",
-			"Metal.IMTLResource Metal.MTLTextureWrapper::RootResource()",
 			"MetalPerformanceShaders.MPSCnnConvolutionDescriptor.GetConvolutionDescriptor(System.UIntPtr, System.UIntPtr, System.UIntPtr, System.UIntPtr, MetalPerformanceShaders.MPSCnnNeuron)",
 			"MetalPerformanceShaders.MPSCnnFullyConnected..ctor(Metal.IMTLDevice, MetalPerformanceShaders.MPSCnnConvolutionDescriptor, System.Single[], System.Single[], MetalPerformanceShaders.MPSCnnConvolutionFlags)",
 			"MetalPerformanceShaders.MPSCnnNeuron MetalPerformanceShaders.MPSCnnConvolution::Neuron()",
@@ -404,6 +403,16 @@ namespace Cecil.Tests {
 		bool SkipSupportedAndObsoleteAtTheSameTime (ICustomAttributeProvider api, ApplePlatform platform, Version version)
 		{
 			var fullname = api.AsFullName ();
+
+			switch (fullname) {
+			case "SceneKit.SCNAnimationPlayer.SetSpeed(System.Runtime.InteropServices.NFloat, Foundation.NSString)":
+				// SetSpeed is in the SCNAnimatable protocol, which was added in iOS 8.0.
+				// The SetSpeed method was added in iOS 10.0, and deprecated in iOS 11.
+				// The SCNAnimatable protocol is implemented by the SCNAnimationPlayer class, which was added in iOS 11.
+				// Thus it's expected that the method was introduced and deprecated in the same OS version.
+				return true;
+			}
+
 			switch (platform) {
 			case ApplePlatform.iOS:
 				switch (fullname) {

--- a/tests/cecil-tests/AttributeTest.cs
+++ b/tests/cecil-tests/AttributeTest.cs
@@ -270,10 +270,13 @@ namespace Cecil.Tests {
 					"Foundation.NSUserActivity.LoadDataAsync (System.String, Foundation.NSProgress&)",
 					"Foundation.NSUserActivity.WritableTypeIdentifiers",
 					"Foundation.NSUserActivity.WritableTypeIdentifiersForItemProvider",
+					"Foundation.NSUserActivity.get_WritableTypeIdentifiers ()",
+					"Foundation.NSUserActivity.get_WritableTypeIdentifiersForItemProvider ()",
 
 					// This is from the NSItemProviderReading protocol: NSUserActivity does not implement NSItemProviderReading on tvOS and macOS.
 					"Foundation.NSUserActivity.GetObject (Foundation.NSData, System.String, Foundation.NSError&)",
 					"Foundation.NSUserActivity.ReadableTypeIdentifiers",
+					"Foundation.NSUserActivity.get_ReadableTypeIdentifiers ()",
 
 					// This is from the NSItemProviderWriting protocol: MKMapItem does not implement NSItemProviderWriting on tvOS and macOS.
 					"MapKit.MKMapItem.GetItemProviderVisibilityForTypeIdentifier (System.String)",
@@ -282,14 +285,18 @@ namespace Cecil.Tests {
 					"MapKit.MKMapItem.LoadDataAsync (System.String, Foundation.NSProgress&)",
 					"MapKit.MKMapItem.WritableTypeIdentifiers",
 					"MapKit.MKMapItem.WritableTypeIdentifiersForItemProvider",
+					"MapKit.MKMapItem.get_WritableTypeIdentifiers ()",
+					"MapKit.MKMapItem.get_WritableTypeIdentifiersForItemProvider ()",
 
 					// This is from the NSItemProviderReading protocol: MKMapItem does not implement NSItemProviderReading on tvOS and macOS.
 					"MapKit.MKMapItem.GetObject (Foundation.NSData, System.String, Foundation.NSError&)",
 					"MapKit.MKMapItem.ReadableTypeIdentifiers",
+					"MapKit.MKMapItem.get_ReadableTypeIdentifiers ()",
 
 					// This is from the NSItemProviderReading protocol: PHLivePhoto does not implement NSItemProviderReading on tvOS and macOS.
 					"Photos.PHLivePhoto.GetObject (Foundation.NSData, System.String, Foundation.NSError&)",
 					"Photos.PHLivePhoto.ReadableTypeIdentifiers",
+					"Photos.PHLivePhoto.get_ReadableTypeIdentifiers ()",
 
 
 					// This is from the NSSecureCoding protocol: SKView only implements NSSecureCoding on macOS.
@@ -305,6 +312,9 @@ namespace Cecil.Tests {
 					"Metal.MTLTextureWrapper.FirstMipmapInTail",
 					"Metal.MTLTextureWrapper.IsSparse",
 					"Metal.MTLTextureWrapper.TailSizeInBytes",
+					"Metal.IMTLTexture.FirstMipmapInTail",
+					"Metal.IMTLTexture.IsSparse",
+					"Metal.IMTLTexture.TailSizeInBytes",
 
 
 					// HKSeriesBuilder doesn't implement the ISNCopying protocol on all platforms (and shouldn't on any according to the headers, so removed for XAMCORE_5_0).

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -1047,45 +1047,55 @@ namespace GeneratorTests {
 			bgen.AssertExecute ("build");
 
 			var type = bgen.ApiAssembly.MainModule.GetType ("NS", "TypeA");
-			var someMethod1 = type.Methods.Single (v => v.Name == "SomeMethod1");
-			var someMethod2 = type.Methods.Single (v => v.Name == "SomeMethod2");
-			var someMethod3 = type.Methods.Single (v => v.Name == "SomeMethod3");
-			var someMethod4 = type.Methods.Single (v => v.Name == "SomeMethod4");
 
-			var renderedSomeMethod1 = string.Join ("\n", someMethod1.CustomAttributes.Select (ca => RenderSupportedOSPlatformAttribute (ca)).OrderBy (v => v));
-			var renderedSomeMethod2 = string.Join ("\n", someMethod2.CustomAttributes.Select (ca => RenderSupportedOSPlatformAttribute (ca)).OrderBy (v => v));
-			var renderedSomeMethod3 = string.Join ("\n", someMethod3.CustomAttributes.Select (ca => RenderSupportedOSPlatformAttribute (ca)).OrderBy (v => v));
-			var renderedSomeMethod4 = string.Join ("\n", someMethod4.CustomAttributes.Select (ca => RenderSupportedOSPlatformAttribute (ca)).OrderBy (v => v));
-
-			const string expectedAttributes1 =
+			var expectedAttributes = new string [] {
 @"[BindingImpl(3)]
 [Export(""someMethod1:"")]
 [SupportedOSPlatform(""ios12.0"")]
 [SupportedOSPlatform(""maccatalyst"")]
-[UnsupportedOSPlatform(""tvos"")]";
-			const string expectedAttributes2 =
+[UnsupportedOSPlatform(""tvos"")]",
+
 @"[BindingImpl(3)]
 [Export(""someMethod2:"")]
 [SupportedOSPlatform(""ios12.0"")]
 [SupportedOSPlatform(""maccatalyst"")]
-[UnsupportedOSPlatform(""tvos"")]";
-			const string expectedAttributes3 =
+[UnsupportedOSPlatform(""tvos"")]",
+
 @"[BindingImpl(3)]
 [Export(""someMethod3:"")]
 [SupportedOSPlatform(""ios11.0"")]
 [SupportedOSPlatform(""maccatalyst"")]
-[UnsupportedOSPlatform(""tvos"")]";
-			const string expectedAttributes4 =
+[UnsupportedOSPlatform(""tvos"")]",
+
 @"[BindingImpl(3)]
 [Export(""someMethod4:"")]
 [SupportedOSPlatform(""ios11.0"")]
 [SupportedOSPlatform(""maccatalyst"")]
-[UnsupportedOSPlatform(""tvos"")]";
+[UnsupportedOSPlatform(""tvos"")]",
+			};
 
-			Assert.AreEqual (expectedAttributes1, renderedSomeMethod1, "SomeMethod1");
-			Assert.AreEqual (expectedAttributes2, renderedSomeMethod2, "SomeMethod2");
-			Assert.AreEqual (expectedAttributes3, renderedSomeMethod3, "SomeMethod3");
-			Assert.AreEqual (expectedAttributes4, renderedSomeMethod4, "SomeMethod4");
+			int someMethodCount = expectedAttributes.Length;
+			var someMethod = new MethodDefinition [someMethodCount];
+			var renderedSomeMethod = new string [someMethodCount];
+			var failures = new List<string> ();
+			for (var i = 0; i < someMethodCount; i++) {
+				someMethod [i] = type.Methods.Single (v => v.Name == "SomeMethod" + (i + 1).ToString ());
+				renderedSomeMethod [i] = string.Join ("\n", someMethod [i].CustomAttributes.Select (ca => RenderSupportedOSPlatformAttribute (ca)).OrderBy (v => v));
+
+				if (expectedAttributes [i] == renderedSomeMethod [i])
+					continue;
+
+				var msg =
+					$"{someMethod [i].Name} has different attributes.\n" +
+					$"Expected attributes:\n" +
+					expectedAttributes [i] + "\n" +
+					"Actual attributes:\n" +
+					renderedSomeMethod [i];
+				Console.WriteLine ($"❌ {msg}\n");
+				failures.Add (msg);
+			}
+
+			Assert.That (failures, Is.Empty, "Failures");
 		}
 
 		[Test]
@@ -1182,6 +1192,185 @@ namespace GeneratorTests {
 			Assert.AreEqual (expectedPropertyAttributes, RenderSupportedOSPlatformAttributes (property), "Property attributes");
 			Assert.AreEqual (string.Empty, RenderSupportedOSPlatformAttributes (getter), "Getter Attributes");
 			Assert.AreEqual (expectedSetterAttributes, RenderSupportedOSPlatformAttributes (setter), "Setter Attributes");
+		}
+
+#if !NET
+		[Ignore ("This only applies to .NET")]
+#endif
+		[Test]
+		[TestCase (Profile.iOS)]
+		public void NewerAvailabilityInInlinedProtocol (Profile profile)
+		{
+			var bgen = BuildFile (profile, "tests/newer-availability-in-inlined-protocol.cs");
+
+			var expectedMethods = new [] {
+				new {
+					Type = "Whatever",
+					MethodCount = 21,
+					Methods = new [] {
+						new { Method = "get_IPropA", Attributes = "[SupportedOSPlatform(\"tvos140.0\")]" },
+						new { Method = "get_IPropAOpt", Attributes = "[SupportedOSPlatform(\"tvos140.0\")]" },
+						new { Method = "set_IPropB", Attributes = "[SupportedOSPlatform(\"tvos150.0\")]" },
+						new { Method = "set_IPropBOpt", Attributes = "[SupportedOSPlatform(\"tvos150.0\")]" },
+						new { Method = "get_IPropC", Attributes = "[SupportedOSPlatform(\"tvos130.0\")]" },
+						new { Method = "set_IPropC", Attributes = "[SupportedOSPlatform(\"tvos130.0\")]" },
+						new { Method = "get_IPropCOpt", Attributes = "[SupportedOSPlatform(\"tvos130.0\")]" },
+						new { Method = "set_IPropCOpt", Attributes = "[SupportedOSPlatform(\"tvos130.0\")]" },
+
+						new { Method = "get_IPropD", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Method = "get_IPropDOpt", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Method = "set_IPropE", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Method = "set_IPropEOpt", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Method = "get_IPropF", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Method = "set_IPropF", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Method = "get_IPropFOpt", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Method = "set_IPropFOpt", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+					},
+				},
+				new {
+					Type = "IIProtocol",
+					MethodCount = 4,
+					Methods = new [] {
+						new { Method = "get_IPropA", Attributes = "" },
+						new { Method = "set_IPropB", Attributes = "[SupportedOSPlatform(\"tvos150.0\")]" },
+						new { Method = "get_IPropC", Attributes = "" },
+						new { Method = "set_IPropC", Attributes = "" },
+					},
+				},
+				new {
+					Type = "IProtocol_Extensions",
+					MethodCount = 4,
+					Methods = new [] {
+						new { Method = "GetIPropAOpt", Attributes = "" },
+						new { Method = "SetIPropBOpt", Attributes = "[SupportedOSPlatform(\"tvos150.0\")]" },
+						new { Method = "GetIPropCOpt", Attributes = "" },
+						new { Method = "SetIPropCOpt", Attributes = "" },
+					},
+				},
+				new {
+					Type = "IIProtocolLower",
+					MethodCount = 4,
+					Methods = new [] {
+						new { Method = "get_IPropD", Attributes = "" },
+						new { Method = "set_IPropE", Attributes = "[SupportedOSPlatform(\"tvos110.0\")]" },
+						new { Method = "get_IPropF", Attributes = "" },
+						new { Method = "set_IPropF", Attributes = "" },
+					},
+				},
+				new {
+					Type = "IProtocolLower_Extensions",
+					MethodCount = 4,
+					Methods = new [] {
+						new { Method = "GetIPropDOpt", Attributes = "" },
+						new { Method = "SetIPropEOpt", Attributes = "[SupportedOSPlatform(\"tvos110.0\")]" },
+						new { Method = "GetIPropFOpt", Attributes = "" },
+						new { Method = "SetIPropFOpt", Attributes = "" },
+					},
+				},
+			};
+
+			var expectedProperties = new []  {
+				new {
+					Type = "Whatever",
+					PropertyCount = 13,
+					Properties = new [] {
+						new { Property = "IPropA", Attributes = "[SupportedOSPlatform(\"tvos140.0\")]" },
+						new { Property = "IPropB", Attributes = "[SupportedOSPlatform(\"tvos130.0\")]" },
+						new { Property = "IPropAOpt", Attributes = "[SupportedOSPlatform(\"tvos140.0\")]" },
+						new { Property = "IPropBOpt", Attributes = "[SupportedOSPlatform(\"tvos130.0\")]" },
+						new { Property = "IPropC", Attributes = "[SupportedOSPlatform(\"tvos130.0\")]" },
+						new { Property = "IPropCOpt", Attributes = "[SupportedOSPlatform(\"tvos130.0\")]" },
+						new { Property = "IPropD", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Property = "IPropE", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Property = "IPropDOpt", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Property = "IPropEOpt", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Property = "IPropF", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+						new { Property = "IPropFOpt", Attributes = "[SupportedOSPlatform(\"tvos120.0\")]" },
+					},
+				},
+				new {
+					Type = "IIProtocol",
+					PropertyCount = 3,
+					Properties = new [] {
+						new { Property = "IPropA", Attributes = "[SupportedOSPlatform(\"tvos140.0\")]" },
+						new { Property = "IPropB", Attributes = "" },
+						new { Property = "IPropC", Attributes = "" },
+					},
+				},
+				new {
+					Type = "IProtocol_Extensions",
+					PropertyCount = 0,
+					Properties = new [] {
+						new { Property = "fake property for c# anonymous type compilation", Attributes = "..." },
+					},
+				},
+				new {
+					Type = "IIProtocolLower",
+					PropertyCount = 3,
+					Properties = new [] {
+						new { Property = "IPropD", Attributes = "[SupportedOSPlatform(\"tvos100.0\")]" },
+						new { Property = "IPropE", Attributes = "" },
+						new { Property = "IPropF", Attributes = "" },
+					},
+				},
+				new {
+					Type = "IProtocolLower_Extensions",
+					PropertyCount = 0,
+					Properties = new [] {
+						new { Property = "fake property for c# anonymous type compilation", Attributes = "..." },
+					},
+				},
+			};
+
+			var failures = new List<string> ();
+
+			foreach (var expected in expectedMethods) {
+				var type = bgen.ApiAssembly.MainModule.Types.FirstOrDefault (v => v.Name == expected.Type);
+				Assert.IsNotNull (type, $"Type not found: {expected.Type}");
+				Assert.AreEqual (expected.MethodCount, type.Methods.Count, $"Unexpected method count.\n\tActual methods:\n\t\t{string.Join ("\n\t\t", type.Methods.Select (v => v.FullName))}");
+				if (expected.MethodCount == 0)
+					continue;
+				foreach (var expectedMember in expected.Methods) {
+					var member = type.Methods.SingleOrDefault (v => v.Name == expectedMember.Method);
+					Assert.IsNotNull (member, $"Method not found: {expectedMember.Method} in {type.FullName}");
+					var renderedAttributes = RenderSupportedOSPlatformAttributes (member);
+					if (renderedAttributes != expectedMember.Attributes) {
+						var msg =
+							$"Property: {type.FullName}::{member.Name}\n" +
+							$"\tExpected attributes:\n" +
+							$"\t\t{string.Join ("\n\t\t", expectedMember.Attributes.Split ('\n'))}\n" +
+							$"\tActual attributes:\n" +
+							$"\t\t{string.Join ("\n\t\t", renderedAttributes.Split ('\n'))}";
+						failures.Add (msg);
+						Console.WriteLine ($"❌ {msg}");
+					}
+				}
+			}
+
+			foreach (var expected in expectedProperties) {
+				var type = bgen.ApiAssembly.MainModule.Types.FirstOrDefault (v => v.Name == expected.Type);
+				Assert.IsNotNull (type, $"Type not found: {expected.Type}");
+				Assert.AreEqual (expected.PropertyCount, type.Properties.Count, $"Unexpected property count.\n\tActual properties:\n\t\t{string.Join ("\n\t\t", type.Properties.Select (v => v.Name))}");
+				if (expected.PropertyCount == 0)
+					continue;
+				foreach (var expectedMember in expected.Properties) {
+					var member = type.Properties.SingleOrDefault (v => v.Name == expectedMember.Property);
+					Assert.IsNotNull (member, $"Property not found: {expectedMember.Property} in {type.FullName}");
+					var renderedAttributes = RenderSupportedOSPlatformAttributes (member);
+					if (renderedAttributes != expectedMember.Attributes) {
+						var msg =
+							$"Property: {type.FullName}::{member.Name}\n" +
+							$"\tExpected attributes:\n" +
+							$"\t\t{string.Join ("\n\t\t", expectedMember.Attributes.Split ('\n'))}\n" +
+							$"\tActual attributes:\n" +
+							$"\t\t{string.Join ("\n\t\t", renderedAttributes.Split ('\n'))}";
+						failures.Add (msg);
+						Console.WriteLine ($"❌ {msg}");
+					}
+				}
+			}
+
+			Assert.That (failures, Is.Empty, "Failures");
 		}
 
 		BGenTool BuildFile (Profile profile, params string [] filenames)

--- a/tests/generator/tests/newer-availability-in-inlined-protocol.cs
+++ b/tests/generator/tests/newer-availability-in-inlined-protocol.cs
@@ -1,0 +1,101 @@
+using System;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	[Introduced (PlatformName.TvOS, 120, 0)]
+	[BaseType (typeof (NSObject))]
+	interface Whatever : IProtocol, IProtocolLower {
+	}
+
+	[Introduced (PlatformName.TvOS, 130, 0)]
+	[Protocol]
+	interface IProtocol {
+		[Introduced (PlatformName.TvOS, 140, 0)]
+		[Abstract]
+		[Export ("iPropA")]
+		NSObject IPropA {
+			get;
+			[NoiOS]
+			set;
+		}
+
+		[Abstract]
+		[Export ("iPropB")]
+		NSObject IPropB {
+			[NoiOS]
+			get;
+			[Introduced (PlatformName.TvOS, 150, 0)]
+			set;
+		}
+
+		[Abstract]
+		[Export ("iPropC")]
+		NSObject IPropC { get; set; }
+
+		[Introduced (PlatformName.TvOS, 140, 0)]
+		[Export ("iPropAOpt")]
+		NSObject IPropAOpt {
+			get;
+			[NoiOS]
+			set;
+		}
+
+		[Export ("iPropBOpt")]
+		NSObject IPropBOpt {
+			[NoiOS]
+			get;
+			[Introduced (PlatformName.TvOS, 150, 0)]
+			set;
+		}
+
+		[Export ("iPropCOpt")]
+		NSObject IPropCOpt { get; set; }
+	}
+
+	[Introduced (PlatformName.TvOS, 90, 0)]
+	[Protocol]
+	interface IProtocolLower {
+		[Introduced (PlatformName.TvOS, 100, 0)]
+		[Abstract]
+		[Export ("iPropD")]
+		NSObject IPropD {
+			get;
+			[NoiOS]
+			set;
+		}
+
+		[Abstract]
+		[Export ("iPropE")]
+		NSObject IPropE {
+			[NoiOS]
+			get;
+			[Introduced (PlatformName.TvOS, 110, 0)]
+			set;
+		}
+
+		[Abstract]
+		[Export ("iPropF")]
+		NSObject IPropF { get; set; }
+
+		[Introduced (PlatformName.TvOS, 100, 0)]
+		[Export ("iPropDOpt")]
+		NSObject IPropDOpt {
+			get;
+			[NoiOS]
+			set;
+		}
+
+		[Export ("iPropEOpt")]
+		NSObject IPropEOpt {
+			[NoiOS]
+			get;
+			[Introduced (PlatformName.TvOS, 110, 0)]
+			set;
+		}
+
+		[Export ("iPropFOpt")]
+		NSObject IPropFOpt { get; set; }
+	}
+}


### PR DESCRIPTION
Protocols with one set of introduced attributes ([TV (12, 0)]) inlined in
types that were introduced in a different version ([TV (10, 0)]) would always
use the attributes from the type.

This is wrong if the protocol was introduced after the type, in which case we
should instead use the introduced attributes from the protocol.

Fix this by choosing the latest introduced attribute when we have multiple to
choose from.

This required passing a bit more information around so that we always know if
a member is being inlined in another type.

This PR will also print availability attributes on the protocol members themselves:

	[Protocol]
	interface IProtocol
	{
		[TV (12, 0)] // this was not printed before
		[Export ("someProperty")]
		string SomeProperty { get; set; }
	}

Also add and improve some tests.

Contributes towards https://github.com/xamarin/xamarin-macios/issues/14802.