### PR TITLE
[net8.0] Go back to using .NET's version band instead of hardcoding an older version.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -648,12 +648,12 @@ endif
 
 # These are the manifest version band used for Mono and Emscripten.
 # It will typically be $(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT), unless the corresponding teams decided to hardcode something else.
-MONO_TOOLCHAIN_MANIFEST_VERSION_BAND=8.0.100-preview.2
-EMSCRIPTEN_MANIFEST_VERSION_BAND=8.0.100-preview.2
+MONO_TOOLCHAIN_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT)
+EMSCRIPTEN_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT)
 
 # This is the manifest version band we use for our .Manifest-$(VERSION_BAND) packages.
 # It should typically be $(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT), unless we decide to hardcode it to something else
-MACIOS_MANIFEST_VERSION_BAND=$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)
+MACIOS_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT)
 
 # Set this to 1 if the Microsoft.NETCore.App.Ref dependency in eng/Version.Details.xml does *not* specify a CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal.
 TRACKING_DOTNET_RUNTIME_SEPARATELY=


### PR DESCRIPTION
Should fix this:

> D:\a\_work\1\s\src\DotNet\Dependencies\Workloads.csproj : error NU1102: Unable to find package Microsoft.NET.Sdk.macOS.Manifest-8.0.100-preview.4 with version (= 13.1.8510-net8-p4) [D:\a\_work\1\s\src\DotNet\DotNet.csproj]

from https://github.com/dotnet/maui/pull/14241#issuecomment-1487598894.