### PR TITLE
Centralize AgentPoolSelector

### DIFF
--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -35,32 +35,13 @@ parameters:
   type: string
 
 jobs:
-
-- ${{ if eq(parameters.pool, 'automatic') }}:
-  - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
-    pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
-      vmImage: ubuntu-latest
-    steps:
-    - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-
-    # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-    - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
-      parameters:
-        agentPoolPR: $(PRBuildPool)
-        agentPoolPRUrl: $(PRBuildPoolUrl)
-        agentPoolCI: $(CIBuildPool)
-        agentPoolCIUrl: $(CIBuildPoolUrl)
-
 # Detect changes
 - job: api_diff
-  dependsOn:
-  - ${{ if eq(parameters.pool, 'automatic') }}:
-    - AgentPoolSelector
   displayName: 'Detect API changes'
   timeoutInMinutes: 1000
   variables:
     ${{ if eq(parameters.pool, 'automatic') }}:
-      AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
+      AgentPoolComputed: $[ stageDependencies.configure_build.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
     ${{ if eq(parameters.pool, 'ci') }}:
       AgentPoolComputed: $(CIBuildPool)
     ${{ if eq(parameters.pool, 'pr') }}:

--- a/tools/devops/automation/templates/build/build-mac-tests-stage.yml
+++ b/tools/devops/automation/templates/build/build-mac-tests-stage.yml
@@ -36,29 +36,8 @@ parameters:
 
 jobs:
 
-- ${{ if eq(parameters.pool, 'automatic') }}:
-  - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
-    pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
-      vmImage: ubuntu-latest
-    steps:
-    - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-
-    # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-    - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
-      parameters:
-        agentPoolPR: $(PRBuildPool)
-        agentPoolPRUrl: $(PRBuildPoolUrl)
-        agentPoolCI: $(CIBuildPool)
-        agentPoolCIUrl: $(CIBuildPoolUrl)
-
 # This job builds the macOS tests.
-#
-# - AgentPoolSelector: If the build was not manually triggered to use a specific pool, this job is used to decide if the build is using a 
-#                      private pool or a public one.
 - job: build_macos_tests_job
-  dependsOn:
-  - ${{ if eq(parameters.pool, 'automatic') }}:
-    - AgentPoolSelector
   displayName: 'Build macOS tests'
   timeoutInMinutes: 120
   variables:
@@ -66,7 +45,7 @@ jobs:
     ENABLE_DOTNET: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'] ]
     INCLUDE_XAMARIN_LEGACY: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_XAMARIN_LEGACY'] ]
     ${{ if eq(parameters.pool, 'automatic') }}:
-      AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
+      AgentPoolComputed: $[ stageDependencies.configure_build.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
     ${{ if eq(parameters.pool, 'ci') }}:
       AgentPoolComputed: $(CIBuildPool)
     ${{ if eq(parameters.pool, 'pr') }}:

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -47,29 +47,8 @@ parameters:
   type: string
 
 jobs:
-- ${{ if eq(parameters.pool, 'automatic') }}:
-  - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
-    pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
-      vmImage: ubuntu-latest
-    steps:
-    - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-
-    # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-    - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
-      parameters:
-        agentPoolPR: $(PRBuildPool)
-        agentPoolPRUrl: $(PRBuildPoolUrl)
-        agentPoolCI: $(CIBuildPool)
-        agentPoolCIUrl: $(CIBuildPoolUrl)
-
 # This job performs the build of the nuget pkgs and the framework pkgs. There are two interesting dependencies in this job:
-#
-# - AgentPoolSelector: If the build was not manually triggered to use a specific pool, this job is used to decide if the build is using a 
-#                      private pool or a public one.
 - job: build
-  dependsOn:
-  - ${{ if eq(parameters.pool, 'automatic') }}:
-    - AgentPoolSelector
   displayName: 'Build packages'
   timeoutInMinutes: 1000
   variables:
@@ -85,7 +64,7 @@ jobs:
     INCLUDE_LEGACY_WATCH: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_LEGACY_WATCH'] ]
     INCLUDE_XAMARIN_LEGACY: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_XAMARIN_LEGACY'] ]
     ${{ if eq(parameters.pool, 'automatic') }}:
-      AgentPoolComputed: $[ dependencies.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
+      AgentPoolComputed: $[ stageDependencies.configure_build.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
     ${{ if eq(parameters.pool, 'ci') }}:
       AgentPoolComputed: $(CIBuildPool)
     ${{ if eq(parameters.pool, 'pr') }}:

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -181,6 +181,22 @@ stages:
   ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
     condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
   jobs:
+  
+  - ${{ if eq(parameters.pool, 'automatic') }}:
+    - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
+      pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
+        vmImage: ubuntu-latest
+      steps:
+      - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
+
+      # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
+      - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
+        parameters:
+          agentPoolPR: $(PRBuildPool)
+          agentPoolPRUrl: $(PRBuildPoolUrl)
+          agentPoolCI: $(CIBuildPool)
+          agentPoolCIUrl: $(CIBuildPoolUrl)
+
   - job: configure
     displayName: 'Configure build'
     pool:


### PR DESCRIPTION
Following #19491 , this change moves the AgentPoolSelector to the Config stage since it is deterministic per build.