### PR TITLE
[src] Make BlockLiteral disposable and update usage accordingly.

### DIFF
--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -608,7 +608,7 @@ namespace AudioUnit {
 		[iOS (16,0)]
 #endif
 		[DllImport (Constants.AudioUnitLibrary)]
-		static extern int AudioComponentValidateWithResults (IntPtr /* AudioComponent* */ inComponent, IntPtr /* CFDictionaryRef* */ inValidationParameters, ref BlockLiteral inCompletionHandler);
+		unsafe static extern int AudioComponentValidateWithResults (IntPtr /* AudioComponent* */ inComponent, IntPtr /* CFDictionaryRef* */ inValidationParameters, BlockLiteral* inCompletionHandler);
 
 #if NET
 		[SupportedOSPlatform ("macos13.0")]
@@ -627,12 +627,10 @@ namespace AudioUnit {
 			if (onCompletion is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (onCompletion));
 			
-			var block_handler= new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_action, onCompletion);
-			try {
-				resultCode = AudioComponentValidateWithResults (GetCheckedHandle (), validationParameters.GetHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_action, onCompletion);
+				resultCode = AudioComponentValidateWithResults (GetCheckedHandle (), validationParameters.GetHandle (), &block);
 			}
 		}
 

--- a/src/CoreFoundation/DispatchBlock.cs
+++ b/src/CoreFoundation/DispatchBlock.cs
@@ -91,7 +91,7 @@ namespace CoreFoundation {
 		}
 
 		[DllImport (Constants.libcLibrary)]
-		extern static IntPtr dispatch_block_create (/*DispatchBlockFlags*/ nuint flags, ref BlockLiteral block);
+		unsafe extern static IntPtr dispatch_block_create (/*DispatchBlockFlags*/ nuint flags, BlockLiteral* block);
 
 		// Returns a retained heap-allocated block
 		[BindingImpl (BindingImplOptions.Optimizable)]
@@ -100,17 +100,14 @@ namespace CoreFoundation {
 			if (action is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (action));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			try {
-				block_handler.SetupBlockUnsafe (BlockStaticDispatchClass.static_dispatch_block, action);
-				return dispatch_block_create ((nuint) (ulong) flags, ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = BlockStaticDispatchClass.CreateBlock (action);
+				return dispatch_block_create ((nuint) (ulong) flags, &block);
 			}
 		}
 
 		[DllImport (Constants.libcLibrary)]
-		extern static IntPtr dispatch_block_create_with_qos_class (/*DispatchBlockFlags*/ nuint flags, DispatchQualityOfService qosClass, int relative_priority, ref BlockLiteral dispatchBlock);
+		unsafe extern static IntPtr dispatch_block_create_with_qos_class (/*DispatchBlockFlags*/ nuint flags, DispatchQualityOfService qosClass, int relative_priority, BlockLiteral* dispatchBlock);
 
 		[DllImport (Constants.libcLibrary)]
 		extern static IntPtr dispatch_block_create_with_qos_class (/*DispatchBlockFlags*/ nuint flags, DispatchQualityOfService qosClass, int relative_priority, IntPtr dispatchBlock);
@@ -122,12 +119,9 @@ namespace CoreFoundation {
 			if (action is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (action));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			try {
-				block_handler.SetupBlockUnsafe (BlockStaticDispatchClass.static_dispatch_block, action);
-				return dispatch_block_create_with_qos_class ((nuint) (ulong) flags, qosClass, relative_priority, ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = BlockStaticDispatchClass.CreateBlock (action);
+				return dispatch_block_create_with_qos_class ((nuint) (ulong) flags, qosClass, relative_priority, &block);
 			}
 		}
 
@@ -202,23 +196,6 @@ namespace CoreFoundation {
 		public void Invoke ()
 		{
 			((Action) this!) ();
-		}
-
-		//
-		// You must invoke ->CleanupBlock after you have transferred ownership to
-		// the unmanaged code to release the resources allocated on the managed side
-		//
-		[BindingImpl (BindingImplOptions.Optimizable)]
-		internal static unsafe void Invoke (Action codeToRun, Action<IntPtr> invoker)
-		{
-			BlockLiteral* block_ptr;
-			BlockLiteral block;
-			block = new BlockLiteral ();
-			block_ptr = &block;
-
-			block.SetupBlockUnsafe (Trampolines.SDAction.Handler, codeToRun);
-			invoker ((IntPtr) block_ptr);
-			block_ptr->CleanupBlock ();
 		}
 	}
 

--- a/src/CoreFoundation/DispatchIO.cs
+++ b/src/CoreFoundation/DispatchIO.cs
@@ -81,7 +81,7 @@ namespace CoreFoundation {
 		}
 
 		[DllImport (Constants.libcLibrary)]
-		extern static void dispatch_read (int fd, nuint length, IntPtr dispatchQueue, ref BlockLiteral block);
+		unsafe extern static void dispatch_read (int fd, nuint length, IntPtr dispatchQueue, BlockLiteral* block);
 
 		//
 		// if size == nuint.MaxValue, reads as much data as is available
@@ -94,14 +94,15 @@ namespace CoreFoundation {
 			if (dispatchQueue is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dispatchQueue));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_DispatchReadWriteHandler, handler);
-			dispatch_read (fd, size, dispatchQueue.Handle, ref block_handler);
-			block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_DispatchReadWriteHandler, handler);
+				dispatch_read (fd, size, dispatchQueue.Handle, &block);
+			}
 		}
 
 		[DllImport (Constants.libcLibrary)]
-		extern static void dispatch_write (int fd, IntPtr dispatchData, IntPtr dispatchQueue, ref BlockLiteral handler);
+		unsafe extern static void dispatch_write (int fd, IntPtr dispatchData, IntPtr dispatchQueue, BlockLiteral* handler);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void Write (int fd, DispatchData dispatchData, DispatchQueue dispatchQueue, DispatchIOHandler handler)
@@ -113,10 +114,11 @@ namespace CoreFoundation {
 			if (dispatchQueue is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (dispatchQueue));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_DispatchReadWriteHandler, handler);
-			dispatch_write (fd, dispatchData.Handle, dispatchQueue.Handle, ref block_handler);
-			block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_DispatchReadWriteHandler, handler);
+				dispatch_write (fd, dispatchData.Handle, dispatchQueue.Handle, &block);
+			}
 		}
 	}
 }

--- a/src/CoreFoundation/DispatchSource.cs
+++ b/src/CoreFoundation/DispatchSource.cs
@@ -94,13 +94,13 @@ namespace CoreFoundation {
 		extern static IntPtr dispatch_source_merge_data (dispatch_source_t source, IntPtr data);
 
 		[DllImport (Constants.libcLibrary)]
-		unsafe extern static IntPtr dispatch_source_set_event_handler (dispatch_source_t source, IntPtr handler);
+		unsafe extern static IntPtr dispatch_source_set_event_handler (dispatch_source_t source, BlockLiteral* handler);
 
 		[DllImport (Constants.libcLibrary)]
-		unsafe extern static IntPtr dispatch_source_set_registration_handler (dispatch_source_t source, IntPtr handler);
+		unsafe extern static IntPtr dispatch_source_set_registration_handler (dispatch_source_t source, BlockLiteral* handler);
 
 		[DllImport (Constants.libcLibrary)]
-		unsafe extern static IntPtr dispatch_source_set_cancel_handler (dispatch_source_t source, IntPtr handler);
+		unsafe extern static IntPtr dispatch_source_set_cancel_handler (dispatch_source_t source, BlockLiteral* handler);
 
 		[DllImport (Constants.libcLibrary)]
 		unsafe extern static IntPtr dispatch_source_set_event_handler_f (dispatch_source_t source, IntPtr handler);
@@ -118,7 +118,7 @@ namespace CoreFoundation {
 				return;
 			}
 
-			DispatchBlock.Invoke (
+			Action callback =
 				delegate
 				{
 					var sc = SynchronizationContext.Current;
@@ -133,7 +133,11 @@ namespace CoreFoundation {
 						if (sc is null)
 							SynchronizationContext.SetSynchronizationContext (null);
 					}
-				}, block => dispatch_source_set_event_handler (GetCheckedHandle (), block));
+				};
+			unsafe {
+				using var block = BlockStaticDispatchClass.CreateBlock (callback);
+				dispatch_source_set_event_handler (GetCheckedHandle (), &block);
+			}
 		}
 
 		public void Suspend ()
@@ -151,7 +155,7 @@ namespace CoreFoundation {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			DispatchBlock.Invoke (
+			Action callback =
 				delegate
 				{
 					var sc = SynchronizationContext.Current;
@@ -166,7 +170,11 @@ namespace CoreFoundation {
 						if (sc is null)
 							SynchronizationContext.SetSynchronizationContext (null);
 					}
-				}, block => dispatch_source_set_registration_handler (GetCheckedHandle (), block));
+				};
+			unsafe {
+				using var block = BlockStaticDispatchClass.CreateBlock (callback);
+				dispatch_source_set_registration_handler (GetCheckedHandle (), &block);
+			}
 		}
 
 		public void SetCancelHandler (Action handler)
