### PR TITLE
[tests] Fix running dotnet with MSBUILD_EXE_PATH.

### DIFF
--- a/tests/test-libraries/custom-type-assembly/Makefile
+++ b/tests/test-libraries/custom-type-assembly/Makefile
@@ -12,7 +12,7 @@ include $(TOP)/Make.config
 	$(Q) mkdir -p $@
 
 bin/Debug/$(DOTNET_TFM)-macos/custom-type-assembly.dll: custom-type-assembly.csproj custom-type-assembly.cs
-	$(Q) $(DOTNET) build $< "/bl:$@.binlog" $(MSBUILD_VERBOSITY)
+	$(Q) unset MSBUILD_EXE_PATH && $(DOTNET) build $< "/bl:$@.binlog" $(MSBUILD_VERBOSITY)
 
 ifdef INCLUDE_MAC
 


### PR DESCRIPTION
'dotnet build' doesn't work when MSBUILD_EXE_PATH is set (which we do in some places
for legacy tests), so make sure to unset MSBUILD_EXE_PATH before running 'dotnet
build'.