### PR TITLE
[release/6.0.4xx-xcode14.3] [maestro] Make 'Microsoft.NETCore.App.Ref' depend on 'Microsoft.Dotnet.Sdk.Internal'.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -659,6 +659,9 @@ MANIFEST_VERSION_BAND=6.0.400
 # for this to follow suit, in which case we can keep things working by hardcoding the previous version band.
 TOOLCHAIN_MANIFEST_VERSION_BAND=6.0.300
 
+# Set this to 1 if the Microsoft.NETCore.App.Ref dependency in eng/Version.Details.xml does *not* specify a CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal.
+TRACKING_DOTNET_RUNTIME_SEPARATELY=
+
 # The location of csc changes depending on whether we're using a preview or a stable/service release :/
 DOTNET_CSC_PATH_PREVIEW=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION)/Roslyn/bincore/csc.dll
 DOTNET_CSC_PATH_STABLE=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION_BAND)/Roslyn/bincore/csc.dll

--- a/NuGet.config
+++ b/NuGet.config
@@ -10,12 +10,13 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-emsdk -->
-    <add key="darc-pub-dotnet-emsdk-3c730c2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-3c730c2c/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-a243060" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-a243060c/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-a243060-2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-a243060c-2/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-a243060-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-a243060c-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-pub-dotnet-runtime-300ceb8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-300ceb88/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -144,14 +144,17 @@ package-download/all-package-references.csproj: $(TOP)/.git/HEAD $(TOP)/.git/ind
 		/p:PackageRuntimeIdentifiers="$(DOTNET_RUNTIME_IDENTIFIERS)" \
 		/p:PackageRuntimeIdentifiersCoreCLR="$(DOTNET_CORECLR_RUNTIME_IDENTIFIERS)" \
 		/p:CustomDotNetVersion="$(DOWNLOAD_DOTNET_VERSION)" \
-		/p:DotNetManifestVersionBand="$(DOTNET_MANIFEST_VERSION_BAND)" \
-		/p:ToolChainManifestVersionBand="$(TOOLCHAIN_MANIFEST_VERSION_BAND)" \
+		/p:MonoToolChainManifestVersionBand="$(DOTNET_MANIFEST_VERSION_BAND)" \
+		/p:EmscriptenManifestVersionBand="$(TOOLCHAIN_MANIFEST_VERSION_BAND)" \
+		/p:TrackingDotNetRuntimeSeparately="$(TRACKING_DOTNET_RUNTIME_SEPARATELY)" \
 		/bl \
 		$(DOTNET_BUILD_VERBOSITY)
