### PR TITLE
[tests] Revert workaround for bug in MSBuild[.StructuredLogger]. Fixes #18568.

### DIFF
--- a/tests/common/BinLog.cs
+++ b/tests/common/BinLog.cs
@@ -112,12 +112,6 @@ namespace Xamarin.Tests {
 					continue;
 
 				yield return record.Args;
-
-				if (record.Args is BuildFinishedEventArgs) {
-					// Skip over anything that follows
-					// https://github.com/xamarin/xamarin-macios/issues/18568
-					break;
-				}
 			}
 		}
 


### PR DESCRIPTION
We no longer need this workaround.

Fixes https://github.com/xamarin/xamarin-macios/issues/18568.