### PR TITLE
[release/8.0.1xx-preview7] [net8.0] Update dependencies from xamarin/xamarin-macios

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,9 +31,9 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>43ae6c749407e47fdf5fa07295119b87f7328ea6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7089">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7090">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>663e05acb1277c55dc9f88fab18dc985f034ffa2</Sha>
+      <Sha>43ae6c749407e47fdf5fa07295119b87f7328ea6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7090">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -35,9 +35,9 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>663e05acb1277c55dc9f88fab18dc985f034ffa2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7089">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7090">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>663e05acb1277c55dc9f88fab18dc985f034ffa2</Sha>
+      <Sha>43ae6c749407e47fdf5fa07295119b87f7328ea6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7089">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,9 +27,9 @@
       <Sha>3e46711f5a933551557286d211970faa08b07b7e</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 7 versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.7089">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.7090">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>663e05acb1277c55dc9f88fab18dc985f034ffa2</Sha>
+      <Sha>43ae6c749407e47fdf5fa07295119b87f7328ea6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7089">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,9 +39,9 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>43ae6c749407e47fdf5fa07295119b87f7328ea6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7089">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7090">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>663e05acb1277c55dc9f88fab18dc985f034ffa2</Sha>
+      <Sha>43ae6c749407e47fdf5fa07295119b87f7328ea6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Runtime.MonoTargets.Sdk" Version="7.0.7">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <Emscriptennet7WorkloadVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion)</Emscriptennet7WorkloadVersion>
     <EmscriptenWorkloadVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion)</EmscriptenWorkloadVersion>
     <!-- This is a subscription of the .NET 7 versions of our packages -->
-    <MicrosoftMacCatalystSdkPackageVersion>16.4.7089</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>16.4.7090</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>13.3.7089</MicrosoftmacOSSdkPackageVersion>
     <MicrosoftiOSSdkPackageVersion>16.4.7090</MicrosoftiOSSdkPackageVersion>
     <MicrosofttvOSSdkPackageVersion>16.4.7089</MicrosofttvOSSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
     <!-- This is a subscription of the .NET 7 versions of our packages -->
     <MicrosoftMacCatalystSdkPackageVersion>16.4.7089</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>13.3.7089</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>16.4.7089</MicrosoftiOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>16.4.7090</MicrosoftiOSSdkPackageVersion>
     <MicrosofttvOSSdkPackageVersion>16.4.7089</MicrosofttvOSSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,6 +17,6 @@
     <MicrosoftMacCatalystSdkPackageVersion>16.4.7090</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>13.3.7090</MicrosoftmacOSSdkPackageVersion>
     <MicrosoftiOSSdkPackageVersion>16.4.7090</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>16.4.7089</MicrosofttvOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>16.4.7090</MicrosofttvOSSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <EmscriptenWorkloadVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion)</EmscriptenWorkloadVersion>
     <!-- This is a subscription of the .NET 7 versions of our packages -->
     <MicrosoftMacCatalystSdkPackageVersion>16.4.7090</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>13.3.7089</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>13.3.7090</MicrosoftmacOSSdkPackageVersion>
     <MicrosoftiOSSdkPackageVersion>16.4.7090</MicrosoftiOSSdkPackageVersion>
     <MicrosofttvOSSdkPackageVersion>16.4.7089</MicrosofttvOSSdkPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
This pull request updates the following dependencies

[marker]: <> (Begin:34d10fbb-96e7-4139-42ad-08db73ee5f69)
## From https://github.com/xamarin/xamarin-macios
- **Subscription**: 34d10fbb-96e7-4139-42ad-08db73ee5f69
- **Build**: 20230630.11
- **Date Produced**: June 30, 2023 5:09:35 PM UTC
- **Commit**: 43ae6c749407e47fdf5fa07295119b87f7328ea6
- **Branch**: refs/heads/release/7.0.3xx

[DependencyUpdate]: <> (Begin)

- **Updates**:
  - **Microsoft.tvOS.Sdk**: [from 16.4.7089 to 16.4.7090][4]

[4]: https://github.com/xamarin/xamarin-macios/compare/663e05acb1...43ae6c7494

[DependencyUpdate]: <> (End)


[marker]: <> (End:34d10fbb-96e7-4139-42ad-08db73ee5f69)










Backport of #18527
