### PR TITLE
[release/7.0.3xx] [tools] Always link weakly with NewsstandKit. Fixes #18606.

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -341,7 +341,7 @@ public class Frameworks : Dictionary<string, Framework> {
 
 				{ "Accounts", "Accounts", 5 },
 				{ "GLKit", "GLKit", 5 },
-				{ "NewsstandKit", "NewsstandKit", 5 },
+				{ "NewsstandKit", "NewsstandKit", 5, /* alwaysWeakLink: */ true }, // This framework was completely removed in iOS 17, so make sure existing apps that may link with NewsstandKit don't crash (by linking weakly). Ref: https://github.com/xamarin/xamarin-macios/issues/18606
 				{ "CoreImage", "CoreImage", 5 },
 				{ "CoreBluetooth", "CoreBluetooth", 5 },
 				{ "Twitter", "Twitter", 5 },


### PR DESCRIPTION
It seems that Apple will completely remove the NewsstandKit framework from iOS 17.

This poses a problem for existing apps that link with NewsstandKit: they will
crash at launch.

Solve this by always linking weakly with the NewsstandKit framework; this way
any apps that link with it will keep working if the framework ends up being
removed by Apple.

Fixes https://github.com/xamarin/xamarin-macios/issues/18606.
Fixes https://github.com/dotnet/maui/issues/16316.


Backport of #18621
