### PR TITLE
[xcode14.3] [devops] Remove option to disable .NET from CI.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -56,11 +56,6 @@ parameters:
   type: boolean
   default: false
   
-- name: enableDotnet
-  displayName: Build Dotnet 
-  type: boolean
-  default: true
-
 - name: enableAPIDiff
   displayName: Enable API diff generation
   type: boolean
@@ -219,7 +214,6 @@ stages:
     runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
     runGovernanceTests: ${{ parameters.runGovernanceTests }}
     runSamples: ${{ parameters.runSamples }}
-    enableDotnet: ${{ parameters.enableDotnet }}
     enableAPIDiff: ${{ parameters.enableAPIDiff }}
     forceInsertion: ${{ parameters.forceInsertion }}
     skipESRP: ${{ parameters.skipESRP }}

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -51,11 +51,6 @@ parameters:
   type: boolean
   default: false
   
-- name: enableDotnet
-  displayName: Build Dotnet 
-  type: boolean
-  default: true
-
 - name: enableAPIDiff
   displayName: Enable API diff generation
   type: boolean
@@ -202,7 +197,6 @@ stages:
     runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
     runGovernanceTests: ${{ parameters.runGovernanceTests }}
     runSamples: ${{ parameters.runSamples }}
-    enableDotnet: ${{ parameters.enableDotnet }}
     enableAPIDiff: ${{ parameters.enableAPIDiff }}
     forceInsertion: false
     skipESRP: true

--- a/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
+++ b/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
@@ -13,10 +13,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: prID
   type: string
   default: '' # default empty, meaning we are building in CI
@@ -47,7 +43,6 @@ steps:
     keyringPass: ${{ parameters.keyringPass }}
     gitHubToken: ${{ parameters.gitHubToken }}
     xqaCertPass: ${{ parameters.xqaCertPass }}
-    enableDotnet: ${{ parameters.enableDotnet }}
     makeParallelism: '4'
 
 # detect changes

--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -13,10 +13,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: pool
   type: string
   default: automatic
@@ -54,7 +50,6 @@ jobs:
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
       uploadArtifacts: false
-      enableDotnet: ${{ parameters.enableDotnet }}
 
 - ${{ if eq(parameters.pool, 'automatic') }}:
   - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
@@ -110,7 +105,6 @@ jobs:
       keyringPass: ${{ parameters.keyringPass }}
       gitHubToken: ${{ parameters.gitHubToken }}
       xqaCertPass: ${{ parameters.xqaCertPass }}
-      enableDotnet: ${{ parameters.enableDotnet }}
       prID: variables['PrID']
 
 # Upload results to vsdrops & publish to github

--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -19,10 +19,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: uploadBinlogs
   type: boolean
   default: true
@@ -61,7 +57,6 @@ steps:
     keyringPass: ${{ parameters.keyringPass }}
     gitHubToken: ${{ parameters.gitHubToken }}
     xqaCertPass: ${{ parameters.xqaCertPass }}
-    enableDotnet: ${{ parameters.enableDotnet }}
     buildSteps:
     # build not signed .pkgs for the SDK
     - bash: |
@@ -76,8 +71,7 @@ steps:
       timeoutInMinutes: 180
 
     # build nugets
-    - ${{ if eq(parameters.enableDotnet, true) }}:
-      - template: build-nugets.yml
+    - template: build-nugets.yml
 
     - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/generate-workload-rollback.sh
       name: workload_file

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -21,10 +21,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: skipESRP
   type: boolean
   default: false # only to be used when testing the CI and we do not need a signed pkg
@@ -66,7 +62,6 @@ jobs:
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
       uploadArtifacts: true
-      enableDotnet: ${{ parameters.enableDotnet }}
 
 - ${{ if eq(parameters.pool, 'automatic') }}:
   - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
@@ -153,5 +148,4 @@ jobs:
       keyringPass: ${{ parameters.keyringPass }}
       gitHubToken: ${{ parameters.gitHubToken }}
       xqaCertPass: ${{ parameters.xqaCertPass }}
-      enableDotnet: ${{ parameters.enableDotnet }}
       skipESRP: ${{ parameters.skipESRP }}

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -15,10 +15,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: isPR
   type: boolean
   default: false
@@ -185,11 +181,6 @@ steps:
 
     CONFIGURE_FLAGS="--enable-xamarin"
 
-    if [[ "$EnableDotNet" == "True" ]]; then
-      echo "Enabling dotnet builds."
-      CONFIGURE_FLAGS="$CONFIGURE_FLAGS --enable-dotnet"
-    fi
-
     CONFIGURE_FLAGS="$CONFIGURE_FLAGS --enable-install-source"
     echo "Configuration flags are '$CONFIGURE_FLAGS'"
 
