### PR TITLE
[iOS] HybridGlobalization set flag in SDK

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -126,6 +126,7 @@
 		<EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
 		<HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
 		<InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
+		<HybridGlobalization Condition="'$(HybridGlobalization)' == ''">false</HybridGlobalization>
 		<StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
 		<UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == '' And '$(_BundlerDebug)' != 'true'">true</UseSystemResourceKeys>
 		<UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == '' And '$(_BundlerDebug)' == 'true'">false</UseSystemResourceKeys>
@@ -143,7 +144,8 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<_GlobalizationDataFile Condition="'$(_PlatformName)' != 'macOS' And '$(InvariantGlobalization)' != 'true' And '$(_GlobalizationDataFile)' == ''">icudt.dat</_GlobalizationDataFile>
+		<_GlobalizationDataFile Condition="'$(_PlatformName)' != 'macOS' And '$(InvariantGlobalization)' != 'true' And '$(HybridGlobalization)' != 'true' And '$(_GlobalizationDataFile)' == ''">icudt.dat</_GlobalizationDataFile>
+		<_GlobalizationDataFile Condition="'$(_PlatformName)' != 'macOS' And '$(InvariantGlobalization)' != 'true' And '$(HybridGlobalization)' == 'true' And '$(_GlobalizationDataFile)' == ''">icudt_hybrid.dat</_GlobalizationDataFile>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -494,6 +496,7 @@
 				Interpreter=$(MtouchInterpreter)
 				IntermediateLinkDir=$(IntermediateLinkDir)
 				InvariantGlobalization=$(InvariantGlobalization)
+				HybridGlobalization=$(HybridGlobalization)
 				ItemsDirectory=$(_LinkerItemsDirectory)
 				IsAppExtension=$(IsAppExtension)
 				IsSimulatorBuild=$(_SdkIsSimulator)

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -218,6 +218,7 @@ namespace Xamarin.Tests {
 					var filename = Path.GetFileName (v);
 					switch (filename) {
 					case "icudt.dat":
+					case "icudt_hybrid.dat":
 						return false; // ICU data file only present on .NET
 					case "runtime-options.plist":
 						return false; // the .NET runtime will deal with selecting the http handler, no need for us to do anything

--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -282,7 +282,6 @@ namespace Xamarin.Tests {
 			if (!isCoreCLR)
 			{
 				expectedFiles.Add (Path.Combine (assemblyDirectory, "icudt.dat"));
-				expectedFiles.Add (Path.Combine (assemblyDirectory, "icudt_hybrid.dat"));
 			}
 			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "BundleStructure", runtimeIdentifiers, addConfig: true, includeDebugFiles: includeDebugFiles);
 			if (platform != ApplePlatform.MacOSX)

--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -280,7 +280,10 @@ namespace Xamarin.Tests {
 
 			// misc other files not directly related to the test itself
 			if (!isCoreCLR)
+			{
 				expectedFiles.Add (Path.Combine (assemblyDirectory, "icudt.dat"));
+				expectedFiles.Add (Path.Combine (assemblyDirectory, "icudt_hybrid.dat"));
+			}
 			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "BundleStructure", runtimeIdentifiers, addConfig: true, includeDebugFiles: includeDebugFiles);
 			if (platform != ApplePlatform.MacOSX)
 				AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "MonoTouch.Dialog", runtimeIdentifiers, forceSingleRid: true, includeDebugFiles: includeDebugFiles);

--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -279,9 +279,8 @@ namespace Xamarin.Tests {
 			}
 
 			// misc other files not directly related to the test itself
-			if (!isCoreCLR) {
+			if (!isCoreCLR)
 				expectedFiles.Add (Path.Combine (assemblyDirectory, "icudt.dat"));
-			}
 			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "BundleStructure", runtimeIdentifiers, addConfig: true, includeDebugFiles: includeDebugFiles);
 			if (platform != ApplePlatform.MacOSX)
 				AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "MonoTouch.Dialog", runtimeIdentifiers, forceSingleRid: true, includeDebugFiles: includeDebugFiles);

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Linker {
 		public string GlobalizationDataFile { get; private set; } = string.Empty;
 		public string IntermediateLinkDir { get; private set; } = string.Empty;
 		public bool InvariantGlobalization { get; private set; }
+		public bool HybridGlobalization { get; private set; }
 		public string ItemsDirectory { get; private set; } = string.Empty;
 		public bool IsSimulatorBuild { get; private set; }
 		public string PartialStaticRegistrarLibrary { get; set; } = string.Empty;
@@ -315,6 +316,9 @@ namespace Xamarin.Linker {
 					break;
 				case "InvariantGlobalization":
 					InvariantGlobalization = string.Equals ("true", value, StringComparison.OrdinalIgnoreCase);
+					break;
+				case "HybridGlobalization":
+					HybridGlobalization = string.Equals ("true", value, StringComparison.OrdinalIgnoreCase);
 					break;
 				case "XamarinNativeLibraryDirectory":
 					XamarinNativeLibraryDirectory = value;

--- a/tools/dotnet-linker/Steps/GenerateMainStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateMainStep.cs
@@ -38,6 +38,8 @@ namespace Xamarin {
 				if (Configuration.InvariantGlobalization) {
 					contents.AppendLine ("\tsetenv (\"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT\", \"1\", 1);");
 				} else {
+					if (Configuration.HybridGlobalization)
+					    contents.AppendLine ("\tsetenv (\"DOTNET_SYSTEM_GLOBALIZATION_HYBRID\", \"1\", 1);");
 					contents.AppendLine ($"\txamarin_icu_dat_file_name = \"{Configuration.GlobalizationDataFile}\";");
 				}
 				if (Configuration.Application.PackageManagedDebugSymbols && Configuration.Application.UseInterpreter)


### PR DESCRIPTION
Add HybridGlobalization flag in SDK and load icudt_hybrid.dat file when HybridGlobalization is on.

Contributes to https://github.com/dotnet/runtime/issues/80689

cc @SamMonoRT