### PR TITLE
[Tests] Use the correct nuget version on CI

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -541,7 +541,9 @@ namespace Xamarin.Tests {
 
 		public static string GetNuGetVersionNoMetadata (ApplePlatform platform)
 		{
-			return GetVariable ($"{platform.AsString ().ToUpper ()}_NUGET_VERSION_NO_METADATA", string.Empty);
+			var workloadVersion = Environment.GetEnvironmentVariable ($"{platform.ToUpperInvariant ()}_WORKLOAD_VERSION");
+			return string.IsNullOrEmpty (workloadVersion) ?  
+				GetVariable ($"{platform.AsString ().ToUpper ()}_NUGET_VERSION_NO_METADATA", string.Empty) : workloadVersion;
 		}
 
 		// This is only applicable for .NET

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -541,7 +541,7 @@ namespace Xamarin.Tests {
 
 		public static string GetNuGetVersionNoMetadata (ApplePlatform platform)
 		{
-			var workloadVersion = Environment.GetEnvironmentVariable ($"{platform.ToUpperInvariant ()}_WORKLOAD_VERSION");
+			var workloadVersion = Environment.GetEnvironmentVariable ($"{platform.AsString ().ToUpper ()}_WORKLOAD_VERSION");
 			return string.IsNullOrEmpty (workloadVersion) ?  
 				GetVariable ($"{platform.AsString ().ToUpper ()}_NUGET_VERSION_NO_METADATA", string.Empty) : workloadVersion;
 		}

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -542,7 +542,7 @@ namespace Xamarin.Tests {
 		public static string GetNuGetVersionNoMetadata (ApplePlatform platform)
 		{
 			var workloadVersion = Environment.GetEnvironmentVariable ($"{platform.AsString ().ToUpper ()}_WORKLOAD_VERSION");
-			return string.IsNullOrEmpty (workloadVersion) ?  
+			return string.IsNullOrEmpty (workloadVersion) ?
 				GetVariable ($"{platform.AsString ().ToUpper ()}_NUGET_VERSION_NO_METADATA", string.Empty) : workloadVersion;
 		}
 


### PR DESCRIPTION
Similar to PR https://github.com/xamarin/xamarin-macios/pull/18600 we need to use the same verison as the one found in the workload file in CI and not that one from the make.config.