### PR TITLE
[release/8.0.1xx] [msbuild] Copy files to be signed into the correct directory for Hot Restart. Fixes #19278.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/ComputeHotRestartBundleContents.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Tasks/ComputeHotRestartBundleContents.cs
@@ -25,7 +25,7 @@ namespace Xamarin.iOS.HotRestart.Tasks {
 		public string HotRestartContentStampDir { get; set; } = string.Empty;
 
 		[Required]
-		public string HotRestartSignedAppDir { get; set; } = string.Empty;
+		public string HotRestartAppBundlePath { get; set; } = string.Empty;
 
 		[Required]
 		public string RelativeAppBundlePath { get; set; } = string.Empty;
@@ -47,7 +47,7 @@ namespace Xamarin.iOS.HotRestart.Tasks {
 		public ITaskItem [] HotRestartContentDirContents { get; set; } = Array.Empty<ITaskItem> ();
 
 		[Output]
-		public ITaskItem [] HotRestartSignedAppDirContents { get; set; } = Array.Empty<ITaskItem> ();
+		public ITaskItem [] HotRestartAppBundleContents { get; set; } = Array.Empty<ITaskItem> ();
 
 		#endregion
 
@@ -108,7 +108,7 @@ namespace Xamarin.iOS.HotRestart.Tasks {
 		{
 			var appContentDirContents = new List<ITaskItem> ();
 			var contentDirContents = new List<ITaskItem> ();
-			var signedAppDirContents = new List<ITaskItem> ();
+			var appBundleContents = new List<ITaskItem> ();
 
 			foreach (var item in ResolvedFileToPublish) {
 				var publishFolderType = item.GetPublishFolderType ();
@@ -126,13 +126,13 @@ namespace Xamarin.iOS.HotRestart.Tasks {
 					if (string.Equals (filename + ".framework", dirname, StringComparison.OrdinalIgnoreCase))
 						item.ItemSpec = Path.GetDirectoryName (item.ItemSpec);
 					// These have to be signed
-					signedAppDirContents.Add (CopyWithDestinationAndStamp (item, HotRestartSignedAppDir));
+					appBundleContents.Add (CopyWithDestinationAndStamp (item, HotRestartAppBundlePath));
 					break;
 				case PublishFolderType.PlugIns:
 				case PublishFolderType.DynamicLibrary:
 				case PublishFolderType.PluginLibrary:
 					// These have to be signed
-					signedAppDirContents.Add (CopyWithDestinationAndStamp (item, HotRestartSignedAppDir));
+					appBundleContents.Add (CopyWithDestinationAndStamp (item, HotRestartAppBundlePath));
 					break;
 
 				case PublishFolderType.Unset: // Don't copy unknown stuff anywhere
@@ -155,11 +155,11 @@ namespace Xamarin.iOS.HotRestart.Tasks {
 
 			appContentDirContents = ExpandDirectories (appContentDirContents);
 			contentDirContents = ExpandDirectories (contentDirContents);
-			signedAppDirContents = ExpandDirectories (signedAppDirContents);
+			appBundleContents = ExpandDirectories (appBundleContents);
 
 			HotRestartAppContentDirContents = appContentDirContents.ToArray ();
 			HotRestartContentDirContents = contentDirContents.ToArray ();
-			HotRestartSignedAppDirContents = signedAppDirContents.ToArray ();
+			HotRestartAppBundleContents = appBundleContents.ToArray ();
 
 			return !Log.HasLoggedErrors;
 		}

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.props
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.props
@@ -4,11 +4,46 @@
 		<!-- Use single-project MSBuild properties to generate the application manifest by default -->
 		<GenerateApplicationManifest Condition="'$(GenerateApplicationManifest)' == ''">true</GenerateApplicationManifest>
 		
+		<!-- HotRestartAppBundlePath: the app bundle that will be signed. Any files that must be signed or present at app startup must be in this directory before the _CodesignHotRestartAppBundle target -->
+		<!-- This property is calculated in the _ComputeHotRestartAppBundlePath target -->
+
+		<!-- HotRestartSignedAppOutputDir: the main location of all the final files. It contains the Payload dir + the contents dir used for incremental deployments. -->
 		<HotRestartSignedAppOutputDir Condition="'$(HotRestartSignedAppOutputDir)' == ''">$(TEMP)\Xamarin\HotRestart\Signing\$(_AppBundleName)$(AppBundleExtension)\out\</HotRestartSignedAppOutputDir>
+
+		<!-- HotRestartPayloadDir: it essentially contains the final signed app bundle, that we then zip it to create an IPA file. The app bundle in this folder is the result of re-signing the one in HotRestartAppBundlePath + adding the .contents dir. -->
 		<HotRestartPayloadDir>$(HotRestartSignedAppOutputDir)Payload\</HotRestartPayloadDir>
+
+		<!--
+
+			This is the location of the signed app bundle.
+
+			Nothing should be put in this directory directly by the targets, because:
+				1. This directory will be cleared before signing (the _PrepareHotRestartAppBundle target);
+				   anything in this directory before this point will be deleted.
+				2. After signing, it shouldn't change (because that would invalidate the signature).
+
+		-->
 		<HotRestartSignedAppDir>$(HotRestartPayloadDir)$(_AppBundleName).app\</HotRestartSignedAppDir>
+		<!--
+
+			HotRestartContentDir and HotRestartAppContentDir:
+
+			These two are virtually the same but used for different purposes.
+			The Content dir contains the files that don't need to be shipped
+			in the root of the app bundle, and don't need to be signed. This
+			files can then be pushed to the app individually without needing
+			to redeploy the app, making things much faster. This usually
+			contains assemblies, like the app project one.
+			HotRestartAppContentDir is the location of the Content dir inside
+			the signed app bundle (in case we need to re-deploy the whole
+			app). HotRestartContentDir has the same content with some stamp
+			files to detect which file can be incrementally pushed to the app
+			(in case we don't need to re-deploy the app)
+
+		-->
 		<HotRestartContentDir>$(HotRestartSignedAppOutputDir)$(_AppBundleName).content\</HotRestartContentDir>
 		<HotRestartAppContentDir>$(HotRestartSignedAppDir)$(_AppBundleName).content\</HotRestartAppContentDir>
+
 		<HotRestartContentStampDir>$(HotRestartSignedAppOutputDir)$(_AppBundleName).stamp\</HotRestartContentStampDir>
 		<HotRestartIPAPath>$(HotRestartSignedAppOutputDir)$(_AppBundleName).ipa</HotRestartIPAPath>
 

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -54,14 +54,14 @@
 			HotRestartAppContentDir="$(HotRestartAppContentDir)"
 			HotRestartContentDir="$(HotRestartContentDir)"
 			HotRestartContentStampDir="$(HotRestartContentStampDir)"
-			HotRestartSignedAppDir="$(HotRestartSignedAppDir)"
+			HotRestartAppBundlePath="$(HotRestartAppBundlePath)"
 			RelativeAppBundlePath="$(_RelativeAppBundlePath)"
 			ResolvedFileToPublish="@(ResolvedFileToPublish);@(_FileNativeReference);@(_FrameworkNativeReference);@(_DecompressedPlugIns);@(_PlugIns)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 		>
 			<Output TaskParameter="HotRestartAppContentDirContents" ItemName="_HotRestartAppContentDirContents" />
 			<Output TaskParameter="HotRestartContentDirContents" ItemName="_HotRestartContentDirContents" />
-			<Output TaskParameter="HotRestartSignedAppDirContents" ItemName="_HotRestartSignedAppDirContents" />
+			<Output TaskParameter="HotRestartAppBundleContents" ItemName="_HotRestartAppBundleDirContents" />
 		</ComputeHotRestartBundleContents>
 	</Target>
 
@@ -153,27 +153,27 @@
 		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsHotRestartBuild)' == 'true'"
 		DependsOnTargets="_CreateHotRestartCachedBundle;_UnpackLibraryResources"
 		Inputs="@(_BundleResourceWithLogicalName)"
-		Outputs="@(_BundleResourceWithLogicalName -> '$(HotRestartSignedAppDir)%(LogicalName)')">
+		Outputs="@(_BundleResourceWithLogicalName -> '$(HotRestartAppBundlePath)\%(LogicalName)')">
 
 		<Copy
 			SourceFiles="@(_BundleResourceWithLogicalName)"
-			DestinationFiles="@(_BundleResourceWithLogicalName -> '$(HotRestartSignedAppDir)%(LogicalName)')"
+			DestinationFiles="@(_BundleResourceWithLogicalName -> '$(HotRestartAppBundlePath)\%(LogicalName)')"
 			SkipUnchangedFiles="true"
 		>
 			<Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
 		</Copy>
 	</Target>
 
-	<!-- Copy the items in _HotRestartSignedAppDirContents to their destination directory -->
+	<!-- Copy the items in _HotRestartAppBundleDirContents to their destination directory -->
 	<Target Name="_CopyFilesToHotRestartSignedAppDirContents"
 		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsHotRestartBuild)' == 'true'"
 		DependsOnTargets="_CreateHotRestartCachedBundle;_ComputeHotRestartBundleContents"
-		Inputs="@(_HotRestartSignedAppDirContents)"
-		Outputs="@(_HotRestartSignedAppDirContents -> '%(DestinationFile)')">
+		Inputs="@(_HotRestartAppBundleDirContents)"
+		Outputs="@(_HotRestartAppBundleDirContents -> '%(DestinationFile)')">
 
 		<Copy
-			SourceFiles="@(_HotRestartSignedAppDirContents)"
-			DestinationFiles="@(_HotRestartSignedAppDirContents -> '%(DestinationFile)')"
+			SourceFiles="@(_HotRestartAppBundleDirContents)"
+			DestinationFiles="@(_HotRestartAppBundleDirContents -> '%(DestinationFile)')"
 			SkipUnchangedFiles="true"
 		>
 			<Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
@@ -236,7 +236,7 @@
 			<_CodeSignHotRestartInputs Include="$(_AppBundleManifestPath)" Outputs="$(HotRestartSignedAppDir)Info.plist" />
 			<_CodeSignHotRestartInputs Include="$(CodesignEntitlements)" Outputs="$(HotRestartSignedAppDir)$(CodesignEntitlements)" />
 			<_CodeSignHotRestartInputs Include="$(_ProvisioningProfilePath)" Outputs="$(HotRestartSignedAppDir)embedded.mobileprovision" />
-			<_CodeSignHotRestartInputs Include="@(_HotRestartSignedAppDirContents)" Outputs="%(_HotRestartSignedAppDirContents.DestinationFile)" />
+			<_CodeSignHotRestartInputs Include="@(_HotRestartAppBundleDirContents)" Outputs="%(_HotRestartAppBundleDirContents.DestinationFile)" />
 			<_CodeSignHotRestartInputs Include="$(HotRestartAppBundlePath)\Extracted" Outputs="$(HotRestartSignedAppDir)Extracted" />
 		</ItemGroup>
 	</Target>
@@ -246,9 +246,9 @@
 			_CreateHotRestartCachedBundle;
 			_UnpackLibraryResources;
 			_ComputeHotRestartBundleContents;
-			_CodesignHotRestartAppBundle;
 			_CopyHotRestartBundleResources;
 			_CopyFilesToHotRestartSignedAppDirContents;
+			_CodesignHotRestartAppBundle;
 			_CopyFilesToHotRestartContentDir;
 			_CopyFilesToHotRestartAppContentDir;
 			_CreateHotRestartAppMarkers;


### PR DESCRIPTION
1. Move the signing to after we copy files that must be signed into the app bundle
   that will be signed: we sign in the _CodesignHotRestartAppBundle target, so this
   means the targets _CopyHotRestartBundleResources and _CopyFilesToHotRestartSignedAppDirContents
   must execute first.

2. Try to clear up some confusion about the directories involved. The HotRestartSignedAppOutputDir
   property indicates the location of the _signed_ app bundle, which means no files
   should be added there. Instead files that should be signed (or present when the
   app launches) must be placed in the HotRestartAppBundlePath directory.

3. Document each property involved to try to avoid more mistakes in the future.

Fixes https://github.com/xamarin/xamarin-macios/issues/19278.


Backport of #19302
