### PR TITLE
[msbuild] Remove the SdkVersion property in the ReadAppManifest task.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadAppManifestTaskBase.cs
@@ -11,9 +11,6 @@ namespace Xamarin.MacDev.Tasks {
 	public abstract class ReadAppManifestTaskBase : XamarinTask {
 		public ITaskItem? AppManifest { get; set; }
 
-		[Required]
-		public string? SdkVersion { get; set; }
-
 		[Output]
 		public string? CLKComplicationGroup { get; set; }
 
@@ -70,7 +67,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (Platform == ApplePlatform.MacCatalyst) {
 				// The minimum version in the Info.plist is the macOS version. However, the rest of our tooling
 				// expects the iOS version, so expose that.
-				if (!MacCatalystSupport.TryGetiOSVersion (Sdks.GetAppleSdk (Platform).GetSdkPath (SdkVersion, false), MinimumOSVersion!, out var convertedVersion, out var knownMacOSVersions))
+				if (!MacCatalystSupport.TryGetiOSVersion (Sdks.GetAppleSdk (Platform).GetSdkPath (string.Empty, false), MinimumOSVersion!, out var convertedVersion, out var knownMacOSVersions))
 					Log.LogError (MSBStrings.E0187, MinimumOSVersion, string.Join (", ", knownMacOSVersions));
 				MinimumOSVersion = convertedVersion;
 			}

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -579,7 +579,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			AppManifest="$(_TemporaryAppManifest)"
-			SdkVersion="$(_SdkVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			>
 			<Output TaskParameter="CFBundleExecutable" PropertyName="_ExecutableName" />

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ReadAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ReadAppManifestTaskTests.cs
@@ -24,7 +24,6 @@ namespace Xamarin.MacDev.Tasks {
 
 			var task = CreateTask<ReadAppManifest> ();
 			task.AppManifest = new TaskItem (plistPath);
-			task.SdkVersion = Sdks.GetAppleSdk (platform).GetInstalledSdkVersions (false).First ().ToString ();
 			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform, true).ToString ();
 
 			return task;


### PR DESCRIPTION
The ReadAppManifest task doesn't need the SdkVersion, because it's only used to compute
the path to the sdk on disk, and that path can be calculated without an sdk version
now:

    $ ls -la /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs
    total 0
    drwxrwxr-x  4 rolf  staff  128 Dec 14 10:58 .
    drwxr-xr-x  5 rolf  staff  160 Nov 11 01:38 ..
    drwxrwxr-x  8 rolf  staff  256 Dec 14 10:48 iPhoneOS.sdk
    lrwxr-xr-x  1 rolf  staff   12 Dec 14 10:56 iPhoneOS16.2.sdk -> iPhoneOS.sdk

In fact, the path with the version just symlinks to the path without.