### PR TITLE
[msbuild] Pass DeviceSpecificIntermediateOutputPath instead of IntermediateOutputPath to the ComputeRemoteGeneratorProperties task.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1723,7 +1723,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<ComputeRemoteGeneratorProperties
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '$(BuildSessionId)' != ''"
-			IntermediateOutputPath="$(IntermediateOutputPath)"
+			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 		>
 			<Output TaskParameter="BaseLibDllPath" PropertyName="BaseLibDllPath" />


### PR DESCRIPTION
IntermediateOutputPath can be an absolute path [1], but the
ComputeRemoteGeneratorProperties task can only take a relative path (because
it will run on the Mac, and an absolute path when executing remotely will be
path on the Windows system).

So use DeviceSpecificIntermediateOutputPath instead, which solves two issues:

* It's the intermediate output path we use everywhere else.
* We already ensure it's a relative path.

[1]: this happens in .NET 8 when using the new-style artifacts output path
(which is the default when there's a Directory.Build.props file somewhere).

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1847166.