### PR TITLE
Add the .NET TFM as a constant to the generated SdkVersions.cs from our Makefile variables.

### DIFF
--- a/src/generate-frameworks-constants/dotnet/generate-frameworks-constants.csproj
+++ b/src/generate-frameworks-constants/dotnet/generate-frameworks-constants.csproj
@@ -14,6 +14,9 @@
     <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\SdkVersions.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>

--- a/src/generate-frameworks-constants/legacy/generate-frameworks-constants.csproj
+++ b/src/generate-frameworks-constants/legacy/generate-frameworks-constants.csproj
@@ -39,6 +39,9 @@
     <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\SdkVersions.cs">
+      <Link>ApplePlatform.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>

--- a/tests/EmbeddedResources/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/EmbeddedResources.csproj
@@ -58,6 +58,9 @@
     <Compile Include="..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Welcome.resx">

--- a/tests/EmbeddedResources/dotnet/shared.csproj
+++ b/tests/EmbeddedResources/dotnet/shared.csproj
@@ -19,6 +19,9 @@
 		<Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
 			<Link>ApplePlatform.cs</Link>
 		</Compile>
+		<Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+			<Link>SdkVersions.cs</Link>
+		</Compile>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/bindings-test/dotnet/shared.csproj
+++ b/tests/bindings-test/dotnet/shared.csproj
@@ -47,6 +47,9 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="$(BindingsTestDirectory)\RuntimeTest.cs" />
     <Compile Include="$(BindingsTestDirectory)\CodeBehind.cs" />
     <Compile Include="$(BindingsTestDirectory)\Messaging.cs" />

--- a/tests/bindings-test/iOS/bindings-test.csproj
+++ b/tests/bindings-test/iOS/bindings-test.csproj
@@ -86,6 +86,9 @@
     <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\RuntimeTest.cs" />
     <Compile Include="..\CodeBehind.cs" />
     <Compile Include="..\Messaging.cs" />

--- a/tests/bindings-test/macOS/bindings-test.csproj
+++ b/tests/bindings-test/macOS/bindings-test.csproj
@@ -72,6 +72,9 @@
     <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\RuntimeTest.cs" />
     <Compile Include="..\CodeBehind.cs" />
     <Compile Include="..\Messaging.cs" />

--- a/tests/framework-test/dotnet/shared.csproj
+++ b/tests/framework-test/dotnet/shared.csproj
@@ -38,5 +38,8 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/tests/framework-test/macOS/framework-test-mac.csproj
+++ b/tests/framework-test/macOS/framework-test-mac.csproj
@@ -78,6 +78,9 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\Touch.Unit\Touch.Client\macOS\mobile\Touch.Client-macOS-mobile.csproj">

--- a/tests/interdependent-binding-projects/dotnet/shared.csproj
+++ b/tests/interdependent-binding-projects/dotnet/shared.csproj
@@ -37,5 +37,8 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/tests/linker/ios/dont link/dotnet/shared.csproj
+++ b/tests/linker/ios/dont link/dotnet/shared.csproj
@@ -37,6 +37,9 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="$(ThisTestDirectory)\DontLinkRegressionTests.cs" />
     <Compile Include="$(ThisTestDirectory)\TableViewSourceTest.cs" />
     <Compile Include="$(ThisTestDirectory)\CalendarTest.cs" />

--- a/tests/linker/ios/trimmode copy/dotnet/shared.csproj
+++ b/tests/linker/ios/trimmode copy/dotnet/shared.csproj
@@ -44,6 +44,9 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="$(RootTestsDirectory)\common\TestAssemblyLoader.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/linker/ios/trimmode link/dotnet/shared.csproj
+++ b/tests/linker/ios/trimmode link/dotnet/shared.csproj
@@ -81,6 +81,9 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="$(RootTestsDirectory)\common\TestAssemblyLoader.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/linker/mac/dont link/dont link-mac.csproj
+++ b/tests/linker/mac/dont link/dont link-mac.csproj
@@ -71,6 +71,9 @@
     <Compile Include="..\..\..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\common\mac\MacMain.cs">
       <Link>MacMain.cs</Link>
     </Compile>

--- a/tests/linker/mac/link all/link all-mac.csproj
+++ b/tests/linker/mac/link all/link all-mac.csproj
@@ -86,6 +86,9 @@
     <Compile Include="..\..\..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\common\PlatformInfo.cs">
       <Link>PlatformInfo.cs</Link>
     </Compile>

--- a/tests/linker/mac/link sdk/link sdk-mac.csproj
+++ b/tests/linker/mac/link sdk/link sdk-mac.csproj
@@ -80,6 +80,9 @@
     <Compile Include="..\..\..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\common\PlatformInfo.cs">
       <Link>PlatformInfo.cs</Link>
     </Compile>

--- a/tests/mono-native/macOS/mono-native.csproj.template
+++ b/tests/mono-native/macOS/mono-native.csproj.template
@@ -71,6 +71,9 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\Touch.Unit\Touch.Client\macOS\mobile\Touch.Client-macOS-mobile.csproj">

--- a/tests/monotouch-test/dotnet/shared.csproj
+++ b/tests/monotouch-test/dotnet/shared.csproj
@@ -64,6 +64,9 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="$(RootTestsDirectory)\common\AppDelegate.cs" Condition="!$(TargetFramework.EndsWith('-macos'))" />
   </ItemGroup>
 

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -157,6 +157,9 @@
     <Compile Include="..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="SceneKit\SCNVector3Test.cs" />
     <Compile Include="SceneKit\SCNVector4Test.cs" />
     <Compile Include="..\common\AppDelegate.cs" />

