### PR TITLE
[release/7.0.3xx] Updating Xamarin.iOS.HotRestart.Client to 1.0.125

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<MessagingVersion>1.9.102</MessagingVersion>
-		<HotRestartVersion>1.0.114</HotRestartVersion>
+		<HotRestartVersion>1.0.125</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
The latest version has Component Governance fixes in it: https://github.com/xamarin/isignsharp/pull/52/files

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1869900

Backport of #19046