### PR TITLE
[release/6.0.4xx-xcode14.2] [Sim] Bump min simulator versions for ventura.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -288,13 +288,13 @@ DOTNET_MIN_MACCATALYST_SDK_VERSION=13.1
 DOTNET_MIN_MACOS_SDK_VERSION=10.14
 
 # The min simulator version available in the Xcode we're using
-MIN_IOS_SIMULATOR_VERSION=12.4
+MIN_IOS_SIMULATOR_VERSION=13.7
 MIN_WATCHOS_SIMULATOR_VERSION=7.0
 # This is the iOS version that matches the watchOS version (i.e same Xcode)
 MIN_WATCHOS_COMPANION_SIMULATOR_VERSION=14.5
-MIN_TVOS_SIMULATOR_VERSION=12.4
+MIN_TVOS_SIMULATOR_VERSION=13.4
 # These are the simulator package ids for the versions above
-EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK12_4 com.apple.pkg.AppleTVSimulatorSDK12_4 com.apple.pkg.iPhoneSimulatorSDK14_5 com.apple.pkg.WatchSimulatorSDK7_0
+EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK13_7 com.apple.pkg.AppleTVSimulatorSDK13_4 com.apple.pkg.iPhoneSimulatorSDK14_5 com.apple.pkg.WatchSimulatorSDK7_0
 
 INCLUDE_IOS=1
 INCLUDE_MAC=1


### PR DESCRIPTION



Backport of #17645
