### PR TITLE
NativeAOT: Mark module constructors in MSR 

### DIFF
--- a/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
@@ -159,6 +159,8 @@ namespace Xamarin.Linker {
 
 			il.InsertBefore (lastInstruction, il.Create (OpCodes.Newobj, registrarType.GetDefaultInstanceConstructor ()));
 			il.InsertBefore (lastInstruction, il.Create (OpCodes.Call, abr.RegistrarHelper_Register));
+
+			Annotations.Mark (moduleConstructor);
 		}
 
 		List<TypeData> GetTypesToRegister (TypeDefinition registrarType, AssemblyTrampolineInfo info)


### PR DESCRIPTION
There is an issue with managed static registrar and explicitly rooted assemblies (through linker descriptor files) where the linker does not emit the created module initializer.

This was originally reported in: https://github.com/dotnet/runtime/issues/92106
and a smaller repro can be set up in: `tests/dotnet/MySingleView` test project with the following changes:

### Smaller repro
1. Add a descriptor xml - `Roots.xml`
```xml
<linker>
  <assembly fullname="MySingleView" preserve="All" />
</linker>
```

2. Include the root descriptor in the `MySingleView.csproj`
```xml
<ItemGroup>
     <TrimmerRootDescriptor Condition="'$(_RootSelf)' == 'true'" Include="Roots.xml" />
</ItemGroup>
```

3.  Publish/run the app on a device
```bash
dotnet publish -c Release -r ios-arm64 -p:PublishAot=true -p:PublishAotUsingRuntimePack=true -p:_RootSelf=true -t:Run /bl
```

4. The app crashes at start up with:
```
2023-09-25 18:55:42.562 MySingleView[477:55844] *** Terminating app due to uncaught exception 'ObjCRuntime.RuntimeException', reason: 'Can't register the class MySingleView.AppDelegate when the dynamic registrar has been linked away. (ObjCRuntime.RuntimeException)
   at ObjCRuntime.Class.GetClassHandle(Type, Boolean, Boolean&) + 0x1c4
   at UIKit.UIApplication.Main(String[], Type, Type) + 0x8c
   at MySingleView!<BaseAddress>+0x2fae7c
'
```

NOTE: This is reported for NativeAOT but seems like a general problem

Additionally, here are the disassembled linked assemblies:
- regular: https://gist.github.com/ivanpovazan/e82bdcb5313a846ff50de0a79d560553
- rooted: https://gist.github.com/ivanpovazan/760e931fdcd3ef3e573d88087718dad2

It can be seen that the rooted one is missing:
```asm
// ================== GLOBAL METHODS =========================

.method private hidebysig specialname rtspecialname static 
        void  .cctor() cil managed
{
  // Code size       11 (0xb)
  .maxstack  1
  IL_0000:  newobj     instance void ObjCRuntime.__Registrar__::.ctor()
  IL_0005:  call       void [Microsoft.iOS]ObjCRuntime.RegistrarHelper::Register(class [Microsoft.iOS]ObjCRuntime.IManagedRegistrar)
  IL_000a:  ret
} // end of global method .cctor
```

### The fix

This PR fixes this behaviour by explicitly marking module constructor to prevent this from happening.

---
Fixes https://github.com/dotnet/runtime/issues/92106