### PR TITLE
[xharness] Convert to .NET.

### DIFF
--- a/src/intents.cs
+++ b/src/intents.cs
@@ -7405,7 +7405,9 @@ namespace Intents {
 		IINSpeakable [] AlternativeSpeakableMatches { get; }
 
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'VocabularyIdentifier' instead.")]
+#if !NET
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'VocabularyIdentifier' instead.")]
+#endif
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'VocabularyIdentifier' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'VocabularyIdentifier' instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'VocabularyIdentifier' instead.")]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -4056,7 +4056,10 @@ namespace SceneKit {
 		[Wrap ("WeakShaderModifiers")]
 		SCNShaderModifiers ShaderModifiers { get; set; }
 
-		[Mac (12, 0), iOS (15, 0), TV (15, 0), Watch (8, 0)]
+#if !NET
+		[Watch (8, 0)]
+#endif
+		[Mac (12, 0), iOS (15, 0), TV (15, 0)]
 		[MacCatalyst (15, 0)]
 		[NullAllowed] // by default this property is null
 		[Export ("minimumLanguageVersion", ArgumentSemantic.Retain)]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,6 +12,8 @@ endif
 
 MTOUCH=$(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/bin/mtouch
 
+XHARNESS_EXECUTABLE=xharness/bin/Debug/$(DOTNET_TFM)/xharness.dll
+
 export MD_MTOUCH_SDK_ROOT=$(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)
 export MSBUILD_EXE_PATH=$(MONO_PREFIX)/lib/mono/msbuild/15.0/bin/MSBuild.dll
 export TargetFrameworkFallbackSearchPaths=$(IOS_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild-frameworks
@@ -183,8 +185,8 @@ logdev:
 build-test-libraries:
 	@$(MAKE) -C $(TOP)/tests/test-libraries
 
-.stamp-xharness-configure: xharness/xharness.exe
-	$(Q_GEN) $(SYSTEM_MONO) --debug $(CURDIR)/$< $(XHARNESS_VERBOSITY) --configure --autoconf --rootdir $(CURDIR)
+.stamp-xharness-configure: $(XHARNESS_EXECUTABLE)
+	$(Q_GEN) $(DOTNET) $< $(XHARNESS_VERBOSITY) --configure --autoconf --rootdir $(CURDIR)
 	$(Q) touch $@
 
 all-local:: .stamp-xharness-configure
@@ -196,8 +198,9 @@ $(TOP)/tools/common/SdkVersions.cs: $(TOP)/tools/common/SdkVersions.in.cs
 	@$(MAKE) -C $(TOP)/src project-files
 	@touch $@
 
-xharness/xharness.exe: $(xharness_dependencies) test.config test-system.config .stamp-src-project-files $(TOP)/tools/common/SdkVersions.cs
-	$(Q_GEN) $(SYSTEM_MSBUILD) "/bl:$@.binlog" /restore $(MSBUILD_VERBOSITY_QUIET) xharness/xharness.csproj
+$(XHARNESS_EXECUTABLE): MSBUILD_EXE_PATH=
+$(XHARNESS_EXECUTABLE): $(xharness_dependencies) test.config test-system.config .stamp-src-project-files $(TOP)/tools/common/SdkVersions.cs
+	$(Q_GEN) $(DOTNET) build "/bl:$@.binlog" $(MSBUILD_VERBOSITY_QUIET) xharness/xharness.csproj
 xharness/xharness.csproj.inc: export BUILD_VERBOSITY=$(XBUILD_VERBOSITY)
 xharness/xharness.csproj.inc: export ABSOLUTE_PATHS=1
 -include xharness/xharness.csproj.inc
@@ -321,9 +324,9 @@ wrench-bcl-sim-%:
 wrench-%:
 	@echo Not here anymore
 
-wrench-jenkins: xharness/xharness.exe
+wrench-jenkins: $(XHARNESS_EXECUTABLE)
 	$(Q) rm -f $@-failed.stamp
-	$(Q) ulimit -n 4096 && $(SYSTEM_MONO) --trace=E:all --debug $(CURDIR)/$< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT) --label run-all-tests,skip-device-tests --markdown-summary=$(abspath $(CURDIR))/TestSummary.md $(TESTS_PERIODIC_COMMAND) --use-system=true || echo "$$?" > $@-failed.stamp
+	$(Q) ulimit -n 4096 && $(DOTNET) $< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT) --label run-all-tests,skip-device-tests --markdown-summary=$(abspath $(CURDIR))/TestSummary.md $(TESTS_PERIODIC_COMMAND) --use-system=true || echo "$$?" > $@-failed.stamp
 	@echo "@MonkeyWrench: SetSummary: <br/>`cat $(abspath $(CURDIR))/TestSummary.md | awk 1 ORS='<br/>'`"
 	@echo "@MonkeyWrench: AddFile: $(abspath $(CURDIR))/TestSummary.md"
 	$(Q) if test -e $@-failed.stamp; then EC=`cat $@-failed.stamp`; rm -f $@-failed.stamp; exit $$EC; fi
@@ -331,19 +334,19 @@ wrench-jenkins: xharness/xharness.exe
 wrench-xtro:
 	@echo Not here anymore
 
-jenkins: xharness/xharness.exe
-	$(Q) $(SYSTEM_MONO) --trace=E:all,-E:System.Reflection.ReflectionTypeLoadException --debug $(CURDIR)/$< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT) --markdown-summary=$(abspath $(CURDIR))/TestSummary.md --use-system=true $(TESTS_EXTRA_ARGUMENTS) $(TESTS_PERIODIC_COMMAND)
+jenkins: $(XHARNESS_EXECUTABLE)
+	$(Q) $(DOTNET) $< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT) --markdown-summary=$(abspath $(CURDIR))/TestSummary.md --use-system=true $(TESTS_EXTRA_ARGUMENTS) $(TESTS_PERIODIC_COMMAND)
 
 # This will launch xharness' interactive test runner in the system's default browser
-runner: xharness/xharness.exe
+runner: $(XHARNESS_EXECUTABLE)
 	@echo "Running xharness in server mode. Press Ctrl-C to exit (or click Quit / press Q in the browser page)"
