### PR TITLE
[Localization] Revert change to non-breaking space

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Vista de Mac Catalyst",
+  "name": "Vista de Mac\u00A0Catalyst",
   "description": "Vista de MacCatalyst",
   "symbols/namespace/description": "espacio de nombres para el código generado"
 }


### PR DESCRIPTION
This change didn't really get rid of the non-breaking space and caused extra changes after we built xamarin-macios.