### PR TITLE
[CoreMidi] Sprinkle a few more NativeName attributes for various structs.

### DIFF
--- a/src/CoreMidi/MidiThruConnectionParams.cs
+++ b/src/CoreMidi/MidiThruConnectionParams.cs
@@ -45,6 +45,7 @@ namespace CoreMidi {
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 #endif
+	[NativeName ("MIDITransform")]
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MidiTransform {
 		public MidiTransformType Transform;
@@ -62,6 +63,7 @@ namespace CoreMidi {
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 #endif
+	[NativeName ("MIDIValueMap")]
 	[StructLayout (LayoutKind.Sequential)]
 	public unsafe struct MidiValueMap {
 		byte [] map_value;
@@ -84,6 +86,7 @@ namespace CoreMidi {
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 #endif
+	[NativeName ("MIDIControlTransform")]
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MidiControlTransform {
 		public MidiTransformControlType ControlType;
@@ -110,6 +113,7 @@ namespace CoreMidi {
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 #endif
+	[NativeName ("MIDIThruConnectionEndpoint")]
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MidiThruConnectionEndpoint {
 		public MidiEndpointRef EndpointRef;


### PR DESCRIPTION
Otherwise the static registrar won't know that the native name is different
from the managed name in generated registrar code (and the generated registrar
code won't compile).