### PR TITLE
Remove duplicated make logic.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -693,9 +693,6 @@ MACIOS_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMP
 # Set this to 1 if the Microsoft.NETCore.App.Ref dependency in eng/Version.Details.xml does *not* specify a CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal.
 TRACKING_DOTNET_RUNTIME_SEPARATELY=
 
-# Set this to 1 if the Microsoft.NETCore.App.Ref dependency in eng/Version.Details.xml does *not* specify a CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal.
-TRACKING_DOTNET_RUNTIME_SEPARATELY=
-
 # The location of csc changes depending on whether we're using a preview or a stable/service release :/
 DOTNET_CSC_PATH_PREVIEW=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION)/Roslyn/bincore/csc.dll
 DOTNET_CSC_PATH_STABLE=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION_BAND)/Roslyn/bincore/csc.dll


### PR DESCRIPTION
The duplicated code probably happened during a merge conflict, which wasn't
resolved correctly.