### PR TITLE
[xcode14.3] Bump api-tools

### DIFF
--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -32,8 +32,8 @@ endif
 endif
 endif
 
-MONO_API_INFO = $(API_TOOLS_PATH)/mono-api-info/bin/Debug/net6.0/mono-api-info.dll
-MONO_API_HTML = $(API_TOOLS_PATH)/mono-api-html/bin/Debug/net6.0/mono-api-html.dll
+MONO_API_INFO = $(API_TOOLS_PATH)/mono-api-info/bin/Debug/$(DOTNET_TFM)/mono-api-info.dll
+MONO_API_HTML = $(API_TOOLS_PATH)/mono-api-html/bin/Debug/$(DOTNET_TFM)/mono-api-html.dll
 MONO_BUILD = $(SYSTEM_MONO)
 
 MONO_API_INFO_EXEC = $(DOTNET) --roll-forward Major $(MONO_API_INFO) --ignore-inherited-interfaces


### PR DESCRIPTION
Bump api-tools to be able to handle newer reference xmls (#19436).

New commits in rolfbjarne/api-tools:

* rolfbjarne/api-tools@1fbbe00 [mono-api-html] Render abstract members correctly with the 'abstract' keyword.
* rolfbjarne/api-tools@6c37358 [mono-api-html] Handle default interface members better.
* rolfbjarne/api-tools@6d4007a [mono-api-html] Allow changing the base type if the old base type is a super class of the new base type.
* rolfbjarne/api-tools@cbc1e08 [mono-api-html] Fix compiler warning about obsolete formatter-based serialization attributes.
* rolfbjarne/api-tools@c7d5208 Use the current .NET version to build.
* rolfbjarne/api-tools@254f0e0 [mono-api-info] Add support for comparing function pointers.
* rolfbjarne/api-tools@ebc175f Update the .editorconfig file

Diff: https://github.com/rolfbjarne/api-tools/compare/373fc1b50a23bf933aaeea7485ed7fb82c2cc268..1fbbe003a141231439c08b23989d3dc910bd6182