### PR TITLE
[bgen] Add support for converting ObsoletedOSPlatform attributes. Fixes #18966.

### DIFF
--- a/src/bgen/AttributeManager.cs
+++ b/src/bgen/AttributeManager.cs
@@ -219,6 +219,8 @@ public class AttributeManager {
 			return typeof (System.Runtime.Versioning.SupportedOSPlatformAttribute);
 		case "System.Runtime.Versioning.UnsupportedOSPlatformAttribute":
 			return typeof (System.Runtime.Versioning.UnsupportedOSPlatformAttribute);
+		case "System.Runtime.Versioning.ObsoletedOSPlatformAttribute":
+			return typeof (System.Runtime.Versioning.ObsoletedOSPlatformAttribute);
 #endif
 		}
 
@@ -338,6 +340,14 @@ public class AttributeManager {
 				return AttributeFactory.CreateNewAttribute<UnavailableAttribute> (up).Yield ();
 			else
 				return Enumerable.Empty<System.Attribute> ();
+		case "ObsoletedOSPlatformAttribute":
+			var oarg = attribute.ConstructorArguments [0].Value as string;
+			(var op, var ov) = ParseOSPlatformAttribute (oarg);
+			// might have been available for a while...
+			if (ov is null)
+				return AttributeFactory.CreateNewAttribute<ObsoletedAttribute> (op).Yield ();
+			else
+				return AttributeFactory.CreateNewAttribute<ObsoletedAttribute> (op, ov.Major, ov.Minor).Yield ();
 #endif
 		default:
 			return Enumerable.Empty<System.Attribute> ();

--- a/tests/bgen/Makefile
+++ b/tests/bgen/Makefile
@@ -2,4 +2,4 @@ TOP=../..
 include $(TOP)/Make.config
 
 run-tests:
-	$(DOTNET) test
+	$(DOTNET) test $(TEST_FILTER)

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -810,11 +810,16 @@ namespace Xamarin.Tests {
 			}
 		}
 
-
 		public static IEnumerable<string> GetRefLibraries ()
 		{
 			foreach (var platform in GetIncludedPlatforms (true))
 				yield return Path.Combine (GetRefDirectory (platform), GetBaseLibraryName (platform, true));
+		}
+
+
+		public static string GetRefLibrary (ApplePlatform platform)
+		{
+			return GetBaseLibrary (platform, true);
 		}
 
 		public static string GetTargetFramework (Profile profile)

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -1405,6 +1405,21 @@ namespace GeneratorTests {
 			Assert.That (failures, Is.Empty, "Failures");
 		}
 
+#if !NET
+		[Ignore ("This only applies to .NET")]
+#endif
+		[Test]
+		[TestCase (Profile.iOS)]
+		public void ObsoletedOSPlatform (Profile profile)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (profile.AsPlatform ());
+			var bgen = new BGenTool ();
+			bgen.Profile = profile;
+			bgen.AddTestApiDefinition ("tests/obsoletedosplatform.cs");
+			bgen.CreateTemporaryBinding ();
+			bgen.AssertExecute ("build");
+		}
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/tests/obsoletedosplatform.cs
+++ b/tests/generator/tests/obsoletedosplatform.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Versioning;
+using Foundation;
+using UIKit;
+
+namespace iosbindinglib {
+	[Protocol, Model]
+	[BaseType(typeof(UIApplicationDelegate))]
+	public interface TestDelegate
+	{
+	}
+}

--- a/tests/generator/tests/obsoletedosplatform.cs
+++ b/tests/generator/tests/obsoletedosplatform.cs
@@ -4,8 +4,7 @@ using UIKit;
 
 namespace iosbindinglib {
 	[Protocol, Model]
-	[BaseType(typeof(UIApplicationDelegate))]
-	public interface TestDelegate
-	{
+	[BaseType (typeof (UIApplicationDelegate))]
+	public interface TestDelegate {
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/18966.