### PR TITLE
[release/7.0.2xx-xcode14.3] [tests] Find a workaround for #xamarin/maccore@2668.

### DIFF
--- a/tests/common/AppDelegate.cs
+++ b/tests/common/AppDelegate.cs
@@ -2,7 +2,10 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
 
+using ObjCRuntime;
 using Foundation;
 #if !__MACOS__
 using UIKit;
@@ -48,9 +51,31 @@ public partial class AppDelegate : UIApplicationDelegate {
 public static class MainClass {
 	static void Main (string [] args)
 	{
+#if __MACCATALYST__
+		NativeLibrary.SetDllImportResolver (typeof (NSObject).Assembly, DllImportResolver);
+		NativeLibrary.SetDllImportResolver (typeof (MainClass).Assembly, DllImportResolver);
+#endif
 #if !__MACOS__
 		UIApplication.Main (args, null, typeof (AppDelegate));
 #endif
 	}
+
+#if __MACCATALYST__
+	// This is a workaround for a temporary issue in the .NET runtime
+	// See https://github.com/xamarin/maccore/issues/2668
+	// The issue is present in .NET 7.0.5, and will likely be fixed in .NET 7.0.6.
+	static IntPtr DllImportResolver (string libraryName, global::System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
+	{
+		switch (libraryName) {
+		case "/System/Library/Frameworks/SceneKit.framework/SceneKit":
+		case "/System/Library/Frameworks/SceneKit.framework/Versions/A/SceneKit":
+			var rv = NativeLibrary.Load (libraryName);
+			Console.WriteLine ($"DllImportResolver callback loaded library \"{libraryName}\" from a P/Invoke in \"{assembly}\" => 0x{rv.ToString ("x")}");
+			return rv;
+		default:
+			return IntPtr.Zero;
+		}
+	}
+#endif
 }
 #endif // !__WATCHOS__


### PR DESCRIPTION
1. Mono changed dyld lookup to start looking in directories in
   NATIVE_DLL_SEARCH_DIRECTORIES before the actual given path, even when the
   given path is absolute [1].
2. This turned out to break Mac Catalyst, because when a DllImport says a
   P/Invoke is in "/System/Library/Frameworks/SceneKit.framework/SceneKit",
   Mono would try loading by prefixing the directories in
   NATIVE_DLL_SEARCH_DIRECTORIES. We add the Contents/MonoBundle directory to
   NATIVE_DLL_SEARCH_DIRECTORIES, so Mono would try to load
   "/path/to/my.app/Contents/MonoBundle//System/Library/Frameworks/SceneKit.framework/SceneKit",
   and things would go wrong.
3. We found a workaround: add "/" to NATIVE_DLL_SEARCH_DIRECTORIES. This works
   on Ventura, but apparently not on older macOS version, because the actual
   path we pass to dlopen ends up being "///System/Library/Frameworks/SceneKit.framework/SceneKit"
   (note the three initial slashes instead of a single slash).
4. Add a second workaround, where we add a dll import resolver to load exactly
   the path we want to load.

[1]: https://github.com/dotnet/runtime/commit/5a1baebc09b34a58fe2f8e1b29d4e1f7ca7dabbc
[2]: https://github.com/dotnet/runtime/pull/85255

Technical sidenote:

Why trying to load "/path/to/my.app/Contents/MonoBundle//System/Library/Frameworks/SceneKit.framework/SceneKit"
turned out so bad on Mac Catalyst is not obvious. What happens is this:

* The app calls 'dlopen ("/path/to/my.app/Contents/MonoBundle//System/Library/Frameworks/SceneKit.framework/SceneKit")'
* dlopen checks if this is a Mac Catalyst override of a macOS system
  framework, by prefixing "/System/iOSSupport" and trying to load that. So
  dlopen would try to load "/System/iOSSupport/path/to/my.app/Contents/MonoBundle//System/Library/Frameworks/SceneKit.framework/SceneKit",
  which would obviously fail.
* Then dlopen would try a few more fallbacks, eventually trying
  "/System/Library/Frameworks/SceneKit.framework/SceneKit", and successfully
  loading that library.
* Unfortunately "/System/Library/Frameworks/SceneKit.framework/SceneKit" is
  the wrong library to load for Mac Catalyst ("/System/iOSSupport/System/Library/Frameworks/SceneKit.framework/SceneKit"
  is the correct version). These two libraries are incompatible, and calling
  one when you mean to call the other will do nasty things like corrupting the
  stack.


Backport of #18159
