### PR TITLE
[xharness] Add a release + all optimization test variation of monotouch-test for desktop.

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -2655,7 +2655,7 @@ namespace Registrar {
 			case "System.Double": return "d";
 			case "System.Boolean":
 				// map managed 'bool' to ObjC BOOL = 'unsigned char' in OSX and 32bit iOS architectures and 'bool' in 64bit iOS architectures
-#if MONOMAC
+#if MONOMAC || __MACCATALYST__
 				return IsARM64 ? "B" : "c";
 #else
 				return Is64Bits ? "B" : "c";

--- a/tests/monotouch-test/AppKit/DerivedEventTest.cs
+++ b/tests/monotouch-test/AppKit/DerivedEventTest.cs
@@ -42,8 +42,13 @@ namespace Xamarin.Mac.Tests {
 		[Test]
 		public void DerivedEvents_OverwriteThrows ()
 		{
-			TestOverrideThrow (false, true);
-			TestOverrideThrow (true, true);
+#if RELEASE
+			var checkTrimmedAway = TestRuntime.IsLinkAll;
+#else
+			var checkTrimmedAway = false;
+#endif
+			TestOverrideThrow (false, !checkTrimmedAway);
+			TestOverrideThrow (true, !checkTrimmedAway);
 #if MONOMAC
 			NSApplication.CheckForEventAndDelegateMismatches = false;
 #else

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -1450,10 +1450,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		{
 			var cl = new Class (typeof (TestTypeEncodingsClass));
 			var sig = Runtime.GetNSObject<NSMethodSignature> (Messaging.IntPtr_objc_msgSend_IntPtr (cl.Handle, Selector.GetHandle ("methodSignatureForSelector:"), Selector.GetHandle ("foo::::::::::::::::")));
-#if MONOMAC
+#if MONOMAC || __MACCATALYST__
 			var boolEncoding = TrampolineTest.IsArm64CallingConvention ? "B" : "c";
-#elif __MACCATALYST__
-			var boolEncoding = "B";
 #else
 			var boolEncoding = (IntPtr.Size == 8 || TrampolineTest.IsArmv7k || TrampolineTest.IsArm64CallingConvention) ? "B" : "c";
 

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -158,6 +158,9 @@ namespace Xharness.Jenkins {
 						if (test.Platform == TestPlatform.Mac) {
 							yield return new TestData { Variation = "Release", Debug = false, Ignored = !jenkins.TestSelection.IsEnabled (TestLabel.Monotouch) || !jenkins.TestSelection.IsEnabled (PlatformLabel.Mac) };
 						}
+						if (test.TestProject.IsDotNetProject) {
+							yield return new TestData { Variation = "Release (all optimizations)", BundlerArguments = "--optimize:all", Registrar = "static", Debug = false, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Ignored = ignore };
+						}
 					}
 					break;
 				case "xammac tests":


### PR DESCRIPTION
Add a 'release + all optimization' test variation of monotouch-test for macOS
and Mac Catalyst.