### PR TITLE
[tests] Disable build parallelism when setting IntermediateOutputPath as a property for the build.

### DIFF
--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -28,14 +28,14 @@ namespace Xamarin.Tests {
 			}
 		}
 
-		public static ExecutionResult AssertPack (string project, Dictionary<string, string>? properties = null)
+		public static ExecutionResult AssertPack (string project, Dictionary<string, string>? properties = null, bool? msbuildParallelism = null)
 		{
-			return Execute ("pack", project, properties, true);
+			return Execute ("pack", project, properties, true, msbuildParallelism: msbuildParallelism);
 		}
 
-		public static ExecutionResult AssertPackFailure (string project, Dictionary<string, string>? properties = null)
+		public static ExecutionResult AssertPackFailure (string project, Dictionary<string, string>? properties = null, bool? msbuildParallelism = null)
 		{
-			var rv = Execute ("pack", project, properties, false);
+			var rv = Execute ("pack", project, properties, false, msbuildParallelism: msbuildParallelism);
 			Assert.AreNotEqual (0, rv.ExitCode, "Unexpected success");
 			return rv;
 		}
@@ -113,7 +113,7 @@ namespace Xamarin.Tests {
 			return new ExecutionResult (output, output, rv.ExitCode);
 		}
 
-		public static ExecutionResult Execute (string verb, string project, Dictionary<string, string>? properties, bool assert_success = true, string? target = null)
+		public static ExecutionResult Execute (string verb, string project, Dictionary<string, string>? properties, bool assert_success = true, string? target = null, bool? msbuildParallelism = null)
 		{
 			if (!File.Exists (project))
 				throw new FileNotFoundException ($"The project file '{project}' does not exist.");
@@ -172,6 +172,15 @@ namespace Xamarin.Tests {
 				var binlogPath = Path.Combine (Path.GetDirectoryName (project)!, $"log-{verb}-{DateTime.Now:yyyyMMdd_HHmmss}.binlog");
 				args.Add ($"/bl:{binlogPath}");
 				Console.WriteLine ($"Binlog: {binlogPath}");
+
+				if (msbuildParallelism.HasValue) {
+					if (msbuildParallelism.Value) {
+						args.Add ("-maxcpucount"); // this means "use as many processes as there are cpus"
+					} else {
+						args.Add ("-maxcpucount:1");
+					}
+				}
+
 				var env = new Dictionary<string, string?> ();
 				env ["MSBuildSDKsPath"] = null;
 				env ["MSBUILD_EXE_PATH"] = null;

--- a/tests/dotnet/UnitTests/PackTest.cs
+++ b/tests/dotnet/UnitTests/PackTest.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Tests {
 			properties ["OutputPath"] = outputPath + Path.DirectorySeparatorChar;
 			properties ["IntermediateOutputPath"] = intermediateOutputPath + Path.DirectorySeparatorChar;
 
-			var rv = DotNet.AssertPackFailure (project_path, properties);
+			var rv = DotNet.AssertPackFailure (project_path, properties, msbuildParallelism: false);
 			var errors = BinLog.GetBuildLogErrors (rv.BinLogPath).ToArray ();
 			Assert.AreEqual (1, errors.Length, "Error count");
 			Assert.AreEqual ($"Creating a NuGet package is not supported for projects that have ObjcBindingNativeLibrary items. Migrate to use NativeReference items instead.", errors [0].Message, "Error message");
@@ -57,7 +57,7 @@ namespace Xamarin.Tests {
 			properties ["IntermediateOutputPath"] = intermediateOutputPath + Path.DirectorySeparatorChar;
 			properties ["NoBindingEmbedding"] = noBindingEmbedding ? "true" : "false";
 
-			DotNet.AssertPack (project_path, properties);
+			DotNet.AssertPack (project_path, properties, msbuildParallelism: false);
 
 			var nupkg = Path.Combine (outputPath, project + ".1.0.0.nupkg");
 			Assert.That (nupkg, Does.Exist, "nupkg existence");
@@ -121,7 +121,7 @@ namespace Xamarin.Tests {
 			properties ["IntermediateOutputPath"] = intermediateOutputPath + Path.DirectorySeparatorChar;
 			properties ["NoBindingEmbedding"] = noBindingEmbedding ? "true" : "false";
 
-			DotNet.AssertPack (project_path, properties);
+			DotNet.AssertPack (project_path, properties, msbuildParallelism: false);
 
 			var nupkg = Path.Combine (outputPath, assemblyName + ".1.0.0.nupkg");
 			Assert.That (nupkg, Does.Exist, "nupkg existence");


### PR DESCRIPTION
* A property set on the command line is set for all projects that are built,
  including projects referenced by the main project.
* If the main project references more than one project, those referenced
  projects may be built in parallel.
* This means multiple projects might have the same IntermediateOutputPath if
  set on the command line, and thus accessing files in the directory
  simultaneously, which is a bad idea.

Fix this by manually disabling build parallelism in tests that set
IntermediateOutputPath.

Fixes https://github.com/xamarin/maccore/issues/2567.