### PR TITLE
[devops] Split building the macOS tests from the main build stage.

### DIFF
--- a/tools/devops/automation/templates/build/build-mac-tests-stage.yml
+++ b/tools/devops/automation/templates/build/build-mac-tests-stage.yml
@@ -1,0 +1,122 @@
+# template that contains all the different steps to create a pkgs, publish the results and provide feedback to the
+# developers in github.
+parameters:
+- name: vsdropsPrefix
+  type: string
+
+- name: keyringPass
+  type: string
+
+- name: gitHubToken
+  type: string
+
+- name: xqaCertPass
+  type: string
+
+- name: enableDotnet
+  type: boolean
+  default: false
+
+- name: pool
+  type: string
+  default: automatic
+
+- name: isPR
+  type: boolean
+
+- name: repositoryAlias
+  type: string
+  default: self
+
+- name: commit
+  type: string
+  default: HEAD
+
+- name: xcodeChannel
+  type: string
+
+- name: macOSName
+  type: string
+
+jobs:
+- job: configure
+  displayName: 'Configure build'
+  pool:
+    vmImage: windows-latest
+
+  variables:
+    isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+    isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+
+  steps:
+  - template: ../common/configure.yml
+    parameters:
+      repositoryAlias: ${{ parameters.repositoryAlias }}
+      commit: ${{ parameters.commit }}
+      uploadArtifacts: true
+      enableDotnet: ${{ parameters.enableDotnet }}
+
+- ${{ if eq(parameters.pool, 'automatic') }}:
+  - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
+    pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
+      vmImage: ubuntu-latest
+    steps:
+    - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
+
+    # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
+    - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
+      parameters:
+        agentPoolPR: $(PRBuildPool)
+        agentPoolPRUrl: $(PRBuildPoolUrl)
+        agentPoolCI: $(CIBuildPool)
+        agentPoolCIUrl: $(CIBuildPoolUrl)
+
+# This job builds the macOS tests.
+#
+# - configure: Get the labels from gihub and populate the output.
+# - AgentPoolSelector: If the build was not manually triggered to use a specific pool, this job is used to decide if the build is using a 
+#                      private pool or a public one.
+- job: build_macos_tests_job
+  dependsOn:
+  - ${{ if eq(parameters.pool, 'automatic') }}:
+    - AgentPoolSelector
+  - configure
+  displayName: 'Build macOS tests'
+  timeoutInMinutes: 120
+  variables:
+    DOTNET_PLATFORMS: $[ dependencies.configure.outputs['configure_platforms.DOTNET_PLATFORMS'] ]
+    ENABLE_DOTNET: $[ dependencies.configure.outputs['configure_platforms.ENABLE_DOTNET'] ]
+    INCLUDE_XAMARIN_LEGACY: $[ dependencies.configure.outputs['configure_platforms.INCLUDE_XAMARIN_LEGACY'] ]
+    ${{ if eq(parameters.pool, 'automatic') }}:
+      AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
+    ${{ if eq(parameters.pool, 'ci') }}:
+      AgentPoolComputed: $(CIBuildPool)
+    ${{ if eq(parameters.pool, 'pr') }}:
+      AgentPoolComputed: $(PRBuildPool)
+    # add all the variables that have been parsed by the configuration step. Could we have a less verbose way??
+    # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
+    PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
+    # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
+    BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+    RUN_MAC_TESTS: $[ dependencies.configure.outputs['decisions.RUN_MAC_TESTS'] ]
+  condition: ne(dependencies.configure.outputs['decisions.RUN_MAC_TESTS'],'')
+  pool:
+    name: $(AgentPoolComputed)
+    demands:
+    - Agent.OS -equals Darwin
+    - macOS.Name -equals ${{ parameters.macOSName }}
+    - XcodeChannel -equals ${{ parameters.xcodeChannel }}
+  workspace:
+    clean: all
+
+  steps:
+  - template: build-mac-tests.yml
+    parameters:
+      isPR: ${{ parameters.isPR }}
+      repositoryAlias: ${{ parameters.repositoryAlias }}
+      commit: ${{ parameters.commit }}
+      vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
+      keyringPass: ${{ parameters.keyringPass }}
+      gitHubToken: ${{ parameters.gitHubToken }}
+      xqaCertPass: ${{ parameters.xqaCertPass }}
+      enableDotnet: ${{ parameters.enableDotnet }}

