### PR TITLE
[dotnet] Enable generation of runtime configuration file

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -50,6 +50,7 @@
 			* https://github.com/dotnet/sdk/blob/c5a58bc6c3eb2b236b314e6d17a89a537459890c/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets#L102
 		-->
 		<_IsTrimmingEnabled>true</_IsTrimmingEnabled>
+		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
 	</PropertyGroup>
 
 	<!-- Set the default RuntimeIdentifier if not already specified. -->

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -875,6 +875,10 @@ namespace Xamarin.Tests {
 
 			var extensionPath = Path.Combine (Path.GetDirectoryName (consumingProjectDir)!, "bin", "Debug", platform.ToFramework (), GetDefaultRuntimeIdentifier (platform), "MySimpleApp.app", GetPlugInsRelativePath (platform), "ExtensionProject.appex");
 			Assert.That (Directory.Exists (extensionPath), $"App extension directory does not exist: {extensionPath}");
+
+			var pathToSearch = Path.Combine (Path.GetDirectoryName (consumingProjectDir)!, "bin", "Debug");
+			string [] configFiles = Directory.GetFiles (pathToSearch, "*.runtimeconfig.*", SearchOption.AllDirectories);
+			Assert.That (configFiles.Length > 0, "runtimeconfig.json file does not exist");
 		}
 
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64;iossimulator-arm64")]


### PR DESCRIPTION
Set the GenerateRuntimeConfigurationFiles property to be true 
to avoid warnings at build time for users + add test for change.

Diving deeper into the fix...
- GRCF == GenerateRuntimeConfigurationFiles property
- This warning only occurs with .NET apps which is why the 
property is only updated in the dotnet directory and not msbuild (legacy code)
- Diving deeper into the fix, after examining the binlog (in issue), 
it was found that the GRCF was contingent upon the HasRuntimeOutput 
property, which is only defined for executable projects. And in this case, 
the user's project output type is library thus both the RuntimeOutput and 
consequently GRCF properties were not enabled.
- By setting the GRCF to true we can address the original warning of concern 
while ensuring the rest of the projects's behavior is not altered in mysterious 
ways (i.e. by touching the RuntimeOutput property or the project output type 
instead, these changes could have extraneous effects).

Fixes #17543