### PR TITLE
[registrar] Call INativeObject ctors directly in the managed static registrar.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3309,6 +3309,12 @@ namespace Registrar {
 
 		bool HasIntPtrBoolCtor (TypeDefinition type, List<Exception> exceptions)
 		{
+			return HasIntPtrBoolCtor (type, exceptions, out var _);
+		}
+
+		bool HasIntPtrBoolCtor (TypeDefinition type, List<Exception> exceptions, [NotNullWhen (true)] out MethodDefinition? ctor)
+		{
+			ctor = null;
 			if (!type.HasMethods)
 				return false;
 			foreach (var method in type.Methods) {
@@ -3330,6 +3336,7 @@ namespace Registrar {
 					if (!method.Parameters [0].ParameterType.Is ("System", "IntPtr"))
 						continue;
 				}
+				ctor = method;
 				return true;
 			}
 			return false;
@@ -4529,6 +4536,11 @@ namespace Registrar {
 
 		public TypeDefinition GetInstantiableType (TypeDefinition td, List<Exception> exceptions, string descriptiveMethodName)
 		{
+			return GetInstantiableType (td, exceptions, descriptiveMethodName, out var _);
+		}
+
+		public TypeDefinition GetInstantiableType (TypeDefinition td, List<Exception> exceptions, string descriptiveMethodName, out MethodDefinition ctor)
+		{
 			TypeDefinition nativeObjType = td;
 
 			if (td.IsInterface) {
@@ -4540,7 +4552,7 @@ namespace Registrar {
 			}
 
 			// verify that the type has a ctor with two parameters
-			if (!HasIntPtrBoolCtor (nativeObjType, exceptions))
+			if (!HasIntPtrBoolCtor (nativeObjType, exceptions, out ctor))
 				throw ErrorHelper.CreateError (4103, Errors.MT4103, nativeObjType.FullName, descriptiveMethodName);
 
 			return nativeObjType;

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -231,6 +231,12 @@ namespace Xamarin.Linker {
 			}
 		}
 
+		public FieldReference System_IntPtr_Zero {
+			get {
+				return GetFieldReference (CorlibAssembly, System_IntPtr, "Zero", "System.IntPtr::Zero", out var _);
+			}
+		}
+
 		public TypeReference System_Nullable_1 {
 			get {
 				return GetTypeReference (CorlibAssembly, "System.Nullable`1", out var _);
@@ -779,6 +785,16 @@ namespace Xamarin.Linker {
 			}
 		}
 
+		public MethodReference Runtime_TryGetNSObject {
+			get {
+				return GetMethodReference (PlatformAssembly,
+						ObjCRuntime_Runtime, "TryGetNSObject",
+						nameof (Runtime_TryGetNSObject),
+						isStatic: true,
+						System_IntPtr,
+						System_Boolean);
+			}
+		}
 		public MethodReference Runtime_GetNSObject__System_IntPtr {
 			get {
 				return GetMethodReference (PlatformAssembly,
@@ -811,19 +827,6 @@ namespace Xamarin.Linker {
 						isStatic: true,
 						genericParameterCount: 1,
 						System_IntPtr);
-			}
-		}
-
-		public MethodReference Runtime_GetINativeObject__IntPtr_Boolean_Type_Type {
-			get {
-				return GetMethodReference (PlatformAssembly,
-						ObjCRuntime_Runtime, "GetINativeObject",
-						nameof (Runtime_GetINativeObject__IntPtr_Boolean_Type_Type),
-						isStatic: true,
-						System_IntPtr,
-						System_Boolean,
-						System_Type,
-						System_Type);
 			}
 		}
 
@@ -1142,6 +1145,7 @@ namespace Xamarin.Linker {
 			current_assembly = null;
 			type_map.Clear ();
 			method_map.Clear ();
+			field_map.Clear ();
 		}
 	}
 }

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -921,14 +921,42 @@ namespace Xamarin.Linker {
 						// cast to the generic type to verify that the item is actually of the correct type
 						il.Emit (OpCodes.Unbox_Any, type);
 					} else {
-						var nativeObjType = StaticRegistrar.GetInstantiableType (type.Resolve (), exceptions, GetMethodSignature (method));
+						StaticRegistrar.GetInstantiableType (type.Resolve (), exceptions, GetMethodSignature (method), out var ctor);
+						EnsureVisible (method, ctor);
+						var targetType = method.Module.ImportReference (type);
+						var handleVariable = il.Body.AddVariable (abr.System_IntPtr);
+						var objectVariable = il.Body.AddVariable (targetType);
+						var loadHandle = il.Create (OpCodes.Ldloc, handleVariable);
+						var loadObjectVariable = il.Create (OpCodes.Ldloc, objectVariable);
+						il.Emit (OpCodes.Stloc, handleVariable);
+						// objectVariable = null
+						il.Emit (OpCodes.Ldnull);
+						il.Emit (OpCodes.Stloc, objectVariable);
+						// if (handle == IntPtr.Zero)
+						//     goto done;
+						il.Emit (OpCodes.Ldloc, handleVariable); // handle
+						il.Emit (OpCodes.Ldsfld, abr.System_IntPtr_Zero);
+						il.Emit (OpCodes.Beq, done);
+						// objectVariable = TryGetNSObject (handle, false) as TargetType
+						il.Emit (OpCodes.Ldloc, handleVariable); // handle
 						il.Emit (OpCodes.Ldc_I4_0); // false
-						il.Emit (OpCodes.Ldtoken, method.Module.ImportReference (type)); // target type
-						il.Emit (OpCodes.Call, abr.Type_GetTypeFromHandle);
-						il.Emit (OpCodes.Ldtoken, method.Module.ImportReference (nativeObjType)); // implementation type
-						il.Emit (OpCodes.Call, abr.Type_GetTypeFromHandle);
-						il.Emit (OpCodes.Call, abr.Runtime_GetINativeObject__IntPtr_Boolean_Type_Type);
-						il.Emit (OpCodes.Castclass, type);
+						il.Emit (OpCodes.Call, abr.Runtime_TryGetNSObject);
+						il.Emit (OpCodes.Castclass, targetType);
+						il.Emit (OpCodes.Stloc, objectVariable);
+						// if (objectVariable is null)
+						//     objectVariable = new TargetType (handle, false)
+						il.Emit (OpCodes.Ldloc, objectVariable);
+						il.Emit (OpCodes.Brfalse, loadHandle);
+						il.Emit (OpCodes.Br, done);
+						il.Append (loadHandle);
+						if (ctor.Parameters [0].ParameterType.Is ("ObjCRuntime", "NativeHandle"))
+							il.Emit (OpCodes.Call, abr.NativeObject_op_Implicit_NativeHandle);
+						il.Emit (OpCodes.Ldc_I4_0); // false
+						il.Emit (OpCodes.Newobj, method.Module.ImportReference (ctor));
+						il.Emit (OpCodes.Stloc, objectVariable);
+						// done:
+						// (load objectVariable on the stack)
+						il.Append (loadObjectVariable);
 					}
 					nativeType = abr.System_IntPtr;
 				} else {

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -936,7 +936,7 @@ namespace Xamarin.Linker {
 						//     goto done;
 						il.Emit (OpCodes.Ldloc, handleVariable); // handle
 						il.Emit (OpCodes.Ldsfld, abr.System_IntPtr_Zero);
-						il.Emit (OpCodes.Beq, done);
+						il.Emit (OpCodes.Beq, loadObjectVariable);
 						// objectVariable = TryGetNSObject (handle, false) as TargetType
 						il.Emit (OpCodes.Ldloc, handleVariable); // handle
 						il.Emit (OpCodes.Ldc_I4_0); // false
@@ -947,7 +947,7 @@ namespace Xamarin.Linker {
 						//     objectVariable = new TargetType (handle, false)
 						il.Emit (OpCodes.Ldloc, objectVariable);
 						il.Emit (OpCodes.Brfalse, loadHandle);
-						il.Emit (OpCodes.Br, done);
+						il.Emit (OpCodes.Br, loadObjectVariable);
 						il.Append (loadHandle);
 						if (ctor.Parameters [0].ParameterType.Is ("ObjCRuntime", "NativeHandle"))
 							il.Emit (OpCodes.Call, abr.NativeObject_op_Implicit_NativeHandle);


### PR DESCRIPTION
We can determine the exact constructor to call when creating INativeObject instances
in the generated code, so do exactly that. This avoids a lot of slow reflection,
and also makes the constructor call visible for any linkers.