### PR TITLE
[src] Refactor block code to use blittable callbacks.

### DIFF
--- a/src/AddressBook/ABAddressBook.cs
+++ b/src/AddressBook/ABAddressBook.cs
@@ -200,15 +200,15 @@ namespace AddressBook {
 			}
 		}
 
-		internal delegate void InnerCompleted (IntPtr block, bool success, IntPtr error);
+		internal delegate void InnerCompleted (IntPtr block, byte success, IntPtr error);
 		static readonly InnerCompleted static_completionHandler = TrampolineCompletionHandler;
 		[MonoPInvokeCallback (typeof (InnerCompleted))]
-		static unsafe void TrampolineCompletionHandler (IntPtr block, bool success, IntPtr error)
+		static unsafe void TrampolineCompletionHandler (IntPtr block, byte success, IntPtr error)
 		{
 			var descriptor = (BlockLiteral*) block;
 			var del = descriptor->Target as Action<bool, NSError?>;
 			if (del is not null)
-				del (success, Runtime.GetNSObject<NSError> (error));
+				del (success != 0, Runtime.GetNSObject<NSError> (error));
 		}
 
 		[DllImport (Constants.AddressBookLibrary)]

--- a/src/CoreGraphics/CGPDFArray.cs
+++ b/src/CoreGraphics/CGPDFArray.cs
@@ -218,19 +218,21 @@ namespace CoreGraphics {
 		}
 #endif
 
-		delegate bool ApplyBlockHandlerDelegate (IntPtr block, nint index, IntPtr value, IntPtr info);
+		delegate byte ApplyBlockHandlerDelegate (IntPtr block, nint index, IntPtr value, IntPtr info);
 		static readonly ApplyBlockHandlerDelegate applyblock_handler = ApplyBlockHandler;
 
 #if !MONOMAC
 		[MonoPInvokeCallback (typeof (ApplyBlockHandlerDelegate))]
 #endif
-		static bool ApplyBlockHandler (IntPtr block, nint index, IntPtr value, IntPtr info)
+		static byte ApplyBlockHandler (IntPtr block, nint index, IntPtr value, IntPtr info)
 		{
 			var del = BlockLiteral.GetTarget<ApplyCallback> (block);
-			if (del is not null)
-				return del (index, CGPDFObject.FromHandle (value), info == IntPtr.Zero ? null : GCHandle.FromIntPtr (info).Target);
+			if (del is not null) {
+				var context = info == IntPtr.Zero ? null : GCHandle.FromIntPtr (info).Target;
+				return del (index, CGPDFObject.FromHandle (value), context) ? (byte) 1 : (byte) 0;
+			}
 
-			return false;
+			return 0;
 		}
 
 		public delegate bool ApplyCallback (nint index, object? value, object? info);

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -232,14 +232,18 @@ namespace CoreText {
 #endif
 		public delegate bool CTFontRegistrationHandler (NSError [] errors, bool done);
 
-		internal delegate bool InnerRegistrationHandler (IntPtr block, IntPtr errors, bool done);
+		internal delegate byte InnerRegistrationHandler (IntPtr block, IntPtr errors, byte done);
 		static readonly InnerRegistrationHandler callback = TrampolineRegistrationHandler;
 
 		[MonoPInvokeCallback (typeof (InnerRegistrationHandler))]
-		static unsafe bool TrampolineRegistrationHandler (IntPtr block, /* NSArray */ IntPtr errors, bool done)
+		static unsafe byte TrampolineRegistrationHandler (IntPtr block, /* NSArray */ IntPtr errors, byte done)
 		{
 			var del = BlockLiteral.GetTarget<CTFontRegistrationHandler> (block);
-			return del is not null ? del (NSArray.ArrayFromHandle<NSError> (errors), done) : true;
+			if (del is null)
+				return 0;
+
+			var rv = del (NSArray.ArrayFromHandle<NSError> (errors), done == 0 ? false : true);
+			return rv ? (byte) 1 : (byte) 0;
 		}
 
 #if NET

--- a/src/ImageIO/CGImageAnimation.cs
+++ b/src/ImageIO/CGImageAnimation.cs
@@ -129,8 +129,7 @@ namespace ImageIO {
 				if (del is not null) {
 					del (index, new CoreGraphics.CGImage (image, false), out var stopValue);
 					*stop = stopValue ? (byte) 1 : (byte) 0;
-				}
-				else
+				} else
 					*stop = 0;
 			}
 		} /* class SDCGImageSourceAnimationBlock */

