### PR TITLE
[devops] Remove option to disable .NET from CI.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -56,11 +56,6 @@ parameters:
   type: boolean
   default: false
   
-- name: enableDotnet
-  displayName: Build Dotnet 
-  type: boolean
-  default: true
-
 - name: enableAPIDiff
   displayName: Enable API diff generation
   type: boolean
@@ -221,7 +216,6 @@ stages:
     runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
     runGovernanceTests: ${{ parameters.runGovernanceTests }}
     runSamples: ${{ parameters.runSamples }}
-    enableDotnet: ${{ parameters.enableDotnet }}
     enableAPIDiff: ${{ parameters.enableAPIDiff }}
     forceInsertion: ${{ parameters.forceInsertion }}
     skipESRP: ${{ parameters.skipESRP }}

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -51,11 +51,6 @@ parameters:
   type: boolean
   default: false
   
-- name: enableDotnet
-  displayName: Build Dotnet 
-  type: boolean
-  default: true
-
 - name: enableAPIDiff
   displayName: Enable API diff generation
   type: boolean
@@ -204,7 +199,6 @@ stages:
     runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
     runGovernanceTests: ${{ parameters.runGovernanceTests }}
     runSamples: ${{ parameters.runSamples }}
-    enableDotnet: ${{ parameters.enableDotnet }}
     enableAPIDiff: ${{ parameters.enableAPIDiff }}
     forceInsertion: false
     skipESRP: true

--- a/tools/devops/automation/scripts/bash/configure-build.sh
+++ b/tools/devops/automation/scripts/bash/configure-build.sh
@@ -1,10 +1,5 @@
 #!/bin/bash -xe
 flags=( "--enable-xamarin" )
 
-if [[ "$ENABLE_DOT_NET" == "True" ]]; then
-  echo "Enabling dotnet builds."
-  flags=("${flags[@]}" --enable-dotnet)
-fi
-
 flags=("${flags[@]}" --enable-install-source)
 ./configure "${flags[@]}"

--- a/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
+++ b/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
@@ -13,10 +13,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: prID
   type: string
   default: '' # default empty, meaning we are building in CI
@@ -47,7 +43,6 @@ steps:
     keyringPass: ${{ parameters.keyringPass }}
     gitHubToken: ${{ parameters.gitHubToken }}
     xqaCertPass: ${{ parameters.xqaCertPass }}
-    enableDotnet: ${{ parameters.enableDotnet }}
     makeParallelism: '4'
 
 # detect changes

--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -13,10 +13,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: pool
   type: string
   default: automatic
@@ -54,7 +50,6 @@ jobs:
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
       uploadArtifacts: false
-      enableDotnet: ${{ parameters.enableDotnet }}
 
 - ${{ if eq(parameters.pool, 'automatic') }}:
   - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
@@ -110,7 +105,6 @@ jobs:
       keyringPass: ${{ parameters.keyringPass }}
       gitHubToken: ${{ parameters.gitHubToken }}
       xqaCertPass: ${{ parameters.xqaCertPass }}
-      enableDotnet: ${{ parameters.enableDotnet }}
       prID: variables['PrID']
 
 # Upload results to vsdrops & publish to github

--- a/tools/devops/automation/templates/build/build-mac-tests-stage.yml
+++ b/tools/devops/automation/templates/build/build-mac-tests-stage.yml
@@ -13,10 +13,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: pool
   type: string
   default: automatic
@@ -54,7 +50,6 @@ jobs:
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
       uploadArtifacts: true
-      enableDotnet: ${{ parameters.enableDotnet }}
 
 - ${{ if eq(parameters.pool, 'automatic') }}:
   - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
@@ -119,4 +114,3 @@ jobs:
       keyringPass: ${{ parameters.keyringPass }}
       gitHubToken: ${{ parameters.gitHubToken }}
       xqaCertPass: ${{ parameters.xqaCertPass }}
-      enableDotnet: ${{ parameters.enableDotnet }}

--- a/tools/devops/automation/templates/build/build-mac-tests.yml
+++ b/tools/devops/automation/templates/build/build-mac-tests.yml
@@ -11,10 +11,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: uploadBinlogs
   type: boolean
   default: true
@@ -44,7 +40,6 @@ steps:
     keyringPass: ${{ parameters.keyringPass }}
     gitHubToken: ${{ parameters.gitHubToken }}
     xqaCertPass: ${{ parameters.xqaCertPass }}
-    enableDotnet: ${{ parameters.enableDotnet }}
     buildSteps:
 
     # funny enough we need these profiles to build the mac tests

--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -19,10 +19,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: uploadBinlogs
   type: boolean
   default: true
