### PR TITLE
[Generator] Ensure that selectors fields do not have overlapping names. Fixes #18645

### DIFF
--- a/src/AppKit/Compat.cs
+++ b/src/AppKit/Compat.cs
@@ -19,9 +19,9 @@ namespace AppKit {
 				throw new ArgumentNullException (nameof (array));
 			var nsa_array = NSArray.FromNSObjects (array);
 			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr (this.Handle, selSetTextBlocks_Handle, nsa_array.Handle);
+				global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr (this.Handle, selSetTextBlocks_XHandle, nsa_array.Handle);
 			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_IntPtr (this.SuperHandle, selSetTextBlocks_Handle, nsa_array.Handle);
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_IntPtr (this.SuperHandle, selSetTextBlocks_XHandle, nsa_array.Handle);
 			}
 			nsa_array.Dispose ();
 		}
@@ -35,9 +35,9 @@ namespace AppKit {
 				throw new ArgumentNullException (nameof (array));
 			var nsa_array = NSArray.FromNSObjects (array);
 			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr (this.Handle, selSetTextLists_Handle, nsa_array.Handle);
+				global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr (this.Handle, selSetTextLists_XHandle, nsa_array.Handle);
 			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_IntPtr (this.SuperHandle, selSetTextLists_Handle, nsa_array.Handle);
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_IntPtr (this.SuperHandle, selSetTextLists_XHandle, nsa_array.Handle);
 			}
 			nsa_array.Dispose ();
 		}

