### PR TITLE
[tests] Filter out any warnings about out-of-support workloads.

### DIFF
--- a/tests/common/BinLog.cs
+++ b/tests/common/BinLog.cs
@@ -176,7 +176,12 @@ namespace Xamarin.Tests {
 
 		public static IEnumerable<BuildLogEvent> GetBuildLogWarnings (string path)
 		{
-			return GetBuildMessages (path).Where (v => v.Type == BuildLogEventType.Warning);
+			return GetBuildMessages (path)
+				// Filter to warnings
+				.Where (v => v.Type == BuildLogEventType.Warning)
+				// We're often referencing earlier .NET projects (Touch.Unit/MonoTouch.Dialog), so ignore any out-of-support warnings.
+				.Where (v => v.Message?.Contains ("is out of support and will not receive security updates in the future") != true)
+				;
 		}
 
 		public static IEnumerable<BuildLogEvent> GetBuildLogErrors (string path)


### PR DESCRIPTION
Our test projects may be using an earlier version of .NET (in particular
Touch.Unit and MonoTouch.Dialog often are), so ignore any warnings about
out-of-support workloads.

Fixes test failures like:

    Xamarin.Tests.BundleStructureTest.Build(MacCatalyst,"maccatalyst-x64;maccatalyst-arm64",All,"Debug"): Warnings

        Expected is <System.Collections.Generic.List`1[System.String]> with 22 elements, actual is <System.String[28]>
        Values differ at index [22]
        Extra: < "The workload 'maccatalyst' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.", "The workload 'maccatalyst' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.", "The workload 'maccatalyst' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy."... >