@@ -61,7 +57,6 @@ steps:
     keyringPass: ${{ parameters.keyringPass }}
     gitHubToken: ${{ parameters.gitHubToken }}
     xqaCertPass: ${{ parameters.xqaCertPass }}
-    enableDotnet: ${{ parameters.enableDotnet }}
     buildSteps:
     # build not signed .pkgs for the SDK
     - bash: |
@@ -76,8 +71,7 @@ steps:
       timeoutInMinutes: 180
 
     # build nugets
-    - ${{ if eq(parameters.enableDotnet, true) }}:
-      - template: build-nugets.yml
+    - template: build-nugets.yml
 
     - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/generate-workload-rollback.sh
       name: workload_file

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -21,10 +21,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: skipESRP
   type: boolean
   default: false # only to be used when testing the CI and we do not need a signed pkg
@@ -66,7 +62,6 @@ jobs:
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
       uploadArtifacts: true
-      enableDotnet: ${{ parameters.enableDotnet }}
 
 - ${{ if eq(parameters.pool, 'automatic') }}:
   - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
@@ -153,5 +148,4 @@ jobs:
       keyringPass: ${{ parameters.keyringPass }}
       gitHubToken: ${{ parameters.gitHubToken }}
       xqaCertPass: ${{ parameters.xqaCertPass }}
-      enableDotnet: ${{ parameters.enableDotnet }}
       skipESRP: ${{ parameters.skipESRP }}

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -15,10 +15,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: isPR
   type: boolean
   default: false
@@ -128,8 +124,6 @@ steps:
       IsPR: 'True'
     ${{ else }}:
       IsPR: 'False'
-    ${{ if eq(parameters.enableDotnet, true) }}:
-      ENABLE_DOT_NET: 'True'
   displayName: "Configure build"
   workingDirectory: "$(Build.SourcesDirectory)/xamarin-macios"
   timeoutInMinutes: 5

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -3,10 +3,6 @@
 # variables to be used by the rest of the projects
 parameters:
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: uploadArtifacts
   type: boolean
   default: false
@@ -33,9 +29,6 @@ steps:
 - bash: ./xamarin-macios/tools/devops/automation/scripts/bash/configure-platforms.sh
   name: configure_platforms
   displayName: 'Configure platforms'
-  env:
-    ${{ if eq(parameters.enableDotnet, true) }}:
-      ENABLE_DOTNET: "True"
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MaciosCI.psd1

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -20,10 +20,6 @@ parameters:
 - name: keyringPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: demands
   type: object
   default: []
@@ -64,7 +60,6 @@ stages:
         repositoryAlias: ${{ parameters.repositoryAlias }}
         commit: ${{ parameters.commit }}
         uploadArtifacts: false
-        enableDotnet: ${{ parameters.enableDotnet }}
 
   - job: run_tests
     dependsOn:

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -36,10 +36,6 @@ parameters:
   type: boolean
   default: false
   
-- name: enableDotnet
-  type: boolean
-  default: true
-
 - name: enableLegacySigning
   type: boolean
   default: true
@@ -199,7 +195,6 @@ stages:
       keyringPass: $(pass--lab--mac--builder--keychain)
       gitHubToken: $(Github.Token)
       xqaCertPass: $(xqa--certificates--password)
-      enableDotnet: ${{ parameters.enableDotnet }}
       skipESRP: ${{ parameters.skipESRP }}
       pool: ${{ parameters.pool }}
 
@@ -220,7 +215,6 @@ stages:
       keyringPass: $(pass--lab--mac--builder--keychain)
       gitHubToken: $(Github.Token)
       xqaCertPass: $(xqa--certificates--password)
-      enableDotnet: ${{ parameters.enableDotnet }}
       pool: ${{ parameters.pool }}
 
 - stage: prepare_packages_legacy
@@ -236,7 +230,6 @@ stages:
       commit: ${{ parameters.commit }}
       signingSetupSteps: ${{ parameters.signingSetupSteps }}
       keyringPass: $(pass--lab--mac--builder--keychain)
-      enableDotnet: ${{ parameters.enableDotnet }}
       skipESRP: ${{ parameters.skipESRP }}
       packages: ${{ parameters.legacyPackageJobs }}
 
@@ -289,7 +282,6 @@ stages:
         keyringPass: $(pass--lab--mac--builder--keychain)
         gitHubToken: $(Github.Token)
         xqaCertPass: $(xqa--certificates--password)
-        enableDotnet: ${{ parameters.enableDotnet }}
         pool: ${{ parameters.pool }}
 
 # Test stages
@@ -315,7 +307,6 @@ stages:
     keyringPass: $(pass--lab--mac--builder--keychain)
     gitHubToken: $(Github.Token)
     xqaCertPass: $(xqa--certificates--password)
