### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 17751: Build ID 7737739

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Vista de Mac\u00A0Catalyst",
+  "name": "Vista de Mac Catalyst",
   "description": "Vista de MacCatalyst",
   "symbols/namespace/description": "espacio de nombres para el código generado"
 }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/localize/templatestrings.es.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Vista de Mac Catalyst",
+  "name": "Vista de Mac\u00A0Catalyst",
   "description": "Vista de MacCatalyst",
   "symbols/namespace/description": "espacio de nombres para el código generado"
 }

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>Soubor ZIP {0} nelze na této platformě zpracovat: soubor {1} je symbolický odkaz.</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>Die ZIP-Datei "{0}" kann auf dieser Plattform nicht verarbeitet werden: Die Datei "{1}" ist ein symbolischer Link.</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>No se puede procesar el archivo ZIP "{0}" en esta plataforma: el archivo "{1}" es un symlink.</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>Impossible de traiter le fichier zip '{0}' sur cette plateforme : le fichier '{1}' est un lien symbolique.</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>Non è possibile elaborare il file ZIP '{0}' in questa piattaforma: il file '{1}' è un collegamento simbolico.</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>このプラットフォームで zip ファイル '{0}' を処理できません: ファイル '{1}' は symlink です。</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>이 플랫폼에서 zip 파일 '{0}'을(를) 처리할 수 없습니다. 파일 '{1}'은(는) symlink입니다.</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>Nie można przetworzyć pliku zip „{0}” na tej platformie: plik „{1}” jest linkiem symlink.</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>Não é possível processar o arquivo zip '{0}' nesta plataforma: o arquivo '{1}' é um link simbólico.</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>Невозможно обработать ZIP-файл "{0}" на этой платформе: файл "{1}" является символической ссылкой.</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>'{0}' zip dosyası bu platformda işlenemiyor: '{1}' dosyası bir sembolik bağlantı.</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>无法处理此平台上的 zip 文件“{0}”: 文件“{1}”为符号链接。</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -1202,4 +1202,7 @@
   <data name="E7113" xml:space="preserve">
         <value>無法處理此平台上的 zip 檔案 '{0}'; 檔案 '{1}' 是符號連結。</value>
     </data>
+  <data name="E7114" xml:space="preserve">
+        <value>The "{0}" task was not given a value for the parameter "{1}", which is required when building on this platform.</value>
+    </data>
 </root>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.