### PR TITLE
[release/7.0.3xx] [msbuild] Add support to the ResolveNativeReferences task to execute remotely. Fixes #19027.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferences.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferences.cs
@@ -1,4 +1,0 @@
-namespace Xamarin.MacDev.Tasks {
-	public class ResolveNativeReferences : ResolveNativeReferencesBase {
-	}
-}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferencesBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferencesBase.cs
@@ -291,15 +291,11 @@ namespace Xamarin.MacDev.Tasks {
 
 		public bool ShouldCreateOutputFile (ITaskItem item)
 		{
-			if (NativeFrameworks is not null && Array.IndexOf (NativeFrameworks, item) >= 0) {
-				// Don't copy any resolved frameworks back to Windows, because
-				// 1. They're not used in Inputs/Outputs, so the lack of them won't affect anything
-				// 2. They may be directories, and as such we'd have to expand them to (potentially numerous and large) files to copy them (uselessly) to Windows.
-				// 3. They may contain symlinks, which may not work correctly on Windows.
-				return false;
-			}
-
-			return true;
+			// Don't copy any files to Windows, because
+			// 1. They're not used in Inputs/Outputs, so the lack of them won't affect anything
+			// 2. They may be directories, and as such we'd have to expand them to (potentially numerous and large) files to copy them (uselessly) to Windows.
+			// 3. They may contain symlinks, which may not work correctly on Windows.
+			return false;
 		}
 
 		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferencesBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferencesBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 
 using Microsoft.Build.Framework;
@@ -10,12 +11,13 @@ using Xamarin;
 using Xamarin.MacDev;
 using Xamarin.MacDev.Tasks;
 using Xamarin.Localization.MSBuild;
+using Xamarin.Messaging.Build.Client;
 
 #nullable enable
 
 namespace Xamarin.MacDev.Tasks {
 
-	public abstract class ResolveNativeReferencesBase : XamarinTask {
+	public class ResolveNativeReferences : XamarinTask, ITaskCallback {
 		#region Inputs
 
 		[Required]
@@ -57,6 +59,14 @@ namespace Xamarin.MacDev.Tasks {
 		}
 
 		public override bool Execute ()
+		{
+			if (ShouldExecuteRemotely ())
+				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+
+			return ExecuteLocally ();
+		}
+
+		bool ExecuteLocally ()
 		{
 			var native_frameworks = new List<ITaskItem> ();
 
@@ -270,5 +280,28 @@ namespace Xamarin.MacDev.Tasks {
 			}
 			return String.Empty;
 		}
+
+		public void Cancel ()
+		{
+			if (ShouldExecuteRemotely ())
+				BuildConnection.CancelAsync (BuildEngine4).Wait ();
+		}
+
+		public bool ShouldCopyToBuildServer (ITaskItem item) => true;
+
+		public bool ShouldCreateOutputFile (ITaskItem item)
+		{
+			if (NativeFrameworks is not null && Array.IndexOf (NativeFrameworks, item) >= 0) {
+				// Don't copy any resolved frameworks back to Windows, because
+				// 1. They're not used in Inputs/Outputs, so the lack of them won't affect anything
+				// 2. They may be directories, and as such we'd have to expand them to (potentially numerous and large) files to copy them (uselessly) to Windows.
+				// 3. They may contain symlinks, which may not work correctly on Windows.
+				return false;
+			}
+
+			return true;
+		}
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ResolveNativeReferencesTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ResolveNativeReferencesTaskTest.cs
@@ -30,7 +30,7 @@ namespace Xamarin.MacDev.Tasks.Tests {
 			// on Xcode 12.2+ you get arm64 for all (iOS, tvOS and watchOS) simulators
 			var path = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location), "Resources", "xcf-xcode12.2.plist");
 			var plist = PDictionary.FromFile (path);
-			var result = ResolveNativeReferencesBase.ResolveXCFramework (plist, platform, variant, architecture);
+			var result = ResolveNativeReferences.ResolveXCFramework (plist, platform, variant, architecture);
 			Assert.That (result, Is.EqualTo (expected), expected);
 		}
 
@@ -42,7 +42,7 @@ namespace Xamarin.MacDev.Tasks.Tests {
 		{
 			var path = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location), "Resources", "xcf-prexcode12.plist");
 			var plist = PDictionary.FromFile (path);
-			var result = ResolveNativeReferencesBase.ResolveXCFramework (plist, platform, variant, architecture);
+			var result = ResolveNativeReferences.ResolveXCFramework (plist, platform, variant, architecture);
 			Assert.That (result, Is.EqualTo (expected), expected);
 		}
 
@@ -50,7 +50,7 @@ namespace Xamarin.MacDev.Tasks.Tests {
 		public void BadInfoPlist ()
 		{
 			var plist = new PDictionary ();
-			var result = ResolveNativeReferencesBase.ResolveXCFramework (plist, "iOS", null, "x86_64");
+			var result = ResolveNativeReferences.ResolveXCFramework (plist, "iOS", null, "x86_64");
 			Assert.Null (result, "Invalid Info.plist");
 		}
 	}


### PR DESCRIPTION
It looks like ResolveNativeReferences was always intended to execute remotely
from Windows (when used in the _ExpandNativeReferences target, the task is
given a session id, and only called when IsMacEnabled=true), but the task
itself never implemented the code to execute remotely.

Weirdly enough this was never an issue, because the task never did something
that had to be done on a Mac.

That is, until recently, when the task learned to decompress zip files, by
executing /usr/bin/unzip.

Obviously this doesn't work on Windows, so fix it by adding support for the
task to execute remotely.

Fixes https://github.com/xamarin/xamarin-macios/issues/19027.

Backport of #19047.