### PR TITLE
[msbuild] Simplify the CompileAppManifest a bit by removing the SdkPlatform input property.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifestTaskBase.cs
@@ -73,9 +73,6 @@ namespace Xamarin.MacDev.Tasks {
 		public string ResourceRules { get; set; } = String.Empty;
 
 		[Required]
-		public string SdkPlatform { get; set; } = String.Empty;
-
-		[Required]
 		public bool SdkIsSimulator { get; set; }
 
 		[Required]
@@ -91,6 +88,12 @@ namespace Xamarin.MacDev.Tasks {
 		protected TargetArchitecture architectures;
 		IPhoneDeviceType supportedDevices;
 		AppleSdkVersion sdkVersion;
+
+		public string SdkPlatform {
+			get {
+				return GetSdkPlatform (SdkIsSimulator);
+			}
+		}
 
 		public override bool Execute ()
 		{

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -554,7 +554,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ResourceRules="$(_PreparedResourceRules)"
 			TargetArchitectures="$(TargetArchitectures)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
-			SdkPlatform="$(_SdkPlatform)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkVersion="$(_SdkVersion)"
 			SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
@@ -22,7 +22,6 @@ namespace Xamarin.MacDev.Tasks {
 			task.AppBundleName = "AppBundleName";
 			task.CompiledAppManifest = new TaskItem (Path.Combine (tmpdir, "TemporaryAppManifest.plist"));
 			task.DefaultSdkVersion = Sdks.GetAppleSdk (platform).GetInstalledSdkVersions (false).First ().ToString ();
-			task.SdkPlatform = PlatformFrameworkHelper.GetSdkPlatform (platform, false);
 			task.SdkVersion = task.DefaultSdkVersion;
 			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform, true).ToString ();
 

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
@@ -50,7 +50,6 @@ namespace Xamarin.MacDev.Tasks {
 			Task.CompiledAppManifest = new TaskItem (Path.Combine (Cache.CreateTemporaryDirectory (), "AppBundlePath", "Info.plist"));
 			Task.AssemblyName = assemblyName;
 			Task.AppManifest = new TaskItem (CreateTempFile ("foo.plist"));
-			Task.SdkPlatform = "iPhoneSimulator";
 			Task.SdkVersion = "10.0";
 
 			Plist = new PDictionary ();


### PR DESCRIPTION
We don't need the SdkPlatform input, because we can compute it from other input properties.