### PR TITLE
[xharness] Add support for tests labeled 'Windows'.

### DIFF
--- a/tests/xharness/TestLabel.cs
+++ b/tests/xharness/TestLabel.cs
@@ -76,6 +76,8 @@ namespace Xharness {
 		Xtro = 1 << 27,
 		[Label ("packaged-macos")]
 		PackagedMacOS = 1 << 28,
+		[Label ("windows")]
+		Windows = 1 << 29,
 		[Label ("all")]
 		All = Int64.MaxValue,
 	}


### PR DESCRIPTION
We already have support for 'run-windows-tests' and 'skip-windows-tests' labels: 3e86254ef8f91b41eafcecdf3934fc74c7f115d9.