### PR TITLE
[release/8.0.1xx-rc1] [registrar] Skip registering types removed in Xcode 15.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2901,6 +2901,24 @@ namespace Registrar {
 				}
 #endif
 
+				// Xcode 15 removed NewsstandKit
+				if (Driver.XcodeVersion.Major >= 15) {
+					if (IsTypeCore (@class, "NewsstandKit")) {
+						exceptions.Add (ErrorHelper.CreateWarning (4178, $"The class '{@class.Type.FullName}' will not be registered because the NewsstandKit framework has been removed from the {App.Platform} SDK."));
+						continue;
+					}
+
+					if (@class.Type.Is ("PassKit", "PKDisbursementAuthorizationControllerDelegate")) {
+						exceptions.Add (ErrorHelper.CreateWarning (4189, $"The class '{@class.Type.FullName}' will not be registered it has been removed from the {App.Platform} SDK."));
+						continue;
+					}
+
+					if (@class.Type.Is ("PassKit", "PKDisbursementAuthorizationController")) {
+						exceptions.Add (ErrorHelper.CreateWarning (4189, $"The class '{@class.Type.FullName}' will not be registered it has been removed from the {App.Platform} SDK."));
+						continue;
+					}
+				}
+
 				if (@class.IsFakeProtocol)
 					continue;
 

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -3066,7 +3066,7 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The class &apos;{0}&apos; will not be registered because the WatchKit framework has been removed from the iOS SDK.
+        ///   Looks up a localized string similar to The class &apos;{0}&apos; will not be registered because the {1} framework has been removed from the {2} SDK.
         ///		.
         /// </summary>
         public static string MT4178 {
@@ -4047,6 +4047,15 @@ namespace Xamarin.Bundler {
         public static string MX4188 {
             get {
                 return ResourceManager.GetString("MX4188", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The class &apos;{0}&apos; will not be registered because it has been removed from the {1} SDK..
+        /// </summary>
+        public static string MX4189 {
+            get {
+                return ResourceManager.GetString("MX4189", resourceCulture);
             }
         }
         

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1912,7 +1912,7 @@
 	</data>
 
 	<data name="MT4178" xml:space="preserve">
-		<value>The class '{0}' will not be registered because the WatchKit framework has been removed from the iOS SDK.
+		<value>The class '{0}' will not be registered because the {1} framework has been removed from the {2} SDK.
 		</value>
 	</data>
 	
@@ -1941,6 +1941,10 @@
 
 	<data name="MX4188" xml:space="preserve">
 		<value>Unable to compute the block signature for the type '{0}': {1}</value>
+	</data>
+
+	<data name="MX4189" xml:space="preserve">
+		<value>The class '{0}' will not be registered because it has been removed from the {1} SDK.</value>
 	</data>
 
 	<data name="MT5101" xml:space="preserve">


### PR DESCRIPTION
Apple completely removed the NewsstandKit framework and the
PKDisbursementAuthorizationController[Delegate] types in Xode 15, so let's not
generate any corresponding code in the static registrar.

This effectively adds basic support for using Xcode 15 with .NET 7 (take 2).


Backport of #18812