@@ -174,7 +182,7 @@ namespace CoreFoundation {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			DispatchBlock.Invoke (
+			Action callback =
 				delegate
 				{
 					var sc = SynchronizationContext.Current;
@@ -189,7 +197,11 @@ namespace CoreFoundation {
 						if (sc is null)
 							SynchronizationContext.SetSynchronizationContext (null);
 					}
-				}, block => dispatch_source_set_cancel_handler (GetCheckedHandle (), block));
+				};
+			unsafe {
+				using var block = BlockStaticDispatchClass.CreateBlock (callback);
+				dispatch_source_set_cancel_handler (GetCheckedHandle (), &block);
+			}
 		}
 
 		public void Cancel ()

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -254,21 +254,7 @@ namespace CoreText {
 		[iOS (13, 0)]
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern void CTFontManagerRegisterFontURLs (/* CFArrayRef */ IntPtr fontUrls, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, IntPtr registrationHandler);
-
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst")]
-#else
-		[Watch (6, 0)]
-		[TV (13, 0)]
-		[Mac (10, 15)]
-		[iOS (13, 0)]
-#endif
-		[DllImport (Constants.CoreTextLibrary)]
-		static extern void CTFontManagerRegisterFontURLs (/* CFArrayRef */ IntPtr fontUrls, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, ref BlockLiteral registrationHandler);
+		unsafe static extern void CTFontManagerRegisterFontURLs (/* CFArrayRef */ IntPtr fontUrls, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, BlockLiteral* registrationHandler);
 
 #if NET
 		[SupportedOSPlatform ("tvos13.0")]
@@ -286,12 +272,15 @@ namespace CoreText {
 		{
 			using (var arr = EnsureNonNullArray (fontUrls, nameof (fontUrls))) {
 				if (registrationHandler is null) {
-					CTFontManagerRegisterFontURLs (arr.Handle, scope, enabled, IntPtr.Zero);
+					unsafe {
+						CTFontManagerRegisterFontURLs (arr.Handle, scope, enabled, null);
+					}
 				} else {
-					BlockLiteral block_handler = new BlockLiteral ();
-					block_handler.SetupBlockUnsafe (callback, registrationHandler);
-					CTFontManagerRegisterFontURLs (arr.Handle, scope, enabled, ref block_handler);
-					block_handler.CleanupBlock ();
+					unsafe {
+						using var block = new BlockLiteral ();
+						block.SetupBlockUnsafe (callback, registrationHandler);
+						CTFontManagerRegisterFontURLs (arr.Handle, scope, enabled, &block);
+					}
 				}
 			}
 		}
@@ -372,21 +361,7 @@ namespace CoreText {
 		[iOS (13, 0)]
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerUnregisterFontURLs (/* CFArrayRef */ IntPtr fontUrls, CTFontManagerScope scope, IntPtr registrationHandler);
-
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst")]
-#else
-		[Watch (6, 0)]
-		[TV (13, 0)]
-		[Mac (10, 15)]
-		[iOS (13, 0)]
-#endif
-		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerUnregisterFontURLs (/* CFArrayRef */ IntPtr fontUrls, CTFontManagerScope scope, ref BlockLiteral registrationHandler);
+		static extern unsafe void CTFontManagerUnregisterFontURLs (/* CFArrayRef */ IntPtr fontUrls, CTFontManagerScope scope, BlockLiteral* registrationHandler);
 
 #if NET
 		[SupportedOSPlatform ("tvos13.0")]
@@ -400,16 +375,15 @@ namespace CoreText {
 		[iOS (13, 0)]
 #endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public static void UnregisterFonts (NSUrl [] fontUrls, CTFontManagerScope scope, CTFontRegistrationHandler registrationHandler)
+		public unsafe static void UnregisterFonts (NSUrl [] fontUrls, CTFontManagerScope scope, CTFontRegistrationHandler registrationHandler)
 		{
 			using (var arr = EnsureNonNullArray (fontUrls, nameof (fontUrls))) {
 				if (registrationHandler is null) {
-					CTFontManagerUnregisterFontURLs (arr.Handle, scope, IntPtr.Zero);
+					CTFontManagerUnregisterFontURLs (arr.Handle, scope, null);
 				} else {
-					BlockLiteral block_handler = new BlockLiteral ();
-					block_handler.SetupBlockUnsafe (callback, registrationHandler);
-					CTFontManagerUnregisterFontURLs (arr.Handle, scope, ref block_handler);
-					block_handler.CleanupBlock ();
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (callback, registrationHandler);
+					CTFontManagerUnregisterFontURLs (arr.Handle, scope, &block);
 				}
 			}
 		}
@@ -550,21 +524,7 @@ namespace CoreText {
 		[iOS (13, 0)]
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerRegisterFontDescriptors (/* CFArrayRef */ IntPtr fontDescriptors, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, IntPtr registrationHandler);
-
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst")]
-#else
-		[Watch (6, 0)]
-		[TV (13, 0)]
-		[Mac (10, 15)]
-		[iOS (13, 0)]
-#endif
-		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerRegisterFontDescriptors (/* CFArrayRef */ IntPtr fontDescriptors, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, ref BlockLiteral registrationHandler);
+		static extern unsafe void CTFontManagerRegisterFontDescriptors (/* CFArrayRef */ IntPtr fontDescriptors, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, BlockLiteral* registrationHandler);
 
 #if NET
 		[SupportedOSPlatform ("tvos13.0")]
@@ -578,16 +538,15 @@ namespace CoreText {
 		[iOS (13, 0)]
 #endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public static void RegisterFontDescriptors (CTFontDescriptor [] fontDescriptors, CTFontManagerScope scope, bool enabled, CTFontRegistrationHandler registrationHandler)
+		public unsafe static void RegisterFontDescriptors (CTFontDescriptor [] fontDescriptors, CTFontManagerScope scope, bool enabled, CTFontRegistrationHandler registrationHandler)
 		{
 			using (var arr = EnsureNonNullArray (fontDescriptors, nameof (fontDescriptors))) {
 				if (registrationHandler is null) {
-					CTFontManagerRegisterFontDescriptors (arr.Handle, scope, enabled, IntPtr.Zero);
+					CTFontManagerRegisterFontDescriptors (arr.Handle, scope, enabled, null);
 				} else {
-					BlockLiteral block_handler = new BlockLiteral ();
-					block_handler.SetupBlockUnsafe (callback, registrationHandler);
-					CTFontManagerRegisterFontDescriptors (arr.Handle, scope, enabled, ref block_handler);
-					block_handler.CleanupBlock ();
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (callback, registrationHandler);
+					CTFontManagerRegisterFontDescriptors (arr.Handle, scope, enabled, &block);
 				}
 			}
 		}
@@ -604,21 +563,7 @@ namespace CoreText {
 		[iOS (13, 0)]
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerUnregisterFontDescriptors (/* CFArrayRef */ IntPtr fontDescriptors, CTFontManagerScope scope, IntPtr registrationHandler);
-
-#if NET
-		[SupportedOSPlatform ("tvos13.0")]
-		[SupportedOSPlatform ("macos10.15")]
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst")]
-#else
-		[Watch (6, 0)]
-		[TV (13, 0)]
-		[Mac (10, 15)]
-		[iOS (13, 0)]
-#endif
-		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerUnregisterFontDescriptors (/* CFArrayRef */ IntPtr fontDescriptors, CTFontManagerScope scope, ref BlockLiteral registrationHandler);
+		static extern unsafe void CTFontManagerUnregisterFontDescriptors (/* CFArrayRef */ IntPtr fontDescriptors, CTFontManagerScope scope, BlockLiteral* registrationHandler);
 
 #if NET
 		[SupportedOSPlatform ("tvos13.0")]
@@ -632,16 +577,15 @@ namespace CoreText {
 		[iOS (13, 0)]
 #endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public static void UnregisterFontDescriptors (CTFontDescriptor [] fontDescriptors, CTFontManagerScope scope, CTFontRegistrationHandler registrationHandler)
+		public unsafe static void UnregisterFontDescriptors (CTFontDescriptor [] fontDescriptors, CTFontManagerScope scope, CTFontRegistrationHandler registrationHandler)
 		{
 			using (var arr = EnsureNonNullArray (fontDescriptors, nameof (fontDescriptors))) {
 				if (registrationHandler is null) {
-					CTFontManagerUnregisterFontDescriptors (arr.Handle, scope, IntPtr.Zero);
+					CTFontManagerUnregisterFontDescriptors (arr.Handle, scope, null);
 				} else {
-					BlockLiteral block_handler = new BlockLiteral ();
-					block_handler.SetupBlockUnsafe (callback, registrationHandler);
-					CTFontManagerUnregisterFontDescriptors (arr.Handle, scope, ref block_handler);
-					block_handler.CleanupBlock ();
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (callback, registrationHandler);
+					CTFontManagerUnregisterFontDescriptors (arr.Handle, scope, &block);
 				}
 			}
 		}
@@ -740,21 +684,7 @@ namespace CoreText {
 		[iOS (13,0)]
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerRegisterFontsWithAssetNames (/* CFArrayRef */ IntPtr fontAssetNames, /* CFBundleRef _Nullable */ IntPtr bundle, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, IntPtr registrationHandler);
-
-#if NET
-		[SupportedOSPlatform ("ios13.0")]
-		[SupportedOSPlatform ("maccatalyst")]
-		[UnsupportedOSPlatform ("tvos")]
-		[UnsupportedOSPlatform ("macos")]
-#else
-		[NoWatch]
-		[NoTV]
-		[NoMac]
-		[iOS (13,0)]
-#endif
-		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerRegisterFontsWithAssetNames (/* CFArrayRef */ IntPtr fontAssetNames, /* CFBundleRef _Nullable */ IntPtr bundle, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, ref BlockLiteral registrationHandler);
+		static extern unsafe void CTFontManagerRegisterFontsWithAssetNames (/* CFArrayRef */ IntPtr fontAssetNames, /* CFBundleRef _Nullable */ IntPtr bundle, CTFontManagerScope scope, [MarshalAs (UnmanagedType.I1)] bool enabled, BlockLiteral* registrationHandler);
 
 		// reminder that NSBundle and CFBundle are NOT toll-free bridged :(
 #if NET
@@ -769,16 +699,15 @@ namespace CoreText {
 		[iOS (13,0)]
 #endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public static void RegisterFonts (string[] assetNames, CFBundle bundle, CTFontManagerScope scope, bool enabled, CTFontRegistrationHandler registrationHandler)
+		public unsafe static void RegisterFonts (string[] assetNames, CFBundle bundle, CTFontManagerScope scope, bool enabled, CTFontRegistrationHandler registrationHandler)
 		{
 			using (var arr = EnsureNonNullArray (assetNames, nameof (assetNames))) {
 				if (registrationHandler is null) {
-					CTFontManagerRegisterFontsWithAssetNames (arr.Handle, bundle.GetHandle (), scope, enabled, IntPtr.Zero);
+					CTFontManagerRegisterFontsWithAssetNames (arr.Handle, bundle.GetHandle (), scope, enabled, null);
 				} else {
-					BlockLiteral block_handler = new BlockLiteral ();
-					block_handler.SetupBlockUnsafe (callback, registrationHandler);
-					CTFontManagerRegisterFontsWithAssetNames (arr.Handle, bundle.GetHandle (), scope, enabled, ref block_handler);
-					block_handler.CleanupBlock ();
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (callback, registrationHandler);
+					CTFontManagerRegisterFontsWithAssetNames (arr.Handle, bundle.GetHandle (), scope, enabled, &block);
 				}
 			}
 		}
@@ -808,7 +737,7 @@ namespace CoreText {
 		[iOS (13,0)]
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern unsafe void CTFontManagerRequestFonts (/* CFArrayRef */ IntPtr fontDescriptors, ref BlockLiteral completionHandler);
+		static extern unsafe void CTFontManagerRequestFonts (/* CFArrayRef */ IntPtr fontDescriptors, BlockLiteral* completionHandler);
 
 		internal delegate void InnerRequestFontsHandler (IntPtr block, IntPtr fontDescriptors);
 		static readonly InnerRequestFontsHandler requestCallback = TrampolineRequestFonts;
@@ -839,10 +768,11 @@ namespace CoreText {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (completionHandler));
 
 			using (var arr = EnsureNonNullArray (fontDescriptors, nameof (fontDescriptors))) {
-				BlockLiteral block_handler = new BlockLiteral ();
-				block_handler.SetupBlockUnsafe (requestCallback, completionHandler);
-				CTFontManagerRequestFonts (arr.Handle, ref block_handler);
-				block_handler.CleanupBlock ();
+				unsafe {
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (requestCallback, completionHandler);
+					CTFontManagerRequestFonts (arr.Handle, &block);
+				}
 			}
 		}
 #endif

--- a/src/CoreText/CTLine.cs
+++ b/src/CoreText/CTLine.cs
@@ -220,7 +220,7 @@ namespace CoreText {
 		[Mac (10, 11)]
 #endif
 		[DllImport (Constants.CoreTextLibrary)]
-		static extern void CTLineEnumerateCaretOffsets (IntPtr line, ref BlockLiteral blockEnumerator);
+		unsafe static extern void CTLineEnumerateCaretOffsets (IntPtr line, BlockLiteral* blockEnumerator);
 
 		static unsafe readonly CaretEdgeEnumeratorProxy static_enumerate = TrampolineEnumerate;
 
@@ -247,10 +247,11 @@ namespace CoreText {
 			if (enumerator is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (enumerator));
 
-			var block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_enumerate, enumerator);
-			CTLineEnumerateCaretOffsets (Handle, ref block_handler);
-			block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_enumerate, enumerator);
+				CTLineEnumerateCaretOffsets (Handle, &block);
+			}
 		}
 		#endregion
 	}

--- a/src/ImageIO/CGImageAnimation.cs
+++ b/src/ImageIO/CGImageAnimation.cs
@@ -40,7 +40,7 @@ namespace ImageIO {
 		[Introduced (PlatformName.WatchOS, 6, 0, PlatformArchitecture.All)]
 #endif
 		[DllImport (Constants.ImageIOLibrary)]
-		static extern /* OSStatus */ CGImageAnimationStatus CGAnimateImageAtURLWithBlock ( /* CFURLRef */ IntPtr url, /* CFDictionaryRef _iio_Nullable */ IntPtr options, /* CGImageSourceAnimationHandler */ ref BlockLiteral block);
+		unsafe static extern /* OSStatus */ CGImageAnimationStatus CGAnimateImageAtURLWithBlock ( /* CFURLRef */ IntPtr url, /* CFDictionaryRef _iio_Nullable */ IntPtr options, /* CGImageSourceAnimationHandler */ BlockLiteral* block);
 
 #if NET
         [SupportedOSPlatform ("macos10.15")]
@@ -54,7 +54,7 @@ namespace ImageIO {
 		[Introduced (PlatformName.WatchOS, 6, 0, PlatformArchitecture.All)]
 #endif
 		[DllImport (Constants.ImageIOLibrary)]
-		static extern /* OSStatus */ CGImageAnimationStatus CGAnimateImageDataWithBlock ( /* CFDataRef _Nonnull */ IntPtr data, /* CFDictionaryRef _Nullable */ IntPtr options, /* CGImageSourceAnimationHandler _Nonnull */ ref BlockLiteral block);
+		unsafe static extern /* OSStatus */ CGImageAnimationStatus CGAnimateImageDataWithBlock ( /* CFDataRef _Nonnull */ IntPtr data, /* CFDictionaryRef _Nullable */ IntPtr options, /* CGImageSourceAnimationHandler _Nonnull */ BlockLiteral* block);
 
 #if NET
         [SupportedOSPlatform ("macos10.15")]
@@ -78,13 +78,10 @@ namespace ImageIO {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			var block = new BlockLiteral ();
-			block.SetupBlockUnsafe (SDCGImageSourceAnimationBlock.Handler, handler);
-
-			try {
-				return CGAnimateImageAtURLWithBlock (url.Handle, options.GetHandle (), ref block);
-			} finally {
-				block.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (SDCGImageSourceAnimationBlock.Handler, handler);
+				return CGAnimateImageAtURLWithBlock (url.Handle, options.GetHandle (), &block);
 			}
 #endif
 		}
@@ -111,13 +108,10 @@ namespace ImageIO {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			var block = new BlockLiteral ();
-			block.SetupBlockUnsafe (SDCGImageSourceAnimationBlock.Handler, handler);
-
-			try {
-				return CGAnimateImageDataWithBlock (data.Handle, options.GetHandle (), ref block);
-			} finally {
-				block.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (SDCGImageSourceAnimationBlock.Handler, handler);
+				return CGAnimateImageDataWithBlock (data.Handle, options.GetHandle (), &block);
 			}
 #endif
 		}

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -100,7 +100,7 @@ namespace Metal {
 		[Mac (10, 13)]
 #endif
 		[DllImport (Constants.MetalLibrary)]
-		static extern IntPtr MTLCopyAllDevicesWithObserver (out IntPtr observer, ref BlockLiteral handler);
+		unsafe static extern IntPtr MTLCopyAllDevicesWithObserver (out IntPtr observer, BlockLiteral* handler);
 
 #if NET
 		[SupportedOSPlatform ("macos")]
@@ -113,14 +113,18 @@ namespace Metal {
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static IMTLDevice [] GetAllDevices (MTLDeviceNotificationHandler handler, out NSObject? observer)
 		{
-			var block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_notificationHandler, handler);
+			IntPtr rv;
+			IntPtr observer_handle;
 
-			var rv = MTLCopyAllDevicesWithObserver (out var observer_handle, ref block_handler);
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_notificationHandler, handler);
+
+				rv = MTLCopyAllDevicesWithObserver (out observer_handle, &block);
+			}
+
 			var obj = NSArray.ArrayFromHandle<IMTLDevice> (rv);
 			NSObject.DangerousRelease (rv);
-
-			block_handler.CleanupBlock ();
 
 			observer = Runtime.GetNSObject (observer_handle);
 			NSObject.DangerousRelease (observer_handle); // Apple's documentation says "The observer out parameter is returned with a +1 retain count [...]."

--- a/src/Network/NWBrowseResult.cs
+++ b/src/Network/NWBrowseResult.cs
@@ -63,7 +63,7 @@ namespace Network {
 			=> nw_browse_result_get_changes (oldResult.GetHandle (), newResult.GetHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_browse_result_enumerate_interfaces (OS_nw_browse_result result, ref BlockLiteral enumerator);
+		unsafe static extern void nw_browse_result_enumerate_interfaces (OS_nw_browse_result result, BlockLiteral* enumerator);
 
 		delegate void nw_browse_result_enumerate_interfaces_t (IntPtr block, IntPtr nwInterface);
 		static nw_browse_result_enumerate_interfaces_t static_EnumerateInterfacesHandler = TrampolineEnumerateInterfacesHandler;
@@ -84,12 +84,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_EnumerateInterfacesHandler, handler);
-			try {
-				nw_browse_result_enumerate_interfaces (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_EnumerateInterfacesHandler, handler);
+				nw_browse_result_enumerate_interfaces (GetCheckedHandle (), &block);
 			}
 		}
 	}

--- a/src/Network/NWBrowser.cs
+++ b/src/Network/NWBrowser.cs
@@ -129,7 +129,7 @@ namespace Network {
 			=> new NWParameters (nw_browser_copy_parameters (GetCheckedHandle ()), owns: true);
 
 		[DllImport (Constants.NetworkLibrary)]
-		unsafe static extern void nw_browser_set_browse_results_changed_handler (OS_nw_browser browser, void* handler);
+		unsafe static extern void nw_browser_set_browse_results_changed_handler (OS_nw_browser browser, BlockLiteral* handler);
 
 		delegate void nw_browser_browse_results_changed_handler_t (IntPtr block, IntPtr oldResult, IntPtr newResult, bool completed);
 		static nw_browser_browse_results_changed_handler_t static_ChangesHandler = TrampolineChangesHandler;
@@ -198,14 +198,10 @@ namespace Network {
 					nw_browser_set_browse_results_changed_handler (GetCheckedHandle (), null);
 					return;
 				}
-				BlockLiteral block_handler = new BlockLiteral ();
-				BlockLiteral* block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_ChangesHandler, handler);
-				try {
-					nw_browser_set_browse_results_changed_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ChangesHandler, handler);
+				nw_browser_set_browse_results_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -216,7 +212,7 @@ namespace Network {
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]
-		unsafe static extern void nw_browser_set_state_changed_handler (OS_nw_browser browser, void* state_changed_handler);
+		unsafe static extern void nw_browser_set_state_changed_handler (OS_nw_browser browser, BlockLiteral* state_changed_handler);
 
 		delegate void nw_browser_set_state_changed_handler_t (IntPtr block, NWBrowserState state, IntPtr error);
 		static nw_browser_set_state_changed_handler_t static_StateChangesHandler = TrampolineStateChangesHandler;
@@ -239,14 +235,9 @@ namespace Network {
 					nw_browser_set_state_changed_handler (GetCheckedHandle (), null);
 					return;
 				}
-				BlockLiteral block_handler = new BlockLiteral ();
-				BlockLiteral* block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_StateChangesHandler, handler);
-				try {
-					nw_browser_set_state_changed_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_StateChangesHandler, handler);
+				nw_browser_set_state_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
 	}

--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -125,15 +125,9 @@ namespace Network {
 			}
 
 			unsafe {
-				BlockLiteral block_handler = new BlockLiteral ();
-				BlockLiteral* block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_stateChangeHandler, stateHandler);
-
-				try {
-					nw_connection_set_state_changed_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_stateChangeHandler, stateHandler);
+				nw_connection_set_state_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -160,15 +154,9 @@ namespace Network {
 			}
 
 			unsafe {
-				BlockLiteral block_handler = new BlockLiteral ();
-				BlockLiteral* block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_BooleanChangeHandler, callback);
-
-				try {
-					nw_connection_set_viability_changed_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_BooleanChangeHandler, callback);
+				nw_connection_set_viability_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -184,15 +172,9 @@ namespace Network {
 			}
 
 			unsafe {
-				BlockLiteral block_handler = new BlockLiteral ();
-				BlockLiteral* block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_BooleanChangeHandler, callback);
-
-				try {
-					nw_connection_set_better_path_available_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_BooleanChangeHandler, callback);
+				nw_connection_set_better_path_available_handler (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -210,18 +192,15 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_connection_set_path_changed_handler (IntPtr handle, ref BlockLiteral callback);
+		unsafe static extern void nw_connection_set_path_changed_handler (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void SetPathChangedHandler (Action<NWPath> callback)
 		{
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_PathChanged, callback);
-
-			try {
-				nw_connection_set_path_changed_handler (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_PathChanged, callback);
+				nw_connection_set_path_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -338,7 +317,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_connection_receive (IntPtr handle, /* uint32_t */ uint minimumIncompleteLength, /* uint32_t */ uint maximumLength, ref BlockLiteral callback);
+		unsafe static extern void nw_connection_receive (IntPtr handle, /* uint32_t */ uint minimumIncompleteLength, /* uint32_t */ uint maximumLength, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void Receive (uint minimumIncompleteLength, uint maximumLength, NWConnectionReceiveCompletion callback)
@@ -346,12 +325,10 @@ namespace Network {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_ReceiveCompletion, callback);
-			try {
-				nw_connection_receive (GetCheckedHandle (), minimumIncompleteLength, maximumLength, ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ReceiveCompletion, callback);
+				nw_connection_receive (GetCheckedHandle (), minimumIncompleteLength, maximumLength, &block);
 			}
 		}
 
@@ -361,13 +338,10 @@ namespace Network {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_ReceiveCompletionDispatchData, callback);
-
-			try {
-				nw_connection_receive (GetCheckedHandle (), minimumIncompleteLength, maximumLength, ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ReceiveCompletionDispatchData, callback);
+				nw_connection_receive (GetCheckedHandle (), minimumIncompleteLength, maximumLength, &block);
 			}
 		}
 
@@ -377,18 +351,15 @@ namespace Network {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_ReceiveCompletionDispatchReadnOnlyData, callback);
-
-			try {
-				nw_connection_receive (GetCheckedHandle (), minimumIncompleteLength, maximumLength, ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ReceiveCompletionDispatchReadnOnlyData, callback);
+				nw_connection_receive (GetCheckedHandle (), minimumIncompleteLength, maximumLength, &block);
 			}
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_connection_receive_message (IntPtr handle, ref BlockLiteral callback);
+		unsafe static extern void nw_connection_receive_message (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void ReceiveMessage (NWConnectionReceiveCompletion callback)
@@ -396,14 +367,12 @@ namespace Network {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_ReceiveCompletion, callback);
-
-			try {
-				nw_connection_receive_message (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ReceiveCompletion, callback);
+				nw_connection_receive_message (GetCheckedHandle (), &block);
 			}
+
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
@@ -412,13 +381,10 @@ namespace Network {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_ReceiveCompletionDispatchData, callback);
-
-			try {
-				nw_connection_receive_message (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ReceiveCompletionDispatchData, callback);
+				nw_connection_receive_message (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -428,13 +394,10 @@ namespace Network {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_ReceiveCompletionDispatchReadnOnlyData, callback);
-
-			try {
-				nw_connection_receive_message (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ReceiveCompletionDispatchReadnOnlyData, callback);
+				nw_connection_receive_message (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -457,14 +420,14 @@ namespace Network {
 								  IntPtr dispatchData,
 								  IntPtr contentContext,
 								  [MarshalAs (UnmanagedType.U1)] bool isComplete,
-								  void* callback);
+								  BlockLiteral* callback);
 
 		//
 		// This has more uses than the current ones, we might want to introduce
 		// additional SendXxx methods to encode the few options that are currently
 		// configured via one of the three NWContentContext static properties
 		//
-		unsafe void LowLevelSend (IntPtr handle, DispatchData? buffer, IntPtr contentContext, bool isComplete, void* callback)
+		unsafe void LowLevelSend (IntPtr handle, DispatchData? buffer, IntPtr contentContext, bool isComplete, BlockLiteral* callback)
 		{
 			nw_connection_send (handle: GetCheckedHandle (),
 						dispatchData: buffer.GetHandle (),
@@ -500,15 +463,9 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
-				BlockLiteral block_handler = new BlockLiteral ();
-				BlockLiteral* block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_SendCompletion, callback);
-
-				try {
-					LowLevelSend (GetCheckedHandle (), buffer, context.Handle, isComplete, block_ptr_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_SendCompletion, callback);
+				LowLevelSend (GetCheckedHandle (), buffer, context.Handle, isComplete, &block);
 			}
 		}
 
@@ -517,7 +474,7 @@ namespace Network {
 			if (context is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (context));
 
-			LowLevelSend (GetCheckedHandle (), buffer, context.Handle, isComplete, (void*) NWConnectionConstants._SendIdempotentContent);
+			LowLevelSend (GetCheckedHandle (), buffer, context.Handle, isComplete, (BlockLiteral*) NWConnectionConstants._SendIdempotentContent);
 		}
 
 		public void SendIdempotent (byte [] buffer, NWContentContext context, bool isComplete)
@@ -602,7 +559,7 @@ namespace Network {
 		[iOS (13, 0)]
 #endif
 		[DllImport (Constants.NetworkLibrary)]
-		unsafe static extern void nw_connection_access_establishment_report (IntPtr connection, IntPtr queue, ref BlockLiteral access_block);
+		unsafe static extern void nw_connection_access_establishment_report (IntPtr connection, IntPtr queue, BlockLiteral* access_block);
 
 		delegate void nw_establishment_report_access_block_t (IntPtr block, nw_establishment_report_t report);
 		static nw_establishment_report_access_block_t static_GetEstablishmentReportHandler = TrampolineGetEstablishmentReportHandler;
@@ -636,12 +593,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_GetEstablishmentReportHandler, handler);
-			try {
-				nw_connection_access_establishment_report (GetCheckedHandle (), queue.Handle, ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_GetEstablishmentReportHandler, handler);
+				nw_connection_access_establishment_report (GetCheckedHandle (), queue.Handle, &block);
 			}
 		}
 	}

--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -581,11 +581,14 @@ namespace Network {
 		public uint MaximumDatagramSize => nw_connection_get_maximum_datagram_size (GetCheckedHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
-		extern static void nw_connection_batch (IntPtr handle, IntPtr callback_block);
+		unsafe extern static void nw_connection_batch (IntPtr handle, BlockLiteral* callback_block);
 
 		public void Batch (Action method)
 		{
-			BlockLiteral.SimpleCall (method, (arg) => nw_connection_batch (GetCheckedHandle (), arg));
+			unsafe {
+				using var block = BlockStaticDispatchClass.CreateBlock (method);
+				nw_connection_batch (GetCheckedHandle (), &block);
+			}
 		}
 
 #if NET

--- a/src/Network/NWConnectionGroup.cs
+++ b/src/Network/NWConnectionGroup.cs
@@ -214,17 +214,13 @@ namespace Network {
 					return;
 				}
 
-				BlockLiteral block_handler = new BlockLiteral ();
-				block_handler.SetupBlockUnsafe (static_SendCompletion, handler);
-				try {
-					nw_connection_group_send_message (GetCheckedHandle (),
-						content.GetHandle (),
-						endpoint.GetHandle (),
-						context.GetCheckedHandle (),
-						&block_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_SendCompletion, handler);
+				nw_connection_group_send_message (GetCheckedHandle (),
+					content.GetHandle (),
+					endpoint.GetHandle (),
+					context.GetCheckedHandle (),
+					&block);
 			}
 		}
 
@@ -254,13 +250,9 @@ namespace Network {
 					return;
 				}
 
-				BlockLiteral block_handler = new BlockLiteral ();
-				block_handler.SetupBlockUnsafe (static_ReceiveHandler, handler);
-				try {
-					nw_connection_group_set_receive_handler (GetCheckedHandle (), maximumMessageSize, rejectOversizedMessages, &block_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ReceiveHandler, handler);
+				nw_connection_group_set_receive_handler (GetCheckedHandle (), maximumMessageSize, rejectOversizedMessages, &block);
 			}
 		}
 
@@ -289,13 +281,9 @@ namespace Network {
 					return;
 				}
 
-				BlockLiteral block_handler = new BlockLiteral ();
-				block_handler.SetupBlockUnsafe (static_StateChangedHandler, handler);
-				try {
-					nw_connection_group_set_state_changed_handler (GetCheckedHandle (), &block_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_StateChangedHandler, handler);
+				nw_connection_group_set_state_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -452,7 +440,7 @@ namespace Network {
 		[MacCatalyst (15, 0)]
 #endif
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_connection_group_set_new_connection_handler (OS_nw_connection_group group, ref BlockLiteral connectionHandler);
+		unsafe static extern void nw_connection_group_set_new_connection_handler (OS_nw_connection_group group, BlockLiteral* connectionHandler);
 
 		delegate void nw_connection_group_new_connection_handler_t (IntPtr block, IntPtr connection);
 		static nw_connection_group_new_connection_handler_t static_SetNewConnectionHandler = TrampolineSetNewConnectionHandler;
@@ -486,12 +474,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			var block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_SetNewConnectionHandler, handler);
-			try {
-				nw_connection_group_set_new_connection_handler (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_SetNewConnectionHandler, handler);
+				nw_connection_group_set_new_connection_handler (GetCheckedHandle (), &block);
 			}
 		}
 	}

--- a/src/Network/NWContentContext.cs
+++ b/src/Network/NWContentContext.cs
@@ -182,18 +182,15 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_content_context_foreach_protocol_metadata (IntPtr handle, ref BlockLiteral callback);
+		unsafe static extern void nw_content_context_foreach_protocol_metadata (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void IterateProtocolMetadata (Action<NWProtocolDefinition?, NWProtocolMetadata?> callback)
 		{
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_ProtocolIterator, callback);
-
-			try {
-				nw_content_context_foreach_protocol_metadata (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ProtocolIterator, callback);
+				nw_content_context_foreach_protocol_metadata (GetCheckedHandle (), &block);
 			}
 		}
 

--- a/src/Network/NWDataTransferReport.cs
+++ b/src/Network/NWDataTransferReport.cs
@@ -144,7 +144,7 @@ namespace Network {
 			=> nw_data_transfer_report_get_sent_ip_packet_count (GetCheckedHandle (), pathIndex);
 
 		[DllImport (Constants.NetworkLibrary)]
-		unsafe static extern void nw_data_transfer_report_collect (OS_nw_data_transfer_report report, IntPtr queue, ref BlockLiteral collect_block);
+		unsafe static extern void nw_data_transfer_report_collect (OS_nw_data_transfer_report report, IntPtr queue, BlockLiteral* collect_block);
 
 		delegate void nw_data_transfer_report_collect_t (IntPtr block, IntPtr report);
 		static nw_data_transfer_report_collect_t static_CollectHandler = TrampolineCollectHandler;
@@ -166,12 +166,11 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (queue));
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_CollectHandler, handler);
-			try {
-				nw_data_transfer_report_collect (GetCheckedHandle (), queue.Handle, ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_CollectHandler, handler);
+				nw_data_transfer_report_collect (GetCheckedHandle (), queue.Handle, &block);
 			}
 		}
 

--- a/src/Network/NWEstablishmentReport.cs
+++ b/src/Network/NWEstablishmentReport.cs
@@ -73,7 +73,7 @@ namespace Network {
 		public TimeSpan ConnectionSetupTime => TimeSpan.FromMilliseconds (nw_establishment_report_get_attempt_started_after_milliseconds (GetCheckedHandle ()));
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_establishment_report_enumerate_resolutions (OS_nw_establishment_report report, ref BlockLiteral enumerate_block);
+		unsafe static extern void nw_establishment_report_enumerate_resolutions (OS_nw_establishment_report report, BlockLiteral* enumerate_block);
 
 		delegate void nw_report_resolution_enumerator_t (IntPtr block, NWReportResolutionSource source, nuint milliseconds, int endpoint_count, nw_endpoint_t successful_endpoint, nw_endpoint_t preferred_endpoint);
 		static nw_report_resolution_enumerator_t static_ResolutionEnumeratorHandler = TrampolineResolutionEnumeratorHandler;
@@ -95,17 +95,15 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_ResolutionEnumeratorHandler, handler);
-			try {
-				nw_establishment_report_enumerate_resolutions (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ResolutionEnumeratorHandler, handler);
+				nw_establishment_report_enumerate_resolutions (GetCheckedHandle (), &block);
 			}
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_establishment_report_enumerate_protocols (OS_nw_establishment_report report, ref BlockLiteral enumerate_block);
+		unsafe static extern void nw_establishment_report_enumerate_protocols (OS_nw_establishment_report report, BlockLiteral* enumerate_block);
 
 		delegate void nw_establishment_report_enumerate_protocols_t (IntPtr block, nw_protocol_definition_t protocol, nuint handshake_milliseconds, nuint handshake_rtt_milliseconds);
 		static nw_establishment_report_enumerate_protocols_t static_EnumerateProtocolsHandler = TrampolineEnumerateProtocolsHandler;
@@ -126,12 +124,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_EnumerateProtocolsHandler, handler);
-			try {
-				nw_establishment_report_enumerate_protocols (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_EnumerateProtocolsHandler, handler);
+				nw_establishment_report_enumerate_protocols (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -158,7 +154,7 @@ namespace Network {
 		[MacCatalyst (15, 0)]
 #endif
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_establishment_report_enumerate_resolution_reports (OS_nw_establishment_report report, ref BlockLiteral enumerateBlock);
+		unsafe static extern void nw_establishment_report_enumerate_resolution_reports (OS_nw_establishment_report report, BlockLiteral* enumerateBlock);
 
 		delegate void nw_report_resolution_report_enumerator_t (IntPtr block, nw_resolution_report_t report);
 		static nw_report_resolution_report_enumerator_t static_EnumerateResolutionReport = TrampolineEnumerateResolutionReport;
@@ -191,12 +187,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral blockHandler = new ();
-			blockHandler.SetupBlockUnsafe (static_EnumerateResolutionReport, handler);
-			try {
-				nw_establishment_report_enumerate_protocols (GetCheckedHandle (), ref blockHandler);
-			} finally {
-				blockHandler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_EnumerateResolutionReport, handler);
+				nw_establishment_report_enumerate_protocols (GetCheckedHandle (), &block);
 			}
 		}
 	}

--- a/src/Network/NWFramer.cs
+++ b/src/Network/NWFramer.cs
@@ -99,14 +99,9 @@ namespace Network {
 						nw_framer_set_wakeup_handler (GetCheckedHandle (), null);
 						return;
 					}
-					BlockLiteral block_handler = new BlockLiteral ();
-					BlockLiteral* block_ptr_handler = &block_handler;
-					block_handler.SetupBlockUnsafe (static_WakeupHandler, value);
-					try {
-						nw_framer_set_wakeup_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-					} finally {
-						block_handler.CleanupBlock ();
-					}
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (static_WakeupHandler, value);
+					nw_framer_set_wakeup_handler (GetCheckedHandle (), &block);
 				}
 			}
 		}
@@ -135,14 +130,9 @@ namespace Network {
 						nw_framer_set_stop_handler (GetCheckedHandle (), null);
 						return;
 					}
-					BlockLiteral block_handler = new BlockLiteral ();
-					BlockLiteral* block_ptr_handler = &block_handler;
-					block_handler.SetupBlockUnsafe (static_StopHandler, value);
-					try {
-						nw_framer_set_stop_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-					} finally {
-						block_handler.CleanupBlock ();
-					}
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (static_StopHandler, value);
+					nw_framer_set_stop_handler (GetCheckedHandle (), &block);
 				}
 			}
 		}
