### PR TITLE
[monotouch-test] Fix BlocksTest to work on maccatalyst-arm64.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -72,7 +72,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
-#if !DEVICE && !MONOMAC && !AOT // some of these tests cause the AOT compiler to assert
+#if !DEVICE && !MONOMAC && !AOT && !__MACCATALYST__ // some of these tests cause the AOT compiler to assert
 		// No MonoPInvokeCallback
 		static void InvalidTrampoline1 () { }
 


### PR DESCRIPTION
We use the AOT compiler on ARM64 on Mac Catalyst, so these tests have to be excluded on Mac Catalyst.