### PR TITLE
[vs-workload] Remove @(MultiTargetPackNames)

### DIFF
--- a/dotnet/generate-vs-workload.csharp
+++ b/dotnet/generate-vs-workload.csharp
@@ -89,12 +89,6 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 		var version = entry.Item2;
 		writer.WriteLine ($"    <WorkloadPackages Include=\"$(NuGetPackagePath)\\Microsoft.NET.Sdk.{platform}.Manifest*.nupkg\" Version=\"{version}\" SupportsMachineArch=\"true\" />");
 	}
-	foreach (var entry in platforms) {
-		var platform = entry.Item1;
-		writer.WriteLine ($"    <MultiTargetPackNames Include=\"Microsoft.{platform}.Sdk\" />");
-		if (windowsPlatforms.Contains (platform))
-			writer.WriteLine ($"    <MultiTargetPackNames Include=\"Microsoft.{platform}.Windows.Sdk\" />");
-	}
 	writer.WriteLine ("  </ItemGroup>");
 	writer.WriteLine ("</Project>");
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/251

The VS manifest files generated during MSI conversion will now be split up using the workload pack type rather than a substring match.