--- a/tools/devops/automation/templates/build/build-mac-tests.yml
+++ b/tools/devops/automation/templates/build/build-mac-tests.yml
@@ -1,0 +1,97 @@
+parameters:
+- name: vsdropsPrefix
+  type: string
+
+- name: keyringPass
+  type: string
+
+- name: gitHubToken
+  type: string
+
+- name: xqaCertPass
+  type: string
+
+- name: enableDotnet
+  type: boolean
+  default: false
+
+- name: uploadBinlogs
+  type: boolean
+  default: true
+
+- name: isPR
+  type: boolean
+
+- name: repositoryAlias
+  type: string
+  default: self
+
+- name: commit
+  type: string
+  default: HEAD
+
+- name: uploadPrefix
+  type: string
+  default: '$(MaciosUploadPrefix)'
+
+steps:
+- template: build.yml
+  parameters:
+    isPR: ${{ parameters.isPR }}
+    repositoryAlias: ${{ parameters.repositoryAlias }}
+    commit: ${{ parameters.commit }}
+    vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
+    keyringPass: ${{ parameters.keyringPass }}
+    gitHubToken: ${{ parameters.gitHubToken }}
+    xqaCertPass: ${{ parameters.xqaCertPass }}
+    enableDotnet: ${{ parameters.enableDotnet }}
+    buildSteps:
+
+    # funny enough we need these profiles to build the mac tests
+    - bash: '"$BUILD_SOURCESDIRECTORY"/maccore/tools/install-qa-provisioning-profiles.sh -v'
+      displayName: 'Add tests provisioning profiles'
+      timeoutInMinutes: 30
+      continueOnError: true # should not stop the build will result in test failures but we do want the pkg
+      env:
+        AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
+        AUTH_TOKEN_LA_DEV_APPLE_P12: ${{ parameters.xqaCertPass }}
+        AUTH_TOKEN_LA_DISTR_APPLE_P12: ${{ parameters.xqaCertPass }}
+        AUTH_TOKEN_LA_MAC_INSTALLER_DISTR_P12: ${{ parameters.xqaCertPass }}
+        AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_P12: ${{ parameters.xqaCertPass }}
+        AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_2_P12: ${{ parameters.xqaCertPass }}
+
+    - bash: |
+        set -x
+        set -e
+
+        make -C $(Build.SourcesDirectory)/xamarin-macios/tests package-tests
+
+        if test -f "$(Build.SourcesDirectory)/xamarin-macios/tests/mac-test-package.7z"; then
+          set +x
+          echo "##vso[artifact.upload containerfolder=CrashReports;artifactname=${{ parameters.uploadPrefix }}mac-test-package]$(Build.SourcesDirectory)/xamarin-macios/tests/mac-test-package.7z"
+          set -x
+        fi
+
+      name: macTestPkg
+      displayName: 'Package macOS tests'
+      condition: and(succeeded(), contains(variables['RUN_MAC_TESTS'], 'true'))
+      timeoutInMinutes: 60
+
+    - ${{ if eq(parameters.uploadBinlogs, true) }}:
+      # Copy all the binlogs to a separate directory, keeping directory structure.
+      - script: |
+          set -x
+          mkdir -p $(Build.ArtifactStagingDirectory)/mactests-binlogs
+          rsync -av --prune-empty-dirs --include '*/' --include '*.binlog' --exclude '*' $(Build.SourcesDirectory)/xamarin-macios $(Build.ArtifactStagingDirectory)/mactests-binlogs
+        displayName: Copy all binlogs
+        continueOnError: true
+        condition: succeededOrFailed()
+
+      # Publish all the binlogs we collected in the previous step
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish Artifact: All binlogs'
+        inputs:
+          targetPath: $(Build.ArtifactStagingDirectory)/mactests-binlogs
+          artifactName: '${{ parameters.uploadPrefix }}mactests-binlogs-$(Build.BuildId)-$(System.JobAttempt)'
+        continueOnError: true
+        condition: succeededOrFailed()