@@ -172,14 +162,9 @@ namespace Network {
 						nw_framer_set_output_handler (GetCheckedHandle (), null);
 						return;
 					}
-					BlockLiteral block_handler = new BlockLiteral ();
-					BlockLiteral* block_ptr_handler = &block_handler;
-					block_handler.SetupBlockUnsafe (static_OutputHandler, value);
-					try {
-						nw_framer_set_output_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-					} finally {
-						block_handler.CleanupBlock ();
-					}
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (static_OutputHandler, value);
+					nw_framer_set_output_handler (GetCheckedHandle (), &block);
 				}
 			}
 		}
@@ -209,14 +194,9 @@ namespace Network {
 						nw_framer_set_input_handler (GetCheckedHandle (), null);
 						return;
 					}
-					BlockLiteral block_handler = new BlockLiteral ();
-					BlockLiteral* block_ptr_handler = &block_handler;
-					block_handler.SetupBlockUnsafe (static_InputHandler, value);
-					try {
-						nw_framer_set_input_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-					} finally {
-						block_handler.CleanupBlock ();
-					}
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (static_InputHandler, value);
+					nw_framer_set_input_handler (GetCheckedHandle (), &block);
 				}
 			}
 		}
@@ -245,14 +225,9 @@ namespace Network {
 						nw_framer_set_cleanup_handler (GetCheckedHandle (), null);
 						return;
 					}
