### PR TITLE
[Foundation] Fix a few issues with NSUrlConnection.SendSynchronousRequest.

### DIFF
--- a/tests/monotouch-test/Foundation/UrlConnectionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlConnectionTest.cs
@@ -39,5 +39,18 @@ namespace MonoTouchFixtures.Foundation {
 				c.Cancel ();
 			}
 		}
+
+		[Test]
+		public void SendSynchronousRequest ()
+		{
+			using var url = new NSUrl (NetworkResources.MicrosoftUrl);
+			using var request = new NSUrlRequest (url);
+			using var data = NSUrlConnection.SendSynchronousRequest (request, out var response, out var error);
+			Assert.IsNull (error, "Error");
+			Assert.IsNotNull (data, "Data");
+			Assert.IsNotNull (response, "Response");
+			response?.Dispose ();
+			error?.Dispose ();
+		}
 	}
 }


### PR DESCRIPTION
* Simplify code by using unsafe pointers.
* Add our own objc_msgSend P/Invoke to avoid depending on generated signatures.
* Enable nullability.
* Call GC.KeepAlive to ensure the request isn't collected prematurely by the GC.

The last point might do something about #19289.