### PR TITLE
[src] Update dependencies of bgen.csproj to not use the dependencies of generator.csproj.

### DIFF
--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -14,7 +14,11 @@ $(BUILD_DIR)/generator.csproj.inc: export BUILD_VERBOSITY=$(MSBUILD_VERBOSITY)
 $(BUILD_DIR)/common/bgen.exe: $(generator_dependencies) Makefile.generator $(BUILD_DIR)/generator-frameworks.g.cs
 	$(Q_GEN) $(SYSTEM_MSBUILD) "/bl:$@.binlog" $(XBUILD_VERBOSITY) /p:Configuration=Debug generator.csproj /p:IntermediateOutputPath=$(BUILD_DIR)/IDE/obj/common/ /p:OutputPath=$(BUILD_DIR)/common /restore
 
-$(DOTNET_BUILD_DIR)/bgen/bgen:  $(generator_dependencies) Makefile.generator $(BUILD_DIR)/generator-frameworks.g.cs | $(DOTNET_BUILD_DIR)/bgen
+# bgen.csproj.inc contains the generator_dependencies variable used to determine if the generator needs to be rebuilt or not.
+$(DOTNET_BUILD_DIR)/bgen.csproj.inc: export BUILD_VERBOSITY=$(MSBUILD_VERBOSITY)
+-include $(DOTNET_BUILD_DIR)/bgen.csproj.inc
+
+$(DOTNET_BUILD_DIR)/bgen/bgen:  $(bgen_dependencies) Makefile.generator $(BUILD_DIR)/generator-frameworks.g.cs | $(DOTNET_BUILD_DIR)/bgen
 	$(Q_DOTNET_BUILD) $(DOTNET) publish bgen/bgen.csproj $(DOTNET_BUILD_VERBOSITY) /p:Configuration=Debug /p:IntermediateOutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/obj/common/bgen)/ /p:OutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/bin/common/bgen/)/
 	$(Q) $(CP) $(DOTNET_BUILD_DIR)/IDE/bin/common/bgen/publish/* $(dir $@)
 	$(Q) printf 'exec $(DOTNET) "$$(dirname "$$0")"/bgen.dll $$@\n' > $@


### PR DESCRIPTION
They're not quite the same, and in any case this decouples a .NET project from
a legacy Xamarin project, which is good long-term.