### PR TITLE
[release/7.0.1xx-xcode14.2] [tests] Allow for timeouts in CI in a few tests.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -12,6 +12,7 @@ using System.Reflection.Emit;
 
 using AVFoundation;
 using CoreBluetooth;
+using CoreFoundation;
 using Foundation;
 #if !__TVOS__
 using Contacts;

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1371,9 +1371,13 @@ partial class TestRuntime
 		}
 	}
 
-	public static void IgnoreInCIIfBadNetwork (Exception ex)
+	public static void IgnoreInCIIfBadNetwork (Exception? ex)
 	{
+		if (ex is null)
+			return;
+
 		IgnoreInCIfHttpStatusCodes (ex, HttpStatusCode.BadGateway, HttpStatusCode.GatewayTimeout, HttpStatusCode.ServiceUnavailable);
+		IgnoreInCIIfNetworkConnectionLost (ex);
 	}
 
 	public static void IgnoreInCIIfBadNetwork (HttpStatusCode status)
@@ -1398,6 +1402,18 @@ partial class TestRuntime
 			return;
 
 		IgnoreInCI ($"Ignored due to http status code '{status}': {ex.Message}");
+	}
+
+	public static void IgnoreInCIIfNetworkConnectionLost (Exception ex)
+	{
+		// <Foundation.NSErrorException: Error Domain=NSURLErrorDomain Code=-1005 "The network connection was lost." UserInfo ...
+		if (!(ex is NSErrorException nex))
+			return;
+
+		if (nex.Code != (nint) (long) CFNetworkErrors.NetworkConnectionLost)
+			return;
+
+		IgnoreInCI ($"Ignored due to CFNetwork error {(CFNetworkErrors) (long) nex.Code}");
 	}
 
 	static bool TryGetHttpStatusCode (Exception ex, out HttpStatusCode status)

--- a/tests/linker/mac/LinkAnyTest.cs
+++ b/tests/linker/mac/LinkAnyTest.cs
@@ -26,6 +26,15 @@ namespace LinkAnyTest {
 		static bool requestError;
 		static HttpStatusCode statusCode;
 
+		void TimedWait (Task task)
+		{
+				var rv = task.Wait (TimeSpan.FromMinutes (1));
+				if (rv)
+					return;
+
+				TestRuntime.IgnoreInCI ("This test times out randomly in CI due to bad network.");
+				Assert.Fail ("Test timed out");
+		}
 
 		// http://blogs.msdn.com/b/csharpfaq/archive/2012/06/26/understanding-a-simple-async-program.aspx
 		// ref: https://bugzilla.xamarin.com/show_bug.cgi?id=7114
@@ -53,7 +62,7 @@ namespace LinkAnyTest {
 			try {
 				// we do not want the async code to get back to the AppKit thread, hanging the process
 				SynchronizationContext.SetSynchronizationContext (null);
-				GetWebPageAsync ().Wait ();
+				TimedWait (GetWebPageAsync ());
 				if (requestError) {
 					Assert.Inconclusive ($"Test cannot be trusted. Issues performing the request. Status code '{statusCode}'");
 				} else {
@@ -115,7 +124,7 @@ namespace LinkAnyTest {
 							data = await task;
 						}
 
-						GetWebPage (url).Wait ();
+						TimedWait (GetWebPage (url));
 						Assert.That (data, Is.Not.Empty, "Downloaded content");
 						return; // one url succeeded, that's enough
 					} catch (Exception e) {

--- a/tests/monotouch-test/Foundation/UrlSessionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTest.cs
@@ -26,10 +26,13 @@ namespace MonoTouchFixtures.Foundation {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class UrlSessionTest {
-		void AssertTrueOrIgnoreInCI (bool value, string message)
+		void AssertTrueOrIgnoreInCI (bool value, ref Exception ex, string message)
 		{
-			if (value)
+			if (value) {
+				TestRuntime.IgnoreInCIIfBadNetwork (ex);
+				Assert.IsNull (ex, message + " Exception");
 				return;
+			}
 
 			TestRuntime.IgnoreInCI ($"This test times out randomly in CI due to bad network: {message}");
 			Assert.Fail (message);
@@ -67,8 +70,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateDataTask a");
-			Assert.IsNull (ex, "CreateDataTask a Exception");
+			}, () => completed), ref ex, "CreateDataTask a");
 
 			completed = false;
 			AssertTrueOrIgnoreInCI (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
@@ -79,8 +81,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateDataTask b");
-			Assert.IsNull (ex, "CreateDataTask b Exception");
+			}, () => completed), ref ex, "CreateDataTask b");
 
 			/* CreateDownloadTask */
 			completed = false;
@@ -92,8 +93,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateDownloadTask a");
-			Assert.IsNull (ex, "CreateDownloadTask a Exception");
+			}, () => completed), ref ex, "CreateDownloadTask a");
 
 
 			completed = false;
@@ -105,8 +105,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateDownloadTask b");
-			Assert.IsNull (ex, "CreateDownloadTask b Exception");
+			}, () => completed), ref ex, "CreateDownloadTask b");
 
 			/* CreateUploadTask */
 			completed = false;
