### PR TITLE
[release/7.0.3xx] [tests] Filter out any warnings about out-of-support workloads.

### DIFF
--- a/tests/common/BinLog.cs
+++ b/tests/common/BinLog.cs
@@ -179,7 +179,7 @@ namespace Xamarin.Tests {
 				// Filter to warnings
 				.Where (v => v.Type == BuildLogEventType.Warning)
 				// We're often referencing earlier .NET projects (Touch.Unit/MonoTouch.Dialog), so ignore any out-of-support warnings.
-				.Where (v => v.Message?.Contains ("is out of support and will not receive security updates in the future") != false)
+				.Where (v => v.Message?.Contains ("is out of support and will not receive security updates in the future") != true)
 				;
 		}
 

--- a/tests/common/BinLog.cs
+++ b/tests/common/BinLog.cs
@@ -175,7 +175,12 @@ namespace Xamarin.Tests {
 
 		public static IEnumerable<BuildLogEvent> GetBuildLogWarnings (string path)
 		{
-			return GetBuildMessages (path).Where (v => v.Type == BuildLogEventType.Warning);
+			return GetBuildMessages (path)
+				// Filter to warnings
+				.Where (v => v.Type == BuildLogEventType.Warning)
+				// We're often referencing earlier .NET projects (Touch.Unit/MonoTouch.Dialog), so ignore any out-of-support warnings.
+				.Where (v => v.Message?.Contains ("is out of support and will not receive security updates in the future") != false)
+				;
 		}
 
 		public static IEnumerable<BuildLogEvent> GetBuildLogErrors (string path)


### PR DESCRIPTION
Our test projects may be using an earlier version of .NET (in particular
Touch.Unit and MonoTouch.Dialog often are), so ignore any warnings about
out-of-support workloads.

Fixes test failures like:

    Xamarin.Tests.BundleStructureTest.Build(MacCatalyst,"maccatalyst-x64;maccatalyst-arm64",All,"Debug"): Warnings

        Expected is <System.Collections.Generic.List`1[System.String]> with 22 elements, actual is <System.String[28]>
        Values differ at index [22]
        Extra: < "The workload 'maccatalyst' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.", "The workload 'maccatalyst' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.", "The workload 'maccatalyst' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy."... >

Backport of #18679.