--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -126,37 +126,6 @@ steps:
         artifactName: '${{ parameters.uploadPrefix }}not-signed-package'
       continueOnError: true
 
-    # funny enough we need these profiles to build the mac tests
-    - bash: '"$BUILD_SOURCESDIRECTORY"/maccore/tools/install-qa-provisioning-profiles.sh -v'
-      displayName: 'Add tests provisioning profiles'
-      timeoutInMinutes: 30
-      continueOnError: true # should not stop the build will result in test failures but we do want the pkg
-      env:
-        AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
-        AUTH_TOKEN_LA_DEV_APPLE_P12: ${{ parameters.xqaCertPass }}
-        AUTH_TOKEN_LA_DISTR_APPLE_P12: ${{ parameters.xqaCertPass }}
-        AUTH_TOKEN_LA_MAC_INSTALLER_DISTR_P12: ${{ parameters.xqaCertPass }}
-        AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_P12: ${{ parameters.xqaCertPass }}
-        AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_2_P12: ${{ parameters.xqaCertPass }}
-
-    - bash: |
-        set -x
-        set -e
-
-        make -C $(Build.SourcesDirectory)/xamarin-macios/tests package-tests
-
-        if test -f "$(Build.SourcesDirectory)/xamarin-macios/tests/mac-test-package.7z"; then
-          set +x
-          echo "##vso[artifact.upload containerfolder=CrashReports;artifactname=${{ parameters.uploadPrefix }}mac-test-package]$(Build.SourcesDirectory)/xamarin-macios/tests/mac-test-package.7z"
-          set -x
-        fi
-
-      name: macTestPkg
-      displayName: 'Package macOS tests'
-      condition: and(succeeded(), contains(variables['RUN_MAC_TESTS'], 'true'))
-      continueOnError: true # not a terrible blocking issue
-      timeoutInMinutes: 60
-
     - bash: |
         set -x
         set -e

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -217,7 +217,6 @@ steps:
 
 # We'll need these profiles to build the hot restart prebuilt app during the build
 # (it's built for device, and thus needs a certificate available so that the app can be signed).
-# We do this again before running the tests further below.
 - bash: |
     set -x
     set -e

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -137,39 +137,6 @@ steps:
   displayName: "Remove artifacts"
   condition: always()
 
-- task: DownloadPipelineArtifact@2
-  displayName: Download not notarized build
-  inputs:
-    artifact: '${{ parameters.uploadPrefix }}not-signed-package'
-    allowFailedBuilds: true
-    path: $(Build.SourcesDirectory)/package
-
-- pwsh: |
-    $dir = "$(Build.SourcesDirectory)/package"
-    Dir $dir
-    $items = Get-ChildItem $dir -Recurse
-    foreach ($i in $items) {
-      if ($i.Name -like "xamarin.mac-*.pkg") {
-        $path = $i.FullName
-        Write-Host "##vso[task.setvariable variable=XM_PACKAGE;]$path"
-      }
-    }
-  displayName: 'Set Mac pkgs url'
-  timeoutInMinutes: 5
-
-- bash: |
-    echo "Pkg uri is $XM_PACKAGE"
-    make -C $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/ mac-tests-provisioning.csx
-  displayName: 'Generate Provisionator csx file'
-
-- task: xamops.azdevex.provisionator-task.provisionator@2
-  displayName: 'Provision Products & Frameworks'
-  inputs:
-    provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/mac-tests-provisioning.csx
-    provisioning_extra_args: '-vvvv'
-    github_token: $(Github.Token)
-  timeoutInMinutes: 250
-
 # Executed ONLY if we want to clear the provisionator cache.
 - bash: rm -rf "$TOOLS_DIR/provisionator"
   env:
