### PR TITLE
[release/7.0.2xx] [xharness] Bump the timeout for the .NET tests.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -224,7 +224,7 @@ namespace Xharness.Jenkins {
 				TestProject = buildDotNetTestsProject,
 				Platform = TestPlatform.All,
 				TestName = "DotNet tests",
-				Timeout = TimeSpan.FromMinutes (240),
+				Timeout = TimeSpan.FromMinutes (360),
 				Ignored = !TestSelection.IsEnabled (TestLabel.DotnetTest),
 			};
 			Tasks.Add (runDotNetTests);


### PR DESCRIPTION
We keep adding more and more tests...


Backport of #17110
