### PR TITLE
CGEventCreate fixed broken call, added tests

### DIFF
--- a/src/CoreGraphics/CGEvent.cs
+++ b/src/CoreGraphics/CGEvent.cs
@@ -103,27 +103,33 @@ namespace CoreGraphics {
 
 #if NET
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
-		extern static unsafe IntPtr CGEventTapCreateForPSN (IntPtr processSerialNumer, CGEventTapLocation location, CGEventTapPlacement place, CGEventTapOptions options, CGEventMask mask, delegate* unmanaged<IntPtr, CGEventType, IntPtr, IntPtr, IntPtr> cback, IntPtr data);
+		extern static unsafe IntPtr CGEventTapCreateForPSN (IntPtr processSerialNumer, CGEventTapPlacement place, CGEventTapOptions options, CGEventMask mask, delegate* unmanaged<IntPtr, CGEventType, IntPtr, IntPtr, IntPtr> cback, IntPtr data);
 #else
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
-		extern static IntPtr CGEventTapCreateForPSN (IntPtr processSerialNumer, CGEventTapLocation location, CGEventTapPlacement place, CGEventTapOptions options, CGEventMask mask, CGEventTapCallback cback, IntPtr data);
+		extern static IntPtr CGEventTapCreateForPSN (IntPtr processSerialNumer, CGEventTapPlacement place, CGEventTapOptions options, CGEventMask mask, CGEventTapCallback cback, IntPtr data);
 #endif
 		
+		[Obsolete ("The location parameter is not used. Consider using the overload without the location parameter.", false)]
 		public static CFMachPort? CreateTap (IntPtr processSerialNumber, CGEventTapLocation location, CGEventTapPlacement place, CGEventTapOptions options, CGEventMask mask, CGEventTapCallback cback, IntPtr data)
 		{
-#if NET
-			IntPtr r;
+			return CreateTap (processSerialNumber, place, options, mask, cback, data);
+		}
+
+		public static CFMachPort? CreateTap (IntPtr processSerialNumber, CGEventTapPlacement place, CGEventTapOptions options, CGEventMask mask, CGEventTapCallback cback, IntPtr data)
+		{
 			unsafe {
+				var psnPtr = new IntPtr (&processSerialNumber);
+#if NET
 				var tapData = new TapData (cback, data);
 				var gch = GCHandle.Alloc (tapData);
-				r = CGEventTapCreateForPSN (processSerialNumber, location, place, options, mask, &TapCallback, GCHandle.ToIntPtr (gch));
-			}
+				var r = CGEventTapCreateForPSN (psnPtr, place, options, mask, &TapCallback, GCHandle.ToIntPtr (gch));
 #else
-			var r = CGEventTapCreateForPSN (processSerialNumber, location, place, options, mask, cback, data);
+				var r = CGEventTapCreateForPSN (psnPtr, place, options, mask, cback, data);
 #endif
-			if (r == IntPtr.Zero)
-				return null;
-			return new CFMachPort (r, true);
+				if (r == IntPtr.Zero)
+					return null;
+				return new CFMachPort (r, true);
+			}
 		}
 
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]

--- a/tests/monotouch-test/CoreGraphics/CGEventTests.cs
+++ b/tests/monotouch-test/CoreGraphics/CGEventTests.cs
@@ -1,0 +1,47 @@
+using System;
+using Foundation;
+#if MONOMAC
+using AppKit;
+#else
+using UIKit;
+#endif
+using CoreGraphics;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreGraphics {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class CGEventTests {
+#if MONOMAC
+		bool tapCalled = false;
+
+		IntPtr callBack (IntPtr tapProxyEvent, CGEventType eventType,
+			IntPtr eventRef, IntPtr userInfo)
+		{
+			tapCalled = true;
+			return eventRef;
+		}
+
+		[Test]
+		public void CreateTap ()
+		{
+			tapCalled = false;
+			var psn = (IntPtr)2; // kCurrentProcess
+			var tapPort = CGEvent.CreateTap (CGEventTapLocation.AnnotatedSession, CGEventTapPlacement.HeadInsert, CGEventTapOptions.Default, CGEventMask.KeyDown, callBack, IntPtr.Zero);
+			Assert.IsNull (tapPort, "magically created tap port when not root");
+			Assert.IsFalse (tapCalled, "tap was mistakenly called.");
+		}
+
+		[Test]
+		public void CreateTapPSN ()
+		{
+			tapCalled = false;
+			var psn = (IntPtr)2; // kCurrentProcess
+			var tapPort = CGEvent.CreateTap (psn, CGEventTapPlacement.HeadInsert, CGEventTapOptions.Default, CGEventMask.KeyDown, callBack, IntPtr.Zero);
+			Assert.IsNull (tapPort, "magically created tap port with OSN when not root");
+			Assert.IsFalse (tapCalled, "tap was mistakenly called.");
+		}
+#endif
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/17656

Unfortunately, neither of these calls do anything useful unless the caller is root. Since we don't make that guarantee all I can do it test for the "I am not root" behavior which is return null and never call the callback.

The PSN flavor call had both the wrong arguments and incorrect calling. I fixed both of these.