### PR TITLE
[release/7.0.1xx-xcode13.3] Turn off tests on Windows.

### DIFF
--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -26,7 +26,7 @@ parameters:
 
 - name: runWindowsIntegration
   type: boolean
-  default: true
+  default: false
 
 - name: runGovernanceTests
   type: boolean


### PR DESCRIPTION
We don't have any tests on Windows in this branch anyways, so it's just
useless consumption of bots (and the code fails too, making builds red).