### PR TITLE
[msbuild] Fix ILStripping of resource assemblies on Windows.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ILStripBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ILStripBase.cs
@@ -38,7 +38,20 @@ namespace Xamarin.MacDev.Tasks {
 			return result;
 		}
 
-		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+		public bool ShouldCopyToBuildServer (ITaskItem item)
+		{
+			// Some assemblies are already on the Mac, and we have a 0-length
+			// output file on Windows. We don't want to copy these files.
+			// However, some assemblies have to be copied, because they don't
+			// already exist on the Mac (typically resource assemblies). So
+			// filter to assemblies with a non-zero length.
+
+			var finfo = new FileInfo (item.ItemSpec);
+			if (!finfo.Exists || finfo.Length == 0)
+				return false;
+
+			return true;
+		}
 
 		public bool ShouldCreateOutputFile (ITaskItem item) => true;
 


### PR DESCRIPTION
Any assembly that's not already on the Mac must be copied there, so do that.
We detect if an assembly exist on the Mac by checking the file size of the
file on Windows: a 0-length file is an output file from an assembly that exist
on the Mac, otherwise it doesn't and must be copied.

Fixes https://github.com/xamarin/xamarin-macios/issues/17009.
Fixes https://github.com/xamarin/xamarin-macios/issues/14841.
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1817898.