### PR TITLE
Exclude assemblies from NativeAOT app bundles

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1321,6 +1321,17 @@
 		</ItemGroup>
 	</Target>
 
+	<Target Name="_ExcludeUnusedFilesFromTheBundle"
+		Condition="'$(_UseNativeAot)' == 'true'"
+		AfterTargets="_LinkNativeExecutable"
+		BeforeTargets="CopyFilesToPublishDirectory">
+		<ItemGroup>
+			<!-- We don't ship assemblies with NativeAOT -->
+			<!-- Exclude assemblies explicitly until https://github.com/dotnet/runtime/issues/87187 is not resolved -->
+			<ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.Extension)' == '.dll'" />
+		</ItemGroup>
+	</Target>
+
 	<PropertyGroup>
 		<_GenerateBindingsDependsOn>
 			_ComputeBindingVariables;

--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -558,9 +558,11 @@ xamarin_bridge_call_runtime_initialize (struct InitializationOptions* options, G
 void
 xamarin_bridge_register_product_assembly (GCHandle* exception_gchandle)
 {
+#if !defined (NATIVEAOT)
 	MonoAssembly *assembly;
 	assembly = xamarin_open_and_register (PRODUCT_DUAL_ASSEMBLY, exception_gchandle);
 	xamarin_mono_object_release (&assembly);
+#endif // !defined (NATIVEAOT)
 }
 
 MonoMethod *

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -441,6 +441,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	if (xamarin_register_assemblies != NULL)
 		xamarin_register_assemblies ();
 
+#if !defined (NATIVEAOT)
 	if (xamarin_executable_name) {
 		assembly = xamarin_open_and_register (xamarin_executable_name, &exception_gchandle);
 		xamarin_process_fatal_exception_gchandle (exception_gchandle, "An exception occurred while opening the main executable");
@@ -454,14 +455,16 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 		xamarin_process_fatal_exception_gchandle (exception_gchandle, "An exception occurred while opening an assembly");
 	}
 
-#if SUPPORTS_DYNAMIC_REGISTRATION
 	if (xamarin_supports_dynamic_registration) {
 		MonoReflectionAssembly *rassembly = mono_assembly_get_object (mono_domain_get (), assembly);
 		xamarin_register_entry_assembly (rassembly, &exception_gchandle);
 		xamarin_mono_object_release (&rassembly);
 		xamarin_process_fatal_exception_gchandle (exception_gchandle, "An exception occurred while opening the entry assembly");
 	}
-#endif // SUPPORTS_DYNAMIC_REGISTRATION
+#else
+	assembly = NULL;
+	(void)exception_gchandle;
+#endif // !defined (NATIVEAOT)
 
 	DEBUG_LAUNCH_TIME_PRINT ("\tAssembly register time");
 


### PR DESCRIPTION
Since NativeAOT generates native libraries and executables that do not rely on assemblies they were compiled from, all managed assemblies can be excluded from the application bundle.

This reduces the size of the application bundle by `3,17Mb` (or ~19% compared to the baseline)

| MAUI ios app | Base | This PR | diff (%) |
|--------------|-----------|-----------|----------|
| SOD (Mb)     | 50,13 | 41,93 | -16,3%      |
| .ipa (Mb)    | 16,59  | 13,43  | -19%      |

Fixes: https://github.com/xamarin/xamarin-macios/issues/18472