### PR TITLE
[docs] Document properties for configurations

### DIFF
--- a/docs/configuration-properties.md
+++ b/docs/configuration-properties.md
@@ -1,0 +1,26 @@
+Debug vs. Release Configuration Property Documentation
+========================================================
+
+There are a number of properties that are contingent upon the configuration setting chosen. The properties and their corresponding values are documented here to provide transparency and enable users to better create custom configuration modes as well.<br />
+
+### Release Configuration
+
+| **Property**                                            	| **Default value**                 	| **Condition?**                        	|
+|---------------------------------------------------------	|-----------------------------------	|---------------------------------------	|
+| UseSystemResourceKeys                                   	| true                              	|                                       	|
+| VerifyDependencyInjectionOpenGenericServiceTrimmability 	| false                             	|                                       	|
+| DebuggerSupport                                         	| false                             	|                                       	|
+| EnableAssemblyILStripping                               	| true                              	|                                       	|
+| RuntimeIdentifiers                                      	| maccatalyst-x64;maccatalyst-arm64 	| TargetFramework == netx.x-maccatalyst 	|
+| RuntimeIdentifiers                                      	| osx-x64;osx-arm64                 	| TargetFramework == netx.x-macos       	|
+<br />
+
+### Debug Configuration
+
+| **Property**             	| **Default value** 	| **Condition?**                        	|
+|--------------------------	|-------------------	|---------------------------------------	|
+| UseSystemResourceKeys    	| false             	|                                       	|
+| CodesignDisableTimestamp 	| true              	|                                       	|
+| DebuggerSupport          	| true              	|                                       	|
+| RuntimeIdentifiers       	| maccatalyst-x64   	| TargetFramework == netx.x-maccatalyst 	|
+| RuntimeIdentifiers       	| osx-x64           	| TargetFramework == netx.x-macos       	|

--- a/docs/configuration-properties.md
+++ b/docs/configuration-properties.md
@@ -1,26 +1,26 @@
 Debug vs. Release Configuration Property Documentation
 ========================================================
 
-There are a number of properties that are contingent upon the configuration setting chosen. The properties and their corresponding values are documented here to provide transparency and enable users to better create custom configuration modes as well.<br />
+There are a number of properties that are contingent upon the configuration setting chosen. The properties and their corresponding values are documented here to provide transparency and enable users to better create custom configuration modes.
 
 ### Release Configuration
 
 | **Property**                                            	| **Default value**                 	| **Condition?**                        	|
 |---------------------------------------------------------	|-----------------------------------	|---------------------------------------	|
-| UseSystemResourceKeys                                   	| true                              	|                                       	|
-| VerifyDependencyInjectionOpenGenericServiceTrimmability 	| false                             	|                                       	|
 | DebuggerSupport                                         	| false                             	|                                       	|
 | EnableAssemblyILStripping                               	| true                              	|                                       	|
 | RuntimeIdentifiers                                      	| maccatalyst-x64;maccatalyst-arm64 	| TargetFramework == netx.x-maccatalyst 	|
 | RuntimeIdentifiers                                      	| osx-x64;osx-arm64                 	| TargetFramework == netx.x-macos       	|
-<br />
+| UseSystemResourceKeys                                   	| true                              	|                                       	|
+| VerifyDependencyInjectionOpenGenericServiceTrimmability 	| false                             	|                                       	|
+
 
 ### Debug Configuration
 
 | **Property**             	| **Default value** 	| **Condition?**                        	|
 |--------------------------	|-------------------	|---------------------------------------	|
-| UseSystemResourceKeys    	| false             	|                                       	|
 | CodesignDisableTimestamp 	| true              	|                                       	|
 | DebuggerSupport          	| true              	|                                       	|
 | RuntimeIdentifiers       	| maccatalyst-x64   	| TargetFramework == netx.x-maccatalyst 	|
 | RuntimeIdentifiers       	| osx-x64           	| TargetFramework == netx.x-macos       	|
+| UseSystemResourceKeys    	| false             	|                                       	|


### PR DESCRIPTION
Fixes #17738
Addresses the initial issue of just documenting which properties are tied to which configuration. But to make the documentation more helpful, we should provide further context about what exactly these properties mean. However, this isn't trivial as some properties are a bit cryptic..once further info is acquired, it will be integrated in a later revision.