### PR TITLE
NativeAOT: Do not suppress trim warnings by default with NativeAOT

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -10,18 +10,6 @@
     <EnableDefaultwatchOSItems Condition=" '$(_PlatformName)' == 'watchOS' And '$(EnableDefaultwatchOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultwatchOSItems>
     <EnableDefaultmacOSItems Condition=" '$(_PlatformName)' == 'macOS' And '$(EnableDefaultmacOSItems)' == '' ">$(EnableDefaultItems)</EnableDefaultmacOSItems>
     <EnableDefaultMacCatalystItems Condition=" '$(_PlatformName)' == 'MacCatalyst' And '$(EnableDefaultMacCatalystItems)' == '' ">$(EnableDefaultItems)</EnableDefaultMacCatalystItems>
-
-    <!--
-        PublishAot should only take effect when doing 'dotnet publish', not when doing 'dotnet build'. We distinguish these cases using the '_IsPublishing' property,
-        but it's rather annoying to always have to check both PublishAot and _IsPublishing to see if we're using NativeAOT, so introduce a third property that's
-        only set to true if both PublishAot=true and _IsPublishing=true
-    -->
-    <_UseNativeAot Condition="'$(PublishAot)' == 'true' And '$(_IsPublishing)' == 'true'">true</_UseNativeAot>
-
-    <UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_PlatformName)' == 'macOS'">false</UseMonoRuntime>
-    <UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_UseNativeAot)' == 'true'">false</UseMonoRuntime>
-    <UseMonoRuntime Condition=" '$(UseMonoRuntime)' == ''">true</UseMonoRuntime>
-
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -20,7 +20,27 @@
 		<_XamarinSdkRootDirectoryOnMac>$(_XamarinSdkRootDirectory)</_XamarinSdkRootDirectoryOnMac>
 		<_XamarinTaskAssembly Condition="'$(_PlatformName)' != 'macOS'">$(_XamarinSdkRootDirectory)\tools\msbuild\iOS\Xamarin.iOS.Tasks.dll</_XamarinTaskAssembly>
 		<_XamarinTaskAssembly Condition="'$(_PlatformName)' == 'macOS'">$(_XamarinSdkRootDirectory)\tools\msbuild\macOS\Xamarin.Mac.Tasks.dll</_XamarinTaskAssembly>
-		<SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
+
+		<!--
+			PublishAot should only take effect when doing 'dotnet publish', not when doing 'dotnet build'. We distinguish these cases using the '_IsPublishing' property,
+			but it's rather annoying to always have to check both PublishAot and _IsPublishing to see if we're using NativeAOT, so introduce a third property that's
+			only set to true if both PublishAot=true and _IsPublishing=true
+		-->
+		<_UseNativeAot Condition="'$(PublishAot)' == 'true' And '$(_IsPublishing)' == 'true'">true</_UseNativeAot>
+
+		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_PlatformName)' == 'macOS'">false</UseMonoRuntime>
+		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_UseNativeAot)' == 'true'">false</UseMonoRuntime>
+		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == ''">true</UseMonoRuntime>
+
+		<!--
+			With NativeAOT we want to suppress trim warnings coming from ILLink and enable them only for ILC.
+			For this reason, in case of NativeAOT, we set SuppressTrimAnalysisWarnings to true by default and store the overwriten default in
+			_OriginalSuppressTrimAnalysisWarnings property, which is later used to properly configure warning suppression for ILC.
+		-->
+		<_OriginalSuppressTrimAnalysisWarnings>$(SuppressTrimAnalysisWarnings)</_OriginalSuppressTrimAnalysisWarnings>
+		<SuppressTrimAnalysisWarnings Condition="'$(_UseNativeAot)' == 'true'">true</SuppressTrimAnalysisWarnings>
+		<SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == ''">true</SuppressTrimAnalysisWarnings>
+
 		<AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)Microsoft.$(_PlatformName).Sdk.targets</AfterMicrosoftNETSdkTargets>
 
 		<!-- _XamarinSdkRoot is used by the existing MSBuild targets files -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1229,6 +1229,9 @@
 		<PropertyGroup>
 			<!-- Ask ILC to produce a static library -->
 			<NativeLib>static</NativeLib>
+
+			<!-- Always enable trim warnings by default with NativeAOT -->
+			<SuppressTrimAnalysisWarnings Condition="'$(_OriginalSuppressTrimAnalysisWarnings)' != 'true'">false</SuppressTrimAnalysisWarnings>
 		</PropertyGroup>
 
 		<ItemGroup>


### PR DESCRIPTION
This PR enables trim warnings with NativeAOT by default.

In our current ILLink+ILC setup, we first need to suppress the warnings for ILLink, after which we need to enable them for ILC. 
For this reason, setting up `SuppressTrimAnalysisWarnings` properly needs to happen very early as it will get overwritten by https://github.com/dotnet/runtime/blob/45acd380b37c9ee883070a70a2ef2cb7eca77683/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets#L54-L59 

