### PR TITLE
[tests] Remove files from the generator tests to fix compiler warnings.

### DIFF
--- a/src/bgen/AttributeFactory.ConstructorArguments.cs
+++ b/src/bgen/AttributeFactory.ConstructorArguments.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using ObjCRuntime;
 
 #nullable enable
@@ -66,7 +67,7 @@ public static partial class AttributeFactory {
 			return new [] { PlatformEnum, typeof (int), typeof (int), typeof (int), typeof (string) };
 		}
 
-		public static bool TryGetCtorArguments (object [] constructorArguments, PlatformName platform, out object? []? ctorValues, out Type []? ctorTypes)
+		public static bool TryGetCtorArguments (object [] constructorArguments, PlatformName platform, [NotNullWhen (true)] out object? []? ctorValues, [NotNullWhen (true)] out Type []? ctorTypes)
 		{
 			ctorValues = null;
 			ctorTypes = null;

--- a/tests/generator/ConstructorArgumentsTests.cs
+++ b/tests/generator/ConstructorArgumentsTests.cs
@@ -194,11 +194,11 @@ namespace GeneratorTests {
 			var success = AttributeFactory.ConstructorArguments.TryGetCtorArguments (arguments, platformName,
 				out var actualValues, out var actualTypes);
 			Assert.True (success, "success");
-			Assert.AreEqual (expectedValues.Length, actualValues.Length, "Values Length");
+			Assert.AreEqual (expectedValues!.Length, actualValues!.Length, "Values Length");
 			for (int index = 0; index < expectedValues.Length; index++) {
 				Assert.AreEqual (expectedValues [index], actualValues [index], $"Values [{index}]");
 			}
-			Assert.AreEqual (expectedTypes.Length, actualTypes.Length, "Types Length");
+			Assert.AreEqual (expectedTypes!.Length, actualTypes!.Length, "Types Length");
 			for (int index = 0; index < expectedTypes.Length; index++) {
 				Assert.AreEqual (expectedTypes [index], actualTypes [index], $"Types [{index}]");
 			}

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -38,12 +38,6 @@
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\src\bgen\AttributeFactory.ConstructorArguments.cs">
-      <Link>AttributeFactory.ConstructorArguments.cs</Link>
-    </Compile>
-    <Compile Include="..\..\src\bgen\AttributeFactory.cs">
-      <Link>AttributeFactory.cs</Link>
-    </Compile>
     <Compile Include="..\..\tools\common\SdkVersions.cs">
       <Link>SdkVersions.cs</Link>
     </Compile>


### PR DESCRIPTION
Also fix a nullability warning.

Fixes these warnings:

    "tests/generator/generator-tests.csproj" (default target) (1:7) ->
    (CoreCompile target) ->
      tests/generator/AttributeFactoryTests.cs(43,29): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(44,29): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(45,29): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/ConstructorArgumentsTests.cs(17,19): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/ConstructorArgumentsTests.cs(34,19): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(53,39): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(54,39): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(55,39): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(56,39): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(64,34): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(69,11): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(76,34): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/ConstructorArgumentsTests.cs(55,19): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(83,34): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/ConstructorArgumentsTests.cs(78,19): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(111,16): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(138,16): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/ConstructorArgumentsTests.cs(95,19): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/AttributeFactoryTests.cs(178,16): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.
      tests/generator/ConstructorArgumentsTests.cs(116,19): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.]
      tests/generator/ConstructorArgumentsTests.cs(194,18): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.]
      tests/generator/ConstructorArgumentsTests.cs(210,18): warning CS0436: The type 'AttributeFactory' in 'tests/generator/../../src/bgen/AttributeFactory.cs' conflicts with the imported type 'AttributeFactory' in 'bgen, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/generator/../../src/bgen/AttributeFactory.cs'.]
      tests/generator/ConstructorArgumentsTests.cs(197,44): warning CS8602: Dereference of a possibly null reference.
      tests/generator/ConstructorArgumentsTests.cs(201,43): warning CS8602: Dereference of a possibly null reference.