### PR TITLE
[xharness] Bump the timeout for the cecil tests.

### DIFF
--- a/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
+++ b/tests/xharness/Jenkins/NUnitTestTasksEnumerable.cs
@@ -143,7 +143,7 @@ namespace Xharness.Jenkins {
 				TestProject = buildCecilTestsProject,
 				Platform = TestPlatform.iOS,
 				TestName = "Cecil-based tests",
-				Timeout = TimeSpan.FromMinutes (5),
+				Timeout = TimeSpan.FromMinutes (10),
 				Ignored = !jenkins.TestSelection.IsEnabled (TestLabel.Cecil) || !jenkins.TestSelection.IsEnabled (PlatformLabel.Dotnet),
 			};
 			yield return runCecilTests;


### PR DESCRIPTION
It seems it's getting close to 5 minutes for slower bots, once in a while
hitting it, causing unnecessary test failures.