@@ -201,8 +192,6 @@ steps:
       IsPR: 'True'
     ${{ else }}:
       IsPR: 'False'
-    ${{ if eq(parameters.enableDotnet, true) }}:
-      EnableDotNet: 'True'
   displayName: "Configure build"
   timeoutInMinutes: 5
 

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -3,10 +3,6 @@
 # variables to be used by the rest of the projects
 parameters:
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: uploadArtifacts
   type: boolean
   default: false
@@ -33,9 +29,6 @@ steps:
 - bash: ./xamarin-macios/tools/devops/automation/scripts/bash/configure-platforms.sh
   name: configure_platforms
   displayName: 'Configure platforms'
-  env:
-    ${{ if eq(parameters.enableDotnet, true) }}:
-      ENABLE_DOTNET: "True"
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MaciosCI.psd1

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -20,10 +20,6 @@ parameters:
 - name: keyringPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: demands
   type: object
   default: []
@@ -64,7 +60,6 @@ stages:
         repositoryAlias: ${{ parameters.repositoryAlias }}
         commit: ${{ parameters.commit }}
         uploadArtifacts: false
-        enableDotnet: ${{ parameters.enableDotnet }}
 
   - job: run_tests
     dependsOn:

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -35,10 +35,6 @@ parameters:
 - name: runSamples
   type: boolean
   default: false
-  
-- name: enableDotnet
-  type: boolean
-  default: true
 
 - name: enableAPIDiff
   type: boolean
@@ -231,7 +227,6 @@ stages:
       keyringPass: $(pass--lab--mac--builder--keychain)
       gitHubToken: $(Github.Token)
       xqaCertPass: $(xqa--certificates--password)
-      enableDotnet: ${{ parameters.enableDotnet }}
       skipESRP: ${{ parameters.skipESRP }}
       pool: ${{ parameters.pool }}
 
@@ -248,21 +243,19 @@ stages:
         commit: ${{ parameters.commit }}
         signingSetupSteps: ${{ parameters.signingSetupSteps }}
         keyringPass: $(pass--lab--mac--builder--keychain)
-        enableDotnet: ${{ parameters.enableDotnet }}
         skipESRP: ${{ parameters.skipESRP }}
         packages: ${{ pkg_obj.packages }}
 
-- ${{ if eq(parameters.enableDotnet, true) }}:
-  - stage: sign_notarize_dotnet
-    displayName: '${{ parameters.stageDisplayNamePrefix }}Sign & Notarize Dotnet'
-    dependsOn:
-    - build_packages
-    jobs:
-    - template: ./sign-and-notarized/dotnet-signing.yml
-      parameters:
-        isPR: ${{ parameters.isPR }}
-        repositoryAlias: ${{ parameters.repositoryAlias }}
-        commit: ${{ parameters.commit }}
+- stage: sign_notarize_dotnet
+  displayName: '${{ parameters.stageDisplayNamePrefix }}Sign & Notarize Dotnet'
+  dependsOn:
+  - build_packages
+  jobs:
+  - template: ./sign-and-notarized/dotnet-signing.yml
+    parameters:
+      isPR: ${{ parameters.isPR }}
+      repositoryAlias: ${{ parameters.repositoryAlias }}
+      commit: ${{ parameters.commit }}
 
 # .NET Release Prep and VS Insertion Stages, only execute them when the build comes from an official branch and is not a schedule build from OneLoc
 # setting the stage at this level makes the graph of the UI look better, else the lines overlap and is not clear.
@@ -282,8 +275,7 @@ stages:
   displayName: '${{ parameters.stageDisplayNamePrefix }}Collect signed artifacts'
   dependsOn:
   - build_packages
-  - ${{ if eq(parameters.enableDotnet, true) }}:
-    - sign_notarize_dotnet
+  - sign_notarize_dotnet
   - ${{ each pkg_obj in parameters.packages }}:
     - ${{ pkg_obj.job }}
   jobs:
@@ -317,7 +309,6 @@ stages:
         keyringPass: $(pass--lab--mac--builder--keychain)
         gitHubToken: $(Github.Token)
         xqaCertPass: $(xqa--certificates--password)
-        enableDotnet: ${{ parameters.enableDotnet }}
         pool: ${{ parameters.pool }}
 
 # Test stages
@@ -343,7 +334,6 @@ stages:
     keyringPass: $(pass--lab--mac--builder--keychain)
     gitHubToken: $(Github.Token)
     xqaCertPass: $(xqa--certificates--password)
-    enableDotnet: ${{ parameters.enableDotnet }}
     condition: ${{ parameters.runTests }}
 
 # devices are optional and will only be ran when we set them OR in CI
