### PR TITLE
[dotnet] Add support for asking more of 'open' when launching desktop apps.

### DIFF
--- a/dotnet/Microsoft.MacCatalyst.Sdk/targets/Microsoft.MacCatalyst.Sdk.targets
+++ b/dotnet/Microsoft.MacCatalyst.Sdk/targets/Microsoft.MacCatalyst.Sdk.targets
@@ -3,7 +3,16 @@
   <Import Project="Xamarin.Shared.Sdk.targets" />
 
   <PropertyGroup>
+    <RunEnvironment Condition="'$(XamarinDebugMode)' != ''">$(RunEnvironment) --env '__XAMARIN_DEBUG_MODE__=$(XamarinDebugMode)'</RunEnvironment>
+    <RunEnvironment Condition="'$(XamarinDebugPort)' != ''">$(RunEnvironment) --env '__XAMARIN_DEBUG_PORT__=$(XamarinDebugPort)'</RunEnvironment>
+    <RunEnvironment Condition="'$(XamarinDebugHosts)' != ''">$(RunEnvironment) --env '__XAMARIN_DEBUG_HOSTS__=$(XamarinDebugHosts)'</RunEnvironment>
+    <RunEnvironment Condition="'$(XamarinDebugConnectTimeout)' != ''">$(RunEnvironment) --env '__XAMARIN_DEBUG_CONNECT_TIMEOUT__=$(XamarinDebugConnectTimeout)'</RunEnvironment>
+    <OpenArguments>$(OpenArguments) $(RunEnvironment)</OpenArguments>
+    <OpenArguments Condition="'$(StandardOutputPath)' != ''">$(OpenArguments) --stdout '$(StandardOutputPath)'</OpenArguments>
+    <OpenArguments Condition="'$(StandardErrorPath)' != ''">$(OpenArguments) --stderr '$(StandardErrorPath)'</OpenArguments>
+    <OpenArguments Condition="'$(StandardInputPath)' != ''">$(OpenArguments) --stdin '$(StandardInputPath)'</OpenArguments>
+    <OpenArguments Condition="'$(OpenNewInstance)' == 'true'">$(OpenArguments) -n</OpenArguments>
     <RunCommand>open</RunCommand>
-    <RunArguments>"$(TargetDir)/$(AssemblyName).app" --args</RunArguments>
+    <RunArguments>$(OpenArguments) "$(TargetDir)/$(AssemblyName).app" --args</RunArguments>
   </PropertyGroup>
 </Project>

--- a/dotnet/Microsoft.macOS.Sdk/targets/Microsoft.macOS.Sdk.targets
+++ b/dotnet/Microsoft.macOS.Sdk/targets/Microsoft.macOS.Sdk.targets
@@ -3,7 +3,16 @@
   <Import Project="Xamarin.Shared.Sdk.targets" />
 
   <PropertyGroup>
+    <RunEnvironment Condition="'$(XamarinDebugMode)' != ''">$(RunEnvironment) --env '__XAMARIN_DEBUG_MODE__=$(XamarinDebugMode)'</RunEnvironment>
+    <RunEnvironment Condition="'$(XamarinDebugPort)' != ''">$(RunEnvironment) --env '__XAMARIN_DEBUG_PORT__=$(XamarinDebugPort)'</RunEnvironment>
+    <RunEnvironment Condition="'$(XamarinDebugHosts)' != ''">$(RunEnvironment) --env '__XAMARIN_DEBUG_HOSTS__=$(XamarinDebugHosts)'</RunEnvironment>
+    <RunEnvironment Condition="'$(XamarinDebugConnectTimeout)' != ''">$(RunEnvironment) --env '__XAMARIN_DEBUG_CONNECT_TIMEOUT__=$(XamarinDebugConnectTimeout)'</RunEnvironment>
+    <OpenArguments>$(OpenArguments) $(RunEnvironment)</OpenArguments>
+    <OpenArguments Condition="'$(StandardOutputPath)' != ''">$(OpenArguments) --stdout '$(StandardOutputPath)'</OpenArguments>
+    <OpenArguments Condition="'$(StandardErrorPath)' != ''">$(OpenArguments) --stderr '$(StandardErrorPath)'</OpenArguments>
+    <OpenArguments Condition="'$(StandardInputPath)' != ''">$(OpenArguments) --stdin '$(StandardInputPath)'</OpenArguments>
+    <OpenArguments Condition="'$(OpenNewInstance)' == 'true'">$(OpenArguments) -n</OpenArguments>
     <RunCommand>open</RunCommand>
-    <RunArguments>"$(TargetDir)/$(AssemblyName).app" --args</RunArguments>
+    <RunArguments>$(OpenArguments) "$(TargetDir)/$(AssemblyName).app" --args</RunArguments>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
* Add support for forwarding our debugging msbuild properties to their
  corresponding environment variables (the XamarinDebug* properties).
* Add support for passing --stdout/--stderr/--stdin to open to redirect
  to/from a file. This is particularly useful for debugging debugging.
* Add support for passing -a (to always create a new instance of the app).
  This is useful when debugging (when the developer would always want a new
  instance, instead of opening an existing instance).
* Also add support for any other argument using the 'OpenArguments' property.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1825427.