### PR TITLE
[dotnet] Always pass -lobjc to the native linker.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1205,6 +1205,9 @@
 			<_MainLinkerFlags Include="-liconv" />
 			<_MainLinkerFlags Include="-lcompression" />
 
+			<!-- In some cases ld may crash if -lobjc isn't passed -->
+			<_MainLinkerFlags Include="-lobjc" />
+
 			<_MainLinkerFlags Condition="'$(_ExportSymbolsExplicitly)' == 'true'" Include="-exported_symbols_list" />
 			<_MainLinkerFlags Condition="'$(_ExportSymbolsExplicitly)' == 'true'" Include="$(_ExportedSymbolsFile)" />
 


### PR DESCRIPTION
In some cases ld will crash otherwise:

    0  0x102a1871c  __assert_rtn + 140
    1  0x102a21688  ld::tool::SymbolTableAtom<arm64>::classicOrdinalForProxy(ld::Atom const*) (.cold.3) + 0
    2  0x10291daf8  ld::tool::SymbolTableAtom<arm64>::classicOrdinalForProxy(ld::Atom const*) + 248
    3  0x10291d15c  ld::tool::SymbolTableAtom<arm64>::addImport(ld::Atom const*, ld::tool::StringPoolAtom*) + 204
    4  0x10291c824  ld::tool::SymbolTableAtom<arm64>::encode() + 416
    5  0x102907b6c  ___ZN2ld4tool10OutputFile20buildLINKEDITContentERNS_8InternalE_block_invoke.387 + 36
    6  0x185df2874  _dispatch_call_block_and_release + 32
    7  0x185df4400  _dispatch_client_callout + 20
    8  0x185e060c8  _dispatch_root_queue_drain + 956
    9  0x185e066c0  _dispatch_worker_thread2 + 164
    10  0x185fa0038  _pthread_wqthread + 228
    A linker snapshot was created at:
    	/tmp/tesrt-2023-08-28-143541.ld-snapshot
    ld: Assertion failed: (it != _dylibToOrdinal.end()), function dylibToOrdinal, file OutputFile.cpp, line 5133.