### PR TITLE
[main] Hot Restart fixes

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<MessagingVersion>1.10.0</MessagingVersion>
-		<HotRestartVersion>1.0.114</HotRestartVersion>
+		<HotRestartVersion>1.0.119</HotRestartVersion>
 	</PropertyGroup>
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -217,6 +217,15 @@
 		</Copy>
 	</Target>
 
+	<Target Name="_CreateHotRestartAppMarkers">
+		<MakeDir Directories="$(HotRestartContentStampDir)"/>
+		<MakeDir Directories="@(_HotRestartContentDirContents -> '$(HotRestartContentStampDir)%(DestinationSubDirectory)')"/>
+
+		<Touch AlwaysCreate="true" Files="@(_HotRestartContentDirContents -> '$(HotRestartContentStampDir)%(DestinationSubDirectory)%(FileName)%(Extension).stamp')" />
+		<Touch AlwaysCreate="true" Files="$(HotRestartContentStampDir)$(AssemblyName).hotrestartapp.stamp" />
+		<Touch AlwaysCreate="true" Files="$(HotRestartAppContentDir)$(AssemblyName).hotrestartapp" />
+	</Target>
+
 	<Target Name="_CollectCodeSignHotRestartInputs">
 		<ItemGroup>
 			<_CodeSignHotRestartInputs Include="$(_AppBundleManifestPath)" Outputs="$(HotRestartSignedAppDir)Info.plist" />
@@ -232,11 +241,12 @@
 			_CreateHotRestartCachedBundle;
 			_UnpackLibraryResources;
 			_ComputeHotRestartBundleContents;
+			_CodesignHotRestartAppBundle;
 			_CopyHotRestartBundleResources;
 			_CopyFilesToHotRestartSignedAppDirContents;
 			_CopyFilesToHotRestartContentDir;
 			_CopyFilesToHotRestartAppContentDir;
-			_CodesignHotRestartAppBundle;
+			_CreateHotRestartAppMarkers;
 		</_CreateHotRestartOutputBundleDependsOn>
 	</PropertyGroup>
 
@@ -247,7 +257,7 @@
 		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsHotRestartBuild)' == 'true' And '$(EnableCodeSigning)' != 'false'"
 		DependsOnTargets="_CreateHotRestartCachedBundle;_CollectCodeSignHotRestartInputs"
 		Inputs="@(_CodeSignHotRestartInputs)"
-		Outputs="$(HotRestartAppBundlePath)\_CodeSignature\CodeResources">
+		Outputs="@(_CodeSignHotRestartInputs -> '%(Outputs)')">
 		
 		<CodesignHotRestartApp
 			AppBundlePath="$(HotRestartAppBundlePath)"

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -221,7 +221,15 @@
 		<MakeDir Directories="$(HotRestartContentStampDir)"/>
 		<MakeDir Directories="@(_HotRestartContentDirContents -> '$(HotRestartContentStampDir)%(DestinationSubDirectory)')"/>
 
+		<!-- We need to create a .stamp file for every file in the .content folder to know what to copy in incremental deployments -->
+		<!-- The idea of incremental deployments in Hot Restart is that we will copy only the content files that changed, without the need of re-installing the application -->
+		<!-- We use the .stamp files to compare inputs/outputs and determine which files have changed so we can upload them to the .content folder -->
+		<!-- We only re-install the app when a file that requires the app to be re-signed is changed -->
 		<Touch AlwaysCreate="true" Files="@(_HotRestartContentDirContents -> '$(HotRestartContentStampDir)%(DestinationSubDirectory)%(FileName)%(Extension).stamp')" />
+		<!-- The Hot Restart pre-built app doesn't know anything about the real app, it just knows that inside the bundle there should be a .content folder with a bunch of files belonging to the real app -->
+		<!-- The .hotrestartapp file is the marker that we use to identify the main entry point of the app to dynamically load when the Hot Restart pre-built app initializes -->
+		<!-- In build time, we name that file the same as the main $(AssemblyName), so if the app is Maui1.dll o Forms1.exe, we name the marker Maui1.hotrestartapp or Forms1.hotrestartapp -->
+		<!-- When the pre-built app initializes, it searches for the marker in the .content dir and then it loads the file that has the same name -->
 		<Touch AlwaysCreate="true" Files="$(HotRestartContentStampDir)$(AssemblyName).hotrestartapp.stamp" />
 		<Touch AlwaysCreate="true" Files="$(HotRestartAppContentDir)$(AssemblyName).hotrestartapp" />
 	</Target>


### PR DESCRIPTION
- Update Hot Restart client to 1.0.119: bring latest isignsharp fix https://github.com/xamarin/isignsharp/commit/71220d490a83761a63bf005e326d3834e8b18d00

- Added missing app markers back:
    - Added .stamp files to make incremental deployments work again and to avoid re-installing the application. We use .stamp files to know which files to copy on incremental deployments and also to avoid unnecessary app installations
    - Added .hotrestartapp file back to identify the main app entry point. We need this since the main entry point to dynamically load the app might change between Forms and MAUI (could be a .dll or an .exe), so we need a way to let the Hot Restart app to know which is the main assembly to load
    
- Fixed outputs in _CodesignHotRestartAppBundle target: the codesign was being executed always, causing the incremental builds to not work as expected.

- Ensure the _CodesignHotRestartAppBundle target is executed before the copy of the content files and not after: Hot Restart content files doesn't affect the code signing, so they don't need to be copied before the signing process. Copying the content files before the code sign was causing unwanted behaviors and errors since the code sign logic will try to clear the signing folder before the execution, to avoid mixing old and new content