### PR TITLE
[autoformat] Fix running sed on Linux.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/MTouchTaskBase.cs
@@ -449,7 +449,7 @@ namespace Xamarin.iOS.Tasks {
 
 		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied ()
 		{
-			if (NativeReferences == null)
+			if (NativeReferences is null)
 				yield break;
 
 			foreach (var nativeRef in NativeReferences) {

--- a/tools/autoformat.sh
+++ b/tools/autoformat.sh
@@ -10,12 +10,28 @@ SRC_DIR=$(pwd)
 # except in a few tests files, where we have tests for (in)equality operators, and in that case the '== null' and '!= null' code is correct.
 #
 IFS=$'\n'
-for file in $(git ls-files -- '*.cs' ':(exclude)tests/monotouch-test/Foundation/UrlTest.cs' ':(exclude)tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs'); do
-	if [[ -L "$file" ]]; then
-		continue
+
+(
+	set +x
+	export LANG=en
+	IFS=$'\n'
+	cd "$SRC_DIR"
+
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		SED=(sed -i "")
+	else
+		SED=(sed -i)
 	fi
-	LANG=en sed -i '' -e 's/!= null/is not null/g' -e 's/== null/is null/g' "$file"
-done
+
+	for file in $(git ls-files -- '*.cs' ':(exclude)tests/monotouch-test/Foundation/UrlTest.cs' ':(exclude)tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs'); do
+		if [[ -L "$file" ]]; then
+			echo "Skipping $file because it's a symlink"
+			continue
+		fi
+
+		"${SED[@]}" -e 's/!= null/is not null/g' -e 's/== null/is null/g' "$file"
+	done
+)
 
 # Go one directory up, to avoid any global.json in xamarin-macios
 cd ..


### PR DESCRIPTION
The autoformat action doesn't necessarily run on macOS, and sed's syntax is
different between macOS and Linux - so make sure to cope with these
differences.

Also execute the nullability fixes in a separate subshell to not interfere
with the rest of the script.

This fixes an issue where autoformat would fail with:

    + sed -i '' -e 's/!= null/is not null/g' -e 's/== null/is null/g' builds/fix-maccatalyst-assembly/Program.cs
    sed: can't read : No such file or directory