### PR TITLE
[tests] Don't build Mac Catalyst projects using a target framework later than the current one.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -479,6 +479,12 @@ namespace Xamarin.Tests {
 			return GetVariable (variableName, variableName + " not found");
 		}
 
+		public static string GetNuGetOsVersion (ApplePlatform platform)
+		{
+			var variableName = platform.AsString ().ToUpper () + "_NUGET_OS_VERSION";
+			return GetVariable (variableName, variableName + " not found");
+		}
+
 		public static string GetDotNetRoot ()
 		{
 			if (IsVsts) {

--- a/tests/dotnet/UnitTests/PackTest.cs
+++ b/tests/dotnet/UnitTests/PackTest.cs
@@ -180,6 +180,7 @@ namespace Xamarin.Tests {
 
 			// Get all the supported API versions
 			var supportedApiVersion = Configuration.GetVariableArray ($"SUPPORTED_API_VERSIONS_{platform.AsString ().ToUpperInvariant ()}");
+			supportedApiVersion = DotNetProjectTest.RemovePostCurrentOnMacCatalyst (supportedApiVersion, platform);
 			var targetFrameworks = string.Join (";", supportedApiVersion.Select (v => v.Replace ("-", "-" + platform.AsString ().ToLowerInvariant ())));
 
 			var project = "MultiTargetingLibrary";

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1503,6 +1503,7 @@ namespace Xamarin.Tests {
 
 			// Get all the supported API versions
 			var supportedApiVersion = Configuration.GetVariableArray ($"SUPPORTED_API_VERSIONS_{platform.AsString ().ToUpperInvariant ()}");
+			supportedApiVersion = RemovePostCurrentOnMacCatalyst (supportedApiVersion, platform);
 			var targetFrameworks = string.Join (";", supportedApiVersion.Select (v => v.Replace ("-", "-" + platform.AsString ().ToLowerInvariant ())));
 
 			var project = "MultiTargetingLibrary";
@@ -1512,6 +1513,19 @@ namespace Xamarin.Tests {
 			properties ["cmdline:AllTheTargetFrameworks"] = targetFrameworks;
 			var rv = DotNet.AssertBuild (project_path, properties);
 			rv.AssertNoWarnings ();
+		}
+
+		// Mac Catalyst projects can't be built with an earlier version of Xcode (even library projects),
+		// which means that we can't build for target frameworks > than the current one (because we'll only have
+		// the Xcode installed for the current target framework, especially on bots).
+		// So filter out any target framework on Mac Catalyst that's after the current one.
+		internal static IList<string> RemovePostCurrentOnMacCatalyst (IList<string> self, ApplePlatform platform)
+		{
+			if (platform == ApplePlatform.MacCatalyst) {
+				var current = Configuration.DotNetTfm + "_" + Configuration.GetNuGetOsVersion (platform);
+				return self.Where (v => string.Compare (v, current, StringComparison.Ordinal) <= 0).ToList ();
+			}
+			return self;
 		}
 
 		[Test]


### PR DESCRIPTION
With multi-targeting, we can end up supporting a newer target framework than
the current one (when including support for preview versions of Xcode), but we
can't build Mac Catalyst projects using these newer target frameworks, because
it would require using the corresponding Xcode version, which may not be
available (in particular on bots).

Fixes these test failures:

    Xamarin.Tests.DotNetProjectTest.MultiTargetLibrary(MacCatalyst): 'dotnet build' failed with exit code 1
    Full command: /Users/builder/azdo/_work/2/s/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23422.1/dotnet build /Users/builder/azdo/_work/2/s/xamarin-macios/tests/dotnet/MultiTargetingLibrary/MacCatalyst/MultiTargetingLibrary.csproj /p:_BundlerVerbosity=1 "/p:AllTheTargetFrameworks=\"net8.0-maccatalyst16.4;net7.0-maccatalyst15.4;net7.0-maccatalyst16.4;net8.0-maccatalyst17.0\"" /bl:/Users/builder/azdo/_work/2/s/xamarin-macios/tests/dotnet/MultiTargetingLibrary/MacCatalyst/log-build-20230912_200113.binlog /v:diag /consoleloggerparameters:Verbosity=Quiet
    Listing first 1 error(s) (of 1 error(s)):
    /Users/builder/azdo/_work/2/s/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23422.1/packs/Microsoft.MacCatalyst.Sdk.net8.0_17.0/17.0.8316-ci.release-test-net8-0-xcode15-multi-targeting/tools/msbuild/iOS/Xamarin.Shared.targets(535): error: Could not map the Mac Catalyst version 17.0 to a corresponding macOS version. Valid Mac Catalyst versions are: 15.0, 13.3.1, 16.2, 14.3, 15.5, 13.1, 16.0, 14.1, 15.3, 14.6, 13.4, 16.3, 15.6, 13.2, 14.4, 16.1, 14.2, 15.4, 13.5, 14.7, 15.2, 14.0, 16.4, 13.3, 14.5

    Xamarin.Tests.PostBuildTest.PublishTest(MacCatalyst,"maccatalyst-arm64;maccatalyst-x64"): 'dotnet publish' failed with exit code 1
    Full command: /Users/builder/azdo/_work/2/s/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23422.1/dotnet publish /Users/builder/azdo/_work/2/s/xamarin-macios/tests/dotnet/MySimpleApp/MacCatalyst/MySimpleApp.csproj /p:_BundlerVerbosity=1 "/p:RuntimeIdentifiers=\"maccatalyst-arm64;maccatalyst-x64\"" /p:PkgPackagePath=/Users/builder/azdo/_work/2/s/xamarin-macios/tests/dotnet/UnitTests/bin/Debug/net8.0/tmp-test-dir/Xamarin.Tests.PostBuildTest.PublishTest27/MyPackage.pkg /bl:/Users/builder/azdo/_work/2/s/xamarin-macios/tests/dotnet/MySimpleApp/MacCatalyst/log-publish-20230912_204753.binlog /v:diag /consoleloggerparameters:Verbosity=Quiet
    Listing first 1 error(s) (of 1 error(s)):
    /Users/builder/azdo/_work/2/s/xamarin-macios/builds/downloads/dotnet-sdk-8.0.100-rc.1.23422.1/sdk-manifests/8.0.100-rc.1/microsoft.net.workload.mono.toolchain.current/8.0.0-rc.1.23414.4/WorkloadTelemetry.targets(41): error MSB4186: Invalid static method invocation syntax: "[System.IO.Path]::GetFileName().ToLower()". Method 'System.IO.Path.GetFileName' not found. Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). Check that all parameters are defined, are of the correct type, and are specified in the right order.