### PR TITLE
[msbuild] Honor any existing values for HotRestartSignedAppOutputDir and HotRestartAppBundlePath.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/PrepareAppBundle.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/PrepareAppBundle.cs
@@ -29,7 +29,8 @@ namespace Xamarin.iOS.HotRestart.Tasks {
 
 		public override bool Execute ()
 		{
-			AppBundlePath = HotRestartContext.Default.GetAppBundlePath (AppBundleName, SessionId.Substring (0, 8));
+			if (string.IsNullOrEmpty (AppBundlePath))
+				AppBundlePath = HotRestartContext.Default.GetAppBundlePath (AppBundleName, SessionId.Substring (0, 8));
 
 			if (!Directory.Exists (AppBundlePath) && ShouldExtract) {
 				var preBuiltAppBundlePath = Path.Combine (

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.props
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.props
@@ -4,7 +4,7 @@
 		<!-- Use single-project MSBuild properties to generate the application manifest by default -->
 		<GenerateApplicationManifest Condition="'$(GenerateApplicationManifest)' == ''">true</GenerateApplicationManifest>
 		
-		<HotRestartSignedAppOutputDir>$(TEMP)\Xamarin\HotRestart\Signing\$(_AppBundleName)$(AppBundleExtension)\out\</HotRestartSignedAppOutputDir>
+		<HotRestartSignedAppOutputDir Condition="'$(HotRestartSignedAppOutputDir)' == ''">$(TEMP)\Xamarin\HotRestart\Signing\$(_AppBundleName)$(AppBundleExtension)\out\</HotRestartSignedAppOutputDir>
 		<HotRestartPayloadDir>$(HotRestartSignedAppOutputDir)Payload\</HotRestartPayloadDir>
 		<HotRestartSignedAppDir>$(HotRestartPayloadDir)$(_AppBundleName).app\</HotRestartSignedAppDir>
 		<HotRestartContentDir>$(HotRestartSignedAppOutputDir)$(_AppBundleName).content\</HotRestartContentDir>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -162,6 +162,7 @@
 		<!--Create app bundle dir and get its path-->
 		<PrepareAppBundle 
 			AppBundleName="$(_AppBundleName)"
+			AppBundlePath="$(HotRestartAppBundlePath)"
 			SessionId="$(HotRestartBuildSessionId)" 
 			ShouldExtract="true">
 


### PR DESCRIPTION
This makes it easier to write tests that verify the files written in this paths,
because the tests can specify these output directories instead of evaluating a project
file or duplicating the logic to compute them.

Additionally, the tests can also easily make sure the output is cleaned up once the test is done.