### PR TITLE
[AutomaticAssessmentConfiguration] Add missing constructors to AEAssessmentApplication. Fixes #19133.

### DIFF
--- a/src/automaticassessmentconfiguration.cs
+++ b/src/automaticassessmentconfiguration.cs
@@ -172,7 +172,19 @@ namespace AutomaticAssessmentConfiguration {
 
 	[Mac (12, 0), iOS (15, 0), MacCatalyst (15, 0)]
 	[BaseType (typeof (NSObject))]
+#if XAMCORE_5_0
+	[DisableDefaultCtor]
+#endif
 	interface AEAssessmentApplication : NSCopying {
+		[NoiOS]
+		[Export ("initWithBundleIdentifier:")]
+		NativeHandle Constructor (string bundleIdentifier);
+
+		[NoiOS]
+		[NoMacCatalyst] // header says it's available in Mac Catalyst, Apple's documentation + xtro says it's not, so don't add it for now.
+		[Export ("initWithBundleIdentifier:teamIdentifier")]
+		NativeHandle Constructor (string bundleIdentifier, [NullAllowed] string TeamIdentifier);
+
 		[Export ("bundleIdentifier")]
 		string BundleIdentifier { get; }
 

--- a/src/automaticassessmentconfiguration.cs
+++ b/src/automaticassessmentconfiguration.cs
@@ -182,7 +182,7 @@ namespace AutomaticAssessmentConfiguration {
 
 		[NoiOS]
 		[NoMacCatalyst] // header says it's available in Mac Catalyst, Apple's documentation + xtro says it's not, so don't add it for now.
-		[Export ("initWithBundleIdentifier:teamIdentifier")]
+		[Export ("initWithBundleIdentifier:teamIdentifier:")]
 		NativeHandle Constructor (string bundleIdentifier, [NullAllowed] string TeamIdentifier);
 
 		[Export ("bundleIdentifier")]

--- a/src/automaticassessmentconfiguration.cs
+++ b/src/automaticassessmentconfiguration.cs
@@ -177,6 +177,7 @@ namespace AutomaticAssessmentConfiguration {
 #endif
 	interface AEAssessmentApplication : NSCopying {
 		[NoiOS]
+		[MacCatalyst (15, 0)]
 		[Export ("initWithBundleIdentifier:")]
 		NativeHandle Constructor (string bundleIdentifier);
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AutomaticAssessmentConfiguration.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AutomaticAssessmentConfiguration.ignore
@@ -1,1 +1,0 @@
-!missing-selector! AEAssessmentApplication::initWithBundleIdentifier: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AutomaticAssessmentConfiguration.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AutomaticAssessmentConfiguration.ignore
@@ -1,2 +1,0 @@
-!missing-selector! AEAssessmentApplication::initWithBundleIdentifier: not bound
-!missing-selector! AEAssessmentApplication::initWithBundleIdentifier:teamIdentifier: not bound

--- a/tests/xtro-sharpie/macOS-AutomaticAssessmentConfiguration.ignore
+++ b/tests/xtro-sharpie/macOS-AutomaticAssessmentConfiguration.ignore
@@ -1,2 +1,0 @@
-!missing-selector! AEAssessmentApplication::initWithBundleIdentifier: not bound
-!missing-selector! AEAssessmentApplication::initWithBundleIdentifier:teamIdentifier: not bound


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/19133.