### PR TITLE
[release/7.0.1xx-xcode14.2] [tests] Adjust ImageCaptioningTest to skip network-related failures in CI.

### DIFF
--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -33,11 +33,9 @@ namespace MonoTouchFixtures.MediaAccessibility {
 				var s = MAImageCaptioning.GetCaption (url, out var e);
 				Assert.Null (s, "remote / return value");
 				if (e != null && e.Description.Contains ("Invalid url:")) {
-					Assert.Fail ("Ignore this failure when network is down"); // could not connect to the network, fail and add a nice reason
-				} else {
-					Assert.Null (e, "remote / no error"); // weird should be an "image on disk"
-
+					TestRuntime.IgnoreInCI ($"Ignore this failure when network is down: {e}"); // could not connect to the network, fail and add a nice reason
 				}
+				Assert.Null (e, "remote / no error"); // weird should be an "image on disk"
 			}
 			string file = Path.Combine (NSBundle.MainBundle.ResourcePath, "basn3p08.png");
 			file = file.Replace (" ", "%20");


### PR DESCRIPTION
Fixes:

    MonoTouchFixtures.MediaAccessibility.ImageCaptioningTest
    	[FAIL] GetCaption : Ignore this failure when network is down
    		   at MonoTouchFixtures.MediaAccessibility.ImageCaptioningTest.GetCaption() in /Users/builder/azdo/_work/3/s/xamarin-macios/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs:line 36

Ref: https://github.com/xamarin/maccore/issues/2088.


Backport of #16814
