### PR TITLE
[tests] Fix adding no files to package-test-libraries.zip.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -350,9 +350,9 @@ package-test-libraries.zip:
 	$(Q_GEN) cd $(TOP) && zip -9r --symlinks $(abspath $@).tmp ./tests/mono-native/macOS/unified ./tests/mono-native/macOS/compat
 	$(Q_GEN) cd $(TOP) && zip -9r --symlinks $(abspath $@).tmp ./tests/mono-native/iOS/unified ./tests/mono-native/iOS/compat
 	$(Q_GEN) cd $(TOP) && zip -9r --symlinks $(abspath $@).tmp ./tests/bcl-test/generated ./tests/bcl-test/templates
-	$(Q_GEN) cd $(TOP) && find tests -regex '.*/generated-projects/.*[c|f]sproj' | zip -9r --symlinks $(abspath $@).tmp -@
-	$(Q_GEN) cd $(TOP) && find tests -regex '.*/generated-projects/.*sln' | zip -9r --symlinks $(abspath $@).tmp -@
-	$(Q_GEN) cd $(TOP) && find tests -regex 'tests/test-libraries/custom-type-assembly/.libs/.*dll' | zip -9r --symlinks $(abspath $@).tmp -@
+	$(Q_GEN) cd $(TOP) && find tests -regex '.*/generated-projects/.*[c|f]sproj' -exec zip -9r --symlinks $(abspath $@).tmp {} +
+	$(Q_GEN) cd $(TOP) && find tests -regex '.*/generated-projects/.*sln' -exec zip -9r --symlinks $(abspath $@).tmp {} +
+	$(Q_GEN) cd $(TOP) && find tests -regex 'tests/test-libraries/custom-type-assembly/.libs/.*dll' -exec zip -9r --symlinks $(abspath $@).tmp {} +
 	$(Q_GEN) cd $(TOP) && git ls-files -o -- 'tests/*/Info-*plist' | zip -9r --symlinks $(abspath $@).tmp -@
 ifdef INCLUDE_XAMARIN_LEGACY
 ifdef INCLUDE_IOS


### PR DESCRIPTION
If only some platforms are enabled, some of the commands to find files to add
to package-test-libraries.zip won't find any files at all.

Asking 'zip' to add no files fails with:

    zip error: Nothing to do!

and there's no way to add 'zip' to ignore this error condition.

However, we can instead try to not call zip at all when we don't find any
files, and we do that by using:

    "find ... -exec zip"

instead of:

   "find .. | zip ..."