### PR TITLE
[release/7.0.3xx] [devops] Ignore any errors when printing the system's .NET version on Windows.

### DIFF
--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -51,6 +51,8 @@ steps:
     & dotnet --version
     & dotnet --info
     & dotnet workload list
+    # We don't care if anything went wrong here.
+    exit 0
   displayName: 'Show .NET info'
   continueOnError: true
 


### PR DESCRIPTION
Because Windows sometimes gives this random and somewhat cute error:

    Unhandled exception: System.IO.FileNotFoundException: Retrieving the COM class factory for component with CLSID {177F0C4A-1CD3-4DE7-A32C-71DBBB9FA36D} failed due to the following error: 8007007e The specified module could not be found. (0x8007007E).
       at System.RuntimeTypeHandle.AllocateComObject(Void* pClassFactory)
       at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
       at Microsoft.DotNet.Workloads.Workload.List.VisualStudioWorkloads.GetVisualStudioInstances()
       at Microsoft.DotNet.Workloads.Workload.List.VisualStudioWorkloads.GetInstalledWorkloads(IWorkloadResolver workloadResolver, SdkFeatureBand sdkFeatureBand, InstalledWorkloadsCollection installedWorkloads)
       at Microsoft.DotNet.Workloads.Workload.List.WorkloadInfoHelper.AddInstalledVsWorkloads(IEnumerable`1 sdkWorkloadIds)
       at Microsoft.DotNet.Workloads.Workload.List.WorkloadListCommand.Execute()
       at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
    --- End of stack trace from previous location ---
       at Microsoft.DotNet.Cli.Parser.<>c__DisplayClass17_0.<<UseParseErrorReporting>b__0>d.MoveNext()
    --- End of stack trace from previous location ---
       at System.CommandLine.CommandLineBuilderExtensions.<>c__DisplayClass11_0.<<UseHelp>b__0>d.MoveNext()
    --- End of stack trace from previous location ---
       at System.CommandLine.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__17_0>d.MoveNext()
    --- End of stack trace from previous location ---
       at System.CommandLine.CommandLineBuilderExtensions.<>c__DisplayClass15_0.<<UseParseDirective>b__0>d.MoveNext()
    --- End of stack trace from previous location ---
       at System.CommandLine.CommandLineBuilderExtensions.<>c__DisplayClass7_0.<<UseExceptionHandler>b__0>d.MoveNext()
    ##[error]PowerShell exited with code '1'.

Despite the scary-looking log, nothing bad actually happens, so just complete
ignore any errors whatsoever.


Backport of #18124
