### PR TITLE
[tests] Implement a workaround for an unreliable url to download a command-line installer for .NET.

### DIFF
--- a/tests/dotnet/Windows/InstallDotNet.csproj
+++ b/tests/dotnet/Windows/InstallDotNet.csproj
@@ -63,6 +63,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <DotNetInstallScriptUrl>https://dot.net/v1/dotnet-install.ps1</DotNetInstallScriptUrl>
+    <!-- the main url often doesn't work, so have a backup url (the main url redirects to this one, and main url has a cache timeout of 1 year, so it should be fairly safe) -->
+    <DotNetInstallScriptBackupUrl>https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1</DotNetInstallScriptBackupUrl>
     <DotNetInstallScriptName>dotnet-install.ps1</DotNetInstallScriptName>
     <DotNetInstallScriptPath>$(DotNetOutputPath)$(DotNetInstallScriptName)</DotNetInstallScriptPath>
     <DotNetInstallCommand>&amp; '$(DotNetInstallScriptPath)' -Version $(MicrosoftDotnetSdkInternalPackageVersion) -InstallDir '$(DotNetDirectory)' -Verbose</DotNetInstallCommand>
@@ -71,6 +73,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('osx'))">
     <DotNetInstallScriptUrl>https://dot.net/v1/dotnet-install.sh</DotNetInstallScriptUrl>
+    <!-- the main url often doesn't work, so have a backup url (the main url redirects to this one, and main url has a cache timeout of 1 year, so it should be fairly safe) -->
+    <DotNetInstallScriptBackupUrl>https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh</DotNetInstallScriptBackupUrl>
     <DotNetInstallScriptName>dotnet-install.sh</DotNetInstallScriptName>
     <DotNetInstallScriptPath>$(DotNetOutputPath)$(DotNetInstallScriptName)</DotNetInstallScriptPath>
     <DotNetInstallCommand>bash '$(DotNetInstallScriptPath)' --version $(MicrosoftDotnetSdkInternalPackageVersion) --install-dir '$(DotNetDirectory)' --verbose</DotNetInstallCommand>
@@ -127,7 +131,15 @@
         SourceUrl="$(DotNetInstallScriptUrl)"
         DestinationFolder="$(DotNetOutputPath)"
         DestinationFileName="$(DotNetInstallScriptName)"
+        ContinueOnError="true"
     />
+    <DownloadFile
+        SourceUrl="$(DotNetInstallScriptBackupUrl)"
+        DestinationFolder="$(DotNetOutputPath)"
+        DestinationFileName="$(DotNetInstallScriptName)"
+        Condition="'$(MSBuildLastTaskResult)' == 'false'"
+    />
+
   </Target>
 
   <Target Name="_InstallDotNet"


### PR DESCRIPTION
The documented URL for downloading a script to install .NET
(https://dot.net/v1/dotnet-install.[ps1|sh]) is rather unreliable and fails
quite often. So add support for a fallback URL - which is just the url the
documented URL redirects to - and use that if the main URL doesn't work.

Hopefully this will decrease the number of times the Windows tests fail
because we couldn't download the install script.