### PR TITLE
[net8.0] Fix the Windows tests

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -20,6 +20,8 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="Dotnet arcade" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <!-- We've dropped support for .NET 6, but let's keep the feed in for a little while longer to make sure it's dropped throughout our entire stack and the lack of this feed doesn't break our build. -->
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <!-- dotnet8-transport is required for Microsoft.DotNet.Cecil -->

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -130,7 +130,7 @@ steps:
         test `
         "$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/UnitTests/DotNetUnitTests.csproj" `
         --filter Category=Windows `
-        --verbosity quiet `
+        --verbosity diag `
         "-bl:$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/run-dotnet-tests.binlog"
   displayName: 'Run .NET tests'
 

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -126,7 +126,7 @@ steps:
 
 - pwsh: |
     $runsettings = @"
-    <?xml version='1.0' encoding='utf-8'?>"
+    <?xml version="1.0" encoding="utf-8"?>
     <RunSettings>
       <RunConfiguration>
         <DotNetHostPath>$(Build.SourcesDirectory)\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe</DotNetHostPath>

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -125,12 +125,13 @@ steps:
   continueOnError: true
 
 - pwsh: |
-    $runsettings = @"<?xml version='1.0' encoding='utf-8'?>"
-          <RunSettings>
-            <RunConfiguration>
-              <DotNetHostPath>$(Build.SourcesDirectory)\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe</DotNetHostPath>
-            </RunConfiguration>
-          </RunSettings>
+    $runsettings = @"
+    <?xml version='1.0' encoding='utf-8'?>"
+    <RunSettings>
+      <RunConfiguration>
+        <DotNetHostPath>$(Build.SourcesDirectory)\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe</DotNetHostPath>
+      </RunConfiguration>
+    </RunSettings>
     "@
     Set-Content -Path $(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/config.runsettings -Value $runsettings
     Get-Content -Path $(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/config.runsettings | Write-Host

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -125,12 +125,25 @@ steps:
   continueOnError: true
 
 - pwsh: |
+    $runsettings = @"<?xml version='1.0' encoding='utf-8'?>"
+          <RunSettings>
+            <RunConfiguration>
+              <DotNetHostPath>$(Build.SourcesDirectory)\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe</DotNetHostPath>
+            </RunConfiguration>
+          </RunSettings>
+    "@
+    Set-Content -Path $(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/config.runsettings -Value $runsettings
+    Get-Content -Path $(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/config.runsettings | Write-Host
+  displayName: 'Create runsettings for .NET tests'
+
+- pwsh: |
     $Env:DOTNET = "$(Build.SourcesDirectory)\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe"
     & $(Build.SourcesDirectory)\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe `
         test `
         "$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/UnitTests/DotNetUnitTests.csproj" `
         --filter Category=Windows `
         --verbosity diag `
+        --settings $(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/config.runsettings `
         "-bl:$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/run-dotnet-tests.binlog"
   displayName: 'Run .NET tests'
 

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -143,7 +143,7 @@ steps:
         test `
         "$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/UnitTests/DotNetUnitTests.csproj" `
         --filter Category=Windows `
-        --verbosity diag `
+        --verbosity quiet `
         --settings $(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/config.runsettings `
         "-bl:$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/run-dotnet-tests.binlog"
   displayName: 'Run .NET tests'


### PR DESCRIPTION
1. Keep the .NET 6 feed, because even though we've dropped support for .NET 6, parts of the build may still need access to the feed.

    > Workload installation failed: microsoft.maccatalyst.sdk::16.2.19 is not found in NuGet feeds [long list of feeds, but not the right one]

2. Pass a runsettings to 'dotnet test' to tell it to use the .NET version we've downloaded, otherwise it will try to use any .NET version installed on the system (🤦‍♂️) - which doesn't work because we need to use .NET 8, and the system only has .NET 7.