### PR TITLE
[devops] Clean simulator runtimes from bots.

### DIFF
--- a/tools/devops/automation/scripts/bash/clean-bot.sh
+++ b/tools/devops/automation/scripts/bash/clean-bot.sh
@@ -124,40 +124,8 @@ for oldXcode in "${oldXcodes[@]}"; do
 	fi
 done
 
-# list simulator runtimes
-ls -lad /Library/Developer/CoreSimulator/Images/mnt/
-ls -lad /Library/Developer/CoreSimulator/Images/mnt/*/Library/Developer/CoreSimulator/Profiles/Runtimes
-ls -lad /Library/Developer/CoreSimulator/Images/mnt/*/Library/Developer/CoreSimulator/Profiles/Runtimes/*.simruntime
-
-# find if there are any duplicated simulator runtimes for a given platform
-# here we look through all the simulator runtimes, and assign any to a variable whose name contains the platform
-# we also check if that variable already exists, in which case we assign the value 'delete'
-# at the end we loop over all the platforms, and delete all simulator runtimes whose platform variable we assigned the value 'delete'
-PLATFORMS=()
-for sr in /Library/Developer/CoreSimulator/Images/mnt/*/Library/Developer/CoreSimulator/Profiles/Runtimes/*.simruntime; do
-	if ! test -d "$sr"; then
-		continue
-	fi
-	PLATFORM=$(basename -s .simruntime "$sr")
-	PLATFORMS+=("$PLATFORM")
-	varname="simruntime_$PLATFORM"
-	EXISTING=${!varname}
-	if test -z "$EXISTING"; then
-		declare "$varname=$sr"
-	else
-		declare "$varname=delete"
-	fi
-done
-for PLATFORM in $(echo "${PLATFORMS[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '); do
-	varname="simruntime_$PLATFORM"
-	EXISTING=${!varname}
-	if [[ "$EXISTING" == "delete" ]]; then
-		for sr in /Library/Developer/CoreSimulator/Images/mnt/*/Library/Developer/CoreSimulator/Profiles/Runtimes/"$PLATFORM".simruntime; do
-			ID="$(basename "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$sr")")")")")")")"
-			sudo xrun simctl runtime delete "$ID"
-		done
-	fi
-done
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+"$DIR"/clean-simulator-runtime.sh
 
 # Print disk status after cleaning
 df -h

--- a/tools/devops/automation/scripts/bash/clean-bot.sh
+++ b/tools/devops/automation/scripts/bash/clean-bot.sh
@@ -125,6 +125,8 @@ for oldXcode in "${oldXcodes[@]}"; do
 done
 
 # list simulator runtimes
+ls -lad /Library/Developer/CoreSimulator/Images/mnt/
+ls -lad /Library/Developer/CoreSimulator/Images/mnt/*/Library/Developer/CoreSimulator/Profiles/Runtimes
 ls -lad /Library/Developer/CoreSimulator/Images/mnt/*/Library/Developer/CoreSimulator/Profiles/Runtimes/*.simruntime
 
 # find if there are any duplicated simulator runtimes for a given platform
@@ -133,6 +135,9 @@ ls -lad /Library/Developer/CoreSimulator/Images/mnt/*/Library/Developer/CoreSimu
 # at the end we loop over all the platforms, and delete all simulator runtimes whose platform variable we assigned the value 'delete'
 PLATFORMS=()
 for sr in /Library/Developer/CoreSimulator/Images/mnt/*/Library/Developer/CoreSimulator/Profiles/Runtimes/*.simruntime; do
+	if ! test -d "$sr"; then
+		continue
+	fi
 	PLATFORM=$(basename -s .simruntime "$sr")
 	PLATFORMS+=("$PLATFORM")
 	varname="simruntime_$PLATFORM"

--- a/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
+++ b/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
@@ -17,7 +17,7 @@ cat simruntime-runtimes.txt
 sort simruntime-runtimes.txt | uniq -c | sort -n | sed 's/^[[:blank:]]*//' > simruntime-runtimes-by-count.txt
 cat simruntime-runtimes-by-count.txt
 
-grep -v '^2 ' simruntime-runtimes-by-count.txt | sed 's/^[0-9 ]*//' > simruntime-duplicated-runtimes.txt
+grep -v '^1 ' simruntime-runtimes-by-count.txt | sed 's/^[0-9 ]*//' > simruntime-duplicated-runtimes.txt
 cat simruntime-duplicated-runtimes.txt
 
 while IFS= read -r simruntime
@@ -26,7 +26,11 @@ do
   grep "$simruntime" simruntime-lines.txt | sed 's/ .*//' | while IFS= read -r id
   do
     echo "    sudo xcrun simctl runtime delete $id"
-    sudo xcrun simctl runtime delete "$id"
+    if ! sudo xcrun simctl runtime delete "$id"; then
+      echo "    failed to delete runtime $id"
+    else
+      echo "    deleted runtime $id"
+    fi
   done
 done < simruntime-duplicated-runtimes.txt
 

--- a/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
+++ b/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eux
+
+# find if there are any duplicated simulator runtimes for a given platform
+
+set -o pipefail
+IFS=$'\n\t'
+
+xcrun simctl runtime list -j > simruntime.json
+cat simruntime.json
+
+grep -e '"identifier" : ' -e '"runtimeIdentifier" : ' simruntime.json | tr '\n' ' ' | sed -e 's/,//g' -e 's/"//g' -e 's/runtimeIdentifier : //g' -e $'s/identifier : /@/g' | tr '@' '\n' | awk NF | sed 's/^[[:blank:]]*//' > simruntime-lines.txt
+cat simruntime-lines.txt
+
+sed -e 's/.*com.apple/com.apple/g' simruntime-lines.txt > simruntime-runtimes.txt
+cat simruntime-runtimes.txt
+
+sort simruntime-runtimes.txt | uniq -c | sort -n | sed 's/^[[:blank:]]*//' > simruntime-runtimes-by-count.txt
+cat simruntime-runtimes-by-count.txt
+
+grep -v '^2 ' simruntime-runtimes-by-count.txt | sed 's/^[0-9 ]*//' > simruntime-duplicated-runtimes.txt
+cat simruntime-duplicated-runtimes.txt
+
+while IFS= read -r simruntime
+do
+  echo "Duplicated: $simruntime"
+  grep "$simruntime" simruntime-lines.txt | sed 's/ .*//' | while IFS= read -r id
+  do
+    echo "    sudo xcrun simctl runtime delete $id"
+    sudo xcrun simctl runtime delete "$id"
+  done
+done < simruntime-duplicated-runtimes.txt
+
+xcrun simctl runtime list -v


### PR DESCRIPTION
If there are more than one simulator runtime for a given platform, then remove
all of them.

This will hopefully fix a few problems we're having with hard drive space
issues (we end up with a lot of identical simulator runtimes downloaded).