Verified with building an iOS application that the trim warnings are displayed only during ILC trimming (after `Generating native code` message below):
```                 
../dotnet publish -c Release -r ios-arm64 -bl /p:PublishAot=true /p:PublishAotUsingRuntimePack=true
MSBuild version 17.7.0+5785ed5c2 for .NET
  Determining projects to restore...
  Restored /Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj (in 127 ms).
/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/sdk/8.0.100-rc.1.23415.19/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
  Detected signing identity:
          
    Code Signing Key: "Apple Development: Ivan Povazan (53PXX466YZ)" (3CC7B9372E3BB19DEBECBA95A6AF3E0EB26C5B29)
    Provisioning Profile: "iOS Team Provisioning Profile: *" (6e598984-dd21-4632-b707-72cfa247991d)
    Bundle Id: com.companyname.TrimTest
    App Id: SGGM6D27TK.com.companyname.TrimTest
  TrimTest -> /Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/bin/Release/net8.0-ios/ios-arm64/TrimTest.dll
/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/packs/Microsoft.iOS.Sdk/16.4.8777-ci.trim-warn/targets/Xamarin.Shared.Sdk.targets(1826,3): warning : The file '/Users/ivan/repos/xamarin/xamarin-macios/packages/microsoft.netcore.app.runtime.nativeaot.ios-arm64/8.0.0-rc.1.23414.4/runtimes/ios-arm64/native/libbootstrapper.o' does not specify a 'PublishFolderType' metadata, and a default value could not be calculated. The file will not be copied to the app bundle. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/packs/Microsoft.iOS.Sdk/16.4.8777-ci.trim-warn/targets/Xamarin.Shared.Sdk.targets(1826,3): warning : The file '/Users/ivan/repos/xamarin/xamarin-macios/packages/microsoft.netcore.app.runtime.nativeaot.ios-arm64/8.0.0-rc.1.23414.4/runtimes/ios-arm64/native/libbootstrapperdll.o' does not specify a 'PublishFolderType' metadata, and a default value could not be calculated. The file will not be copied to the app bundle. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/packs/Microsoft.iOS.Sdk/16.4.8777-ci.trim-warn/targets/Xamarin.Shared.Sdk.targets(536,3): warning : All assemblies must be processed by the linker when using NativeAOT. Please don't set neither the 'MtouchLink' nor the 'TrimMode' property, so that the build can default to linking all assemblies. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
  Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink
  Optimizing assemblies for size. This process might take a while.
  Generating native code
resource ILLink.LinkAttributes.xml in System.Private.CoreLib(335,8): warning IL2049: System.Private.CoreLib: The internal attribute name 'RemoveAttributeInstances' being used in the xml is not supported by ILLink, check the spelling and the supported internal attributes. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
resource ILLink.LinkAttributes.xml in System.Private.CoreLib(342,8): warning IL2049: System.Private.CoreLib: The internal attribute name 'RemoveAttributeInstances' being used in the xml is not supported by ILLink, check the spelling and the supported internal attributes. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
resource ILLink.LinkAttributes.xml in System.Private.CoreLib(349,8): warning IL2049: System.Private.CoreLib: The internal attribute name 'RemoveAttributeInstances' being used in the xml is not supported by ILLink, check the spelling and the supported internal attributes. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
resource ILLink.LinkAttributes.xml in System.Private.CoreLib(356,8): warning IL2049: System.Private.CoreLib: The internal attribute name 'RemoveAttributeInstances' being used in the xml is not supported by ILLink, check the spelling and the supported internal attributes. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
resource ILLink.LinkAttributes.xml in System.Private.CoreLib(363,8): warning IL2049: System.Private.CoreLib: The internal attribute name 'RemoveAttributeInstances' being used in the xml is not supported by ILLink, check the spelling and the supported internal attributes. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
resource ILLink.LinkAttributes.xml in System.Private.CoreLib(370,8): warning IL2049: System.Private.CoreLib: The internal attribute name 'RemoveAttributeInstances' being used in the xml is not supported by ILLink, check the spelling and the supported internal attributes. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
/Users/ivan/repos/xamarin/xamarin-macios/src/ObjCRuntime/Runtime.CoreCLR.cs(171): Trim analysis warning IL2026: ObjCRuntime.Runtime.ResolvingEventHandler(AssemblyLoadContext,AssemblyName): Using member 'System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyPath(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types and members the loaded assembly depends on might be removed. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
/Users/ivan/repos/xamarin/xamarin-macios/src/ObjCRuntime/Runtime.CoreCLR.cs(267): Trim analysis warning IL2026: ObjCRuntime.Runtime.FindAssembly(IntPtr): Using member 'System.Reflection.Assembly.LoadFrom(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types and members the loaded assembly depends on might be removed. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/obj/Release/net8.0-ios/ios-arm64/linked/Microsoft.iOS.dll : warning IL3053: Assembly 'Microsoft.iOS' produced AOT analysis warnings. [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/obj/Release/net8.0-ios/ios-arm64/linked/Microsoft.iOS.dll : warning IL2104: Assembly 'Microsoft.iOS' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries [/Users/ivan/repos/xamarin/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23415.19/TrimTest/TrimTest.csproj]
  Created the package: bin/Release/net8.0-ios/ios-arm64/publish//TrimTest.ipa
```

---
Fixes: https://github.com/xamarin/xamarin-macios/issues/18571