### PR TITLE
Run the generator tests on Windows.

### DIFF
--- a/tests/common/Tool.cs
+++ b/tests/common/Tool.cs
@@ -196,7 +196,7 @@ namespace Xamarin.Tests {
 		public void ParseMessages ()
 		{
 			messages.Clear ();
-			ParseMessages (messages, output.ToString ().Split ('\n'), MessageToolName);
+			ParseMessages (messages, output.ToString ().Split ('\n', '\r'), MessageToolName);
 		}
 
 		static bool TrySplitCode (string code, out string prefix, out int number)

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -917,6 +917,11 @@ namespace Xamarin.Tests {
 		[OneTimeSetUp]
 		public void KillEverything ()
 		{
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
+				Console.WriteLine ($"Skipped killing everything, because there's nothing to kill on Windows.");
+				return;
+			}
+
 			ExecutionHelper.Execute ("launchctl", new [] { "remove", "com.apple.CoreSimulator.CoreSimulatorService" }, timeout: TimeSpan.FromSeconds (10));
 
 			var to_kill = new string [] { "iPhone Simulator", "iOS Simulator", "Simulator", "Simulator (Watch)", "com.apple.CoreSimulator.CoreSimulatorService", "ibtoold" };

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -283,7 +283,7 @@ namespace GeneratorTests {
 			foreach (var ca in attributes)
 				lines.Add (RenderSupportedOSPlatformAttribute (ca));
 			lines.Sort ();
-			return string.Join ("\n", lines);
+			return string.Join ("\n", lines).Replace ("\r", string.Empty);
 		}
 
 		static string RenderSupportedOSPlatformAttribute (CustomAttribute ca)
@@ -311,7 +311,7 @@ namespace GeneratorTests {
 			var preserves = allSupportedAttributes.Count ();
 			var renderedAttributes = "\t" + string.Join ("\n\t", renderedSupportedAttributes.OrderBy (v => v)) + "\n";
 #if NET
-			const string expectedAttributes =
+			string expectedAttributes =
 @"	Bug35176.IFooInterface: [SupportedOSPlatform(""ios14.3"")]
 	Bug35176.IFooInterface: [SupportedOSPlatform(""maccatalyst14.3"")]
 	Bug35176.IFooInterface: [SupportedOSPlatform(""macos11.2"")]
@@ -332,7 +332,7 @@ namespace GeneratorTests {
 	UIKit.UIView Bug35176.FooInterface_Extensions::GetBarView(Bug35176.IFooInterface): [SupportedOSPlatform(""macos11.2"")]
 ";
 #else
-			const string expectedAttributes =
+			string expectedAttributes =
 @"	Bug35176.IFooInterface: [Introduced(ObjCRuntime.PlatformName.iOS, 14, 3, ObjCRuntime.PlatformArchitecture.None, null)]
 	Bug35176.IFooInterface: [Introduced(ObjCRuntime.PlatformName.MacCatalyst, 14, 3, ObjCRuntime.PlatformArchitecture.None, null)]
 	Bug35176.IFooInterface: [Introduced(ObjCRuntime.PlatformName.MacOSX, 11, 2, ObjCRuntime.PlatformArchitecture.None, null)]
@@ -351,6 +351,9 @@ namespace GeneratorTests {
 	UIKit.UIView Bug35176.FooInterface_Extensions::GetBarView(Bug35176.IFooInterface): [Introduced(ObjCRuntime.PlatformName.MacCatalyst, 14, 4, ObjCRuntime.PlatformArchitecture.None, null)]
 ";
 #endif
+
+			expectedAttributes = expectedAttributes.Replace ("\r", string.Empty);
+			renderedAttributes = renderedAttributes.Replace ("\r", string.Empty);
 
 			if (renderedAttributes != expectedAttributes) {
 				Console.WriteLine ($"Expected:");
@@ -1101,6 +1104,9 @@ namespace GeneratorTests {
 				someMethod [i] = type.Methods.Single (v => v.Name == "SomeMethod" + (i + 1).ToString ());
 				renderedSomeMethod [i] = string.Join ("\n", someMethod [i].CustomAttributes.Select (ca => RenderSupportedOSPlatformAttribute (ca)).OrderBy (v => v));
 
+				expectedAttributes [i] = expectedAttributes [i].Replace ("\r", string.Empty);
+				renderedSomeMethod [i] = renderedSomeMethod [i].Replace ("\r", string.Empty);
+
 				if (expectedAttributes [i] == renderedSomeMethod [i])
 					continue;
 
@@ -1180,6 +1186,8 @@ namespace GeneratorTests {
 [SupportedOSPlatform(""macos10.15"")]
 [UnsupportedOSPlatform(""ios"")]
 [UnsupportedOSPlatform(""tvos"")]";
+			expectedPropertyAttributes = expectedPropertyAttributes.Replace ("\r", string.Empty);
+
 			Assert.AreEqual (expectedPropertyAttributes, RenderSupportedOSPlatformAttributes (property), "Property attributes");
 			Assert.AreEqual (string.Empty, RenderSupportedOSPlatformAttributes (getter), "Getter Attributes");
 		}
@@ -1207,6 +1215,9 @@ namespace GeneratorTests {
 [SupportedOSPlatform(""maccatalyst"")]
 [SupportedOSPlatform(""macos11.0"")]
 [UnsupportedOSPlatform(""tvos"")]";
+
+			expectedPropertyAttributes = expectedPropertyAttributes.Replace ("\r", string.Empty);
+			expectedSetterAttributes = expectedSetterAttributes.Replace ("\r", string.Empty);
 
 			Assert.AreEqual (expectedPropertyAttributes, RenderSupportedOSPlatformAttributes (property), "Property attributes");
 			Assert.AreEqual (string.Empty, RenderSupportedOSPlatformAttributes (getter), "Getter Attributes");
@@ -1353,7 +1364,8 @@ namespace GeneratorTests {
 					var member = type.Methods.SingleOrDefault (v => v.Name == expectedMember.Method);
 					Assert.IsNotNull (member, $"Method not found: {expectedMember.Method} in {type.FullName}");
 					var renderedAttributes = RenderSupportedOSPlatformAttributes (member);
-					if (renderedAttributes != expectedMember.Attributes) {
+					var expectedAttributes = expectedMember.Attributes.Replace ("\r", string.Empty);
+					if (renderedAttributes != expectedAttributes) {
 						var msg =
 							$"Property: {type.FullName}::{member.Name}\n" +
 							$"\tExpected attributes:\n" +
@@ -1376,7 +1388,8 @@ namespace GeneratorTests {
 					var member = type.Properties.SingleOrDefault (v => v.Name == expectedMember.Property);
 					Assert.IsNotNull (member, $"Property not found: {expectedMember.Property} in {type.FullName}");
 					var renderedAttributes = RenderSupportedOSPlatformAttributes (member);
-					if (renderedAttributes != expectedMember.Attributes) {
+					var expectedAttributes = expectedMember.Attributes.Replace ("\r", string.Empty);
+					if (renderedAttributes != expectedAttributes) {
 						var msg =
 							$"Property: {type.FullName}::{member.Name}\n" +
 							$"\tExpected attributes:\n" +

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -55,10 +55,14 @@ namespace Xamarin.Tests {
 
 		public BGenTool ()
 		{
-			EnvironmentVariables = new Dictionary<string, string> {
-				{ "MD_MTOUCH_SDK_ROOT", Configuration.SdkRootXI },
-				{ "XamarinMacFrameworkRoot", Configuration.SdkRootXM },
-			};
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
+				EnvironmentVariables = new Dictionary<string, string> ();
+			} else {
+				EnvironmentVariables = new Dictionary<string, string> {
+					{ "MD_MTOUCH_SDK_ROOT", Configuration.SdkRootXI },
+					{ "XamarinMacFrameworkRoot", Configuration.SdkRootXM },
+				};
+			}
 		}
 
 		public void AddTestApiDefinition (string filename)

--- a/tools/devops/automation/scripts/VSTS.Tests.ps1
+++ b/tools/devops/automation/scripts/VSTS.Tests.ps1
@@ -212,7 +212,9 @@ Describe 'New-BuildConfiguration' {
   ""BuildId"": ""BUILD_BUILDID"",
   ""DOTNET_PLATFORMS"": ""iOS tvOS"",
   ""INCLUDE_DOTNET_IOS"": null,
+  ""IOS_NUGET_VERSION_NO_METADATA"": null,
   ""INCLUDE_DOTNET_TVOS"": ""true"",
+  ""TVOS_NUGET_VERSION_NO_METADATA"": null,
   ""Commit"": ""BUILD_SOURCEVERSION"",
   ""Tags"": [
     ""ciBuild"",
@@ -238,7 +240,9 @@ Describe 'New-BuildConfiguration' {
   ""BuildId"": ""BUILD_BUILDID"",
   ""DOTNET_PLATFORMS"": ""iOS tvOS"",
   ""INCLUDE_DOTNET_IOS"": null,
+  ""IOS_NUGET_VERSION_NO_METADATA"": null,
   ""INCLUDE_DOTNET_TVOS"": ""true"",
+  ""TVOS_NUGET_VERSION_NO_METADATA"": null,
   ""Commit"": ""BUILD_SOURCEVERSION"",
   ""Tags"": [
     ""ciBuild"",

--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -259,6 +259,10 @@ class BuildConfiguration {
             $variableName = "INCLUDE_DOTNET_$($platform.ToUpper())"
             $variableValue = $config.$variableName
             Write-Host "##vso[task.setvariable variable=$variableName;isOutput=true]$variableValue"
+
+            $variableName = "$($platform.ToUpper())_NUGET_VERSION_NO_METADATA"
+            $variableValue = $config.$variableName
+            Write-Host "##vso[task.setvariable variable=$variableName;isOutput=true]$variableValue"
         }
 
         return $config
@@ -279,6 +283,10 @@ class BuildConfiguration {
         $dotnetPlatforms = $configuration.DOTNET_PLATFORMS.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
         foreach ($platform in $dotnetPlatforms) {
             $variableName = "INCLUDE_DOTNET_$($platform.ToUpper())"
+            $variableValue = [Environment]::GetEnvironmentVariable("CONFIGURE_PLATFORMS_$variableName")
+            $configuration | Add-Member -NotePropertyName $variableName -NotePropertyValue $variableValue
+
+            $variableName = "$($platform.ToUpper())_NUGET_VERSION_NO_METADATA"
             $variableValue = [Environment]::GetEnvironmentVariable("CONFIGURE_PLATFORMS_$variableName")
             $configuration | Add-Member -NotePropertyName $variableName -NotePropertyValue $variableValue
         }

--- a/tools/devops/automation/scripts/bash/configure-platforms.sh
+++ b/tools/devops/automation/scripts/bash/configure-platforms.sh
@@ -30,8 +30,6 @@ INCLUDE_WATCH=$(cat "$FILE")
 make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable-value-to-file FILE="$FILE" VARIABLE=INCLUDE_MAC
 INCLUDE_MAC=$(cat "$FILE")
 
-rm -f "$FILE"
-
 # print it out, so turn off echoing since that confuses Azure DevOps
 set +x
 
@@ -42,6 +40,11 @@ for platform in $DOTNET_PLATFORMS; do
 	PLATFORM_UPPER=$(echo "$platform" | tr '[:lower:]' '[:upper:]')
 	echo "##vso[task.setvariable variable=INCLUDE_DOTNET_$PLATFORM_UPPER;isOutput=true]1"
 	DISABLED_DOTNET_PLATFORMS=${DISABLED_DOTNET_PLATFORMS/ $platform / }
+
+	VARIABLE="${PLATFORM_UPPER}_NUGET_VERSION_NO_METADATA"
+	make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable-value-to-file FILE="$FILE" VARIABLE="$VARIABLE"
+	VALUE=$(cat "$FILE")
+	echo "##vso[task.setvariable variable=$VARIABLE;isOutput=true]$VALUE"
 done
 for platform in $DISABLED_DOTNET_PLATFORMS; do
 	PLATFORM_UPPER=$(echo "$platform" | tr '[:lower:]' '[:upper:]')
@@ -61,3 +64,5 @@ else
 	echo "##vso[task.setvariable variable=INCLUDE_LEGACY_MAC;isOutput=true]"
 fi
 set -x
+
+rm -f "$FILE"

--- a/tools/devops/automation/scripts/run-generator-tests-on-windows.ps1
+++ b/tools/devops/automation/scripts/run-generator-tests-on-windows.ps1
@@ -1,0 +1,37 @@
+# Dump the environment to see what we're working with.
+& "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\show_env.ps1"
+
+# Set a few variables
+$Env:DOTNET = "$Env:BUILD_SOURCESDIRECTORY\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe"
+$Env:DOTNET_DIR = "$Env:BUILD_SOURCESDIRECTORY\xamarin-macios\tests\dotnet\Windows\bin\dotnet\"
+$Env:TESTS_USE_SYSTEM = "1"
+
+# Compute the <platform>_NUGET_VERSION_NO_METADATA variables and set them in the environment
+$configurationDotNetPlatforms = $Env:CONFIGURATION_DOTNET_PLATFORMS
+$dotnetPlatforms = $configurationDotNetPlatforms.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
+foreach ($platform in $dotnetPlatforms) {
+  $manifestPath = "$Env:BUILD_SOURCESDIRECTORY\artifacts\AssetManifests\$($platform)\AssetManifest.xml"
+  $productVersion = Select-Xml -Path "$manifestPath" -XPath "/Build/Package[@Id='Microsoft.$($platform).Sdk']/@Version" | ForEach-Object { $_.Node.Value }
+  $variableName = "$($platform.ToUpper())_NUGET_VERSION_NO_METADATA"
+  [Environment]::SetEnvironmentVariable($variableName, $productVersion)
+  Write-Host "$variableName = $productVersion"
+}
+
+# Tell the tests how they can execute the C# compiler
+$csc = Get-ChildItem "$Env:BUILD_SOURCESDIRECTORY\xamarin-macios\tests\dotnet\Windows\bin\dotnet" -Include csc.dll -Recurse -File | %{$_.FullName}
+$Env:DOTNET_CSC_COMMAND = "$Env:DOTNET exec $csc".Replace("\", "/")
+Write-Host "DOTNET_CSC_COMMAND: $Env:DOTNET_CSC_COMMAND"
+
+# Tell the tests where the BCL is
+$Env:DOTNET_BCL_DIR = Get-ChildItem "$Env:BUILD_SOURCESDIRECTORY\xamarin-macios\tests\dotnet\Windows\bin\dotnet\packs\Microsoft.NETCore.App.Ref" -Include System.dll -Recurse -File | %{$_.DirectoryName}
+Write-Host "DOTNET_BCL_DIR: $Env:DOTNET_BCL_DIR"
+
+# Finally we can run the tests
+& $Env:BUILD_SOURCESDIRECTORY\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe `
+    test `
+    "$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/tests/bgen/bgen-tests.csproj" `
+    "--results-directory:$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows/bgen-tests/" `
+    "--logger:console;verbosity=detailed" `
+    "--logger:trx;LogFileName=$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows/bgen-tests/results.trx" `
+    "--logger:html;LogFileName=$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows/bgen-tests/results.html" `
+    "-bl:$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows/bgen-tests/results.binlog"

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -145,6 +145,19 @@ steps:
         "-bl:$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/run-dotnet-tests.binlog"
   displayName: 'Run .NET tests'
 
+- pwsh: |
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
+    $configFile = "$(Build.SourcesDirectory)\artifacts\build-configuration\configuration.json"
+    $config = Import-BuildConfiguration -ConfigFile $configFile
+    $config | Write-Host
+  name: configuration
+  continueOnError: true
+  displayName: 'Parse build configuration'
+  timeoutInMinutes: 1
+
+- pwsh: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/run-generator-tests-on-windows.ps1
+  displayName: 'Run generator tests'
+
 # Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
 - task: ArchiveFiles@1
   displayName: 'Archive HtmlReport'


### PR DESCRIPTION
We'll soon change the generator to execute locally on Windows, even for remote builds. As a stepping stone towards that goal, this PR adds the generator tests to the list of tests we run on Windows.