### PR TITLE
Bump mlaunch.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -18,7 +18,7 @@ endif
 
 # Available versions can be seen here:
 # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.Tools.Mlaunch/versions
-MLAUNCH_NUGET_VERSION=1.0.83
+MLAUNCH_NUGET_VERSION=1.0.95
 
 define CheckVersionTemplate
 check-$(1)::


### PR DESCRIPTION
Related new commits in xamarin/maccore:

* xamarin/maccore@39a7e52166 [mlaunch] Show all output from a failing devicectl command.
* xamarin/maccore@f29148cb58 [mlaunch] Add support for killing apps on device using devicectl. Fixes #xamarin/xamarin-macios@19577.
* xamarin/maccore@632997797a [mlaunch] Fix launching apps on device using a bundle id when using devicectl.

Diff: https://github.com/xamarin/maccore/compare/699ed5eaf2..39a7e52166