-					BlockLiteral block_handler = new BlockLiteral ();
-					BlockLiteral* block_ptr_handler = &block_handler;
-					block_handler.SetupBlockUnsafe (static_InputHandler, value);
-					try {
-						nw_framer_set_cleanup_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-					} finally {
-						block_handler.CleanupBlock ();
-					}
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (static_CleanupHandler, value);
+					nw_framer_set_cleanup_handler (GetCheckedHandle (), &block);
 				}
 			}
 		}
@@ -354,7 +329,7 @@ namespace Network {
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern unsafe bool nw_framer_parse_output (OS_nw_framer framer, nuint minimum_incomplete_length, nuint maximum_length, byte* temp_buffer, ref BlockLiteral parse);
+		static extern unsafe bool nw_framer_parse_output (OS_nw_framer framer, nuint minimum_incomplete_length, nuint maximum_length, byte* temp_buffer, BlockLiteral* parse);
 
 		delegate void nw_framer_parse_output_t (IntPtr block, IntPtr buffer, nuint buffer_length, bool is_complete);
 		static nw_framer_parse_output_t static_ParseOutputHandler = TrampolineParseOutputHandler;
@@ -377,20 +352,16 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 			unsafe {
-				BlockLiteral block_handler = new BlockLiteral ();
-				block_handler.SetupBlockUnsafe (static_ParseOutputHandler, handler);
-				try {
-					using (var mh = tempBuffer.Pin ())
-						return nw_framer_parse_output (GetCheckedHandle (), minimumIncompleteLength, maximumLength, (byte*) mh.Pointer, ref block_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ParseOutputHandler, handler);
+				using (var mh = tempBuffer.Pin ())
+					return nw_framer_parse_output (GetCheckedHandle (), minimumIncompleteLength, maximumLength, (byte*) mh.Pointer, &block);
 			}
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern unsafe bool nw_framer_parse_input (OS_nw_framer framer, nuint minimum_incomplete_length, nuint maximum_length, byte* temp_buffer, ref BlockLiteral parse);
+		static extern unsafe bool nw_framer_parse_input (OS_nw_framer framer, nuint minimum_incomplete_length, nuint maximum_length, byte* temp_buffer, BlockLiteral* parse);
 
 		delegate nuint nw_framer_parse_input_t (IntPtr block, IntPtr buffer, nuint buffer_length, bool is_complete);
 		static nw_framer_parse_input_t static_ParseInputHandler = TrampolineParseInputHandler;
@@ -414,14 +385,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 			unsafe {
-				BlockLiteral block_handler = new BlockLiteral ();
-				block_handler.SetupBlockUnsafe (static_ParseInputHandler, handler);
-				try {
-					using (var mh = tempBuffer.Pin ())
-						return nw_framer_parse_input (GetCheckedHandle (), minimumIncompleteLength, maximumLength, (byte*) mh.Pointer, ref block_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ParseInputHandler, handler);
+				using (var mh = tempBuffer.Pin ())
+					return nw_framer_parse_input (GetCheckedHandle (), minimumIncompleteLength, maximumLength, (byte*) mh.Pointer, &block);
 			}
 		}
 

--- a/src/Network/NWFramerMessage.cs
+++ b/src/Network/NWFramerMessage.cs
@@ -59,7 +59,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_framer_message_set_value (OS_nw_protocol_metadata message, IntPtr key, IntPtr value, ref BlockLiteral dispose_value);
+		unsafe static extern void nw_framer_message_set_value (OS_nw_protocol_metadata message, IntPtr key, IntPtr value, BlockLiteral* dispose_value);
 		delegate void nw_framer_message_set_value_t (IntPtr block, IntPtr data);
 		static nw_framer_message_set_value_t static_SetDataHandler = TrampolineSetDataHandler;
 
@@ -85,19 +85,17 @@ namespace Network {
 			Action<IntPtr> callback = (_) => {
 				pinned.Free ();
 			};
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_SetDataHandler, callback);
-			try {
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_SetDataHandler, callback);
 				using var keyPtr = new TransientString (key);
-				nw_framer_message_set_value (GetCheckedHandle (), keyPtr, pinned.AddrOfPinnedObject (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+				nw_framer_message_set_value (GetCheckedHandle (), keyPtr, pinned.AddrOfPinnedObject (), &block);
 			}
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool nw_framer_message_access_value (OS_nw_protocol_metadata message, IntPtr key, ref BlockLiteral access_value);
+		unsafe static extern bool nw_framer_message_access_value (OS_nw_protocol_metadata message, IntPtr key, BlockLiteral* access_value);
 		delegate bool nw_framer_message_access_value_t (IntPtr block, IntPtr data);
 		static nw_framer_message_access_value_t static_AccessValueHandler = TrampolineAccessValueHandler;
 
@@ -127,12 +125,12 @@ namespace Network {
 				}
 			};
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_AccessValueHandler, callback);
-			try {
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_AccessValueHandler, callback);
 				// the callback is inlined!!!
 				using var keyPtr = new TransientString (key);
-				var found = nw_framer_message_access_value (GetCheckedHandle (), keyPtr, ref block_handler);
+				var found = nw_framer_message_access_value (GetCheckedHandle (), keyPtr, &block);
 				if (found) {
 					unsafe {
 						outData = new ReadOnlySpan<byte> ((void*) outPointer, dataLength);
@@ -141,8 +139,6 @@ namespace Network {
 					outData = ReadOnlySpan<byte>.Empty;
 				}
 				return found;
-			} finally {
-				block_handler.CleanupBlock ();
 			}
 		}
 

--- a/src/Network/NWListener.cs
+++ b/src/Network/NWListener.cs
@@ -146,7 +146,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern unsafe void nw_listener_set_state_changed_handler (IntPtr handle, void* callback);
+		static extern unsafe void nw_listener_set_state_changed_handler (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void SetStateChangedHandler (Action<NWListenerState, NWError?> callback)
@@ -157,15 +157,9 @@ namespace Network {
 					return;
 				}
 
-				BlockLiteral block_handler = new BlockLiteral ();
-				BlockLiteral* block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_ListenerStateChanged, callback);
-
-				try {
-					nw_listener_set_state_changed_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ListenerStateChanged, callback);
+				nw_listener_set_state_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -183,7 +177,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern unsafe void nw_listener_set_new_connection_handler (IntPtr handle, void* callback);
+		static extern unsafe void nw_listener_set_new_connection_handler (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void SetNewConnectionHandler (Action<NWConnection> callback)
@@ -195,16 +189,10 @@ namespace Network {
 						return;
 					}
 
-					BlockLiteral block_handler = new BlockLiteral ();
-					BlockLiteral* block_ptr_handler = &block_handler;
-					block_handler.SetupBlockUnsafe (static_NewConnection, callback);
-
-					try {
-						nw_listener_set_new_connection_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-						connectionHandlerWasSet = true;
-					} finally {
-						block_handler.CleanupBlock ();
-					}
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (static_NewConnection, callback);
+					nw_listener_set_new_connection_handler (GetCheckedHandle (), &block);
+					connectionHandlerWasSet = true;
 				}
 			}
 		}
