### PR TITLE
[configure] Make 'macos' work like 'mac'.

### DIFF
--- a/configure
+++ b/configure
@@ -70,12 +70,12 @@ while test "x$1" != x; do
         echo "Disabled all platforms"
         shift
         ;;
-    --disable-mac)
+    --disable-mac | --disable-macos)
         echo "INCLUDE_MAC=" >> $CONFIGURED_FILE
         echo "Mac Build disabled"
         shift
         ;;
-    --enable-mac)
+    --enable-mac | --enable-macos)
         echo "INCLUDE_MAC=1" >> $CONFIGURED_FILE
         echo "Mac Build enabled"
         shift

--- a/src/UIKit/UIMenu.cs
+++ b/src/UIKit/UIMenu.cs
@@ -15,7 +15,7 @@ namespace UIKit {
 		[SupportedOSPlatform ("maccatalyst15.0")]
 #else
 		[iOS (15, 0)]
-		[TV (15,0)]
+		[TV (15, 0)]
 #endif
 		public virtual UIMenuElement [] SelectedElements {
 			get {


### PR DESCRIPTION
I can never remember which one is the right one, so just make them both work.