--- a/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
@@ -29,6 +29,9 @@
     <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
       <Link>external\ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\SdkVersions.cs">
+      <Link>external\SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\tools\common\TargetFramework.cs">
       <Link>external\TargetFramework.cs</Link>
     </Compile>

--- a/tests/sampletester/sampletester.csproj
+++ b/tests/sampletester/sampletester.csproj
@@ -65,6 +65,9 @@
     <Compile Include="..\..\tools\common\ApplePlatform.cs">
       <Link>external\ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\SdkVersions.cs">
+      <Link>external\SdkVersions.cs</Link>
+    </Compile>
     <Compile Include="..\..\tools\common\TargetFramework.cs">
       <Link>external\TargetFramework.cs</Link>
     </Compile>

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -128,6 +128,9 @@
     <Compile Include="..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/xcframework-test/dotnet/shared.csproj
+++ b/tests/xcframework-test/dotnet/shared.csproj
@@ -39,5 +39,8 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/tests/xcframework-test/macOS/xcframework-test-mac.csproj
+++ b/tests/xcframework-test/macOS/xcframework-test-mac.csproj
@@ -78,6 +78,9 @@
     <Compile Include="$(RootTestsDirectory)\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="$(RootTestsDirectory)\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\Touch.Unit\Touch.Client\macOS\mobile\Touch.Client-macOS-mobile.csproj">

--- a/tests/xtro-sharpie/xtro-sanity/xtro-sanity.csproj
+++ b/tests/xtro-sharpie/xtro-sanity/xtro-sanity.csproj
@@ -41,6 +41,9 @@
     <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
       <Link>ApplePlatform.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\SdkVersions.cs">
+      <Link>SdkVersions.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tools/common/ApplePlatform.cs
+++ b/tools/common/ApplePlatform.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Utils {
 		public static string ToFramework (this ApplePlatform @this, string? netVersion = null)
 		{
 			if (netVersion is null)
-				netVersion = "net8.0";
+				netVersion = Xamarin.DotNetVersions.Tfm;
 
 			switch (@this) {
 			case ApplePlatform.iOS:

--- a/tools/common/Make.common
+++ b/tools/common/Make.common
@@ -56,6 +56,9 @@
 		-e "s/@DEFAULT_TARGET_PLATFORM_VERSION_MACCATALYST@/$(DEFAULT_TARGET_PLATFORM_VERSION_MACCATALYST)/g" \
 		\
 		-e "s/@PRODUCT_HASH@/$(CURRENT_HASH_LONG)/g" \
+		\
+		-e "s/@DOTNET_TFM@/$(DOTNET_TFM)/g" \
+		-e "s/@DOTNET_VERSION@/$(subst net,,$(DOTNET_TFM))/g" \
 		$< > $@.tmp
 	$(Q) if ! diff $@ $@.tmp >/dev/null; then $(CP) $@.tmp $@; git diff "$@"; echo "The file $(TOP)/tools/common/SdkVersions.cs has been automatically re-generated; please commit the changes."; exit 1; fi
 	$(Q) touch $@

--- a/tools/common/SdkVersions.cs
+++ b/tools/common/SdkVersions.cs
@@ -155,4 +155,9 @@ namespace Xamarin {
 		public static Version MinimumMonoVersion { get { return new Version (MinimumMono); } }
 	}
 #endif
+
+	static class DotNetVersions {
+		public const string Tfm = "net8.0";
+		public const string Version = "8.0";
+	}
 }

--- a/tools/common/SdkVersions.in.cs
+++ b/tools/common/SdkVersions.in.cs
@@ -155,4 +155,9 @@ namespace Xamarin {
 		public static Version MinimumMonoVersion { get { return new Version (MinimumMono); } }
 	}
 #endif
+
+	static class DotNetVersions {
+		public const string Tfm = "@DOTNET_TFM@";
+		public const string Version = "@DOTNET_VERSION@";
+	}
 }

--- a/tools/common/TargetFramework.cs
+++ b/tools/common/TargetFramework.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace Xamarin.Utils {
 	public struct TargetFramework : IEquatable<TargetFramework> {
-		const string TFMVersion = "8.0";
+		const string TFMVersion = Xamarin.DotNetVersions.Version;
 		public const string DotNet_iOS_String = ".NETCoreApp,Version=" + TFMVersion + ",Profile=ios"; // Short form: netX.Y-ios
 		public const string DotNet_tvOS_String = ".NETCoreApp,Version=" + TFMVersion + ",Profile=tvos"; // Short form: netX.Y-tvos
 		public const string DotNet_watchOS_String = ".NETCoreApp,Version=" + TFMVersion + ",Profile=watchos"; // Short form: netX.Y-watchos

--- a/tools/nnyeah/tests/nnyeah-tests.csproj
+++ b/tools/nnyeah/tests/nnyeah-tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="../../common/StringUtils.cs" Link="StringUtils.cs" />
     <Compile Include="../../common/TargetFramework.cs" Link="TargetFramework.cs" />
     <Compile Include="../../common/ApplePlatform.cs" Link="ApplePlatform.cs" />
+    <Compile Include="../../common/SdkVersions.cs" Link="SdkVersions.cs" />
 
     <Compile Include="../../../tests/mtouch/Cache.cs" Link="Cache.cs" />
     <Compile Include="../../../tests/common/BinLog.cs" Link="BinLog.cs" />


### PR DESCRIPTION
This way we can avoid hardcoding the TFM in a few more places.