### PR TITLE
[DevOps] Do not sign the sbom on the prs.

### DIFF
--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -166,6 +166,8 @@ variables:
   value: ''
 - name: MaciosUploadPrefix
   value: ''
+- name: Packaging.EnableSBOMSigning
+  value: false
 
 trigger: none
 


### PR DESCRIPTION
That step is failing or Prs with the following messsage:

`
##[error]The signing feature is not available for your organization yet.
`

Yet we do not need or care about the sbom on a pr. We can remove it and that way not get the error and use less resources.