### PR TITLE
[release/7.0.2xx-xcode14.3] [runtime] Add support for keeping the same block alive multiple times. Fixes #18161.

### DIFF
--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -564,10 +564,27 @@ namespace ObjCRuntime {
 	}
 
 	// This class will free the specified block when it's collected by the GC.
-	internal class BlockCollector : TrampolineBlockBase {
+	internal class BlockCollector {
+		IntPtr block;
+		int count;
 		public BlockCollector (IntPtr block)
-			: base (block, owns: true)
 		{
+			this.block = block;
+			count = 1;
+		}
+
+		public void Add (IntPtr block)
+		{
+			if (block != this.block)
+				throw new InvalidOperationException (string.Format ("Can't release the block 0x{0} because this BlockCollector instance is already tracking 0x{1}.", block.ToString ("x"), this.block.ToString ("x")));
+			Interlocked.Increment (ref count);
+		}
+
+		~BlockCollector ()
+		{
+			for (var i = 0; i < count; i++)
+				Runtime.ReleaseBlockOnMainThread (block);
+			count = 0;
 		}
 	}
 #endif

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2046,7 +2046,11 @@ namespace ObjCRuntime {
 			if (block == IntPtr.Zero)
 				return @delegate;
 
-			block_lifetime_table.Add (@delegate, new BlockCollector (block));
+			if (block_lifetime_table.TryGetValue (@delegate, out var existingCollector)) {
+				existingCollector.Add (block);
+			} else {
+				block_lifetime_table.Add (@delegate, new BlockCollector (block));
+			}
 			return @delegate;
 		}
 


### PR DESCRIPTION
We can be asked to keep the same block+delegate pair alive multiple times, so
add support for keeping track how many times a block must be freed once the
corresponding delegate is collected by the GC.

Fixes https://github.com/xamarin/xamarin-macios/issues/18161.


Backport of #18277
