### PR TITLE
[msbuild] Set the '_SdkIsSimulator' property for HotRestart builds.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1763,6 +1763,11 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<Output TaskParameter="XamarinSdkRoot" PropertyName="_XamarinSdkRoot" />
 			<Output TaskParameter="XcodeVersion" PropertyName="_XcodeVersion" />
 		</DetectSdkLocations>
+
+		<PropertyGroup Condition="'$(IsHotRestartBuild)' == 'true'">
+			<!-- hot restart builds are always for device -->
+			<_SdkIsSimulator>false</_SdkIsSimulator>
+		</PropertyGroup>
 	</Target>
 
 	<Target Name="_EmbedProvisionProfile" Condition="'$(_ProvisioningProfile)' != ''" DependsOnTargets="_GenerateBundleName;_DetectSigningIdentity"

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -204,7 +204,7 @@
 			CompiledEntitlements="$(HotRestartAppBundlePath)\Entitlements.plist"
 			IsAppExtension="$(IsAppExtension)"
 			ProvisioningProfile="$(_ProvisioningProfileId)"
-			SdkIsSimulator="False"
+			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkPlatform="iPhoneOS"
 			SdkVersion="12.2"
 			SdkDevPath=" "


### PR DESCRIPTION
This makes it easier to consume other tasks in the future that already takes
'_SdkIsSimulator'. It also documents exactly why we hardcode
_SdkIsSimulator=false for Hot Restart.