### PR TITLE
[devops] Avoid long lines in yaml.

### DIFF
--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -235,17 +235,27 @@ stages:
 
 # .NET Release Prep and VS Insertion Stages, only execute them when the build comes from an official branch and is not a schedule build from OneLoc
 # setting the stage at this level makes the graph of the UI look better, else the lines overlap and is not clear.
-# Got to disable the lint check because azp yaml template engine does not allow use to do a multiline if :/ 
-# yamllint disable-line rule: line-length
-- ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-test/'), eq(variables['Build.SourceBranch'], 'refs/heads/net7.0'), eq(variables['Build.SourceBranch'], 'refs/heads/net8.0'), eq(parameters.forceInsertion, true))) }}:
-  - template: ./release/vs-insertion-prep.yml
-    parameters:
-      dependsOn: build_packages
-      stageDisplayNamePrefix: ${{ parameters.stageDisplayNamePrefix }}
-      isPR: ${{ parameters.isPR }}
-      repositoryAlias: ${{ parameters.repositoryAlias }}
-      commit: ${{ parameters.commit }}
-      pushNugets: ${{ parameters.pushNugets }}
+- ? ${{ if
+      and(
+        ne(variables['Build.Reason'], 'Schedule'),
+        or(
+          eq(variables['Build.SourceBranch'], 'refs/heads/main'),
+          startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'),
+          startsWith(variables['Build.SourceBranch'], 'refs/heads/release-test/'),
+          eq(variables['Build.SourceBranch'], 'refs/heads/net7.0'),
+          eq(variables['Build.SourceBranch'], 'refs/heads/net8.0'),
+          eq(parameters.forceInsertion, true)
+        )
+      )
+    }}
+  : - template: ./release/vs-insertion-prep.yml
+      parameters:
+        dependsOn: build_packages
+        stageDisplayNamePrefix: ${{ parameters.stageDisplayNamePrefix }}
+        isPR: ${{ parameters.isPR }}
+        repositoryAlias: ${{ parameters.repositoryAlias }}
+        commit: ${{ parameters.commit }}
+        pushNugets: ${{ parameters.pushNugets }}
 
 - stage: funnel
   displayName: '${{ parameters.stageDisplayNamePrefix }}Collect signed artifacts'

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -142,7 +142,13 @@ steps:
     Write-Host "$Env:VIRTUAL_PATH"
     Write-Host "Artifacts url $Env:AZURE_CONTAINER/$Env:VIRTUAL_PATH/${{ parameters.uploadPrefix }}package"
 
-    Invoke-Expression "$execPath artifacts -s `"$maciosPath`" -a $Env:AZURE_STORAGE -c $Env:STORAGE_PASS -u `"$Env:AZURE_CONTAINER/$Env:VIRTUAL_PATH/${{ parameters.uploadPrefix }}package`" -d `"$(Build.SourcesDirectory)\\artifacts\${{ parameters.uploadPrefix }}package`" -o `"$(Build.SourcesDirectory)\\artifacts\${{ parameters.uploadPrefix }}package`""
+    Invoke-Expression `
+      "$execPath artifacts -s `"$maciosPath`" `
+      -a $Env:AZURE_STORAGE `
+      -c $Env:STORAGE_PASS `
+      -u `"$Env:AZURE_CONTAINER/$Env:VIRTUAL_PATH/${{ parameters.uploadPrefix }}package`" `
+      -d `"$(Build.SourcesDirectory)\\artifacts\${{ parameters.uploadPrefix }}package`" `
+      -o `"$(Build.SourcesDirectory)\\artifacts\${{ parameters.uploadPrefix }}package`""
   env:
     VIRTUAL_PATH: $(Build.SourceBranchName)/$(Build.SourceVersion)/$(Build.BuildId)
     GITHUB_AUTH_TOKEN: $(GitHub.Token)

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -142,13 +142,20 @@ steps:
     Write-Host "$Env:VIRTUAL_PATH"
     Write-Host "Artifacts url $Env:AZURE_CONTAINER/$Env:VIRTUAL_PATH/${{ parameters.uploadPrefix }}package"
 
-    Invoke-Expression `
-      "$execPath artifacts -s `"$maciosPath`" `
-      -a $Env:AZURE_STORAGE `
-      -c $Env:STORAGE_PASS `
-      -u `"$Env:AZURE_CONTAINER/$Env:VIRTUAL_PATH/${{ parameters.uploadPrefix }}package`" `
-      -d `"$(Build.SourcesDirectory)\\artifacts\${{ parameters.uploadPrefix }}package`" `
-      -o `"$(Build.SourcesDirectory)\\artifacts\${{ parameters.uploadPrefix }}package`""
+    $execExpression = (
+                    "$execPath artifacts" +
+                    " -s `"$maciosPath`"" +
+                    " -a $Env:AZURE_STORAGE" +
+                    " -c $Env:STORAGE_PASS" +
+                    " -u `"$Env:AZURE_CONTAINER/$Env:VIRTUAL_PATH/${{ parameters.uploadPrefix }}package`"" +
+                    " -d `"$(Build.SourcesDirectory)\\artifacts\${{ parameters.uploadPrefix }}package`"" +
+                    " -o `"$(Build.SourcesDirectory)\\artifacts\${{ parameters.uploadPrefix }}package`""
+                    )
+
+    Write-Host "Expression is:"
+    Write-Host $execExpression
+
+    Invoke-Expression $execExpression
   env:
     VIRTUAL_PATH: $(Build.SourceBranchName)/$(Build.SourceVersion)/$(Build.BuildId)
     GITHUB_AUTH_TOKEN: $(GitHub.Token)

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -64,7 +64,8 @@ steps:
   continueOnError: true
 
 # This task fixes errors such as these:
-#     error MSB4242: SDK Resolver Failure: "The SDK resolver "NuGetSdkResolver" failed while attempting to resolve the SDK "Microsoft.Build.NoTargets/3.3.0". Exception: "NuGet.Packaging.Core.PackagingException: Unable to find fallback package folder 'D:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages'.
+#     error MSB4242: SDK Resolver Failure: "The SDK resolver "NuGetSdkResolver" failed while attempting to resolve the SDK "Microsoft.Build.NoTargets/3.3.0".
+#                    Exception: "NuGet.Packaging.Core.PackagingException: Unable to find fallback package folder 'D:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages'.
 - pwsh: |
     try {
       New-Item -Path "D:\Program Files (x86)\Microsoft SDKs\" -Name "NuGetPackages" -ItemType "directory"


### PR DESCRIPTION
Use yaml's support for multiline keys (?:) to avoid an enormously long line
for a compile-time Azure DevOps expression.

Ref: https://github.com/microsoft/azure-pipelines-yaml/issues/533#issuecomment-1007398866

Also fix a few other cases with long lines.