### PR TITLE
[release/8.0.1xx-rc2] [CI] Ensure we use python 3 before we install the ESRP plugin.

### DIFF
--- a/tools/devops/automation/templates/sign-and-notarized/setup.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/setup.yml
@@ -43,6 +43,10 @@ steps:
 # the ddsign plugin needs this version or it will crash and will make the sign step fail
 
 - ${{ if eq(parameters.isPR, false) }}:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.x'
+
   - task: UseDotNet@2
     inputs:
       packageType: sdk


### PR DESCRIPTION



Backport of #19147
