### PR TITLE
[tests] Try to fix a few random test failures in UserDefaultsTests.

### DIFF
--- a/tests/monotouch-test/Foundation/UserDefaultsTest.cs
+++ b/tests/monotouch-test/Foundation/UserDefaultsTest.cs
@@ -8,6 +8,7 @@
 //
 
 using System;
+using System.Diagnostics;
 using Foundation;
 #if MONOMAC
 using AppKit;
@@ -30,24 +31,26 @@ namespace MonoTouchFixtures.Foundation {
 			// confusing API for .NET developers since the parameters are 'value', 'key'
 			// http://stackoverflow.com/q/12415054/220643
 			NSUserDefaults defaults = NSUserDefaults.StandardUserDefaults;
-			defaults.RemoveObject ("spid");
-			Assert.Null (defaults.StringForKey ("spid"), "StringForKey-1");
-			defaults.SetString ("coucou", "spid");
+			var keyName = $"spid-{Process.GetCurrentProcess ().Id}";
+			defaults.RemoveObject (keyName);
+			Assert.Null (defaults.StringForKey (keyName), "StringForKey-1");
+			defaults.SetString ("coucou", keyName);
 			defaults.Synchronize ();
-			Assert.That (defaults.StringForKey ("spid"), Is.EqualTo ("coucou"), "StringForKey-2");
+			Assert.That (defaults.StringForKey (keyName), Is.EqualTo ("coucou"), "StringForKey-2");
 		}
 
 		[Test]
 		public void Ctor_UserName ()
 		{
+			var userName = $"username-{Process.GetCurrentProcess ().Id}";
 			// initWithUser:
-			using (var ud = new NSUserDefaults ("username")) {
+			using (var ud = new NSUserDefaults (userName)) {
 				Assert.That (ud.RetainCount, Is.EqualTo ((nuint) 1), "RetainCount");
 				ud.SetString ("value", "key");
 				ud.Synchronize ();
 			}
 
-			using (var ud = new NSUserDefaults ("username", NSUserDefaultsType.UserName)) {
+			using (var ud = new NSUserDefaults (userName, NSUserDefaultsType.UserName)) {
 				Assert.That (ud.RetainCount, Is.EqualTo ((nuint) 1), "RetainCount");
 				Assert.That (ud ["key"].ToString (), Is.EqualTo ("value"), "[key]-1");
 				ud.RemoveObject ("key");
@@ -63,7 +66,8 @@ namespace MonoTouchFixtures.Foundation {
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 
 			// initWithSuiteName:
-			using (var ud = new NSUserDefaults ("suitename", NSUserDefaultsType.SuiteName)) {
+			var suiteName = $"suitename-{Process.GetCurrentProcess ().Id}";
+			using (var ud = new NSUserDefaults (suiteName, NSUserDefaultsType.SuiteName)) {
 				Assert.That (ud.RetainCount, Is.EqualTo ((nuint) 1), "RetainCount");
 			}
 		}


### PR DESCRIPTION
Try to fix a few random test failures in UserDefaultsTests by making sure they
won't fail if another process is running the test at the same time by adding
the PID to any machine-wide identifiers.

Might fix:

* https://github.com/xamarin/maccore/issues/2488
* https://github.com/xamarin/maccore/issues/2725