### PR TITLE
[Xharness] Fix path to mlaunch when using mlaunch from a .NET SDK pack on CI.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -166,7 +166,7 @@ namespace Xharness {
 					// there is a diff between getting the path for the current platform when running on CI or off CI. The config files in the CI do not 
 					// contain the correct workload version, the reason for this is that the workload is built in a different machine which means that
 					// the Make.config will use the wrong version. The CI set the version in the environment variable {platform}_WORKLOAD_VERSION via a script.
-					var workloadVersion = Environment.GetEnvironmentVariable ($"{platform.ToUpperInvariant ()}_WORKLOAD_VERSION ");
+					var workloadVersion = Environment.GetEnvironmentVariable ($"{platform.ToUpperInvariant ()}_WORKLOAD_VERSION");
 					mlaunchPath = Path.Combine (mlaunchPath, $"Microsoft.{platform}.Sdk",
 							string.IsNullOrEmpty (workloadVersion) ? config [$"{platform.ToUpperInvariant ()}_NUGET_VERSION_NO_METADATA"] : workloadVersion);
 					mlaunchPath = Path.Combine (mlaunchPath, "tools", "bin", "mlaunch");

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -166,10 +166,9 @@ namespace Xharness {
 					// there is a diff between getting the path for the current platform when running on CI or off CI. The config files in the CI do not 
 					// contain the correct workload version, the reason for this is that the workload is built in a different machine which means that
 					// the Make.config will use the wrong version. The CI set the version in the environment variable {platform}_WORKLOAD_VERSION via a scritp.
-					var workloadVersion = InCI ?
-						Environment.GetEnvironmentVariable ($"{platform.ToUpperInvariant ()}_WORKLOAD_VERSION ")
-						: config [$"{platform.ToUpperInvariant ()}_NUGET_VERSION_NO_METADATA"];
-					mlaunchPath = Path.Combine (mlaunchPath, $"Microsoft.{platform}.Sdk", workloadVersion);
+					var workloadVersion = Environment.GetEnvironmentVariable ($"{platform.ToUpperInvariant ()}_WORKLOAD_VERSION ");
+					mlaunchPath = Path.Combine (mlaunchPath, $"Microsoft.{platform}.Sdk",
+							string.IsNullOrEmpty (workloadVersion) ? config [$"{platform.ToUpperInvariant ()}_NUGET_VERSION_NO_METADATA"] : workloadVersion);
 					mlaunchPath = Path.Combine (mlaunchPath, "tools", "bin", "mlaunch");
 					return mlaunchPath;
 				} else if (INCLUDE_XAMARIN_LEGACY && INCLUDE_IOS) {

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -163,7 +163,13 @@ namespace Xharness {
 						return $"Not building any mobile platform, so can't provide a location to mlaunch.";
 					}
 					var mlaunchPath = Path.Combine (DOTNET_DIR, "packs");
-					mlaunchPath = Path.Combine (mlaunchPath, $"Microsoft.{platform}.Sdk", config [$"{platform.ToUpperInvariant ()}_NUGET_VERSION_NO_METADATA"]);
+					// there is a diff between getting the path for the current platform when running on CI or off CI. The config files in the CI do not 
+					// contain the correct workload version, the reason for this is that the workload is built in a different machine which means that
+					// the Make.config will use the wrong version. The CI set the version in the environment variable {platform}_WORKLOAD_VERSION via a scritp.
+					var workloadVersion = InCI ?
+						Environment.GetEnvironmentVariable ($"{platform.ToUpperInvariant ()}_WORKLOAD_VERSION ")
+						: config [$"{platform.ToUpperInvariant ()}_NUGET_VERSION_NO_METADATA"];
+					mlaunchPath = Path.Combine (mlaunchPath, $"Microsoft.{platform}.Sdk", workloadVersion);
 					mlaunchPath = Path.Combine (mlaunchPath, "tools", "bin", "mlaunch");
 					return mlaunchPath;
 				} else if (INCLUDE_XAMARIN_LEGACY && INCLUDE_IOS) {


### PR DESCRIPTION
This commit fixes the code that was added in
https://github.com/xamarin/xamarin-macios/pull/16361.

The previous change uses the version number that is part of the config file in the current build machine. That is correct when we are working when we are running the tests in the same machine that built them. That IS NOT THE CASE when building on CI.

Back when the CI did the separation to accommodate the EO we noticed that if the workload is built in a diff machine, the versions were not to be trusted, that is why the CI sets and enviroment variable to track the version that was built in the original step. This change check if we are on the CI, if we are we trust the version given by the previos machine, else we use the config one.