### PR TITLE
[xcode14.3] [tools] Skip more types and namespaces when using Xcode 15.

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -769,6 +769,11 @@ public class Frameworks : Dictionary<string, Framework> {
 
 	static bool FilterFrameworks (Application app, Framework framework)
 	{
+		if (framework.Name == "NewsstandKit" && Driver.XcodeVersion.Major >= 15) {
+			Driver.Log (3, "Not linking with the framework {0} because it's not available when using Xcode 15+.", framework.Name);
+			return false;
+		}
+
 		switch (app.Platform) {
 #if !NET
 		// CHIP has been removed in Xcode 14 Beta 5 in favor of Matter

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2865,7 +2865,7 @@ namespace Registrar {
 						continue;
 					}
 
-					if (@class.Type.Is ("PassKit", "PKDisbursementAuthorizationControllerDelegate")) {
+					if (@class.Type.Is ("PassKit", "PKDisbursementAuthorizationControllerDelegate") || @class.Type.Is ("PassKit", "IPKDisbursementAuthorizationControllerDelegate")) {
 						exceptions.Add (ErrorHelper.CreateWarning (4189, $"The class '{@class.Type.FullName}' will not be registered it has been removed from the {App.Platform} SDK."));
 						continue;
 					}

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -271,6 +271,12 @@ namespace Xamarin.Bundler {
 								continue;
 							}
 							break;
+						case "NewsstandKit":
+							if (Driver.XcodeVersion.Major >= 15) {
+								Driver.Log (3, "Not linking with the framework {0} because it's not available when using Xcode 15+.", framework.Name);
+								continue;
+							}
+							break;
 						default:
 							if (App.IsSimulatorBuild && !App.IsFrameworkAvailableInSimulator (framework.Name)) {
 								if (App.AreAnyAssembliesTrimmed) {


### PR DESCRIPTION
Makes the iTravel submission test compile successfully.