### PR TITLE
[release/7.0.3xx] Use the current version of .NET in a few projects. This pull request updates the following dependencies

### DIFF
--- a/builds/package-download/download-packages.csproj
+++ b/builds/package-download/download-packages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
     <ActualPackageVersion Condition="'$(CustomDotNetVersion)' != ''">$(CustomDotNetVersion)</ActualPackageVersion>
     <ActualPackageVersion Condition="'$(ActualPackageVersion)' == ''">$(BundledNETCorePlatformsPackageVersion)</ActualPackageVersion>
     <NoWarn>$(NoWarn);NU1505</NoWarn> <!--  warning NU1505: Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. -->

--- a/src/bgen/bgen.csproj
+++ b/src/bgen/bgen.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
     <DefineConstants>DEBUG;BGENERATOR;NET_4_0;NO_AUTHENTICODE;STATIC;NO_SYMBOL_WRITER;NET</DefineConstants>
   </PropertyGroup>

--- a/tools/mlaunch/download-mlaunch.csproj
+++ b/tools/mlaunch/download-mlaunch.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
   </PropertyGroup>
 
   <Import Project="../../eng/Versions.props" />


### PR DESCRIPTION
## From https://github.com/dotnet/installer
- **Subscription**: bf101622-944d-4df0-c2e9-08db41128f2e
- **Build**: 20230515.5
- **Date Produced**: May 15, 2023 10:11:52 PM UTC
- **Commit**: e74a6d397c32e5d383d9dc5862b025029d296853
- **Branch**: refs/heads/release/7.0.3xx

- **Updates**:
- **Microsoft.Dotnet.Sdk.Internal**: [from 7.0.303-servicing.23261.12 to
7.0.304-servicing.23265.5][1]

[1]: https://github.com/dotnet/installer/compare/012752e08c...e74a6d397c


Backport of #18206.