### PR TITLE
[release/8.0.1xx-preview5] Update Messaging and System.Diagnostics.Tracer versions

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.10.0</MessagingVersion>
+		<MessagingVersion>1.10.37</MessagingVersion>
 		<HotRestartVersion>1.0.119</HotRestartVersion>
 	</PropertyGroup>
 </Project>

--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -506,7 +506,6 @@ DOTNET_IOS_WINDOWS_OUTPUT_FILES =                                \
 	$(foreach dll,$(IOS_WINDOWS_TASK_ASSEMBLIES),$(dll).*)       \
 	$(foreach dll,$(IOS_WINDOWS_DEPENDENCIES),$(dll).*)          \
 	iSign.Core.pdb                                               \
-	System.Diagnostics.Tracer.pdb                                \
 	Xamarin.iOS.Windows.Client.pdb                               \
 	Broker.zip                                                   \
 	Build.zip                                                    \

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Xamarin.Messaging.Core" Version="$(MessagingVersion)" IncludeAssets="build" />
     <PackageReference Include="Xamarin.Messaging.Server" Version="$(MessagingVersion)" IncludeAssets="contentFiles" />
     <PackageReference Include="Xamarin.iOS.HotRestart.Client" Version="$(HotRestartVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="System.Diagnostics.Tracer" Version="2.0.8" GeneratePathProperty="true" />
+    <PackageReference Include="System.Diagnostics.Tracer" Version="2.1.0-alpha" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messaging\Xamarin.Messaging.Build\Xamarin.Messaging.Build.csproj">
@@ -41,7 +41,6 @@
     </None>
     <None Include="$(PkgXamarin_iOS_HotRestart_Client)\lib\netstandard2.0\iSign.Core.pdb" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgXamarin_iOS_HotRestart_Client)\lib\netstandard2.0\Xamarin.iOS.Windows.Client.pdb" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(PkgSystem_Diagnostics_Tracer)\lib\netstandard1.3\System.Diagnostics.Tracer.pdb" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="../Versions.ios.g.cs" />
     <Compile Include="..\Xamarin.MacDev.Tasks\PublishFolderType.cs">
       <Link>PublishFolderType.cs</Link>


### PR DESCRIPTION
We need to update the `System.Diagnostics.Tracer` package to version `2.1.0-alpha` due to an issue with the `ChecksumAlgorithm` property of older versions.

Cherry-pick: https://github.com/xamarin/xamarin-macios/pull/18310


Backport of #18416
