### PR TITLE
[monotouch-test] Improve security tests a little bit.

### DIFF
--- a/tests/monotouch-test/Security/KeyChainTest.cs
+++ b/tests/monotouch-test/Security/KeyChainTest.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.IO;
 using System.Reflection;
+using System.Threading;
 
 using CoreFoundation;
 using Foundation;
@@ -47,7 +48,7 @@ namespace MonoTouchFixtures.Security {
 				// add the new certificate
 				SecStatusCode rc = SecKeyChain.Add (rec);
 				// Try again a few times if we get SecStatusCode.DuplicateItem - we might be running in parallel with another test run in another process.
-				var attempts = 10;
+				var attemptsLeft = 10;
 				while (rc == SecStatusCode.DuplicateItem && attemptsLeft-- > 0) {
 					Thread.Sleep (100);
 					rc = SecKeyChain.Add (rec);

--- a/tests/monotouch-test/Security/KeyChainTest.cs
+++ b/tests/monotouch-test/Security/KeyChainTest.cs
@@ -45,7 +45,13 @@ namespace MonoTouchFixtures.Security {
 				// delete any existing certificates first.
 				SecKeyChain.Remove (query);
 				// add the new certificate
-				var rc = SecKeyChain.Add (rec);
+				SecStatusCode rc = SecKeyChain.Add (rec);
+				// Try again a few times if we get SecStatusCode.DuplicateItem - we might be running in parallel with another test run in another process.
+				var attempts = 10;
+				while (rc == SecStatusCode.DuplicateItem && attemptsLeft-- > 0) {
+					Thread.Sleep (100);
+					rc = SecKeyChain.Add (rec);
+				}
 				Assert.That (rc, Is.EqualTo (SecStatusCode.Success), "Add_Certificate");
 			} finally {
 				// clean up after ourselves

--- a/tests/monotouch-test/Security/RecordTest.cs
+++ b/tests/monotouch-test/Security/RecordTest.cs
@@ -188,24 +188,25 @@ namespace MonoTouchFixtures.Security {
 
 		void Protocol (SecProtocol protocol)
 		{
+			var account = $"Protocol-{protocol}-{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}";
 			var rec = CreateSecRecord (SecKind.InternetPassword,
-				account: $"Protocol-{protocol}-{CFBundle.GetMain ().Identifier}-{GetType ().FullName}-{Process.GetCurrentProcess ().Id}"
+				account: account
 			);
 			try {
 				SecKeyChain.Remove (rec); // it might already exists (or not)
 
 				rec = CreateSecRecord (SecKind.InternetPassword,
-					account: "Protocol",
+					account: account,
 					valueData: NSData.FromString ("Password"),
 					protocol: protocol,
 					server: "www.xamarin.com"
 				);
 
-				Assert.That (SecKeyChain.Add (rec), Is.EqualTo (SecStatusCode.Success), "Add");
+				Assert.That (SecKeyChain.Add (rec), Is.EqualTo (SecStatusCode.Success), $"Add: {protocol}");
 
 				SecStatusCode code;
 				var match = SecKeyChain.QueryAsRecord (rec, out code);
-				Assert.That (code, Is.EqualTo (SecStatusCode.Success), "QueryAsRecord");
+				Assert.That (code, Is.EqualTo (SecStatusCode.Success), $"QueryAsRecord: {protocol}");
 
 				Assert.That (match.Protocol, Is.EqualTo (protocol), "Protocol");
 			} finally {


### PR DESCRIPTION
* Try again if we get a DuplicateItem error in MonoTouchFixtures.Security.KeyChainTest.Add_Certificate, hopefully fixes this random test failure:

       MonoTouchFixtures.Security.KeyChainTest
       	[FAIL] Add_Certificate :   Add_Certificate
         Expected: Success
         But was:  DuplicateItem
          at MonoTouchFixtures.Security.KeyChainTest.Add_Certificate() in /Users/builder/azdo/_work/2/s/xamarin-macios/tests/monotouch-test/Security/KeyChainTest.cs:line 49

    Ref: https://github.com/xamarin/maccore/issues/2394

* Use a unique account name in MonoTouchFixtures.Security.RecordTest.Protocol_17579, hopefully fixes this random test failure:

     MonoTouchFixtures.Security.RecordTest
      [FAIL] Protocol_17579 :   Add
       Expected: Success
       But was:  DuplicateItem
          at MonoTouchFixtures.Security.RecordTest.Protocol(SecProtocol protocol) in /Users/builder/azdo/_work/2/s/xamarin-macios/tests/monotouch-test/Security/RecordTest.cs:line 204
          at MonoTouchFixtures.Security.RecordTest.Protocol_17579() in /Users/builder/azdo/_work/2/s/xamarin-macios/tests/monotouch-test/Security/RecordTest.cs:line 232

    Ref: https://github.com/xamarin/maccore/issues/2692