### PR TITLE
[mmp] Don't run pkg-config when generating partial static registrar code.

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -106,6 +106,8 @@ namespace Xamarin.Bundler {
 		public static bool LinkProhibitedFrameworks { get; private set; }
 		public static bool UseLegacyAssemblyResolution { get; private set; }
 
+		internal static Action Action { get => action; }
+
 		static string mono_prefix;
 		static string MonoPrefix {
 			get {

--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -114,7 +114,7 @@ namespace Xamarin.Bundler {
 		{
 			base.Configure ();
 
-			if (!Driver.UseLegacyAssemblyResolution && (Driver.IsUnifiedFullSystemFramework || Driver.IsUnifiedFullXamMacFramework)) {
+			if (!Driver.UseLegacyAssemblyResolution && (Driver.IsUnifiedFullSystemFramework || Driver.IsUnifiedFullXamMacFramework) && Driver.Action != Action.RunRegistrar) {
 				// We need to look in the GAC/System mono for both FullSystem and FullXamMac, because that's
 				// how we've been resolving assemblies in the past (Cecil has a fall-back mode where it looks
 				// in the GAC, and we never disabled that, meaning that we always looked in the GAC if failing


### PR DESCRIPTION
Lately I've been seeing an increase in a build failure on boths due to
pkg-config crashing when generating the partial static registrar code in mmp.

Turns out it's not necessary to run pkg-config when generating the partial
static registrar code, so just skip it in that case.

Example crash:

    Process exited with code 134, command:
    /Library/Frameworks/Mono.framework/Versions/Current/bin/pkg-config --variable=prefix mono-2
    mono_os_sem_post: semaphore_signal failed with error 15

    =================================================================
    	Native Crash Reporting
    =================================================================
    Got a abrt while executing native code. This usually indicates
    a fatal error in the mono runtime or one of the native libraries
    used by your application.
    =================================================================

    =================================================================
    	Native stacktrace:
    =================================================================
    	0x1018d2639 - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : mono_dump_native_crash_info
    	0x10186a3ee - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : mono_handle_native_crash
    	0x1018d1bff - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : sigabrt_signal_handler
    	0x7ff819ca35ed - /usr/lib/system/libsystem_platform.dylib : _sigtramp
    	0x0 - Unknown
    	0x7ff819b9cb45 - /usr/lib/system/libsystem_c.dylib : abort
    	0x101abee97 - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : monoeg_assert_abort
    	0x101a9fcff - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : mono_log_write_logfile
    	0x101abf32e - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : monoeg_g_logv_nofree
    	0x101abf3e2 - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : monoeg_g_log
    	0x101a42017 - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : mono_gc_finalize_notify
    	0x10192c512 - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : mono_sigchld_signal_handler
    	0x7ff819ca35ed - /usr/lib/system/libsystem_platform.dylib : _sigtramp
    	0x0 - Unknown
    	0x101d9b6c7 - /Users/builder/azdo/_work/_temp/codeql3000/distribution/codeql/tools/osx64/libtrace.dylib : _ZL18execve_with_tracerPKcS0_PKPcS3_i
    	0x101d9afc7 - /Users/builder/azdo/_work/_temp/codeql3000/distribution/codeql/tools/osx64/libtrace.dylib : codeql_execve
    	0x10192915c - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : process_create
    	0x101929d26 - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : ves_icall_System_Diagnostics_Process_CreateProcess_internal
    	0x101985a5f - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : ves_icall_System_Diagnostics_Process_CreateProcess_internal_raw
    	0x104538e11 - Unknown
    	0x10453702b - Unknown
    	0x10531156b - /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/4.5/mscorlib.dll.dylib : System_Threading_ThreadHelper_ThreadStart_Context_object
    	0x10530ec23 - /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/4.5/mscorlib.dll.dylib : System_Threading_ExecutionContext_Run_System_Threading_ExecutionContext_System_Threading_ContextCallback_object_bool
    	0x1017c7332 - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : mono_jit_runtime_invoke
    	0x1019d6db7 - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : mono_runtime_invoke_checked
    	0x1019dd6b0 - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : mono_runtime_delegate_try_invoke
    	0x101a01c5d - /Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 : start_wrapper
    	0x7ff819c761d3 - /usr/lib/system/libsystem_pthread.dylib : _pthread_start
    	0x7ff819c71bd3 - /usr/lib/system/libsystem_pthread.dylib : thread_start

    =================================================================
    	Telemetry Dumper:
    =================================================================
    Pkilling 0x140704692385536x from 0x123145518841856x
    Pkilling 0x123145515659264x from 0x123145518841856x
    Entering thread summarizer pause from 0x123145518841856x
    Finished thread summarizer pause from 0x123145518841856x.
    Failed to create breadcrumb file (null)/crash_hash_0x4409842f2

    Waiting for dumping threads to resume

    =================================================================
    	External Debugger Dump:
    =================================================================

    =================================================================
    	Basic Fault Address Reporting
    =================================================================
    Memory around native instruction pointer (0x7ff819c3e1e2):0x7ff819c3e1d2  ff ff c3 90 90 90 b8 48 01 00 02 49 89 ca 0f 05  .......H...I....
    0x7ff819c3e1e2  73 08 48 89 c7 e9 df 9a ff ff c3 90 90 90 b8 53  s.H............S
    0x7ff819c3e1f2  00 00 02 49 89 ca 0f 05 73 08 48 89 c7 e9 c7 9a  ...I....s.H.....
    0x7ff819c3e202  ff ff c3 90 90 90 b8 83 01 00 02 49 89 ca 0f 05  ...........I....

    =================================================================
    	Managed Stacktrace:
    =================================================================
    	  at <unknown> <0xffffffff>
    	  at System.Diagnostics.Process:CreateProcess_internal <0x000a0>
    	  at System.Diagnostics.Process:StartWithCreateProcess <0x0075a>
    	  at System.Diagnostics.Process:Start <0x000ba>
    	  at System.Diagnostics.Process:Start <0x000a2>
    	  at <>c__DisplayClass24_1:<RunAsync>b__0 <0x0031a>
    	  at System.Threading.ThreadHelper:ThreadStart_Context <0x000aa>
    	  at System.Threading.ExecutionContext:RunInternal <0x001a9>
    	  at System.Threading.ExecutionContext:Run <0x00042>
    	  at System.Threading.ExecutionContext:Run <0x00067>
    	  at System.Threading.ThreadHelper:ThreadStart <0x00042>
    	  at System.Object:runtime_invoke_void__this__ <0x000b0>
    =================================================================

    error MM5312: pkg-config failed with an error code '134'. Check build log for details.