@@ -120,8 +119,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateUploadTask a");
-			Assert.IsNull (ex, "CreateUploadTask a Exception");
+			}, () => completed), ref ex, "CreateUploadTask a");
 
 			completed = false;
 			AssertTrueOrIgnoreInCI (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
@@ -134,8 +132,7 @@ namespace MonoTouchFixtures.Foundation {
 				} finally {
 					completed = true;
 				}
-			}, () => completed), "CreateUploadTask b");
-			Assert.IsNull (ex, "CreateUploadTask b Exception");
+			}, () => completed), ref ex, "CreateUploadTask b");
 		}
 
 		[Test]
@@ -170,6 +167,7 @@ namespace MonoTouchFixtures.Foundation {
 				}
 			}, () => completed);
 
+			TestRuntime.IgnoreInCIIfBadNetwork (ex);
 			Assert.IsNull (ex, "Exception");
 			Assert.AreEqual (-1, failed_iteration, "Failed");
 		}

--- a/tests/monotouch-test/Foundation/UrlSessionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTest.cs
@@ -26,6 +26,14 @@ namespace MonoTouchFixtures.Foundation {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class UrlSessionTest {
+		void AssertTrueOrIgnoreInCI (bool value, string message)
+		{
+			if (value)
+				return;
+
+			TestRuntime.IgnoreInCI ($"This test times out randomly in CI due to bad network: {message}");
+			Assert.Fail (message);
+		}
 
 		//TODO: TestRuntime.RunAsync is not on mac currently
 #if !MONOMAC
@@ -47,37 +55,62 @@ namespace MonoTouchFixtures.Foundation {
 
 			var completed = false;
 			var timeout = 30;
+			Exception ex = null;
 
 			/* CreateDataTask */
 			completed = false;
-			Assert.IsTrue (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
-				await session.CreateDataTaskAsync (request);
-				completed = true;
+			AssertTrueOrIgnoreInCI (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
+				try {
+					await session.CreateDataTaskAsync (request);
+				} catch (Exception e) {
+					ex = e;
+				} finally {
+					completed = true;
+				}
 			}, () => completed), "CreateDataTask a");
+			Assert.IsNull (ex, "CreateDataTask a Exception");
 
 			completed = false;
-			Assert.IsTrue (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
-				await session.CreateDataTaskAsync (url);
-				completed = true;
+			AssertTrueOrIgnoreInCI (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
+				try {
+					await session.CreateDataTaskAsync (url);
+				} catch (Exception e) {
+					ex = e;
+				} finally {
+					completed = true;
+				}
 			}, () => completed), "CreateDataTask b");
+			Assert.IsNull (ex, "CreateDataTask b Exception");
 
 			/* CreateDownloadTask */
 			completed = false;
-			Assert.IsTrue (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
-				await session.CreateDownloadTaskAsync (request);
-				completed = true;
+			AssertTrueOrIgnoreInCI (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
+				try {
+					await session.CreateDownloadTaskAsync (request);
+				} catch (Exception e) {
+					ex = e;
+				} finally {
+					completed = true;
+				}
 			}, () => completed), "CreateDownloadTask a");
+			Assert.IsNull (ex, "CreateDownloadTask a Exception");
 
 
 			completed = false;
-			Assert.IsTrue (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
-				await session.CreateDownloadTaskAsync (url);
-				completed = true;
+			AssertTrueOrIgnoreInCI (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
+				try {
+					await session.CreateDownloadTaskAsync (url);
+				} catch (Exception e) {
+					ex = e;
+				} finally {
+					completed = true;
+				}
 			}, () => completed), "CreateDownloadTask b");
+			Assert.IsNull (ex, "CreateDownloadTask b Exception");
 
 			/* CreateUploadTask */
 			completed = false;
-			Assert.IsTrue (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
+			AssertTrueOrIgnoreInCI (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
 				try {
 					var uploadRequest = new NSMutableUrlRequest (url);
 					uploadRequest.HttpMethod = "POST";
@@ -88,9 +121,10 @@ namespace MonoTouchFixtures.Foundation {
 					completed = true;
 				}
 			}, () => completed), "CreateUploadTask a");
+			Assert.IsNull (ex, "CreateUploadTask a Exception");
 
 			completed = false;
-			Assert.IsTrue (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
+			AssertTrueOrIgnoreInCI (TestRuntime.RunAsync (DateTime.Now.AddSeconds (timeout), async () => {
 				try {
 					var uploadRequest = new NSMutableUrlRequest (url);
 					uploadRequest.HttpMethod = "POST";
@@ -101,6 +135,7 @@ namespace MonoTouchFixtures.Foundation {
 					completed = true;
 				}
 			}, () => completed), "CreateUploadTask b");
+			Assert.IsNull (ex, "CreateUploadTask b Exception");
 		}
 
 		[Test]


### PR DESCRIPTION
Also add some exception handling.

Hopefully fixes more issues with broken network in CI.


Backport of #16945 and #17649.