### PR TITLE
[generator] The trampoline name is always 'Invoke', so simplify code accordingly.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -873,7 +873,6 @@ public partial class Generator : IMemberGatherer {
 		var trampoline_name = Nomenclator.GetTrampolineName (t);
 		var ti = new TrampolineInfo (userDelegate: FormatType (null, t),
 						 delegateName: "D" + trampoline_name,
-						 trampolineName: "T" + trampoline_name,
 						 pars: pars.ToString (),
 									 convert: convert.ToString (),
 						 invoke: invoke.ToString (),
@@ -1720,14 +1719,14 @@ public partial class Generator : IMemberGatherer {
 			// but we have a workaround in place because we can't fix old, binary bindings so...
 			// print ("[Preserve (Conditional=true)]");
 			// For .NET we fix it using the DynamicDependency attribute below
-			print ("static internal readonly {0} Handler = {1};", ti.DelegateName, ti.TrampolineName);
+			print ("static internal readonly {0} Handler = Invoke;", ti.DelegateName);
 			print ("");
 #if NET
 			print ("[Preserve (Conditional = true)]");
 			print ("[global::System.Diagnostics.CodeAnalysis.DynamicDependency (\"Handler\")]");
 #endif
 			print ("[MonoPInvokeCallback (typeof ({0}))]", ti.DelegateName);
-			print ("static unsafe {0} {1} ({2}) {{", ti.ReturnType, ti.TrampolineName, ti.Parameters);
+			print ("static unsafe {0} Invoke ({1}) {{", ti.ReturnType, ti.Parameters);
 			indent++;
 			print ("var descriptor = (BlockLiteral *) block;");
 			print ("var del = ({0}) (descriptor->Target);", ti.UserDelegate);

--- a/src/bgen/TrampolineInfo.cs
+++ b/src/bgen/TrampolineInfo.cs
@@ -16,7 +16,6 @@ using System;
 public class TrampolineInfo {
 	public string UserDelegate;
 	public string DelegateName;
-	public string TrampolineName;
 	public string Parameters;
 	public string Convert;
 	public string Invoke;
@@ -29,14 +28,13 @@ public class TrampolineInfo {
 	public string? UserDelegateTypeAttribute;
 	public Type Type;
 
-	public TrampolineInfo (string userDelegate, string delegateName, string trampolineName, string pars,
+	public TrampolineInfo (string userDelegate, string delegateName, string pars,
 		string convert, string invoke, string returnType, string delegateReturnType, string returnFormat,
 		string clear, string postConvert, Type type)
 	{
 		UserDelegate = userDelegate;
 		DelegateName = delegateName;
 		Parameters = pars;
-		TrampolineName = trampolineName;
 		Convert = convert;
 		Invoke = invoke;
 		ReturnType = returnType;
@@ -45,8 +43,6 @@ public class TrampolineInfo {
 		Clear = clear;
 		PostConvert = postConvert;
 		Type = type;
-
-		TrampolineName = "Invoke";
 	}
 
 	// Name for the static class generated that contains the Objective-C to C# block bridge


### PR DESCRIPTION
We try to pass another name to the TrampolineInfo constructor, but it's
ignored, and 'Invoke' is always used, so just hardcode 'Invoke' everywhere
instead.

This makes the code a little bit simpler.