### PR TITLE
Avoid using Activator.CreateInstance

### DIFF
--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -219,7 +219,7 @@ namespace AudioUnit {
 
 		public ResourceUsageInfo? ResourceUsage {
 			get {
-				return GetStrongDictionary<ResourceUsageInfo> (resourceUsageK);
+				return GetStrongDictionary<ResourceUsageInfo> (resourceUsageK, (dict) => new ResourceUsageInfo (dict));
 			}
 			set {
 				SetNativeValue (resourceUsageK, value?.Dictionary, true);

--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -234,7 +234,19 @@ namespace Foundation {
 			return value as NSDictionary<TKey, TValue>;
 		}
 
-		protected T? GetStrongDictionary<T> (NSString key) where T : DictionaryContainer
+#if NET
+		protected T? GetStrongDictionary<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T> (NSString key)
+#else
+		protected T? GetStrongDictionary<T> (NSString key)
+#endif
+			where T : DictionaryContainer
+		{
+			return GetStrongDictionary (key, dict =>
+				(T?) Activator.CreateInstance (typeof (T), new object [] { dict }));
+		}
+
+		protected T? GetStrongDictionary<T> (NSString? key, Func<NSDictionary, T?> createStrongDictionary)
+			where T : DictionaryContainer
 		{
 			if (key is null)
 				throw new ArgumentNullException (nameof (key));
@@ -242,9 +254,8 @@ namespace Foundation {
 			var dict = GetNSDictionary (key);
 			if (dict is null)
 				return null;
-			return (T?) Activator.CreateInstance (typeof (T),
-				new object [] { dict }
-			);
+
+			return createStrongDictionary (dict);
 		}
 
 		protected NSString? GetNSStringValue (NSString key)

--- a/src/Foundation/NSConnection.cs
+++ b/src/Foundation/NSConnection.cs
@@ -29,6 +29,7 @@
 #if MONOMAC
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 using ObjCRuntime;
 
@@ -52,7 +53,11 @@ namespace Foundation
 			return GetRootProxy<TProxy> (_GetRootProxy (name, hostName, server));
 		}
 
+#if NET
+		static TProxy GetRootProxy<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TProxy> (IntPtr handle) where TProxy : NSObject
+#else
 		static TProxy GetRootProxy<TProxy> (IntPtr handle) where TProxy : NSObject
+#endif
 		{
 			var result = Runtime.TryGetNSObject (handle) as TProxy;
 

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2016,7 +2016,7 @@ public partial class Generator : IMemberGatherer {
 							setter = "SetNativeValue ({0}, value)";
 						} else if (IsDictionaryContainerType (pi.PropertyType) || AttributeManager.HasAttribute<StrongDictionaryAttribute> (pi)) {
 							var strType = pi.PropertyType.Name;
-							getter = "GetStrongDictionary<" + strType + ">({0})";
+							getter = $"GetStrongDictionary<{strType}>({{0}}, (dict) => new {strType} (dict))";
 							setter = "SetNativeValue ({0}, value.GetDictionary ())";
 						} else if (IsWrappedType (pi.PropertyType)) {
 							getter = "Dictionary [{0}] as " + pi.PropertyType;


### PR DESCRIPTION
Ref #18779

- We can get rid of Activator.CreateInstance in `DictionaryContainer.GetStrongDictionary<T>` by passing a factory method
- For the cases where we need to use Activator.CreateInstance we need to add `[DynamicallyAccessedMembers(...)]` to the type parameter