### PR TITLE
[ObjCRuntime] Make BlockLiteral a ref struct in XAMCORE_5_0.

### DIFF
--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -58,7 +58,12 @@ namespace ObjCRuntime {
 	}
 
 	[StructLayout (LayoutKind.Sequential)]
-#if COREBUILD
+#if XAMCORE_5_0
+	// Let's try to make this a ref struct in XAMCORE_5_0, that will mean blocks can't be boxed (which is good, because it would most likely result in broken code).
+	// Note that the presence of a Dispose method is enough to be able to do a 'using var block = new BlockLiteral ()' in C# due to pattern-based using for 'ref structs':
+	// Ref: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/using#pattern-based-using
+	public unsafe ref struct BlockLiteral
+#elif COREBUILD
 	public unsafe struct BlockLiteral {
 #else
 	public unsafe struct BlockLiteral : IDisposable {


### PR DESCRIPTION
A ref struct has a few limitations that makes a lot of sense for blocks:
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct,
so by making BlockLiteral a ref struct, we're getting the C# compiler to help
us not writing broken code by accident.

The limitations also mean that it's a breaking change, so we can't do it
before XAMCORE_5_0.