### PR TITLE
[src] Create XML documentation when building our platform assemblies for .NET. Fixes #17395.

### DIFF
--- a/src/CoreServices/FSEvents.cs
+++ b/src/CoreServices/FSEvents.cs
@@ -207,7 +207,7 @@ namespace CoreServices
 		/// The service will supply events that have happened after the given event ID. To ask for
 		/// events "since now," set to <c>null</c> or <see cref="FSEvent.SinceNowId"/>. Often, clients
 		/// will supply the highest-numbered event ID they have received in a callback, which they can
-		/// obtain via <see cref="FSEventStream.LatestEventId">. Do not set to zero, unless you want to
+		/// obtain via <see cref="FSEventStream.LatestEventId"/>. Do not set to zero, unless you want to
 		/// receive events for every directory modified since "the beginning of time" -- an unlikely scenario.
 		/// </summary>
 		public ulong? SinceWhenId { get; set; }

--- a/src/Makefile
+++ b/src/Makefile
@@ -112,6 +112,11 @@ BGEN_WARNINGS_TO_FIX=BI1234
 #
 CSC_WARNINGS_TO_FIX=108,219,618,114,414,1635,3021,4014
 
+# warning CS1591: Missing XML comment for publicly visible type or member
+# We (will) post-process xml documentation to add missing members, so
+# we can ignore this warning.
+CSC_WARNINGS_TO_FIX:=$(CSC_WARNINGS_TO_FIX),1591
+
 WARNINGS_TO_FIX = -nowarn:$(CSC_WARNINGS_TO_FIX)
 CORE_WARNINGS_TO_FIX = -nowarn:$(CSC_WARNINGS_TO_FIX),$(BGEN_WARNINGS_TO_FIX)
 
@@ -1183,12 +1188,15 @@ $($(2)_DOTNET_BUILD_DIR)/$(3).rsp: Makefile Makefile.generator frameworks.source
 DOTNET_TARGETS += \
 	$($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1).dll \
 	$(DOTNET_DESTDIR)/$($(2)_NUGET).Ref/ref/$(DOTNET_TFM)/Microsoft.$(1).dll \
+	$(DOTNET_DESTDIR)/$($(2)_NUGET).Ref/ref/$(DOTNET_TFM)/Microsoft.$(1).xml \
 
 DOTNET_TARGETS_DIRS += \
 	$($(2)_DOTNET_BUILD_DIR) \
 	$($(2)_DOTNET_BUILD_DIR)/generated-sources \
 	$($(2)_DOTNET_BUILD_DIR)/ref \
+	$($(2)_DOTNET_BUILD_DIR)/doc \
 	$(DOTNET_DESTDIR)/$($(2)_NUGET).Ref/ref/$(DOTNET_TFM) \
+	$(DOTNET_DESTDIR)/$($(2)_NUGET).Ref/doc/$(DOTNET_TFM) \
 
 dotnet-gen-$(3):: $($(2)_DOTNET_BUILD_DIR)/$(3)-generated-sources
 dotnet-gen:: dotnet-gen-$(3)
@@ -1202,6 +1210,11 @@ $($(2)_DOTNET_BUILD_DIR)/ILLink.Substitutions.xml: $(TOP)/src/ILLink.Substitutio
 $(DOTNET_DESTDIR)/$($(2)_NUGET).Ref/ref/$(DOTNET_TFM)/Microsoft.$(1).dll: $($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1).dll | $(DOTNET_DESTDIR)/$($(2)_NUGET).Ref/ref/$(DOTNET_TFM)
 	$(Q) $(CP) $$< $$@
 
+$(DOTNET_DESTDIR)/$($(2)_NUGET).Ref/ref/$(DOTNET_TFM)/Microsoft.$(1).xml: $($(2)_DOTNET_BUILD_DIR)/doc/Microsoft.$(1).xml | $(DOTNET_DESTDIR)/$($(2)_NUGET).Ref/ref/$(DOTNET_TFM)
+	$(Q) $(CP) $$< $$@
+
+$($(2)_DOTNET_BUILD_DIR)/doc/Microsoft.$(1).xml: $($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1).xml $($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1).dll | $($(2)_DOTNET_BUILD_DIR)/doc
+	$$(Q_GEN) $(TOP)/tools/add-apple-links-to-docs.sh --assembly $($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1).dll --input $($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1).xml --output $$@
 endef
 
 # Template variables:
@@ -1219,6 +1232,8 @@ define BuildDotNetPlatformAssembly
 ifeq ($(4),64)
 $(2)_$(4)_REFOUT_ARG = -refout:$($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1).dll
 $(2)_$(4)_REF_TARGET = $($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1)%dll
