### PR TITLE
Update Messaging and HotRestart versions

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.9.102</MessagingVersion>
-		<HotRestartVersion>1.0.114</HotRestartVersion>
+		<MessagingVersion>1.10.26</MessagingVersion>
+		<HotRestartVersion>1.0.115</HotRestartVersion>
 	</PropertyGroup>
 </Project>

--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.10.26</MessagingVersion>
-		<HotRestartVersion>1.0.115</HotRestartVersion>
+		<MessagingVersion1.10.30</MessagingVersion>
+		<HotRestartVersion>1.0.119</HotRestartVersion>
 	</PropertyGroup>
 </Project>

--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion1.10.30</MessagingVersion>
+		<MessagingVersion>1.10.30</MessagingVersion>
 		<HotRestartVersion>1.0.119</HotRestartVersion>
 	</PropertyGroup>
 </Project>

--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -501,7 +501,6 @@ DOTNET_IOS_WINDOWS_OUTPUT_FILES =                                \
 	$(foreach dll,$(IOS_WINDOWS_TASK_ASSEMBLIES),$(dll).*)       \
 	$(foreach dll,$(IOS_WINDOWS_DEPENDENCIES),$(dll).*)          \
 	iSign.Core.pdb                                               \
-	System.Diagnostics.Tracer.pdb                                \
 	Xamarin.iOS.Windows.Client.pdb                               \
 	Broker.zip                                                   \
 	Build.zip                                                    \

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -41,7 +41,6 @@
     </None>
     <None Include="$(PkgXamarin_iOS_HotRestart_Client)\lib\netstandard2.0\iSign.Core.pdb" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgXamarin_iOS_HotRestart_Client)\lib\netstandard2.0\Xamarin.iOS.Windows.Client.pdb" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(PkgSystem_Diagnostics_Tracer)\lib\netstandard2.0\System.Diagnostics.Tracer.pdb" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="../Versions.ios.g.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Xamarin.Messaging.Core" Version="$(MessagingVersion)" IncludeAssets="build" />
     <PackageReference Include="Xamarin.Messaging.Server" Version="$(MessagingVersion)" IncludeAssets="contentFiles" />
     <PackageReference Include="Xamarin.iOS.HotRestart.Client" Version="$(HotRestartVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="System.Diagnostics.Tracer" Version="2.0.8" GeneratePathProperty="true" />
+    <PackageReference Include="System.Diagnostics.Tracer" Version="2.1.0-alpha" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messaging\Xamarin.Messaging.Build\Xamarin.Messaging.Build.csproj">

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -41,7 +41,7 @@
     </None>
     <None Include="$(PkgXamarin_iOS_HotRestart_Client)\lib\netstandard2.0\iSign.Core.pdb" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgXamarin_iOS_HotRestart_Client)\lib\netstandard2.0\Xamarin.iOS.Windows.Client.pdb" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(PkgSystem_Diagnostics_Tracer)\lib\netstandard1.3\System.Diagnostics.Tracer.pdb" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgSystem_Diagnostics_Tracer)\lib\netstandard2.0\System.Diagnostics.Tracer.pdb" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="../Versions.ios.g.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
We need to update the `System.Diagnostics.Tracer` package to version `2.1.0-alpha` due to an issue with the `ChecksumAlgorithm` property of older versions.