### PR TITLE
[builds] Always download .NET.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -179,9 +179,7 @@ DOTNET_DOWNLOADS = \
 	.stamp-install-t4 \
 
 dotnet: $(DOTNET_DOWNLOADS)
-ifdef ENABLE_DOTNET
 all-local:: $(DOTNET_DOWNLOADS)
-endif
 
 clean-local::
 	$(Q) rm -Rf downloads .stamp-download-mono


### PR DESCRIPTION
We always need to have a local .NET, because our T4 scripts are executed using
.NET (which is needed even if we're not building anyhing for .NET).