### PR TITLE
[bgen] Make the generated code check for zero handle before creating an INativeObject wrapper instance. Fixes part of #18452.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -706,7 +706,10 @@ public partial class Generator : IMemberGatherer {
 
 			if (TypeManager.INativeObject.IsAssignableFrom (pi.ParameterType)) {
 				pars.Add (new TrampolineParameterInfo (NativeHandleType, safe_name));
-				invoke.AppendFormat ("new {0} ({1}, false)", pi.ParameterType, safe_name);
+				if (BindThirdPartyLibrary)
+					invoke.AppendFormat ("Runtime.GetINativeObject<{0}> ({1}, false)!", pi.ParameterType, safe_name);
+				else
+					invoke.AppendFormat ("{1} == IntPtr.Zero ? null! : new {0} ({1}, false)", pi.ParameterType, safe_name);
 				continue;
 			}
 


### PR DESCRIPTION
Also don't create the instance directly from third-party bindings, the
required constructor might not be public - use Runtime.GetINativeObject
instead.

Fixes part 4 of https://github.com/xamarin/xamarin-macios/issues/18452.