### PR TITLE
[msbuild/dotnet] Handle dylibs that don't start with 'lib' better. Fixes #15044.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/LinkerOptions.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/LinkerOptions.cs
@@ -59,17 +59,19 @@ namespace Xamarin.MacDev.Tasks {
 				} else if (kind == NativeReferenceKind.Dynamic) {
 					var path = item.ItemSpec;
 					var directory = Path.GetDirectoryName (path);
-					if (!string.IsNullOrEmpty (directory) && !libraryPaths.Contains (directory)) {
-						Arguments.AddQuoted ("-L" + directory);
-						libraryPaths.Add (directory);
-					}
-					// remove extension + "lib" prefix
 					var lib = Path.GetFileName (path);
-					if (lib.EndsWith (".dylib", StringComparison.OrdinalIgnoreCase))
-						lib = Path.GetFileNameWithoutExtension (lib);
-					if (lib.StartsWith ("lib", StringComparison.OrdinalIgnoreCase))
-						lib = lib.Substring (3);
-					Arguments.AddQuoted ("-l" + lib);
+					if (lib.StartsWith ("lib", StringComparison.Ordinal)) {
+						if (!string.IsNullOrEmpty (directory) && !libraryPaths.Contains (directory)) {
+							Arguments.AddQuoted ("-L" + directory);
+							libraryPaths.Add (directory);
+						}
+						// remove extension + "lib" prefix
+						if (lib.EndsWith (".dylib", StringComparison.OrdinalIgnoreCase))
+							lib = Path.GetFileNameWithoutExtension (lib);
+						Arguments.AddQuoted ("-l" + lib.Substring (3));
+					} else {
+						Arguments.AddQuoted (path);
+					}
 				} else {
 					Log.LogWarning (MSBStrings.W0052, item.ItemSpec);
 					continue;

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCodeTaskBase.cs
@@ -141,11 +141,13 @@ namespace Xamarin.MacDev.Tasks {
 						arguments.Add (lib);
 						break;
 					case ".dylib":
-						arguments.Add ("-L" + Path.GetDirectoryName (lib));
 						var libName = Path.GetFileNameWithoutExtension (lib);
-						if (libName.StartsWith ("lib", StringComparison.Ordinal))
-							libName = libName.Substring (3);
-						arguments.Add ("-l" + libName);
+						if (libName.StartsWith ("lib", StringComparison.Ordinal)) {
+							arguments.Add ("-L" + Path.GetDirectoryName (lib));
+							arguments.Add ("-l" + libName.Substring (3));
+						} else {
+							arguments.Add (libSpec.ItemSpec);
+						}
 						hasDylibs = true;
 						break;
 					case ".framework":

--- a/tests/dotnet/BundleStructure/AppDelegate.cs
+++ b/tests/dotnet/BundleStructure/AppDelegate.cs
@@ -13,5 +13,8 @@ namespace MySimpleApp {
 
 			return args.Length;
 		}
+
+		[DllImport ("__Internal")]
+		static extern IntPtr getNoLibPrefix ();
 	}
 }

--- a/tests/dotnet/BundleStructure/shared.csproj
+++ b/tests/dotnet/BundleStructure/shared.csproj
@@ -178,6 +178,8 @@
 		<!-- https://github.com/xamarin/xamarin-macios/issues/15727 -->
 		<None Include="$(RootTestsDirectory)/test-libraries/frameworks/.libs/$(RuntimeIdentifier)/Framework.With.Dots.framework"           CopyToPublishDirectory="PreserveNewest" PublishFolderType="AppleFramework" />
 
+		<!-- https://github.com/xamarin/xamarin-macios/issues/15044 -->
+		<None Include="$(RootTestsDirectory)/test-libraries/libraries/.libs/$(RuntimeIdentifier)/NoLibPrefix.dylib" CopyToPublishDirectory="PreserveNewest" PublishFolderType="DynamicLibrary" />
 		<!-- Content items -->
 
 		<!-- Content without any metadata: bundled -->

