### PR TITLE
[tests] Improve assertion when a .NET test fails executing 'dotnet'.

### DIFF
--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -181,6 +181,19 @@ namespace Xamarin.Tests {
 					var outputStr = output.ToString ();
 					Console.WriteLine ($"'{Executable} {StringUtils.FormatArguments (args)}' failed with exit code {rv.ExitCode}.");
 					Console.WriteLine (outputStr);
+					if (rv.ExitCode != 0) {
+						var errors = BinLog.GetBuildLogErrors (binlogPath).ToArray ();
+						var msg = new StringBuilder ();
+						msg.AppendLine ($"'dotnet {verb}' failed with exit code {rv.ExitCode}");
+						msg.AppendLine ($"Full command: {Executable} {StringUtils.FormatArguments (args)}");
+						if (errors.Any ()) {
+							var errorsToList = errors.Take (10).ToArray ();
+							msg.AppendLine ($"Listing first {errorsToList.Length} error(s) (of {errors.Length} error(s)):");
+							foreach (var error in errorsToList)
+								msg.AppendLine ($"    {string.Join ($"{Environment.NewLine}        ", error.ToString ().Split ('\n', '\r'))}");
+						}
+						Assert.Fail (msg.ToString ());
+					}
 					Assert.AreEqual (0, rv.ExitCode, $"Exit code: {Executable} {StringUtils.FormatArguments (args)}");
 				}
 				return new ExecutionResult (output, output, rv.ExitCode) {

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -182,16 +182,18 @@ namespace Xamarin.Tests {
 					Console.WriteLine ($"'{Executable} {StringUtils.FormatArguments (args)}' failed with exit code {rv.ExitCode}.");
 					Console.WriteLine (outputStr);
 					if (rv.ExitCode != 0) {
-						var errors = BinLog.GetBuildLogErrors (binlogPath).ToArray ();
 						var msg = new StringBuilder ();
 						msg.AppendLine ($"'dotnet {verb}' failed with exit code {rv.ExitCode}");
 						msg.AppendLine ($"Full command: {Executable} {StringUtils.FormatArguments (args)}");
+#if !MSBUILD_TASKS
+						var errors = BinLog.GetBuildLogErrors (binlogPath).ToArray ();
 						if (errors.Any ()) {
 							var errorsToList = errors.Take (10).ToArray ();
 							msg.AppendLine ($"Listing first {errorsToList.Length} error(s) (of {errors.Length} error(s)):");
 							foreach (var error in errorsToList)
 								msg.AppendLine ($"    {string.Join ($"{Environment.NewLine}        ", error.ToString ().Split ('\n', '\r'))}");
 						}
+#endif
 						Assert.Fail (msg.ToString ());
 					}
 					Assert.AreEqual (0, rv.ExitCode, $"Exit code: {Executable} {StringUtils.FormatArguments (args)}");

--- a/tools/nnyeah/tests/nnyeah-tests.csproj
+++ b/tools/nnyeah/tests/nnyeah-tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.758" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,6 +22,7 @@
     <Compile Include="../../common/ApplePlatform.cs" Link="ApplePlatform.cs" />
 
     <Compile Include="../../../tests/mtouch/Cache.cs" Link="Cache.cs" />
+    <Compile Include="../../../tests/common/BinLog.cs" Link="BinLog.cs" />
     <Compile Include="../../../tests/common/Configuration.cs" Link="Configuration.cs" />
     <Compile Include="../../../tests/common/Profile.cs" Link="Profile.cs" />
     <Compile Include="../../../tests/common/ExecutionHelper.cs" Link="ExecutionHelper.cs" />


### PR DESCRIPTION
Improve assertion when a .NET test fails executing 'dotnet' by including more
information (any errors in particular) in the assert message.