### PR TITLE
[tests] Parse configure.inc for build settings as well.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -179,6 +179,7 @@ namespace Xamarin.Tests {
 			}
 			if (test_config.Any ())
 				ParseConfigFiles (test_config);
+			ParseConfigFiles (FindConfigFiles ("configure.inc"));
 			ParseConfigFiles (FindConfigFiles ("Make.config.local"));
 			ParseConfigFiles (FindConfigFiles ("Make.config"));
 		}
@@ -194,7 +195,7 @@ namespace Xamarin.Tests {
 			if (string.IsNullOrEmpty (file))
 				return;
 
-			foreach (var line in File.ReadAllLines (file)) {
+			foreach (var line in File.ReadAllLines (file).Reverse ()) {
 				var eq = line.IndexOf ('=');
 				if (eq == -1)
 					continue;

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -622,6 +622,7 @@ namespace Xharness {
 		IEnumerable<string> GetConfigFiles ()
 		{
 			return FindConfigFiles (useSystemXamarinIOSMac ? "test-system.config" : "test.config")
+				.Concat (FindConfigFiles ("configure.inc"))
 				.Concat (FindConfigFiles ("Make.config"))
 				.Concat (FindConfigFiles ("Make.config.local"));
 		}


### PR DESCRIPTION
Additionally parse files in reverse order, because any variables at the end
should take precedence (when parsing config files the first time variable is
found is the one we use).