### PR TITLE
[release/6.0.4xx-xcode14.3] [runtime] Always look for dynamic libraries relative to the root directory first. Fixes #xamarin/maccore@2668.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2544,6 +2544,9 @@ xamarin_compute_native_dll_search_directories ()
 
 	NSMutableArray<NSString *> *directories = [NSMutableArray array];
 
+	// Always check in the root directory first.
+	[directories addObject: @"/"];
+
 	// Native libraries might be in the app bundle
 	[directories addObject: [NSString stringWithUTF8String: bundle_path]];
 	// They won't be in the runtimeidentifier-specific directory (because they get lipo'ed into a fat file instead)


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/2668.

Backport of #18121.