### PR TITLE
[msbuild] Fix resolving static libraries inside an XCFramework in a NuGet.

### DIFF
--- a/builds/create-csproj-for-all-packagereferences.sh
+++ b/builds/create-csproj-for-all-packagereferences.sh
@@ -49,6 +49,7 @@ sed -i '' 's/""/"/g' "$TMPPATH"
 # Remove packages that we build locally
 sed -i '' '/Xamarin.Tests.FrameworksInRuntimesNativeDirectory/d' "$TMPPATH"
 sed -i '' '/Xamarin.Tests.DynamicLibrariesInRuntimesNativeDirectory/d' "$TMPPATH"
+sed -i '' '/Xamarin.Tests.XCFrameworkWithStaticLibraryInRuntimesNativeDirectory/d' "$TMPPATH"
 
 # Get only the name and version of each package, and write that back in a PackageDownload item
 sed -i '' 's@.*<PackageReference.*Include="\([a-zA-Z0-9._-]*\)".*Version="\([a-zA-Z0-9._-]*\)".*>.*@\t\t<PackageDownload Include="\1" Version="[\2]" />@g' "$TMPPATH"

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferencesBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferencesBase.cs
@@ -194,8 +194,16 @@ namespace Xamarin.MacDev.Tasks {
 					return;
 				var nr = new TaskItem (item);
 				nr.ItemSpec = GetActualLibrary (frameworkPath);
-				nr.SetMetadata ("Kind", "Framework");
-				nr.SetMetadata ("PublishFolderType", "AppleFramework");
+				if (nr.ItemSpec.EndsWith (".a", StringComparison.OrdinalIgnoreCase)) {
+					nr.SetMetadata ("Kind", "Static");
+					nr.SetMetadata ("PublishFolderType", "StaticLibrary");
+				} else if (nr.ItemSpec.EndsWith (".dylib", StringComparison.OrdinalIgnoreCase)) {
+					nr.SetMetadata ("Kind", "Dynamic");
+					nr.SetMetadata ("PublishFolderType", "DynamicLibrary");
+				} else {
+					nr.SetMetadata ("Kind", "Framework");
+					nr.SetMetadata ("PublishFolderType", "AppleFramework");
+				}
 				nr.SetMetadata ("RelativePath", Path.Combine (FrameworksDirectory, Path.GetFileName (Path.GetDirectoryName (nr.ItemSpec))));
 				native_frameworks.Add (nr);
 				return;

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/AppDelegate.cs
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/AppDelegate.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace AppWithXCFrameworkWithStaticLibraryInPackageReference {
+	public class Program {
+		[DllImport ("__Internal")]
+		static extern int theUltimateAnswer ();
+
+		static int Main (string [] args)
+		{
+			Console.WriteLine ($"Static library from XCFramework: {theUltimateAnswer ()}");
+
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/MacCatalyst/AppWithXCFrameworkWithStaticLibraryInPackageReference.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/MacCatalyst/AppWithXCFrameworkWithStaticLibraryInPackageReference.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/MacCatalyst/Makefile
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/Makefile
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/Makefile
@@ -1,0 +1,2 @@
+TOP=../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/iOS/AppWithXCFrameworkWithStaticLibraryInPackageReference.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/iOS/AppWithXCFrameworkWithStaticLibraryInPackageReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/iOS/Makefile
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/macOS/AppWithXCFrameworkWithStaticLibraryInPackageReference.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/macOS/AppWithXCFrameworkWithStaticLibraryInPackageReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/macOS/Makefile
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/shared.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/shared.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<ApplicationTitle>AppWithXCFrameworkWithStaticLibraryInPackageReference</ApplicationTitle>
+		<ApplicationId>com.xamarin.appwithxcframeworkwithstaticlibraryinpackagereference</ApplicationId>
+		<ApplicationVersion>1.0</ApplicationVersion>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<PackageReference Include="Xamarin.Tests.XCFrameworkWithStaticLibraryInRuntimesNativeDirectory" Version="1.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/shared.mk
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/shared.mk
@@ -1,0 +1,3 @@
+TOP=../../../..
+TESTNAME=AppWithXCFrameworkWithStaticLibraryInPackageReference
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/tvOS/AppWithXCFrameworkWithStaticLibraryInPackageReference.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/tvOS/AppWithXCFrameworkWithStaticLibraryInPackageReference.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/tvOS/Makefile
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1398,6 +1398,24 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		public void BuildAndExecuteAppWithXCFrameworkWithStaticLibraryInRuntimesNativeDirectory (ApplePlatform platform, string runtimeIdentifier)
+		{
+			var project = "AppWithXCFrameworkWithStaticLibraryInPackageReference";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifier, platform: platform, out var appPath);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifier);
+			DotNet.AssertBuild (project_path, properties);
+
+			var appExecutable = Path.Combine (appPath, "Contents", "MacOS", Path.GetFileNameWithoutExtension (project_path));
+			Assert.That (appExecutable, Does.Exist, "There is an executable");
+
+			ExecuteWithMagicWordAndAssert (appExecutable);
+		}
+
+		[Test]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
 		public void BuildAndExecuteAppWithWinExeOutputType (ApplePlatform platform, string runtimeIdentifier)
 		{

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1399,20 +1399,23 @@ namespace Xamarin.Tests {
 
 		[Test]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
-		public void BuildAndExecuteAppWithXCFrameworkWithStaticLibraryInRuntimesNativeDirectory (ApplePlatform platform, string runtimeIdentifier)
+		public void BuildAndExecuteAppWithXCFrameworkWithStaticLibraryInRuntimesNativeDirectory (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "AppWithXCFrameworkWithStaticLibraryInPackageReference";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 
-			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifier, platform: platform, out var appPath);
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
 			Clean (project_path);
-			var properties = GetDefaultProperties (runtimeIdentifier);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
 			DotNet.AssertBuild (project_path, properties);
 
 			var appExecutable = Path.Combine (appPath, "Contents", "MacOS", Path.GetFileNameWithoutExtension (project_path));
 			Assert.That (appExecutable, Does.Exist, "There is an executable");
 
-			ExecuteWithMagicWordAndAssert (appExecutable);
+			if (CanExecute (platform, runtimeIdentifiers)) {
+				var output = ExecuteWithMagicWordAndAssert (appExecutable);
+				Assert.That (output, Does.Contain ("42"), "Execution");
+			}
 		}
 
 		[Test]

--- a/tests/test-libraries/nugets/Makefile
+++ b/tests/test-libraries/nugets/Makefile
@@ -1,4 +1,7 @@
 TOP=../../..
-SUBDIRS=FrameworksInRuntimesNativeDirectory DynamicLibrariesInRuntimesNativeDirectory
+SUBDIRS = \
+	FrameworksInRuntimesNativeDirectory \
+	DynamicLibrariesInRuntimesNativeDirectory \
+	XCFrameworkWithStaticLibraryInRuntimesNativeDirectory \
 
 include $(TOP)/Make.config

--- a/tests/test-libraries/nugets/XCFrameworkWithStaticLibraryInRuntimesNativeDirectory/Library.cs
+++ b/tests/test-libraries/nugets/XCFrameworkWithStaticLibraryInRuntimesNativeDirectory/Library.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace XCFrameworkWithStaticLibraryInRuntimesNativeDirectory {
+	public static class PInvokes {
+		[DllImport ("__Internal")]
+		public static extern int theUltimateAnswer ();
+	}
+}

--- a/tests/test-libraries/nugets/XCFrameworkWithStaticLibraryInRuntimesNativeDirectory/Makefile
+++ b/tests/test-libraries/nugets/XCFrameworkWithStaticLibraryInRuntimesNativeDirectory/Makefile
@@ -1,0 +1,32 @@
+TOP=../../../..
+include $(TOP)/Make.config
+
+unexport MSBUILD_EXE_PATH
+
+NAME=XCFrameworkWithStaticLibraryInRuntimesNativeDirectory
+LOWERCASED_NAME:=$(shell echo $(NAME) | tr 'A-Z' 'a-z')
+
+.libs:
+	$(Q) mkdir -p $@
+
+PACKAGE_ID=$(shell grep PackageId $(NAME).csproj | sed 's_.*<PackageId>\(.*\)</PackageId>.*_\1_')
+PACKAGE_VERSION=$(shell grep '<PackageVersion>' $(NAME).csproj | sed 's_.*<PackageVersion>\(.*\)</PackageVersion>.*_\1_')
+
+# Test case for https://github.com/xamarin/xamarin-macios/issues/12440
+.libs/$(NAME).nupkg: export DOTNET_PLATFORMS:=$(shell echo $(DOTNET_PLATFORMS) | tr ' ' ';')
+.libs/$(NAME).nupkg: $(NAME).csproj $(wildcard *.cs) | .libs
+	$(Q) mkdir -p $(abspath $(NUGET_TEST_FEED))
+	$(Q_GEN) $(DOTNET) pack /bl $(DOTNET_PACK_VERBOSITY) $<
+	$(Q) $(CP) bin/Release/Xamarin.Tests.$(NAME).$(PACKAGE_VERSION).nupkg $@
+
+INSTALLED_PACKAGE=$(NUGET_TEST_FEED)/xamarin.tests.$(LOWERCASED_NAME)/$(PACKAGE_VERSION)/xamarin.tests.$(LOWERCASED_NAME).$(PACKAGE_VERSION).nupkg
+
+$(INSTALLED_PACKAGE): .libs/$(NAME).nupkg
+	if test -d $(NUGET_TEST_FEED)/$(PACKAGE_ID)/$(PACKAGE_VERSION); then nuget delete $(PACKAGE_ID) $(PACKAGE_VERSION) -source $(abspath $(NUGET_TEST_FEED)) -NonInteractive || true; fi
+	rm -Rf $(TOP)/tests/dotnet/packages/xamarin.tests.$(LOWERCASED_NAME)
+	mkdir -p $(abspath $(NUGET_TEST_FEED))
+	nuget add "$<" -source $(abspath $(NUGET_TEST_FEED)) -NonInteractive
+
+ifdef ENABLE_DOTNET
+all-local:: $(INSTALLED_PACKAGE)
+endif

--- a/tests/test-libraries/nugets/XCFrameworkWithStaticLibraryInRuntimesNativeDirectory/XCFrameworkWithStaticLibraryInRuntimesNativeDirectory.csproj
+++ b/tests/test-libraries/nugets/XCFrameworkWithStaticLibraryInRuntimesNativeDirectory/XCFrameworkWithStaticLibraryInRuntimesNativeDirectory.csproj
@@ -1,0 +1,105 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>Xamarin.Tests.XCFrameworkWithStaticLibraryInRuntimesNativeDirectory</PackageId>
+    <PackageVersion>1.0.0</PackageVersion>
+    <RepositoryUrl>https://github.com/xamarin/xamarin-macios</RepositoryUrl>
+    <RepositoryBranch>main</RepositoryBranch>
+    <Authors>Microsoft</Authors>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/xamarin/xamarin-macios</PackageProjectUrl>
+    <RootTestDirectory>../../..</RootTestDirectory>
+    <TestFrameworksDirectory>$(RootTestDirectory)/test-libraries</TestFrameworksDirectory>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\..\eng\Versions.props" />
+  <!-- Code to automatically create FrameworkList.xml or RuntimeList.xml -->
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Arcade.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
+  <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetSharedFrameworkTaskFile)"/>
+  <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
+
+  <PropertyGroup>
+    <PackageType>Dependency</PackageType>
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <Target Name="_GenerateFrameworkListFile">
+    <!-- https://github.com/dotnet/runtime/blob/0647ec314948904319da5eb15e9931f7c85ed1e2/src/installer/pkg/projects/Directory.Build.targets#L281 -->
+    <PropertyGroup>
+      <_FrameworkListFile>$(IntermediateOutputPath)data/RuntimeList.xml</_FrameworkListFile>
+      <_PackNativePath>runtimes/$(_RuntimeIdentifier)/native</_PackNativePath>
+    </PropertyGroup>
+    <ItemGroup>
+      <DotnetPlatforms Include="$(DOTNET_PLATFORMS)" />
+      <DotnetPlatforms>
+        <Platform>%(Identity)</Platform>
+      </DotnetPlatforms>
+    </ItemGroup>
+    <PropertyGroup>
+      <iOS_Included Condition="@(DotnetPlatforms->AnyHaveMetadataValue('Platform', 'iOS'))">true</iOS_Included>
+      <tvOS_Included Condition="@(DotnetPlatforms->AnyHaveMetadataValue('Platform', 'tvOS'))">true</tvOS_Included>
+      <macOS_Included Condition="@(DotnetPlatforms->AnyHaveMetadataValue('Platform', 'macOS'))">true</macOS_Included>
+      <MacCatalyst_Included Condition="@(DotnetPlatforms->AnyHaveMetadataValue('Platform', 'MacCatalyst'))">true</MacCatalyst_Included>
+    </PropertyGroup>
+
+    <!-- libtest.xcframework -->
+
+    <ItemGroup Condition="'$(iOS_Included)' == 'true'">
+      <!-- iOS -->
+      <_PackageFiles Include="$(TestFrameworksDirectory)/.libs/libtest.xcframework/**" IsNative="true" PackagePath="runtimes/ios/native/libtest.xcframework/" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(tvOS_Included)' == 'true'">
+      <!-- tvOS -->
+      <_PackageFiles Include="$(TestFrameworksDirectory)/.libs/libtest.xcframework/**" IsNative="true" PackagePath="runtimes/tvos/native/libtest.xcframework/" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(macOS_Included)' == 'true'">
+      <!-- macOS -->
+      <_PackageFiles Include="$(TestFrameworksDirectory)/.libs/libtest.xcframework/**" IsNative="true" PackagePath="runtimes/osx/native/libtest.xcframework/" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(MacCatalyst_Included)' == 'true'">
+      <!-- Mac Catalyst -->
+      <_PackageFiles Include="$(TestFrameworksDirectory)/.libs/libtest.xcframework/**" IsNative="true" PackagePath="runtimes/maccatalyst/native/libtest.xcframework/" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Set TargetPath=PackagePath for all files -->
+      <_PackageFiles TargetPath="%(PackagePath)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Hardcode framework attributes -->
+      <_FrameworkListRootAttributes Include="Name" Value="Microsoft $(_PlatformName) - NET 6.0" />
+      <_FrameworkListRootAttributes Include="TargetFrameworkIdentifier" Value=".NETCoreApp" />
+      <_FrameworkListRootAttributes Include="TargetFrameworkVersion" Value="6.0" />
+      <_PackageFiles Include="$(_FrameworkListFile)" PackagePath="data" />
+
+      <!-- The CreateFrameworkListFile task will add _PackageFiles to the files to pack, so remove them if they're already there -->
+      <None Remove="@(_PackageFiles)" />
+    </ItemGroup>
+    <!-- https://github.com/dotnet/arcade/blob/5824baf1c9a900ee00c167f96201c750bba6a574/src/Microsoft.DotNet.SharedFramework.Sdk/src/CreateFrameworkListFile.cs -->
+    <CreateFrameworkListFile
+        Files="@(_PackageFiles)"
+        TargetFile="$(_FrameworkListFile)"
+        TargetFilePrefixes="ref;runtimes"
+        RootAttributes="@(_FrameworkListRootAttributes)"
+    />
+  </Target>
+
+  <PropertyGroup>
+    <BeforePack>
+      _GenerateFrameworkListFile;
+      $(BeforePack);
+    </BeforePack>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
The ResolveNativeReferences task would incorrectly set Kind=Framework for static
libraries and dylibs if these files came from an XCFramework in the runtimes/native
directory in a NuGet (as opposed to a binding project, or the NuGet built from a
binding project).

Fix this by properly assigning the Kind and PublishFolderType metadata for such static
libraries and dylibs.

Also add a test.