### PR TITLE
[AVFoundation] Fix a few issues with the AVAssetImageGenerator bindings. Partial fix for #18452.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -112,6 +112,7 @@ namespace AVFoundation {
 	delegate void AVAssetImageGeneratorCompletionHandler (CMTime requestedTime, IntPtr imageRef, CMTime actualTime, AVAssetImageGeneratorResult result, NSError error);
 	delegate void AVAssetImageGeneratorCompletionHandler2 (CMTime requestedTime, CGImage imageRef, CMTime actualTime, AVAssetImageGeneratorResult result, NSError error);
 #endif
+	delegate void AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler (CGImage imageRef, CMTime actualTime, NSError error);
 	delegate void AVCompletion (bool finished);
 	delegate void AVRequestAccessStatus (bool accessGranted);
 	delegate AVAudioBuffer AVAudioConverterInputHandler (uint inNumberOfPackets, out AVAudioConverterInputStatus outStatus);
@@ -4231,6 +4232,10 @@ namespace AVFoundation {
 		[Export ("initWithAsset:")]
 		NativeHandle Constructor (AVAsset asset);
 
+		[Deprecated (PlatformName.MacOSX, 13, 0, message: "Use the 'GenerateCGImagesAsynchronously' method instead.")]
+		[Deprecated (PlatformName.TvOS, 16, 0, message: "Use the 'GenerateCGImagesAsynchronously' method instead.")]
+		[Deprecated (PlatformName.iOS, 16, 0, message: "Use the 'GenerateCGImagesAsynchronously' method instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 16, 0, message: "Use the 'GenerateCGImagesAsynchronously' method instead.")]
 		[Export ("copyCGImageAtTime:actualTime:error:")]
 		[return: NullAllowed]
 		[return: Release ()]
@@ -4244,6 +4249,9 @@ namespace AVFoundation {
 		[Export ("generateCGImagesAsynchronouslyForTimes:completionHandler:")]
 		void GenerateCGImagesAsynchronously (NSValue [] cmTimesRequestedTimes, AVAssetImageGeneratorCompletionHandler2 handler);
 #endif
+
+		[Export ("generateCGImageAsynchronouslyForTime:completionHandler:")]
+		void GenerateCGImageAsynchronously (CMTime requestedTime, AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler handler);
 
 		[Export ("cancelAllCGImageGeneration")]
 		void CancelAllCGImageGeneration ();

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -4250,6 +4250,10 @@ namespace AVFoundation {
 		void GenerateCGImagesAsynchronously (NSValue [] cmTimesRequestedTimes, AVAssetImageGeneratorCompletionHandler2 handler);
 #endif
 
+		[iOS (16, 0)]
+		[Mac (13, 0)]
+		[MacCatalyst (16, 0)]
+		[TV (16, 0)]
 		[Export ("generateCGImageAsynchronouslyForTime:completionHandler:")]
 		void GenerateCGImageAsynchronously (CMTime requestedTime, AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler handler);
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AVFoundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AVFoundation.todo
@@ -6,7 +6,6 @@
 !deprecated-attribute-missing! AVAsset::tracksWithMediaType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::trackWithTrackID: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::unusedTrackID missing a [Deprecated] attribute
-!deprecated-attribute-missing! AVAssetImageGenerator::copyCGImageAtTime:actualTime:error: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::associatedTracksOfType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::metadataForFormat: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::samplePresentationTimeForTrackTime: missing a [Deprecated] attribute
@@ -74,7 +73,6 @@
 !missing-selector! +NSValue::valueWithCMVideoDimensions: not bound
 !missing-selector! AVAssetExportSession::audioTrackGroupHandling not bound
 !missing-selector! AVAssetExportSession::setAudioTrackGroupHandling: not bound
-!missing-selector! AVAssetImageGenerator::generateCGImageAsynchronouslyForTime:completionHandler: not bound
 !missing-selector! AVAssetPlaybackAssistant::loadPlaybackConfigurationOptionsWithCompletionHandler: not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::isEntireLengthAvailableOnDemand not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::setEntireLengthAvailableOnDemand: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-AVFoundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-AVFoundation.todo
@@ -6,7 +6,6 @@
 !deprecated-attribute-missing! AVAsset::tracksWithMediaType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::trackWithTrackID: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::unusedTrackID missing a [Deprecated] attribute
-!deprecated-attribute-missing! AVAssetImageGenerator::copyCGImageAtTime:actualTime:error: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::associatedTracksOfType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::metadataForFormat: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::samplePresentationTimeForTrackTime: missing a [Deprecated] attribute
@@ -69,7 +68,6 @@
 !missing-selector! +AVVideoComposition::videoCompositionWithPropertiesOfAsset:completionHandler: not bound
 !missing-selector! AVAssetExportSession::audioTrackGroupHandling not bound
 !missing-selector! AVAssetExportSession::setAudioTrackGroupHandling: not bound
-!missing-selector! AVAssetImageGenerator::generateCGImageAsynchronouslyForTime:completionHandler: not bound
 !missing-selector! AVAssetPlaybackAssistant::loadPlaybackConfigurationOptionsWithCompletionHandler: not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::isEntireLengthAvailableOnDemand not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::setEntireLengthAvailableOnDemand: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AVFoundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AVFoundation.todo
@@ -7,7 +7,6 @@
 !deprecated-attribute-missing! AVAsset::tracksWithMediaType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::trackWithTrackID: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::unusedTrackID missing a [Deprecated] attribute
-!deprecated-attribute-missing! AVAssetImageGenerator::copyCGImageAtTime:actualTime:error: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::associatedTracksOfType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::metadataForFormat: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::samplePresentationTimeForTrackTime: missing a [Deprecated] attribute
@@ -73,7 +72,6 @@
 !missing-selector! +AVVideoComposition::videoCompositionWithPropertiesOfAsset:completionHandler: not bound
 !missing-selector! AVAssetExportSession::audioTrackGroupHandling not bound
 !missing-selector! AVAssetExportSession::setAudioTrackGroupHandling: not bound
-!missing-selector! AVAssetImageGenerator::generateCGImageAsynchronouslyForTime:completionHandler: not bound
 !missing-selector! AVAssetPlaybackAssistant::loadPlaybackConfigurationOptionsWithCompletionHandler: not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::isEntireLengthAvailableOnDemand not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::setEntireLengthAvailableOnDemand: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-AVFoundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-AVFoundation.todo
@@ -6,7 +6,6 @@
 !deprecated-attribute-missing! AVAsset::tracksWithMediaType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::trackWithTrackID: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::unusedTrackID missing a [Deprecated] attribute
-!deprecated-attribute-missing! AVAssetImageGenerator::copyCGImageAtTime:actualTime:error: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::associatedTracksOfType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::metadataForFormat: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::samplePresentationTimeForTrackTime: missing a [Deprecated] attribute
@@ -68,7 +67,6 @@
 !missing-selector! +AVVideoComposition::videoCompositionWithPropertiesOfAsset:completionHandler: not bound
 !missing-selector! AVAssetExportSession::audioTrackGroupHandling not bound
 !missing-selector! AVAssetExportSession::setAudioTrackGroupHandling: not bound
-!missing-selector! AVAssetImageGenerator::generateCGImageAsynchronouslyForTime:completionHandler: not bound
 !missing-selector! AVAssetPlaybackAssistant::loadPlaybackConfigurationOptionsWithCompletionHandler: not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::isEntireLengthAvailableOnDemand not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::setEntireLengthAvailableOnDemand: not bound

--- a/tests/xtro-sharpie/iOS-AVFoundation.todo
+++ b/tests/xtro-sharpie/iOS-AVFoundation.todo
@@ -6,7 +6,6 @@
 !deprecated-attribute-missing! AVAsset::tracksWithMediaType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::trackWithTrackID: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::unusedTrackID missing a [Deprecated] attribute
-!deprecated-attribute-missing! AVAssetImageGenerator::copyCGImageAtTime:actualTime:error: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::associatedTracksOfType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::metadataForFormat: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::samplePresentationTimeForTrackTime: missing a [Deprecated] attribute
@@ -69,7 +68,6 @@
 !missing-selector! +AVVideoComposition::videoCompositionWithPropertiesOfAsset:completionHandler: not bound
 !missing-selector! AVAssetExportSession::audioTrackGroupHandling not bound
 !missing-selector! AVAssetExportSession::setAudioTrackGroupHandling: not bound
-!missing-selector! AVAssetImageGenerator::generateCGImageAsynchronouslyForTime:completionHandler: not bound
 !missing-selector! AVAssetPlaybackAssistant::loadPlaybackConfigurationOptionsWithCompletionHandler: not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::isEntireLengthAvailableOnDemand not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::setEntireLengthAvailableOnDemand: not bound

--- a/tests/xtro-sharpie/macOS-AVFoundation.todo
+++ b/tests/xtro-sharpie/macOS-AVFoundation.todo
@@ -7,7 +7,6 @@
 !deprecated-attribute-missing! AVAsset::tracksWithMediaType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::trackWithTrackID: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::unusedTrackID missing a [Deprecated] attribute
-!deprecated-attribute-missing! AVAssetImageGenerator::copyCGImageAtTime:actualTime:error: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::associatedTracksOfType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::metadataForFormat: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::samplePresentationTimeForTrackTime: missing a [Deprecated] attribute
@@ -73,7 +72,6 @@
 !missing-selector! +AVVideoComposition::videoCompositionWithPropertiesOfAsset:completionHandler: not bound
 !missing-selector! AVAssetExportSession::audioTrackGroupHandling not bound
 !missing-selector! AVAssetExportSession::setAudioTrackGroupHandling: not bound
-!missing-selector! AVAssetImageGenerator::generateCGImageAsynchronouslyForTime:completionHandler: not bound
 !missing-selector! AVAssetPlaybackAssistant::loadPlaybackConfigurationOptionsWithCompletionHandler: not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::isEntireLengthAvailableOnDemand not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::setEntireLengthAvailableOnDemand: not bound

--- a/tests/xtro-sharpie/tvOS-AVFoundation.todo
+++ b/tests/xtro-sharpie/tvOS-AVFoundation.todo
@@ -6,7 +6,6 @@
 !deprecated-attribute-missing! AVAsset::tracksWithMediaType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::trackWithTrackID: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAsset::unusedTrackID missing a [Deprecated] attribute
-!deprecated-attribute-missing! AVAssetImageGenerator::copyCGImageAtTime:actualTime:error: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::associatedTracksOfType: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::metadataForFormat: missing a [Deprecated] attribute
 !deprecated-attribute-missing! AVAssetTrack::samplePresentationTimeForTrackTime: missing a [Deprecated] attribute
@@ -68,7 +67,6 @@
 !missing-selector! +AVVideoComposition::videoCompositionWithPropertiesOfAsset:completionHandler: not bound
 !missing-selector! AVAssetExportSession::audioTrackGroupHandling not bound
 !missing-selector! AVAssetExportSession::setAudioTrackGroupHandling: not bound
-!missing-selector! AVAssetImageGenerator::generateCGImageAsynchronouslyForTime:completionHandler: not bound
 !missing-selector! AVAssetPlaybackAssistant::loadPlaybackConfigurationOptionsWithCompletionHandler: not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::isEntireLengthAvailableOnDemand not bound
 !missing-selector! AVAssetResourceLoadingContentInformationRequest::setEntireLengthAvailableOnDemand: not bound


### PR DESCRIPTION
* The 'copyCGImageAtTime:actualTime:error:' selector is deprecated, so replicate that.
* Bind the 'generateCGImageAsynchronouslyForTime:completionHandler:' selector.

Fixes parts 1 and 2 of https://github.com/xamarin/xamarin-macios/issues/18452.