### PR TITLE
[msbuild] Use a single generated versions file for all platforms.

### DIFF
--- a/msbuild/.gitignore
+++ b/msbuild/.gitignore
@@ -1,4 +1,4 @@
-Versions.*.g.cs
+Versions.g.cs
 .failed-stamp
 .build-stamp
 .stamp-test-xml

--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -37,9 +37,7 @@ ALL_SOURCES:= \
 	$(shell git ls-files | sed 's/ /\\ /g') \
 	$(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.cs) \
 	$(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.csproj) \
-	Versions.ios.g.cs \
-	Versions.mac.g.cs \
-	Versions.dotnet.g.cs \
+	Versions.g.cs \
 
 CONFIG      = Debug
 TARGETFRAMEWORK = netstandard2.0
@@ -560,24 +558,10 @@ clean-local::
 	cd $(XAMARIN_MACDEV_PATH) && git clean -xfdq
 
 # We use the legacy Xamarin versions for the .NET assemblies as well.
-Versions.mac.g.cs: Makefile $(TOP)/Make.config.inc
-	$(Q) printf "static class VersionConstants {\\n" > $@.tmp
+Versions.g.cs: Makefile $(TOP)/Make.config.inc
+	$(Q) printf "public static class VersionConstants {\\n" > $@.tmp
 	$(Q) printf "\\tpublic const string XamarinMacVersion = \"$(MAC_PACKAGE_VERSION)\";\\n" >> $@.tmp
-	$(Q) printf "\\tpublic const string NuGetPrereleaseIdentifier = \"$(NUGET_PRERELEASE_IDENTIFIER)\";\\n" >> $@.tmp
-	$(Q) printf "\\tpublic const string NuGetBuildMetadata = \"$(NUGET_BUILD_METADATA)\";\\n" >> $@.tmp
-	$(Q) printf "}\\n" >> $@.tmp
-	$(Q) mv $@.tmp $@
-
-Versions.ios.g.cs: Makefile $(TOP)/Make.config.inc
-	$(Q) printf "static class VersionConstants {\\n" > $@.tmp
 	$(Q) printf "\\tpublic const string XamarinIOSVersion = \"$(IOS_PACKAGE_VERSION)\";\\n" >> $@.tmp
-	$(Q) printf "\\tpublic const string NuGetPrereleaseIdentifier = \"$(NUGET_PRERELEASE_IDENTIFIER)\";\\n" >> $@.tmp
-	$(Q) printf "\\tpublic const string NuGetBuildMetadata = \"$(NUGET_BUILD_METADATA)\";\\n" >> $@.tmp
-	$(Q) printf "}\\n" >> $@.tmp
-	$(Q) mv $@.tmp $@
-
-Versions.dotnet.g.cs: Makefile $(TOP)/Make.config.inc
-	$(Q) printf "static class DotNetVersionConstants {\\n" > $@.tmp
 	$(Q) echo $(foreach platform,$(ALL_DOTNET_PLATFORMS),"\\tpublic const string Microsoft_$(platform)_Version = \"$($(shell echo $(platform) | tr 'a-z' 'A-Z')_NUGET_VERSION_FULL)\";\\n") >> $@.tmp
 	$(Q) printf "\\tpublic const string NuGetPrereleaseIdentifier = \"$(NUGET_PRERELEASE_IDENTIFIER)\";\\n" >> $@.tmp
 	$(Q) printf "\\tpublic const string NuGetBuildMetadata = \"$(NUGET_BUILD_METADATA)\";\\n" >> $@.tmp

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -31,12 +31,7 @@
     <None Include="../Xamarin.Shared/*.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <Compile Include="../Versions.mac.g.cs" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\ILMerge.targets" />
-
-  <Target Name="BuildGeneratedVersionsFile" Inputs="../../Make.config.inc;../Makefile" Outputs="../Versions.mac.g.cs" BeforeTargets="BeforeBuild">
-    <Exec Command="make -C .. Versions.mac.g.cs" />
-  </Target>
 </Project>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
