### PR TITLE
[msbuild] Remove the CodesignProvision property from the DetectSigningIdentity task.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSigningIdentityTaskBase.cs
@@ -105,8 +105,6 @@ namespace Xamarin.MacDev.Tasks {
 
 		public string BundleIdentifier { get; set; }
 
-		public string CodesignProvision { get; set; }
-
 		public ITaskItem CodesignEntitlements { get; set; }
 
 		public string CodesignRequireProvisioningProfile { get; set; }
@@ -164,7 +162,7 @@ namespace Xamarin.MacDev.Tasks {
 							break;
 						case ApplePlatform.MacCatalyst:
 						case ApplePlatform.MacOSX:
-							requireProvisioningProfile = !string.IsNullOrEmpty (CodesignProvision);
+							requireProvisioningProfile = !string.IsNullOrEmpty (ProvisioningProfile);
 							break;
 						default:
 							throw new InvalidOperationException (string.Format (MSBStrings.InvalidPlatform, Platform));

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1804,7 +1804,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="$(_DetectSigningIdentityDependsOn)">
 		<DetectSigningIdentity
 			SessionId="$(BuildSessionId)"
-			CodesignProvision="$(CodesignProvision)"
 			CodesignEntitlements="$(CodesignEntitlements)"
 			CodesignRequireProvisioningProfile="$(CodesignRequireProvisioningProfile)"
 			Condition="'$(IsMacEnabled)' == 'true'"


### PR DESCRIPTION
It's a duplicate of the ProvisioningProfile property, so use that instead.