### PR TITLE
[release/7.0.2xx] [tests] Update introspection to run on latest Ventura version.

### DIFF
--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -59,6 +59,9 @@ namespace Introspection {
 			// was removed by apple and is a compat class.
 			case "HMMatterRequestHandler":
 				return true;
+			// CAEdrMetadata needs API updates available with Xcode 14.3 bindings.
+			case "CAEdrMetadata":
+				return true;
 			default:
 				return SkipDueToAttribute (type);
 			}

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -967,6 +967,29 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			// CAEdrMetadata needs API updates available with Xcode 14.3 bindings.
+			case "CAEdrMetadata":
+				switch (selectorName) {
+				case "copyWithZone:":
+				case "encodeWithCoder:":
+					return true;
+				}
+				break;
+			// GCKeyboard needs API updates available with Xcode 14.3 bindings.
+			case "GCKeyboard":
+				switch (selectorName) {
+				case "encodeWithCoder:": // removed comformance
+					return true;
+				}
+				break;
+			// VSUserAccount needs API updates available with Xcode 14.3 bindings.
+			case "VSUserAccount":
+				switch (selectorName) {
+				case "isDeleted":
+				case "setDeleted:":
+					return true;
+				}
+				break;
 #if NET
 			// Incorrect attributes in inlined protocol selectors - https://github.com/xamarin/xamarin-macios/issues/14802
 			case "NSTextAttachment":


### PR DESCRIPTION
The corresponding API fixes are available in our Xcode 14.3 branch, so this is
just to make sure the current branch (supporting Xcode 14.2) doesn't have test
failures when executing on a later version of macOS.

Fixes:

    Introspection.MacApiProtocolTest
    	[FAIL] Coding :   1 types conforms to NSCoding but does not implement INSCoding: CAEdrMetadata
            Expected: 1
            But was:  0
    
        [FAIL] CAEdrMetadata conforms to NSCoding but does not implement INSCoding
    
    		   at Introspection.ApiProtocolTest.Coding() in /Users/builder/azdo/_work/5/s/xamarin-macios/tests/introspection/ApiProtocolTest.cs:line 611
    	[FAIL] Copying :   1 types conforms to NSCopying but does not implement INSCopying: CAEdrMetadata
            Expected: 1
            But was:  0
    
        [FAIL] CAEdrMetadata conforms to NSCopying but does not implement INSCopying
    
    		   at Introspection.ApiProtocolTest.Copying() in /Users/builder/azdo/_work/5/s/xamarin-macios/tests/introspection/ApiProtocolTest.cs:line 703
    	[FAIL] SecureCoding :   1 types conforms to NSSecureCoding but does not implement INSSecureCoding: 
            Expected: 1
            But was:  0
            
        [FAIL] CAEdrMetadata conforms to NSSecureCoding but does not implement INSSecureCoding
    
    		   at Introspection.ApiProtocolTest.SecureCoding() in /Users/builder/azdo/_work/5/s/xamarin-macios/tests/introspection/ApiProtocolTest.cs:line 627
    		   at Introspection.MacApiProtocolTest.SecureCoding() in /Users/builder/azdo/_work/5/s/xamarin-macios/tests/introspection/Mac/MacApiProtocolTest.cs:line 442
    Introspection.MacApiProtocolTest : 1406.182 ms
    
    Introspection.MacApiSelectorTest
    	[FAIL] InstanceMethods :   3 errors found in 32150 instance selector validated:
            Selector not found for VideoSubscriberAccount.VSUserAccount : isDeleted in Boolean get_Deleted() on VideoSubscriberAccount.VSUserAccount
            Selector not found for VideoSubscriberAccount.VSUserAccount : setDeleted: in Void set_Deleted(Boolean) on VideoSubscriberAccount.VSUserAccount
            Selector not found for GameController.GCKeyboard : encodeWithCoder: in Void EncodeTo(Foundation.NSCoder) on GameController.GCKeyboard
            Expected: 0
            But was:  3
    
        [FAIL] Selector not found for VideoSubscriberAccount.VSUserAccount : isDeleted in Boolean get_Deleted() on VideoSubscriberAccount.VSUserAccount
        [FAIL] Selector not found for VideoSubscriberAccount.VSUserAccount : setDeleted: in Void set_Deleted(Boolean) on VideoSubscriberAccount.VSUserAccount
        [FAIL] Selector not found for GameController.GCKeyboard : encodeWithCoder: in Void EncodeTo(Foundation.NSCoder) on GameController.GCKeyboard
    		   at Introspection.ApiSelectorTest.InstanceMethods() in /Users/builder/azdo/_work/5/s/xamarin-macios/tests/introspection/ApiSelectorTest.cs:line 1137