### PR TITLE
[msbuild] Really fix calling the GetFileSystemEntries task on Windows.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1876,7 +1876,9 @@ global using nfloat = global::System.Runtime.InteropServices.NFloat%3B
 
 			This is somewhat complicated by the fact that we can have
 			.resources bundles (i.e. directories), so we need to expand those
-			to all their contained files.
+			to all their contained files (and why just not adding the
+			extensions to the AllowedReferenceRelatedFileExtensions property
+			would work)
 
 		-->
 
@@ -1892,24 +1894,16 @@ global using nfloat = global::System.Runtime.InteropServices.NFloat%3B
 			<_BindingPackagesFromReferencedAssembliesDirectoriesExists Include="@(_BindingPackagesFromReferencedAssembliesDirectoriesCandidates->Distinct())" Condition="Exists('%(Identity)')" />
 		</ItemGroup>
 
-		<PropertyGroup Condition="'$(IsMacEnabled)' == 'true'">
-			<BuildSessionIdIfConnected>$(BuildSessionId)</BuildSessionIdIfConnected>
-		</PropertyGroup>
-
 		<!--
 			We need to expand items in an item group using globs, which is
 			kind of tricky, because globs in item transformations aren't
 			treated as globs. The workaround is to use a custom task for this.
 
-			Note that this task should run remotely from Windows when there's
-			a Mac connected, but locally when there's not a Mac connected (for
-			Hot Restart builds for instance), so we're not conditioning this
-			task on IsMacEnabled. Instead we're only setting SessionId if we
-			have a session id *and* we're connected to a Mac.
+			Note that this task should run locally on Windows even for a remote build,
+			so there's no SessionId property.
 
 		-->
 		<GetFileSystemEntries
-			SessionId="$(BuildSessionIdIfConnected)"
 			DirectoryPath="@(_BindingPackagesFromReferencedAssembliesDirectoriesExists)"
 			Pattern="*"
 			Recursive="true"


### PR DESCRIPTION
The GetFileSystemEntries task does not need to be remoted, because it's only
used to figure out which additional files to copy from binding projects to
projects that reference the binding projects, and that can happen entirely on
the local build (wherever that is).

Ref:

* https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1808448 (third attempt)
* https://github.com/xamarin/xamarin-macios/issues/18308