### PR TITLE
[net8.0-xcode15] [runtime] Bump the min OS version in the Info.plist in Xamarin.framework.

### DIFF
--- a/builds/Mono.framework-Info.plist
+++ b/builds/Mono.framework-Info.plist
@@ -48,7 +48,7 @@
         <key>DTXcodeBuild</key>
         <string>6C131e</string>
         <key>MinimumOSVersion</key>
-        <string>8.0</string>
+        <string>11.0</string>
         <key>UIDeviceFamily</key>
         <array>
                 <integer>1</integer>

--- a/builds/Mono.framework-tvos.Info.plist
+++ b/builds/Mono.framework-tvos.Info.plist
@@ -47,7 +47,7 @@
         <key>DTXcodeBuild</key>
         <string>6C131e</string>
         <key>MinimumOSVersion</key>
-        <string>9.0</string>
+        <string>11.0</string>
         <key>UIDeviceFamily</key>
         <array>
                 <integer>3</integer>

--- a/builds/Mono.framework-watchos.Info.plist
+++ b/builds/Mono.framework-watchos.Info.plist
@@ -47,7 +47,7 @@
         <key>DTXcodeBuild</key>
         <string>6C131e</string>
         <key>MinimumOSVersion</key>
-        <string>2.0</string>
+        <string>4.0</string>
         <key>UIDeviceFamily</key>
         <array>
                 <integer>4</integer>

--- a/runtime/Xamarin.framework-iphoneos.Info.plist
+++ b/runtime/Xamarin.framework-iphoneos.Info.plist
@@ -47,7 +47,7 @@
         <key>DTXcodeBuild</key>
         <string>6C131e</string>
         <key>MinimumOSVersion</key>
-        <string>8.0</string>
+        <string>11.0</string>
         <key>UIDeviceFamily</key>
         <array>
                 <integer>1</integer>

--- a/runtime/Xamarin.framework-iphonesimulator.Info.plist
+++ b/runtime/Xamarin.framework-iphonesimulator.Info.plist
@@ -47,7 +47,7 @@
         <key>DTXcodeBuild</key>
         <string>6C131e</string>
         <key>MinimumOSVersion</key>
-        <string>8.0</string>
+        <string>11.0</string>
         <key>UIDeviceFamily</key>
         <array>
                 <integer>1</integer>

--- a/runtime/Xamarin.framework-tvos.Info.plist
+++ b/runtime/Xamarin.framework-tvos.Info.plist
@@ -47,7 +47,7 @@
         <key>DTXcodeBuild</key>
         <string>6C131e</string>
         <key>MinimumOSVersion</key>
-        <string>9.0</string>
+        <string>11.0</string>
         <key>UIDeviceFamily</key>
         <array>
                 <integer>3</integer>

--- a/runtime/Xamarin.framework-tvsimulator.Info.plist
+++ b/runtime/Xamarin.framework-tvsimulator.Info.plist
@@ -47,7 +47,7 @@
         <key>DTXcodeBuild</key>
         <string>6C131e</string>
         <key>MinimumOSVersion</key>
-        <string>9.0</string>
+        <string>11.0</string>
         <key>UIDeviceFamily</key>
         <array>
                 <integer>3</integer>

--- a/runtime/Xamarin.framework-watchos.Info.plist
+++ b/runtime/Xamarin.framework-watchos.Info.plist
@@ -47,7 +47,7 @@
         <key>DTXcodeBuild</key>
         <string>6C131e</string>
         <key>MinimumOSVersion</key>
-        <string>2.0</string>
+        <string>4.0</string>
         <key>UIDeviceFamily</key>
         <array>
                 <integer>4</integer>

--- a/runtime/Xamarin.framework-watchsimulator.Info.plist
+++ b/runtime/Xamarin.framework-watchsimulator.Info.plist
@@ -47,7 +47,7 @@
         <key>DTXcodeBuild</key>
         <string>6C131e</string>
         <key>MinimumOSVersion</key>
-        <string>2.0</string>
+        <string>4.0</string>
         <key>UIDeviceFamily</key>
         <array>
                 <integer>4</integer>


### PR DESCRIPTION
Bump the min OS version to match our actual min OS version.