### PR TITLE
[release/8.0.1xx] [bgen] Fix assembly comparison. Fixes #19612.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -5086,7 +5086,7 @@ public partial class Generator : IMemberGatherer {
 			if (sb.Length > 0)
 				sb.Append (", ");
 			sb.Append (iface.Namespace).Append ('.');
-			if (iface.Assembly.GetName ().Name == "temp")
+			if (IsApiAssembly (iface.Assembly))
 				sb.Append ('I');
 			else if (iface.IsClass)
 				sb.Append ('I');
@@ -5763,7 +5763,7 @@ public partial class Generator : IMemberGatherer {
 				string pname = protocolType.Name;
 				// the extra 'I' is only required for the bindings being built, if it comes from something already
 				// built (e.g. monotouch.dll) then the interface will alreadybe prefixed
-				if (protocolType.Assembly.GetName ().Name == "temp")
+				if (IsApiAssembly (protocolType.Assembly))
 					pname = "I" + pname;
 				var iface = FormatType (type, protocolType.Namespace, pname);
 				if (!implements_list.Contains (iface))
@@ -7262,4 +7262,10 @@ public partial class Generator : IMemberGatherer {
 			return provider?.ToString ();
 		}
 	}
+
+	public bool IsApiAssembly (Assembly assembly)
+	{
+		return assembly == TypeManager.ApiAssembly;
+	}
+
 }

--- a/src/bgen/TypeManager.cs
+++ b/src/bgen/TypeManager.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 #nullable enable
 
 public class TypeManager {
+	public Assembly ApiAssembly { get; }
+
 	Frameworks Frameworks { get; }
 
 	public Type System_Attribute { get; }
@@ -276,6 +278,7 @@ public class TypeManager {
 			throw ErrorHelper.CreateError (4, bindingTouch.CurrentPlatform);
 
 		Frameworks = bindingTouch.Frameworks;
+		ApiAssembly = apiAssembly;
 
 		/* corlib */
 		System_Attribute = Lookup (corlibAssembly, "System", "Attribute");

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -8,7 +8,9 @@ using NUnit.Framework;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
+using Xamarin;
 using Xamarin.Tests;
+using Xamarin.Utils;
 
 namespace GeneratorTests {
 	[TestFixture ()]
@@ -1431,6 +1433,45 @@ namespace GeneratorTests {
 		{
 			BuildFile (Profile.iOS, "tests/internal-delegate.cs");
 		}
+
+#if NET
+		[Test]
+		public void Issue19612 ()
+		{
+			var profile = Profile.iOS;
+			var filename = Path.Combine (Configuration.SourceRoot, "tests", "generator", "issue19612.cs");
+
+			Configuration.IgnoreIfIgnoredPlatform (profile.AsPlatform ());
+
+			// Compile the temporary assembly and pass the compiled assembly to the generator instead
+			// of relying on the generator to compile.
+			var tmpdir = Cache.CreateTemporaryDirectory ();
+			var tmpassembly = Path.Combine (tmpdir, "temporaryAssembly.dll");
+			var cscArguments = new List<string> ();
+			if (!StringUtils.TryParseArguments (Configuration.DotNetCscCommand, out var cscCommand, out var ex))
+				throw new InvalidOperationException ($"Unable to parse the .NET csc command '{Configuration.DotNetCscCommand}': {ex.Message}");
+			cscArguments.AddRange (cscCommand);
+			var cscExecutable = cscArguments [0];
+			cscArguments.RemoveAt (0);
+			cscArguments.Add (filename);
+			cscArguments.Add ($"/out:{tmpassembly}");
+			cscArguments.Add ("/target:library");
+			cscArguments.Add ($"/r:{Path.Combine (Configuration.DotNetBclDir, "System.Runtime.dll")}");
+			var tf = TargetFramework.Parse (BGenTool.GetTargetFramework (profile));
+			cscArguments.Add ($"/r:{Configuration.GetBindingAttributePath (tf)}");
+			cscArguments.Add ($"/r:{Configuration.GetBaseLibrary (tf)}");
+			var rv = ExecutionHelper.Execute (cscExecutable, cscArguments);
+			Assert.AreEqual (0, rv, "CSC exit code");
+
+			var bgen = new BGenTool ();
+			bgen.Profile = profile;
+			bgen.CompiledApiDefinitionAssembly = tmpassembly;
+			bgen.Defines = BGenTool.GetDefaultDefines (bgen.Profile);
+			bgen.CreateTemporaryBinding (filename);
+			bgen.AssertExecute ("build");
+			bgen.AssertNoWarnings ();
+		}
+#endif
 
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Tests {
 		public string? BaseLibrary;
 		public string? AttributeLibrary;
 		public bool ReferenceBclByDefault = true;
+		public string? CompiledApiDefinitionAssembly = null;
 #else
 		public string BaseLibrary = None;
 		public string AttributeLibrary = None;
@@ -133,6 +134,11 @@ namespace Xamarin.Tests {
 			if (CompileCommand.Count > 0) {
 				sb.Add ($"--compile-command");
 				sb.Add (string.Join (" ", StringUtils.QuoteForProcess (CompileCommand.ToArray ())));
+			}
+
+			if (CompiledApiDefinitionAssembly is not null) {
+				sb.Add ($"--compiled-api-definition-assembly");
+				sb.Add (CompiledApiDefinitionAssembly);
 			}
 #endif
 

--- a/tests/generator/issue19612.cs
+++ b/tests/generator/issue19612.cs
@@ -1,0 +1,16 @@
+using System;
+
+using Foundation;
+using ObjCRuntime;
+using UIKit;
+
+namespace iosbindinglib {
+	[Protocol]
+	[BaseType (typeof (NSObject))]
+	public interface ReaderProtocol {
+	}
+
+	[BaseType (typeof (NSObject))]
+	public interface Reader : ReaderProtocol {
+	}
+}


### PR DESCRIPTION
This fixes a regression in .NET 8, where we changed the temporary assembly name when
building using a project file / MSBuild - we started compiling the temporary binding
code in MSBuild instead of in the generator, and in the process we changed the name
of the temporary assembly. This broke logic in bgen that compared the assembly name
to check if a given type is from the temporary assembly or not.

Fix this by checking the actual temporary assembly instead of the name of the assembly
instead.

Fixes https://github.com/xamarin/xamarin-macios/issues/19612.

Backport of #19619.