### PR TITLE
[UIKit] Store the delegate in a local variable in the UIContextMenuInteraction.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -3377,6 +3377,7 @@ namespace UIKit {
 
 		[Export ("initWithDelegate:")]
 		[DesignatedInitializer]
+		[PostSnippet ("MarkDirty ();\n__mt_WeakDelegate_var = @delegate;", Optimizable = true)] // passing in the delegate as a parameter is basically the same as setting the property, so we also need to store it in a local field.
 		NativeHandle Constructor (IUIContextMenuInteractionDelegate @delegate);
 
 		[Export ("locationInView:")]


### PR DESCRIPTION
The UIContextMenuInteraction type is a bit uncommon: the delegate is passed as
an argument to the constructor, instead of setting the 'delegate' property
later on (in fact, the 'delegate' property is read-only).

Typically, the generated WeakDelegate property will store the value in an instance field:

	object? __mt_WeakDelegate_var;
	public virtual NSObject? WeakDelegate {
		get {
			NSObject? ret = /* ... */;
			MarkDirty ();
			__mt_WeakDelegate_var = ret;
			return ret!;
		}
	}

And in order to have the same behavior in the UIContextMenuInteraction we need to
store the delegate passed to the constructor as well, so do that.

Otherwise the GC will eventually collect the delegate, and things stop working.

Ref: https://github.com/dotnet/maui/pull/18449