### PR TITLE
[ImageIO] We don't typically own input parameters.

### DIFF
--- a/src/ImageIO/CGImageMetadata.cs
+++ b/src/ImageIO/CGImageMetadata.cs
@@ -127,14 +127,15 @@ namespace ImageIO {
 		[MonoPInvokeCallback (typeof (TrampolineCallback))]
 		static bool TagEnumerator (IntPtr block, NativeHandle key, NativeHandle value)
 		{
-			var nsKey = Runtime.GetNSObject<NSString> (key, true)!;
-			var nsValue = Runtime.GetINativeObject<CGImageMetadataTag> (value, true)!;
+			var nsKey = Runtime.GetNSObject<NSString> (key, false)!;
+			var nsValue = Runtime.GetINativeObject<CGImageMetadataTag> (value, false)!;
 			var del = BlockLiteral.GetTarget<CGImageMetadataTagBlock> (block);
 			return del (nsKey, nsValue);
 		}
 
 		static unsafe readonly TrampolineCallback static_action = TagEnumerator;
 
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void EnumerateTags (NSString? rootPath, CGImageMetadataEnumerateOptions? options, CGImageMetadataTagBlock block)
 		{
 			using var o = options?.ToDictionary ();


### PR DESCRIPTION
We don't typically own input parameters, so make sure to pass 'false' for the
'owns' parameter to Runtime.GetNSObject.

This fixes a crash due to overreleasing these objects.

Also make the block creation code optimizable.