### PR TITLE
[release/7.0.3xx] [dotnet] Add a missing IsMacEnabled check before executing a task in the _ComputeLinkerArguments target.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -633,7 +633,12 @@
 		</ItemGroup>
 
 		<!-- Create the file with our custom linker options -->
-		<WriteLinesToFile SessionId="$(BuildSessionId)" File="$(_CustomLinkerOptionsFile)" Lines="$(_CustomLinkerOptions)" Overwrite="true" />
+		<WriteLinesToFile
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			File="$(_CustomLinkerOptionsFile)"
+			Lines="$(_CustomLinkerOptions)"
+			Overwrite="true" />
 	</Target>
 
 	<PropertyGroup>


### PR DESCRIPTION
This fixes an issue where the build would fail on Windows if the Windows
machine wasn't connected to a remote Mac.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1808448.


Backport of #18145
