### PR TITLE
[dotnet] Use the type_map_path arg

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -166,6 +166,7 @@ namespace Xamarin.Bundler {
 		public bool EnableBitCode { get { return BitCodeMode != BitCodeMode.None; } }
 
 		public bool SkipMarkingNSObjectsInUserAssemblies { get; set; }
+		public string ClassMapPath = "";
 
 		// assembly_build_targets describes what kind of native code each assembly should be compiled into for mobile targets (iOS, tvOS, watchOS).
 		// An assembly can be compiled into: static object (.o), dynamic library (.dylib) or a framework (.framework).
@@ -1028,9 +1029,9 @@ namespace Xamarin.Bundler {
 #endif
 			var registrar = new Registrar.StaticRegistrar (this);
 			if (RootAssemblies.Count == 1)
-				registrar.GenerateSingleAssembly (resolver, resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m, Path.GetFileNameWithoutExtension (RootAssembly), out var _);
+				registrar.GenerateSingleAssembly (resolver, resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m, Path.GetFileNameWithoutExtension (RootAssembly), out var _, ClassMapPath);
 			else
-				registrar.Generate (resolver, resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m, out var _);
+				registrar.Generate (resolver, resolvedAssemblies.Values, Path.ChangeExtension (registrar_m, "h"), registrar_m, out var _, ClassMapPath);
 		}
 
 		public IEnumerable<Abi> Abis {

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -257,6 +257,7 @@ namespace Xamarin.Bundler {
 			options.Add ("skip-marking-nsobjects-in-user-assemblies:", "Don't mark NSObject (and any subclass of NSObject) in user assemblies in the linker. This may break your app, use at own risk.", v => {
 				app.SkipMarkingNSObjectsInUserAssemblies = ParseBool (v, "--skip-marking-nsobjects-in-user-assemblies");
 			});
+			options.Add ("class-map-path=", "Sets the path for an output path to generate a class map XML file used to optimize class handle access when the static registrar has been used.", v => { app.ClassMapPath = v; });
 
 
 			// Keep the ResponseFileSource option at the end.

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -5145,18 +5145,18 @@ namespace Registrar {
 			pinfo.EntryPoint = wrapperName;
 		}
 
-		public void GenerateSingleAssembly (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, string assembly, out string initialization_method, string type_map_path = null)
+		public void GenerateSingleAssembly (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, string assembly, out string initialization_method, string type_map_path)
 		{
 			single_assembly = assembly;
 			Generate (resolver, assemblies, header_path, source_path, out initialization_method, type_map_path);
 		}
 
-		public void Generate (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, out string initialization_method, string type_map_path = null)
+		public void Generate (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, out string initialization_method, string type_map_path)
 		{
 			Generate (null, assemblies, header_path, source_path, out initialization_method, type_map_path);
 		}
 
-		public void Generate (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, out string initialization_method, string type_map_path = null)
+		public void Generate (PlatformResolver resolver, IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, out string initialization_method, string type_map_path)
 		{
 			this.resolver = resolver;
 
@@ -5173,7 +5173,7 @@ namespace Registrar {
 			Generate (header_path, source_path, out initialization_method, type_map_path);
 		}
 
-		void Generate (string header_path, string source_path, out string initialization_method, string type_map_path = null)
+		void Generate (string header_path, string source_path, out string initialization_method, string type_map_path)
 		{
 			var sb = new AutoIndentStringBuilder ();
 			header = new AutoIndentStringBuilder ();

--- a/tools/dotnet-linker/Steps/RegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/RegistrarStep.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Linker {
 					if (Annotations.GetAction (assembly) != Mono.Linker.AssemblyAction.Delete)
 						bundled_assemblies.Add (assembly);
 				}
-				Configuration.Target.StaticRegistrar.Generate (bundled_assemblies, header, code, out var initialization_method);
+				Configuration.Target.StaticRegistrar.Generate (bundled_assemblies, header, code, out var initialization_method, app.ClassMapPath);
 
 				var items = new List<MSBuildItem> ();
 				foreach (var abi in Configuration.Abis) {

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -794,7 +794,7 @@ namespace Xamarin.Bundler {
 			if (App.Registrar == RegistrarMode.Static) {
 				registrarPath = Path.Combine (App.Cache.Location, "registrar.m");
 				var registrarH = Path.Combine (App.Cache.Location, "registrar.h");
-				BuildTarget.StaticRegistrar.Generate (BuildTarget.Resolver.ResolverCache.Values, registrarH, registrarPath, out initialization_method);
+				BuildTarget.StaticRegistrar.Generate (BuildTarget.Resolver.ResolverCache.Values, registrarH, registrarPath, out initialization_method, App.ClassMapPath);
 
 				var platform_assembly = BuildTarget.Resolver.ResolverCache.First ((v) => v.Value.Name.Name == BuildTarget.StaticRegistrar.PlatformAssembly).Value;
 				Frameworks.Gather (App, platform_assembly, BuildTarget.Frameworks, BuildTarget.WeakFrameworks);

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -120,7 +120,7 @@ namespace Xamarin.Bundler {
 
 		protected override void Execute ()
 		{
-			Target.StaticRegistrar.Generate (Target.Assemblies.Select ((a) => a.AssemblyDefinition), RegistrarHeaderPath, RegistrarCodePath, out var initialization_name);
+			Target.StaticRegistrar.Generate (Target.Assemblies.Select ((a) => a.AssemblyDefinition), RegistrarHeaderPath, RegistrarCodePath, out var initialization_name, Target.App.ClassMapPath);
 			RegistrationMethods.Add (initialization_name);
 		}
 	}


### PR DESCRIPTION
Removed the default argument value
Added `Application.ClassMapPath`
Added options and setter for `ClassMapPath`
Integrated usage.

Note that the test for whether or not to write the file is based on whether the path passed in is `null` or empty, so this should cause no immediate problems.