### PR TITLE
[dotnet] Add a property to opt-out of the _CopyLocalBindingResources logic easily.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1870,7 +1870,11 @@ global using nfloat = global::System.Runtime.InteropServices.NFloat%3B
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_CopyLocalBindingResources" AfterTargets="ResolveAssemblyReferences" BeforeTargets="CopyFilesToOutputDirectory">
+	<Target Name="_CopyLocalBindingResources"
+		AfterTargets="ResolveAssemblyReferences"
+		BeforeTargets="CopyFilesToOutputDirectory"
+		Condition="'$(_DisableCopyLocalBindingResources)' != 'true'"
+		>
 		<!--
 
 			We need to copy binding resource packages (either zipped or as a


### PR DESCRIPTION
It seems this target has more problems than at first I thought, so make it
easier to opt-out of it by just setting a property in the csproj.

More investigation is needed, but I'm keeping the target on by default for
now, since it solves a real-world problem as well.

Ref: https://github.com/xamarin/xamarin-macios/issues/18445