@@ -225,7 +213,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern unsafe void nw_listener_set_advertised_endpoint_changed_handler (IntPtr handle, void* callback);
+		static extern unsafe void nw_listener_set_advertised_endpoint_changed_handler (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void SetAdvertisedEndpointChangedHandler (AdvertisedEndpointChanged callback)
@@ -236,15 +224,9 @@ namespace Network {
 					return;
 				}
 
-				BlockLiteral block_handler = new BlockLiteral ();
-				BlockLiteral* block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_AdvertisedEndpointChangedHandler, callback);
-
-				try {
-					nw_listener_set_advertised_endpoint_changed_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_AdvertisedEndpointChangedHandler, callback);
+				nw_listener_set_advertised_endpoint_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -310,7 +292,7 @@ namespace Network {
 		[MacCatalyst (15, 0)]
 #endif
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_listener_set_new_connection_group_handler (IntPtr listener, /* [NullAllowed] */ ref BlockLiteral handler);
+		unsafe static extern void nw_listener_set_new_connection_group_handler (IntPtr listener, /* [NullAllowed] */ BlockLiteral* handler);
 
 		delegate void nw_listener_new_connection_group_handler_t (IntPtr block, nw_connection_group_t group);
 		static nw_listener_new_connection_group_handler_t static_NewConnectionGroup = TrampolineNewConnectionGroup;
@@ -340,12 +322,10 @@ namespace Network {
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void SetNewConnectionGroupHandler (Action<NWConnectionGroup> handler)
 		{
-			BlockLiteral blockHandler = new ();
-			blockHandler.SetupBlockUnsafe (static_NewConnectionGroup, handler);
-			try {
-				nw_listener_set_new_connection_group_handler (GetCheckedHandle (), ref blockHandler);
-			} finally {
-				blockHandler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_NewConnectionGroup, handler);
+				nw_listener_set_new_connection_group_handler (GetCheckedHandle (), &block);
 			}
 		}
 	}

