### PR TITLE
[dotnet] Remove support for MtouchArch and XamMacArch.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -21,12 +21,6 @@
   </ItemGroup>
 
   <!-- Architecture -->
-  <!-- If the old-style variables are set, use those -->
-  <PropertyGroup Condition=" '$(TargetArchitectures)' == '' ">
-    <TargetArchitectures Condition=" '$(_PlatformName)' == 'macOS' And '$(XamMacArch)' != '' ">$(XamMacArch)</TargetArchitectures>
-    <TargetArchitectures Condition=" '$(_PlatformName)' != 'macOS' And '$(MtouchArch)' != '' ">$(MtouchArch)</TargetArchitectures>
-  </PropertyGroup>
-  <!-- If the old-style variables aren't set, figure it out using RuntimeIdentifier. -->
   <PropertyGroup Condition="'$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' ">
     <!-- Clear RuntimeIdentifier -->
     <RuntimeIdentifier />

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -994,12 +994,24 @@
 			/>
 	</Target>
 
+	<Target Name="_VerifyValidProperties">
+		<Error
+			Text="The property 'MtouchArch' is deprecated, please remove it from the project file. Use 'RuntimeIdentifier' or 'RuntimeIdentifiers' instead to specify the target architecture."
+			Condition="'$(MtouchArch)' != '' And '$(AllowMtouchArchProperty)' != 'true'"
+			/>
+		<Error
+			Text="The property 'XamMacArch' is deprecated, please remove it from the project file. Use 'RuntimeIdentifier' or 'RuntimeIdentifiers' instead to specify the target architecture."
+			Condition="'$(XamMacArch)' != '' And '$(AllowXamMacArchArchProperty)' != 'true'"
+			/>
+	</Target>
+
 	<PropertyGroup>
 		<_ComputeVariablesDependsOn>
 			_VerifyPreviewFeaturesIfUnstableXcode;
 			_VerifyValidRuntime;
 			_GenerateBundleName;
 			_ComputeFrameworkVariables;
+			_VerifyValidProperties;
 		</_ComputeVariablesDependsOn>
 		<!--
 			Don't execute ComputeResolvedFileToPublishList if we're in the


### PR DESCRIPTION
When migrating Xamarin projects to .NET projects, somewhat frequently people
will leave the MtouchArch/XamMacArch properties in their project files with
old values. This won't work, since we use RuntimeIdentifier(s) now to control
the target architecture, so remove support for MtouchArch/XamMacArch, and show
an error if we detect that they're set.

This will hopefully prevent some really confusing problems, especially in the IDEs.

Example: https://github.com/xamarin/xamarin-macios/issues/19258