+ifneq ($(TRACKING_DOTNET_RUNTIME_SEPARATELY),)
 	$(Q) mkdir -p ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain/
 	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.mono.toolchain.manifest-$(TOOLCHAIN_MANIFEST_VERSION_BAND)/$(DOWNLOAD_DOTNET_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain/
 	$(Q) mkdir -p ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten/
 	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.emscripten.manifest-$(TOOLCHAIN_MANIFEST_VERSION_BAND)/$(EMSCRIPTEN_MANIFEST_PACKAGE_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(DOTNET_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten/
+endif
 	$(Q) touch $@
 
 .stamp-install-t4: $(TOP)/.config/dotnet-tools.json .stamp-download-dotnet-packages

--- a/builds/package-download/download-packages.csproj
+++ b/builds/package-download/download-packages.csproj
@@ -23,11 +23,11 @@
     <!-- download the nfloat reference assembly for .NET 6 (but only for .NET 6, once we switch to .NET 7 this can be removed) -->
     <PackageDownload Include="System.Runtime.InteropServices.NFloat.Internal" Version="[6.0.1]" Condition="'$(ActualPackageVersion.Substring(0,1))' == '6'" />
 
-    <!-- and get the mono workload as well -->
-    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-$(ToolChainManifestVersionBand)" Version="[$(ActualPackageVersion)]" />
+    <!-- and get the mono workload(s) as well -->
+    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-$(MonoToolChainManifestVersionBand)" Version="[$(ActualPackageVersion)]" Condition="'$(TrackingDotNetRuntimeSeparately)' != ''" />
 
-    <!-- and get the emscripten workload as well -->
-    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.Manifest-$(ToolChainManifestVersionBand)" Version="[$(MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion)]" />
+    <!-- and get the emscripten workload(s) as well -->
+    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.Manifest-$(EmscriptenManifestVersionBand)" Version="[$(Emscriptennet7WorkloadVersion)]" Condition="'$(TrackingDotNetRuntimeSeparately)' != ''" />
   </ItemGroup>
 
   <Import Project="all-package-references.csproj" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,25 +1,26 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.409-servicing.23204.4">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.409-servicing.23212.5">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>43b126737f98aa46f532dcdcc805a5bc436c836a</Sha>
+      <Sha>5f54896027e69d550e1ad5e229f72257ffc9645d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.200-1.22553.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/linker</Uri>
       <Sha>4be765525a1b45d28ab69a48f92e008b70a4e56e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.17">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>300ceb88348a1d9590ec942e1a77cb4ae2cdddef</Sha>
+    <!-- Set TRACKING_DOTNET_RUNTIME_SEPARATELY to something in Make.config if removing the CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal -->
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.16" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
+      <Sha>1e620a42e71ca8c7efb033fd525f04be5fa701fe</Sha>
     </Dependency>
     <!-- This is required for our test apps to build; in some cases Microsoft.AspNetCore.App is pulled in, and when building test apps the build needs to be able to resolve that -->
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.15" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.16" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>6a6d775f49623bbd742c02f89d373630668547bb</Sha>
+      <Sha>d6f154cca3863703cf87c8b840eea9cbe20229b2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="6.0.17" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="6.0.16" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>3c730c2c99c521adabe9b67b74bdba3a682d66d7</Sha>
+      <Sha>a243060cdb356f166664b5d0c3dad206299935e7</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,12 +1,13 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>6.0.409-servicing.23204.4</MicrosoftDotnetSdkInternalPackageVersion>
+    <!-- Versions updated by maestro -->
+    <MicrosoftDotnetSdkInternalPackageVersion>6.0.409-servicing.23212.5</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>6.0.200-1.22553.1</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETILStripTasksPackageVersion>6.0.0-rc.2.21468.3</MicrosoftNETILStripTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.17</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion>6.0.17</MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.16</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion>6.0.16</MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "6.0.409-servicing.23204.4"
+    "version": "6.0.409-servicing.23212.5"
   }
 }

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -489,30 +489,6 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		[TestCase (ApplePlatform.iOS, "win10-x86", null)]
-		[TestCase (ApplePlatform.TVOS, "win10-x64", null)]
-		[TestCase (ApplePlatform.MacOSX, "win10-arm", null)]
-		[TestCase (ApplePlatform.MacCatalyst, "win10-arm64", "Unable to find package Microsoft.NETCore.App.Runtime.Mono.win-arm64. No packages exist with this id in source[(]s[)]:.*")]
-		public void InvalidRuntimeIdentifier_Restore (ApplePlatform platform, string runtimeIdentifier, string? failureMessagePattern)
-		{
-			var project = "MySimpleApp";
-			Configuration.IgnoreIfIgnoredPlatform (platform);
-
-			var project_path = GetProjectPath (project, platform: platform);
-			Clean (project_path);
-			var properties = GetDefaultProperties (runtimeIdentifier);
-			if (string.IsNullOrEmpty (failureMessagePattern)) {
-				DotNet.AssertRestore (project_path, properties);
-			} else {
-				var rv = DotNet.Restore (project_path, properties);
-				Assert.AreNotEqual (0, rv.ExitCode, "Expected failure");
-				var errors = BinLog.GetBuildLogErrors (rv.BinLogPath).ToArray ();
-				Assert.That (errors.Length, Is.GreaterThan (0), "Error count");
-				Assert.That (errors [0].Message, Does.Match (failureMessagePattern), "Message failure");
-			}
-		}
-
-		[Test]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
 		public void FilesInAppBundle (ApplePlatform platform, string runtimeIdentifiers)
 		{


### PR DESCRIPTION
This way we always get a consistent build (at the cost of flexibility:
sometimes we won't be getting 'Microsoft.NETCore.App.Ref' updates for a while
if either dotnet/runtime or dotnet/sdk have security fixes in the works, but
this shouldn't be much of an issue for a stable .NET version, since we usually
work with any dotnet/runtime version at that point).

Backport of #18026.