### PR TITLE
[tests] Move the ARConfigurationTest.Subclasses test from monotouch-test to cecil-test.

### DIFF
--- a/tests/cecil-tests/ApiTest.cs
+++ b/tests/cecil-tests/ApiTest.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+using NUnit.Framework;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using Xamarin.Tests;
+using Xamarin.Utils;
+
+#nullable enable
+
+namespace Cecil.Tests {
+
+	[TestFixture]
+	public class ApiTest {
+		[TestCaseSource (typeof (Helper), nameof (Helper.PlatformAssemblyDefinitions))]
+		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformAssemblyDefinitions))]
+		public void ARConfiguration_GetSupportedVideoFormats (AssemblyInfo info)
+		{
+			// all subclasses of ARConfiguration must (re)export 'GetSupportedVideoFormats'
+			var assembly = info.Assembly;
+			List<string>? failures = null;
+
+			if (!assembly.EnumerateTypes ((type) => type.Is ("ARKit", "ARConfiguration")).Any ())
+				Assert.Ignore ("This assembly doesn't contain ARKit.ARConfiguration");
+
+			var subclasses = assembly.EnumerateTypes ((type) => !type.Is ("ARKit", "ARConfiguration") && type.IsSubclassOf ("ARKit", "ARConfiguration"));
+			Assert.That (subclasses, Is.Not.Empty, "At least some subclasses");
+
+			foreach (var type in subclasses) {
+				var method = type.Methods.SingleOrDefault (m => m.Name == "GetSupportedVideoFormats" && m.IsPublic && m.IsStatic && !m.HasParameters);
+				if (method is null)
+					AddFailure (ref failures, $"The type {type.FullName} does not implement the method GetSupportedVideoFormats.");
+			}
+
+			Assert.That (failures, Is.Null.Or.Empty, "All subclasses from ARConfiguration must explicitly implement GetSupportedVideoFormats.");
+		}
+
+		static void AddFailure (ref List<string>? failures, string failure)
+		{
+			if (failures is null)
+				failures = new List<string> ();
+
+			failures.Add (failure);
+			Console.WriteLine (failure);
+		}
+	}
+}

--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -477,6 +477,17 @@ namespace Cecil.Tests {
 
 			return rv;
 		}
+
+		public static bool IsSubclassOf (this TypeDefinition? type, string @namespace, string name)
+		{
+			if (type is null)
+				return false;
+
+			if (type.Is (@namespace, name))
+				return true;
+
+			return IsSubclassOf (type.BaseType?.Resolve (), @namespace, name);
+		}
 	}
 
 	public static class CompatExtensions {

--- a/tests/monotouch-test/ARKit/ARConfigurationTest.cs
+++ b/tests/monotouch-test/ARKit/ARConfigurationTest.cs
@@ -46,20 +46,6 @@ namespace MonoTouchFixtures.ARKit {
 			Assert.NotNull (ARImageTrackingConfiguration.GetSupportedVideoFormats (), "ARImageTrackingConfiguration");
 			Assert.NotNull (ARObjectScanningConfiguration.GetSupportedVideoFormats (), "ARObjectScanningConfiguration");
 		}
-
-		[Test]
-		public void Subclasses ()
-		{
-			// note: this can be run on any xcode / OS version since it's reflection only
-			// all subclasses of ARConfiguration must (re)export 'GetSupportedVideoFormats'
-			var c = typeof (ARConfiguration);
-			foreach (var sc in c.Assembly.GetTypes ()) {
-				if (!sc.IsSubclassOf (c))
-					continue;
-				var m = sc.GetMethod ("GetSupportedVideoFormats", BindingFlags.Static | BindingFlags.Public);
-				Assert.NotNull (m, sc.FullName);
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
This test uses reflection to figure out if there are any ARConfiguration
subclasses that don't implement a particular method. The reflection usage is
problematic when trimming apps, and this is really what the Cecil tests are
for, so just re-implement the entire tests as a Cecil test.