@@ -96,13 +96,13 @@ namespace Xamarin.MacDev.Tasks {
 			get {
 				switch (Platform) {
 				case ApplePlatform.iOS:
-					return DotNetVersionConstants.Microsoft_iOS_Version;
+					return VersionConstants.Microsoft_iOS_Version;
 				case ApplePlatform.MacCatalyst:
-					return DotNetVersionConstants.Microsoft_MacCatalyst_Version;
+					return VersionConstants.Microsoft_MacCatalyst_Version;
 				case ApplePlatform.MacOSX:
-					return DotNetVersionConstants.Microsoft_macOS_Version;
+					return VersionConstants.Microsoft_macOS_Version;
 				case ApplePlatform.TVOS:
-					return DotNetVersionConstants.Microsoft_tvOS_Version;
+					return VersionConstants.Microsoft_tvOS_Version;
 				default:
 					throw new InvalidOperationException (string.Format (MSBStrings.InvalidPlatform, Platform));
 				}

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -66,8 +66,8 @@
     <Compile Include="..\..\tools\common\NullableAttributes.cs">
       <Link>external\NullableAttributes.cs</Link>
     </Compile>
-    <Compile Include="..\Versions.dotnet.g.cs">
-      <Link>Versions.dotnet.g.cs</Link>
+    <Compile Include="..\Versions.g.cs">
+      <Link>Versions.g.cs</Link>
     </Compile>
     <Compile Remove="Errors.designer.cs" /> <!-- The 'CoreResGen' target will add it again from the EmbeddedResource item, this avoids a warning about the file being compiled twice -->
     <Compile Include="..\..\tools\common\SdkVersions.cs">

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -42,7 +42,7 @@
     </None>
     <None Include="$(PkgXamarin_iOS_HotRestart_Client)\lib\netstandard2.0\iSign.Core.pdb" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgXamarin_iOS_HotRestart_Client)\lib\netstandard2.0\Xamarin.iOS.Windows.Client.pdb" CopyToOutputDirectory="PreserveNewest" />
-    <Compile Include="../Versions.ios.g.cs" />
+    <Compile Include="../Versions.g.cs" />
     <Compile Include="..\Xamarin.MacDev.Tasks\PublishFolderType.cs">
       <Link>PublishFolderType.cs</Link>
     </Compile>
@@ -66,8 +66,8 @@
 
   <Import Project="$(MSBuildThisFileDirectory)..\ILMerge.targets" />
 
-  <Target Name="BuildGeneratedVersionsFile" Inputs="../../Make.config.inc;../Makefile" Outputs="../Versions.ios.g.cs" BeforeTargets="BeforeBuild">
-    <Exec Command="make -C .. Versions.ios.g.cs" />
+  <Target Name="BuildGeneratedVersionsFile" Inputs="../../Make.config.inc;../Makefile" Outputs="../Versions.g.cs" BeforeTargets="BeforeBuild">
+    <Exec Command="make -C .. Versions.g.cs" />
   </Target>
 
   <!-- Replaces the reference assemblies by the runtime implementation -->

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -45,8 +45,6 @@
   <ItemGroup>
     <Folder Include="Model\" />
     <Folder Include="Contracts\" />
-    <Compile Include="../Versions.ios.g.cs" />
-
     <None Include="../Xamarin.Shared/NoCode.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -74,10 +72,6 @@
 
   <Import Project="$(MSBuildThisFileDirectory)..\ILMerge.targets" />
 
-  <Target Name="BuildGeneratedVersionsFile" Inputs="../../Make.config.inc;../Makefile" Outputs="../Versions.ios.g.cs" BeforeTargets="BeforeBuild">
-    <Exec Command="make -C .. Versions.ios.g.cs" />
-  </Target>
-  
   <!-- Replaces the ProtectedData assembly by the runtime implementation -->
   <Target Name="CopyRuntimeAssemblies" BeforeTargets="ILRepack">
     <ItemGroup>

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -58,9 +58,7 @@ steps:
 - bash: |
     make -C src build/generator-frameworks.g.cs
     make -C src build/ios/Constants.cs
-    make -C msbuild Versions.dotnet.g.cs
-    make -C msbuild Versions.ios.g.cs
-    make -C msbuild Versions.mac.g.cs
+    make -C msbuild Versions.g.cs
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios
   displayName: Generate constants files 
   timeoutInMinutes: 15


### PR DESCRIPTION
This is a step (among many) towards merging the iOS and Mac task assemblies
into a single assembly, which would simplify and speed up our build quite a
bit.