### PR TITLE
[tests] Remove the 32-bit/64-bit difference for iOS tests.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2039,7 +2039,14 @@ public class TestApp {
 			var nunit_framework = Path.Combine (Configuration.RootPath, "packages", "nunit", version, "lib", "netstandard2.0", "nunit.framework.dll");
 			if (!File.Exists (nunit_framework))
 				throw new FileNotFoundException ($"Could not find nunit.framework.dll in {nunit_framework}. Has the version changed?");
-			return new string [] { lib, nunit_framework };
+			var src_unsafe = Path.Combine (Configuration.RootPath, "packages", "system.runtime.compilerservices.unsafe", "4.3.0", "lib", "netstandard1.0", "System.Runtime.CompilerServices.Unsafe.dll");
+			if (!File.Exists (src_unsafe))
+				throw new FileNotFoundException ($"Could not find System.Runtime.CompilerServices.Unsafe.dll in {src_unsafe}. Has the version changed?");
+			return new string [] {
+				lib,
+				nunit_framework,
+				src_unsafe,
+			};
 		}
 
 		static string GetBindingsLibrary (Profile profile, out string version)

--- a/tests/xharness/Jenkins/RunDeviceTasksFactory.cs
+++ b/tests/xharness/Jenkins/RunDeviceTasksFactory.cs
@@ -61,24 +61,7 @@ namespace Xharness.Jenkins {
 						tunnelBore: jenkins.TunnelBore,
 						errorKnowledgeBase: jenkins.ErrorKnowledgeBase,
 						useTcpTunnel: jenkins.Harness.UseTcpTunnel,
-						candidates: jenkins.Devices.Connected64BitIOS.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !jenkins.TestSelection.IsEnabled (PlatformLabel.iOS64) });
-
-					var build32 = new MSBuildTask (jenkins: jenkins, testProject: project, processManager: processManager) {
-						ProjectConfiguration = project.Name != "dont link" ? "Debug32" : "Release32",
-						ProjectPlatform = "iPhone",
-						Platform = TestPlatform.iOS_Unified32,
-						TestName = project.Name,
-					};
-					build32.CloneTestProject (jenkins.MainLog, processManager, project, HarnessConfiguration.RootDirectory);
-					projectTasks.Add (new RunDeviceTask (
-						jenkins: jenkins,
-						devices: jenkins.Devices,
-						buildTask: build32,
-						processManager: processManager,
-						tunnelBore: jenkins.TunnelBore,
-						errorKnowledgeBase: jenkins.ErrorKnowledgeBase,
-						useTcpTunnel: jenkins.Harness.UseTcpTunnel,
-						candidates: jenkins.Devices.Connected32BitIOS.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !jenkins.TestSelection.IsEnabled (PlatformLabel.iOS32) });
+						candidates: jenkins.Devices.Connected64BitIOS.Where (d => project.IsSupported (d.DevicePlatform, d.ProductVersion))) { Ignored = !jenkins.TestSelection.IsEnabled (PlatformLabel.iOS) });
 
 					if (createTodayExtension) {
 						var todayProject = project.GenerateVariations ? project.AsTodayExtensionProject () : project;

--- a/tests/xharness/Jenkins/RunSimulatorTasksFactory.cs
+++ b/tests/xharness/Jenkins/RunSimulatorTasksFactory.cs
@@ -48,7 +48,7 @@ namespace Xharness.Jenkins {
 						switch (testPlatform) {
 						case TestPlatform.iOS_Unified:
 						case TestPlatform.iOS_TodayExtension64:
-							configIgnored |= !jenkins.TestSelection.IsEnabled (PlatformLabel.iOS64);
+							configIgnored |= !jenkins.TestSelection.IsEnabled (PlatformLabel.iOS);
 							break;
 						case TestPlatform.tvOS:
 							configIgnored |= !jenkins.TestSelection.IsEnabled (PlatformLabel.tvOS);

--- a/tests/xharness/Jenkins/TestSelector.cs
+++ b/tests/xharness/Jenkins/TestSelector.cs
@@ -246,8 +246,6 @@ namespace Xharness.Jenkins {
 			if (!Harness.INCLUDE_IOS) {
 				MainLog?.WriteLine ("The iOS build is disabled, so any iOS tests will be disabled as well.");
 				selection.SetEnabled (PlatformLabel.iOS, false);
-				selection.SetEnabled (PlatformLabel.iOS64, false);
-				selection.SetEnabled (PlatformLabel.iOS32, false);
 			}
 
 			if (!Harness.INCLUDE_WATCH) {

--- a/tests/xharness/TestLabel.cs
+++ b/tests/xharness/TestLabel.cs
@@ -94,10 +94,6 @@ namespace Xharness {
 		iOSExtension = 1 << 3,
 		[Label ("ios-simulator")]
 		iOSSimulator = 1 << 4,
-		[Label ("ios-32")]
-		iOS32 = 1 << 5,
-		[Label ("ios-64")]
-		iOS64 = 1 << 6,
 		[Label ("mac")]
 		Mac = 1 << 7,
 		[Label ("maccatalyst")]

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -86,7 +86,7 @@ parameters:
       displayName: 'iOS64 Device Tests',
       testPool: 'VSEng-Xamarin-Mac-Devices',
       useXamarinStorage: false,
-      testsLabels: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
+      testsLabels: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
       statusContext: 'VSTS: device tests iOS',
       makeTarget: 'vsts-device-tests',
       extraBotDemands: [

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -71,7 +71,7 @@ parameters:
       displayName: 'iOS64 Device Tests',
       testPool: 'VSEng-Xamarin-Mac-Devices',
       useXamarinStorage: false,
-      testsLabels: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
+      testsLabels: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
       statusContext: 'VSTS: device tests iOS',
       makeTarget: 'vsts-device-tests',
       extraBotDemands: [

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -300,7 +300,7 @@ stages:
     displayName: '${{ parameters.stageDisplayNamePrefix }}Simulator tests'
     testPool: '' # use the default
     useXamarinStorage: false
-    testsLabels: '--label=skip-all-tests,run-ios-64-tests,run-ios-simulator-tests,run-tvos-tests,run-watchos-tests,run-mac-tests,run-maccatalyst-tests,run-dotnet-tests,run-system-permission-tests,run-legacy-xamarin-tests'
+    testsLabels: '--label=skip-all-tests,run-ios-tests,run-ios-simulator-tests,run-tvos-tests,run-watchos-tests,run-mac-tests,run-maccatalyst-tests,run-dotnet-tests,run-system-permission-tests,run-legacy-xamarin-tests'
     statusContext: 'VSTS: simulator tests'
     makeTarget: 'jenkins'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
@@ -360,28 +360,6 @@ stages:
       displayName: '${{ parameters.stageDisplayNamePrefix }}Windows Integration Tests'
       pool: 'VSEng-Xamarin-Mac-Devices' # currently ignored until the VS team provides a real one
       statusContext: 'Windows Integration Tests'
-
-# iOS 32b tests are slow and do not have many machines, for that reason we are going just to run them in the Schedule builds.
-# This means we are going to get the translations AND the iOS 32b on those builds.
-#
-- ${{ if eq(variables['Build.Reason'], 'Schedule') }}: 
-  - template: ./tests/stage.yml
-    parameters:
-      isPR: ${{ parameters.isPR }}
-      repositoryAlias: ${{ parameters.repositoryAlias }}
-      commit: ${{ parameters.commit }}
-      testPrefix: 'iOS32b'
-      stageName: 'ios32b_device'
-      displayName: '${{ parameters.stageDisplayNamePrefix }}iOS32b Device Tests'
-      testPool: 'VSEng-Xamarin-QA'
-      useXamarinStorage: false
-      testsLabels: '--label=run-ios-32-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests'
-      statusContext: 'VSTS: device tests iOS32b'
-      extraBotDemands: ['xismoke-32']
-      vsdropsPrefix: ${{ variables.vsdropsPrefix }}
-      keyringPass: $(pass--lab--mac--builder--keychain)
-      gitHubToken: $(Github.Token)
-      xqaCertPass: $(xqa--certificates--password)
 
 - ${{ if eq(parameters.runSamples, true) }}:
   # TODO: Not the real step

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -12,7 +12,7 @@ parameters:
 
 - name: testsLabels
   type: string
-  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices.
+  default: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices.
 
 - name: label
   type: string

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -5,7 +5,7 @@ parameters:
 
 - name: testsLabels
   type: string
-  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices.
+  default: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices.
 
 - name: label
   type: string

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -17,7 +17,7 @@ parameters:
 # string that contains the extra labels to pass to xharness to select the tests to execute.
 - name: testsLabels
   type: string
-  default: '--label=run-ios-64-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices.
+  default: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests' # default context, since we started dealing with iOS devices.
 
 # name of the pool that contains the iOS devices
 - name: testPool


### PR DESCRIPTION
This fixes an issue where we wouldn't enable the mtouch tests, because we
check if iOS is enabled to enable them, and it turns out iOS isn't enabled by
default, only 64-bit iOS.

This is rather unintuitive, so just remove the 32-bit/64-bit distinction in
xharness and Azure Pipeline, since our support for 32-bit iOS is very rapidly
going away (with Xcode 15 support) anyway.