### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 17751: Build ID 7636799

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
@@ -1,6 +1,6 @@
-{
+﻿{
   "author": "Microsoft",
-  "name": "Vista de Mac\u00A0Catalyst",
+  "name": "Vista de Mac Catalyst",
   "description": "Vista de MacCatalyst",
   "symbols/namespace/description": "espacio de nombres para el código generado"
 }

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} má nesprávný nebo neznámý formát a nedá se zpracovat.
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>V „{0}“ nebyla nalezena odpovídající architektura.
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Konfliktní možnosti {0} a {1}. {1} se bude ignorovat.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Neočekávané rozšíření{0}pro nativní odkaz{1}v manifestu{2}</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} weist ein ungültiges oder unbekanntes Format auf und kann nicht verarbeitet werden.
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>In "{0}" wurde kein passendes Framework gefunden.
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Optionen „{0}“ und „{1}“ sind widersprüchlich. '{1}' wird ignoriert.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Unerwartete Erweiterung "{0}" für systemeigenen Verweis "{1}" im Manifest "{2}".</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} tiene un formato incorrecto o desconocido y no se puede procesar.
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>No se ha encontrado ninguna estructura que empate dentro de '{0}".
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Opciones en conflicto '{0}" y "{1}" opciones. '{1}' será ignorado.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Extensión inesperada '{0}' para la referencia nativa '{1}' en el manifiesto '{2}'.</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} a un format incorrect ou inconnu et ne peut pas être traité.
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>Aucune infrastructure correspondante n’a été trouvée dans' {0} '.
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Les options « {0} » et « {1} » sont en conflit. « {1} » sera ignoré.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Extension inattendue '{0}' pour la référence native '{1}' dans le manifeste '{2}'.</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} ha un formato non corretto o sconosciuto e non può essere elaborato.
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>Non è stato trovato alcun framework corrispondente in "{0}".
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Le opzioni "{0}" e "{1}" sono in conflitto. "{1}" verrà ignorato.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Estensione imprevista '{0}' per il riferimento nativo '{1}' nel manifesto '{2}'.</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} の形式が正しくないか、不明なため、処理できません。
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>一致するフレームワークが '{0}' 内に見つかりませんでした。
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>'{0}' と '{1}' のオプションが競合しています。'{1}' は無視されます。
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>マニフェスト '{2}' のネイティブ参照 '{1}' に予期しない拡張機能 '{0}'。</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0}의 형식이 잘못되었거나 알 수 없으므로 처리할 수 없습니다.
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>'{0}' 내에서 일치하는 프레임워크를 찾을 수 없습니다.
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>'{0}' 옵션과 '{1}' 옵션이 충돌합니다. '{1}'은(는) 무시됩니다.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>매니페스트 '{2}'의 네이티브 참조 '{1}'에 대한 예기치 않은 확장 '{0}'.</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} ma niepoprawny lub nieznany format i nie można go przetworzyć.
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>W elemencie "{0}" nie znaleziono żadnej zgodnej struktury.
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Konflikt opcji "{0}" i "{1}". Element "{1}" zostanie zignorowany.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Nieoczekiwane rozszerzenie „{0}” dla natywnego odwołania „{1}” w manifeście „{2}”.</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} tem um formato incorreto ou desconhecido e não pode ser processado.
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>Nenhuma estrutura correspondente encontrada dentro de '{0}'.
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Opções conflitantes '{0}' e '{1}'. '{1}' será ignorado.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Extensão inesperada '{0}' para referência nativa '{1}' no manifesto '{2}'.</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} имеет неправильный или неизвестный формат и не может быть обработан.
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>Не найдена соответствующая платформа в "{0}".
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Конфликтующие параметры "{0}" и "{1}". "{1}" будет пропущен.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Непредвиденное расширение "{0}" для собственной ссылки "{1}" в манифесте "{2}".</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} geçersiz veya bilinmeyen bir biçimde ve işlenemiyor.
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>'{0}' içinde eşleşen çerçeve bulunamadı.
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>'{0}' ve '{1}' seçenekleri çakışıyor. '{1}' yoksayılacak.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>'{2}' bildiriminde '{1}' yerel başvurusu için beklenmeyen '{0}' uzantısı.</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} 的格式不正确或未知，无法处理。
-        </value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>在“{0}”中找不到匹配的框架。
-        </value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>“{0}”和“{1}”选项冲突。将忽略“{1}”。
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>清单“{2}”中本机引用“{1}”的意外扩展“{0}”。</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} 的格式未知或不正確，因此無法處理。
-</value>
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>在 '{0}' 內找不到相符的架構。
-</value>
+        <value>No matching framework found inside '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>衝突的 '{0}' 和 '{1}' 選項。將忽略 '{1}'。
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>在資訊清單 '{2}' 中的原生參考 '{1}' 發生非預期的延伸模組 '{0}'。</value>
+        <value>Unexpected extension '{0}' for native reference '{1}' in binding resource package '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Expected a file named '{1}' in the zip file {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>The zip file '{0}' does not exist.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>The file '{0}' does not exist.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Unable to process the item '{0}' as a native reference: unknown type.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Could not load Info.plist '{0}' from the xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>The directory '{0}' does not exist.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Could not find the file or directory '{0}' in the zip file '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Can't process the zip file '{0}' on this platform: the file '{1}' is a symlink.</value>
     </data>
 </root>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.