### PR TITLE
[tests] Improve a test about warnings to list all the underlying warnings.

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1452,15 +1452,15 @@ namespace Xamarin.Tests {
 			properties ["_IsPublishing"] = "true"; // quack like "dotnet publish"
 			properties ["ExcludeNUnitLiteReference"] = "true"; // we're asserting no warnings, and NUnitLite produces a lot of them, so ignore NUnitLite
 			properties ["ExcludeTouchUnitReference"] = "true"; // we're asserting no warnings, and Touch.Unit produces a lot of them, so ignore Touch.Unit
+			properties ["TrimmerSingleWarn"] = "false"; // don't be shy, we want to know what the problem is
 			var rv = DotNet.AssertBuild (project_path, properties);
 
 			// Verify that we have no warnings, but unfortunately we still have some we haven't fixed yet.
 			// Ignore those, and fail the test if we stop getting them (so that we can update the test to not ignore them anymore).
-			var foundIL3053 = false;
+			var foundIL3050 = false;
 			rv.AssertNoWarnings ((evt) => {
-				// This will probably go away when the IL2049 warning from above is fixed.
-				if (evt.Code == "IL3053" && evt.Message == $"Assembly 'Microsoft.{platform.AsString ()}' produced AOT analysis warnings.") {
-					foundIL3053 = true;
+				if (evt.Code == "IL3050" && evt.Message == "<Module>..cctor(): Using member 'System.Enum.GetValues(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead.") {
+					foundIL3050 = true;
 					return false;
 				}
 
@@ -1470,7 +1470,7 @@ namespace Xamarin.Tests {
 				return true;
 			});
 
-			Assert.IsTrue (foundIL3053, "IL3053 not found - update test code to remove the code to ignore the IL3053");
+			Assert.IsTrue (foundIL3050, "IL3050 not found - update test code to remove the code to ignore the IL3050");
 		}
 
 		void AssertThatDylibExistsAndIsReidentified (string appPath, string dylibRelPath)


### PR DESCRIPTION
Improve a test about warnings to list all the underlying linker warnings,
instead of just stating that a specific assembly has any linker warnings.