### PR TITLE
[xharness] Use .NET to build the MSBuild test projects.

### DIFF
--- a/msbuild/ILMerge.targets
+++ b/msbuild/ILMerge.targets
@@ -81,6 +81,9 @@
       <ILRepackArgs>$(ILRepackArgs) @(MergedAssemblies -&gt; '"%(FullPath)"', ' ')</ILRepackArgs>
       <ILRepackArgs>$(ILRepackArgs) "/lib:$(NetstandardDirectory)"</ILRepackArgs> <!-- This is needed for ilrepack to find netstandard.dll, which is referenced by the System.Text.Json assembly -->
     </PropertyGroup>
+    <PropertyGroup>
+      <SYSTEM_MONO Condition="'$(SYSTEM_MONO)' == ''">/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono</SYSTEM_MONO>
+    </PropertyGroup>
     <Exec Command="$(SYSTEM_MONO) &quot;$(ILRepack)&quot; $(ILRepackArgs)" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
 
   <Target Name="BuildTasksAssembly" AfterTargets="BeforeBuild">
+    <MSBuild Projects="..\..\..\msbuild\Xamarin.iOS.Tasks\Xamarin.iOS.Tasks.csproj" Targets="Restore" Properties="SomeGlobalPropertyToMakeThisUnique=RestoreMe" />
     <MSBuild Projects="..\..\..\msbuild\Xamarin.iOS.Tasks\Xamarin.iOS.Tasks.csproj" />
   </Target>
 

--- a/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
+++ b/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
@@ -20,7 +20,7 @@ namespace Xharness.Jenkins {
 		public IEnumerator<RunTestTask> GetEnumerator ()
 		{
 			var netstandard2Project = new TestProject (TestLabel.Msbuild, Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "msbuild", "Xamarin.MacDev.Tasks.Tests", "Xamarin.MacDev.Tasks.Tests.csproj"))) {
-				IsDotNetProject = false,
+				IsDotNetProject = true,
 			};
 			var env = new Dictionary<string, string>
 			{
@@ -33,7 +33,6 @@ namespace Xharness.Jenkins {
 				Platform = TestPlatform.iOS,
 				SolutionPath = Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "..", "msbuild", "Xamarin.MacDev.Tasks.sln")),
 				SupportsParallelExecution = false,
-				RestoreNugets = true,
 				Environment = env,
 			};
 			var nunitExecutioniOSMSBuild = new NUnitExecuteTask (jenkins, buildiOSMSBuild, processManager) {
@@ -50,7 +49,7 @@ namespace Xharness.Jenkins {
 			yield return nunitExecutioniOSMSBuild;
 
 			var msbuildIntegrationTestsProject = new TestProject (TestLabel.Msbuild, Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "msbuild", "Xamarin.MacDev.Tests", "Xamarin.MacDev.Tests.csproj"))) {
-				IsDotNetProject = false,
+				IsDotNetProject = true,
 			};
 			var buildiOSMSBuildIntegration = new MSBuildTask (jenkins: jenkins, testProject: msbuildIntegrationTestsProject, processManager: processManager) {
 				SpecifyPlatform = false,
@@ -59,7 +58,6 @@ namespace Xharness.Jenkins {
 				Platform = TestPlatform.iOS,
 				SolutionPath = Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "..", "msbuild", "Xamarin.MacDev.Tasks.sln")),
 				SupportsParallelExecution = false,
-				RestoreNugets = true,
 				Environment = env,
 			};
 			var nunitExecutioniOSMSBuildIntegration = new NUnitExecuteTask (jenkins, buildiOSMSBuildIntegration, processManager) {


### PR DESCRIPTION
This is one more step towards dropping Mono, and also solves a random network
failure when doing 'nuget restore' with Mono (due to a bug in Mono).