### PR TITLE
[xharness] Fix parsing configuration files.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -647,7 +647,7 @@ namespace Xharness {
 			if (string.IsNullOrEmpty (file))
 				return;
 
-			foreach (var line in File.ReadAllLines (file)) {
+			foreach (var line in File.ReadAllLines (file).Reverse ()) {
 				var eq = line.IndexOf ('=');
 				if (eq == -1)
 					continue;


### PR DESCRIPTION
When parsing configuration files, our logic works on a first-come-wins basis,
where the first time we find a variable, that's the value we get.

In the makefiles it's the opposite: the final value is the last time a
variable is set.

This means we must parse configuration files in the reverse order, otherwise this:

    INCLUDE_IOS=
    INCLUDE_IOS=1

will get the opposite result of what we want.