### PR TITLE
[tests] Allow a little bit of leeway when testing floating point numbers in SKTransformNodeTest.

### DIFF
--- a/tests/monotouch-test/SpriteKit/SKTransformNodeTest.cs
+++ b/tests/monotouch-test/SpriteKit/SKTransformNodeTest.cs
@@ -46,9 +46,9 @@ namespace MonoTouchFixtures.SpriteKit {
 				V3 = new VectorFloat3 (1, 2, 3);
 				obj.EulerAngles = V3;
 				// The values bellow match what the same code in Swift returns.
-				Assert.AreEqual (-2.14159298f, obj.EulerAngles.X, "#x1");
-				Assert.AreEqual (1.14159274f, obj.EulerAngles.Y, "#y1");
-				Assert.AreEqual (-0.141592711f, obj.EulerAngles.Z, "#z1");
+				Assert.AreEqual (-2.14159298f, obj.EulerAngles.X, 0.000001f, "#x1");
+				Assert.AreEqual (1.14159274f, obj.EulerAngles.Y, 0.000001f, "#y1");
+				Assert.AreEqual (-0.141592711f, obj.EulerAngles.Z, 0.000001f, "#z1");
 			}
 		}
 


### PR DESCRIPTION
Fixes this test failure:

    MonoTouchFixtures.SpriteKit.SKTransformNodeTest
        [FAIL] EulerAngles :   #x1
            Expected: -2.14159298f
            But was:  -2.14159274f