### PR TITLE
[UIKit] Fix availability attributes for a few members in UIScrollViewKeyboardDismissMode. Fixes #19066.

### DIFF
--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -1576,9 +1576,9 @@ namespace UIKit {
 		None,
 		OnDrag,
 		Interactive,
-		[TV (16, 0), iOS (16, 0), MacCatalyst (16, 0)]
+		[TV (16, 0)] // Added in Xcode 14.0, but headers and documentation say it's available in iOS 7+ and Mac Catalyst 13.1+ (and tvOS 16.0)
 		OnDragWithAccessory,
-		[TV (16, 0), iOS (16, 0), MacCatalyst (16, 0)]
+		[TV (16, 0)] // Added in Xcode 14.0, but headers and documentation say it's available in iOS 7+ and Mac Catalyst 13.1+ (and tvOS 16.0)
 		InteractiveWithAccessory,
 	}
 


### PR DESCRIPTION
These members were introduced in Xcode 14, but seems to be backwards
compatible on iOS and Mac Catalyst (according to headers, documentation, and
the reporter).

Fixes https://github.com/xamarin/xamarin-macios/issues/19066.