### PR TITLE
[bgen] Remove useless catch/(re)throw.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -1269,22 +1269,18 @@ public partial class Generator : IMemberGatherer {
 		if (AttributeManager.HasAttribute<WrapAttribute> (mi))
 			return;
 
-		try {
-			// arm64 never requires stret, so we'll always need the non-stret variants
-			RegisterMethod (false, mi, MakeSig (mi, false), false);
-			RegisterMethod (false, mi, MakeSuperSig (mi, false), false);
+		// arm64 never requires stret, so we'll always need the non-stret variants
+		RegisterMethod (false, mi, MakeSig (mi, false), false);
+		RegisterMethod (false, mi, MakeSuperSig (mi, false), false);
 
-			if (CheckNeedStret (mi)) {
-				RegisterMethod (true, mi, MakeSig (mi, true), false);
-				RegisterMethod (true, mi, MakeSuperSig (mi, true), false);
+		if (CheckNeedStret (mi)) {
+			RegisterMethod (true, mi, MakeSig (mi, true), false);
+			RegisterMethod (true, mi, MakeSuperSig (mi, true), false);
 
-				if (AttributeManager.HasAttribute<AlignAttribute> (mi)) {
-					RegisterMethod (true, mi, MakeSig (mi, true, true), true);
-					RegisterMethod (true, mi, MakeSuperSig (mi, true, true), true);
-				}
+			if (AttributeManager.HasAttribute<AlignAttribute> (mi)) {
+				RegisterMethod (true, mi, MakeSig (mi, true, true), true);
+				RegisterMethod (true, mi, MakeSuperSig (mi, true, true), true);
 			}
-		} catch (BindingException ex) {
-			throw ex;
 		}
 	}
 	static char [] invalid_selector_chars = new char [] { '*', '^', '(', ')' };


### PR DESCRIPTION
There's no purpose to catching an exception just to throw it, so remove the
entire try/catch handler.

Fixes this compiler warning:

    src/bgen/Generator.cs(1284,4): warning CA2200: Re-throwing caught exception changes stack information