### PR TITLE
[tests] System.Numerics.Vector3.Length is a method, not a property, so treat it as such.

### DIFF
--- a/tests/monotouch-test/Phase/PhaseObjectTest.cs
+++ b/tests/monotouch-test/Phase/PhaseObjectTest.cs
@@ -42,7 +42,7 @@ namespace MonoTouchFixtures.Phase {
 		{
 			var right = PhaseObject.Right;
 			Assert.NotNull (right, "not null");
-			Assert.AreEqual (1, right.Length, "length");
+			Assert.AreEqual (1, right.Length (), "length");
 		}
 
 		[Test]
@@ -50,7 +50,7 @@ namespace MonoTouchFixtures.Phase {
 		{
 			var up = PhaseObject.Up;
 			Assert.NotNull (up, "not null");
-			Assert.AreEqual (1, up.Length, "length");
+			Assert.AreEqual (1, up.Length (), "length");
 		}
 
 		[Test]
@@ -58,7 +58,7 @@ namespace MonoTouchFixtures.Phase {
 		{
 			var fwd = PhaseObject.Forward;
 			Assert.NotNull (fwd, "not null");
-			Assert.AreEqual (1, fwd.Length, "length");
+			Assert.AreEqual (1, fwd.Length (), "length");
 		}
 
 		[Test]

--- a/tests/monotouch-test/Phase/PhaseObjectTest.cs
+++ b/tests/monotouch-test/Phase/PhaseObjectTest.cs
@@ -42,7 +42,11 @@ namespace MonoTouchFixtures.Phase {
 		{
 			var right = PhaseObject.Right;
 			Assert.NotNull (right, "not null");
+#if NET
 			Assert.AreEqual (1, right.Length (), "length");
+#else
+			Assert.AreEqual (1, right.Length, "length");
+#endif
 		}
 
 		[Test]
@@ -50,7 +54,11 @@ namespace MonoTouchFixtures.Phase {
 		{
 			var up = PhaseObject.Up;
 			Assert.NotNull (up, "not null");
+#if NET
 			Assert.AreEqual (1, up.Length (), "length");
+#else
+			Assert.AreEqual (1, up.Length, "length");
+#endif
 		}
 
 		[Test]
@@ -58,7 +66,11 @@ namespace MonoTouchFixtures.Phase {
 		{
 			var fwd = PhaseObject.Forward;
 			Assert.NotNull (fwd, "not null");
+#if NET
 			Assert.AreEqual (1, fwd.Length (), "length");
+#else
+			Assert.AreEqual (1, fwd.Length, "length");
+#endif
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes:

    MonoTouchFixtures.Phase.PhaseObjectTest
    	[FAIL] ForwardTest :   length
			Expected: 1
			But was:  <System.Func`1[System.Single]>
    	[FAIL] RigthTest :   length
			Expected: 1
			But was:  <System.Func`1[System.Single]>
    	[FAIL] UpTest :   length
			Expected: 1
			But was:  <System.Func`1[System.Single]>