### PR TITLE
[release/8.0.1xx] [msbuild] Don't add frameworks with static libraries to Hot Restart apps.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -8,7 +8,6 @@
 	</PropertyGroup>
 
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CompileNativeCode" AssemblyFile="$(_XamarinTaskAssembly)" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.FilterStaticFrameworks" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.FindAotCompiler" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetFullPaths" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.InstallNameTool" AssemblyFile="$(_XamarinTaskAssembly)" />

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworksTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworksTaskBase.cs
@@ -29,13 +29,13 @@ namespace Xamarin.MacDev.Tasks {
 							frameworkExecutablePath = Path.Combine (frameworkExecutablePath, Path.GetFileNameWithoutExtension (frameworkExecutablePath));
 						}
 
-						if (!File.Exists (frameworkExecutablePath)) {
-							Log.LogError (158, frameworkExecutablePath, MSBStrings.E0158 /* The file '{0}' does not exist. */, frameworkExecutablePath);
+						if (OnlyFilterFrameworks && !Path.GetDirectoryName (frameworkExecutablePath).EndsWith (".framework", StringComparison.OrdinalIgnoreCase)) {
+							Log.LogMessage (MessageImportance.Low, $"Skipped processing {item.ItemSpec} because it's not a framework");
 							continue;
 						}
 
-						if (OnlyFilterFrameworks && !Path.GetDirectoryName (frameworkExecutablePath).EndsWith (".framework", StringComparison.OrdinalIgnoreCase)) {
-							Log.LogMessage (MessageImportance.Low, $"Skipped processing {item.ItemSpec} because it's not a framework");
+						if (!File.Exists (frameworkExecutablePath)) {
+							Log.LogError (158, frameworkExecutablePath, MSBStrings.E0158 /* The file '{0}' does not exist. */, frameworkExecutablePath);
 							continue;
 						}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworksTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworksTaskBase.cs
@@ -12,6 +12,8 @@ using Xamarin.Utils;
 namespace Xamarin.MacDev.Tasks {
 	// This task takes an itemgroup of frameworks, and filters out frameworks that aren't dynamic libraries.
 	public abstract class FilterStaticFrameworksTaskBase : XamarinTask {
+		public bool OnlyFilterFrameworks { get; set; }
+
 		[Output]
 		public ITaskItem []? FrameworkToPublish { get; set; }
 
@@ -29,6 +31,11 @@ namespace Xamarin.MacDev.Tasks {
 
 						if (!File.Exists (frameworkExecutablePath)) {
 							Log.LogError (158, frameworkExecutablePath, MSBStrings.E0158 /* The file '{0}' does not exist. */, frameworkExecutablePath);
+							continue;
+						}
+
+						if (OnlyFilterFrameworks && !Path.GetDirectoryName (frameworkExecutablePath).EndsWith (".framework", StringComparison.OrdinalIgnoreCase)) {
+							Log.LogMessage (MessageImportance.Low, $"Skipped processing {item.ItemSpec} because it's not a framework");
 							continue;
 						}
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -85,7 +85,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.Ditto" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.DSymUtil" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.EmbedProvisionProfile" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.FilterStaticFrameworks" AssemblyFile="$(_XamarinTaskAssembly)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.FilterStaticFrameworks" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.FindItemWithLogicalName" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GenerateBundleName" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetDirectories" AssemblyFile="$(_TaskAssemblyName)" />

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -85,6 +85,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.Ditto" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.DSymUtil" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.EmbedProvisionProfile" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.FilterStaticFrameworks" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.FindItemWithLogicalName" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GenerateBundleName" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetDirectories" AssemblyFile="$(_TaskAssemblyName)" />

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -48,15 +48,25 @@
 
 	</Target>
 
+	<Target Name="_CollectHotRestartBundleContent" DependsOnTargets="_GenerateBundleName;_ParseBundlerArguments;_ComputeTargetArchitectures;_ComputeVariables;_CollectDecompressedPlugIns">
+		<!-- Collect everything to put in the app bundle, except static frameworks -->
+		<FilterStaticFrameworks
+			OnlyFilterFrameworks="true"
+			FrameworkToPublish="@(ResolvedFileToPublish);@(_FileNativeReference);@(_FrameworkNativeReference);@(_DecompressedPlugIns);@(_PlugIns);@(_DecompressedXpcServices);@(_XpcServices)"
+		>
+			<Output TaskParameter="FrameworkToPublish" ItemName="_CollectedHotRestartBundleContent" />
+		</FilterStaticFrameworks>
+	</Target>
+
 	<!-- Collect everything that goes in the app bundle, and figure out where to put it all -->
-	<Target Name="_ComputeHotRestartBundleContents" DependsOnTargets="_GenerateBundleName;_ParseBundlerArguments;_ComputeTargetArchitectures;_ComputeVariables;_CollectDecompressedPlugIns">
+	<Target Name="_ComputeHotRestartBundleContents" DependsOnTargets="_CollectHotRestartBundleContent">
 		<ComputeHotRestartBundleContents
 			HotRestartAppContentDir="$(HotRestartAppContentDir)"
 			HotRestartContentDir="$(HotRestartContentDir)"
 			HotRestartContentStampDir="$(HotRestartContentStampDir)"
 			HotRestartSignedAppDir="$(HotRestartSignedAppDir)"
 			RelativeAppBundlePath="$(_RelativeAppBundlePath)"
-			ResolvedFileToPublish="@(ResolvedFileToPublish);@(_FileNativeReference);@(_FrameworkNativeReference);@(_DecompressedPlugIns);@(_PlugIns)"
+			ResolvedFileToPublish="@(_CollectedHotRestartBundleContent)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 		>
 			<Output TaskParameter="HotRestartAppContentDirContents" ItemName="_HotRestartAppContentDirContents" />


### PR DESCRIPTION
The main problem is that an app with unsigned executable code will fail any signing
verification, and the app won't install on device.

This is implemented by doing two changes:

1. Augment the FilterStaticFrameworks task to only filter out frameworks with
   static libraries (and thus keeping everything that's not a static framework, even
   if it's not even a framework).

2. Execute the FilterStaticFrameworks task to filter out static frameworks from
   the entire list of files to bundle in the hot restart app bundle.


Backport of #19300
