### PR TITLE
[registrar] Look in nested types when looking for protocol wrapper types to register. Fixes #18973.

### DIFF
--- a/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
@@ -188,7 +188,8 @@ namespace Xamarin.Linker {
 			types.RemoveAll (v => IsTrimmed (v.Definition));
 
 			// We also want all the protocol wrapper types
-			foreach (var type in registrarType.Module.Types) {
+			var allTypes = IterateTypes (registrarType.Module.Types);
+			foreach (var type in allTypes) {
 				if (IsTrimmed (type))
 					continue;
 				var wrapperType = StaticRegistrar.GetProtocolAttributeWrapperType (type);
@@ -202,6 +203,17 @@ namespace Xamarin.Linker {
 				info.RegisterType (types [i].Definition, (uint) i);
 
 			return types;
+		}
+
+		IEnumerable<TypeDefinition> IterateTypes (IEnumerable<TypeDefinition> types)
+		{
+			foreach (var type in types) {
+				yield return type;
+				if (type.HasNestedTypes) {
+					foreach (var td in IterateTypes(type.NestedTypes))
+						yield return td;
+				}
+			}
 		}
 
 		IEnumerable<TypeDefinition> GetRelevantTypes (Func<TypeDefinition, bool> isRelevant)

--- a/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
@@ -210,7 +210,7 @@ namespace Xamarin.Linker {
 			foreach (var type in types) {
 				yield return type;
 				if (type.HasNestedTypes) {
-					foreach (var td in IterateTypes(type.NestedTypes))
+					foreach (var td in IterateTypes (type.NestedTypes))
 						yield return td;
 				}
 			}


### PR DESCRIPTION
Protocol wrapper types may be nested types, so make sure to look in nested
types when looking for protocol wrapper types.

Fixes https://github.com/xamarin/xamarin-macios/issues/18973.