-	$(Q) $(SYSTEM_MONO) $(CURDIR)/xharness/xharness.exe $(XHARNESS_VERBOSITY) --jenkins:server --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT)
+	$(Q) $(DOTNET) $< $(XHARNESS_VERBOSITY) --jenkins:server --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT)
 
 # This makefile target will run the device tests using the Xamarin.iOS version
 # installed on the system.
-vsts-device-tests: xharness/xharness.exe
+vsts-device-tests: $(XHARNESS_EXECUTABLE)
 	$(MAKE) -C $(TOP)/builds .stamp-mono-ios-sdk-destdir download -j
-	$(Q) ulimit -n 4096 && $(SYSTEM_MONO) --debug $(CURDIR)/$< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT) --use-system:true --label=skip-all-tests,run-device-tests,run-bcl-tests --markdown-summary=$(CURDIR)/TestSummary.md $(TESTS_EXTRA_ARGUMENTS) $(TESTS_PERIODIC_COMMAND)
+	$(Q) ulimit -n 4096 && $(DOTNET) $< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT) --use-system:true --label=skip-all-tests,run-device-tests,run-bcl-tests --markdown-summary=$(CURDIR)/TestSummary.md $(TESTS_EXTRA_ARGUMENTS) $(TESTS_PERIODIC_COMMAND)
 
 verify-system-vsmac-xcode-match:
 	@SYSTEM_XCODE=$$(dirname $$(dirname $$(xcode-select -p))); \

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -4509,8 +4509,8 @@ public class Dummy {
 				environment_variables ["SKIP_SIMULATOR_SETUP"] = "1";
 			environment_variables ["USE_TCP_TUNNEL"] = null;
 
+			var executable = Path.Combine (Configuration.RootPath, "tests", "xharness", "bin", "Debug", Configuration.DotNetTfm, "xharness");
 			var args = new List<string> ();
-			args.Add (Path.Combine (Configuration.RootPath, "tests", "xharness", "xharness.exe"));
 			args.Add ("--run");
 			args.Add (csprojpath);
 			args.Add ("--target");
@@ -4521,7 +4521,7 @@ public class Dummy {
 			args.Add (Path.Combine (tmpdir, "log.txt"));
 			args.Add ("--configuration");
 			args.Add (configuration);
-			ExecutionHelper.Execute ("mono", args, environmentVariables: environment_variables);
+			ExecutionHelper.Execute (executable, args, environmentVariables: environment_variables);
 		}
 
 		public static string CompileTestAppExecutable (string targetDirectory, string code = null, IList<string> extraArgs = null, Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null)

--- a/tests/xharness/GitHub.cs
+++ b/tests/xharness/GitHub.cs
@@ -43,7 +43,7 @@ namespace Xharness {
 		}
 
 		static HttpClient? static_client;
-		static bool TryDownloadData (string url, out byte[] data, out HttpResponseMessage response)
+		static bool TryDownloadData (string url, out byte [] data, out HttpResponseMessage response)
 		{
 			HttpClient client;
 			if (static_client is null)

--- a/tests/xharness/GitHub.cs
+++ b/tests/xharness/GitHub.cs
@@ -4,10 +4,16 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Runtime.Serialization.Json;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
+
+#nullable enable
 
 namespace Xharness {
 	/// <summary>
@@ -36,14 +42,22 @@ namespace Xharness {
 			this.processManager = processManager;
 		}
 
-		static WebClient CreateClient ()
+		static HttpClient? static_client;
+		static bool TryDownloadData (string url, out byte[] data, out HttpResponseMessage response)
 		{
-			var client = new WebClient ();
-			client.Headers.Add (HttpRequestHeader.UserAgent, "xamarin");
+			HttpClient client;
+			if (static_client is null)
+				static_client = new HttpClient ();
+			client = static_client;
+
+			var request = new HttpRequestMessage (HttpMethod.Get, url);
+			request.Headers.Add ("UserAgent", "xamarin");
 			var xharness_github_token = Environment.GetEnvironmentVariable ("GITHUB_TOKEN");
 			if (!string.IsNullOrEmpty (xharness_github_token))
-				client.Headers.Add (HttpRequestHeader.Authorization, xharness_github_token);
-			return client;
+				request.Headers.Add ("Authorization", xharness_github_token);
+			response = client.Send (request, HttpCompletionOption.ResponseContentRead, default (CancellationToken));
+			data = response.Content.ReadAsByteArrayAsync ().Result;
+			return response.IsSuccessStatusCode;
 		}
 
 		public string GetPullRequestTargetBranch (int pullRequest)
@@ -58,7 +72,7 @@ namespace Xharness {
 			using (var reader = JsonReaderWriterFactory.CreateJsonReader (info, new XmlDictionaryReaderQuotas ())) {
 				var doc = new XmlDocument ();
 				doc.Load (reader);
-				return doc.SelectSingleNode ("/root/base/ref").InnerText;
+				return doc.SelectSingleNode ("/root/base/ref")!.InnerText;
 			}
 		}
 
@@ -69,7 +83,7 @@ namespace Xharness {
 				var doc = new XmlDocument ();
 				doc.Load (reader);
 				var rv = new List<string> ();
-				foreach (XmlNode node in doc.SelectNodes ("/root/labels/item/name")) {
+				foreach (XmlNode node in doc.SelectNodes ("/root/labels/item/name")!) {
 					rv.Add (node.InnerText);
 				}
 				return rv;
@@ -99,69 +113,72 @@ namespace Xharness {
 			var path = Path.Combine (harness.LogDirectory, "pr" + pullRequest + "-remote-files.log");
 			if (!File.Exists (path)) {
 				Directory.CreateDirectory (harness.LogDirectory);
-				using (var client = CreateClient ()) {
-					var rv = new List<string> ();
-					var url = $"https://api.github.com/repos/xamarin/xamarin-macios/pulls/{pullRequest}/files?per_page=100"; // 100 items per page is max
-					do {
-						byte [] data;
-						try {
-							data = client.DownloadData (url);
-						} catch (WebException we) {
-							harness.Log ("Could not load pull request files: {0}\n{1}", we, new StreamReader (we.Response.GetResponseStream ()).ReadToEnd ());
+				var rv = new List<string> ();
+				var url = $"https://api.github.com/repos/xamarin/xamarin-macios/pulls/{pullRequest}/files?per_page=100"; // 100 items per page is max
+				do {
+					byte [] data;
+					HttpResponseMessage response;
+					try {
+						if (!TryDownloadData (url, out data, out response)) {
+							harness.Log ("Unable to load pull request files:\n{0}", System.Text.Encoding.UTF8.GetString (data));
 							File.WriteAllText (path, string.Empty);
 							return new string [] { };
 						}
-						var reader = JsonReaderWriterFactory.CreateJsonReader (data, new XmlDictionaryReaderQuotas ());
-						var doc = new XmlDocument ();
-						doc.Load (reader);
-						foreach (XmlNode node in doc.SelectNodes ("/root/item/filename")) {
-							rv.Add (node.InnerText);
-						}
+					} catch (Exception we) {
+						harness.Log ("Could not load pull request files: {0}", we);
+						File.WriteAllText (path, string.Empty);
+						return new string [] { };
+					}
+					var reader = JsonReaderWriterFactory.CreateJsonReader (data, new XmlDictionaryReaderQuotas ());
+					var doc = new XmlDocument ();
+					doc.Load (reader);
+					foreach (XmlNode node in doc.SelectNodes ("/root/item/filename")!) {
+						rv.Add (node.InnerText);
+					}
 
-						url = null;
+					url = null;
 
-						var link = client.ResponseHeaders ["Link"];
-						try {
-							if (link is not null) {
-								var ltIdx = link.IndexOf ('<');
-								var gtIdx = link.IndexOf ('>', ltIdx + 1);
-								while (ltIdx >= 0 && gtIdx > ltIdx) {
-									var linkUrl = link.Substring (ltIdx + 1, gtIdx - ltIdx - 1);
-									if (link [gtIdx + 1] != ';')
-										break;
-									var commaIdx = link.IndexOf (',', gtIdx + 1);
-									string rel;
-									if (commaIdx != -1) {
-										rel = link.Substring (gtIdx + 3, commaIdx - gtIdx - 3);
-									} else {
-										rel = link.Substring (gtIdx + 3);
-									}
-
-									if (rel == "rel=\"next\"") {
-										url = linkUrl;
-										break;
-									}
-
-									if (commaIdx == -1)
-										break;
-
-									ltIdx = link.IndexOf ('<', commaIdx);
-									gtIdx = link.IndexOf ('>', ltIdx + 1);
+					var link = string.Join (";", response.Headers.GetValues ("Link"));
+					try {
+						if (link is not null) {
+							var ltIdx = link.IndexOf ('<');
+							var gtIdx = link.IndexOf ('>', ltIdx + 1);
+							while (ltIdx >= 0 && gtIdx > ltIdx) {
+								var linkUrl = link.Substring (ltIdx + 1, gtIdx - ltIdx - 1);
+								if (link [gtIdx + 1] != ';')
+									break;
+								var commaIdx = link.IndexOf (',', gtIdx + 1);
+								string rel;
+								if (commaIdx != -1) {
+									rel = link.Substring (gtIdx + 3, commaIdx - gtIdx - 3);
+								} else {
+									rel = link.Substring (gtIdx + 3);
 								}
+
+								if (rel == "rel=\"next\"") {
+									url = linkUrl;
+									break;
+								}
+
+								if (commaIdx == -1)
+									break;
+
+								ltIdx = link.IndexOf ('<', commaIdx);
+								gtIdx = link.IndexOf ('>', ltIdx + 1);
 							}
-						} catch (Exception e) {
-							harness.Log ("Could not paginate github response: {0}: {1}", link, e.Message);
 						}
-					} while (url is not null);
-					File.WriteAllLines (path, rv.ToArray ());
-					return rv;
-				}
+					} catch (Exception e) {
+						harness.Log ("Could not paginate github response: {0}: {1}", link, e.Message);
+					}
+				} while (url is not null);
+				File.WriteAllLines (path, rv.ToArray ());
+				return rv;
 			}
 
 			return File.ReadAllLines (path);
 		}
 
-		IEnumerable<string> GetModifiedFilesLocally (int pullRequest)
+		IEnumerable<string>? GetModifiedFilesLocally (int pullRequest)
 		{
 			var base_commit = $"origin/pull/{pullRequest}/merge^";
 			var head_commit = $"origin/pull/{pullRequest}/merge";
@@ -193,17 +210,18 @@ namespace Xharness {
 			var path = Path.Combine (harness.LogDirectory, "pr" + pullRequest + ".log");
 			if (!File.Exists (path)) {
 				Directory.CreateDirectory (harness.LogDirectory);
-				using (var client = CreateClient ()) {
-					byte [] data;
-					try {
-						data = client.DownloadData ($"https://api.github.com/repos/xamarin/xamarin-macios/pulls/{pullRequest}");
-						File.WriteAllBytes (path, data);
-						return data;
-					} catch (WebException we) {
-						harness.Log ("Could not load pull request info: {0}\n{1}", we, new StreamReader (we.Response.GetResponseStream ()).ReadToEnd ());
+				try {
+					if (!TryDownloadData ($"https://api.github.com/repos/xamarin/xamarin-macios/pulls/{pullRequest}", out var data, out var _)) {
+						harness.Log ("Unable to load pull request info:\n{0}", Encoding.UTF8.GetString (data));
 						File.WriteAllText (path, string.Empty);
 						return new byte [0];
 					}
+					File.WriteAllBytes (path, data);
+					return data;
+				} catch (Exception we) {
+					harness.Log ("Could not load pull request info: {0}", we);
+					File.WriteAllText (path, string.Empty);
+					return new byte [0];
 				}
 			}
 			return File.ReadAllBytes (path);

--- a/tests/xharness/Jenkins/ErrorKnowledgeBase.cs
+++ b/tests/xharness/Jenkins/ErrorKnowledgeBase.cs
@@ -30,7 +30,7 @@ namespace Xharness.Jenkins {
 
 			using var reader = log.GetReader ();
 			while (!reader.EndOfStream) {
-				string line = reader.ReadLine ();
+				var line = reader.ReadLine ();
 				if (line is null)
 					continue;
 				//go over errors and return true as soon as we find one that matches

--- a/tests/xharness/Jenkins/ResourceManager.cs
+++ b/tests/xharness/Jenkins/ResourceManager.cs
@@ -20,8 +20,7 @@ namespace Xharness.Jenkins {
 			List<Resource> resources = new List<Resource> ();
 			lock (deviceResources) {
 				foreach (var device in devices) {
-					Resource res;
-					if (!deviceResources.TryGetValue (device.UDID, out res))
+					if (!deviceResources.TryGetValue (device.UDID, out var res))
 						deviceResources.Add (device.UDID, res = new Resource (device.UDID, 1, device.Name));
 					resources.Add (res);
 				}

--- a/tests/xharness/Jenkins/TestSelector.cs
+++ b/tests/xharness/Jenkins/TestSelector.cs
@@ -57,7 +57,7 @@ namespace Xharness.Jenkins {
 		public void SetEnabled (string label, bool value)
 		{
 			// there are two possible cases, either we are setting a test label OR a platform
-			if (label.TryGetLabel (out TestLabel tLabel)) {
+			if (label.TryGetLabel<TestLabel> (out var tLabel)) {
 				SetEnabled (tLabel, value);
 				// some labels overlap, not ideal, but is just a few
 				switch (tLabel) {

--- a/tests/xharness/Jenkins/TestTasks/BuildProject.cs
+++ b/tests/xharness/Jenkins/TestTasks/BuildProject.cs
@@ -104,7 +104,7 @@ namespace Xharness.Jenkins.TestTasks {
 				result.Add (fixPath);
 				// get all possible references
 				if (!Path.IsPathRooted (fixPath))
-					fixPath = Path.Combine (Path.GetDirectoryName (csproj), fixPath);
+					fixPath = Path.Combine (Path.GetDirectoryName (csproj)!, fixPath);
 				result.AddRange (GetNestedReferenceProjects (fixPath));
 			}
 			return result;

--- a/tests/xharness/MonoNativeInfo.cs
+++ b/tests/xharness/MonoNativeInfo.cs
@@ -64,7 +64,7 @@ namespace Xharness {
 			case DevicePlatform.tvOS:
 				return Xamarin.SdkVersions.MinTVOS;
 			case DevicePlatform.watchOS:
-				return Xamarin.SdkVersions.MinWatchOS;
+				return Xamarin.SdkVersions.LegacyMinWatchOS;
 			case DevicePlatform.macOS:
 				return Xamarin.SdkVersions.MinOSX;
 			default:

--- a/tests/xharness/Program.cs
+++ b/tests/xharness/Program.cs
@@ -16,7 +16,7 @@ namespace Xharness {
 				tVOS: Xamarin.SdkVersions.TVOS,
 				minOSX: Xamarin.SdkVersions.MinOSX,
 				miniOS: Xamarin.SdkVersions.MiniOS,
-				minWatchOS: Xamarin.SdkVersions.MinWatchOS,
+				minWatchOS: Xamarin.SdkVersions.LegacyMinWatchOS,
 				minTVOS: Xamarin.SdkVersions.MinTVOS,
 				miniOSSimulator: Xamarin.SdkVersions.MiniOSSimulator,
 				minWatchOSSimulator: Xamarin.SdkVersions.MinWatchOSSimulator,

--- a/tests/xharness/Properties/AssemblyInfo.cs
+++ b/tests/xharness/Properties/AssemblyInfo.cs
@@ -4,20 +4,11 @@ using System.Runtime.CompilerServices;
 // Information about this assembly is defined by the following attributes.
 // Change them to the values specific to your project.
 
-[assembly: AssemblyTitle ("xharness")]
 [assembly: AssemblyDescription ("")]
-[assembly: AssemblyConfiguration ("")]
-[assembly: AssemblyCompany ("Xamarin")]
-[assembly: AssemblyProduct ("")]
 [assembly: AssemblyCopyright ("(C) Rolf Bjarne Kvinge")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/tests/xharness/SimulatorLoaderFactory.cs
+++ b/tests/xharness/SimulatorLoaderFactory.cs
@@ -28,9 +28,9 @@ namespace Xharness {
 			return target.Platform switch {
 				TestTarget.Simulator_iOS => "com.apple.CoreSimulator.SimDeviceType.iPhone-5s",
 				TestTarget.Simulator_iOS32 => "com.apple.CoreSimulator.SimDeviceType.iPhone-5s",
-				TestTarget.Simulator_iOS64 => GetiOSDeviceType (Version.Parse (target.OSVersion)),
+				TestTarget.Simulator_iOS64 => GetiOSDeviceType (Version.Parse (target.OSVersion!)),
 				TestTarget.Simulator_tvOS => "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p",
-				TestTarget.Simulator_watchOS => GetWatchOSDeviceType (Version.Parse (target.OSVersion)),
+				TestTarget.Simulator_watchOS => GetWatchOSDeviceType (Version.Parse (target.OSVersion!)),
 				_ => throw new Exception (string.Format ("Invalid simulator target: {0}", target))
 			};
 		}

--- a/tests/xharness/SimulatorLoaderFactory.cs
+++ b/tests/xharness/SimulatorLoaderFactory.cs
@@ -64,7 +64,7 @@ namespace Xharness {
 			companionDeviceType = null;
 
 			if (target.Platform == TestTarget.Simulator_watchOS) {
-				var companionVersion = minVersion ? SdkVersions.MinWatchOSCompanionSimulator : SdkVersions.MaxWatchOSCompanionSimulator;
+				var companionVersion = minVersion ? Xamarin.SdkVersions.MinWatchOSCompanionSimulator : Xamarin.SdkVersions.MaxWatchOSCompanionSimulator;
 				companionRuntime = "com.apple.CoreSimulator.SimRuntime.iOS-" + companionVersion.Replace ('.', '-');
 				companionDeviceType = GetiOSDeviceType (Version.Parse (companionVersion));
 			}

--- a/tests/xharness/Targets/Target.cs
+++ b/tests/xharness/Targets/Target.cs
@@ -236,7 +236,7 @@ namespace Xharness.Targets {
 				templateName = Path.GetFileNameWithoutExtension (templateName);
 			templateName = Path.GetFileNameWithoutExtension (templateName);
 
-			if (templateName.Equals ("mono-native-mac"))
+			if (templateName.Equals ("mono-native-mac", StringComparison.Ordinal))
 				templateName = "mono-native";
 
 			if (!ShouldSkipProjectGeneration) {

--- a/tests/xharness/Targets/TodayExtensionTarget.cs
+++ b/tests/xharness/Targets/TodayExtensionTarget.cs
@@ -58,7 +58,7 @@ namespace Xharness.Targets {
 			info_plist.LoadWithoutNetworkAccess (Path.Combine (Harness.TodayContainerTemplate, "Info.plist"));
 			info_plist.SetCFBundleIdentifier (BundleIdentifier);
 			info_plist.SetCFBundleName (Name);
-			info_plist.SetMinimumOSVersion (GetMinimumOSVersion (SdkVersions.MiniOS));
+			info_plist.SetMinimumOSVersion (GetMinimumOSVersion (Xamarin.SdkVersions.MiniOS));
 			info_plist.Save (target_info_plist, Harness);
 		}
 
@@ -90,7 +90,7 @@ namespace Xharness.Targets {
 			info_plist.LoadWithoutNetworkAccess (Path.Combine (TargetDirectory, original_info_plist_include));
 			BundleIdentifier = info_plist.GetCFBundleIdentifier () + "-today";
 			info_plist.SetCFBundleIdentifier (BundleIdentifier + ".todayextension");
-			info_plist.SetMinimumOSVersion (GetMinimumOSVersion (SdkVersions.MiniOS));
+			info_plist.SetMinimumOSVersion (GetMinimumOSVersion (Xamarin.SdkVersions.MiniOS));
 			info_plist.AddPListStringValue ("CFBundlePackageType", "XPC!");
 			info_plist.SetCFBundleDisplayName (Name);
 			info_plist.AddPListKeyValuePair ("NSExtension", "dict",

--- a/tests/xharness/Targets/WatchOSTarget.cs
+++ b/tests/xharness/Targets/WatchOSTarget.cs
@@ -77,7 +77,7 @@ namespace Xharness.Targets {
 			info_plist.LoadWithoutNetworkAccess (Path.Combine (Harness.WatchOSContainerTemplate, "Info.plist"));
 			info_plist.SetCFBundleIdentifier (BundleIdentifier);
 			info_plist.SetCFBundleName (Name);
-			info_plist.SetMinimumOSVersion (Xamarin.SdkVersions.LegacyMinWatchOS);
+			info_plist.SetMinimumOSVersion (Xamarin.SdkVersions.MiniOS);
 			info_plist.Save (target_info_plist, Harness);
 		}
 

--- a/tests/xharness/Targets/WatchOSTarget.cs
+++ b/tests/xharness/Targets/WatchOSTarget.cs
@@ -77,7 +77,7 @@ namespace Xharness.Targets {
 			info_plist.LoadWithoutNetworkAccess (Path.Combine (Harness.WatchOSContainerTemplate, "Info.plist"));
 			info_plist.SetCFBundleIdentifier (BundleIdentifier);
 			info_plist.SetCFBundleName (Name);
-			info_plist.SetMinimumOSVersion (SdkVersions.MiniOS);
+			info_plist.SetMinimumOSVersion (Xamarin.SdkVersions.LegacyMinWatchOS);
 			info_plist.Save (target_info_plist, Harness);
 		}
 
@@ -134,7 +134,7 @@ namespace Xharness.Targets {
 			if (BundleIdentifier.Length >= 58)
 				BundleIdentifier = BundleIdentifier.Substring (0, 57); // If the main app's bundle id is 58 characters (or sometimes more), then the watch extension crashes at launch. radar #29847128.
 			info_plist.SetCFBundleIdentifier (BundleIdentifier + ".watchkitapp.watchkitextension");
-			info_plist.SetMinimumOSVersion (GetMinimumOSVersion (SdkVersions.MinWatchOS));
+			info_plist.SetMinimumOSVersion (GetMinimumOSVersion (Xamarin.SdkVersions.LegacyMinWatchOS));
 			info_plist.SetUIDeviceFamily (4);
 			info_plist.AddPListStringValue ("RemoteInterfacePrincipleClass", "InterfaceController");
 			info_plist.AddPListKeyValuePair ("NSExtension", "dict", string.Format (

--- a/tests/xharness/TestImporter/Platform.cs
+++ b/tests/xharness/TestImporter/Platform.cs
@@ -32,7 +32,7 @@ namespace Xharness.TestImporter {
 			case Platform.TvOS:
 				return global::Xamarin.SdkVersions.MinTVOS;
 			case Platform.WatchOS:
-				return global::Xamarin.SdkVersions.MinWatchOS;
+				return global::Xamarin.SdkVersions.LegacyMinWatchOS;
 			default:
 				throw new NotImplementedException (@this.ToString ());
 			}

--- a/tests/xharness/TestLabel.cs
+++ b/tests/xharness/TestLabel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -115,12 +116,12 @@ namespace Xharness {
 	static class TestLabelExtensions {
 		static string GetLabel<T> (this T self) where T : Enum
 		{
-			var name = Enum.GetName (typeof (T), self);
-			var attr = typeof (T).GetField (name).GetCustomAttribute<LabelAttribute> ();
-			return attr.Label;
+			var name = Enum.GetName (typeof (T), self)!;
+			var attr = typeof (T).GetField (name)!.GetCustomAttribute<LabelAttribute> ();
+			return attr!.Label;
 		}
 
-		public static bool TryGetLabel<T> (this string self, out T? label) where T : Enum
+		public static bool TryGetLabel<T> (this string self, out T label) where T : struct, Enum
 		{
 #if NET
 			foreach (var obj in Enum.GetValues<T> ()) {

--- a/tests/xharness/TestPlatformExtensions.cs
+++ b/tests/xharness/TestPlatformExtensions.cs
@@ -12,13 +12,13 @@ namespace Xharness {
 			case TestPlatform.iOS_TodayExtension64:
 			case TestPlatform.iOS_Unified32:
 			case TestPlatform.iOS_Unified64:
-				return "iOS " + SdkVersions.MiniOSSimulator;
+				return "iOS " + Xamarin.SdkVersions.MiniOSSimulator;
 			case TestPlatform.tvOS:
-				return "tvOS " + SdkVersions.MinTVOSSimulator;
+				return "tvOS " + Xamarin.SdkVersions.MinTVOSSimulator;
 			case TestPlatform.watchOS:
 			case TestPlatform.watchOS_32:
 			case TestPlatform.watchOS_64_32:
-				return "watchOS " + SdkVersions.MinWatchOSSimulator;
+				return "watchOS " + Xamarin.SdkVersions.MinWatchOSSimulator;
 			default:
 				throw new NotImplementedException (platform.ToString ());
 			}

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -138,7 +138,7 @@ namespace Xharness {
 					// Many types of files below the csproj directory are included by default,
 					// which means that we have to include them manually in the cloned csproj,
 					// because the cloned project is stored in a very different directory.
-					var test_dir = System.IO.Path.GetDirectoryName (original_path);
+					var test_dir = System.IO.Path.GetDirectoryName (original_path)!;
 
 					var files = await HarnessConfiguration.ListFilesInGitAsync (log, test_dir, processManager);
 					foreach (var file in files) {
@@ -196,12 +196,12 @@ namespace Xharness {
 		void InlineSharedImports (XmlDocument doc, string original_path, Dictionary<string, string> variableSubstitution, string rootDirectory)
 		{
 			// Find Import nodes that point to a shared code file, load that shared file and inject it here.
-			var nodes = doc.SelectNodes ("//*[local-name() = 'Import']");
-			foreach (XmlNode node in nodes) {
+			var nodes = doc.SelectNodes ("//*[local-name() = 'Import']")!;
+			foreach (XmlNode? node in nodes) {
 				if (node is null)
 					continue;
 
-				var project = node.Attributes ["Project"].Value.Replace ('\\', '/');
+				var project = node.Attributes! ["Project"]!.Value!.Replace ('\\', '/');
 				var projectName = System.IO.Path.GetFileName (project);
 				if (projectName != "shared.csproj" && projectName != "shared.fsproj" && projectName != "shared-dotnet.csproj")
 					continue;
@@ -211,7 +211,7 @@ namespace Xharness {
 
 				project = project.Replace ("$(RootTestsDirectory)", rootDirectory);
 
-				var sharedProjectPath = System.IO.Path.Combine (System.IO.Path.GetDirectoryName (original_path), project);
+				var sharedProjectPath = System.IO.Path.Combine (System.IO.Path.GetDirectoryName (original_path)!, project);
 				// Check for variables that won't work correctly if the shared code is moved to a different file
 				var xml = File.ReadAllText (sharedProjectPath);
 				xml = xml.Replace ("$(MSBuildThisFileDirectory)", System.IO.Path.GetDirectoryName (sharedProjectPath) + System.IO.Path.DirectorySeparatorChar);
@@ -222,21 +222,21 @@ namespace Xharness {
 				import.LoadXmlWithoutNetworkAccess (xml);
 				// Inline any shared imports in the inlined shared import too
 				InlineSharedImports (import, sharedProjectPath, variableSubstitution, rootDirectory);
-				var importNodes = import.SelectSingleNode ("/Project").ChildNodes;
+				var importNodes = import.SelectSingleNode ("/Project")!.ChildNodes;
 				var previousNode = node;
 				foreach (XmlNode importNode in importNodes) {
 					var importedNode = doc.ImportNode (importNode, true);
-					previousNode.ParentNode.InsertAfter (importedNode, previousNode);
+					previousNode.ParentNode!.InsertAfter (importedNode, previousNode);
 					previousNode = importedNode;
 				}
-				node.ParentNode.RemoveChild (node);
+				node.ParentNode!.RemoveChild (node);
 
 				variableSubstitution ["_PlatformName"] = TestPlatform.ToPlatformName ();
 				variableSubstitution = doc.CollectAndEvaluateTopLevelProperties (variableSubstitution);
 			}
 		}
 
-		public override string ToString ()
+		public override string? ToString ()
 		{
 			return Name ?? base.ToString ();
 		}

--- a/tests/xharness/TestTargetExtensions.cs
+++ b/tests/xharness/TestTargetExtensions.cs
@@ -29,11 +29,11 @@ namespace Xharness {
 		public static TestTargetOs GetTargetOs (this TestTarget target, bool minVersion)
 		{
 			return target switch {
-				TestTarget.Simulator_iOS32 => new TestTargetOs (target, minVersion ? SdkVersions.MiniOSSimulator : "10.3"),
-				TestTarget.Simulator_iOS64 => new TestTargetOs (target, minVersion ? SdkVersions.MiniOSSimulator : SdkVersions.MaxiOSSimulator),
-				TestTarget.Simulator_iOS => new TestTargetOs (target, minVersion ? SdkVersions.MiniOSSimulator : SdkVersions.MaxiOSSimulator),
-				TestTarget.Simulator_tvOS => new TestTargetOs (target, minVersion ? SdkVersions.MinTVOSSimulator : SdkVersions.MaxTVOSSimulator),
-				TestTarget.Simulator_watchOS => new TestTargetOs (target, minVersion ? SdkVersions.MinWatchOSSimulator : SdkVersions.MaxWatchOSSimulator),
+				TestTarget.Simulator_iOS32 => new TestTargetOs (target, minVersion ? Xamarin.SdkVersions.MiniOSSimulator : "10.3"),
+				TestTarget.Simulator_iOS64 => new TestTargetOs (target, minVersion ? Xamarin.SdkVersions.MiniOSSimulator : Xamarin.SdkVersions.MaxiOSSimulator),
+				TestTarget.Simulator_iOS => new TestTargetOs (target, minVersion ? Xamarin.SdkVersions.MiniOSSimulator : Xamarin.SdkVersions.MaxiOSSimulator),
+				TestTarget.Simulator_tvOS => new TestTargetOs (target, minVersion ? Xamarin.SdkVersions.MinTVOSSimulator : Xamarin.SdkVersions.MaxTVOSSimulator),
+				TestTarget.Simulator_watchOS => new TestTargetOs (target, minVersion ? Xamarin.SdkVersions.MinWatchOSSimulator : Xamarin.SdkVersions.MaxWatchOSSimulator),
 				_ => throw new Exception (string.Format ("Invalid simulator target: {0}", target))
 			};
 

--- a/tests/xharness/Xharness.Tests/Jenkins/JenkinsDeviceLoadterTests.cs
+++ b/tests/xharness/Xharness.Tests/Jenkins/JenkinsDeviceLoadterTests.cs
@@ -92,12 +92,12 @@ namespace Xharness.Tests.Jenkins {
 
 			logs.Setup (l => l.Create (
 				It.IsAny<string> (),
-				It.Is<string> (s => s.Equals ("Simulator Listing")),
+				It.Is<string> (s => s.Equals ("Simulator Listing", StringComparison.OrdinalIgnoreCase)),
 				null)).Returns (log.Object);
 
 			logs.Setup (l => l.Create (
 				It.IsAny<string> (),
-				It.Is<string> (s => s.Equals ("Device Listing")),
+				It.Is<string> (s => s.Equals ("Device Listing", StringComparison.OrdinalIgnoreCase)),
 				null)).Returns (log.Object);
 
 			log.SetupSet (l => l.Description = It.IsAny<string> ()).Verifiable ();
@@ -118,7 +118,7 @@ namespace Xharness.Tests.Jenkins {
 
 			await loader.LoadDevicesAsync ();
 			// validate that the log description will be set as expected
-			log.VerifySet (l => l.Description = It.Is<string> (s => s.Equals (expectedDescription)));
+			log.VerifySet (l => l.Description = It.Is<string> (s => s.Equals (expectedDescription, StringComparison.OrdinalIgnoreCase)));
 		}
 
 		[Test, TestCaseSource (typeof (TestCasesData), "GetSimulatorTestCases")]
@@ -128,7 +128,7 @@ namespace Xharness.Tests.Jenkins {
 
 			await loader.LoadSimulatorsAsync ();
 			// validate that the log description will be set as expected
-			log.VerifySet (l => l.Description = It.Is<string> (s => s.Equals (expectedDescription)));
+			log.VerifySet (l => l.Description = It.Is<string> (s => s.Equals (expectedDescription, StringComparison.OrdinalIgnoreCase)));
 		}
 
 	}

--- a/tests/xharness/Xharness.Tests/Tests/TestPlatformExtensionsTests.cs
+++ b/tests/xharness/Xharness.Tests/Tests/TestPlatformExtensionsTests.cs
@@ -15,13 +15,13 @@ namespace Xharness.Tests.Tests {
 													  TestPlatform.iOS_TodayExtension64,
 													  TestPlatform.iOS_Unified32,
 													  TestPlatform.iOS_Unified64,}) {
-						yield return new TestCaseData (platform).Returns ("iOS " + SdkVersions.MiniOSSimulator);
+						yield return new TestCaseData (platform).Returns ("iOS " + Xamarin.SdkVersions.MiniOSSimulator);
 					}
-					yield return new TestCaseData (TestPlatform.tvOS).Returns ("tvOS " + SdkVersions.MinTVOSSimulator);
+					yield return new TestCaseData (TestPlatform.tvOS).Returns ("tvOS " + Xamarin.SdkVersions.MinTVOSSimulator);
 					foreach (var platform in new [] { TestPlatform.watchOS,
 													  TestPlatform.watchOS_32,
 													  TestPlatform.watchOS_64_32}) {
-						yield return new TestCaseData (platform).Returns ("watchOS " + SdkVersions.MinWatchOSSimulator);
+						yield return new TestCaseData (platform).Returns ("watchOS " + Xamarin.SdkVersions.MinWatchOSSimulator);
 					}
 				}
 			}

--- a/tests/xharness/Xharness.Tests/Xharness.Tests.csproj
+++ b/tests/xharness/Xharness.Tests/Xharness.Tests.csproj
@@ -1,34 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{AD1B78C3-6A36-40D0-B45D-246504A39D64}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
     <RootNamespace>Xharness.Tests</RootNamespace>
     <AssemblyName>Xharness.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <LangVersion>latest</LangVersion>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
+    <!--<Nullable>enable</Nullable>-->
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="Jenkins\ErrorKnowledgeBaseTests.cs" />
     <Compile Include="TestImporter\Templates\Tests\PListExtensionsTests.cs" />
@@ -89,5 +69,4 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Configure' ">
     <StartAction>Project</StartAction>
-    <StartArguments>--configure --autoconf --rootdir ..</StartArguments>
+    <StartArguments>--configure --autoconf --rootdir ../../../..</StartArguments>
   </PropertyGroup>
   <Import Project="../../eng/Versions.props" />
   <ItemGroup>

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -1,38 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{E1F53F80-8399-499B-8017-C414B9CD263B}</ProjectGuid>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>Xharness</RootNamespace>
     <AssemblyName>xharness</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>.</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
+    <!--<Nullable>enable</Nullable>-->
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Externalconsole>true</Externalconsole>
-    <OutputPath>bin\Release</OutputPath>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
     <StartAction>Project</StartAction>
     <StartArguments>--verbose --jenkins:server --autoconf --rootdir ..</StartArguments>
@@ -56,19 +34,12 @@
     <StartAction>Project</StartAction>
     <StartArguments>--configure --autoconf --rootdir ..</StartArguments>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Web" />
-    <Reference Include="Mono.Posix" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
   <Import Project="../../eng/Versions.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.XHarness.iOS.Shared" Version="$(MicrosoftDotNetXHarnessiOSSharedPackageVersion)" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppBundleLocator.cs" />
@@ -188,10 +159,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="xharness.js" Condition="'$(OutputPath)' != '.'">
+    <Content Include="xharness.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="xharness.css" Condition="'$(OutputPath)' != '.'">
+    <Content Include="xharness.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -200,5 +171,4 @@
     <Compile Remove="TestImporter\Templates\Managed\Resources\**\*.cs" />
     <EmbeddedResource Include="TestImporter\Templates\Managed\Resources\**\*" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tools/common/SdkVersions.cs
+++ b/tools/common/SdkVersions.cs
@@ -24,7 +24,6 @@ namespace Xamarin {
 #if NET
 		public const string MinOSX = "10.15";
 		public const string MiniOS = "11.0";
-		public const string MinWatchOS = "99.99"; // TODO not supported, many changes required to remove it
 		public const string MinTVOS = "11.0";
 		public const string MinMacCatalyst = "13.1";
 #else
@@ -75,7 +74,9 @@ namespace Xamarin {
 
 		public static Version MinOSXVersion { get { return new Version (MinOSX); } }
 		public static Version MiniOSVersion { get { return new Version (MiniOS); } }
+#if !NET
 		public static Version MinWatchOSVersion { get { return new Version (MinWatchOS); } }
+#endif
 		public static Version MinTVOSVersion { get { return new Version (MinTVOS); } }
 		public static Version MinMacCatalystVersion { get { return new Version (MinMacCatalyst); } }
 
@@ -122,7 +123,9 @@ namespace Xamarin {
 			switch (app.Platform) {
 			case ApplePlatform.MacOSX: return MinOSXVersion;
 			case ApplePlatform.iOS: return MiniOSVersion;
+#if !NET
 			case ApplePlatform.WatchOS: return MinWatchOSVersion;
+#endif
 			case ApplePlatform.TVOS: return MinTVOSVersion;
 			case ApplePlatform.MacCatalyst: return MinMacCatalystVersion;
 			default:
@@ -149,7 +152,9 @@ namespace Xamarin {
 			switch (platform) {
 			case ApplePlatform.MacOSX: return MinOSXVersion;
 			case ApplePlatform.iOS: return MiniOSVersion;
+#if !NET
 			case ApplePlatform.WatchOS: return MinWatchOSVersion;
+#endif
 			case ApplePlatform.TVOS: return MinTVOSVersion;
 			case ApplePlatform.MacCatalyst: return MinMacCatalystVersion;
 			default:

--- a/tools/common/SdkVersions.cs
+++ b/tools/common/SdkVersions.cs
@@ -35,6 +35,15 @@ namespace Xamarin {
 		public const string MinMacCatalyst = "13.1";
 #endif
 
+		public const string DotNetMinOSX = "10.15";
+		public const string DotNetMiniOS = "11.0";
+		public const string DotNetMinTVOS = "11.0";
+		public const string DotNetMinMacCatalyst = "13.1";
+		public const string LegacyMinOSX = "10.15";
+		public const string LegacyMiniOS = "11.0";
+		public const string LegacyMinWatchOS = "4.0";
+		public const string LegacyMinTVOS = "11.0";
+
 		public const string MiniOSSimulator = "14.3";
 		public const string MinWatchOSSimulator = "7.1";
 		public const string MinWatchOSCompanionSimulator = "14.5";

--- a/tools/common/SdkVersions.in.cs
+++ b/tools/common/SdkVersions.in.cs
@@ -35,6 +35,15 @@ namespace Xamarin {
 		public const string MinMacCatalyst = "@MIN_MACCATALYST_SDK_VERSION@";
 #endif
 
+		public const string DotNetMinOSX = "@DOTNET_MIN_MACOS_SDK_VERSION@";
+		public const string DotNetMiniOS = "@DOTNET_MIN_IOS_SDK_VERSION@";
+		public const string DotNetMinTVOS = "@DOTNET_MIN_TVOS_SDK_VERSION@";
+		public const string DotNetMinMacCatalyst = "@DOTNET_MIN_MACCATALYST_SDK_VERSION@";
+		public const string LegacyMinOSX = "@MIN_MACOS_SDK_VERSION@";
+		public const string LegacyMiniOS = "@MIN_IOS_SDK_VERSION@";
+		public const string LegacyMinWatchOS = "@MIN_WATCHOS_SDK_VERSION@";
+		public const string LegacyMinTVOS = "@MIN_TVOS_SDK_VERSION@";
+
 		public const string MiniOSSimulator = "@MIN_IOS_SIMULATOR_VERSION@";
 		public const string MinWatchOSSimulator = "@MIN_WATCHOS_SIMULATOR_VERSION@";
 		public const string MinWatchOSCompanionSimulator = "@MIN_WATCHOS_COMPANION_SIMULATOR_VERSION@";

--- a/tools/common/SdkVersions.in.cs
+++ b/tools/common/SdkVersions.in.cs
@@ -24,7 +24,6 @@ namespace Xamarin {
 #if NET
 		public const string MinOSX = "@DOTNET_MIN_MACOS_SDK_VERSION@";
 		public const string MiniOS = "@DOTNET_MIN_IOS_SDK_VERSION@";
-		public const string MinWatchOS = "99.99"; // TODO not supported, many changes required to remove it
 		public const string MinTVOS = "@DOTNET_MIN_TVOS_SDK_VERSION@";
 		public const string MinMacCatalyst = "@DOTNET_MIN_MACCATALYST_SDK_VERSION@";
 #else
@@ -75,7 +74,9 @@ namespace Xamarin {
 
 		public static Version MinOSXVersion { get { return new Version (MinOSX); } }
 		public static Version MiniOSVersion { get { return new Version (MiniOS); } }
+#if !NET
 		public static Version MinWatchOSVersion { get { return new Version (MinWatchOS); } }
+#endif
 		public static Version MinTVOSVersion { get { return new Version (MinTVOS); } }
 		public static Version MinMacCatalystVersion { get { return new Version (MinMacCatalyst); } }
 
@@ -122,7 +123,9 @@ namespace Xamarin {
 			switch (app.Platform) {
 			case ApplePlatform.MacOSX: return MinOSXVersion;
 			case ApplePlatform.iOS: return MiniOSVersion;
+#if !NET
 			case ApplePlatform.WatchOS: return MinWatchOSVersion;
+#endif
 			case ApplePlatform.TVOS: return MinTVOSVersion;
 			case ApplePlatform.MacCatalyst: return MinMacCatalystVersion;
 			default:
@@ -149,7 +152,9 @@ namespace Xamarin {
 			switch (platform) {
 			case ApplePlatform.MacOSX: return MinOSXVersion;
 			case ApplePlatform.iOS: return MiniOSVersion;
+#if !NET
 			case ApplePlatform.WatchOS: return MinWatchOSVersion;
+#endif
 			case ApplePlatform.TVOS: return MinTVOSVersion;
 			case ApplePlatform.MacCatalyst: return MinMacCatalystVersion;
 			default:


### PR DESCRIPTION
* Convert xharness.csproj and Xharness.Tests.csproj to .NET/sdk-style projects.
* Fix numerous nullability issues that came up.
* Adjust Make logic to do the correct thing now that the executable is named differently.
* Port usage of WebClient to HttpClient, since WebClient is deprecated.
* Find an alternative solution to System.Web.MimeMapping.GetMimeMapping, which
  doesn’t exist in .NET.
* Fix misc other warnings and errors.