### PR TITLE
[dotnet] add metadata about .NET 6 EOL

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -113,10 +113,11 @@ Microsoft.$(1).Sdk/Sdk/AutoImport.props: targets/AutoImport.template.props Makef
 	$(Q) rm -f $$@.tmp
 	$$(Q_GEN) sed \
 		-e "s/@PLATFORM@/$(1)/g" \
+		-e "s/@PLATFORM_LOWERCASE@/$(2)/g" \
 		$$< > $$@.tmp
 	$(Q) mv $$@.tmp $$@
 endef
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call AutoImports,$(platform))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call AutoImports,$(platform),$(shell echo $(platform) | tr A-Z a-z))))
 
 define DefaultItems
 Microsoft.$1.Sdk/targets/Microsoft.$1.Sdk.DefaultItems.props: targets/Microsoft.Sdk.DefaultItems.template.props Makefile

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -114,6 +114,7 @@ Microsoft.$(1).Sdk/Sdk/AutoImport.props: targets/AutoImport.template.props Makef
 	$$(Q_GEN) sed \
 		-e "s/@PLATFORM@/$(1)/g" \
 		-e "s/@PLATFORM_LOWERCASE@/$(2)/g" \
+		-e "s/@TARGET_FRAMEWORK_VERSION@/$(subst net,,$(DOTNET_TFM))/g" \
 		$$< > $$@.tmp
 	$(Q) mv $$@.tmp $$@
 endef

--- a/dotnet/targets/AutoImport.template.props
+++ b/dotnet/targets/AutoImport.template.props
@@ -1,4 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == '@PLATFORM@' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@TARGET_FRAMEWORK_VERSION@'))">
+		<EolWorkload Include="@PLATFORM_LOWERCASE@" Url="https://aka.ms/maui-support-policy" />
+	</ItemGroup>
 	<Import Project="..\targets\Microsoft.@PLATFORM@.Sdk.DefaultItems.props" />
 	<Import Project="..\targets\Microsoft.@PLATFORM@.Sdk.ImplicitNamespaceImports.props" />
 </Project>


### PR DESCRIPTION
Context: https://aka.ms/maui-support-policy
Context: https://github.com/xamarin/xamarin-android/commit/25cb50d78ac929b03d2ec6f1a4c0a7aeb9bcebc3
Context: https://github.com/dotnet/sdk/pull/32426

dotnet/sdk#32426 adds support for an optional workload to specify that it is no longer supported by adding an item to the `@(EolWorkload)` item group:

    <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'iOS' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
      <EolWorkload Include="ios" Url="https://aka.ms/maui-support-policy" />
    </ItemGroup>

This will cause `dotnet build` to issue a new NETSDK1202 build warning:

    dotnet\sdk\6.0.409\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(35,5):
    warning NETSDK1202: The workload 'ios' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.

I had to update the `Makefile` to do a `@PLATFORM_LOWERCASE@` replacement for this.