### PR TITLE
[tests/xharness] Add support for setting test configuration using environment variables.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -224,11 +224,15 @@ namespace Xamarin.Tests {
 
 		public static string EvaluateVariable (string variable)
 		{
+			var result = Environment.GetEnvironmentVariable (variable);
+			if (!string.IsNullOrEmpty (result))
+				return result;
+
 			var output = new StringBuilder ();
 			var rv = ExecutionHelper.Execute ("/usr/bin/make", new string [] { "-C", Path.Combine (SourceRoot, "tools", "devops"), "print-abspath-variable", $"VARIABLE={variable}" }, environmentVariables: null, stdout: output, stderr: output, timeout: TimeSpan.FromSeconds (5));
 			if (rv != 0)
 				throw new Exception ($"Failed to evaluate variable '{variable}'. Exit code: {rv}. Output:\n{output}");
-			var result = output.ToString ().Split (new char [] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Where (v => v.StartsWith (variable + "=", StringComparison.Ordinal)).SingleOrDefault ();
+			result = output.ToString ().Split (new char [] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries).Where (v => v.StartsWith (variable + "=", StringComparison.Ordinal)).SingleOrDefault ();
 			if (result is null)
 				throw new Exception ($"Could not find the variable '{variable}' to evaluate.");
 			return result.Substring (variable.Length + 1);

--- a/tests/xharness/IHarness.cs
+++ b/tests/xharness/IHarness.cs
@@ -47,6 +47,7 @@ namespace Xharness {
 		bool INCLUDE_XAMARIN_LEGACY { get; }
 		string SYSTEM_MONO { get; set; }
 		string DOTNET_DIR { get; set; }
+		string DOTNET_TFM { get; }
 		string XcodeRoot { get; }
 		string LogDirectory { get; }
 		double Timeout { get; }
@@ -64,7 +65,6 @@ namespace Xharness {
 		bool UseGroupedApps { get; }
 		string VSDropsUri { get; }
 		bool DisableWatchOSOnWrench { get; }
-		string DotNetTfm { get; }
 
 		#endregion
 

--- a/tests/xharness/Targets/Target.cs
+++ b/tests/xharness/Targets/Target.cs
@@ -65,7 +65,7 @@ namespace Xharness.Targets {
 
 		public const string FSharpGuid = "{F2A71F9B-5D33-465A-A702-920D77279786}";
 		public const string CSharpGuid = "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";
-		public string DotNetTfm => Harness.DotNetTfm;
+		public string DotNetTfm => Harness.DOTNET_TFM;
 
 		public string LanguageGuid { get { return IsFSharp ? FSharpGuid : CSharpGuid; } }
 


### PR DESCRIPTION
Setting test configuration variables using the environment is useful when
running tests on a Windows machine (easier than having to deal with make).

Also refactor the code a bit to not use constants, and more consistent naming.