### PR TITLE
[src] Make Runtime.GetDelegateForBlock a generic method to pass the delegate type.

### DIFF
--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -373,7 +373,7 @@ namespace ObjCRuntime {
 		public T GetDelegateForBlock<T> () where T : class
 #endif
 		{
-			return (T) (object) Runtime.GetDelegateForBlock (invoke, typeof (T));
+			return Runtime.GetDelegateForBlock<T> (invoke);
 		}
 
 #if NET

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1065,7 +1065,7 @@ namespace ObjCRuntime {
 			return del;
 		}
 
-		internal static T GetDelegateForBlock<T> (IntPtr methodPtr) where T: System.MulticastDelegate
+		internal static T GetDelegateForBlock<T> (IntPtr methodPtr) where T : System.MulticastDelegate
 		{
 			// We do not care if there is a race condition and we initialize two caches
 			// since the worst that can happen is that we end up with an extra

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1065,7 +1065,11 @@ namespace ObjCRuntime {
 			return del;
 		}
 
+#if NET
 		internal static T GetDelegateForBlock<T> (IntPtr methodPtr) where T : System.MulticastDelegate
+#else
+		internal static T GetDelegateForBlock<T> (IntPtr methodPtr) where T : class
+#endif
 		{
 			// We do not care if there is a race condition and we initialize two caches
 			// since the worst that can happen is that we end up with an extra
@@ -1076,13 +1080,21 @@ namespace ObjCRuntime {
 					block_to_delegate_cache = new Dictionary<IntPtrTypeValueTuple, Delegate> ();
 
 				if (block_to_delegate_cache.TryGetValue (pair, out var cachedValue))
+#if NET
 					return (T) cachedValue;
+#else
+					return (T) (object) cachedValue;
+#endif
 			}
 
 			var val = Marshal.GetDelegateForFunctionPointer<T> (methodPtr);
 
 			lock (lock_obj) {
+#if NET
 				block_to_delegate_cache [pair] = val;
+#else
+				block_to_delegate_cache [pair] = (Delegate) (object) val;
+#endif
 			}
 			return val;
 		}

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1065,22 +1065,21 @@ namespace ObjCRuntime {
 			return del;
 		}
 
-		internal static Delegate? GetDelegateForBlock (IntPtr methodPtr, Type type)
+		internal static T GetDelegateForBlock<T> (IntPtr methodPtr) where T: System.MulticastDelegate
 		{
 			// We do not care if there is a race condition and we initialize two caches
 			// since the worst that can happen is that we end up with an extra
 			// delegate->function pointer.
-			Delegate? val;
-			var pair = new IntPtrTypeValueTuple (methodPtr, type);
+			var pair = new IntPtrTypeValueTuple (methodPtr, typeof (T));
 			lock (lock_obj) {
 				if (block_to_delegate_cache is null)
 					block_to_delegate_cache = new Dictionary<IntPtrTypeValueTuple, Delegate> ();
 
-				if (block_to_delegate_cache.TryGetValue (pair, out val))
-					return val;
+				if (block_to_delegate_cache.TryGetValue (pair, out var cachedValue))
+					return (T) cachedValue;
 			}
 
-			val = Marshal.GetDelegateForFunctionPointer (methodPtr, type);
+			var val = Marshal.GetDelegateForFunctionPointer<T> (methodPtr);
 
 			lock (lock_obj) {
 				block_to_delegate_cache [pair] = val;


### PR DESCRIPTION
This makes it possible to call the generic
Marshal.GetDelegateForFunctionPointer<T> method instead of the non-generic
Marshal.GetDelegateForFunctionPointer method, which is easier for AOT
compilers to handle (no reflection for
Marshal.GetDelegateForFunctionPointer<T>).

Contributes towards https://github.com/xamarin/xamarin-macios/issues/18629.