### PR TITLE
[UIKit] Make UIView.HitTest's return value nullable. Fixes #19019.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -16425,6 +16425,7 @@ namespace UIKit {
 		bool ExclusiveTouch { [Bind ("isExclusiveTouch")] get; set; }
 
 		[Export ("hitTest:withEvent:")]
+		[return: NullAllowed]
 		UIView HitTest (CGPoint point, [NullAllowed] UIEvent uievent);
 
 		[Export ("pointInside:withEvent:")]

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
@@ -337,7 +337,6 @@
 !missing-null-allowed! 'UIKit.UIView UIKit.UITableViewDelegate::GetViewForHeader(UIKit.UITableView,System.IntPtr)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UITouch::get_View()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::get_Superview()' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'UIKit.UIView UIKit.UIView::HitTest(CoreGraphics.CGPoint,UIKit.UIEvent)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::SnapshotView(System.Boolean)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::ViewWithTag(System.IntPtr)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIViewControllerContextTransitioning::GetViewFor(Foundation.NSString)' is missing an [NullAllowed] on return type

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
@@ -288,7 +288,6 @@
 !missing-null-allowed! 'UIKit.UIView UIKit.UITableViewDelegate::GetViewForHeader(UIKit.UITableView,System.IntPtr)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UITouch::get_View()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::get_Superview()' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'UIKit.UIView UIKit.UIView::HitTest(CoreGraphics.CGPoint,UIKit.UIEvent)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::SnapshotView(System.Boolean)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::ViewWithTag(System.IntPtr)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIViewControllerContextTransitioning::GetViewFor(Foundation.NSString)' is missing an [NullAllowed] on return type

--- a/tests/xtro-sharpie/iOS-UIKit.ignore
+++ b/tests/xtro-sharpie/iOS-UIKit.ignore
@@ -361,7 +361,6 @@
 !missing-null-allowed! 'UIKit.UIView UIKit.UITableViewDelegate::GetViewForHeader(UIKit.UITableView,System.nint)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UITouch::get_View()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::get_Superview()' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'UIKit.UIView UIKit.UIView::HitTest(CoreGraphics.CGPoint,UIKit.UIEvent)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::SnapshotView(System.Boolean)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::ViewWithTag(System.nint)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIViewControllerContextTransitioning::GetViewFor(Foundation.NSString)' is missing an [NullAllowed] on return type

--- a/tests/xtro-sharpie/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/tvOS-UIKit.ignore
@@ -300,7 +300,6 @@
 !missing-null-allowed! 'UIKit.UIView UIKit.UITableViewDelegate::GetViewForHeader(UIKit.UITableView,System.nint)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UITouch::get_View()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::get_Superview()' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'UIKit.UIView UIKit.UIView::HitTest(CoreGraphics.CGPoint,UIKit.UIEvent)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::SnapshotView(System.Boolean)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIView::ViewWithTag(System.nint)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'UIKit.UIView UIKit.UIViewControllerContextTransitioning::GetViewFor(Foundation.NSString)' is missing an [NullAllowed] on return type


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/19019.