--- a/src/ImageIO/CGImageAnimation.cs
+++ b/src/ImageIO/CGImageAnimation.cs
@@ -120,22 +120,24 @@ namespace ImageIO {
 		// This class bridges native block invocations that call into C#
 		//
 		static internal class SDCGImageSourceAnimationBlock {
-			static internal readonly DCGImageSourceAnimationBlock Handler = Invoke;
+			unsafe static internal readonly DCGImageSourceAnimationBlock Handler = Invoke;
 
 			[MonoPInvokeCallback (typeof (DCGImageSourceAnimationBlock))]
-			static void Invoke (IntPtr block, nint index, IntPtr image, [MarshalAs (UnmanagedType.I1)] out bool stop)
+			internal unsafe static void Invoke (IntPtr block, nint index, IntPtr image, byte* stop)
 			{
 				var del = BlockLiteral.GetTarget<CGImageSourceAnimationHandler> (block);
-				if (del is not null)
-					del (index, new CoreGraphics.CGImage (image, false), out stop);
+				if (del is not null) {
+					del (index, new CoreGraphics.CGImage (image, false), out var stopValue);
+					*stop = stopValue ? (byte) 1 : (byte) 0;
+				}
 				else
-					stop = false;
+					*stop = 0;
 			}
 		} /* class SDCGImageSourceAnimationBlock */
 
 		[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
 		[UserDelegateType (typeof (CGImageSourceAnimationHandler))]
-		internal delegate void DCGImageSourceAnimationBlock (IntPtr block, nint index, IntPtr imageHandle, [MarshalAs (UnmanagedType.I1)] out bool stop);
+		unsafe internal delegate void DCGImageSourceAnimationBlock (IntPtr block, nint index, IntPtr imageHandle, byte* stop);
 	}
 
 }

--- a/src/Network/NWBrowser.cs
+++ b/src/Network/NWBrowser.cs
@@ -131,18 +131,18 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_browser_set_browse_results_changed_handler (OS_nw_browser browser, BlockLiteral* handler);
 
-		delegate void nw_browser_browse_results_changed_handler_t (IntPtr block, IntPtr oldResult, IntPtr newResult, bool completed);
+		delegate void nw_browser_browse_results_changed_handler_t (IntPtr block, IntPtr oldResult, IntPtr newResult, byte completed);
 		static nw_browser_browse_results_changed_handler_t static_ChangesHandler = TrampolineChangesHandler;
 
 		[MonoPInvokeCallback (typeof (nw_browser_browse_results_changed_handler_t))]
-		static void TrampolineChangesHandler (IntPtr block, IntPtr oldResult, IntPtr newResult, bool completed)
+		static void TrampolineChangesHandler (IntPtr block, IntPtr oldResult, IntPtr newResult, byte completed)
 		{
 			var del = BlockLiteral.GetTarget<NWBrowserChangesDelegate> (block);
 			if (del is not null) {
 				// we do the cleanup of the objs in the internal handlers
 				NWBrowseResult? nwOldResult = (oldResult == IntPtr.Zero) ? null : new NWBrowseResult (oldResult, owns: false);
 				NWBrowseResult? nwNewResult = (newResult == IntPtr.Zero) ? null : new NWBrowseResult (newResult, owns: false);
-				del (nwOldResult, nwNewResult, completed);
+				del (nwOldResult, nwNewResult, completed != 0);
 			}
 		}
 

--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -131,15 +131,15 @@ namespace Network {
 			}
 		}
 
-		delegate void nw_connection_boolean_event_handler_t (IntPtr block, [MarshalAs (UnmanagedType.U1)] bool value);
+		delegate void nw_connection_boolean_event_handler_t (IntPtr block, byte value);
 		static nw_connection_boolean_event_handler_t static_BooleanChangeHandler = TrampolineBooleanChangeHandler;
 
 		[MonoPInvokeCallback (typeof (nw_connection_boolean_event_handler_t))]
