### PR TITLE
[tests] Move a calendar test from being macOS-specific to run on all platforms. Fixes #12468.

### DIFF
--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -163,6 +163,28 @@ namespace LinkAll {
 			Assert.True (default_value, "DefaultValue");
 		}
 
+		static void Check (string calendarName, bool present)
+		{
+			var type = Type.GetType ("System.Globalization." + calendarName);
+			bool success = present == (type is not null);
+			Assert.AreEqual (present, type is not null, calendarName);
+		}
+
+		[Test]
+		public void Calendars ()
+		{
+			Check ("GregorianCalendar", true);
+#if NET
+			Check ("UmAlQuraCalendar", true);
+			Check ("HijriCalendar", true);
+			Check ("ThaiBuddhistCalendar", true);
+#else
+			Check ("UmAlQuraCalendar", false);
+			Check ("HijriCalendar", false);
+			Check ("ThaiBuddhistCalendar", false);
+#endif
+		}
+
 		public enum CertificateProblem : long {
 			CertEXPIRED = 0x800B0101,
 			CertVALIDITYPERIODNESTING = 0x800B0102,

--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -163,6 +163,7 @@ namespace LinkAll {
 			Assert.True (default_value, "DefaultValue");
 		}
 
+#if NET
 		static void Check (string calendarName, bool present)
 		{
 			var type = Type.GetType ("System.Globalization." + calendarName);
@@ -174,16 +175,11 @@ namespace LinkAll {
 		public void Calendars ()
 		{
 			Check ("GregorianCalendar", true);
-#if NET
 			Check ("UmAlQuraCalendar", true);
 			Check ("HijriCalendar", true);
 			Check ("ThaiBuddhistCalendar", true);
-#else
-			Check ("UmAlQuraCalendar", false);
-			Check ("HijriCalendar", false);
-			Check ("ThaiBuddhistCalendar", false);
-#endif
 		}
+#endif // NET
 
 		public enum CertificateProblem : long {
 			CertEXPIRED = 0x800B0101,

--- a/tests/linker/mac/link all/LinkAllTest.cs
+++ b/tests/linker/mac/link all/LinkAllTest.cs
@@ -15,7 +15,7 @@ namespace LinkAllTests {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class LinkAllTest {
-
+#if !NET // this test is in a file shared with all platforms for .NET
 		static void Check (string calendarName, bool present)
 		{
 			var type = Type.GetType ("System.Globalization." + calendarName);
@@ -27,16 +27,11 @@ namespace LinkAllTests {
 		public void Calendars ()
 		{
 			Check ("GregorianCalendar", true);
-#if NET && __MACOS__ // I'm not sure if this is the expected behavior for macOS, or if it's a bug somewhere.
-			Check ("UmAlQuraCalendar", true);
-			Check ("HijriCalendar", true);
-			Check ("ThaiBuddhistCalendar", true);
-#else
 			Check ("UmAlQuraCalendar", false);
 			Check ("HijriCalendar", false);
 			Check ("ThaiBuddhistCalendar", false);
-#endif
 		}
+#endif // !NET
 
 		[Test]
 		public void EnsureUIThreadException ()


### PR DESCRIPTION
By moving the test from a macOS-specific location to a general location, it
becomes obvious that the test behaves the same on all platforms (which the
issue was about: it looked like we had different behavior on macOS vs the
other platforms, and the issue requested validation that this was correct - by
running the test on all platforms, with no platform-specific code, it
demonstrates that there's no macOS-specific behavior).

Fixes https://github.com/xamarin/xamarin-macios/issues/12468.