### PR TITLE
[Introspection] Fix intro skip when the properties are internal.

### DIFF
--- a/tests/introspection/ApiBaseTest.cs
+++ b/tests/introspection/ApiBaseTest.cs
@@ -170,8 +170,8 @@ namespace Introspection {
 
 			// FIXME: In the future we could cache this to reduce memory requirements
 			var property = m.DeclaringType
-							.GetProperties ()
-							.SingleOrDefault (p => p.GetGetMethod () == m || p.GetSetMethod () == m);
+							.GetProperties (BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+							.SingleOrDefault (p => p.GetGetMethod (true) == m || p.GetSetMethod (true) == m);
 			return property is not null && SkipDueToAttribute (property);
 		}
 


### PR DESCRIPTION
The issue relies in the fact that this code path was not executed when using classic because in the classic version of the SDK we added the availavility attrs both in the property, the getters and the setters. With dotnet, we only add the attr in the property.

The code uses the GetProperty method which does not return internal/private properties which means that some of those properties are not correctly skipped when on dotnet. This was discovered while working on xcode 15.