### PR TITLE
[runtime] Use objc_[retain|release|autorelease] instead of sending messages.

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -226,7 +226,7 @@ exit_with_message (const char *reason, const char *argv0, bool request_mono)
 		[alert addButtonWithTitle:@"OK"];
 	}
 	NSInteger answer = [alert runModal];
-	[alert release];
+	objc_release (alert);
 	
 	if (request_mono && answer == NSAlertFirstButtonReturn) {
 		NSString *mono_download_url = @"https://www.mono-project.com/download/stable/";

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1986,7 +1986,7 @@ xamarin_release_managed_ref (id self, bool user_type)
 
 	xamarin_handle_to_be_released = self;
 
-	[self release];
+	objc_release (self);
 
 	xamarin_handle_to_be_released = NULL;
 }
@@ -2726,7 +2726,7 @@ xamarin_vprintf (const char *format, va_list args)
 	NSLog (@"%@", message);	
 #endif
 
-	[message release];
+	objc_release (message);
 }
 
 void
@@ -3269,7 +3269,7 @@ xamarin_get_runtime_arch ()
 {
 	XamarinGCHandle *rv = [[XamarinGCHandle alloc] init];
 	rv->handle = h;
-	[rv autorelease];
+	objc_autorelease (rv);
 	return rv;
 }
 

--- a/runtime/shared.m
+++ b/runtime/shared.m
@@ -52,9 +52,9 @@
 	// COOP: no managed memory access: any mode.
 	target = targ;
 	if (is_direct)
-		[((id) targ) retain];
+		objc_retain ((id) targ);
 	selector = sel;
-	argument = [arg retain];
+	argument = objc_retain (arg);
 	is_direct_binding = is_direct;
 	return self;
 }
@@ -81,8 +81,8 @@
 	void *targ = (void *) (is_direct_binding ? target : nil);
 	void *arg = (void *) argument;
 	dispatch_async (dispatch_get_main_queue (), ^{
-		[((id) targ) release];
-		[((id) arg) release];
+		objc_release ((id) targ);
+		objc_release ((id) arg);
 	});
 	[super dealloc];
 }
@@ -92,7 +92,8 @@ id
 xamarin_init_nsthread (id obj, bool is_direct, id target, SEL sel, id arg)
 {
 	// COOP: no managed memory access: any mode.
-	XamarinNSThreadObject *wrap = [[[XamarinNSThreadObject alloc] initWithData: target selector: sel argument: arg is_direct_binding: is_direct] autorelease];
+	XamarinNSThreadObject *wrap = [[XamarinNSThreadObject alloc] initWithData: target selector: sel argument: arg is_direct_binding: is_direct];
+	objc_autorelease (wrap);
 	id (*invoke) (id, SEL, id, SEL, id) = (id (*)(id, SEL, id, SEL, id)) objc_msgSend;
 	return invoke (obj, @selector(initWithTarget:selector:object:), wrap, @selector(start:), nil);
 }
@@ -145,7 +146,7 @@ void
 xamarin_initialize_cocoa_threads (init_cocoa_func *func)
 {
 	// COOP: no managed memory access: any mode.
-	[[[XamarinCocoaThreadInitializer alloc] initWithFunc: func] autorelease];
+	objc_autorelease ([[XamarinCocoaThreadInitializer alloc] initWithFunc: func]);
 }
 
 /* Threads & Blocks

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -110,7 +110,7 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 			} else if (xamarin_is_class_array (r_klass)) {
 				NSArray *rv = xamarin_managed_array_to_nsarray ((MonoArray *) retval, NULL, r_klass, exception_gchandle);
 				if (retain && rv)
-					[rv retain];
+					objc_retain (rv);
 				returnValue = rv;
 			} else if (xamarin_is_class_nsobject (r_klass)) {
 				id i = xamarin_get_handle (retval, exception_gchandle);
@@ -172,9 +172,9 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 
 					xamarin_framework_peer_waypoint ();
 
-					[i retain];
+					objc_retain (i);
 					if (!retain)
-						[i autorelease];
+						objc_autorelease (i);
 
 					mt_dummy_use (retval);
 					returnValue = i;
@@ -196,7 +196,7 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 							return returnValue;
 						if (retained) {
 							id i = (id) returnValue;
-							[i autorelease];
+							objc_autorelease (i);
 						}
 					}
 				}
@@ -850,7 +850,7 @@ xamarin_set_gchandle_trampoline (id self, SEL sel, GCHandle gc_handle, enum Xama
 		obj->flags = flags;
 		obj->native_object = self;
 		objc_setAssociatedObject (self, associated_key, obj, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-		[obj release];
+		objc_release (obj);
 	}
 
 	if (obj != NULL) {

--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -78,7 +78,7 @@ xamarin_log (const unsigned short *unicodeMessage)
 		NSLog (@"%@", msg);
 	}
 #endif
-	[msg release];
+	objc_release (msg);
 }
 
 // NOTE: The timezone functions are duplicated in mono, so if you're going to modify here, it would be nice
@@ -93,8 +93,8 @@ xamarin_timezone_get_data (const char *name, uint32_t *size)
 	NSTimeZone *tz = nil;
 	if (name) {
 		NSString *n = [[NSString alloc] initWithUTF8String: name];
-		tz = [[[NSTimeZone alloc] initWithName:n] autorelease];
-		[n release];
+		tz = objc_autorelease ([[NSTimeZone alloc] initWithName:n]);
+		objc_release (n);
 	} else {
 		tz = [NSTimeZone localTimeZone];
 	}

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -460,6 +460,10 @@ public:
 	} while (0)
 #endif
 
+void objc_release (id value);
+id objc_retain (id value);
+id objc_autorelease (id value);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif


### PR DESCRIPTION
Calling the direct functions instead of sending messages is slightly faster,
and additionally it may make some static analyzers think we've enabled ARC for
our Objective-C code (which we don't, because we need to manually manage
reference counting).

These direct functions aren't in any public header (they're in a private header),
but they're documented as part of ARC here: https://clang.llvm.org/docs/AutomaticReferenceCounting.html#runtime-support,
and clang emits references to these methods from user code, so it should be safe for us to use them.

Fixes https://github.com/xamarin/xamarin-macios/issues/19413.