### PR TITLE
[xcode14.3] [maestro] Make 'Microsoft.NETCore.App.Ref' depend on 'Microsoft.Dotnet.Sdk.Internal'.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -644,6 +644,9 @@ EMSCRIPTEN_MANIFEST_VERSION_BAND=$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)
 # It should typically be $(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT), unless we decide to hardcode it to something else
 MACIOS_MANIFEST_VERSION_BAND=$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)
 
+# Set this to 1 if the Microsoft.NETCore.App.Ref dependency in eng/Version.Details.xml does *not* specify a CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal.
+TRACKING_DOTNET_RUNTIME_SEPARATELY=
+
 # The location of csc changes depending on whether we're using a preview or a stable/service release :/
 DOTNET_CSC_PATH_PREVIEW=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION)/Roslyn/bincore/csc.dll
 DOTNET_CSC_PATH_STABLE=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION_BAND)/Roslyn/bincore/csc.dll

--- a/NuGet.config
+++ b/NuGet.config
@@ -14,7 +14,6 @@
     <!--  Begin: Package sources from dotnet-aspnetcore -->
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-pub-dotnet-runtime-1e9466d" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-1e9466d9/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -41,6 +41,8 @@
     <add key="darc-pub-dotnet-runtime-e013e98" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-e013e98b/nuget/v3/index.json" />
     <!-- Add a 6.0.16 feed -->
     <add key="darc-pub-dotnet-runtime-00c6cedf" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-00c6cedf/nuget/v3/index.json" />
+    <!-- Add a 6.0.17 feed -->
+    <add key="darc-pub-dotnet-runtime-3e10983" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-3e109839/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -132,13 +132,17 @@ endif
 endif
 
 .stamp-install-custom-dotnet-runtime-workloads:
+ifneq ($(TRACKING_DOTNET_RUNTIME_SEPARATELY),)
 	@# mono toolchain
