### PR TITLE
[release/7.0.3xx] [dotnet] Fix assembly stripping of resource assemblies. Fixes #17262.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -747,9 +747,8 @@
 			<_StrippedAssemblyDirectory>$(DeviceSpecificIntermediateOutputPath)\stripped</_StrippedAssemblyDirectory>
 		</PropertyGroup>
 		<ItemGroup>
-			<_AssembliesToBeStripped Include="@(ResolvedFileToPublish)" Condition="'%(Extension)' == '.dll'">
-				<OutputPath Condition="'%(ResolvedFileToPublish.DestinationSubPath)' != ''">$(_StrippedAssemblyDirectory)\%(ResolvedFileToPublish.DestinationSubPath)</OutputPath>
-				<OutputPath Condition="'%(ResolvedFileToPublish.DestinationSubPath)' == ''">$(_StrippedAssemblyDirectory)\%(Filename)%(Extension)</OutputPath>
+			<_AssembliesToBeStripped Include="@(ResolvedFileToPublish)" Condition="'%(Extension)' == '.dll' And '%(ResolvedFileToPublish.Culture)' == ''">
+				<OutputPath>$(_StrippedAssemblyDirectory)\%(ResolvedFileToPublish.OriginalRelativePath)</OutputPath>
 			</_AssembliesToBeStripped>
 
 			<!-- Use forward slashes in OutputPath, otherwise ILStrip will create filenames that resemble the part of
@@ -1570,7 +1569,7 @@
 			<ResolvedFileToPublish Remove="@(_CompressedAppleBindingResourcePackage)" />
 
 			<!-- Rewrite the relative path so that everything ends up in the app bundle -->
-			<ResolvedFileToPublish RelativePath="$(_RelativeAppBundlePath)\%(RelativePath)" />
+			<ResolvedFileToPublish RelativePath="$(_RelativeAppBundlePath)\%(RelativePath)" OriginalRelativePath="%(RelativePath)" />
 		</ItemGroup>
 
 		<!-- resolve any .xcframeworks and binding resource packages -->


### PR DESCRIPTION
* Don't strip resource assemblies, there's no code in them to strip anyways.
* Use the relative path inside the app bundle when computing the intermediate
  location for stripped assemblies, so that if we were to find two identically
  named assemblies in different directories, they're handled correctly (by
  putting them in different intermediate locations, instead of overwriting
  eachother).

Fixes https://github.com/xamarin/xamarin-macios/issues/17262.


Backport of #18749
