### PR TITLE
[xharness] Improve listing files in the repository.

### DIFF
--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -85,29 +86,6 @@ namespace Xharness {
 			return CreateCopyAsync (log, processManager, test, rootDirectory, pr);
 		}
 
-		static SemaphoreSlim ls_files_semaphore = new SemaphoreSlim (1);
-
-		async Task<string []> ListFilesAsync (ILog log, string test_dir, IProcessManager processManager)
-		{
-			var acquired = await ls_files_semaphore.WaitAsync (TimeSpan.FromMinutes (5));
-			try {
-				if (!acquired)
-					log.WriteLine ($"Unable to acquire lock to run 'git ls-files {test_dir}' in 5 minutes; will try to run anyway.");
-				using var process = new Process ();
-				process.StartInfo.FileName = "git";
-				process.StartInfo.Arguments = "ls-files";
-				process.StartInfo.WorkingDirectory = test_dir;
-				var stdout = new MemoryLog () { Timestamp = false };
-				var result = await processManager.RunAsync (process, stdout, stdout, stdout, timeout: TimeSpan.FromSeconds (60));
-				if (!result.Succeeded)
-					throw new Exception ($"Failed to list the files in the directory {test_dir} (TimedOut: {result.TimedOut} ExitCode: {result.ExitCode}):\n{stdout}");
-				return stdout.ToString ().Split ('\n');
-			} finally {
-				if (acquired)
-					ls_files_semaphore.Release ();
-			}
-		}
-
 		async Task CreateCopyAsync (ILog log, IProcessManager processManager, ITestTask test, string rootDirectory, Dictionary<string, TestProject> allProjectReferences)
 		{
 			var directory = Cache.CreateTemporaryDirectory (test.TestName ?? System.IO.Path.GetFileNameWithoutExtension (Path));
@@ -164,7 +142,7 @@ namespace Xharness {
 					// because the cloned project is stored in a very different directory.
 					var test_dir = System.IO.Path.GetDirectoryName (original_path);
 
-					var files = await ListFilesAsync (log, test_dir, processManager);
+					var files = await HarnessConfiguration.ListFilesInGitAsync (log, test_dir, processManager);
 					foreach (var file in files) {
 						var ext = System.IO.Path.GetExtension (file);
 						var full_path = System.IO.Path.Combine (test_dir, file);


### PR DESCRIPTION
When cloning projects, we need to list all the files in the original project
directory and manually include some of them in the cloned project (because in
.NET some files from the project directory are included automatically, and if
we clone a project and put the cloned project in a different directory, those
files won't be picked up automatically by the build anymore).

The previous code to list the files in the project directory would run 'git
ls-files' for each project directory. This is rather slow, since it happens
quite a few times. Instead modify the logic to run 'git ls-files' once for the
entire tests/ directory, store the result, and then when we need to list files
in a particular project directory, just look in that stored list for the
applicable files.

This is much, much faster.