### PR TITLE
[bgen] Check for null (no) namespace when matching namespace to framework. Fixes #18025.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2440,6 +2440,8 @@ public partial class Generator : IMemberGatherer {
 	bool IsInSupportedFramework (MemberInfo klass, PlatformName platform)
 	{
 		string ns = FindNamespace (klass);
+		if (string.IsNullOrEmpty (ns))
+			return false;
 		var list = GetFrameworkListForPlatform (platform);
 		return list.Contains (ns.ToLower (CultureInfo.InvariantCulture));
 	}

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -381,6 +381,9 @@ namespace GeneratorTests {
 			bgen.AssertWarning (1103, "'FooType`1' does not live under a namespace; namespaces are a highly recommended .NET best practice");
 		}
 
+#if !NET
+		[Ignore ("This only applies to .NET")]
+#endif
 		[TestCase (Profile.iOS)]
 		public void Bug18035 (Profile profile)
 		{

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -381,6 +381,18 @@ namespace GeneratorTests {
 			bgen.AssertWarning (1103, "'FooType`1' does not live under a namespace; namespaces are a highly recommended .NET best practice");
 		}
 
+		[TestCase (Profile.iOS)]
+		public void Bug18035 (Profile profile)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (profile.AsPlatform ());
+			var bgen = new BGenTool ();
+			bgen.Profile = profile;
+			bgen.AddTestApiDefinition ("bug18025.cs");
+			bgen.CreateTemporaryBinding ();
+			bgen.AssertExecute ("build");
+			bgen.AssertWarning (1103, "'FooType' does not live under a namespace; namespaces are a highly recommended .NET best practice");
+		}
+
 		[Test]
 		public void Bug40282 ()
 		{

--- a/tests/generator/bug18025.cs
+++ b/tests/generator/bug18025.cs
@@ -1,0 +1,9 @@
+using System;
+using Foundation;
+
+[BaseType (typeof (NSObject))]
+public interface FooType {
+	[Introduced (PlatformName.iOS, 8, 0)]
+	[Export ("getBar:")]
+	string GetBar (string bar);
+}


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/18025.