### PR TITLE
[xcode14.3] [tools] Don't link with NewsstandKit if we're using Xcode 15+.

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -790,6 +790,12 @@ public class Frameworks : Dictionary<string, Framework> {
 					return false;
 				}
 				break;
+			case "NewsstandKit":
+				if (Driver.XcodeVersion.Major >= 15) {
+					Driver.Log (3, "Not linking with the framework {0} because it's been removed from Xcode 15+.", framework.Name);
+					return false;
+				}
+				break;
 			}
 			break;
 		case ApplePlatform.TVOS:


### PR DESCRIPTION
Apple completely removed the NewsstandKit framework in Xode 15.

This effectively adds basic support for using Xcode 15 with .NET 7.

While this technically won't be a supported scenario, we have tests that
ensures .NET 7 apps can be built with .NET 8, and .NET 8 will ship with Xcode
15 support. This means that in order to make these tests work, we'll otherwise
have to have Xcode 14.3 installed both locally and on bots (in addition to
Xcode 15 of course), which is a rather big nightmare.

It's much easier to must try to make Xcode 15 work with .NET 7.


Backport of #18626