-		static void TrampolineBooleanChangeHandler (IntPtr block, bool value)
+		static void TrampolineBooleanChangeHandler (IntPtr block, byte value)
 		{
 			var del = BlockLiteral.GetTarget<Action<bool>> (block);
 			if (del is not null)
-				del (value);
+				del (value != 0);
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
@@ -242,7 +242,7 @@ namespace Network {
 		delegate void nw_connection_receive_completion_t (IntPtr block,
 								  IntPtr dispatchData,
 								  IntPtr contentContext,
-								  [MarshalAs (UnmanagedType.U1)] bool isComplete,
+								  byte isComplete,
 								  IntPtr error);
 
 		static nw_connection_receive_completion_t static_ReceiveCompletion = TrampolineReceiveCompletion;
@@ -250,7 +250,7 @@ namespace Network {
 		static nw_connection_receive_completion_t static_ReceiveCompletionDispatchReadnOnlyData = TrampolineReceiveCompletionReadOnlyData;
 
 		[MonoPInvokeCallback (typeof (nw_connection_receive_completion_t))]
-		static void TrampolineReceiveCompletion (IntPtr block, IntPtr dispatchDataPtr, IntPtr contentContext, bool isComplete, IntPtr error)
+		static void TrampolineReceiveCompletion (IntPtr block, IntPtr dispatchDataPtr, IntPtr contentContext, byte isComplete, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<NWConnectionReceiveCompletion> (block);
 			if (del is not null) {
@@ -266,7 +266,7 @@ namespace Network {
 				del (bufferAddress,
 					 bufferSize,
 					 contentContext == IntPtr.Zero ? null : new NWContentContext (contentContext, owns: false),
-					 isComplete,
+					 isComplete != 0,
 					 error == IntPtr.Zero ? null : new NWError (error, owns: false));
 
 				if (dispatchData is not null) {
@@ -277,7 +277,7 @@ namespace Network {
 		}
 
 		[MonoPInvokeCallback (typeof (nw_connection_receive_completion_t))]
-		static void TrampolineReceiveCompletionData (IntPtr block, IntPtr dispatchDataPtr, IntPtr contentContext, bool isComplete, IntPtr error)
+		static void TrampolineReceiveCompletionData (IntPtr block, IntPtr dispatchDataPtr, IntPtr contentContext, byte isComplete, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<NWConnectionReceiveDispatchDataCompletion> (block);
 			if (del is not null) {
@@ -289,7 +289,7 @@ namespace Network {
 
 				del (dispatchData,
 					 contentContext == IntPtr.Zero ? null : new NWContentContext (contentContext, owns: false),
-					 isComplete,
+					 isComplete != 0,
 					 error == IntPtr.Zero ? null : new NWError (error, owns: false));
 
 				if (dispatchData is not null)
@@ -298,7 +298,7 @@ namespace Network {
 		}
 
 		[MonoPInvokeCallback (typeof (nw_connection_receive_completion_t))]
-		static void TrampolineReceiveCompletionReadOnlyData (IntPtr block, IntPtr dispatchDataPtr, IntPtr contentContext, bool isComplete, IntPtr error)
+		static void TrampolineReceiveCompletionReadOnlyData (IntPtr block, IntPtr dispatchDataPtr, IntPtr contentContext, byte isComplete, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<NWConnectionReceiveReadOnlySpanCompletion> (block);
 			if (del is not null) {
@@ -307,7 +307,7 @@ namespace Network {
 				var spanData = new ReadOnlySpan<byte> (dispatchData?.ToArray () ?? Array.Empty<byte> ());
 				del (spanData,
 					contentContext == IntPtr.Zero ? null : new NWContentContext (contentContext, owns: false),
-					isComplete,
+					isComplete != 0,
 					error == IntPtr.Zero ? null : new NWError (error, owns: false));
 
 				if (dispatchData is not null) {

--- a/src/Network/NWConnectionGroup.cs
+++ b/src/Network/NWConnectionGroup.cs
@@ -227,17 +227,17 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_connection_group_set_receive_handler (OS_nw_connection_group group, uint maximum_message_size, [MarshalAs (UnmanagedType.I1)] bool reject_oversized_messages, BlockLiteral* handler);
 
-		delegate void nw_connection_group_receive_handler_t (IntPtr block, IntPtr content, IntPtr context, bool isCompleted);
+		delegate void nw_connection_group_receive_handler_t (IntPtr block, IntPtr content, IntPtr context, byte isCompleted);
 		static nw_connection_group_receive_handler_t static_ReceiveHandler = TrampolineReceiveHandler;
 
 		[MonoPInvokeCallback (typeof (nw_connection_group_receive_handler_t))]
-		static void TrampolineReceiveHandler (IntPtr block, IntPtr content, IntPtr context, bool isCompleted)
+		static void TrampolineReceiveHandler (IntPtr block, IntPtr content, IntPtr context, byte isCompleted)
 		{
 			var del = BlockLiteral.GetTarget<NWConnectionGroupReceiveDelegate> (block);
 			if (del is not null) {
 				using var nsContent = new DispatchData (content, owns: false);
 				using var nsContext = new NWContentContext (context, owns: false);
-				del (nsContent, nsContext, isCompleted);
+				del (nsContent, nsContext, isCompleted != 0);
 			}
 		}
 

--- a/src/Network/NWFramer.cs
+++ b/src/Network/NWFramer.cs
@@ -140,17 +140,17 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_framer_set_output_handler (OS_nw_framer framer, void* output_handler);
 
-		delegate void nw_framer_set_output_handler_t (IntPtr block, OS_nw_framer framer, OS_nw_protocol_metadata message, nuint message_length, bool is_complete);
+		delegate void nw_framer_set_output_handler_t (IntPtr block, OS_nw_framer framer, OS_nw_protocol_metadata message, nuint message_length, byte is_complete);
 		static nw_framer_set_output_handler_t static_OutputHandler = TrampolineOutputHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_set_output_handler_t))]
-		static void TrampolineOutputHandler (IntPtr block, OS_nw_framer framer, OS_nw_protocol_metadata message, nuint message_length, bool is_complete)
+		static void TrampolineOutputHandler (IntPtr block, OS_nw_framer framer, OS_nw_protocol_metadata message, nuint message_length, byte is_complete)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWFramer, NWProtocolMetadata, nuint, bool>> (block);
 			if (del is not null) {
 				var nwFramer = new NWFramer (framer, owns: true);
 				var nwProtocolMetadata = new NWFramerMessage (message, owns: true);
-				del (nwFramer, nwProtocolMetadata, message_length, is_complete);
+				del (nwFramer, nwProtocolMetadata, message_length, is_complete != 0);
 			}
 		}
 
@@ -331,18 +331,18 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool nw_framer_parse_output (OS_nw_framer framer, nuint minimum_incomplete_length, nuint maximum_length, byte* temp_buffer, BlockLiteral* parse);
 
-		delegate void nw_framer_parse_output_t (IntPtr block, IntPtr buffer, nuint buffer_length, bool is_complete);
+		delegate void nw_framer_parse_output_t (IntPtr block, IntPtr buffer, nuint buffer_length, byte is_complete);
 		static nw_framer_parse_output_t static_ParseOutputHandler = TrampolineParseOutputHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_parse_output_t))]
-		static void TrampolineParseOutputHandler (IntPtr block, IntPtr buffer, nuint buffer_length, bool is_complete)
+		static void TrampolineParseOutputHandler (IntPtr block, IntPtr buffer, nuint buffer_length, byte is_complete)
 		{
 			var del = BlockLiteral.GetTarget<Action<Memory<byte>, bool>> (block);
 			if (del is not null) {
 				var bBuffer = new byte [buffer_length];
 				Marshal.Copy (buffer, bBuffer, 0, (int) buffer_length);
 				var mValue = new Memory<byte> (bBuffer);
-				del (mValue, is_complete);
+				del (mValue, is_complete != 0);
 			}
 		}
 
@@ -363,18 +363,18 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool nw_framer_parse_input (OS_nw_framer framer, nuint minimum_incomplete_length, nuint maximum_length, byte* temp_buffer, BlockLiteral* parse);
 
-		delegate nuint nw_framer_parse_input_t (IntPtr block, IntPtr buffer, nuint buffer_length, bool is_complete);
+		delegate nuint nw_framer_parse_input_t (IntPtr block, IntPtr buffer, nuint buffer_length, byte is_complete);
 		static nw_framer_parse_input_t static_ParseInputHandler = TrampolineParseInputHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_parse_input_t))]
-		static nuint TrampolineParseInputHandler (IntPtr block, IntPtr buffer, nuint buffer_length, bool is_complete)
+		static nuint TrampolineParseInputHandler (IntPtr block, IntPtr buffer, nuint buffer_length, byte is_complete)
 		{
 			var del = BlockLiteral.GetTarget<NWFramerParseCompletionDelegate> (block);
 			if (del is not null) {
 				var bBuffer = new byte [buffer_length];
 				Marshal.Copy (buffer, bBuffer, 0, (int) buffer_length);
 				var mValue = new Memory<byte> (bBuffer);
-				return del (mValue, is_complete);
+				return del (mValue, is_complete != 0);
 			}
 			return 0;
 		}

--- a/src/Network/NWFramerMessage.cs
+++ b/src/Network/NWFramerMessage.cs
@@ -96,19 +96,19 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_framer_message_access_value (OS_nw_protocol_metadata message, IntPtr key, BlockLiteral* access_value);
-		delegate bool nw_framer_message_access_value_t (IntPtr block, IntPtr data);
+		delegate byte nw_framer_message_access_value_t (IntPtr block, IntPtr data);
 		static nw_framer_message_access_value_t static_AccessValueHandler = TrampolineAccessValueHandler;
 
 
 		[MonoPInvokeCallback (typeof (nw_framer_message_access_value_t))]
-		static bool TrampolineAccessValueHandler (IntPtr block, IntPtr data)
+		static byte TrampolineAccessValueHandler (IntPtr block, IntPtr data)
 		{
 			// get and call, this is internal and we are trying to do all the magic in the call
 			var del = BlockLiteral.GetTarget<Func<IntPtr, bool>> (block);
 			if (del is not null) {
-				return del (data);
+				return del (data) ? (byte) 1 : (byte) 0;
 			}
-			return false;
+			return 0;
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]

--- a/src/Network/NWMulticastGroup.cs
+++ b/src/Network/NWMulticastGroup.cs
@@ -77,18 +77,18 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_group_descriptor_enumerate_endpoints (OS_nw_group_descriptor descriptor, BlockLiteral* enumerate_block);
 
-		delegate bool nw_group_descriptor_enumerate_endpoints_block_t (IntPtr block, OS_nw_endpoint endpoint);
+		delegate byte nw_group_descriptor_enumerate_endpoints_block_t (IntPtr block, OS_nw_endpoint endpoint);
 		static nw_group_descriptor_enumerate_endpoints_block_t static_EnumerateEndpointsHandler = TrampolineEnumerateEndpointsHandler;
 
 		[MonoPInvokeCallback (typeof (nw_group_descriptor_enumerate_endpoints_block_t))]
-		static bool TrampolineEnumerateEndpointsHandler (IntPtr block, OS_nw_endpoint endpoint)
+		static byte TrampolineEnumerateEndpointsHandler (IntPtr block, OS_nw_endpoint endpoint)
 		{
 			var del = BlockLiteral.GetTarget<Func<NWEndpoint, bool>> (block);
 			if (del is not null) {
 				using var nsEndpoint = new NWEndpoint (endpoint, owns: false);
-				return del (nsEndpoint);
+				return del (nsEndpoint) ? (byte) 1 : (byte) 0;
 			}
-			return false;
+			return 0;
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]

--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -382,21 +382,20 @@ namespace Network {
 			nw_parameters_clear_prohibited_interface_types (GetCheckedHandle ());
 		}
 
-		delegate bool nw_parameters_iterate_interfaces_block_t (IntPtr block, IntPtr iface);
+		delegate byte nw_parameters_iterate_interfaces_block_t (IntPtr block, IntPtr iface);
 		static nw_parameters_iterate_interfaces_block_t static_iterateProhibitedHandler = TrampolineIterateProhibitedHandler;
 
 		[MonoPInvokeCallback (typeof (nw_parameters_iterate_interfaces_block_t))]
-		[return: MarshalAs (UnmanagedType.I1)]
-		static bool TrampolineIterateProhibitedHandler (IntPtr block, IntPtr iface)
+		static byte TrampolineIterateProhibitedHandler (IntPtr block, IntPtr iface)
 		{
 			var del = BlockLiteral.GetTarget<Func<NWInterface, bool>> (block);
 			if (del is not null) {
 				var x = new NWInterface (iface, owns: false);
 				var ret = del (x);
 				x.Dispose ();
-				return ret;
+				return ret ? (byte) 1 : (byte) 0;
 			}
-			return false;
+			return 0;
 		}
 
 		[DllImport (Constants.NetworkLibrary)]
@@ -412,17 +411,16 @@ namespace Network {
 			}
 		}
 
-		delegate bool nw_parameters_iterate_interface_types_block_t (IntPtr block, NWInterfaceType type);
+		delegate byte nw_parameters_iterate_interface_types_block_t (IntPtr block, NWInterfaceType type);
 		static nw_parameters_iterate_interface_types_block_t static_IterateProhibitedTypeHandler = TrampolineIterateProhibitedTypeHandler;
 
 		[MonoPInvokeCallback (typeof (nw_parameters_iterate_interface_types_block_t))]
-		[return: MarshalAs (UnmanagedType.I1)]
-		static bool TrampolineIterateProhibitedTypeHandler (IntPtr block, NWInterfaceType type)
+		static byte TrampolineIterateProhibitedTypeHandler (IntPtr block, NWInterfaceType type)
 		{
 			var del = BlockLiteral.GetTarget<Func<NWInterfaceType, bool>> (block);
 			if (del is not null)
-				return del (type);
-			return false;
+				return del (type) ? (byte) 1 : (byte) 0;
+			return 0;
 		}
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWTxtRecord.cs
+++ b/src/Network/NWTxtRecord.cs
@@ -175,7 +175,7 @@ namespace Network {
 				return (byte) 1;
 			}
 			if (del is NWTxtRecordApplyDelegate2 apply2)
-				return apply2 (key, found, mValue) ? (byte) 1 : (byte) 0;;
+				return apply2 (key, found, mValue) ? (byte) 1 : (byte) 0; ;
 
 			return (byte) 0;
 #endif

--- a/src/Network/NWTxtRecord.cs
+++ b/src/Network/NWTxtRecord.cs
@@ -144,18 +144,18 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_txt_record_apply (OS_nw_txt_record txt_record, BlockLiteral* applier);
 
-		delegate bool nw_txt_record_apply_t (IntPtr block, string key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
+		delegate byte nw_txt_record_apply_t (IntPtr block, IntPtr key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
 		unsafe static nw_txt_record_apply_t static_ApplyHandler = TrampolineApplyHandler;
 
 #if NET
-		public delegate bool NWTxtRecordApplyDelegate (string key, NWTxtRecordFindKey result, ReadOnlySpan<byte> value);
+		public delegate bool NWTxtRecordApplyDelegate (string? key, NWTxtRecordFindKey result, ReadOnlySpan<byte> value);
 #else
-		public delegate void NWTxtRecordApplyDelegate (string key, NWTxtRecordFindKey rersult, ReadOnlySpan<byte> value);
-		public delegate bool NWTxtRecordApplyDelegate2 (string key, NWTxtRecordFindKey result, ReadOnlySpan<byte> value);
+		public delegate void NWTxtRecordApplyDelegate (string? key, NWTxtRecordFindKey rersult, ReadOnlySpan<byte> value);
+		public delegate bool NWTxtRecordApplyDelegate2 (string? key, NWTxtRecordFindKey result, ReadOnlySpan<byte> value);
 #endif
 
 		[MonoPInvokeCallback (typeof (nw_txt_record_apply_t))]
-		unsafe static bool TrampolineApplyHandler (IntPtr block, string key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen)
+		unsafe static byte TrampolineApplyHandler (IntPtr block, IntPtr keyPointer, NWTxtRecordFindKey found, IntPtr value, nuint valueLen)
 		{
 #if NET
 			var del = BlockLiteral.GetTarget<NWTxtRecordApplyDelegate> (block);
@@ -163,20 +163,21 @@ namespace Network {
 			var del = BlockLiteral.GetTarget<MulticastDelegate> (block);
 #endif
 			if (del is null)
-				return false;
+				return (byte) 0;
 
 			var mValue = new ReadOnlySpan<byte> ((void*) value, (int) valueLen);
+			var key = Marshal.PtrToStringAuto (keyPointer);
 #if NET
-			return del (key, found, mValue);
+			return del (key, found, mValue) ? (byte) 1 : (byte) 0;
 #else
 			if (del is NWTxtRecordApplyDelegate apply) {
 				apply (key, found, mValue);
-				return true;
+				return (byte) 1;
 			}
 			if (del is NWTxtRecordApplyDelegate2 apply2)
-				return apply2 (key, found, mValue);
+				return apply2 (key, found, mValue) ? (byte) 1 : (byte) 0;;
 
-			return false;
+			return (byte) 0;
 #endif
 		}
 
@@ -215,13 +216,13 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool nw_txt_record_access_key (OS_nw_txt_record txt_record, IntPtr key, BlockLiteral* access_value);
 
-		unsafe delegate void nw_txt_record_access_key_t (IntPtr block, string key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
+		unsafe delegate void nw_txt_record_access_key_t (IntPtr IntPtr, IntPtr key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
 		unsafe static nw_txt_record_access_key_t static_AccessKeyHandler = TrampolineAccessKeyHandler;
 
-		public delegate void NWTxtRecordGetValueDelegete (string key, NWTxtRecordFindKey result, ReadOnlySpan<byte> value);
+		public delegate void NWTxtRecordGetValueDelegete (string? key, NWTxtRecordFindKey result, ReadOnlySpan<byte> value);
 
 		[MonoPInvokeCallback (typeof (nw_txt_record_access_key_t))]
-		unsafe static void TrampolineAccessKeyHandler (IntPtr block, string key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen)
+		unsafe static void TrampolineAccessKeyHandler (IntPtr block, IntPtr keyPointer, NWTxtRecordFindKey found, IntPtr value, nuint valueLen)
 		{
 			var del = BlockLiteral.GetTarget<NWTxtRecordGetValueDelegete> (block);
 			if (del is not null) {
@@ -230,6 +231,7 @@ namespace Network {
 					mValue = new ReadOnlySpan<byte> ((void*) value, (int) valueLen);
 				else
 					mValue = Array.Empty<byte> ();
+				var key = Marshal.PtrToStringAuto (keyPointer);
 				del (key, found, mValue);
 			}
 		}

--- a/src/Network/NWWebSocketRequest.cs
+++ b/src/Network/NWWebSocketRequest.cs
@@ -43,20 +43,22 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_ws_request_enumerate_additional_headers (OS_nw_ws_request request, BlockLiteral* enumerator);
 
-		delegate void nw_ws_request_enumerate_additional_headers_t (IntPtr block, string header, string value);
+		delegate void nw_ws_request_enumerate_additional_headers_t (IntPtr block, IntPtr header, IntPtr value);
 		static nw_ws_request_enumerate_additional_headers_t static_EnumerateHeaderHandler = TrampolineEnumerateHeaderHandler;
 
 		[MonoPInvokeCallback (typeof (nw_ws_request_enumerate_additional_headers_t))]
-		static void TrampolineEnumerateHeaderHandler (IntPtr block, string header, string value)
+		static void TrampolineEnumerateHeaderHandler (IntPtr block, IntPtr headerPointer, IntPtr valuePointer)
 		{
-			var del = BlockLiteral.GetTarget<Action<string, string>> (block);
+			var del = BlockLiteral.GetTarget<Action<string?, string?>> (block);
 			if (del is not null) {
+				var header = Marshal.PtrToStringAuto (headerPointer);
+				var value = Marshal.PtrToStringAuto (valuePointer);
 				del (header, value);
 			}
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public void EnumerateAdditionalHeaders (Action<string, string> handler)
+		public void EnumerateAdditionalHeaders (Action<string?, string?> handler)
 		{
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
@@ -72,20 +74,21 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_ws_request_enumerate_subprotocols (OS_nw_ws_request request, BlockLiteral* enumerator);
 
-		delegate void nw_ws_request_enumerate_subprotocols_t (IntPtr block, string subprotocol);
+		delegate void nw_ws_request_enumerate_subprotocols_t (IntPtr block, IntPtr subprotocol);
 		static nw_ws_request_enumerate_subprotocols_t static_EnumerateSubprotocolHandler = TrampolineEnumerateSubprotocolHandler;
 
 		[MonoPInvokeCallback (typeof (nw_ws_request_enumerate_subprotocols_t))]
-		static void TrampolineEnumerateSubprotocolHandler (IntPtr block, string subprotocol)
+		static void TrampolineEnumerateSubprotocolHandler (IntPtr block, IntPtr subprotocolPointer)
 		{
-			var del = BlockLiteral.GetTarget<Action<string>> (block);
+			var del = BlockLiteral.GetTarget<Action<string?>> (block);
 			if (del is not null) {
+				var subprotocol = Marshal.PtrToStringAuto (subprotocolPointer);
 				del (subprotocol);
 			}
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public void EnumerateSubprotocols (Action<string> handler)
+		public void EnumerateSubprotocols (Action<string?> handler)
 		{
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));

--- a/src/Network/NWWebSocketResponse.cs
+++ b/src/Network/NWWebSocketResponse.cs
@@ -72,20 +72,22 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_ws_response_enumerate_additional_headers (OS_nw_ws_response response, BlockLiteral* enumerator);
 
-		delegate void nw_ws_response_enumerate_additional_headers_t (IntPtr block, string header, string value);
+		delegate void nw_ws_response_enumerate_additional_headers_t (IntPtr block, IntPtr header, IntPtr value);
 		static nw_ws_response_enumerate_additional_headers_t static_EnumerateHeadersHandler = TrampolineEnumerateHeadersHandler;
 
 		[MonoPInvokeCallback (typeof (nw_ws_response_enumerate_additional_headers_t))]
-		static void TrampolineEnumerateHeadersHandler (IntPtr block, string header, string value)
+		static void TrampolineEnumerateHeadersHandler (IntPtr block, IntPtr headerPointer, IntPtr valuePointer)
 		{
-			var del = BlockLiteral.GetTarget<Action<string, string>> (block);
+			var del = BlockLiteral.GetTarget<Action<string?, string?>> (block);
 			if (del is not null) {
+				var header = Marshal.PtrToStringAuto (headerPointer);
+				var value = Marshal.PtrToStringAuto (valuePointer);
 				del (header, value);
 			}
 		}
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		public bool EnumerateAdditionalHeaders (Action<string, string> handler)
+		public bool EnumerateAdditionalHeaders (Action<string?, string?> handler)
 		{
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));

--- a/src/Security/SecTrust.cs
+++ b/src/Security/SecTrust.cs
@@ -238,17 +238,17 @@ namespace Security {
 		[DllImport (Constants.SecurityLibrary)]
 		unsafe static extern SecStatusCode SecTrustEvaluateAsyncWithError (IntPtr /* SecTrustRef */ trust, IntPtr /* dispatch_queue_t */ queue, BlockLiteral* block);
 
-		internal delegate void TrustEvaluateErrorHandler (IntPtr block, IntPtr trust, bool result, IntPtr /* CFErrorRef _Nullable */  error);
+		internal delegate void TrustEvaluateErrorHandler (IntPtr block, IntPtr trust, byte result, IntPtr /* CFErrorRef _Nullable */  error);
 		static readonly TrustEvaluateErrorHandler evaluate_error = TrampolineEvaluateError;
 
 		[MonoPInvokeCallback (typeof (TrustEvaluateErrorHandler))]
-		static void TrampolineEvaluateError (IntPtr block, IntPtr trust, bool result, IntPtr /* CFErrorRef _Nullable */  error)
+		static void TrampolineEvaluateError (IntPtr block, IntPtr trust, byte result, IntPtr /* CFErrorRef _Nullable */  error)
 		{
 			var del = BlockLiteral.GetTarget<SecTrustWithErrorCallback> (block);
 			if (del is not null) {
 				var t = trust == IntPtr.Zero ? null : new SecTrust (trust, false);
 				var e = error == IntPtr.Zero ? null : new NSError (error);
-				del (t, result, e);
+				del (t, result != 0, e);
 			}
 		}
 

--- a/src/UIKit/UIAccessibility.cs
+++ b/src/UIKit/UIAccessibility.cs
@@ -268,16 +268,16 @@ namespace UIKit {
 			return tcs.Task;
 		}
 
-		internal delegate void InnerRequestGuidedAccessSession (IntPtr block, bool enable);
+		internal delegate void InnerRequestGuidedAccessSession (IntPtr block, byte enable);
 		static readonly InnerRequestGuidedAccessSession callback = TrampolineRequestGuidedAccessSession;
 
 		[MonoPInvokeCallback (typeof (InnerRequestGuidedAccessSession))]
-		static unsafe void TrampolineRequestGuidedAccessSession (IntPtr block, bool enable)
+		static unsafe void TrampolineRequestGuidedAccessSession (IntPtr block, byte enable)
 		{
 			var descriptor = (BlockLiteral*) block;
 			var del = (Action<bool>) (descriptor->Target);
 			if (del != null)
-				del (enable);
+				del (enable != 0);
 		}
 
 #if NET

--- a/src/UIKit/UIGuidedAccessRestriction.cs
+++ b/src/UIKit/UIGuidedAccessRestriction.cs
@@ -62,18 +62,18 @@ namespace UIKit {
 		public delegate void UIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler (bool success, NSError error);
 
 		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-		internal delegate void DUIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler (IntPtr block, bool success, IntPtr error);
+		internal delegate void DUIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler (IntPtr block, byte success, IntPtr error);
 
 		static internal class UIGuidedAccessConfigureAccessibilityFeaturesTrampoline {
 			static internal readonly DUIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler Handler = Invoke;
 
 			[MonoPInvokeCallback (typeof (DUIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler))]
-			static unsafe void Invoke (IntPtr block, bool success, IntPtr error)
+			static unsafe void Invoke (IntPtr block, byte success, IntPtr error)
 			{
 				var descriptor = (BlockLiteral*) block;
 				var del = (UIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler) (descriptor->Target);
 				if (del != null)
-					del (success, Runtime.GetNSObject<NSError> (error));
+					del (success != 0, Runtime.GetNSObject<NSError> (error));
 			}
 		}
 


### PR DESCRIPTION
This is mostly converting 'bool' arguments to 'byte' arguments, and 'string'
arguments to 'IntPtr' with custom utf8->string conversions.

This is necessary in order to convert all block callbacks to use
UnmanagedCallersOnly function pointers (which can't have non-blittable types
in their signature).

Contributes towards https://github.com/xamarin/xamarin-macios/issues/15783.