### PR TITLE
[DevOps] Provide a script that will allow use to debug the expanded yaml.

### DIFF
--- a/tools/devops/automation/scripts/preview_yaml.ps1
+++ b/tools/devops/automation/scripts/preview_yaml.ps1
@@ -1,0 +1,27 @@
+param (
+    [Parameter(Mandatory)]
+    [String]
+    $AccessToken,
+
+    [String]
+    $Pipeline="ci",
+
+    [String]
+    $Branch="main",
+
+    [Parameter(Mandatory)]
+    [String]
+    $OutputFile
+)
+
+Import-Module ./VSTS.psm1 -Force
+
+if ($Pipeline -eq "pr") {
+    Write-Host "Querying the PR pipeline."
+    $PipelineId="16533"
+} else {
+    Write-Host "Querying the CI pipeline."
+    $PipelineId="14411"
+}
+
+Get-YamlPreview -Org "devdiv" -Project "DevDiv" -AccessToken $AccessToken -PipelineId $PipelineId -Branch $Branch -OutputFile $OutputFile


### PR DESCRIPTION


This pr provides a script that will allow to create a dry run in vsts and will return the expanded yaml after the yaml compiler has been executed, this will be written in the given output file.

Usage:

Basic usage: Query the expanded template from the ci pipeline in main:

```pwsh
./preview_yaml.ps1 -AccessToken $pat -OutputFile ./full.yaml
```

Query the expansion in the pr pipeline:
```pwsh
./preview_yaml.ps1 -AccessToken $pat -OutputFile ./full.yaml -Pipeline "pr"
```

Query the expansion in the ci pipeline for a diff branch than main:
```pwsh
./preview_yaml.ps1 -AccessToken $pat -OutputFile ./full.yaml -Branch "trigger-issues"
```

The output file is ALLWAYS overriden.