### PR TITLE
[Localization] Create a new branch for the automated PRs

### DIFF
--- a/tools/devops/automation/build-lego.yml
+++ b/tools/devops/automation/build-lego.yml
@@ -50,11 +50,12 @@ trigger:
   branches:
     include:
     - Localization
+    - Localization-NewBranchAutomatedPR
 
 stages:
 
 - ${{ if eq(parameters.runGovernanceTests, true) }}:
-  - stage: governance_checks
+  - stage: LocalizationChanges
     displayName: 'Governance Checks'
     jobs:
     - job: governance
@@ -84,11 +85,17 @@ stages:
 
           git fetch origin
 
+          # create a new branch from the Localization branch for our PR in case the Localization branch gets overwritten
+          git checkout Localization
+          git checkout -b Localization-$(Build.BuildNumber)
+          git checkout main
+
           gh pr create `
-          --title "Bring changes from Localization branch #$(Build.BuildNumber)" `
+          # --title "Bring changes from Localization branch #$(Build.BuildNumber)" `
+          --title "[Do not merge] TJ testing Localization Pipeline Auto PR" `
           --body "The OneLoc team creates these translations to be consumed later on in the second step of the Localization process. We need to bring these into the main branch in order to continue the process." `
           --base main `
-          --head Localization `
+          --head Localization-$(Build.BuildNumber) `
           --label not-notes-worthy `
           --milestone Future `
           --draft=false

--- a/tools/devops/automation/build-lego.yml
+++ b/tools/devops/automation/build-lego.yml
@@ -91,7 +91,6 @@ stages:
           git checkout main
 
           gh pr create `
-          # --title "Bring changes from Localization branch #$(Build.BuildNumber)" `
           --title "[Do not merge] TJ testing Localization Pipeline Auto PR" `
           --body "The OneLoc team creates these translations to be consumed later on in the second step of the Localization process. We need to bring these into the main branch in order to continue the process." `
           --base main `

--- a/tools/devops/automation/build-lego.yml
+++ b/tools/devops/automation/build-lego.yml
@@ -50,7 +50,6 @@ trigger:
   branches:
     include:
     - Localization
-    - Localization-NewBranchAutomatedPR
 
 stages:
 
@@ -86,21 +85,20 @@ stages:
           git fetch origin
 
           # create a new branch from the Localization branch for our PR in case the Localization branch gets overwritten
-          # git checkout Localization
-          git checkout Localization-NewBranchAutomatedPR
-          git checkout -b Localization-$(Build.BuildNumber)
-          git push origin Localization-$(Build.BuildNumber)
-          
+          git checkout Localization
+          git checkout -b Localization-Automated-$(Build.BuildNumber)
+          git push origin Localization-Automated-$(Build.BuildNumber)
+
           git checkout main
 
           gh pr create `
-          --title "[Do not merge] TJ testing Localization Pipeline Auto PR" `
+          --title "Bring changes from Localization branch #$(Build.BuildNumber)" `
           --body "The OneLoc team creates these translations to be consumed later on in the second step of the Localization process. We need to bring these into the main branch in order to continue the process." `
           --base main `
-          --head Localization-$(Build.BuildNumber) `
+          --head Localization-Automated-$(Build.BuildNumber) `
           --label not-notes-worthy `
           --milestone Future `
-          --draft=true
+          --draft=false
 
         name: BringLocChanges
         displayName: "BringLocChanges"

--- a/tools/devops/automation/build-lego.yml
+++ b/tools/devops/automation/build-lego.yml
@@ -87,6 +87,7 @@ stages:
 
           # create a new branch from the Localization branch for our PR in case the Localization branch gets overwritten
           # git checkout Localization
+          git checkout Localization-NewBranchAutomatedPR
           git checkout -b Localization-$(Build.BuildNumber)
           git checkout main
 

--- a/tools/devops/automation/build-lego.yml
+++ b/tools/devops/automation/build-lego.yml
@@ -89,6 +89,8 @@ stages:
           # git checkout Localization
           git checkout Localization-NewBranchAutomatedPR
           git checkout -b Localization-$(Build.BuildNumber)
+          git push origin Localization-$(Build.BuildNumber)
+          
           git checkout main
 
           gh pr create `
@@ -98,7 +100,7 @@ stages:
           --head Localization-$(Build.BuildNumber) `
           --label not-notes-worthy `
           --milestone Future `
-          --draft=false
+          --draft=true
 
         name: BringLocChanges
         displayName: "BringLocChanges"

--- a/tools/devops/automation/build-lego.yml
+++ b/tools/devops/automation/build-lego.yml
@@ -86,7 +86,7 @@ stages:
           git fetch origin
 
           # create a new branch from the Localization branch for our PR in case the Localization branch gets overwritten
-          git checkout Localization
+          # git checkout Localization
           git checkout -b Localization-$(Build.BuildNumber)
           git checkout main
 


### PR DESCRIPTION
In my Localization inspection, I wanted to figure out why the automated PRs I was creating in Pipelines were auto-closing themselves a few hours after creating them - [example](https://github.com/xamarin/xamarin-macios/pull/18713).

There are a few different steps in the localization process and long story short is that I am creating these PRs from the Localization branch. Each commit into main runs a tool that alerts the Loc team and it syncs up our Localization branch to our main branch which temporarily deletes our Localization branch thus closing the automated PR!

This PR creates a new unique branch for each Localization PR so that we can keep updating the Loc team, but also make sure syncing the Localization branch will not delete this PR.

Testing this created this PR below:
https://github.com/xamarin/xamarin-macios/pull/18880