### PR TITLE
[dotnet] Add support for passing environment variables and custom arguments when launching apps with mlaunch.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1848,6 +1848,7 @@
 			<!-- don't set standard output/error path, mlaunch will by default write to stdout/stderr -->
 		</PropertyGroup>
 		<ItemGroup>
+			<MlaunchEnvironmentVariables Include="__XAMARIN_DEBUG_MODE__=$(XamarinDebugMode)" Condition="'$(XamarinDebugMode)' != ''" />
 			<MlaunchEnvironmentVariables Include="__XAMARIN_DEBUG_PORT__=$(XamarinDebugPort)" Condition="'$(XamarinDebugPort)' != ''" />
 			<MlaunchEnvironmentVariables Include="__XAMARIN_DEBUG_HOSTS__=$(XamarinDebugHosts.Replace(';', '%3B'))" Condition="'$(XamarinDebugHosts)' != ''" />
 		</ItemGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1847,12 +1847,18 @@
 			<_MlaunchWaitForExit Condition="'$(_MlaunchWaitForExit)' == ''">true</_MlaunchWaitForExit>
 			<!-- don't set standard output/error path, mlaunch will by default write to stdout/stderr -->
 		</PropertyGroup>
+		<ItemGroup>
+			<MlaunchEnvironmentVariables Include="__XAMARIN_DEBUG_PORT__=$(XamarinDebugPort)" Condition="'$(XamarinDebugPort)' != ''" />
+			<MlaunchEnvironmentVariables Include="__XAMARIN_DEBUG_HOSTS__=$(XamarinDebugHosts.Replace(';', '%3B'))" Condition="'$(XamarinDebugHosts)' != ''" />
+		</ItemGroup>
 		<GetMlaunchArguments
 			SessionId="$(BuildSessionId)"
+			AdditionalArguments="@(MlaunchAdditionalArguments)"
 			AppBundlePath="$(_AppBundlePath)"
 			AppManifestPath="$(_AppBundleManifestPath)"
 			CaptureOutput="$(_MlaunchCaptureOutput)"
 			DeviceName="$(_DeviceName)"
+			EnvironmentVariables="@(MlaunchEnvironmentVariables)"
 			LaunchApp="$(_AppBundlePath)"
 			MlaunchPath="$(_MlaunchPath)"
 			SdkIsSimulator="$(_SdkIsSimulator)"

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/GetMlaunchArgumentsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/GetMlaunchArgumentsTaskBase.cs
@@ -31,7 +31,9 @@ namespace Xamarin.iOS.Tasks {
 		[Required]
 		public string SdkDevPath { get; set; }
 
+		public ITaskItem [] AdditionalArguments { get; set; } = Array.Empty<ITaskItem> ();
 		public string DeviceName { get; set; }
+		public ITaskItem [] EnvironmentVariables { get; set; } = Array.Empty<ITaskItem> ();
 		public string LaunchApp { get; set; }
 		public string InstallApp { get; set; }
 		public bool CaptureOutput { get; set; } // Set to true to capture output. If StandardOutput|ErrorPath is not set, write to the current terminal's stdout/stderr (requires WaitForExit)
@@ -180,6 +182,12 @@ namespace Xamarin.iOS.Tasks {
 				sb.Add ("--stderr");
 				sb.AddQuoted (StandardErrorPath);
 			}
+
+			foreach (var envvar in EnvironmentVariables)
+				sb.AddQuoted ("--setenv=" + envvar.ItemSpec);
+
+			foreach (var arg in AdditionalArguments)
+				sb.AddQuoted (arg.ItemSpec);
 
 			if (WaitForExit)
 				sb.Add ("--wait-for-exit");


### PR DESCRIPTION
Environment variables can be specified using the MlaunchEnvironmentVariables
item group, and any other mlaunch argument can be specified using the
MlaunchAdditionalArguments item group.

Also add support for the XamarinDebugPort and XamarinDebugHosts properties to
make it easy to set the corresponding environment variable using the command
line (since setting item groups using the command line isn't trivial).

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1755574.