### PR TITLE
[tools] Store list of trampolines even if it's empty. Fixes #18570.

### DIFF
--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -158,10 +158,9 @@ namespace Xamarin.Linker {
 				assembly.MainModule.Types.Add (additionalType);
 
 			// Make sure the linker saves any changes in the assembly.
-			if (modified) {
-				DerivedLinkContext.Annotations.SetCustomAnnotation ("ManagedRegistrarStep", assembly, current_trampoline_lists);
+			DerivedLinkContext.Annotations.SetCustomAnnotation ("ManagedRegistrarStep", assembly, current_trampoline_lists);
+			if (modified)
 				abr.SaveCurrentAssembly ();
-			}
 
 			abr.ClearCurrentAssembly ();
 		}


### PR DESCRIPTION
This is a bit non-obvious, but we later use the presence of such a stored list
to determine if we need to generate the __Registrar__ type in the assembly.

The problem is that we need to generate the __Registrar__ type even if no
trampolines were created, because we use it for numerous other purposes as
well (type lookup for instance).

Fixes https://github.com/xamarin/xamarin-macios/issues/18570.