### PR TITLE
[msbuild/generator] Compile api definitions in MSBuild logic instead of inside the generator.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/BTouchTaskBase.cs
@@ -23,8 +23,6 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public string BTouchToolExe { get; set; }
 
-		public string DotNetCscCompiler { get; set; }
-
 		public ITaskItem [] ObjectiveCLibraries { get; set; }
 
 		public ITaskItem [] AdditionalLibPaths { get; set; }
@@ -38,6 +36,9 @@ namespace Xamarin.MacDev.Tasks {
 		public ITaskItem [] ApiDefinitions { get; set; }
 
 		public string AttributeAssembly { get; set; }
+
+		[Required]
+		public string CompiledApiDefinitionAssembly { get; set; }
 
 		public ITaskItem [] CoreSources { get; set; }
 
@@ -79,9 +80,15 @@ namespace Xamarin.MacDev.Tasks {
 			get {
 				// Return the dotnet executable we're executing with.
 				var dotnet_path = Environment.GetEnvironmentVariable ("DOTNET_HOST_PATH");
-				if (string.IsNullOrEmpty (dotnet_path))
-					throw new InvalidOperationException ($"DOTNET_HOST_PATH is not set");
-				return dotnet_path;
+				if (!string.IsNullOrEmpty (dotnet_path))
+					return dotnet_path;
+
+				if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
+					// This might happen when building from inside VS (design-time builds, etc.)
+					return "dotnet.exe";
+				}
+
+				throw new InvalidOperationException ($"DOTNET_HOST_PATH is not set");
 			}
 		}
 
