### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 17751: Build ID 8579266

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>Nepovedlo se parsovat argumenty vlastního linkeru -{0}: {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>Položka NativeResource {0} neexistuje.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Nepovedlo se přeložit IP adresy hostitele pro nastavení ladicího programu Wi-Fi.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>Die benutzerdefinierten Linkerargumente konnten nicht analysiert werden "-{0}": {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>Das NativeResource-Element "{0}" ist nicht vorhanden.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Die Host-IP-Adressen für die WLAN-Debuggereinstellungen konnten nicht aufgelöst werden.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>No se han podido analizar los argumentos del enlazador personalizado "-{0}": {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>El elemento NativeResource ''{0}'' no existe.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>No se pudieron resolver las direcciones IP del host para la configuración del depurador Wi-Fi.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>Impossible d’analyser le ou les arguments de l’éditeur de liens personnalisés « -{0} » : {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>L'élément NativeResource « {0} » n'existe pas.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Impossible de résoudre les adresses IP des hôtes pour les paramètres du débogueur Wi-Fi.
         </value>
@@ -1206,7 +1212,7 @@
         <value>La tâche « {0} » n’a pas reçu de valeur pour le paramètre « {1} », ce qui est requis lors de la génération sur cette plateforme.</value>
     </data>
   <data name="E7115" xml:space="preserve">
-        <value>L’assembly illink n’existe pas : '{0}'.</value>
+        <value>L’assembly illink n’existe pas : '{0}'.</value>
         <comment>
             {0}: the path to the linker assembly
         </comment>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>Non è stato possibile analizzare gli argomenti del linker personalizzati '-{0}': {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>L'elemento NativeResource "{0}" non esiste.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Non è stato possibile risolvere gli indirizzi IP host per le impostazioni del debugger Wi-Fi.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>カスタム リンカー引数 '-{0}' を解析できませんでした: {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>NativeResource アイテム '{0}' が存在しません。</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>WiFi デバッガー設定のホスト IP を解決できませんでした。
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>사용자 지정 링커 인수 '-{0}'을(를) 구문 분석할 수 없습니다. {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>The NativeResource item '{0}' does not exist.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>WiFi 디버거 설정의 호스트 IP를 확인할 수 없습니다.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>Nie można przeanalizować niestandardowych argumentów konsolidatora „-{0}”: {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>Element NativeResource „{0}” nie istnieje.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Nie można rozpoznać adresów IP hosta dla ustawień debugera WiFi.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>Não foi possível analisar os argumentos do vinculador personalizado '-{0}': {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>O item NativeResource '{0}' não existe.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Não foi possível resolver os IPs do host para as configurações do depurador de WiFi.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>Не удалось проанализировать настраиваемые аргументы компоновщика "-{0}": {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>Элемент NativeResource "{0}" не существует.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Не удалось разрешить IP-адреса узлов для параметров отладчика Wi-Fi.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>Özel bağlayıcı bağımsız değişkenleri '-{0}' ayrıştırılamadı: {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>The NativeResource item '{0}' does not exist.</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Wi-Fi hata ayıklayıcısı ayarları için konak IP'leri çözümlenemedi.
         </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>无法分析自定义链接器参数 "-{0}": {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>NativeResource 项“{0}”不存在。</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>无法解析 WiFi 调试程序设置的主机 IP。
 </value>

--- a/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -724,6 +724,12 @@
   <data name="E0189" xml:space="preserve">
         <value>無法剖析自訂連結器引數 '-{0}': {1}</value>
     </data>
+  <data name="E0190" xml:space="preserve">
+        <value>NativeResource 項目 '{0}' 不存在。</value>
+        <comment>
+            NativeResource: do not translate (this is the name of an item in the project file).
+        </comment>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>無法解析 WiFi 偵錯工具設定的主機 IP。
         </value>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.