### PR TITLE
[release/7.0.3xx] [msbuild] Re-aot referencing assemblies. Fixes #17708.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1039,8 +1039,7 @@
 	<Target Name="_AOTCompile"
 			Condition="'$(_RunAotCompiler)' == 'true'"
 			DependsOnTargets="$(_AOTCompileDependsOn)"
-			Inputs="@(_AssembliesToAOT)"
-			Outputs="@(_AssembliesToAOT -> '%(ObjectFile)');@(_AssembliesToAOT -> '%(LLVMFile)');">
+		>
 
 		<AOTCompile
 			SessionId="$(BuildSessionId)"

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1467,4 +1467,33 @@
         </comment>
     </data>
 
+    <data name="E7116" xml:space="preserve">
+        <value>The assembly {0} does not provide an 'ObjectFile' metadata.</value>
+        <comment>
+            Don't translate: 'ObjectFile'.
+        </comment>
+    </data>
+
+    <data name="E7117" xml:space="preserve">
+        <value>The assembly {0} was passed multiple times as an input assembly (referenced from {1}).</value>
+        <comment>
+            {0}: the name of an assembly
+            {1}: the path to an assembly
+        </comment>
+    </data>
+
+    <data name="E7118" xml:space="preserve">
+        <value>Failed to AOT compile {0}, the AOT compiler exited with code {1}.</value>
+        <comment>
+            {0}: the path to an assembly
+            {1}: the exit code of a process
+        </comment>
+    </data>
+
+    <data name="E7119" xml:space="preserve">
+        <value>Encountered an assembly reference cycle related to the assembly {0}.</value>
+        <comment>
+            {0}: the path to an assembly
+        </comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompileTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompileTaskBase.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
+using Mono.Cecil;
+
 using Xamarin.Localization.MSBuild;
 using Xamarin.Utils;
 
