### PR TITLE
[Code Style] Add some extra style checks focused on nullability.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -117,6 +117,12 @@ csharp_style_unused_value_expression_statement_preference = discard_variable:sil
 # 'using' directive preferences
 csharp_using_directive_placement = outside_namespace:suggestion
 
+# nullability checks
+
+dotnet_diagnostic.IDE0029.severity = error
+dotnet_diagnostic.IDE0031.severity = error
+dotnet_diagnostic.IDE0041.severity = erro
+
 #### C# Formatting Rules ####
 
 # New line preferences


### PR DESCRIPTION
Added the following new checks:

```csharp
// dotnet_style_coalesce_expression = true
var v = x ?? y;

// dotnet_style_coalesce_expression = false
var v = x != null ? x : y; // or
var v = x == null ? y : x;
```

```csharp
// dotnet_style_null_propagation = true
var v = o?.ToString();

// dotnet_style_null_propagation = false
var v = o == null ? null : o.ToString(); // or
var v = o != null ? o.String() : null;
```

```csharp
// dotnet_style_prefer_is_null_check_over_reference_equality_method = true
if (value is null)
    return;

// dotnet_style_prefer_is_null_check_over_reference_equality_method = false
if (object.ReferenceEquals(value, null))
    return;

// dotnet_style_prefer_is_null_check_over_reference_equality_method = false
if ((object)o == null)
    return;
```