### PR TITLE
[devops] Don't ignore setup failures in the windows tests.

### DIFF
--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -90,7 +90,6 @@ steps:
     "-bl:$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/install.binlog" `
     -p:DisableImplicitNuGetFallbackFolder=true
   displayName: 'Install custom .NET'
-  continueOnError: true
 
 - pwsh: |
     $Env:DOTNET = "$(Build.SourcesDirectory)\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe"
@@ -100,7 +99,6 @@ steps:
       -p:DisableImplicitNuGetFallbackFolder=true `
       -t:Install
   displayName: 'Install workloads'
-  continueOnError: true
 
 # get and expand the needed libs for monotouch
 - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
Failing to install .NET or the corresponding workloads is a failure that should not
be ignored.