+$(2)_$(4)_DOC_ARG = -doc:$($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1).xml
+$(2)_$(4)_DOC_TARGET = $($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1)%xml
 endif
 
 $(2)_DOTNET_PLATFORM_ASSEMBLY_DEPENDENCIES = \
@@ -1232,7 +1247,7 @@ $(2)_DOTNET_PLATFORM_ASSEMBLY_DIR_DEPENDENCIES = \
 	$($(2)_DOTNET_BUILD_DIR)/$(4) \
 	$($(2)_DOTNET_BUILD_DIR)/ref \
 
-$($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1)%dll $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1)%pdb $$($(2)_$(4)_REF_TARGET): $$($(2)_DOTNET_PLATFORM_ASSEMBLY_DEPENDENCIES) | $$($(2)_DOTNET_PLATFORM_ASSEMBLY_DIR_DEPENDENCIES)
+$($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1)%dll $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1)%pdb $$($(2)_$(4)_REF_TARGET) $$($(2)_$(4)_DOC_TARGET): $$($(2)_DOTNET_PLATFORM_ASSEMBLY_DEPENDENCIES) | $$($(2)_DOTNET_PLATFORM_ASSEMBLY_DIR_DEPENDENCIES)
 	$$(call Q_PROF_CSC,dotnet/$(4)-bit) \
 		$(DOTNET_CSC)  \
 		$(DOTNET_FLAGS) \
@@ -1241,6 +1256,7 @@ $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1)%dll $($(2)_DOTNET_BUILD_DIR)/$(4)/M
 		$$(ARGS_$(1)) \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) \
 		$$($(2)_$(4)_REFOUT_ARG) \
+		$$($(2)_$(4)_DOC_ARG) \
 		$$($(2)_DEFINES) \
 		$(ARGS_$(4)) \
 		$$(DOTNET_WARNINGS_TO_FIX) \

