### PR TITLE
[release/7.0.1xx-xcode13.3] Bump maccore to get fix for updating the provisionator.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,8 +7,8 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 9a347bd708eb0ef975cf52cefdb23cb3a83d2690
-NEEDED_MACCORE_BRANCH := main
+NEEDED_MACCORE_VERSION := f474dd1a7ebad9fb083a322fde61117d68680f7b
+NEEDED_MACCORE_BRANCH := release/7.0.1xx
 
 MACCORE_DIRECTORY := maccore
 MACCORE_MODULE    := git@github.com:xamarin/maccore.git


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@f474dd1a7e Update provisionator bootstrap

Diff: https://github.com/xamarin/maccore/compare/9a347bd708eb0ef975cf52cefdb23cb3a83d2690..f474dd1a7ebad9fb083a322fde61117d68680f7b