@@ -42,6 +44,104 @@ namespace Xamarin.MacDev.Tasks {
 		public ITaskItem []? FileWrites { get; set; }
 		#endregion
 
+		class AssemblyInfo {
+			public ITaskItem TaskItem;
+			public bool? IsUpToDate;
+
+			public AssemblyInfo (ITaskItem item)
+			{
+				TaskItem = item;
+			}
+		}
+
+		Dictionary<string, AssemblyInfo> assemblyInfos = new Dictionary<string, AssemblyInfo> (StringComparer.OrdinalIgnoreCase);
+
+		string GetAssemblyName (ITaskItem item)
+		{
+			return Path.GetFileNameWithoutExtension (item.ItemSpec);
+		}
+
+		bool IsUpToDate (ITaskItem assembly)
+		{
+			var assemblyPath = assembly.ItemSpec;
+			var key = GetAssemblyName (assembly);
+			if (assemblyInfos.TryGetValue (key, out var info)) {
+				if (!info.IsUpToDate.HasValue) {
+					Log.LogError (MSBStrings.E7119 /* Encountered an assembly reference cycle related to the assembly {0}. */, assemblyPath);
+					info.IsUpToDate = false;
+					return false;
+				}
+				return info.IsUpToDate.Value;
+			}
+
+			info = new AssemblyInfo (assembly);
+			assemblyInfos [key] = info;
+
+			var finfo = new FileInfo (assemblyPath);
+			if (!finfo.Exists) {
+				Log.LogError (MSBStrings.E0158 /* The file {0} does not exist. */, assemblyPath);
+				info.IsUpToDate = false;
+				return false;
+			}
+
+			// ObjectFile is required
+			var objectFile = assembly.GetMetadata ("ObjectFile");
+			if (string.IsNullOrEmpty (objectFile)) {
+				Log.LogError (MSBStrings.E7116 /* The assembly {0} does not provide an 'ObjectFile' metadata. */, assembly.ItemSpec);
+				info.IsUpToDate = false;
+				return false;
+			}
+			var objectFileInfo = new FileInfo (objectFile);
+			if (!IsUpToDate (finfo, objectFileInfo)) {
+				Log.LogMessage (MessageImportance.Low, "The assembly {0} is not up-to-date with regards to the object file {1}", assemblyPath, objectFile);
+				info.IsUpToDate = false;
+				return false;
+			}
+
+			// LLVMFile is optional
+			var llvmFile = assembly.GetMetadata ("LLVMFile");
+			if (!string.IsNullOrEmpty (llvmFile)) {
+				var llvmFileInfo = new FileInfo (llvmFile);
+				if (!IsUpToDate (finfo, llvmFileInfo)) {
+					Log.LogMessage (MessageImportance.Low, "The assembly {0} is not up-to-date with regards to the llvm file {1}", assemblyPath, llvmFile);
+					info.IsUpToDate = false;
+					return false;
+				}
+			}
+
+			// We know now the assembly itself is up-to-date, but what about every referenced assembly?
+			// This assembly must be AOT-compiled again if any referenced assembly has changed as well.
+			using var ad = AssemblyDefinition.ReadAssembly (assembly.ItemSpec, new ReaderParameters { ReadingMode = ReadingMode.Deferred });
+			foreach (var ar in ad.MainModule.AssemblyReferences) {
+				var referencedItems = Assemblies.Where (v => string.Equals (GetAssemblyName (v), ar.Name, StringComparison.OrdinalIgnoreCase)).ToArray ();
+				if (referencedItems.Length == 0) {
+					Log.LogMessage (MessageImportance.Low, $"Ignoring unresolved assembly {ar.Name} (referenced from {assemblyPath}).");
+					continue;
+				} else if (referencedItems.Length > 1) {
+					Log.LogError (MSBStrings.E7117 /* The assembly {0} was passed multiple times as an input assembly (referenced from {1}). */ ar.Name, assemblyPath);
+					info.IsUpToDate = false;
+					return false;
+				}
+				var referencedItem = referencedItems [0];
+				if (!IsUpToDate (referencedItem)) {
+					info.IsUpToDate = false;
+					Log.LogMessage (MessageImportance.Low, "The assembly {0} is not up-to-date with regards to the reference {1}", assemblyPath, ar.Name);
+					return false;
+				}
+			}
+
+			Log.LogMessage (MessageImportance.Low, $"The AOT-compiled code for {assemblyPath} is up-to-date.");
+			info.IsUpToDate = true;
+			return true;
+		}
+
+		bool IsUpToDate (FileInfo input, FileInfo output)
+		{
+			if (!output.Exists)
+				return false;
+			return input.LastWriteTimeUtc <= output.LastWriteTimeUtc;
+		}
+
 		public override bool Execute ()
 		{
 			var inputs = new List<string> (Assemblies.Length);
@@ -64,24 +164,31 @@ namespace Xamarin.MacDev.Tasks {
 				InputDirectory = assemblyDirectories [0];
 			}
 
+			// Figure out which assemblies need to be aot'ed, and which are up-to-date.
+			var assembliesToAOT = Assemblies.Where (asm => !IsUpToDate (asm)).ToArray ();
+			if (assembliesToAOT.Length == 0) {
+				Log.LogMessage (MessageImportance.Low, $"All the AOT-compiled code is up-to-date.");
+				return !Log.HasLoggedErrors;
+			}
+
 			Directory.CreateDirectory (OutputDirectory);
 
 			var aotAssemblyFiles = new List<ITaskItem> ();
-			var processes = new Task<Execution> [Assemblies.Length];
+			var processes = new Task<Execution> [assembliesToAOT.Length];
 
 			var environment = new Dictionary<string, string> {
 				{ "MONO_PATH", Path.GetFullPath (InputDirectory) },
 			};
 
 			var globalAotArguments = AotArguments?.Select (v => v.ItemSpec).ToList ();
-			for (var i = 0; i < Assemblies.Length; i++) {
-				var asm = Assemblies [i];
+			for (var i = 0; i < assembliesToAOT.Length; i++) {
+				var asm = assembliesToAOT [i];
 				var input = inputs [i];
-				var arch = Assemblies [i].GetMetadata ("Arch");
-				var aotArguments = Assemblies [i].GetMetadata ("Arguments");
-				var processArguments = Assemblies [i].GetMetadata ("ProcessArguments");
-				var aotData = Assemblies [i].GetMetadata ("AOTData");
-				var aotAssembly = Assemblies [i].GetMetadata ("AOTAssembly");
+				var arch = asm.GetMetadata ("Arch");
+				var aotArguments = asm.GetMetadata ("Arguments");
+				var processArguments = asm.GetMetadata ("ProcessArguments");
+				var aotData = asm.GetMetadata ("AOTData");
+				var aotAssembly = asm.GetMetadata ("AOTAssembly");
 
 				var aotAssemblyItem = new TaskItem (aotAssembly);
 				aotAssemblyItem.SetMetadata ("Arguments", "-Xlinker -rpath -Xlinker @executable_path/ -Qunused-arguments -x assembler -D DEBUG");
@@ -106,7 +213,7 @@ namespace Xamarin.MacDev.Tasks {
 				processes [i] = ExecuteAsync (AOTCompilerPath, arguments, environment: environment, sdkDevPath: SdkDevPath, showErrorIfFailure: false /* we show our own error below */)
 					.ContinueWith ((v) => {
 						if (v.Result.ExitCode != 0)
-							Log.LogError ("Failed to AOT compile {0}, the AOT compiler exited with code {1}", Path.GetFileName (input), v.Result.ExitCode);
+							Log.LogError (MSBStrings.E7118 /* Failed to AOT compile {0}, the AOT compiler exited with code {1} */, Path.GetFileName (input), v.Result.ExitCode);
 
 						return System.Threading.Tasks.Task.FromResult<Execution> (v.Result);
 					}).Unwrap ();
@@ -118,8 +225,8 @@ namespace Xamarin.MacDev.Tasks {
 
 			// For Windows support it's necessary to have the files we're going to create as an Output parameter, so that the files are
 			// created on the windows side too, which makes the Inputs/Outputs logic work properly when working from Windows.
-			var objectFiles = Assemblies.Select (v => v.GetMetadata ("ObjectFile")).Where (v => !string.IsNullOrEmpty (v));
-			var llvmFiles = Assemblies.Select (v => v.GetMetadata ("LLVMFile")).Where (v => !string.IsNullOrEmpty (v));
+			var objectFiles = assembliesToAOT.Select (v => v.GetMetadata ("ObjectFile")).Where (v => !string.IsNullOrEmpty (v));
+			var llvmFiles = assembliesToAOT.Select (v => v.GetMetadata ("LLVMFile")).Where (v => !string.IsNullOrEmpty (v));
 			FileWrites = objectFiles.Union (llvmFiles).Select (v => new TaskItem (v)).ToArray ();
 
 			return !Log.HasLoggedErrors;

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompileTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompileTaskBase.cs
@@ -118,7 +118,7 @@ namespace Xamarin.MacDev.Tasks {
 					Log.LogMessage (MessageImportance.Low, $"Ignoring unresolved assembly {ar.Name} (referenced from {assemblyPath}).");
 					continue;
 				} else if (referencedItems.Length > 1) {
-					Log.LogError (MSBStrings.E7117 /* The assembly {0} was passed multiple times as an input assembly (referenced from {1}). */ ar.Name, assemblyPath);
+					Log.LogError (MSBStrings.E7117 /* The assembly {0} was passed multiple times as an input assembly (referenced from {1}). */, ar.Name, assemblyPath);
 					info.IsUpToDate = false;
 					return false;
 				}
@@ -146,7 +146,9 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var inputs = new List<string> (Assemblies.Length);
 			for (var i = 0; i < Assemblies.Length; i++) {
-				inputs.Add (Path.GetFullPath (Assemblies [i].ItemSpec));
+				var input = Path.GetFullPath (Assemblies [i].ItemSpec);
+				inputs.Add (input);
+				Assemblies [i].SetMetadata ("Input", input);
 			}
 
 			// All the assemblies to AOT must be in the same directory
@@ -183,7 +185,7 @@ namespace Xamarin.MacDev.Tasks {
 			var globalAotArguments = AotArguments?.Select (v => v.ItemSpec).ToList ();
 			for (var i = 0; i < assembliesToAOT.Length; i++) {
 				var asm = assembliesToAOT [i];
-				var input = inputs [i];
+				var input = asm.GetMetadata ("Input");
 				var arch = asm.GetMetadata ("Arch");
 				var aotArguments = asm.GetMetadata ("Arguments");
 				var processArguments = asm.GetMetadata ("ProcessArguments");

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/AppDelegate.cs
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/AppDelegate.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace MySimpleApp {
+	public class Program {
+		static int Main (string [] args)
+		{
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+			Console.WriteLine (Library.Class.SomeFunction ());
+
+			return args.Length;
+		}
+	}
+}

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/Library.cs
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/Library.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Library {
+	public class Class {
+		public static string SomeFunction ()
+		{
+#if FIRSTBUILD
+			return "FIRSTBUILD";
+#elif SECONDBUILD
+			return "SECONDBUILD";
+#endif
+		}
+	}
+}

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/MacCatalyst/Library.csproj
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/MacCatalyst/Library.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFrameworks>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/MacCatalyst/Makefile
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/Makefile
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/Makefile
@@ -1,0 +1,2 @@
+TOP=../../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/iOS/Library.csproj
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/iOS/Library.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFrameworks>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/iOS/Makefile
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/macOS/Library.csproj
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/macOS/Library.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFrameworks>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/macOS/Makefile
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/shared.csproj
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/shared.csproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<DefineConstants Condition="'$(BuildCounter)' == 'First'">$(DefineConstants);FIRSTBUILD</DefineConstants>
+		<DefineConstants Condition="'$(BuildCounter)' == 'Second'">$(DefineConstants);SECONDBUILD</DefineConstants>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/shared.mk
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/shared.mk
@@ -1,0 +1,2 @@
+TOP=../../../../..
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/tvOS/Library.csproj
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/tvOS/Library.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFrameworks>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Library/tvOS/Makefile
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Library/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/MacCatalyst/Makefile
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/MacCatalyst/RebuildTestAppWithLibraryReference.csproj
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/MacCatalyst/RebuildTestAppWithLibraryReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/Makefile
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/Makefile
@@ -1,0 +1,2 @@
+TOP=../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/iOS/Makefile
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/iOS/RebuildTestAppWithLibraryReference.csproj
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/iOS/RebuildTestAppWithLibraryReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/macOS/Makefile
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/macOS/RebuildTestAppWithLibraryReference.csproj
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/macOS/RebuildTestAppWithLibraryReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/shared.csproj
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/shared.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>RebuildTestAppWithLibraryReference</ApplicationTitle>
+		<ApplicationId>com.xamarin.rebuildtestappwithlibraryreference</ApplicationId>
+
+		<ExcludeTouchUnitReference>true</ExcludeTouchUnitReference>
+		<ExcludeNUnitLiteReference>true</ExcludeNUnitLiteReference>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+		<ProjectReference Include="../Library/$(_PlatformName)/Library.csproj" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/shared.mk
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/shared.mk
@@ -1,0 +1,2 @@
+TOP=../../../..
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/tvOS/Makefile
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/RebuildTestAppWithLibraryReference/tvOS/RebuildTestAppWithLibraryReference.csproj
+++ b/tests/dotnet/RebuildTestAppWithLibraryReference/tvOS/RebuildTestAppWithLibraryReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/UnitTests/RebuildTest.cs
+++ b/tests/dotnet/UnitTests/RebuildTest.cs
@@ -1,0 +1,37 @@
+namespace Xamarin.Tests
+{
+	[TestFixture]
+	public class RebuildTest : TestBaseClass {
+		[Test]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		public void ReAotTest (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "RebuildTestAppWithLibraryReference";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["BuildCounter"] = "First";
+
+			DotNet.AssertBuild (project_path, properties);
+
+			var appExecutable = Path.Combine (appPath, "Contents", "MacOS", Path.GetFileNameWithoutExtension (project_path));
+
+			Assert.That (appExecutable, Does.Exist, "There is an executable");
+			var output = ExecuteWithMagicWordAndAssert (appExecutable);
+			Assert.That (output, Does.Contain ("FIRSTBUILD"), "First build");
+
+			// Build again, changing something
+			properties ["BuildCounter"] = "Second";
+			DotNet.AssertBuild (project_path, properties);
+			Assert.That (appExecutable, Does.Exist, "There is an executable");
+			output = ExecuteWithMagicWordAndAssert (appExecutable);
+			Assert.That (output, Does.Contain ("SECONDBUILD"), "Second build");
+
+		}
+	}
+}
+

--- a/tests/dotnet/UnitTests/RebuildTest.cs
+++ b/tests/dotnet/UnitTests/RebuildTest.cs
@@ -1,5 +1,4 @@
-namespace Xamarin.Tests
-{
+namespace Xamarin.Tests {
 	[TestFixture]
 	public class RebuildTest : TestBaseClass {
 		[Test]

--- a/tests/dotnet/UnitTests/RebuildTest.cs
+++ b/tests/dotnet/UnitTests/RebuildTest.cs
@@ -20,16 +20,19 @@ namespace Xamarin.Tests {
 			var appExecutable = Path.Combine (appPath, "Contents", "MacOS", Path.GetFileNameWithoutExtension (project_path));
 
 			Assert.That (appExecutable, Does.Exist, "There is an executable");
-			var output = ExecuteWithMagicWordAndAssert (appExecutable);
-			Assert.That (output, Does.Contain ("FIRSTBUILD"), "First build");
+			if (CanExecute (platform, runtimeIdentifiers)) {
+				var output = ExecuteWithMagicWordAndAssert (appExecutable);
+				Assert.That (output, Does.Contain ("FIRSTBUILD"), "First build");
+			}
 
 			// Build again, changing something
 			properties ["BuildCounter"] = "Second";
 			DotNet.AssertBuild (project_path, properties);
 			Assert.That (appExecutable, Does.Exist, "There is an executable");
-			output = ExecuteWithMagicWordAndAssert (appExecutable);
-			Assert.That (output, Does.Contain ("SECONDBUILD"), "Second build");
-
+			if (CanExecute (platform, runtimeIdentifiers)) {
+				var output = ExecuteWithMagicWordAndAssert (appExecutable);
+				Assert.That (output, Does.Contain ("SECONDBUILD"), "Second build");
+			}
 		}
 	}
 }

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -308,19 +308,20 @@ namespace Xamarin.Tests {
 			return csproj;
 		}
 
-		protected void ExecuteWithMagicWordAndAssert (ApplePlatform platform, string runtimeIdentifiers, string executable)
+		protected string ExecuteWithMagicWordAndAssert (ApplePlatform platform, string runtimeIdentifiers, string executable)
 		{
 			if (!CanExecute (platform, runtimeIdentifiers))
-				return;
+				return string.Empty;
 
-			ExecuteWithMagicWordAndAssert (executable);
+			return ExecuteWithMagicWordAndAssert (executable);
 		}
 
-		protected void ExecuteWithMagicWordAndAssert (string executable)
+		protected string ExecuteWithMagicWordAndAssert (string executable)
 		{
 			var rv = Execute (executable, out var output, out string magicWord);
 			Assert.That (output.ToString (), Does.Contain (magicWord), "Contains magic word");
 			Assert.AreEqual (0, rv.ExitCode, "ExitCode");
+			return output.ToString ();
 		}
 
 		protected Execution Execute (string executable, out StringBuilder output, out string magicWord)


### PR DESCRIPTION
If an assembly changes, then we must AOT compile that assembly again (which we already
did), in addition to any assembly that references the modified assembly (which we
didn't do).

So rework the AOTCompile target: remove the Inputs and Outputs (because the dependency
tracking is too complicated for MSBuild to resolve), and instead move the logic to
detect if an assembly must be AOT-compiled again into the AOTCompile task.

Note that this PR has a custom port to .NET 8: #18518.

Fixes https://github.com/xamarin/xamarin-macios/issues/17708.


Backport of #18509
