### PR TITLE
[devops] Use fully qualified path to load MaciosCI.psd1.

### DIFF
--- a/tools/devops/automation/scripts/clean_past_comments.ps1
+++ b/tools/devops/automation/scripts/clean_past_comments.ps1
@@ -18,7 +18,7 @@ param
     $CommentToHide
 )
 
-Import-Module MaciosCI.psd1
+Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MaciosCI.psd1
 
 $comments = New-GitHubCommentsObjectFromUrl -Url "$RepositoryUri" -Token $GithubToken
 


### PR DESCRIPTION
Fixes:

    Import-Module : The specified module 'MaciosCI.psd1' was not loaded because no valid module file was found in any module directory.
    At D:\a\1\s\xamarin-macios\tools\devops\automation\scripts\clean_past_comments.ps1:21 char:1
    + Import-Module MaciosCI.psd1