### PR TITLE
MSR: Generate additional constructors to reduce usage of reflection

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -231,16 +231,14 @@ namespace Foundation {
 			GC.SuppressFinalize (this);
 		}
 
-		static T AllocateNSObject<T> (IntPtr handle) where T : NSObject
-		{
-			var obj = (T) RuntimeHelpers.GetUninitializedObject (typeof (T));
-			obj.handle = handle;
-			obj.flags = Flags.NativeRef;
-			return obj;
-		}
-
 		internal static IntPtr CreateNSObject (IntPtr type_gchandle, IntPtr handle, Flags flags)
 		{
+#if NET
+			if (Runtime.IsManagedStaticRegistrar) {
+				throw new System.Diagnostics.UnreachableException ();
+			}
+#endif
+			
 			// This function is called from native code before any constructors have executed.
 			var type = (Type) Runtime.GetGCHandleTarget (type_gchandle);
 			try {

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -238,7 +238,7 @@ namespace Foundation {
 				throw new System.Diagnostics.UnreachableException ();
 			}
 #endif
-			
+
 			// This function is called from native code before any constructors have executed.
 			var type = (Type) Runtime.GetGCHandleTarget (type_gchandle);
 			try {

--- a/tools/dotnet-linker/CecilExtensions.cs
+++ b/tools/dotnet-linker/CecilExtensions.cs
@@ -30,6 +30,14 @@ namespace Xamarin.Linker {
 			return rv;
 		}
 
+		public static FieldDefinition AddField (this TypeDefinition self, string name, FieldAttributes attributes, TypeReference type)
+		{
+			var rv = new FieldDefinition (name, attributes, type);
+			rv.DeclaringType = self;
+			self.Fields.Add (rv);
+			return rv;
+		}
+
 		public static MethodBody CreateBody (this MethodDefinition self, out ILProcessor il)
 		{
 			var body = new MethodBody (self);

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -480,13 +480,13 @@ namespace Xamarin.Linker {
 					//   would allocate a new Objective-C object if `handle` is a zero pointer.
 					// - The `NSObjectInitializationData` type is generated at build time and so it can't be used
 					//   anywhere in the app. The generated ctors will have a unique signature.
-					
+
 					if (initializationDataType is null) {
 						initializationDataType = CreateNSObjectInitializationDataStruct ();
 						abr.PlatformAssembly.MainModule.Types.Add (initializationDataType.Type.Resolve ());
 						Annotations.Mark (initializationDataType.Type);
 					}
-					
+
 					initializationDataType.Type = abr.CurrentAssembly.MainModule.ImportReference (initializationDataType.Type);
 					initializationDataType.HandleField = abr.CurrentAssembly.MainModule.ImportReference (initializationDataType.HandleField);
 					initializationDataType.FlagsField = abr.CurrentAssembly.MainModule.ImportReference (initializationDataType.FlagsField);
@@ -1320,19 +1320,18 @@ namespace Xamarin.Linker {
 			}
 		}
 
-		class NSObjectInitializationDataType
-		{
+		class NSObjectInitializationDataType {
 			public required FieldReference HandleField { get; set; }
 			public required FieldReference FlagsField { get; set; }
 			public required TypeReference Type { get; set; }
 		}
 
-		NSObjectInitializationDataType CreateNSObjectInitializationDataStruct()
+		NSObjectInitializationDataType CreateNSObjectInitializationDataStruct ()
 		{
 			var type = new TypeDefinition (string.Empty, "NSObjectInitializationData", TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.AnsiClass | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit);
 			type.BaseType = abr.System_ValueType;
 
-			return new NSObjectInitializationDataType() {
+			return new NSObjectInitializationDataType () {
 				Type = type,
 				HandleField = type.AddField ("Handle", FieldAttributes.Public, abr.System_IntPtr),
 				FlagsField = type.AddField ("Flags", FieldAttributes.Public, abr.System_Byte),
@@ -1382,7 +1381,7 @@ namespace Xamarin.Linker {
 			foreach (var parameter in clonedCtor.Parameters.Skip (1)) {
 				il.Emit (OpCodes.Ldarg, parameter);
 			}
-			
+
 			il.Emit (OpCodes.Call, ctor);
 			il.Emit (OpCodes.Ret);
 

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -83,7 +83,6 @@ namespace Xamarin.Linker {
 
 		AppBundleRewriter abr { get { return Configuration.AppBundleRewriter; } }
 		List<Exception> exceptions = new List<Exception> ();
-		NSObjectInitializationDataType? initializationDataType;
 
 		void AddException (Exception exception)
 		{
@@ -427,6 +426,7 @@ namespace Xamarin.Linker {
 			// and later on remove everything after this instruction. Maybe at a later point I'll figure out a way to make the code emission conditional without
 			// littering the logic with conditional statements.
 			Instruction? skipEverythingAfter = null;
+
 			if (isInstanceCategory) {
 				il.Emit (OpCodes.Ldarg_0);
 				EmitConversion (method, il, method.Parameters [0].ParameterType, true, 0, out var nativeType, postProcessing);
@@ -469,49 +469,24 @@ namespace Xamarin.Linker {
 					// public .ctor (T0 p0, T1 p1, ...) { /* ... */ }
 					//
 					// // The generated constructor with pre-initialization: 
-					// public .ctor (NSObjectInitializationData initData, T0 p0, T1 p1, ...) {
-					//     this.handle = initData.Handle;
-					//     this.flags = initData.Flags;
+					// public .ctor (T0 p0, T1 p1, ..., IntPtr nativeHandle, IManagedRegistrar dummy) {
+					//     this.handle = (NativeHandle)nativeHandle;
+					//     this.flags = 2; // Flags.NativeRef == 2
 					//     this..ctor (p0, p1, ...);
 					// }
 					//
 					// - This code can't be expressed in C# and it can only be expressed directly in IL.
 					// - The reason we need to do this is because the base NSObject parameterless constructor 
 					//   would allocate a new Objective-C object if `handle` is a zero pointer.
-					// - The `NSObjectInitializationData` type is generated at build time and so it can't be used
-					//   anywhere in the app. The generated ctors will have a unique signature.
+					// - The `IManagedRegistrar` dummy parameter is used only to make sure that the signature
+					//   is unique and there aren't any conflicts. The IManagedRegistrar type is internal and
+					//   we only make it public through a custom linker step.
 
-					if (initializationDataType is null) {
-						initializationDataType = CreateNSObjectInitializationDataStruct ();
-						abr.PlatformAssembly.MainModule.Types.Add (initializationDataType.Type.Resolve ());
-						Annotations.Mark (initializationDataType.Type);
-					}
-
-					initializationDataType.Type = abr.CurrentAssembly.MainModule.ImportReference (initializationDataType.Type);
-					initializationDataType.HandleField = abr.CurrentAssembly.MainModule.ImportReference (initializationDataType.HandleField);
-					initializationDataType.FlagsField = abr.CurrentAssembly.MainModule.ImportReference (initializationDataType.FlagsField);
-
-					ctor = CloneConstructorWithNSObjectInitializationData (method, initializationDataType);
+					ctor = CloneConstructorWithNativeHandle (method);
 					method.DeclaringType.Methods.Add (ctor.Resolve ());
 
-					// prepare the init data
-					var initDataVariable = body.AddVariable (initializationDataType.Type);
-					il.Emit (OpCodes.Ldloca_S, initDataVariable);
+					il.Emit (OpCodes.Nop);
 					postLeaveBranch.Operand = il.Body.Instructions.Last ();
-
-					il.Emit (OpCodes.Initobj, initializationDataType.Type);
-
-					// set the handle
-					il.Emit (OpCodes.Ldloca_S, initDataVariable);
-					il.Emit (OpCodes.Ldarg_0); // pobj
-					il.Emit (OpCodes.Stfld, initializationDataType.HandleField);
-
-					// set flags
-					il.Emit (OpCodes.Ldloca_S, initDataVariable);
-					il.Emit (OpCodes.Ldc_I4, 2); // Flags.NativeRef == 2
-					il.Emit (OpCodes.Stfld, initializationDataType.FlagsField);
-
-					il.Emit (OpCodes.Ldloc, initDataVariable);
 				}
 			} else if (isGeneric) {
 				// this is a proxy method and we can simply use `this` without any conversion
@@ -557,6 +532,10 @@ namespace Xamarin.Linker {
 			callback.AddParameter ("exception_gchandle", new PointerType (abr.System_IntPtr));
 
 			if (ctor is not null) {
+				// in addition to the params of the original ctor we pass also the native handle and a null
+				// value for the dummy (de-duplication) parameter
+				il.Emit (OpCodes.Ldarg_0);
+				il.Emit (OpCodes.Ldnull);
 				il.Emit (OpCodes.Newobj, ctor);
 			} else if (isGeneric && !method.IsConstructor) {
 				var targetMethod = method.DeclaringType.CreateMethodReferenceOnGenericType (method, method.DeclaringType.GenericParameters.ToArray ());
@@ -1320,33 +1299,20 @@ namespace Xamarin.Linker {
 			}
 		}
 
-		class NSObjectInitializationDataType {
-			public required FieldReference HandleField { get; set; }
-			public required FieldReference FlagsField { get; set; }
-			public required TypeReference Type { get; set; }
-		}
-
-		NSObjectInitializationDataType CreateNSObjectInitializationDataStruct ()
-		{
-			var type = new TypeDefinition (string.Empty, "NSObjectInitializationData", TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.AnsiClass | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit);
-			type.BaseType = abr.System_ValueType;
-
-			return new NSObjectInitializationDataType () {
-				Type = type,
-				HandleField = type.AddField ("Handle", FieldAttributes.Public, abr.System_IntPtr),
-				FlagsField = type.AddField ("Flags", FieldAttributes.Public, abr.System_Byte),
-			};
-		}
-
-		MethodDefinition CloneConstructorWithNSObjectInitializationData (MethodDefinition ctor, NSObjectInitializationDataType initDataType)
+		MethodDefinition CloneConstructorWithNativeHandle (MethodDefinition ctor)
 		{
 			var clonedCtor = new MethodDefinition (ctor.Name, ctor.Attributes, ctor.ReturnType);
 			clonedCtor.IsPublic = false;
 
-			var initParameter = clonedCtor.AddParameter ("initData", initDataType.Type);
+			// clone the original parameters firsts
 			foreach (var parameter in ctor.Parameters) {
 				clonedCtor.AddParameter (parameter.Name, parameter.ParameterType);
 			}
+
+			// add a native handle param + a dummy parameter that we know for a fact won't be used anywhere
+			// to make the signature of the new constructor unique
+			var handleParameter = clonedCtor.AddParameter ("nativeHandle", abr.System_IntPtr);
+			var dummyParameter = clonedCtor.AddParameter ("dummy", abr.ObjCRuntime_IManagedRegistrar);
 
 			var body = clonedCtor.CreateBody (out var il);
 
@@ -1360,25 +1326,23 @@ namespace Xamarin.Linker {
 
 			// store the handle and flags first
 			il.Emit (OpCodes.Ldarg_0);
-			il.Emit (OpCodes.Ldarg, initParameter);
-			il.Emit (OpCodes.Ldfld, initDataType.HandleField);
+			il.Emit (OpCodes.Ldarg, handleParameter);
 #if NET
 			il.Emit (OpCodes.Call, abr.NativeObject_op_Implicit_NativeHandle);
 #endif
 			il.Emit (OpCodes.Stfld, abr.CurrentAssembly.MainModule.ImportReference (abr.Foundation_NSObject_HandleField));
 
 			il.Emit (OpCodes.Ldarg_0);
-			il.Emit (OpCodes.Ldarg, initParameter);
-			il.Emit (OpCodes.Ldfld, initDataType.FlagsField);
+			il.Emit (OpCodes.Ldc_I4_2); // Flags.NativeRef == 2
 #if NET
 			il.Emit (OpCodes.Call, abr.Foundation_NSObject_FlagsSetterMethod);
 #else
 			il.Emit (OpCodes.Stfld, abr.Foundation_NSObject_FlagsField);
 #endif
 
-			// call the original constructor with all of the parameters
+			// call the original constructor with all of the original parameters
 			il.Emit (OpCodes.Ldarg_0);
-			foreach (var parameter in clonedCtor.Parameters.Skip (1)) {
+			foreach (var parameter in clonedCtor.Parameters.SkipLast (2)) {
 				il.Emit (OpCodes.Ldarg, parameter);
 			}
 


### PR DESCRIPTION
Closes #18357

This PR implements the idea described in the linked issue:

Whenever there's an NSObject constructor that we call from a registrar callback, we need to create
a separate constructor that will first set the `handle` and `flags` values of the NSObject before
calling the original constructor. Here's an example of the code we generate:

```csharp
// The original constructor:
public .ctor (T0 p0, T1 p1, ...) { /* ... */ }

// The generated constructor with pre-initialization: 
public .ctor (T0 p0, T1 p1, ..., IntPtr handle, IManagedRegistrar dummy) {
    this.handle = (NativeHandle)handle;
    this.flags = 2; // Flags.NativeRef == 2
    this..ctor (p0, p1, ...);
}
```

- This code can't be expressed in C# and it can only be expressed directly in IL.
- The reason we need to do this is because the base NSObject parameterless constructor 
  would allocate a new Objective-C object if `handle` is a zero pointer.
- The `IManagedRegistrar` type is added only to make the constructor signature unique (IManagedRegistrar is not a public class and customers can't use it in their apps directly)