### PR TITLE
[Localization] Remove Duplicate Translations

### DIFF
--- a/Localize/loc/cs/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
+++ b/Localize/loc/cs/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
@@ -2560,39 +2560,6 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
-      <Item ItemId=";W7106" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Expected a file named '{1}' in the zip file {0}.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7107" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The zip file '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7108" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The file '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Soubor {0} neexistuje.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7109" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Unable to process the item '{0}' as a native reference: unknown type.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7111" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The directory '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
     </Item>
   </Item>
 </LCX>

--- a/Localize/loc/de/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
+++ b/Localize/loc/de/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
@@ -2560,42 +2560,6 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
-      <Item ItemId=";W7106" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Expected a file named '{1}' in the zip file {0}.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7107" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The zip file '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7108" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The file '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Die Datei "{0}" ist nicht vorhanden.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7109" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Unable to process the item '{0}' as a native reference: unknown type.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7111" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The directory '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Das Verzeichnis "{0}" ist nicht vorhanden.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
     </Item>
   </Item>
 </LCX>

--- a/Localize/loc/es/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
+++ b/Localize/loc/es/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
@@ -2560,42 +2560,6 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
-      <Item ItemId=";W7106" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Expected a file named '{1}' in the zip file {0}.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7107" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The zip file '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7108" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The file '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[El archivo '{0}' no existe.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7109" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Unable to process the item '{0}' as a native reference: unknown type.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7111" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The directory '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[El directorio '{0}' no existe.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
     </Item>
   </Item>
 </LCX>

--- a/Localize/loc/it/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
+++ b/Localize/loc/it/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
@@ -2560,42 +2560,6 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
-      <Item ItemId=";W7106" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Expected a file named '{1}' in the zip file {0}.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7107" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The zip file '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7108" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The file '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Il file '{0}' non esiste.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7109" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Unable to process the item '{0}' as a native reference: unknown type.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7111" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The directory '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[La directory '{0}' non esiste.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
     </Item>
   </Item>
 </LCX>

--- a/Localize/loc/pl/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
+++ b/Localize/loc/pl/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
@@ -2560,39 +2560,6 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
-      <Item ItemId=";W7106" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Expected a file named '{1}' in the zip file {0}.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7107" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The zip file '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7108" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The file '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Plik '{0}' nie istnieje.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7109" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Unable to process the item '{0}' as a native reference: unknown type.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7111" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The directory '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
     </Item>
   </Item>
 </LCX>

--- a/Localize/loc/pt-BR/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
+++ b/Localize/loc/pt-BR/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
@@ -2560,42 +2560,6 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
-      <Item ItemId=";W7106" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Expected a file named '{1}' in the zip file {0}.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7107" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The zip file '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7108" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The file '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[O arquivo '{0}' não existe.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7109" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Unable to process the item '{0}' as a native reference: unknown type.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7111" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The directory '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[O diretório '{0}' não existe.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
     </Item>
   </Item>
 </LCX>

--- a/Localize/loc/tr/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
+++ b/Localize/loc/tr/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
@@ -2560,39 +2560,6 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
-      <Item ItemId=";W7106" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Expected a file named '{1}' in the zip file {0}.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7107" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The zip file '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7108" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The file '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA['{0}' dosyası yok.]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7109" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Unable to process the item '{0}' as a native reference: unknown type.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7111" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The directory '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
     </Item>
   </Item>
 </LCX>

--- a/Localize/loc/zh-Hans/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
+++ b/Localize/loc/zh-Hans/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
@@ -2560,42 +2560,6 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
-      <Item ItemId=";W7106" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Expected a file named '{1}' in the zip file {0}.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7107" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The zip file '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7108" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The file '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[文件“{0}”不存在。]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7109" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Unable to process the item '{0}' as a native reference: unknown type.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7111" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The directory '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[目录“{0}”不存在。]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
     </Item>
   </Item>
 </LCX>

--- a/Localize/loc/zh-Hant/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
+++ b/Localize/loc/zh-Hant/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx.lcl
@@ -2560,42 +2560,6 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
-      <Item ItemId=";W7106" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Expected a file named '{1}' in the zip file {0}.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7107" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The zip file '{0}' does not exist.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7108" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The file '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[檔案 '{0}' 不存在。]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7109" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Unable to process the item '{0}' as a native reference: unknown type.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
-      <Item ItemId=";W7111" ItemType="0;.resx" PsrId="211" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[The directory '{0}' does not exist.]]></Val>
-          <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[目錄 '{0}' 不存在。]]></Val>
-          </Tgt>
-        </Str>
-        <Disp Icon="Str" />
-      </Item>
     </Item>
   </Item>
 </LCX>


### PR DESCRIPTION
When bringing over the translations in this [PR](https://github.com/xamarin/xamarin-macios/pull/18105), I brought over a few and did not notice that the old ones were still there. This removes the duplicates