### PR TITLE
[vs-workload] Add @(ShortNames) items for net7.0

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -203,10 +203,10 @@ $(DOTNET_NUPKG_DIR)/vs-workload.props: Makefile generate-vs-workload.csharp
 		$(foreach platform,$(DOTNET_PLATFORMS),--platform $(platform) $($(platform)_MSI_VERSION)) \
 		$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),--windows-platform $(platform)) \
 		$(foreach platform,$(DOTNET_PLATFORMS),--shorten Microsoft.NET.Sdk.$(platform).Manifest=Microsoft.$(platform).Manifest) \
-		$(foreach platform,$(DOTNET_PLATFORMS),--shorten $($(platform)_NUGET_REF_NAME)=Microsoft.$(platform).Ref) \
-		$(foreach platform,$(DOTNET_PLATFORMS),--shorten $($(platform)_NUGET_SDK_NAME)=Microsoft.$(platform).Sdk) \
+		$(foreach platform,$(DOTNET_PLATFORMS),$(foreach supportedtpv,$(SUPPORTED_API_VERSIONS_$(shell echo $(platform) | tr a-z A-Z)),--shorten Microsoft.$(platform).Ref.$(supportedtpv)=Microsoft.$(platform).Ref)) \
+		$(foreach platform,$(DOTNET_PLATFORMS),$(foreach supportedtpv,$(SUPPORTED_API_VERSIONS_$(shell echo $(platform) | tr a-z A-Z)),--shorten Microsoft.$(platform).Sdk.$(supportedtpv)=Microsoft.$(platform).Sdk)) \
 		$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),--shorten $($(platform)_NUGET_WINDOWS_SDK_NAME)=Microsoft.$(platform).Win.Sdk) \
-		$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),--shorten Microsoft.$(platform).Windows.Sdk.Aliased.$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION)=Microsoft.$(platform).Aliased.Sdk) \
+		$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(foreach supportedtpv,$(SUPPORTED_API_VERSIONS_$(shell echo $(platform) | tr a-z A-Z)),--shorten Microsoft.$(platform).Windows.Sdk.Aliased.$(supportedtpv)=Microsoft.$(platform).Aliased.Sdk)) \
 		$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),--shorten $($(rid)_NUGET_RUNTIME_NAME)=Microsoft.Runtime.$(rid))) \
 		--tfm $(DOTNET_TFM) \
 		--output $@.tmp


### PR DESCRIPTION
The `@(ShortNames)` items in `vs-workload.props` need to be consistent
across branches that depend on eachother in order to generate valid VS
manifests, as this item group is used to construct the VS component IDs
that correspond with each workload pack.

This means that in the .NET 8 branches, we also need `@(ShortNames)`
items for all .NET 7 pack names that are trimmed when building various
.NET 7 branches.

The generated `vs-workload.props` file has been updated to include such
entries, for example:

    <ShortNames Include="Microsoft.iOS.Ref.net8.0-16.4">
      <Replacement>Microsoft.iOS.Ref</Replacement>
    </ShortNames>
    <ShortNames Include="Microsoft.iOS.Ref.net7.0-16.0">
      <Replacement>Microsoft.iOS.Ref</Replacement>
    </ShortNames>
    <ShortNames Include="Microsoft.iOS.Ref.net7.0-16.4">
      <Replacement>Microsoft.iOS.Ref</Replacement>
    </ShortNames>
    <ShortNames Include="Microsoft.iOS.Ref.net8.0-17.0">
      <Replacement>Microsoft.iOS.Ref</Replacement>
    </ShortNames>

Some more information about our VS manifest files can be found here:
https://github.com/xamarin/sdk-insertions/wiki/How-to-create-a-new-insertion#msi-generation-and-vs-versioning-requirements