### PR TITLE
[tests] Add support for specifying whether build properties should be specified on the command line or in a file.

### DIFF
--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -131,24 +131,37 @@ namespace Xamarin.Tests {
 				if (properties is not null) {
 					Dictionary<string, string>? generatedProps = null;
 					foreach (var prop in properties) {
-						if (prop.Value.IndexOfAny (new char [] { ';' }) >= 0) {
-							// https://github.com/dotnet/msbuild/issues/471
-							// Escaping the semi colon like the issue suggests at one point doesn't work, because in
-							// that case MSBuild won't split the string into its parts for tasks that take a string[].
-							// This means that a task that takes a "string[] RuntimeIdentifiers" will get an array with
-							// a single element, where that single element is the whole RuntimeIdentifiers string.
-							// Example task: https://github.com/dotnet/sdk/blob/ffca47e9a36652da2e7041360f2201a2ba197194/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs#L45
-							// args.Add ($"/p:{prop.Key}=\"{prop.Value}\"");
-
-							// Setting a property with a semicolon from the command line doesn't work anymore.
-							// Ref: https://github.com/dotnet/sdk/issues/27059#issuecomment-1219319513
-							// So write these properties in a file instead. This is a behavioural difference, because
-							// they'll be project-specific instead of global, but I don't see a better workaround.
+						// Some properties must be specified on the command line to work properly ("TargetFrameworks").
+						// Some tests require certain properties to be specified in a file.
+						// So we support both, where prefixing a property name with "cmdline:" forces it to be passed on the command line,
+						// while prefixing it with "file:" forces it to be specified in a file.
+						// No prefix means the default (which can change): currently on the command line.
+						var cmdline = true; // default
+						var key = prop.Key;
+						var value = prop.Value;
+						if (key.StartsWith ("file:", StringComparison.Ordinal)) {
+							key = key.Substring ("file:".Length);
+							cmdline = false;
+						} else if (key.StartsWith ("cmdline:", StringComparison.Ordinal)) {
+							key = key.Substring ("cmdline:".Length);
+							cmdline = true;
+						}
+						if (cmdline) {
+							if (prop.Value.IndexOfAny (new char [] { ';' }) >= 0) {
+								// https://github.com/dotnet/msbuild/issues/471
+								// Escaping the semi colon like the issue suggests at one point doesn't work, because in
+								// that case MSBuild won't split the string into its parts for tasks that take a string[].
+								// This means that a task that takes a "string[] RuntimeIdentifiers" will get an array with
+								// a single element, where that single element is the whole RuntimeIdentifiers string.
+								// Example task: https://github.com/dotnet/sdk/blob/ffca47e9a36652da2e7041360f2201a2ba197194/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs#L45
+								args.Add ($"/p:{key}=\"{value}\"");
+							} else {
+								args.Add ($"/p:{key}={value}");
+							}
+						} else {
 							if (generatedProps is null)
 								generatedProps = new Dictionary<string, string> ();
-							generatedProps.Add (prop.Key, prop.Value);
-						} else {
-							args.Add ($"/p:{prop.Key}={prop.Value}");
+							generatedProps.Add (key, value);
 						}
 					}
 					if (generatedProps is not null) {

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -129,7 +129,6 @@ namespace Xamarin.Tests {
 				args.Add (verb);
 				args.Add (project);
 				if (properties is not null) {
-					Dictionary<string, string>? generatedProps = null;
 					foreach (var prop in properties) {
 						if (prop.Value.IndexOfAny (new char [] { ';' }) >= 0) {
 							// https://github.com/dotnet/msbuild/issues/471
@@ -138,33 +137,10 @@ namespace Xamarin.Tests {
 							// This means that a task that takes a "string[] RuntimeIdentifiers" will get an array with
 							// a single element, where that single element is the whole RuntimeIdentifiers string.
 							// Example task: https://github.com/dotnet/sdk/blob/ffca47e9a36652da2e7041360f2201a2ba197194/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs#L45
-							// args.Add ($"/p:{prop.Key}=\"{prop.Value}\"");
-
-							// Setting a property with a semicolon from the command line doesn't work anymore.
-							// Ref: https://github.com/dotnet/sdk/issues/27059#issuecomment-1219319513
-							// So write these properties in a file instead. This is a behavioural difference, because
-							// they'll be project-specific instead of global, but I don't see a better workaround.
-							if (generatedProps is null)
-								generatedProps = new Dictionary<string, string> ();
-							generatedProps.Add (prop.Key, prop.Value);
+							args.Add ($"/p:{prop.Key}=\"{prop.Value}\"");
 						} else {
 							args.Add ($"/p:{prop.Key}={prop.Value}");
 						}
-					}
-					if (generatedProps is not null) {
-						var sb = new StringBuilder ();
-						sb.AppendLine ("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-						sb.AppendLine ("<Project>");
-						sb.AppendLine ("\t<PropertyGroup>");
-						foreach (var prop in generatedProps) {
-							sb.AppendLine ($"\t\t<{prop.Key}>{prop.Value}</{prop.Key}>");
-						}
-						sb.AppendLine ("\t</PropertyGroup>");
-						sb.AppendLine ("</Project>");
-
-						var generatedProjectFile = Path.Combine (Cache.CreateTemporaryDirectory (), "GeneratedProjectFile.props");
-						File.WriteAllText (generatedProjectFile, sb.ToString ());
-						args.Add ($"/p:GeneratedProjectFile={generatedProjectFile}");
 					}
 				}
 				if (!string.IsNullOrEmpty (target))

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -129,6 +129,7 @@ namespace Xamarin.Tests {
 				args.Add (verb);
 				args.Add (project);
 				if (properties is not null) {
+					Dictionary<string, string>? generatedProps = null;
 					foreach (var prop in properties) {
 						if (prop.Value.IndexOfAny (new char [] { ';' }) >= 0) {
 							// https://github.com/dotnet/msbuild/issues/471
@@ -137,10 +138,33 @@ namespace Xamarin.Tests {
 							// This means that a task that takes a "string[] RuntimeIdentifiers" will get an array with
 							// a single element, where that single element is the whole RuntimeIdentifiers string.
 							// Example task: https://github.com/dotnet/sdk/blob/ffca47e9a36652da2e7041360f2201a2ba197194/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs#L45
-							args.Add ($"/p:{prop.Key}=\"{prop.Value}\"");
+							// args.Add ($"/p:{prop.Key}=\"{prop.Value}\"");
+
+							// Setting a property with a semicolon from the command line doesn't work anymore.
+							// Ref: https://github.com/dotnet/sdk/issues/27059#issuecomment-1219319513
+							// So write these properties in a file instead. This is a behavioural difference, because
+							// they'll be project-specific instead of global, but I don't see a better workaround.
+							if (generatedProps is null)
+								generatedProps = new Dictionary<string, string> ();
+							generatedProps.Add (prop.Key, prop.Value);
 						} else {
 							args.Add ($"/p:{prop.Key}={prop.Value}");
 						}
+					}
+					if (generatedProps is not null) {
+						var sb = new StringBuilder ();
+						sb.AppendLine ("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+						sb.AppendLine ("<Project>");
+						sb.AppendLine ("\t<PropertyGroup>");
+						foreach (var prop in generatedProps) {
+							sb.AppendLine ($"\t\t<{prop.Key}>{prop.Value}</{prop.Key}>");
+						}
+						sb.AppendLine ("\t</PropertyGroup>");
+						sb.AppendLine ("</Project>");
+
+						var generatedProjectFile = Path.Combine (Cache.CreateTemporaryDirectory (), "GeneratedProjectFile.props");
+						File.WriteAllText (generatedProjectFile, sb.ToString ());
+						args.Add ($"/p:GeneratedProjectFile={generatedProjectFile}");
 					}
 				}
 				if (!string.IsNullOrEmpty (target))

--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -67,4 +67,6 @@
 
 	<Import Project="$(MSBuildThisFileDirectory)/../ComputeRegistrarConstant.targets" />
 	<Import Project="$(MSBuildThisFileDirectory)/../nunit.framework.targets" Condition="'$(ExcludeNUnitLiteReference)' != 'true'" />
+
+	<Import Project="$(GeneratedProjectFile)" Condition="'$(GeneratedProjectFile)' != ''" />
 </Project>

--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -67,6 +67,4 @@
 
 	<Import Project="$(MSBuildThisFileDirectory)/../ComputeRegistrarConstant.targets" />
 	<Import Project="$(MSBuildThisFileDirectory)/../nunit.framework.targets" Condition="'$(ExcludeNUnitLiteReference)' != 'true'" />
-
-	<Import Project="$(GeneratedProjectFile)" Condition="'$(GeneratedProjectFile)' != ''" />
 </Project>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -441,7 +441,10 @@ namespace Xamarin.Tests {
 			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
 			Clean (project_path);
 			var properties = GetDefaultProperties (runtimeIdentifiers);
-			properties ["RuntimeIdentifier"] = "maccatalyst-x64";
+			// Be specific that we want "RuntimeIdentifier" specified on the command line, and "RuntimeIdentifiers" in a file
+			properties ["file:RuntimeIdentifiers"] = properties ["RuntimeIdentifiers"];
+			properties.Remove ("RuntimeIdentifiers");
+			properties ["cmdline:RuntimeIdentifier"] = "maccatalyst-x64";
 			var rv = DotNet.AssertBuild (project_path, properties);
 			var warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).ToArray ();
 			Assert.AreEqual (1, warnings.Length, "Warning Count");


### PR DESCRIPTION
Some time ago we added a workaround for an msbuild bug that has since been fixed (since the initial .NET 7 release). This workaround involved writing build properties to a file instead of passing them on the command line.

We no longer need the workaround, but it turnes out we still need to be able to pass build properties in a file (because we have a test that needs this behavior). We'll also soon run into a scenario where we need to be able to specify a build property on the command line (`TargetFrameworks`) - the build won't work if specified in a file.

So add support for both, and make the test that needs to specify the build property on the command line say so explicitly.