### PR TITLE
[tests] Update the Xcode version check for Xcode 13.3.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -479,6 +479,18 @@ partial class TestRuntime {
 #else
 				throw new NotImplementedException ();
 #endif
+			case 3:
+#if __WATCHOS__
+				return CheckWatchOSSystemVersion (8, 5);
+#elif __TVOS__
+				return ChecktvOSSystemVersion (15, 4);
+#elif __IOS__
+				return CheckiOSSystemVersion (15, 4);
+#elif MONOMAC
+				return CheckMacSystemVersion (12, 3);
+#else
+				throw new NotImplementedException ();
+#endif
 			default:
 				throw new NotImplementedException ();
 			}


### PR DESCRIPTION
Fixes:

    MonoTouchFixtures.AVFoundation.CaptureMetadataOutputTest
    	[PASS] Defaults
    	[PASS] Flags
    	[FAIL] MetadataObjectTypesTest : System.NotImplementedException : The method or operation is not implemented.
    		   at TestRuntime.CheckXcodeVersion(Int32 major, Int32 minor, Int32 build) in xamarin-macios/tests/common/TestRuntime.cs:line 483
    		   at MonoTouchFixtures.AVFoundation.CaptureMetadataOutputTest.MetadataObjectTypesTest() in xamarin-macios/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs:line 131
    		   at System.Reflection.MethodInvoker.InterpretedInvoke(Object , Span`1 , BindingFlags )