### PR TITLE
[devops] Tell 'dotnet test' to use the correct 'dotnet' executable when running the generator tests.

### DIFF
--- a/tools/devops/automation/scripts/run-generator-tests-on-windows.ps1
+++ b/tools/devops/automation/scripts/run-generator-tests-on-windows.ps1
@@ -34,4 +34,5 @@ Write-Host "DOTNET_BCL_DIR: $Env:DOTNET_BCL_DIR"
     "--logger:console;verbosity=detailed" `
     "--logger:trx;LogFileName=$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows/bgen-tests/results.trx" `
     "--logger:html;LogFileName=$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows/bgen-tests/results.html" `
+    "--settings" "$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/tests/dotnet/Windows/config.runsettings" `
     "-bl:$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows/bgen-tests/results.binlog"


### PR DESCRIPTION
'dotnet test' has this very nonintuitive behavior where it will execute the
tests with the 'dotnet' executable found in PATH, not the 'dotnet' executable
we're executing.

This matters when we're using a preview version of .NET: the system does not
have that preview version installed, so executing the tests with our locally
built .NET doesn't work, because it just switches to using the system .NET,
which doesn't have the version we need.

So use a settings file to tell .NET to not go looking for .NET in any other
.NET location than the .NET location we want it to use.