### PR TITLE
[Localization] Use xamarin-release-manager to create PRs

### DIFF
--- a/tools/devops/automation/build-lego.yml
+++ b/tools/devops/automation/build-lego.yml
@@ -79,8 +79,8 @@ stages:
           git remote add origin https://$(GitHub.Token)@github.com/xamarin/xamarin-macios.git
           git remote # don't add -v else we see the pat
 
-          git config user.email "valco@microsoft.com"
-          git config user.name "vs-mobiletools-engineering-service2"
+          git config user.email "release-manager@xamarin.com"
+          git config user.name "xamarin-release-manager"
 
           git fetch origin
 


### PR DESCRIPTION
Pull requests created from pipelines that bring over Localization strings created by `vs-mobiletools-engineering-service2` were automatically closed a few hours after creation such as [this](https://github.com/xamarin/xamarin-macios/pull/18051). Michael Bond suggested using the `xamarin-release-manager` account since it also has access to the repo. 

The email for the account is the one I found on Github and am not totally sure if this has changed since then or not.