--- a/src/Network/NWMulticastGroup.cs
+++ b/src/Network/NWMulticastGroup.cs
@@ -75,7 +75,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_group_descriptor_enumerate_endpoints (OS_nw_group_descriptor descriptor, ref BlockLiteral enumerate_block);
+		unsafe static extern void nw_group_descriptor_enumerate_endpoints (OS_nw_group_descriptor descriptor, BlockLiteral* enumerate_block);
 
 		delegate bool nw_group_descriptor_enumerate_endpoints_block_t (IntPtr block, OS_nw_endpoint endpoint);
 		static nw_group_descriptor_enumerate_endpoints_block_t static_EnumerateEndpointsHandler = TrampolineEnumerateEndpointsHandler;
@@ -97,12 +97,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_EnumerateEndpointsHandler, handler);
-			try {
-				nw_group_descriptor_enumerate_endpoints (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_EnumerateEndpointsHandler, handler);
+				nw_group_descriptor_enumerate_endpoints (GetCheckedHandle (), &block);
 			}
 		}
 	}

--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -113,6 +113,7 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		static unsafe extern nw_parameters_t nw_parameters_create_secure_tcp (BlockLiteral* configure_tls, BlockLiteral* configure_tcp);
 
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		unsafe static BlockLiteral* CreateBlock (Action<NWProtocolOptions>? callback, BlockLiteral* callbackBlock, out bool disposeReturnValue)
 		{
 			if (callback is null) {

--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -134,7 +134,7 @@ namespace Network {
 		public unsafe static NWParameters CreateSecureTcp (Action<NWProtocolOptions>? configureTls = null, Action<NWProtocolOptions>? configureTcp = null)
 		{
 			var tlsHandler = default (BlockLiteral);
-			var tcpHandler = default (BlockLiteral);;
+			var tcpHandler = default (BlockLiteral); ;
 
 			var tlsPtr = CreateBlock (configureTls, &tlsHandler, out var disposeTlsPtr);
 			var tcpPtr = CreateBlock (configureTcp, &tcpHandler, out var disposeTcpPtr);

--- a/src/Network/NWPath.cs
+++ b/src/Network/NWPath.cs
@@ -127,7 +127,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_path_enumerate_interfaces (IntPtr handle, ref BlockLiteral callback);
+		unsafe static extern void nw_path_enumerate_interfaces (IntPtr handle, BlockLiteral* callback);
 
 
 #if !XAMCORE_5_0
@@ -152,13 +152,10 @@ namespace Network {
 			if (callback is null)
 				return;
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_Enumerator, callback);
-
-			try {
-				nw_path_enumerate_interfaces (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_Enumerator, callback);
+				nw_path_enumerate_interfaces (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -199,7 +196,7 @@ namespace Network {
 		[iOS (13, 0)]
 #endif
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_path_enumerate_gateways (IntPtr path, ref BlockLiteral enumerate_block);
+		unsafe static extern void nw_path_enumerate_gateways (IntPtr path, BlockLiteral* enumerate_block);
 
 		// Returning 'byte' since 'bool' isn't blittable
 		delegate byte nw_path_enumerate_gateways_t (IntPtr block, IntPtr endpoint);
@@ -255,13 +252,10 @@ namespace Network {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_EnumerateGatewaysHandler, callback);
-
-			try {
-				nw_path_enumerate_gateways (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_EnumerateGatewaysHandler, callback);
+				nw_path_enumerate_gateways (GetCheckedHandle (), &block);
 			}
 		}
 

--- a/src/Network/NWPathMonitor.cs
+++ b/src/Network/NWPathMonitor.cs
@@ -144,20 +144,8 @@ namespace Network {
 			}
 		}
 
-		delegate void nw_path_monitor_cancel_handler_t (IntPtr block);
-		static nw_path_monitor_cancel_handler_t static_MonitorCanceled = TrampolineMonitorCanceled;
-
-		[MonoPInvokeCallback (typeof (nw_path_monitor_cancel_handler_t))]
-		static void TrampolineMonitorCanceled (IntPtr block)
-		{
-			var del = BlockLiteral.GetTarget<Action> (block);
-			if (del is not null) {
-				del ();
-			}
-		}
-
 		[DllImport (Constants.NetworkLibrary)]
-		static extern unsafe void nw_path_monitor_set_cancel_handler (IntPtr handle, void* callback);
+		static extern unsafe void nw_path_monitor_set_cancel_handler (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void SetMonitorCanceledHandler (Action callback)
@@ -168,15 +156,8 @@ namespace Network {
 					return;
 				}
 
-				BlockLiteral block_handler = new BlockLiteral ();
-				BlockLiteral* block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_MonitorCanceled, callback);
-
-				try {
-					nw_path_monitor_set_cancel_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = BlockStaticDispatchClass.CreateBlock (callback);
+				nw_path_monitor_set_cancel_handler (GetCheckedHandle (), &block);
 			}
 		}
 

--- a/src/Network/NWPathMonitor.cs
+++ b/src/Network/NWPathMonitor.cs
@@ -99,7 +99,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern unsafe void nw_path_monitor_set_update_handler (IntPtr handle, void* callback);
+		static extern unsafe void nw_path_monitor_set_update_handler (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		void _SetUpdatedSnapshotHandler (Action<NWPath> callback)
@@ -110,15 +110,9 @@ namespace Network {
 					return;
 				}
 
-				BlockLiteral block_handler = new BlockLiteral ();
-				BlockLiteral* block_ptr_handler = &block_handler;
-				block_handler.SetupBlockUnsafe (static_UpdateSnapshot, callback);
-
-				try {
-					nw_path_monitor_set_update_handler (GetCheckedHandle (), (void*) block_ptr_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_UpdateSnapshot, callback);
+				nw_path_monitor_set_update_handler (GetCheckedHandle (), &block);
 			}
 		}
 

--- a/src/Network/NWProtocolDefinition.cs
+++ b/src/Network/NWProtocolDefinition.cs
@@ -140,7 +140,7 @@ namespace Network {
 		[iOS (13, 0)]
 #endif
 		[DllImport (Constants.NetworkLibrary)]
-		static extern unsafe OS_nw_protocol_definition nw_framer_create_definition (IntPtr identifier, NWFramerCreateFlags flags, ref BlockLiteral start_handler);
+		static extern unsafe OS_nw_protocol_definition nw_framer_create_definition (IntPtr identifier, NWFramerCreateFlags flags, BlockLiteral* start_handler);
 		delegate NWFramerStartResult nw_framer_create_definition_t (IntPtr block, IntPtr framer);
 		static nw_framer_create_definition_t static_CreateFramerHandler = TrampolineCreateFramerHandler;
 
@@ -169,13 +169,11 @@ namespace Network {
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static NWProtocolDefinition CreateFramerDefinition (string identifier, NWFramerCreateFlags flags, Func<NWFramer, NWFramerStartResult> startCallback)
 		{
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_CreateFramerHandler, startCallback);
-			try {
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_CreateFramerHandler, startCallback);
 				using var identifierPtr = new TransientString (identifier);
-				return new NWProtocolDefinition (nw_framer_create_definition (identifierPtr, flags, ref block_handler), owns: true);
-			} finally {
-				block_handler.CleanupBlock ();
+				return new NWProtocolDefinition (nw_framer_create_definition (identifierPtr, flags, &block), owns: true);
 			}
 		}
 

--- a/src/Network/NWProtocolStack.cs
+++ b/src/Network/NWProtocolStack.cs
@@ -95,18 +95,15 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		extern static void nw_protocol_stack_iterate_application_protocols (nw_protocol_stack_t stack, ref BlockLiteral completion);
+		unsafe extern static void nw_protocol_stack_iterate_application_protocols (nw_protocol_stack_t stack, BlockLiteral* completion);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void IterateProtocols (Action<NWProtocolOptions> callback)
 		{
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_iterateHandler, callback);
-
-			try {
-				nw_protocol_stack_iterate_application_protocols (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_iterateHandler, callback);
+				nw_protocol_stack_iterate_application_protocols (GetCheckedHandle (), &block);
 			}
 		}
 

--- a/src/Network/NWTxtRecord.cs
+++ b/src/Network/NWTxtRecord.cs
@@ -142,7 +142,7 @@ namespace Network {
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		unsafe static extern bool nw_txt_record_apply (OS_nw_txt_record txt_record, ref BlockLiteral applier);
+		unsafe static extern bool nw_txt_record_apply (OS_nw_txt_record txt_record, BlockLiteral* applier);
 
 		delegate bool nw_txt_record_apply_t (IntPtr block, string key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
 		unsafe static nw_txt_record_apply_t static_ApplyHandler = TrampolineApplyHandler;
@@ -189,12 +189,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_ApplyHandler, handler);
-			try {
-				return nw_txt_record_apply (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ApplyHandler, handler);
+				return nw_txt_record_apply (GetCheckedHandle (), &block);
 			}
 		}
 
@@ -205,19 +203,17 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_ApplyHandler, handler);
-			try {
-				return nw_txt_record_apply (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ApplyHandler, handler);
+				return nw_txt_record_apply (GetCheckedHandle (), &block);
 			}
 		}
 #endif
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern unsafe bool nw_txt_record_access_key (OS_nw_txt_record txt_record, IntPtr key, ref BlockLiteral access_value);
+		static extern unsafe bool nw_txt_record_access_key (OS_nw_txt_record txt_record, IntPtr key, BlockLiteral* access_value);
 
 		unsafe delegate void nw_txt_record_access_key_t (IntPtr block, string key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
 		unsafe static nw_txt_record_access_key_t static_AccessKeyHandler = TrampolineAccessKeyHandler;
@@ -244,19 +240,17 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_AccessKeyHandler, handler);
-			try {
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_AccessKeyHandler, handler);
 				using var keyPtr = new TransientString (key);
-				return nw_txt_record_access_key (GetCheckedHandle (), keyPtr, ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+				return nw_txt_record_access_key (GetCheckedHandle (), keyPtr, &block);
 			}
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		unsafe static extern bool nw_txt_record_access_bytes (OS_nw_txt_record txt_record, ref BlockLiteral access_bytes);
+		unsafe static extern bool nw_txt_record_access_bytes (OS_nw_txt_record txt_record, BlockLiteral* access_bytes);
 
 		unsafe delegate void nw_txt_record_access_bytes_t (IntPtr block, IntPtr value, nuint valueLen);
 		unsafe static nw_txt_record_access_bytes_t static_RawBytesHandler = TrampolineRawBytesHandler;
@@ -279,12 +273,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_RawBytesHandler, handler);
-			try {
-				return nw_txt_record_access_bytes (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_RawBytesHandler, handler);
+				return nw_txt_record_access_bytes (GetCheckedHandle (), &block);
 			}
 		}
 	}

--- a/src/Network/NWWebSocketMetadata.cs
+++ b/src/Network/NWWebSocketMetadata.cs
@@ -64,7 +64,7 @@ namespace Network {
 		public NWWebSocketOpCode OpCode => nw_ws_metadata_get_opcode (GetCheckedHandle ());
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_ws_metadata_set_pong_handler (OS_nw_protocol_metadata metadata, dispatch_queue_t client_queue, ref BlockLiteral pong_handler);
+		unsafe static extern void nw_ws_metadata_set_pong_handler (OS_nw_protocol_metadata metadata, dispatch_queue_t client_queue, BlockLiteral* pong_handler);
 
 		delegate void nw_ws_metadata_set_pong_handler_t (IntPtr block, IntPtr error);
 		static nw_ws_metadata_set_pong_handler_t static_PongHandler = TrampolinePongHandler;
@@ -89,13 +89,9 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
-				BlockLiteral block_handler = new BlockLiteral ();
-				block_handler.SetupBlockUnsafe (static_PongHandler, handler);
-				try {
-					nw_ws_metadata_set_pong_handler (GetCheckedHandle (), queue.Handle, ref block_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_PongHandler, handler);
+				nw_ws_metadata_set_pong_handler (GetCheckedHandle (), queue.Handle, &block);
 			}
 		}
 

