### PR TITLE
[NativeAOT] Preserve all constructors instead of no members

### DIFF
--- a/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
+++ b/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
@@ -259,7 +259,10 @@ namespace Mono.Tuner {
 			abr.SetCurrentAssembly (type.Module.Assembly);
 
 			var moduleConstructor = GetOrCreateModuleConstructor (type.GetModule ());
-			var attrib = abr.CreateDynamicDependencyAttribute (allMembers ? DynamicallyAccessedMemberTypes.All : DynamicallyAccessedMemberTypes.None, type);
+			var members = allMembers
+				? DynamicallyAccessedMemberTypes.All
+				: DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+			var attrib = abr.CreateDynamicDependencyAttribute (members, type);
 			moduleConstructor.CustomAttributes.Add (attrib);
 
 			abr.ClearCurrentAssembly ();


### PR DESCRIPTION
`None` seems to be equivalent to not having the attribute at all. The type will be stripped by ILLink and ILC. The `PublicConstructors | NonPublicConstructors` seems to be a better option to keep the type while making it possible to trim as much of its members as possible.

This change resolves two warnings:
```
ILLink : warning IL2037: <Module>..cctor(): No members were resolved for 'None' on type 'Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameView'.
ILC : warning IL2037: <Module>..cctor(): No members were resolved for '0' on type 'Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameView'. 
```
(Note: these warnings will still be present for _static_ classes which don't have a static constructor)

@rolfbjarne I believe we don't need https://github.com/dotnet/runtime/pull/90154 anymore
