### PR TITLE
[CI] Ensure that the new dependencies are correcly managed.

### DIFF
--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -286,6 +286,7 @@ stages:
     }}
   : - template: ./release/vs-insertion-prep.yml
       parameters:
+        buildStage: build_packages
         dependsOn: [ build_packages, configure_build ]
         stageDisplayNamePrefix: ${{ parameters.stageDisplayNamePrefix }}
         isPR: ${{ parameters.isPR }}

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -1,4 +1,7 @@
 parameters:
+- name: buildStage
+  type: string
+
 - name: dependsOn
   type: object
   default: null
@@ -33,8 +36,8 @@ stages:
     dependsOn: ${{ parameters.dependsOn }}
     condition: and(
         or(
-          eq(dependencies.${{ parameters.dependsOn }}.result, 'Succeeded'),
-          eq(dependencies.${{ parameters.dependsOn }}.result, 'SucceededWithIssues')
+          eq(dependencies.${{ parameters.buildStage }}.result, 'Succeeded'),
+          eq(dependencies.${{ parameters.buildStage }}.result, 'SucceededWithIssues')
         ),
         eq(${{ parameters.isPR }}, false)
       )
@@ -50,7 +53,6 @@ stages:
       signType: Real
       usePipelineArtifactTasks: true
       condition: "ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')"
-      dependsOn: configure
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
   - template: nuget-msi-convert/job/v3.yml@yaml-templates


### PR DESCRIPTION
Once we move to the configure stage we have the situation in which we cannot longer have a simple condition to decide if we are preparing a released based in a single previos stage.

The issue we have is that templates cannot be used to create condition expressions and the expressions API from AZP does nor provide a map function (would have been ideal to do some mapping from the depends on object to an array).

The way we are going to fix the template is by taking a collection of stages we depend on, as we did, plus the name of the stage that builds the pacakges, that way we ensure that the condition will continue to work.