### PR TITLE
[tests] Adjust UrlSessionTests to ignore more failure scenarios in CI.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1415,9 +1415,13 @@ partial class TestRuntime {
 		}
 	}
 
-	public static void IgnoreInCIIfBadNetwork (Exception ex)
+	public static void IgnoreInCIIfBadNetwork (Exception? ex)
 	{
+		if (ex is null)
+			return;
+
 		IgnoreInCIfHttpStatusCodes (ex, HttpStatusCode.BadGateway, HttpStatusCode.GatewayTimeout, HttpStatusCode.ServiceUnavailable);
+		IgnoreInCIIfNetworkConnectionLost (ex);
 	}
 
 	public static void IgnoreInCIIfForbidden (Exception ex)
@@ -1447,6 +1451,18 @@ partial class TestRuntime {
 			return;
 
 		IgnoreInCI ($"Ignored due to http status code '{status}': {ex.Message}");
+	}
+
+	public static void IgnoreInCIIfNetworkConnectionLost (Exception ex)
+	{
+		// <Foundation.NSErrorException: Error Domain=NSURLErrorDomain Code=-1005 "The network connection was lost." UserInfo ...
+		if (!(ex is NSErrorException nex))
+			return;
+
+		if (nex.Code != (nint) (long) CFNetworkErrors.NetworkConnectionLost)
+			return;
+
+		IgnoreInCI ($"Ignored due to CFNetwork error {(CFNetworkErrors) (long) nex.Code}");
 	}
 
 	static bool TryGetHttpStatusCode (Exception ex, out HttpStatusCode status)

--- a/tests/monotouch-test/Foundation/UrlSessionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTest.cs
@@ -167,6 +167,7 @@ namespace MonoTouchFixtures.Foundation {
 				}
 			}, () => completed);
 
+			TestRuntime.IgnoreInCIIfBadNetwork (ex);
 			Assert.IsNull (ex, "Exception");
 			Assert.AreEqual (-1, failed_iteration, "Failed");
 		}

--- a/tests/monotouch-test/Foundation/UrlSessionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTest.cs
@@ -26,10 +26,13 @@ namespace MonoTouchFixtures.Foundation {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class UrlSessionTest {
-		void AssertTrueOrIgnoreInCI (bool value, string message)
+		void AssertTrueOrIgnoreInCI (bool value, ref Exception ex, string message)
 		{
-			if (value)
+			if (value) {
+				TestRuntime.IgnoreInCIIfBadNetwork (ex);
+				Assert.IsNull (ex, message + " Exception");
 				return;
+			}
 
 			TestRuntime.IgnoreInCI ($"This test times out randomly in CI due to bad network: {message}");
 			Assert.Fail (message);
@@ -67,8 +70,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateDataTask a");
-			Assert.IsNull (ex, "CreateDataTask a Exception");
+			}, () => completed), ref ex, "CreateDataTask a");
 
 			completed = false;
 			AssertTrueOrIgnoreInCI (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
@@ -79,8 +81,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateDataTask b");
-			Assert.IsNull (ex, "CreateDataTask b Exception");
+			}, () => completed), ref ex, "CreateDataTask b");
 
 			/* CreateDownloadTask */
 			completed = false;
@@ -92,8 +93,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateDownloadTask a");
-			Assert.IsNull (ex, "CreateDownloadTask a Exception");
+			}, () => completed), ref ex, "CreateDownloadTask a");
 
 
 			completed = false;
@@ -105,8 +105,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateDownloadTask b");
-			Assert.IsNull (ex, "CreateDownloadTask b Exception");
+			}, () => completed), ref ex, "CreateDownloadTask b");
 
 			/* CreateUploadTask */
 			completed = false;
@@ -120,8 +119,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateUploadTask a");
-			Assert.IsNull (ex, "CreateUploadTask a Exception");
+			}, () => completed), ref ex, "CreateUploadTask a");
 
 			completed = false;
 			AssertTrueOrIgnoreInCI (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
@@ -134,8 +132,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateUploadTask b");
-			Assert.IsNull (ex, "CreateUploadTask b Exception");
+			}, () => completed), ref ex, "CreateUploadTask b");
 		}
 
 		[Test]


### PR DESCRIPTION
Should fix random test failures like this:

    MonoTouchFixtures.Foundation.UrlSessionTest
        [FAIL] CreateDataTaskAsync :   CreateDataTask a Exception
            Expected: null
            But was:  <Foundation.NSErrorException: Error Domain=NSURLErrorDomain Code=-1005 "The network connection was lost." UserInfo={_kCFStreamErrorCodeKey=57, NSUnderlyingError=0x6000011f4990 {Error Domain=kCFErrorDomainCFNetwork Code=-1005 "(null)" UserInfo={NSErrorPeerAddressKey=<CFData 0x600003deaa80 [0x7ff865b1f1c0]>{length = 16, capacity = 16, bytes = 0x100201bb6007a9b70000000000000000}, _kCFStreamErrorCodeKey=57, _kCFStreamErrorDomainKey=1}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <5E766082-B379-491A-BCB0-EA1B36E54A8B>.<15>, _NSURLErrorRelatedURLSessionTaskErrorKey=("LocalDataTask <5E766082-B379-491A-BCB0-EA1B36E54A8B>.<15>"), NSLocalizedDescription=The network connection was lost., NSErrorFailingURLStringKey=https://www.microsoft.com/, NSErrorFailingURLKey=https://www.microsoft.com/, _kCFStreamErrorDomainKey=1}
                at MonoTouchFixtures.Foundation.UrlSessionTest+<>c__DisplayClass1_0.<CreateDataTaskAsync>b__0 () [0x00039] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/Foundation/UrlSessionTest.cs:64 >
                at MonoTouchFixtures.Foundation.UrlSessionTest.CreateDataTaskAsync () [0x000b7] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/monotouch-test/Foundation/UrlSessionTest.cs:71