### PR TITLE
[msbuild] Make sure to copy the manifest from a binding resource package back to Windows. Fixes #18402.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs
@@ -96,6 +96,7 @@ namespace Xamarin.MacDev.Tasks {
 						Log.LogWarning (MSBStrings.W7100, bindingOutputPath);
 					}
 				}
+				packagedFiles.Add (manifestPath);
 			}
 
 			PackagedFiles = packagedFiles.Select (v => new TaskItem (v)).ToArray ();


### PR DESCRIPTION
This fixes a build problem on windows when a project has a project reference
to a binding project. The binding resource package from the binding project
would lack the manifest, and thus the main project wouldn't detect it as a
binding resource package, effectively not seeing any native resource from the
binding project.

Fixes https://github.com/xamarin/xamarin-macios/issues/18402.