### PR TITLE
[release/8.0.1xx-rc2.1] Bump mlaunch to get resource fix.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -18,7 +18,7 @@ endif
 
 # Available versions can be seen here:
 # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.Tools.Mlaunch/versions
-MLAUNCH_NUGET_VERSION=1.0.82
+MLAUNCH_NUGET_VERSION=1.0.83
 
 define CheckVersionTemplate
 check-$(1)::


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@699ed5eaf2 [mlaunch] Fix the resource name for the error/warning strings.

Diff: https://github.com/xamarin/maccore/compare/04b71d98c8..699ed5eaf2


Backport of #19291
