### PR TITLE
[tests] Make any ObjCRuntime.Messaging internal.

### DIFF
--- a/tests/bindings-test/Messaging.cs
+++ b/tests/bindings-test/Messaging.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 
 namespace ObjCRuntime {
-	public static class Messaging {
+	static class Messaging {
 		internal const string LIBOBJC_DYLIB = "/usr/lib/libobjc.dylib";
 
 		public struct objc_super {

--- a/tests/monotouch-test/ObjCRuntime/Messaging.cs
+++ b/tests/monotouch-test/ObjCRuntime/Messaging.cs
@@ -22,7 +22,7 @@ using NativeHandle = System.IntPtr;
 #endif
 
 namespace ObjCRuntime {
-	public static class Messaging {
+	static class Messaging {
 		internal const string LIBOBJC_DYLIB = "/usr/lib/libobjc.dylib";
 
 		public struct objc_super {


### PR DESCRIPTION
This fixes ~1600 warnings like these:

     warning CS0436: The type 'Messaging' in 'xamarin-macios/tests/monotouch-test/ObjCRuntime/Messaging.cs' conflicts with the imported type 'Messaging' in 'bindings-test, Version=1.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'