### PR TITLE
[tests] Set RuntimeIdentifier in CollectAppManifestsTests.PartialAppManifest

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/CollectAppManifestsTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/CollectAppManifestsTests.cs
@@ -22,6 +22,7 @@ namespace Xamarin.MacDev.Tasks {
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
 		<TargetFramework>{Configuration.DotNetTfm}-macos</TargetFramework>
+		<RuntimeIdentifier>osx-x64</RuntimeIdentifier>
 		<OutputType>Exe</OutputType>
 
 		<CollectAppManifestsDependsOn>


### PR DESCRIPTION
Make RuntimeIdentifier explicit in
CollectAppManifestsTests.PartialAppManifest, because we later try to look for
a path that depends on the runtime identifier, and setting the runtime
identifier explicitly is easier than figuring out the default runtime
identifier (which depends on the host architecture).

Fixes this failure on arm64 machines:

    1) Failed : Xamarin.MacDev.Tasks.CollectAppManifestsTests.PartialAppManifest
      App manifest existence
      Expected: file or directory exists
      But was:  "xamarin-macios/tests/msbuild/Xamarin.MacDev.Tests/bin/Debug/net472/tmp-test-dir/Xamarin.MacDev.Tasks.CollectAppManifestsTests.PartialAppManifest/bin/Debug/net8.0-macos/osx-x64/PartialAppManifest.app/Contents/Info.plist"
      at Xamarin.MacDev.Tasks.CollectAppManifestsTests.PartialAppManifest () [0x0011d] in xamarin-macios/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/CollectAppManifestsTests.cs:71