### PR TITLE
[release/7.0.2xx] Updated Xamarin.Messaging to 1.9.94

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.9.59</MessagingVersion>
+		<MessagingVersion>1.9.94</MessagingVersion>
 		<HotRestartVersion>1.0.93</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Should fix an issue in remote builds where if the connection gets disconnected unexpectedly, the build might end up failing because the main session id is changed and also the reconnection fails. 

More details: https://github.com/xamarin/Xamarin.Messaging/pull/587


Backport of #17925
