### PR TITLE
[NativeAOT] Add support for [Preserve] attributes

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -632,6 +632,9 @@
 			<!-- Enable serialization discovery. Ref: https://github.com/xamarin/xamarin-macios/issues/15676 -->
 			<_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --enable-serialization-discovery</_ExtraTrimmerArgs>
 
+			<!-- If we're using NativeAOT, tell ILLink to not remove dependency attributes (DynamicDependencyAttribute), because NativeAOT's trimmer also needs to see them. -->
+			<_ExtraTrimmerArgs Condition="'$(_UseNativeAot)' == 'true'">$(_ExtraTrimmerArgs) --keep-dep-attributes</_ExtraTrimmerArgs>
+
 			<!-- We always want the linker to process debug symbols, even when building in Release mode, because the AOT compiler uses the managed debug symbols to output DWARF debugging symbols -->
 			<TrimmerRemoveSymbols Condition="'$(TrimmerRemoveSymbols)' == ''">false</TrimmerRemoveSymbols>
 

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using Mono.Cecil;
@@ -309,6 +310,12 @@ namespace Xamarin.Linker {
 			}
 		}
 
+		public TypeReference System_Diagnostics_CodeAnalysis_DynamicallyAccessedMemberTypes {
+			get {
+				return GetTypeReference (CorlibAssembly, "System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes", out var _);
+			}
+		}
+
 		public TypeReference System_Reflection_MethodBase {
 			get {
 				return GetTypeReference (CorlibAssembly, "System.Reflection.MethodBase", out var _);
@@ -466,8 +473,21 @@ namespace Xamarin.Linker {
 				return GetMethodReference (CorlibAssembly,
 						System_Diagnostics_CodeAnalysis_DynamicDependencyAttribute,
 						".ctor",
+						".ctor(String,Type)",
 						isStatic: false,
 						System_String,
+						System_Type);
+			}
+		}
+
+		public MethodReference DynamicDependencyAttribute_ctor__DynamicallyAccessedMemberTypes_Type {
+			get {
+				return GetMethodReference (CorlibAssembly,
+						System_Diagnostics_CodeAnalysis_DynamicDependencyAttribute,
+						".ctor",
+						".ctor(DynamicallyAccessedMemberTypes,Type)",
+						isStatic: false,
+						System_Diagnostics_CodeAnalysis_DynamicallyAccessedMemberTypes,
 						System_Type);
 			}
 		}
@@ -1146,6 +1166,23 @@ namespace Xamarin.Linker {
 			type_map.Clear ();
 			method_map.Clear ();
 			field_map.Clear ();
+		}
+
+		public CustomAttribute CreateDynamicDependencyAttribute (string memberSignature, TypeDefinition type)
+		{
+			var attribute = new CustomAttribute (DynamicDependencyAttribute_ctor__String_Type);
+			attribute.ConstructorArguments.Add (new CustomAttributeArgument (System_String, memberSignature));
+			attribute.ConstructorArguments.Add (new CustomAttributeArgument (System_Type, type));
+			return attribute;
+		}
+
+		public CustomAttribute CreateDynamicDependencyAttribute (DynamicallyAccessedMemberTypes memberTypes, TypeDefinition type)
+		{
+			var attribute = new CustomAttribute (DynamicDependencyAttribute_ctor__DynamicallyAccessedMemberTypes_Type);
+			// typed as 'int' because that's how the linker expects it: https://github.com/dotnet/runtime/blob/3c5ad6c677b4a3d12bc6a776d654558cca2c36a9/src/tools/illink/src/linker/Linker/DynamicDependency.cs#L97
+			attribute.ConstructorArguments.Add (new CustomAttributeArgument (System_Diagnostics_CodeAnalysis_DynamicallyAccessedMemberTypes, (int) memberTypes));
+			attribute.ConstructorArguments.Add (new CustomAttributeArgument (System_Type, type));
+			return attribute;
 		}
 	}
 }

--- a/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
+++ b/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
@@ -9,12 +9,17 @@ using Mono.Linker;
 using Mono.Linker.Steps;
 
 using Mono.Cecil;
