### PR TITLE
[tests] Bump Microsoft.NET.Test.Sdk version to latest stable.

### DIFF
--- a/tests/bgen/bgen-tests.csproj
+++ b/tests/bgen/bgen-tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
   </ItemGroup>

--- a/tests/dotnet/UnitTests/DotNetUnitTests.csproj
+++ b/tests/dotnet/UnitTests/DotNetUnitTests.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="nunit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Mono.Cecil" Version="0.11.4" />
 		<PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
 		<PackageReference Include="System.Text.Json" Version="5.0.2" />

--- a/tools/nnyeah/tests/nnyeah-tests.csproj
+++ b/tools/nnyeah/tests/nnyeah-tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />


### PR DESCRIPTION
The older version of Microsoft.NET.Test.Sdk depends on an older version of
Newtonsoft.Json, which triggers automated security warnings.

Ref: https://devdiv.visualstudio.com/DevDiv/_componentGovernance/113130/alert/7090885?typeId=12169115