### PR TITLE
[devops] Add the bundle.zip and msbuild.zip files to the 'package' artifact.

### DIFF
--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -144,8 +144,8 @@ jobs:
   - bash: |
       set -x
       set -e
-      cp "$BUILD_SOURCESDIRECTORY"/not-signed-package/*.zip "$BUILD_SOURCESDIRECTORY"/package
       ls -la "$BUILD_SOURCESDIRECTORY"/not-signed-package
+      cp "$BUILD_SOURCESDIRECTORY"/not-signed-package/not-signed-package/*.zip "$BUILD_SOURCESDIRECTORY"/package
       ls -la "$BUILD_SOURCESDIRECTORY"/package
     displayName: Copy msbuild.zip and bundle.zip to the package artifact
 

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -133,13 +133,21 @@ jobs:
   # download msbuild.zip and bundle.zip to the 'package' dir, so that they're uploaded into the 'package' artifact,
   # since we later depend on these files being there later.
   - task: DownloadPipelineArtifact@2
-    displayName: Add msbuild.zip and bundle.zip to the package artifact
+    displayName: Download msbuild.zip and bundle.zip
     inputs:
       patterns: |
         not-signed-package/msbuild.zip
         not-signed-package/bundle.zip
       allowFailedBuilds: true
-      path: $(Build.SourcesDirectory)/package
+      path: $(Build.SourcesDirectory)/not-signed-package
+
+  - bash: |
+      set -x
+      set -e
+      cp "$BUILD_SOURCESDIRECTORY"/not-signed-package/*.zip "$BUILD_SOURCESDIRECTORY"/package
+      ls -la "$BUILD_SOURCESDIRECTORY"/not-signed-package
+      ls -la "$BUILD_SOURCESDIRECTORY"/package
+    displayName: Copy msbuild.zip and bundle.zip to the package artifact
 
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Build Artifacts (notarized)'

--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -130,6 +130,17 @@ jobs:
       artifactName: '${{ parameters.uploadPrefix }}package-internal'
     continueOnError: true
 
+  # download msbuild.zip and bundle.zip to the 'package' dir, so that they're uploaded into the 'package' artifact,
+  # since we later depend on these files being there later.
+  - task: DownloadPipelineArtifact@2
+    displayName: Add msbuild.zip and bundle.zip to the package artifact
+    inputs:
+      patterns: |
+        not-signed-package/msbuild.zip
+        not-signed-package/bundle.zip
+      allowFailedBuilds: true
+      path: $(Build.SourcesDirectory)/package
+
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Build Artifacts (notarized)'
     inputs:


### PR DESCRIPTION
This fixes this error in Azure DevOps:

* [PR] bundle.zip — bundle.zip not found.
* [PR] msbuild.zip — msbuild.zip not found.