### PR TITLE
[UIKit] Fix UIKit selector on TvOS

### DIFF
--- a/src/UIKit/UIMenu.cs
+++ b/src/UIKit/UIMenu.cs
@@ -1,5 +1,7 @@
 #if !WATCH
 using System;
+using System.Runtime.InteropServices;
+
 using ObjCRuntime;
 using Foundation;
 
@@ -7,6 +9,13 @@ namespace UIKit {
 	public partial class UIMenu {
 #if !XAMCORE_5_0
 
+#if NET
+		[SupportedOSPlatform ("tvos13.0")]
+		[SupportedOSPlatform ("ios15.0")]
+		[SupportedOSPlatform ("maccatalyst15.0")]
+#else
+		[iOS (15, 0)]
+#endif
 		public virtual UIMenuElement [] SelectedElements { 
 			get {
 				// check if we are on tvos earlier than 15, if so, return and empty array, else return

--- a/src/UIKit/UIMenu.cs
+++ b/src/UIKit/UIMenu.cs
@@ -16,7 +16,7 @@ namespace UIKit {
 #else
 		[iOS (15, 0)]
 #endif
-		public virtual UIMenuElement [] SelectedElements { 
+		public virtual UIMenuElement [] SelectedElements {
 			get {
 				// check if we are on tvos earlier than 15, if so, return and empty array, else return
 				// the correct value

--- a/src/UIKit/UIMenu.cs
+++ b/src/UIKit/UIMenu.cs
@@ -1,0 +1,28 @@
+#if !WATCH
+using System;
+using ObjCRuntime;
+using Foundation;
+
+namespace UIKit {
+	public partial class UIMenu {
+#if !XAMCORE_5_0
+
+		public virtual UIMenuElement [] SelectedElements { 
+			get {
+				// check if we are on tvos earlier than 15, if so, return and empty array, else return
+				// the correct value
+#if TVOS
+				if (SystemVersion.ChecktvOS (15, 0)) {
+					return _SelectedElements;
+				} else {
+					return Array.Empty<UIMenuElement> ();
+				}
+#else
+				return _SelectedElements;
+#endif
+			}
+#endif
+		}
+	}
+}
+#endif

--- a/src/UIKit/UIMenu.cs
+++ b/src/UIKit/UIMenu.cs
@@ -15,6 +15,7 @@ namespace UIKit {
 		[SupportedOSPlatform ("maccatalyst15.0")]
 #else
 		[iOS (15, 0)]
+		[TV (15,0)]
 #endif
 		public virtual UIMenuElement [] SelectedElements {
 			get {

--- a/src/UIKit/UIMenu.cs
+++ b/src/UIKit/UIMenu.cs
@@ -10,7 +10,7 @@ namespace UIKit {
 #if !XAMCORE_5_0
 
 #if NET
-		[SupportedOSPlatform ("tvos13.0")]
+		[SupportedOSPlatform ("tvos15.0")]
 		[SupportedOSPlatform ("ios15.0")]
 		[SupportedOSPlatform ("maccatalyst15.0")]
 #else

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1741,6 +1741,7 @@ UIKIT_SOURCES = \
 	UIKit/UIKeyboard.cs \
 	UIKit/UIKitSynchronizationContext.cs \
 	UIKit/UIListSeparatorConfiguration.cs \
+	UIKit/UIMenu.cs \
 	UIKit/UINavigationBar.cs \
 	UIKit/UINavigationController.cs \
 	UIKit/UIPageViewController.cs \

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -9161,7 +9161,7 @@ namespace UIKit {
 		[Export ("selectedElements")]
 #if XAMCORE_5_0
 		UIMenuElement [] SelectedElements { get; }
-#else 
+#else
 		[Internal]
 		UIMenuElement [] _SelectedElements { get; }
 #endif

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -9157,9 +9157,14 @@ namespace UIKit {
 		[Export ("options")]
 		UIMenuOptions Options { get; }
 
-		[iOS (15, 0), MacCatalyst (15, 0)]
+		[iOS (15, 0), MacCatalyst (15, 0), TV (15, 0)]
 		[Export ("selectedElements")]
+#if XAMCORE_5_0
 		UIMenuElement [] SelectedElements { get; }
+#else 
+		[Internal]
+		UIMenuElement [] _SelectedElements { get; }
+#endif
 
 		[Export ("children")]
 		UIMenuElement [] Children { get; }


### PR DESCRIPTION
This API was missed because the old sim intro tests are not running and we missed it. This was found while working on xcode15. The tvOS attr is missing which defaults to the min version of tvOS when it should be 15.

Added a compat implementation so that the API remains.