+using Xamarin.Linker;
 
 #nullable enable
 
 namespace Mono.Tuner {
 
-	public abstract class ApplyPreserveAttributeBase : BaseSubStep {
+	public abstract class ApplyPreserveAttributeBase : ConfigurationAwareSubStep {
+
+		protected override string Name { get => "Apply Preserve Attribute"; }
+
+		protected override int ErrorCode { get => 2450; }
 
 		// set 'removeAttribute' to true if you want the preserved attribute to be removed from the final assembly
 		protected abstract bool IsPreservedAttribute (ICustomAttributeProvider provider, CustomAttribute attribute, out bool removeAttribute);
@@ -35,23 +40,23 @@ namespace Mono.Tuner {
 			return Annotations.GetAction (assembly) == AssemblyAction.Link;
 		}
 
-		public override void ProcessType (TypeDefinition type)
+		protected override void Process (TypeDefinition type)
 		{
 			TryApplyPreserveAttribute (type);
 		}
 
-		public override void ProcessField (FieldDefinition field)
+		protected override void Process (FieldDefinition field)
 		{
 			foreach (var attribute in GetPreserveAttributes (field))
 				Mark (field, attribute);
 		}
 
-		public override void ProcessMethod (MethodDefinition method)
+		protected override void Process (MethodDefinition method)
 		{
 			MarkMethodIfPreserved (method);
 		}
 
-		public override void ProcessProperty (PropertyDefinition property)
+		protected override void Process (PropertyDefinition property)
 		{
 			foreach (var attribute in GetPreserveAttributes (property)) {
 				MarkMethod (property.GetMethod, attribute);
@@ -59,7 +64,7 @@ namespace Mono.Tuner {
 			}
 		}
 
-		public override void ProcessEvent (EventDefinition @event)
+		protected override void Process (EventDefinition @event)
 		{
 			foreach (var attribute in GetPreserveAttributes (@event)) {
 				MarkMethod (@event.AddMethod, attribute);

--- a/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
+++ b/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
@@ -3,19 +3,27 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 
 using Mono.Linker;
 using Mono.Linker.Steps;
 
 using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using Xamarin.Bundler;
 using Xamarin.Linker;
+using Xamarin.Utils;
 
 #nullable enable
 
 namespace Mono.Tuner {
 
 	public abstract class ApplyPreserveAttributeBase : ConfigurationAwareSubStep {
+
+		AppBundleRewriter? abr;
 
 		protected override string Name { get => "Apply Preserve Attribute"; }
 
@@ -33,6 +41,14 @@ namespace Mono.Tuner {
 					| SubStepTargets.Event
 					| SubStepTargets.Assembly;
 			}
+		}
+
+		public override void Initialize (LinkContext context)
+		{
+			base.Initialize (context);
+
+			if (Configuration.Application.XamarinRuntime == XamarinRuntime.NativeAOT)
+				abr = Configuration.AppBundleRewriter;
 		}
 
 		public override bool IsActiveFor (AssemblyDefinition assembly)
@@ -108,6 +124,7 @@ namespace Mono.Tuner {
 			}
 
 			Annotations.AddPreservedMethod (method.DeclaringType, method);
+			AddConditionalDynamicDependencyAttribute (method.DeclaringType, method);
 		}
 
 		static bool IsConditionalAttribute (CustomAttribute? attribute)
@@ -125,6 +142,7 @@ namespace Mono.Tuner {
 		void PreserveUnconditional (IMetadataTokenProvider provider)
 		{
 			Annotations.Mark (provider);
+			AddDynamicDependencyAttribute (provider);
 
 			var member = provider as IMemberDefinition;
 			if (member is null || member.DeclaringType is null)
@@ -136,14 +154,7 @@ namespace Mono.Tuner {
 		void TryApplyPreserveAttribute (TypeDefinition type)
 		{
 			foreach (var attribute in GetPreserveAttributes (type)) {
-				Annotations.Mark (type);
-
-				if (!attribute.HasFields)
-					continue;
-
-				foreach (var named_argument in attribute.Fields)
-					if (named_argument.Name == "AllMembers" && (bool) named_argument.Argument.Value)
-						Annotations.SetPreserve (type, TypePreserve.All);
+				PreserveType (type, attribute);
 			}
 		}
 
@@ -169,6 +180,83 @@ namespace Mono.Tuner {
 			}
 
 			return attrs;
+		}
+
+		protected void PreserveType (TypeDefinition type, CustomAttribute preserveAttribute)
+		{
+			var allMembers = false;
+			if (preserveAttribute.HasFields) {
+				foreach (var named_argument in preserveAttribute.Fields)
+					if (named_argument.Name == "AllMembers" && (bool) named_argument.Argument.Value)
+						allMembers = true;
+			}
+
+			PreserveType (type, allMembers);
+		}
+
+		protected void PreserveType (TypeDefinition type, bool allMembers)
+		{
+			Annotations.Mark (type);
+			if (allMembers)
+				Annotations.SetPreserve (type, TypePreserve.All);
+			AddDynamicDependencyAttribute (type, allMembers);
+		}
+
+		MethodDefinition GetOrCreateModuleConstructor (ModuleDefinition @module)
+		{
+			var moduleType = @module.GetModuleType ();
+			var moduleConstructor = moduleType.GetTypeConstructor ();
+			if (moduleConstructor is null) {
+				moduleConstructor = moduleType.AddMethod (".cctor", MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.RTSpecialName | MethodAttributes.SpecialName | MethodAttributes.Static, abr!.System_Void);
+				moduleConstructor.CreateBody (out var il);
+				il.Emit (OpCodes.Ret);
+			}
+			return moduleConstructor;
+		}
+
+		void AddDynamicDependencyAttribute (TypeDefinition type, bool allMembers)
+		{
+			if (abr is null)
+				return;
+
+			abr.ClearCurrentAssembly ();
+			abr.SetCurrentAssembly (type.Module.Assembly);
+
+			var moduleConstructor = GetOrCreateModuleConstructor (type.GetModule ());
+			var attrib = abr.CreateDynamicDependencyAttribute (allMembers ? DynamicallyAccessedMemberTypes.All : DynamicallyAccessedMemberTypes.None, type);
+			moduleConstructor.CustomAttributes.Add (attrib);
+
+			abr.ClearCurrentAssembly ();
+		}
+
+		void AddConditionalDynamicDependencyAttribute (TypeDefinition onType, MethodDefinition forMethod)
+		{
+			if (abr is null)
+				return;
+
+			// I haven't found a way to express a conditional Preserve attribute using DynamicDependencyAttribute :/
+			ErrorHelper.Warning (2112, Errors.MX2112 /* Unable to apply the conditional [Preserve] attribute on the member {0} */, forMethod.FullName);
+		}
+
+		void AddDynamicDependencyAttribute (IMetadataTokenProvider provider)
+		{
+			if (abr is null)
+				return;
+
+			var member = provider as IMemberDefinition;
+			if (member is null)
+				throw ErrorHelper.CreateError (99, $"Unable to add dynamic dependency attribute to {provider.GetType ().FullName}");
+
+			var module = member.GetModule ();
+			abr.ClearCurrentAssembly ();
+			abr.SetCurrentAssembly (module.Assembly);
+
+			var moduleConstructor = GetOrCreateModuleConstructor (module);
+			var signature = DocumentationComments.GetSignature (member);
+			var attrib = abr.CreateDynamicDependencyAttribute (signature, member.DeclaringType);
+			moduleConstructor.CustomAttributes.Add (attrib);
+
+			abr.ClearCurrentAssembly ();
 		}
 	}
 }

--- a/tools/dotnet-linker/CecilExtensions.cs
+++ b/tools/dotnet-linker/CecilExtensions.cs
@@ -1,7 +1,10 @@
 using System.Collections.Generic;
+using System.Linq;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+
+using Xamarin.Bundler;
 
 #nullable enable
 
@@ -127,5 +130,25 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Ret);
 			return defaultCtor;
 		}
+
+		public static ModuleDefinition GetModule (this IMetadataTokenProvider provider)
+		{
+			if (provider is TypeDefinition td)
+				return td.Module;
+
+			if (provider is IMemberDefinition md)
+				return md.DeclaringType.Module;
+
+			throw ErrorHelper.CreateError (99, $"Unable to get the module of {provider.GetType ().FullName}");
+		}
+
+		public static TypeDefinition GetModuleType (this ModuleDefinition @module)
+		{
+			var moduleType = @module.Types.SingleOrDefault (v => v.Name == "<Module>");
+			if (moduleType is null)
+				throw ErrorHelper.CreateError (99, $"No <Module> type found in {@module.Name}");
+			return moduleType;
+		}
+
 	}
 }

--- a/tools/dotnet-linker/DocumentionComments.cs
+++ b/tools/dotnet-linker/DocumentionComments.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Mono.Cecil;
+
+using Xamarin.Bundler;
+
+#nullable enable
+
+namespace Xamarin.Utils {
+	// signature format: https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/documentation-comments.md#d42-id-string-format
+	public static class DocumentationComments {
+		public static string GetSignature (IMetadataTokenProvider member)
+		{
+			if (member is FieldDefinition fd)
+				return GetSignature (fd);
+
+			if (member is MethodDefinition md)
+				return GetSignature (md);
+
+			if (member is TypeDefinition td)
+				return GetSignature (td);
+
+			throw ErrorHelper.CreateError (99, $"Unable to get the doc signature for {member.GetType ().FullName}");
+		}
+
+		public static string GetSignature (TypeDefinition type)
+		{
+			if (type.IsNested)
+				return type.Name;
+			return type.FullName;
+		}
+
+		public static string GetSignature (FieldDefinition field)
+		{
+			return field.Name.Replace ('.', '#');
+		}
+
+		public static string GetSignature (MethodDefinition method)
+		{
+			var sb = new StringBuilder ();
+			sb.Append (method.Name.Replace ('.', '#'));
+			sb.Append ('(');
+			for (var i = 0; i < method.Parameters.Count; i++) {
+				if (i > 0)
+					sb.Append (',');
+
+				var parameterType = method.Parameters [i].ParameterType;
+				WriteTypeSignature (sb, parameterType);
+			}
+			sb.Append (')');
+
+			return sb.ToString ();
+		}
+
+		static void WriteTypeSignature (StringBuilder sb, TypeReference type)
+		{
+			if (type is ByReferenceType brt) {
+				WriteTypeSignature (sb, brt.GetElementType ());
+				sb.Append ('@');
+				return;
+			}
+
+			if (type is ArrayType at) {
+				WriteTypeSignature (sb, at.GetElementType ());
+				sb.Append ("[]");
+				return;
+			}
+
+			if (type is PointerType pt) {
+				WriteTypeSignature (sb, pt.GetElementType ());
+				sb.Append ('*');
+				return;
+			}
+
+			sb.Append (type.FullName.Replace ('/', '.'));
+		}
+	}
+}

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -292,7 +292,7 @@ namespace Xamarin.Linker {
 			infos.Add (new TrampolineInfo (callback, method, name));
 
 			// If the target method is marked, then we must mark the trampoline as well.
-			method.CustomAttributes.Add (CreateDynamicDependencyAttribute (callbackType, callback.Name));
+			method.CustomAttributes.Add (abr.CreateDynamicDependencyAttribute (callback.Name, callbackType));
 
 			callback.AddParameter ("pobj", abr.System_IntPtr);
 
@@ -1119,14 +1119,6 @@ namespace Xamarin.Linker {
 			var entryPointPrefix = Driver.TargetFramework.Version.Major < 8 ? "_" : string.Empty;
 			unmanagedCallersAttribute.Fields.Add (new CustomAttributeNamedArgument ("EntryPoint", new CustomAttributeArgument (abr.System_String, entryPointPrefix + entryPoint)));
 			return unmanagedCallersAttribute;
-		}
-
-		CustomAttribute CreateDynamicDependencyAttribute (TypeDefinition type, string member)
-		{
-			var attribute = new CustomAttribute (abr.DynamicDependencyAttribute_ctor__String_Type);
-			attribute.ConstructorArguments.Add (new CustomAttributeArgument (abr.System_String, member));
-			attribute.ConstructorArguments.Add (new CustomAttributeArgument (abr.System_Type, type));
-			return attribute;
 		}
 
 		void GenerateConversionToManaged (MethodDefinition method, ILProcessor il, TypeReference inputType, TypeReference outputType, string descriptiveMethodName, int parameter, out TypeReference nativeCallerType)

--- a/tools/linker/ApplyPreserveAttribute.cs
+++ b/tools/linker/ApplyPreserveAttribute.cs
@@ -27,8 +27,9 @@ namespace Xamarin.Linker.Steps {
 		}
 
 #if NET
-		public override void ProcessAssembly (AssemblyDefinition assembly)
+		protected override void Process (AssemblyDefinition assembly)
 		{
+			base.Process (assembly);
 			ProcessAssemblyAttributes (assembly);
 		}
 #else

--- a/tools/linker/ApplyPreserveAttribute.cs
+++ b/tools/linker/ApplyPreserveAttribute.cs
@@ -63,6 +63,10 @@ namespace Xamarin.Linker.Steps {
 				// (a) we're potentially processing a different assembly and `is_active` represent the current one
 				// (b) it will try to fetch the [Preserve] attribute on the type (and it's not there) as `base` would
 				var type = tr.Resolve ();
+
+#if NET
+				PreserveType (type, attribute);
+#else
 				Annotations.Mark (type);
 				if (attribute.HasFields) {
 					foreach (var named_argument in attribute.Fields) {
@@ -70,6 +74,7 @@ namespace Xamarin.Linker.Steps {
 							Annotations.SetPreserve (type, TypePreserve.All);
 					}
 				}
+#endif
 
 				// In .NET6, ApplyPreserveAttribute no longer runs on all assemblies.
 				// [assembly: Preserve (typeof (SomeAttribute))] no longer gives SomeAttribute "Preserve" semantics.

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -3986,6 +3986,15 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to apply the conditional [Preserve] attribute on the member {0}..
+        /// </summary>
+        public static string MX2112 {
+            get {
+                return ResourceManager.GetString("MX2112", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not {0} the assembly &apos;{1}&apos;
         ///		.
         /// </summary>

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1338,6 +1338,11 @@
 		</value>
 	</data>
 
+	<data name="MX2112" xml:space="preserve">
+		<!-- This is a warning -->
+		<value>Unable to apply the conditional [Preserve] attribute on the member {0}.</value>
+	</data>
+
 	<!-- 2200 -> 2299 is used by/reserved for ExceptionalSubStep subclasses in the linker -->
 	<!-- 220x: PreserveSmartEnumConversionsSubStep -->
 	<!-- 221x: RemoveBitcodeIncompatibleCodeStep -->
@@ -1371,6 +1376,15 @@
 	<!-- 234x: ExtractBindingLibrariesStep -->
 	<!-- 235x: LoadNonSkippedAssembliesStep -->
 	<!-- 236x: RegistrarStep -->
+	<!-- 237x: ComputeAOTArguments -->
+	<!-- 238x: RegistrarRemovalTrackingStep -->
+	<!-- 239x: CoreTypeMapStep -->
+	<!-- 240x: BackingFieldDelayHandler -->
+	<!-- 241x: BackingFieldReintroductionSubStep -->
+	<!-- 242x: MarkIProtocolHandler -->
+	<!-- 243x: ManagedRegistrarStep -->
+	<!-- 244x: ManagedRegistrarLookupTablesStep -->
+	<!-- 245x: ApplyPreserveAttribute -->
 
 	<data name="MX3001" xml:space="preserve">
 		<value>Could not {0} the assembly '{1}'


### PR DESCRIPTION
Add partial support for the `[Preserve]` attribute for NativeAOT. This is done by injecting an equivalent `[DynamicDependency]` attribute. The partial support comes from the fact that there's no way to map a conditional preserve attribute (`[Preserve (Conditional = true)]`) to a `[DynamicDependency]` attribute, so we report a warning instead.

For non-conditional `[Preserve]` attributes, we'll now add a `[DynamicDependency]` attribute to the assembly's module constructor for the type/member in question, effectively rooting it.

This makes it possible to fully link all our test suites when NativeAOT (otherwise NativeAOT would just link out all the tests, leaving the test suites empty - and unfortunately green, so this was a rather accidental discovery).