### PR TITLE
[tests] Adjust BundleTest to cope with a differently named app.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/BundleTest.cs
+++ b/tests/monotouch-test/CoreFoundation/BundleTest.cs
@@ -111,7 +111,8 @@ namespace MonoTouchFixtures.CoreFoundation {
 #else
 			var executableRelativePath = Path.Combine (ExpectedAppName, "monotouchtest");
 #endif
-			Assert.That (main.ExecutableUrl.ToString (), Contains.Substring (executableRelativePath));
+			var alternativeRelativePath = executableRelativePath.Replace (ExpectedAppName, "PublicStaging.app");
+			Assert.That (main.ExecutableUrl.ToString (), Does.Contain (executableRelativePath).Or.Contain (alternativeRelativePath));
 		}
 
 		[Test]
@@ -125,7 +126,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		public void TestResourcesDirectoryUrl ()
 		{
 			var main = CFBundle.GetMain ();
-			Assert.That (main.ResourcesDirectoryUrl.ToString (), Contains.Substring (ExpectedAppName + "/"));
+			Assert.That (main.ResourcesDirectoryUrl.ToString (), Does.Contain (ExpectedAppName + "/").Or.Contain ("PublicStaging.app/"));
 		}
 
 		[Test]
@@ -146,7 +147,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		public void TestSupportFilesDirectoryUrl ()
 		{
 			var main = CFBundle.GetMain ();
-			Assert.That (main.SupportFilesDirectoryUrl.ToString (), Contains.Substring (ExpectedAppName + "/"));
+			Assert.That (main.SupportFilesDirectoryUrl.ToString (), Does.Contain (ExpectedAppName + "/").Or.Contain ("PublicStaging.app/"));
 		}
 
 		[Test]
@@ -160,7 +161,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		public void TestUrl ()
 		{
 			var main = CFBundle.GetMain ();
-			Assert.That (main.Url.ToString (), Contains.Substring (ExpectedAppName + "/"));
+			Assert.That (main.Url.ToString (), Does.Contain (ExpectedAppName + "/").Or.Contain ("PublicStaging.app/"));
 		}
 
 		[Test]


### PR DESCRIPTION
It seems the actual app name might be "PublicStaging.app" on device now.

Fixes:

    MonoTouchFixtures.CoreFoundation.BundleTest
        [FAIL] TestExecutableUrl :
            Expected: String containing "monotouchtest.app/monotouchtest"
            But was:  "file:///private/var/containers/Bundle/Application/4B2AD441-C411-42D4-ACCB-4E964A905A17/PublicStaging.app/monotouchtest"
        [FAIL] TestResourcesDirectoryUrl :
            Expected: String containing "monotouchtest.app/"
            But was:  "file:///private/var/containers/Bundle/Application/4B2AD441-C411-42D4-ACCB-4E964A905A17/PublicStaging.app/"
        [FAIL] TestSupportFilesDirectoryUrl :
            Expected: String containing "monotouchtest.app/"
            But was:  "file:///private/var/containers/Bundle/Application/4B2AD441-C411-42D4-ACCB-4E964A905A17/PublicStaging.app/"
         [FAIL] TestUrl :
            Expected: String containing "monotouchtest.app/"
            But was:  "file:///private/var/containers/Bundle/Application/4B2AD441-C411-42D4-ACCB-4E964A905A17/PublicStaging.app/"