### PR TITLE
[bgen] Fix a few nullability warnings.

### DIFF
--- a/src/bgen/BindingTouch.cs
+++ b/src/bgen/BindingTouch.cs
@@ -525,6 +525,13 @@ public class BindingTouch : IDisposable {
 			typeManager ??= new (this, api, universe.CoreAssembly, baselib);
 
 			foreach (var linkWith in AttributeManager.GetCustomAttributes<LinkWithAttribute> (api)) {
+#if NET
+				if (string.IsNullOrEmpty (linkWith.LibraryName))
+#else
+				if (linkWith.LibraryName is null || string.IsNullOrEmpty (linkWith.LibraryName))
+#endif
+					continue;
+
 				if (!linkwith.Contains (linkWith.LibraryName)) {
 					Console.Error.WriteLine ("Missing native library {0}, please use `--link-with' to specify the path to this library.", linkWith.LibraryName);
 					return 1;

--- a/src/bgen/Filters.cs
+++ b/src/bgen/Filters.cs
@@ -211,7 +211,7 @@ public partial class Generator {
 				if (export is null)
 					throw new BindingException (1074, true, type.Name, p.Name);
 
-				var sel = export.Selector;
+				var sel = export.Selector!;
 				if (sel.StartsWith ("input", StringComparison.Ordinal))
 					name = sel;
 				else
@@ -237,7 +237,7 @@ public partial class Generator {
 		if (export is null)
 			return;
 
-		var selector = export.Selector;
+		var selector = export.Selector!;
 		if (setter)
 			selector = "set" + selector.Capitalize () + ":";
 

--- a/src/bgen/bgen.csproj
+++ b/src/bgen/bgen.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
     <DefineConstants>DEBUG;BGENERATOR;NET_4_0;NO_AUTHENTICODE;STATIC;NO_SYMBOL_WRITER;NET</DefineConstants>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Also make nullability warnings errors, so we don't add any more nullability issues.

Fixes:

	src/bgen/Filters.cs(215,9): warning CS8602: Dereference of a possibly null reference.
	src/bgen/Filters.cs(242,23): warning CS8604: Possible null reference argument for parameter 'str' in 'string StringExtensions.Capitalize(string str)'.
	src/bgen/BindingTouch.cs(528,29): warning CS8604: Possible null reference argument for parameter 'item' in 'bool List<string>.Contains(string item)'.