### PR TITLE
[CI] Remove the translations from the main stage.

### DIFF
--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -191,19 +191,6 @@ stages:
           repositoryAlias: ${{ parameters.repositoryAlias }}
           commit: ${{ parameters.commit }}
 
-    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-      - job: translations
-        displayName: 'Loc translations'
-        pool:
-          vmImage: windows-latest
-        steps:
-        - template: loc-translations.yml
-          parameters:
-            isPR: ${{ parameters.isPR }}
-            repositoryAlias: ${{ parameters.repositoryAlias }}
-            commit: ${{ parameters.commit }}
-
-
 - ${{ if parameters.isPR }}:
   - stage: clean
     displayName: '${{ parameters.stageDisplayNamePrefix }}Clean up'


### PR DESCRIPTION
The trnalsations are meant to be done per week using the cron job. The cron job does not use the main stage template, ergo we can simplify the stage by removing the translations.