### PR TITLE
[net8.0-xcode15] [tools] Improve enforcement of the classic linker.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1558,6 +1558,10 @@
 		<ItemGroup>
 			<_AllLinkerFlags Include="@(_AssemblyLinkerFlags);@(_MainLinkerFlags);@(_CustomLinkFlags)" />
 			<_AllLinkerFlags Condition="'$(_ExportSymbolsExplicitly)' != 'true'" Include="@(_ReferencesLinkerFlags)" />
+
+			<!-- check if needs to be removed: https://github.com/xamarin/xamarin-macios/issues/18693 -->
+			<_AllLinkerFlags Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_XcodeVersion)', '15.0')) And '$(_UseClassicLinker)' != 'false'" Include="-Xlinker" />
+			<_AllLinkerFlags Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_XcodeVersion)', '15.0')) And '$(_UseClassicLinker)' != 'false'" Include="-ld_classic" />
 		</ItemGroup>
 
 		<LinkNativeCode

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCodeTaskBase.cs
@@ -75,9 +75,6 @@ namespace Xamarin.MacDev.Tasks {
 
 			var arguments = new List<string> ();
 			arguments.Add ("clang++");
-			// check if needs to be removed: https://github.com/xamarin/xamarin-macios/issues/18556
-			arguments.Add ("-Xlinker");
-			arguments.Add ("-ld_classic");
 
 			var hasEmbeddedFrameworks = false;
 

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -169,6 +169,9 @@ namespace Xamarin.Bundler {
 
 		public bool SkipMarkingNSObjectsInUserAssemblies { get; set; }
 
+		// check if needs to be removed: https://github.com/xamarin/xamarin-macios/issues/18693
+		public bool DisableAutomaticLinkerSelection { get; set; }
+
 		// assembly_build_targets describes what kind of native code each assembly should be compiled into for mobile targets (iOS, tvOS, watchOS).
 		// An assembly can be compiled into: static object (.o), dynamic library (.dylib) or a framework (.framework).
 		// In the case of a framework, each framework may contain the native code for multiple assemblies.

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -16,10 +16,7 @@ namespace Xamarin.Utils {
 		public HashSet<string> LinkWithLibraries; // X, added to Inputs
 		public HashSet<string> ForceLoadLibraries; // -force_load X, added to Inputs
 		public HashSet<string []> OtherFlags; // X
-		public List<string> InitialOtherFlags = new List<string> () {
-			"-Xlinker",
-			"-ld_classic",
-		}; // same as OtherFlags, only that they're the first argument(s) to clang (because order matters!). This is a list to preserve order (fifo).
+		public List<string> InitialOtherFlags; // same as OtherFlags, only that they're the first argument(s) to clang (because order matters!). This is a list to preserve order (fifo).
 
 		public HashSet<string> Defines; // -DX
 		public HashSet<string> UnresolvedSymbols; // -u X
@@ -109,10 +106,7 @@ namespace Xamarin.Utils {
 		public void AddOtherInitialFlag (string flag)
 		{
 			if (InitialOtherFlags is null)
-				InitialOtherFlags = new List<string> () {
-					"-Xlinker",
-					"-ld_classic",
-				};
+				InitialOtherFlags = new List<string> ();
 			InitialOtherFlags.Add (flag);
 		}
 
@@ -243,6 +237,12 @@ namespace Xamarin.Utils {
 					args.Insert (idx, flag);
 					idx++;
 				}
+			}
+
+			// check if needs to be removed: https://github.com/xamarin/xamarin-macios/issues/18693
+			if (Driver.XcodeVersion.Major >= 15 && !Application.DisableAutomaticLinkerSelection) {
+				args.Insert (0, "-Xlinker");
+				args.Insert (1, "-ld_classic");
 			}
 
 			ProcessFrameworksForArguments (args);

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -258,6 +258,11 @@ namespace Xamarin.Bundler {
 				app.SkipMarkingNSObjectsInUserAssemblies = ParseBool (v, "--skip-marking-nsobjects-in-user-assemblies");
 			});
 
+			// check if needs to be removed: https://github.com/xamarin/xamarin-macios/issues/18693
+			options.Add ("disable-automatic-linker-selection:", "Don't force the classic linker (ld64).", v => {
+				app.DisableAutomaticLinkerSelection = ParseBool (v, "--disable-automatic-linker-selection");
+			});
+
 			// Keep the ResponseFileSource option at the end.
 			options.Add (new Mono.Options.ResponseFileSource ());
 

--- a/tools/mmp/aot.cs
+++ b/tools/mmp/aot.cs
@@ -233,8 +233,11 @@ namespace Xamarin.Bundler {
 					aotArgs.Add ("hybrid");
 				if (needsLipo)
 					aotArgs.Add ($"outfile={Path.Combine (tempAotDir, "aot", abi.AsArchString (), Path.GetFileName (file) + ".dylib")}");
-				if (Driver.XcodeVersion.Major >= 15)
+
+				// check if needs to be removed: https://github.com/xamarin/xamarin-macios/issues/18693
+				if (Driver.XcodeVersion.Major >= 15 && !Driver.App.DisableAutomaticLinkerSelection)
 					aotArgs.Add ("ld-flags=-Xlinker -ld_classic");
+
 				cmd.Add ($"--aot={string.Join (",", aotArgs)}");
 				if (IsModern)
 					cmd.Add ("--runtime=mobile");

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1012,10 +1012,9 @@ namespace Xamarin.Bundler {
 						args.Add (Path.Combine (DeveloperDirectory, "Platforms", "MacOSX.platform", "Developer", "SDKs", "MacOSX" + sysRootSDKVersion + ".sdk"));
 					}
 
-					if (XcodeVersion.Major >= 15) {
-						// Xcode 15 ships with a new linker, which doesn't work, so request the old one.
+					// check if needs to be removed: https://github.com/xamarin/xamarin-macios/issues/18693
+					if (XcodeVersion.Major >= 15 && !App.DisableAutomaticLinkerSelection)
 						args.Add ("-Wl,-ld_classic");
-					}
 
 					if (App.RequiresPInvokeWrappers) {
 						var state = BuildTarget.LinkerOptions.MarshalNativeExceptionsState;


### PR DESCRIPTION
* Only ask for the classic linker if we're using Xcode 15+.
* Implement a way out of the enforcing the classic linker.