### PR TITLE
[msbuild] Store the command line to sign in the stamp file. Fixes #16124.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeCodesignItemsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeCodesignItemsTaskBase.cs
@@ -75,7 +75,7 @@ namespace Xamarin.MacDev.Tasks {
 				bundle.CopyMetadataTo (item);
 
 				// Compute the stamp file to use
-				item.SetMetadataIfNotSet ("CodesignStampFile", Path.Combine (bundlePath, CodeSignatureRelativePath, "_CodeSignature", "CodeResources"));
+				item.SetMetadataIfNotSet ("CodesignStampFile", Path.Combine (CodesignStampPath, Path.GetFileName (bundle.ItemSpec), ".stampfile"));
 
 				// Get any additional stamp files we must touch when the item is signed.
 				var additionalStampFiles = new List<string> ();


### PR DESCRIPTION
When figuring out whether something needs to be (re)signed or not, we must
also take into account that the signing identity may have changed (for
instance a release build will often have a different signing identity than a
debug build).

Do this by storing the command line to sign for each item we need to sign in
the stamp file, and if the stored contents doesn't match the new command line
to sign, then we must resign the item.

This is rather obnoxious to write unit tests for (since we'd need to have two
different signing identities available on the bots), so I've only done local
testing.

Fixes https://github.com/xamarin/xamarin-macios/issues/16124.