### PR TITLE
[ObjCRuntime] Remove unnecessary macOS code from .NET.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -259,7 +259,7 @@ namespace ObjCRuntime {
 			if (options->Size != Marshal.SizeOf<InitializationOptions> ()) {
 				var msg = $"Version mismatch between the native {ProductName} runtime and {AssemblyName}. Please reinstall {ProductName}.";
 				NSLog (msg);
-#if MONOMAC
+#if MONOMAC && !NET
 				try {
 					// Print out where Xamarin.Mac.dll and the native runtime was loaded from.
 					NSLog ($"{AssemblyName} was loaded from {typeof (NSObject).Assembly.Location}");

--- a/src/ObjCRuntime/Runtime.mac.cs
+++ b/src/ObjCRuntime/Runtime.mac.cs
@@ -173,9 +173,12 @@ namespace ObjCRuntime {
 
 		unsafe static void InitializePlatform (InitializationOptions* options)
 		{
+#if !NET
 			// BaseDirectory may not be set in some Mono embedded environments
 			// so try some reasonable fallbacks in these cases.
+#endif
 			string basePath = AppDomain.CurrentDomain.BaseDirectory;
+#if !NET
 			if(!string.IsNullOrEmpty(basePath))
 				basePath = Path.Combine (basePath, "..");
 			else {
@@ -189,6 +192,7 @@ namespace ObjCRuntime {
 					basePath = Path.Combine (Environment.CurrentDirectory, "..");
 				}
 			}
+#endif
 
 			ResourcesPath = Path.Combine (basePath, "Resources");
 			FrameworksPath = Path.Combine (basePath, "Frameworks");


### PR DESCRIPTION
In Xamarin.Mac we have some code to support unusual ways of creating app
bundles while including Xamarin.Mac, and also dynamic loading of the Mono
runtime.

In .NET, we don't support these unusual app bundle creating logic for any
platform, and the Mono runtime isn't even an option for macOS, so exclude some
of the corresponding code from .NET.

This fixes a few warnings in NativeAOT about this code not being trimmer-safe.