### PR TITLE
Add support for function pointers to BlockLiteral.

### DIFF
--- a/src/CoreGraphics/CGPDFArray.cs
+++ b/src/CoreGraphics/CGPDFArray.cs
@@ -218,11 +218,15 @@ namespace CoreGraphics {
 		}
 #endif
 
+#if !NET
 		delegate byte ApplyBlockHandlerDelegate (IntPtr block, nint index, IntPtr value, IntPtr info);
 		static readonly ApplyBlockHandlerDelegate applyblock_handler = ApplyBlockHandler;
 
 #if !MONOMAC
 		[MonoPInvokeCallback (typeof (ApplyBlockHandlerDelegate))]
+#endif
+#else
+		[UnmanagedCallersOnly]
 #endif
 		static byte ApplyBlockHandler (IntPtr block, nint index, IntPtr value, IntPtr info)
 		{
@@ -270,8 +274,13 @@ namespace CoreGraphics {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, nint, IntPtr, IntPtr, byte> trampoline = &ApplyBlockHandler;
+				using var block = new BlockLiteral (trampoline, callback, typeof (CGPDFArray), nameof (ApplyBlockHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (applyblock_handler, callback);
+#endif
 				var gc_handle = info is null ? default (GCHandle) : GCHandle.Alloc (info);
 				try {
 					return CGPDFArrayApplyBlock (Handle, &block, info is null ? IntPtr.Zero : GCHandle.ToIntPtr (gc_handle));

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -232,10 +232,14 @@ namespace CoreText {
 #endif
 		public delegate bool CTFontRegistrationHandler (NSError [] errors, bool done);
 
+#if !NET
 		internal delegate byte InnerRegistrationHandler (IntPtr block, IntPtr errors, byte done);
 		static readonly InnerRegistrationHandler callback = TrampolineRegistrationHandler;
 
 		[MonoPInvokeCallback (typeof (InnerRegistrationHandler))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static unsafe byte TrampolineRegistrationHandler (IntPtr block, /* NSArray */ IntPtr errors, byte done)
 		{
 			var del = BlockLiteral.GetTarget<CTFontRegistrationHandler> (block);
@@ -281,8 +285,13 @@ namespace CoreText {
 					}
 				} else {
 					unsafe {
+#if NET
+						delegate* unmanaged<IntPtr, IntPtr, byte, byte> trampoline = &TrampolineRegistrationHandler;
+						using var block = new BlockLiteral (trampoline, registrationHandler, typeof (CTFontManager), nameof (TrampolineRegistrationHandler));
+#else
 						using var block = new BlockLiteral ();
 						block.SetupBlockUnsafe (callback, registrationHandler);
+#endif
 						CTFontManagerRegisterFontURLs (arr.Handle, scope, enabled, &block);
 					}
 				}
@@ -385,8 +394,13 @@ namespace CoreText {
 				if (registrationHandler is null) {
 					CTFontManagerUnregisterFontURLs (arr.Handle, scope, null);
 				} else {
+#if NET
+					delegate* unmanaged<IntPtr, IntPtr, byte, byte> trampoline = &TrampolineRegistrationHandler;
+					using var block = new BlockLiteral (trampoline, registrationHandler, typeof (CTFontManager), nameof (TrampolineRegistrationHandler));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (callback, registrationHandler);
+#endif
 					CTFontManagerUnregisterFontURLs (arr.Handle, scope, &block);
 				}
 			}
@@ -548,8 +562,13 @@ namespace CoreText {
 				if (registrationHandler is null) {
 					CTFontManagerRegisterFontDescriptors (arr.Handle, scope, enabled, null);
 				} else {
+#if NET
+					delegate* unmanaged<IntPtr, IntPtr, byte, byte> trampoline = &TrampolineRegistrationHandler;
+					using var block = new BlockLiteral (trampoline, registrationHandler, typeof (CTFontManager), nameof (TrampolineRegistrationHandler));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (callback, registrationHandler);
+#endif
 					CTFontManagerRegisterFontDescriptors (arr.Handle, scope, enabled, &block);
 				}
 			}
@@ -587,8 +606,13 @@ namespace CoreText {
 				if (registrationHandler is null) {
 					CTFontManagerUnregisterFontDescriptors (arr.Handle, scope, null);
 				} else {
+#if NET
+					delegate* unmanaged<IntPtr, IntPtr, byte, byte> trampoline = &TrampolineRegistrationHandler;
+					using var block = new BlockLiteral (trampoline, registrationHandler, typeof (CTFontManager), nameof (TrampolineRegistrationHandler));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (callback, registrationHandler);
+#endif
 					CTFontManagerUnregisterFontDescriptors (arr.Handle, scope, &block);
 				}
 			}
@@ -709,8 +733,13 @@ namespace CoreText {
 				if (registrationHandler is null) {
 					CTFontManagerRegisterFontsWithAssetNames (arr.Handle, bundle.GetHandle (), scope, enabled, null);
 				} else {
+#if NET
+					delegate* unmanaged<IntPtr, IntPtr, byte, byte> trampoline = &TrampolineRegistrationHandler;
+					using var block = new BlockLiteral (trampoline, registrationHandler, typeof (CTFontManager), nameof (TrampolineRegistrationHandler));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (callback, registrationHandler);
+#endif
 					CTFontManagerRegisterFontsWithAssetNames (arr.Handle, bundle.GetHandle (), scope, enabled, &block);
 				}
 			}
@@ -743,10 +772,16 @@ namespace CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern unsafe void CTFontManagerRequestFonts (/* CFArrayRef */ IntPtr fontDescriptors, BlockLiteral* completionHandler);
 
+#if !NET
 		internal delegate void InnerRequestFontsHandler (IntPtr block, IntPtr fontDescriptors);
 		static readonly InnerRequestFontsHandler requestCallback = TrampolineRequestFonts;
+#endif
 
+#if NET
+		[UnmanagedCallersOnly]
+#else
 		[MonoPInvokeCallback (typeof (InnerRequestFontsHandler))]
+#endif
 		static unsafe void TrampolineRequestFonts (IntPtr block, /* CFArray */ IntPtr fontDescriptors)
 		{
 			var del = BlockLiteral.GetTarget<CTFontManagerRequestFontsHandler> (block);
@@ -773,8 +808,13 @@ namespace CoreText {
 
 			using (var arr = EnsureNonNullArray (fontDescriptors, nameof (fontDescriptors))) {
 				unsafe {
+#if NET
+					delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineRequestFonts;
+					using var block = new BlockLiteral (trampoline, completionHandler, typeof (CTFontManager), nameof (TrampolineRequestFonts));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (requestCallback, completionHandler);
+#endif
 					CTFontManagerRequestFonts (arr.Handle, &block);
 				}
 			}

--- a/src/ImageIO/CGImageAnimation.cs
+++ b/src/ImageIO/CGImageAnimation.cs
@@ -79,8 +79,13 @@ namespace ImageIO {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, nint, IntPtr, byte*, void> trampoline = &SDCGImageSourceAnimationBlock.Invoke;
+				using var block = new BlockLiteral (trampoline, handler, typeof (SDCGImageSourceAnimationBlock), nameof (SDCGImageSourceAnimationBlock.Invoke));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (SDCGImageSourceAnimationBlock.Handler, handler);
+#endif
 				return CGAnimateImageAtURLWithBlock (url.Handle, options.GetHandle (), &block);
 			}
 #endif
@@ -109,8 +114,13 @@ namespace ImageIO {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, nint, IntPtr, byte*, void> trampoline = &SDCGImageSourceAnimationBlock.Invoke;
+				using var block = new BlockLiteral (trampoline, handler, typeof (SDCGImageSourceAnimationBlock), nameof (SDCGImageSourceAnimationBlock.Invoke));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (SDCGImageSourceAnimationBlock.Handler, handler);
+#endif
 				return CGAnimateImageDataWithBlock (data.Handle, options.GetHandle (), &block);
 			}
 #endif
@@ -120,9 +130,13 @@ namespace ImageIO {
 		// This class bridges native block invocations that call into C#
 		//
 		static internal class SDCGImageSourceAnimationBlock {
+#if !NET
 			unsafe static internal readonly DCGImageSourceAnimationBlock Handler = Invoke;
 
 			[MonoPInvokeCallback (typeof (DCGImageSourceAnimationBlock))]
+#else
+			[UnmanagedCallersOnly]
+#endif
 			internal unsafe static void Invoke (IntPtr block, nint index, IntPtr image, byte* stop)
 			{
 				var del = BlockLiteral.GetTarget<CGImageSourceAnimationHandler> (block);
@@ -134,9 +148,11 @@ namespace ImageIO {
 			}
 		} /* class SDCGImageSourceAnimationBlock */
 
+#if !NET
 		[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
 		[UserDelegateType (typeof (CGImageSourceAnimationHandler))]
 		unsafe internal delegate void DCGImageSourceAnimationBlock (IntPtr block, nint index, IntPtr imageHandle, byte* stop);
+#endif
 	}
 
 }

--- a/src/ImageIO/CGImageMetadata.cs
+++ b/src/ImageIO/CGImageMetadata.cs
@@ -122,9 +122,13 @@ namespace ImageIO {
 		extern unsafe static void CGImageMetadataEnumerateTagsUsingBlock (/* CGImageMetadataRef __nonnull */ IntPtr metadata,
 						/* CFStringRef __nullable */ IntPtr rootPath, /* CFDictionaryRef __nullable */ IntPtr options, BlockLiteral* block);
 
+#if !NET
 		delegate byte TrampolineCallback (IntPtr blockPtr, NativeHandle key, NativeHandle value);
 
 		[MonoPInvokeCallback (typeof (TrampolineCallback))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static byte TagEnumerator (IntPtr block, NativeHandle key, NativeHandle value)
 		{
 			var nsKey = Runtime.GetNSObject<NSString> (key, false)!;
@@ -133,15 +137,22 @@ namespace ImageIO {
 			return del (nsKey, nsValue) ? (byte) 1 : (byte) 0;
 		}
 
+#if !NET
 		static unsafe readonly TrampolineCallback static_action = TagEnumerator;
+#endif
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void EnumerateTags (NSString? rootPath, CGImageMetadataEnumerateOptions? options, CGImageMetadataTagBlock block)
 		{
 			using var o = options?.ToDictionary ();
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, NativeHandle, NativeHandle, byte> trampoline = &TagEnumerator;
+				using var block_handler = new BlockLiteral (trampoline, block, typeof (CGImageMetadata), nameof (TagEnumerator));
+#else
 				using var block_handler = new BlockLiteral ();
 				block_handler.SetupBlockUnsafe (static_action, block);
+#endif
 				CGImageMetadataEnumerateTagsUsingBlock (Handle, rootPath.GetHandle (), o.GetHandle (), &block_handler);
 			}
 		}

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -117,8 +117,13 @@ namespace Metal {
 			IntPtr observer_handle;
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, void> trampoline = &TrampolineNotificationHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (MTLDevice), nameof (TrampolineNotificationHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_notificationHandler, handler);
+#endif
 
 				rv = MTLCopyAllDevicesWithObserver (out observer_handle, &block);
 			}
@@ -144,9 +149,13 @@ namespace Metal {
 		}
 #endif // !NET
 
+#if !NET
 		internal delegate void InnerNotification (IntPtr block, IntPtr device, IntPtr notifyName);
 		static readonly InnerNotification static_notificationHandler = TrampolineNotificationHandler;
 		[MonoPInvokeCallback (typeof (InnerNotification))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		public static unsafe void TrampolineNotificationHandler (IntPtr block, IntPtr device, IntPtr notifyName)
 		{
 			var descriptor = (BlockLiteral*) block;

--- a/src/Network/NWBrowseResult.cs
+++ b/src/Network/NWBrowseResult.cs
@@ -65,10 +65,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_browse_result_enumerate_interfaces (OS_nw_browse_result result, BlockLiteral* enumerator);
 
+#if !NET
 		delegate void nw_browse_result_enumerate_interfaces_t (IntPtr block, IntPtr nwInterface);
 		static nw_browse_result_enumerate_interfaces_t static_EnumerateInterfacesHandler = TrampolineEnumerateInterfacesHandler;
 
 		[MonoPInvokeCallback (typeof (nw_browse_result_enumerate_interfaces_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineEnumerateInterfacesHandler (IntPtr block, IntPtr inter)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWInterface>> (block);
@@ -85,8 +89,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineEnumerateInterfacesHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWBrowseResult), nameof (TrampolineEnumerateInterfacesHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_EnumerateInterfacesHandler, handler);
+#endif
 				nw_browse_result_enumerate_interfaces (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/Network/NWBrowser.cs
+++ b/src/Network/NWBrowser.cs
@@ -131,10 +131,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_browser_set_browse_results_changed_handler (OS_nw_browser browser, BlockLiteral* handler);
 
+#if !NET
 		delegate void nw_browser_browse_results_changed_handler_t (IntPtr block, IntPtr oldResult, IntPtr newResult, byte completed);
 		static nw_browser_browse_results_changed_handler_t static_ChangesHandler = TrampolineChangesHandler;
 
 		[MonoPInvokeCallback (typeof (nw_browser_browse_results_changed_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineChangesHandler (IntPtr block, IntPtr oldResult, IntPtr newResult, byte completed)
 		{
 			var del = BlockLiteral.GetTarget<NWBrowserChangesDelegate> (block);
@@ -199,8 +203,13 @@ namespace Network {
 					return;
 				}
 
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, void> trampoline = &TrampolineChangesHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWBrowser), nameof (TrampolineChangesHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ChangesHandler, handler);
+#endif
 				nw_browser_set_browse_results_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
@@ -214,10 +223,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_browser_set_state_changed_handler (OS_nw_browser browser, BlockLiteral* state_changed_handler);
 
+#if !NET
 		delegate void nw_browser_set_state_changed_handler_t (IntPtr block, NWBrowserState state, IntPtr error);
 		static nw_browser_set_state_changed_handler_t static_StateChangesHandler = TrampolineStateChangesHandler;
 
 		[MonoPInvokeCallback (typeof (nw_browser_set_state_changed_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineStateChangesHandler (IntPtr block, NWBrowserState state, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWBrowserState, NWError?>> (block);
@@ -235,8 +248,13 @@ namespace Network {
 					nw_browser_set_state_changed_handler (GetCheckedHandle (), null);
 					return;
 				}
+#if NET
+				delegate* unmanaged<IntPtr, NWBrowserState, IntPtr, void> trampoline = &TrampolineStateChangesHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWBrowser), nameof (TrampolineStateChangesHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_StateChangesHandler, handler);
+#endif
 				nw_browser_set_state_changed_handler (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/Network/NWConnection.cs
+++ b/src/Network/NWConnection.cs
@@ -100,10 +100,14 @@ namespace Network {
 			}
 		}
 
+#if !NET
 		delegate void StateChangeCallback (IntPtr block, NWConnectionState state, IntPtr error);
 		static StateChangeCallback static_stateChangeHandler = Trampoline_StateChangeCallback;
 
 		[MonoPInvokeCallback (typeof (StateChangeCallback))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void Trampoline_StateChangeCallback (IntPtr block, NWConnectionState state, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWConnectionState, NWError?>> (block);
@@ -125,16 +129,25 @@ namespace Network {
 			}
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, NWConnectionState, IntPtr, void> trampoline = &Trampoline_StateChangeCallback;
+				using var block = new BlockLiteral (trampoline, stateHandler, typeof (NWConnection), nameof (Trampoline_StateChangeCallback));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_stateChangeHandler, stateHandler);
+#endif
 				nw_connection_set_state_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
 
+#if !NET
 		delegate void nw_connection_boolean_event_handler_t (IntPtr block, byte value);
 		static nw_connection_boolean_event_handler_t static_BooleanChangeHandler = TrampolineBooleanChangeHandler;
 
 		[MonoPInvokeCallback (typeof (nw_connection_boolean_event_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineBooleanChangeHandler (IntPtr block, byte value)
 		{
 			var del = BlockLiteral.GetTarget<Action<bool>> (block);
@@ -154,8 +167,13 @@ namespace Network {
 			}
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, byte, void> trampoline = &TrampolineBooleanChangeHandler;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWConnection), nameof (TrampolineBooleanChangeHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_BooleanChangeHandler, callback);
+#endif
 				nw_connection_set_viability_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
@@ -172,16 +190,25 @@ namespace Network {
 			}
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, byte, void> trampoline = &TrampolineBooleanChangeHandler;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWConnection), nameof (TrampolineBooleanChangeHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_BooleanChangeHandler, callback);
+#endif
 				nw_connection_set_better_path_available_handler (GetCheckedHandle (), &block);
 			}
 		}
 
+#if !NET
 		delegate void nw_connection_path_event_handler_t (IntPtr block, IntPtr path);
 		static nw_connection_path_event_handler_t static_PathChanged = TrampolinePathChanged;
 
 		[MonoPInvokeCallback (typeof (nw_connection_path_event_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolinePathChanged (IntPtr block, IntPtr path)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWPath>> (block);
@@ -198,8 +225,13 @@ namespace Network {
 		public void SetPathChangedHandler (Action<NWPath> callback)
 		{
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolinePathChanged;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWConnection), nameof (TrampolinePathChanged));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_PathChanged, callback);
+#endif
 				nw_connection_set_path_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
@@ -239,6 +271,7 @@ namespace Network {
 
 		public void CancelCurrentEndpoint () => nw_connection_cancel_current_endpoint (GetCheckedHandle ());
 
+#if !NET
 		delegate void nw_connection_receive_completion_t (IntPtr block,
 								  IntPtr dispatchData,
 								  IntPtr contentContext,
@@ -248,8 +281,13 @@ namespace Network {
 		static nw_connection_receive_completion_t static_ReceiveCompletion = TrampolineReceiveCompletion;
 		static nw_connection_receive_completion_t static_ReceiveCompletionDispatchData = TrampolineReceiveCompletionData;
 		static nw_connection_receive_completion_t static_ReceiveCompletionDispatchReadnOnlyData = TrampolineReceiveCompletionReadOnlyData;
+#endif
 
+#if !NET
 		[MonoPInvokeCallback (typeof (nw_connection_receive_completion_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineReceiveCompletion (IntPtr block, IntPtr dispatchDataPtr, IntPtr contentContext, byte isComplete, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<NWConnectionReceiveCompletion> (block);
@@ -276,7 +314,11 @@ namespace Network {
 			}
 		}
 
+#if !NET
 		[MonoPInvokeCallback (typeof (nw_connection_receive_completion_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineReceiveCompletionData (IntPtr block, IntPtr dispatchDataPtr, IntPtr contentContext, byte isComplete, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<NWConnectionReceiveDispatchDataCompletion> (block);
@@ -297,7 +339,11 @@ namespace Network {
 			}
 		}
 
+#if !NET
 		[MonoPInvokeCallback (typeof (nw_connection_receive_completion_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineReceiveCompletionReadOnlyData (IntPtr block, IntPtr dispatchDataPtr, IntPtr contentContext, byte isComplete, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<NWConnectionReceiveReadOnlySpanCompletion> (block);
@@ -326,8 +372,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, IntPtr, void> trampoline = &TrampolineReceiveCompletion;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWConnection), nameof (TrampolineReceiveCompletion));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ReceiveCompletion, callback);
+#endif
 				nw_connection_receive (GetCheckedHandle (), minimumIncompleteLength, maximumLength, &block);
 			}
 		}
@@ -339,8 +390,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, IntPtr, void> trampoline = &TrampolineReceiveCompletionData;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWConnection), nameof (TrampolineReceiveCompletionData));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ReceiveCompletionDispatchData, callback);
+#endif
 				nw_connection_receive (GetCheckedHandle (), minimumIncompleteLength, maximumLength, &block);
 			}
 		}
@@ -352,8 +408,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, IntPtr, void> trampoline = &TrampolineReceiveCompletionReadOnlyData;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWConnection), nameof (TrampolineReceiveCompletionReadOnlyData));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ReceiveCompletionDispatchReadnOnlyData, callback);
+#endif
 				nw_connection_receive (GetCheckedHandle (), minimumIncompleteLength, maximumLength, &block);
 			}
 		}
@@ -368,8 +429,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, IntPtr, void> trampoline = &TrampolineReceiveCompletion;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWConnection), nameof (TrampolineReceiveCompletion));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ReceiveCompletion, callback);
+#endif
 				nw_connection_receive_message (GetCheckedHandle (), &block);
 			}
 
@@ -382,8 +448,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, IntPtr, void> trampoline = &TrampolineReceiveCompletionData;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWConnection), nameof (TrampolineReceiveCompletionData));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ReceiveCompletionDispatchData, callback);
+#endif
 				nw_connection_receive_message (GetCheckedHandle (), &block);
 			}
 		}
@@ -395,16 +466,25 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, IntPtr, void> trampoline = &TrampolineReceiveCompletionReadOnlyData;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWConnection), nameof (TrampolineReceiveCompletionReadOnlyData));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ReceiveCompletionDispatchReadnOnlyData, callback);
+#endif
 				nw_connection_receive_message (GetCheckedHandle (), &block);
 			}
 		}
 
+#if !NET
 		delegate void nw_connection_send_completion_t (IntPtr block, IntPtr error);
 		static nw_connection_send_completion_t static_SendCompletion = TrampolineSendCompletion;
 
 		[MonoPInvokeCallback (typeof (nw_connection_send_completion_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineSendCompletion (IntPtr block, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWError?>> (block);
@@ -463,8 +543,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineSendCompletion;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWConnection), nameof (TrampolineSendCompletion));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_SendCompletion, callback);
+#endif
 				LowLevelSend (GetCheckedHandle (), buffer, context.Handle, isComplete, &block);
 			}
 		}
@@ -561,10 +646,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_connection_access_establishment_report (IntPtr connection, IntPtr queue, BlockLiteral* access_block);
 
+#if !NET
 		delegate void nw_establishment_report_access_block_t (IntPtr block, nw_establishment_report_t report);
 		static nw_establishment_report_access_block_t static_GetEstablishmentReportHandler = TrampolineGetEstablishmentReportHandler;
 
 		[MonoPInvokeCallback (typeof (nw_establishment_report_access_block_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineGetEstablishmentReportHandler (IntPtr block, nw_establishment_report_t report)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWEstablishmentReport>> (block);
@@ -594,8 +683,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, nw_establishment_report_t, void> trampoline = &TrampolineGetEstablishmentReportHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWConnection), nameof (TrampolineGetEstablishmentReportHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_GetEstablishmentReportHandler, handler);
+#endif
 				nw_connection_access_establishment_report (GetCheckedHandle (), queue.Handle, &block);
 			}
 		}

--- a/src/Network/NWConnectionGroup.cs
+++ b/src/Network/NWConnectionGroup.cs
@@ -188,10 +188,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_connection_group_send_message (OS_nw_connection_group group, /* [NullAllowed] DispatchData */ IntPtr content, /* [NullAllowed] */ OS_nw_endpoint endpoint, OS_nw_content_context context, BlockLiteral* handler);
 
+#if !NET
 		delegate void nw_connection_group_send_completion_t (IntPtr block, IntPtr error);
 		static nw_connection_group_send_completion_t static_SendCompletion = TrampolineSendCompletion;
 
 		[MonoPInvokeCallback (typeof (nw_connection_group_send_completion_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineSendCompletion (IntPtr block, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWError?>> (block);
@@ -214,8 +218,13 @@ namespace Network {
 					return;
 				}
 
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineSendCompletion;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWConnectionGroup), nameof (TrampolineSendCompletion));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_SendCompletion, handler);
+#endif
 				nw_connection_group_send_message (GetCheckedHandle (),
 					content.GetHandle (),
 					endpoint.GetHandle (),
@@ -227,10 +236,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_connection_group_set_receive_handler (OS_nw_connection_group group, uint maximum_message_size, [MarshalAs (UnmanagedType.I1)] bool reject_oversized_messages, BlockLiteral* handler);
 
+#if !NET
 		delegate void nw_connection_group_receive_handler_t (IntPtr block, IntPtr content, IntPtr context, byte isCompleted);
 		static nw_connection_group_receive_handler_t static_ReceiveHandler = TrampolineReceiveHandler;
 
 		[MonoPInvokeCallback (typeof (nw_connection_group_receive_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineReceiveHandler (IntPtr block, IntPtr content, IntPtr context, byte isCompleted)
 		{
 			var del = BlockLiteral.GetTarget<NWConnectionGroupReceiveDelegate> (block);
@@ -250,8 +263,13 @@ namespace Network {
 					return;
 				}
 
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, void> trampoline = &TrampolineReceiveHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWConnectionGroup), nameof (TrampolineReceiveHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ReceiveHandler, handler);
+#endif
 				nw_connection_group_set_receive_handler (GetCheckedHandle (), maximumMessageSize, rejectOversizedMessages, &block);
 			}
 		}
@@ -259,10 +277,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_connection_group_set_state_changed_handler (OS_nw_connection_group group, BlockLiteral* handler);
 
+#if !NET
 		delegate void nw_connection_group_state_changed_handler_t (IntPtr block, NWConnectionGroupState state, IntPtr error);
 		static nw_connection_group_state_changed_handler_t static_StateChangedHandler = TrampolineStateChangedHandler;
 
 		[MonoPInvokeCallback (typeof (nw_connection_group_state_changed_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineStateChangedHandler (IntPtr block, NWConnectionGroupState state, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<NWConnectionGroupStateChangedDelegate> (block);
@@ -281,8 +303,13 @@ namespace Network {
 					return;
 				}
 
+#if NET
+				delegate* unmanaged<IntPtr, NWConnectionGroupState, IntPtr, void> trampoline=  &TrampolineStateChangedHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWConnectionGroup), nameof (TrampolineStateChangedHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_StateChangedHandler, handler);
+#endif
 				nw_connection_group_set_state_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
@@ -442,10 +469,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_connection_group_set_new_connection_handler (OS_nw_connection_group group, BlockLiteral* connectionHandler);
 
+#if !NET
 		delegate void nw_connection_group_new_connection_handler_t (IntPtr block, IntPtr connection);
 		static nw_connection_group_new_connection_handler_t static_SetNewConnectionHandler = TrampolineSetNewConnectionHandler;
 
 		[MonoPInvokeCallback (typeof (nw_connection_group_new_connection_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineSetNewConnectionHandler (IntPtr block, IntPtr connection)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWConnection>> (block);
@@ -475,8 +506,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineSetNewConnectionHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWConnectionGroup), nameof (TrampolineSetNewConnectionHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_SetNewConnectionHandler, handler);
+#endif
 				nw_connection_group_set_new_connection_handler (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/Network/NWDataTransferReport.cs
+++ b/src/Network/NWDataTransferReport.cs
@@ -146,10 +146,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_data_transfer_report_collect (OS_nw_data_transfer_report report, IntPtr queue, BlockLiteral* collect_block);
 
+#if !NET
 		delegate void nw_data_transfer_report_collect_t (IntPtr block, IntPtr report);
 		static nw_data_transfer_report_collect_t static_CollectHandler = TrampolineCollectHandler;
 
 		[MonoPInvokeCallback (typeof (nw_data_transfer_report_collect_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineCollectHandler (IntPtr block, IntPtr report)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWDataTransferReport>> (block);
@@ -168,8 +172,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineCollectHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWDataTransferReport), nameof (TrampolineCollectHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_CollectHandler, handler);
+#endif
 				nw_data_transfer_report_collect (GetCheckedHandle (), queue.Handle, &block);
 			}
 		}

--- a/src/Network/NWEstablishmentReport.cs
+++ b/src/Network/NWEstablishmentReport.cs
@@ -75,10 +75,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_establishment_report_enumerate_resolutions (OS_nw_establishment_report report, BlockLiteral* enumerate_block);
 
+#if !NET
 		delegate void nw_report_resolution_enumerator_t (IntPtr block, NWReportResolutionSource source, nuint milliseconds, int endpoint_count, nw_endpoint_t successful_endpoint, nw_endpoint_t preferred_endpoint);
 		static nw_report_resolution_enumerator_t static_ResolutionEnumeratorHandler = TrampolineResolutionEnumeratorHandler;
 
 		[MonoPInvokeCallback (typeof (nw_report_resolution_enumerator_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineResolutionEnumeratorHandler (IntPtr block, NWReportResolutionSource source, nuint milliseconds, int endpoint_count, nw_endpoint_t successful_endpoint, nw_endpoint_t preferred_endpoint)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWReportResolutionSource, TimeSpan, int, NWEndpoint, NWEndpoint>> (block);
@@ -96,8 +100,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, NWReportResolutionSource, nuint, int, nw_endpoint_t, nw_endpoint_t, void> trampoline = &TrampolineResolutionEnumeratorHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWEstablishmentReport),nameof (TrampolineResolutionEnumeratorHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ResolutionEnumeratorHandler, handler);
+#endif
 				nw_establishment_report_enumerate_resolutions (GetCheckedHandle (), &block);
 			}
 		}
@@ -105,10 +114,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_establishment_report_enumerate_protocols (OS_nw_establishment_report report, BlockLiteral* enumerate_block);
 
+#if !NET
 		delegate void nw_establishment_report_enumerate_protocols_t (IntPtr block, nw_protocol_definition_t protocol, nuint handshake_milliseconds, nuint handshake_rtt_milliseconds);
 		static nw_establishment_report_enumerate_protocols_t static_EnumerateProtocolsHandler = TrampolineEnumerateProtocolsHandler;
 
 		[MonoPInvokeCallback (typeof (nw_establishment_report_enumerate_protocols_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineEnumerateProtocolsHandler (IntPtr block, nw_protocol_definition_t protocol, nuint handshake_milliseconds, nuint handshake_rtt_milliseconds)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWProtocolDefinition, TimeSpan, TimeSpan>> (block);
@@ -125,8 +138,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, nw_protocol_definition_t, nuint, nuint, void> trampoline = &TrampolineEnumerateProtocolsHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWEstablishmentReport), nameof (TrampolineEnumerateProtocolsHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_EnumerateProtocolsHandler, handler);
+#endif
 				nw_establishment_report_enumerate_protocols (GetCheckedHandle (), &block);
 			}
 		}
@@ -156,10 +174,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_establishment_report_enumerate_resolution_reports (OS_nw_establishment_report report, BlockLiteral* enumerateBlock);
 
+#if !NET
 		delegate void nw_report_resolution_report_enumerator_t (IntPtr block, nw_resolution_report_t report);
 		static nw_report_resolution_report_enumerator_t static_EnumerateResolutionReport = TrampolineEnumerateResolutionReport;
 
 		[MonoPInvokeCallback (typeof (nw_report_resolution_report_enumerator_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineEnumerateResolutionReport (IntPtr block, nw_resolution_report_t report)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWResolutionReport>> (block);
@@ -188,8 +210,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, nw_resolution_report_t, void> trampoline = &TrampolineEnumerateResolutionReport;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWEstablishmentReport), nameof (TrampolineEnumerateResolutionReport));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_EnumerateResolutionReport, handler);
+#endif
 				nw_establishment_report_enumerate_protocols (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/Network/NWEthernetChannel.cs
+++ b/src/Network/NWEthernetChannel.cs
@@ -124,10 +124,14 @@ namespace Network {
 		unsafe static extern void nw_ethernet_channel_send (OS_nw_ethernet_channel ethernet_channel, OS_dispatch_data content, ushort vlan_tag, string remote_address, BlockLiteral* completion);
 #endif
 
+#if !NET
 		delegate void nw_ethernet_channel_send_completion_t (IntPtr block, IntPtr error);
 		static nw_ethernet_channel_send_completion_t static_SendCompletion = TrampolineSendCompletion;
 
 		[MonoPInvokeCallback (typeof (nw_ethernet_channel_send_completion_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineSendCompletion (IntPtr block, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWError?>> (block);
@@ -145,12 +149,14 @@ namespace Network {
 
 			using (var dispatchData = DispatchData.FromReadOnlySpan (content)) {
 				unsafe {
-					using var block = new BlockLiteral ();
-					block.SetupBlockUnsafe (static_SendCompletion, callback);
 #if NET
+					delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineSendCompletion;
+					using var block = new BlockLiteral (trampoline, callback, typeof (NWEthernetChannel), nameof (TrampolineSendCompletion));
 					var remoteAddressStr = new TransientString (remoteAddress);
 					nw_ethernet_channel_send (GetCheckedHandle (), dispatchData.GetHandle (), vlanTag, remoteAddressStr, &block);
 #else
+					using var block = new BlockLiteral ();
+					block.SetupBlockUnsafe (static_SendCompletion, callback);
 					nw_ethernet_channel_send (GetCheckedHandle (), dispatchData.GetHandle (), vlanTag, remoteAddress, &block);
 #endif
 				}
@@ -160,10 +166,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_ethernet_channel_set_receive_handler (OS_nw_ethernet_channel ethernet_channel, /* [NullAllowed] */ BlockLiteral *handler);
 
+#if !NET
 		delegate void nw_ethernet_channel_receive_handler_t (IntPtr block, OS_dispatch_data content, ushort vlan_tag, IntPtr local_address, IntPtr remote_address);
 		static nw_ethernet_channel_receive_handler_t static_ReceiveHandler = TrampolineReceiveHandler;
 
 		[MonoPInvokeCallback (typeof (nw_ethernet_channel_receive_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineReceiveHandler (IntPtr block, OS_dispatch_data content, ushort vlanTag, IntPtr localAddressArray, IntPtr remoteAddressArray)
 		{
 			// localAddress and remoteAddress are defined as:
@@ -188,8 +198,13 @@ namespace Network {
 					return;
 				}
 
+#if NET
+				delegate* unmanaged<IntPtr, OS_dispatch_data, ushort, IntPtr, IntPtr, void> trampoline = &TrampolineReceiveHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWEthernetChannel), nameof (TrampolineReceiveHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ReceiveHandler, handler);
+#endif
 				nw_ethernet_channel_set_receive_handler (GetCheckedHandle (), &block);
 			}
 		}
@@ -197,10 +212,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_ethernet_channel_set_state_changed_handler (OS_nw_ethernet_channel ethernet_channel, /* [NullAllowed] */ BlockLiteral *handler);
 
+#if !NET
 		delegate void nw_ethernet_channel_state_changed_handler_t (IntPtr block, NWEthernetChannelState state, IntPtr error);
 		static nw_ethernet_channel_state_changed_handler_t static_StateChangesHandler = TrampolineStateChangesHandler;
 
 		[MonoPInvokeCallback (typeof (nw_ethernet_channel_state_changed_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineStateChangesHandler (IntPtr block, NWEthernetChannelState state, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWEthernetChannelState, NWError?>> (block);
@@ -219,8 +238,13 @@ namespace Network {
 					return;
 				}
 
+#if NET
+				delegate* unmanaged<IntPtr, NWEthernetChannelState, IntPtr, void> trampoline = &TrampolineStateChangesHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWEthernetChannel), nameof (TrampolineStateChangesHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_StateChangesHandler, handler);
+#endif
 				nw_ethernet_channel_set_state_changed_handler (GetCheckedHandle (), &block);
 			}
 		}	

--- a/src/Network/NWFramer.cs
+++ b/src/Network/NWFramer.cs
@@ -78,10 +78,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_framer_set_wakeup_handler (OS_nw_framer framer, void* wakeup_handler);
 
+#if !NET
 		delegate void nw_framer_set_wakeup_handler_t (IntPtr block, OS_nw_framer framer);
 		static nw_framer_set_wakeup_handler_t static_WakeupHandler = TrampolineWakeupHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_set_wakeup_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineWakeupHandler (IntPtr block, OS_nw_framer framer)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWFramer>> (block);
@@ -99,8 +103,13 @@ namespace Network {
 						nw_framer_set_wakeup_handler (GetCheckedHandle (), null);
 						return;
 					}
+#if NET
+					delegate* unmanaged<IntPtr, OS_nw_framer, void> trampoline = &TrampolineWakeupHandler;
+					using var block = new BlockLiteral (trampoline, value, typeof (NWFramer), nameof (TrampolineWakeupHandler));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (static_WakeupHandler, value);
+#endif
 					nw_framer_set_wakeup_handler (GetCheckedHandle (), &block);
 				}
 			}
@@ -109,10 +118,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_framer_set_stop_handler (OS_nw_framer framer, void* stop_handler);
 
+#if !NET
 		delegate void nw_framer_set_stop_handler_t (IntPtr block, OS_nw_framer framer);
 		static nw_framer_set_stop_handler_t static_StopHandler = TrampolineStopHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_set_stop_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineStopHandler (IntPtr block, OS_nw_framer framer)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWFramer>> (block);
@@ -130,8 +143,13 @@ namespace Network {
 						nw_framer_set_stop_handler (GetCheckedHandle (), null);
 						return;
 					}
+#if NET
+					delegate* unmanaged<IntPtr, OS_nw_framer, void> trampoline = &TrampolineStopHandler;
+					using var block = new BlockLiteral (trampoline, value, typeof (NWFramer), nameof (TrampolineStopHandler));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (static_StopHandler, value);
+#endif
 					nw_framer_set_stop_handler (GetCheckedHandle (), &block);
 				}
 			}
@@ -140,10 +158,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_framer_set_output_handler (OS_nw_framer framer, void* output_handler);
 
+#if !NET
 		delegate void nw_framer_set_output_handler_t (IntPtr block, OS_nw_framer framer, OS_nw_protocol_metadata message, nuint message_length, byte is_complete);
 		static nw_framer_set_output_handler_t static_OutputHandler = TrampolineOutputHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_set_output_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineOutputHandler (IntPtr block, OS_nw_framer framer, OS_nw_protocol_metadata message, nuint message_length, byte is_complete)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWFramer, NWProtocolMetadata, nuint, bool>> (block);
@@ -162,8 +184,13 @@ namespace Network {
 						nw_framer_set_output_handler (GetCheckedHandle (), null);
 						return;
 					}
+#if NET
+					delegate* unmanaged<IntPtr, OS_nw_framer, OS_nw_protocol_metadata, nuint, byte, void> trampoline = &TrampolineOutputHandler;
+					using var block = new BlockLiteral (trampoline, value, typeof (NWFramer), nameof (TrampolineOutputHandler));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (static_OutputHandler, value);
+#endif
 					nw_framer_set_output_handler (GetCheckedHandle (), &block);
 				}
 			}
@@ -172,10 +199,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_framer_set_input_handler (OS_nw_framer framer, void* input_handler);
 
+#if !NET
 		delegate nuint nw_framer_set_input_handler_t (IntPtr block, OS_nw_framer framer);
 		static nw_framer_set_input_handler_t static_InputHandler = TrampolineInputHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_set_input_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static nuint TrampolineInputHandler (IntPtr block, OS_nw_framer framer)
 		{
 			var del = BlockLiteral.GetTarget<NWFramerInputDelegate> (block);
@@ -194,8 +225,13 @@ namespace Network {
 						nw_framer_set_input_handler (GetCheckedHandle (), null);
 						return;
 					}
+#if NET
+					delegate* unmanaged<IntPtr, OS_nw_framer, nuint> trampoline = &TrampolineInputHandler;
+					using var block = new BlockLiteral (trampoline, value, typeof (NWFramer), nameof (TrampolineInputHandler));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (static_InputHandler, value);
+#endif
 					nw_framer_set_input_handler (GetCheckedHandle (), &block);
 				}
 			}
@@ -204,10 +240,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_framer_set_cleanup_handler (OS_nw_framer framer, void* cleanup_handler);
 
+#if !NET
 		delegate void nw_framer_set_cleanup_handler_t (IntPtr block, OS_nw_framer framer);
 		static nw_framer_set_cleanup_handler_t static_CleanupHandler = TrampolineCleanupHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_set_cleanup_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineCleanupHandler (IntPtr block, OS_nw_framer framer)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWFramer>> (block);
@@ -225,8 +265,13 @@ namespace Network {
 						nw_framer_set_cleanup_handler (GetCheckedHandle (), null);
 						return;
 					}
+#if NET
+					delegate* unmanaged<IntPtr, OS_nw_framer, void> trampoline = &TrampolineCleanupHandler;
+					using var block = new BlockLiteral (trampoline, value, typeof (NWFramer), nameof (TrampolineCleanupHandler));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (static_CleanupHandler, value);
+#endif
 					nw_framer_set_cleanup_handler (GetCheckedHandle (), &block);
 				}
 			}
@@ -331,10 +376,14 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool nw_framer_parse_output (OS_nw_framer framer, nuint minimum_incomplete_length, nuint maximum_length, byte* temp_buffer, BlockLiteral* parse);
 
+#if !NET
 		delegate void nw_framer_parse_output_t (IntPtr block, IntPtr buffer, nuint buffer_length, byte is_complete);
 		static nw_framer_parse_output_t static_ParseOutputHandler = TrampolineParseOutputHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_parse_output_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineParseOutputHandler (IntPtr block, IntPtr buffer, nuint buffer_length, byte is_complete)
 		{
 			var del = BlockLiteral.GetTarget<Action<Memory<byte>, bool>> (block);
@@ -352,8 +401,13 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, nuint, byte, void> trampoline = &TrampolineParseOutputHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWFramer), nameof (TrampolineParseOutputHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ParseOutputHandler, handler);
+#endif
 				using (var mh = tempBuffer.Pin ())
 					return nw_framer_parse_output (GetCheckedHandle (), minimumIncompleteLength, maximumLength, (byte*) mh.Pointer, &block);
 			}
@@ -363,10 +417,14 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool nw_framer_parse_input (OS_nw_framer framer, nuint minimum_incomplete_length, nuint maximum_length, byte* temp_buffer, BlockLiteral* parse);
 
+#if !NET
 		delegate nuint nw_framer_parse_input_t (IntPtr block, IntPtr buffer, nuint buffer_length, byte is_complete);
 		static nw_framer_parse_input_t static_ParseInputHandler = TrampolineParseInputHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_parse_input_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static nuint TrampolineParseInputHandler (IntPtr block, IntPtr buffer, nuint buffer_length, byte is_complete)
 		{
 			var del = BlockLiteral.GetTarget<NWFramerParseCompletionDelegate> (block);
@@ -385,8 +443,13 @@ namespace Network {
 			if (handler is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, nuint, byte, nuint> trampoline = &TrampolineParseInputHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWFramer), nameof (TrampolineParseInputHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ParseInputHandler, handler);
+#endif
 				using (var mh = tempBuffer.Pin ())
 					return nw_framer_parse_input (GetCheckedHandle (), minimumIncompleteLength, maximumLength, (byte*) mh.Pointer, &block);
 			}

--- a/src/Network/NWFramerMessage.cs
+++ b/src/Network/NWFramerMessage.cs
@@ -60,10 +60,14 @@ namespace Network {
 
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_framer_message_set_value (OS_nw_protocol_metadata message, IntPtr key, IntPtr value, BlockLiteral* dispose_value);
+#if !NET
 		delegate void nw_framer_message_set_value_t (IntPtr block, IntPtr data);
 		static nw_framer_message_set_value_t static_SetDataHandler = TrampolineSetDataHandler;
 
 		[MonoPInvokeCallback (typeof (nw_framer_message_set_value_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineSetDataHandler (IntPtr block, IntPtr data)
 		{
 			// get and call, this is internal and we are trying to do all the magic in the call
@@ -86,8 +90,13 @@ namespace Network {
 				pinned.Free ();
 			};
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineSetDataHandler;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWFramerMessage), nameof (TrampolineSetDataHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_SetDataHandler, callback);
+#endif
 				using var keyPtr = new TransientString (key);
 				nw_framer_message_set_value (GetCheckedHandle (), keyPtr, pinned.AddrOfPinnedObject (), &block);
 			}
@@ -96,11 +105,15 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_framer_message_access_value (OS_nw_protocol_metadata message, IntPtr key, BlockLiteral* access_value);
+#if !NET
 		delegate byte nw_framer_message_access_value_t (IntPtr block, IntPtr data);
 		static nw_framer_message_access_value_t static_AccessValueHandler = TrampolineAccessValueHandler;
 
 
 		[MonoPInvokeCallback (typeof (nw_framer_message_access_value_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static byte TrampolineAccessValueHandler (IntPtr block, IntPtr data)
 		{
 			// get and call, this is internal and we are trying to do all the magic in the call
@@ -126,8 +139,13 @@ namespace Network {
 			};
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, byte> trampoline = &TrampolineAccessValueHandler;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWFramerMessage), nameof (TrampolineAccessValueHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_AccessValueHandler, callback);
+#endif
 				// the callback is inlined!!!
 				using var keyPtr = new TransientString (key);
 				var found = nw_framer_message_access_value (GetCheckedHandle (), keyPtr, &block);

--- a/src/Network/NWListener.cs
+++ b/src/Network/NWListener.cs
@@ -131,10 +131,14 @@ namespace Network {
 
 		public void Cancel () => nw_listener_cancel (GetCheckedHandle ());
 
+#if !NET
 		delegate void nw_listener_state_changed_handler_t (IntPtr block, NWListenerState state, IntPtr nwerror);
 		static nw_listener_state_changed_handler_t static_ListenerStateChanged = TrampolineListenerStateChanged;
 
 		[MonoPInvokeCallback (typeof (nw_listener_state_changed_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineListenerStateChanged (IntPtr block, NWListenerState state, IntPtr nwerror)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWListenerState, NWError?>> (block);
@@ -157,16 +161,25 @@ namespace Network {
 					return;
 				}
 
+#if NET
+				delegate* unmanaged<IntPtr, NWListenerState, IntPtr, void> trampoline = &TrampolineListenerStateChanged;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWListener), nameof (TrampolineListenerStateChanged));
+#else
 				var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ListenerStateChanged, callback);
+#endif
 				nw_listener_set_state_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
 
+#if !NET
 		delegate void nw_listener_new_connection_handler_t (IntPtr block, IntPtr connection);
 		static nw_listener_new_connection_handler_t static_NewConnection = TrampolineNewConnection;
 
 		[MonoPInvokeCallback (typeof (nw_listener_new_connection_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineNewConnection (IntPtr block, IntPtr connection)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWConnection>> (block);
@@ -189,20 +202,31 @@ namespace Network {
 						return;
 					}
 
+#if NET
+					delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineNewConnection;
+					using var block = new BlockLiteral (trampoline, callback, typeof (NWListener), nameof (TrampolineNewConnection));
+#else
 					using var block = new BlockLiteral ();
 					block.SetupBlockUnsafe (static_NewConnection, callback);
+#endif
 					nw_listener_set_new_connection_handler (GetCheckedHandle (), &block);
 					connectionHandlerWasSet = true;
 				}
 			}
 		}
 
+#if !NET
 		delegate void nw_listener_advertised_endpoint_changed_handler_t (IntPtr block, IntPtr endpoint, byte added);
 		static nw_listener_advertised_endpoint_changed_handler_t static_AdvertisedEndpointChangedHandler = TrampolineAdvertisedEndpointChangedHandler;
+#endif
 
 		public delegate void AdvertisedEndpointChanged (NWEndpoint endpoint, bool added);
 
+#if !NET
 		[MonoPInvokeCallback (typeof (nw_listener_advertised_endpoint_changed_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineAdvertisedEndpointChangedHandler (IntPtr block, IntPtr endpoint, byte added)
 		{
 			var del = BlockLiteral.GetTarget<AdvertisedEndpointChanged> (block);
@@ -224,8 +248,13 @@ namespace Network {
 					return;
 				}
 
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, byte, void> trampoline = &TrampolineAdvertisedEndpointChangedHandler;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWListener), nameof (TrampolineAdvertisedEndpointChangedHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_AdvertisedEndpointChangedHandler, callback);
+#endif
 				nw_listener_set_advertised_endpoint_changed_handler (GetCheckedHandle (), &block);
 			}
 		}
@@ -294,10 +323,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_listener_set_new_connection_group_handler (IntPtr listener, /* [NullAllowed] */ BlockLiteral* handler);
 
+#if !NET
 		delegate void nw_listener_new_connection_group_handler_t (IntPtr block, nw_connection_group_t group);
 		static nw_listener_new_connection_group_handler_t static_NewConnectionGroup = TrampolineNewConnectionGroup;
 
 		[MonoPInvokeCallback (typeof (nw_listener_new_connection_group_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineNewConnectionGroup (IntPtr block, nw_connection_group_t connectionGroup)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWConnectionGroup>> (block);
@@ -323,8 +356,13 @@ namespace Network {
 		public void SetNewConnectionGroupHandler (Action<NWConnectionGroup> handler)
 		{
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, nw_connection_group_t, void> trampoline = &TrampolineNewConnectionGroup;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWListener), nameof (TrampolineNewConnectionGroup));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_NewConnectionGroup, handler);
+#endif
 				nw_listener_set_new_connection_group_handler (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -77,10 +77,14 @@ namespace Network {
 
 		static unsafe BlockLiteral* DISABLE_PROTOCOL () => (BlockLiteral*) NWParametersConstants._ProtocolDisable;
 
+#if !NET
 		delegate void nw_parameters_configure_protocol_block_t (IntPtr block, IntPtr iface);
 		static nw_parameters_configure_protocol_block_t static_ConfigureHandler = TrampolineConfigureHandler;
 
 		[MonoPInvokeCallback (typeof (nw_parameters_configure_protocol_block_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineConfigureHandler (IntPtr block, IntPtr iface)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWProtocolOptions>> (block);
@@ -121,8 +125,13 @@ namespace Network {
 				return DEFAULT_CONFIGURATION ();
 			}
 
+#if NET
+			delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineConfigureHandler;
+			var block = new BlockLiteral (trampoline, callback, typeof (NWParameters), nameof (TrampolineConfigureHandler));
+#else
 			var block = new BlockLiteral ();
 			block.SetupBlockUnsafe (static_ConfigureHandler, callback);
+#endif
 			*callbackBlock = block;
 			disposeReturnValue = true;
 			return callbackBlock;
@@ -382,10 +391,14 @@ namespace Network {
 			nw_parameters_clear_prohibited_interface_types (GetCheckedHandle ());
 		}
 
+#if !NET
 		delegate byte nw_parameters_iterate_interfaces_block_t (IntPtr block, IntPtr iface);
 		static nw_parameters_iterate_interfaces_block_t static_iterateProhibitedHandler = TrampolineIterateProhibitedHandler;
 
 		[MonoPInvokeCallback (typeof (nw_parameters_iterate_interfaces_block_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static byte TrampolineIterateProhibitedHandler (IntPtr block, IntPtr iface)
 		{
 			var del = BlockLiteral.GetTarget<Func<NWInterface, bool>> (block);
@@ -405,16 +418,25 @@ namespace Network {
 		public void IterateProhibitedInterfaces (Func<NWInterface, bool> iterationCallback)
 		{
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, byte> trampoline = &TrampolineIterateProhibitedHandler;
+				using var block = new BlockLiteral (trampoline, iterationCallback, typeof (NWParameters), nameof (TrampolineIterateProhibitedHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_iterateProhibitedHandler, iterationCallback);
+#endif
 				nw_parameters_iterate_prohibited_interfaces (GetCheckedHandle (), &block);
 			}
 		}
 
+#if !NET
 		delegate byte nw_parameters_iterate_interface_types_block_t (IntPtr block, NWInterfaceType type);
 		static nw_parameters_iterate_interface_types_block_t static_IterateProhibitedTypeHandler = TrampolineIterateProhibitedTypeHandler;
 
 		[MonoPInvokeCallback (typeof (nw_parameters_iterate_interface_types_block_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static byte TrampolineIterateProhibitedTypeHandler (IntPtr block, NWInterfaceType type)
 		{
 			var del = BlockLiteral.GetTarget<Func<NWInterfaceType, bool>> (block);
@@ -430,8 +452,13 @@ namespace Network {
 		public void IterateProhibitedInterfaces (Func<NWInterfaceType, bool> callback)
 		{
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, NWInterfaceType, byte> trampoline = &TrampolineIterateProhibitedTypeHandler;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWParameters), nameof (TrampolineIterateProhibitedTypeHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_IterateProhibitedTypeHandler, callback);
+#endif
 				nw_parameters_iterate_prohibited_interface_types (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/Network/NWPath.cs
+++ b/src/Network/NWPath.cs
@@ -114,10 +114,14 @@ namespace Network {
 		}
 
 		// Returning 'byte' since 'bool' isn't blittable
+#if !NET
 		delegate byte nw_path_enumerate_interfaces_block_t (IntPtr block, IntPtr iface);
 		static nw_path_enumerate_interfaces_block_t static_Enumerator = TrampolineEnumerator;
 
 		[MonoPInvokeCallback (typeof (nw_path_enumerate_interfaces_block_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static byte TrampolineEnumerator (IntPtr block, IntPtr iface)
 		{
 			var del = BlockLiteral.GetTarget<Func<NWInterface, bool>> (block);
@@ -153,8 +157,13 @@ namespace Network {
 				return;
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, byte> trampoline = &TrampolineEnumerator;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWPath), nameof (TrampolineEnumerator));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_Enumerator, callback);
+#endif
 				nw_path_enumerate_interfaces (GetCheckedHandle (), &block);
 			}
 		}
@@ -199,10 +208,14 @@ namespace Network {
 		unsafe static extern void nw_path_enumerate_gateways (IntPtr path, BlockLiteral* enumerate_block);
 
 		// Returning 'byte' since 'bool' isn't blittable
+#if !NET
 		delegate byte nw_path_enumerate_gateways_t (IntPtr block, IntPtr endpoint);
 		static nw_path_enumerate_gateways_t static_EnumerateGatewaysHandler = TrampolineGatewaysHandler;
 
 		[MonoPInvokeCallback (typeof (nw_path_enumerate_gateways_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static byte TrampolineGatewaysHandler (IntPtr block, IntPtr endpoint)
 		{
 			var del = BlockLiteral.GetTarget<Func<NWEndpoint, bool>> (block);
@@ -253,8 +266,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, byte> trampoline = &TrampolineGatewaysHandler;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWPath), nameof (TrampolineGatewaysHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_EnumerateGatewaysHandler, callback);
+#endif
 				nw_path_enumerate_gateways (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/Network/NWPathMonitor.cs
+++ b/src/Network/NWPathMonitor.cs
@@ -85,10 +85,14 @@ namespace Network {
 			nw_path_monitor_set_queue (GetCheckedHandle (), queue.Handle);
 		}
 
+#if !NET
 		delegate void nw_path_monitor_update_handler_t (IntPtr block, IntPtr path);
 		static nw_path_monitor_update_handler_t static_UpdateSnapshot = TrampolineUpdatedSnapshot;
 
 		[MonoPInvokeCallback (typeof (nw_path_monitor_update_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineUpdatedSnapshot (IntPtr block, IntPtr path)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWPath>> (block);
@@ -110,8 +114,13 @@ namespace Network {
 					return;
 				}
 
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineUpdatedSnapshot;
+				using var block = new BlockLiteral (trampoline, callback, typeof (NWPathMonitor), nameof (TrampolineUpdatedSnapshot));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_UpdateSnapshot, callback);
+#endif
 				nw_path_monitor_set_update_handler (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/Network/NWTxtRecord.cs
+++ b/src/Network/NWTxtRecord.cs
@@ -144,8 +144,10 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_txt_record_apply (OS_nw_txt_record txt_record, BlockLiteral* applier);
 
+#if !NET
 		delegate byte nw_txt_record_apply_t (IntPtr block, IntPtr key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
 		unsafe static nw_txt_record_apply_t static_ApplyHandler = TrampolineApplyHandler;
+#endif
 
 #if NET
 		public delegate bool NWTxtRecordApplyDelegate (string? key, NWTxtRecordFindKey result, ReadOnlySpan<byte> value);
@@ -154,7 +156,11 @@ namespace Network {
 		public delegate bool NWTxtRecordApplyDelegate2 (string? key, NWTxtRecordFindKey result, ReadOnlySpan<byte> value);
 #endif
 
+#if !NET
 		[MonoPInvokeCallback (typeof (nw_txt_record_apply_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		unsafe static byte TrampolineApplyHandler (IntPtr block, IntPtr keyPointer, NWTxtRecordFindKey found, IntPtr value, nuint valueLen)
 		{
 #if NET
@@ -191,8 +197,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, NWTxtRecordFindKey, IntPtr, nuint, byte> trampoline = &TrampolineApplyHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWTxtRecord), nameof (TrampolineApplyHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ApplyHandler, handler);
+#endif
 				return nw_txt_record_apply (GetCheckedHandle (), &block);
 			}
 		}
@@ -216,12 +227,18 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		static extern unsafe bool nw_txt_record_access_key (OS_nw_txt_record txt_record, IntPtr key, BlockLiteral* access_value);
 
+#if !NET
 		unsafe delegate void nw_txt_record_access_key_t (IntPtr IntPtr, IntPtr key, NWTxtRecordFindKey found, IntPtr value, nuint valueLen);
 		unsafe static nw_txt_record_access_key_t static_AccessKeyHandler = TrampolineAccessKeyHandler;
+#endif
 
 		public delegate void NWTxtRecordGetValueDelegete (string? key, NWTxtRecordFindKey result, ReadOnlySpan<byte> value);
 
+#if !NET
 		[MonoPInvokeCallback (typeof (nw_txt_record_access_key_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		unsafe static void TrampolineAccessKeyHandler (IntPtr block, IntPtr keyPointer, NWTxtRecordFindKey found, IntPtr value, nuint valueLen)
 		{
 			var del = BlockLiteral.GetTarget<NWTxtRecordGetValueDelegete> (block);
@@ -243,8 +260,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, NWTxtRecordFindKey, IntPtr, nuint, void> trampoline = &TrampolineAccessKeyHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWTxtRecord), nameof (TrampolineAccessKeyHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_AccessKeyHandler, handler);
+#endif
 				using var keyPtr = new TransientString (key);
 				return nw_txt_record_access_key (GetCheckedHandle (), keyPtr, &block);
 			}
@@ -254,12 +276,18 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_txt_record_access_bytes (OS_nw_txt_record txt_record, BlockLiteral* access_bytes);
 
+#if !NET
 		unsafe delegate void nw_txt_record_access_bytes_t (IntPtr block, IntPtr value, nuint valueLen);
 		unsafe static nw_txt_record_access_bytes_t static_RawBytesHandler = TrampolineRawBytesHandler;
+#endif
 
 		public delegate void NWTxtRecordGetRawByteDelegate (ReadOnlySpan<byte> value);
 
+#if !NET
 		[MonoPInvokeCallback (typeof (nw_txt_record_access_bytes_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		unsafe static void TrampolineRawBytesHandler (IntPtr block, IntPtr value, nuint valueLen)
 		{
 			var del = BlockLiteral.GetTarget<NWTxtRecordGetRawByteDelegate> (block);
@@ -276,8 +304,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, nuint, void> trampoline = &TrampolineRawBytesHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWTxtRecord), nameof (TrampolineRawBytesHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_RawBytesHandler, handler);
+#endif
 				return nw_txt_record_access_bytes (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/Network/NWWebSocketMetadata.cs
+++ b/src/Network/NWWebSocketMetadata.cs
@@ -66,10 +66,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_ws_metadata_set_pong_handler (OS_nw_protocol_metadata metadata, dispatch_queue_t client_queue, BlockLiteral* pong_handler);
 
+#if !NET
 		delegate void nw_ws_metadata_set_pong_handler_t (IntPtr block, IntPtr error);
 		static nw_ws_metadata_set_pong_handler_t static_PongHandler = TrampolinePongHandler;
 
 		[MonoPInvokeCallback (typeof (nw_ws_metadata_set_pong_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolinePongHandler (IntPtr block, IntPtr error)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWError?>> (block);
@@ -89,8 +93,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolinePongHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWWebSocketMetadata), nameof (TrampolinePongHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_PongHandler, handler);
+#endif
 				nw_ws_metadata_set_pong_handler (GetCheckedHandle (), queue.Handle, &block);
 			}
 		}

--- a/src/Network/NWWebSocketOptions.cs
+++ b/src/Network/NWWebSocketOptions.cs
@@ -108,10 +108,14 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		unsafe static extern void nw_ws_options_set_client_request_handler (OS_nw_protocol_options options, IntPtr client_queue, BlockLiteral* handler);
 
+#if !NET
 		delegate void nw_ws_options_set_client_request_handler_t (IntPtr block, nw_ws_request_t request);
 		static nw_ws_options_set_client_request_handler_t static_ClientRequestHandler = TrampolineClientRequestHandler;
 
 		[MonoPInvokeCallback (typeof (nw_ws_options_set_client_request_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineClientRequestHandler (IntPtr block, nw_ws_request_t request)
 		{
 			var del = BlockLiteral.GetTarget<Action<NWWebSocketRequest>> (block);
@@ -130,8 +134,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, nw_ws_request_t, void> trampoline = &TrampolineClientRequestHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWWebSocketOptions), nameof (TrampolineClientRequestHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_ClientRequestHandler, handler);
+#endif
 				nw_ws_options_set_client_request_handler (GetCheckedHandle (), queue.Handle, &block);
 			}
 		}

--- a/src/Network/NWWebSocketRequest.cs
+++ b/src/Network/NWWebSocketRequest.cs
@@ -43,10 +43,14 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_ws_request_enumerate_additional_headers (OS_nw_ws_request request, BlockLiteral* enumerator);
 
+#if !NET
 		delegate void nw_ws_request_enumerate_additional_headers_t (IntPtr block, IntPtr header, IntPtr value);
 		static nw_ws_request_enumerate_additional_headers_t static_EnumerateHeaderHandler = TrampolineEnumerateHeaderHandler;
 
 		[MonoPInvokeCallback (typeof (nw_ws_request_enumerate_additional_headers_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineEnumerateHeaderHandler (IntPtr block, IntPtr headerPointer, IntPtr valuePointer)
 		{
 			var del = BlockLiteral.GetTarget<Action<string?, string?>> (block);
@@ -64,8 +68,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, void> trampoline = &TrampolineEnumerateHeaderHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWWebSocketRequest), nameof (TrampolineEnumerateHeaderHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_EnumerateHeaderHandler, handler);
+#endif
 				nw_ws_request_enumerate_additional_headers (GetCheckedHandle (), &block);
 			}
 		}
@@ -74,10 +83,14 @@ namespace Network {
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool nw_ws_request_enumerate_subprotocols (OS_nw_ws_request request, BlockLiteral* enumerator);
 
+#if !NET
 		delegate void nw_ws_request_enumerate_subprotocols_t (IntPtr block, IntPtr subprotocol);
 		static nw_ws_request_enumerate_subprotocols_t static_EnumerateSubprotocolHandler = TrampolineEnumerateSubprotocolHandler;
 
 		[MonoPInvokeCallback (typeof (nw_ws_request_enumerate_subprotocols_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineEnumerateSubprotocolHandler (IntPtr block, IntPtr subprotocolPointer)
 		{
 			var del = BlockLiteral.GetTarget<Action<string?>> (block);
@@ -94,8 +107,13 @@ namespace Network {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineEnumerateSubprotocolHandler;
+				using var block = new BlockLiteral (trampoline, handler, typeof (NWWebSocketRequest), nameof (TrampolineEnumerateSubprotocolHandler));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_EnumerateSubprotocolHandler, handler);
+#endif
 				nw_ws_request_enumerate_subprotocols (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -34,6 +34,10 @@ using System.Threading;
 using Foundation;
 using ObjCRuntime;
 
+#if !COREBUILD
+using Xamarin.Bundler;
+#endif
+
 // http://clang.llvm.org/docs/Block-ABI-Apple.html
 
 namespace ObjCRuntime {
@@ -91,8 +95,95 @@ namespace ObjCRuntime {
 		[DllImport ("__Internal")]
 		static extern IntPtr xamarin_get_block_descriptor ();
 
+#if NET
+		/// <summary>
+		/// Creates a block literal.
+		/// </summary>
+		/// <param name="trampoline">A function pointer that will be called when the block is called. This function must have an [UnmanagedCallersOnly] attribute.</param>
+		/// <param name="context">A context object that can be retrieved from the trampoline. This is typically a delegate to the managed function to call.</param>
+		/// <param name="trampolineType">The type where the trampoline is located.</param>
+		/// <param name="trampolineMethod">The name of the trampoline method.</param>
+		/// <remarks>
+		/// The 'trampolineType' and 'trampolineMethod' must uniquely define the trampoline method (it will be looked up using reflection).
+		/// If there are multiple methods with the same name, use the overload that takes a MethodInfo instead.
+		/// </remarks>
+		public BlockLiteral (void* trampoline, object context, Type trampolineType, string trampolineMethod)
+			: this (trampoline, context, FindTrampoline (trampolineType, trampolineMethod))
+		{
+		}
+
+		/// <summary>
+		/// Creates a block literal.
+		/// </summary>
+		/// <param name="trampoline">A function pointer that will be called when the block is called. This function must have an [UnmanagedCallersOnly] attribute.</param>
+		/// <param name="context">A context object that can be retrieved from the trampoline. This is typically a delegate to the managed function to call.</param>
+		/// <param name="trampolineMethod">The MethodInfo instance corresponding with the trampoline method.</param>
+		public BlockLiteral (void* trampoline, object context, MethodInfo trampolineMethod)
+			: this (trampoline, context, GetBlockSignature (trampoline, trampolineMethod))
+		{
+		}
+
+		/// <summary>
+		/// Creates a block literal.
+		/// </summary>
+		/// <param name="trampoline">A function pointer that will be called when the block is called. This function must have an [UnmanagedCallersOnly] attribute.</param>
+		/// <param name="context">A context object that can be retrieved from the trampoline. This is typically a delegate to the managed function to call.</param>
+		/// <param name="trampolineSignature">The Objective-C signature of the trampoline method.</param>
+		public BlockLiteral (void* trampoline, object context, string trampolineSignature)
+		{
+			isa = IntPtr.Zero;
+			flags = (BlockFlags) 0;
+			reserved = 0;
+			invoke = IntPtr.Zero;
+			block_descriptor = IntPtr.Zero;
+			local_handle = IntPtr.Zero;
+			global_handle = IntPtr.Zero;
+			SetupFunctionPointerBlock ((IntPtr) trampoline, context, System.Text.Encoding.UTF8.GetBytes (trampolineSignature));
+		}
+
+		static MethodInfo FindTrampoline (Type trampolineType, string trampolineMethod)
+		{
+			var rv = trampolineType.GetMethod (trampolineMethod, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+			if (rv is null)
+				throw ErrorHelper.CreateError (8046, Errors.MX8046 /* Unable to find the method '{0}' in the type '{1}' */, trampolineMethod, trampolineType.FullName);
+
+			return rv;
+		}
+
 		[BindingImpl (BindingImplOptions.Optimizable)]
-		void SetupBlock (Delegate trampoline, Delegate userDelegate, bool safe)
+		static string GetBlockSignature (void* trampoline, MethodInfo trampolineMethod)
+		{
+			if (!Runtime.DynamicRegistrationSupported)
+				throw ErrorHelper.CreateError (8050, Errors.MX8050 /* BlockLiteral.GetBlockSignature is not supported when the dynamic registrar has been linked away. */);
+
+			// Verify that the function pointer matches the trampoline
+			var functionPointer = trampolineMethod.MethodHandle.GetFunctionPointer ();
+			if (functionPointer != (IntPtr) trampoline)
+				throw ErrorHelper.CreateError (8047, Errors.MX8047 /* The trampoline method {0} does not match the function pointer 0x{1} for the trampolineMethod argument (they're don't refer to the same method) */, trampolineMethod.DeclaringType.FullName + "." + trampolineMethod.Name, ((IntPtr) trampoline).ToString ("x"));
+
+			// Verify that there's at least one parameter, and it must be System.IntPtr, void* or ObjCRuntime.BlockLiteral*.
+			var parameters = trampolineMethod.GetParameters ();
+			if (parameters.Length < 1)
+				throw ErrorHelper.CreateError (8048, Errors.MX8048 /* The trampoline method {0} must have at least one parameter. */, trampolineMethod.DeclaringType.FullName + "." + trampolineMethod.Name);
+			var firstParameterType = parameters [0].ParameterType;
+			if (firstParameterType != typeof (IntPtr) &&
+				firstParameterType != typeof (void*) &&
+				firstParameterType != typeof (BlockLiteral*)) {
+				throw ErrorHelper.CreateError (8049, Errors.MX8049 /* The first parameter in the trampoline method {0} must be either 'System.IntPtr', 'void*' or 'ObjCRuntime.BlockLiteral*'. */, trampolineMethod.DeclaringType.FullName + "." + trampolineMethod.Name);
+			}
+
+			// Verify that the method as an [UnmanagedCallersOnly] attribute
+			if (!trampolineMethod.IsDefined (typeof (UnmanagedCallersOnlyAttribute), false))
+				throw ErrorHelper.CreateError (8051, Errors.MX8051 /* The trampoline method {0} must have an [UnmanagedCallersOnly] attribute. */, trampolineMethod.DeclaringType.FullName + "." + trampolineMethod.Name);
+
+			// We're good to go!
+			return Runtime.ComputeSignature (trampolineMethod, true);
+		}
+#endif // NET
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlock (Delegate trampoline, Delegate target, bool safe)
 		{
 			if (!Runtime.DynamicRegistrationSupported)
 				throw ErrorHelper.CreateError (8026, "BlockLiteral.SetupBlock is not supported when the dynamic registrar has been linked away.");
@@ -119,23 +210,40 @@ namespace ObjCRuntime {
 			}
 
 			var signature = Runtime.ComputeSignature (userMethod, blockSignature);
-			SetupBlockImpl (trampoline, userDelegate, safe, signature);
+			SetupBlockImpl (trampoline, target, safe, System.Text.Encoding.UTF8.GetBytes (signature));
 		}
 
-		// This method is not to be called manually by user code.
-		// This is enforced by making it private. If the SetupBlock optimization is enabled,
-		// the linker will make it public so that it's callable from optimized user code.
-		unsafe void SetupBlockImpl (Delegate trampoline, Delegate userDelegate, bool safe, string signature)
+		void SetupBlockImpl (Delegate trampoline, Delegate target, bool safe, string signature)
 		{
-			isa = NSConcreteStackBlock;
-			invoke = Marshal.GetFunctionPointerForDelegate (trampoline);
-			object delegates;
+			SetupBlockImpl (trampoline, target, safe, System.Text.Encoding.UTF8.GetBytes (signature));
+		}
+
+		void SetupBlockImpl (Delegate trampoline, Delegate target, bool safe, byte [] utf8Signature)
+		{
+			var invoke = Marshal.GetFunctionPointerForDelegate (trampoline);
+			SetupFunctionPointerBlock (invoke, GetContext (trampoline, target, safe), utf8Signature);
+		}
+
+		static object GetContext (Delegate trampoline, Delegate target, bool safe)
+		{
 			if (safe) {
-				delegates = new Tuple<Delegate, Delegate> (trampoline, userDelegate);
+				return new Tuple<Delegate, Delegate> (trampoline, target);
 			} else {
-				delegates = userDelegate;
+				return target;
 			}
-			local_handle = (IntPtr) GCHandle.Alloc (delegates);
+		}
+
+		void SetupFunctionPointerBlock (IntPtr invokeMethod, object context, byte [] utf8Signature)
+		{
+			if (utf8Signature is null)
+				ThrowHelper.ThrowArgumentNullException (nameof (utf8Signature));
+
+			if (utf8Signature.Length == 0)
+				ThrowHelper.ThrowArgumentException (nameof (utf8Signature), Errors.MX8052 /* The signature must be a non-empty string. */);
+
+			isa = NSConcreteStackBlock;
+			invoke = invokeMethod;
+			local_handle = (IntPtr) GCHandle.Alloc (context);
 			global_handle = IntPtr.Zero;
 			flags = BlockFlags.BLOCK_HAS_COPY_DISPOSE | BlockFlags.BLOCK_HAS_SIGNATURE;
 
@@ -146,8 +254,9 @@ namespace ObjCRuntime {
 			// for the signature if we can avoid it). One descriptor is allocated for every 
 			// Block; this is potentially something the static registrar can fix, since it
 			// should know every possible trampoline signature.
-			var bytes = System.Text.Encoding.UTF8.GetBytes (signature);
-			var desclen = sizeof (XamarinBlockDescriptor) + bytes.Length + 1 /* null character */;
+			var bytes = utf8Signature;
+			var hasNull = utf8Signature [utf8Signature.Length - 1] == 0;
+			var desclen = sizeof (XamarinBlockDescriptor) + bytes.Length + (hasNull ? 0 : 1 /* null character */);
 			var descptr = Marshal.AllocHGlobal (desclen);
 
 			block_descriptor = descptr;
@@ -156,7 +265,8 @@ namespace ObjCRuntime {
 			xblock_descriptor->descriptor.signature = descptr + sizeof (BlockDescriptor) + 4 /* signature_length */;
 			xblock_descriptor->ref_count = 1;
 			Marshal.Copy (bytes, 0, xblock_descriptor->descriptor.signature, bytes.Length);
-			Marshal.WriteByte (xblock_descriptor->descriptor.signature + bytes.Length, 0); // null terminate string
+			if (!hasNull)
+				Marshal.WriteByte (xblock_descriptor->descriptor.signature + bytes.Length, 0); // null terminate string
 		}
 
 		// trampoline must be static, and someone else needs to keep a ref to it
@@ -167,6 +277,7 @@ namespace ObjCRuntime {
 		}
 
 		// trampoline must be static, but it's not necessary to keep a ref to it
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		public void SetupBlock (Delegate trampoline, Delegate userDelegate)
 		{
 			if (trampoline is null)
@@ -236,10 +347,19 @@ namespace ObjCRuntime {
 			}
 		}
 
-		public object Target {
+		/// <summary>
+		/// This is the 'context' value that was specified when creating the BlockLiteral.
+		/// </summary>
+		public object Context {
 			get {
 				var handle = global_handle != IntPtr.Zero ? global_handle : local_handle;
-				var target = GCHandle.FromIntPtr (handle).Target;
+				return GCHandle.FromIntPtr (handle).Target;
+			}
+		}
+
+		public object Target {
+			get {
+				var target = Context;
 				var tuple = target as Tuple<Delegate, Delegate>;
 				if (tuple != null)
 					return tuple.Item2;
@@ -318,6 +438,24 @@ namespace ObjCRuntime {
 			throw ErrorHelper.CreateError (8011, $"Unable to locate the delegate to block conversion attribute ([DelegateProxy]) for the return value for the method {baseMethod.DeclaringType.FullName}.{baseMethod.Name}. {Constants.PleaseFileBugReport}");
 		}
 
+#if NET
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		unsafe static IntPtr GetBlockForFunctionPointer (MethodInfo delegateInvokeMethod, object @delegate, string signature)
+		{
+			void* invokeFunctionPointer = (void *) delegateInvokeMethod.MethodHandle.GetFunctionPointer ();
+			if (signature is null) {
+				if (!Runtime.DynamicRegistrationSupported)
+					throw ErrorHelper.CreateError (8026, $"BlockLiteral.GetBlockForDelegate with a null signature is not supported when the dynamic registrar has been linked away (delegate type: {@delegate.GetType ().FullName}).");
+
+				using (var block = new BlockLiteral (invokeFunctionPointer, @delegate, delegateInvokeMethod))
+					return _Block_copy (&block);
+			} else {
+				using (var block = new BlockLiteral (invokeFunctionPointer, @delegate, signature))
+					return _Block_copy (&block);
+			}
+		}
+#endif // NET
+
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		internal static IntPtr GetBlockForDelegate (MethodInfo minfo, object @delegate, uint token_ref, string signature)
 		{
@@ -332,6 +470,12 @@ namespace ObjCRuntime {
 				baseMethod = minfo; // 'baseMethod' is only used in error messages, and if it's null, we just use the closest alternative we have (minfo).
 			if (delegateProxyType == null)
 				throw ErrorHelper.CreateError (8012, $"Invalid DelegateProxyAttribute for the return value for the method {baseMethod.DeclaringType.FullName}.{baseMethod.Name}: DelegateType is null. {Constants.PleaseFileBugReport}");
+
+#if NET
+			var delegateInvokeMethod = delegateProxyType.GetMethod ("Invoke", BindingFlags.NonPublic | BindingFlags.Static);
+			if (delegateInvokeMethod is not null && delegateInvokeMethod.IsDefined (typeof (UnmanagedCallersOnlyAttribute), false))
+				return GetBlockForFunctionPointer (delegateInvokeMethod, @delegate, signature);
+#endif
 
 			var delegateProxyField = delegateProxyType.GetField ("Handler", BindingFlags.NonPublic | BindingFlags.Static);
 			if (delegateProxyField is null)

--- a/src/Security/SecIdentity2.cs
+++ b/src/Security/SecIdentity2.cs
@@ -107,10 +107,14 @@ namespace Security {
 		[return: MarshalAs (UnmanagedType.I1)]
 		unsafe static extern bool sec_identity_access_certificates (IntPtr identity, BlockLiteral* block);
 
+#if !NET
 		internal delegate void AccessCertificatesHandler (IntPtr block, IntPtr cert);
 		static readonly AccessCertificatesHandler access = TrampolineAccessCertificates;
 
 		[MonoPInvokeCallback (typeof (AccessCertificatesHandler))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineAccessCertificates (IntPtr block, IntPtr cert)
 		{
 			var del = BlockLiteral.GetTarget<Action<SecCertificate2>> (block);
@@ -137,8 +141,13 @@ namespace Security {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineAccessCertificates;
+				using var block = new BlockLiteral (trampoline, handler, typeof (SecIdentity2), nameof (TrampolineAccessCertificates));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (access, handler);
+#endif
 				return sec_identity_access_certificates (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -191,10 +191,14 @@ namespace Security {
 			return sec_protocol_metadata_peers_are_equal (metadataA.GetCheckedHandle (), metadataB.GetCheckedHandle ());
 		}
 
+#if !NET
 		delegate void sec_protocol_metadata_access_distinguished_names_handler_t (IntPtr block, IntPtr dispatchData);
 		static sec_protocol_metadata_access_distinguished_names_handler_t static_DistinguishedNamesForPeer = TrampolineDistinguishedNamesForPeer;
 
 		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_distinguished_names_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineDistinguishedNamesForPeer (IntPtr block, IntPtr data)
 		{
 			var del = BlockLiteral.GetTarget<Action<DispatchData>> (block);
@@ -215,17 +219,26 @@ namespace Security {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineDistinguishedNamesForPeer;
+				using var block = new BlockLiteral (trampoline, callback, typeof (SecProtocolMetadata), nameof (TrampolineDistinguishedNamesForPeer));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_DistinguishedNamesForPeer, callback);
+#endif
 				if (!sec_protocol_metadata_access_distinguished_names (GetCheckedHandle (), &block))
 					throw new InvalidOperationException ("Distinguished names are not accessible.");
 			}
 		}
 
+#if !NET
 		delegate void sec_protocol_metadata_access_ocsp_response_handler_t (IntPtr block, IntPtr dispatchData);
 		static sec_protocol_metadata_access_ocsp_response_handler_t static_OcspReposeForPeer = TrampolineOcspReposeForPeer;
 
 		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_ocsp_response_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineOcspReposeForPeer (IntPtr block, IntPtr data)
 		{
 			var del = BlockLiteral.GetTarget<Action<DispatchData>> (block);
@@ -246,17 +259,26 @@ namespace Security {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineOcspReposeForPeer;
+				using var block = new BlockLiteral (trampoline, callback, typeof (SecProtocolMetadata), nameof (TrampolineOcspReposeForPeer));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_OcspReposeForPeer, callback);
+#endif
 				if (!sec_protocol_metadata_access_ocsp_response (GetCheckedHandle (), &block))
 					throw new InvalidOperationException ("The OSCP response is not accessible.");
 			}
 		}
 
+#if !NET
 		delegate void sec_protocol_metadata_access_peer_certificate_chain_handler_t (IntPtr block, IntPtr certificate);
 		static sec_protocol_metadata_access_peer_certificate_chain_handler_t static_CertificateChainForPeer = TrampolineCertificateChainForPeer;
 
 		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_peer_certificate_chain_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineCertificateChainForPeer (IntPtr block, IntPtr certificate)
 		{
 			var del = BlockLiteral.GetTarget<Action<SecCertificate>> (block);
@@ -277,17 +299,26 @@ namespace Security {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &TrampolineCertificateChainForPeer;
+				using var block = new BlockLiteral (trampoline, callback, typeof (SecProtocolMetadata), nameof (TrampolineCertificateChainForPeer));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_CertificateChainForPeer, callback);
+#endif
 				if (!sec_protocol_metadata_access_peer_certificate_chain (GetCheckedHandle (), &block))
 					throw new InvalidOperationException ("The peer certificates are not accessible.");
 			}
 		}
 
+#if !NET
 		delegate void sec_protocol_metadata_access_supported_signature_algorithms_handler_t (IntPtr block, ushort signatureAlgorithm);
 		static sec_protocol_metadata_access_supported_signature_algorithms_handler_t static_SignatureAlgorithmsForPeer = TrampolineSignatureAlgorithmsForPeer;
 
 		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_supported_signature_algorithms_handler_t))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineSignatureAlgorithmsForPeer (IntPtr block, ushort signatureAlgorithm)
 		{
 			var del = BlockLiteral.GetTarget<Action<ushort>> (block);
@@ -307,8 +338,13 @@ namespace Security {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (callback));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, ushort, void> trampoline = &TrampolineSignatureAlgorithmsForPeer;
+				using var block = new BlockLiteral (trampoline, callback, typeof (SecProtocolMetadata), nameof (TrampolineSignatureAlgorithmsForPeer));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (static_SignatureAlgorithmsForPeer, callback);
+#endif
 				if (sec_protocol_metadata_access_supported_signature_algorithms (GetCheckedHandle (), &block) != 0)
 					throw new InvalidOperationException ("The supported signature list is not accessible.");
 			}
@@ -390,10 +426,14 @@ namespace Security {
 
 		public delegate void SecAccessPreSharedKeysHandler (DispatchData psk, DispatchData pskIdentity);
 
+#if !NET
 		internal delegate void AccessPreSharedKeysHandler (IntPtr block, IntPtr dd_psk, IntPtr dd_psk_identity);
 		static readonly AccessPreSharedKeysHandler presharedkeys = TrampolineAccessPreSharedKeys;
 
 		[MonoPInvokeCallback (typeof (AccessPreSharedKeysHandler))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static void TrampolineAccessPreSharedKeys (IntPtr block, IntPtr psk, IntPtr psk_identity)
 		{
 			var del = BlockLiteral.GetTarget<Action<DispatchData?, DispatchData?>> (block);
@@ -420,8 +460,13 @@ namespace Security {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (handler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, IntPtr, IntPtr, void> trampoline = &TrampolineAccessPreSharedKeys;
+				using var block = new BlockLiteral (trampoline, handler, typeof (SecProtocolMetadata), nameof (TrampolineAccessPreSharedKeys));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (presharedkeys, handler);
+#endif
 				return sec_protocol_metadata_access_pre_shared_keys (GetCheckedHandle (), &block);
 			}
 		}

--- a/src/UIKit/UIAccessibility.cs
+++ b/src/UIKit/UIAccessibility.cs
@@ -248,8 +248,13 @@ namespace UIKit {
 		public static void RequestGuidedAccessSession (bool enable, Action<bool> completionHandler)
 		{
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, byte, void> trampoline = &TrampolineRequestGuidedAccessSession;
+				using var block = new BlockLiteral (trampoline, completionHandler, typeof (UIAccessibility), nameof (TrampolineRequestGuidedAccessSession));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlock (callback, completionHandler);
+#endif
 				UIAccessibilityRequestGuidedAccessSession (enable, &block);
 			}
 		}
@@ -268,10 +273,14 @@ namespace UIKit {
 			return tcs.Task;
 		}
 
+#if !NET
 		internal delegate void InnerRequestGuidedAccessSession (IntPtr block, byte enable);
 		static readonly InnerRequestGuidedAccessSession callback = TrampolineRequestGuidedAccessSession;
 
 		[MonoPInvokeCallback (typeof (InnerRequestGuidedAccessSession))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static unsafe void TrampolineRequestGuidedAccessSession (IntPtr block, byte enable)
 		{
 			var descriptor = (BlockLiteral*) block;

--- a/src/UIKit/UICellAccessory.cs
+++ b/src/UIKit/UICellAccessory.cs
@@ -62,9 +62,13 @@ namespace UIKit {
 	// This class bridges native block invocations that call into C#
 	//
 	static internal class SDUICellAccessoryPosition {
+#if !NET
 		static internal readonly DUICellAccessoryPosition Handler = Invoke;
 
 		[MonoPInvokeCallback (typeof (DUICellAccessoryPosition))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static unsafe nuint Invoke (IntPtr block, IntPtr accessories)
 		{
 			var descriptor = (BlockLiteral*) block;

--- a/src/UIKit/UIConfigurationColorTransformer.cs
+++ b/src/UIKit/UIConfigurationColorTransformer.cs
@@ -46,9 +46,13 @@ namespace UIKit {
 	// This class bridges native block invocations that call into C#
 	//
 	static internal class SDUIConfigurationColorTransformerHandler {
+#if !NET
 		static internal readonly DUIConfigurationColorTransformerHandler Handler = Invoke;
 
 		[MonoPInvokeCallback (typeof (DUIConfigurationColorTransformerHandler))]
+#else
+		[UnmanagedCallersOnly]
+#endif
 		static unsafe IntPtr Invoke (IntPtr block, IntPtr color)
 		{
 			var descriptor = (BlockLiteral*) block;

--- a/src/UIKit/UIGuidedAccessRestriction.cs
+++ b/src/UIKit/UIGuidedAccessRestriction.cs
@@ -61,14 +61,22 @@ namespace UIKit {
 #endif
 		public delegate void UIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler (bool success, NSError error);
 
+#if !NET
 		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		internal delegate void DUIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler (IntPtr block, byte success, IntPtr error);
+#endif
 
 		static internal class UIGuidedAccessConfigureAccessibilityFeaturesTrampoline {
+#if !NET
 			static internal readonly DUIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler Handler = Invoke;
+#endif
 
+#if NET
+			[UnmanagedCallersOnlyAttribute]
+#else
 			[MonoPInvokeCallback (typeof (DUIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler))]
-			static unsafe void Invoke (IntPtr block, byte success, IntPtr error)
+#endif
+			internal static unsafe void Invoke (IntPtr block, byte success, IntPtr error)
 			{
 				var descriptor = (BlockLiteral*) block;
 				var del = (UIGuidedAccessConfigureAccessibilityFeaturesCompletionHandler) (descriptor->Target);
@@ -91,8 +99,13 @@ namespace UIKit {
 				throw new ArgumentNullException (nameof (completionHandler));
 
 			unsafe {
+#if NET
+				delegate* unmanaged<IntPtr, byte, IntPtr, void> trampoline = &UIGuidedAccessConfigureAccessibilityFeaturesTrampoline.Invoke;
+				using var block = new BlockLiteral (trampoline, completionHandler, typeof (UIGuidedAccessConfigureAccessibilityFeaturesTrampoline), nameof (UIGuidedAccessConfigureAccessibilityFeaturesTrampoline.Invoke));
+#else
 				using var block = new BlockLiteral ();
 				block.SetupBlockUnsafe (UIGuidedAccessConfigureAccessibilityFeaturesTrampoline.Handler, completionHandler);
+#endif
 				UIGuidedAccessConfigureAccessibilityFeatures ((nuint) (ulong) features, enabled, &block);
 			}
 		}

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -198,7 +198,7 @@ namespace Xamarin.Bundler {
 					"    remove-dynamic-registrar: By default enabled when the static registrar is enabled and the interpreter is not used. Removes the dynamic registrar (makes the app smaller).\n" +
 					"    inline-runtime-arch: By default always enabled (requires the linker). Inlines calls to ObjCRuntime.Runtime.Arch to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
 #endif
-					"    blockliteral-setupblock: By default enabled when using the static registrar. Optimizes calls to BlockLiteral.SetupBlock to avoid having to calculate the block signature at runtime.\n" +
+					"    blockliteral-setupblock: By default enabled when using the static registrar. Optimizes calls to BlockLiteral.SetupBlock and certain BlockLiteral constructors to avoid having to calculate the block signature at runtime.\n" +
 					"    inline-intptr-size: By default enabled for builds that target a single architecture (requires the linker). Inlines calls to IntPtr.Size to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
 					"    inline-dynamic-registration-supported: By default always enabled (requires the linker). Optimizes calls to Runtime.DynamicRegistrationSupported to be a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
 #if !MONOTOUCH

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -241,7 +241,7 @@ namespace Xamarin.Bundler {
 					InlineRuntimeArch = true;
 			}
 
-			// We try to optimize calls to BlockLiteral.SetupBlock if the static registrar is enabled
+			// We try to optimize calls to BlockLiteral.SetupBlock and certain BlockLiteral constructors if the static registrar is enabled
 			if (!OptimizeBlockLiteralSetupBlock.HasValue) {
 				OptimizeBlockLiteralSetupBlock = app.Registrar == RegistrarMode.Static;
 			}

--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -759,6 +759,7 @@ namespace Xamarin.Linker {
 			for (int i = 0; i < instructions.Count; i++) {
 				var ins = instructions [i];
 				switch (ins.OpCode.Code) {
+				case Code.Newobj:
 				case Code.Call:
 					i += ProcessCalls (method, ins);
 					break;

--- a/tools/linker/RegistrarRemovalTrackingStep.cs
+++ b/tools/linker/RegistrarRemovalTrackingStep.cs
@@ -122,21 +122,37 @@ namespace MonoTouch.Tuner {
 						}
 						break;
 					case "BlockLiteral":
+						// Req 2:
+						// * Nobody must call BlockLiteral.SetupBlock[Unsafe].
+						// * Nobody must call BlockLiteral..ctor (void*, object, Type, string)
+						//
+						// Fortunately the linker is able to rewrite:
+						//
+						// * Calls to SetupBlock[Unsafe] to call SetupBlockImpl
+						// * Calls to .ctor(void*, object, Type, string) to call .ctor(void*, object, string)
+						//
+						// and these overloads don't need the dynamic registrar, which means we only have
+						// to look in assemblies that aren't linked.
+						if (Annotations.GetAction (assembly) == AssemblyAction.Link && Optimizations.OptimizeBlockLiteralSetupBlock == true)
+							break;
+
 						switch (mr.Name) {
 						case "SetupBlock":
 						case "SetupBlockUnsafe":
-							// Req 2: Nobody must call BlockLiteral.SetupBlock[Unsafe].
-							//
-							// Fortunately the linker is able to rewrite calls to SetupBlock[Unsafe] to call
-							// SetupBlockImpl (which doesn't need the dynamic registrar), which means we only have
-							// to look in assemblies that aren't linked.
-							if (Annotations.GetAction (assembly) == AssemblyAction.Link && Optimizations.OptimizeBlockLiteralSetupBlock == true)
-								break;
-
 							if (warnIfRequired)
 								Warn (assembly, mr);
 
 							requires = true;
+							break;
+						case ".ctor":
+							var md = mr.Resolve () as MethodDefinition;
+#if NET
+							requires |= Xamarin.Linker.OptimizeGeneratedCodeHandler.IsBlockLiteralCtor_Type_String (md);
+#else
+							requires |= Xamarin.Linker.OptimizeGeneratedCodeSubStep.IsBlockLiteralCtor_Type_String (md);
+#endif
+							if (requires && warnIfRequired)
+								Warn (assembly, mr);
 							break;
 						}
 						break;

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -3932,6 +3932,51 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the more than one method named &apos;{3}&apos; was found in the type &apos;{4}..
+        /// </summary>
+        public static string MX2106_E {
+            get {
+                return ResourceManager.GetString("MX2106_E", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the method &apos;{3}&apos; must have at least one parameter..
+        /// </summary>
+        public static string MX2106_F {
+            get {
+                return ResourceManager.GetString("MX2106_F", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the first parameter in the method &apos;{3}&apos; isn&apos;t &apos;System.IntPtr&apos;, &apos;void*&apos; or &apos;ObjCRuntime.BlockLiteral*&apos; (it&apos;s &apos;{4}&apos;).
+        /// </summary>
+        public static string MX2106_G {
+            get {
+                return ResourceManager.GetString("MX2106_G", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the method &apos;{3}&apos; does not have an [UnmanagedCallersOnly] attribute..
+        /// </summary>
+        public static string MX2106_H {
+            get {
+                return ResourceManager.GetString("MX2106_H", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the method &apos;{3}&apos; does not have an [UnmanagedCallersOnly] attribute..
+        /// </summary>
+        public static string MX2106_I {
+            get {
+                return ResourceManager.GetString("MX2106_I", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Can not find the corlib assembly &apos;{0}&apos; in the list of loaded assemblies.
         ///		.
         /// </summary>

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -4149,5 +4149,68 @@ namespace Xamarin.Bundler {
                 return ResourceManager.GetString("MX8045", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find the method &apos;{0}&apos; in the type &apos;{1}&apos;.
+        /// </summary>
+        public static string MX8046 {
+            get {
+                return ResourceManager.GetString("MX8046", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The trampoline method {0} does not match the function pointer 0x{1} for the trampolineMethod argument (they&apos;re don&apos;t refer to the same method)..
+        /// </summary>
+        public static string MX8047 {
+            get {
+                return ResourceManager.GetString("MX8047", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The trampoline method {0} must have at least one parameter..
+        /// </summary>
+        public static string MX8048 {
+            get {
+                return ResourceManager.GetString("MX8048", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The first parameter in the trampoline method {0} must be either &apos;System.IntPtr&apos;, &apos;void*&apos; or &apos;ObjCRuntime.BlockLiteral*&apos;..
+        /// </summary>
+        public static string MX8049 {
+            get {
+                return ResourceManager.GetString("MX8049", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to BlockLiteral.GetBlockSignature is not supported when the dynamic registrar has been linked away..
+        /// </summary>
+        public static string MX8050 {
+            get {
+                return ResourceManager.GetString("MX8050", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The trampoline method {0} must have an [UnmanagedCallersOnly] attribute..
+        /// </summary>
+        public static string MX8051 {
+            get {
+                return ResourceManager.GetString("MX8051", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The signature must be a non-empty string..
+        /// </summary>
+        public static string MX8052 {
+            get {
+                return ResourceManager.GetString("MX8052", resourceCulture);
+            }
+        }
     }
 }

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2191,4 +2191,33 @@
 	<data name="MX8045" xml:space="preserve">
 		<value>Unable to call release on an instance of the type {0}</value>
 	</data>
+
+	<data name="MX8046" xml:space="preserve">
+		<value>Unable to find the method '{0}' in the type '{1}'</value>
+	</data>
+
+	<data name="MX8047" xml:space="preserve">
+		<value>The trampoline method {0} does not match the function pointer 0x{1} for the trampolineMethod argument (they're don't refer to the same method).</value>
+	</data>
+
+	<data name="MX8048" xml:space="preserve">
+		<value>The trampoline method {0} must have at least one parameter.</value>
+	</data>
+
+	<data name="MX8049" xml:space="preserve">
+		<value>The first parameter in the trampoline method {0} must be either 'System.IntPtr', 'void*' or 'ObjCRuntime.BlockLiteral*'.</value>
+	</data>
+
+	<data name="MX8050" xml:space="preserve">
+		<value>BlockLiteral.GetBlockSignature is not supported when the dynamic registrar has been linked away.</value>
+	</data>
+
+	<data name="MX8051" xml:space="preserve">
+		<value>The trampoline method {0} must have an [UnmanagedCallersOnly] attribute.</value>
+	</data>
+
+	<data name="MX8052" xml:space="preserve">
+		<value>The signature must be a non-empty string.</value>
+	</data>
+
 </root>

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1298,7 +1298,27 @@
 		<value>Could not optimize the call to BlockLiteral.SetupBlock in {0} at offset {1}: {2}.
 		</value>
 	</data>
+
+	<data name="MX2106_E" xml:space="preserve">
+		<value>Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the more than one method named '{3}' was found in the type '{4}.</value>
+	</data>
 	
+	<data name="MX2106_F" xml:space="preserve">
+		<value>Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the method '{3}' must have at least one parameter.</value>
+	</data>
+
+	<data name="MX2106_G" xml:space="preserve">
+		<value>Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the first parameter in the method '{3}' isn't 'System.IntPtr', 'void*' or 'ObjCRuntime.BlockLiteral*' (it's '{4}')</value>
+	</data>
+
+	<data name="MX2106_H" xml:space="preserve">
+		<value>Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the method '{3}' does not have an [UnmanagedCallersOnly] attribute.</value>
+	</data>
+
+	<data name="MX2106_I" xml:space="preserve">
+		<value>Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the method '{3}' does not have an [UnmanagedCallersOnly] attribute.</value>
+	</data>
+
 	<data name="MM2107" xml:space="preserve">
 		<value>It's not safe to remove the dynamic registrar, because {0} references '{1}.{2} ({3})'.
 		</value>


### PR DESCRIPTION
Add support for function pointers to BlockLiteral, and use it to update almost
all manually bound block code to use function pointers (in .NET).

Also add support to the linker for optimizing the new block API.

Contributes towards https://github.com/xamarin/xamarin-macios/issues/15783.