### PR TITLE
[release/7.0.2xx] Hardcode a version bump to make sure versions are repeated across release branches.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -14,9 +14,9 @@ CURL_RETRY = $(CURL) --retry 20 --retry-delay 2 --retry-all-errors
 
 # calculate commit distance and store it in a file so that we don't have to re-calculate it every time make is executed.
 
-# Hardcode this for now to have a higher version number than the current stable release.
-NUGET_VERSION_COMMIT_DISTANCE_START=1000
-NUGET_VERSION_STABLE_COMMIT_DISTANCE_START=30
+# Hardcode this for now to have a higher version number than the current stable release in 7.0.1xx.
+NUGET_VERSION_COMMIT_DISTANCE_START=2000
+NUGET_VERSION_STABLE_COMMIT_DISTANCE_START=100
 
 -include $(TOP)/Make.config.inc
 $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk


### PR DESCRIPTION
Fixes:

> ##[error]The nuget command failed with exit code(1) and error(System.AggregateException: One or more errors occurred. ---> System.Net.Http.HttpRequestException: Response status code does not indicate success: 409 (Conflict - The feed already contains 'Microsoft.MacCatalyst.Ref 16.2.1020+sha.fadaa6ffe'. (DevOps Activity ID: 384C96F7-56C7-4433-8E9F-B96CFDB61942)).

Versions are now:

```
$ make show-versions
Building:
    The .NET NuGet(s):
        Microsoft.iOS 16.2.2020+sha.fadaa6ffee
        Microsoft.tvOS 16.1.2517+sha.fadaa6ffee
        Microsoft.MacCatalyst 16.2.2020+sha.fadaa6ffee
        Microsoft.macOS 13.1.2020+sha.fadaa6ffee
```