### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 17751: Build ID 7704520

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Vista de Mac\u00A0Catalyst",
+  "name": "Vista de Mac Catalyst",
   "description": "Vista de MacCatalyst",
   "symbols/namespace/description": "espacio de nombres para el código generado"
 }

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} má nesprávný nebo neznámý formát a nedá se zpracovat.
-        </value>
+        <value>Standard xcframework {0} má nesprávný nebo neznámý formát a nedá se zpracovat.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>V „{0}“ nebyla nalezena odpovídající architektura.
-        </value>
+        <value>Uvnitř {0} nebyl nalezen žádný odpovídající standard zásad. SupportedPlatform: {0}, SupportedPlatformVariant: {1}, SupportedArchitectures: {2}.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Konfliktní možnosti {0} a {1}. {1} se bude ignorovat.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Neočekávané rozšíření{0}pro nativní odkaz{1}v manifestu{2}</value>
+        <value>Neočekávané rozšíření {0} pro nativní odkaz {1}v balíčku prostředků vazby {2}.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>V souboru ZIP {0} se očekával soubor s názvem {1}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>Soubor ZIP {0} neexistuje.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>Soubor {0} neexistuje.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Položku {0} se nepovedlo zpracovat jako nativní odkaz: neznámý typ.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Ze standardu xcframework {1} se nepovedlo načíst soubor Info.plist {0}.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>Adresář {0} neexistuje.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>V souboru ZIP {1} se nepovedlo najít soubor nebo adresář {0}.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Soubor ZIP {0} nelze na této platformě zpracovat: soubor {1} je symbolický odkaz.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} weist ein ungültiges oder unbekanntes Format auf und kann nicht verarbeitet werden.
-        </value>
+        <value>Der xcframework "{0}" weist ein ungültiges oder unbekanntes Format auf und kann nicht verarbeitet werden.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>In "{0}" wurde kein passendes Framework gefunden.
-        </value>
+        <value>In "{0}" wurde kein übereinstimmendes Framework gefunden. SupportedPlatform: "{0}", SupportedPlatformVariant: "{1}", SupportedArchitectures: "{2}".</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Optionen „{0}“ und „{1}“ sind widersprüchlich. '{1}' wird ignoriert.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Unerwartete Erweiterung "{0}" für systemeigenen Verweis "{1}" im Manifest "{2}".</value>
+        <value>Unerwartete Erweiterung "{0}" für systemeigenen Verweis "{1}" im Bindungsressourcenpaket "{2}".</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Es wurde eine Datei namens "{1}" in der ZIP-Datei "{0}" erwartet.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>Die ZIP-Datei "{0}" ist nicht vorhanden.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>Die Datei "{0}" ist nicht vorhanden.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Das Element "{0}" kann nicht als nativer Verweis verarbeitet werden: unbekannter Typ.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Info.plist "{0}" konnte nicht aus dem xcframework "{1}" geladen werden.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>Das Verzeichnis "{0}" ist nicht vorhanden.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Die Datei oder das Verzeichnis "{0}" wurde in der ZIP-Datei "{1}" nicht gefunden.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Die ZIP-Datei "{0}" kann auf dieser Plattform nicht verarbeitet werden: Die Datei "{1}" ist ein symbolischer Link.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} tiene un formato incorrecto o desconocido y no se puede procesar.
-        </value>
+        <value>El xcframework {0} tiene un formato incorrecto o desconocido y no se puede procesar.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>No se ha encontrado ninguna estructura que empate dentro de '{0}".
-        </value>
+        <value>No se encontró ningún marco coincidente en "{0}". SupportedPlatform: "{0}", SupportedPlatformVariant: "{1}", SupportedArchitectures: "{2}".</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Opciones en conflicto '{0}" y "{1}" opciones. '{1}' será ignorado.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Extensión inesperada '{0}' para la referencia nativa '{1}' en el manifiesto '{2}'.</value>
+        <value>Extensión inesperada "{0}" para la referencia nativa "{1}" en el paquete de recursos de enlace "{2}".</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Se esperaba un archivo denominado "{1}" en el archivo ZIP {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>El archivo ZIP "{0}" no existe.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>El archivo '{0}' no existe.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>No se puede procesar el elemento "{0}" como referencia nativa: tipo desconocido.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>No se pudo cargar el archivo Info.plist "{0}" desde el xcframework "{1}".</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>El directorio '{0}' no existe.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>No se pudo encontrar el archivo o directorio "{0}" en el archivo ZIP "{1}".</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>No se puede procesar el archivo ZIP "{0}" en esta plataforma: el archivo "{1}" es un symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} a un format incorrect ou inconnu et ne peut pas être traité.
-        </value>
+        <value>Le xcframework {0} a un format incorrect ou inconnu et ne peut pas être traité.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>Aucune infrastructure correspondante n’a été trouvée dans' {0} '.
-        </value>
+        <value>Framework correspondant introuvable dans '{0}'. SupportedPlatform : '{0}', SupportedPlatformVariant : '{1}', SupportedArchitectures : '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Les options « {0} » et « {1} » sont en conflit. « {1} » sera ignoré.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Extension inattendue '{0}' pour la référence native '{1}' dans le manifeste '{2}'.</value>
+        <value>Extension inattendue «{0}» pour la référence native «{1}» dans le package de ressources de liaison «{2}».</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Fichier nommé «{1}» attendu dans le fichier zip {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>Le fichier zip «{0}» n’existe pas.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>Le fichier « {0} » n'existe pas.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Impossible de traiter l’élément «{0}» en tant que référence native : type inconnu.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Impossible de charger Info.plist '{0}' à partir du xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>Le répertoire « {0} » n'existe pas.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Impossible de trouver le fichier ou le répertoire '{0}' dans le fichier zip '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Impossible de traiter le fichier zip '{0}' sur cette plateforme : le fichier '{1}' est un lien symbolique.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} ha un formato non corretto o sconosciuto e non può essere elaborato.
-        </value>
+        <value>Il formato del {0} xcframework non è corretto o sconosciuto e non può essere elaborato.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>Non è stato trovato alcun framework corrispondente in "{0}".
-        </value>
+        <value>Non sono stati trovati framework corrispondenti all'interno di '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Le opzioni "{0}" e "{1}" sono in conflitto. "{1}" verrà ignorato.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Estensione imprevista '{0}' per il riferimento nativo '{1}' nel manifesto '{2}'.</value>
+        <value>Estensione imprevista '{0}' per il riferimento nativo '{1}' nel pacchetto di risorse di associazione '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>È previsto un file denominato '{1}' nel file ZIP {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>Il file ZIP '{0}' non esiste.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>Il file '{0}' non esiste.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Non è possibile elaborare l'elemento '{0}' come riferimento nativo: tipo sconosciuto.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Non è stato possibile caricare Info.plist '{0}' da xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>La directory '{0}' non esiste.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Non è possibile trovare il file o la directory '{0}' nel file ZIP '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Non è possibile elaborare il file ZIP '{0}' in questa piattaforma: il file '{1}' è un collegamento simbolico.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} の形式が正しくないか、不明なため、処理できません。
-        </value>
+        <value>xcframework {0} の形式が正しくないか、不明なため、処理できません。</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>一致するフレームワークが '{0}' 内に見つかりませんでした。
-        </value>
+        <value>'{0}' 内に一致するフレームワークが見つかりません。SupportedPlatform: '{0}'、SupportedPlatformVariant: '{1}'、SupportedArchitectures: '{2}'。</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>'{0}' と '{1}' のオプションが競合しています。'{1}' は無視されます。
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>マニフェスト '{2}' のネイティブ参照 '{1}' に予期しない拡張機能 '{0}'。</value>
+        <value>バインド リソース パッケージ '{2}' のネイティブ参照 '{1}' に対して、予期しない拡張機能 '{0}'。</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>zip ファイル {0} に '{1}' という名前のファイルが必要です。</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>zip ファイル '{0}' が存在しません。</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>ファイル '{0}' が存在しません。</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>項目'{0}' をネイティブ参照として処理できません: 不明な型です。</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>xcframework '{1}' から Info.plist '{0}' を読み込めませんでした。</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>ディレクトリ '{0}' は存在しません。</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>zip ファイル '{1}' にファイルまたはディレクトリ '{0}' が見つかりませんでした。</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>このプラットフォームで zip ファイル '{0}' を処理できません: ファイル '{1}' は symlink です。</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0}의 형식이 잘못되었거나 알 수 없으므로 처리할 수 없습니다.
-        </value>
+        <value>xcframework {0}의 형식이 잘못되었거나 알 수 없어 처리할 수 없습니다.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>'{0}' 내에서 일치하는 프레임워크를 찾을 수 없습니다.
-        </value>
+        <value>내부 '{0}'에 일치하는 프레임워크가 없습니다. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>'{0}' 옵션과 '{1}' 옵션이 충돌합니다. '{1}'은(는) 무시됩니다.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>매니페스트 '{2}'의 네이티브 참조 '{1}'에 대한 예기치 않은 확장 '{0}'.</value>
+        <value>바인딩 리소스 패키지 '{2}'의 기본 참조 '{1}'에 대해 예기치 않은 확장 '{0}'이(가) 발생했습니다.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>zip 파일 {0}에 이름이 '{1}'인 파일이 있어야 합니다.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>zip 파일 '{0}'이(가) 존재하지 않습니다.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>'{0}' 파일이 없습니다.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>항목 '{0}'을(를) 기본 참조로 처리할 수 없음: 알 수 없는 유형.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>xcframework '{1}'에서 Info.plist '{0}'을(를) 로드할 수 없습니다.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>'{0}' 디렉터리가 없습니다.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>zip 파일 '{1}'에서 파일 또는 디렉터리 '{0}'을(를) 찾을 수 없습니다.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>이 플랫폼에서 zip 파일 '{0}'을(를) 처리할 수 없습니다. 파일 '{1}'은(는) symlink입니다.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} ma niepoprawny lub nieznany format i nie można go przetworzyć.
-        </value>
+        <value>Element xcframework {0} ma niepoprawny lub nieznany format i nie można go przetworzyć.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>W elemencie "{0}" nie znaleziono żadnej zgodnej struktury.
-        </value>
+        <value>Nie znaleziono pasującej struktury wewnątrz elementu „{0}”. SupportedPlatform: „{0}”, SupportedPlatformVariant: „{1}”, SupportedArchitectures: „{2}”.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Konflikt opcji "{0}" i "{1}". Element "{1}" zostanie zignorowany.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Nieoczekiwane rozszerzenie „{0}” dla natywnego odwołania „{1}” w manifeście „{2}”.</value>
+        <value>Nieoczekiwane rozszerzenie „{0}” dla odwołania natywnego „{1}” w powiązaniu pakietu zasobów „{2}”.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Oczekiwano pliku o nazwie „{1}” w pliku zip {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>Plik zip „{0}” nie istnieje.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>Plik '{0}' nie istnieje.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Nie można przetworzyć elementu „{0}” jako odwołania natywnego: nieznany typ.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Nie można załadować pliku Info.plist „{0}” z elementu xcframework „{1}”.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>Katalog „{0}” nie istnieje.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Nie można odnaleźć pliku lub katalogu „{0}” w pliku zip „{1}”.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Nie można przetworzyć pliku zip „{0}” na tej platformie: plik „{1}” jest linkiem symlink.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} tem um formato incorreto ou desconhecido e não pode ser processado.
-        </value>
+        <value>O xcframework {0} tem um formato incorreto ou desconhecido e não pode ser processado.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>Nenhuma estrutura correspondente encontrada dentro de '{0}'.
-        </value>
+        <value>Nenhuma estrutura correspondente encontrada dentro de '{0}'. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Opções conflitantes '{0}' e '{1}'. '{1}' será ignorado.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Extensão inesperada '{0}' para referência nativa '{1}' no manifesto '{2}'.</value>
+        <value>Extensão inesperada '{0}' para referência nativa '{1}' no pacote de recursos de ligação '{2}'.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>Esperava um arquivo chamado '{1}' no arquivo zip {0}.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>O arquivo zip '{0}' não existe.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>O arquivo '{0}' não existe.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Não é possível processar o item '{0}' como uma referência nativa: tipo desconhecido.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Não foi possível carregar Info.plist '{0}' do xcframework '{1}'.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>O diretório '{0}' não existe.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Não foi possível encontrar o arquivo ou diretório '{0}' no arquivo zip '{1}'.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Não é possível processar o arquivo zip '{0}' nesta plataforma: o arquivo '{1}' é um link simbólico.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} имеет неправильный или неизвестный формат и не может быть обработан.
-        </value>
+        <value>Невозможно обработать xcframework {0} из-за неверного или неизвестного формата.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>Не найдена соответствующая платформа в "{0}".
-        </value>
+        <value>Не найдена соответствующая платформа в "{0}". SupportedPlatform: "{0}". SupportedPlatformVariant: "{1}". SupportedArchitectures: "{2}".</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>Конфликтующие параметры "{0}" и "{1}". "{1}" будет пропущен.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>Непредвиденное расширение "{0}" для собственной ссылки "{1}" в манифесте "{2}".</value>
+        <value>Непредусмотренное расширение "{0}" для внутренней ссылки "{1}" в пакете ресурсов привязки "{2}".</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>В ZIP-файле {0} ожидался файл с именем "{1}".</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>ZIP-файл "{0}" не существует.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>Файл "{0}" не существует.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>Невозможно обработать элемент "{0}" как внутреннюю ссылку: неизвестный тип.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Не удалось загрузить Info.plist "{0}" из xcframework "{1}".</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>Каталог "{0}" не существует.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>Не удалось найти файл или каталог "{0}" в ZIP-файле "{1}".</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>Невозможно обработать ZIP-файл "{0}" на этой платформе: файл "{1}" является символической ссылкой.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} geçersiz veya bilinmeyen bir biçimde ve işlenemiyor.
-        </value>
+        <value>xcframework {0} hatalı veya bilinmeyen bir biçime sahip ve işlenemiyor.</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>'{0}' içinde eşleşen çerçeve bulunamadı.
-        </value>
+        <value>'{0}' içinde eşleşen çerçeve bulunamadı. SupportedPlatform: '{0}', SupportedPlatformVariant: '{1}', SupportedArchitectures: '{2}'.</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>'{0}' ve '{1}' seçenekleri çakışıyor. '{1}' yoksayılacak.
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>'{2}' bildiriminde '{1}' yerel başvurusu için beklenmeyen '{0}' uzantısı.</value>
+        <value>'{2}' bağlama kaynak paketindeki '{1}' yerel referansı için beklenmeyen '{0}' uzantısı.</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>{0} zip dosyasında '{1}' adlı bir dosya bekleniyordu.</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>'{0}' zip dosyası mevcut değil.</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>'{0}' dosyası yok.</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>'{0}' öğesi yerel referans olarak işlenemiyor: bilinmeyen tür.</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>Info.plist '{0}' xcframework '{1}'den yüklenemedi.</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>'{0}' dizini yok.</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>'{1}' zip dosyasında '{0}' dosya veya dizini bulunamadı.</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>'{0}' zip dosyası bu platformda işlenemiyor: '{1}' dosyası bir sembolik bağlantı.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} 的格式不正确或未知，无法处理。
-        </value>
+        <value>xcframework“{0}”的格式不正确或未知，无法处理。</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>在“{0}”中找不到匹配的框架。
-        </value>
+        <value>在“{0}”中找不到匹配的框架。SupportedPlatform: “{0}”，SupportedPlatformVariant: “{1}”，SupportedArchitectures: “{2}”。</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>“{0}”和“{1}”选项冲突。将忽略“{1}”。
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>清单“{2}”中本机引用“{1}”的意外扩展“{0}”。</value>
+        <value>绑定的资源包“{2}”中本机引用“{1}”的意外扩展“{0}”。</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>zip 文件“{0}”中应有名为“{1}”的文件。</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>zip 文件“{0}”不存在。</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>文件“{0}”不存在。</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>无法以本机引用处理项“{0}”: 未知类型。</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>无法从 xcframework“{1}”加载 Info.plist“{0}”。</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>目录“{0}”不存在。</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>在 zip 文件“{1}”中找不到文件或目录“{0}”。</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>无法处理此平台上的 zip 文件“{0}”: 文件“{1}”为符号链接。</value>
     </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -672,12 +672,13 @@
         </value>
     </data>
   <data name="E0174" xml:space="preserve">
