### PR TITLE
[ModelIO] Include MDLMaterial.cs in the build.

### DIFF
--- a/src/ModelIO/MDLMaterial.cs
+++ b/src/ModelIO/MDLMaterial.cs
@@ -1,3 +1,5 @@
+using System;
+
 #nullable enable
 
 namespace ModelIO {

--- a/src/ModelIO/MDLMaterial.cs
+++ b/src/ModelIO/MDLMaterial.cs
@@ -1,14 +1,14 @@
 #nullable enable
 
 namespace ModelIO {
-	public partial class MDLAsset {
-		public MDLMaterialProperty this [nuint index] {
+	public partial class MDLMaterial {
+		public MDLMaterialProperty? this [nuint index] {
 			get {
 				return ObjectAtIndexedSubscript (index);
 			}
 		}
 
-		public MDLMaterialProperty this [string name] {
+		public MDLMaterialProperty? this [string name] {
 			get {
 				return ObjectForKeyedSubscript (name);
 			}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1263,6 +1263,7 @@ MODELIO_SOURCES = \
 	ModelIO/MDLAnimatedQuaternion.cs \
 	ModelIO/MDLAnimatedValueTypes.cs \
 	ModelIO/MDLAsset.cs \
+	ModelIO/MDLMaterial.cs \
 	ModelIO/MDLNoiseTexture.cs \
 	ModelIO/MDLTransform.cs \
 	ModelIO/MDLTransformComponent.cs \


### PR DESCRIPTION
Looks like we forgot to add this file to the build when we bound the
corresponding APIs.