### PR TITLE
[tests] Install workloads on Windows without checking the signature of the packages.

### DIFF
--- a/tests/dotnet/Windows/InstallDotNet.csproj
+++ b/tests/dotnet/Windows/InstallDotNet.csproj
@@ -158,7 +158,7 @@
       Inputs="$(_Inputs)"
       Outputs="$(DotNetPacksDirectory).stamp">
     <Exec
-        Command="&quot;$(DotNetToolPath)&quot; workload install %(_WorkloadIds.Identity) --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(MacIosRootDirectory)NuGet.config&quot;"
+        Command="&quot;$(DotNetToolPath)&quot; workload install %(_WorkloadIds.Identity) --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(MacIosRootDirectory)NuGet.config&quot; --skip-sign-check"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
         EnvironmentVariables="DOTNET_MULTILEVEL_LOOKUP=0"
     />


### PR DESCRIPTION
Hopefully fixes:

    MSBuild version 17.4.1+9a89d02ff for .NET
    D:\AzDO\_work\_tool\dotnet\sdk\7.0.102\MSBuild.dll --property:DisableImplicitNuGetFallbackFolder=true -bl:D:\AzDO\_work\2\s/xamarin-macios/tests/dotnet/Windows/install.binlog -consoleloggerparameters:Summary -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,D:\AzDO\_work\_tool\dotnet\sdk\7.0.102\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,D:\AzDO\_work\_tool\dotnet\sdk\7.0.102\dotnet.dll -maxcpucount -restore -verbosity:m -verbosity:quiet D:\AzDO\_work\2\s/xamarin-macios/tests/dotnet/Windows/InstallDotNet.csproj
    EXEC : error : NU3004: The package is not signed. [D:\AzDO\_work\2\s\xamarin-macios\tests\dotnet\Windows\InstallDotNet.csproj]