### PR TITLE
[CI] [siminstaller] Bump bots to use the Ventura and make siminstaller more resilient

### DIFF
--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -15,6 +15,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <RootTestsDirectory>..</RootTestsDirectory>
     <CompilerResponseFile>$(RootTestsDirectory)\..\src\rsp\macos-defines.rsp</CompilerResponseFile>
+    <MonoBundlingExtraArgs>$(MonoBundlingExtraArgs) --marshal-objectivec-exceptions:throwmanagedexception</MonoBundlingExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -204,6 +204,7 @@ stages:
 - template: templates/main-stage.yml
   parameters:
     xcodeChannel: Stable
+    macOSName: Ventura # comes from the build agent demand named macOS.Name
     isPR: false
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -12,6 +12,11 @@ parameters:
   type: string
   default: 'latest'
 
+- name: macOSName # comes from the build agent demand named macOS.Name
+  displayName: Name of the version of macOS to use
+  type: string
+  default: 'Ventura'
+
 - name: pool
   type: string
   displayName: Bot pool to use
@@ -204,7 +209,7 @@ stages:
 - template: templates/main-stage.yml
   parameters:
     xcodeChannel: Stable
-    macOSName: Ventura # comes from the build agent demand named macOS.Name
+    macOSName: ${{ parameters.macOSName }}
     isPR: false
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -187,6 +187,7 @@ stages:
 - template: templates/main-stage.yml
   parameters:
     xcodeChannel: Stable
+    macOSName: Ventura # comes from the build agent demand named macOS.Name
     isPR: true
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -12,6 +12,11 @@ parameters:
   type: string
   default: 'latest'
 
+- name: macOSName # comes from the build agent demand named macOS.Name
+  displayName: Name of the version of macOS to use
+  type: string
+  default: 'Ventura'
+
 - name: pool
   type: string
   displayName: Bot pool to use
@@ -187,7 +192,7 @@ stages:
 - template: templates/main-stage.yml
   parameters:
     xcodeChannel: Stable
-    macOSName: Ventura # comes from the build agent demand named macOS.Name
+    macOSName: ${{ parameters.macOSName }}
     isPR: true
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}

--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -91,7 +91,7 @@ jobs:
     name: $(AgentPoolComputed)
     demands:
     - Agent.OS -equals Darwin
-    - macios_image -equals v2.1     # Big Sur image with Xcode 12.4 and 12.5 installed
+    - macOS.Name -equals Ventura
     - XcodeChannel -equals ${{ parameters.xcodeChannel }}
   workspace:
     clean: all

--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -35,6 +35,9 @@ parameters:
 - name: xcodeChannel
   type: string
 
+- name: macOSName
+  type: string
+
 jobs:
 - job: configure
   displayName: 'Configure build'
@@ -91,7 +94,7 @@ jobs:
     name: $(AgentPoolComputed)
     demands:
     - Agent.OS -equals Darwin
-    - macOS.Name -equals Ventura
+    - macOS.Name -equals ${{ parameters.macOSName }}
     - XcodeChannel -equals ${{ parameters.xcodeChannel }}
   workspace:
     clean: all

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -47,6 +47,9 @@ parameters:
 - name: xcodeChannel
   type: string
 
+- name: macOSName
+  type: string
+
 jobs:
 - job: configure
   displayName: 'Configure build'
@@ -133,7 +136,7 @@ jobs:
     name: $(AgentPoolComputed)
     demands:
     - Agent.OS -equals Darwin
-    - macOS.Name -equals Ventura
+    - macOS.Name -equals ${{ parameters.macOSName }}
     - XcodeChannel -equals ${{ parameters.xcodeChannel }}
   workspace:
     clean: all

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -133,7 +133,7 @@ jobs:
     name: $(AgentPoolComputed)
     demands:
     - Agent.OS -equals Darwin
-    - macios_image -equals v2.1     # Big Sur image with Xcode 12.4 and 12.5 installed
+    - macOS.Name -equals Ventura
     - XcodeChannel -equals ${{ parameters.xcodeChannel }}
   workspace:
     clean: all

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -74,6 +74,9 @@ parameters:
 - name: xcodeChannel
   type: string
 
