### PR TITLE
[msbuild] Use new msbuild syntax to fetch properties and items using the command line.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1540,4 +1540,15 @@
             {0}: the path to an assembly
         </comment>
     </data>
+
+    <data name="E7120" xml:space="preserve">
+        <value>The mlaunch tool doesn't exist: '{0}'.</value>
+        <comment>
+            {0}: the path to the mlaunch tool
+        </comment>
+    </data>
+
+    <data name="E7121" xml:space="preserve">
+        <value>Unable to parse the json output from the AOT compiler search.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1541,13 +1541,6 @@
         </comment>
     </data>
 
-    <data name="E7120" xml:space="preserve">
-        <value>The mlaunch tool doesn't exist: '{0}'.</value>
-        <comment>
-            {0}: the path to the mlaunch tool
-        </comment>
-    </data>
-
     <data name="E7121" xml:space="preserve">
         <value>Unable to parse the json output from the AOT compiler search.</value>
     </data>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FindAotCompilerTaskBase.cs
@@ -1,40 +1,47 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
+
 using Microsoft.Build.Framework;
 using Xamarin.Localization.MSBuild;
+
+#nullable enable
 
 namespace Xamarin.MacDev.Tasks {
 	public class FindAotCompiler : XamarinBuildTask {
 		[Required]
-		public ITaskItem [] MonoAotCrossCompiler { get; set; }
+		public ITaskItem [] MonoAotCrossCompiler { get; set; } = Array.Empty<ITaskItem> ();
 
 		[Output]
-		public string AotCompiler { get; set; }
+		public string AotCompiler { get; set; } = string.Empty;
 
 		protected override bool ExecuteLocally ()
 		{
 			// If we can't find the AOT compiler path in MonoAotCrossCompiler, evaluate a project file that does know how to find it.
 			// This happens when executing remotely from Windows, because the MonoAotCrossCompiler item group will be empty in that case.
-			var targetName = "ComputeAotCompilerPath";
-			var target = $@"<Target Name=""{targetName}"">
-	<PropertyGroup>
-		<_XamarinAOTCompiler>@(MonoAotCrossCompiler->WithMetadataValue(""RuntimeIdentifier"", ""$(RuntimeIdentifier)""))</_XamarinAOTCompiler>
-	</PropertyGroup>
-	<WriteLinesToFile File=""$(OutputFilePath)"" Lines=""$(_XamarinAOTCompiler)"" />
-</Target>";
+			var evaluate = false;
 
 			if (MonoAotCrossCompiler?.Length > 0 && string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("XAMARIN_FORCE_AOT_COMPILER_PATH_COMPUTATION"))) {
 				var aotCompilerItem = MonoAotCrossCompiler.SingleOrDefault (v => v.GetMetadata ("RuntimeIdentifier") == RuntimeIdentifier);
 
 				if (aotCompilerItem is null) {
 					Log.LogMessage (MessageImportance.Low, "Unable to find the AOT compiler for the RuntimeIdentifier '{0}' in the MonoAotCrossCompiler item group", RuntimeIdentifier);
-					AotCompiler = ComputeValueUsingTarget (target, targetName);
+					evaluate = true;
 				} else {
 					AotCompiler = aotCompilerItem.ItemSpec;
 				}
 			} else {
-				AotCompiler = ComputeValueUsingTarget (target, targetName);
+				evaluate = true;
+			}
+
+			if (evaluate) {
+				if (!TryGetItem ("MonoAotCrossCompiler", null, out var json))
+					return false;
+				if (!TryFindAotCompilerInJson (json, out var compiler))
+					return false;
+				AotCompiler = compiler;
 			}
 
 			// Don't check if the aot compiler exists if an error was already reported.
@@ -45,6 +52,67 @@ namespace Xamarin.MacDev.Tasks {
 				Log.LogError (MSBStrings.E7081 /*"The AOT compiler '{0}' does not exist." */, AotCompiler);
 
 			return !Log.HasLoggedErrors;
+		}
+
+		bool TryFindAotCompilerInJson (string json, [NotNullWhen (true)] out string? value)
+		{
+			value = null;
+
+			// The json looks like this:
+			//
+			//    {
+			//      "Items": {
+			//        "MonoAotCrossCompiler": [
+			//          {
+			//            "Identity": "/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Runtime.AOT.osx-arm64.Cross.maccatalyst-arm64/8.0.0/Sdk/../tools/mono-aot-cross",
+			//            "RuntimeIdentifier": "maccatalyst-arm64",
+			//            [...]
+			//          },
+			//          {
+			//            "Identity": "/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Runtime.AOT.osx-arm64.Cross.maccatalyst-x64/8.0.0/Sdk/../tools/mono-aot-cross",
+			//            "RuntimeIdentifier": "maccatalyst-x64",
+			//            [...]
+			//          }
+			//        ]
+			//      }
+			//    }
+			//
+
+			var options = new JsonDocumentOptions () {
+				AllowTrailingCommas = true,
+			};
+
+			using var doc = JsonDocument.Parse (json, options);
+
+			if (!doc.RootElement.TryGetProperty ("Items", out var items))
+				return ShowError ();
+
+			if (!items.TryGetProperty ("MonoAotCrossCompiler", out var compilers))
+				return ShowError ();
+
+			foreach (var compiler in compilers.EnumerateArray ()) {
+				if (!compiler.TryGetProperty ("RuntimeIdentifier", out var ridElement))
+					return ShowError ();
+
+				var rid = ridElement.GetString ();
+				if (!string.Equals (rid, RuntimeIdentifier, StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				if (!compiler.TryGetProperty ("Identity", out var identity))
+					return ShowError ();
+
+				value = identity.GetString ();
+				return true;
+			}
+
+			return false;
+
+			bool ShowError ()
+			{
+				Log.LogError (MSBStrings.E7121 /* Unable to parse the json output from the AOT compiler search. */);
+				Log.LogMessage (MessageImportance.Low, json);
+				return false;
+			}
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FindILLink.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FindILLink.cs
@@ -3,19 +3,17 @@ using System.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Localization.MSBuild;
 
+#nullable enable
+
 namespace Xamarin.MacDev.Tasks {
 	public class FindILLink : XamarinBuildTask {
 		[Output]
-		public string ILLinkPath { get; set; }
+		public string ILLinkPath { get; set; } = string.Empty;
 
 		protected override bool ExecuteLocally ()
 		{
-			var targetName = "ComputeILLinkTaskPath";
-			var target = $@"<Target Name=""{targetName}"">
-	<WriteLinesToFile File=""$(OutputFilePath)"" Lines=""$(ILLinkTasksAssembly)"" />
-</Target>";
-
-			var illinkTaskPath = ComputeValueUsingTarget (target, targetName);
+			if (!TryGetProperty ("ILLinkTasksAssembly", out var illinkTaskPath))
+				return false;
 
 			// Don't do anything else if something already went wrong (in particular don't check if illink.dll exists).
 			if (Log.HasLoggedErrors)
@@ -31,4 +29,3 @@ namespace Xamarin.MacDev.Tasks {
 		}
 	}
 }
-


### PR DESCRIPTION
This is faster to execute because we don't have to execute a target, we'll
just execute the MSBuild evaluation phase to get any properties or items we
need.

Also enable nullability.