### PR TITLE
Revert "[MacCatalyst] Added Default Entitlements for MacCatalyst projects"

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -23,19 +23,6 @@
     <None Include="@(ObjcBindingCoreSource)" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(_PlatformName)' == 'MacCatalyst'">
-    <EnableDefaultMacCatalystReleaseEntitlements Condition="'$(EnableDefaultMacCatalystReleaseEntitlements)' == ''">True</EnableDefaultMacCatalystReleaseEntitlements>
-    <EnableDefaultMacCatalystDebugEntitlements Condition="'$(EnableDefaultMacCatalystDebugEntitlements)' == ''">True</EnableDefaultMacCatalystDebugEntitlements>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(EnableDefaultMacCatalystDebugEntitlements)' == 'True' and '$(Configuration)' == 'Debug'">
-    <CustomEntitlements Include="com.apple.security.get-task-allow" Type="boolean" Value="true" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(EnableDefaultMacCatalystReleaseEntitlements)' == 'True' and '$(Configuration)' == 'Release'">
-    <CustomEntitlements Include="com.apple.security.app-sandbox" Type="boolean" Value="true" />
-  </ItemGroup>
-
   <!-- Architecture -->
   <!-- If the old-style variables are set, use those -->
   <PropertyGroup Condition=" '$(TargetArchitectures)' == '' ">

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1309,32 +1309,6 @@ namespace Xamarin.Tests {
 			}
 		}
 
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", "Release")]
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", "Debug")]
-		public void CheckForMacCatalystDefaultEntitlements (ApplePlatform platform, string runtimeIdentifiers, string configuration)
-		{
-			var project = "Entitlements";
-			Configuration.IgnoreIfIgnoredPlatform (platform);
-			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
-
-			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
-			Clean (project_path);
-
-			var properties = GetDefaultProperties (runtimeIdentifiers);
-			properties ["Configuration"] = configuration;
-			DotNet.AssertBuild (project_path, properties);
-
-			var executable = GetNativeExecutable (platform, appPath);
-			var foundEntitlements = TryGetEntitlements (executable, out var entitlements);
-			Assert.IsTrue (foundEntitlements, "Issues found with Entitlements.");
-			if (configuration == "Release") {
-				Assert.IsTrue (entitlements!.Get<PBoolean> ("com.apple.security.app-sandbox")?.Value, "com.apple.security.app-sandbox enlistment was not found in Release configuration.");
-				Assert.IsNull (entitlements.Get<PBoolean> ("com.apple.security.get-task-allow")?.Value, "com.apple.security.get-task-allow enlistment was found in Release configuration.");
-			} else if (configuration == "Debug") {
-				Assert.IsTrue (entitlements!.Get<PBoolean> ("com.apple.security.get-task-allow")?.Value, "com.apple.security.get-task-allow enlistment was not found in Debug configuration.");
-			}
-		}
-
 		// [TestCase (ApplePlatform.MacCatalyst, null, "Release")]
 		[TestCase (ApplePlatform.MacOSX, null, "Release")]
 		public void NoWarnCodesign (ApplePlatform platform, string runtimeIdentifiers, string configuration)


### PR DESCRIPTION
Reverts xamarin/xamarin-macios#18669 per discussion in MAUI about sdk defaults.

 See https://github.com/dotnet/maui/pull/16355 for more information. Consult teams thread for more information:
https://teams.microsoft.com/l/message/19:989ffa44998147aca4ceaf7482967668@thread.skype/1696009594958?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=0056f60b-301f-43ac-bbcf-f356d3c42c92&parentMessageId=1696009594958&teamName=VS%20Client%20Experiences&channelName=MAUI%20🌺&createdTime=1696009594958 (MSFT only)