### PR TITLE
[tests] Adjust a few tests to not write a temporary file into the user directory.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/UrlTest.cs
+++ b/tests/monotouch-test/CoreFoundation/UrlTest.cs
@@ -8,6 +8,8 @@
 //
 
 using System;
+using System.IO;
+
 using Foundation;
 using CoreFoundation;
 using ObjCRuntime;

--- a/tests/monotouch-test/Foundation/FileManagerTest.cs
+++ b/tests/monotouch-test/Foundation/FileManagerTest.cs
@@ -93,7 +93,8 @@ namespace MonoTouchFixtures.Foundation {
 		{
 			Assert.False (NSFileManager.GetSkipBackupAttribute (NSBundle.MainBundle.ExecutableUrl.ToString ()), "MainBundle");
 
-			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), $"DoNotBackupMe-NSFileManager-{Process.GetCurrentProcess ().Id}");
+			var paths = NSSearchPath.GetDirectories (NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomain.User);
+			var filename = Path.Combine (paths [0], $"DoNotBackupMe-NSFileManager-{Process.GetCurrentProcess ().Id}");
 			try {
 				File.WriteAllText (filename, "not worth a bit");
 

--- a/tests/monotouch-test/Foundation/UrlTest.cs
+++ b/tests/monotouch-test/Foundation/UrlTest.cs
@@ -49,7 +49,8 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.That (value, Is.TypeOf (typeof (NSNumber)), "NSNumber");
 			Assert.That ((int) (value as NSNumber), Is.EqualTo (0), "0");
 
-			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), $"DoNotBackupMe-NSUrl-{Process.GetCurrentProcess ().Id}");
+			var paths = NSSearchPath.GetDirectories (NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomain.User);
+			var filename = Path.Combine (paths [0], $"DoNotBackupMe-NSUrl-{Process.GetCurrentProcess ().Id}");
 			try {
 				File.WriteAllText (filename, "not worth a bit");
 				using (NSUrl url = NSUrl.FromFilename (filename)) {


### PR DESCRIPTION
Fixes:

    MonoTouchFixtures.Foundation.NSFileManagerTest
    	[FAIL] GetSkipBackupAttribute : System.UnauthorizedAccessException : Access to the path '/private/var/mobile/Containers/Data/Application/F9F5B72D-D452-49F9-93AC-5CBB1E60A81C/DoNotBackupMe-NSFileManager-14036' is denied.
      ----> System.IO.IOException : Operation not permitted
    		   at Interop.ThrowExceptionForIoErrno(ErrorInfo , String , Boolean )
    		   at Interop.CheckIo(Error , String , Boolean )
    		   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String , OpenFlags , Int32 , Func`4 )
    		   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String , FileMode , FileAccess , FileShare , FileOptions , Int64 , UnixFileMode , Int64& , UnixFileMode& , Func`4 )
    		   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String , FileMode , FileAccess , FileShare , FileOptions , Int64 , Nullable`1 , Func`4 )
    		   at System.IO.File.OpenHandle(String , FileMode , FileAccess , FileShare , FileOptions , Int64 )
    		   at System.IO.File.WriteToFile(String , FileMode , String , Encoding )
    		   at System.IO.File.WriteAllText(String , String , Encoding )
    		   at System.IO.File.WriteAllText(String , String )
    		   at MonoTouchFixtures.Foundation.NSFileManagerTest.GetSkipBackupAttribute() in xamarin-macios/tests/monotouch-test/Foundation/FileManagerTest.cs:line 98
    		   at System.Reflection.MethodInvoker.InterpretedInvoke(Object , Span`1 , BindingFlags )
    		--IOException
    MonoTouchFixtures.Foundation.UrlTest
    	[FAIL] IsExcludedFromBackupKey : System.UnauthorizedAccessException : Access to the path '/private/var/mobile/Containers/Data/Application/F9F5B72D-D452-49F9-93AC-5CBB1E60A81C/DoNotBackupMe-NSUrl-14036' is denied.
      ----> System.IO.IOException : Operation not permitted
    		   at Interop.ThrowExceptionForIoErrno(ErrorInfo , String , Boolean )
    		   at Interop.CheckIo(Error , String , Boolean )
    		   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String , OpenFlags , Int32 , Func`4 )
    		   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String , FileMode , FileAccess , FileShare , FileOptions , Int64 , UnixFileMode , Int64& , UnixFileMode& , Func`4 )
    		   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String , FileMode , FileAccess , FileShare , FileOptions , Int64 , Nullable`1 , Func`4 )
    		   at System.IO.File.OpenHandle(String , FileMode , FileAccess , FileShare , FileOptions , Int64 )
    		   at System.IO.File.WriteToFile(String , FileMode , String , Encoding )
    		   at System.IO.File.WriteAllText(String , String , Encoding )
    		   at System.IO.File.WriteAllText(String , String )
    		   at MonoTouchFixtures.Foundation.UrlTest.IsExcludedFromBackupKey() in xamarin-macios/tests/monotouch-test/Foundation/UrlTest.cs:line 54
    		   at System.Reflection.MethodInvoker.InterpretedInvoke(Object , Span`1 , BindingFlags )
    		--IOException