### PR TITLE
[src] Try to fix race condition with regards to restoring NuGet packages.

### DIFF
--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -20,6 +20,13 @@ $(DOTNET_BUILD_DIR)/bgen/bgen:  $(generator_dependencies) Makefile.generator $(B
 	$(Q) printf 'exec $(DOTNET) "$$(dirname "$$0")"/bgen.dll $$@\n' > $@
 	$(Q) chmod +x $@
 
+# Serialize the building of the legacy bgen and the .NET version, because they can both try to restore the same NuGet package at the same time, and that runs into race conditions
+# This is done by adding a dependency from the legacy bgen to the .NET bgen, so the legacy bgen doesn't start building until the .NET one is done.
+ifdef INCLUDE_XAMARIN_LEGACY
+ifdef ENABLE_DOTNET
+$(BUILD_DIR)/common/bgen.exe: $(DOTNET_BUILD_DIR)/bgen/bgen
+endif
+endif
 
 define BGenTargets
 $(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/tools/lib/bgen/bgen: $(DOTNET_BUILD_DIR)/bgen/bgen | $(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/tools/lib/bgen


### PR DESCRIPTION
The build is somewhat frequently failing on the bots with this:

> /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/NuGet.targets(131,5): error : Could not find file "/Users/builder/azdo/_work/2/a/change-detection/tmp/src/xamarin-macios/packages/mono.options/6.12.0.148/qo8orsfq.fp5"

Although I haven't been able to reproduce it, I believe it to be a race
condition between building the .NET version of the generator and the legacy
Xamarin version of the generator: if they both try to restore NuGet packages
at the same time, things may break.

Fix this by introducing an artificial dependency between the generators, so
that they're not built simultaneously, but instead sequentially.

This might make the build a few seconds slower, but predicable builds on the
bots are way more important. Also the speed will be back to normal once we
stop building legacy Xamarin.