@@ -185,20 +152,13 @@ steps:
     allowFailedBuilds: true
     path: $(Build.SourcesDirectory)/artifacts/tmp
 
-# sometimes the make that creates the pkgs fails.
 - bash: |
     set -ex
-    if ! test -f $(Build.SourcesDirectory)/artifacts/tmp/${{ parameters.uploadPrefix }}mac-test-package/mac-test-package.7z; then
-      echo "No test package could be found for tests on macOS $CONTEXT" > "$GITHUB_FAILURE_COMMENT_FILE"
-      exit 1
-    fi
     ls -Rla $(Build.SourcesDirectory)/artifacts/tmp
     7z x $(Build.SourcesDirectory)/artifacts/tmp/${{ parameters.uploadPrefix }}mac-test-package/mac-test-package.7z -o$(Build.SourcesDirectory)/artifacts/ -bb1
     # no prefix! we did expand to the exact name we are using
     ls -Rla $(Build.SourcesDirectory)/artifacts/mac-test-package
   displayName: Expand tests.
-  env:
-    CONTEXT: ${{ parameters.statusContext }}
 
 - bash: |
     ls -Rla $(Build.SourcesDirectory)/artifacts

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -43,8 +43,8 @@ stages:
 - stage: ${{ parameters.stageName }}
   displayName: ${{ parameters.displayName }}
   dependsOn:
-  - build_packages
-  condition: and(succeeded(), eq(dependencies.build_packages.outputs['configure.decisions.RUN_MAC_TESTS'], 'true'))
+  - build_macos_tests
+  condition: and(succeeded(), eq(dependencies.build_macos_tests.outputs['configure.decisions.RUN_MAC_TESTS'], 'true'))
   variables:
     GITHUB_FAILURE_COMMENT_FILE: $(System.DefaultWorkingDirectory)/github-comment-file.md
 
@@ -83,7 +83,7 @@ stages:
 
     variables:
       PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
-      GIT_HASH: $[ stageDependencies.build_packages.build.outputs['fix_commit.GIT_HASH'] ]
+      GIT_HASH: $[ stageDependencies.build_macos_tests.build.outputs['fix_commit.GIT_HASH'] ]
 
     steps:
     - template: build.yml

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -235,6 +235,26 @@ stages:
       skipESRP: ${{ parameters.skipESRP }}
       pool: ${{ parameters.pool }}
 
+- stage: build_macos_tests
+  displayName: '${{ parameters.stageDisplayNamePrefix }}Build macOS tests'
+  dependsOn: ${{ parameters.dependsOn }}
+  ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
+    condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
+  jobs:
+  - template: ./build/build-mac-tests-stage.yml
+    parameters:
+      xcodeChannel: ${{ parameters.xcodeChannel }}
+      macOSName: ${{ parameters.macOSName }}
+      isPR: ${{ parameters.isPR }}
+      repositoryAlias: ${{ parameters.repositoryAlias }}
+      commit: ${{ parameters.commit }}
+      vsdropsPrefix: ${{ variables.vsdropsPrefix }}
+      keyringPass: $(pass--lab--mac--builder--keychain)
+      gitHubToken: $(Github.Token)
+      xqaCertPass: $(xqa--certificates--password)
+      enableDotnet: ${{ parameters.enableDotnet }}
+      pool: ${{ parameters.pool }}
+
 - ${{ each pkg_obj in parameters.packages }}:
   - stage: ${{ pkg_obj.job }}
     displayName: '${{ parameters.stageDisplayNamePrefix }}${{ pkg_obj.displayName }}'


### PR DESCRIPTION
This has a few benefits:

* We can get packages build sooner, since the main build stage is faster
  (about 10 minutes faster, since that's how long it takes to build the macOS
  tests).
* We can re-start the macOS test building stage without having to re-do the
  entire main build stage (which would also cause a re-run of all the other
  tests).
* It's easier to see if the macOS test failed to build, since they're not as
  hidden (we can make them red instead of orange since they won't cause
  packages to fail to build/publish anymore).