### PR TITLE
[release/7.0.2xx] Fixed remote and local build issues

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.9.94</MessagingVersion>
+		<MessagingVersion>1.9.99</MessagingVersion>
 		<HotRestartVersion>1.0.93</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
- Updated Xamarin.Messaging to 1.9.99 to fix a connection problem in remote builds because of an invalid reference to System.Security.Cryptography.ProtectedData
- Generate Hot Restart specific build session id to fix an issue in local builds that was conflicting with remote builds


Backport of #17964
