### PR TITLE
[release/7.0.1xx-xcode14.2] Add ventura to mac tests configurations.

### DIFF
--- a/src/Foundation/NSObject.mac.cs
+++ b/src/Foundation/NSObject.mac.cs
@@ -109,6 +109,7 @@ namespace Foundation {
 		static IntPtr sw = Dlfcn.dlopen (Constants.SharedWithYouLibrary, 1);
 		static IntPtr swc = Dlfcn.dlopen (Constants.SharedWithYouCoreLibrary, 1);
 		static IntPtr th = Dlfcn.dlopen (Constants.ThreadNetworkLibrary, 1);
+		static IntPtr ni = Dlfcn.dlopen (Constants.NearbyInteractionLibrary, 1);
 
 #if !NET
 		[Obsolete ("Use PlatformAssembly for easier code sharing across platforms.")]

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -175,7 +175,7 @@ namespace HomeKit {
 		string FirmwareVersion { get; }
 
 		[NullAllowed]
-		[Mac (13,0), iOS (16,1), MacCatalyst (16,1), Watch (9,1), TV (16,1)]
+		[Mac (13, 0), iOS (16, 1), MacCatalyst (16, 1), Watch (9, 1), TV (16, 1)]
 		[Export ("matterNodeID", ArgumentSemantic.Copy)]
 		NSNumber MatterNodeId { get; }
 

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -113,11 +113,21 @@ partial class TestRuntime
 		return new Version (major, minor, build);
 	}
 
+	static bool? is_in_ci;
+	public static bool IsInCI {
+		get {
+			if (!is_in_ci.HasValue) {
+				var in_ci = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_REVISION"));
+				in_ci |= !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION")); // set by Azure DevOps
+				is_in_ci = in_ci;
+			}
+			return is_in_ci.Value;
+		}
+	}
+
 	public static void IgnoreInCI (string message)
 	{
-		var in_ci = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_REVISION"));
-		in_ci |= !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION")); // set by Azure DevOps
-		if (!in_ci) {
+		if (!IsInCI) {
 			Console.WriteLine ($"Not ignoring test ('{message}'), because not running in CI. BUILD_REVISION={Environment.GetEnvironmentVariable ("BUILD_REVISION")} BUILD_SOURCEVERSION={Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION")}");
 			return;
 		}

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -169,6 +169,29 @@ partial class TestRuntime
 #endif
 	}
 
+	public static void AssertDesktop (string message = "This test only runs on Desktops (macOS or MacCatalyst).")
+	{
+#if __MACOS__ || __MACCATALYST__
+		return;
+#endif
+		NUnit.Framework.Assert.Ignore (message);
+	}
+
+	public static void AssertNotDesktop (string message = "This test does not run on Desktops (macOS or MacCatalyst).")
+	{
+#if __MACOS__ || __MACCATALYST__
+		NUnit.Framework.Assert.Ignore (message);
+#endif
+	}
+
+	public static void AssertNotX64Desktop (string message = "This test does not run on x64 desktops.")
+	{
+#if __MACOS__ || __MACCATALYST__
+		if (!IsARM64)
+			NUnit.Framework.Assert.Ignore (message);
+#endif
+	}
+
 	public static void AssertNotARM64Desktop (string message = "This test does not run on an ARM64 desktop.")
 	{
 #if __MACOS__ || __MACCATALYST__

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -134,6 +134,10 @@ namespace Introspection {
 				return true;
 			case "HMMatterRequestHandler": // got removed and the current API throws an exception at run time.
 				return true;
+#if __MACCATALYST__
+			case "PKIdentityButton":
+				return true;
+#endif
 			}
 
 #if !NET

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -380,9 +380,9 @@ namespace Introspection {
 					return true;
 				}
 				break;
-#if __WATCHOS__
+#if (__WATCHOS__ || __MACOS__ || __MACCATALYST__)
 			case "AVPlayerItem":
-				switch (selectorName) {
+				switch (selectorName) { // comes from AVPlayerItem+MPAdditions.h
 				case "nowPlayingInfo":
 				case "setNowPlayingInfo:":
 					return TestRuntime.IsSimulatorOrDesktop;
@@ -936,6 +936,26 @@ namespace Introspection {
 				switch (selectorName) {
 				case "shortcutItem":
 					if (!TestRuntime.CheckXcodeVersion (12, 0))
+						return true;
+					break;
+				}
+#endif
+				break;
+			case "SKAdImpression":
+#if __MACCATALYST__
+				switch (selectorName) {
+				case "initWithSourceAppStoreItemIdentifier:advertisedAppStoreItemIdentifier:adNetworkIdentifier:adCampaignIdentifier:adImpressionIdentifier:timestamp:signature:version:":
+					if (TestRuntime.CheckXcodeVersion (14, 0))
+						return true;
+					break;
+				}
+#endif
+				break;
+			case "EKParticipant":
+#if __MACCATALYST__
+				switch (selectorName) {
+				case "ABRecordWithAddressBook:": // Deprecated in 13.1
+					if (TestRuntime.CheckXcodeVersion (14, 0))
 						return true;
 					break;
 				}

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -1072,8 +1072,12 @@ namespace Introspection
 					Assert.True (CheckLibrary (s), fi.Name);
 					break;
 #endif
+				case "ChipLibrary": // Chip is removed entirely beginning Xcode 14
+					if (!TestRuntime.CheckXcodeVersion (14, 0))
+						if (TestRuntime.IsDevice)
+							Assert.True (CheckLibrary (s), fi.Name);
+					break;
 #if !__MACOS__
-				case "ChipLibrary":
 				case "ThreadNetworkLibrary":
 				case "MediaSetupLibrary":
 				case "MLComputeLibrary":

--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -70,6 +70,7 @@ namespace Introspection {
 			case "Foundation.NSUnitPressure": // -init should never be called on NSUnit!
 			case "Foundation.NSUnitSpeed": // -init should never be called on NSUnit!
 			case "MonoMac.EventKit.EKParticipant":
+			case "EventKit.EKCalendarItem":
 			case "EventKit.EKParticipant":
 			case "XamCore.CoreImage.CISampler":
 			case "CoreImage.CISampler":

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -205,7 +205,6 @@ namespace Introspection {
 #if __MACCATALYST__
 			case "BCChatButton":
 			case "PKAddPassButton":
-			case "PKPaymentButton":
 			case "UIButton":
 			case "UIControl":
 			case "UISegmentedControl":
@@ -221,6 +220,32 @@ namespace Introspection {
 			case "INUIAddVoiceShortcutButton":
 				if (protocolName == "UIContextMenuInteractionDelegate")
 					return !TestRuntime.CheckXcodeVersion (12, 0);
+				break;
+
+			// We have to special case the following PKPayment* in MacCatalyst
+			// since it gets all of these via inheritance from UIView
+			case "PKPaymentButton":
+			case "PKPaymentAuthorizationViewController":
+				switch (protocolName) {
+				case "UIUserActivityRestoring":
+				case "UIAppearanceContainer":
+				case "UIFocusItem":
+				case "UICoordinateSpace":
+				case "UIPopoverPresentationControllerSourceItem":
+				case "UIContextMenuInteractionDelegate":
+				case "UIFocusItemContainer":
+				case "UITraitEnvironment":
+				case "UIActivityItemsConfigurationProviding":
+				case "UIResponderStandardEditActions":
+				case "UILargeContentViewerItem":
+				case "UIDynamicItem":
+				case "UIAppearance":
+				case "UIAccessibilityContentSizeCategoryImageAdjusting":
+				case "UIContentContainer":
+					if (TestRuntime.CheckXcodeVersion (14, 0))
+						return true;
+					break;
+				}
 				break;
 #endif
 			}

--- a/tests/monotouch-test/AppKit/NSTextInputClient.cs
+++ b/tests/monotouch-test/AppKit/NSTextInputClient.cs
@@ -82,8 +82,13 @@ namespace apitest
 			NSRange range;
 			var rect = textView.GetFirstRect (new NSRange (12, 18), out range);
 
-			Assert.AreEqual (rect, new CGRect (0, 0, 12, 14), "NSTextInputClient_ShouldGetFirstRect - Returned wrong rect");
-			Assert.AreEqual (range, new NSRange (10, 4), "NSTextInputClient_ShouldGetFirstRect - Returned wrong Range");
+			if (TestRuntime.CheckXcodeVersion (14, 0)) {
+				Assert.AreEqual (rect, new CGRect (0, 0, 0, 14), "NSTextInputClient_ShouldGetFirstRect - Returned wrong rect");
+				Assert.AreEqual (range, new NSRange (12, 0), "NSTextInputClient_ShouldGetFirstRect - Returned wrong Range");
+			} else {
+				Assert.AreEqual (rect, new CGRect (0, 0, 12, 14), "NSTextInputClient_ShouldGetFirstRect - Returned wrong rect");
+				Assert.AreEqual (range, new NSRange (10, 4), "NSTextInputClient_ShouldGetFirstRect - Returned wrong Range");
+			}
 		}
 
 		[Test]
@@ -101,7 +106,10 @@ namespace apitest
 		[Test]
 		public void NSTextInputClient_ShouldGetBaselineDelta ()
 		{
-			Assert.IsTrue (textView.GetBaselineDelta (4) == 11, "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");
+			if (TestRuntime.CheckXcodeVersion (14, 0))
+				Assert.IsTrue (textView.GetBaselineDelta (4) == 0, "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");
+			else
+				Assert.IsTrue (textView.GetBaselineDelta (4) == 11, "NSTextInputClient_ShouldGetBaselineDelta - Returned wrong baseline delta value");
 		}
 
 		[Test]

--- a/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
+++ b/tests/monotouch-test/CoreBluetooth/CentralManagerTest.cs
@@ -76,6 +76,8 @@ namespace MonoTouchFixtures.CoreBluetooth {
 		[SetUp]
 		public void SetUp ()
 		{
+			if (TestRuntime.IsInCI && TestRuntime.CheckXcodeVersion (14, 0))
+				TestRuntime.AssertNotDesktop (); // Looks like this particular test doesn't like Desktop + M1 bot machines
 			// iOS 13 and friends require bluetooth permission
 			if (TestRuntime.CheckXcodeVersion (11, 0))
 				TestRuntime.CheckBluetoothPermission (true);

--- a/tests/monotouch-test/EventKit/CalendarTest.cs
+++ b/tests/monotouch-test/EventKit/CalendarTest.cs
@@ -78,7 +78,11 @@ namespace MonoTouchFixtures.EventKit {
 			Assert.Null (c.Source, "Source");
 			Assert.False (c.Subscribed, "Subscribed");
 #if MONOMAC || __MACCATALYST__
-			Assert.That (c.SupportedEventAvailabilities, Is.EqualTo (EKCalendarEventAvailability.Busy | EKCalendarEventAvailability.Free), "SupportedEventAvailabilities");
+			if (TestRuntime.CheckXcodeVersion (14, 0))
+				Assert.That (c.SupportedEventAvailabilities, Is.EqualTo (EKCalendarEventAvailability.None), "SupportedEventAvailabilities");
+			else
+				Assert.That (c.SupportedEventAvailabilities, Is.EqualTo (EKCalendarEventAvailability.Busy | EKCalendarEventAvailability.Free), "SupportedEventAvailabilities");
+
 			Assert.That (c.Title, Is.EqualTo (string.Empty), "Title");
 #else
 			Assert.That (c.SupportedEventAvailabilities, Is.EqualTo (EKCalendarEventAvailability.None), "SupportedEventAvailabilities");
@@ -120,7 +124,11 @@ namespace MonoTouchFixtures.EventKit {
 			Assert.Null (c.Source, "Source");
 			Assert.False (c.Subscribed, "Subscribed");
 #if MONOMAC || __MACCATALYST__
-			Assert.That (c.SupportedEventAvailabilities, Is.EqualTo (EKCalendarEventAvailability.Busy | EKCalendarEventAvailability.Free), "SupportedEventAvailabilities");
+			if (TestRuntime.CheckXcodeVersion (14, 0))
+				Assert.That (c.SupportedEventAvailabilities, Is.EqualTo (EKCalendarEventAvailability.None), "SupportedEventAvailabilities");
+			else
+				Assert.That (c.SupportedEventAvailabilities, Is.EqualTo (EKCalendarEventAvailability.Busy | EKCalendarEventAvailability.Free), "SupportedEventAvailabilities");
+
 			Assert.That (c.Title, Is.EqualTo (string.Empty), "Title");
 #else
 			Assert.That (c.SupportedEventAvailabilities, Is.EqualTo (EKCalendarEventAvailability.None), "SupportedEventAvailabilities");

--- a/tests/monotouch-test/HealthKit/HKAppleWalkingSteadinessTest.cs
+++ b/tests/monotouch-test/HealthKit/HKAppleWalkingSteadinessTest.cs
@@ -20,11 +20,8 @@ namespace MonoTouchFixtures.HealthKit {
 		[SetUp]
 		public void SetUp ()
 		{
-#if MONOMAC
-			TestRuntime.AssertXcodeVersion (14, 0);
-#else
+			TestRuntime.AssertNotDesktop (); // Only runs on iOS Devices or Simulators, which makes sense `Apple Walking Steadiness`.
 			TestRuntime.AssertXcodeVersion (13, 0);
-#endif
 		}
 
 		[Test]

--- a/tests/monotouch-test/MetalPerformanceShaders/MnistTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MnistTest.cs
@@ -43,6 +43,7 @@ namespace MonoTouchFixtures.MetalPerformanceShadersGraph {
 				TestRuntime.AssertNotSimulator ("Fails with 'Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -[MTLSimHeap protectionOptions]: unrecognized selector sent to instance 0x600002a09090' - note that we don't call this selector.");
 #endif
 			TestRuntime.IgnoreInCI ("This test seems to make bots keel over and die.");
+			TestRuntime.AssertNotX64Desktop (); // Intel Mac is not fast enough.
 
 			var device = MTLDevice.SystemDefault;
 			// some older hardware won't have a default

--- a/tests/monotouch-test/Network/NWPathMonitorTest.cs
+++ b/tests/monotouch-test/Network/NWPathMonitorTest.cs
@@ -126,6 +126,7 @@ namespace monotouchtest.Network
 			});
 		}
 #if MONOMAC
+		[Ignore ("Unusable nil instance returned, verified with ObjC project. Filled rdar://FB11984039.")]
 		[Test]
 		public void CreateForEthernetChannelTest ()
 		{

--- a/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/DelegateAndDataSourceTest.cs
@@ -136,6 +136,9 @@ namespace Xamarin.Mac.Tests
 				// The default constructor doesn't work (it's also obsolete)
 				return true;
 #endif
+			case "SWCollaborationView":
+				// Crashes when calling setDelegate: with null.
+				return true;
 			}
 
 			switch (t.Namespace) {

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -612,6 +612,8 @@ namespace MonoTests.System.Net.Http
 					callbackWasExecuted = true;
 					try {
 						Assert.IsNotNull (certificate);
+						if (errors == SslPolicyErrors.RemoteCertificateChainErrors && TestRuntime.IsInCI)
+							return false;
 						Assert.AreEqual (SslPolicyErrors.None, errors);
 					} catch (Exception e) {
 						ex2 = e;

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -124,6 +124,20 @@ parameters:
         "Agent.HasDevices -equals False",
         "Agent.IsPaired -equals False"
       ]
+    },
+    {
+      stageName: 'mac_13_0_m1',
+      displayName: 'M1 - Mac Ventura (13.0)',
+      macPool: 'VSEng-VSMac-Xamarin-Shared',
+      useImage: false,
+      statusContext: 'M1 - Mac Ventura (13.0)',
+      demands: [
+        "Agent.OS -equals Darwin",
+        "macOS.Name -equals Ventura",
+        "macOS.Architecture -equals arm64",
+        "Agent.HasDevices -equals False",
+        "Agent.IsPaired -equals False"
+      ]
     }]
 
 resources:

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -109,6 +109,20 @@ parameters:
         "Agent.HasDevices -equals False",
         "Agent.IsPaired -equals False"
       ]
+    },
+    {
+      stageName: 'mac_13_0_m1',
+      displayName: 'M1 - Mac Ventura (13.0)',
+      macPool: 'VSEng-VSMac-Xamarin-Shared',
+      useImage: false,
+      statusContext: 'M1 - Mac Ventura (13.0)',
+      demands: [
+        "Agent.OS -equals Darwin",
+        "macOS.Name -equals Ventura",
+        "macOS.Architecture -equals arm64",
+        "Agent.HasDevices -equals False",
+        "Agent.IsPaired -equals False"
+      ]
     }]
 
 resources:


### PR DESCRIPTION
Added Ventura machines to macTestConfigurations within both the
build-ci-pipeline and the build-pr-pipelines.

This is a backport of #17349, #16743, and #16777.