### PR TITLE
Use Mono.Options NuGet instead of building from source in a few projects.

### DIFF
--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="4.7.2" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -133,7 +134,6 @@
     <Compile Include="..\tools\common\TargetFramework.cs" />
     <Compile Include="..\tools\common\StringUtils.cs" />
     <Compile Include="$(BuildDir)generator-frameworks.g.cs" />
-    <Compile Include="..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\Mono.Options\Mono.Options\Options.cs" />
     <Compile Include="..\src\Foundation\AdviceAttribute.cs" />
     <Compile Include="..\src\Foundation\ExportAttribute.cs" />
     <Compile Include="..\src\Foundation\FieldAttribute.cs" />

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -17,7 +17,7 @@ mmp.csproj.inc: export BUILD_VERBOSITY=$(MSBUILD_VERBOSITY)
 -include mmp.csproj.inc
 
 $(MMP_DIR)/mmp.exe: $(mmp_dependencies)
-	$(Q_GEN) $(SYSTEM_MSBUILD) "/bl:$@.binlog" $(TOP)/Xamarin.Mac.sln "/t:mmp" $(XBUILD_VERBOSITY) /p:Configuration=$(MMP_CONF)
+	$(Q_GEN) $(SYSTEM_MSBUILD) "/bl:$@.binlog" mmp.csproj /r $(XBUILD_VERBOSITY) /p:Configuration=$(MMP_CONF)
 
 MMP_TARGETS_DOTNET = \
 	$(DOTNET_DESTDIR)/$(osx-x64_NUGET_RUNTIME_NAME)/runtimes/osx-x64/native/Microsoft.macOS.registrar.a \

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -44,6 +44,7 @@
       <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Application.mmp.cs" />
@@ -240,9 +241,6 @@
     </Compile>
     <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\external\linker\src\tuner\Mono.Tuner\Profile.cs">
       <Link>mono-archive\Mono.Tuner\Profile.cs</Link>
-    </Compile>
-    <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\Mono.Options\Mono.Options\Options.cs">
-      <Link>mono-archive\Options.cs</Link>
     </Compile>
     <Compile Include="linker\MonoMac.Tuner\MonoMacMarkStep.cs">
       <Link>linker\MonoMac.Tuner\MonoMacMarkStep.cs</Link>

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -234,7 +234,7 @@ mtouch.csproj.inc: export BUILD_VERBOSITY=$(MSBUILD_VERBOSITY)
 -include mtouch.csproj.inc
 
 $(MTOUCH_DIR)/mtouch.exe: $(mtouch_dependencies)
-	$(Q_GEN) $(SYSTEM_MSBUILD) $(TOP)/Xamarin.iOS.sln "/t:mtouch" $(XBUILD_VERBOSITY) /p:Configuration=$(MTOUCH_CONF)
+	$(Q_GEN) $(SYSTEM_MSBUILD) mtouch.csproj /r $(XBUILD_VERBOSITY) /p:Configuration=$(MTOUCH_CONF)
 
 Constants.cs: Constants.cs.in Makefile $(TOP)/Make.config.inc
 	$(Q_GEN) sed \

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -52,9 +52,6 @@
     <Compile Include="Stripper.cs" />
     <Compile Include="Target.mtouch.cs" />
     <Compile Include="Tuning.mtouch.cs" />
-    <Compile Include="..\..\builds\mono-ios-sdk-destdir\ios-sources\mcs\class\Mono.Options\Mono.Options\Options.cs">
-      <Link>mono-archive\Options.cs</Link>
-    </Compile>
     <Compile Include="Constants.cs" />
     <Compile Include="..\..\src\ObjCRuntime\Constants.cs">
       <Link>src\ObjCRuntime\Constants.cs</Link>
@@ -520,6 +517,7 @@
     <Reference Include="Mono.Cecil.Mdb">
       <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile" />


### PR DESCRIPTION
This reduces a source dependency on the legacy Mono package.