### PR TITLE
[release/8.0.1xx-preview1] [dotnet-linker] Make this a .NET 7 app to work around the fact that the linker is still a .NET 7 app.

### DIFF
--- a/tools/dotnet-linker/Makefile
+++ b/tools/dotnet-linker/Makefile
@@ -3,7 +3,7 @@ TOP=../..
 include $(TOP)/Make.config
 include $(TOP)/mk/rules.mk
 
-BUILD_DIR=bin/Debug/net8.0
+BUILD_DIR=bin/Debug/net7.0
 
 DOTNET_TARGETS += \
 	$(BUILD_DIR)/dotnet-linker.dll \

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>dotnet_linker</RootNamespace>
     <DefineConstants>$(DefineConstants);BUNDLER</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Hopefully works around https://github.com/dotnet/runtime/issues/82241.