### PR TITLE
[SceneKit] Add support for Xcode 15 beta 6

### DIFF
--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -3293,6 +3293,13 @@ namespace SceneKit {
 #endif
 		[Export ("currentRenderPassDescriptor")]
 		MTLRenderPassDescriptor CurrentRenderPassDescriptor { get; }
+
+		[Watch(10, 0), TV(17, 0), Mac(14, 0), iOS(17, 0), MacCatalyst(17, 0)]
+#if XAMCORE_5_0
+		[Abstract]
+#endif
+		[Export("workingColorSpace")]
+		CGColorSpace WorkingColorSpace { get; }
 	}
 
 	[MacCatalyst (13, 1)]

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-SceneKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-SceneKit.ignore
@@ -64,3 +64,6 @@
 
 # normal pattern accept null delegate and unit tests shows it works just fine
 !extra-null-allowed! 'System.Void SceneKit.SCNAvoidOccluderConstraint::set_Delegate(SceneKit.ISCNAvoidOccluderConstraintDelegate)' has a extraneous [NullAllowed] on parameter #0
+
+## we cannot add abstract members to existing SCNSceneRenderer protocols (breaking changes)
+!incorrect-protocol-member! SCNSceneRenderer::workingColorSpace is REQUIRED and should be abstract

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-SceneKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-SceneKit.todo
@@ -1,1 +1,0 @@
-!missing-protocol-member! SCNSceneRenderer::workingColorSpace not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-SceneKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-SceneKit.todo
@@ -1,1 +1,0 @@
-!missing-protocol-member! SCNSceneRenderer::workingColorSpace not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-SceneKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-SceneKit.todo
@@ -1,1 +1,0 @@
-!missing-protocol-member! SCNSceneRenderer::workingColorSpace not found

--- a/tests/xtro-sharpie/common-SceneKit.ignore
+++ b/tests/xtro-sharpie/common-SceneKit.ignore
@@ -18,6 +18,7 @@
 !incorrect-protocol-member! SCNSceneRenderer::setTemporalAntialiasingEnabled: is REQUIRED and should be abstract
 !incorrect-protocol-member! SCNSceneRenderer::setUsesReverseZ: is REQUIRED and should be abstract
 !incorrect-protocol-member! SCNSceneRenderer::usesReverseZ is REQUIRED and should be abstract
+!incorrect-protocol-member! SCNSceneRenderer::workingColorSpace is REQUIRED and should be abstract
 
 ## same for SCNActionable, it is required member of a protocol added to .NET
 !incorrect-protocol-member! SCNActionable::actionKeys is REQUIRED and should be abstract

--- a/tests/xtro-sharpie/iOS-SceneKit.todo
+++ b/tests/xtro-sharpie/iOS-SceneKit.todo
@@ -1,1 +1,0 @@
-!missing-protocol-member! SCNSceneRenderer::workingColorSpace not found

--- a/tests/xtro-sharpie/macOS-SceneKit.todo
+++ b/tests/xtro-sharpie/macOS-SceneKit.todo
@@ -1,1 +1,0 @@
-!missing-protocol-member! SCNSceneRenderer::workingColorSpace not found

--- a/tests/xtro-sharpie/tvOS-SceneKit.todo
+++ b/tests/xtro-sharpie/tvOS-SceneKit.todo
@@ -1,1 +1,0 @@
-!missing-protocol-member! SCNSceneRenderer::workingColorSpace not found

--- a/tests/xtro-sharpie/watchOS-SceneKit.todo
+++ b/tests/xtro-sharpie/watchOS-SceneKit.todo
@@ -1,1 +1,0 @@
-!missing-protocol-member! SCNSceneRenderer::workingColorSpace not found


### PR DESCRIPTION
Notes:
- Beta 6 changes are targeting only visionOS
- Adding an [Abstract] to an existing protocol is a breaking change so added a conditional XAMCORE and added xtro error to .ignore