### PR TITLE
[AppKit] Make NSGraphics.NSBestDepth P/Invoke blittable.

### DIFF
--- a/tests/cecil-tests/BlittablePInvokes.KnownFailures.cs
+++ b/tests/cecil-tests/BlittablePInvokes.KnownFailures.cs
@@ -17,7 +17,6 @@ using Xamarin.Utils;
 namespace Cecil.Tests {
 	public partial class BlittablePInvokes {
 		static HashSet<string> knownFailuresPInvokes = new HashSet<string> {
-			"AppKit.NSWindowDepth AppKit.NSGraphics::NSBestDepth(System.IntPtr,System.IntPtr,System.IntPtr,System.Boolean,System.Boolean&)",
 			"AudioToolbox.AudioConverterError AudioToolbox.AudioConverter::AudioConverterGetPropertyInfo(System.IntPtr,AudioToolbox.AudioConverterPropertyID,System.Int32&,System.Boolean&)",
 			"AudioToolbox.AudioFileError AudioToolbox.AudioFile::AudioFileWritePackets(System.IntPtr,System.Boolean,System.Int32,AudioToolbox.AudioStreamPacketDescription[],System.Int64,System.Int32&,System.IntPtr)",
 			"AudioToolbox.AudioFileStreamStatus AudioToolbox.AudioFileStream::AudioFileStreamGetPropertyInfo(System.IntPtr,AudioToolbox.AudioFileStreamProperty,System.Int32&,System.Boolean&)",

--- a/tests/monotouch-test/AppKit/NSGraphics.cs
+++ b/tests/monotouch-test/AppKit/NSGraphics.cs
@@ -1,0 +1,34 @@
+#if __MACOS__
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+using AppKit;
+using Foundation;
+
+namespace Xamarin.Mac.Tests {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NSGraphicsTest {
+#if !XAMCORE_5_0
+		[Test]
+		public void BestDepth ()
+		{
+			bool exactMatch = false;
+			var rv = NSGraphics.BestDepth (NSColorSpace.DeviceRGB, 8, 8, false, ref exactMatch);
+			Assert.AreEqual (NSWindowDepth.TwentyfourBitRgb, rv, "BestDepth");
+			Assert.IsTrue (exactMatch, "ExactMatch");
+		}
+#endif
+
+		[Test]
+		public void GetBestDepth ()
+		{
+			var rv = NSGraphics.GetBestDepth (NSColorSpace.DeviceRGB, 8, 8, false, out var exactMatch);
+			Assert.AreEqual (NSWindowDepth.TwentyfourBitRgb, rv, "GetBestDepth");
+			Assert.IsTrue (exactMatch, "ExactMatch");
+		}
+	}
+}
+
+#endif // __MACOS__


### PR DESCRIPTION
Also introduce a few other improvements:

* Add an varation that takes an 'out bool' instead of a 'ref bool'. According
  to the documentation the value is out-only.
* Name this variation according to our guidelines (with a verb).
* Deprecate the old version.

Contributes towards https://github.com/xamarin/xamarin-macios/issues/15684.