--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -227,6 +227,8 @@ namespace Xamarin.Tests {
 
 			AddExpectedFrameworkFiles (platform, expectedFiles, "Framework.With.Dots", isSigned); // https://github.com/xamarin/xamarin-macios/issues/15727
 
+			expectedFiles.Add (Path.Combine (assemblyDirectory, "NoLibPrefix.dylib")); // https://github.com/xamarin/xamarin-macios/issues/15044
+
 			expectedFiles.Add (Path.Combine (resourcesDirectory, "ContentA.txt"));
 			expectedFiles.Add (Path.Combine (resourcesDirectory, "ContentB.txt"));
 			expectedFiles.Add (Path.Combine (resourcesDirectory, "ContentC.txt"));

--- a/tests/test-libraries/libraries/Makefile
+++ b/tests/test-libraries/libraries/Makefile
@@ -2,6 +2,7 @@ TOP=../../..
 include $(TOP)/Make.config
 
 NAMES+=NoneE NoneF UnknownD SomewhatUnknownD SkipInstallNameTool
+NOPREFIX+=NoLibPrefix
 
 NO_INSTALL_NAME_TOOL_SkipInstallNameTool=1
 
@@ -32,33 +33,33 @@ maccatalyst-arm64_ARCHITECTURES=arm64
 define DotNetTemplate
 
 $(1)_$(3)_TARGETS += \
-	.libs/$(3)/lib$(1).a \
-	.libs/$(3)/lib$(1).o \
-	.libs/$(3)/lib$(1).dylib \
-	.libs/$(3)/lib$(1).so \
+	.libs/$(3)/$(4)$(1).a \
+	.libs/$(3)/$(4)$(1).o \
+	.libs/$(3)/$(4)$(1).dylib \
+	.libs/$(3)/$(4)$(1).so \
 
 $(3)_TARGETS += \
 	$$($(1)_$(3)_TARGETS) \
 
 all-local:: $$($(3)_TARGETS)
 
-.libs/$(3)/lib$(1).dylib: shared.c | .libs/$(3)
+.libs/$(3)/$(4)$(1).dylib: shared.c | .libs/$(3)
 	$$(call Q_2,CC,    [$(3)]) $$(XCODE_CC) -o $$@ $$(foreach arch,$$($(3)_ARCHITECTURES),-arch $$(arch)) $$($(2)_COMPILER_FLAGS) $$($(3)_COMPILER_FLAGS) -DNAME=$(1) -shared -framework Foundation -lz
 ifneq ($(NO_INSTALL_NAME_TOOL_$(1)),1)
-	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/lib$(1).dylib $$@
+	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/$(4)$(1).dylib $$@
 endif
 
-.libs/$(3)/lib$(1).o: shared.c | .libs/$(3)
+.libs/$(3)/$(4)$(1).o: shared.c | .libs/$(3)
 	$$(call Q_2,CC,    [$(3)]) $$(XCODE_CC) -o $$@ $$(foreach arch,$$($(3)_ARCHITECTURES),-arch $$(arch)) $$($(2)_COMPILER_FLAGS) $$($(3)_COMPILER_FLAGS) -DNAME=$(1) -c
 ifneq ($(NO_INSTALL_NAME_TOOL_$(1)),1)
-	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/lib$(1).dylib $$@
+	$$(Q) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool -id @rpath/$(4)$(1).dylib $$@
 endif
 
-.libs/$(3)/lib$(1).a: .libs/$(3)/lib$(1).o
+.libs/$(3)/$(4)$(1).a: .libs/$(3)/$(4)$(1).o
 	$$(call Q_2,AR     [$(1)]) $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar cru $$@ $$<
 
-.libs/$(3)/lib$(1).so: .libs/$(3)/lib$(1).dylib
-	$$(Q) $(CP) .libs/$(3)/lib$(1).dylib .libs/$(3)/lib$(1).so
+.libs/$(3)/$(4)$(1).so: .libs/$(3)/$(4)$(1).dylib
+	$$(Q) $(CP) .libs/$(3)/$(4)$(1).dylib .libs/$(3)/$(4)$(1).so
 
 $$($(3)_$(1)_DIRECTORIES):
 	$$(Q) mkdir -p $$@
@@ -68,7 +69,8 @@ endef
 # 1: name
 # 2: sdk platform (iphoneos, iphonesimulator, tvos, tvsimulator, maccatalyst, mac)
 # 3: runtime identifier
-$(foreach name,$(NAMES),$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call DotNetTemplate,$(name),$(DOTNET_$(rid)_SDK_PLATFORM),$(rid))))))
+$(foreach name,$(NAMES),$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call DotNetTemplate,$(name),$(DOTNET_$(rid)_SDK_PLATFORM),$(rid),lib)))))
+$(foreach name,$(NOPREFIX),$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call DotNetTemplate,$(name),$(DOTNET_$(rid)_SDK_PLATFORM),$(rid))))))
 
 $(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),.libs/$(rid))):
 	$(Q) mkdir -p $@


### PR DESCRIPTION
For a given dylib named '/path/to/libMyLibrary.dylib', we pass this to the native linker:

    -L/path/to -lMyLibrary

however, that doesn't work unless the dylib's name starts with 'lib'.

So detect this, and if the dylib doesn't start with 'lib' (say it's just
'MyLibrary.dylib'), then just pass the path to the dylib as-is to the native
linker:

	/path/to/MyLibrary.dylib

Fixes https://github.com/xamarin/xamarin-macios/issues/15044.