### PR TITLE
[release/7.0.1xx-xcode13.3-multi-targeting] Fix nupkg pattern matching.

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -52,7 +52,7 @@ stages:
         # * Template packs (Microsoft.<platform>.Templates.*)
         patterns: |
           Microsoft.@(iOS|tvOS|MacCatalyst|macOS).Sdk.*.nupkg
-          Microsoft.@(iOS|tvOS|MacCatalyst|macOS).iOS.Windows.Sdk.*.nupkg
+          Microsoft.@(iOS|tvOS|MacCatalyst|macOS).Windows.Sdk.*.nupkg
           Microsoft.@(iOS|tvOS|MacCatalyst|macOS).Ref.*.nupkg
           Microsoft.@(iOS|tvOS|MacCatalyst|macOS).Runtime.*.nupkg
 


### PR DESCRIPTION
Correctly match Microsoft.iOS.Windows.Sdk.*.nupkg when selecting nupkgs to publish.