### PR TITLE
[release/8.0.1xx] [dotnet/msbuild] Create directory in the ILStrip task instead of using MSBuild logic.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -857,7 +857,7 @@
 	<!-- The DependsOnTargets here will not force EnableAssemblyILStripping to be calculated before the condition is evaulated. The order in CreateAppBundleDependsOn matters. -->
 	<Target Name="_StripAssemblyIL" Condition="'$(EnableAssemblyILStripping)' == 'true'" DependsOnTargets="_ComputeStripAssemblyIL">
 		<PropertyGroup>
-			<_StrippedAssemblyDirectory>$(DeviceSpecificIntermediateOutputPath)\stripped</_StrippedAssemblyDirectory>
+			<_StrippedAssemblyDirectory>$(DeviceSpecificIntermediateOutputPath)stripped</_StrippedAssemblyDirectory>
 		</PropertyGroup>
 		<ItemGroup>
 			<_AssembliesToBeStripped Include="@(ResolvedFileToPublish)" Condition="'%(Extension)' == '.dll' And '%(ResolvedFileToPublish.Culture)' == ''">
@@ -870,10 +870,7 @@
 			<_AssembliesToBeStripped>
 				<OutputPath>$([System.String]::Copy('%(OutputPath)').Replace('\', '/'))</OutputPath>
 			</_AssembliesToBeStripped>
-
-			<_AssemblyDirsToCreate Include="@(_AssembliesToBeStripped->'%(OutputPath)%(Directory)'->Distinct())"/>
 		</ItemGroup>
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="@(_AssemblyDirsToCreate)" />
 		<Xamarin.MacDev.Tasks.ILStrip
 			Assemblies="@(_AssembliesToBeStripped)"
 			SessionId="$(BuildSessionId)"

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ILStripBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ILStripBase.cs
@@ -23,19 +23,17 @@ namespace Xamarin.MacDev.Tasks {
 			if (this.ShouldExecuteRemotely (SessionId))
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
-			var result = base.Execute ();
-
 			var stripedItems = new List<ITaskItem> ();
-
-			if (result) {
-				foreach (var item in Assemblies) {
-					var outputPath = item.GetMetadata ("OutputPath");
-					stripedItems.Add (new TaskItem (outputPath, item.CloneCustomMetadata ()));
-					Directory.CreateDirectory (Path.GetDirectoryName (outputPath));
-				}
+			foreach (var item in Assemblies) {
+				var outputPath = item.GetMetadata ("OutputPath");
+				stripedItems.Add (new TaskItem (outputPath, item.CloneCustomMetadata ()));
+				Directory.CreateDirectory (Path.GetDirectoryName (outputPath));
 			}
 
-			StrippedAssemblies = stripedItems.ToArray ();
+			var result = base.Execute ();
+
+			if (result)
+				StrippedAssemblies = stripedItems.ToArray ();
 
 			return result;
 		}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ILStripBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ILStripBase.cs
@@ -29,7 +29,9 @@ namespace Xamarin.MacDev.Tasks {
 
 			if (result) {
 				foreach (var item in Assemblies) {
-					stripedItems.Add (new TaskItem (item.GetMetadata ("OutputPath"), item.CloneCustomMetadata ()));
+					var outputPath = item.GetMetadata ("OutputPath");
+					stripedItems.Add (new TaskItem (outputPath, item.CloneCustomMetadata ()));
+					Directory.CreateDirectory (Path.GetDirectoryName (outputPath));
 				}
 			}
 


### PR DESCRIPTION
The current logic doesn't work on Windows for some reason.

Also avoid extra slash in _StrippedAssemblyDirectory, because
DeviceSpecificIntermediateOutputPath already has a trailing slash.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1864985.


Backport of #19181
