### PR TITLE
[msbuild] Report a better error if a NativeResource doesn't exist on disk.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -898,6 +898,13 @@
         <value>Could not parse the custom linker argument(s) '-{0}': {1}</value>
     </data>
 
+    <data name="E0190" xml:space="preserve">
+        <value>The NativeResource item '{0}' does not exist.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
+
     <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs
@@ -40,7 +40,7 @@ namespace Xamarin.MacDev.Tasks {
 			var nonexistent = NativeReferences.Where (v => !(Directory.Exists (v.ItemSpec) || File.Exists (v.ItemSpec)));
 			if (nonexistent.Any ()) {
 				foreach (var nonex in nonexistent)
-					Log.LogError (MSBStrings.E0190 /* The NativeResource item '{0}' does not exist. */, inex.ItemSpec);
+					Log.LogError (MSBStrings.E0190 /* The NativeResource item '{0}' does not exist. */, nonex.ItemSpec);
 				return false;
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs
@@ -37,9 +37,9 @@ namespace Xamarin.MacDev.Tasks {
 				return true;
 			}
 
-			var inexistent = NativeReferences.Where (v => !(Directory.Exists (v.ItemSpec) || File.Exists (v.ItemSpec)));
-			if (inexistent.Any ()) {
-				foreach (var inex in inexistent)
+			var nonexistent = NativeReferences.Where (v => !(Directory.Exists (v.ItemSpec) || File.Exists (v.ItemSpec)));
+			if (nonexistent.Any ()) {
+				foreach (var nonex in nonexistent)
 					Log.LogError (MSBStrings.E0190 /* The NativeResource item '{0}' does not exist. */, inex.ItemSpec);
 				return false;
 			}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs
@@ -37,6 +37,13 @@ namespace Xamarin.MacDev.Tasks {
 				return true;
 			}
 
+			var inexistent = NativeReferences.Where (v => !(Directory.Exists (v.ItemSpec) || File.Exists (v.ItemSpec)));
+			if (inexistent.Any ()) {
+				foreach (var inex in inexistent)
+					Log.LogError (MSBStrings.E0190 /* The NativeResource item '{0}' does not exist. */, inex.ItemSpec);
+				return false;
+			}
+
 			var compress = false;
 			if (string.Equals (Compress, "true", StringComparison.OrdinalIgnoreCase)) {
 				compress = true;


### PR DESCRIPTION
This fixes makes this rather unhelpful error:

    error MSB4018: The "CreateBindingResourcePackage" task failed unexpectedly.
    error MSB4018: System.Exception: Could not lstat 'mylib.a': 2
    error MSB4018:    at Xamarin.Utils.PathUtils.IsSymlink(String file) in /Users/rolf/work/maccore/main/xamarin-macios/tools/common/PathUtils.cs:line 222
    error MSB4018:    at Xamarin.Utils.PathUtils.IsSymlinkOrContainsSymlinks(String directoryOrFile) in /Users/rolf/work/maccore/main/xamarin-macios/tools/common/PathUtils.cs:line 229
    error MSB4018:    at Xamarin.MacDev.Tasks.CreateBindingResourcePackageBase.ContainsSymlinks(ITaskItem[] items) in /Users/rolf/work/maccore/main/xamarin-macios/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs:line 110
    error MSB4018:    at Xamarin.MacDev.Tasks.CreateBindingResourcePackageBase.Execute() in /Users/rolf/work/maccore/main/xamarin-macios/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackageBase.cs:line 46
    error MSB4018:    at Xamarin.MacDev.Tasks.CreateBindingResourcePackage.Execute() in /Users/rolf/work/maccore/main/xamarin-macios/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateBindingResourcePackage.cs:line 15
    error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
    error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)

turn into this instead:

    error : The NativeResource 'mylib.a' does not exist.