### PR TITLE
[release/8.0.1xx] [devops] Set System.Debug to false by default.

### DIFF
--- a/tools/devops/automation/templates/variables.yml
+++ b/tools/devops/automation/templates/variables.yml
@@ -14,7 +14,7 @@ variables:
 - name: AzDoBuildAccess.Token
   value: $(pat--xamarinc--build-access)
 - name: system.debug
-  value: true
+  value: false
 - name: SigningKeychain
   value: "builder.keychain"
 - name: VSDropsPrefix


### PR DESCRIPTION
Otherwise our build logs ends up being huge, and takes a long time to download
(or just completely crashes the browser).


Backport of #19468
