### PR TITLE
[Localization] Use new custom powershell script for removing BOM - Part 2

### DIFF
--- a/tools/devops/automation/scripts/localizationBomRemoval.ps1
+++ b/tools/devops/automation/scripts/localizationBomRemoval.ps1
@@ -4,9 +4,9 @@ function RemoveUtf8Bom
         [string]$FilePath
     )
 
-    $encoding = New-Object -TypeName System.Text.UTF8Encoding
-    $content = Get-Content -Path $FilePath -Raw
-    [System.IO.File]::WriteAllLines($FilePath, $content, $encoding)
+    $encoding = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+    $content = Get-Content -Path $FilePath -Encoding UTF8
+    [System.IO.File]::WriteAllText($FilePath, $content -join "`n", $encoding)
 }
 
 foreach ($locFile in (Get-Content -Path $env:XLocFileList))

--- a/tools/devops/automation/templates/loc-translations.yml
+++ b/tools/devops/automation/templates/loc-translations.yml
@@ -90,7 +90,6 @@ steps:
     packageSourceAuth: patAuth
     patVariable: '$(OneLocBuild--PAT)'
     isAutoCompletePrSelected: false
-    isUseLfLineEndingsSelected: true
     prSourceBranchPrefix: 'locfiles'
     repoType: gitHub
     gitHubPatVariable: '$(GitHub.Token)'


### PR DESCRIPTION
Please see the issue - https://github.com/xamarin/xamarin-macios/issues/18099

This PR updates the custom powershell script to try to remove the BOM.

After this lands, I will manually run the pipeline to create a new Localization PR in main and see if the BOM is removed.

You can see the ticket from the Loc team here which specifies this change - https://ceapex.visualstudio.com/CEINTL/_workitems/edit/816066