### PR TITLE
[devops] Set the BRANCH_NAME variable before configuring the build.

### DIFF
--- a/tools/devops/automation/scripts/bash/configure-platforms.sh
+++ b/tools/devops/automation/scripts/bash/configure-platforms.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -eux
 
+env | sort
+
 set -o pipefail
 IFS=$'\n\t '
 

--- a/tools/devops/automation/scripts/run-generator-tests-on-windows.ps1
+++ b/tools/devops/automation/scripts/run-generator-tests-on-windows.ps1
@@ -10,11 +10,10 @@ $Env:TESTS_USE_SYSTEM = "1"
 $configurationDotNetPlatforms = $Env:CONFIGURATION_DOTNET_PLATFORMS
 $dotnetPlatforms = $configurationDotNetPlatforms.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
 foreach ($platform in $dotnetPlatforms) {
-  $manifestPath = "$Env:BUILD_SOURCESDIRECTORY\artifacts\AssetManifests\$($platform)\AssetManifest.xml"
-  $productVersion = Select-Xml -Path "$manifestPath" -XPath "/Build/Package[@Id='Microsoft.$($platform).Sdk']/@Version" | ForEach-Object { $_.Node.Value }
   $variableName = "$($platform.ToUpper())_NUGET_VERSION_NO_METADATA"
-  [Environment]::SetEnvironmentVariable($variableName, $productVersion)
-  Write-Host "$variableName = $productVersion"
+  $variableValue = [Environment]::GetEnvironmentVariable("CONFIGURATION_" + $variableName)
+  [Environment]::SetEnvironmentVariable($variableName, $variableValue)
+  Write-Host "$variableName = $variableName"
 
   $variableName = "$($platform.ToUpper())_NUGET_SDK_NAME"
   $variableValue = [Environment]::GetEnvironmentVariable("CONFIGURATION_" + $variableName)

--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -43,6 +43,7 @@ jobs:
   variables:
     isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
     isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+    BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
   steps:
   - template: ../common/configure.yml

--- a/tools/devops/automation/templates/build/build-mac-tests-stage.yml
+++ b/tools/devops/automation/templates/build/build-mac-tests-stage.yml
@@ -43,6 +43,7 @@ jobs:
   variables:
     isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
     isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+    BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
   steps:
   - template: ../common/configure.yml

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -55,6 +55,7 @@ jobs:
   variables:
     isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
     isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+    BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
   steps:
   - template: ../common/configure.yml

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -22,7 +22,7 @@ parameters:
 steps:
 - template: checkout.yml
   parameters:
-    isPR: false # always use the latests set of scripts merged with main
+    isPR: true
     repositoryAlias: ${{ parameters.repositoryAlias }}
     commit: ${{ parameters.commit }}
 

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -53,6 +53,7 @@ stages:
     variables:
       isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
       isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+      BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
     steps:
     - template: ../common/configure.yml

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -50,6 +50,7 @@ stages:
     variables:
       isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
       isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+      BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
     steps:
     - template: ../common/configure.yml

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -33,6 +33,7 @@ jobs:
   variables:
     isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
     isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+    BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
   steps:
   - template: ../common/configure.yml

--- a/tools/devops/automation/templates/sign-and-notarized/prepare-pkg-stage.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/prepare-pkg-stage.yml
@@ -35,6 +35,7 @@ jobs:
   variables:
     isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
     isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+    BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
   steps:
   - template: ../common/configure.yml

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -104,6 +104,7 @@ stages:
       variables:
         isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
         isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+        BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
       steps:
       - template: ../common/configure.yml

--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -48,6 +48,7 @@ stages:
     variables:
       isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
       isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+      BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
     steps:
     - template: ../common/configure.yml


### PR DESCRIPTION
This way we compute the correct version numbers in configure-platforms.sh.

Also tell the configure job that we're a PR, so that we undo the merge and don't use the wrong hash for the version calculations.