### PR TITLE
[AppKit] Add missing NSView.ClipsToBounds. Fixes #18916.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -16142,6 +16142,9 @@ namespace AppKit {
 		[Export ("setNeedsDisplayInRect:")]
 		void SetNeedsDisplayInRect (CGRect invalidRect);
 
+		[Export ("clipsToBounds")]
+		bool ClipsToBounds { get; set; }
+
 		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Subclass NSView and implement 'DrawRect'.")]
 		[Export ("lockFocus")]
 		void LockFocus ();


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/18916.