### PR TITLE
Bump MSBuild.StructuredLogger to v2.2.100

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<!-- Disables the transitive restore of packages like Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref -->
 		<DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+		<MSBuildStructuredLoggerPackageVersion>2.2.100</MSBuildStructuredLoggerPackageVersion>
 	</PropertyGroup>
 	<Import Project="Build.props" Condition="Exists('Build.props')" />
 </Project>

--- a/tests/bgen/bgen-tests.csproj
+++ b/tests/bgen/bgen-tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.846" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/bgen/bgen-tests.csproj
+++ b/tests/bgen/bgen-tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/UnitTests/DotNetUnitTests.csproj
+++ b/tests/dotnet/UnitTests/DotNetUnitTests.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Mono.Cecil" Version="0.11.4" />
-		<PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
+		<PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerPackageVersion)" />
 		<PackageReference Include="System.Text.Json" Version="5.0.2" />
 	</ItemGroup>
 

--- a/tests/dotnet/UnitTests/DotNetUnitTests.csproj
+++ b/tests/dotnet/UnitTests/DotNetUnitTests.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Mono.Cecil" Version="0.11.4" />
-		<PackageReference Include="MSBuild.StructuredLogger" Version="2.1.846" />
+		<PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
 		<PackageReference Include="System.Text.Json" Version="5.0.2" />
 	</ItemGroup>
 

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\tools\common\SdkVersions.cs">

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.846" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\tools\common\SdkVersions.cs">

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -42,7 +42,7 @@
       <HintPath Condition="$(TESTS_USE_SYSTEM) != ''">\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\lib\mmp\mmp.exe</HintPath>
     </Reference>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -42,7 +42,7 @@
       <HintPath Condition="$(TESTS_USE_SYSTEM) != ''">\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\lib\mmp\mmp.exe</HintPath>
     </Reference>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.846" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/tests/msbuild/Xamarin.MacDev.Tests/TestHelpers/BuildEngine.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TestHelpers/BuildEngine.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 
 using Xamarin.Utils;
+using PathUtils = Xamarin.Utils.PathUtils;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging.StructuredLogger;

--- a/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\mtouch\Cache.cs">

--- a/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.846" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\mtouch\Cache.cs">

--- a/tests/mtouch/mtouchtests.csproj
+++ b/tests/mtouch/mtouchtests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.846" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
     <Reference Include="Mono.Cecil">
       <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.dll</HintPath>
     </Reference>

--- a/tests/mtouch/mtouchtests.csproj
+++ b/tests/mtouch/mtouchtests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0" />
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.6.0" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerPackageVersion)" />
     <Reference Include="Mono.Cecil">
       <HintPath>..\..\builds\mono-ios-sdk-destdir\ios-bcl\monotouch_tools\Mono.Cecil.dll</HintPath>
     </Reference>

--- a/tools/create-dotnet-linker-launch-json/create-dotnet-linker-launch-json.csproj
+++ b/tools/create-dotnet-linker-launch-json/create-dotnet-linker-launch-json.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.846" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
 

--- a/tools/create-dotnet-linker-launch-json/create-dotnet-linker-launch-json.csproj
+++ b/tools/create-dotnet-linker-launch-json/create-dotnet-linker-launch-json.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerPackageVersion)" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
 

--- a/tools/nnyeah/tests/nnyeah-tests.csproj
+++ b/tools/nnyeah/tests/nnyeah-tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/nnyeah/tests/nnyeah-tests.csproj
+++ b/tools/nnyeah/tests/nnyeah-tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.846" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Also store the version globally to avoid having to update so many places in future bumps.