### PR TITLE
[runtime] Re-generate product.h when the current commit changes.

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -71,7 +71,7 @@ bindings-generated.m: bindings-generator.exe
 app-main.m watchextension-main.m tvextension-main.m: extension-main.m
 	$(Q_LN) ln -fs $< $@
 
-product.h: product.in.h Makefile
+product.h: product.in.h Makefile $(TOP)/.git/index
 	$(Q) sed -e 's/@PRODUCT_HASH@/$(CURRENT_HASH_LONG)/' $< > $@.tmp
 	$(Q) mv $@.tmp $@
 #


### PR DESCRIPTION
This way the runtime libraries are always up-to-date after building after
making local commits.