### PR TITLE
[xharness] Use our own SetProperty to set properties instead of the SetTopLevelPropertyGroupValue extension method.

### DIFF
--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -260,22 +260,22 @@ namespace Xharness.Jenkins {
 							MonoNativeHelper.AddProjectDefines (clone.Xml, mono_native_link);
 						}
 						if (test_data.EnableSGenConc)
-							clone.Xml.SetTopLevelPropertyGroupValue ("EnableSGenConc", "true");
+							clone.Xml.SetProperty ("EnableSGenConc", "true");
 						if (test_data.UseThumb) // no need to check the platform, already done at the data iterator
-							clone.Xml.SetNode ("MtouchUseThumb", "true", task.ProjectPlatform, configuration);
+							clone.Xml.SetProperty ("MtouchUseThumb", "true");
 						if (use_llvm)
-							clone.Xml.SetTopLevelPropertyGroupValue ("MtouchUseLlvm", "true");
+							clone.Xml.SetProperty ("MtouchUseLlvm", "true");
 
 						if (!debug && !isMac)
 							clone.Xml.SetMtouchUseLlvm (true, task.ProjectPlatform, configuration);
 						if (use_mono_runtime.HasValue)
-							clone.Xml.SetTopLevelPropertyGroupValue ("UseMonoRuntime", use_mono_runtime.Value ? "true" : "false");
+							clone.Xml.SetProperty ("UseMonoRuntime", use_mono_runtime.Value ? "true" : "false");
 						if (!string.IsNullOrEmpty (xammac_arch))
-							clone.Xml.SetNode ("XamMacArch", xammac_arch, task.ProjectPlatform, configuration);
+							clone.Xml.SetProperty ("XamMacArch", xammac_arch);
 						if (!string.IsNullOrEmpty (runtime_identifer))
-							clone.Xml.SetTopLevelPropertyGroupValue ("RuntimeIdentifier", runtime_identifer);
+							clone.Xml.SetProperty ("RuntimeIdentifier", runtime_identifer);
 						if (!string.IsNullOrEmpty (registrar))
-							clone.Xml.SetTopLevelPropertyGroupValue ("Registrar", registrar);
+							clone.Xml.SetProperty ("Registrar", registrar);
 						clone.Xml.Save (clone.Path);
 					});
 


### PR DESCRIPTION
This is because the SetTopLevelPropertyGroupValue method doesn't always work
as expected (it doesn't always set seomthing), while SetProperty does.

Fixing the SetTopLevelPropertyGroup method is somewhat complex, since it lives
in the dotnet/xharness repository, so instead use the SetProperty method,
which is our own (working) version.