### PR TITLE
Fix nullability of WebView.EditingDelegate

### DIFF
--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -2963,7 +2963,7 @@ namespace WebKit {
 		[Export ("continuousSpellCheckingEnabled")]
 		bool ContinuousSpellCheckingEnabled { [Bind ("isContinuousSpellCheckingEnabled")] get; set; }
 
-		[Export ("editingDelegate", ArgumentSemantic.Assign)]
+		[Export ("editingDelegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject EditingDelegate { get; set; }
 
 		[Export ("replaceSelectionWithMarkupString:")]


### PR DESCRIPTION
Note that both the headers and the documentation are incorrect in this case. All of the `WebView.*Delegate` objects are documented as non-nullable, but in all cases it's wrong. The binding for the other `Delegate`s allows `null`s in Xamarin.

Failure to remove the `EditingDelegate` reference may result in a crash when the `WebView` object gets disposed:
```
16  xamarin_release_managed_ref + 108 (eM Client + 63772) [0x100ecf91c]
  16  -[Xilium_CefGlue_CefWebView release] + 32 (eM Client + 116128) [0x100edc5a0]
  16  xamarin_invoke_objc_method_implementation + 140 (eM Client + 73400) 
[0x100ed1eb8]
  16  -[WebView dealloc] + 112 (WebKitLegacy + 166520) [0x1ccf72a78]
  16  -[WebView(WebPrivate) _close] + 364 (WebKitLegacy + 167048) [0x1ccf72c88]
  16  WebCore::FrameLoader::detachFromParent() + 48 (WebCore + 628864) [0x1d248f880]
  16  WebCore::FrameLoader::closeURL() + 244 (WebCore + 26226672) [0x1d3cf8ff0]
  16  WebEditorClient::clearUndoRedoOperations() + 52 (WebKitLegacy + 102060) 
[0x1ccf62eac]
  16  -[WebView(WebViewEditing) undoManager] + 72 (WebKitLegacy + 153444) 
[0x1ccf6f764]
  16  _CF_forwarding_prep_0 + 96 (CoreFoundation + 408816) [0x1b6993cf0]
  16  ___forwarding___ + 1004 (CoreFoundation + 410012) [0x1b699419c]
  16  objc_opt_respondsToSelector + 48 (libobjc.A.dylib + 185536) [0x1b67944c0]
  7   PAL_DispatchExceptionWrapper + 16 (libcoreclr.dylib + 262040) [0x102db7f98]
```