### PR TITLE
[xcode15] Add back armv7k support for watchOS. Fixes #18902.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -318,10 +318,15 @@ else
 IOS_SUPPORTS_32BIT_ARCHITECTURES=1
 endif
 
-ifeq ($(shell test $(shell echo $(MIN_WATCHOS_SDK_VERSION) | sed 's/[.].*//') -ge 4; echo $$?),0)
-WATCHOS_SUPPORTS_32BIT_ARCHITECTURES=
+ifeq ($(shell test $(shell echo $(MIN_WATCHOS_SDK_VERSION) | sed 's/[.].*//') -ge 9; echo $$?),0)
+WATCHOS_SUPPORTS_32BIT_DEVICE_ARCHITECTURES=
 else
-WATCHOS_SUPPORTS_32BIT_ARCHITECTURES=1
+WATCHOS_SUPPORTS_32BIT_DEVICE_ARCHITECTURES=1
+endif
+ifeq ($(shell test $(shell echo $(MIN_WATCHOS_SDK_VERSION) | sed 's/[.].*//') -ge 4; echo $$?),0)
+WATCHOS_SUPPORTS_32BIT_SIMULATOR_ARCHITECTURES=
+else
+WATCHOS_SUPPORTS_32BIT_SIMULATOR_ARCHITECTURES=1
 endif
 
 -include $(TOP)/Make.config.local

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -167,7 +167,7 @@ endif
 
 ifdef INCLUDE_WATCH
 ifdef INCLUDE_DEVICE
-ifdef WATCHOS_SUPPORTS_32BIT_ARCHITECTURES
+ifdef WATCHOS_SUPPORTS_32BIT_DEVICE_ARCHITECTURES
 $(eval $(call FrameworkTemplate,watchos,WATCHOS,armv7k arm64_32))
 else
 $(eval $(call FrameworkTemplate,watchos,WATCHOS,arm64_32))
@@ -242,7 +242,7 @@ endif
 
 ifdef INCLUDE_WATCH
 ifdef INCLUDE_DEVICE
-ifdef WATCHOS_SUPPORTS_32BIT_ARCHITECTURES
+ifdef WATCHOS_SUPPORTS_32BIT_DEVICE_ARCHITECTURES
 $(eval $(call PlatformTemplate,watchos,WATCHOS,armv7k arm64_32))
 else
 $(eval $(call PlatformTemplate,watchos,WATCHOS,arm64_32))

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2587,8 +2587,9 @@ public class TestApp {
 		}
 
 		[Test]
+		[TestCase (Target.Dev, null, "ARMv7k", MTouchBitcode.Unspecified)]
 		[TestCase (Target.Dev, "arm64_32+llvm", "ARM64_32", MTouchBitcode.Unspecified)]
-		[TestCase (Target.Dev, "armv7k+llvm,arm64_32+llvm", "ARM64_32", MTouchBitcode.Full)]
+		[TestCase (Target.Dev, "armv7k+llvm,arm64_32+llvm", "ARMv7k,ARM64_32", MTouchBitcode.Full)]
 		[TestCase (Target.Sim, null, "i386", MTouchBitcode.Unspecified)]
 		[TestCase (Target.Sim, "x86_64", "x86_64", MTouchBitcode.Unspecified)]
 		public void Architectures_WatchOS (Target target, string abi, string expected_abi, MTouchBitcode bitcode)