@@ -123,6 +130,8 @@ namespace Xamarin.MacDev.Tasks {
 			cmd.Add ("/v");
 #endif
 
+			cmd.AddQuotedSwitchIfNotNull ("/compiled-api-definition-assembly:", CompiledApiDefinitionAssembly);
+
 			cmd.Add ("/nostdlib");
 			cmd.AddQuotedSwitchIfNotNull ("/baselib:", BaseLibDll);
 			cmd.AddQuotedSwitchIfNotNull ("/out:", OutputAssembly);
@@ -143,14 +152,6 @@ namespace Xamarin.MacDev.Tasks {
 
 			if (AllowUnsafeBlocks)
 				cmd.Add ("/unsafe");
-
-			if (!string.IsNullOrEmpty (DotNetCscCompiler)) {
-				var compileCommand = new string [] {
-					DotNetPath,
-					DotNetCscCompiler,
-				};
-				cmd.AddQuoted ("/compile-command:" + string.Join (" ", StringUtils.QuoteForProcess (compileCommand)));
-			}
 
 			cmd.AddQuotedSwitchIfNotNull ("/ns:", Namespace);
 
@@ -266,7 +267,6 @@ namespace Xamarin.MacDev.Tasks {
 			BaseLibDll = PathUtils.ConvertToMacPath (BaseLibDll);
 			BTouchToolExe = PathUtils.ConvertToMacPath (BTouchToolExe);
 			BTouchToolPath = PathUtils.ConvertToMacPath (BTouchToolPath);
-			DotNetCscCompiler = PathUtils.ConvertToMacPath (DotNetCscCompiler);
 
 			if (IsDotNet) {
 				var customHome = Environment.GetEnvironmentVariable ("DOTNET_CUSTOM_HOME");

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1599,6 +1599,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<PropertyGroup>
 		<_GenerateBindingsDependsOn>
 			_ComputeTargetFrameworkMoniker;
+			_CompileApiDefinitions;
 			$(_GenerateBindingsDependsOn);
 		</_GenerateBindingsDependsOn>
 
@@ -1620,6 +1621,78 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<WriteLinesToFile File="$(OutputFilePath)" Lines="@(_ComputedRemoteGeneratorProperties)" />
 	</Target>
 
+	<Target Name="_ComputeCompileApiDefinitionsInputs" DependsOnTargets="_ComputeBindingVariables">
+		<ItemGroup>
+			<BTouchReferencePath Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
+		</ItemGroup>
+
+		<PropertyGroup>
+			<_CompiledApiDefinitionAssembly>$(DeviceSpecificIntermediateOutputPath)compiled-api-definitions.dll</_CompiledApiDefinitionAssembly>
+			<_CompiledApiDefinitionDefines>$(DefineConstants)</_CompiledApiDefinitionDefines>
+			<_CompiledApiDefinitionDefines Condition="'$(UsingAppleNETSdk)' == 'true'">$(_CompiledApiDefinitionDefines);NET</_CompiledApiDefinitionDefines>
+
+			<_CompiledApiDefinitionLibPaths>$(AdditionalLibPaths);$([System.IO.Path]::GetDirectoryName('$(BaseLibDllPath)'))</_CompiledApiDefinitionLibPaths>
+
+			<_CompiledApiDefinitionGlobalUsingsFile Condition="'$(UsingAppleNETSdk)' == 'true' And '$(NoNFloatUsing)' != 'true'">$(DeviceSpecificIntermediateOutputPath)compiled-api-definitions-usings.cs</_CompiledApiDefinitionGlobalUsingsFile>
+		</PropertyGroup>
+
+
+		<ItemGroup>
+			<_CompiledApiDefinitionReferences Include="$(_GeneratorAttributeAssembly)" />
+			<_CompiledApiDefinitionReferences Include="@(ReferencePath)" />
+			<_CompiledApiDefinitionReferences Include="@(BTouchReferencePath)" />
+
+			<_CompiledApiDefinitionsCompile Include="@(ObjcBindingApiDefinition)" />
+			<_CompiledApiDefinitionsCompile Include="@(ObjcBindingCoreSource)" />
+		</ItemGroup>
+
+		<WriteLinesToFile
+			Condition="'$(_CompiledApiDefinitionGlobalUsingsFile)' != ''"
+			File="$(_CompiledApiDefinitionGlobalUsingsFile)"
+			Lines="global using nfloat = global::System.Runtime.InteropServices.NFloat%3B"
+			Overwrite="true"
+			WriteOnlyWhenDifferent="true" />
+
+		<ItemGroup Condition="'$(_CompiledApiDefinitionGlobalUsingsFile)' != ''">
+			<_CompiledApiDefinitionsCompile Include="$(_CompiledApiDefinitionGlobalUsingsFile)" />
+		</ItemGroup>
+
+	</Target>
+
+	<Target Name="_CompileApiDefinitions"
+		Inputs="$(MSBuildAllProjects);
+			$(_CompiledApiDefinitionLibPaths);
+			$(_CompiledApiDefinitionGlobalUsingsFile);
+			@(_CompiledApiDefinitionReferences);
+			@(_CompiledApiDefinitionsCompile);"
+		Outputs="$(_CompiledApiDefinitionAssembly)"
+		DependsOnTargets="_ComputeCompileApiDefinitionsInputs"
+		Condition="'$(IsBindingProject)' == 'true' And '$(DesignTimeBuild)' != 'true'">
+		>
+
+		<!-- This is a mirror of the method GetCompiledApiBindingsAssembly in BindingTouch.cs where the compilation is done inside bgen -->
+		<Csc
+			AdditionalLibPaths="$(_CompiledApiDefinitionLibPaths)"
+			AllowUnsafeBlocks="true"
+			DebugType="portable"
+			DefineConstants="$(_CompiledApiDefinitionDefines)"
+			DisabledWarnings="436"
+			NoConfig="true"
+			NoStandardLib="true"
+			Deterministic="true"
+			OutputAssembly="$(_CompiledApiDefinitionAssembly)"
+			References="@(_CompiledApiDefinitionReferences)"
+			Sources="@(_CompiledApiDefinitionsCompile)"
+			TargetType="library"
+			ToolExe="$(CscToolExe)"
+			ToolPath="$(CscToolPath)"
+			UseHostCompilerIfAvailable="$(UseHostCompilerIfAvailable)"
+			UseSharedCompilation="$(UseSharedCompilation)"
+			VsSessionGuid="$(VsSessionGuid)"
+			>
+		</Csc>
+	</Target>
+
 	<Target Name="_GenerateBindings"
 		Inputs="$(MSBuildAllProjects);@(ObjcBindingApiDefinition);@(ObjcBindingCoreSource);@(ReferencePath);@(ObjcBindingNativeLibrary)"
 		Outputs="$(_GeneratedSourcesFileList)"
@@ -1627,10 +1700,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		Condition="'$(IsBindingProject)' == 'true' And '$(DesignTimeBuild)' != 'true'">
 
 		<Warning Condition="'$(IsMacEnabled)' != 'true'" Text="It's currently not supported to build a binding project from Windows unless a connection to a Mac is available." />
-
-		<ItemGroup>
-			<BTouchReferencePath Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
-		</ItemGroup>
 
 		<PropertyGroup>
 			<BTouchEmitDebugInformation>false</BTouchEmitDebugInformation>
@@ -1664,8 +1733,8 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			AttributeAssembly="$(_GeneratorAttributeAssembly)"
 			BaseLibDll="$(BaseLibDllPath)"
 			CoreSources="@(ObjcBindingCoreSource)"
+			CompiledApiDefinitionAssembly="$(_CompiledApiDefinitionAssembly)"
 			DefineConstants="$(DefineConstants)"
-			DotNetCscCompiler="$(_DotNetCscCompiler)"
 			EmitDebugInformation="$(BTouchEmitDebugInformation)"
 			ExtraArgs="$(BTouchExtraArgs)"
 			GeneratedSourcesDir="$(GeneratedSourcesDir)"


### PR DESCRIPTION
This has a few advantages:

* A step towards simplifying the generator.
* A step towards being able to build binding projects on Windows, since it's easier
  to build C# code in MSBuild using the Csc task rather than figuring out how to
  call csc as an external program (which we've already done on macOS, but having
  a single solution that works on all platforms is preferrable).