--- a/src/Foundation/NSArray.cs
+++ b/src/Foundation/NSArray.cs
@@ -247,7 +247,7 @@ namespace Foundation {
 		internal static nuint GetCount (IntPtr handle)
 		{
 #if MONOMAC
-			return (nuint) Messaging.UIntPtr_objc_msgSend (handle, selCountHandle);
+			return (nuint) Messaging.UIntPtr_objc_msgSend (handle, selCountXHandle);
 #else
 			return (nuint) Messaging.UIntPtr_objc_msgSend (handle, Selector.GetHandle ("count"));
 #endif
@@ -259,7 +259,7 @@ namespace Foundation {
 			return Messaging.NativeHandle_objc_msgSend_UIntPtr (handle, Selector.GetHandle ("objectAtIndex:"), (UIntPtr) i);
 #else
 #if MONOMAC
-			return Messaging.IntPtr_objc_msgSend_UIntPtr (handle, selObjectAtIndex_Handle, (UIntPtr) i);
+			return Messaging.IntPtr_objc_msgSend_UIntPtr (handle, selObjectAtIndex_XHandle, (UIntPtr) i);
 #else
 			return Messaging.IntPtr_objc_msgSend_UIntPtr (handle, Selector.GetHandle ("objectAtIndex:"), (UIntPtr) i);
 #endif

--- a/src/Foundation/NSDictionary.cs
+++ b/src/Foundation/NSDictionary.cs
@@ -402,7 +402,7 @@ namespace Foundation {
 		public IntPtr LowlevelObjectForKey (IntPtr key)
 		{
 #if MONOMAC
-			return ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, selObjectForKey_Handle, key);
+			return ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, selObjectForKey_XHandle, key);
 #else
 			return ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle ("objectForKey:"), key);
 #endif

--- a/src/Foundation/NSMutableDictionary.cs
+++ b/src/Foundation/NSMutableDictionary.cs
@@ -319,7 +319,7 @@ namespace Foundation {
 		public static NSMutableDictionary LowlevelFromObjectAndKey (IntPtr obj, IntPtr key)
 		{
 #if MONOMAC
-			return (NSMutableDictionary) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr (class_ptr, selDictionaryWithObject_ForKey_Handle, obj, key));
+			return (NSMutableDictionary) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr (class_ptr, selDictionaryWithObject_ForKey_XHandle, obj, key));
 #else
 			return (NSMutableDictionary) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr (class_ptr, Selector.GetHandle ("dictionaryWithObject:forKey:"), obj, key));
 #endif
@@ -328,7 +328,7 @@ namespace Foundation {
 		public void LowlevelSetObject (IntPtr obj, IntPtr key)
 		{
 #if MONOMAC
-			ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, selSetObject_ForKey_Handle, obj, key);
+			ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, selSetObject_ForKey_XHandle, obj, key);
 #else
 			ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle ("setObject:forKey:"), obj, key);
 #endif

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -880,9 +880,9 @@ namespace Foundation {
 #else
 #if MONOMAC
 			if (IsDirectBinding) {
-				ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, selSetValue_ForKeyPath_Handle, handle, keyPath.Handle);
+				ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, selSetValue_ForKeyPath_XHandle, handle, keyPath.Handle);
 			} else {
-				ObjCRuntime.Messaging.void_objc_msgSendSuper_IntPtr_IntPtr (this.SuperHandle, selSetValue_ForKeyPath_Handle, handle, keyPath.Handle);
+				ObjCRuntime.Messaging.void_objc_msgSendSuper_IntPtr_IntPtr (this.SuperHandle, selSetValue_ForKeyPath_XHandle, handle, keyPath.Handle);
 			}
 #else
 			if (IsDirectBinding) {

--- a/src/Foundation/NSUrlProtocol.cs
+++ b/src/Foundation/NSUrlProtocol.cs
@@ -47,9 +47,9 @@ namespace Foundation {
 			if (client is null)
 				throw new ArgumentNullException ("client");
 			if (IsDirectBinding) {
-				InitializeHandle (IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr (this.Handle, selInitWithRequest_CachedResponse_Client_Handle, request.Handle, cachedResponse is null ? IntPtr.Zero : cachedResponse.Handle, client.Handle), "initWithRequest:cachedResponse:client:");
+				InitializeHandle (IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr (this.Handle, selInitWithRequest_CachedResponse_Client_XHandle, request.Handle, cachedResponse is null ? IntPtr.Zero : cachedResponse.Handle, client.Handle), "initWithRequest:cachedResponse:client:");
 			} else {
-				InitializeHandle (IntPtr_objc_msgSendSuper_IntPtr_IntPtr_IntPtr (this.SuperHandle, selInitWithRequest_CachedResponse_Client_Handle, request.Handle, cachedResponse is null ? IntPtr.Zero : cachedResponse.Handle, client.Handle), "initWithRequest:cachedResponse:client:");
+				InitializeHandle (IntPtr_objc_msgSendSuper_IntPtr_IntPtr_IntPtr (this.SuperHandle, selInitWithRequest_CachedResponse_Client_XHandle, request.Handle, cachedResponse is null ? IntPtr.Zero : cachedResponse.Handle, client.Handle), "initWithRequest:cachedResponse:client:");
 			}
 		}
 

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2669,8 +2669,8 @@ public partial class Generator : IMemberGatherer {
 			} else
 				sb.Append (c);
 		}
-		if (!InlineSelectors)
-			sb.Append ("Handle");
+		if (!InlineSelectors) 
+			sb.Append ("XHandle");
 		name = sb.ToString ();
 		selector_names [s] = name;
 		return name;

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2669,7 +2669,7 @@ public partial class Generator : IMemberGatherer {
 			} else
 				sb.Append (c);
 		}
