### PR TITLE
[CI] Use the template to generate a matrix strategy which reduces the yaml explosion.

### DIFF
--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -298,7 +298,7 @@ steps:
   displayName: 'Publish Artifact: All binlogs'
   inputs:
     targetPath: $(Build.ArtifactStagingDirectory)/all-binlogs
-    artifactName: ${{ parameters.uploadPrefix }}all-binlogs-test-${{ parameters.testPrefix }}-$(Build.BuildId)-$(System.JobAttempt)'
+    artifactName: ${{ parameters.uploadPrefix }}all-binlogs-test-${{ parameters.testPrefix }}-$(Build.BuildId)-$(System.JobAttempt)
   continueOnError: true
   condition: succeededOrFailed()
 

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -142,6 +142,8 @@ stages:
       - Agent.OS -equals Darwin
       - macOS.Name -equals ${{ parameters.macOSName }}
       - XcodeChannel -equals ${{ parameters.XcodeChannel }}
+      - ${{ each demand in parameters.extraBotDemands }}:
+          - demand
       workspace:
         clean: all
     strategy:

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -149,7 +149,7 @@ stages:
     strategy:
       matrix:
         ${{ each label in parameters.simTestsConfigurations }}:
-        ${{ replace(label, '-', '_') }}:
+          ${{ replace(label, '-', '_') }}:
             LABEL: ${{ label }}
             TESTS_LABELS: '${{ parameters.testsLabels }},run-${{ label }}-tests'
             STATUS_CONTEXT: '${{ parameters.statusContext }} - ${{ label }}'

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -117,53 +117,57 @@ stages:
           uploadArtifacts: false
           enableDotnet: ${{ parameters.enableDotnet }}
 
-  - ${{ each label in parameters.simTestsConfigurations }}:
-    - job: "tests_${{ replace(label, '-', '_') }}"
-      ${{ if eq(parameters.parseLabels, true) }}:
-        condition: ne(dependencies.configure.outputs['labels.skip_all_tests'], 'True')
-      dependsOn:
-      - ${{ if eq(parameters.parseLabels, true) }}:
-        - configure
-      displayName: 'Running ${{ label}} - ${{ parameters.displayName }}' 
-      timeoutInMinutes: 1000
+  - job: "tests"
+    ${{ if eq(parameters.parseLabels, true) }}:
+      condition: ne(dependencies.configure.outputs['labels.skip_all_tests'], 'True')
+    dependsOn:
+    - ${{ if eq(parameters.parseLabels, true) }}:
+      - configure
+    displayName: 'Running tests' 
+    timeoutInMinutes: 1000
+    variables:
+      # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
+      PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
+      # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
+      BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+      XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness_labels'] ]
+      ${{ if eq(parameters.testPool, '') }}:
+        AgentPoolComputed: $(PRBuildPool)
+      ${{ else }}:
+        AgentPoolComputed: ${{ parameters.testPool }}
 
-      variables:
-        # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
-        PR_ID: $[ dependencies.configure.outputs['labels.pr_number'] ]
-        # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
-        BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
-        XHARNESS_LABELS: $[ dependencies.configure.outputs['labels.xharness_labels'] ]
-        ${{ if eq(parameters.testPool, '') }}:
-          AgentPoolComputed: $(PRBuildPool)
-        ${{ else }}:
-          AgentPoolComputed: ${{ parameters.testPool }}
-
-      pool:
-        name: $(AgentPoolComputed)
-        demands:
-        - Agent.OS -equals Darwin
-        - macOS.Name -equals ${{ parameters.macOSName }}
-        - XcodeChannel -equals ${{ parameters.XcodeChannel }}
-        - ${{ each demand in parameters.extraBotDemands }}:
-          - demand
-        workspace:
-          clean: all
-      steps:
-      - template: build.yml
-        parameters:
-          isPR: ${{ parameters.isPR }} 
-          repositoryAlias: ${{ parameters.repositoryAlias }}
-          commit: ${{ parameters.commit }}
-          label: ${{ label }}
-          testsLabels: '${{ parameters.testsLabels }},run-${{ label }}-tests'
-          statusContext: '${{ parameters.statusContext }} - ${{ label }}'
-          useXamarinStorage: ${{ parameters.useXamarinStorage }}
-          vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
-          keyringPass: ${{ parameters.keyringPass }}
-          testPrefix: "${{ parameters.testPrefix }}${{ replace(label, '-', '_') }}"
-          makeTarget: ${{ parameters.makeTarget }}
-          gitHubToken: ${{ parameters.gitHubToken }}
-          xqaCertPass: ${{ parameters.xqaCertPass }}
+    pool:
+      name: $(AgentPoolComputed)
+      demands:
+      - Agent.OS -equals Darwin
+      - macOS.Name -equals ${{ parameters.macOSName }}
+      - XcodeChannel -equals ${{ parameters.XcodeChannel }}
+      workspace:
+        clean: all
+    strategy:
+      matrix:
+        ${{ each label in parameters.simTestsConfigurations }}:
+          TEST_${{ replace(label, '-', '_') }}:
+            LABEL: ${{ label }}
+            TESTS_LABELS: '${{ parameters.testsLabels }},run-${{ label }}-tests'
+            STATUS_CONTEXT: '${{ parameters.statusContext }} - ${{ label }}'
+            TEST_PREFIX: "${{ parameters.testPrefix }}${{ replace(label, '-', '_') }}"
+    steps:
+    - template: build.yml
+      parameters:
+        isPR: ${{ parameters.isPR }}
+        repositoryAlias: ${{ parameters.repositoryAlias }}
+        commit: ${{ parameters.commit }}
+        label: $(LABEL)
+        testsLabels: $(TESTS_LABELS)
+        statusContext: $(STATUS_CONTEXT)
+        useXamarinStorage: ${{ parameters.useXamarinStorage }}
+        vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
+        keyringPass: ${{ parameters.keyringPass }}
+        testPrefix: $(TEST_PREFIX)
+        makeTarget: ${{ parameters.makeTarget }}
+        gitHubToken: ${{ parameters.gitHubToken }}
+        xqaCertPass: ${{ parameters.xqaCertPass }}
 
   - job: publish_test_results
     ${{ if eq(parameters.parseLabels, true) }}:
