### PR TITLE
[src] Exclude more code from .NET to fix compiler warning.

### DIFF
--- a/src/ObjCRuntime/Dlfcn.cs
+++ b/src/ObjCRuntime/Dlfcn.cs
@@ -92,7 +92,7 @@ namespace ObjCRuntime {
 			First = 0x100,
 		}
 
-#if MONOMAC
+#if MONOMAC && !NET
 		[DllImport (Constants.libcLibrary)]
 		internal static extern int dladdr (IntPtr addr, out Dl_info info);
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreFoundation.ignore
@@ -1,9 +1,6 @@
 ## /usr/include/dispatch/queue.h
 !unknown-pinvoke! dispatch_main bound
 
-## dlfcn.h
-!unknown-pinvoke! dladdr bound
-
 ## unsorted
 
 !missing-enum! CFXMLEntityTypeCode not bound


### PR DESCRIPTION
Fixes this:

    ObjCRuntime/Dlfcn.cs(102,20): warning CS0649: Field 'Dlfcn.Dl_info.dli_fbase' is never assigned to, and will always have its default value
    ObjCRuntime/Dlfcn.cs(103,20): warning CS0649: Field 'Dlfcn.Dl_info.dli_sname' is never assigned to, and will always have its default value
    ObjCRuntime/Dlfcn.cs(104,20): warning CS0649: Field 'Dlfcn.Dl_info.dli_saddr' is never assigned to, and will always have its default value
    ObjCRuntime/Dlfcn.cs(101,20): warning CS0649: Field 'Dlfcn.Dl_info.dli_fname' is never assigned to, and will always have its default value

The warning is new, after we removed the referencing code from .NET in a recent commit.