### PR TITLE
[msbuild] Fix null check when validating Hot Restart app identifier

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/DetectHotRestartSigningIdentity.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/DetectHotRestartSigningIdentity.cs
@@ -103,7 +103,7 @@ namespace Xamarin.iOS.HotRestart.Tasks {
 
 				identity.AppId = ConstructValidAppId (identity.Profile, identity.BundleId);
 
-				if (identity.AppId is not null) {
+				if (identity.AppId is null) {
 					Log.LogError ("Project bundle identifier '{0}' does not match specified provisioning profile '{1}'. Please enable Automatic Provisioning from the iOS Bundle Signing page.", identity.BundleId, ProvisioningProfile);
 					return false;
 				}


### PR DESCRIPTION
The detection of signing identities should fail if we could not build a valid app id. This code originally checked for null (`AppId == null`) and was replaced by `is not null` as part of https://github.com/xamarin/xamarin-macios/commit/36af0292043a63897311c035bb0d4afb7a1a44b2#diff-ff4502eb16b65dc59bb7de2bf980024260e83d7b97fef727c9c033374f2b3533R106.