### PR TITLE
[remote] Explicitly import .mobile.props file

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -8,8 +8,15 @@
 
 	<Import Project="Xamarin.Shared.Sdk.TargetFrameworkInference.props" />
 	
-	<!-- Imports the .user.env file if exists and the build is from VS -->
-	<Import Project="$(MSBuildProjectFullPath).user.env" Condition="Exists('$(MSBuildProjectFullPath).user.env') And '$(BuildingInsideVisualStudio)' == 'true'" />
+	<PropertyGroup>
+		<!-- e.g: C:\Users\user1\app1\app1\obj\ -->
+		<_MobilePropsDir>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(BaseIntermediateOutputPath)))</_MobilePropsDir>
+		<!-- e.g: C:\Users\user1\app1\app1\obj\app1.mobile.props -->
+		<_MobilePropsPath>$(_MobilePropsDir)$(MSBuildProjectName).mobile.props</_MobilePropsPath>
+	</PropertyGroup>
+
+	<!-- Imports the .mobile.props file if exists and the build is from VS -->
+	<Import Project="$(_MobilePropsPath)" Condition="Exists('$(_MobilePropsPath)') And '$(BuildingInsideVisualStudio)' == 'true'" />
 	
 	<PropertyGroup>
 		<!-- Set to true when using the Microsoft.<platform>.Sdk NuGet. This is used by pre-existing/shared targets to tweak behavior depending on build system -->


### PR DESCRIPTION
The .mobile.props file is a file created and written by the mobile VS extension to store property values that needs to be read early enough in the build chain, as in design time builds, and that can't be set by CPS because of a limitation in the project system. See more information here: https://github.com/xamarin/XamarinVS/pull/13606

Initially it was named .user.env file and then was renamed in another PR as part of a feedback from the project system team. See more information here: https://github.com/xamarin/XamarinVS/pull/13628

Because this file was saved in the intermediate output path, it was meant to be imported automatically by MSBuild, however we recently detected that this was not happening reliably. Because of this, some things like C# Hot Reload for iOS stopped working because Roslyn was reading incorrect values from the Design Time Builds.

For that reason and to avoid relying on the project system, I'm importing this file explicitly (and removing old .user.env import), so the values in the file are always available and the dependent properties are calculated correctly and available for all the consumers (including Roslyn).

This should fix the following bugs:

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1822041

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1851677