### PR TITLE
[dotnet] Call the _CreateAssetPackManifest target during the build. Fixes #19669.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -233,7 +233,7 @@
 			_CopyResourcesToBundle;
 			_CompileCoreMLModels;
 			_CreatePkgInfo;
-			_CreateAssetPackManifest;
+			_CreateAssetPackManifestMobile;
 			_SmeltMetal;
 			_TemperMetal;
 			_DetectAppManifest;
@@ -273,6 +273,8 @@
 			_PostProcessAppBundle;
 		</CreateAppBundleDependsOn>
 	</PropertyGroup>
+
+	<Target Name="_CreateAssetPackManifestMobile" Condition="'$(_PlatformName)' != 'macOS'" DependsOnTargets="_CreateAssetPackManifest" />
 
 	<!-- PublishTrimmed must be calculated as part of a target because IsMacEnabled on Windows will be set after connecting to the Mac -->
 	<Target Name="_ComputePublishTrimmed">

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -233,6 +233,7 @@
 			_CopyResourcesToBundle;
 			_CompileCoreMLModels;
 			_CreatePkgInfo;
+			_CreateAssetPackManifest;
 			_SmeltMetal;
 			_TemperMetal;
 			_DetectAppManifest;


### PR DESCRIPTION
We're calling the _CreateAssetPackManifest target during the build for legacy
Xamarin apps, but somehow this seems to have been skipped over when
implementing .NET support.

The reason this has not showed up before is that it requires:

* OnDemand resources.
* An AdHoc provisioning profile (and a distribution certificate).

The last part makes it rather complicated to write a unit test, so this has
been verified manually.

Fixes https://github.com/xamarin/xamarin-macios/issues/19669.