### PR TITLE
[release/8.0.1xx-preview7] [vs-workload] Set EnableSideBySideManifests=true

### DIFF
--- a/dotnet/generate-vs-workload.csharp
+++ b/dotnet/generate-vs-workload.csharp
@@ -63,6 +63,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	var iOSPlatform = platforms.Where (v => v.Item1 == "iOS");
 	var manifestBuildVersion = iOSPlatform.Any () ? iOSPlatform.First ().Item2 : platforms.First ().Item2;
 	writer.WriteLine ($"    <ManifestBuildVersion>{manifestBuildVersion}</ManifestBuildVersion>");
+	writer.WriteLine ($"    <EnableSideBySideManifests>true</EnableSideBySideManifests>");
 	writer.WriteLine ($"  </PropertyGroup>");
 	writer.WriteLine ($"  <ItemGroup>");
 	writer.WriteLine ($"    <!-- Shorten package names to avoid long path caching issues in Visual Studio -->");


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/274

Enables side by side workload manifest support when generating workload MSIs.

This should only be enabled for builds shipping with .NET 8 Preview 7 or later.


Backport of #18554
