### PR TITLE
[NativeAOT] Improve the transformation of [Preserve(AllMembers = true)]

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1454,20 +1454,12 @@ namespace Xamarin.Tests {
 
 			// Verify that we have no warnings, but unfortunately we still have some we haven't fixed yet.
 			// Ignore those, and fail the test if we stop getting them (so that we can update the test to not ignore them anymore).
-			var foundIL3050 = false;
 			rv.AssertNoWarnings ((evt) => {
-				if (evt.Code == "IL3050" && evt.Message == "<Module>..cctor(): Using member 'System.Enum.GetValues(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead.") {
-					foundIL3050 = true;
-					return false;
-				}
-
 				if (platform == ApplePlatform.iOS && evt.Message?.Trim () == "Supported iPhone orientations have not been set")
 					return false;
 
 				return true;
 			});
-
-			Assert.IsTrue (foundIL3050, "IL3050 not found - update test code to remove the code to ignore the IL3050");
 		}
 
 		void AssertThatDylibExistsAndIsReidentified (string appPath, string dylibRelPath)

--- a/tests/linker/ios/link all/PreserveTest.cs
+++ b/tests/linker/ios/link all/PreserveTest.cs
@@ -193,15 +193,7 @@ namespace LinkAll.Attributes {
 		{
 			var enumType = GetType ().Assembly.GetType ("LinkAll.Attributes.MyEnum" + WorkAroundLinkerHeuristics);
 			Assert.NotNull (enumType, "MyEnum");
-
-			var values = Enum.GetValuesAsUnderlyingType (enumType);
-			Assert.AreEqual (3, values.Length, "values");
-			Assert.Contains (1, values, "A");
-			Assert.Contains (2, values, "B");
-			Assert.Contains (4, values, "C");
-
 			Assert.AreEqual (3, enumType.GetFields (BindingFlags.Public | BindingFlags.Static).Length, "fields");
-
 			AssertHasStaticField ("A", 1);
 			AssertHasStaticField ("B", 2);
 			AssertHasStaticField ("C", 4);

--- a/tests/linker/ios/link all/PreserveTest.cs
+++ b/tests/linker/ios/link all/PreserveTest.cs
@@ -206,11 +206,11 @@ namespace LinkAll.Attributes {
 			AssertHasStaticField ("B", 2);
 			AssertHasStaticField ("C", 4);
 
-			void AssertHasStaticField(string name, int value)
+			void AssertHasStaticField (string name, int value)
 			{
 				var field = enumType.GetField (name, BindingFlags.Public | BindingFlags.Static);
 				Assert.NotNull (field, name);
-				Assert.AreEqual (value, (int)field.GetValue (null), $"{name} == {value}");
+				Assert.AreEqual (value, (int) field.GetValue (null), $"{name} == {value}");
 			}
 		}
 	}
@@ -247,14 +247,13 @@ namespace LinkAll.Attributes {
 		}
 	}
 
-	[Preserve(AllMembers = true)]
-	public class ParentClass
-	{
+	[Preserve (AllMembers = true)]
+	public class ParentClass {
 		public enum NestedEnum { A, B };
 		public class NestedClass { }
 		public struct NestedStruct { }
 	}
 
-	[Preserve(AllMembers = true)]
+	[Preserve (AllMembers = true)]
 	public enum MyEnum { A = 1, B = 2, C = 4 }
 }

--- a/tests/linker/ios/link all/PreserveTest.cs
+++ b/tests/linker/ios/link all/PreserveTest.cs
@@ -174,6 +174,45 @@ namespace LinkAll.Attributes {
 			Assert.IsNull (typeof (NSObject).Assembly.GetType ("AVFoundation.AVMediaTypes"), "AVMediaTypes");
 			Assert.IsNull (typeof (NSObject).Assembly.GetType ("AVFoundation.AVMediaTypesExtensions"), "AVMediaTypesExtensions");
 		}
+
+		[Test]
+		public void PreserveAllExcludesNestedTypes ()
+		{
+			var parentClass = GetType ().Assembly.GetType ("LinkAll.Attributes.ParentClass" + WorkAroundLinkerHeuristics);
+			Assert.NotNull (parentClass, "ParentClass");
+			var nestedEnum = GetType ().Assembly.GetType ("LinkAll.Attributes.ParentClass.NestedEnum" + WorkAroundLinkerHeuristics);
+			Assert.Null (nestedEnum, "NestedEnum");
+			var nestedStruct = GetType ().Assembly.GetType ("LinkAll.Attributes.ParentClass.NestedStruct" + WorkAroundLinkerHeuristics);
+			Assert.Null (nestedStruct, "NestedStruct");
+			var nestedClass = GetType ().Assembly.GetType ("LinkAll.Attributes.ParentClass.NestedClass" + WorkAroundLinkerHeuristics);
+			Assert.Null (nestedClass, "NestedClass");
+		}
+
+		[Test]
+		public void PreserveAllKeepsEnumValues ()
+		{
+			var enumType = GetType ().Assembly.GetType ("LinkAll.Attributes.MyEnum" + WorkAroundLinkerHeuristics);
+			Assert.NotNull (enumType, "MyEnum");
+
+			var values = Enum.GetValuesAsUnderlyingType (enumType);
+			Assert.AreEqual (3, values.Length, "values");
+			Assert.Contains (1, values, "A");
+			Assert.Contains (2, values, "B");
+			Assert.Contains (4, values, "C");
+
+			Assert.AreEqual (3, enumType.GetFields (BindingFlags.Public | BindingFlags.Static).Length, "fields");
+
+			AssertHasStaticField ("A", 1);
+			AssertHasStaticField ("B", 2);
+			AssertHasStaticField ("C", 4);
+
+			void AssertHasStaticField(string name, int value)
+			{
+				var field = enumType.GetField (name, BindingFlags.Public | BindingFlags.Static);
+				Assert.NotNull (field, name);
+				Assert.AreEqual (value, (int)field.GetValue (null), $"{name} == {value}");
+			}
+		}
 	}
 
 	[Preserve (AllMembers = true)]
