### PR TITLE
[xcode14.3] Bump api references for .NET 8 and legacy Xamarin.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -40,12 +40,12 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config $(TOP)/mk/mono.mk
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES_iOS=https://dl.internalx.com/wrench/xcode14.1/6714e055b242715aaa682b578f898070facf243a/7021940/package/bundle.zip
-APIDIFF_REFERENCES_Mac=https://dl.internalx.com/wrench/xcode14.1/6714e055b242715aaa682b578f898070facf243a/7021940/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_iOS=https://dl.internalx.com/wrench/7.0.1xx/c51a20dbde7bb30d896019f178e0055559071177/6999758/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_tvOS=https://dl.internalx.com/wrench/7.0.1xx/c51a20dbde7bb30d896019f178e0055559071177/6999758/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_macOS=https://dl.internalx.com/wrench/7.0.1xx/c51a20dbde7bb30d896019f178e0055559071177/6999758/package/bundle.zip
-APIDIFF_REFERENCES_DOTNET_MacCatalyst=https://dl.internalx.com/wrench/7.0.1xx/c51a20dbde7bb30d896019f178e0055559071177/6999758/package/bundle.zip
+APIDIFF_REFERENCES_iOS=https://dl.internalx.com/wrench/xcode14.3/9defd91b37e5b4c3ab1f63e3ca77095d09aa4c93/8579896/package/bundle.zip
+APIDIFF_REFERENCES_Mac=https://dl.internalx.com/wrench/xcode14.3/9defd91b37e5b4c3ab1f63e3ca77095d09aa4c93/8579896/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_iOS=https://dl.internalx.com/wrench/8.0.1xx/c0a9cc341307be8fe397ba6b729d61e19700f343/8674056/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_tvOS=https://dl.internalx.com/wrench/8.0.1xx/c0a9cc341307be8fe397ba6b729d61e19700f343/8674056/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_macOS=https://dl.internalx.com/wrench/8.0.1xx/c0a9cc341307be8fe397ba6b729d61e19700f343/8674056/package/bundle.zip
+APIDIFF_REFERENCES_DOTNET_MacCatalyst=https://dl.internalx.com/wrench/8.0.1xx/c0a9cc341307be8fe397ba6b729d61e19700f343/8674056/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -45,8 +45,8 @@ export MARKDOWN_BREAKING_CHANGES_MESSAGE=:heavy_exclamation_mark: Breaking chang
 export MARKDOWN_NO_BREAKING_CHANGES_MESSAGE=No breaking changes
 
 ifeq ($(DOTNET_TFM_REFERENCE),)
-# Change the below to net8.0 once we have reference assemblies from net8.0 (i.e. once net8.0 goes stable).
-DOTNET_TFM_REFERENCE=net7.0
+# Change the below to net9.0 once we have reference assemblies from net9.0 (i.e. once net8.0 goes stable).
+DOTNET_TFM_REFERENCE=net8.0
 endif
 
 # I18N are excluded - but otherwise if should be like ../../builds/Makefile + what XI adds
@@ -444,7 +444,10 @@ $$(BUNDLE_ZIP_$(1)):
 		$$(CP) ~/Library/Caches/xamarin-macios/$$(notdir $$@) $$@.tmp; \
 	else \
 		$(MAKE) check-token || exit 1; \
-		$(CURL_RETRY) -H "Authorization: token $(AUTH_TOKEN_GITHUB_COM)" "$$(BUNDLE_ZIP_$(1)_URL)" --output $$@.tmp; \
+		if ! $(CURL_RETRY) -H "Authorization: token $(AUTH_TOKEN_GITHUB_COM)" "$$(BUNDLE_ZIP_$(1)_URL)" --output $$@.tmp; then \
+			echo "Failed to download $$(BUNDLE_ZIP_$(1)_URL)"; \
+			exit 1; \
+		fi; \
 		if [[ "x$$$$MACIOS_CACHE_DOWNLOADS" != "x" ]]; then \
 			mkdir -p ~/Library/Caches/xamarin-macios/; \
 			$$(CP) $$@.tmp ~/Library/Caches/xamarin-macios/"$$(notdir $$@)"; \


### PR DESCRIPTION
The released commit for .NET 8 isn't the exact same commit as the one
referenced here, because the build.zip file wasn't produced in that commit -
this was fixed, so it's a few commits later. There were no API changes between
these commits though, so the API references are identical.

Backport of #19434.