### PR TITLE
[Localization] Remove Schedule Variables and use displayName

### DIFF
--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -56,7 +56,7 @@ schedules:
 
 # Create the PR into main with the newest usable localization strings once a week on Sundays
 - cron: "0 12 * * 0"
-  displayName: Sunday Build
+  displayName: Sunday Build # Do not change this string to 'Daily Build' as it is used in the 'translations' job
   branches:
     include:
     - main
@@ -67,7 +67,7 @@ schedules:
 # to look for new usable translation PRs everyday.
 # This will run around midnight in the US after each workday
 - cron: "0 5 * * 2-6"
-  displayName: Daily Build
+  displayName: Daily Build # Do not change this string as it is used in the 'translations' job
   branches:
     include:
     - main

--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -56,26 +56,22 @@ schedules:
 
 # Create the PR into main with the newest usable localization strings once a week on Sundays
 - cron: "0 12 * * 0"
-  displayName: Weekly Translations build (Sunday @ noon)
+  displayName: Sunday Build
   branches:
     include:
     - main
   always: true
-  variables:
-    createLocPR: true
 
 # Run the OneLocTask everyday without setting the createLocPR var to true.
 # This will ensure that OneLoc gets our newly added error strings faster but we do not need
 # to look for new usable translation PRs everyday.
 # This will run around midnight in the US after each workday
 - cron: "0 5 * * 2-6"
-  displayName: Weekly Translations build (Sunday @ noon)
+  displayName: Daily Build
   branches:
     include:
     - main
   always: true
-  variables:
-    createLocPR: false
 
 stages:
 
@@ -104,4 +100,4 @@ stages:
           isPR: false
           repositoryAlias: self
           commit: HEAD
-          createLocPR: $(createLocPR)
+          createLocPR: or(eq(variables['createLocPR'], true), eq(variables['schedule.displayName'], 'Daily Build'))

--- a/tools/devops/automation/build-cronjob.yml
+++ b/tools/devops/automation/build-cronjob.yml
@@ -57,7 +57,7 @@ schedules:
 
 # Create the PR into main with the newest usable localization strings once a week on Sundays
 - cron: "0 12 * * 0"
-  displayName: Sunday Build # Do not change this string to 'Daily Build' as it is used in the 'translations' job
+  displayName: Sunday Build
   branches:
     include:
     - main

--- a/tools/devops/automation/templates/loc-translations.yml
+++ b/tools/devops/automation/templates/loc-translations.yml
@@ -83,7 +83,7 @@ steps:
   inputs:
     locProj: '$(Build.SourcesDirectory)\\Localize\\LocProject.json'
     outDir: '$(Build.ArtifactStagingDirectory)'
-    ${{ if or(eq(variables['Build.Reason'], 'Schedule'), variables.createLocPR) }}:
+    ${{ eq(variables['createLocPR'], true) }}:
       isCreatePrSelected: true
     ${{ else }}:
       isCreatePrSelected: false


### PR DESCRIPTION
Pipelines didn't like the scheduled variables so let's try using the schedule displayName instead