### PR TITLE
[NativeAOT] Don't publish any *.o files that comes from NativeAOT.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1728,7 +1728,7 @@
 			/>
 
 			<!-- There's no need to ship any *.o files shipped by NativeAOT -->
-			<!-- We need to remove these from ResolvedFileToPublish before calling ComputeBundleLocation, because otherwise we get warnings about no knowing what to do with these files -->
+			<!-- We need to remove these from ResolvedFileToPublish before calling ComputeBundleLocation, because otherwise we get warnings about not knowing what to do with these files -->
 			<ResolvedFileToPublish
 				Remove="@(ResolvedFileToPublish)"
 				Condition=" '%(ResolvedFileToPublish.AssetType)' == 'native' And

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1727,6 +1727,18 @@
 				            "
 			/>
 
+			<!-- There's no need to ship any *.o files shipped by NativeAOT -->
+			<!-- We need to remove these from ResolvedFileToPublish before calling ComputeBundleLocation, because otherwise we get warnings about no knowing what to do with these files -->
+			<ResolvedFileToPublish
+				Remove="@(ResolvedFileToPublish)"
+				Condition=" '%(ResolvedFileToPublish.AssetType)' == 'native' And
+				            '%(ResolvedFileToPublish.RuntimeIdentifier)' == '$(RuntimeIdentifier)' And
+				            '%(ResolvedFileToPublish.Extension)' == '.o' And
+				            '%(ResolvedFileToPublish.NuGetPackageId)' == '$(_MonoNugetPackageId)' And
+				            '$(_UseNativeAot)' == 'true'
+				            "
+			/>
+
 			<!-- Put the 'createdump' executable in the expected location in the app bundle when using CoreCLR -->
 			<!-- Ref: https://github.com/xamarin/xamarin-macios/issues/11432 -->
 			<_CreateDumpExecutable


### PR DESCRIPTION
If anything we're supposed to link with *.o files, not publish them, but since
we're currently not handling any *.o files, just explicitly remove them from
the build. This avoids a warning where ComputeBundleLocation would issue a
warning about not knowing what to do with them.

Contributes towards https://github.com/xamarin/xamarin-macios/issues/18629.