--- a/src/Network/NWWebSocketOptions.cs
+++ b/src/Network/NWWebSocketOptions.cs
@@ -106,7 +106,7 @@ namespace Network {
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
-		static extern void nw_ws_options_set_client_request_handler (OS_nw_protocol_options options, IntPtr client_queue, ref BlockLiteral handler);
+		unsafe static extern void nw_ws_options_set_client_request_handler (OS_nw_protocol_options options, IntPtr client_queue, BlockLiteral* handler);
 
 		delegate void nw_ws_options_set_client_request_handler_t (IntPtr block, nw_ws_request_t request);
 		static nw_ws_options_set_client_request_handler_t static_ClientRequestHandler = TrampolineClientRequestHandler;
@@ -128,14 +128,11 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
+
 			unsafe {
-				BlockLiteral block_handler = new BlockLiteral ();
-				block_handler.SetupBlockUnsafe (static_ClientRequestHandler, handler);
-				try {
-					nw_ws_options_set_client_request_handler (GetCheckedHandle (), queue.Handle, ref block_handler);
-				} finally {
-					block_handler.CleanupBlock ();
-				}
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_ClientRequestHandler, handler);
+				nw_ws_options_set_client_request_handler (GetCheckedHandle (), queue.Handle, &block);
 			}
 		}
 	}

--- a/src/Network/NWWebSocketRequest.cs
+++ b/src/Network/NWWebSocketRequest.cs
@@ -41,7 +41,7 @@ namespace Network {
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		unsafe static extern bool nw_ws_request_enumerate_additional_headers (OS_nw_ws_request request, ref BlockLiteral enumerator);
+		unsafe static extern bool nw_ws_request_enumerate_additional_headers (OS_nw_ws_request request, BlockLiteral* enumerator);
 
 		delegate void nw_ws_request_enumerate_additional_headers_t (IntPtr block, string header, string value);
 		static nw_ws_request_enumerate_additional_headers_t static_EnumerateHeaderHandler = TrampolineEnumerateHeaderHandler;
@@ -61,18 +61,16 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_EnumerateHeaderHandler, handler);
-			try {
-				nw_ws_request_enumerate_additional_headers (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_EnumerateHeaderHandler, handler);
+				nw_ws_request_enumerate_additional_headers (GetCheckedHandle (), &block);
 			}
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool nw_ws_request_enumerate_subprotocols (OS_nw_ws_request request, ref BlockLiteral enumerator);
+		unsafe static extern bool nw_ws_request_enumerate_subprotocols (OS_nw_ws_request request, BlockLiteral* enumerator);
 
 		delegate void nw_ws_request_enumerate_subprotocols_t (IntPtr block, string subprotocol);
 		static nw_ws_request_enumerate_subprotocols_t static_EnumerateSubprotocolHandler = TrampolineEnumerateSubprotocolHandler;
@@ -92,12 +90,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_EnumerateSubprotocolHandler, handler);
-			try {
-				nw_ws_request_enumerate_subprotocols (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_EnumerateSubprotocolHandler, handler);
+				nw_ws_request_enumerate_subprotocols (GetCheckedHandle (), &block);
 			}
 		}
 	}

--- a/src/Network/NWWebSocketResponse.cs
+++ b/src/Network/NWWebSocketResponse.cs
@@ -70,7 +70,7 @@ namespace Network {
 
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		unsafe static extern bool nw_ws_response_enumerate_additional_headers (OS_nw_ws_response response, ref BlockLiteral enumerator);
+		unsafe static extern bool nw_ws_response_enumerate_additional_headers (OS_nw_ws_response response, BlockLiteral* enumerator);
 
 		delegate void nw_ws_response_enumerate_additional_headers_t (IntPtr block, string header, string value);
 		static nw_ws_response_enumerate_additional_headers_t static_EnumerateHeadersHandler = TrampolineEnumerateHeadersHandler;
@@ -90,12 +90,10 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_EnumerateHeadersHandler, handler);
-			try {
-				return nw_ws_response_enumerate_additional_headers (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_EnumerateHeadersHandler, handler);
+				return nw_ws_response_enumerate_additional_headers (GetCheckedHandle (), &block);
 			}
 		}
 

