### PR TITLE
[dotnet] Stop looking for the AOT compiler if cached

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -998,11 +998,6 @@
 			<Output TaskParameter="Lines" PropertyName="_XamarinAOTCompiler" />
 		</ReadLinesFromFile>
 
-		<!-- If the cached value points to a file that doesn't exist, then don't use it -->
-		<PropertyGroup Condition="!Exists('$(_XamarinAOTCompiler)')">
-			<_XamarinAOTCompiler />
-		</PropertyGroup>
-
 		<FindAotCompiler
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '$(_RunAotCompiler)' == 'true' And '$(_XamarinAOTCompiler)' == ''"


### PR DESCRIPTION
The AOT compiler does not exist on Windows, so this check was making the cache never work there. We don't really need to check if the compiler does still exist, since the cache can be deleted by rebuilding the project if anything fails.