### PR TITLE
[AppKit/UIKit] Adjust a few availability attributes in NS[Mutable]ParagraphStyle. Fixes #19209.

### DIFF
--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -1862,7 +1862,6 @@ namespace UIKit {
 #endif
 
 		[NoWatch, MacCatalyst (13, 1)]
-		[NoMacCatalyst]
 		[Override]
 		[Export ("textLists")]
 		NSTextList [] TextLists { get; set; }

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -244,15 +244,16 @@ namespace UIKit {
 		GreaterThanOrEqual = 1,
 	}
 
-	[Watch (7, 0), TV (14, 0), iOS (14, 0)]
-	[Mac (11, 0)]
 	[MacCatalyst (13, 1)]
 	[Flags]
 	[Native]
 	public enum NSLineBreakStrategy : ulong {
+		[Mac (11, 0), iOS (14, 0), TV (14, 0), Watch (7, 0), MacCatalyst (14, 0)]
 		None = 0x0,
 		PushOut = 1uL << 0,
+		[Mac (11, 0), iOS (14, 0), TV (14, 0), Watch (7, 0), MacCatalyst (14, 0)]
 		HangulWordPriority = 1uL << 1,
+		[Mac (11, 0), iOS (14, 0), TV (14, 0), Watch (7, 0), MacCatalyst (14, 0)]
 		Standard = 0xffff,
 	}
 
@@ -1745,7 +1746,7 @@ namespace UIKit {
 		NSTextTableBlock [] TextBlocks { get; [NotImplemented] set; }
 #endif
 
-		[iOS (16, 0), TV (16, 0), NoWatch, MacCatalyst (16, 0)]
+		[NoWatch, MacCatalyst (13, 1)]
 		[Export ("textLists")]
 		NSTextList [] TextLists { get; [NotImplemented] set; }
 
@@ -1759,8 +1760,7 @@ namespace UIKit {
 		[Export ("headerLevel")]
 		nint HeaderLevel { get; [NotImplemented] set; }
 
-		[Mac (11, 0), Watch (7, 0), TV (14, 0), iOS (14, 0)]
-		[MacCatalyst (14, 0)]
+		[MacCatalyst (13, 1)]
 		[Export ("lineBreakStrategy")]
 		NSLineBreakStrategy LineBreakStrategy { get; [NotImplemented] set; }
 	}
@@ -1861,7 +1861,7 @@ namespace UIKit {
 		NSTextTableBlock [] TextBlocks { get; set; }
 #endif
 
-		[iOS (16, 0), TV (16, 0), NoWatch, MacCatalyst (16, 0)]
+		[NoWatch, MacCatalyst (13, 1)]
 		[NoMacCatalyst]
 		[Override]
 		[Export ("textLists")]
@@ -1879,8 +1879,7 @@ namespace UIKit {
 		[Override]
 		nint HeaderLevel { get; set; }
 
-		[Mac (11, 0), Watch (7, 0), TV (14, 0), iOS (14, 0)]
-		[MacCatalyst (14, 0)]
+		[MacCatalyst (13, 1)]
 		[Override]
 		[Export ("lineBreakStrategy", ArgumentSemantic.Assign)]
 		NSLineBreakStrategy LineBreakStrategy { get; set; }


### PR DESCRIPTION
Both headers and documentation agree that:

* The TextLists and LineBreakStrategy properties are available in all OS
  versions we support, so adjust the availability attributes accordingly.

* While the NSLineBreakStrategy enum is supposedly not available in all OS
  versions we support, the NSLineBreakStrategy.PushOut enum value is. This
  doesn't make much sense, so I've made our enum available in all OS versions
  + the PushOut enum value as well. All the other enum values are only
  available in iOS 14+ (according to docs + headers).

Fixes https://github.com/xamarin/xamarin-macios/issues/19209.