### PR TITLE
Update MessagingVersion in Directory.Build.props

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.9.102</MessagingVersion>
+		<MessagingVersion>1.10.0</MessagingVersion>
 		<HotRestartVersion>1.0.114</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
There is a new version of `Xamarin.Messaging`, so updating nugget package to that. 