### PR TITLE
[msbuild] Don't try to read a file that might not exist in the XamarinBuildTask task.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinBuildTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinBuildTask.cs
@@ -106,7 +106,9 @@ namespace Xamarin.MacDev.Tasks {
 
 			await ExecuteAsync (dotnetPath, arguments, environment: environment);
 
-			return File.ReadAllText (outputFile).Trim ();
+			if (File.Exists (outputFile))
+				return File.ReadAllText (outputFile).Trim ();
+			return string.Empty;
 		}
 	}
 }


### PR DESCRIPTION
This isn't very helpful:

	packs\Microsoft.iOS.Windows.Sdk\16.4.7123-ci.issue-19229\tools\msbuild\iOS\Xamarin.iOS.Common.After.targets(321,3): MessagingRemoteException: An error occurred on client Build1647107 while executing a reply for topic xvs/build/16.4.7107/execute-task/issue19229/ba129ce002fFindILLink
	AggregateException: One or more errors occurred.
	FileNotFoundException: Could not find file "/var/folders/43/h027tm1n101cdrq2_b6n9n2m0000gn/T/tmp2f66981e.tmp/Output.txt"

Now we'll get a much better error message that includes what 'dotnet build'
failed to do.