### PR TITLE
[StoreKit] Add a default SKCloudServiceController constructor. Fixes #18577.

### DIFF
--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -952,9 +952,6 @@ namespace StoreKit {
 	[Mac (11, 0), Watch (7, 0), iOS (9, 3), TV (9, 2)]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
-#if XAMCORE_3_0 // Avoid breaking change in iOS
-	[DisableDefaultCtor]
-#endif
 	interface SKCloudServiceController {
 		[Static]
 		[Export ("authorizationStatus")]


### PR DESCRIPTION
Using the default constructor is the doumented way to create an instance of an
SKCloudServiceController.

Fixes https://github.com/xamarin/xamarin-macios/issues/18577.