### PR TITLE
[msbuild] Detect any dylibs in NativeReferences. Fixes #19520.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCodeTaskBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 using Microsoft.Build.Framework;
 
@@ -164,6 +165,8 @@ namespace Xamarin.MacDev.Tasks {
 					}
 				}
 			}
+
+			hasDylibs |= NativeReferences.Any (v => string.Equals (".dylib", Path.GetExtension (v.ItemSpec), StringComparison.OrdinalIgnoreCase));
 
 			if (hasDylibs) {
 				arguments.Add ("-rpath");

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCodeTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCodeTaskBase.cs
@@ -40,7 +40,7 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public string MinimumOSVersion { get; set; }
 
-		public ITaskItem [] NativeReferences { get; set; }
+		public ITaskItem [] NativeReferences { get; set; } = Array.Empty<ITaskItem> ();
 
 		public ITaskItem [] Frameworks { get; set; }
 
@@ -82,7 +82,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var hasEmbeddedFrameworks = false;
 
-			if (NativeReferences?.Length > 0) {
+			if (NativeReferences.Length > 0) {
 				var linkerArguments = new LinkerOptions ();
 				linkerArguments.BuildNativeReferenceFlags (Log, NativeReferences);
 				foreach (var framework in linkerArguments.Frameworks) {

--- a/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/MacCatalyst/Makefile
+++ b/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/macOS/Makefile
+++ b/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/shared.mk
+++ b/tests/dotnet/AppWithNativeDynamicLibrariesInPackageReference/shared.mk
@@ -1,0 +1,3 @@
+TOP=../../../..
+TESTNAME=MySimpleApp
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1376,8 +1376,9 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
-		public void BuildAndExecuteAppWithNativeDynamicLibrariesInPackageReference (ApplePlatform platform, string runtimeIdentifier)
+		[TestCase (ApplePlatform.MacOSX, "osx-x64", false)]
+		[TestCase (ApplePlatform.MacOSX, "osx-x64", true)]
+		public void BuildAndExecuteAppWithNativeDynamicLibrariesInPackageReference (ApplePlatform platform, string runtimeIdentifier, bool isNativeAot)
 		{
 			var project = "AppWithNativeDynamicLibrariesInPackageReference";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
@@ -1385,6 +1386,10 @@ namespace Xamarin.Tests {
 			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifier, platform: platform, out var appPath);
 			Clean (project_path);
 			var properties = GetDefaultProperties (runtimeIdentifier);
+			if (isNativeAot) {
+				properties ["PublishAot"] = "true";
+				properties ["_IsPublishing"] = "true";
+			}
 			DotNet.AssertBuild (project_path, properties);
 
 			var appExecutable = Path.Combine (appPath, "Contents", "MacOS", Path.GetFileNameWithoutExtension (project_path));


### PR DESCRIPTION
We add the dylib location as an rpath if the app has any location, so make
sure to correctly detect dylibs in native references.

Fixes https://github.com/xamarin/xamarin-macios/issues/19520.