### PR TITLE
[AppKit] Remove [NSImage imageWithSymbolName:bundle:variableValue:] from Mac Catalyst.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -9871,7 +9871,7 @@ namespace AppKit {
 		[Export ("locale", ArgumentSemantic.Copy)]
 		NSLocale Locale { get; }
 
-		[Mac (14, 0)]
+		[Mac (14, 0), NoMacCatalyst]
 		[Static]
 		[Export ("imageWithSymbolName:bundle:variableValue:")]
 		[return: NullAllowed]


### PR DESCRIPTION
It doesn't exist there, and it also fails a test:

    [FAIL] StaticMethods :   1 errors found in 3389 static selector validated:
        AppKit.NSImage : imageWithSymbolName:bundle:variableValue:
          Expected: 0
          But was:  1
