### PR TITLE
[release/6.0.4xx-xcode14.2] Imports the .user.env file if exists and the build is from VS

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -7,7 +7,10 @@
 	<Import Project="Microsoft.$(_PlatformName).Sdk.SupportedTargetPlatforms.props" />
 
 	<Import Project="Xamarin.Shared.Sdk.TargetFrameworkInference.props" />
-
+	
+	<!-- Imports the .user.env file if exists and the build is from VS -->
+	<Import Project="$(MSBuildProjectFullPath).user.env" Condition="Exists('$(MSBuildProjectFullPath).user.env') And '$(BuildingInsideVisualStudio)' == 'true'" />
+	
 	<PropertyGroup>
 		<!-- Set to true when using the Microsoft.<platform>.Sdk NuGet. This is used by pre-existing/shared targets to tweak behavior depending on build system -->
 		<UsingAppleNETSdk>true</UsingAppleNETSdk>


### PR DESCRIPTION
This will allow the latest runtime identifier values to be evaluated in time during the MSBuild property evaluation phase.

Related and dependent of this PR: https://github.com/xamarin/XamarinVS/pull/13606


Backport of #17466
