### PR TITLE
[release/8.0.1xx] [tools] Don't detect/resolve binding resource packages in mtouch/mmp/dotnet-linker. Fixes #19378.

### DIFF
--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -157,6 +157,17 @@ namespace Xamarin.Bundler {
 			if (!assembly.HasCustomAttributes)
 				return;
 
+			string resourceBundlePath = Path.ChangeExtension (FullPath, ".resources");
+			if (Directory.Exists (resourceBundlePath)) {
+				Driver.Log (3, $"Found a binding resource package for the assembly '{FullPath}' in {resourceBundlePath}, so not looking for any libraries embedded in the assembly.");
+				return;
+			}
+			var zipPath = resourceBundlePath + ".zip";
+			if (File.Exists (zipPath)) {
+				Driver.Log (3, $"Found a binding resource package for the assembly '{FullPath}' in {zipPath}, so not looking for any libraries embedded in the assembly.");
+				return;
+			}
+
 			ProcessLinkWithAttributes (assembly);
 
 			// Make sure there are no duplicates between frameworks and weak frameworks.


### PR DESCRIPTION
We currently detect/resolve binding resource packages (the sidecar) in two places:

* The ResolveNativeReferences MSBuild task.
* Inside mtouch/mmp/dotnet-linker.

Which means we end up passing every native library or framework twice to the native linker.

This is usually not a problem, the native linker will ignore duplicated
arguments, except when building remotely from Windows, in which case the build
process may end up with native libraries in different locations, because files
may end up in multiple places on the remote Mac if using absolute paths (see
https://github.com/xamarin/xamarin-macios/issues/18997 for a thorough explanation).

So completely remove the logic to detect/resolve binding resource packages in
mtouch/mmp/dotnet-linker, which will avoid the issue completely.

A few mtouch tests also needed updating, since they're calling mtouch directly instead
of going through the msbuild targets.

Fixes https://github.com/xamarin/xamarin-macios/issues/19378.


Backport of #19407
