### PR TITLE
[main] Updated Xamarin.Messaging to 1.9.59

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -62,10 +62,12 @@
     <!-- Microsoft.iOS.Windows.Sdk content -->
     <FirstParty Include="iSign.Core.dll" />
     <FirstParty Include="System.Diagnostics.Tracer.dll" />
+    <!-- Xamarin.Messaging -->
+    <FirstParty Include="Merq.dll" />
+    <FirstParty Include="Merq.Core.dll" />
     <!-- Broker.zip -->
     <FirstParty Include="Broker.exe" />
     <FirstParty Include="Broker.resources.dll" />
-    <FirstParty Include="Merq.dll" />
     <!-- Build.zip -->
     <FirstParty Include="Build.exe" />
     <FirstParty Include="Microsoft.Build*.dll" />

--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.9.40</MessagingVersion>
+		<MessagingVersion>1.9.59</MessagingVersion>
 		<HotRestartVersion>1.0.93</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Includes latest fixes like support for retry and reconnect, new telemetry, bug fixing, etc.

Also added Merq.Core.dll to dotnet/Workloads/SignList.xml because now it comes as part of Xamarin.Messaging