### PR TITLE
[Generator] Move GeneratedTypes out and enable nullability.

### DIFF
--- a/src/bgen/GeneratedTypes.cs
+++ b/src/bgen/GeneratedTypes.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+public class GeneratedTypes {
+	public Generator Generator;
+
+	readonly Dictionary<Type, GeneratedType> knownTypes = new ();
+
+	public GeneratedTypes (Generator generator)
+	{
+		this.Generator = generator;
+	}
+
+	public GeneratedType Lookup (Type t)
+	{
+		if (knownTypes.TryGetValue (t, out var n))
+			return n;
+		n = new (t, this);
+		knownTypes [t] = n;
+		return n;
+	}
+}

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -54,26 +54,6 @@ using ObjCRuntime;
 using Foundation;
 using Xamarin.Utils;
 
-public class GeneratedTypes {
-	public Generator Generator;
-
-	Dictionary<Type, GeneratedType> knownTypes = new Dictionary<Type, GeneratedType> ();
-
-	public GeneratedTypes (Generator generator)
-	{
-		this.Generator = generator;
-	}
-
-	public GeneratedType Lookup (Type t)
-	{
-		if (knownTypes.ContainsKey (t))
-			return knownTypes [t];
-		var n = new GeneratedType (t, this);
-		knownTypes [t] = n;
-		return n;
-	}
-}
-
 public interface IMemberGatherer {
 	IEnumerable<MethodInfo> GetTypeContractMethods (Type source);
 }

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -101,6 +101,7 @@
     <Compile Include="..\src\bgen\ExtensionMethods.cs" />
     <Compile Include="..\src\bgen\Filters.cs" />
     <Compile Include="..\src\bgen\GeneratedType.cs" />
+    <Compile Include="..\src\bgen\GeneratedTypes.cs" />
     <Compile Include="..\src\bgen\Generator.cs" />
     <Compile Include="..\src\bgen\MarshalInfo.cs" />
     <Compile Include="..\src\bgen\NamespaceManager.cs" />


### PR DESCRIPTION
Moved the code out, also made a small improvement by reducing the number of lookups are needed to get the GeneratedType.