### PR TITLE
[CloudKit] Expose the CKQueryOperationMaximumResults field. Fixes #19013.

### DIFF
--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -1497,8 +1497,7 @@ namespace CloudKit {
 	interface CKQueryOperation {
 
 		[Field ("CKQueryOperationMaximumResults")]
-		[Internal]
-		IntPtr _MaximumResults { get; set; }
+		nint MaximumResults { get; }
 
 		[Export ("initWithQuery:")]
 		NativeHandle Constructor (CKQuery query);


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/19013.