### PR TITLE
Use https when resetting versions in CI

### DIFF
--- a/mk/xamarin-reset.sh
+++ b/mk/xamarin-reset.sh
@@ -9,7 +9,11 @@ if [[ $DEPENDENCY_MODULE =~ git@github.com ]]; then
 	# git@ url
 	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/git@github.com:/}
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}
-else
+elif [[ $DEPENDENCY_MODULE =~ https.*@github.com ]]; then
+	# https:// url with auth
+	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/github.com\//}
+	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%%/*}
+else 
 	# https:// url
 	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/github.com\//}
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}

--- a/mk/xamarin-reset.sh
+++ b/mk/xamarin-reset.sh
@@ -11,7 +11,7 @@ if [[ $DEPENDENCY_MODULE =~ git@github.com ]]; then
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}
 elif [[ $DEPENDENCY_MODULE =~ https.*@github.com ]]; then
 	# https:// url with auth
-	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:.*github.com\//}
+	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/[[:graph:]]*github.com\//}
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}
 else 
 	# https:// url

--- a/mk/xamarin-reset.sh
+++ b/mk/xamarin-reset.sh
@@ -11,8 +11,8 @@ if [[ $DEPENDENCY_MODULE =~ git@github.com ]]; then
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}
 elif [[ $DEPENDENCY_MODULE =~ https.*@github.com ]]; then
 	# https:// url with auth
-	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/github.com\//}
-	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%%/*}
+	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:.*github.com\//}
+	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}
 else 
 	# https:// url
 	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/github.com\//}

--- a/mk/xamarin-reset.sh
+++ b/mk/xamarin-reset.sh
@@ -9,13 +9,9 @@ if [[ $DEPENDENCY_MODULE =~ git@github.com ]]; then
 	# git@ url
 	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/git@github.com:/}
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}
-elif [[ $DEPENDENCY_MODULE =~ https.*@github.com ]]; then
-	# https:// url with auth
-	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/[[:graph:]]*github.com\//}
-	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}
 else 
-	# https:// url
-	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/github.com\//}
+	# https:// url with optional auth in front
+	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/[[:graph:]]*github.com\//}
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}
 fi
 

--- a/mk/xamarin-reset.sh
+++ b/mk/xamarin-reset.sh
@@ -9,7 +9,7 @@ if [[ $DEPENDENCY_MODULE =~ git@github.com ]]; then
 	# git@ url
 	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/git@github.com:/}
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}
-else 
+else
 	# https:// url with optional auth in front
 	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/[[:graph:]]*github.com\//}
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -12,7 +12,7 @@ NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore
 # Use https to clone maccore during pipeline builds, avoiding broken SSH connections when GH changes RSA key
-ifdef SYSTEM_ACCESSTOKEN
+ifdef IN_CI
 MACCORE_MODULE    := https://github.com/xamarin/maccore.git
 else
 MACCORE_MODULE    := git@github.com:xamarin/maccore.git

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -13,7 +13,7 @@ NEEDED_MACCORE_BRANCH := main
 MACCORE_DIRECTORY := maccore
 # Use https to clone maccore during pipeline builds, avoiding broken SSH connections when GH changes RSA key
 ifdef SYSTEM_ACCESSTOKEN
-MACCORE_MODULE    := git@github.com:xamarin/maccore.git
+MACCORE_MODULE    := https://github.com/xamarin/maccore.git
 else
 MACCORE_MODULE    := git@github.com:xamarin/maccore.git
 endif

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -12,8 +12,8 @@ NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore
 # Use https to clone maccore during pipeline builds, avoiding broken SSH connections when GH changes RSA key
-ifdef IN_CI
-MACCORE_MODULE    := https://github.com/xamarin/maccore.git
+ifdef CI_PAT
+MACCORE_MODULE    := https://vs-mobiletools-engineering-service2:$(CI_PAT)github.com/xamarin/maccore.git
 else
 MACCORE_MODULE    := git@github.com:xamarin/maccore.git
 endif

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -11,7 +11,12 @@ NEEDED_MACCORE_VERSION := 893e01ae00872bcf0458ca094a9beb3f6fda3709
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore
+# Use https to clone maccore during pipeline builds, avoiding broken SSH connections when GH changes RSA key
+ifdef SYSTEM_ACCESSTOKEN
 MACCORE_MODULE    := git@github.com:xamarin/maccore.git
+else
+MACCORE_MODULE    := git@github.com:xamarin/maccore.git
+endif
 MACCORE_VERSION   := $(shell cd $(MACCORE_PATH) 2> /dev/null && git rev-parse HEAD 2> /dev/null)
 MACCORE_BRANCH    := $(shell cd $(MACCORE_PATH) 2> /dev/null && git symbolic-ref --short HEAD 2> /dev/null)
 endif

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -13,7 +13,7 @@ NEEDED_MACCORE_BRANCH := main
 MACCORE_DIRECTORY := maccore
 # Use https to clone maccore during pipeline builds, avoiding broken SSH connections when GH changes RSA key
 ifdef CI_PAT
-MACCORE_MODULE    := https://vs-mobiletools-engineering-service2:$(CI_PAT)github.com/xamarin/maccore.git
+MACCORE_MODULE    := https://vs-mobiletools-engineering-service2:$(CI_PAT)@github.com/xamarin/maccore.git
 else
 MACCORE_MODULE    := git@github.com:xamarin/maccore.git
 endif

--- a/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
+++ b/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
@@ -59,6 +59,7 @@ steps:
   env:
     PR_ID: ${{ parameters.prID }} # reusing jenkins vars, to be fixed
     AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
+    CI_PAT: ${{ parameters.gitHubToken }}
 
 # publish the resulting artifact
 - task: PublishPipelineArtifact@1

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -210,7 +210,8 @@ steps:
 # the provisioning profiles.
 - bash: |
     set -ex
-    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset CI_PAT=${{ parameters.gitHubToken }}
+    CI_PAT=${{ parameters.gitHubToken }}
+    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset
   name: resetDependencies
   displayName: 'Reset dependencies'
   timeoutInMinutes: 10

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -210,8 +210,7 @@ steps:
 # the provisioning profiles.
 - bash: |
     set -ex
-    CI_PAT=${{ parameters.gitHubToken }}
-    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset
+    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset CI_PAT=${{ parameters.gitHubToken }}
   name: resetDependencies
   displayName: 'Reset dependencies'
   timeoutInMinutes: 10

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -210,7 +210,7 @@ steps:
 # the provisioning profiles.
 - bash: |
     set -ex
-    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset
+    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset IN_CI=true
   name: resetDependencies
   displayName: 'Reset dependencies'
   timeoutInMinutes: 10

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -210,7 +210,7 @@ steps:
 # the provisioning profiles.
 - bash: |
     set -ex
-    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset IN_CI=true
+    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset CI_PAT=${{ parameters.gitHubToken }}
   name: resetDependencies
   displayName: 'Reset dependencies'
   timeoutInMinutes: 10

--- a/tools/devops/automation/templates/common/checkout.yml
+++ b/tools/devops/automation/templates/common/checkout.yml
@@ -18,7 +18,6 @@ steps:
   parameters:
     resource: ${{ parameters.repositoryAlias }}
     commit: ${{ parameters.commit }}
-    persistCredentials: true
     clean: true
     submodules: recursive
     path: s/xamarin-macios

--- a/tools/devops/automation/templates/common/checkout.yml
+++ b/tools/devops/automation/templates/common/checkout.yml
@@ -18,6 +18,7 @@ steps:
   parameters:
     resource: ${{ parameters.repositoryAlias }}
     commit: ${{ parameters.commit }}
+    persistCredentials: true
     clean: true
     submodules: recursive
     path: s/xamarin-macios


### PR DESCRIPTION
Github changed their RSA key after it was [briefly leaked on Thursday Mar 23.](https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/)

As a result, out CI machines are failing to set maccore's remote because it cannot auth through git+ssh.

Instead, use https only when we're running in a CI environment