### PR TITLE
[devops] Fail the 'Add summaries' task if something goes wrong.

### DIFF
--- a/tools/devops/automation/templates/tests/publish-html.yml
+++ b/tools/devops/automation/templates/tests/publish-html.yml
@@ -89,6 +89,7 @@ steps:
         $gihubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $Env:GITHUB_TOKEN -Hash $Env:COMMENT_HASH -Debug
         $result = $gihubComments.NewCommentFromObject("Test results", $emoji, $parallelResults)
       } catch {
+        Write-Host "##vso[task.complete result=Failed;]Failed to compute test summaries: $_"
         New-GitHubComment -Header "Failed to compute test summaries on $Env:CONTEXT" -Emoji ":fire:" -Description "Failed to compute test summaries: $_."
       }
   env:


### PR DESCRIPTION
That way we can re-run it when something does go wrong (instead of rerunning the _entire pipeline_).