@@ -208,4 +247,14 @@ namespace LinkAll.Attributes {
 		}
 	}
 
+	[Preserve(AllMembers = true)]
+	public class ParentClass
+	{
+		public enum NestedEnum { A, B };
+		public class NestedClass { }
+		public struct NestedStruct { }
+	}
+
+	[Preserve(AllMembers = true)]
+	public enum MyEnum { A = 1, B = 2, C = 4 }
 }

--- a/tests/monotouch-test/CoreMedia/BlockBufferTest.cs
+++ b/tests/monotouch-test/CoreMedia/BlockBufferTest.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Reflection;
 
 using Foundation;
 using CoreMedia;
@@ -33,7 +34,7 @@ namespace MonoTouchFixtures.CoreMedia {
 		[Test]
 		public void CMBlockBufferCustomBlockSource ()
 		{
-			var type = Type.GetType ("CoreMedia.CMCustomBlockAllocator+CMBlockBufferCustomBlockSource, " + typeof (NSObject).Assembly.GetName ().Name);
+			var type = typeof (CMCustomBlockAllocator).GetNestedType ("CMBlockBufferCustomBlockSource", BindingFlags.NonPublic);
 			Assert.NotNull (type, "CMBlockBufferCustomBlockSource");
 			// it's 28 (not 32) bytes when executed on 64bits iOS, which implies it's packed to 4 bytes
 			Assert.That (Marshal.SizeOf (type), Is.EqualTo (4 + 3 * IntPtr.Size), "Size");

--- a/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
+++ b/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
@@ -271,9 +271,9 @@ namespace Mono.Tuner {
 
 			var moduleConstructor = GetOrCreateModuleConstructor (type.GetModule ());
 			var members = (type, allMembers) switch {
-				({ IsEnum: true }, _) => DynamicallyAccessedMemberTypes.PublicFields,
+				( { IsEnum: true }, _) => DynamicallyAccessedMemberTypes.PublicFields,
 				(_, false) => DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors,
-				(_, true) =>  allMemberTypes,
+				(_, true) => allMemberTypes,
 			};
 			var attrib = abr.CreateDynamicDependencyAttribute (members, type);
 			moduleConstructor.CustomAttributes.Add (attrib);

--- a/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
+++ b/tools/dotnet-linker/ApplyPreserveAttributeBase.cs
@@ -270,11 +270,15 @@ namespace Mono.Tuner {
 			abr.SetCurrentAssembly (type.Module.Assembly);
 
 			var moduleConstructor = GetOrCreateModuleConstructor (type.GetModule ());
-			var members = (type, allMembers) switch {
-				( { IsEnum: true }, _) => DynamicallyAccessedMemberTypes.PublicFields,
-				(_, false) => DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors,
-				(_, true) => allMemberTypes,
-			};
+			var members = allMembers
+				? allMemberTypes
+				: DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+
+			// only preserve fields for enums
+			if (type.IsEnum) {
+				members = DynamicallyAccessedMemberTypes.PublicFields;
+			}
+
 			var attrib = abr.CreateDynamicDependencyAttribute (members, type);
 			moduleConstructor.CustomAttributes.Add (attrib);
 


### PR DESCRIPTION
Closes #19505 

We transform `[Preserve(AllMembers = true)]` into `[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(T))]`. There is difference between which members are preserved in these two cases. The `DynamicallyAccessedMemberTypes.All` preserves many more, especially nested types and their members. This manifested with the `IL3050` AOT analysis warning we got from ILC when building any app:
1. `NSObject_Disposer` has `[Preserve(AllMembers = true)]`
2. `NSObject_Disposer` is a subclass of NSObject
3. `NSObject` has nested enums `Flags` and `XamarinGCHandleFlags`
4. the base class `Enum` has a public static method `GetValues(Type)`
5. the `GetValues` method is annotated with `RequiresDynamicCode` and ILC produces a warning because even though it isn't used anywhere in the codebase, it could be used via reflection

I changed two things when transforming Preserve:
- For enums, we only need to preserve public fields. We especially want to avoid `PublicMethods` since that would preserve public methods in the base class which includes the `GetValues(Type)` method.
- For other types, I list explicitly the member types that should be preserved instead of using `All`.
    - The code is verbose, but in the end, I chose the explicit list instead of `All ^ PublicNestedTypes ^ NonPublicNestedTypes` since that would automatically include any new flag added to the enum in the future.