-		if (!InlineSelectors) 
+		if (!InlineSelectors)
 			sb.Append ("XHandle");
 		name = sb.ToString ();
 		selector_names [s] = name;

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -824,6 +824,9 @@ namespace GeneratorTests {
 		[Test]
 		public void GHIssue9065_Sealed () => BuildFile (Profile.iOS, nowarnings: true, "ghissue9065.cs");
 
+		[Test]
+		public void GHIssue18645_DuplicatedFiled() => BuildFile (Profile.iOS, nowarnings: true, "ghissue18645.cs");
+
 		// looking for [BindingImpl (BindingImplOptions.Optimizable)]
 		bool IsOptimizable (MethodDefinition method)
 		{

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -825,7 +825,7 @@ namespace GeneratorTests {
 		public void GHIssue9065_Sealed () => BuildFile (Profile.iOS, nowarnings: true, "ghissue9065.cs");
 
 		[Test]
-		public void GHIssue18645_DuplicatedFiled() => BuildFile (Profile.iOS, nowarnings: true, "ghissue18645.cs");
+		public void GHIssue18645_DuplicatedFiled () => BuildFile (Profile.iOS, nowarnings: true, "ghissue18645.cs");
 
 		// looking for [BindingImpl (BindingImplOptions.Optimizable)]
 		bool IsOptimizable (MethodDefinition method)

--- a/tests/generator/ghissue18645.cs
+++ b/tests/generator/ghissue18645.cs
@@ -1,0 +1,44 @@
+using Foundation;
+using ObjCRuntime;
+
+namespace GHIssue18645{
+
+	[Protocol]
+	[BaseType (typeof(NSObject))]
+	interface ASCredentialIdentity {
+
+		[Abstract]
+		[Export ("user")]
+		string User { get; }
+
+		[Abstract]
+		[NullAllowed, Export ("recordIdentifier")]
+		string RecordIdentifier { get; }
+
+		[Abstract]
+		[Export ("rank")]
+		nint Rank { get; set; }
+	}
+
+	[BaseType (typeof (NSObject))]
+	interface ASPasskeyCredentialIdentity : ASCredentialIdentity {
+		[Export ("relyingPartyIdentifier")]
+		string RelyingPartyIdentifier { get; }
+
+		[Export ("userName")]
+		string UserName { get; }
+
+		[Export ("credentialID", ArgumentSemantic.Copy)]
+		NSData CredentialID { get; }
+
+		[Export ("userHandle", ArgumentSemantic.Copy)]
+		NSData UserHandle { get; }
+
+		[NullAllowed, Export ("recordIdentifier")]
+		new string RecordIdentifier { get; }
+
+		[Export ("rank")]
+		new nint Rank { get; set; }
+	}
+
+}

--- a/tests/generator/ghissue18645.cs
+++ b/tests/generator/ghissue18645.cs
@@ -1,10 +1,10 @@
 using Foundation;
 using ObjCRuntime;
 
-namespace GHIssue18645{
+namespace GHIssue18645 {
 
 	[Protocol]
-	[BaseType (typeof(NSObject))]
+	[BaseType (typeof (NSObject))]
 	interface ASCredentialIdentity {
 
 		[Abstract]

--- a/tests/mmp-regression/link-frameworks-1/LinkFrameworks1.cs
+++ b/tests/mmp-regression/link-frameworks-1/LinkFrameworks1.cs
@@ -47,9 +47,9 @@ namespace Xamarin.Mac.Linker.Test {
 
 				switch (field.Name) {
 				case "selConformsToProtocolHandle":
-				case "selDescriptionHandle":
-				case "selHashHandle":
-				case "selIsEqual_Handle":
+				case "selDescriptionXHandle":
+				case "selHashXHandle":
+				case "selIsEqual_XHandle":
 				case "class_ptr":
 					// Unrelated fields
 					continue;


### PR DESCRIPTION


The way the generator names private fields for selectors results on not compilable code when there are two selectoors A and B such that selector B == AHandle.

That is, if selector A is "user", selector B will be "userHandle". This happens because Handle is quite a common postfix in security when working with user accounts (userHandler and others) and we need to ensure that the Handle postfix added by the generator is unique.

As stated in the bug we could try to fix this by keeping track of the variables in the context in wich the generator is creating code. The problem with such approach is that it will make very hard to predict the name of the fields making the manual code harder to write. The PR contains examples of such manual code.

To fix the situation we have moved from using Handle to XHandle as a postfix in the field names whihc reduces the chances of finding a similar corner case in the future.

A test has been added to show the case in which we found the bug.

Fixes #18645