### PR TITLE
[release-test/net8.0-xcode15-multi-targeting] Update vsman name

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -208,7 +208,7 @@ $(DOTNET_NUPKG_DIR)/vs-workload.props: Makefile generate-vs-workload.csharp
 		$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),--shorten $($(platform)_NUGET_WINDOWS_SDK_NAME)=Microsoft.$(platform).Win.Sdk) \
 		$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),--shorten Microsoft.$(platform).Windows.Sdk.Aliased.$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION)=Microsoft.$(platform).Aliased.Sdk) \
 		$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),--shorten $($(rid)_NUGET_RUNTIME_NAME)=Microsoft.Runtime.$(rid))) \
-		--tfm $(DOTNET_TFM) \
+		--tfm $(DOTNET_TFM).xcode15 \
 		--output $@.tmp
 	$(Q) mv $@.tmp $@
 


### PR DESCRIPTION
Adds `.xcode15` to the VS manifest file name to avoid conflicts with the
main .NET 8 branch.

The manifests produced by this branch will now have the following names:

    Microsoft.NET.Sdk.iOS.MacCatalyst.macOS.tvOS.Workload.net8.0.xcode15.vsman
    Microsoft.NET.Sdk.iOS.MacCatalyst.macOS.tvOS.Workload.net8.0.xcode15.multitarget.vsman