### PR TITLE
[devops] 'simctl diagnose' tend to return an error code, so make sure it doesn't bubble up to the CI.

### DIFF
--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -175,7 +175,9 @@ steps:
 
     rm -Rf $(System.DefaultWorkingDirectory)/diagnostic-sim-output/output
     mkdir -p $(System.DefaultWorkingDirectory)/diagnostic-sim-output/output
-    printf "\n" | xcrun simctl diagnose -b -X --output=$(System.DefaultWorkingDirectory)/diagnostic-sim-output/output
+    if ! printf "\n" | xcrun simctl diagnose -b -X --output=$(System.DefaultWorkingDirectory)/diagnostic-sim-output/output; then
+      echo "simctl diagnose failed with exit code $?"
+    fi
 
   displayName: 'Collect diagnostic info from simulators'
   condition: eq(variables['system.debug'], true)


### PR DESCRIPTION
This seems to happen fairly often:

   + xcrun simctl diagnose -b -X --output=/Users/builder/azdo/_work/1/s/diagnostic-sim-output/output
   Error creating archive at '/Users/builder/azdo/_work/1/s/diagnostic-sim-output/output.tar.gz'. Files are still in /Users/builder/azdo/_work/1/s/diagnostic-sim-output/output
   An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=17):
   Unable to write or file already exists
   File exists

The output directory is empty (created in the line before), so I have no idea what's going on.

An archive with the diagnostic info still seems to be created though, so just
ignore any failures from 'simctl diagnose' instead of bubbling them up to
Azure DevOps. This makes our test runs not show up with warnings.