### PR TITLE
[release/8.0.1xx-preview3] [vs-workload] Update VS Component versions

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -186,14 +186,8 @@ LOCAL_WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/LICENSE
 endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform),$(shell echo $(platform) | tr A-Z a-z),$($(platform)_NUGET_VERSION_NO_METADATA),$(NET6_$(platform)_NUGET_VERSION_NO_METADATA),$(shell echo $(platform) | tr a-z A-Z),$(NET7_$(platform)_NUGET_VERSION_NO_METADATA))))
 
-# We use a different versioning for stable releases (which is determined by the NUGET_PRERELEASE_IDENTIFIER variable being empty):
-# We reset the commit distance (to the commits since NUGET_PRERELEASE_IDENTIFIER changed - which must have changed for a branch to become a stable branch)
-# We use the commit distance as the third number in the version, instead of the fourth.
-ifeq ($(NUGET_PRERELEASE_IDENTIFIER),)
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).$(NUGET_STABLE_COMMIT_DISTANCE).0))
-else
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).0.$($(shell echo $(platform) | tr a-z A-Z)_NUGET_COMMIT_DISTANCE)))
-endif
+# Always use the commit distance as the third number in the VS component version, as it should always increase across all branches.
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).$($(shell echo $(platform) | tr a-z A-Z)_NUGET_COMMIT_DISTANCE).0))
 
 $(DOTNET_NUPKG_DIR)/vs-workload.props: Makefile generate-vs-workload.csharp
 	$(Q) rm -f $@.tmp


### PR DESCRIPTION
Context: https://github.com/xamarin/sdk-insertions/issues/56

Updates the VS component version for all workloads to use the NuGet versions commit distance as the third version part.


Backport of #17883
