### PR TITLE
[CI] Fix the GIT_HASH variable inside the buildjob.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -276,7 +276,7 @@ steps:
   displayName: 'Report build failure'
   env:
     ${{ if eq(parameters.repositoryAlias, 'self') }}:
-      COMMENT_HASH: $(GIT_HASH)
+      COMMENT_HASH: $(fix_commit.GIT_HASH)
     ${{ else }}:
       COMMENT_HASH: $(Build.SourceVersion)
 


### PR DESCRIPTION
Because the variable is an output variable, we need to provide the name of the step that creates the variable. This is nto needed in other stages because we are setting the variable via the env vars of the stage.