### PR TITLE
[release/7.0.3xx] [CI] Pin the python version to 3.11 until ESRP fixes their deps.

### DIFF
--- a/tools/devops/automation/templates/sign-and-notarized/setup.yml
+++ b/tools/devops/automation/templates/sign-and-notarized/setup.yml
@@ -45,7 +45,7 @@ steps:
 - ${{ if eq(parameters.isPR, false) }}:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.x'
+      versionSpec: '3.11.x'
 
   - task: UseDotNet@2
     inputs:


### PR DESCRIPTION



Backport of #19423