@@ -173,10 +177,9 @@ stages:
     displayName: 'GitHub comment - Publish results'
     timeoutInMinutes: 1000
     dependsOn: # has to wait for the tests to be done AND the data to be uploaded
+    - tests
     - ${{ if eq(parameters.parseLabels, true) }}:
       - configure
-    - ${{ each label in parameters.simTestsConfigurations }}:
-      - tests_${{ replace(label, '-', '_') }}
     variables:
       GIT_HASH: $[ stageDependencies.build_packages.build.outputs['fix_commit.GIT_HASH'] ]
       ${{ each label in parameters.simTestsConfigurations }}:

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -187,8 +187,8 @@ stages:
       ${{ each label in parameters.simTestsConfigurations }}:
         # Define the variable FOO from the previous job
         # Note the use of single quotes!
-        TESTS_BOT_${{ upper(replace(label, '-', '_')) }}: $[ dependencies.tests.outputs['${{ replace(label, '-', '_'}}.runTests.TESTS_BOT'] ]
-        TESTS_JOBSTATUS_${{ upper(replace(label, '-', '_')) }}: $[ dependencies.tests.outputs['${{ replace(label, '-', '_'runTests.TESTS_JOBSTATUS'] ]
+        TESTS_BOT_${{ upper(replace(label, '-', '_')) }}: $[ dependencies.tests.outputs['${{ replace(label, '-', '_')}}.runTests.TESTS_BOT'] ]
+        TESTS_JOBSTATUS_${{ upper(replace(label, '-', '_')) }}: $[ dependencies.tests.outputs['${{ replace(label, '-', '_')}}.runTests.TESTS_JOBSTATUS'] ]
     pool:
       vmImage: 'windows-latest'
       workspace:

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -123,7 +123,7 @@ stages:
     dependsOn:
     - ${{ if eq(parameters.parseLabels, true) }}:
       - configure
-    displayName: 'Running tests' 
+    displayName: 'Running tests:' 
     timeoutInMinutes: 1000
     variables:
       # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
@@ -147,7 +147,7 @@ stages:
     strategy:
       matrix:
         ${{ each label in parameters.simTestsConfigurations }}:
-          TEST_${{ replace(label, '-', '_') }}:
+        ${{ replace(label, '-', '_') }}:
             LABEL: ${{ label }}
             TESTS_LABELS: '${{ parameters.testsLabels }},run-${{ label }}-tests'
             STATUS_CONTEXT: '${{ parameters.statusContext }} - ${{ label }}'

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -187,8 +187,8 @@ stages:
       ${{ each label in parameters.simTestsConfigurations }}:
         # Define the variable FOO from the previous job
         # Note the use of single quotes!
-        TESTS_BOT_${{ upper(replace(label, '-', '_')) }}: $[ dependencies.tests_${{ replace(label, '-', '_') }}.outputs['runTests.TESTS_BOT'] ]
-        TESTS_JOBSTATUS_${{ upper(replace(label, '-', '_')) }}: $[ dependencies.tests_${{ replace(label, '-', '_') }}.outputs['runTests.TESTS_JOBSTATUS'] ]
+        TESTS_BOT_${{ upper(replace(label, '-', '_')) }}: $[ dependencies.tests.outputs['${{ replace(label, '-', '_'}}.runTests.TESTS_BOT'] ]
+        TESTS_JOBSTATUS_${{ upper(replace(label, '-', '_')) }}: $[ dependencies.tests.outputs['${{ replace(label, '-', '_'runTests.TESTS_JOBSTATUS'] ]
     pool:
       vmImage: 'windows-latest'
       workspace:

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -143,7 +143,7 @@ stages:
       - macOS.Name -equals ${{ parameters.macOSName }}
       - XcodeChannel -equals ${{ parameters.XcodeChannel }}
       - ${{ each demand in parameters.extraBotDemands }}:
-          - demand
+        - demand
       workspace:
         clean: all
     strategy:


### PR DESCRIPTION
The final result is the same, but because a matrix strategy is a native element of azure pipeline, it does not get expanded. This makes our pipeline to be reduce to under 10.000 lines of yaml when it was around 40.000. This should unblock the dev of https://github.com/xamarin/xamarin-macios/pull/18279