### PR TITLE
[dotnet] Load the current, not latest, sdk for the error logic in WorkloadManifest.targets.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -178,7 +178,7 @@ Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.json: Makefile $(TOP)/Make.con
 
 Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.targets: Makefile $(TOP)/Make.config.inc $(TOP)/.git/HEAD $(TOP)/.git/index Makefile generate-workloadmanifest-targets.csharp | Workloads/Microsoft.NET.Sdk.$(1)
 	$$(Q) rm -f $$@.tmp
-	$$(Q_GEN) ./generate-workloadmanifest-targets.csharp "$(1)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)" "$$(SUPPORTED_API_VERSIONS_$(4))" "$$(DEFAULT_TARGET_PLATFORM_VERSIONS_$(4))"
+	$$(Q_GEN) ./generate-workloadmanifest-targets.csharp "$(1)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)" "$$(SUPPORTED_API_VERSIONS_$(4))" "$$(DEFAULT_TARGET_PLATFORM_VERSIONS_$(4))" "$$(DOTNET_TFM)-$($(4)_NUGET_OS_VERSION)"
 	$$(Q) mv $$@.tmp $$@
 
 Workloads/Microsoft.NET.Sdk.$(1)/LICENSE: $(TOP)/LICENSE | Workloads/Microsoft.NET.Sdk.$(1)

--- a/dotnet/generate-workloadmanifest-targets.csharp
+++ b/dotnet/generate-workloadmanifest-targets.csharp
@@ -6,7 +6,7 @@ using System.IO;
 using System.Xml;
 
 var args = Environment.GetCommandLineArgs ();
-var expectedArgumentCount = 5;
+var expectedArgumentCount = 6;
 if (args.Length != expectedArgumentCount + 3 /* 2 default arguments (executable + script) + 'expectedArgumentCount' arguments we're interested in */) {
 	// first arg is "/Library/Frameworks/Mono.framework/Versions/4.8.0/lib/mono/4.5/csharp.exe"
 	// second arg the script itself
@@ -23,6 +23,7 @@ var windowsPlatforms = args [argumentIndex++].Split (new char [] { ' ' }, String
 var hasWindows = Array.IndexOf (windowsPlatforms, platform) >= 0;
 var supportedApiVersions = args [argumentIndex++].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 var defaultTargetPlatformVersions = args [argumentIndex++].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+var currentApiVersion = args [argumentIndex++].Replace ('-', '_');
 
 var platformLowerCase = platform.ToLowerInvariant ();
 
@@ -64,13 +65,13 @@ using (var writer = new StreamWriter (outputPath)) {
 
 	writer.WriteLine ($"	<!-- Using a .NET version we no longer support -->");
 	writer.WriteLine ($"	<ImportGroup Condition=\" '$(TargetPlatformIdentifier)' == '{platform}' And '$(_AppleSdkLoaded)' != 'true' And '$(TargetFrameworkVersion)' != '' And $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '{minDotNetVersion}'))\">");
-	writer.WriteLine ($"		<Import Project=\"Sdk-eol.props\" Sdk=\"Microsoft.{platform}.Sdk.{supportedApiVersions.OrderBy (v => v).Last ().Replace ('-', '_')}\" />");
+	writer.WriteLine ($"		<Import Project=\"Sdk-eol.props\" Sdk=\"Microsoft.{platform}.Sdk.{currentApiVersion}\" />");
 	writer.WriteLine ($"	</ImportGroup>");
 	writer.WriteLine ();
 
 	writer.WriteLine ($"	<!-- Using a specific, but unsupported, target platform version -->");
 	writer.WriteLine ($"	<ImportGroup Condition=\" '$(TargetPlatformIdentifier)' == '{platform}' And '$(_AppleSdkLoaded)' != 'true'\">");
-	writer.WriteLine ($"		<Import Project=\"Sdk-error.props\" Sdk=\"Microsoft.{platform}.Sdk.{supportedApiVersions.OrderBy (v => v).Last ().Replace ('-', '_')}\" />");
+	writer.WriteLine ($"		<Import Project=\"Sdk-error.props\" Sdk=\"Microsoft.{platform}.Sdk.{currentApiVersion}\" />");
 	writer.WriteLine ($"	</ImportGroup>");
 
 	writer.WriteLine ($"</Project>");


### PR DESCRIPTION
We might actually support a newer OS version than the one we're building for,
if we're supporting a preview version in a stable release. In this case, we
need to make sure to load the correct sdk when we run into errors, so that we
show the correct error messages.

Fixes this test failure:

    Xamarin.Tests.DotNetProjectTest.InvalidTargetPlatformVersion(MacCatalyst): Error message
    Expected string length 92 but was 87. Strings differ at index 84.
    Expected: "...ormVersion for MacCatalyst. Valid versions include:\n16.4\n17.0"
    But was: "...ormVersion for MacCatalyst. Valid versions include:\n17.0"