### PR TITLE
[devops] Skip installing workloads, not .NET itself, if .NET isn't enabled.

### DIFF
--- a/tools/devops/automation/scripts/bash/install-workloads.sh
+++ b/tools/devops/automation/scripts/bash/install-workloads.sh
@@ -40,15 +40,16 @@ fi
 #  Start working
 make global.json
 
+make -C builds dotnet
+
 # Check if .NET is even enabled
+# Note that we do this after downloading .NET, because we need .NET to build some of our tests that may contain legacy tests (such as the MSBuild tests).
 var=$(make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable VARIABLE=ENABLE_DOTNET)
 ENABLE_DOTNET=${var#*=}
 if test -z "$ENABLE_DOTNET"; then
   echo "Not installing anything, because .NET is not enabled."
   exit 0
 fi
-
-make -C builds dotnet
 
 var=$(make -C "$BUILD_SOURCESDIRECTORY/xamarin-macios/tools/devops" print-variable VARIABLE=DOTNET)
 DOTNET=${var#*=}


### PR DESCRIPTION
Some of our tests (such as the MSBuild tests), are built with .NET, and thus
need some version of .NET installed to be buildable.

Note that in this case we don't need any workloads, so we still skip that part.