### PR TITLE
[tests] Ignore the FSEventStream tests on the bots. Fixes xamarin/maccore@2630.

### DIFF
--- a/tests/monotouch-test/CoreServices/FSEventStreamTest.cs
+++ b/tests/monotouch-test/CoreServices/FSEventStreamTest.cs
@@ -75,6 +75,7 @@ namespace MonoTouchFixtures.CoreServices {
 
 		static void RunTest (FSEventStreamCreateFlags createFlags)
 		{
+			TestRuntime.IgnoreInCI ("This test fails randomly on the bots, potentially due to (randomly) high CPU usage.");
 			using var monitor = new TestFSMonitor (
 				Xamarin.Cache.CreateTemporaryDirectory (),
 				createFlags,


### PR DESCRIPTION
They fail randomly, and there doesn't seem to be a way to fix that as far as I
can figure out.

Fixes https://github.com/xamarin/maccore/issues/2630.