### PR TITLE
[tests] Fix BlittablePInvokes.CheckForNonBlittablePInvokes to not verify known failures unless building for all platforms.

### DIFF
--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -66,7 +66,11 @@ namespace Cecil.Tests {
 			}
 
 			Assert.IsEmpty (newFailures, $"Failures: {message}");
-			Assert.IsEmpty (fixedFailures, $"Known failures that aren't failing anymore - remove these from the list of known failures: {message}");
+
+			// The list of known failures often doesn't separate based on platform, which means that we might not see all the known failures
+			// unless we're currently building for all platforms. As such, only verify the list of known failures if we're building for all platforms.
+			if (!Configuration.AnyIgnoredPlatforms ())
+				Assert.IsEmpty (fixedFailures, $"Known failures that aren't failing anymore - remove these from the list of known failures: {message}");
 		}
 
 		// Enumerates all the methods in the assembly, for all types (including nested types), potentially providing a custom filter function.

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -1117,15 +1117,20 @@ namespace Xamarin.Tests {
 
 		public static bool AnyIgnoredPlatforms (bool dotnet = true)
 		{
+			return AnyIgnoredPlatforms (dotnet, out var _);
+		}
+
+		public static bool AnyIgnoredPlatforms (bool dotnet, out IEnumerable<ApplePlatform> notIncluded)
+		{
 			var allPlatforms = GetAllPlatforms (dotnet);
 			var includedPlatforms = GetIncludedPlatforms (dotnet);
-			var notIncluded = allPlatforms.Where (v => !includedPlatforms.Contains (v));
+			notIncluded = allPlatforms.Where (v => !includedPlatforms.Contains (v)).ToArray ();
 			return notIncluded.Any ();
 		}
 
 		public static void IgnoreIfAnyIgnoredPlatforms (bool dotnet = true)
 		{
-			if (AnyIgnoredPlatforms (dotnet))
+			if (AnyIgnoredPlatforms (dotnet, out var notIncluded))
 				Assert.Ignore ($"This test requires all platforms to be included, but the following platforms aren't included: {string.Join (", ", notIncluded.Select (v => v.AsString ()))}");
 		}
 

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -1115,12 +1115,17 @@ namespace Xamarin.Tests {
 			}
 		}
 
-		public static void IgnoreIfAnyIgnoredPlatforms (bool dotnet = true)
+		public static bool AnyIgnoredPlatforms (bool dotnet = true)
 		{
 			var allPlatforms = GetAllPlatforms (dotnet);
 			var includedPlatforms = GetIncludedPlatforms (dotnet);
 			var notIncluded = allPlatforms.Where (v => !includedPlatforms.Contains (v));
-			if (notIncluded.Any ())
+			return notIncluded.Any ();
+		}
+
+		public static void IgnoreIfAnyIgnoredPlatforms (bool dotnet = true)
+		{
+			if (AnyIgnoredPlatforms (dotnet))
 				Assert.Ignore ($"This test requires all platforms to be included, but the following platforms aren't included: {string.Join (", ", notIncluded.Select (v => v.AsString ()))}");
 		}
 


### PR DESCRIPTION
This fixes a test failure when not including all platforms:

	Cecil.Tests.BlittablePInvokes.CheckForNonBlittablePInvokes: Known failures that aren't failing anymore - remove these from the list of known failures: In the file tests/cecil-tests/BlittablePInvokes.cs, read the guide carefully.
		Expected: <empty>
		But was: < "AudioUnit.AudioComponentStatus AudioUnit.AudioUnit::AudioOutputUnitPublish(AudioUnit.AudioComponentDescription,System.IntPtr,System.UInt32,System.IntPtr)", ...