### PR TITLE
[msbuild] Don't try to run 'dotnet build' if 'dotnet restore' failed in the XamarinBuild task.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompilerTaskBase.cs
@@ -37,6 +37,10 @@ namespace Xamarin.MacDev.Tasks {
 				AotCompiler = ComputeValueUsingTarget (target, targetName);
 			}
 
+			// Don't check if the aot compiler exists if an error was already reported.
+			if (Log.HasLoggedErrors)
+				return false;
+
 			if (!File.Exists (AotCompiler))
 				Log.LogError (MSBStrings.E7081 /*"The AOT compiler '{0}' does not exist." */, AotCompiler);
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FindILLink.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FindILLink.cs
@@ -23,6 +23,10 @@ namespace Xamarin.MacDev.Tasks {
 
 			var illinkTaskPath = ComputeValueUsingTarget (target, targetName);
 
+			// Don't do anything else if something already went wrong (in particular don't check if illink.dll exists).
+			if (Log.HasLoggedErrors)
+				return false;
+
 			if (!string.IsNullOrEmpty (illinkTaskPath))
 				ILLinkPath = Path.Combine (Path.GetDirectoryName (illinkTaskPath), "illink.dll");
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinBuildTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinBuildTask.cs
@@ -47,6 +47,10 @@ namespace Xamarin.MacDev.Tasks {
 			try {
 				ExecuteRestoreAsync (dotnetPath, projectPath, targetName, environment).Wait ();
 
+				// Don't try to run 'dotnet build' if restore failed.
+				if (Log.HasLoggedErrors)
+					return string.Empty;
+
 				return ExecuteBuildAsync (dotnetPath, projectPath, targetName, environment).Result;
 			} finally {
 				if (KeepTemporaryOutput) {


### PR DESCRIPTION
This avoids throwing spurious exceptions when we blinding keep executing stuff
that doesn't make sense anymore.