### PR TITLE
[dotnet] integrate writing out class map into static registrar

### DIFF
--- a/tools/common/CSToObjCMap.cs
+++ b/tools/common/CSToObjCMap.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Linq;
 
 #nullable enable

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -33,6 +33,7 @@ using ObjCRuntime;
 using Mono.Cecil;
 using Mono.Linker;
 using Mono.Tuner;
+using ClassRedirector;
 
 namespace Registrar {
 	/*
@@ -2803,14 +2804,14 @@ namespace Registrar {
 			}
 		}
 
-		void Specialize (AutoIndentStringBuilder sb, out string initialization_method)
+		void Specialize (AutoIndentStringBuilder sb, out string initialization_method, string type_map_path)
 		{
 			List<Exception> exceptions = new List<Exception> ();
 			List<ObjCMember> skip = new List<ObjCMember> ();
 
 			var map = new AutoIndentStringBuilder (1);
 			var map_init = new AutoIndentStringBuilder ();
-			var map_dict = new Dictionary<ObjCType, int> (); // maps ObjCType to its index in the map
+			var map_dict = new CSToObjCMap (); // maps CS type to ObjC type name and index
 			var map_entries = 0;
 			var protocol_wrapper_map = new Dictionary<uint, Tuple<ObjCType, uint>> ();
 			var protocols = new List<ProtocolInfo> ();
@@ -2893,7 +2894,7 @@ namespace Registrar {
 									token_ref,
 									GetAssemblyQualifiedName (@class.Type), map_entries,
 									(int) flags, flags);
-					map_dict [@class] = map_entries++;
+					map_dict [GetAssemblyQualifiedName (@class.Type)] = new ObjCNameIndex (@class.ExportedName, map_entries++);
 
 					bool use_dynamic;
 
@@ -3256,6 +3257,11 @@ namespace Registrar {
 
 			sb.WriteLine (map.ToString ());
 			sb.WriteLine (map_init.ToString ());
+
+			if (!string.IsNullOrEmpty (type_map_path)) {
+				var doc = CSToObjCMap.ToXDocument (map_dict);
+				doc.Save (type_map_path);
+			}
 
 			ErrorHelper.ThrowIfErrors (exceptions);
 		}
@@ -5135,18 +5141,18 @@ namespace Registrar {
 			pinfo.EntryPoint = wrapperName;
 		}
 
-		public void GenerateSingleAssembly (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, string assembly, out string initialization_method)
+		public void GenerateSingleAssembly (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, string assembly, out string initialization_method, string type_map_path = null)
 		{
 			single_assembly = assembly;
-			Generate (resolver, assemblies, header_path, source_path, out initialization_method);
+			Generate (resolver, assemblies, header_path, source_path, out initialization_method, type_map_path);
 		}
 
-		public void Generate (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, out string initialization_method)
+		public void Generate (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, out string initialization_method, string type_map_path = null)
 		{
-			Generate (null, assemblies, header_path, source_path, out initialization_method);
+			Generate (null, assemblies, header_path, source_path, out initialization_method, type_map_path);
 		}
 
-		public void Generate (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, out string initialization_method)
+		public void Generate (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, out string initialization_method, string type_map_path = null)
 		{
 			this.resolver = resolver;
 
@@ -5160,10 +5166,10 @@ namespace Registrar {
 				RegisterAssembly (assembly);
 			}
 
-			Generate (header_path, source_path, out initialization_method);
+			Generate (header_path, source_path, out initialization_method, type_map_path);
 		}
 
-		void Generate (string header_path, string source_path, out string initialization_method)
+		void Generate (string header_path, string source_path, out string initialization_method, string type_map_path = null)
 		{
 			var sb = new AutoIndentStringBuilder ();
 			header = new AutoIndentStringBuilder ();
@@ -5198,7 +5204,7 @@ namespace Registrar {
 			if (App.Embeddinator)
 				methods.WriteLine ("void xamarin_embeddinator_initialize ();");
 
-			Specialize (sb, out initialization_method);
+			Specialize (sb, out initialization_method, type_map_path);
 
 			methods.WriteLine ();
 			methods.AppendLine ();

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -104,6 +104,12 @@
     <Compile Include="..\common\OSPlatformAttributeExtensions.cs">
       <Link>external\tools\common\OSPlatformAttributeExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\common\CSToObjCMap.cs">
+      <Link>tools\common\CSToObjCMap.cs</Link>
+    </Compile>
+    <Compile Include="..\common\ObjCNameIndex.cs">
+      <Link>tools\common\ObjCNameIndex.cs</Link>
+    </Compile>
     <Compile Include="..\common\StaticRegistrar.cs">
       <Link>external\tools\common\StaticRegistrar.cs</Link>
     </Compile>

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -43,6 +43,7 @@
     <Reference Include="Mono.Cecil.Mdb">
       <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Application.mmp.cs" />
@@ -359,6 +360,12 @@
     </Compile>
     <Compile Include="..\common\OSPlatformAttributeExtensions.cs">
       <Link>tools\common\OSPlatformAttributeExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\common\CSToObjCMap.cs">
+      <Link>tools\common\CSToObjCMap.cs</Link>
+    </Compile>
+    <Compile Include="..\common\ObjCNameIndex.cs">
+      <Link>tools\common\ObjCNameIndex.cs</Link>
     </Compile>
     <Compile Include="..\common\StaticRegistrar.cs">
       <Link>tools\common\StaticRegistrar.cs</Link>

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -338,6 +338,12 @@
     <Compile Include="..\common\OSPlatformAttributeExtensions.cs">
       <Link>tools\common\OSPlatformAttributeExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\common\CSToObjCMap.cs">
+      <Link>tools\common\CSToObjCMap.cs</Link>
+    </Compile>
+    <Compile Include="..\common\ObjCNameIndex.cs">
+      <Link>tools\common\ObjCNameIndex.cs</Link>
+    </Compile>
     <Compile Include="..\common\StaticRegistrar.cs">
       <Link>tools\common\StaticRegistrar.cs</Link>
     </Compile>


### PR DESCRIPTION
Replaced the existing type map in StaticRegistrar.cs with a `CSToObjCMap`.
Added code to write it out to a specified path as XML.
Currently the path is a parameter that defaults to null and is not (yet) used.