### PR TITLE
[release/7.0.3xx] Bump mlaunch to get fix for older devices.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -18,7 +18,7 @@ endif
 
 # Available versions can be seen here:
 # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.Tools.Mlaunch/versions
-MLAUNCH_NUGET_VERSION=1.0.76
+MLAUNCH_NUGET_VERSION=1.0.81
 
 define CheckVersionTemplate
 check-$(1)::

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -18,7 +18,7 @@ endif
 
 # Available versions can be seen here:
 # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.Tools.Mlaunch/versions
-MLAUNCH_NUGET_VERSION=1.0.81
+MLAUNCH_NUGET_VERSION=1.0.82
 
 define CheckVersionTemplate
 check-$(1)::


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@753d531872 [mlaunch] Only use devicectl for iOS 17 or newer devices.
* xamarin/maccore@46ca2f35d3 [mlaunch] Add a null check when detecting whether a device supports wireless debugging.
* xamarin/maccore@864285310c [mlaunch] Use ExceptionDispatchInfo to rethrow exceptions.
* xamarin/maccore@1bc6e4bd53 Merge net8.0-xcode15 into main
* xamarin/maccore@76fcfa4ea3 [mlaunch] Automatically update the codebehind from the resx file during build.

Diff: https://github.com/xamarin/maccore/compare/bfaf53ffa1..753d531872


Backport of #19249
