### PR TITLE
[CI] Fix the windows tests in the unified pipeline.

### DIFF
--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -13,11 +13,11 @@ parameters:
 
 - name: commit
   type: string
+  default: HEAD
 
 - name: uploadPrefix
   type: string
   default: '$(MaciosUploadPrefix)'
-  default: HEAD
 
 steps:
 

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -13,6 +13,10 @@ parameters:
 
 - name: commit
   type: string
+
+- name: uploadPrefix
+  type: string
+  default: '$(MaciosUploadPrefix)'
   default: HEAD
 
 steps:
@@ -102,13 +106,13 @@ steps:
 - task: DownloadPipelineArtifact@2
   displayName: Download test libraries dependencies
   inputs:
-    patterns: '**/package-test-libraries.zip'
+    patterns: '**/${{ parameters.uploadPrefix }}package-test-libraries.zip'
     allowFailedBuilds: true
     path: $(Build.SourcesDirectory)/artifacts/tmp
 
 # this step replaces the test-libraries dir
 - pwsh: |
-    $zip = "$(Build.SourcesDirectory)/artifacts/tmp/package-test-libraries/package-test-libraries.zip"
+    $zip = "$(Build.SourcesDirectory)/artifacts/tmp/${{ parameters.uploadPrefix }}package-test-libraries/package-test-libraries.zip"
     $target = "$(Build.SourcesDirectory)/xamarin-macios/tests/test-libraries"
     Expand-Archive -Force $zip -DestinationPath $target
     Get-ChildItem "$target" -Recurse


### PR DESCRIPTION
We need the upload prefix. The parameter uses the default which will be empty in this repo but will have the correct prefix in the unified pipeline.