### PR TITLE
[release/8.0.1xx-preview3] [msbuild] Always pass --wait-for-exit:<value> to mlaunch.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks/Tasks/GetMlaunchArgumentsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/GetMlaunchArgumentsTaskBase.cs
@@ -186,11 +186,12 @@ namespace Xamarin.iOS.Tasks {
 			foreach (var envvar in EnvironmentVariables)
 				sb.AddQuoted ("--setenv=" + envvar.ItemSpec);
 
+			sb.Add (WaitForExit ? "--wait-for-exit:true" : "--wait-for-exit:false");
+
+			// Add additional arguments at the end, so they can override any
+			// other argument.
 			foreach (var arg in AdditionalArguments)
 				sb.AddQuoted (arg.ItemSpec);
-
-			if (WaitForExit)
-				sb.Add ("--wait-for-exit");
 
 			return sb.ToString ();
 		}


### PR DESCRIPTION
Because depending on other options the default can be either 'true' or
'false', and this way we always ask mlaunch to do the right thing.

Also ensure any additional arguments are added last, so they can override any
other argument.


Backport of #17865
