### PR TITLE
[dotnet] Remove dead method, add some ignores

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -689,16 +689,6 @@ namespace ObjCRuntime {
 
 		[DllImport (Messaging.LIBOBJC_DYLIB)]
 		[return: MarshalAs (UnmanagedType.U1)]
-		internal extern static bool class_addMethod (IntPtr cls, IntPtr name, Delegate imp, IntPtr types);
-
-		internal static bool class_addMethod (IntPtr cls, IntPtr name, Delegate imp, string types)
-		{
-			using var typesPtr = new TransientString (types);
-			return class_addMethod (cls, name, imp, typesPtr);
-		}
-
-		[DllImport (Messaging.LIBOBJC_DYLIB)]
-		[return: MarshalAs (UnmanagedType.U1)]
 		internal extern static bool class_addProtocol (IntPtr cls, IntPtr protocol);
 
 		[DllImport (Messaging.LIBOBJC_DYLIB)]

--- a/tests/cecil-tests/BlittablePInvokes.cs
+++ b/tests/cecil-tests/BlittablePInvokes.cs
@@ -41,7 +41,7 @@ namespace Cecil.Tests {
 			public string Reason;
 		}
 
-		[Ignore ("work in progress - there are 4 failures, mostly due to delegates")]
+		[Ignore ("work in progress - there are 17 failures in mac version, mostly due to delegates and strings")]
 		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformImplementationAssemblyDefinitions))]
 		public void CheckForNonBlittablePInvokes (AssemblyInfo info)
 		{
@@ -205,6 +205,12 @@ namespace Cecil.Tests {
 		{
 			var fullName = method.FullName;
 			switch (fullName) {
+			case "System.IntPtr ObjCRuntime.Selector::GetHandle(System.String)":
+#if !NET8_0_OR_GREATER
+			case "System.Boolean CoreFoundation.CFReadStream::CFReadStreamSetClient(System.IntPtr,System.IntPtr,CoreFoundation.CFStream/CFStreamCallback,System.IntPtr)":
+			case "System.Boolean CoreFoundation.CFWriteStream::CFWriteStreamSetClient(System.IntPtr,System.IntPtr,CoreFoundation.CFStream/CFStreamCallback,System.IntPtr)":
+#endif
+				return false;
 			default:
 				return true;
 			}


### PR DESCRIPTION
Removed a flavor of `class_addMethod` that is unused.
Ignored a few cases that are going to be in .NET and/or may break AOT optimizations

Now all iOS pivots pass, 17 macOS remain.