### PR TITLE
[runtime] Remove native usage of MonoReferenceQueue and use a ConditionalWeakTable in managed code instead.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -962,26 +962,6 @@ xamarin_bridge_free_mono_signature (MonoMethodSignature **psig)
 	*psig = NULL;
 }
 
-MonoReferenceQueue *
-mono_gc_reference_queue_new (mono_reference_queue_callback callback)
-{
-	MonoReferenceQueue *rv = xamarin_bridge_gc_reference_queue_new (callback);
-
-	LOG_CORECLR (stderr, "%s (%p) => %p\n", __func__, callback, rv);
-
-	return rv;
-}
-
-gboolean
-mono_gc_reference_queue_add (MonoReferenceQueue *queue, MonoObject *obj, void *user_data)
-{
-	LOG_CORECLR (stderr, "%s (%p, %p, %p)\n", __func__, queue, obj, user_data);
-
-	xamarin_bridge_gc_reference_queue_add (queue, obj, user_data);
-
-	return true;
-}
-
 void
 mono_free (void *ptr)
 {

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -415,24 +415,6 @@
 			OnlyCoreCLR = true,
 		},
 
-		new XDelegate ("MonoReferenceQueue *", "MonoObject *", "xamarin_bridge_gc_reference_queue_new",
-			"mono_reference_queue_callback", "IntPtr", "callback"
-		) {
-			WrappedManagedFunction = "CreateGCReferenceQueue",
-			OnlyDynamicUsage = false,
-			OnlyCoreCLR = true,
-		},
-
-		new XDelegate ("void", "void", "xamarin_bridge_gc_reference_queue_add",
-			"MonoReferenceQueue *", "MonoObject *", "queue_handle",
-			"MonoObject *", "MonoObject *", "obj",
-			"void *", "IntPtr", "user_data"
-		) {
-			WrappedManagedFunction = "GCReferenceQueueAdd",
-			OnlyDynamicUsage = false,
-			OnlyCoreCLR = true,
-		},
-
 		new XDelegate ("MonoObject *", "MonoObject *", "xamarin_bridge_box",
 			"MonoObject *", "MonoObject *", "typeobj",
 			"void *", "IntPtr", "value"

--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -589,20 +589,6 @@
 
 		#region metadata/gc-internal.h
 
-		new Export ("MonoReferenceQueue *", "mono_gc_reference_queue_new",
-			"mono_reference_queue_callback", "callback"
-		) {
-			HasCoreCLRBridgeFunction = true,
-		},
-
-		new Export ("gboolean", "mono_gc_reference_queue_add",
-			"MonoReferenceQueue *", "queue",
-			"MonoObject *", "obj",
-			"void *", "user_data"
-		) {
-			HasCoreCLRBridgeFunction = true,
-		},
-
 		new Export ("void", "mono_gc_register_finalizer_callbacks",
 			"MonoGCFinalizerCallbacks *", "callbacks"
 		) {

--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -376,6 +376,10 @@ namespace ObjCRuntime {
 			}
 		}
 
+		internal static IntPtr Copy (IntPtr block)
+		{
+			return _Block_copy (block);
+		}
 #endif
 	}
 
@@ -396,6 +400,14 @@ namespace ObjCRuntime {
 		}
 
 		internal static dispatch_block_t static_dispatch_block = TrampolineDispatchBlock;
+	}
+
+	// This class will free the specified block when it's collected by the GC.
+	internal class BlockCollector : TrampolineBlockBase {
+		public BlockCollector (IntPtr block)
+			: base (block, owns: true)
+		{
+		}
 	}
 #endif
 

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -938,57 +938,6 @@ namespace ObjCRuntime {
 			return Marshal.PtrToStructure (ptr, type);
 		}
 
-		/* Managed version of a mono_reference_queue */
-		/* The semantics are:
-		 * - Adding an object to the queue will not prevent the GC from collecting it (it's a weak reference)
-		 * - A native callback will be called when the object is collected.
-		 * This can be accomplished with a ConditionalWeakTable: the object in question is the key, and then
-		 * we add a wrapper object as the value, and we call the native callback when the wrapper object is
-		 * collected.
-		 */
-		delegate void mono_reference_queue_callback (IntPtr user_data);
-
-		class ReferenceQueue {
-			public mono_reference_queue_callback Callback;
-			public ConditionalWeakTable<object, object?> Table = new ConditionalWeakTable<object, object?> ();
-
-			public ReferenceQueue (mono_reference_queue_callback callback)
-			{
-				Callback = callback;
-			}
-		}
-
-		class ReferenceQueueEntry {
-			public ReferenceQueue Queue;
-			public IntPtr UserData;
-
-			public ReferenceQueueEntry (ReferenceQueue queue)
-			{
-				Queue = queue;
-			}
-
-			~ReferenceQueueEntry ()
-			{
-				Queue.Callback (UserData);
-			}
-		}
-
-		unsafe static MonoObject* CreateGCReferenceQueue (IntPtr callback)
-		{
-			var queue = new ReferenceQueue (Marshal.GetDelegateForFunctionPointer<mono_reference_queue_callback> (callback));
-			return (MonoObject *) GetMonoObject (queue);
-		}
-
-		unsafe static void GCReferenceQueueAdd (MonoObject* mqueue, MonoObject* mobj, IntPtr user_data)
-		{
-			var queue = (ReferenceQueue) GetMonoObjectTarget (mqueue)!;
-			var obj = GetMonoObjectTarget (mobj)!;
-			var entry = new ReferenceQueueEntry (queue) {
-				UserData = user_data,
-			};
-			queue.Table.Add (obj, entry);
-		}
-
 		/* Managed version of mono_g_hash_table The mono_g_hash_table can be configured
 		   in several ways, depending on whether the GC should track keys,
 		   values or both, but in our case we only want the GC to track the

--- a/src/ObjCRuntime/TrampolineBlockBase.cs
+++ b/src/ObjCRuntime/TrampolineBlockBase.cs
@@ -13,12 +13,18 @@ namespace ObjCRuntime {
 
 		readonly IntPtr blockPtr;
 
-		[DllImport (Messaging.LIBOBJC_DYLIB)]
-		static extern IntPtr _Block_copy (IntPtr ptr);
+		internal TrampolineBlockBase (IntPtr block, bool owns)
+		{
+			if (owns) {
+				blockPtr = block;
+			} else {
+				blockPtr = BlockLiteral.Copy (block);
+			}
+		}
 
 		protected unsafe TrampolineBlockBase (BlockLiteral* block)
+			: this ((IntPtr) block, false)
 		{
-			blockPtr = _Block_copy ((IntPtr) block);
 		}
 
 		~TrampolineBlockBase ()


### PR DESCRIPTION
This makes it possible to simplify and remove a good chunk of related code.

Especially for CoreCLR this should be a minor perf improvement, because we'll do fewer transitions between managed and native code.