### PR TITLE
[CI] Fix the windows tests in the unified pipeline.

### DIFF
--- a/tests/dotnet/Windows/InstallDotNet.csproj
+++ b/tests/dotnet/Windows/InstallDotNet.csproj
@@ -14,8 +14,8 @@
 
     <MacIosRootDirectory>$(RootSourceDirectory)</MacIosRootDirectory>
     <PackageOutputPath>$(RootSourceDirectory)..\artifacts\</PackageOutputPath>
-    <RollbackFile>$(PackageOutputPath)WorkloadRollback\WorkloadRollback.json</RollbackFile>
-    <RollbackSource>$(PackageOutputPath)not-signed-package</RollbackSource>
+    <RollbackFile>$(PackageOutputPath)$(MaciosUploadPrefix)WorkloadRollback\WorkloadRollback.json</RollbackFile>
+    <RollbackSource>$(PackageOutputPath)$(MaciosUploadPrefix)not-signed-package</RollbackSource>
   </PropertyGroup>
 
   <Target Name="GetNuGetSources">

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -37,6 +37,10 @@ steps:
     path: $(Build.SourcesDirectory)/artifacts
 
 - pwsh: |
+    Get-ChildItem $(Build.SourcesDirectory)/artifacts -Recurse 
+  displayName: "Debug downloads"
+
+- pwsh: |
     try {
       Write-Host "Looking in '$(Build.SourcesDirectory)\artifacts"
       Get-ChildItem "$(Build.SourcesDirectory)\artifacts" -Recurse


### PR DESCRIPTION
Add the prefixes that were missing in the csproj using the env variable set by the pipeline.