### PR TITLE
[Generator] Move naming logic to its own class and add tests.

### DIFF
--- a/src/bgen/AttributeManager.cs
+++ b/src/bgen/AttributeManager.cs
@@ -7,7 +7,15 @@ using ObjCRuntime;
 using PlatformName = ObjCRuntime.PlatformName;
 #endif
 
-public class AttributeManager {
+public interface IAttributeManager {
+	T [] GetCustomAttributes<T> (ICustomAttributeProvider provider) where T : System.Attribute;
+	bool HasAttribute<T> (ICustomAttributeProvider provider) where T : Attribute;
+	bool HasAttribute<T> (ICustomAttributeProvider i, Attribute [] attributes) where T : Attribute;
+	T GetCustomAttribute<T> (ICustomAttributeProvider provider) where T : System.Attribute;
+	bool HasNativeAttribute (ICustomAttributeProvider provider);
+}
+
+public class AttributeManager : IAttributeManager {
 	public BindingTouch BindingTouch;
 	TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
 

--- a/src/bgen/AttributeManager.cs
+++ b/src/bgen/AttributeManager.cs
@@ -8,10 +8,10 @@ using PlatformName = ObjCRuntime.PlatformName;
 #endif
 
 public interface IAttributeManager {
-	T [] GetCustomAttributes<T> (ICustomAttributeProvider provider) where T : System.Attribute;
+	T [] GetCustomAttributes<T> (ICustomAttributeProvider provider) where T : Attribute;
 	bool HasAttribute<T> (ICustomAttributeProvider provider) where T : Attribute;
 	bool HasAttribute<T> (ICustomAttributeProvider i, Attribute [] attributes) where T : Attribute;
-	T GetCustomAttribute<T> (ICustomAttributeProvider provider) where T : System.Attribute;
+	T GetCustomAttribute<T> (ICustomAttributeProvider provider) where T : Attribute;
 	bool HasNativeAttribute (ICustomAttributeProvider provider);
 }
 

--- a/src/bgen/AttributeManager.cs
+++ b/src/bgen/AttributeManager.cs
@@ -7,15 +7,7 @@ using ObjCRuntime;
 using PlatformName = ObjCRuntime.PlatformName;
 #endif
 
-public interface IAttributeManager {
-	T [] GetCustomAttributes<T> (ICustomAttributeProvider provider) where T : Attribute;
-	bool HasAttribute<T> (ICustomAttributeProvider provider) where T : Attribute;
-	bool HasAttribute<T> (ICustomAttributeProvider i, Attribute [] attributes) where T : Attribute;
-	T GetCustomAttribute<T> (ICustomAttributeProvider provider) where T : Attribute;
-	bool HasNativeAttribute (ICustomAttributeProvider provider);
-}
-
-public class AttributeManager : IAttributeManager {
+public class AttributeManager {
 	public BindingTouch BindingTouch;
 	TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
 
@@ -24,7 +16,7 @@ public class AttributeManager : IAttributeManager {
 		BindingTouch = binding_touch;
 	}
 
-	System.Type LookupReflectionType (string fullname, ICustomAttributeProvider provider)
+	Type LookupReflectionType (string fullname, ICustomAttributeProvider provider)
 	{
 		switch (fullname) {
 		case "AbstractAttribute":
@@ -506,7 +498,7 @@ public class AttributeManager : IAttributeManager {
 		return Array.Empty<T> ();
 	}
 
-	public T [] GetCustomAttributes<T> (ICustomAttributeProvider provider) where T : System.Attribute
+	public virtual T [] GetCustomAttributes<T> (ICustomAttributeProvider provider) where T : System.Attribute
 	{
 		return FilterAttributes<T> (GetIKVMAttributes (provider), provider);
 	}
@@ -535,7 +527,7 @@ public class AttributeManager : IAttributeManager {
 		return false;
 	}
 
-	public bool HasAttribute<T> (ICustomAttributeProvider provider) where T : Attribute
+	public virtual bool HasAttribute<T> (ICustomAttributeProvider provider) where T : Attribute
 	{
 		var attribute_type = ConvertTypeToMeta (typeof (T), provider);
 		var attribs = GetIKVMAttributes (provider);
@@ -553,7 +545,7 @@ public class AttributeManager : IAttributeManager {
 		return false;
 	}
 
-	public T GetCustomAttribute<T> (ICustomAttributeProvider provider) where T : System.Attribute
+	public virtual T GetCustomAttribute<T> (ICustomAttributeProvider provider) where T : System.Attribute
 	{
 		if (provider is null)
 			return null;
@@ -583,7 +575,7 @@ public class AttributeManager : IAttributeManager {
 		throw ErrorHelper.CreateError (1059, rv.Length, typeof (T).FullName, name);
 	}
 
-	public bool HasNativeAttribute (ICustomAttributeProvider provider)
+	public virtual bool HasNativeAttribute (ICustomAttributeProvider provider)
 	{
 		if (provider is null)
 			return false;
@@ -591,7 +583,7 @@ public class AttributeManager : IAttributeManager {
 		return HasAttribute (provider, "NativeIntegerAttribute");
 	}
 
-	public bool HasAttribute<T> (ICustomAttributeProvider i, Attribute [] attributes) where T : Attribute
+	public virtual bool HasAttribute<T> (ICustomAttributeProvider i, Attribute [] attributes) where T : Attribute
 	{
 		if (attributes is null)
 			return HasAttribute<T> (i);

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -6825,7 +6825,7 @@ public partial class Generator : IMemberGatherer {
 							PrintObsoleteAttributes (mi);
 
 							if (bta.Singleton && mi.GetParameters ().Length == 0 || mi.GetParameters ().Length == 1)
-								print ("public event EventHandler {0} {{", nomenclator.GetEventName (mi).CamelCase ());
+								print ("public event EventHandler {0} {{", Nomenclator.GetEventName (mi).CamelCase ());
 							else
 								print ("public event EventHandler<{0}> {1} {{", Nomenclator.GetEventArgName (mi), Nomenclator.GetEventName (mi).CamelCase ());
 							print ("\tadd {{ Ensure{0} ({1})!.{2} += value; }}", dtype.Name, ensureArg, miname);

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -64,11 +64,9 @@ public partial class Generator : IMemberGatherer {
 	public AttributeManager AttributeManager { get { return BindingTouch.AttributeManager; } }
 
 	Nomenclator nomenclator;
-	Nomenclator Nomenclator
-	{
-		get
-		{
-			nomenclator ??= new(AttributeManager);
+	Nomenclator Nomenclator {
+		get {
+			nomenclator ??= new (AttributeManager);
 			return nomenclator;
 		}
 	}
@@ -673,7 +671,7 @@ public partial class Generator : IMemberGatherer {
 		owns = att.Owns ? "true" : "false";
 		return true;
 	}
-	
+
 	//
 	// MakeTrampoline: processes a delegate type and registers a TrampolineInfo with all the information
 	// necessary to create trampolines that allow Objective-C blocks to call C# code, and C# code to call
@@ -7346,7 +7344,7 @@ public partial class Generator : IMemberGatherer {
 	{
 		return parameters.Any (pi => pi.ParameterType.IsByRef);
 	}
-	
+
 	object GetDefaultValue (MethodInfo mi)
 	{
 		Attribute a = AttributeManager.GetCustomAttribute<DefaultValueAttribute> (mi);

--- a/src/bgen/Nomenclator.cs
+++ b/src/bgen/Nomenclator.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+#nullable enable
+
+// Noun. nomenclator (plural nomenclators) An assistant who specializes in providing timely and spatially relevant
+// reminders of the names of persons and other socially important information
+public class Nomenclator {
+	readonly Dictionary<string, bool> skipGeneration = new();
+	readonly HashSet<string> repeatedDelegateApiNames = new();
+	readonly Dictionary<Type, int> trampolinesGenericVersions = new();
+
+	readonly IAttributeManager attributeManager;
+
+	public Nomenclator (IAttributeManager attributeManager)
+	{
+		this.attributeManager = attributeManager;
+	}
+	
+	public string GetDelegateName (MethodInfo mi)
+	{
+		Attribute a = attributeManager.GetCustomAttribute<DelegateNameAttribute> (mi);
+		if (a is not null)
+			return ((DelegateNameAttribute) a).Name;
+
+		a = attributeManager.GetCustomAttribute<EventArgsAttribute> (mi);
+		if (a is null)
+			throw new BindingException (1006, true, mi.DeclaringType!.FullName, mi.Name);
+
+		ErrorHelper.Warning (1102, mi.DeclaringType!.FullName, mi.Name);
+		return ((EventArgsAttribute) a).ArgName;
+	}
+	
+	public string GetEventName (MethodInfo mi)
+	{
+		var a = attributeManager.GetCustomAttribute<EventNameAttribute> (mi);
+		return a is null ? mi.Name : a.EvtName;
+	}
+
+	public string GetDelegateApiName (MethodInfo mi)
+	{
+		var apiName = attributeManager.GetCustomAttribute<DelegateApiNameAttribute> (mi);
+
+		if (repeatedDelegateApiNames.Contains (mi.Name) && apiName is null)
+			throw new BindingException (1043, true, mi.Name);
+		if (apiName is null) {
+			repeatedDelegateApiNames.Add (mi.Name);
+			return mi.Name;
+		}
+
+		if (repeatedDelegateApiNames.Contains (apiName.Name))
+			throw new BindingException (1044, true, apiName.Name);
+
+		return apiName.Name;
+	}
+	
+	public string GetEventArgName (MethodInfo mi)
+	{
+		if (mi.GetParameters ().Length == 1)
+			return "EventArgs";
+
+		var a = attributeManager.GetCustomAttribute<EventArgsAttribute> (mi);
+		if (a is null)
+			throw new BindingException (1004, true, mi.DeclaringType!.FullName, mi.Name, mi.GetParameters ().Length);
+
+		var ea = (EventArgsAttribute) a;
+		if (ea.ArgName.EndsWith ("EventArgs", StringComparison.Ordinal))
+			throw new BindingException (1005, true, mi.DeclaringType!.FullName, mi.Name);
+
+		if (ea.SkipGeneration) {
+			skipGeneration [ea.FullName ? ea.ArgName : ea.ArgName + "EventArgs"] = true;
+		}
+
+		if (ea.FullName)
+			return ea.ArgName;
+
+		return ea.ArgName + "EventArgs";
+	}
+
+	public bool WasEventArgGenerated (string eaclass)
+		=> skipGeneration.ContainsKey (eaclass);
+	
+	public string GetTrampolineName (Type t)
+	{
+		var trampolineName = t.Name.Replace ("`", "Arity");
+		if (t.IsGenericType) {
+			var gdef = t.GetGenericTypeDefinition ();
+
+			if (!trampolinesGenericVersions.ContainsKey (gdef))
+				trampolinesGenericVersions.Add (gdef, 0);
+
+			trampolineName = trampolineName + "V" + trampolinesGenericVersions [gdef]++;
+		}
+		return trampolineName;
+	}
+
+	public void ForgetDelegateApiNames ()
+		=> repeatedDelegateApiNames.Clear ();
+}

--- a/src/bgen/Nomenclator.cs
+++ b/src/bgen/Nomenclator.cs
@@ -7,9 +7,9 @@ using System.Reflection;
 // Noun. nomenclator (plural nomenclators) An assistant who specializes in providing timely and spatially relevant
 // reminders of the names of persons and other socially important information
 public class Nomenclator {
-	readonly Dictionary<string, bool> skipGeneration = new();
-	readonly HashSet<string> repeatedDelegateApiNames = new();
-	readonly Dictionary<Type, int> trampolinesGenericVersions = new();
+	readonly Dictionary<string, bool> skipGeneration = new ();
+	readonly HashSet<string> repeatedDelegateApiNames = new ();
+	readonly Dictionary<Type, int> trampolinesGenericVersions = new ();
 
 	readonly IAttributeManager attributeManager;
 
@@ -17,7 +17,7 @@ public class Nomenclator {
 	{
 		this.attributeManager = attributeManager;
 	}
-	
+
 	public string GetDelegateName (MethodInfo mi)
 	{
 		Attribute a = attributeManager.GetCustomAttribute<DelegateNameAttribute> (mi);
@@ -31,7 +31,7 @@ public class Nomenclator {
 		ErrorHelper.Warning (1102, mi.DeclaringType!.FullName, mi.Name);
 		return ((EventArgsAttribute) a).ArgName;
 	}
-	
+
 	public string GetEventName (MethodInfo mi)
 	{
 		var a = attributeManager.GetCustomAttribute<EventNameAttribute> (mi);
@@ -54,7 +54,7 @@ public class Nomenclator {
 
 		return apiName.Name;
 	}
-	
+
 	public string GetEventArgName (MethodInfo mi)
 	{
 		if (mi.GetParameters ().Length == 1)
@@ -80,7 +80,7 @@ public class Nomenclator {
 
 	public bool WasEventArgGenerated (string eaclass)
 		=> skipGeneration.ContainsKey (eaclass);
-	
+
 	public string GetTrampolineName (Type t)
 	{
 		var trampolineName = t.Name.Replace ("`", "Arity");

--- a/src/bgen/Nomenclator.cs
+++ b/src/bgen/Nomenclator.cs
@@ -11,9 +11,9 @@ public class Nomenclator {
 	readonly HashSet<string> repeatedDelegateApiNames = new ();
 	readonly Dictionary<Type, int> trampolinesGenericVersions = new ();
 
-	readonly IAttributeManager attributeManager;
+	readonly AttributeManager attributeManager;
 
-	public Nomenclator (IAttributeManager attributeManager)
+	public Nomenclator (AttributeManager attributeManager)
 	{
 		this.attributeManager = attributeManager;
 	}

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -115,6 +115,7 @@
     <Compile Include="..\src\bgen\IMemberGatherer.cs" />
     <Compile Include="..\src\bgen\MemberInformation.cs" />
     <Compile Include="..\src\bgen\NamespaceManager.cs" />
+    <Compile Include="..\src\bgen\Nomenclator.cs" />
     <Compile Include="..\src\bgen\NullabilityInfoContext.cs" />
     <Compile Include="..\src\bgen\PlatformNameExtensions.cs" />
     <Compile Include="..\src\bgen\StringExtensions.cs" />

--- a/tests/bgen/bgen-tests.csproj
+++ b/tests/bgen/bgen-tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
   </ItemGroup>
 
@@ -28,6 +29,9 @@
     <Compile Include="..\generator\BGenTool.cs">
       <Link>BGenTool.cs</Link>
     </Compile>
+    <Compile Include="..\generator\CollectionsExtensionsTests.cs">
+      <Link>CollectionsExtensionsTests.cs</Link>
+    </Compile>
     <Compile Include="..\generator\ErrorTests.cs">
       <Link>ErrorTests.cs</Link>
     </Compile>
@@ -43,11 +47,20 @@
     <Compile Include="..\common\Profile.cs">
       <Link>Profile.cs</Link>
     </Compile>
+    <Compile Include="..\generator\NomenclatorTests.cs">
+      <Link>NomenclatorTests.cs</Link>
+    </Compile>
     <Compile Include="..\generator\NullabilityContextTests.cs">
       <Link>NullabilityContextTests.cs</Link>
     </Compile>
     <Compile Include="..\generator\StringExtensionTests.cs">
       <Link>StringExtensionTests.cs</Link>
+    </Compile>
+    <Compile Include="..\generator\PlatformNameExtensionsTests.cs">
+      <Link>PlatformNameExtensionsTests.cs</Link>
+    </Compile>
+    <Compile Include="..\generator\ReflectionTest.cs">
+      <Link>ReflectionTest.cs</Link>
     </Compile>
     <Compile Include="..\mtouch\Cache.cs">
       <Link>Cache.cs</Link>

--- a/tests/generator/NomenclatorTests.cs
+++ b/tests/generator/NomenclatorTests.cs
@@ -1,0 +1,202 @@
+using System;
+using Foundation;
+using Moq;
+using NUnit.Framework;
+
+namespace GeneratorTests {
+	[TestFixture]
+	public class NomenclatorTests : ReflectionTest {
+
+		interface NSAnimationDelegate {
+			[Export ("animation:valueForProgress:"), DelegateName ("NSAnimationProgress"),
+			 DefaultValueFromArgumentAttribute ("progress")]
+			float ComputeAnimationCurve (object animation, float progress);
+
+			[Export ("animation:didReachProgressMark:"), EventArgs ("NSAnimation")]
+			void AnimationDidReachProgressMark (object animation, float progress);
+
+			[Export ("accelerometer:didAccelerate:"), EventArgs ("UIAccelerometer"), EventName ("Acceleration")]
+			void DidAccelerate (object accelerometer, object acceleration);
+			
+			[Export ("accelerometer:")]
+			void DidAccelerateSingle (object accelerometer);
+			
+			[Export ("accelerometer:")]
+			void DidAccelerateSeveral (object accelerometer, object second, object last);
+		}
+
+		interface GenericTrampoline<T> where T: class {
+			[Export ("accelerometer:")]
+			void DidAccelerateSeveral (object accelerometer, object second, object last);
+		}
+
+		Type testType = typeof (object);
+		Mock<IAttributeManager> attributeManager;
+		Nomenclator nomenclator;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			testType = typeof (NSAnimationDelegate);
+			attributeManager = new();
+			nomenclator = new(attributeManager.Object);
+		}
+
+		[TestCase ("ComputeAnimationCurve")]
+		public void GetDelegateNameNoEventArgsTest (string methodName)
+		{
+			var method = GetMethod (methodName, testType);
+			var attr = new DelegateNameAttribute ("NSAnimationProgress");
+			attributeManager.Setup (am => am.GetCustomAttribute<DelegateNameAttribute> (method))
+				.Returns (attr);
+
+			Assert.AreEqual ("NSAnimationProgress", nomenclator.GetDelegateName (method));
+			attributeManager.Verify ();
+		}
+
+		[TestCase ("AnimationDidReachProgressMark")]
+		public void GetDelegateNameEventArgsTest (string methodName)
+		{
+			var method = GetMethod (methodName, testType);
+			var attr = new EventArgsAttribute ("NSAnimation");
+			attributeManager.Setup (am => am.GetCustomAttribute<DelegateNameAttribute> (method))
+				.Returns ((DelegateNameAttribute) null);
+			attributeManager.Setup (am => am.GetCustomAttribute<EventArgsAttribute> (method))
+				.Returns (attr);
+			Assert.AreEqual ("NSAnimation", nomenclator.GetDelegateName (method));
+			attributeManager.Verify ();
+		}
+
+		[Test]
+		public void GetDelegateNameEventThrows ()
+		{
+			var method = GetMethod ("DidAccelerate", testType);
+			attributeManager.Setup (am => am.GetCustomAttribute<DelegateNameAttribute> (method))
+				.Returns ((DelegateNameAttribute) null);
+			attributeManager.Setup (am => am.GetCustomAttribute<EventArgsAttribute> (method))
+				.Returns ((EventArgsAttribute) null);
+			Assert.Throws<BindingException> (() => nomenclator.GetDelegateName (method));
+			attributeManager.Verify ();
+		}
+
+		[Test]
+		public void GetEventNameNoAttribute ()
+		{
+			var method = GetMethod ("DidAccelerate", testType);
+			attributeManager.Setup (am => am.GetCustomAttribute<EventNameAttribute> (method))
+				.Returns ((EventNameAttribute) null);
+			Assert.AreEqual ("DidAccelerate", nomenclator.GetEventName (method));
+			attributeManager.Verify ();
+		}
+
+		[Test]
+		public void GetEnventNameAttribute ()
+		{
+			var method = GetMethod ("DidAccelerate", testType);
+			string eventName = "DidAccelerateEventRaised";
+			var attr = new EventNameAttribute (eventName);
+			attributeManager.Setup (am => am.GetCustomAttribute<EventNameAttribute> (method))
+				.Returns (attr);
+			Assert.AreEqual (eventName, nomenclator.GetEventName (method));
+			attributeManager.Verify ();
+		}
+
+		[Test]
+		public void GetDelegateApiName ()
+		{
+			var method = GetMethod ("DidAccelerate", testType);
+			var attr = new DelegateApiNameAttribute ("TestFramework");
+			attributeManager.Setup (am => am.GetCustomAttribute<DelegateApiNameAttribute> (method))
+				.Returns (attr);
+			Assert.AreEqual ("TestFramework", nomenclator.GetDelegateApiName (method));
+			attributeManager.Verify ();
+		}
+
+		[Test]
+		public void GetDelegateApiNameMissingAttr ()
+		{
+			var method = GetMethod ("DidAccelerate", testType);
+			attributeManager.Setup (am => am.GetCustomAttribute<DelegateApiNameAttribute> (method))
+				.Returns ((DelegateApiNameAttribute) null);
+			Assert.AreEqual ("DidAccelerate", nomenclator.GetDelegateApiName (method));
+			attributeManager.Verify ();
+		}
+
+		[Test]
+		public void GetDelegateApiNameDuplicate ()
+		{
+			var method = GetMethod ("DidAccelerate", testType);
+			attributeManager.Setup (am => am.GetCustomAttribute<DelegateApiNameAttribute> (method))
+				.Returns ((DelegateApiNameAttribute) null);
+			Assert.AreEqual ("DidAccelerate", nomenclator.GetDelegateApiName (method));
+			Assert.Throws<BindingException> (() => nomenclator.GetDelegateApiName (method));
+			attributeManager.Verify ();
+		}
+
+		[Test]
+		public void GetEventArgNameSingleParamTest ()
+		{
+			var method = GetMethod ("DidAccelerateSingle", testType);
+			Assert.AreEqual ("EventArgs", nomenclator.GetEventArgName (method));
+		}
+
+		[Test]
+		public void GetEventArgsNameSeveralParamsNoAttr ()
+		{
+			var method = GetMethod ("DidAccelerate", testType);
+			attributeManager.Setup (am => am.GetCustomAttribute<EventArgsAttribute> (method))
+				.Returns ((EventArgsAttribute) null);
+			Assert.Throws<BindingException>( () => nomenclator.GetEventArgName (method));
+			attributeManager.Verify();
+		}
+
+		[Test]
+		public void GetEventArgsSkipGenerationEndWithEventArgs ()
+		{
+			var method = GetMethod ("DidAccelerateSeveral", testType);
+			var attr = new EventArgsAttribute ("ThisIsATestEventArgs");
+			attributeManager.Setup (am => am.GetCustomAttribute<EventArgsAttribute> (method))
+				.Returns (attr);
+			Assert.Throws<BindingException>( () => nomenclator.GetEventArgName (method));
+			attributeManager.Verify();
+		}
+		
+		[Test]
+		public void GetEventArgsSkipGeneration ()
+		{
+			var method = GetMethod ("DidAccelerateSeveral", testType);
+			var attr = new EventArgsAttribute ("ThisIsATest", true);
+			attributeManager.Setup (am => am.GetCustomAttribute<EventArgsAttribute> (method))
+				.Returns (attr);
+			var name = nomenclator.GetEventArgName (method);
+			Assert.AreEqual ("ThisIsATestEventArgs", name, "name");
+			Assert.True (nomenclator.WasEventArgGenerated (name), "was generated");
+		}
+
+		[Test]
+		public void GetEventArgsFullName ()
+		{
+			var method = GetMethod ("DidAccelerateSeveral", testType);
+			var attr = new EventArgsAttribute ("ThisIsATest", false, true);
+			attributeManager.Setup (am => am.GetCustomAttribute<EventArgsAttribute> (method))
+				.Returns (attr);
+			var name = nomenclator.GetEventArgName (method);
+			Assert.AreEqual ("ThisIsATest", name, "name");
+			Assert.False (nomenclator.WasEventArgGenerated (name), "was generated");
+		}
+
+		[Test]
+		public void GetTrampolineNameNotGeneric ()
+			=> Assert.AreEqual ("NSAnimationDelegate", nomenclator.GetTrampolineName (testType));
+
+		[Test]
+		public void GetTrampolineNameGeneric ()
+		{
+			var name1 = nomenclator.GetTrampolineName (typeof(GenericTrampoline<string>));
+			var name2 = nomenclator.GetTrampolineName (typeof(GenericTrampoline<object>));
+			Assert.AreEqual ("GenericTrampolineArity1V0", name1, "name1");
+			Assert.AreEqual ("GenericTrampolineArity1V1", name2, "name2");
+			Assert.AreNotEqual (name1, name2, "equal");
+		}
+	}
+}

--- a/tests/generator/NomenclatorTests.cs
+++ b/tests/generator/NomenclatorTests.cs
@@ -17,15 +17,15 @@ namespace GeneratorTests {
 
 			[Export ("accelerometer:didAccelerate:"), EventArgs ("UIAccelerometer"), EventName ("Acceleration")]
 			void DidAccelerate (object accelerometer, object acceleration);
-			
+
 			[Export ("accelerometer:")]
 			void DidAccelerateSingle (object accelerometer);
-			
+
 			[Export ("accelerometer:")]
 			void DidAccelerateSeveral (object accelerometer, object second, object last);
 		}
 
-		interface GenericTrampoline<T> where T: class {
+		interface GenericTrampoline<T> where T : class {
 			[Export ("accelerometer:")]
 			void DidAccelerateSeveral (object accelerometer, object second, object last);
 		}
@@ -38,8 +38,8 @@ namespace GeneratorTests {
 		public void SetUp ()
 		{
 			testType = typeof (NSAnimationDelegate);
-			attributeManager = new();
-			nomenclator = new(attributeManager.Object);
+			attributeManager = new ();
+			nomenclator = new (attributeManager.Object);
 		}
 
 		[TestCase ("ComputeAnimationCurve")]
@@ -146,8 +146,8 @@ namespace GeneratorTests {
 			var method = GetMethod ("DidAccelerate", testType);
 			attributeManager.Setup (am => am.GetCustomAttribute<EventArgsAttribute> (method))
 				.Returns ((EventArgsAttribute) null);
-			Assert.Throws<BindingException>( () => nomenclator.GetEventArgName (method));
-			attributeManager.Verify();
+			Assert.Throws<BindingException> (() => nomenclator.GetEventArgName (method));
+			attributeManager.Verify ();
 		}
 
 		[Test]
@@ -157,10 +157,10 @@ namespace GeneratorTests {
 			var attr = new EventArgsAttribute ("ThisIsATestEventArgs");
 			attributeManager.Setup (am => am.GetCustomAttribute<EventArgsAttribute> (method))
 				.Returns (attr);
-			Assert.Throws<BindingException>( () => nomenclator.GetEventArgName (method));
-			attributeManager.Verify();
+			Assert.Throws<BindingException> (() => nomenclator.GetEventArgName (method));
+			attributeManager.Verify ();
 		}
-		
+
 		[Test]
 		public void GetEventArgsSkipGeneration ()
 		{
@@ -192,8 +192,8 @@ namespace GeneratorTests {
 		[Test]
 		public void GetTrampolineNameGeneric ()
 		{
-			var name1 = nomenclator.GetTrampolineName (typeof(GenericTrampoline<string>));
-			var name2 = nomenclator.GetTrampolineName (typeof(GenericTrampoline<object>));
+			var name1 = nomenclator.GetTrampolineName (typeof (GenericTrampoline<string>));
+			var name2 = nomenclator.GetTrampolineName (typeof (GenericTrampoline<object>));
 			Assert.AreEqual ("GenericTrampolineArity1V0", name1, "name1");
 			Assert.AreEqual ("GenericTrampolineArity1V1", name2, "name2");
 			Assert.AreNotEqual (name1, name2, "equal");

--- a/tests/generator/NomenclatorTests.cs
+++ b/tests/generator/NomenclatorTests.cs
@@ -39,7 +39,7 @@ namespace GeneratorTests {
 		public void SetUp ()
 		{
 			testType = typeof (NSAnimationDelegate);
-			bindingTouch = new();
+			bindingTouch = new ();
 			attributeManager = new (bindingTouch.Object);
 			nomenclator = new (attributeManager.Object);
 		}

--- a/tests/generator/NomenclatorTests.cs
+++ b/tests/generator/NomenclatorTests.cs
@@ -31,14 +31,16 @@ namespace GeneratorTests {
 		}
 
 		Type testType = typeof (object);
-		Mock<IAttributeManager> attributeManager;
+		Mock<BindingTouch> bindingTouch;
+		Mock<AttributeManager> attributeManager;
 		Nomenclator nomenclator;
 
 		[SetUp]
 		public void SetUp ()
 		{
 			testType = typeof (NSAnimationDelegate);
-			attributeManager = new ();
+			bindingTouch = new();
+			attributeManager = new (bindingTouch.Object);
 			nomenclator = new (attributeManager.Object);
 		}
 

--- a/tests/generator/NullabilityContextTests.cs
+++ b/tests/generator/NullabilityContextTests.cs
@@ -131,7 +131,7 @@ namespace GeneratorTests {
 			context = new ();
 		}
 
-		
+
 		[TestCase ("NotNullableValueTypeField", typeof (int))]
 		[TestCase ("NotNullableRefTypeField", typeof (string))]
 		public void NotNullableFieldTest (string fieldName, Type expectedType)

--- a/tests/generator/ReflectionTest.cs
+++ b/tests/generator/ReflectionTest.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace GeneratorTests {
+	
+	public class ReflectionTest {
+		
+		protected FieldInfo GetField (string fieldName, Type testType)
+		{
+			var fieldInfo = testType.GetField (fieldName);
+			Assert.NotNull (fieldInfo, "fieldInfo != null");
+			return fieldInfo!;
+		}
+
+		protected PropertyInfo GetProperty (string propertyName, Type testType)
+		{
+			var propertyInfo = testType.GetProperty (propertyName);
+			Assert.NotNull (propertyInfo, "propertyInto != null");
+			return propertyInfo!;
+		}
+
+		protected MethodInfo GetMethod (string methodName, Type testType)
+		{
+			var memberInfo = testType.GetMethod (methodName);
+			Assert.NotNull (memberInfo, "memberInfo != null");
+			return memberInfo!;
+		}
+	}
+}

--- a/tests/generator/ReflectionTest.cs
+++ b/tests/generator/ReflectionTest.cs
@@ -3,9 +3,9 @@ using System.Reflection;
 using NUnit.Framework;
 
 namespace GeneratorTests {
-	
+
 	public class ReflectionTest {
-		
+
 		protected FieldInfo GetField (string fieldName, Type testType)
 		{
 			var fieldInfo = testType.GetField (fieldName);

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
@@ -64,8 +65,10 @@
     <Compile Include="..\common\BinLog.cs">
       <Link>BinLog.cs</Link>
     </Compile>
+    <Compile Include="NomenclatorTests.cs" />
     <Compile Include="NullabilityContextTests.cs" />
     <Compile Include="PlatformNameExtensionsTests.cs" />
+    <Compile Include="ReflectionTest.cs" />
     <Compile Include="StringExtensionTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Naming could be problematic when generating code, move the logic out of the generator class to a helper class whose only job is to name classes and keep track of names.