--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -217,13 +217,13 @@ namespace ObjCRuntime {
 			}
 
 			if (block_descriptor != IntPtr.Zero) {
-				var xblock_descriptor = (XamarinBlockDescriptor *) block_descriptor;
-	#pragma warning disable 420
+				var xblock_descriptor = (XamarinBlockDescriptor*) block_descriptor;
+#pragma warning disable 420
 				// CS0420: A volatile field references will not be treated as volatile
 				// Documentation says: "A volatile field should not normally be passed using a ref or out parameter, since it will not be treated as volatile within the scope of the function. There are exceptions to this, such as when calling an interlocked API."
 				// So ignoring the warning, since it's a documented exception.
 				var rc = Interlocked.Decrement (ref xblock_descriptor->ref_count);
-	#pragma warning restore 420
+#pragma warning restore 420
 
 				if (rc == 0)
 					Marshal.FreeHGlobal (block_descriptor);

--- a/src/Security/SecIdentity2.cs
+++ b/src/Security/SecIdentity2.cs
@@ -105,7 +105,7 @@ namespace Security {
 #endif
 		[DllImport (Constants.SecurityLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool sec_identity_access_certificates (IntPtr identity, ref BlockLiteral block);
+		unsafe static extern bool sec_identity_access_certificates (IntPtr identity, BlockLiteral* block);
 
 		internal delegate void AccessCertificatesHandler (IntPtr block, IntPtr cert);
 		static readonly AccessCertificatesHandler access = TrampolineAccessCertificates;
@@ -136,12 +136,10 @@ namespace Security {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			try {
-				block_handler.SetupBlockUnsafe (access, handler);
-				return sec_identity_access_certificates (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (access, handler);
+				return sec_identity_access_certificates (GetCheckedHandle (), &block);
 			}
 		}
 #endif

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -206,7 +206,7 @@ namespace Security {
 
 		[DllImport (Constants.SecurityLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool sec_protocol_metadata_access_distinguished_names (IntPtr handle, ref BlockLiteral callback);
+		unsafe static extern bool sec_protocol_metadata_access_distinguished_names (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void SetDistinguishedNamesForPeerHandler (Action<DispatchData> callback)
@@ -214,15 +214,11 @@ namespace Security {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			var block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_DistinguishedNamesForPeer, callback);
-
-			try {
-				if (!sec_protocol_metadata_access_distinguished_names (GetCheckedHandle (), ref block_handler)) {
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_DistinguishedNamesForPeer, callback);
+				if (!sec_protocol_metadata_access_distinguished_names (GetCheckedHandle (), &block))
 					throw new InvalidOperationException ("Distinguished names are not accessible.");
-				}
-			} finally {
-				block_handler.CleanupBlock ();
 			}
 		}
 
@@ -241,7 +237,7 @@ namespace Security {
 
 		[DllImport (Constants.SecurityLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool sec_protocol_metadata_access_ocsp_response (IntPtr handle, ref BlockLiteral callback);
+		unsafe static extern bool sec_protocol_metadata_access_ocsp_response (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void SetOcspResponseForPeerHandler (Action<DispatchData> callback)
@@ -249,15 +245,11 @@ namespace Security {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			var block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_OcspReposeForPeer, callback);
-
-			try {
-				if (!sec_protocol_metadata_access_ocsp_response (GetCheckedHandle (), ref block_handler)) {
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_OcspReposeForPeer, callback);
+				if (!sec_protocol_metadata_access_ocsp_response (GetCheckedHandle (), &block))
 					throw new InvalidOperationException ("The OSCP response is not accessible.");
-				}
-			} finally {
-				block_handler.CleanupBlock ();
 			}
 		}
 
@@ -276,7 +268,7 @@ namespace Security {
 
 		[DllImport (Constants.SecurityLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool sec_protocol_metadata_access_peer_certificate_chain (IntPtr handle, ref BlockLiteral callback);
+		unsafe static extern bool sec_protocol_metadata_access_peer_certificate_chain (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void SetCertificateChainForPeerHandler (Action<SecCertificate> callback)
@@ -284,15 +276,11 @@ namespace Security {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			var block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_CertificateChainForPeer, callback);
-
-			try {
-				if (!sec_protocol_metadata_access_peer_certificate_chain (GetCheckedHandle (), ref block_handler)) {
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_CertificateChainForPeer, callback);
+				if (!sec_protocol_metadata_access_peer_certificate_chain (GetCheckedHandle (), &block))
 					throw new InvalidOperationException ("The peer certificates are not accessible.");
-				}
-			} finally {
-				block_handler.CleanupBlock ();
 			}
 		}
 
@@ -310,7 +298,7 @@ namespace Security {
 
 		[DllImport (Constants.SecurityLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		static extern bool sec_protocol_metadata_access_supported_signature_algorithms (IntPtr handle, ref BlockLiteral callback);
+		unsafe static extern byte sec_protocol_metadata_access_supported_signature_algorithms (IntPtr handle, BlockLiteral* callback);
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void SetSignatureAlgorithmsForPeerHandler (Action<ushort> callback)
@@ -318,15 +306,11 @@ namespace Security {
 			if (callback is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
-			var block_handler = new BlockLiteral ();
-			block_handler.SetupBlockUnsafe (static_SignatureAlgorithmsForPeer, callback);
-
-			try {
-				if (!sec_protocol_metadata_access_supported_signature_algorithms (GetCheckedHandle (), ref block_handler)) {
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (static_SignatureAlgorithmsForPeer, callback);
+				if (sec_protocol_metadata_access_supported_signature_algorithms (GetCheckedHandle (), &block) != 0)
 					throw new InvalidOperationException ("The supported signature list is not accessible.");
-				}
-			} finally {
-				block_handler.CleanupBlock ();
 			}
 		}
 
@@ -402,7 +386,7 @@ namespace Security {
 #endif
 		[DllImport (Constants.SecurityLibrary)]
 		[return: MarshalAs (UnmanagedType.U1)]
-		static extern bool sec_protocol_metadata_access_pre_shared_keys (IntPtr /* sec_protocol_metadata_t */ handle, ref BlockLiteral block);
+		unsafe static extern bool sec_protocol_metadata_access_pre_shared_keys (IntPtr /* sec_protocol_metadata_t */ handle, BlockLiteral* block);
 
 		public delegate void SecAccessPreSharedKeysHandler (DispatchData psk, DispatchData pskIdentity);
 
@@ -435,12 +419,10 @@ namespace Security {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			try {
-				block_handler.SetupBlockUnsafe (presharedkeys, handler);
-				return sec_protocol_metadata_access_pre_shared_keys (GetCheckedHandle (), ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (presharedkeys, handler);
+				return sec_protocol_metadata_access_pre_shared_keys (GetCheckedHandle (), &block);
 			}
 		}
 #endif

--- a/src/Security/SecSharedCredential.cs
+++ b/src/Security/SecSharedCredential.cs
@@ -15,8 +15,8 @@ namespace Security {
 	public static partial class SecSharedCredential {
 
 		[DllImport (Constants.SecurityLibrary)]
-		extern static void SecAddSharedWebCredential (IntPtr /* CFStringRef */ fqdn, IntPtr /* CFStringRef */ account, IntPtr /* CFStringRef */ password,
-			IntPtr /* void (^completionHandler)( CFErrorRef error) ) */ completionHandler);
+		unsafe extern static void SecAddSharedWebCredential (IntPtr /* CFStringRef */ fqdn, IntPtr /* CFStringRef */ account, IntPtr /* CFStringRef */ password,
+			BlockLiteral* /* void (^completionHandler)( CFErrorRef error) ) */ completionHandler);
 			
 		[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
 		internal delegate void DActionArity1V12 (IntPtr block, IntPtr obj);
@@ -45,23 +45,12 @@ namespace Security {
 			// we need to create our own block literal. We can reuse the SDActionArity1V12 which is generated and takes a
 			// NSError because a CFError is a toll-free bridget to CFError
 			unsafe {
-				BlockLiteral *block_ptr_onComplete;
-				BlockLiteral block_onComplete;
-				block_onComplete = new BlockLiteral ();
-				block_ptr_onComplete = &block_onComplete;
-				block_onComplete.SetupBlockUnsafe (ActionTrampoline.Handler, handler);
-
-				using (var nsDomain = new NSString (domainName))
-				using (var nsAccount = new NSString (account)) {
-					if (password is null) {  // we are removing a password
-						SecAddSharedWebCredential (nsDomain.Handle, nsAccount.Handle, IntPtr.Zero, (IntPtr) block_ptr_onComplete);
-					} else {
-						using (var nsPassword = new NSString (password)) {
-							SecAddSharedWebCredential (nsDomain.Handle, nsAccount.Handle, nsPassword.Handle, (IntPtr) block_ptr_onComplete);
-						}
-					}
-					block_ptr_onComplete->CleanupBlock ();
-				}
+				using var nsDomain = new NSString (domainName);
+				using var nsAccount = new NSString (account);
+				using var nsPassword = (NSString?) password;
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (ActionTrampoline.Handler, handler);
+				SecAddSharedWebCredential (nsDomain.Handle, nsAccount.Handle, nsPassword.GetHandle (), &block);
 			}
 		}
 
@@ -77,8 +66,8 @@ namespace Security {
 		[Deprecated (PlatformName.MacOSX, 11,0)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
-		extern static void SecRequestSharedWebCredential ( IntPtr /* CFStringRef */ fqdn, IntPtr /* CFStringRef */ account,
-			IntPtr /* void (^completionHandler)( CFArrayRef credentials, CFErrorRef error) */ completionHandler);
+		unsafe extern static void SecRequestSharedWebCredential ( IntPtr /* CFStringRef */ fqdn, IntPtr /* CFStringRef */ account,
+			BlockLiteral* /* void (^completionHandler)( CFArrayRef credentials, CFErrorRef error) */ completionHandler);
 
 		[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
 		internal delegate void ArrayErrorAction (IntPtr block, IntPtr array, IntPtr err);
@@ -130,28 +119,13 @@ namespace Security {
 				handler (creds, e);
 			};
 			// we need to create our own block literal.
+			using var nsDomain = (NSString?) domainName;
+			using var nsAccount = (NSString?) account;
+
 			unsafe {
-				BlockLiteral *block_ptr_onComplete;
-				BlockLiteral block_onComplete;
-				block_onComplete = new BlockLiteral ();
-				block_ptr_onComplete = &block_onComplete;
-				block_onComplete.SetupBlockUnsafe (ArrayErrorActionTrampoline.Handler, onComplete);
-
-				NSString? nsDomain = null;
-				if (domainName is not null)
-					nsDomain = new NSString (domainName);
-
-				NSString? nsAccount = null;
-				if (account is not null)
-					nsAccount = new NSString (account);
-				
-				SecRequestSharedWebCredential (nsDomain.GetHandle (), nsAccount.GetHandle (),
-					(IntPtr) block_ptr_onComplete); 
-				block_ptr_onComplete->CleanupBlock ();
-				if (nsDomain is not null)
-					nsDomain.Dispose ();
-				if (nsAccount is not null)
-					nsAccount.Dispose ();
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (ArrayErrorActionTrampoline.Handler, onComplete);
+				SecRequestSharedWebCredential (nsDomain.GetHandle (), nsAccount.GetHandle (), &block);
 			}
 		}
 

--- a/src/Security/SecTrust.cs
+++ b/src/Security/SecTrust.cs
@@ -179,7 +179,7 @@ namespace Security {
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'Evaluate (DispatchQueue, SecTrustWithErrorCallback)' instead.")]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
-		extern static SecStatusCode /* OSStatus */ SecTrustEvaluateAsync (IntPtr /* SecTrustRef */ trust, IntPtr /* dispatch_queue_t */ queue, ref BlockLiteral block);
+		unsafe extern static SecStatusCode /* OSStatus */ SecTrustEvaluateAsync (IntPtr /* SecTrustRef */ trust, IntPtr /* dispatch_queue_t */ queue, BlockLiteral* block);
 
 		internal delegate void TrustEvaluateHandler (IntPtr block, IntPtr trust, SecTrustResult trustResult);
 		static readonly TrustEvaluateHandler evaluate = TrampolineEvaluate;
@@ -217,12 +217,10 @@ namespace Security {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			try {
-				block_handler.SetupBlockUnsafe (evaluate, handler);
-				return SecTrustEvaluateAsync (Handle, queue.Handle, ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (evaluate, handler);
+				return SecTrustEvaluateAsync (Handle, queue.Handle, &block);
 			}
 		}
 
@@ -238,7 +236,7 @@ namespace Security {
 		[iOS (13, 0)]
 #endif
 		[DllImport (Constants.SecurityLibrary)]
-		static extern SecStatusCode SecTrustEvaluateAsyncWithError (IntPtr /* SecTrustRef */ trust, IntPtr /* dispatch_queue_t */ queue, ref BlockLiteral block);
+		unsafe static extern SecStatusCode SecTrustEvaluateAsyncWithError (IntPtr /* SecTrustRef */ trust, IntPtr /* dispatch_queue_t */ queue, BlockLiteral* block);
 
 		internal delegate void TrustEvaluateErrorHandler (IntPtr block, IntPtr trust, bool result, IntPtr /* CFErrorRef _Nullable */  error);
 		static readonly TrustEvaluateErrorHandler evaluate_error = TrampolineEvaluateError;
@@ -273,12 +271,10 @@ namespace Security {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
-			BlockLiteral block_handler = new BlockLiteral ();
-			try {
-				block_handler.SetupBlockUnsafe (evaluate_error, handler);
-				return SecTrustEvaluateAsyncWithError (Handle, queue.Handle, ref block_handler);
-			} finally {
-				block_handler.CleanupBlock ();
+			unsafe {
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (evaluate_error, handler);
+				return SecTrustEvaluateAsyncWithError (Handle, queue.Handle, &block);
 			}
 		}
 

--- a/src/UIKit/UIAccessibility.cs
+++ b/src/UIKit/UIAccessibility.cs
@@ -237,7 +237,7 @@ namespace UIKit {
 		[SupportedOSPlatform ("tvos")]
 #endif
 		[DllImport (Constants.UIKitLibrary)]
-		extern unsafe static void UIAccessibilityRequestGuidedAccessSession (/* BOOL */ [MarshalAs (UnmanagedType.I1)] bool enable, /* void(^completionHandler)(BOOL didSucceed) */ void* completionHandler);
+		extern unsafe static void UIAccessibilityRequestGuidedAccessSession (/* BOOL */ [MarshalAs (UnmanagedType.I1)] bool enable, /* void(^completionHandler)(BOOL didSucceed) */ BlockLiteral* completionHandler);
 
 #if NET
 		[SupportedOSPlatform ("ios")]
@@ -248,14 +248,9 @@ namespace UIKit {
 		public static void RequestGuidedAccessSession (bool enable, Action<bool> completionHandler)
 		{
 			unsafe {
-				BlockLiteral* block_ptr_handler;
-				BlockLiteral block_handler;
-				block_handler = new BlockLiteral ();
-				block_ptr_handler = &block_handler;
-				block_handler.SetupBlock (callback, completionHandler);
-
-				UIAccessibilityRequestGuidedAccessSession (enable, (void*) block_ptr_handler);
-				block_ptr_handler->CleanupBlock ();
+				using var block = new BlockLiteral ();
+				block.SetupBlock (callback, completionHandler);
+				UIAccessibilityRequestGuidedAccessSession (enable, &block);
 			}
 		}
 

--- a/src/UIKit/UIGuidedAccessRestriction.cs
+++ b/src/UIKit/UIGuidedAccessRestriction.cs
@@ -50,7 +50,7 @@ namespace UIKit {
 		[iOS (12,2)]
 #endif
 		[DllImport (Constants.UIKitLibrary)]
-		static extern void UIGuidedAccessConfigureAccessibilityFeatures (/* UIGuidedAccessAccessibilityFeature */ nuint features, [MarshalAs (UnmanagedType.I1)] bool enabled, IntPtr completion);
+		static unsafe extern void UIGuidedAccessConfigureAccessibilityFeatures (/* UIGuidedAccessAccessibilityFeature */ nuint features, [MarshalAs (UnmanagedType.I1)] bool enabled, BlockLiteral* completion);
 
 #if NET
 		// [SupportedOSPlatform ("ios12.2")] -- Not valid for Delegates
@@ -91,14 +91,9 @@ namespace UIKit {
 				throw new ArgumentNullException (nameof (completionHandler));
 
 			unsafe {
-				BlockLiteral* block_ptr_completionHandler;
-				BlockLiteral block_completionHandler;
-				block_completionHandler = new BlockLiteral ();
-				block_ptr_completionHandler = &block_completionHandler;
-				block_completionHandler.SetupBlockUnsafe (UIGuidedAccessConfigureAccessibilityFeaturesTrampoline.Handler, completionHandler);
-
-				UIGuidedAccessConfigureAccessibilityFeatures ((nuint) (ulong) features, enabled, (IntPtr) block_ptr_completionHandler);
-				block_ptr_completionHandler->CleanupBlock ();
+				using var block = new BlockLiteral ();
+				block.SetupBlockUnsafe (UIGuidedAccessConfigureAccessibilityFeaturesTrampoline.Handler, completionHandler);
+				UIGuidedAccessConfigureAccessibilityFeatures ((nuint) (ulong) features, enabled, &block);
 			}
 		}
 


### PR DESCRIPTION
* Make BlockLiteral disposable.

    This also means to modify the cleanup logic so that it's safe to call
    Dispose more than once.

* Create a helper class to create a block for a simple Action delegate.

    This allows us to simplify a good chunk of code.

* Update all block creation to use the new block API, where blocks are
  disposable. This makes the code pattern a lot simpler.

    I've changed all the P/Invokes to use an unsafe 'BlockLiteral*' pointer,
    because 'using' variables can't be passed as ref arguments, so the choice
    was either to make the parameter type 'IntPtr' and cast away the pointer:

        using var block = new BlockLiteral ();
        PInvoke ((IntPtr) &block);

    or make the parameter an unsafe 'BlockLiteral*' pointer:

        unsafe {
            using var block = new BlockLiteral ();
            PInvoke (&block);
        }

    The upcoming support for function pointers don't have this choice:
    function pointers are always unsafe, so I chose to go the unsafe route
    here as well, since it makes the code simpler once support for function
    pointers has been implemented.

Contributes towards https://github.com/xamarin/xamarin-macios/issues/15783.

This PR might be easier to review commit-by-commit.