### PR TITLE
[Localization] Use backticks and include label and milestone

### DIFF
--- a/tools/devops/automation/build-lego.yml
+++ b/tools/devops/automation/build-lego.yml
@@ -84,11 +84,13 @@ stages:
 
           git fetch origin
 
-          gh pr create \
-          --title "Bring changes from Localization branch #$(Build.BuildNumber)" \
-          --body "The OneLoc team creates these translations to be consumed later on in the second step of the Localization process. We need to bring these into the main branch in order to continue the process." \
-          --base main \
-          --head Localization \
+          gh pr create `
+          --title "Bring changes from Localization branch #$(Build.BuildNumber)" `
+          --body "The OneLoc team creates these translations to be consumed later on in the second step of the Localization process. We need to bring these into the main branch in order to continue the process." `
+          --base main `
+          --head Localization `
+          --label not-notes-worthy `
+          --milestone Future `
           --draft=false
 
         name: BringLocChanges


### PR DESCRIPTION
This fixes a syntax issue to allow the [xamarin.macios-legoChanges](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=18272&_a=summary) pipeline to bring over the Loc changes from the Localization branch in PRs similar to the one below!
https://github.com/xamarin/xamarin-macios/pull/17998