### PR TITLE
[Generator] Add support for nullability. Part 1.

### DIFF
--- a/src/bgen/bgen.csproj
+++ b/src/bgen/bgen.csproj
@@ -60,6 +60,9 @@
     <Compile Include="$(RepositoryPath)\tools\common\Execution.cs">
       <Link>Execution.cs</Link>
     </Compile>
+    <Compile Include="..\generator-nullability-info-context.cs">
+      <Link>src\generator-nullability-info-context.cs</Link>
+    </Compile>
     <Compile Include="..\Resources.Designer.cs">
       <DependentUpon>..\Resources.resx</DependentUpon>
     </Compile>

--- a/src/generator-nullability-info-context.cs
+++ b/src/generator-nullability-info-context.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace bgen {
 
-	// extension shared between NET and !NET make our lifes a little easier
+	// extension shared between NET and !NET make our lives a little easier
 	public static class NullabilityInfoExtensions {
 		public static bool IsNullable (this NullabilityInfo self)
 			=> self.ReadState == NullabilityState.Nullable;

--- a/src/generator-nullability-info-context.cs
+++ b/src/generator-nullability-info-context.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+
+#nullable enable
+
+namespace bgen {
+
+	// from: https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md
+	public enum NullableFlag : byte {
+		Oblivious = 0,
+		NotAnnotated = 1,
+		Annotated = 2,
+	}
+
+	public class NullabilityInfo {
+		public bool IsNullable { get; set; }
+		public Type? Type { get; set; }
+		public NullabilityInfo? ElementType { get; set; }
+		public NullabilityInfo []? GenericTypeArguments { get; set; }
+	}
+	
+	// helper class that allows to check the custom attrs in a method,property or field
+	// in order for the generator to support ? in the bindings definition. This class should be
+	// replaced by NullabilityInfoContext from the dotnet6 in the future. The API can be maintained (hopefully).
+	public static class GeneratorNullabilityInfoContext {
+
+		static readonly string NullableAttributeName = "System.Runtime.CompilerServices.NullableAttribute";
+		static readonly string NullableContextAttributeName = "System.Runtime.CompilerServices.NullableContextAttribute";
+		
+		public static NullabilityInfo Create (PropertyInfo propertyInfo)
+			=> Create(propertyInfo.PropertyType, propertyInfo.DeclaringType, propertyInfo.CustomAttributes);
+
+		public static NullabilityInfo Create (FieldInfo fieldInfo)
+			=> Create (fieldInfo.FieldType, fieldInfo.DeclaringType, fieldInfo.CustomAttributes);
+
+		public static NullabilityInfo Create (ParameterInfo parameterInfo)
+			=> Create (parameterInfo.ParameterType, parameterInfo.Member, parameterInfo.CustomAttributes);
+
+		static NullabilityInfo Create (Type memberType, MemberInfo? declaringType,
+			IEnumerable<CustomAttributeData>? customAttributes, int depth = 0)
+		{
+			var info = new NullabilityInfo { Type = memberType };
+
+			if (memberType.IsArray) {
+				info.ElementType = Create (memberType.GetElementType ()!, declaringType, customAttributes, depth + 1);
+			}
+
+			if (memberType.IsGenericType) {
+				// we need to get the nullability type of each of the generics, we use an array to make sure
+				// order is kept
+				var genericArguments = memberType.GetGenericArguments ();
+				info.GenericTypeArguments = new NullabilityInfo[genericArguments.Length];
+				for (int i = 0; i < genericArguments.Length; i++) {
+					info.GenericTypeArguments [i] = Create (genericArguments [i], declaringType,
+						customAttributes, depth + (i + 1)); // the depth can be complicated
+				}
+			}
+			
+			// there are two possible cases we have to take care of:
+			//
+			// 1. ValueType: If we are dealing with a value type the compiler converts it to Nullable<ValueType>
+			// 2. ReferenceType: Ret types do not use an interface, but a custom attr is used in the signature
+			
+			if (memberType.IsValueType) {
+				var nullableType = Nullable.GetUnderlyingType (memberType);
+				info.IsNullable = nullableType != null;
+				info.Type = nullableType ?? memberType;
+				return info;
+			}
+
+			// at this point, we  have to use the attributes (metadata) added by the compiler to decide if we have a
+			// nullable type or not from a ref type. From https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md
+			//
+			// The byte[] is constructed as follows:
+			// Reference type: the nullability (0, 1, or 2), followed by the representation of the type arguments in order including containing types
+			// Nullable value type: the representation of the type argument only
+			// Non-generic value type: skipped
+			// 	Generic value type: 0, followed by the representation of the type arguments in order including containing types
+			// Array: the nullability (0, 1, or 2), followed by the representation of the element type
+			// Tuple: the representation of the underlying constructed type
+			// 	Type parameter reference: the nullability (0, 1, or 2, with 0 for unconstrained type parameter)
+			
+			var nullable = customAttributes?.FirstOrDefault(
+				x => x.AttributeType.FullName == NullableAttributeName);
+
+			NullableFlag flag = NullableFlag.Oblivious;
+			if (nullable is not  null && nullable.ConstructorArguments.Count == 1)
+			{
+				var attributeArgument = nullable.ConstructorArguments[0];
+				if (attributeArgument.ArgumentType == typeof(byte[]))
+				{
+					var args = (ReadOnlyCollection<CustomAttributeTypedArgument>) attributeArgument.Value!;
+					if (args.Count > 0 && args[depth].ArgumentType == typeof(byte)) {
+						flag = (NullableFlag) args [depth].Value;
+
+					}
+				} else if (attributeArgument.ArgumentType == typeof(byte)) {
+					flag = (NullableFlag) attributeArgument.Value!;
+				}
+
+				if (flag != NullableFlag.Annotated) {
+					info.IsNullable = false;
+					info.Type = memberType;
+					return info;
+				}
+
+				info.Type = memberType;
+				info.IsNullable = true;
+				return info;
+			}
+
+			// we are using the context of the declaring type to decide if the type is nullable
+			for (var type = declaringType; type != null; type = type.DeclaringType)
+			{
+				var context = type.CustomAttributes
+					.FirstOrDefault(x => x.AttributeType.FullName == NullableContextAttributeName);
+				if (context is null ||
+				    context.ConstructorArguments.Count != 1 ||
+				    context.ConstructorArguments [0].ArgumentType != typeof (byte)) continue;
+				if (NullableFlag.Annotated == (NullableFlag) context.ConstructorArguments [0].Value!) {
+					info.Type = memberType;
+					info.IsNullable = true;
+					return info;
+				}
+			}
+
+			return info;
+		}
+	}
+}

--- a/src/generator-nullability-info-context.cs
+++ b/src/generator-nullability-info-context.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 #nullable enable
 
 namespace bgen {
-	
+
 	// extension shared between NET and !NET make our lifes a little easier
 	public static class NullabilityInfoExtensions {
 		public static bool IsNullable (this NullabilityInfo self)
@@ -28,7 +28,7 @@ namespace bgen {
 		public NullabilityInfo? ElementType { get; set; }
 		public NullabilityInfo []? GenericTypeArguments { get; set; }
 	}
-	
+
 	// helper class that allows to check the custom attrs in a method,property or field
 	// in order for the generator to support ? in the bindings definition. This class should be
 	// replaced by NullabilityInfoContext from the dotnet6 in the future. The API can be maintained (hopefully).
@@ -36,11 +36,11 @@ namespace bgen {
 
 		static readonly string NullableAttributeName = "System.Runtime.CompilerServices.NullableAttribute";
 		static readonly string NullableContextAttributeName = "System.Runtime.CompilerServices.NullableContextAttribute";
-		
-		public NullabilityInfoContext () {}
-		
+
+		public NullabilityInfoContext () { }
+
 		public NullabilityInfo Create (PropertyInfo propertyInfo)
-			=> Create(propertyInfo.PropertyType, propertyInfo.DeclaringType, propertyInfo.CustomAttributes);
+			=> Create (propertyInfo.PropertyType, propertyInfo.DeclaringType, propertyInfo.CustomAttributes);
 
 		public NullabilityInfo Create (FieldInfo fieldInfo)
 			=> Create (fieldInfo.FieldType, fieldInfo.DeclaringType, fieldInfo.CustomAttributes);
@@ -60,7 +60,7 @@ namespace bgen {
 				info.Type = memberType;
 				return info;
 			}
-			
+
 			if (memberType.IsArray) {
 				info.ElementType = Create (memberType.GetElementType ()!, declaringType, customAttributes, depth + 1);
 			}
@@ -69,18 +69,18 @@ namespace bgen {
 				// we need to get the nullability type of each of the generics, we use an array to make sure
 				// order is kept
 				var genericArguments = memberType.GetGenericArguments ();
-				info.GenericTypeArguments = new NullabilityInfo[genericArguments.Length];
+				info.GenericTypeArguments = new NullabilityInfo [genericArguments.Length];
 				for (int i = 0; i < genericArguments.Length; i++) {
 					info.GenericTypeArguments [i] = Create (genericArguments [i], declaringType,
 						customAttributes, depth + (i + 1)); // the depth can be complicated
 				}
 			}
-			
+
 			// there are two possible cases we have to take care of:
 			//
 			// 1. ValueType: If we are dealing with a value type the compiler converts it to Nullable<ValueType>
 			// 2. ReferenceType: Ret types do not use an interface, but a custom attr is used in the signature
-			
+
 			if (memberType.IsValueType) {
 				var nullableType = Nullable.GetUnderlyingType (memberType);
 				info.ReadState = nullableType != null ? NullabilityState.Nullable : NullabilityState.NotNull;
@@ -99,26 +99,24 @@ namespace bgen {
 			// Array: the nullability (0, 1, or 2), followed by the representation of the element type
 			// Tuple: the representation of the underlying constructed type
 			// 	Type parameter reference: the nullability (0, 1, or 2, with 0 for unconstrained type parameter)
-			
+
 			// interesting case when we have constrains from a generic method
-			if ((customAttributes?.Count() ?? 0) == 0 && memberType.CustomAttributes is not null)
+			if ((customAttributes?.Count () ?? 0) == 0 && memberType.CustomAttributes is not null)
 				customAttributes = memberType.CustomAttributes;
-			
-			var nullable = customAttributes?.FirstOrDefault(
+
+			var nullable = customAttributes?.FirstOrDefault (
 				x => x.AttributeType.FullName == NullableAttributeName);
 
 			var flag = NullabilityState.Unknown;
-			if (nullable is not  null && nullable.ConstructorArguments.Count == 1)
-			{
-				var attributeArgument = nullable.ConstructorArguments[0];
-				if (attributeArgument.ArgumentType == typeof(byte[]))
-				{
+			if (nullable is not null && nullable.ConstructorArguments.Count == 1) {
+				var attributeArgument = nullable.ConstructorArguments [0];
+				if (attributeArgument.ArgumentType == typeof (byte [])) {
 					var args = (ReadOnlyCollection<CustomAttributeTypedArgument>) attributeArgument.Value!;
-					if (args.Count > 0 && args[depth].ArgumentType == typeof(byte)) {
+					if (args.Count > 0 && args [depth].ArgumentType == typeof (byte)) {
 						flag = (NullabilityState) args [depth].Value;
 
 					}
-				} else if (attributeArgument.ArgumentType == typeof(byte)) {
+				} else if (attributeArgument.ArgumentType == typeof (byte)) {
 					flag = (NullabilityState) attributeArgument.Value!;
 				}
 
@@ -128,13 +126,12 @@ namespace bgen {
 			}
 
 			// we are using the context of the declaring type to decide if the type is nullable
-			for (var type = declaringType; type is not null; type = type.DeclaringType)
-			{
+			for (var type = declaringType; type is not null; type = type.DeclaringType) {
 				var context = type.CustomAttributes
-					.FirstOrDefault(x => x.AttributeType.FullName == NullableContextAttributeName);
+					.FirstOrDefault (x => x.AttributeType.FullName == NullableContextAttributeName);
 				if (context is null ||
-				    context.ConstructorArguments.Count != 1 ||
-				    context.ConstructorArguments [0].ArgumentType != typeof (byte))
+					context.ConstructorArguments.Count != 1 ||
+					context.ConstructorArguments [0].ArgumentType != typeof (byte))
 					continue;
 				if (NullabilityState.Nullable == (NullabilityState) context.ConstructorArguments [0].Value!) {
 					info.Type = memberType;
@@ -146,7 +143,7 @@ namespace bgen {
 			// we need to consider the generic constrains
 			if (!memberType.IsGenericParameter)
 				return info;
-			
+
 			// if we do have a custom null atr in any of them, use it
 			if (memberType.GenericParameterAttributes.HasFlag (GenericParameterAttributes.NotNullableValueTypeConstraint))
 				info.ReadState = NullabilityState.NotNull;

--- a/src/generator-nullability-info-context.cs
+++ b/src/generator-nullability-info-context.cs
@@ -107,7 +107,7 @@ namespace bgen {
 			var nullable = customAttributes?.FirstOrDefault(
 				x => x.AttributeType.FullName == NullableAttributeName);
 
-			NullabilityState flag = NullabilityState.Unknown;
+			var flag = NullabilityState.Unknown;
 			if (nullable is not  null && nullable.ConstructorArguments.Count == 1)
 			{
 				var attributeArgument = nullable.ConstructorArguments[0];

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -128,6 +128,7 @@
     <Compile Include="..\tools\common\Execution.cs">
       <Link>Execution.cs</Link>
     </Compile>
+    <Compile Include="generator-nullability-info-context.cs" />
     <Compile Include="Resources.Designer.cs">
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>

--- a/tests/bgen/bgen-tests.csproj
+++ b/tests/bgen/bgen-tests.csproj
@@ -43,6 +43,9 @@
     <Compile Include="..\common\Profile.cs">
       <Link>Profile.cs</Link>
     </Compile>
+    <Compile Include="..\generator\NullabilityContextTests.cs">
+      <Link>NullabilityContextTests.cs</Link>
+    </Compile>
     <Compile Include="..\mtouch\Cache.cs">
       <Link>Cache.cs</Link>
     </Compile>

--- a/tests/generator/NullabilityContextTests.cs
+++ b/tests/generator/NullabilityContextTests.cs
@@ -375,14 +375,6 @@ namespace GeneratorTests {
 			Assert.AreEqual (returnTypeIsNull, info.IsNullable ());
 		}
 		
-		/*
-		 * 
-			public void GenericNotNullParameterConstrain<T> (T param) where T: notnull {}
-			public void GenericNullableClassParameterConstrain<T> (T param) where T : class? { }
-			public void GenericNullableRefTypeParameterConstrain<T> (T? param) where T : ObjectTest { }
-			public void GenericNullableInterfaceParameterConstrain<T> (T? param) where T : IInterfaceTest => default;
-		 */
-		
 		[TestCase("GenericNotNullParameterConstrain", false)]
 		[TestCase("GenericNullableClassParameterConstrain", true)]
 		[TestCase("GenericNullableRefTypeParameterConstrain", true)] 

--- a/tests/generator/NullabilityContextTests.cs
+++ b/tests/generator/NullabilityContextTests.cs
@@ -8,19 +8,19 @@ using NUnit.Framework;
 #nullable enable
 
 namespace GeneratorTests {
-	
+
 	[TestFixture]
 	[Parallelizable (ParallelScope.None)] // dotnet implementation is not thread safe..
 	public class NullabilityContextTests {
 
 		interface IInterfaceTest { }
-		
+
 		class ObjectTest : IInterfaceTest {
 			public int NotNullableValueTypeField = 0;
 			public string NotNullableRefTypeField = string.Empty;
 			public int? NullableValueTypeField = 0;
 			public string? NullableRefTypeField = string.Empty;
-			
+
 			public int NotNullableValueTypeProperty { get; set; }
 			public string NotNullableRefProperty { get; set; } = string.Empty;
 			public int? NullableValueTypeProperty { get; set; }
@@ -39,17 +39,17 @@ namespace GeneratorTests {
 			public string this [double? i] {
 				get => string.Empty;
 				set { }
-			} 
-			
+			}
+
 			public void NotNullableValueTypeParameter (int myParam) { }
 			public void NotNullableOutValueTypeParameter (out int myParam) { myParam = 1; }
 			public void NotNullableRefValueTypeParameter (ref int myParam) { myParam = 1; }
 			public void NotNullableRefParameter (string myParam) { }
 			public void NotNullableOutRefParameter (out string myParam) { myParam = string.Empty; }
 			public void NotNullableRefRefParameter (ref string myParam) { myParam = string.Empty; }
-			
+
 			public void NullableValueTypeParameter (int? myParam) { }
-			public void NullableOutValueTypeParameter (out int? myParam) { myParam = null;}
+			public void NullableOutValueTypeParameter (out int? myParam) { myParam = null; }
 			public void NullableRefValueTypeParameter (ref int? myParam) { myParam = null; }
 			public void NullableRefTypeParameter (string? myParam) { }
 			public void NullableOutRefTypeParameter (out string? myParam) { myParam = null; }
@@ -60,13 +60,13 @@ namespace GeneratorTests {
 
 			public int? NullableValueTypeReturn () => null;
 			public string? NullableRefTypeReturn () => null;
-			
+
 			// array return type tests
 			public int [] NotNullableValueTypeArray () => Array.Empty<int> ();
 			public int? [] NotNullableNullableValueTypeArray () => Array.Empty<int?> ();
 			public int []? NullableValueTypeArray () => null;
 			public int? []? NullableNullableValueTypeArray () => null;
-			
+
 			public string [] NotNullableRefTypeArray () => Array.Empty<string> ();
 			public string? [] NotNullableNullableRefTypeArray () => Array.Empty<string?> ();
 			public string []? NullableRefTypeArray () => null;
@@ -76,34 +76,34 @@ namespace GeneratorTests {
 			public int? [] [] NotNullableNestedArrayNullableValueType () => Array.Empty<int? []> ();
 			public int? []? [] NotNullableNestedNullableArrayNullableValueType () => Array.Empty<int? []?> ();
 			public int? []? []? NullableNestedNullableArrayNullableValueType () => null;
-			
-			
+
+
 			public string [] [] NotNullableNestedArrayNotNullableRefType () => Array.Empty<string []> ();
 			public string? [] [] NotNullableNestedArrayNullableRefType () => Array.Empty<string? []> ();
 			public string? []? [] NotNullableNestedNullableArrayNullableRefType () => Array.Empty<string? []?> ();
 			public string? []? []? NullableNestedNullableArrayNullableRefType () => null;
 
-			public List<int> NotNullableValueTypeList () => new();
-			public List<int?> NullableValueTypeList () => new();
+			public List<int> NotNullableValueTypeList () => new ();
+			public List<int?> NullableValueTypeList () => new ();
 			public List<int?>? NullableListNullableValueType () => null;
-			
-			public List<string> NotNullableRefTypeList () => new();
-			public List<string?> NullableRefTypeList () => new();
+
+			public List<string> NotNullableRefTypeList () => new ();
+			public List<string?> NullableRefTypeList () => new ();
 			public List<string?>? NullableListNullableRefType () => null;
 
-			public List<HashSet<int>> NestedGenericNotNullableValueType () => new();
-			public List<HashSet<int?>> NestedGenericNullableValueType () => new();
-			public List<HashSet<int?>?> NestedNullableGenericNullableValueType () => new();
-			public List<HashSet<int?>?>? NullableNestedNullableGenericNullableValueType () => new();
-			
-			public List<HashSet<string>> NestedGenericNotNullableRefType () => new();
-			public List<HashSet<string?>> NestedGenericNullableRefType () => new();
-			public List<HashSet<string?>?> NestedNullableGenericNullableRefType () => new();
-			public List<HashSet<string?>?>? NullableNestedNullableGenericNullableRefType () => new();
+			public List<HashSet<int>> NestedGenericNotNullableValueType () => new ();
+			public List<HashSet<int?>> NestedGenericNullableValueType () => new ();
+			public List<HashSet<int?>?> NestedNullableGenericNullableValueType () => new ();
+			public List<HashSet<int?>?>? NullableNestedNullableGenericNullableValueType () => new ();
 
-			public Dictionary<string, int> DictionaryStringInt () => new();
+			public List<HashSet<string>> NestedGenericNotNullableRefType () => new ();
+			public List<HashSet<string?>> NestedGenericNullableRefType () => new ();
+			public List<HashSet<string?>?> NestedNullableGenericNullableRefType () => new ();
+			public List<HashSet<string?>?>? NullableNestedNullableGenericNullableRefType () => new ();
+
+			public Dictionary<string, int> DictionaryStringInt () => new ();
 			public Dictionary<string, int?> DictionaryStringNullableInt () => new ();
-			public Dictionary<string?, int?> DictionaryNullableStringNullableInt () => new();
+			public Dictionary<string?, int?> DictionaryNullableStringNullableInt () => new ();
 			public Dictionary<string?, int?>? NullableDictionaryNullableStringNullableInt () => new ();
 
 			public T GenericNotNullConstrain<T> () where T : notnull => default!;
@@ -111,28 +111,28 @@ namespace GeneratorTests {
 			public T? GenericNullableRefTypeConstrain<T> () where T : ObjectTest => null;
 			public T GenericNotNullableRefTypeConstrain<T> () where T : ObjectTest => default!;
 			public T? GenericNullableInterface<T> () where T : IInterfaceTest => default;
-			
-			public void GenericNotNullParameterConstrain<T> (T param) where T: notnull {}
+
+			public void GenericNotNullParameterConstrain<T> (T param) where T : notnull { }
 			public void GenericNullableClassParameterConstrain<T> (T param) where T : class? { }
 			public void GenericNullableRefTypeParameterConstrain<T> (T? param) where T : ObjectTest { }
 			public void GenericNullableInterfaceParameterConstrain<T> (T? param) where T : IInterfaceTest { }
 		}
 
-		public static PropertyInfo GetIndexer (Type type, params Type[] arguments) => type.GetProperties().First(
-			x => x.GetIndexParameters().Select(y => y.ParameterType).SequenceEqual(arguments));
-		
-		Type testType = typeof(object);
-		NullabilityInfoContext context = new();
+		public static PropertyInfo GetIndexer (Type type, params Type [] arguments) => type.GetProperties ().First (
+			x => x.GetIndexParameters ().Select (y => y.ParameterType).SequenceEqual (arguments));
+
+		Type testType = typeof (object);
+		NullabilityInfoContext context = new ();
 
 		[SetUp]
 		public void SetUp ()
 		{
 			testType = typeof (ObjectTest);
-			context = new();
+			context = new ();
 		}
-		
-		[TestCase ("NotNullableValueTypeField", typeof(int))]
-		[TestCase ("NotNullableRefTypeField", typeof(string))]
+
+		[TestCase ("NotNullableValueTypeField", typeof (int))]
+		[TestCase ("NotNullableRefTypeField", typeof (string))]
 		public void NotNullableFieldTest (string fieldName, Type expectedType)
 		{
 			var fieldInfo = testType.GetField (fieldName);
@@ -142,19 +142,19 @@ namespace GeneratorTests {
 			Assert.AreEqual (expectedType, info.Type);
 		}
 
-		[TestCase ("NullableValueTypeField", typeof(Nullable<int>))]
-		[TestCase ("NullableRefTypeField", typeof(string))]
+		[TestCase ("NullableValueTypeField", typeof (Nullable<int>))]
+		[TestCase ("NullableRefTypeField", typeof (string))]
 		public void NullableFieldTest (string fieldName, Type expectedType)
 		{
 			var fieldInfo = testType.GetField (fieldName);
 			Assert.NotNull (fieldInfo);
-			var info = context.Create (fieldInfo); 
+			var info = context.Create (fieldInfo);
 			Assert.True (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
-		
-		[TestCase ("NotNullableValueTypeProperty", typeof(int))]
-		[TestCase ("NotNullableRefProperty", typeof(string))]
+
+		[TestCase ("NotNullableValueTypeProperty", typeof (int))]
+		[TestCase ("NotNullableRefProperty", typeof (string))]
 		public void NotNullablePropertyTest (string propertyName, Type expectedType)
 		{
 			var propertyInfo = testType.GetProperty (propertyName);
@@ -165,26 +165,26 @@ namespace GeneratorTests {
 		}
 
 		// public int? this [int i] {
-		[TestCase(typeof(int), typeof(Nullable<int>), true, typeof(int), false)]
+		[TestCase (typeof (int), typeof (Nullable<int>), true, typeof (int), false)]
 		// public string? this [string? i] 
-		[TestCase(typeof(string), typeof(string), true, typeof(string), true)]
+		[TestCase (typeof (string), typeof (string), true, typeof (string), true)]
 		// public string this [double? i] {
-		[TestCase(typeof(double?), typeof(string), false, typeof(Nullable<double>), true)]
+		[TestCase (typeof (double?), typeof (string), false, typeof (Nullable<double>), true)]
 		public void IndexersTests (Type indexersTypes, Type resultType, bool isNullable, Type indexParameter, bool isIndexParameterNull)
 		{
 			var propertyInfo = GetIndexer (testType, indexersTypes);
 			Assert.NotNull (propertyInfo, "propertyInto != null");
 			var info = context.Create (propertyInfo.GetMethod.ReturnParameter);
-			Assert.AreEqual(isNullable, info.IsNullable (), "info.IsNullable");
+			Assert.AreEqual (isNullable, info.IsNullable (), "info.IsNullable");
 			Assert.AreEqual (resultType, info.Type, "info.Type");
 			var parameters = propertyInfo.SetMethod.GetParameters ();
-			var paramInfo = context.Create (parameters[0]);
-			Assert.AreEqual(isIndexParameterNull, paramInfo.IsNullable (), "paramInfo.IsNullable");
+			var paramInfo = context.Create (parameters [0]);
+			Assert.AreEqual (isIndexParameterNull, paramInfo.IsNullable (), "paramInfo.IsNullable");
 			Assert.AreEqual (indexParameter, paramInfo.Type, "paramInfo.Type");
 		}
 
-		[TestCase ("NullableValueTypeProperty", typeof(Nullable<int>))]
-		[TestCase ("NullableRefProperty", typeof(string))]
+		[TestCase ("NullableValueTypeProperty", typeof (Nullable<int>))]
+		[TestCase ("NullableRefProperty", typeof (string))]
 		public void NullablePropertyTest (string propertyName, Type expectedType)
 		{
 			var propertyInfo = testType.GetProperty (propertyName);
@@ -193,26 +193,26 @@ namespace GeneratorTests {
 			Assert.True (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
-		
-		[TestCase ("NotNullableValueTypeParameter", typeof(int))]
-		[TestCase ("NotNullableRefParameter", typeof(string))]
+
+		[TestCase ("NotNullableValueTypeParameter", typeof (int))]
+		[TestCase ("NotNullableRefParameter", typeof (string))]
 		public void NotNullableParameterTest (string methodName, Type expectedType)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var paramInfo = memberInfo.GetParameters () [0];
 			var info = context.Create (paramInfo);
 			Assert.False (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
-		
-		[TestCase ("NotNullableOutValueTypeParameter", typeof(int))]
-		[TestCase ("NotNullableRefValueTypeParameter", typeof(int))]
-		[TestCase ("NotNullableOutRefParameter", typeof(string))]
-		[TestCase ("NotNullableRefRefParameter", typeof(string))]
+
+		[TestCase ("NotNullableOutValueTypeParameter", typeof (int))]
+		[TestCase ("NotNullableRefValueTypeParameter", typeof (int))]
+		[TestCase ("NotNullableOutRefParameter", typeof (string))]
+		[TestCase ("NotNullableRefRefParameter", typeof (string))]
 		public void NotNullableRefParameterTest (string methodName, Type expectedType)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var paramInfo = memberInfo.GetParameters () [0];
 			var info = context.Create (paramInfo);
@@ -220,82 +220,82 @@ namespace GeneratorTests {
 			Assert.AreEqual (expectedType.MakeByRefType (), info.Type);
 		}
 
-		[TestCase ("NullableValueTypeParameter", typeof(Nullable<int>))]
-		[TestCase ("NullableRefTypeParameter", typeof(string))]
+		[TestCase ("NullableValueTypeParameter", typeof (Nullable<int>))]
+		[TestCase ("NullableRefTypeParameter", typeof (string))]
 		public void NullableParameterTest (string methdName, Type expectedType)
 		{
-			var memberInfo = testType.GetMethod(methdName);
+			var memberInfo = testType.GetMethod (methdName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var paramInfo = memberInfo.GetParameters () [0];
 			var info = context.Create (paramInfo);
 			Assert.True (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
-		
-		[TestCase ("NullableOutValueTypeParameter", typeof(Nullable<int>))]
-		[TestCase ("NullableRefValueTypeParameter", typeof(Nullable<int>))]
-		[TestCase ("NullableOutRefTypeParameter", typeof(string))]
-		[TestCase ("NullableRefRefTypeParameter", typeof(string))]
+
+		[TestCase ("NullableOutValueTypeParameter", typeof (Nullable<int>))]
+		[TestCase ("NullableRefValueTypeParameter", typeof (Nullable<int>))]
+		[TestCase ("NullableOutRefTypeParameter", typeof (string))]
+		[TestCase ("NullableRefRefTypeParameter", typeof (string))]
 		public void NullableRefParameterTest (string methdName, Type expectedType)
 		{
-			var memberInfo = testType.GetMethod(methdName);
+			var memberInfo = testType.GetMethod (methdName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var paramInfo = memberInfo.GetParameters () [0];
 			var info = context.Create (paramInfo);
 			Assert.True (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType.MakeByRefType (), info.Type);
 		}
-		
-		[TestCase ("NotNullableValueTypeReturn", typeof(int))]
-		[TestCase ("NotNullableRefTypeReturn", typeof(string))]
+
+		[TestCase ("NotNullableValueTypeReturn", typeof (int))]
+		[TestCase ("NotNullableRefTypeReturn", typeof (string))]
 		public void NotNullableReturnTypeTest (string methodName, Type expectedType)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.IsFalse (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
 
-		[TestCase ("NullableValueTypeReturn", typeof(Nullable<int>))]
-		[TestCase ("NullableRefTypeReturn", typeof(string))]
+		[TestCase ("NullableValueTypeReturn", typeof (Nullable<int>))]
+		[TestCase ("NullableRefTypeReturn", typeof (string))]
 		public void NullableReturnTypeTest (string methodName, Type expectedType)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.IsTrue (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
 
-		[TestCase("NotNullableValueTypeArray", typeof(int[]), false, typeof(int), false)]
-		[TestCase("NotNullableNullableValueTypeArray", typeof(int[]), false, typeof(Nullable<int>), true)]
-		[TestCase("NullableValueTypeArray", typeof(int[]), true, typeof(int), false)]
-		[TestCase("NullableNullableValueTypeArray", typeof(int[]), true, typeof(Nullable<int>), true)]
-		[TestCase("NotNullableRefTypeArray", typeof(string[]), false, typeof(string), false)]
-		[TestCase("NotNullableNullableRefTypeArray", typeof(string[]), false, typeof(string), true)]
+		[TestCase ("NotNullableValueTypeArray", typeof (int []), false, typeof (int), false)]
+		[TestCase ("NotNullableNullableValueTypeArray", typeof (int []), false, typeof (Nullable<int>), true)]
+		[TestCase ("NullableValueTypeArray", typeof (int []), true, typeof (int), false)]
+		[TestCase ("NullableNullableValueTypeArray", typeof (int []), true, typeof (Nullable<int>), true)]
+		[TestCase ("NotNullableRefTypeArray", typeof (string []), false, typeof (string), false)]
+		[TestCase ("NotNullableNullableRefTypeArray", typeof (string []), false, typeof (string), true)]
 		public void ReturnTypeArrayTests (string methodName, Type? expectedType, bool arrayIsNullable, Type expectedElementType, bool elementTypeIsNullable)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.AreEqual (arrayIsNullable, info.IsNullable (), "info.IsNullable");
 			Assert.AreEqual (expectedElementType, info.ElementType!.Type, "info.ElementType.Type");
 			Assert.AreEqual (elementTypeIsNullable, info.ElementType.IsNullable (), "info.ElementTyps.IsNullable");
 		}
-	
-		[TestCase("NotNullableNestedArrayNotNullableValueType", typeof(int[][]), false, false, typeof(int), false)]
-		[TestCase("NotNullableNestedArrayNullableValueType", typeof(int?[][]), false, false, typeof(Nullable<int>), true)]
-		[TestCase("NotNullableNestedNullableArrayNullableValueType", typeof(int?[][]), false, true, typeof(Nullable<int>), true)]
-		[TestCase("NullableNestedNullableArrayNullableValueType", typeof(int?[][]), true, true, typeof(Nullable<int>), true)]
-		[TestCase("NotNullableNestedArrayNotNullableRefType", typeof(string[][]), false, false, typeof(string), false)]
-		[TestCase("NotNullableNestedArrayNullableRefType", typeof(string?[][]), false, false, typeof(string), true)]
-		[TestCase("NotNullableNestedNullableArrayNullableRefType", typeof(string?[][]), false, true, typeof(string), true)]
-		[TestCase("NullableNestedNullableArrayNullableRefType", typeof(string?[][]), true, true, typeof(string), true)]
+
+		[TestCase ("NotNullableNestedArrayNotNullableValueType", typeof (int [] []), false, false, typeof (int), false)]
+		[TestCase ("NotNullableNestedArrayNullableValueType", typeof (int? [] []), false, false, typeof (Nullable<int>), true)]
+		[TestCase ("NotNullableNestedNullableArrayNullableValueType", typeof (int? [] []), false, true, typeof (Nullable<int>), true)]
+		[TestCase ("NullableNestedNullableArrayNullableValueType", typeof (int? [] []), true, true, typeof (Nullable<int>), true)]
+		[TestCase ("NotNullableNestedArrayNotNullableRefType", typeof (string [] []), false, false, typeof (string), false)]
+		[TestCase ("NotNullableNestedArrayNullableRefType", typeof (string? [] []), false, false, typeof (string), true)]
+		[TestCase ("NotNullableNestedNullableArrayNullableRefType", typeof (string? [] []), false, true, typeof (string), true)]
+		[TestCase ("NullableNestedNullableArrayNullableRefType", typeof (string? [] []), true, true, typeof (string), true)]
 		public void ReturnNestedArrayTests (string methodName, Type? expectedType, bool isArrayNullable,
 			bool isNestedArrayNullable, Type nestedArrayType, bool isNestedArrayElementNullable)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.AreEqual (isArrayNullable, info.IsNullable (), "isArrayNullable");
@@ -303,87 +303,87 @@ namespace GeneratorTests {
 			Assert.AreEqual (nestedArrayType, info.ElementType!.ElementType!.Type, "nestedArrayType");
 			Assert.AreEqual (isNestedArrayElementNullable, info.ElementType.ElementType.IsNullable (), "isNestedArrayElementNullable");
 		}
-		
-		[TestCase("NotNullableValueTypeList", typeof(List<int>), false, typeof(int), false)]
-		[TestCase("NullableValueTypeList", typeof(List<Nullable<int>>), false, typeof(Nullable<int>), true)]
-		[TestCase("NullableListNullableValueType", typeof(List<Nullable<int>>), true, typeof(Nullable<int>), true)]
-		[TestCase("NotNullableRefTypeList", typeof(List<string>), false, typeof(string), false)]
-		[TestCase("NullableRefTypeList", typeof(List<string>), false, typeof(string), true)]
-		[TestCase("NullableListNullableRefType", typeof(List<string>), true, typeof(string), true)]
+
+		[TestCase ("NotNullableValueTypeList", typeof (List<int>), false, typeof (int), false)]
+		[TestCase ("NullableValueTypeList", typeof (List<Nullable<int>>), false, typeof (Nullable<int>), true)]
+		[TestCase ("NullableListNullableValueType", typeof (List<Nullable<int>>), true, typeof (Nullable<int>), true)]
+		[TestCase ("NotNullableRefTypeList", typeof (List<string>), false, typeof (string), false)]
+		[TestCase ("NullableRefTypeList", typeof (List<string>), false, typeof (string), true)]
+		[TestCase ("NullableListNullableRefType", typeof (List<string>), true, typeof (string), true)]
 		public void ReturnSimpleGenericType (string methodName, Type? expectedType, bool isGenericTypeNullable,
 			Type? genericParameterType, bool isGenericParameterNull)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.AreEqual (expectedType, info.Type, "info.Type");
 			Assert.AreEqual (isGenericTypeNullable, info.IsNullable (), "info.IsNullable");
-			Assert.AreEqual (genericParameterType, info.GenericTypeArguments![0].Type, "genericParameterType");
-			Assert.AreEqual (isGenericParameterNull, info.GenericTypeArguments[0].IsNullable (), "isGenericParameterNull");
+			Assert.AreEqual (genericParameterType, info.GenericTypeArguments! [0].Type, "genericParameterType");
+			Assert.AreEqual (isGenericParameterNull, info.GenericTypeArguments [0].IsNullable (), "isGenericParameterNull");
 		}
-		
-		[TestCase ("NestedGenericNotNullableValueType", typeof(List<HashSet<int>>), false, typeof(HashSet<int>), false, typeof(int), false)]
-		[TestCase ("NestedGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), false, typeof(HashSet<Nullable<int>>), false, typeof(Nullable<int>), true)]
-		[TestCase ("NestedNullableGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), false, typeof(HashSet<Nullable<int>>), true, typeof(Nullable<int>), true)]
-		[TestCase ("NullableNestedNullableGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), true, typeof(HashSet<Nullable<int>>), true, typeof(Nullable<int>), true)]
-		[TestCase ("NestedGenericNotNullableRefType", typeof(List<HashSet<string>>), false, typeof(HashSet<string>), false, typeof(string), false)]
-		[TestCase ("NestedGenericNullableRefType", typeof(List<HashSet<string>>), false, typeof(HashSet<string>), false, typeof(string), true)]
-		[TestCase ("NestedNullableGenericNullableRefType", typeof(List<HashSet<string>>), false, typeof(HashSet<string>), true, typeof(string), true)]
-		[TestCase ("NullableNestedNullableGenericNullableRefType", typeof(List<HashSet<string>>), true, typeof(HashSet<string>), true, typeof(string), true)]
+
+		[TestCase ("NestedGenericNotNullableValueType", typeof (List<HashSet<int>>), false, typeof (HashSet<int>), false, typeof (int), false)]
+		[TestCase ("NestedGenericNullableValueType", typeof (List<HashSet<Nullable<int>>>), false, typeof (HashSet<Nullable<int>>), false, typeof (Nullable<int>), true)]
+		[TestCase ("NestedNullableGenericNullableValueType", typeof (List<HashSet<Nullable<int>>>), false, typeof (HashSet<Nullable<int>>), true, typeof (Nullable<int>), true)]
+		[TestCase ("NullableNestedNullableGenericNullableValueType", typeof (List<HashSet<Nullable<int>>>), true, typeof (HashSet<Nullable<int>>), true, typeof (Nullable<int>), true)]
+		[TestCase ("NestedGenericNotNullableRefType", typeof (List<HashSet<string>>), false, typeof (HashSet<string>), false, typeof (string), false)]
+		[TestCase ("NestedGenericNullableRefType", typeof (List<HashSet<string>>), false, typeof (HashSet<string>), false, typeof (string), true)]
+		[TestCase ("NestedNullableGenericNullableRefType", typeof (List<HashSet<string>>), false, typeof (HashSet<string>), true, typeof (string), true)]
+		[TestCase ("NullableNestedNullableGenericNullableRefType", typeof (List<HashSet<string>>), true, typeof (HashSet<string>), true, typeof (string), true)]
 		public void ReturnNestedGeneric (string methodName, Type? expectedType, bool isGenericNullable,
 			Type? nestedGenericType, bool isNestedGenericNullable, Type? nestedGenericArgumentType,
 			bool isNullableNestedGenericArgument)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.AreEqual (expectedType, info.Type, "info.Type");
 			Assert.AreEqual (isGenericNullable, info.IsNullable (), "info.IsNullable");
-			Assert.AreEqual (nestedGenericType, info.GenericTypeArguments![0].Type, "nestedGenericType");
-			Assert.AreEqual (isNestedGenericNullable, info.GenericTypeArguments[0].IsNullable (), "isNestedGenericNullable");
-			Assert.AreEqual (nestedGenericArgumentType, info.GenericTypeArguments[0].GenericTypeArguments![0].Type, "nestedGenericArgumentType");
-			Assert.AreEqual (isNullableNestedGenericArgument, info.GenericTypeArguments[0].GenericTypeArguments![0].IsNullable (), "isNullableNestedGenericArgument");
+			Assert.AreEqual (nestedGenericType, info.GenericTypeArguments! [0].Type, "nestedGenericType");
+			Assert.AreEqual (isNestedGenericNullable, info.GenericTypeArguments [0].IsNullable (), "isNestedGenericNullable");
+			Assert.AreEqual (nestedGenericArgumentType, info.GenericTypeArguments [0].GenericTypeArguments! [0].Type, "nestedGenericArgumentType");
+			Assert.AreEqual (isNullableNestedGenericArgument, info.GenericTypeArguments [0].GenericTypeArguments! [0].IsNullable (), "isNullableNestedGenericArgument");
 		}
-		
-		[TestCase("DictionaryStringInt", typeof(Dictionary<string, int>), false, typeof(string), false, typeof(int), false)]
-		[TestCase("DictionaryStringNullableInt", typeof(Dictionary<string, Nullable<int>>), false, typeof(string), false, typeof(Nullable<int>), true)]
-		[TestCase("DictionaryNullableStringNullableInt", typeof(Dictionary<string, Nullable<int>>), false, typeof(string), true, typeof(Nullable<int>), true)]
-		[TestCase("NullableDictionaryNullableStringNullableInt", typeof(Dictionary<string, Nullable<int>>), true, typeof(string), true, typeof(Nullable<int>), true)]
+
+		[TestCase ("DictionaryStringInt", typeof (Dictionary<string, int>), false, typeof (string), false, typeof (int), false)]
+		[TestCase ("DictionaryStringNullableInt", typeof (Dictionary<string, Nullable<int>>), false, typeof (string), false, typeof (Nullable<int>), true)]
+		[TestCase ("DictionaryNullableStringNullableInt", typeof (Dictionary<string, Nullable<int>>), false, typeof (string), true, typeof (Nullable<int>), true)]
+		[TestCase ("NullableDictionaryNullableStringNullableInt", typeof (Dictionary<string, Nullable<int>>), true, typeof (string), true, typeof (Nullable<int>), true)]
 		public void ReturnDictionary (string methodName, Type? dictionaryType, bool isDictionaryNullable, Type? keyType,
 			bool isKeyNullable, Type? valueType, bool isValueNullable)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.AreEqual (dictionaryType, info.Type, "info.Type");
 			Assert.AreEqual (isDictionaryNullable, info.IsNullable (), "info.IsNullable");
-			Assert.AreEqual (keyType, info.GenericTypeArguments![0].Type, "keyType");
-			Assert.AreEqual (isKeyNullable, info.GenericTypeArguments[0].IsNullable (), "isKeyNullable");
-			Assert.AreEqual (valueType, info.GenericTypeArguments[1].Type, "valueType");
-			Assert.AreEqual (isValueNullable, info.GenericTypeArguments[1].IsNullable (), "isValueNullable");
+			Assert.AreEqual (keyType, info.GenericTypeArguments! [0].Type, "keyType");
+			Assert.AreEqual (isKeyNullable, info.GenericTypeArguments [0].IsNullable (), "isKeyNullable");
+			Assert.AreEqual (valueType, info.GenericTypeArguments [1].Type, "valueType");
+			Assert.AreEqual (isValueNullable, info.GenericTypeArguments [1].IsNullable (), "isValueNullable");
 		}
-		
-		[TestCase("GenericNotNullConstrain", false)]
-		[TestCase("GenericNullableClassConstrain", true)]
-		[TestCase("GenericNullableRefTypeConstrain", true)] 
-		[TestCase("GenericNullableInterface", true)] // limitation in the lang ? is ignore
+
+		[TestCase ("GenericNotNullConstrain", false)]
+		[TestCase ("GenericNullableClassConstrain", true)]
+		[TestCase ("GenericNullableRefTypeConstrain", true)]
+		[TestCase ("GenericNullableInterface", true)] // limitation in the lang ? is ignore
 		public void GenericReturnConstrainTests (string methodName, bool returnTypeIsNull)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.AreEqual (returnTypeIsNull, info.IsNullable ());
 		}
-		
-		[TestCase("GenericNotNullParameterConstrain", false)]
-		[TestCase("GenericNullableClassParameterConstrain", true)]
-		[TestCase("GenericNullableRefTypeParameterConstrain", true)] 
-		[TestCase("GenericNullableInterfaceParameterConstrain", true)] // limitation in the lang ? is ignore
+
+		[TestCase ("GenericNotNullParameterConstrain", false)]
+		[TestCase ("GenericNullableClassParameterConstrain", true)]
+		[TestCase ("GenericNullableRefTypeParameterConstrain", true)]
+		[TestCase ("GenericNullableInterfaceParameterConstrain", true)] // limitation in the lang ? is ignore
 		public void GenericParamConstrainTests (string methodName, bool returnTypeIsNull)
 		{
-			var memberInfo = testType.GetMethod(methodName);
+			var memberInfo = testType.GetMethod (methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
-			var info = context.Create (memberInfo.GetParameters ()[0]);
+			var info = context.Create (memberInfo.GetParameters () [0]);
 			Assert.AreEqual (returnTypeIsNull, info.IsNullable ());
 		}
 	}

--- a/tests/generator/NullabilityContextTests.cs
+++ b/tests/generator/NullabilityContextTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using bgen;
 using NUnit.Framework;
 
@@ -8,10 +10,12 @@ using NUnit.Framework;
 namespace GeneratorTests {
 	
 	[TestFixture]
-	[Parallelizable (ParallelScope.All)]
+	[Parallelizable (ParallelScope.None)] // dotnet implementation is not thread safe..
 	public class NullabilityContextTests {
 
-		class ObjectTest {
+		interface IInterfaceTest { }
+		
+		class ObjectTest : IInterfaceTest {
 			public int NotNullableValueTypeField = 0;
 			public string NotNullableRefTypeField = string.Empty;
 			public int? NullableValueTypeField = 0;
@@ -21,12 +25,35 @@ namespace GeneratorTests {
 			public string NotNullableRefProperty { get; set; } = string.Empty;
 			public int? NullableValueTypeProperty { get; set; }
 			public string? NullableRefProperty { get; set; }
+
+			public int? this [int i] {
+				get => i;
+				set { }
+			}
+
+			public string? this [string? i] {
+				get => i;
+				set { }
+			}
+
+			public string this [double? i] {
+				get => string.Empty;
+				set { }
+			} 
 			
 			public void NotNullableValueTypeParameter (int myParam) { }
+			public void NotNullableOutValueTypeParameter (out int myParam) { myParam = 1; }
+			public void NotNullableRefValueTypeParameter (ref int myParam) { myParam = 1; }
 			public void NotNullableRefParameter (string myParam) { }
+			public void NotNullableOutRefParameter (out string myParam) { myParam = string.Empty; }
+			public void NotNullableRefRefParameter (ref string myParam) { myParam = string.Empty; }
 			
 			public void NullableValueTypeParameter (int? myParam) { }
+			public void NullableOutValueTypeParameter (out int? myParam) { myParam = null;}
+			public void NullableRefValueTypeParameter (ref int? myParam) { myParam = null; }
 			public void NullableRefTypeParameter (string? myParam) { }
+			public void NullableOutRefTypeParameter (out string? myParam) { myParam = null; }
+			public void NullableRefRefTypeParameter (out string? myParam) { myParam = null; }
 
 			public int NotNullableValueTypeReturn () => 0;
 			public string NotNullableRefTypeReturn () => string.Empty;
@@ -78,14 +105,30 @@ namespace GeneratorTests {
 			public Dictionary<string, int?> DictionaryStringNullableInt () => new ();
 			public Dictionary<string?, int?> DictionaryNullableStringNullableInt () => new();
 			public Dictionary<string?, int?>? NullableDictionaryNullableStringNullableInt () => new ();
+
+			public T GenericNotNullConstrain<T> () where T : notnull => default!;
+			public T? GenericNullableClassConstrain<T> () where T : class? => default;
+			public T? GenericNullableRefTypeConstrain<T> () where T : ObjectTest => null;
+			public T GenericNotNullableRefTypeConstrain<T> () where T : ObjectTest => default!;
+			public T? GenericNullableInterface<T> () where T : IInterfaceTest => default;
+			
+			public void GenericNotNullParameterConstrain<T> (T param) where T: notnull {}
+			public void GenericNullableClassParameterConstrain<T> (T param) where T : class? { }
+			public void GenericNullableRefTypeParameterConstrain<T> (T? param) where T : ObjectTest { }
+			public void GenericNullableInterfaceParameterConstrain<T> (T? param) where T : IInterfaceTest { }
 		}
 
+		public static PropertyInfo GetIndexer (Type type, params Type[] arguments) => type.GetProperties().First(
+			x => x.GetIndexParameters().Select(y => y.ParameterType).SequenceEqual(arguments));
+		
 		Type testType = typeof(object);
+		NullabilityInfoContext context = new();
 
 		[SetUp]
 		public void SetUp ()
 		{
 			testType = typeof (ObjectTest);
+			context = new();
 		}
 		
 		[TestCase ("NotNullableValueTypeField", typeof(int))]
@@ -94,19 +137,19 @@ namespace GeneratorTests {
 		{
 			var fieldInfo = testType.GetField (fieldName);
 			Assert.NotNull (fieldInfo, "fieldInfo != null");
-			var info = GeneratorNullabilityInfoContext.Create (fieldInfo);
-			Assert.False (info.IsNullable, "isNullable");
+			var info = context.Create (fieldInfo);
+			Assert.False (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
 
-		[TestCase ("NullableValueTypeField", typeof(int))]
+		[TestCase ("NullableValueTypeField", typeof(Nullable<int>))]
 		[TestCase ("NullableRefTypeField", typeof(string))]
 		public void NullableFieldTest (string fieldName, Type expectedType)
 		{
 			var fieldInfo = testType.GetField (fieldName);
 			Assert.NotNull (fieldInfo);
-			var info = GeneratorNullabilityInfoContext.Create (fieldInfo); 
-			Assert.True (info.IsNullable, "isNullable");
+			var info = context.Create (fieldInfo); 
+			Assert.True (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
 		
@@ -116,19 +159,38 @@ namespace GeneratorTests {
 		{
 			var propertyInfo = testType.GetProperty (propertyName);
 			Assert.NotNull (propertyInfo, "propertyInto != null");
-			var info = GeneratorNullabilityInfoContext.Create (propertyInfo);
-			Assert.False (info.IsNullable, "isNullable");
+			var info = context.Create (propertyInfo);
+			Assert.False (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
 
-		[TestCase ("NullableValueTypeProperty", typeof(int))]
+		// public int? this [int i] {
+		[TestCase(typeof(int), typeof(Nullable<int>), true, typeof(int), false)]
+		// public string? this [string? i] 
+		[TestCase(typeof(string), typeof(string), true, typeof(string), true)]
+		// public string this [double? i] {
+		[TestCase(typeof(double?), typeof(string), false, typeof(Nullable<double>), true)]
+		public void IndexersTests (Type indexersTypes, Type resultType, bool isNullable, Type indexParameter, bool isIndexParameterNull)
+		{
+			var propertyInfo = GetIndexer (testType, indexersTypes);
+			Assert.NotNull (propertyInfo, "propertyInto != null");
+			var info = context.Create (propertyInfo.GetMethod.ReturnParameter);
+			Assert.AreEqual(isNullable, info.IsNullable (), "info.IsNullable");
+			Assert.AreEqual (resultType, info.Type, "info.Type");
+			var parameters = propertyInfo.SetMethod.GetParameters ();
+			var paramInfo = context.Create (parameters[0]);
+			Assert.AreEqual(isIndexParameterNull, paramInfo.IsNullable (), "paramInfo.IsNullable");
+			Assert.AreEqual (indexParameter, paramInfo.Type, "paramInfo.Type");
+		}
+
+		[TestCase ("NullableValueTypeProperty", typeof(Nullable<int>))]
 		[TestCase ("NullableRefProperty", typeof(string))]
 		public void NullablePropertyTest (string propertyName, Type expectedType)
 		{
 			var propertyInfo = testType.GetProperty (propertyName);
 			Assert.NotNull (propertyInfo, "propertyInfo != null");
-			var info = GeneratorNullabilityInfoContext.Create (propertyInfo);
-			Assert.True (info.IsNullable, "isNullable");
+			var info = context.Create (propertyInfo);
+			Assert.True (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
 		
@@ -139,21 +201,49 @@ namespace GeneratorTests {
 			var memberInfo = testType.GetMethod(methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var paramInfo = memberInfo.GetParameters () [0];
-			var info = GeneratorNullabilityInfoContext.Create (paramInfo);
-			Assert.False (info.IsNullable, "isNullable");
+			var info = context.Create (paramInfo);
+			Assert.False (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
+		
+		[TestCase ("NotNullableOutValueTypeParameter", typeof(int))]
+		[TestCase ("NotNullableRefValueTypeParameter", typeof(int))]
+		[TestCase ("NotNullableOutRefParameter", typeof(string))]
+		[TestCase ("NotNullableRefRefParameter", typeof(string))]
+		public void NotNullableRefParameterTest (string methodName, Type expectedType)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var paramInfo = memberInfo.GetParameters () [0];
+			var info = context.Create (paramInfo);
+			Assert.False (info.IsNullable (), "isNullable");
+			Assert.AreEqual (expectedType.MakeByRefType (), info.Type);
+		}
 
-		[TestCase ("NullableValueTypeParameter", typeof(int))]
+		[TestCase ("NullableValueTypeParameter", typeof(Nullable<int>))]
 		[TestCase ("NullableRefTypeParameter", typeof(string))]
 		public void NullableParameterTest (string methdName, Type expectedType)
 		{
 			var memberInfo = testType.GetMethod(methdName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
 			var paramInfo = memberInfo.GetParameters () [0];
-			var info = GeneratorNullabilityInfoContext.Create (paramInfo);
-			Assert.True (info.IsNullable, "isNullable");
+			var info = context.Create (paramInfo);
+			Assert.True (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
+		}
+		
+		[TestCase ("NullableOutValueTypeParameter", typeof(Nullable<int>))]
+		[TestCase ("NullableRefValueTypeParameter", typeof(Nullable<int>))]
+		[TestCase ("NullableOutRefTypeParameter", typeof(string))]
+		[TestCase ("NullableRefRefTypeParameter", typeof(string))]
+		public void NullableRefParameterTest (string methdName, Type expectedType)
+		{
+			var memberInfo = testType.GetMethod(methdName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var paramInfo = memberInfo.GetParameters () [0];
+			var info = context.Create (paramInfo);
+			Assert.True (info.IsNullable (), "isNullable");
+			Assert.AreEqual (expectedType.MakeByRefType (), info.Type);
 		}
 		
 		[TestCase ("NotNullableValueTypeReturn", typeof(int))]
@@ -162,42 +252,42 @@ namespace GeneratorTests {
 		{
 			var memberInfo = testType.GetMethod(methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
-			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
-			Assert.IsFalse (info.IsNullable, "isNullable");
+			var info = context.Create (memberInfo.ReturnParameter);
+			Assert.IsFalse (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
 
-		[TestCase ("NullableValueTypeReturn", typeof(int))]
+		[TestCase ("NullableValueTypeReturn", typeof(Nullable<int>))]
 		[TestCase ("NullableRefTypeReturn", typeof(string))]
 		public void NullableReturnTypeTest (string methodName, Type expectedType)
 		{
 			var memberInfo = testType.GetMethod(methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
-			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
-			Assert.IsTrue (info.IsNullable, "isNullable");
+			var info = context.Create (memberInfo.ReturnParameter);
+			Assert.IsTrue (info.IsNullable (), "isNullable");
 			Assert.AreEqual (expectedType, info.Type);
 		}
 
 		[TestCase("NotNullableValueTypeArray", typeof(int[]), false, typeof(int), false)]
-		[TestCase("NotNullableNullableValueTypeArray", typeof(int[]), false, typeof(int), true)]
+		[TestCase("NotNullableNullableValueTypeArray", typeof(int[]), false, typeof(Nullable<int>), true)]
 		[TestCase("NullableValueTypeArray", typeof(int[]), true, typeof(int), false)]
-		[TestCase("NullableNullableValueTypeArray", typeof(int[]), true, typeof(int), true)]
+		[TestCase("NullableNullableValueTypeArray", typeof(int[]), true, typeof(Nullable<int>), true)]
 		[TestCase("NotNullableRefTypeArray", typeof(string[]), false, typeof(string), false)]
 		[TestCase("NotNullableNullableRefTypeArray", typeof(string[]), false, typeof(string), true)]
 		public void ReturnTypeArrayTests (string methodName, Type? expectedType, bool arrayIsNullable, Type expectedElementType, bool elementTypeIsNullable)
 		{
 			var memberInfo = testType.GetMethod(methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
-			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
-			Assert.AreEqual (arrayIsNullable, info.IsNullable, "info.IsNullable");
+			var info = context.Create (memberInfo.ReturnParameter);
+			Assert.AreEqual (arrayIsNullable, info.IsNullable (), "info.IsNullable");
 			Assert.AreEqual (expectedElementType, info.ElementType!.Type, "info.ElementType.Type");
-			Assert.AreEqual (elementTypeIsNullable, info.ElementType.IsNullable, "info.ElementTyps.IsNullable");
+			Assert.AreEqual (elementTypeIsNullable, info.ElementType.IsNullable (), "info.ElementTyps.IsNullable");
 		}
 	
 		[TestCase("NotNullableNestedArrayNotNullableValueType", typeof(int[][]), false, false, typeof(int), false)]
-		[TestCase("NotNullableNestedArrayNullableValueType", typeof(int?[][]), false, false, typeof(int), true)]
-		[TestCase("NotNullableNestedNullableArrayNullableValueType", typeof(int?[][]), false, true, typeof(int), true)]
-		[TestCase("NullableNestedNullableArrayNullableValueType", typeof(int?[][]), true, true, typeof(int), true)]
+		[TestCase("NotNullableNestedArrayNullableValueType", typeof(int?[][]), false, false, typeof(Nullable<int>), true)]
+		[TestCase("NotNullableNestedNullableArrayNullableValueType", typeof(int?[][]), false, true, typeof(Nullable<int>), true)]
+		[TestCase("NullableNestedNullableArrayNullableValueType", typeof(int?[][]), true, true, typeof(Nullable<int>), true)]
 		[TestCase("NotNullableNestedArrayNotNullableRefType", typeof(string[][]), false, false, typeof(string), false)]
 		[TestCase("NotNullableNestedArrayNullableRefType", typeof(string?[][]), false, false, typeof(string), true)]
 		[TestCase("NotNullableNestedNullableArrayNullableRefType", typeof(string?[][]), false, true, typeof(string), true)]
@@ -207,16 +297,16 @@ namespace GeneratorTests {
 		{
 			var memberInfo = testType.GetMethod(methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
-			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
-			Assert.AreEqual (isArrayNullable, info.IsNullable, "isArrayNullable");
-			Assert.AreEqual (isNestedArrayNullable, info.ElementType!.IsNullable, "isNestedArrayNullable");
-			Assert.AreEqual (nestedArrayType, info.ElementType.ElementType!.Type, "nestedArrayType");
-			Assert.AreEqual (isNestedArrayElementNullable, info.ElementType.ElementType.IsNullable, "isNestedArrayElementNullable");
+			var info = context.Create (memberInfo.ReturnParameter);
+			Assert.AreEqual (isArrayNullable, info.IsNullable (), "isArrayNullable");
+			Assert.AreEqual (isNestedArrayNullable, info.ElementType!.IsNullable (), "isNestedArrayNullable");
+			Assert.AreEqual (nestedArrayType, info.ElementType!.ElementType!.Type, "nestedArrayType");
+			Assert.AreEqual (isNestedArrayElementNullable, info.ElementType.ElementType.IsNullable (), "isNestedArrayElementNullable");
 		}
 		
 		[TestCase("NotNullableValueTypeList", typeof(List<int>), false, typeof(int), false)]
-		[TestCase("NullableValueTypeList", typeof(List<Nullable<int>>), false, typeof(int), true)]
-		[TestCase("NullableListNullableValueType", typeof(List<Nullable<int>>), true, typeof(int), true)]
+		[TestCase("NullableValueTypeList", typeof(List<Nullable<int>>), false, typeof(Nullable<int>), true)]
+		[TestCase("NullableListNullableValueType", typeof(List<Nullable<int>>), true, typeof(Nullable<int>), true)]
 		[TestCase("NotNullableRefTypeList", typeof(List<string>), false, typeof(string), false)]
 		[TestCase("NullableRefTypeList", typeof(List<string>), false, typeof(string), true)]
 		[TestCase("NullableListNullableRefType", typeof(List<string>), true, typeof(string), true)]
@@ -225,17 +315,17 @@ namespace GeneratorTests {
 		{
 			var memberInfo = testType.GetMethod(methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
-			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
+			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.AreEqual (expectedType, info.Type, "info.Type");
-			Assert.AreEqual (isGenericTypeNullable, info.IsNullable, "info.IsNullable");
+			Assert.AreEqual (isGenericTypeNullable, info.IsNullable (), "info.IsNullable");
 			Assert.AreEqual (genericParameterType, info.GenericTypeArguments![0].Type, "genericParameterType");
-			Assert.AreEqual (isGenericParameterNull, info.GenericTypeArguments[0].IsNullable, "isGenericParameterNull");
+			Assert.AreEqual (isGenericParameterNull, info.GenericTypeArguments[0].IsNullable (), "isGenericParameterNull");
 		}
 		
 		[TestCase ("NestedGenericNotNullableValueType", typeof(List<HashSet<int>>), false, typeof(HashSet<int>), false, typeof(int), false)]
-		[TestCase ("NestedGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), false, typeof(HashSet<Nullable<int>>), false, typeof(int), true)]
-		[TestCase ("NestedNullableGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), false, typeof(HashSet<Nullable<int>>), true, typeof(int), true)]
-		[TestCase ("NullableNestedNullableGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), true, typeof(HashSet<Nullable<int>>), true, typeof(int), true)]
+		[TestCase ("NestedGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), false, typeof(HashSet<Nullable<int>>), false, typeof(Nullable<int>), true)]
+		[TestCase ("NestedNullableGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), false, typeof(HashSet<Nullable<int>>), true, typeof(Nullable<int>), true)]
+		[TestCase ("NullableNestedNullableGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), true, typeof(HashSet<Nullable<int>>), true, typeof(Nullable<int>), true)]
 		[TestCase ("NestedGenericNotNullableRefType", typeof(List<HashSet<string>>), false, typeof(HashSet<string>), false, typeof(string), false)]
 		[TestCase ("NestedGenericNullableRefType", typeof(List<HashSet<string>>), false, typeof(HashSet<string>), false, typeof(string), true)]
 		[TestCase ("NestedNullableGenericNullableRefType", typeof(List<HashSet<string>>), false, typeof(HashSet<string>), true, typeof(string), true)]
@@ -246,31 +336,63 @@ namespace GeneratorTests {
 		{
 			var memberInfo = testType.GetMethod(methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
-			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
+			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.AreEqual (expectedType, info.Type, "info.Type");
-			Assert.AreEqual (isGenericNullable, info.IsNullable, "info.IsNullable");
+			Assert.AreEqual (isGenericNullable, info.IsNullable (), "info.IsNullable");
 			Assert.AreEqual (nestedGenericType, info.GenericTypeArguments![0].Type, "nestedGenericType");
-			Assert.AreEqual (isNestedGenericNullable, info.GenericTypeArguments[0].IsNullable, "isNestedGenericNullable");
+			Assert.AreEqual (isNestedGenericNullable, info.GenericTypeArguments[0].IsNullable (), "isNestedGenericNullable");
 			Assert.AreEqual (nestedGenericArgumentType, info.GenericTypeArguments[0].GenericTypeArguments![0].Type, "nestedGenericArgumentType");
-			Assert.AreEqual (isNullableNestedGenericArgument, info.GenericTypeArguments[0].GenericTypeArguments![0].IsNullable, "isNullableNestedGenericArgument");
+			Assert.AreEqual (isNullableNestedGenericArgument, info.GenericTypeArguments[0].GenericTypeArguments![0].IsNullable (), "isNullableNestedGenericArgument");
 		}
 		
 		[TestCase("DictionaryStringInt", typeof(Dictionary<string, int>), false, typeof(string), false, typeof(int), false)]
-		[TestCase("DictionaryStringNullableInt", typeof(Dictionary<string, Nullable<int>>), false, typeof(string), false, typeof(int), true)]
-		[TestCase("DictionaryNullableStringNullableInt", typeof(Dictionary<string, Nullable<int>>), false, typeof(string), true, typeof(int), true)]
-		[TestCase("NullableDictionaryNullableStringNullableInt", typeof(Dictionary<string, Nullable<int>>), true, typeof(string), true, typeof(int), true)]
+		[TestCase("DictionaryStringNullableInt", typeof(Dictionary<string, Nullable<int>>), false, typeof(string), false, typeof(Nullable<int>), true)]
+		[TestCase("DictionaryNullableStringNullableInt", typeof(Dictionary<string, Nullable<int>>), false, typeof(string), true, typeof(Nullable<int>), true)]
+		[TestCase("NullableDictionaryNullableStringNullableInt", typeof(Dictionary<string, Nullable<int>>), true, typeof(string), true, typeof(Nullable<int>), true)]
 		public void ReturnDictionary (string methodName, Type? dictionaryType, bool isDictionaryNullable, Type? keyType,
 			bool isKeyNullable, Type? valueType, bool isValueNullable)
 		{
 			var memberInfo = testType.GetMethod(methodName);
 			Assert.NotNull (memberInfo, "memberInfo != null");
-			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
+			var info = context.Create (memberInfo.ReturnParameter);
 			Assert.AreEqual (dictionaryType, info.Type, "info.Type");
-			Assert.AreEqual (isDictionaryNullable, info.IsNullable, "info.IsNullable");
+			Assert.AreEqual (isDictionaryNullable, info.IsNullable (), "info.IsNullable");
 			Assert.AreEqual (keyType, info.GenericTypeArguments![0].Type, "keyType");
-			Assert.AreEqual (isKeyNullable, info.GenericTypeArguments[0].IsNullable, "isKeyNullable");
+			Assert.AreEqual (isKeyNullable, info.GenericTypeArguments[0].IsNullable (), "isKeyNullable");
 			Assert.AreEqual (valueType, info.GenericTypeArguments[1].Type, "valueType");
-			Assert.AreEqual (isValueNullable, info.GenericTypeArguments[1].IsNullable, "isValueNullable");
+			Assert.AreEqual (isValueNullable, info.GenericTypeArguments[1].IsNullable (), "isValueNullable");
+		}
+		
+		[TestCase("GenericNotNullConstrain", false)]
+		[TestCase("GenericNullableClassConstrain", true)]
+		[TestCase("GenericNullableRefTypeConstrain", true)] 
+		[TestCase("GenericNullableInterface", true)] // limitation in the lang ? is ignore
+		public void GenericReturnConstrainTests (string methodName, bool returnTypeIsNull)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var info = context.Create (memberInfo.ReturnParameter);
+			Assert.AreEqual (returnTypeIsNull, info.IsNullable ());
+		}
+		
+		/*
+		 * 
+			public void GenericNotNullParameterConstrain<T> (T param) where T: notnull {}
+			public void GenericNullableClassParameterConstrain<T> (T param) where T : class? { }
+			public void GenericNullableRefTypeParameterConstrain<T> (T? param) where T : ObjectTest { }
+			public void GenericNullableInterfaceParameterConstrain<T> (T? param) where T : IInterfaceTest => default;
+		 */
+		
+		[TestCase("GenericNotNullParameterConstrain", false)]
+		[TestCase("GenericNullableClassParameterConstrain", true)]
+		[TestCase("GenericNullableRefTypeParameterConstrain", true)] 
+		[TestCase("GenericNullableInterfaceParameterConstrain", true)] // limitation in the lang ? is ignore
+		public void GenericParamConstrainTests (string methodName, bool returnTypeIsNull)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var info = context.Create (memberInfo.GetParameters ()[0]);
+			Assert.AreEqual (returnTypeIsNull, info.IsNullable ());
 		}
 	}
 }

--- a/tests/generator/NullabilityContextTests.cs
+++ b/tests/generator/NullabilityContextTests.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using bgen;
+using NUnit.Framework;
+
+#nullable enable
+
+namespace GeneratorTests {
+	
+	[TestFixture]
+	[Parallelizable (ParallelScope.All)]
+	public class NullabilityContextTests {
+
+		class ObjectTest {
+			public int NotNullableValueTypeField = 0;
+			public string NotNullableRefTypeField = string.Empty;
+			public int? NullableValueTypeField = 0;
+			public string? NullableRefTypeField = string.Empty;
+			
+			public int NotNullableValueTypeProperty { get; set; }
+			public string NotNullableRefProperty { get; set; } = string.Empty;
+			public int? NullableValueTypeProperty { get; set; }
+			public string? NullableRefProperty { get; set; }
+			
+			public void NotNullableValueTypeParameter (int myParam) { }
+			public void NotNullableRefParameter (string myParam) { }
+			
+			public void NullableValueTypeParameter (int? myParam) { }
+			public void NullableRefTypeParameter (string? myParam) { }
+
+			public int NotNullableValueTypeReturn () => 0;
+			public string NotNullableRefTypeReturn () => string.Empty;
+
+			public int? NullableValueTypeReturn () => null;
+			public string? NullableRefTypeReturn () => null;
+			
+			// array return type tests
+			public int [] NotNullableValueTypeArray () => Array.Empty<int> ();
+			public int? [] NotNullableNullableValueTypeArray () => Array.Empty<int?> ();
+			public int []? NullableValueTypeArray () => null;
+			public int? []? NullableNullableValueTypeArray () => null;
+			
+			public string [] NotNullableRefTypeArray () => Array.Empty<string> ();
+			public string? [] NotNullableNullableRefTypeArray () => Array.Empty<string?> ();
+			public string []? NullableRefTypeArray () => null;
+			public string? []? NullableNullableRefTypeArray () => null;
+
+			public int [] [] NotNullableNestedArrayNotNullableValueType () => Array.Empty<int []> ();
+			public int? [] [] NotNullableNestedArrayNullableValueType () => Array.Empty<int? []> ();
+			public int? []? [] NotNullableNestedNullableArrayNullableValueType () => Array.Empty<int? []?> ();
+			public int? []? []? NullableNestedNullableArrayNullableValueType () => null;
+			
+			
+			public string [] [] NotNullableNestedArrayNotNullableRefType () => Array.Empty<string []> ();
+			public string? [] [] NotNullableNestedArrayNullableRefType () => Array.Empty<string? []> ();
+			public string? []? [] NotNullableNestedNullableArrayNullableRefType () => Array.Empty<string? []?> ();
+			public string? []? []? NullableNestedNullableArrayNullableRefType () => null;
+
+			public List<int> NotNullableValueTypeList () => new();
+			public List<int?> NullableValueTypeList () => new();
+			public List<int?>? NullableListNullableValueType () => null;
+			
+			public List<string> NotNullableRefTypeList () => new();
+			public List<string?> NullableRefTypeList () => new();
+			public List<string?>? NullableListNullableRefType () => null;
+
+			public List<HashSet<int>> NestedGenericNotNullableValueType () => new();
+			public List<HashSet<int?>> NestedGenericNullableValueType () => new();
+			public List<HashSet<int?>?> NestedNullableGenericNullableValueType () => new();
+			public List<HashSet<int?>?>? NullableNestedNullableGenericNullableValueType () => new();
+			
+			public List<HashSet<string>> NestedGenericNotNullableRefType () => new();
+			public List<HashSet<string?>> NestedGenericNullableRefType () => new();
+			public List<HashSet<string?>?> NestedNullableGenericNullableRefType () => new();
+			public List<HashSet<string?>?>? NullableNestedNullableGenericNullableRefType () => new();
+
+			public Dictionary<string, int> DictionaryStringInt () => new();
+			public Dictionary<string, int?> DictionaryStringNullableInt () => new ();
+			public Dictionary<string?, int?> DictionaryNullableStringNullableInt () => new();
+			public Dictionary<string?, int?>? NullableDictionaryNullableStringNullableInt () => new ();
+		}
+
+		Type testType = typeof(object);
+
+		[SetUp]
+		public void SetUp ()
+		{
+			testType = typeof (ObjectTest);
+		}
+		
+		[TestCase ("NotNullableValueTypeField", typeof(int))]
+		[TestCase ("NotNullableRefTypeField", typeof(string))]
+		public void NotNullableFieldTest (string fieldName, Type expectedType)
+		{
+			var fieldInfo = testType.GetField (fieldName);
+			Assert.NotNull (fieldInfo, "fieldInfo != null");
+			var info = GeneratorNullabilityInfoContext.Create (fieldInfo);
+			Assert.False (info.IsNullable, "isNullable");
+			Assert.AreEqual (expectedType, info.Type);
+		}
+
+		[TestCase ("NullableValueTypeField", typeof(int))]
+		[TestCase ("NullableRefTypeField", typeof(string))]
+		public void NullableFieldTest (string fieldName, Type expectedType)
+		{
+			var fieldInfo = testType.GetField (fieldName);
+			Assert.NotNull (fieldInfo);
+			var info = GeneratorNullabilityInfoContext.Create (fieldInfo); 
+			Assert.True (info.IsNullable, "isNullable");
+			Assert.AreEqual (expectedType, info.Type);
+		}
+		
+		[TestCase ("NotNullableValueTypeProperty", typeof(int))]
+		[TestCase ("NotNullableRefProperty", typeof(string))]
+		public void NotNullablePropertyTest (string propertyName, Type expectedType)
+		{
+			var propertyInfo = testType.GetProperty (propertyName);
+			Assert.NotNull (propertyInfo, "propertyInto != null");
+			var info = GeneratorNullabilityInfoContext.Create (propertyInfo);
+			Assert.False (info.IsNullable, "isNullable");
+			Assert.AreEqual (expectedType, info.Type);
+		}
+
+		[TestCase ("NullableValueTypeProperty", typeof(int))]
+		[TestCase ("NullableRefProperty", typeof(string))]
+		public void NullablePropertyTest (string propertyName, Type expectedType)
+		{
+			var propertyInfo = testType.GetProperty (propertyName);
+			Assert.NotNull (propertyInfo, "propertyInfo != null");
+			var info = GeneratorNullabilityInfoContext.Create (propertyInfo);
+			Assert.True (info.IsNullable, "isNullable");
+			Assert.AreEqual (expectedType, info.Type);
+		}
+		
+		[TestCase ("NotNullableValueTypeParameter", typeof(int))]
+		[TestCase ("NotNullableRefParameter", typeof(string))]
+		public void NotNullableParameterTest (string methodName, Type expectedType)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var paramInfo = memberInfo.GetParameters () [0];
+			var info = GeneratorNullabilityInfoContext.Create (paramInfo);
+			Assert.False (info.IsNullable, "isNullable");
+			Assert.AreEqual (expectedType, info.Type);
+		}
+
+		[TestCase ("NullableValueTypeParameter", typeof(int))]
+		[TestCase ("NullableRefTypeParameter", typeof(string))]
+		public void NullableParameterTest (string methdName, Type expectedType)
+		{
+			var memberInfo = testType.GetMethod(methdName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var paramInfo = memberInfo.GetParameters () [0];
+			var info = GeneratorNullabilityInfoContext.Create (paramInfo);
+			Assert.True (info.IsNullable, "isNullable");
+			Assert.AreEqual (expectedType, info.Type);
+		}
+		
+		[TestCase ("NotNullableValueTypeReturn", typeof(int))]
+		[TestCase ("NotNullableRefTypeReturn", typeof(string))]
+		public void NotNullableReturnTypeTest (string methodName, Type expectedType)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
+			Assert.IsFalse (info.IsNullable, "isNullable");
+			Assert.AreEqual (expectedType, info.Type);
+		}
+
+		[TestCase ("NullableValueTypeReturn", typeof(int))]
+		[TestCase ("NullableRefTypeReturn", typeof(string))]
+		public void NullableReturnTypeTest (string methodName, Type expectedType)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
+			Assert.IsTrue (info.IsNullable, "isNullable");
+			Assert.AreEqual (expectedType, info.Type);
+		}
+
+		[TestCase("NotNullableValueTypeArray", typeof(int[]), false, typeof(int), false)]
+		[TestCase("NotNullableNullableValueTypeArray", typeof(int[]), false, typeof(int), true)]
+		[TestCase("NullableValueTypeArray", typeof(int[]), true, typeof(int), false)]
+		[TestCase("NullableNullableValueTypeArray", typeof(int[]), true, typeof(int), true)]
+		[TestCase("NotNullableRefTypeArray", typeof(string[]), false, typeof(string), false)]
+		[TestCase("NotNullableNullableRefTypeArray", typeof(string[]), false, typeof(string), true)]
+		public void ReturnTypeArrayTests (string methodName, Type? expectedType, bool arrayIsNullable, Type expectedElementType, bool elementTypeIsNullable)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
+			Assert.AreEqual (arrayIsNullable, info.IsNullable, "info.IsNullable");
+			Assert.AreEqual (expectedElementType, info.ElementType!.Type, "info.ElementType.Type");
+			Assert.AreEqual (elementTypeIsNullable, info.ElementType.IsNullable, "info.ElementTyps.IsNullable");
+		}
+	
+		[TestCase("NotNullableNestedArrayNotNullableValueType", typeof(int[][]), false, false, typeof(int), false)]
+		[TestCase("NotNullableNestedArrayNullableValueType", typeof(int?[][]), false, false, typeof(int), true)]
+		[TestCase("NotNullableNestedNullableArrayNullableValueType", typeof(int?[][]), false, true, typeof(int), true)]
+		[TestCase("NullableNestedNullableArrayNullableValueType", typeof(int?[][]), true, true, typeof(int), true)]
+		[TestCase("NotNullableNestedArrayNotNullableRefType", typeof(string[][]), false, false, typeof(string), false)]
+		[TestCase("NotNullableNestedArrayNullableRefType", typeof(string?[][]), false, false, typeof(string), true)]
+		[TestCase("NotNullableNestedNullableArrayNullableRefType", typeof(string?[][]), false, true, typeof(string), true)]
+		[TestCase("NullableNestedNullableArrayNullableRefType", typeof(string?[][]), true, true, typeof(string), true)]
+		public void ReturnNestedArrayTests (string methodName, Type? expectedType, bool isArrayNullable,
+			bool isNestedArrayNullable, Type nestedArrayType, bool isNestedArrayElementNullable)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
+			Assert.AreEqual (isArrayNullable, info.IsNullable, "isArrayNullable");
+			Assert.AreEqual (isNestedArrayNullable, info.ElementType!.IsNullable, "isNestedArrayNullable");
+			Assert.AreEqual (nestedArrayType, info.ElementType.ElementType!.Type, "nestedArrayType");
+			Assert.AreEqual (isNestedArrayElementNullable, info.ElementType.ElementType.IsNullable, "isNestedArrayElementNullable");
+		}
+		
+		[TestCase("NotNullableValueTypeList", typeof(List<int>), false, typeof(int), false)]
+		[TestCase("NullableValueTypeList", typeof(List<Nullable<int>>), false, typeof(int), true)]
+		[TestCase("NullableListNullableValueType", typeof(List<Nullable<int>>), true, typeof(int), true)]
+		[TestCase("NotNullableRefTypeList", typeof(List<string>), false, typeof(string), false)]
+		[TestCase("NullableRefTypeList", typeof(List<string>), false, typeof(string), true)]
+		[TestCase("NullableListNullableRefType", typeof(List<string>), true, typeof(string), true)]
+		public void ReturnSimpleGenericType (string methodName, Type? expectedType, bool isGenericTypeNullable,
+			Type? genericParameterType, bool isGenericParameterNull)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
+			Assert.AreEqual (expectedType, info.Type, "info.Type");
+			Assert.AreEqual (isGenericTypeNullable, info.IsNullable, "info.IsNullable");
+			Assert.AreEqual (genericParameterType, info.GenericTypeArguments![0].Type, "genericParameterType");
+			Assert.AreEqual (isGenericParameterNull, info.GenericTypeArguments[0].IsNullable, "isGenericParameterNull");
+		}
+		
+		[TestCase ("NestedGenericNotNullableValueType", typeof(List<HashSet<int>>), false, typeof(HashSet<int>), false, typeof(int), false)]
+		[TestCase ("NestedGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), false, typeof(HashSet<Nullable<int>>), false, typeof(int), true)]
+		[TestCase ("NestedNullableGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), false, typeof(HashSet<Nullable<int>>), true, typeof(int), true)]
+		[TestCase ("NullableNestedNullableGenericNullableValueType", typeof(List<HashSet<Nullable<int>>>), true, typeof(HashSet<Nullable<int>>), true, typeof(int), true)]
+		[TestCase ("NestedGenericNotNullableRefType", typeof(List<HashSet<string>>), false, typeof(HashSet<string>), false, typeof(string), false)]
+		[TestCase ("NestedGenericNullableRefType", typeof(List<HashSet<string>>), false, typeof(HashSet<string>), false, typeof(string), true)]
+		[TestCase ("NestedNullableGenericNullableRefType", typeof(List<HashSet<string>>), false, typeof(HashSet<string>), true, typeof(string), true)]
+		[TestCase ("NullableNestedNullableGenericNullableRefType", typeof(List<HashSet<string>>), true, typeof(HashSet<string>), true, typeof(string), true)]
+		public void ReturnNestedGeneric (string methodName, Type? expectedType, bool isGenericNullable,
+			Type? nestedGenericType, bool isNestedGenericNullable, Type? nestedGenericArgumentType,
+			bool isNullableNestedGenericArgument)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
+			Assert.AreEqual (expectedType, info.Type, "info.Type");
+			Assert.AreEqual (isGenericNullable, info.IsNullable, "info.IsNullable");
+			Assert.AreEqual (nestedGenericType, info.GenericTypeArguments![0].Type, "nestedGenericType");
+			Assert.AreEqual (isNestedGenericNullable, info.GenericTypeArguments[0].IsNullable, "isNestedGenericNullable");
+			Assert.AreEqual (nestedGenericArgumentType, info.GenericTypeArguments[0].GenericTypeArguments![0].Type, "nestedGenericArgumentType");
+			Assert.AreEqual (isNullableNestedGenericArgument, info.GenericTypeArguments[0].GenericTypeArguments![0].IsNullable, "isNullableNestedGenericArgument");
+		}
+		
+		[TestCase("DictionaryStringInt", typeof(Dictionary<string, int>), false, typeof(string), false, typeof(int), false)]
+		[TestCase("DictionaryStringNullableInt", typeof(Dictionary<string, Nullable<int>>), false, typeof(string), false, typeof(int), true)]
+		[TestCase("DictionaryNullableStringNullableInt", typeof(Dictionary<string, Nullable<int>>), false, typeof(string), true, typeof(int), true)]
+		[TestCase("NullableDictionaryNullableStringNullableInt", typeof(Dictionary<string, Nullable<int>>), true, typeof(string), true, typeof(int), true)]
+		public void ReturnDictionary (string methodName, Type? dictionaryType, bool isDictionaryNullable, Type? keyType,
+			bool isKeyNullable, Type? valueType, bool isValueNullable)
+		{
+			var memberInfo = testType.GetMethod(methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			var info = GeneratorNullabilityInfoContext.Create (memberInfo.ReturnParameter);
+			Assert.AreEqual (dictionaryType, info.Type, "info.Type");
+			Assert.AreEqual (isDictionaryNullable, info.IsNullable, "info.IsNullable");
+			Assert.AreEqual (keyType, info.GenericTypeArguments![0].Type, "keyType");
+			Assert.AreEqual (isKeyNullable, info.GenericTypeArguments[0].IsNullable, "isKeyNullable");
+			Assert.AreEqual (valueType, info.GenericTypeArguments[1].Type, "valueType");
+			Assert.AreEqual (isValueNullable, info.GenericTypeArguments[1].IsNullable, "isValueNullable");
+		}
+	}
+}

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="..\common\BinLog.cs">
       <Link>BinLog.cs</Link>
     </Compile>
+    <Compile Include="NullabilityContextTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="tests\is-direct-binding.cs" />


### PR DESCRIPTION
This is the first part of a 2 or more changes that will allow the APIs to use ? as a way to mark a nullable field, parameter, property and return method.

The way it works follows the documentation from the runtime that can be found here: https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md

The tldr; of the documentation is as follows:

1. If we are looking at a value type, the compiler converts int? into Nullable<int>. This was already considered in the old code.
2. If we are inspecting a generic type we have to look for the information in two different attributes added by the compiler: - NullableAttribute: Each type reference in metadata may have an associated NullableAttribute with a byte[] where each byte represents nullability: 0 for oblivious, 1 for not annotated, and 2 for annotated. - NullableContextAttribute is valid in metadata on type and method declarations. The byte value represents the implicit NullableAttribute value for type reference within that scope that do not have an explicit NullableAttribute and would not otherwise be represented by an empty byte[].

The API is very similar to that provided  by dotnet6 but it allows us to support classic. The move to the dotnet6 API should not be hard and probably can be done by an IDE.

Once this API lands we will have to find the old usages of the check for nullability and combine both. This new API should fix several issues we have with nullability and nullability + generics.