### PR TITLE
[dotnet] Copy the pdb for our platform assemblies to the app bundle. Fixes #11879.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1410,8 +1410,36 @@
 		</ItemGroup>
 	</Target>
 
+	<!-- Add the pdb for Microsoft.<platform>.dll to the app bundle if we're debugging -->
+	<PropertyGroup>
+		<BundleDebugSymbolFileForSdkAssembly Condition="'$(BundleDebugSymbolFileForSdkAssembly)' == ''">$(_BundlerDebug)</BundleDebugSymbolFileForSdkAssembly>
+	</PropertyGroup>
+	<Target Name="_AddDebugSymbolsToBundle"
+		DependsOnTargets="ResolveRuntimePackAssets;_ComputeFrameworkVariables"
+		BeforeTargets="_ResolveCopyLocalAssetsForPublish"
+		Condition="'$(BundleDebugSymbolFileForSdkAssembly)' == 'true'"
+		>
+		<ItemGroup>
+			<ReferenceCopyLocalPaths
+				Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pdb')"
+				Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == '$(_XamarinNugetPackageId)' and Exists('%(RootDir)%(Directory)%(Filename).pdb')" />
+		</ItemGroup>
+	</Target>
+
+	<PropertyGroup>
+		<_ComputePublishLocationDependsOn>
+			$(_ComputePublishLocationDependsOn);
+			_GenerateBundleName;
+			_ParseBundlerArguments;
+			_ComputeMonoLibraries;
+			_DetectSigningIdentity;
+			_PrepareResourceRules;
+			_AddDebugSymbolsToBundle;
+		</_ComputePublishLocationDependsOn>
+	</PropertyGroup>
+
 	<Target Name="_ComputePublishLocation"
-		DependsOnTargets="_GenerateBundleName;_ParseBundlerArguments;_ComputeMonoLibraries;_DetectSigningIdentity;_PrepareResourceRules"
+		DependsOnTargets="$(_ComputePublishLocationDependsOn)"
 		Condition="'$(_CanOutputAppBundle)' == 'true'"
 		>
 		<PropertyGroup>

--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -291,7 +291,7 @@ namespace Xamarin.Tests {
 			expectedFiles.Add (Path.Combine (assemblyDirectory, "Touch.Client.dll"));
 			if (includeDebugFiles)
 				expectedFiles.Add (Path.Combine (assemblyDirectory, "Touch.Client.pdb"));
-			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, Path.GetFileNameWithoutExtension (Configuration.GetBaseLibraryName (platform, true)), runtimeIdentifiers, forceSingleRid: (platform == ApplePlatform.MacCatalyst && !isReleaseBuild) || platform == ApplePlatform.MacOSX, hasPdb: false, includeDebugFiles: includeDebugFiles);
+			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, Path.GetFileNameWithoutExtension (Configuration.GetBaseLibraryName (platform, true)), runtimeIdentifiers, forceSingleRid: (platform == ApplePlatform.MacCatalyst && !isReleaseBuild) || platform == ApplePlatform.MacOSX, includeDebugFiles: includeDebugFiles);
 			expectedFiles.Add (Path.Combine (assemblyDirectory, "runtimeconfig.bin"));
 
 			if (platform == ApplePlatform.MacOSX)
@@ -425,11 +425,11 @@ namespace Xamarin.Tests {
 		}
 
 
-		static void AddMultiRidAssembly (ApplePlatform platform, List<string> expectedFiles, string assemblyDirectory, string assemblyName, string [] runtimeIdentifiers, bool forceSingleRid = false, bool hasPdb = true, bool addConfig = false, bool includeDebugFiles = false)
+		static void AddMultiRidAssembly (ApplePlatform platform, List<string> expectedFiles, string assemblyDirectory, string assemblyName, string [] runtimeIdentifiers, bool forceSingleRid = false, bool addConfig = false, bool includeDebugFiles = false)
 		{
 			if (forceSingleRid || runtimeIdentifiers.Length == 1) {
 				expectedFiles.Add (Path.Combine (assemblyDirectory, $"{assemblyName}.dll"));
-				if (hasPdb && includeDebugFiles)
+				if (includeDebugFiles)
 					expectedFiles.Add (Path.Combine (assemblyDirectory, $"{assemblyName}.pdb"));
 				if (addConfig)
 					expectedFiles.Add (Path.Combine (assemblyDirectory, $"{assemblyName}.dll.config"));
@@ -438,7 +438,7 @@ namespace Xamarin.Tests {
 				foreach (var rid in runtimeIdentifiers) {
 					expectedFiles.Add (Path.Combine (Path.Combine (assemblyDirectory, ".xamarin", $"{rid}")));
 					expectedFiles.Add (Path.Combine (Path.Combine (assemblyDirectory, ".xamarin", $"{rid}", $"{assemblyName}.dll")));
-					if (hasPdb && includeDebugFiles)
+					if (includeDebugFiles)
 						expectedFiles.Add (Path.Combine (Path.Combine (assemblyDirectory, ".xamarin", $"{rid}", $"{assemblyName}.pdb")));
 					if (addConfig)
 						expectedFiles.Add (Path.Combine (Path.Combine (assemblyDirectory, ".xamarin", $"{rid}", $"{assemblyName}.dll.config")));


### PR DESCRIPTION
Copy the pdb for our platform assembly to the app bundle if we're in Debug
mode.

Fixes https://github.com/xamarin/xamarin-macios/issues/11879.