### PR TITLE
[tools] Remove some dead code in the class redirector rewriter.

### DIFF
--- a/tools/common/Rewriter.cs
+++ b/tools/common/Rewriter.cs
@@ -20,7 +20,6 @@ namespace ClassRedirector {
 		const string classPtrName = "class_ptr";
 		CSToObjCMap map;
 		string pathToXamarinAssembly;
-		string? outputDirectory = null;
 		Dictionary<string, FieldDefinition> csTypeToFieldDef = new Dictionary<string, FieldDefinition> ();
 		IEnumerable<AssemblyDefinition> assemblies;
 		AssemblyDefinition xamarinAssembly;
@@ -326,11 +325,6 @@ namespace ClassRedirector {
 						yield return nt;
 				}
 			}
-		}
-
-		string ToOutputFileName (string pathToInputFileName)
-		{
-			return Path.Combine (outputDirectory, Path.GetFileName (pathToInputFileName));
 		}
 
 		void MarkForSave (AssemblyDefinition assembly)

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>dotnet_linker</RootNamespace>
     <DefineConstants>$(DefineConstants);BUNDLER</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <Import Project="..\..\eng\Versions.props" />


### PR DESCRIPTION
This also fixes a compiler warnings:

> tools/common/Rewriter.cs(333,25): warning CS8604: Possible null reference argument for parameter 'path1' in 'string Path.Combine(string path1, string path2)'.

And make nullability warnings in dotnet-linker show up as errors to prevent
future introduction of nullability warnings.