### PR TITLE
Revert "[dotnet] Remove libSystem.Net.Security.Native from tvOS build…

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1192,14 +1192,6 @@
 			<NativeLib>static</NativeLib>
 		</PropertyGroup>
 
-		<!-- Remove libSystem.Net.Security.Native.a from tvOS when using NativeAOT, it's not shipped on tvOS -->
-		<ItemGroup>
-			<DirectPInvoke Remove="libSystem.Net.Security.Native" />
-			<NetCoreAppNativeLibrary Remove="System.Net.Security.Native" />
-			<NativeLibrary Remove="@(NativeLibrary)" Condition="'%(Filename)' == 'libSystem.Net.Security.Native'" />
-			<LinkerArg Remove="@(LinkerArg)" Condition="'%(Filename)' == 'libSystem.Net.Security.Native'" />
-		</ItemGroup>
-
 		<ItemGroup>
 			<!-- We need to mark all __Internal P/Invokes as direct, so that the native linker doesn't remove them -->
 			<DirectPInvoke Include="__Internal" />


### PR DESCRIPTION
…s when using NativeAOT."

This reverts commit 97b91f16002d5b0d7844793681a8ba5f129d85ba.

Fixes #18481