### PR TITLE
[CI] Remove code repetition in an attempt to reduce the size of the yaml

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -36,6 +36,7 @@
 		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsHotRestartBuild)' == 'true' And '$(IsHotRestartEnvironmentReady)' == 'true'" >
 		
 		<HotRestart.Tasks.DetectSigningIdentity 
+			Condition="'$(EnableCodeSigning)' != 'false'"
 			GenerateApplicationManifest="$(GenerateApplicationManifest)"
 			ApplicationId="$(ApplicationId)"
 			ApplicationTitle="$(ApplicationTitle)"
@@ -326,7 +327,7 @@
 					AfterTargets="_CodesignAppBundle" />
 	
 	<Target Name="_CodesignHotRestartAppBundle"
-		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsHotRestartBuild)' == 'true'"
+		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsHotRestartBuild)' == 'true' And '$(EnableCodeSigning)' != 'false'"
 		DependsOnTargets="_CreateHotRestartCachedBundle;_CopyFrameworksToHotRestartBundle;_CollectCodeSignHotRestartInputs"
 		Inputs="@(_CodeSignHotRestartInputs)"
 		Outputs="@(_CodeSignHotRestartInputs -> '%(Outputs)')">

--- a/tools/devops/automation/scripts/show_env.ps1
+++ b/tools/devops/automation/scripts/show_env.ps1
@@ -10,5 +10,7 @@ if ($IsMacOS -or $IsLinux) {
 
 gci env: | format-table -autosize -wrap
 
-system_profiler SPSoftwareDataType SPHardwareDataType SPDeveloperToolsDataType
+if ($IsMacOS) {
+    system_profiler SPSoftwareDataType SPHardwareDataType SPDeveloperToolsDataType
+}
 

--- a/tools/devops/automation/scripts/show_env.ps1
+++ b/tools/devops/automation/scripts/show_env.ps1
@@ -1,0 +1,14 @@
+Write-Host "IsMacOS: ${IsMacOS}"
+Write-Host "IsWindows: ${IsWindows}"
+Write-Host "IsLinux: ${IsLinux}"
+
+if ($IsMacOS -or $IsLinux) {
+    Write-Host "HOSTNAME: $(hostname)"
+} else {
+    Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
+}
+
+gci env: | format-table -autosize -wrap
+
+system_profiler SPSoftwareDataType SPHardwareDataType SPDeveloperToolsDataType
+

--- a/tools/devops/automation/templates/build/api-diff-process-results.yml
+++ b/tools/devops/automation/templates/build/api-diff-process-results.yml
@@ -27,18 +27,7 @@ steps:
     repositoryAlias: ${{ parameters.repositoryAlias }}
     commit: ${{ parameters.commit }}
 
-- powershell: |
-    Write-Host "IsMacOS: ${IsMacOS}"
-    Write-Host "IsWindows: ${IsWindows}"
-    Write-Host "IsLinux: ${IsLinux}"
-
-    if ($IsMacOS -or $IsLinux) {
-        Write-Host "HOSTNAME: $(hostname)"
-    } else {
-        Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
-    }
-
-    gci env: | format-table -autosize -wrap
+- pwsh: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/show_env.ps1
   displayName: 'Show Environment'
 
 - pwsh: |

--- a/tools/devops/automation/templates/common/setup.yml
+++ b/tools/devops/automation/templates/common/setup.yml
@@ -27,20 +27,7 @@ steps:
   continueOnError: true
   timeoutInMinutes: 60
 
-- powershell: |
-    Write-Host "IsMacOS: ${IsMacOS}"
-    Write-Host "IsWindows: ${IsWindows}"
-    Write-Host "IsLinux: ${IsLinux}"
-
-    if ($IsMacOS -or $IsLinux) {
-        Write-Host "HOSTNAME: $(hostname)"
-    } else {
-        Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
-    }
-
-    gci env: | format-table -autosize -wrap
-
-    system_profiler SPSoftwareDataType SPHardwareDataType SPDeveloperToolsDataType
+- pwsh: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/show_env.ps1
   displayName: 'Show Environment'
 
 - powershell: |

--- a/tools/devops/automation/templates/governance-checks.yml
+++ b/tools/devops/automation/templates/governance-checks.yml
@@ -34,18 +34,7 @@ steps:
     Dir $(System.DefaultWorkingDirectory)
   displayName: Show directories
 
-- powershell: |
-    Write-Host "IsMacOS: ${IsMacOS}"
-    Write-Host "IsWindows: ${IsWindows}"
-    Write-Host "IsLinux: ${IsLinux}"
-
-    if ($IsMacOS -or $IsLinux) {
-        Write-Host "HOSTNAME: $(hostname)"
-    } else {
-        Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
-    }
-
-    gci env: | format-table -autosize -wrap
+- pwsh: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/show_env.ps1
   displayName: 'Show Environment'
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -73,9 +73,8 @@ steps:
 # download the packages that have been created, install them, later download the zip files that contain the already built
 # tests and execute them.
 
-- pwsh: |
-    gci env: | format-table -autosize -wrap
-  displayName: 'Dump Environment'
+- pwsh: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/show_env.ps1
+  displayName: 'Show Environment'
 
 - bash: |
     ioreg -l | grep -e Manufacturer -e 'Vendor Name'

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -79,20 +79,7 @@ jobs:
   - checkout: release-scripts
     clean: true
 
-  - pwsh: |
-      Write-Host "IsMacOS: ${IsMacOS}"
-      Write-Host "IsWindows: ${IsWindows}"
-      Write-Host "IsLinux: ${IsLinux}"
-
-      if ($IsMacOS -or $IsLinux) {
-          Write-Host "HOSTNAME: $(hostname)"
-      } else {
-          Write-Host "COMPUTERNAME: ${env:COMPUTERNAME}"
-      }
-
-      gci env: | format-table -autosize -wrap
-
-      system_profiler SPSoftwareDataType SPHardwareDataType SPDeveloperToolsDataType
+  - pwsh: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/show_env.ps1
     displayName: 'Show Environment'
 
   - bash: |

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -27,8 +27,7 @@ steps:
     repositoryAlias: ${{ parameters.repositoryAlias }}
     commit: ${{ parameters.commit }}
 
-- pwsh: |
-    gci env: | format-table -autosize -wrap
+- pwsh: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/show_env.ps1
   displayName: 'Dump Environment'
 
 - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
We are trying to minimize as much as possible the size of the expanded yaml, the show  env code was present in several locations

Ref, we are tyring to remove the following error:

> __built-in-schema.yml: Maximum object size exceeded. Reduce the size of your YAML pipeline.
> If you have large inline scripts, for example, can you factor them out and check them in?