### PR TITLE
[net8.0] Revert "[net8.0] Update dependencies from dotnet/installer #18525)"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,22 +1,22 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-preview.7.23360.1">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-preview.7.23329.2">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>62ef57f1140e7fa71cf452542b263e7999cac168</Sha>
+      <Sha>12bfecc01dfa05c84102893928ddc3840f97bb70</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-preview.7.23359.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-preview.7.23328.9" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>31106939ba524a7e6df8225cf8d0fedefba92b9f</Sha>
+      <Sha>cfae69f62414b68e4c98dd3b294154baabf58a5a</Sha>
     </Dependency>
     <!-- Set TRACKING_DOTNET_RUNTIME_SEPARATELY to something in Make.config if removing the CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal -->
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.7.23359.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.7.23328.9" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>31106939ba524a7e6df8225cf8d0fedefba92b9f</Sha>
+      <Sha>cfae69f62414b68e4c98dd3b294154baabf58a5a</Sha>
     </Dependency>
     <!-- This is required for our test apps to build; in some cases Microsoft.AspNetCore.App is pulled in, and when building test apps the build needs to be able to resolve that -->
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="8.0.0-preview.7.23359.2" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="8.0.0-preview.7.23328.3" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be566b1f4ed1ab24765a3a4a2d1751dc73e7fcfc</Sha>
+      <Sha>c7b4724a7d90c247ba58715862dad29a704dd619</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport" Version="8.0.0-preview.7.23326.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,10 +2,10 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- Versions updated by maestro -->
-    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-preview.7.23360.1</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETILLinkTasksPackageVersion>8.0.0-preview.7.23359.1</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-preview.7.23329.2</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>8.0.0-preview.7.23328.9</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.7.23359.1</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.7.23328.9</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>8.0.0-preview.7.23326.1</MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>
     <MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>7.0.7</MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.7.23360.1"
+    "version": "8.0.100-preview.7.23329.2"
   }
 }


### PR DESCRIPTION
This reverts commit a2ce5f3485337c3ff24f635fa28980eb27ab2782.

This is a temporary revert until we figure out why ILLink breaks MAUI with

```
ILLink : unknown error IL7000: An error occured while executing the custom linker steps. Please review the build log for more information. [/Users/builder/azdo/_work/2/s/src/Essentials/samples/Samples/Essentials.Sample.csproj::TargetFramework=net8.0-ios]
ILLINK : error MT2301: The linker step 'Setup' failed during processing: Failed to parse PList data type: dict [/Users/builder/azdo/_work/2/s/src/Essentials/samples/Samples/Essentials.Sample.csproj::TargetFramework=net8.0-ios]
```

As seen here https://dev.azure.com/xamarin/public/_build/results?buildId=91068&view=logs&j=3a2c3e05-58d9-5668-2c58-02c61841ec5f&t=0d23cc4d-c509-5473-9e43-147360f36c68