### PR TITLE
[release/8.0.1xx-preview1] [tests] 'dotnet pack' will now build the Release configuration by default.

### DIFF
--- a/tests/dotnet/UnitTests/PackTest.cs
+++ b/tests/dotnet/UnitTests/PackTest.cs
@@ -149,7 +149,7 @@ namespace Xamarin.Tests {
 			var project = "MyClassLibrary";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 
-			var project_path = GetProjectPath (project, runtimeIdentifiers: string.Empty, platform: platform, out var appPath);
+			var project_path = GetProjectPath (project, runtimeIdentifiers: string.Empty, platform: platform, out var appPath, configuration: "Release");
 			Clean (project_path);
 			var properties = GetDefaultProperties ();
 


### PR DESCRIPTION
So update tests acccordingly.