### PR TITLE
[net8.0] Revert "[tests] Ignore tests that publish universal apps."

### DIFF
--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -116,9 +116,9 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS, "ios-arm64;ios-arm")]
 		[TestCase (ApplePlatform.TVOS, "tvos-arm64")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
-		// [TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64")] // Ignored due to https://github.com/dotnet/runtime/issues/90584
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64")]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
-		// [TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64")] // Ignored due to https://github.com/dotnet/runtime/issues/90584
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64")]
 		public void PublishTest (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "MySimpleApp";


### PR DESCRIPTION
This reverts commit 7691231a86104f711cfa7077fd1fb6fab479d069.

Fixes https://github.com/xamarin/xamarin-macios/issues/18733.