### PR TITLE
[dotnet] Only include the Xamarin.Shared.Sdk.MultiTarget.targets file if it exists. Fixes #16400.

### DIFF
--- a/dotnet/Workloads/WorkloadManifest.MacCatalyst.template.targets
+++ b/dotnet/Workloads/WorkloadManifest.MacCatalyst.template.targets
@@ -9,6 +9,7 @@
 	</ItemGroup>
 
 	<PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == 'MacCatalyst' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
-		<AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(_XamarinSdkRootDirectory)..\@NUGET_VERSION_NO_METADATA@\targets\Xamarin.Shared.Sdk.MultiTarget.targets</AfterMicrosoftNETSdkTargets>
+		<_MultiTargetTargetsFile>$(_XamarinSdkRootDirectory)..\@NUGET_VERSION_NO_METADATA@\targets\Xamarin.Shared.Sdk.MultiTarget.targets</_MultiTargetTargetsFile>
+		<AfterMicrosoftNETSdkTargets Condition="Exists('$(_MultiTargetTargetsFile)')">$(AfterMicrosoftNETSdkTargets);$(_MultiTargetTargetsFile)</AfterMicrosoftNETSdkTargets>
 	</PropertyGroup>
 </Project>

--- a/dotnet/Workloads/WorkloadManifest.iOS.template.targets
+++ b/dotnet/Workloads/WorkloadManifest.iOS.template.targets
@@ -11,6 +11,7 @@
 	</ItemGroup>
 
 	<PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == 'iOS' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
-		<AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(_XamarinSdkRootDirectory)..\@NUGET_VERSION_NO_METADATA@\targets\Xamarin.Shared.Sdk.MultiTarget.targets</AfterMicrosoftNETSdkTargets>
+		<_MultiTargetTargetsFile>$(_XamarinSdkRootDirectory)..\@NUGET_VERSION_NO_METADATA@\targets\Xamarin.Shared.Sdk.MultiTarget.targets</_MultiTargetTargetsFile>
+		<AfterMicrosoftNETSdkTargets Condition="Exists('$(_MultiTargetTargetsFile)')">$(AfterMicrosoftNETSdkTargets);$(_MultiTargetTargetsFile)</AfterMicrosoftNETSdkTargets>
 	</PropertyGroup>
 </Project>

--- a/dotnet/Workloads/WorkloadManifest.macOS.template.targets
+++ b/dotnet/Workloads/WorkloadManifest.macOS.template.targets
@@ -9,6 +9,7 @@
 	</ItemGroup>
 
 	<PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == 'macOS' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
-		<AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(_XamarinSdkRootDirectory)..\@NUGET_VERSION_NO_METADATA@\targets\Xamarin.Shared.Sdk.MultiTarget.targets</AfterMicrosoftNETSdkTargets>
+		<_MultiTargetTargetsFile>$(_XamarinSdkRootDirectory)..\@NUGET_VERSION_NO_METADATA@\targets\Xamarin.Shared.Sdk.MultiTarget.targets</_MultiTargetTargetsFile>
+		<AfterMicrosoftNETSdkTargets Condition="Exists('$(_MultiTargetTargetsFile)')">$(AfterMicrosoftNETSdkTargets);$(_MultiTargetTargetsFile)</AfterMicrosoftNETSdkTargets>
 	</PropertyGroup>
 </Project>

--- a/dotnet/Workloads/WorkloadManifest.tvOS.template.targets
+++ b/dotnet/Workloads/WorkloadManifest.tvOS.template.targets
@@ -9,6 +9,7 @@
 	</ItemGroup>
 
 	<PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == 'tvOS' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
-		<AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(_XamarinSdkRootDirectory)..\@NUGET_VERSION_NO_METADATA@\targets\Xamarin.Shared.Sdk.MultiTarget.targets</AfterMicrosoftNETSdkTargets>
+		<_MultiTargetTargetsFile>$(_XamarinSdkRootDirectory)..\@NUGET_VERSION_NO_METADATA@\targets\Xamarin.Shared.Sdk.MultiTarget.targets</_MultiTargetTargetsFile>
+		<AfterMicrosoftNETSdkTargets Condition="Exists('$(_MultiTargetTargetsFile)')">$(AfterMicrosoftNETSdkTargets);$(_MultiTargetTargetsFile)</AfterMicrosoftNETSdkTargets>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Hopefully fixes https://github.com/xamarin/xamarin-macios/issues/16400.