### PR TITLE
[release/7.0.1xx-xcode14.2] Updated Xamarin.Messaging to 1.9.40

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.9.17</MessagingVersion>
+		<MessagingVersion>1.9.40</MessagingVersion>
 		<HotRestartVersion>1.0.93</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Applies the following changes from Xamarin.Messaging:

xamarin/Xamarin.Messaging#543

xamarin/Xamarin.Messaging#541

It includes fixes for SSH keys handling, UX improvements when SSH is disabled on the Mac and also when the user is not logged in on the Mac


Backport of #17580
