### PR TITLE
[msbuild] Make the GetFileSystemEntries task capable of copying files to the Mac.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1914,6 +1914,7 @@ global using nfloat = global::System.Runtime.InteropServices.NFloat%3B
 			Pattern="*"
 			Recursive="true"
 			IncludeDirectories="false"
+			CopyFromWindows="true"
 			>
 			<Output TaskParameter="Entries" ItemName="_BindingPackagesFromReferencedAssemblies" />
 		</GetFileSystemEntries>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFileSystemEntries.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFileSystemEntries.cs
@@ -1,8 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
 using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.MacDev.Tasks {
-	public class GetFileSystemEntries : GetFileSystemEntriesTaskBase, ICancelableTask {
+	public class GetFileSystemEntries : GetFileSystemEntriesTaskBase, ICancelableTask, ITaskCallback {
 		public override bool Execute ()
 		{
 			if (ShouldExecuteRemotely ())
@@ -16,6 +23,28 @@ namespace Xamarin.MacDev.Tasks {
 			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied ()
+		{
+			if (!CopyFromWindows)
+				return Enumerable.Empty<ITaskItem> ();
+
+			// TaskRunner doesn't know how to copy directories to Mac, so list each file.
+			var rv = new List<string> ();
+			foreach (var path in DirectoryPath) {
+				var spec = path.ItemSpec;
+				if (!Directory.Exists (spec))
+					continue;
+
+				rv.AddRange (Directory.GetFiles (spec, "*", SearchOption.AllDirectories));
+			}
+
+			return rv.Select (f => new TaskItem (f));
+		}
+
+		public bool ShouldCopyToBuildServer (ITaskItem item) => true;
+
+		public bool ShouldCreateOutputFile (ITaskItem item) => true;
 	}
 }
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFileSystemEntriesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFileSystemEntriesTaskBase.cs
@@ -23,6 +23,10 @@ namespace Xamarin.MacDev.Tasks {
 
 		[Required]
 		public bool IncludeDirectories { get; set; }
+
+		// If the input directory should be copied from Windows to the Mac in
+		// a remote build.
+		public bool CopyFromWindows { get; set; }
 		#endregion
 
 		#region Outputs


### PR DESCRIPTION
Make the GetFileSystemEntries task capable of copying files to the Mac, and
enable this new behavior when inspecting references for binding resources.

Otherwise the task might not find anything, if the files aren't copied to the
Mac (this happens if the files originate from NuGets instead of referenced
projects).

Ref:

* https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1808448 (third attempt)
* https://github.com/xamarin/xamarin-macios/issues/18308