-    enableDotnet: ${{ parameters.enableDotnet }}
     condition: ${{ parameters.runTests }}
 
 # devices are optional and will only be ran when we set them OR in CI
@@ -341,7 +332,6 @@ stages:
           keyringPass: $(pass-XamarinQA-bot-login) 
           gitHubToken: $(Github.Token)
           xqaCertPass: $(xqa--certificates--password)
-          enableDotnet: ${{ parameters.enableDotnet }}
           condition: ${{ parameters.runDeviceTests }}
           parseLabels: false
 
@@ -358,7 +348,6 @@ stages:
         useImage: ${{ config.useImage }}
         statusContext: ${{ config.statusContext }}
         keyringPass: $(pass--lab--mac--builder--keychain)
-        enableDotnet: ${{ parameters.enableDotnet }}
         demands: ${{ config.demands }}
 
 - ${{ if eq(parameters.runWindowsIntegration, true) }}:
@@ -393,7 +382,6 @@ stages:
       keyringPass: $(pass--lab--mac--builder--keychain)
       gitHubToken: $(Github.Token)
       xqaCertPass: $(xqa--certificates--password)
-      enableDotnet: ${{ parameters.enableDotnet }}
 
 - ${{ if eq(parameters.runSamples, true) }}:
   # TODO: Not the real step

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -1,8 +1,4 @@
 parameters:
-- name: enableDotnet
-  type: boolean
-  default: true
-
 - name: dependsOn
   type: object
   default: null
@@ -40,14 +36,10 @@ stages:
           eq(dependencies.${{ parameters.dependsOn }}.result, 'Succeeded'),
           eq(dependencies.${{ parameters.dependsOn }}.result, 'SucceededWithIssues')
         ),
-        eq(${{ parameters.isPR }}, false),
-        eq(${{ parameters.enableDotnet }}, true)
+        eq(${{ parameters.isPR }}, false)
       )
   ${{ else }}:
-    condition: and(
-        eq(${{ parameters.isPR }}, false),
-        eq(${{ parameters.enableDotnet }}, true)
-      )
+    condition: eq(${{ parameters.isPR }}, false)
 
   jobs:
   # Check - "xamarin-macios (Prepare Release Sign NuGets)"

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -3,10 +3,6 @@ parameters:
 - name: packages
   type: object
 
-- name: enableDotnet
-  type: boolean
-  default: true
-
 - name: isPR
   type: boolean
 
@@ -165,7 +161,6 @@ jobs:
     parameters:
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
-      enableDotnet: ${{ parameters.enableDotnet }}
       sbomFilter: '*.nupkg;*.pkg;*.msi'
       azureStorage: ${{ parameters.azureStorage }}
       azureContainer: ${{ parameters.azureContainer }}

--- a/tools/devops/automation/templates/sign-and-notarized/prepare-pkg-stage.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/prepare-pkg-stage.yml
@@ -3,10 +3,6 @@ parameters:
 - name: keyringPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: skipESRP
   type: boolean
   default: false # only to be used when testing the CI and we do not need a signed pkg

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -1,8 +1,4 @@
 parameters:
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: sbomFilter
   type: string
   default: '*'            # Supports multiple filters separated by semi-colon such as *.msi;*.nupkg
@@ -246,8 +242,6 @@ steps:
     ACCESSTOKEN: $(System.AccessToken)
     AZURE_CONTAINER: ${{ parameters.azureContainer }}
     VIRTUAL_PATH: $(Build.SourceBranchName)/$(Build.SourceVersion)/$(Build.BuildId)
-    ${{ if eq(parameters.enableDotnet, true) }}:
-      ENABLE_DOTNET: "True"
   displayName: 'Set GithubStatus'
 
 # Executive Order (EO): Software Bill of Materials (SBOM): https://www.1eswiki.com/wiki/ADO_sbom_Generator

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -54,10 +54,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: makeTarget
   type: string
   default: 'vsts-device-tests' # target to be used to run the tests
@@ -115,7 +111,6 @@ stages:
           repositoryAlias: ${{ parameters.repositoryAlias }}
           commit: ${{ parameters.commit }}
           uploadArtifacts: false
-          enableDotnet: ${{ parameters.enableDotnet }}
 
   - job: "tests"
     ${{ if eq(parameters.parseLabels, true) }}:


### PR DESCRIPTION
It's rather rare now that we need to disable .NET from the CI, so just remove the option. It can still be disabled directly in the code when needed.

Also this fixes an issue where we'd build with .NET enabled even if disabled in the code, because we'd always pass --enable-dotnet to configure.