### PR TITLE
[Localization] Revert "[CI] Remove the translations from the main stage. (#17453)"

### DIFF
--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -32,6 +32,10 @@ parameters:
   type: boolean
   default: true
 
+- name: runTranslations
+  type: boolean
+  default: true
+
 - name: runSamples
   type: boolean
   default: false
@@ -195,7 +199,7 @@ stages:
           repositoryAlias: ${{ parameters.repositoryAlias }}
           commit: ${{ parameters.commit }}
 
-    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+    - ${{ if and(eq(parameters.runTranslations, true), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
       - job: translations
         displayName: 'Loc translations'
         pool:

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -195,7 +195,7 @@ stages:
           repositoryAlias: ${{ parameters.repositoryAlias }}
           commit: ${{ parameters.commit }}
 
-    - ${{ if: and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.DefinitionName'], 'xamarin-macios-ci')) }}:
+    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
       - job: translations
         displayName: 'Loc translations'
         pool:

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -195,6 +195,19 @@ stages:
           repositoryAlias: ${{ parameters.repositoryAlias }}
           commit: ${{ parameters.commit }}
 
+    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+      - job: translations
+        displayName: 'Loc translations'
+        pool:
+          vmImage: windows-latest
+        steps:
+        - template: loc-translations.yml
+          parameters:
+            isPR: ${{ parameters.isPR }}
+            repositoryAlias: ${{ parameters.repositoryAlias }}
+            commit: ${{ parameters.commit }}
+
+
 - ${{ if parameters.isPR }}:
   - stage: clean
     displayName: '${{ parameters.stageDisplayNamePrefix }}Clean up'

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -195,7 +195,7 @@ stages:
           repositoryAlias: ${{ parameters.repositoryAlias }}
           commit: ${{ parameters.commit }}
 
-    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+    - ${{ if: and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.DefinitionName'], 'xamarin-macios-ci')) }}:
       - job: translations
         displayName: 'Loc translations'
         pool:


### PR DESCRIPTION
This reverts commit 59aebf259cf936604d72621e3cb6dd8585620d6c.

We actually do need to keep this task inside our normal builds for the Loc team to identify if there are new translations through the localizationDrop artifact. The other pipeline that runs this task on the cron job is used for a separate part of the localization process that creates the PRs with the usable translations.

https://github.com/xamarin/maccore/wiki/Localization#the-translation-process