### PR TITLE
[NativeAOT] Fix ILC warning for NSObject.RegisterToggleRef

### DIFF
--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -370,6 +370,12 @@ namespace Xamarin.Linker {
 				return GetMethodReference (PlatformAssembly, Foundation_NSObject, "set_flags", "Foundation.NSObject::set_flags", predicate: null, out var _);
 			}
 		}
+
+		public MethodReference Foundation_NSObject_RegisterToggleRef {
+			get {
+				return GetMethodReference (PlatformAssembly, Foundation_NSObject, "RegisterToggleRef", "Foundation.NSObject::RegisterToggleRef", predicate: null, out var _);
+			}
+		}
 #else
 		public FieldReference Foundation_NSObject_FlagsField {
 			get {

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -1221,7 +1221,8 @@ namespace Xamarin.Linker {
 		}
 
 #if NET
-		public bool TryGet_NSObject_RegisterToggleRef(out MethodDefinition? md) {
+		public bool TryGet_NSObject_RegisterToggleRef (out MethodDefinition? md)
+		{
 			// the NSObject.RegisterToggleRef method isn't present on all platforms (for example on Mac)
 			try {
 				_ = GetMethodReference (PlatformAssembly, Foundation_NSObject, "RegisterToggleRef", "Foundation.NSObject::RegisterToggleRef", predicate: null, out md);

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -370,12 +370,6 @@ namespace Xamarin.Linker {
 				return GetMethodReference (PlatformAssembly, Foundation_NSObject, "set_flags", "Foundation.NSObject::set_flags", predicate: null, out var _);
 			}
 		}
-
-		public MethodReference Foundation_NSObject_RegisterToggleRef {
-			get {
-				return GetMethodReference (PlatformAssembly, Foundation_NSObject, "RegisterToggleRef", "Foundation.NSObject::RegisterToggleRef", predicate: null, out var _);
-			}
-		}
 #else
 		public FieldReference Foundation_NSObject_FlagsField {
 			get {
@@ -1225,6 +1219,19 @@ namespace Xamarin.Linker {
 						&& v.HasGenericParameters);
 			}
 		}
+
+#if NET
+		public bool TryGet_NSObject_RegisterToggleRef(out MethodDefinition? md) {
+			// the NSObject.RegisterToggleRef method isn't present on all platforms (for example on Mac)
+			try {
+				_ = GetMethodReference (PlatformAssembly, Foundation_NSObject, "RegisterToggleRef", "Foundation.NSObject::RegisterToggleRef", predicate: null, out md);
+				return true;
+			} catch (InvalidOperationException) {
+				md = null;
+				return false;
+			}
+		}
+#endif
 
 		public void SetCurrentAssembly (AssemblyDefinition value)
 		{

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -166,7 +166,10 @@ namespace Xamarin.Linker {
 				var md = abr.RegistrarHelper_RuntimeTypeHandleEquals.Resolve ();
 				md.IsPublic = true;
 				Annotations.Mark (md);
-			} else if (App.XamarinRuntime == XamarinRuntime.NativeAOT && Configuration.Profile.IsProductAssembly (assembly)) {
+			}
+
+			// TODO: Move this to a separate "MakeEverythingWorkWithNativeAOTStep" linker step
+			if (App.XamarinRuntime == XamarinRuntime.NativeAOT && Configuration.Profile.IsProductAssembly (assembly)) {
 				ImplementNSObjectRegisterToggleRefMethodStub ();
 			}
 

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -1391,7 +1391,7 @@ namespace Xamarin.Linker {
 			registerToggleRef.IsPublic = false;
 			registerToggleRef.IsInternalCall = false;
 
-			registerToggleRef.CreateBody(out var il);
+			registerToggleRef.CreateBody (out var il);
 			il.Emit (OpCodes.Ret);
 		}
 	}

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -1381,18 +1381,20 @@ namespace Xamarin.Linker {
 
 		void ImplementNSObjectRegisterToggleRefMethodStub ()
 		{
-			// The NSObject.RegisterToggleRef method is a Mono icall that is unused in NativeAOT
-			// and we need to modify it so that ILC doesn't report the following warning:
+			// The NSObject.RegisterToggleRef method is a Mono icall that is unused in NativeAOT.
+			// The method isn't included on all platforms but when it is present, we need to modify it
+			// so that ILC can trim it and it doesn't report the following warning:
 			// 
 			//    ILC: Method '[Microsoft.iOS]Foundation.NSObject.RegisterToggleRef(NSObject,native int,bool)' will always throw because:
 			//         Invalid IL or CLR metadata in 'Void Foundation.NSObject.RegisterToggleRef(Foundation.NSObject, IntPtr, Boolean)'
 			//
-			var registerToggleRef = abr.Foundation_NSObject_RegisterToggleRef.Resolve ();
-			registerToggleRef.IsPublic = false;
-			registerToggleRef.IsInternalCall = false;
+			if (abr.TryGet_NSObject_RegisterToggleRef(out var registerToggleRef)) {
+				registerToggleRef!.IsPublic = false;
+				registerToggleRef!.IsInternalCall = false;
 
-			registerToggleRef.CreateBody (out var il);
-			il.Emit (OpCodes.Ret);
+				registerToggleRef!.CreateBody(out var il);
+				il.Emit (OpCodes.Ret);
+			}
 		}
 	}
 }

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -1391,11 +1391,11 @@ namespace Xamarin.Linker {
 			//    ILC: Method '[Microsoft.iOS]Foundation.NSObject.RegisterToggleRef(NSObject,native int,bool)' will always throw because:
 			//         Invalid IL or CLR metadata in 'Void Foundation.NSObject.RegisterToggleRef(Foundation.NSObject, IntPtr, Boolean)'
 			//
-			if (abr.TryGet_NSObject_RegisterToggleRef(out var registerToggleRef)) {
+			if (abr.TryGet_NSObject_RegisterToggleRef (out var registerToggleRef)) {
 				registerToggleRef!.IsPublic = false;
 				registerToggleRef!.IsInternalCall = false;
 
-				registerToggleRef!.CreateBody(out var il);
+				registerToggleRef!.CreateBody (out var il);
 				il.Emit (OpCodes.Ret);
 			}
 		}


### PR DESCRIPTION
This PR implements a workaround for the following build warning:
```
ILC: Method '[Microsoft.iOS]Foundation.NSObject.RegisterToggleRef(NSObject,native int,bool)' will always throw because:
Invalid IL or CLR metadata in 'Void Foundation.NSObject.RegisterToggleRef(Foundation.NSObject, IntPtr, Boolean)'
```

Ref #18524