### PR TITLE
[release/7.0.2xx-xcode14.3] [runtime] Add support for passing on a connect timeout to sdb.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1851,6 +1851,7 @@
 			<MlaunchEnvironmentVariables Include="__XAMARIN_DEBUG_MODE__=$(XamarinDebugMode)" Condition="'$(XamarinDebugMode)' != ''" />
 			<MlaunchEnvironmentVariables Include="__XAMARIN_DEBUG_PORT__=$(XamarinDebugPort)" Condition="'$(XamarinDebugPort)' != ''" />
 			<MlaunchEnvironmentVariables Include="__XAMARIN_DEBUG_HOSTS__=$(XamarinDebugHosts.Replace(';', '%3B'))" Condition="'$(XamarinDebugHosts)' != ''" />
+			<MlaunchEnvironmentVariables Include="__XAMARIN_DEBUG_CONNECT_TIMEOUT__=$(XamarinDebugConnectTimeout)" Condition="'$(XamarinDebugConnectTimeout)' != ''" />
 			<!-- It's not possible to set an item group from the command line, so add support for setting a property (with semi-colon separated items) that we'll include into the item group -->
 			<MlaunchAdditionalArguments Include="$(MlaunchAdditionalArgumentsProperty)" Condition="'$(MlaunchAdditionalArgumentsProperty)' != ''" />
 		</ItemGroup>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateDebugConfigurationTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateDebugConfigurationTaskBase.cs
@@ -26,6 +26,7 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public bool SdkIsSimulator { get; set; }
 
+		public string ConnectTimeout { get; set; }
 		#endregion
 
 		public override bool Execute ()
@@ -51,6 +52,11 @@ namespace Xamarin.MacDev.Tasks {
 
 			builder.Append ("Port: ");
 			builder.AppendLine (DebuggerPort);
+
+			if (!string.IsNullOrEmpty (ConnectTimeout)) {
+				builder.Append ("Connect Timeout: ");
+				builder.AppendLine (ConnectTimeout);
+			}
 
 			var text = builder.ToString ();
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2369,6 +2369,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(_AppResourcesPath)"
+			ConnectTimeout="$(IOSDebugConnectTimeout)"
 			DebugOverWiFi="$(IOSDebugOverWiFi)"
 			DebugIPAddresses="$(_DebugIPAddresses)"
 			DebuggerPort="$(IOSDebuggerPort)"


### PR DESCRIPTION
The timeout can be given:

* By setting the __XAMARIN_DEBUG_CONNECT_TIMEOUT__ environment variable for the app when launching it.
* By passing the XamarinDebugConnectTimeout MSBuild property to 'dotnet run' or 'dotnet build /t:Run'.
* By setting the IOSDebugConnectTimeout MSBuild property at build time.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1778177.


Backport of #18037
