### PR TITLE
[xharness] Ignore the mtouch tests if iOS isn't enabled.

### DIFF
--- a/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
+++ b/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
@@ -105,7 +105,7 @@ namespace Xharness.Jenkins {
 				Platform = TestPlatform.iOS,
 				TestName = "MTouch tests",
 				Timeout = TimeSpan.FromMinutes (180),
-				Ignored = !jenkins.TestSelection.IsEnabled (TestLabel.Mtouch),
+				Ignored = !jenkins.TestSelection.IsEnabled (TestLabel.Mtouch) || !jenkins.TestSelection.IsEnabled (PlatformLabel.iOS),
 				InProcess = true,
 			};
 			yield return nunitExecutionMTouch;


### PR DESCRIPTION
This fixes an issue where we'd try to run the mtouch tests when only macOS is
the enabled platform.