### PR TITLE
[xcode14.3] Fixed remote and local build issues

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.9.94</MessagingVersion>
+		<MessagingVersion>1.9.99</MessagingVersion>
 		<HotRestartVersion>1.0.93</HotRestartVersion>
 	</PropertyGroup>
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -14,6 +14,17 @@
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets') And '$(MessagingBuildTargetsImported)' != 'true'" />
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.Apple.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Messaging.Apple.targets') And '$(MessagingAppleTargetsImported)' != 'true'" />
 	
+	<Target Name="_GenerateHotRestartBuildSessionId">
+		<GenerateBuildSessionId MessagingVersion="$(MessagingVersion)" 
+			TargetFramework="$(TargetFramework)" 
+			ProjectFullPath="$(MSBuildProjectFullPath)" 
+			ProjectName="$(MSBuildProjectName)"
+			VisualStudioProcessId="$(VisualStudioProcessId)">
+			<Output TaskParameter="BuildSessionId" PropertyName="HotRestartBuildSessionId" />
+			<Output TaskParameter="BuildAppName" PropertyName="BuildAppName" />
+		</GenerateBuildSessionId>
+	</Target>
+
 	<Target Name="AddHotRestartDefineConstants" BeforeTargets="AddImplicitDefineConstants">
 		<PropertyGroup>
 			<_IsHotRestartDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)HOTRESTART($|;)'))</_IsHotRestartDefined>
@@ -145,13 +156,13 @@
 	<Target Name="_CreateHotRestartCachedBundle" DependsOnTargets="$(_CreateHotRestartCachedBundleDependsOn)" />
 	
 	<!-- Creates HotRestart app bundle and collects files to copy -->
-	<Target Name="_PrepareHotRestartAppBundle" DependsOnTargets="_GenerateBuildSessionId" 
+	<Target Name="_PrepareHotRestartAppBundle" DependsOnTargets="_GenerateHotRestartBuildSessionId" 
 					Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsHotRestartBuild)' == 'true'">
 
 		<!--Create app bundle dir and get its path-->
 		<PrepareAppBundle 
 			AppBundleName="$(_AppBundleName)"
-			SessionId="$(BuildSessionId)" 
+			SessionId="$(HotRestartBuildSessionId)" 
 			ShouldExtract="true">
 
 			<Output TaskParameter="AppBundlePath" PropertyName="HotRestartAppBundlePath" />
@@ -333,12 +344,12 @@
 		</CleanDependsOn>
 	</PropertyGroup>
 
-	<Target Name="_CleanHotRestartBundle" DependsOnTargets="_GenerateBuildSessionId" >
+	<Target Name="_CleanHotRestartBundle" DependsOnTargets="_GenerateHotRestartBuildSessionId" >
 		<!-- Gets the bundle path -->
 		<PrepareAppBundle 
 			Condition="'$(IsHotRestartBuild)' == 'true'"
 			AppBundleName="$(_AppBundleName)"
-			SessionId="$(BuildSessionId)" 
+			SessionId="$(HotRestartBuildSessionId)" 
 			ShouldExtract="false">
 
 			<Output TaskParameter="AppBundlePath" PropertyName="HotRestartAppBundlePath" />


### PR DESCRIPTION
- Updated Xamarin.Messaging to 1.9.99 to fix a connection problem in remote builds because of an invalid reference to System.Security.Cryptography.ProtectedData
- Generate Hot Restart specific build session id to fix an issue in local builds that was conflicting with remote builds


Backport of #17964
