### PR TITLE
[tests] Fix NSTextInputClient tests on macOS Ventura.

### DIFF
--- a/tests/monotouch-test/AppKit/NSTextInputClient.cs
+++ b/tests/monotouch-test/AppKit/NSTextInputClient.cs
@@ -80,13 +80,8 @@ namespace apitest {
 			NSRange range;
 			var rect = textView.GetFirstRect (new NSRange (12, 18), out range);
 
-			if (TestRuntime.CheckXcodeVersion (14, 0)) {
-				Assert.AreEqual (rect, new CGRect (0, 0, 0, 14), "NSTextInputClient_ShouldGetFirstRect - Returned wrong rect");
-				Assert.AreEqual (range, new NSRange (12, 0), "NSTextInputClient_ShouldGetFirstRect - Returned wrong Range");
-			} else {
-				Assert.AreEqual (rect, new CGRect (0, 0, 12, 14), "NSTextInputClient_ShouldGetFirstRect - Returned wrong rect");
-				Assert.AreEqual (range, new NSRange (10, 4), "NSTextInputClient_ShouldGetFirstRect - Returned wrong Range");
-			}
+			Assert.AreEqual (rect, new CGRect (0, 0, 12, 14), "NSTextInputClient_ShouldGetFirstRect - Returned wrong rect");
+			Assert.AreEqual (range, new NSRange (10, 4), "NSTextInputClient_ShouldGetFirstRect - Returned wrong Range");
 		}
 
 		[Test]
@@ -104,10 +99,7 @@ namespace apitest {
 		[Test]
 		public void NSTextInputClient_ShouldGetBaselineDelta ()
 		{
-			if (TestRuntime.CheckXcodeVersion (14, 0))
-				Assert.IsTrue (textView.GetBaselineDelta (4) == 0, "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");
-			else
-				Assert.IsTrue (textView.GetBaselineDelta (4) == 11, "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");
+			Assert.That ((double) textView.GetBaselineDelta (4), Is.EqualTo ((double) 11), "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");
 		}
 
 		[Test]

--- a/tests/monotouch-test/AppKit/NSTextInputClient.cs
+++ b/tests/monotouch-test/AppKit/NSTextInputClient.cs
@@ -80,8 +80,13 @@ namespace apitest {
 			NSRange range;
 			var rect = textView.GetFirstRect (new NSRange (12, 18), out range);
 
-			Assert.AreEqual (rect, new CGRect (0, 0, 12, 14), "NSTextInputClient_ShouldGetFirstRect - Returned wrong rect");
-			Assert.AreEqual (range, new NSRange (10, 4), "NSTextInputClient_ShouldGetFirstRect - Returned wrong Range");
+			if (TestRuntime.CheckXcodeVersion (14, 0)) {
+				Assert.AreEqual (rect, new CGRect (0, 0, 0, 14), "NSTextInputClient_ShouldGetFirstRect - Returned wrong rect");
+				Assert.AreEqual (range, new NSRange (12, 0), "NSTextInputClient_ShouldGetFirstRect - Returned wrong Range");
+			} else {
+				Assert.AreEqual (rect, new CGRect (0, 0, 12, 14), "NSTextInputClient_ShouldGetFirstRect - Returned wrong rect");
+				Assert.AreEqual (range, new NSRange (10, 4), "NSTextInputClient_ShouldGetFirstRect - Returned wrong Range");
+			}
 		}
 
 		[Test]
@@ -99,7 +104,10 @@ namespace apitest {
 		[Test]
 		public void NSTextInputClient_ShouldGetBaselineDelta ()
 		{
-			Assert.That ((double) textView.GetBaselineDelta (4), Is.EqualTo ((double) 11), "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");
+			if (TestRuntime.CheckXcodeVersion (14, 0))
+				Assert.IsTrue (textView.GetBaselineDelta (4) == 0, "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");
+			else
+				Assert.IsTrue (textView.GetBaselineDelta (4) == 11, "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");
 		}
 
 		[Test]

--- a/tests/monotouch-test/AppKit/NSTextInputClient.cs
+++ b/tests/monotouch-test/AppKit/NSTextInputClient.cs
@@ -79,8 +79,13 @@ namespace apitest {
 		{
 			NSRange range;
 			var rect = textView.GetFirstRect (new NSRange (12, 18), out range);
+#if NET
+			var zeroHeight = TestRuntime.CheckXcodeVersion (14, 0);
+#else
+			var zeroHeight = false;
+#endif
 
-			if (TestRuntime.CheckXcodeVersion (14, 0)) {
+			if (zeroHeight) {
 				Assert.AreEqual (rect, new CGRect (0, 0, 0, 14), "NSTextInputClient_ShouldGetFirstRect - Returned wrong rect");
 				Assert.AreEqual (range, new NSRange (12, 0), "NSTextInputClient_ShouldGetFirstRect - Returned wrong Range");
 			} else {
@@ -104,7 +109,13 @@ namespace apitest {
 		[Test]
 		public void NSTextInputClient_ShouldGetBaselineDelta ()
 		{
-			if (TestRuntime.CheckXcodeVersion (14, 0))
+#if NET
+			var zeroHeight = TestRuntime.CheckXcodeVersion (14, 0);
+#else
+			var zeroHeight = false;
+#endif
+
+			if (zeroHeight)
 				Assert.IsTrue (textView.GetBaselineDelta (4) == 0, "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");
 			else
 				Assert.IsTrue (textView.GetBaselineDelta (4) == 11, "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");


### PR DESCRIPTION
Fixes:

    apitest.NSTextInputClient
        [FAIL] NSTextInputClient_ShouldGetBaselineDelta :   NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value
            Expected: True
            But was:  False
              at apitest.NSTextInputClient.NSTextInputClient_ShouldGetBaselineDelta () [0x0000e] in /Users/builder/azdo/_work/3/s/xamarin-macios/tests/monotouch-test/AppKit/NSTextInputClient.cs:108
        [FAIL] NSTextInputClient_ShouldGetFirstRect :   NSTextInputClient_ShouldGetFirstRect - Returned wrong rect
            Expected: {X=0,Y=0,Width=12,Height=14}
            But was:  {X=0,Y=0,Width=0,Height=14}
              at apitest.NSTextInputClient.NSTextInputClient_ShouldGetFirstRect () [0x00030] in /Users/builder/azdo/_work/3/s/xamarin-macios/tests/monotouch-test/AppKit/NSTextInputClient.cs:84