### PR TITLE
[release/7.0.2xx-xcode14.3] [msbuild] Copy the zip file back to Windows from the Zip task for remote builds. Fixes #18402.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Zip.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Zip.cs
@@ -7,8 +7,16 @@ namespace Xamarin.MacDev.Tasks {
 	public class Zip : ZipTaskBase, ITaskCallback {
 		public override bool Execute ()
 		{
-			if (ShouldExecuteRemotely ())
-				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+			if (ShouldExecuteRemotely ()) {
+				var taskRunner = new TaskRunner (SessionId, BuildEngine4);
+				var rv = taskRunner.RunAsync (this).Result;
+
+				// Copy the zipped file back to Windows.
+				if (rv)
+					taskRunner.GetFileAsync (this, OutputFile.ItemSpec).Wait ();
+
+				return rv;
+			}
 
 			return base.Execute ();
 		}


### PR DESCRIPTION
The zip file might be used later directly on Windows (for instance it might be
embedded inside a binding assembly as an embedded resource), so make sure to
copy it back to Windows.

Fixes https://github.com/xamarin/xamarin-macios/issues/18402 part 2.


Backport of #18447
