### PR TITLE
[net8.0] Change the default RuntimeIdentifier.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
@@ -10,14 +10,6 @@
 			<PkgPackageDir Condition="'$(PkgPackageDir)' == '' And '$(PkgPackagePath)' == ''">$(PublishDir)</PkgPackageDir>
 		</PropertyGroup>
 
-		<!-- Unfortunately we can't set a default runtime identifier when publishing, because by the time we know we're publishing,
-		     it's too late to change the runtime identifier. This means that we'll have to make it mandatory to specify a runtime
-		     identifier when publishing for a mobile platform (iOS, tvOS), because the default runtime identifier is for the simulator. -->
-		<Error
-			Text="A runtime identifier must be specified in order to publish this project."
-			Condition="'$(_XamarinUsingDefaultRuntimeIdentifier)' == 'true' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')"
-		/>
-
 		<!-- It's mandatory to specify a runtime identifier for device when publishing for a mobile platform (iOS, tvOS). -->
 		<Error
 			Text="A runtime identifier for a device architecture must be specified in order to publish this project. '$(RuntimeIdentifier)' is a simulator architecture."

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -77,12 +77,26 @@
 
 		<_XamarinUsingDefaultRuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">true</_XamarinUsingDefaultRuntimeIdentifier>
 		
-		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(_PlatformName)' == 'iOS'">iossimulator-x64</RuntimeIdentifier>
-		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(_PlatformName)' == 'tvOS'">tvossimulator-x64</RuntimeIdentifier>
+		<!-- Figure out which architecture we're running on -->
+		<_IsArm64Machine Condition="'$(_IsArm64Machine)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">true</_IsArm64Machine>
+		<_IsArm64Machine Condition="'$(_IsArm64Machine)' == ''">false</_IsArm64Machine>
 
+		<!-- for mobile non-publish builds we default to the simulator (and the host mac's architecture) -->
+		<!-- for mobile publish builds we default to the device architecture -->
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(_PlatformName)' == 'iOS' And '$(_IsPublishing)' == 'true'">ios-arm64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(_PlatformName)' == 'iOS' And '$(_IsPublishing)' != 'true' And '$(_IsArm64Machine)' == 'true'">iossimulator-arm64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(_PlatformName)' == 'iOS' And '$(_IsPublishing)' != 'true' And '$(_IsArm64Machine)' != 'true'">iossimulator-x64</RuntimeIdentifier>
+
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(_PlatformName)' == 'tvOS' And '$(_IsPublishing)' == 'true'">tvos-arm64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(_PlatformName)' == 'tvOS' And '$(_IsPublishing)' != 'true' And '$(_IsArm64Machine)' == 'true'">tvossimulator-arm64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(_PlatformName)' == 'tvOS' And '$(_IsPublishing)' != 'true' And '$(_IsArm64Machine)' != 'true'">tvossimulator-x64</RuntimeIdentifier>
+
+		<!-- For debug desktop builds we default to the host architecture -->
 		<!-- For release desktop builds we default to universal apps in .NET 7+ -->
-		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(Configuration)' != 'Release' And '$(_PlatformName)' == 'macOS'">osx-x64</RuntimeIdentifier>
-		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(Configuration)' != 'Release' And '$(_PlatformName)' == 'MacCatalyst'">maccatalyst-x64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(Configuration)' != 'Release' And '$(_PlatformName)' == 'macOS' And '$(_IsArm64Machine)' == 'true'">osx-arm64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(Configuration)' != 'Release' And '$(_PlatformName)' == 'macOS' And '$(_IsArm64Machine)' != 'true'">osx-x64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(Configuration)' != 'Release' And '$(_PlatformName)' == 'MacCatalyst' And '$(_IsArm64Machine)' == 'true'">maccatalyst-arm64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(Configuration)' != 'Release' And '$(_PlatformName)' == 'MacCatalyst' And '$(_IsArm64Machine)' != 'true'">maccatalyst-x64</RuntimeIdentifier>
 		<RuntimeIdentifiers Condition="'$(RuntimeIdentifier)' == '' And '$(Configuration)' == 'Release' And '$(_PlatformName)' == 'macOS'">osx-x64;osx-arm64</RuntimeIdentifiers>
 		<RuntimeIdentifiers Condition="'$(RuntimeIdentifier)' == '' And '$(Configuration)' == 'Release' And '$(_PlatformName)' == 'MacCatalyst'">maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
 


### PR DESCRIPTION
* When publishing a mobile app, choose a device architecture.
* When targeting a simulator, choose the arm64 version if we're running on an
  arm64 machine.

Fixes https://github.com/xamarin/xamarin-macios/issues/18455.
Fixes https://github.com/xamarin/xamarin-macios/issues/16152.