### PR TITLE
[net8.0] Revert "[tests] Find a workaround for #xamarin/maccore@2668."

### DIFF
--- a/tests/common/AppDelegate.cs
+++ b/tests/common/AppDelegate.cs
@@ -2,10 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
 
-using ObjCRuntime;
 using Foundation;
 #if !__MACOS__
 using UIKit;
@@ -51,31 +48,9 @@ public partial class AppDelegate : UIApplicationDelegate {
 public static class MainClass {
 	static void Main (string [] args)
 	{
-#if __MACCATALYST__
-		NativeLibrary.SetDllImportResolver (typeof (NSObject).Assembly, DllImportResolver);
-		NativeLibrary.SetDllImportResolver (typeof (MainClass).Assembly, DllImportResolver);
-#endif
 #if !__MACOS__
 		UIApplication.Main (args, null, typeof (AppDelegate));
 #endif
 	}
-
-#if __MACCATALYST__
-	// This is a workaround for a temporary issue in the .NET runtime
-	// See https://github.com/xamarin/maccore/issues/2668
-	// The issue is present in .NET 7.0.5, and will likely be fixed in .NET 7.0.6.
-	static IntPtr DllImportResolver (string libraryName, global::System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
-	{
-		switch (libraryName) {
-		case "/System/Library/Frameworks/SceneKit.framework/SceneKit":
-		case "/System/Library/Frameworks/SceneKit.framework/Versions/A/SceneKit":
-			var rv = NativeLibrary.Load (libraryName);
-			Console.WriteLine ($"DllImportResolver callback loaded library \"{libraryName}\" from a P/Invoke in \"{assembly}\" => 0x{rv.ToString ("x")}");
-			return rv;
-		default:
-			return IntPtr.Zero;
-		}
-	}
-#endif
 }
 #endif // !__WATCHOS__


### PR DESCRIPTION
This reverts commit bc272a944601d469f3944f7cf70f538723881e69.

This workaround is no longer necessary.

Fixes https://github.com/xamarin/xamarin-macios/issues/18164.