### PR TITLE
[AppKit] Make sure NSButtons are treated as toggled objects after setting a field. Fixes #17635.

### DIFF
--- a/src/AppKit/NSButton.cs
+++ b/src/AppKit/NSButton.cs
@@ -37,7 +37,14 @@ using Foundation;
 namespace AppKit {
 
 	public partial class NSButton {
-		NSActionDispatcher? dispatcher;
+		NSObject? dispatcher;
+
+		NSObject? Dispatcher {
+			set {
+				dispatcher = value;
+				MarkDirty ();
+			}
+		}
 
 		public new NSButtonCell Cell {
 			get { return (NSButtonCell) base.Cell; }
@@ -54,7 +61,7 @@ namespace AppKit {
 		{
 			var dispatcher = new NSActionDispatcher (action);
 			var control = _CreateButton (title, image, dispatcher, NSActionDispatcher.Selector);
-			control.dispatcher = dispatcher;
+			control.Dispatcher = dispatcher;
 			return control;
 		}
 
@@ -68,7 +75,7 @@ namespace AppKit {
 		{
 			var dispatcher = new NSActionDispatcher (action);
 			var control = _CreateButton (title, dispatcher, NSActionDispatcher.Selector);
-			control.dispatcher = dispatcher;
+			control.Dispatcher = dispatcher;
 			return control;
 		}
 
@@ -82,7 +89,7 @@ namespace AppKit {
 		{
 			var dispatcher = new NSActionDispatcher (action);
 			var control = _CreateButton (image, dispatcher, NSActionDispatcher.Selector);
-			control.dispatcher = dispatcher;
+			control.Dispatcher = dispatcher;
 			return control;
 		}
 
@@ -96,7 +103,7 @@ namespace AppKit {
 		{
 			var dispatcher = new NSActionDispatcher (action);
 			var control = _CreateCheckbox (title, dispatcher, NSActionDispatcher.Selector);
-			control.dispatcher = dispatcher;
+			control.Dispatcher = dispatcher;
 			return control;
 		}
 
@@ -110,7 +117,7 @@ namespace AppKit {
 		{
 			var dispatcher = new NSActionDispatcher (action);
 			var control = _CreateRadioButton (title, dispatcher, NSActionDispatcher.Selector);
-			control.dispatcher = dispatcher;
+			control.Dispatcher = dispatcher;
 			return control;
 		}
 	}

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -2271,6 +2271,7 @@ namespace AppKit {
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSControl))]
+	[Dispose ("dispatcher = null;", Optimizable = true)]
 	interface NSButton : NSAccessibilityButton, NSUserInterfaceCompression, NSUserInterfaceValidations {
 		[Export ("initWithFrame:")]
 		NativeHandle Constructor (CGRect frameRect);


### PR DESCRIPTION
If a wrapper type has a custom field (with a non-default value), we need to
mark the instance as dirty, to make it participate in the toggle-ref
machinery, and not get collected as long as the corresponding native instance
is around (otherwise the GC will collect the value in the field).

Fixes https://github.com/xamarin/xamarin-macios/issues/17635.