### PR TITLE
[Localization] Run the OneLoc Task more efficiently  

### DIFF
--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -11,6 +11,10 @@ parameters:
   type: boolean
   default: true
 
+- name: createLocPR
+  type: boolean
+  default: false
+
 variables:
 - template: templates/variables.yml
 - name: MaciosUploadPrefix
@@ -50,14 +54,28 @@ trigger: none
 
 schedules:
 
-# the translations team wants a green build, we can do that on sundays even if 
-# the code did not change and without the device tests.
+# Create the PR into main with the newest usable localization strings once a week on Sundays
 - cron: "0 12 * * 0"
   displayName: Weekly Translations build (Sunday @ noon)
   branches:
     include:
     - main
   always: true
+  variables:
+    createLocPR: true
+
+# Run the OneLocTask everyday without setting the createLocPR var to true.
+# This will ensure that OneLoc gets our newly added error strings faster but we do not need
+# to look for new usable translation PRs everyday.
+# This will run around midnight in the US after each workday
+- cron: "0 5 * * 2-6"
+  displayName: Weekly Translations build (Sunday @ noon)
+  branches:
+    include:
+    - main
+  always: true
+  variables:
+    createLocPR: false
 
 stages:
 
@@ -86,3 +104,4 @@ stages:
           isPR: false
           repositoryAlias: self
           commit: HEAD
+          createLocPR: $(createLocPR)

--- a/tools/devops/automation/templates/loc-translations.yml
+++ b/tools/devops/automation/templates/loc-translations.yml
@@ -11,6 +11,10 @@ parameters:
   type: string
   default: HEAD
 
+- name: createLocPR
+  type: boolean
+  default: false
+
 steps:
 
 - template: sdk-unified/steps/checkout/v1.yml@yaml-templates
@@ -79,7 +83,7 @@ steps:
   inputs:
     locProj: '$(Build.SourcesDirectory)\\Localize\\LocProject.json'
     outDir: '$(Build.ArtifactStagingDirectory)'
-    ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+    ${{ if or(eq(variables['Build.Reason'], 'Schedule'), variables.createLocPR) }}:
       isCreatePrSelected: true
     ${{ else }}:
       isCreatePrSelected: false


### PR DESCRIPTION
This PR does a few things to help the Localization process happen more efficiently:

1) Add a cron job
    * One will run on Sundays (as before) and this one will set the new variable to be true and will create a PR into main with the usable translations
    * The other will run after each weekday at around midnight and will allow the Loc team to see our newly added error codes much faster but will not look for the new localization for us to use each day.
 2) Allow us to manually run the pipeline and create the Localization PR with the new usable translations whenever we want (for example if there was an error on the weekly build and we don't want to wait until the next weekend to get the new strings)