### PR TITLE
[tests] Ignore DNS lookup failures in CI.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1458,7 +1458,7 @@ partial class TestRuntime {
 		var isDnsResolutionFailed = false;
 		if (se.ErrorCode == 8 /* EAI_NONAME: 'hostname or servname not provided, or not known' */) {
 			isDnsResolutionFailed = true;
-		} else if (se.Message.Contains ("hostname or servname not provided, or not known", StringComparison.Ordinal)) {
+		} else if (se.Message.Contains ("hostname or servname not provided, or not known")) {
 			isDnsResolutionFailed = true;
 		}
 		if (!isDnsResolutionFailed)

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1508,7 +1508,7 @@ partial class TestRuntime {
 		IgnoreInCI ($"Ignored due to CFNetwork error {(CFNetworkErrors) (long) nex.Code}");
 	}
 
-	static T? FindInner<T> (Exception? ex) where T: Exception
+	static T? FindInner<T> (Exception? ex) where T : Exception
 	{
 		while (ex is not null) {
 			if (ex is T target)

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1446,6 +1446,25 @@ partial class TestRuntime {
 
 		IgnoreInCIfHttpStatusCodes (ex, HttpStatusCode.BadGateway, HttpStatusCode.GatewayTimeout, HttpStatusCode.ServiceUnavailable);
 		IgnoreInCIIfNetworkConnectionLost (ex);
+		IgnoreInCIIfDnsResolutionFailed (ex);
+	}
+
+	public static void IgnoreInCIIfDnsResolutionFailed (Exception ex)
+	{
+		var se = FindInner<System.Net.Sockets.SocketException> (ex);
+		if (se is null)
+			return;
+
+		var isDnsResolutionFailed = false;
+		if (se.ErrorCode == 8 /* EAI_NONAME: 'hostname or servname not provided, or not known' */) {
+			isDnsResolutionFailed = true;
+		} else if (se.Message.Contains ("hostname or servname not provided, or not known", StringComparison.Ordinal)) {
+			isDnsResolutionFailed = true;
+		}
+		if (!isDnsResolutionFailed)
+			return;
+
+		IgnoreInCI ($"Ignored due to DNS resolution failure '{se.Message}'");
 	}
 
 	public static void IgnoreInCIIfForbidden (Exception ex)
@@ -1487,6 +1506,16 @@ partial class TestRuntime {
 			return;
 
 		IgnoreInCI ($"Ignored due to CFNetwork error {(CFNetworkErrors) (long) nex.Code}");
+	}
+
+	static T? FindInner<T> (Exception? ex) where T: Exception
+	{
+		while (ex is not null) {
+			if (ex is T target)
+				return target;
+			ex = ex.InnerException;
+		}
+		return null;
 	}
 
 	static bool TryGetHttpStatusCode (Exception ex, out HttpStatusCode status)


### PR DESCRIPTION
This will hopefully fix the following errors:

    [FAIL] TrustUsingNewCallback : System.Net.WebException : nodename nor servname provided, or not known (dotnet.microsoft.com:443)
     ----> System.Net.Http.HttpRequestException : nodename nor servname provided, or not known (dotnet.microsoft.com:443)
     ----> System.Net.Sockets.SocketException : nodename nor servname provided, or not known
    	   at System.Net.HttpWebRequest.GetResponse()
    	   at System.Net.WebClient.GetWebResponse(WebRequest )
    	   at System.Net.WebClient.DownloadBits(WebRequest , Stream )
    	   at System.Net.WebClient.DownloadDataInternal(Uri , WebRequest& )
    	   at System.Net.WebClient.DownloadString(Uri )
    	   at System.Net.WebClient.DownloadString(String )
    	   at LinkSdk.CryptoTest.TrustUsingNewCallback()
    	   at System.Reflection.MethodInvoker.InterpretedInvoke(Object , Span`1 , BindingFlags )
    	--HttpRequestException
    	   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String , Int32 , HttpRequestMessage , Boolean , CancellationToken )
    	   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage , Boolean , CancellationToken )
    	   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage , Boolean , CancellationToken )
    	   at System.Net.Http.HttpConnectionPool.AddHttp11ConnectionAsync(QueueItem )
    	   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1[[System.Net.Http.HttpConnection, System.Net.Http, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]].WaitWithCancellation(CancellationToken )
    	   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1[[System.Net.Http.HttpConnection, System.Net.Http, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]].WaitWithCancellationAsync(Boolean , CancellationToken )
    	   at System.Net.Http.HttpConnectionPool.HttpConnectionWaiter`1.<WaitForConnectionAsync>d__5[[System.Net.Http.HttpConnection, System.Net.Http, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]].MoveNext()
    	   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage , Boolean , Boolean , CancellationToken )
    	   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage , Boolean , CancellationToken )
    	   at System.Net.Http.HttpMessageHandlerStage.Send(HttpRequestMessage , CancellationToken )
    	   at System.Net.Http.SocketsHttpHandler.Send(HttpRequestMessage , CancellationToken )
    	   at System.Net.Http.HttpMessageInvoker.Send(HttpRequestMessage , CancellationToken )
    	   at System.Net.Http.HttpClient.Send(HttpRequestMessage , HttpCompletionOption , CancellationToken )
    	   at System.Net.HttpWebRequest.SendRequest(Boolean )
    	   at System.Net.HttpWebRequest.GetResponse()
    	--SocketException
    	   at System.Net.Dns.GetHostEntryOrAddressesCore(String , Boolean , AddressFamily , Int64 )
    	   at System.Net.Dns.GetHostAddressesCore(String , AddressFamily , Int64 )
    	   at System.Net.Dns.GetHostAddresses(String , AddressFamily )
    	   at System.Net.Dns.GetHostAddresses(String )
    	   at System.Net.Sockets.Socket.Connect(String , Int32 )
    	   at System.Net.Sockets.Socket.Connect(EndPoint )
    	   at System.Net.HttpWebRequest.<>c__DisplayClass219_0.<<CreateHttpClient>b__1>d.MoveNext()
    	--- End of stack trace from previous location ---
    	   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String , Int32 , HttpRequestMessage , Boolean , CancellationToken )