### PR TITLE
[tests] Don't pass a message to Assert.Ignore.

### DIFF
--- a/tests/cecil-tests/ApiTest.cs
+++ b/tests/cecil-tests/ApiTest.cs
@@ -27,7 +27,7 @@ namespace Cecil.Tests {
 			List<string>? failures = null;
 
 			if (!assembly.EnumerateTypes ((type) => type.Is ("ARKit", "ARConfiguration")).Any ())
-				Assert.Ignore ("This assembly doesn't contain ARKit.ARConfiguration");
+				Assert.Ignore (); // This assembly doesn't contain ARKit.ARConfiguration
 
 			var subclasses = assembly.EnumerateTypes ((type) => !type.Is ("ARKit", "ARConfiguration") && type.IsSubclassOf ("ARKit", "ARConfiguration"));
 			Assert.That (subclasses, Is.Not.Empty, "At least some subclasses");


### PR DESCRIPTION
When run in the terminal using 'dotnet test', the text passed to Assert.Ignore is show in red, which makes it look like a failure and is always confusing.

Before:

![Screenshot 2023-11-15 at 10 59 29](https://github.com/xamarin/xamarin-macios/assets/249268/dbc0f4f4-660a-41b7-96fc-84a7d132a880)

After:

![Screenshot 2023-11-15 at 11 06 35](https://github.com/xamarin/xamarin-macios/assets/249268/2a5e60b0-6d9b-41db-ba18-4717e39827a5)
