### PR TITLE
Encode the .NET version we're targeting in the third NuGet version number.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -12,15 +12,31 @@ CURL = curl --fail --location --connect-timeout 15 $(if $(V),--verbose,--silent)
 # --retry-all-errors: ignore the definition of insanity and retry even for errors that seem like you'd get the same result (such as 404). This isn't the real purpose, because this will also retry errors that will get a different result (such as connection failures / resets), which apparently --retry doesn't cover.
 CURL_RETRY = $(CURL) --retry 20 --retry-delay 2 --retry-all-errors
 
+DOTNET_TFM=net7.0
+DOTNET_MAJOR_VERSION:=$(firstword $(subst ., ,$(subst net,,$(DOTNET_TFM))))
 # calculate commit distance and store it in a file so that we don't have to re-calculate it every time make is executed.
 
 # Support for hardcoding a commit distance start offset.
-NUGET_VERSION_COMMIT_DISTANCE_START=0
-NUGET_VERSION_STABLE_COMMIT_DISTANCE_START=0
+#
+# The default is to add X000, where X is the major .NET version: we need to
+# publish different versions of our NuGets for different .NET version
+# (example: we need to publish one NuGet with support for Xcode 14.3 for .NET
+# 6, and another one for .NET 7) - and these need to have different versions,
+# and ordered correctly (the .NET 7 version must have a higher version than
+# the .NET 6 version), and ideally it would be possible to just look at the
+# version to see which .NET version it's targeting. Adding X000 to the commit
+# distance accomplishes all these goals (as long as the commit distance itself
+# doesn't need more than 3 digits).
+NUGET_VERSION_COMMIT_DISTANCE_START=$(DOTNET_MAJOR_VERSION)000
+NUGET_VERSION_STABLE_COMMIT_DISTANCE_START=$(DOTNET_MAJOR_VERSION)000
 
 -include $(TOP)/Make.config.inc
 $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
-	$(Q) cd $(TOP) && ALL_DOTNET_PLATFORMS="$(ALL_DOTNET_PLATFORMS)" ./create-make-config.sh
+	$(Q) cd $(TOP) && \
+		ALL_DOTNET_PLATFORMS="$(ALL_DOTNET_PLATFORMS)" \
+		NUGET_VERSION_COMMIT_DISTANCE_START=$(NUGET_VERSION_COMMIT_DISTANCE_START) \
+		NUGET_VERSION_STABLE_COMMIT_DISTANCE_START=$(NUGET_VERSION_STABLE_COMMIT_DISTANCE_START) \
+		./create-make-config.sh
 
 include $(TOP)/Make.versions
 
@@ -600,7 +616,6 @@ else
 DOTNET_BCL_VERSION=$(BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION)
 endif
 
-DOTNET_TFM=net7.0
 DOTNET_VERSION_BAND=$(firstword $(subst -, ,$(DOTNET_VERSION)))
 DOTNET_VERSION_PRERELEASE_COMPONENT=$(subst $(DOTNET_VERSION_BAND),,$(DOTNET_VERSION))
 DOTNET_INSTALL_NAME=dotnet-sdk-$(DOTNET_VERSION)

--- a/create-make-config.sh
+++ b/create-make-config.sh
@@ -11,10 +11,6 @@ rm -f "$OUTPUT_FILE" "$OUTPUT"
 LANG=C
 export LANG
 
-# Support for hardcoding a commit distance start offset.
-NUGET_VERSION_COMMIT_DISTANCE_START=0
-NUGET_VERSION_STABLE_COMMIT_DISTANCE_START=0
-
 # Compute commit distances
 printf "IOS_COMMIT_DISTANCE:=$(git log $(git blame -- ./Make.versions HEAD | grep IOS_PACKAGE_VERSION= | sed 's/ .*//' )..HEAD --oneline | wc -l | sed 's/ //g')\n" >> "$OUTPUT_FILE"
 printf "MAC_COMMIT_DISTANCE:=$(git log $(git blame -- ./Make.versions HEAD | grep MAC_PACKAGE_VERSION= | sed 's/ .*//' )..HEAD --oneline | wc -l | sed 's/ //g')\n" >> "$OUTPUT_FILE"


### PR DESCRIPTION
Encode the .NET version we're targeting in the third NuGet version number by
adding X000 (where X is the .NET version) to the commit distance.

This accomplishes a few goals:

* We automatically compute a different NuGet version depending on the .NET version we're targeting.
* Versions are sorted correctly (.NET 7 nugets have a higher version number than .NET 6 nugets).
* It's possible to see which .NET version a NuGet is targeting from the version.

The downside is:

* The scheme breaks down if we need more than three digits for the commit
  distance (possible solution: add another zero, so we add X0000 instead of
  X000).