### PR TITLE
[ImageIO] Refactor block code to use blittable callbacks.

### DIFF
--- a/src/ImageIO/CGImageMetadata.cs
+++ b/src/ImageIO/CGImageMetadata.cs
@@ -122,15 +122,15 @@ namespace ImageIO {
 		extern unsafe static void CGImageMetadataEnumerateTagsUsingBlock (/* CGImageMetadataRef __nonnull */ IntPtr metadata,
 						/* CFStringRef __nullable */ IntPtr rootPath, /* CFDictionaryRef __nullable */ IntPtr options, BlockLiteral* block);
 
-		delegate bool TrampolineCallback (IntPtr blockPtr, NativeHandle key, NativeHandle value);
+		delegate byte TrampolineCallback (IntPtr blockPtr, NativeHandle key, NativeHandle value);
 
 		[MonoPInvokeCallback (typeof (TrampolineCallback))]
-		static bool TagEnumerator (IntPtr block, NativeHandle key, NativeHandle value)
+		static byte TagEnumerator (IntPtr block, NativeHandle key, NativeHandle value)
 		{
 			var nsKey = Runtime.GetNSObject<NSString> (key, false)!;
 			var nsValue = Runtime.GetINativeObject<CGImageMetadataTag> (value, false)!;
 			var del = BlockLiteral.GetTarget<CGImageMetadataTagBlock> (block);
-			return del (nsKey, nsValue);
+			return del (nsKey, nsValue) ? (byte) 1 : (byte) 0;
 		}
 
 		static unsafe readonly TrampolineCallback static_action = TagEnumerator;


### PR DESCRIPTION
This is necessary in order to convert all block callbacks to use
UnmanagedCallersOnly function pointers (which can't have non-blittable types
in their signature).

Contributes towards https://github.com/xamarin/xamarin-macios/issues/15783.