### PR TITLE
[CI] Readd the statuses for bundle.zip and msbuild.zip

### DIFF
--- a/tools/devops/automation/templates/sign-and-notarized/funnel.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/funnel.yml
@@ -130,6 +130,25 @@ jobs:
       artifactName: '${{ parameters.uploadPrefix }}package-internal'
     continueOnError: true
 
+  # download msbuild.zip and bundle.zip to the 'package' dir, so that they're uploaded into the 'package' artifact,
+  # since we later depend on these files being there later.
+  - task: DownloadPipelineArtifact@2
+    displayName: Download msbuild.zip and bundle.zip
+    inputs:
+      patterns: |
+        not-signed-package/msbuild.zip
+        not-signed-package/bundle.zip
+      allowFailedBuilds: true
+      path: $(Build.SourcesDirectory)/not-signed-package
+
+  - bash: |
+      set -x
+      set -e
+      ls -la "$BUILD_SOURCESDIRECTORY"/not-signed-package
+      cp "$BUILD_SOURCESDIRECTORY"/not-signed-package/not-signed-package/*.zip "$BUILD_SOURCESDIRECTORY"/package
+      ls -la "$BUILD_SOURCESDIRECTORY"/package
+    displayName: Copy msbuild.zip and bundle.zip to the package artifact
+
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Build Artifacts (notarized)'
     inputs:

--- a/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/upload-azure.yml
@@ -218,6 +218,22 @@ steps:
         TargetUrl = "$pkgsVirtualUrl/notarized/$macPkg" ;
         Error = "Notarized xamarin.mac pkg not found." ;
         ShouldExist = $notarizedShouldExist;
+      },
+      @{
+        Path = "$pkgsPath\\bundle.zip" ;
+        Context = "bundle.zip" ;
+        Description = "bundle.zip" ;
+        TargetUrl = "$pkgsVirtualUrl/bundle.zip" ;
+        Error = "bundle.zip not found." ;
+        ShouldExist = $true;
+      },
+      @{
+        Path = "$pkgsPath\msbuild.zip" ;
+        Context = "msbuild.zip" ;
+        Description = "msbuild.zip" ;
+        TargetUrl = "$pkgsVirtualUrl/msbuild.zip" ;
+        Error = "msbuild.zip not found." ;
+        ShouldExist = $true;
       }
     )
 


### PR DESCRIPTION
Readd the statuses for bundle.zip and msbuild.zip, we use them as api
references when doing the api diff.

This is a partial revert of 3bc4dfde9f88c803628439aa98c593557cc355db, since we
do not need the nugets.