### PR TITLE
[msbuild] Show a warning if asked to load an app manifest that doesn't exist.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifestTaskBase.cs
@@ -102,7 +102,9 @@ namespace Xamarin.MacDev.Tasks {
 			PDictionary plist;
 
 			var appManifest = AppManifest?.ItemSpec;
-			if (appManifest is not null && File.Exists (appManifest)) {
+			if (appManifest is null || string.IsNullOrEmpty (appManifest)) {
+				plist = new PDictionary ();
+			} else if (File.Exists (appManifest)) {
 				try {
 					plist = PDictionary.FromFile (appManifest)!;
 				} catch (Exception ex) {
@@ -110,6 +112,7 @@ namespace Xamarin.MacDev.Tasks {
 					return false;
 				}
 			} else {
+				LogAppManifestWarning (MSBStrings.W7108 /* The file '{0}' does not exist. */, appManifest);
 				plist = new PDictionary ();
 			}
 


### PR DESCRIPTION
This makes it easier to diagnose problems loading/finding app manifests.

Specifying an app manifest that doesn't exist should probably be an error, but
that's very likely to break existing projects, so just make this a warning for
now.