### PR TITLE
[tools] Automatically re-create ProductConstants.cs when the current commit changes.

### DIFF
--- a/tools/common/Make.common
+++ b/tools/common/Make.common
@@ -60,7 +60,7 @@
 	$(Q) if ! diff $@ $@.tmp >/dev/null; then $(CP) $@.tmp $@; git diff "$@"; echo "The file $(TOP)/tools/common/SdkVersions.cs has been automatically re-generated; please commit the changes."; exit 1; fi
 	$(Q) touch $@
 
-../common/ProductConstants.cs: ../common/ProductConstants.in.cs Makefile $(TOP)/Make.config
+../common/ProductConstants.cs: ../common/ProductConstants.in.cs Makefile $(TOP)/Make.config $(TOP)/.git/index
 	$(Q_GEN) sed \
 		-e "s/@IOS_VERSION@/$(IOS_PACKAGE_VERSION_MAJOR).$(IOS_PACKAGE_VERSION_MINOR).$(IOS_PACKAGE_VERSION_REV)/g" \
 		-e "s/@TVOS_VERSION@/$(IOS_PACKAGE_VERSION_MAJOR).$(IOS_PACKAGE_VERSION_MINOR).$(IOS_PACKAGE_VERSION_REV)/g" \


### PR DESCRIPTION
This fixes a frequent issue where building locally again would create test
apps where the registrar would fail due to mismatched runtime versions.