### PR TITLE
[dotnet] Pass path to native swift libraries when linking NativeAOT apps for macOS.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1291,6 +1291,7 @@
 			<_CustomLinkFlags Include="@(NativeSystemLibrary->'-l%(Identity)')" />
 			<_CustomLinkFlags Include="@(NativeFramework->'-Wl,-framework,%(Identity)')" />
 			<_CustomLinkFlags Include="@(ExtraLinkerArg->'-Wl,%(Identity)')" />
+			<_CustomLinkFlags Include="-L/usr/lib/swift" Condition="'$(_PlatformName)' == 'macOS'" />
 		</ItemGroup>
 
 		<ItemGroup>


### PR DESCRIPTION
Fixes this linker failure when compiling monotouch-test:

    clang: error: linker command failed with exit code 1 (use -v to see invocation)
        Errors
            xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.2.23428.11/packs/Microsoft.macOS.Sdk/13.3.8852-net8-rc2/targets/Xamarin.Shared.Sdk.targets(1527,3): clang++ exited with code 1:
    ld: library not found for -lswiftCore
    clang: error: linker command failed with exit code 1 (use -v to see invocation) [/Users/rolf/work/maccore/net8.0/xamarin-macios/tests/dotnet/MySimpleApp/macOS/MySimpleApp.csproj]