### PR TITLE
[release/7.0.3xx] [msbuild] Look for and copy binding resource packages to the remote Mac in the ResolveNativeReferences task. Fixes #19229.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferencesBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferencesBase.cs
@@ -300,7 +300,22 @@ namespace Xamarin.MacDev.Tasks {
 
 		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied ()
 		{
-			return CreateItemsForAllFilesRecursively (NativeReferences);
+			var rv = new List<ITaskItem> ();
+			rv.AddRange (CreateItemsForAllFilesRecursively (NativeReferences));
+			if (References is not null) {
+				foreach (var reference in References) {
+					var resourcesPackage = Path.Combine (Path.GetDirectoryName (reference.ItemSpec), Path.GetFileNameWithoutExtension (reference.ItemSpec)) + ".resources";
+					if (Directory.Exists (resourcesPackage)) {
+						var resources = CreateItemsForAllFilesRecursively (new string [] { resourcesPackage });
+						rv.AddRange (resources);
+						continue;
+					}
+					var zipPackage = resourcesPackage + ".zip";
+					if (File.Exists (zipPackage))
+						rv.Add (new TaskItem (zipPackage));
+				}
+			}
+			return rv;
 		}
 	}
 }


### PR DESCRIPTION
Look for any binding resource packages (a directory named AssemblyName.resources
or a compressed version named AssemblyName.resources.zip) next to any references,
and copy those to the remote Mac when doing remote builds.

Backport of #19325.