### PR TITLE
[tests] Adjust EveryFrameworkSmokeTest to not run when every assembly is linked.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/EveryFrameworkSmokeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/EveryFrameworkSmokeTest.cs
@@ -88,6 +88,9 @@ namespace Xamarin.Mac.Tests {
 		[Test]
 		public void ExpectedLibrariesAreLoaded ()
 		{
+			if (TestRuntime.IsLinkAll)
+				Assert.Ignore ("This test will fail when all assemblies are linked, since we won't link with all frameworks in that case.");
+
 			List<string> failures = new List<string> ();
 
 			// In the past, we've missed frameworks in NSObject.mac.cs and shipped brokeness


### PR DESCRIPTION
It expects the executable to be linked will every system framework we've
bound, which doesn't happen when linker is enabled for all assemblies.