### PR TITLE
[tests] Fix an issue with the ProjectTest.InvalidArchProperty test.

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1566,10 +1566,10 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		[TestCase (ApplePlatform.MacCatalyst, "MtouchArch", "x64")]
-		[TestCase (ApplePlatform.iOS, "MtouchArch", "armv7s")]
-		[TestCase (ApplePlatform.TVOS, "MtouchArch", "arm64")]
-		[TestCase (ApplePlatform.MacOSX, "XamMacArch", "x64")]
+		[TestCase (ApplePlatform.MacCatalyst, "MtouchArch", "x86_64")]
+		[TestCase (ApplePlatform.iOS, "MtouchArch", "ARMv7s")]
+		[TestCase (ApplePlatform.TVOS, "MtouchArch", "ARM64")]
+		[TestCase (ApplePlatform.MacOSX, "XamMacArch", "x86_64")]
 		public void InvalidArchProperty (ApplePlatform platform, string property, string value)
 		{
 			// Only keep this test around for .NET 9+10, after that we'll just assume everyone has removed the MtouchArch/XamMacArch properties from their project files,
@@ -1586,8 +1586,8 @@ namespace Xamarin.Tests {
 			properties [property] = value;
 			var rv = DotNet.AssertBuildFailure (project_path, properties);
 			var errors = BinLog.GetBuildLogErrors (rv.BinLogPath).ToArray ();
-			Assert.AreEqual (1, errors.Length, "Error count");
-			Assert.AreEqual ($"The property '{property}' is deprecated, please remove it from the project file. Use 'RuntimeIdentifier' or 'RuntimeIdentifiers' instead to specify the target architecture.", errors [0].Message, "Error message");
+			AssertErrorCount (errors, 1, "Error count");
+			AssertErrorMessages (errors, $"The property '{property}' is deprecated, please remove it from the project file. Use 'RuntimeIdentifier' or 'RuntimeIdentifiers' instead to specify the target architecture.");
 		}
 	}
 }

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -414,5 +414,31 @@ namespace Xamarin.Tests {
 			entitlements = null;
 			return false;
 		}
+
+		public static void AssertErrorCount (IList<BuildLogEvent> errors, int count, string message)
+		{
+			if (errors.Count == count)
+				return;
+			Assert.Fail ($"Expected {count} errors, got {errors.Count} errors: {message}.\n\t{string.Join ("\n\t", errors.Select (v => v.Message?.TrimEnd ()))}");
+		}
+
+		public static void AssertErrorMessages (IList<BuildLogEvent> errors, params string[] errorMessages)
+		{
+			if (errors.Count != errorMessages.Length) {
+				Assert.Fail ($"Expected {errorMessages.Length} errors, got {errors.Count} errors:\n\t{string.Join ("\n\t", errors.Select (v => v.Message?.TrimEnd ()))}");
+				return;
+			}
+
+			var failures = new List<string> ();
+			for (var i = 0; i < errorMessages.Length; i++) {
+				if (errors [i].Message != errorMessages [i]) {
+					failures.Add ($"\tUnexpected error message #{i}:\n\t\tExpected: {errorMessages [i]}\n\t\tActual: {errors [i].Message?.TrimEnd ()}");
+				}
+			}
+			if (!failures.Any ())
+				return;
+
+			Assert.Fail ($"Failure when comparing error messages:\n{string.Join ("\n", failures)}\n\tAll errors:\n\t\t{string.Join ("\n\t\t", errors.Select (v => v.Message?.TrimEnd ()))}");
+		}
 	}
 }

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -422,7 +422,7 @@ namespace Xamarin.Tests {
 			Assert.Fail ($"Expected {count} errors, got {errors.Count} errors: {message}.\n\t{string.Join ("\n\t", errors.Select (v => v.Message?.TrimEnd ()))}");
 		}
 
-		public static void AssertErrorMessages (IList<BuildLogEvent> errors, params string[] errorMessages)
+		public static void AssertErrorMessages (IList<BuildLogEvent> errors, params string [] errorMessages)
 		{
 			if (errors.Count != errorMessages.Length) {
 				Assert.Fail ($"Expected {errorMessages.Length} errors, got {errors.Count} errors:\n\t{string.Join ("\n\t", errors.Select (v => v.Message?.TrimEnd ()))}");


### PR DESCRIPTION
It seems targets are ran in a different order in .NET 9, which means that we
ran into a different one that the one we expected. So fix that error, which
means we're now getting the error the test is checking for again.

Fixes:

    Xamarin.Tests.DotNetProjectTest.InvalidArchProperty(TVOS,"MtouchArch","arm64"): Error count
        Expected: 1
        But was: 2

    Xamarin.Tests.DotNetProjectTest.InvalidArchProperty(MacCatalyst,"MtouchArch","x64"): Error count
        Expected: 1
        But was: 2

    Xamarin.Tests.DotNetProjectTest.InvalidArchProperty(MacOSX,"XamMacArch","x64"): Error message
        Expected string length 172 but was 50. Strings differ at index 0.
        Expected: "The property 'XamMacArch' is deprecated, please remove it fro..."
        But was: "Could not parse TargetArchitectures 'x64'\n "
        -----------^

    Xamarin.Tests.DotNetProjectTest.InvalidArchProperty(iOS,"MtouchArch","armv7s"): Error count
        Expected: 1
        But was: 2

Also improve error reporting a bit.