+	$(Q) mkdir -p ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)
 	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.mono.toolchain.net7.manifest-$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)/$(DOWNLOAD_DOTNET_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain.net7/
 	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.mono.toolchain.net6.manifest-$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)/$(DOWNLOAD_DOTNET_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain.net6/
-	@# emscripten, which mono depens on
+	@# emscripten, which mono depends on
+	$(Q) mkdir -p ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(EMSCRIPTEN_MANIFEST_VERSION_BAND)
 	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.emscripten.net7.manifest-$(EMSCRIPTEN_MANIFEST_VERSION_BAND)/$(EMSCRIPTEN_MANIFEST_PACKAGE_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(EMSCRIPTEN_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten.net7/
 	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.emscripten.net6.manifest-$(EMSCRIPTEN_MANIFEST_VERSION_BAND)/$(EMSCRIPTEN_MANIFEST_PACKAGE_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(EMSCRIPTEN_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten.net6/
 	$(Q) touch $@
+endif
 
 package-download/all-package-references.csproj: $(TOP)/.git/HEAD $(TOP)/.git/index ./create-csproj-for-all-packagereferences.sh
 	$(Q_GEN) ./create-csproj-for-all-packagereferences.sh --output "$(abspath $@.tmp)" $(if $(V),-v,)
@@ -155,6 +159,7 @@ package-download/all-package-references.csproj: $(TOP)/.git/HEAD $(TOP)/.git/ind
 		/p:CustomDotNetVersion="$(DOWNLOAD_DOTNET_VERSION)" \
 		/p:MonoToolChainManifestVersionBand="$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)" \
 		/p:EmscriptenManifestVersionBand="$(EMSCRIPTEN_MANIFEST_VERSION_BAND)" \
+		/p:TrackingDotNetRuntimeSeparately="$(TRACKING_DOTNET_RUNTIME_SEPARATELY)" \
 		/bl \
 		$(DOTNET_BUILD_VERBOSITY)
 	$(MAKE) .stamp-install-custom-dotnet-runtime-workloads

--- a/builds/package-download/download-packages.csproj
+++ b/builds/package-download/download-packages.csproj
@@ -21,12 +21,12 @@
     <PackageDownload Include="microsoft.netcore.app.ref" Version="[$(ActualPackageVersion)]" />
 
     <!-- and get the mono workload(s) as well -->
-    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(MonoToolChainManifestVersionBand)" Version="[$(ActualPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest-$(MonoToolChainManifestVersionBand)" Version="[$(ActualPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(MonoToolChainManifestVersionBand)" Version="[$(ActualPackageVersion)]" Condition="'$(TrackingDotNetRuntimeSeparately)' != ''" />
+    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest-$(MonoToolChainManifestVersionBand)" Version="[$(ActualPackageVersion)]" Condition="'$(TrackingDotNetRuntimeSeparately)' != ''" />
 
     <!-- and get the emscripten workload(s) as well -->
-    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net7.Manifest-$(EmscriptenManifestVersionBand)" Version="[$(EmscriptenWorkloadVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net6.Manifest-$(EmscriptenManifestVersionBand)" Version="[$(EmscriptenWorkloadVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net7.Manifest-$(EmscriptenManifestVersionBand)" Version="[$(Emscriptennet7WorkloadVersion)]" Condition="'$(TrackingDotNetRuntimeSeparately)' != ''" />
+    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net6.Manifest-$(EmscriptenManifestVersionBand)" Version="[$(Emscriptennet6WorkloadVersion)]" Condition="'$(TrackingDotNetRuntimeSeparately)' != ''" />
   </ItemGroup>
 
   <Import Project="all-package-references.csproj" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,25 +1,22 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.203-servicing.23170.23">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.204-servicing.23204.18">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>332c2bc24954c8305a1985bd8e52088cc6b6a677</Sha>
+      <Sha>fd186ea3cb577d02e7701ec8dce22771f60480c4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="7.0.100-1.23062.2" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/linker</Uri>
       <Sha>19fa656d35252ccf926e6a6d783b16a2f094aaef</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>1e9466d9a2913f3a45893851f79b54da11ba3069</Sha>
+    <!-- Set TRACKING_DOTNET_RUNTIME_SEPARATELY to something in Make.config if removing the CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal -->
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
+      <Sha>0a396acafe9a7d46bce11f4338dbb3dd0d99b1b4</Sha>
     </Dependency>
     <!-- This is required for our test apps to build; in some cases Microsoft.AspNetCore.App is pulled in, and when building test apps the build needs to be able to resolve that -->
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="7.0.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
       <Sha>e56abc45c4f8adc518abfc11a59849d616431e2c</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
-      <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>3d7178d836ea32bb7bb51d8d1c714d52fe641ffa</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,13 +1,15 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>7.0.203-servicing.23170.23</MicrosoftDotnetSdkInternalPackageVersion>
+    <!-- Versions updated by maestro -->
+    <MicrosoftDotnetSdkInternalPackageVersion>7.0.204-servicing.23204.18</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>7.0.100-1.23062.2</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETILStripTasksPackageVersion>6.0.0-rc.2.21468.3</MicrosoftNETILStripTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>7.0.5</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>7.0.4</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>7.0.4</MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
+    <MicrosoftDotNetCecilPackageVersion>0.11.4-alpha.23113.1</MicrosoftDotNetCecilPackageVersion>
     <!-- Manually updated versions -->
     <EmscriptenWorkloadVersion>$(MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion)</EmscriptenWorkloadVersion>
     <!-- custom variables -->

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "7.0.203-servicing.23170.23"
+    "version": "7.0.204-servicing.23204.18"
   }
 }


### PR DESCRIPTION
This way we always get a consistent build (at the cost of flexibility:
sometimes we won't be getting 'Microsoft.NETCore.App.Ref' updates for a while
if either dotnet/runtime or dotnet/sdk have security fixes in the works, but
this shouldn't be much of an issue for a stable .NET version, since we usually
work with any dotnet/runtime version at that point).

Also fix a duplicated entry for 'Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100',
and run 'darc update-dependencies' to update the dependencies.


Backport of #18026
