### PR TITLE
[msbuild] Pass a stream to XDocument.Load instead of a path.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadItemsFromFileBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadItemsFromFileBase.cs
@@ -34,7 +34,10 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var result = new List<ITaskItem> ();
 			foreach (var file in File) {
-				var document = XDocument.Load (file.ItemSpec);
+				// XDocument.Load(string) takes a string to a URI, not a file path, so with certain characters that becomes a problem.
+				// Just File.OpenRead instead and use the XDocument.Load(Stream) overload instead.
+				using var stream = global::System.IO.File.OpenRead (file.ItemSpec);
+				var document = XDocument.Load (stream);
 
 				var items = document.Root
 					.Elements (ItemGroupElementName)


### PR DESCRIPTION
XDocument.Load(string) takes a URI, not a file path. This usually works if
there are no special characters in the file path, but for instance with a path
with a colon (say 'a:b/some/file'), we'll get an exception about invalid uri
scheme.

So instead use the XDocument.Load(Stream) overload, and create the stream
using the file path instead, in which case there's no problem with special
characters.