### PR TITLE
[release/7.0.3xx] [dotnet] Link Mono and Xamarin statically in Mac Catalyst by default. Fixes #14686.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -922,11 +922,15 @@
 			<_AOTInputDirectory>$(_IntermediateNativeLibraryDir)aot-input/</_AOTInputDirectory>
 			<_AOTOutputDirectory>$(_IntermediateNativeLibraryDir)aot-output/</_AOTOutputDirectory>
 
+			<!-- default to 'static' for Mac Catalyst to work around https://github.com/xamarin/xamarin-macios/issues/14686 -->
+			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And '$(_PlatformName)' == 'MacCatalyst'">static</_LibMonoLinkMode>
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And ('$(ComputedPlatform)' != 'iPhone' Or '$(_PlatformName)' == 'macOS')">dylib</_LibMonoLinkMode>
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == ''">static</_LibMonoLinkMode>
 			<_LibMonoExtension Condition="'$(_LibMonoLinkMode)' == 'dylib'">dylib</_LibMonoExtension>
 			<_LibMonoExtension Condition="'$(_LibMonoLinkMode)' == 'static'">a</_LibMonoExtension>
 
+			<!-- default to 'static' for Mac Catalyst to work around https://github.com/xamarin/xamarin-macios/issues/14686 -->
+			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == '' And '$(_PlatformName)' == 'MacCatalyst'">static</_LibXamarinLinkMode>
 			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == '' And '$(ComputedPlatform)' != 'iPhone' And '$(_PlatformName)' != 'macOS'">dylib</_LibXamarinLinkMode>
 			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == ''">static</_LibXamarinLinkMode>
 			<_LibXamarinExtension Condition="'$(_LibXamarinLinkMode)' == 'dylib'">dylib</_LibXamarinExtension>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1164,14 +1164,6 @@ namespace Xamarin.Tests {
 			var signedDylibs = new List<string> {
 				Path.Combine (sharedSupportDir, "app2.app", dylibDir, "lib2.dylib"),
 			};
-			if (platform == ApplePlatform.MacCatalyst) {
-				signedDylibs.Add (Path.Combine (dylibDir, "libSystem.IO.Compression.Native.dylib"));
-				signedDylibs.Add (Path.Combine (dylibDir, "libSystem.Native.dylib"));
-				signedDylibs.Add (Path.Combine (dylibDir, "libSystem.Net.Security.Native.dylib"));
-				signedDylibs.Add (Path.Combine (dylibDir, "libSystem.Security.Cryptography.Native.Apple.dylib"));
-				signedDylibs.Add (Path.Combine (dylibDir, "libmonosgen-2.0.dylib"));
-				signedDylibs.Add (Path.Combine (dylibDir, "libxamarin-dotnet-debug.dylib"));
-			}
 
 			foreach (var dylib in signedDylibs) {
 				var path = Path.Combine (appPath, dylib);

--- a/tests/introspection/ApiPInvokeTest.cs
+++ b/tests/introspection/ApiPInvokeTest.cs
@@ -222,7 +222,23 @@ namespace Introspection {
 						path = null;
 						break;
 					case "libSystem.Native":
-						path += ".dylib";
+						var staticallyLinked = false;
+#if __MACCATALYST__
+						// always statically linked
+						staticallyLinked = true;
+#elif __IOS__ || __TVOS__
+						// statically linked on device
+						staticallyLinked = Runtime.Arch == Arch.DEVICE;
+#elif __MACOS__
+						// never statically linked (by default)
+#else
+#error Unknown platform
+#endif
+						if (staticallyLinked) {
+							path = null;
+						} else {
+							path += ".dylib";
+						}
 						break;
 #endif
 					case "libc":

--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -189,6 +189,9 @@ namespace Xamarin.Linker.Steps {
 					Where (v => v.EndsWith (".dylib", StringComparison.OrdinalIgnoreCase) || v.EndsWith (".a", StringComparison.OrdinalIgnoreCase)).
 					Select (v => Path.GetFileNameWithoutExtension (v)).
 					Select (v => v.StartsWith ("lib", StringComparison.OrdinalIgnoreCase) ? v.Substring (3) : v).ToHashSet ();
+#if !__MACOS__
+				monoLibraryVariations.Add ("System.Globalization.Native"); // System.Private.CoreLib has P/Invokes pointing to libSystem.Globalization.Native, but they're actually in libmonosgen-2.0
+#endif
 				monoLibraryVariations.UnionWith (monoLibraryVariations.Select (v => "lib" + v).ToArray ());
 				monoLibraryVariations.UnionWith (monoLibraryVariations.Select (v => v + ".dylib").ToArray ());
 				// If the P/Invoke points to any of those libraries, then we add it as a P/Invoke symbol.


### PR DESCRIPTION
It's possible to create a provisioning profile for Mac Catalyst that doesn't
allow dylibs in the app. It seems a significant number of people run into this
problem when publishing their apps, so avoid it by linking Mono and Xamarin
statically by default instead.

The downside is that build time might increase a little bit.

An upside however is that the app size might decrese somewhat.

Fixes https://github.com/xamarin/xamarin-macios/issues/14686.


Backport of #18619
