### PR TITLE
Fix non-NativeAOT builds with PublishAot=true in the project file

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -142,6 +142,10 @@
 	</PropertyGroup>
 
 	<!-- Various options when using NativeAOT -->
+	<PropertyGroup Condition="'$(PublishAot)' == 'true'">
+		<!-- This turns off some NativeAOT logic we don't want nor need -->
+		<NativeCompilationDuringPublish>false</NativeCompilationDuringPublish>
+	</PropertyGroup>
 	<PropertyGroup Condition="'$(PublishAot)' == 'true' And '$(_IsPublishing)' == 'true'">
 		<!-- Disable our own assembly IL stripping logic, because ILC does that already -->
 		<EnableAssemblyILStripping>false</EnableAssemblyILStripping>
@@ -151,8 +155,5 @@
 
 		<!-- We must find the BCL libraries using the runtime pack instead of using the built-in NativeAOT BCL -->
 		<PublishAotUsingRuntimePack>true</PublishAotUsingRuntimePack>
-
-		<!-- This turns off some NativeAOT logic we don't want nor need -->
-		<NativeCompilationDuringPublish>false</NativeCompilationDuringPublish>
 	</PropertyGroup>
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -465,12 +465,14 @@
 	</PropertyGroup>
 
 	<Target Name="_ComputeLinkerFeatures">
+		<PropertyGroup Condition="'$(PublishAot)' == 'true'">
+			<!-- Yep, we want to run ILLink as well, because we need our custom steps to run (NativeAOT sets this to false, so set it back to true) -->
+			<RunILLink>true</RunILLink>
+		</PropertyGroup>
+
 		<PropertyGroup Condition="'$(_UseNativeAot)' == 'true'">
 			<!-- The one and only registrar is 'managed-static' when using NativeAOT -->
 			<Registrar Condition="'$(Registrar)' == ''">managed-static</Registrar>
-
-			<!-- Yep, we want to run ILLink as well, because we need our custom steps to run (NativeAOT sets this to false, so set it back to true) -->
-			<RunILLink>true</RunILLink>
 		</PropertyGroup>
 
 		<PropertyGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -464,6 +464,27 @@
 		<IlcCompileDependsOn>Compile;_ComputeLinkerArguments;_ComputeManagedAssemblyToLink;SetupOSSpecificProps;PrepareForILLink;_XamarinComputeIlcCompileInputs</IlcCompileDependsOn>
 	</PropertyGroup>
 
+	<!--
+		Workaround for SDK issue where setting PublishAot=true during build cannot resolve correct
+		runtime pack and IL compiler pack.
+
+		Setting PublishAotUsingRuntimePack=true unconditionally results in the runtime pack label to
+		be updated to "NativeAOT" instead of "Mono" and trying to build against NativeAOT runtime
+		pack instead of the Mono one.
+
+		Setting PublishAotUsingRuntimePack=false causes the NuGet resolution to check for known
+		ILCompiler packs and these don't exist for iOS-like platforms.
+
+		The workaround ensure that PublishAotUsingRuntimePack is false when SDK updates the runtime
+		pack labels, and thus the "Mono" label is used. We then set it to true right before
+		ProcessFrameworkReferences target to skip downloading the target ILCompiler pack.
+	-->
+	<Target Name="_WorkaroundAotRuntimePackResolution" BeforeTargets="ProcessFrameworkReferences" Condition="'$(PublishAot)' == 'true' And '$(_UseNativeAot)' != 'true'">
+		<PropertyGroup>
+			<PublishAotUsingRuntimePack>true</PublishAotUsingRuntimePack>
+		</PropertyGroup>
+	</Target>
+
 	<Target Name="_ComputeLinkerFeatures">
 		<PropertyGroup Condition="'$(PublishAot)' == 'true'">
 			<!-- Yep, we want to run ILLink as well, because we need our custom steps to run (NativeAOT sets this to false, so set it back to true) -->

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1354,6 +1354,23 @@ namespace Xamarin.Tests {
 			Assert.AreEqual ($"WinExe is not a valid output type for macOS", errors [0].Message, "Error message");
 		}
 
+		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
+		public void PublishAotDuringBuild (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["PublishAot"] = "true";
+			DotNet.AssertBuild (project_path, properties);
+		}
+
 		void AssertThatDylibExistsAndIsReidentified (string appPath, string dylibRelPath)
 		{
 			var dylibPath = Path.Join (appPath, "Contents", "MonoBundle", dylibRelPath);


### PR DESCRIPTION
The gist is:
- If you enable `<PublishAot>true</PublishAot>` then the NativeAOT build targets get included.
- Unless `NativeCompilationDuringPublish` is disabled, the NativeAOT targets are chained through `BeforeTargets` attribute to some publish targets (computing the resolved publish paths). Xamarin runs those publish targets even for non-publish builds, so it brings the whole ILC compilation along. That's undesirable.
- The `RunILLink` property is set unconditionally by the NativeAOT build integration. If we don't fix it then ILLink never runs, and neither do all the custom steps to generate registrars and `main()`.

Update: Apparently, we still need to fix runtime pack resolution for iOS-like platforms with `PublishAotUsingRuntimePack=true`.