### PR TITLE
Revert "[release/7.0.3xx] Updating Xamarin.iOS.HotRestart.Client to 1.0.125"

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<MessagingVersion>1.9.102</MessagingVersion>
-		<HotRestartVersion>1.0.125</HotRestartVersion>
+		<HotRestartVersion>1.0.114</HotRestartVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Reverts xamarin/xamarin-macios#19130
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1907373

Per discussion with @mauroa and @emaf this was wrongly back ported to this branch and it was meant only on the legacy xcode14.3 branch.
