### PR TITLE
[Generator] Move the NSValue create map to the TypeCache.

### DIFF
--- a/src/bgen/Caches/TypeCache.cs
+++ b/src/bgen/Caches/TypeCache.cs
@@ -283,11 +283,11 @@ public class TypeCache {
 		// init the NSValueCreateMap
 		NSValueCreateMap = BuildNSValueCreateMap (frameworks);
 	}
-	
+
 	Dictionary<Type, string> BuildNSValueCreateMap (Frameworks frameworks)
 	{
 		var nsvalueCreateMap = new Dictionary<Type, string> {
-			[CGAffineTransform] = "CGAffineTransform", 
+			[CGAffineTransform] = "CGAffineTransform",
 			[NSRange] = "Range",
 			[CGVector] = "CGVector",
 			[SCNMatrix4] = "SCNMatrix4",

--- a/src/bgen/Caches/TypeCache.cs
+++ b/src/bgen/Caches/TypeCache.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using ObjCRuntime;
@@ -134,6 +135,8 @@ public class TypeCache {
 	public Type? UIOffset { get; }
 	public Type? UIEdgeInsets { get; }
 	public Type? NSDirectionalEdgeInsets { get; }
+
+	public IReadOnlyDictionary<Type, string> NSValueCreateMap { get; }
 
 	public TypeCache (MetadataLoadContext universe, Frameworks frameworks, PlatformName currentPlatform, Assembly apiAssembly, Assembly corlibAssembly, Assembly platformAssembly, bool bindThirdPartyLibrary)
 	{
@@ -277,6 +280,51 @@ public class TypeCache {
 			UIEdgeInsets = ConditionalLookup (platformAssembly, "UIKit", "UIEdgeInsets");
 			NSDirectionalEdgeInsets = ConditionalLookup (platformAssembly, "UIKit", "NSDirectionalEdgeInsets");
 		}
+		// init the NSValueCreateMap
+		NSValueCreateMap = BuildNSValueCreateMap (frameworks);
+	}
+	
+	Dictionary<Type, string> BuildNSValueCreateMap (Frameworks frameworks)
+	{
+		var nsvalueCreateMap = new Dictionary<Type, string> {
+			[CGAffineTransform] = "CGAffineTransform", 
+			[NSRange] = "Range",
+			[CGVector] = "CGVector",
+			[SCNMatrix4] = "SCNMatrix4",
+			[SCNVector3] = "Vector",
+			[SCNVector4] = "Vector",
+			[CoreGraphics_CGPoint] = "CGPoint",
+			[CoreGraphics_CGRect] = "CGRect",
+			[CoreGraphics_CGSize] = "CGSize"
+		};
+
+		if (CLLocationCoordinate2D is not null)
+			nsvalueCreateMap [CLLocationCoordinate2D] = "MKCoordinate";
+
+		if (frameworks.HaveUIKit) {
+			// we do know that the following keys are indeed present
+			nsvalueCreateMap [UIEdgeInsets!] = "UIEdgeInsets";
+			nsvalueCreateMap [UIOffset!] = "UIOffset";
+			nsvalueCreateMap [NSDirectionalEdgeInsets!] = "DirectionalEdgeInsets";
+		}
+
+		if (MKCoordinateSpan is not null) {
+			nsvalueCreateMap [MKCoordinateSpan] = "MKCoordinateSpan";
+		}
+
+		if (frameworks.HaveCoreMedia) {
+			// we do know that the following keys are indeed present
+			nsvalueCreateMap [CMTimeRange!] = "CMTimeRange";
+			nsvalueCreateMap [CMTime!] = "CMTime";
+			nsvalueCreateMap [CMTimeMapping!] = "CMTimeMapping";
+			nsvalueCreateMap [CMVideoDimensions!] = "CMVideoDimensions";
+		}
+
+		if (frameworks.HaveCoreAnimation) {
+			// we do know that the following keys are indeed present
+			nsvalueCreateMap [CATransform3D!] = "CATransform3D";
+		}
+		return nsvalueCreateMap;
 	}
 
 #if NET

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -370,7 +370,7 @@ public partial class Generator : IMemberGatherer {
 		// If the above fails it's possible that it comes from another dll (like X.I.dll) so we look for the [Enum]Extensions class existence
 		return type.Assembly.GetType (type.FullName + "Extensions") is not null;
 	}
-	
+
 	string GetToBindAsWrapper (MethodInfo mi, MemberInformation minfo = null, ParameterInfo pi = null)
 	{
 		BindAsAttribute attrib = null;

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -370,47 +370,7 @@ public partial class Generator : IMemberGatherer {
 		// If the above fails it's possible that it comes from another dll (like X.I.dll) so we look for the [Enum]Extensions class existence
 		return type.Assembly.GetType (type.FullName + "Extensions") is not null;
 	}
-
-	Dictionary<Type, string> nsvalue_create_map;
-	Dictionary<Type, string> NSValueCreateMap {
-		get {
-			if (nsvalue_create_map is null) {
-				nsvalue_create_map = new Dictionary<Type, string> ();
-				nsvalue_create_map [TypeCache.CGAffineTransform] = "CGAffineTransform";
-				nsvalue_create_map [TypeCache.NSRange] = "Range";
-				nsvalue_create_map [TypeCache.CGVector] = "CGVector";
-				nsvalue_create_map [TypeCache.SCNMatrix4] = "SCNMatrix4";
-				nsvalue_create_map [TypeCache.CLLocationCoordinate2D] = "MKCoordinate";
-				nsvalue_create_map [TypeCache.SCNVector3] = "Vector";
-				nsvalue_create_map [TypeCache.SCNVector4] = "Vector";
-
-				nsvalue_create_map [TypeCache.CoreGraphics_CGPoint] = "CGPoint";
-				nsvalue_create_map [TypeCache.CoreGraphics_CGRect] = "CGRect";
-				nsvalue_create_map [TypeCache.CoreGraphics_CGSize] = "CGSize";
-
-				if (Frameworks.HaveUIKit) {
-					nsvalue_create_map [TypeCache.UIEdgeInsets] = "UIEdgeInsets";
-					nsvalue_create_map [TypeCache.UIOffset] = "UIOffset";
-					nsvalue_create_map [TypeCache.NSDirectionalEdgeInsets] = "DirectionalEdgeInsets";
-				}
-
-				if (TypeCache.MKCoordinateSpan is not null)
-					nsvalue_create_map [TypeCache.MKCoordinateSpan] = "MKCoordinateSpan";
-
-				if (Frameworks.HaveCoreMedia) {
-					nsvalue_create_map [TypeCache.CMTimeRange] = "CMTimeRange";
-					nsvalue_create_map [TypeCache.CMTime] = "CMTime";
-					nsvalue_create_map [TypeCache.CMTimeMapping] = "CMTimeMapping";
-					nsvalue_create_map [TypeCache.CMVideoDimensions] = "CMVideoDimensions";
-				}
-
-				if (Frameworks.HaveCoreAnimation)
-					nsvalue_create_map [TypeCache.CATransform3D] = "CATransform3D";
-			}
-			return nsvalue_create_map;
-		}
-	}
-
+	
 	string GetToBindAsWrapper (MethodInfo mi, MemberInformation minfo = null, ParameterInfo pi = null)
 	{
 		BindAsAttribute attrib = null;
@@ -450,7 +410,7 @@ public partial class Generator : IMemberGatherer {
 			temp = string.Format ("{3}new NSNumber ({2}{1}{0});", denullify, parameterName, enumCast, nullCheck);
 		} else if (originalType == TypeCache.NSValue) {
 			var typeStr = string.Empty;
-			if (!NSValueCreateMap.TryGetValue (retType, out typeStr)) {
+			if (!TypeCache.NSValueCreateMap.TryGetValue (retType, out typeStr)) {
 				// HACK: These are problematic for X.M due to we do not ship System.Drawing for Full profile
 				if (retType.Name == "RectangleF" || retType.Name == "SizeF" || retType.Name == "PointF")
 					typeStr = retType.Name;
@@ -478,7 +438,7 @@ public partial class Generator : IMemberGatherer {
 				valueConverter = $"new NSNumber ({cast}o{denullify}), {parameterName});";
 			} else if (arrType == TypeCache.NSValue && !isNullable) {
 				var typeStr = string.Empty;
-				if (!NSValueCreateMap.TryGetValue (arrRetType, out typeStr)) {
+				if (!TypeCache.NSValueCreateMap.TryGetValue (arrRetType, out typeStr)) {
 					if (arrRetType.Name == "RectangleF" || arrRetType.Name == "SizeF" || arrRetType.Name == "PointF")
 						typeStr = retType.Name;
 					else


### PR DESCRIPTION
The dictionary needs to be init after the TypeCache. It is only natural for the TypeCache to be the owner of the dictionary.

We make the dictionary readonly to stop other code from introducing mistakes by modifying it.