+- name: macOSName
+  type: string
+
 - name: simTestsConfigurations
   type: object
   default: [
@@ -234,6 +237,7 @@ stages:
   - template: ./build/build-stage.yml
     parameters:
       xcodeChannel: ${{ parameters.xcodeChannel }}
+      macOSName: ${{ parameters.macOSName }}
       isPR: ${{ parameters.isPR }}
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
@@ -321,6 +325,7 @@ stages:
     - template: ./build/api-diff-stage.yml
       parameters:
         xcodeChannel: ${{ parameters.xcodeChannel }}
+        macOSName: ${{ parameters.macOSName }}
         isPR: ${{ parameters.isPR }}
         repositoryAlias: ${{ parameters.repositoryAlias }}
         commit: ${{ parameters.commit }}
@@ -337,6 +342,7 @@ stages:
 - template: ./tests/stage.yml
   parameters:
     xcodeChannel: ${{ parameters.xcodeChannel }}
+    macOSName: ${{ parameters.macOSName }}
     isPR: ${{ parameters.isPR }}
     repositoryAlias: ${{ parameters.repositoryAlias }}
     commit: ${{ parameters.commit }}

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -87,6 +87,9 @@ parameters:
 - name: XcodeChannel
   type: string
 
+- name: macOSName
+  type: string
+
 stages:
 - stage: ${{ parameters.stageName }}
   displayName: ${{ parameters.displayName }}
@@ -139,7 +142,7 @@ stages:
         name: $(AgentPoolComputed)
         demands:
         - Agent.OS -equals Darwin
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals ${{ parameters.macOSName }}
         - XcodeChannel -equals ${{ parameters.XcodeChannel }}
         - ${{ each demand in parameters.extraBotDemands }}:
           - demand

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -139,7 +139,7 @@ stages:
         name: $(AgentPoolComputed)
         demands:
         - Agent.OS -equals Darwin
-        - macios_image -equals v2.1     # Big Sur image with Xcode 12.4 and 12.5 installed
+        - macOS.Name -equals Ventura
         - XcodeChannel -equals ${{ parameters.XcodeChannel }}
         - ${{ each demand in parameters.extraBotDemands }}:
           - demand

--- a/tools/siminstaller/Program.cs
+++ b/tools/siminstaller/Program.cs
@@ -427,10 +427,16 @@ namespace xsiminstaller {
 						Directory.Delete (expanded_path, true);
 					}
 				} finally {
-					TryExecuteAndCapture ("hdiutil", $"detach '{mount_point}' -quiet", out _);
+					if (!TryExecuteAndCapture ("hdiutil", $"detach '{mount_point}' -quiet -force", out _))
+						Console.WriteLine ($"Failed to detach {mount_point}");
 				}
 			} finally {
-				Directory.Delete (mount_point, true);
+				try {
+					Directory.Delete (mount_point, true);
+				} catch (IOException ioex) {
+					Console.WriteLine ($"Unable to remove: {mount_point}");
+					Console.WriteLine ($"    with error: {ioex}");
+				}				
 			}
 
 			File.Delete (download_path);

--- a/tools/siminstaller/Program.cs
+++ b/tools/siminstaller/Program.cs
@@ -436,7 +436,7 @@ namespace xsiminstaller {
 				} catch (IOException ioex) {
 					Console.WriteLine ($"Unable to remove: {mount_point}");
 					Console.WriteLine ($"    with error: {ioex}");
-				}				
+				}
 			}
 
 			File.Delete (download_path);


### PR DESCRIPTION
## siminstaller

We are getting a `System.IO.IOException: Resource busy`
when trying to detach with hdiutil on Ventura. When reaching
this spot we are really done with the mounted resource so
let's force detaching and in the event that it fails let's
just log since at this point the simulator is installed.

## CI

Bump bots to use the Ventura images, and Add `macOSName`
parameter to our yaml templates.

`macOSName` maps to the `macOS.Name` capability in our bots, this
way we can set the macOS name we want to use on the bots in bot build and tests.