--- a/src/SceneKit/SCNMatrix4_dotnet.cs
+++ b/src/SceneKit/SCNMatrix4_dotnet.cs
@@ -965,23 +965,27 @@ namespace SceneKit {
 
 #region Multiply Functions
 
+#if XAMCORE_5_0
 		/// <summary>
 		/// Combines two transformation matrices.
 		/// </summary>
-#if XAMCORE_5_0
 		/// <remarks>
 		/// Combining two transformation matrices means using matrix multiplication to multiply them in the reverse order (secondTransformation * firstTransformation).
 		/// </remarks>
 		/// <param name="firstTransformation">The first transformation of the combination.</param>
 		/// <param name="secondTransformation">The second transformation of the combination.</param>
+		/// <returns>A new instance that is the result of the combination</returns>
 #else
+		/// <summary>
+		/// Combines two transformation matrices.
+		/// </summary>
 		/// <remarks>
 		/// Combining two transformation matrices means using matrix multiplication to multiply them in the reverse order (right * left).
 		/// </remarks>
 		/// <param name="left">The first transformation of the combination.</param>
 		/// <param name="right">The second transformation of the combination.</param>
-#endif
 		/// <returns>A new instance that is the result of the combination</returns>
+#endif
 #if XAMCORE_5_0
 		public static SCNMatrix4 Mult (SCNMatrix4 firstTransformation, SCNMatrix4 secondTransformation)
 #else
@@ -998,23 +1002,27 @@ namespace SceneKit {
 			return result;
 		}
 
+#if XAMCORE_5_0
 		/// <summary>
 		/// Combines two transformation matrices.
 		/// </summary>
-#if XAMCORE_5_0
 		/// <remarks>
 		/// Combining two transformation matrices means using matrix multiplication to multiply them in the reverse order (secondTransformation * firstTransformation).
 		/// </remarks>
 		/// <param name="firstTransformation">The first transformation of the combination.</param>
 		/// <param name="secondTransformation">The second transformation of the combination.</param>
+		/// <param name="result">A new instance that is the result of the combination</param>
 #else
+		/// <summary>
+		/// Combines two transformation matrices.
+		/// </summary>
 		/// <remarks>
 		/// Combining two transformation matrices means using matrix multiplication to multiply them in the reverse order (right * left).
 		/// </remarks>
 		/// <param name="left">The first transformation of the combination.</param>
 		/// <param name="right">The second transformation of the combination.</param>
-#endif
 		/// <param name="result">A new instance that is the result of the combination</param>
+#endif
 #if XAMCORE_5_0
 		public static void Mult (ref SCNMatrix4 firstTransformation, ref SCNMatrix4 secondTransformation, out SCNMatrix4 result)
 #else
@@ -1138,7 +1146,7 @@ namespace SceneKit {
 		/// <summary>
 		/// Calculate the inverse of the given matrix
 		/// </summary>
-		/// <param name="mat">The matrix to invert</param>
+		/// <param name="matrix">The matrix to invert</param>
 		/// <returns>The inverse of the given matrix if it has one, or the input if it is singular</returns>
 		/// <exception cref="InvalidOperationException">Thrown if the SCNMatrix4 is singular.</exception>
 		public static SCNMatrix4 Invert (SCNMatrix4 matrix)

--- a/src/SceneKit/SCNVector3.cs
+++ b/src/SceneKit/SCNVector3.cs
@@ -737,14 +737,16 @@ namespace SceneKit {
         /// Assumes the matrix has a right-most column of (0,0,0,1), that is the translation part is ignored.
         /// </summary>
         /// <param name="vec">The column vector to transform</param>
+		/// <param name="mat">The desired transformation</param>
+		/// <returns>The transformed vector</returns>
 #else
 		/// <summary>Transform a direction vector by the given Matrix
 		/// Assumes the matrix has a bottom row of (0,0,0,1), that is the translation part is ignored.
 		/// </summary>
 		/// <param name="vec">The row vector to transform</param>
-#endif
 		/// <param name="mat">The desired transformation</param>
 		/// <returns>The transformed vector</returns>
+#endif
 		public static SCNVector3 TransformVector (SCNVector3 vec, SCNMatrix4 mat)
 		{
 			TransformVector (ref vec, ref mat, out var v);
@@ -756,14 +758,16 @@ namespace SceneKit {
         /// Assumes the matrix has a right-most column of (0,0,0,1), that is the translation part is ignored.
         /// </summary>
         /// <param name="vec">The column vector to transform</param>
+		/// <param name="mat">The desired transformation</param>
+		/// <param name="result">The transformed vector</param>
 #else
 		/// <summary>Transform a direction vector by the given Matrix
 		/// Assumes the matrix has a bottom row of (0,0,0,1), that is the translation part is ignored.
 		/// </summary>
 		/// <param name="vec">The row vector to transform</param>
-#endif
 		/// <param name="mat">The desired transformation</param>
 		/// <param name="result">The transformed vector</param>
+#endif
 		public static void TransformVector (ref SCNVector3 vec, ref SCNMatrix4 mat, out SCNVector3 result)
 		{
 #if NET
@@ -793,72 +797,100 @@ namespace SceneKit {
 #endif
 		}
 
+#if NET
 		/// <summary>Transform a Normal by the given Matrix</summary>
 		/// <remarks>
 		/// This calculates the inverse of the given matrix, use TransformNormalInverse if you
 		/// already have the inverse to avoid this extra calculation
 		/// </remarks>
-#if NET
         /// <param name="norm">The column-based normal to transform</param>
-#else
-		/// <param name="norm">The row-based normal to transform</param>
-#endif
 		/// <param name="mat">The desired transformation</param>
 		/// <returns>The transformed normal</returns>
+#else
+		/// <summary>Transform a Normal by the given Matrix</summary>
+		/// <remarks>
+		/// This calculates the inverse of the given matrix, use TransformNormalInverse if you
+		/// already have the inverse to avoid this extra calculation
+		/// </remarks>
+		/// <param name="norm">The row-based normal to transform</param>
+		/// <param name="mat">The desired transformation</param>
+		/// <returns>The transformed normal</returns>
+#endif
 		public static SCNVector3 TransformNormal (SCNVector3 norm, SCNMatrix4 mat)
 		{
 			mat.Invert ();
 			return TransformNormalInverse (norm, mat);
 		}
 
+#if NET
 		/// <summary>Transform a Normal by the given Matrix</summary>
 		/// <remarks>
 		/// This calculates the inverse of the given matrix, use TransformNormalInverse if you
 		/// already have the inverse to avoid this extra calculation
 		/// </remarks>
-#if NET
         /// <param name="norm">The column-based normal to transform</param>
-#else
-		/// <param name="norm">The row-based normal to transform</param>
-#endif
 		/// <param name="mat">The desired transformation</param>
 		/// <param name="result">The transformed normal</param>
+#else
+		/// <summary>Transform a Normal by the given Matrix</summary>
+		/// <remarks>
+		/// This calculates the inverse of the given matrix, use TransformNormalInverse if you
+		/// already have the inverse to avoid this extra calculation
+		/// </remarks>
+		/// <param name="norm">The row-based normal to transform</param>
+		/// <param name="mat">The desired transformation</param>
+		/// <param name="result">The transformed normal</param>
+#endif
 		public static void TransformNormal (ref SCNVector3 norm, ref SCNMatrix4 mat, out SCNVector3 result)
 		{
 			SCNMatrix4 Inverse = SCNMatrix4.Invert (mat);
 			SCNVector3.TransformNormalInverse (ref norm, ref Inverse, out result);
 		}
 
+#if NET
 		/// <summary>Transform a Normal by the (transpose of the) given Matrix</summary>
 		/// <remarks>
 		/// This version doesn't calculate the inverse matrix.
 		/// Use this version if you already have the inverse of the desired transform to hand
 		/// </remarks>
-#if NET
         /// <param name="norm">The column-based normal to transform</param>
-#else
-		/// <param name="norm">The row-based normal to transform</param>
-#endif
 		/// <param name="invMat">The inverse of the desired transformation</param>
 		/// <returns>The transformed normal</returns>
+#else
+		/// <summary>Transform a Normal by the (transpose of the) given Matrix</summary>
+		/// <remarks>
+		/// This version doesn't calculate the inverse matrix.
+		/// Use this version if you already have the inverse of the desired transform to hand
+		/// </remarks>
+		/// <param name="norm">The row-based normal to transform</param>
+		/// <param name="invMat">The inverse of the desired transformation</param>
+		/// <returns>The transformed normal</returns>
+#endif
 		public static SCNVector3 TransformNormalInverse (SCNVector3 norm, SCNMatrix4 invMat)
 		{
 			TransformNormalInverse (ref norm, ref invMat, out var n);
 			return n;
 		}
 
+#if NET
 		/// <summary>Transform a Normal by the (transpose of the) given Matrix</summary>
 		/// <remarks>
 		/// This version doesn't calculate the inverse matrix.
 		/// Use this version if you already have the inverse of the desired transform to hand
 		/// </remarks>
-#if NET
         /// <param name="norm">The column-based normal to transform</param>
-#else
-		/// <param name="norm">The row-based normal to transform</param>
-#endif
 		/// <param name="invMat">The inverse of the desired transformation</param>
 		/// <param name="result">The transformed normal</param>
+#else
+		/// <summary>Transform a Normal by the (transpose of the) given Matrix</summary>
+		/// <remarks>
+		/// This version doesn't calculate the inverse matrix.
+		/// Use this version if you already have the inverse of the desired transform to hand
+		/// </remarks>
+		/// <param name="norm">The row-based normal to transform</param>
+		/// <param name="invMat">The inverse of the desired transformation</param>
+		/// <param name="result">The transformed normal</param>
+#endif
 		public static void TransformNormalInverse (ref SCNVector3 norm, ref SCNMatrix4 invMat, out SCNVector3 result)
 		{
 #if NET
@@ -888,28 +920,34 @@ namespace SceneKit {
 #endif
 		}
 
-		/// <summary>Transform a Position by the given Matrix</summary>
 #if NET
+		/// <summary>Transform a Position by the given Matrix</summary>
         /// <param name="pos">The column-based position to transform</param>
-#else
-		/// <param name="pos">The row-based position to transform</param>
-#endif
 		/// <param name="mat">The desired transformation</param>
 		/// <returns>The transformed position</returns>
+#else
+		/// <summary>Transform a Position by the given Matrix</summary>
+		/// <param name="pos">The row-based position to transform</param>
+		/// <param name="mat">The desired transformation</param>
+		/// <returns>The transformed position</returns>
+#endif
 		public static SCNVector3 TransformPosition (SCNVector3 pos, SCNMatrix4 mat)
 		{
 			TransformPosition (ref pos, ref mat, out var p);
 			return p;
 		}
 
-		/// <summary>Transform a Position by the given Matrix</summary>
 #if NET
+		/// <summary>Transform a Position by the given Matrix</summary>
         /// <param name="pos">The column-based position to transform</param>
-#else
-		/// <param name="pos">The row-based position to transform</param>
-#endif
 		/// <param name="mat">The desired transformation</param>
 		/// <param name="result">The transformed position</param>
+#else
+		/// <summary>Transform a Position by the given Matrix</summary>
+		/// <param name="pos">The row-based position to transform</param>
+		/// <param name="mat">The desired transformation</param>
+		/// <param name="result">The transformed position</param>
+#endif
 		public static void TransformPosition (ref SCNVector3 pos, ref SCNMatrix4 mat, out SCNVector3 result)
 		{
 #if NET
@@ -945,28 +983,34 @@ namespace SceneKit {
 #endif
 		}
 
-		/// <summary>Transform a Vector by the given Matrix</summary>
 #if NET
+		/// <summary>Transform a Vector by the given Matrix</summary>
         /// <param name="vec">The column vector to transform</param>
-#else
-		/// <param name="vec">The row vector to transform</param>
-#endif
 		/// <param name="mat">The desired transformation</param>
 		/// <returns>The transformed vector</returns>
+#else
+		/// <summary>Transform a Vector by the given Matrix</summary>
+		/// <param name="vec">The row vector to transform</param>
+		/// <param name="mat">The desired transformation</param>
+		/// <returns>The transformed vector</returns>
+#endif
 		public static SCNVector4 Transform (SCNVector3 vec, SCNMatrix4 mat)
 		{
 			SCNVector4 v4 = new SCNVector4 (vec.X, vec.Y, vec.Z, 1.0f);
 			return SCNVector4.Transform (v4, mat);
 		}
 
-		/// <summary>Transform a Vector by the given Matrix</summary>
 #if NET
+		/// <summary>Transform a Vector by the given Matrix</summary>
         /// <param name="vec">The column vector to transform</param>
-#else
-		/// <param name="vec">The row vector to transform</param>
-#endif
 		/// <param name="mat">The desired transformation</param>
 		/// <param name="result">The transformed vector</param>
+#else
+		/// <summary>Transform a Vector by the given Matrix</summary>
+		/// <param name="vec">The row vector to transform</param>
+		/// <param name="mat">The desired transformation</param>
+		/// <param name="result">The transformed vector</param>
+#endif
 		public static void Transform (ref SCNVector3 vec, ref SCNMatrix4 mat, out SCNVector4 result)
 		{
 			SCNVector4 v4 = new SCNVector4 (vec.X, vec.Y, vec.Z, 1.0f);

--- a/src/SceneKit/SCNVector4.cs
+++ b/src/SceneKit/SCNVector4.cs
@@ -834,28 +834,34 @@ namespace SceneKit {
 
 		#region Transform
 
-		/// <summary>Transform a Vector by the given Matrix</summary>
 #if NET
+		/// <summary>Transform a Vector by the given Matrix</summary>
         /// <param name="vec">The column vector to transform</param>
-#else
-		/// <param name="vec">The row vector to transform</param>
-#endif
 		/// <param name="mat">The desired transformation</param>
 		/// <returns>The transformed vector</returns>
+#else
+		/// <summary>Transform a Vector by the given Matrix</summary>
+		/// <param name="vec">The row vector to transform</param>
+		/// <param name="mat">The desired transformation</param>
+		/// <returns>The transformed vector</returns>
+#endif
 		public static SCNVector4 Transform (SCNVector4 vec, SCNMatrix4 mat)
 		{
 			Transform (ref vec, ref mat, out var result);
 			return result;
 		}
 
-		/// <summary>Transform a Vector by the given Matrix.</summary>
 #if NET
+		/// <summary>Transform a Vector by the given Matrix.</summary>
         /// <param name="vec">The column vector to transform</param>
-#else
-		/// <param name="vec">The row vector to transform</param>
-#endif
 		/// <param name="mat">The desired transformation</param>
 		/// <param name="result">The transformed vector</param>
+#else
+		/// <summary>Transform a Vector by the given Matrix.</summary>
+		/// <param name="vec">The row vector to transform</param>
+		/// <param name="mat">The desired transformation</param>
+		/// <param name="result">The transformed vector</param>
+#endif
 		public static void Transform (ref SCNVector4 vec, ref SCNMatrix4 mat, out SCNVector4 result)
 		{
 #if NET

--- a/tools/add-apple-links-to-docs.sh
+++ b/tools/add-apple-links-to-docs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+#
+# This is just a placeholder script until the tool has been implemented.
+# Ref: https://github.com/xamarin/xamarin-macios/issues/17398
+#
+
+# $1: --assembly
+ASSEMBLY="$2"
+# $3: --input
+INPUT="$4"
+# $5: --output
+OUTPUT="$6"
+
+cp -c "$INPUT" "$OUTPUT"


### PR DESCRIPTION
Also fix XML comments to be valid and not produce compiler warnings.

Unfortunately XML comments can't be conditionally compiled
(https://github.com/dotnet/csharplang/discussions/295), so we have to 
duplicate a lot of content that is just slightly different.

Fixes https://github.com/xamarin/xamarin-macios/issues/17395.