### PR TITLE
[release/6.0.4xx-xcode14.2] [introspection] Ignore the AddressBook namespace for Mac Catalyst when checking static cctors.

### DIFF
--- a/tests/introspection/ApiTypeTest.cs
+++ b/tests/introspection/ApiTypeTest.cs
@@ -28,6 +28,14 @@ namespace Introspection {
 				// and if we call it then the .cctor is executed and we get the same failures :()
 				return ((IntPtr.Size == 4) || TestRuntime.IsSimulatorOrDesktop);
 #endif
+#if __MACCATALYST__
+			case "AddressBook":
+				// The AddressBook framework is sometimes missing from Mac Catalyst, causing:
+				//     [FAIL] AddressBook.InitConstants .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
+				//         ---> System.EntryPointNotFoundException: ABAddressBookCreate
+				// but I wasn't able to reproduce this locally, only on the bots (so only disable this in the tests, and not change the API, since it's still working for me).
+				return true;
+#endif
 			default:
 				return false;
 			}


### PR DESCRIPTION
Fixes these test failures (which only happen on the bots):

    [FAIL] AddressBook.InitConstants .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABGroupProperty .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABGroupProperty' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABGroupProperty..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABPersonPropertyId .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABPersonPropertyId' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABPersonPropertyId..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABPersonAddressKey .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABPersonAddressKey' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABPersonAddressKey..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABPersonDateLabel .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABPersonDateLabel' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABPersonDateLabel..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABPersonKindId .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABPersonKindId' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABPersonKindId..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABPersonPhoneLabel .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABPersonPhoneLabel' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABPersonPhoneLabel..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABPersonInstantMessageService .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABPersonInstantMessageService' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABPersonInstantMessageService..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABPersonInstantMessageKey .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABPersonInstantMessageKey' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABPersonInstantMessageKey..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABPersonUrlLabel .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABPersonUrlLabel' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABPersonUrlLabel..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABPersonRelatedNamesLabel .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABPersonRelatedNamesLabel' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABPersonRelatedNamesLabel..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABLabel .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABLabel' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABLabel..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)
       at Introspection.ApiTypeTest.StaticCtor() in /Users/builder/azdo/_work/4/s/xamarin-macios/tests/introspection/ApiTypeTest.cs:line 51
    [FAIL] AddressBook.ABSourcePropertyId .cctor could not execute properly: System.TypeInitializationException: The type initializer for 'AddressBook.ABSourcePropertyId' threw an exception.
     ---> System.TypeInitializationException: The type initializer for 'AddressBook.InitConstants' threw an exception.
     ---> System.EntryPointNotFoundException: ABAddressBookCreate
       at AddressBook.InitConstants..cctor()
       --- End of inner exception stack trace ---
       at AddressBook.ABSourcePropertyId..cctor()
       --- End of inner exception stack trace ---
       at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)


Backport of #18088
