### PR TITLE
[tests] Fix finding instructions that take methods in cecil-tests.

### DIFF
--- a/tests/cecil-tests/BlittablePInvokes.cs
+++ b/tests/cecil-tests/BlittablePInvokes.cs
@@ -353,7 +353,6 @@ namespace Cecil.Tests {
 						foreach (var instr in body.Instructions) {
 							switch (instr.OpCode.Code) {
 							case Code.Call:
-							case Code.Calli:
 							case Code.Callvirt:
 								break;
 							default:


### PR DESCRIPTION
The calli instruction calls a function pointer on the stack, not a specific
managed function, so include it when looking for calls to managed functions.