### PR TITLE
[net8.0] Updated Xamarin.Messaging and added Merq to ILMerge

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -62,10 +62,12 @@
     <!-- Microsoft.iOS.Windows.Sdk content -->
     <FirstParty Include="iSign.Core.dll" />
     <FirstParty Include="System.Diagnostics.Tracer.dll" />
+    <!-- Xamarin.Messaging -->
+    <FirstParty Include="Merq.dll" />
+    <FirstParty Include="Merq.Core.dll" />
     <!-- Broker.zip -->
     <FirstParty Include="Broker.exe" />
     <FirstParty Include="Broker.resources.dll" />
-    <FirstParty Include="Merq.dll" />
     <!-- Build.zip -->
     <FirstParty Include="Build.exe" />
     <FirstParty Include="Microsoft.Build*.dll" />

--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.9.40</MessagingVersion>
+		<MessagingVersion>1.9.59</MessagingVersion>
 		<HotRestartVersion>1.0.93</HotRestartVersion>
 	</PropertyGroup>
 </Project>

--- a/msbuild/ILMerge.targets
+++ b/msbuild/ILMerge.targets
@@ -33,6 +33,8 @@
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'ILStrip'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Newtonsoft.Json'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Renci.SshNet'" />
+      <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Merq'" />
+      <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Merq.Core'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'SshNet.Security.Cryptography'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.ComponentModel.Annotations'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.ComponentModel.Composition'" />


### PR DESCRIPTION
- Updated Messaging to 1.9.59: includes latest fixes like support for retry and reconnect, new telemetry, bug fixing, etc.
- Added Merq and Merq.Core to ILMerge since they're now required and loaded by Messaging
- Added Merq.Core.dll to dotnet/Workloads/SignList.xml because now it comes as part of Xamarin.Messaging