### PR TITLE
[release/7.0.2xx-xcode14.3] [msbuild] Fix calling the GetFileSystemEntries task on Windows when not connected to a Mac.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2005,6 +2005,10 @@ global using nfloat = global::System.Runtime.InteropServices.NFloat%3B
 			<_BindingPackagesFromReferencedAssembliesDirectoriesExists Include="@(_BindingPackagesFromReferencedAssembliesDirectoriesCandidates->Distinct())" Condition="Exists('%(Identity)')" />
 		</ItemGroup>
 
+		<PropertyGroup Condition="'$(IsMacEnabled)' == 'true'">
+			<BuildSessionIdIfConnected>$(BuildSessionId)</BuildSessionIdIfConnected>
+		</PropertyGroup>
+
 		<!--
 			We need to expand items in an item group using globs, which is
 			kind of tricky, because globs in item transformations aren't
@@ -2013,11 +2017,12 @@ global using nfloat = global::System.Runtime.InteropServices.NFloat%3B
 			Note that this task should run remotely from Windows when there's
 			a Mac connected, but locally when there's not a Mac connected (for
 			Hot Restart builds for instance), so we're not conditioning this
-			task on IsMacEnabled.
+			task on IsMacEnabled. Instead we're only setting SessionId if we
+			have a session id *and* we're connected to a Mac.
 
 		-->
 		<GetFileSystemEntries
-			SessionId="$(BuildSessionId)"
+			SessionId="$(BuildSessionIdIfConnected)"
 			DirectoryPath="@(_BindingPackagesFromReferencedAssembliesDirectoriesExists)"
 			Pattern="*"
 			Recursive="true"


### PR DESCRIPTION
Given the following truths:

* A task will (try to) connect to a Mac if its SessionId property isn't empty.
* The BuildSessionId property is always set on Windows when building from an IDE (even if not connected to a remote Mac).

It stands to reason that we can't use BuildSessionId to distinguish between
connected/not conected status on Windows. Instead introduce a new property,
BuildSessionIdIfConnected, which is only set if connected to a Mac (i.e. if
'IsMacEnabled=true').

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1808448 (second attempt).


Backport of #18287