@@ -369,7 +359,6 @@ stages:
           keyringPass: $(pass-XamarinQA-bot-login) 
           gitHubToken: $(Github.Token)
           xqaCertPass: $(xqa--certificates--password)
-          enableDotnet: ${{ parameters.enableDotnet }}
           condition: ${{ parameters.runDeviceTests }}
           parseLabels: false
 
@@ -386,7 +375,6 @@ stages:
         useImage: ${{ config.useImage }}
         statusContext: ${{ config.statusContext }}
         keyringPass: $(pass--lab--mac--builder--keychain)
-        enableDotnet: ${{ parameters.enableDotnet }}
         demands: ${{ config.demands }}
 
 - ${{ if eq(parameters.runWindowsIntegration, true) }}:
@@ -421,7 +409,6 @@ stages:
       keyringPass: $(pass--lab--mac--builder--keychain)
       gitHubToken: $(Github.Token)
       xqaCertPass: $(xqa--certificates--password)
-      enableDotnet: ${{ parameters.enableDotnet }}
 
 - ${{ if eq(parameters.runSamples, true) }}:
   # TODO: Not the real step

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -1,8 +1,4 @@
 parameters:
-- name: enableDotnet
-  type: boolean
-  default: true
-
 - name: dependsOn
   type: object
   default: null
@@ -40,14 +36,10 @@ stages:
           eq(dependencies.${{ parameters.dependsOn }}.result, 'Succeeded'),
           eq(dependencies.${{ parameters.dependsOn }}.result, 'SucceededWithIssues')
         ),
-        eq(${{ parameters.isPR }}, false),
-        eq(${{ parameters.enableDotnet }}, true)
+        eq(${{ parameters.isPR }}, false)
       )
   ${{ else }}:
-    condition: and(
-        eq(${{ parameters.isPR }}, false),
-        eq(${{ parameters.enableDotnet }}, true)
-      )
+    condition: eq(${{ parameters.isPR }}, false)
 
   jobs:
   # Check - "xamarin-macios (Prepare Release Sign NuGets)"

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -3,10 +3,6 @@ parameters:
 - name: packages
   type: object
 
-- name: enableDotnet
-  type: boolean
-  default: true
-
 - name: isPR
   type: boolean
 
@@ -186,7 +182,6 @@ jobs:
     parameters:
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
-      enableDotnet: ${{ parameters.enableDotnet }}
       sbomFilter: '*.nupkg;*.pkg;*.msi'
       azureStorage: ${{ parameters.azureStorage }}
       azureContainer: ${{ parameters.azureContainer }}

--- a/tools/devops/automation/templates/sign-and-notarized/prepare-pkg-stage.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/prepare-pkg-stage.yml
@@ -3,10 +3,6 @@ parameters:
 - name: keyringPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: skipESRP
   type: boolean
   default: false # only to be used when testing the CI and we do not need a signed pkg

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -1,8 +1,4 @@
 parameters:
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: sbomFilter
   type: string
   default: '*'            # Supports multiple filters separated by semi-colon such as *.msi;*.nupkg
@@ -283,8 +279,6 @@ steps:
     ACCESSTOKEN: $(System.AccessToken)
     AZURE_CONTAINER: ${{ parameters.azureContainer }}
     VIRTUAL_PATH: $(Build.SourceBranchName)/$(Build.SourceVersion)/$(Build.BuildId)
-    ${{ if eq(parameters.enableDotnet, true) }}:
-      ENABLE_DOTNET: "True"
   displayName: 'Set GithubStatus'
 
 # Executive Order (EO): Software Bill of Materials (SBOM): https://www.1eswiki.com/wiki/ADO_sbom_Generator

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -54,10 +54,6 @@ parameters:
 - name: xqaCertPass
   type: string
 
-- name: enableDotnet
-  type: boolean
-  default: false
-
 - name: makeTarget
   type: string
   default: 'vsts-device-tests' # target to be used to run the tests
@@ -115,7 +111,6 @@ stages:
           repositoryAlias: ${{ parameters.repositoryAlias }}
           commit: ${{ parameters.commit }}
           uploadArtifacts: false
-          enableDotnet: ${{ parameters.enableDotnet }}
 
   - ${{ each label in parameters.simTestsConfigurations }}:
     - job: "tests_${{ replace(label, '-', '_') }}"


### PR DESCRIPTION
It's rather rare now that we need to disable .NET from the CI, so just
remove the option. It can still be disabled directly in the code when
needed.

Also this fixes an issue where we'd build with .NET enabled even if
disabled in the code, because we'd always pass --enable-dotnet to
configure.

Backport of #18650.