### PR TITLE
[main] [CoreFoundation] Fix CFStream to use blittable P/Invokes in .NET 8.

### DIFF
--- a/src/CoreFoundation/CFReadStream.cs
+++ b/src/CoreFoundation/CFReadStream.cs
@@ -30,6 +30,7 @@
 #nullable enable
 
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using CoreFoundation;
@@ -150,6 +151,10 @@ namespace CoreFoundation {
 #endif
 
 #if !XAMCORE_5_0
+#if NET8_OR_GREATER
+		[Obsolete ("Use the other overload.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+#endif
 		protected override bool DoSetClient (CFStreamCallback? callback, CFIndex eventTypes,
 											 IntPtr context)
 		{

--- a/src/CoreFoundation/CFReadStream.cs
+++ b/src/CoreFoundation/CFReadStream.cs
@@ -140,15 +140,33 @@ namespace CoreFoundation {
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+#if NET8_OR_GREATER
+		unsafe static extern byte CFReadStreamSetClient (/* CFReadStreamRef */ IntPtr stream, /* CFOptionFlags */ nint streamEvents,
+			/* CFReadStreamClientCallBack */ delegate* unmanaged<IntPtr, nint, IntPtr, void> clientCB, /* CFStreamClientContext* */ IntPtr clientContext);
+#else
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool CFReadStreamSetClient (/* CFReadStreamRef */ IntPtr stream, /* CFOptionFlags */ nint streamEvents,
 			/* CFReadStreamClientCallBack */ CFStreamCallback? clientCB, /* CFStreamClientContext* */ IntPtr clientContext);
+#endif
 
+#if !XAMCORE_5_0
 		protected override bool DoSetClient (CFStreamCallback? callback, CFIndex eventTypes,
 											 IntPtr context)
 		{
+#if NET8_OR_GREATER
+			throw new InvalidOperationException ($"Use the other overload.");
+#else
+			return CFReadStreamSetClient (Handle, (nint) eventTypes, callback, context);
+#endif
+		}
+#endif // !XAMCORE_5_0
+
+#if NET8_OR_GREATER
+		unsafe protected override byte DoSetClient (delegate* unmanaged<IntPtr, nint, IntPtr, void> callback, CFIndex eventTypes, IntPtr context)
+		{
 			return CFReadStreamSetClient (Handle, (nint) eventTypes, callback, context);
 		}
+#endif
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFIndex */ nint CFReadStreamRead (/* CFReadStreamRef */ IntPtr handle, /* UInt8* */ IntPtr buffer, /* CFIndex */ nint count);

--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -33,6 +33,7 @@
 #nullable enable
 
 using System;
+using System.ComponentModel;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -728,6 +729,10 @@ namespace CoreFoundation {
 		}
 
 #if !XAMCORE_5_0
+#if NET8_OR_GREATER
+		[Obsolete ("Use the other overload.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+#endif
 		protected abstract bool DoSetClient (CFStreamCallback? callback, CFIndex eventTypes,
 											 IntPtr context);
 #endif

--- a/src/CoreFoundation/CFWriteStream.cs
+++ b/src/CoreFoundation/CFWriteStream.cs
@@ -30,6 +30,7 @@
 #nullable enable
 
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using CoreFoundation;
 using Foundation;
@@ -142,6 +143,10 @@ namespace CoreFoundation {
 #endif
 
 #if !XAMCORE_5_0
+#if NET8_OR_GREATER
+		[Obsolete ("Use the other overload.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+#endif
 		protected override bool DoSetClient (CFStreamCallback? callback, CFIndex eventTypes,
 											 IntPtr context)
 		{

--- a/src/CoreFoundation/CFWriteStream.cs
+++ b/src/CoreFoundation/CFWriteStream.cs
@@ -132,15 +132,33 @@ namespace CoreFoundation {
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
+#if NET8_OR_GREATER
+		unsafe static extern /* Boolean */ byte CFWriteStreamSetClient (/* CFWriteStreamRef */ IntPtr stream, /* CFOptionFlags */ nint streamEvents,
+			/* CFWriteStreamClientCallBack */ delegate* unmanaged<IntPtr, nint, IntPtr, void> clientCB, /* CFStreamClientContext* */ IntPtr clientContext);
+#else
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern /* Boolean */ bool CFWriteStreamSetClient (/* CFWriteStreamRef */ IntPtr stream, /* CFOptionFlags */ nint streamEvents,
 			/* CFWriteStreamClientCallBack */ CFStreamCallback? clientCB, /* CFStreamClientContext* */ IntPtr clientContext);
+#endif
 
+#if !XAMCORE_5_0
 		protected override bool DoSetClient (CFStreamCallback? callback, CFIndex eventTypes,
 											 IntPtr context)
 		{
+#if NET8_OR_GREATER
+			throw new InvalidOperationException ($"Use the other overload.");
+#else
+			return CFWriteStreamSetClient (Handle, (nint) eventTypes, callback, context);
+#endif
+		}
+#endif // !XAMCORE_5_0
+
+#if NET8_OR_GREATER
+		unsafe protected override byte DoSetClient (delegate* unmanaged<IntPtr, nint, IntPtr, void> callback, CFIndex eventTypes, IntPtr context)
+		{
 			return CFWriteStreamSetClient (Handle, (nint) eventTypes, callback, context);
 		}
+#endif
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static void CFWriteStreamScheduleWithRunLoop (/* CFWriteStreamRef */ IntPtr stream, /* CFRunLoopRef */ IntPtr runLoop, /* CFStringRef */ IntPtr runLoopMode);


### PR DESCRIPTION
This turned out a bit more complex than usual, because the delegate we want to
remove from the call to the P/Invoke is a part of the public API.

I worked around this by adding new API that uses the new P/Invoke, and having
the old API throw an exception until we can remove it, but only in .NET 8,
which seems like the earliest we should do this kind of behavioral breaking
change.


Backport of #17595
