### PR TITLE
[xcode14.2] [system-dependencies] Add diagnostics for duplicate sim download error.

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -335,9 +335,9 @@ function download_xcode_platforms ()
 		return
 	fi
 
-	log "Executing '$SUDO $XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadAllPlatforms'"
-	$SUDO "$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild" -downloadAllPlatforms
-	log "Executed '$SUDO $XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadAllPlatforms'"
+	log "Executing '$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadAllPlatforms'"
+	"$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild" -downloadAllPlatforms
+	log "Executed '$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadAllPlatforms'"
 }
 
 function run_xcode_first_launch ()

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -336,7 +336,13 @@ function download_xcode_platforms ()
 	fi
 
 	log "Executing '$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadAllPlatforms'"
-	"$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild" -downloadAllPlatforms
+	if ! "$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild" -downloadAllPlatforms; then
+		"$XCODE_DEVELOPER_ROOT/usr/bin/simctl" runtime list -v
+		# Don't exit here, just hope for the best instead.
+		set +x
+		echo "##vso[task.logissue type=warning;sourcepath=system-dependencies.sh]Failed to download all simulator platforms, this may result in problems executing tests in the simulator."
+		set -x
+	fi
 	log "Executed '$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadAllPlatforms'"
 }
 


### PR DESCRIPTION
Trying to track down this:

    Downloading watchOS 9.1 Simulator (20S75): Installing (registering download)...
    Downloading watchOS 9.1 Simulator (20S75): Installing (registering download)...
    Downloading watchOS 9.1 Simulator (20S75): Error: Error Domain=SimDiskImageErrorDomain Code=5 "Duplicate of F879602F-0F22-47F5-8252-FF177B9032A0" UserInfo={NSLocalizedDescription=Duplicate of F879602F-0F22-47F5-8252-FF177B9032A0, unusableErrorDetail=}

This is a backport of #16845.