### PR TITLE
[dotnet] Added one more test to ensure that multiple types in a file work.

### DIFF
--- a/tools/class-redirector/class-redirector-tests/CodeTests.cs
+++ b/tools/class-redirector/class-redirector-tests/CodeTests.cs
@@ -371,7 +371,5 @@ namespace ObjCRuntime {
 		var codeOutput = Compiler.Run ("mono", new List<string> () { result.OutputFileName });
 		Assert.That (codeOutput, Is.EqualTo ("0x2c\n"), "incorrect executable output");
 	}
-
-
 }
 

--- a/tools/class-redirector/class-redirector-tests/CodeTests.cs
+++ b/tools/class-redirector/class-redirector-tests/CodeTests.cs
@@ -305,5 +305,73 @@ namespace ObjCRuntime {
 		var cctor = type.Methods.FirstOrDefault (m => m.Name == ".cctor");
 		Assert.IsNull (cctor, "we had a cctor - oops");
 	}
+
+	const string multiObjectCode = @"
+namespace ObjCRuntime {
+	public class Program {
+		public static int Main (string[] args) {
+			var map = new Runtime.MTClassMap [] {
+				new Runtime.MTClassMap(new IntPtr (42), 0, Runtime.MTTypeFlags.None),
+				new Runtime.MTClassMap(new IntPtr (43), 1, Runtime.MTTypeFlags.None),
+				new Runtime.MTClassMap(new IntPtr (44), 2, Runtime.MTTypeFlags.None),
+			};
+			unsafe {
+				fixed (Runtime.MTClassMap* mapPtr = &map [0]) {
+					Runtime.ClassHandles.InitializeClassHandles (mapPtr);
+				}
+			}
+			var baz = new Baz ();
+			Console.WriteLine (baz.ClassHandle);
+			return 0;
+		}
+	}
+
+	public class Class {
+		public static NativeHandle GetHandle (string s) {
+			return NativeHandle.Zero;
+		}
+	}
+
+	public class Foo {
+		static NativeHandle class_ptr = Class.GetHandle (""nothing"");
+		public Foo () { }
+		public NativeHandle ClassHandle => class_ptr;
+	}
+
+	public class Bar {
+		static NativeHandle class_ptr = Class.GetHandle (""nothing"");
+		public Bar () { }
+		public NativeHandle ClassHandle => class_ptr;
+	}
+
+	public class Baz {
+		static NativeHandle class_ptr = Class.GetHandle (""nothing"");
+		public Baz () { }
+		public NativeHandle ClassHandle => class_ptr;
+	}
+}
+";
+
+	[Test]
+	public void MultiObjects ()
+	{
+		var testCode = commonCode + multiObjectCode;
+		var result = Compiler.Compile (testCode);
+		Assert.That (String.IsNullOrEmpty (result.Error), $"Compile failure: {result.Error}");
+
+		var map = new CSToObjCMap () {
+			["ObjCRuntime.Foo"] = new ObjCNameIndex ("xxx", 0),
+			["ObjCRuntime.Bar"] = new ObjCNameIndex ("yyy", 1),
+			["ObjCRuntime.Baz"] = new ObjCNameIndex ("zzz", 2),
+		};
+
+
+		var rewriter = new Rewriter (map, result.OutputFileName, new string [] { result.OutputFileName });
+		rewriter.Process ();
+		var codeOutput = Compiler.Run ("mono", new List<string> () { result.OutputFileName });
+		Assert.That (codeOutput, Is.EqualTo ("0x2c\n"), "incorrect executable output");
+	}
+
+
 }
 


### PR DESCRIPTION
I wanted to make sure that multiple classes work correctly.
In all the previous tests, I was looking at either 1 class or the first class. Great, that works, but keep in mind that the code initializes the class handles looks like this:
```
ClassHandles.SomeObjCName = map [const].handle
```
I'm not really writing this code, since I'm writing directly in IL. The code that I generate looks like this:
```
ldarg map
ldc.i4 const
sizeof ObjCRuntime.Runtime/MTClassMap
mul
add
ldfld ObjCRuntime.Runtime/MTClassMap::handle
```
So what does that do?
1 - puts the address of the start of the map on the stack
2 - puts a constant (the index of the item we care about) on the stack
3 - puts the size of the MTClassMap on the stack
4 - multiply 2 & 3, leaving the result on the stack (this is the offset in bytes to the struct we want)
5 - add 1 and 4, leaving the address of the struct we want to access on the stack

Up to now, all the tests were operating with `const` being 0. You can understand that multiplying by zero in all the tests is not properly exercising this code. 