-        <value>{0} 的格式未知或不正確，因此無法處理。
-</value>
+        <value>xcframework {0} 的格式未知或不正確，因此無法處理。</value>
     </data>
   <data name="E0175" xml:space="preserve">
-        <value>在 '{0}' 內找不到相符的架構。
-</value>
+        <value>在 '{0}' 內找不到相符的架構。SupportedPlatform: '{0}'，SupportedPlatformVariant: '{1}'，SupportedArchitectures: '{2}'。</value>
+        <comment>
+            Do not translate: 'SupportedPlatform', 'SupportedPlatformVariant', 'SupportedArchitectures' (they're keys inside a file with key/value pairs))
+        </comment>
     </data>
   <data name="W0176" xml:space="preserve">
         <value>衝突的 '{0}' 和 '{1}' 選項。將忽略 '{1}'。
@@ -1170,11 +1171,35 @@
         </comment>
     </data>
   <data name="W7105" xml:space="preserve">
-        <value>在資訊清單 '{2}' 中的原生參考 '{1}' 發生非預期的延伸模組 '{0}'。</value>
+        <value>在繫結資源套件 '{2}' 中的原生參考 '{1}' 發生非預期的延伸模組 '{0}'。</value>
         <comment>
             {0}: file extension
             {1}: path to a file
             {2}: path to a file
         </comment>
+    </data>
+  <data name="W7106" xml:space="preserve">
+        <value>在 zip 檔案 {0} 中預期名為 '{1}' 的檔案。</value>
+    </data>
+  <data name="W7107" xml:space="preserve">
+        <value>zip 檔案 '{0}' 不存在。</value>
+    </data>
+  <data name="W7108" xml:space="preserve">
+        <value>檔案 '{0}' 不存在。</value>
+    </data>
+  <data name="W7109" xml:space="preserve">
+        <value>無法將項目 '{0}' 處理為原生參考: 未知的類型。</value>
+    </data>
+  <data name="E7110" xml:space="preserve">
+        <value>無法從 xcframework '{1}' 載入 info.plist '{0}'。</value>
+    </data>
+  <data name="W7111" xml:space="preserve">
+        <value>目錄 '{0}' 不存在。</value>
+    </data>
+  <data name="E7112" xml:space="preserve">
+        <value>在 zip 檔案 '{1}' 中找不到檔案或目錄 '{0}'。</value>
+    </data>
+  <data name="E7113" xml:space="preserve">
+        <value>無法處理此平台上的 zip 檔案 '{0}'; 檔案 '{1}' 是符號連結。</value>
     </data>
 </root>

--- a/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.de.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.de.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.es.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.es.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.it.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.it.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>

--- a/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
+++ b/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.