### PR TITLE
[msbuild] Fix nullability issue when compiling for legacy Xamarin.

### DIFF
--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -91,7 +91,11 @@ namespace Xamarin.Tests {
 				args.Add (name!);
 			}
 
+#if NET
 			if (!string.IsNullOrEmpty (language)) {
+#else
+			if (language is not null && !string.IsNullOrEmpty (language)) {
+#endif
 				args.Add ("--language");
 				args.Add (language);
 			}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj
@@ -8,6 +8,7 @@
     <DefineConstants>$(DefineConstants);MSBUILD_TASKS</DefineConstants>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../../product.snk</AssemblyOriginatorKeyFile>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <!--

--- a/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
@@ -7,6 +7,7 @@
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../../product.snk</AssemblyOriginatorKeyFile>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />


### PR DESCRIPTION
And make sure we don't ignore any such warnings again for a few test projects.