@@ -2618,7 +2619,7 @@ public class TestApp {
 
 				mtouch.Abi = "armv7";
 				mtouch.AssertExecuteFailure (MTouchAction.BuildDev, "device - armv7");
-				mtouch.AssertError ("MT", 75, "Invalid architecture 'ARMv7' for WatchOS projects. Valid architectures are: ARM64_32, ARM64_32+LLVM");
+				mtouch.AssertError ("MT", 75, "Invalid architecture 'ARMv7' for WatchOS projects. Valid architectures are: ARMv7k, ARMv7k+LLVM, ARM64_32, ARM64_32+LLVM");
 				mtouch.AssertErrorCount (1);
 			}
 		}

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2588,6 +2588,7 @@ public class TestApp {
 
 		[Test]
 		[TestCase (Target.Dev, "arm64_32+llvm", "ARM64_32", MTouchBitcode.Unspecified)]
+		[TestCase (Target.Dev, "armv7k+llvm,arm64_32+llvm", "ARM64_32", MTouchBitcode.Full)]
 		[TestCase (Target.Sim, null, "i386", MTouchBitcode.Unspecified)]
 		[TestCase (Target.Sim, "x86_64", "x86_64", MTouchBitcode.Unspecified)]
 		public void Architectures_WatchOS (Target target, string abi, string expected_abi, MTouchBitcode bitcode)
@@ -4166,7 +4167,6 @@ public partial class KeyboardViewController : UIKit.UIInputViewController
 		{
 			using (var intents_extension = new MTouchTool ()) {
 				intents_extension.Profile = Profile.watchOS;
-				intents_extension.Interpreter = "all";
 				intents_extension.CreateTemporaryWatchOSIntentsExtension ();
 				intents_extension.CreateTemporaryCacheDirectory ();
 				intents_extension.DSym = false; // faster test
@@ -4177,7 +4177,6 @@ public partial class KeyboardViewController : UIKit.UIInputViewController
 
 				using (var watch_extension = new MTouchTool ()) {
 					watch_extension.Profile = Profile.watchOS;
-					watch_extension.Interpreter = "all";
 					watch_extension.AppExtensions.Add (intents_extension);
 					watch_extension.CreateTemporaryCacheDirectory ();
 					watch_extension.CreateTemporaryWatchKitExtension ();

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -245,7 +245,7 @@ namespace Xamarin {
 			case Profile.tvOS:
 				return isDevice ? "arm64" : "x86_64";
 			case Profile.watchOS:
-				return isDevice ? "arm64_32" : "i386";
+				return isDevice ? "armv7k" : "i386";
 			default:
 				throw new NotImplementedException ();
 			}

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -196,11 +196,15 @@ $(eval $(call Template,tvsimulator,TVSIMULATOR,x86_64 arm64,AppleTVSimulator,-mt
 $(eval $(call Template,tvos,TVOS,arm64,AppleTVOS,-mtvos-version-min=9.0 -isysroot $(DEVICETV_SDK)))
 endif
 ifdef INCLUDE_WATCH
-$(eval $(call Template,watchsimulator,WATCHSIMULATOR,x86 x86_64,WatchSimulator,-mwatchos-simulator-version-min=2.0 -isysroot $(SIMULATORWATCH_SDK)))
-ifdef WATCHOS_SUPPORTS_32BIT_ARCHITECTURES
-$(eval $(call Template,watchos,WATCHOS,armv7k arm64_32,WatchOS,-mwatchos-version-min=2.0 -fembed-bitcode -isysroot $(DEVICEWATCH_SDK)))
+ifdef WATCHOS_SUPPORTS_32BIT_SIMULATOR_ARCHITECTURES
+$(eval $(call Template,watchsimulator,WATCHSIMULATOR,x86 x86_64,WatchSimulator,-mwatchos-simulator-version-min=$(MIN_WATCH_OS_VERSION) -isysroot $(SIMULATORWATCH_SDK)))
 else
-$(eval $(call Template,watchos,WATCHOS,arm64_32,WatchOS,-mwatchos-version-min=4.0 -fembed-bitcode -isysroot $(DEVICEWATCH_SDK)))
+$(eval $(call Template,watchsimulator,WATCHSIMULATOR,x86_64,WatchSimulator,-mwatchos-simulator-version-min=$(MIN_WATCH_OS_VERSION) -isysroot $(SIMULATORWATCH_SDK)))
+endif
+ifdef WATCHOS_SUPPORTS_32BIT_DEVICE_ARCHITECTURES
+$(eval $(call Template,watchos,WATCHOS,armv7k arm64_32,WatchOS,-mwatchos-version-min=$(MIN_WATCHOS_SDK_VERSION) -fembed-bitcode -isysroot $(DEVICEWATCH_SDK)))
+else
+$(eval $(call Template,watchos,WATCHOS,arm64_32,WatchOS,-mwatchos-version-min=$(MIN_WATCHOS_SDK_VERSION) -fembed-bitcode -isysroot $(DEVICEWATCH_SDK)))
 endif
 endif
 ifdef INCLUDE_MAC
@@ -233,8 +237,10 @@ $(eval $(call LibTemplate,arm64+x86_64,.libs/tvos/libtest.arm64.o,.libs/tvsimula
 endif
 
 ifdef INCLUDE_WATCH
-ifdef WATCHOS_SUPPORTS_32BIT_ARCHITECTURES
+ifdef WATCHOS_SUPPORTS_32BIT_DEVICE_ARCHITECTURES
+ifdef WATCHOS_SUPPORTS_32BIT_SIMULATOR_ARCHITECTURES
 $(eval $(call LibTemplate,armv7k+x86,.libs/watchos/libtest.armv7k.o,.libs/watchsimulator/libtest.x86.o,watchos-fat,WATCHOS))
+endif
 endif
 endif
 

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -1107,6 +1107,8 @@ namespace Xamarin.Bundler {
 				break;
 			case ApplePlatform.WatchOS:
 				if (IsDeviceBuild) {
+					validAbis.Add (Abi.ARMv7k);
+					validAbis.Add (Abi.ARMv7k | Abi.LLVM);
 					validAbis.Add (Abi.ARM64_32);
 					validAbis.Add (Abi.ARM64_32 | Abi.LLVM);
 				} else {

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -277,8 +277,10 @@ $(eval $(call RunRegistrar,tvos,x86_64,64,$(TVOS_SDK_VERSION),TVOS,$(SIMULATORTV
 $(eval $(call RunRegistrar,tvos,arm64,64,$(TVOS_SDK_VERSION),TVOS,$(SIMULATORTV_ARM64_CFLAGS),$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/include,$(MONOTOUCH_TV_MONO_PATH),tvOS,tvossimulator-arm64))
 $(eval $(call RunRegistrar,tvos,arm64,64,$(TVOS_SDK_VERSION),TVOS,$(DEVICETV_CFLAGS),$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/include,$(MONOTOUCH_TV_MONO_PATH),tvOS,tvos-arm64))
 $(eval $(call RunRegistrar,watchos,x86_64,64,$(WATCH_SDK_VERSION),WatchOS,$(SIMULATORWATCH64_CFLAGS),$(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/include,$(MONOTOUCH_WATCH_MONO_PATH),watchOS,watchos-x64))
+ifdef WATCHOS_SUPPORTS_32BIT_SIMULATOR_ARCHITECTURES
 $(eval $(call RunRegistrar,watchos,i386,32,$(WATCH_SDK_VERSION),WatchOS,$(SIMULATORWATCH_CFLAGS),$(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/include,$(MONOTOUCH_WATCH_MONO_PATH),watchOS,watchos-x86))
-ifdef WATCHOS_SUPPORTS_32BIT_ARCHITECTURES
+endif
+ifdef WATCHOS_SUPPORTS_32BIT_DEVICE_ARCHITECTURES
 $(eval $(call RunRegistrar,watchos,armv7k,32,$(WATCH_SDK_VERSION),WatchOS,$(DEVICEWATCH_CFLAGS),$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/include,$(MONOTOUCH_WATCH_MONO_PATH),watchOS,armv7k))
 endif
 $(eval $(call RunRegistrar,watchos,arm64_32,32,$(WATCH_SDK_VERSION),WatchOS,$(DEVICEWATCH64_32_CFLAGS),$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/include,$(MONOTOUCH_WATCH_MONO_PATH),watchOS,arm64_32))
@@ -299,14 +301,18 @@ else
 endif
 	$(Q_LIPO) $(DEVICE_BIN_PATH)/lipo -create -output $@ $^
 
-ifdef WATCHOS_SUPPORTS_32BIT_ARCHITECTURES
+ifdef WATCHOS_SUPPORTS_32BIT_DEVICE_ARCHITECTURES
 %.registrar.watchos.device.a:    %.registrar.watchos.armv7k.a %.registrar.watchos.arm64_32.a
 else
 %.registrar.watchos.device.a:    %.registrar.watchos.arm64_32.a
 endif
 	$(Q_LIPO) $(DEVICE_BIN_PATH)/lipo -create -output $@ $^
 
+ifdef WATCHOS_SUPPORTS_32BIT_SIMULATOR_ARCHITECTURES
 %.registrar.watchos.simulator.a: %.registrar.watchos.i386.a %.registrar.watchos.x86_64.a
+else
+%.registrar.watchos.simulator.a: %.registrar.watchos.x86_64.a
+endif
 	$(Q_LIPO) $(DEVICE_BIN_PATH)/lipo -create -output $@ $^
 
 .libs/Microsoft.iOS.registrar.ios-arm.a: .libs/Microsoft.iOS.registrar.armv7.a .libs/Microsoft.iOS.registrar.armv7s.a


### PR DESCRIPTION
Only i386 is gone from watchOS 4.0, not armv7k.

Fixes https://github.com/xamarin/xamarin-macios/issues/18902.