### PR TITLE
[release/8.0.1xx-rc1] [msbuild] Limit the number of concurrent AOT compilers to the number of processors. (#18793)

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompileTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompileTaskBase.cs
@@ -184,13 +184,13 @@ namespace Xamarin.MacDev.Tasks {
 			Directory.CreateDirectory (OutputDirectory);
 
 			var aotAssemblyFiles = new List<ITaskItem> ();
-			var processes = new Task<Execution> [assembliesToAOT.Count];
 
 			var environment = new Dictionary<string, string?> {
 				{ "MONO_PATH", Path.GetFullPath (InputDirectory) },
 			};
 
 			var globalAotArguments = AotArguments?.Select (v => v.ItemSpec).ToList ();
+			var listOfArguments = new List<(IList<string> Arguments, string Input)> ();
 			for (var i = 0; i < assembliesToAOT.Count; i++) {
 				var asm = assembliesToAOT [i];
 				var input = asm.GetMetadata ("Input");
@@ -224,16 +224,20 @@ namespace Xamarin.MacDev.Tasks {
 				else
 					arguments.Add (input);
 
-				processes [i] = ExecuteAsync (AOTCompilerPath, arguments, environment: environment, sdkDevPath: SdkDevPath, showErrorIfFailure: false /* we show our own error below */)
-					.ContinueWith ((v) => {
-						if (v.Result.ExitCode != 0)
-							Log.LogError (MSBStrings.E7118 /* Failed to AOT compile {0}, the AOT compiler exited with code {1} */, Path.GetFileName (input), v.Result.ExitCode);
-
-						return System.Threading.Tasks.Task.FromResult<Execution> (v.Result);
-					}).Unwrap ();
+				listOfArguments.Add (new (arguments, input));
 			}
 
-			System.Threading.Tasks.Task.WaitAll (processes);
+			Parallel.ForEach (listOfArguments, (arg) => {
+				ExecuteAsync (AOTCompilerPath, arg.Arguments, environment: environment, sdkDevPath: SdkDevPath, showErrorIfFailure: false /* we show our own error below */)
+					.ContinueWith ((v) => {
+						if (v.Result.ExitCode != 0)
+							Log.LogError (MSBStrings.E7118 /* Failed to AOT compile {0}, the AOT compiler exited with code {1} */, Path.GetFileName (arg.Input), v.Result.ExitCode);
+
+						return System.Threading.Tasks.Task.FromResult<Execution> (v.Result);
+					})
+					.Unwrap ()
+					.Wait ();
+			});
 
 			AssemblyFiles = aotAssemblyFiles.ToArray ();
 


### PR DESCRIPTION
This might fix #17825, but even if it doesn't, it's a good thing to do
to not overload machines.

Ref: https://github.com/xamarin/xamarin-macios/issues/17825