### PR TITLE
[ci] Run Codesign Verification after MSI creation

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -191,12 +191,6 @@ $(DOTNET_NUPKG_DIR)/vs-workload.props: Makefile generate-vs-workload.csharp
 		--output $@.tmp
 	$(Q) mv $@.tmp $@
 
-$(DOTNET_NUPKG_DIR)/SignList.xml: Workloads/SignList.xml
-	$(Q) $(CP) $< $@
-
-$(DOTNET_NUPKG_DIR)/SignList.targets: Workloads/SignList.targets
-	$(Q) $(CP) $< $@
-
 TEMPLATED_FILES = \
 	$(foreach platform,$(DOTNET_PLATFORMS),Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.Versions.props) \
 	$(foreach platform,$(DOTNET_PLATFORMS),Microsoft.$(platform).Sdk/targets/Microsoft.$(platform).Sdk.SupportedTargetPlatforms.props) \
@@ -259,7 +253,7 @@ pack-$(shell echo $(1) | tr A-Z a-z): $$(RUNTIME_PACKS_$(1)) $$(REF_PACKS_$(1)) 
 endef
 $(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(eval $(call PacksDefinitions,$(platform))))
 
-TARGETS += $(RUNTIME_PACKS) $(REF_PACKS) $(SDK_PACKS) $(TEMPLATE_PACKS) $(WORKLOAD_PACKS) $(DOTNET_NUPKG_DIR)/vs-workload.props $(DOTNET_NUPKG_DIR)/SignList.xml $(DOTNET_NUPKG_DIR)/SignList.targets $(SDK_PACKS_WINDOWS)
+TARGETS += $(RUNTIME_PACKS) $(REF_PACKS) $(SDK_PACKS) $(TEMPLATE_PACKS) $(WORKLOAD_PACKS) $(DOTNET_NUPKG_DIR)/vs-workload.props $(SDK_PACKS_WINDOWS)
 
 define InstallWorkload
 # .NET comes with a workload for us, but we don't want that, we want our own. So delete the workload that comes with .NET.

--- a/dotnet/Workloads/SignVerifyIgnore.txt
+++ b/dotnet/Workloads/SignVerifyIgnore.txt
@@ -1,0 +1,2 @@
+**\*.xml,ignore unsigned .xml
+**\cab*.cab.cab,ignore unsigned .cab

--- a/tools/devops/automation/scripts/bash/build-nugets.sh
+++ b/tools/devops/automation/scripts/bash/build-nugets.sh
@@ -14,8 +14,9 @@ mkdir -p ../package/
 rm -f ../package/*.nupkg
 cp -c "$DOTNET_NUPKG_DIR"/*.nupkg ../package/
 cp -c "$DOTNET_NUPKG_DIR"/vs-workload.props ../package/
-cp -c "$DOTNET_NUPKG_DIR"/SignList.xml ../package/
-cp -c "$DOTNET_NUPKG_DIR"/SignList.targets ../package/
+cp -c dotnet/Workloads/SignList.xml ../package/
+cp -c dotnet/Workloads/SignList.targets ../package/
+cp -c dotnet/Workloads/SignVerifyIgnore.txt ../package/
 
 DOTNET_PKG_DIR=$(make -C tools/devops print-abspath-variable VARIABLE=DOTNET_PKG_DIR | grep "^DOTNET_PKG_DIR=" | sed -e 's/^DOTNET_PKG_DIR=//')
 make -C dotnet package -j

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -71,6 +71,22 @@ stages:
       binlogsArtifactName: ${{ parameters.uploadPrefix }}nuget-msi-convert-binlogs
       signType: Real
       useDateTimeVersion: true
+      postConvertSteps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifactName: '${{ parameters.uploadPrefix }}not-signed-package'
+          downloadPath: $(Build.StagingDirectory)\sign-verify
+          patterns: |
+            **/SignVerifyIgnore.txt
+
+      - task: MicroBuildCodesignVerify@3
+        displayName: verify signed msi content
+        inputs:
+          TargetFolders: |
+            $(Build.StagingDirectory)\bin\manifests
+            $(Build.StagingDirectory)\bin\manifests-multitarget
+          ExcludeSNVerify: true
+          ApprovalListPathForCerts: $(Build.StagingDirectory)\sign-verify\SignVerifyIgnore.txt
 
   - ${{ if eq(parameters.pushNugets, true) }}:
     # Check - "xamarin-macios (Prepare Release Push NuGets)"


### PR DESCRIPTION
The `MicroBuildCodesignVerify@3` task has been added to validate the
signing status of the MSI files required for VS insertions. This will
allow us to identify any potential signing issues earlier.