### PR TITLE
[msbuild] Add DT* entries to the Info.plist for all platforms. Fixes #13300.

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
@@ -137,5 +137,35 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task, expectedErrorCount: 1);
 			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.StartWith ("Could not map the Mac Catalyst version 10.0 to a corresponding macOS version. Valid Mac Catalyst versions are:"));
 		}
+
+		[Test]
+		[TestCase (ApplePlatform.iOS, true)]
+		[TestCase (ApplePlatform.iOS, false)]
+		[TestCase (ApplePlatform.MacCatalyst, false)]
+		[TestCase (ApplePlatform.TVOS, true)]
+		[TestCase (ApplePlatform.TVOS, false)]
+		[TestCase (ApplePlatform.MacOSX, false)]
+		public void XcodeVariables (ApplePlatform platform, bool isSimulator)
+		{
+			var task = CreateTask (platform: platform);
+			task.SdkIsSimulator = isSimulator;
+			ExecuteTask (task);
+
+			var plist = PDictionary.FromFile (task.CompiledAppManifest.ItemSpec);
+			var variables = new string [] {
+				"DTCompiler",
+				"DTPlatformBuild",
+				"DTPlatformName",
+				"DTPlatformVersion",
+				"DTSDKBuild",
+				"DTSDKName",
+				"DTXcode",
+				"DTXcodeBuild",
+			};
+			foreach (var variable in variables) {
+				var value = plist.GetString (variable)?.Value;
+				Assert.That (value, Is.Not.Null.And.Not.Empty, variable);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Modify the code to add Xcode (DT*) variables to the Info.plist:

* Do it for all platforms, not only mobile platforms. Apple uses these fields to
  determine if an app was built with a prerelease or old version of Xcode, and will
  reject any app submissions if this validation fails.

* Change the behavior to do not distinguish simulator builds, a bit of testing
  in Xcode shows that Xcode always adds these values to the Info.plist, even for
  simulator builds. This is probably something that changed in Xcode a *long* time
  ago, since this code is old (from the initial import of the build logic from MonoDevelop
  around 10 years ago).

* Also bump Xamarin.MacDev to get a related fix:

  New commits in xamarin/Xamarin.MacDev:

  * xamarin/Xamarin.MacDev@74c95ee [Xamarin.MacDev] Always fetch the DTSDKBuild variable.

  Diff: https://github.com/xamarin/Xamarin.MacDev/compare/14d53612d4624459a7ae617141c45e940ada6df5..74c95ee1c345cc194a35e6f0c9400f6a55a9b617

Fixes https://github.com/xamarin/xamarin-macios/issues/13300.