### PR TITLE
[src] Remove the Protocolize attribute.

### DIFF
--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -136,6 +136,8 @@ Please go to [[FieldAttribute]](https://developer.xamarin.com/guides/cross-platf
 
 ### <a name='BI1034'/>BI1034: The [Protocolize] attribute is set on the property *.*, but the property's type (*) is not a protocol.
 
+This error is no longer shown.
+
 ### <a name='BI1035'/>BI1035: The property * on class * is hiding a property from a parent class * but the selectors do not match.
 
 ### <a name='BI1036'/>BI1036: The last parameter in the method '*.*' must be a delegate (it's '*').
@@ -282,6 +284,8 @@ If the property is inlined from a protocol then the `[Export]` value, prefixed w
 ### <a name='BI1107'/>BI1107: The return type of the method *.* exposes a model (*). Please expose the corresponding protocol type instead (*.I*).
 
 ### <a name='BI1108'/>BI1108: The [Protocolize] attribute is applied to the return type of the method *.*, but the return type (*) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.
+
+This error is no longer shown.
 
 ### <a name='BI1109'/>BI1109: The return type of the method *.* exposes a model (*). Please expose the corresponding protocol type instead (*.I*).
 

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -330,9 +330,7 @@
 		</comment>
 	</data>
 		
-	<data name="BI1034" xml:space="preserve">
-		<value>The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol.</value>
-	</data>
+	<!-- BI1034 (no longer used): The [Protocolize] attribute is set on the member {0}.{1}, but the member's type ({2}) is not a protocol. -->
 
 	<data name="BI1035" xml:space="preserve">
 		<value>The property {0} on class {1} is hiding a property from a parent class {2} but the selectors do not match.</value>
@@ -573,9 +571,7 @@
 		<value>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</value>
 	</data>
 
-	<data name="BI1108" xml:space="preserve">
-		<value>The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute.</value>
-	</data>
+	<!-- BI1108 (no longer used): The [Protocolize] attribute is applied to the return type of the method {0}.{1}, but the return type ({2}) isn't a model and can thus not be protocolized. Please remove the [Protocolize] attribute. -->
 
 	<data name="BI1109" xml:space="preserve">
 		<value>The return type of the method {0}.{1} exposes a model ({2}). Please expose the corresponding protocol type instead ({3}.I{4}).</value>

--- a/src/addressbookui.cs
+++ b/src/addressbookui.cs
@@ -39,8 +39,7 @@ namespace AddressBookUI {
 		IntPtr _ParentGroup { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		ABNewPersonViewControllerDelegate Delegate { get; set; }
+		IABNewPersonViewControllerDelegate Delegate { get; set; }
 
 		[Export ("newPersonViewDelegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -56,6 +55,8 @@ namespace AddressBookUI {
 		[Abstract]
 		void DidCompleteWithNewPerson (ABNewPersonViewController controller, [NullAllowed] ABPerson person);
 	}
+
+	interface IABNewPersonViewControllerDelegate { }
 
 	[Deprecated (PlatformName.iOS, 9, 0, message: "Use the 'Contacts' API instead.")]
 	[BaseType (typeof (UINavigationController))]
@@ -76,8 +77,7 @@ namespace AddressBookUI {
 		IntPtr _AddressBook { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		ABPeoplePickerNavigationControllerDelegate Delegate { get; set; }
+		IABPeoplePickerNavigationControllerDelegate Delegate { get; set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("peoplePickerDelegate", ArgumentSemantic.Assign)]
@@ -123,6 +123,8 @@ namespace AddressBookUI {
 		void DidSelectPerson (ABPeoplePickerNavigationController peoplePicker, ABPerson selectedPerson, int /* ABPropertyId = int32 */ propertyId, int /* ABMultiValueIdentifier = int32 */ identifier);
 	}
 
+	interface IABPeoplePickerNavigationControllerDelegate { }
+
 	[Deprecated (PlatformName.iOS, 9, 0, message: "Use the 'Contacts' API instead.")]
 	[BaseType (typeof (UIViewController))]
 	interface ABPersonViewController : UIViewControllerRestoration {
@@ -150,8 +152,7 @@ namespace AddressBookUI {
 		bool ShouldShowLinkedPeople { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		ABPersonViewControllerDelegate Delegate { get; set; }
+		IABPersonViewControllerDelegate Delegate { get; set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("personViewDelegate", ArgumentSemantic.Assign)]
@@ -248,6 +249,8 @@ namespace AddressBookUI {
 		bool ShouldPerformDefaultActionForPerson (ABPersonViewController personViewController, ABPerson person, int /* ABPropertyID = int32 */ propertyId, int /* ABMultiValueIdentifier = int32 */ identifier);
 	}
 
+	interface IABPersonViewControllerDelegate { }
+
 	[Deprecated (PlatformName.iOS, 9, 0, message: "Use the 'Contacts' API instead.")]
 	[BaseType (typeof (UIViewController))]
 	interface ABUnknownPersonViewController {
@@ -276,8 +279,7 @@ namespace AddressBookUI {
 		bool AllowsAddingToAddressBook { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		ABUnknownPersonViewControllerDelegate Delegate { get; set; }
+		IABUnknownPersonViewControllerDelegate Delegate { get; set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("unknownPersonViewDelegate", ArgumentSemantic.Assign)]
@@ -296,4 +298,5 @@ namespace AddressBookUI {
 		[Export ("unknownPersonViewController:shouldPerformDefaultActionForPerson:property:identifier:")]
 		bool ShouldPerformDefaultActionForPerson (ABUnknownPersonViewController personViewController, ABPerson person, int /* ABPropertyID = int32 */ propertyId, int /* ABMultiValueIdentifier = int32 */ identifier);
 	}
+	interface IABUnknownPersonViewControllerDelegate { }
 }

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -210,8 +210,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSAnimationDelegate Delegate { get; set; }
+		INSAnimationDelegate Delegate { get; set; }
 
 		[Export ("progressMarks", ArgumentSemantic.Copy)]
 		NSNumber [] ProgressMarks { get; set; }
@@ -249,6 +248,8 @@ namespace AppKit {
 		[Field ("NSAnimationTriggerOrderOut")]
 		NSString TriggerOrderOut { get; }
 	}
+
+	interface INSAnimationDelegate { }
 
 	[NoiOS]
 	[NoMacCatalyst]
@@ -347,8 +348,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSAlertDelegate Delegate { get; set; }
+		INSAlertDelegate Delegate { get; set; }
 
 		[Export ("showsSuppressionButton")]
 		bool ShowsSuppressionButton { get; set; }
@@ -376,6 +376,8 @@ namespace AppKit {
 		[Export ("window")]
 		NSPanel Window { get; }
 	}
+
+	interface INSAlertDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -490,8 +492,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSApplicationDelegate Delegate { get; set; }
+		INSApplicationDelegate Delegate { get; set; }
 
 		[Export ("context")]
 		[Deprecated (PlatformName.MacOSX, 10, 12, message: "This method always returns null. If you need access to the current drawing context, use NSGraphicsContext.CurrentContext inside of a draw operation.")]
@@ -940,6 +941,8 @@ namespace AppKit {
 #else
 	delegate void ContinueUserActivityRestorationHandler (NSObject [] restorableObjects);
 #endif
+
+	interface INSApplicationDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -1953,8 +1956,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSBrowserDelegate Delegate { get; set; }
+		INSBrowserDelegate Delegate { get; set; }
 
 		[Export ("reusesColumns")]
 		bool ReusesColumns { get; set; }
@@ -2001,6 +2003,8 @@ namespace AppKit {
 		[Export ("lastColumn")]
 		nint LastColumn { get; set; }
 	}
+
+	interface INSBrowserDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -2088,14 +2092,14 @@ namespace AppKit {
 #if NET
 		NSDragOperation ValidateDrop (NSBrowser browser, INSDraggingInfo info, ref nint row, ref nint column, ref NSBrowserDropOperation dropOperation);
 #else
-		NSDragOperation ValidateDrop (NSBrowser browser, [Protocolize (4)] NSDraggingInfo info, ref nint row, ref nint column, ref NSBrowserDropOperation dropOperation);
+		NSDragOperation ValidateDrop (NSBrowser browser, NSDraggingInfo info, ref nint row, ref nint column, ref NSBrowserDropOperation dropOperation);
 #endif
 
 		[Export ("browser:acceptDrop:atRow:column:dropOperation:")]
 #if NET
 		bool AcceptDrop (NSBrowser browser, INSDraggingInfo info, nint row, nint column, NSBrowserDropOperation dropOperation);
 #else
-		bool AcceptDrop (NSBrowser browser, [Protocolize (4)] NSDraggingInfo info, nint row, nint column, NSBrowserDropOperation dropOperation);
+		bool AcceptDrop (NSBrowser browser, NSDraggingInfo info, nint row, nint column, NSBrowserDropOperation dropOperation);
 #endif
 
 		[return: NullAllowed]
@@ -2928,8 +2932,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSCollectionViewDelegate Delegate { get; set; }
+		INSCollectionViewDelegate Delegate { get; set; }
 
 		[Export ("content", ArgumentSemantic.Copy)]
 		NSObject [] Content { get; set; }
@@ -2973,9 +2976,8 @@ namespace AppKit {
 		CGRect FrameForItemAtIndex (nint index, nint numberOfItems);
 #endif
 
-		[Protocolize]
 		[NullAllowed, Export ("dataSource", ArgumentSemantic.Weak)]
-		NSCollectionViewDataSource DataSource { get; set; }
+		INSCollectionViewDataSource DataSource { get; set; }
 
 		[Export ("reloadData")]
 		void ReloadData ();
@@ -3113,6 +3115,8 @@ namespace AppKit {
 		INSCollectionViewPrefetching PrefetchDataSource { get; set; }
 	}
 
+	interface INSCollectionViewDataSource { }
+
 	// @protocol NSCollectionViewDataSource <NSObject>
 	[NoMacCatalyst]
 	[Protocol, Model]
@@ -3132,6 +3136,8 @@ namespace AppKit {
 		[Export ("collectionView:viewForSupplementaryElementOfKind:atIndexPath:")]
 		NSView GetView (NSCollectionView collectionView, NSString kind, NSIndexPath indexPath);
 	}
+
+	interface INSCollectionViewDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -3156,14 +3162,14 @@ namespace AppKit {
 #if NET
 		NSDragOperation ValidateDrop (NSCollectionView collectionView, INSDraggingInfo draggingInfo, ref nint dropIndex, ref NSCollectionViewDropOperation dropOperation);
 #else
-		NSDragOperation ValidateDrop (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, ref nint dropIndex, ref NSCollectionViewDropOperation dropOperation);
+		NSDragOperation ValidateDrop (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref nint dropIndex, ref NSCollectionViewDropOperation dropOperation);
 #endif
 
 		[Export ("collectionView:acceptDrop:index:dropOperation:")]
 #if NET
 		bool AcceptDrop (NSCollectionView collectionView, INSDraggingInfo draggingInfo, nint index, NSCollectionViewDropOperation dropOperation);
 #else
-		bool AcceptDrop (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, nint index, NSCollectionViewDropOperation dropOperation);
+		bool AcceptDrop (NSCollectionView collectionView, NSDraggingInfo draggingInfo, nint index, NSCollectionViewDropOperation dropOperation);
 #endif
 
 		[Export ("collectionView:canDragItemsAtIndexPaths:withEvent:")]
@@ -3182,7 +3188,7 @@ namespace AppKit {
 
 #if !NET
 		[Export ("collectionView:validateDrop:proposedIndexPath:dropOperation:")]
-		NSDragOperation ValidateDropOperation (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation);
+		NSDragOperation ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation);
 #else
 		[Export ("collectionView:validateDrop:proposedIndexPath:dropOperation:")]
 		NSDragOperation ValidateDrop (NSCollectionView collectionView, INSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation);
@@ -3192,7 +3198,7 @@ namespace AppKit {
 #if NET
 		bool AcceptDrop (NSCollectionView collectionView, INSDraggingInfo draggingInfo, NSIndexPath indexPath, NSCollectionViewDropOperation dropOperation);
 #else
-		bool AcceptDrop (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, NSIndexPath indexPath, NSCollectionViewDropOperation dropOperation);
+		bool AcceptDrop (NSCollectionView collectionView, NSDraggingInfo draggingInfo, NSIndexPath indexPath, NSCollectionViewDropOperation dropOperation);
 #endif
 
 		[Export ("collectionView:pasteboardWriterForItemAtIndexPath:")]
@@ -4732,8 +4738,7 @@ namespace AppKit {
 		NativeHandle Constructor (CGRect frameRect);
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSComboBoxDelegate Delegate { get; set; }
+		INSComboBoxDelegate Delegate { get; set; }
 
 		[Export ("hasVerticalScroller")]
 		bool HasVerticalScroller { get; set; }
@@ -4782,8 +4787,7 @@ namespace AppKit {
 
 		[Export ("dataSource", ArgumentSemantic.Assign)]
 		[NullAllowed]
-		[Protocolize]
-		NSComboBoxDataSource DataSource { get; set; }
+		INSComboBoxDataSource DataSource { get; set; }
 
 		[Export ("addItemWithObjectValue:")]
 		void Add (NSObject object1);
@@ -4830,6 +4834,8 @@ namespace AppKit {
 		[Notification, Field ("NSComboBoxWillPopUpNotification")]
 		NSString WillPopUpNotification { get; }
 	}
+
+	interface INSComboBoxDataSource { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -4902,8 +4908,7 @@ namespace AppKit {
 
 		[Export ("dataSource", ArgumentSemantic.Assign)]
 		[NullAllowed]
-		[Protocolize]
-		NSComboBoxCellDataSource DataSource { get; set; }
+		INSComboBoxCellDataSource DataSource { get; set; }
 
 		[Export ("addItemWithObjectValue:")]
 		void Add (NSObject object1);
@@ -4942,6 +4947,8 @@ namespace AppKit {
 		string CompletedString (string substring);
 
 	}
+
+	interface INSComboBoxCellDataSource { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -5502,8 +5509,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSDatePickerCellDelegate Delegate { get; set; }
+		INSDatePickerCellDelegate Delegate { get; set; }
 	}
 
 	[NoMacCatalyst]
@@ -5560,10 +5566,11 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSDatePickerCellDelegate Delegate { get; set; }
+		INSDatePickerCellDelegate Delegate { get; set; }
 
 	}
+
+	interface INSDatePickerCellDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -6330,6 +6337,8 @@ namespace AppKit {
 
 	interface INSDraggingInfo { }
 
+	interface INSDraggingDestination { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -6339,49 +6348,49 @@ namespace AppKit {
 #if NET
 		NSDragOperation DraggingEntered (INSDraggingInfo sender);
 #else
-		NSDragOperation DraggingEntered ([Protocolize (4)] NSDraggingInfo sender);
+		NSDragOperation DraggingEntered (NSDraggingInfo sender);
 #endif
 
 		[Export ("draggingUpdated:"), DefaultValue (NSDragOperation.None)]
 #if NET
 		NSDragOperation DraggingUpdated (INSDraggingInfo sender);
 #else
-		NSDragOperation DraggingUpdated ([Protocolize (4)] NSDraggingInfo sender);
+		NSDragOperation DraggingUpdated (NSDraggingInfo sender);
 #endif
 
 		[Export ("draggingExited:")]
 #if NET
 		void DraggingExited ([NullAllowed] INSDraggingInfo sender);
 #else
-		void DraggingExited ([Protocolize (4)] NSDraggingInfo sender);
+		void DraggingExited (NSDraggingInfo sender);
 #endif
 
 		[Export ("prepareForDragOperation:"), DefaultValue (false)]
 #if NET
 		bool PrepareForDragOperation (INSDraggingInfo sender);
 #else
-		bool PrepareForDragOperation ([Protocolize (4)] NSDraggingInfo sender);
+		bool PrepareForDragOperation (NSDraggingInfo sender);
 #endif
 
 		[Export ("performDragOperation:"), DefaultValue (false)]
 #if NET
 		bool PerformDragOperation (INSDraggingInfo sender);
 #else
-		bool PerformDragOperation ([Protocolize (4)] NSDraggingInfo sender);
+		bool PerformDragOperation (NSDraggingInfo sender);
 #endif
 
 		[Export ("concludeDragOperation:")]
 #if NET
 		void ConcludeDragOperation ([NullAllowed] INSDraggingInfo sender);
 #else
-		void ConcludeDragOperation ([Protocolize (4)] NSDraggingInfo sender);
+		void ConcludeDragOperation (NSDraggingInfo sender);
 #endif
 
 		[Export ("draggingEnded:")]
 #if NET
 		void DraggingEnded (INSDraggingInfo sender);
 #else
-		void DraggingEnded ([Protocolize (4)] NSDraggingInfo sender);
+		void DraggingEnded (NSDraggingInfo sender);
 #endif
 
 		[DebuggerBrowsableAttribute (DebuggerBrowsableState.Never)]
@@ -6418,6 +6427,8 @@ namespace AppKit {
 		[Export ("enumerateDraggingItemsWithOptions:forView:classes:searchOptions:usingBlock:")]
 		void EnumerateDraggingItems (NSDraggingItemEnumerationOptions enumOpts, NSView view, IntPtr classArray, [NullAllowed] NSDictionary searchOptions, NSDraggingEnumerator enumerator);
 	}
+
+	interface INSDraggingSource { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -6468,8 +6479,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSDrawerDelegate Delegate { get; set; }
+		INSDrawerDelegate Delegate { get; set; }
 
 		[Export ("open")]
 		void Open ();
@@ -6510,6 +6520,8 @@ namespace AppKit {
 		[Export ("trailingOffset")]
 		nfloat TrailingOffset { get; set; }
 	}
+
+	interface INSDrawerDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -8185,8 +8197,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSGestureRecognizerDelegate Delegate { get; set; }
+		INSGestureRecognizerDelegate Delegate { get; set; }
 
 		[Export ("enabled")]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
@@ -8293,6 +8304,8 @@ namespace AppKit {
 		[Export ("touchesCancelledWithEvent:")]
 		void TouchesCancelled (NSEvent touchEvent);
 	}
+
+	interface INSGestureRecognizerDelegate { }
 
 	[NoMacCatalyst]
 	[Protocol, Model]
@@ -8471,9 +8484,8 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
 		[NullAllowed]
-		NSMenuDelegate Delegate { get; set; }
+		INSMenuDelegate Delegate { get; set; }
 
 		[Export ("minimumWidth")]
 		nfloat MinimumWidth { get; set; }
@@ -9222,6 +9234,8 @@ namespace AppKit {
 	interface NSRemoteOpenPanel { }
 #endif
 
+	interface INSOpenSavePanelDelegate { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -9337,8 +9351,7 @@ namespace AppKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		NSOutlineViewDelegate Delegate { get; set; }
+		INSOutlineViewDelegate Delegate { get; set; }
 
 		[Export ("dataSource", ArgumentSemantic.Weak)]
 		[NullAllowed]
@@ -9346,8 +9359,7 @@ namespace AppKit {
 
 		[Wrap ("WeakDataSource")]
 		[NullAllowed]
-		[Protocolize]
-		NSOutlineViewDataSource DataSource { get; set; }
+		INSOutlineViewDataSource DataSource { get; set; }
 
 		[Export ("numberOfChildrenOfItem:")]
 		nint NumberOfChildren ([NullAllowed] NSObject item);
@@ -9364,6 +9376,8 @@ namespace AppKit {
 		[Export ("stronglyReferencesItems")]
 		bool StronglyReferencesItems { get; set; }
 	}
+
+	interface INSOutlineViewDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -9495,6 +9509,8 @@ namespace AppKit {
 		void UserDidChangeVisibility (NSOutlineView outlineView, NSTableColumn [] columns);
 	}
 
+	interface INSOutlineViewDataSource { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -9532,14 +9548,14 @@ namespace AppKit {
 #if NET
 		NSDragOperation ValidateDrop (NSOutlineView outlineView, INSDraggingInfo info, [NullAllowed] NSObject item, nint index);
 #else
-		NSDragOperation ValidateDrop (NSOutlineView outlineView, [Protocolize (4)] NSDraggingInfo info, [NullAllowed] NSObject item, nint index);
+		NSDragOperation ValidateDrop (NSOutlineView outlineView, NSDraggingInfo info, [NullAllowed] NSObject item, nint index);
 #endif
 
 		[Export ("outlineView:acceptDrop:item:childIndex:")]
 #if NET
 		bool AcceptDrop (NSOutlineView outlineView, INSDraggingInfo info, [NullAllowed] NSObject item, nint index);
 #else
-		bool AcceptDrop (NSOutlineView outlineView, [Protocolize (4)] NSDraggingInfo info, [NullAllowed] NSObject item, nint index);
+		bool AcceptDrop (NSOutlineView outlineView, NSDraggingInfo info, [NullAllowed] NSObject item, nint index);
 #endif
 
 		[Export ("outlineView:namesOfPromisedFilesDroppedAtDestination:forDraggedItems:")]
@@ -9813,8 +9829,7 @@ namespace AppKit {
 
 		[NoMacCatalyst]
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSImageDelegate Delegate { get; set; }
+		INSImageDelegate Delegate { get; set; }
 
 		[NoMacCatalyst]
 		[Export ("cacheMode")]
@@ -10485,6 +10500,8 @@ namespace AppKit {
 		void UpdateAttachmentsFromPath (string path);
 	}
 
+	interface INSImageDelegate { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -11018,8 +11035,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSMatrixDelegate Delegate { get; set; }
+		INSMatrixDelegate Delegate { get; set; }
 
 		//Detected properties
 		[Export ("tabKeyTraversesCells")]
@@ -11198,6 +11214,8 @@ namespace AppKit {
 		[Export ("magnification")]
 		nfloat Magnification { get; set; }
 	}
+
+	interface INSMatrixDelegate { }
 
 	[NoMacCatalyst]
 	[Model]
@@ -11627,7 +11645,7 @@ namespace AppKit {
 		string GetAvailableTypeFromArray (string [] types);
 
 		[Export ("setDataProvider:forTypes:")]
-		bool SetDataProviderForTypes ([Protocolize] NSPasteboardItemDataProvider dataProvider, string [] types);
+		bool SetDataProviderForTypes (INSPasteboardItemDataProvider dataProvider, string [] types);
 
 		[Export ("setData:forType:")]
 		bool SetDataForType (NSData data, string type);
@@ -11654,6 +11672,8 @@ namespace AppKit {
 		SWCollaborationMetadata CollaborationMetadata { get; set; }
 
 	}
+
+	interface INSPasteboardItemDataProvider { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -11729,8 +11749,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSPathCellDelegate Delegate { get; set; }
+		INSPathCellDelegate Delegate { get; set; }
 
 		[Static, Export ("pathComponentCellClass")]
 		Class PathComponentCellClass { get; }
@@ -11770,6 +11789,8 @@ namespace AppKit {
 		[Export ("setControlSize:")]
 		void SetControlSize (NSControlSize size);
 	}
+
+	interface INSPathCellDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -11830,8 +11851,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSPathControlDelegate Delegate { get; set; }
+		INSPathControlDelegate Delegate { get; set; }
 
 		[Export ("menu", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -11857,6 +11877,8 @@ namespace AppKit {
 
 	}
 
+	interface INSPathControlDelegate { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -11869,14 +11891,14 @@ namespace AppKit {
 #if NET
 		NSDragOperation ValidateDrop (NSPathControl pathControl, INSDraggingInfo info);
 #else
-		NSDragOperation ValidateDrop (NSPathControl pathControl, [Protocolize (4)] NSDraggingInfo info);
+		NSDragOperation ValidateDrop (NSPathControl pathControl, NSDraggingInfo info);
 #endif
 
 		[Export ("pathControl:acceptDrop:")]
 #if NET
 		bool AcceptDrop (NSPathControl pathControl, INSDraggingInfo info);
 #else
-		bool AcceptDrop (NSPathControl pathControl, [Protocolize (4)] NSDraggingInfo info);
+		bool AcceptDrop (NSPathControl pathControl, NSDraggingInfo info);
 #endif
 
 		[Export ("pathControl:willDisplayOpenPanel:")]
@@ -11937,8 +11959,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSPopoverDelegate Delegate { set; get; }
+		INSPopoverDelegate Delegate { set; get; }
 
 		[Export ("showRelativeToRect:ofView:preferredEdge:")]
 		void Show (CGRect relativePositioningRect, NSView positioningView, NSRectEdge preferredEdge);
@@ -11986,6 +12007,8 @@ namespace AppKit {
 		[Internal, Export ("NSPopoverCloseReasonKey")]
 		NSString _Reason { get; }
 	}
+
+	interface INSPopoverDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -13361,8 +13384,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSOpenSavePanelDelegate Delegate { get; set; }
+		INSOpenSavePanelDelegate Delegate { get; set; }
 
 		[Export ("canCreateDirectories")]
 		bool CanCreateDirectories { get; set; }
@@ -13875,8 +13897,7 @@ namespace AppKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		NSSearchFieldDelegate Delegate { get; set; }
+		INSSearchFieldDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Assign)]
 		NSObject WeakDelegate { get; set; }
@@ -13897,6 +13918,8 @@ namespace AppKit {
 		[Export ("cancelButtonBounds")]
 		CGRect CancelButtonBounds { get; }
 	}
+
+	interface INSSearchFieldDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -14409,8 +14432,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSSpeechRecognizerDelegate Delegate { get; set; }
+		INSSpeechRecognizerDelegate Delegate { get; set; }
 
 		[Export ("commands")]
 		string [] Commands { get; set; }
@@ -14424,6 +14446,8 @@ namespace AppKit {
 		[Export ("blocksOtherRecognizers")]
 		bool BlocksOtherRecognizers { get; set; }
 	}
+
+	interface INSSpeechRecognizerDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -14494,8 +14518,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSSpeechSynthesizerDelegate Delegate { get; set; }
+		INSSpeechSynthesizerDelegate Delegate { get; set; }
 
 		[Export ("voice"), Protected]
 		string GetVoice ();
@@ -14512,6 +14535,8 @@ namespace AppKit {
 		[Export ("usesFeedbackWindow")]
 		bool UsesFeedbackWindow { get; set; }
 	}
+
+	interface INSSpeechSynthesizerDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -14788,8 +14813,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSSoundDelegate Delegate { get; set; }
+		INSSoundDelegate Delegate { get; set; }
 
 		[Export ("volume")]
 		float Volume { get; set; } /* float, not CGFloat */
@@ -14807,6 +14831,8 @@ namespace AppKit {
 		[Export ("channelMapping")]
 		NSObject ChannelMapping { get; set; }
 	}
+
+	interface INSSoundDelegate { }
 
 	[NoMacCatalyst]
 	[Model, BaseType (typeof (NSObject))]
@@ -14860,8 +14886,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSSplitViewDelegate Delegate { get; set; }
+		INSSplitViewDelegate Delegate { get; set; }
 
 		[Export ("arrangesAllSubviews")]
 		bool ArrangesAllSubviews { get; set; }
@@ -15079,7 +15104,7 @@ namespace AppKit {
 #if NET
 		void Activated (bool activated, INSDraggingInfo draggingInfo);
 #else
-		void Activated (bool activated, [Protocolize (4)] NSDraggingInfo draggingInfo);
+		void Activated (bool activated, NSDraggingInfo draggingInfo);
 #endif
 
 		[Abstract]
@@ -15087,35 +15112,35 @@ namespace AppKit {
 #if NET
 		void HighlightChanged (INSDraggingInfo draggingInfo);
 #else
-		void HighlightChanged ([Protocolize (4)] NSDraggingInfo draggingInfo);
+		void HighlightChanged (NSDraggingInfo draggingInfo);
 #endif
 
 		[Export ("springLoadingEntered:")]
 #if NET
 		NSSpringLoadingOptions Entered (INSDraggingInfo draggingInfo);
 #else
-		NSSpringLoadingOptions Entered ([Protocolize (4)] NSDraggingInfo draggingInfo);
+		NSSpringLoadingOptions Entered (NSDraggingInfo draggingInfo);
 #endif
 
 		[Export ("springLoadingUpdated:")]
 #if NET
 		NSSpringLoadingOptions Updated (INSDraggingInfo draggingInfo);
 #else
-		NSSpringLoadingOptions Updated ([Protocolize (4)] NSDraggingInfo draggingInfo);
+		NSSpringLoadingOptions Updated (NSDraggingInfo draggingInfo);
 #endif
 
 		[Export ("springLoadingExited:")]
 #if NET
 		void Exited (INSDraggingInfo draggingInfo);
 #else
-		void Exited ([Protocolize (4)] NSDraggingInfo draggingInfo);
+		void Exited (NSDraggingInfo draggingInfo);
 #endif
 
 		[Export ("draggingEnded:")]
 #if NET
 		void DraggingEnded (INSDraggingInfo draggingInfo);
 #else
-		void DraggingEnded ([Protocolize (4)] NSDraggingInfo draggingInfo);
+		void DraggingEnded (NSDraggingInfo draggingInfo);
 #endif
 	}
 
@@ -15130,8 +15155,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSStackViewDelegate Delegate { get; set; }
+		INSStackViewDelegate Delegate { get; set; }
 
 		[Export ("orientation")]
 		NSUserInterfaceLayoutOrientation Orientation { get; set; }
@@ -15216,6 +15240,8 @@ namespace AppKit {
 		[Export ("removeArrangedSubview:")]
 		void RemoveArrangedSubview (NSView view);
 	}
+
+	interface INSStackViewDelegate { }
 
 	[NoMacCatalyst]
 	[Protocol, Model]
@@ -15561,6 +15587,8 @@ namespace AppKit {
 		string Identifier { get; set; }
 	}
 
+	interface INSTextFinderClient { }
+
 	[NoMacCatalyst]
 	[Protocol]
 #if !NET
@@ -15694,6 +15722,8 @@ namespace AppKit {
 
 	}
 
+	interface INSTextFinderBarContainer { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject)), Model, Protocol]
 	partial interface NSTextFinderBarContainer {
@@ -15715,12 +15745,10 @@ namespace AppKit {
 	[BaseType (typeof (NSObject))]
 	partial interface NSTextFinder : NSCoding {
 		[Export ("client", ArgumentSemantic.Assign)]
-		[Protocolize]
-		NSTextFinderClient Client { set; }
+		INSTextFinderClient Client { set; }
 
 		[Export ("findBarContainer", ArgumentSemantic.Assign)]
-		[Protocolize]
-		NSTextFinderBarContainer FindBarContainer { set; }
+		INSTextFinderBarContainer FindBarContainer { set; }
 
 		[Export ("findIndicatorNeedsUpdate")]
 		bool FindIndicatorNeedsUpdate { get; set; }
@@ -16228,7 +16256,7 @@ namespace AppKit {
 		string [] RegisteredDragTypes ();
 
 		[Export ("beginDraggingSessionWithItems:event:source:")]
-		NSDraggingSession BeginDraggingSession (NSDraggingItem [] items, NSEvent evnt, [Protocolize] NSDraggingSource source);
+		NSDraggingSession BeginDraggingSession (NSDraggingItem [] items, NSEvent evnt, INSDraggingSource source);
 
 		[Deprecated (PlatformName.MacOSX, 10, 7, message: "Use BeginDraggingSession instead.")]
 		[Export ("dragImage:at:offset:event:pasteboard:source:slideBack:")]
@@ -16773,7 +16801,7 @@ namespace AppKit {
 		NSViewController PresentingViewController { get; }
 
 		[Export ("presentViewController:animator:")]
-		void PresentViewController (NSViewController viewController, [Protocolize] NSViewControllerPresentationAnimator animator);
+		void PresentViewController (NSViewController viewController, INSViewControllerPresentationAnimator animator);
 
 		[Export ("dismissViewController:")]
 		void DismissViewController (NSViewController viewController);
@@ -16880,8 +16908,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate"), NullAllowed]
-		[Protocolize]
-		NSPageControllerDelegate Delegate { get; set; }
+		INSPageControllerDelegate Delegate { get; set; }
 
 		[Export ("arrangedObjects", ArgumentSemantic.Copy)]
 		NSObject [] ArrangedObjects { get; set; }
@@ -16910,6 +16937,8 @@ namespace AppKit {
 		[Export ("navigateForward:")]
 		void NavigateForward (NSObject sender);
 	}
+
+	interface INSPageControllerDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject)), Model, Protocol]
@@ -17322,8 +17351,7 @@ namespace AppKit {
 
 		[Wrap ("WeakDataSource")]
 		[NullAllowed]
-		[Protocolize]
-		NSTableViewDataSource DataSource { get; set; }
+		INSTableViewDataSource DataSource { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -17331,8 +17359,7 @@ namespace AppKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		NSTableViewDelegate Delegate { get; set; }
+		INSTableViewDelegate Delegate { get; set; }
 
 		[Export ("headerView", ArgumentSemantic.Retain), NullAllowed]
 		NSTableHeaderView HeaderView { get; set; }
@@ -17497,6 +17524,8 @@ namespace AppKit {
 		NSTableViewStyle EffectiveStyle { get; }
 	}
 
+	interface INSTableViewDelegate { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -17589,6 +17618,8 @@ namespace AppKit {
 		NSTableViewRowAction [] RowActions (NSTableView tableView, nint row, NSTableRowActionEdge edge);
 	}
 
+	interface INSTableViewDataSource { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -17614,14 +17645,14 @@ namespace AppKit {
 #if NET
 		NSDragOperation ValidateDrop (NSTableView tableView, INSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
 #else
-		NSDragOperation ValidateDrop (NSTableView tableView, [Protocolize (4)] NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+		NSDragOperation ValidateDrop (NSTableView tableView, NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
 #endif
 
 		[Export ("tableView:acceptDrop:row:dropOperation:")]
 #if NET
 		bool AcceptDrop (NSTableView tableView, INSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
 #else
-		bool AcceptDrop (NSTableView tableView, [Protocolize (4)] NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+		bool AcceptDrop (NSTableView tableView, NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
 #endif
 
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'NSFilePromiseReceiver' instead.")]
@@ -17641,7 +17672,7 @@ namespace AppKit {
 #if NET
 		void UpdateDraggingItems (NSTableView tableView, INSDraggingInfo draggingInfo);
 #else
-		void UpdateDraggingItems (NSTableView tableView, [Protocolize (4)] NSDraggingInfo draggingInfo);
+		void UpdateDraggingItems (NSTableView tableView, NSDraggingInfo draggingInfo);
 #endif
 	}
 
@@ -17753,14 +17784,14 @@ namespace AppKit {
 #if NET
 		NSDragOperation ValidateDrop (NSTableView tableView, INSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
 #else
-		NSDragOperation ValidateDrop (NSTableView tableView, [Protocolize (4)] NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+		NSDragOperation ValidateDrop (NSTableView tableView, NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
 #endif
 
 		[Export ("tableView:acceptDrop:row:dropOperation:")]
 #if NET
 		bool AcceptDrop (NSTableView tableView, INSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
 #else
-		bool AcceptDrop (NSTableView tableView, [Protocolize (4)] NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
+		bool AcceptDrop (NSTableView tableView, NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
 #endif
 
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'NSFilePromiseReceiver' objects instead.")]
@@ -17792,7 +17823,7 @@ namespace AppKit {
 #if NET
 		void UpdateDraggingItems (NSTableView tableView, INSDraggingInfo draggingInfo);
 #else
-		void UpdateDraggingItems (NSTableView tableView, [Protocolize (4)] NSDraggingInfo draggingInfo);
+		void UpdateDraggingItems (NSTableView tableView, NSDraggingInfo draggingInfo);
 #endif
 	}
 
@@ -17935,8 +17966,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate", IsVirtual = true)]
-		[Protocolize]
-		NSTabViewDelegate Delegate { get; set; }
+		INSTabViewDelegate Delegate { get; set; }
 
 		[Export ("tabViewItemAtPoint:")]
 		NSTabViewItem TabViewItemAtPoint (CGPoint point);
@@ -18042,6 +18072,8 @@ namespace AppKit {
 		[Export ("toolbarSelectableItemIdentifiers:"), DelegateName ("NSToolbarIdentifiers")]
 		new string [] SelectableItemIdentifiers (NSToolbar toolbar);
 	}
+
+	interface INSTabViewDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -18217,8 +18249,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSTextDelegate Delegate { get; set; }
+		INSTextDelegate Delegate { get; set; }
 
 		[Export ("editable")]
 		bool Editable { [Bind ("isEditable")] get; set; }
@@ -18271,6 +18302,8 @@ namespace AppKit {
 		[Export ("verticallyResizable")]
 		bool VerticallyResizable { [Bind ("isVerticallyResizable")] get; set; }
 	}
+
+	interface INSTextDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -18476,8 +18509,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSTextFieldDelegate Delegate { get; set; }
+		INSTextFieldDelegate Delegate { get; set; }
 
 		[Export ("bezelStyle")]
 		NSTextFieldBezelStyle BezelStyle { get; set; }
@@ -18605,6 +18637,8 @@ namespace AppKit {
 		bool ShouldSelectCandidate (NSTextField textField, NSTextView textView, nuint index);
 	}
 
+	interface INSComboBoxDelegate { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSTextFieldDelegate))]
 	[Model]
@@ -18622,6 +18656,8 @@ namespace AppKit {
 		[Export ("comboBoxSelectionIsChanging:")]
 		void SelectionIsChanging (NSNotification notification);
 	}
+
+	interface INSTokenFieldCellDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -18733,8 +18769,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSTokenFieldCellDelegate Delegate { get; set; }
+		INSTokenFieldCellDelegate Delegate { get; set; }
 	}
 
 	[NoMacCatalyst]
@@ -18754,7 +18789,7 @@ namespace AppKit {
 	partial interface NSTextInputContext {
 		[Export ("initWithClient:")]
 		[DesignatedInitializer]
-		NativeHandle Constructor ([Protocolize] NSTextInputClient client);
+		NativeHandle Constructor (INSTextInputClient client);
 
 		[Static]
 		[Export ("currentInputContext")]
@@ -19153,7 +19188,7 @@ namespace AppKit {
 #if NET
 		NSDragOperation DragOperationForDraggingInfo (INSDraggingInfo dragInfo, string type);
 #else
-		NSDragOperation DragOperationForDraggingInfo ([Protocolize (4)] NSDraggingInfo dragInfo, string type);
+		NSDragOperation DragOperationForDraggingInfo (NSDraggingInfo dragInfo, string type);
 #endif
 
 		[Export ("cleanUpAfterDragOperation")]
@@ -19272,8 +19307,7 @@ namespace AppKit {
 		bool AllowsImageEditing { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSTextViewDelegate Delegate { get; set; }
+		INSTextViewDelegate Delegate { get; set; }
 
 #pragma warning disable 0109 // warning CS0109: The member 'NSTextView.Editable' does not hide an accessible member. The new keyword is not required.
 		[Export ("editable")]
@@ -19587,6 +19621,8 @@ namespace AppKit {
 		NSTextCursorAccessoryPlacement PreferredTextAccessoryPlacement { get; }
 	}
 
+	interface INSTextViewDelegate { }
+
 	[NoiOS]
 	[NoMacCatalyst]
 	[BaseType (typeof (NSTextDelegate))]
@@ -19703,12 +19739,13 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSTokenFieldDelegate Delegate { get; set; }
+		INSTokenFieldDelegate Delegate { get; set; }
 
 		[Export ("tokenizingCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet CharacterSet { get; set; }
 	}
+
+	interface INSTokenFieldDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -19796,8 +19833,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSToolbarDelegate Delegate { get; set; }
+		INSToolbarDelegate Delegate { get; set; }
 
 		[Export ("visible")]
 		bool Visible { [Bind ("isVisible")] get; set; }
@@ -19897,6 +19933,8 @@ namespace AppKit {
 		[Field ("NSToolbarInspectorTrackingSeparatorItemIdentifier")]
 		NSString NSToolbarInspectorTrackingSeparatorItemIdentifier { get; }
 	}
+
+	interface INSToolbarDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -20543,8 +20581,7 @@ namespace AppKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		NSWindowDelegate Delegate { get; set; }
+		INSWindowDelegate Delegate { get; set; }
 
 		[Export ("windowNumber")]
 		nint WindowNumber { get; }
@@ -21607,6 +21644,8 @@ namespace AppKit {
 		void DismissController (NSObject sender);
 	}
 
+	interface INSWindowDelegate { }
+
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -22451,8 +22490,7 @@ namespace AppKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSRuleEditorDelegate Delegate { get; set; }
+		INSRuleEditorDelegate Delegate { get; set; }
 
 		[Export ("formattingStringsFilename")]
 		string FormattingStringsFilename { get; set; }
@@ -22487,6 +22525,8 @@ namespace AppKit {
 		[Export ("displayValuesKeyPath")]
 		string DisplayValuesKeyPath { get; set; }
 	}
+
+	interface INSRuleEditorDelegate { }
 
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]
@@ -22553,8 +22593,7 @@ namespace AppKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		NSSharingServiceDelegate Delegate { get; set; }
+		INSSharingServiceDelegate Delegate { get; set; }
 
 		[Export ("title", ArgumentSemantic.Copy)]
 		string Title { get; }
@@ -22742,8 +22781,7 @@ namespace AppKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		NSSharingServicePickerDelegate Delegate { get; set; }
+		INSSharingServicePickerDelegate Delegate { get; set; }
 
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
@@ -22983,7 +23021,7 @@ namespace AppKit {
 #if NET
 		void UpdateDraggingItemsForDrag (NSCollectionView collectionView, INSDraggingInfo draggingInfo);
 #else
-		void UpdateDraggingItemsForDrag (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo);
+		void UpdateDraggingItemsForDrag (NSCollectionView collectionView, NSDraggingInfo draggingInfo);
 #endif
 
 		[Export ("collectionView:draggingSession:willBeginAtPoint:forItemsAtIndexes:")]
@@ -23108,7 +23146,7 @@ namespace AppKit {
 #if NET
 		void UpdateDraggingItemsForDrag (NSOutlineView outlineView, INSDraggingInfo draggingInfo);
 #else
-		void UpdateDraggingItemsForDrag (NSOutlineView outlineView, [Protocolize (4)] NSDraggingInfo draggingInfo);
+		void UpdateDraggingItemsForDrag (NSOutlineView outlineView, NSDraggingInfo draggingInfo);
 #endif
 	}
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1608,8 +1608,7 @@ namespace AVFoundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate"), NullAllowed]
-		[Protocolize]
-		AVAudioPlayerDelegate Delegate { get; set; }
+		IAVAudioPlayerDelegate Delegate { get; set; }
 
 		[Export ("url"), NullAllowed]
 		NSUrl Url { get; }
@@ -1685,6 +1684,8 @@ namespace AVFoundation {
 		[NullAllowed, Export ("currentDevice")]
 		string CurrentDevice { get; set; }
 	}
+
+	interface IAVAudioPlayerDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -1845,8 +1846,7 @@ namespace AVFoundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate"), NullAllowed]
-		[Protocolize]
-		AVAudioRecorderDelegate Delegate { get; set; }
+		IAVAudioRecorderDelegate Delegate { get; set; }
 
 #if !XAMCORE_5_0
 		[Obsolete ("Use the 'CurrentTime' property instead.")]
@@ -1890,6 +1890,8 @@ namespace AVFoundation {
 		[Export ("format")]
 		AVAudioFormat Format { get; }
 	}
+
+	interface IAVAudioRecorderDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -1983,13 +1985,12 @@ namespace AVFoundation {
 
 		[NoWatch, NoMac]
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
 		[NullAllowed]
 		[Deprecated (PlatformName.iOS, 6, 0, message: "Use 'AVAudioSession.Notification.Observe*' methods instead.")]
 		[NoTV]
 		[MacCatalyst (13, 1)]
 		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'AVAudioSession.Notification.Observe*' methods instead.")]
-		AVAudioSessionDelegate Delegate { get; set; }
+		IAVAudioSessionDelegate Delegate { get; set; }
 
 		[NoMac]
 		[MacCatalyst (13, 1)]
@@ -2835,6 +2836,8 @@ namespace AVFoundation {
 		[Export ("AVAudioSessionRouteChangePreviousRouteKey")]
 		AVAudioSessionRouteDescription PreviousRoute { get; }
 	}
+
+	interface IAVAudioSessionDelegate { }
 
 	[NoMac]
 	[Deprecated (PlatformName.iOS, 6, 0)]
@@ -4095,8 +4098,7 @@ namespace AVFoundation {
 		[NoWatch]
 		[MacCatalyst (13, 1)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
-		[Protocolize]
-		AVVideoCompositing CustomVideoCompositor { get; }
+		IAVVideoCompositing CustomVideoCompositor { get; }
 	}
 
 	[NoWatch]
@@ -4326,8 +4328,7 @@ namespace AVFoundation {
 		[NoWatch]
 		[MacCatalyst (13, 1)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
-		[Protocolize]
-		AVVideoCompositing CustomVideoCompositor { get; }
+		IAVVideoCompositing CustomVideoCompositor { get; }
 	}
 
 	[NoWatch]
@@ -4336,20 +4337,21 @@ namespace AVFoundation {
 	[DisableDefaultCtor] // no valid handle, docs now says "You do not create resource loader objects yourself."
 	interface AVAssetResourceLoader {
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
-		[Protocolize]
-		AVAssetResourceLoaderDelegate Delegate { get; }
+		IAVAssetResourceLoaderDelegate Delegate { get; }
 
 		[Export ("delegateQueue"), NullAllowed]
 		DispatchQueue DelegateQueue { get; }
 
 		[Export ("setDelegate:queue:")]
-		void SetDelegate ([Protocolize][NullAllowed] AVAssetResourceLoaderDelegate resourceLoaderDelegate, [NullAllowed] DispatchQueue delegateQueue);
+		void SetDelegate ([NullAllowed] IAVAssetResourceLoaderDelegate resourceLoaderDelegate, [NullAllowed] DispatchQueue delegateQueue);
 
 		// AVAssetResourceLoader (AVAssetResourceLoaderContentKeySupport) Category
 		[MacCatalyst (13, 1)]
 		[Export ("preloadsEligibleContentKeys")]
 		bool PreloadsEligibleContentKeys { get; set; }
 	}
+
+	interface IAVAssetResourceLoaderDelegate { }
 
 	[Watch (6, 0)]
 	[MacCatalyst (13, 1)]
@@ -8764,8 +8766,7 @@ namespace AVFoundation {
 		[NoWatch]
 		[MacCatalyst (13, 1)]
 		[NullAllowed, Export ("customVideoCompositor", ArgumentSemantic.Copy)]
-		[Protocolize]
-		AVVideoCompositing CustomVideoCompositor { get; }
+		IAVVideoCompositing CustomVideoCompositor { get; }
 
 		// DOC: Use the values from AVAudioTimePitchAlgorithm class.
 		[MacCatalyst (13, 1)]
@@ -8893,6 +8894,8 @@ namespace AVFoundation {
 		NSString AudioTimePitchAlgorithm { get; set; }
 	}
 
+	interface IAVVideoCompositing { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[Model, BaseType (typeof (NSObject))]
@@ -8967,7 +8970,7 @@ namespace AVFoundation {
 		[NoWatch]
 		[MacCatalyst (13, 1)]
 		[Export ("isValidForAsset:timeRange:validationDelegate:")]
-		bool IsValidForAsset ([NullAllowed] AVAsset asset, CMTimeRange timeRange, [Protocolize][NullAllowed] AVVideoCompositionValidationHandling validationDelegate);
+		bool IsValidForAsset ([NullAllowed] AVAsset asset, CMTimeRange timeRange, [NullAllowed] IAVVideoCompositionValidationHandling validationDelegate);
 
 		[MacCatalyst (13, 1)]
 		[Static, Export ("videoCompositionWithPropertiesOfAsset:")]
@@ -9030,6 +9033,8 @@ namespace AVFoundation {
 		[Export ("newPixelBuffer")]
 		CVPixelBuffer CreatePixelBuffer ();
 	}
+
+	interface IAVVideoCompositionValidationHandling { }
 
 	[Watch (6, 0)]
 	[MacCatalyst (13, 1)]
@@ -9823,7 +9828,7 @@ namespace AVFoundation {
 		NSString [] AvailableOutputFileTypes ();
 
 		[Export ("startRecordingToOutputFileURL:outputFileType:recordingDelegate:")]
-		void StartRecording (NSUrl outputFileUrl, string fileType, [Protocolize] AVCaptureFileOutputRecordingDelegate recordingDelegate);
+		void StartRecording (NSUrl outputFileUrl, string fileType, IAVCaptureFileOutputRecordingDelegate recordingDelegate);
 	}
 
 	[NoiOS, NoWatch, NoTV, NoMacCatalyst]
@@ -10044,8 +10049,7 @@ namespace AVFoundation {
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureVideoDataOutput {
 		[NullAllowed, Export ("sampleBufferDelegate")]
-		[Protocolize]
-		AVCaptureVideoDataOutputSampleBufferDelegate SampleBufferDelegate { get; }
+		IAVCaptureVideoDataOutputSampleBufferDelegate SampleBufferDelegate { get; }
 
 		[NullAllowed, Export ("sampleBufferCallbackQueue")]
 		DispatchQueue SampleBufferCallbackQueue { get; }
@@ -10149,8 +10153,7 @@ namespace AVFoundation {
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureAudioDataOutput {
 		[NullAllowed, Export ("sampleBufferDelegate")]
-		[Protocolize]
-		AVCaptureAudioDataOutputSampleBufferDelegate SampleBufferDelegate { get; }
+		IAVCaptureAudioDataOutputSampleBufferDelegate SampleBufferDelegate { get; }
 
 		[NullAllowed, Export ("sampleBufferCallbackQueue")]
 		DispatchQueue SampleBufferCallbackQueue { get; }
@@ -10271,7 +10274,7 @@ namespace AVFoundation {
 		NSUrl OutputFileURL { get; } // FIXME: should have been Url.
 
 		[Export ("startRecordingToOutputFileURL:recordingDelegate:")]
-		void StartRecordingToOutputFile (NSUrl outputFileUrl, [Protocolize] AVCaptureFileOutputRecordingDelegate recordingDelegate);
+		void StartRecordingToOutputFile (NSUrl outputFileUrl, IAVCaptureFileOutputRecordingDelegate recordingDelegate);
 
 		[Export ("stopRecording")]
 		void StopRecording ();
@@ -10330,8 +10333,7 @@ namespace AVFoundation {
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureMetadataOutput {
 		[NullAllowed, Export ("metadataObjectsDelegate")]
-		[Protocolize]
-		AVCaptureMetadataOutputObjectsDelegate Delegate { get; }
+		IAVCaptureMetadataOutputObjectsDelegate Delegate { get; }
 
 		[NullAllowed, Export ("metadataObjectsCallbackQueue")]
 		DispatchQueue CallbackQueue { get; }
@@ -10344,12 +10346,14 @@ namespace AVFoundation {
 		NSString [] WeakMetadataObjectTypes { get; set; }
 
 		[Export ("setMetadataObjectsDelegate:queue:")]
-		void SetDelegate ([NullAllowed][Protocolize] AVCaptureMetadataOutputObjectsDelegate objectsDelegate, [NullAllowed] DispatchQueue objectsCallbackQueue);
+		void SetDelegate ([NullAllowed] IAVCaptureMetadataOutputObjectsDelegate objectsDelegate, [NullAllowed] DispatchQueue objectsCallbackQueue);
 
 		[Export ("rectOfInterest", ArgumentSemantic.Copy)]
 		CGRect RectOfInterest { get; set; }
 
 	}
+
+	interface IAVCaptureMetadataOutputObjectsDelegate { }
 
 	[NoWatch]
 	[NoTV]
@@ -13077,8 +13081,7 @@ namespace AVFoundation {
 		[NoWatch]
 		[MacCatalyst (13, 1)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
-		[Protocolize]
-		AVVideoCompositing CustomVideoCompositor { get; }
+		IAVVideoCompositing CustomVideoCompositor { get; }
 
 		[MacCatalyst (13, 1)]
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
@@ -13335,8 +13338,7 @@ namespace AVFoundation {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		AVPlayerItemMetadataOutputPushDelegate Delegate { get; }
+		IAVPlayerItemMetadataOutputPushDelegate Delegate { get; }
 
 		[Export ("delegateQueue"), NullAllowed]
 		DispatchQueue DelegateQueue { get; }
@@ -13345,8 +13347,10 @@ namespace AVFoundation {
 		double AdvanceIntervalForDelegateInvocation { get; set; }
 
 		[Export ("setDelegate:queue:")]
-		void SetDelegate ([Protocolize][NullAllowed] AVPlayerItemMetadataOutputPushDelegate pushDelegate, [NullAllowed] DispatchQueue delegateQueue);
+		void SetDelegate ([NullAllowed] IAVPlayerItemMetadataOutputPushDelegate pushDelegate, [NullAllowed] DispatchQueue delegateQueue);
 	}
+
+	interface IAVPlayerItemMetadataOutputPushDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Watch (6, 0)]
@@ -13569,8 +13573,7 @@ namespace AVFoundation {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		AVPlayerItemOutputPullDelegate Delegate { get; }
+		IAVPlayerItemOutputPullDelegate Delegate { get; }
 
 		[Export ("delegateQueue"), NullAllowed]
 		DispatchQueue DelegateQueue { get; }
@@ -13600,11 +13603,13 @@ namespace AVFoundation {
 		IntPtr WeakCopyPixelBuffer (CMTime itemTime, ref CMTime outItemTimeForDisplay);
 
 		[Export ("setDelegate:queue:")]
-		void SetDelegate ([Protocolize][NullAllowed] AVPlayerItemOutputPullDelegate delegateClass, [NullAllowed] DispatchQueue delegateQueue);
+		void SetDelegate ([NullAllowed] IAVPlayerItemOutputPullDelegate delegateClass, [NullAllowed] DispatchQueue delegateQueue);
 
 		[Export ("requestNotificationOfMediaDataChangeWithAdvanceInterval:")]
 		void RequestNotificationOfMediaDataChange (double advanceInterval);
 	}
+
+	interface IAVPlayerItemOutputPullDelegate { }
 
 	[Watch (6, 0)]
 	[MacCatalyst (13, 1)]
@@ -13629,6 +13634,8 @@ namespace AVFoundation {
 		void OutputSequenceWasFlushed (AVPlayerItemOutput output);
 	}
 
+	interface IAVPlayerItemLegibleOutputPushDelegate { }
+
 	[Watch (6, 0)]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (AVPlayerItemOutputPushDelegate))]
@@ -13649,11 +13656,10 @@ namespace AVFoundation {
 		NativeHandle Constructor (NSNumber [] subtypesFourCCcodes);
 
 		[Export ("setDelegate:queue:")]
-		void SetDelegate ([Protocolize][NullAllowed] AVPlayerItemLegibleOutputPushDelegate delegateObject, [NullAllowed] DispatchQueue delegateQueue);
+		void SetDelegate ([NullAllowed] IAVPlayerItemLegibleOutputPushDelegate delegateObject, [NullAllowed] DispatchQueue delegateQueue);
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Copy)]
-		[Protocolize]
-		AVPlayerItemLegibleOutputPushDelegate Delegate { get; }
+		IAVPlayerItemLegibleOutputPushDelegate Delegate { get; }
 
 		[NullAllowed, Export ("delegateQueue", ArgumentSemantic.Copy)]
 		DispatchQueue DelegateQueue { get; }
@@ -14480,8 +14486,7 @@ namespace AVFoundation {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		AVSpeechSynthesizerDelegate Delegate { get; set; }
+		IAVSpeechSynthesizerDelegate Delegate { get; set; }
 
 		[Export ("speaking")]
 		bool Speaking { [Bind ("isSpeaking")] get; }
@@ -14521,6 +14526,8 @@ namespace AVFoundation {
 		[NullAllowed, Export ("outputChannels", ArgumentSemantic.Retain)]
 		AVAudioSessionChannelDescription [] OutputChannels { get; set; }
 	}
+
+	interface IAVSpeechSynthesizerDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[Model]

--- a/src/avkit.cs
+++ b/src/avkit.cs
@@ -225,8 +225,7 @@ namespace AVKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		AVPlayerViewControllerDelegate Delegate { get; set; }
+		IAVPlayerViewControllerDelegate Delegate { get; set; }
 
 		[MacCatalyst (13, 1)]
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
@@ -353,6 +352,8 @@ namespace AVKit {
 		[Export ("selectSpeed:")]
 		void SelectSpeed (AVPlaybackSpeed speed);
 	}
+
+	interface IAVPlayerViewControllerDelegate { }
 
 	[NoMac]
 	[MacCatalyst (13, 1)]
@@ -615,8 +616,7 @@ namespace AVKit {
 		[Mac (12, 0)]
 		[NoMacCatalyst]
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		AVPlayerViewDelegate Delegate { get; set; }
+		IAVPlayerViewDelegate Delegate { get; set; }
 
 		[Mac (12, 0)]
 		[NoMacCatalyst]
@@ -1030,6 +1030,8 @@ namespace AVKit {
 		[Export ("pictureInPictureControllerShouldProhibitBackgroundAudioPlayback:")]
 		bool ShouldProhibitBackgroundAudioPlayback (AVPictureInPictureController pictureInPictureController);
 	}
+
+	interface IAVPlayerViewDelegate { }
 
 	[Mac (12, 0), NoiOS, NoTV, NoMacCatalyst]
 #if NET

--- a/src/bgen/AttributeManager.cs
+++ b/src/bgen/AttributeManager.cs
@@ -176,8 +176,6 @@ public class AttributeManager {
 			return typeof (PrivateDefaultCtorAttribute);
 		case "ProtectedAttribute":
 			return typeof (ProtectedAttribute);
-		case "ProtocolizeAttribute":
-			return typeof (ProtocolizeAttribute);
 		case "SealedAttribute":
 			return typeof (SealedAttribute);
 		case "StaticAttribute":

--- a/src/bgen/Attributes.cs
+++ b/src/bgen/Attributes.cs
@@ -52,6 +52,7 @@ public class ForcedTypeAttribute : Attribute {
 	public bool Owns;
 }
 
+#if !XAMCORE_5_0
 // Used to flag a type as needing to be turned into a protocol on output for Unified
 // For example:
 //   [Protocolize, Wrap ("WeakDelegate")]
@@ -66,6 +67,7 @@ public class ForcedTypeAttribute : Attribute {
 //
 // To protocolize newer versions, use [Protocolize (3)] for XAMCORE_3_0, [Protocolize (4)] for NET, etc
 //
+[Obsolete ("This attribute no longer has any effect; do no use")]
 public class ProtocolizeAttribute : Attribute {
 	public ProtocolizeAttribute ()
 	{
@@ -79,6 +81,7 @@ public class ProtocolizeAttribute : Attribute {
 
 	public int Version { get; set; }
 }
+#endif
 
 // Used to mark if a type is not a wrapper type.
 public class SyntheticAttribute : Attribute {

--- a/src/bgen/Attributes.cs
+++ b/src/bgen/Attributes.cs
@@ -67,7 +67,7 @@ public class ForcedTypeAttribute : Attribute {
 //
 // To protocolize newer versions, use [Protocolize (3)] for XAMCORE_3_0, [Protocolize (4)] for NET, etc
 //
-[Obsolete ("This attribute no longer has any effect; do no use")]
+[Obsolete ("This attribute no longer has any effect; do not use")]
 public class ProtocolizeAttribute : Attribute {
 	public ProtocolizeAttribute ()
 	{

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -303,18 +303,6 @@ public partial class Generator : IMemberGatherer {
 		return AttributeManager.HasAttribute<ProtocolAttribute> (protocol);
 	}
 
-	string FindProtocolInterface (Type type, MemberInfo pi)
-	{
-		var isArray = type.IsArray;
-		var declType = isArray ? type.GetElementType () : type;
-
-		if (!AttributeManager.HasAttribute<ProtocolAttribute> (declType))
-			throw new BindingException (1034, true,
-				pi.DeclaringType, pi.Name, declType);
-
-		return "I" + type.Name;
-	}
-
 	public BindAsAttribute GetBindAsAttribute (ICustomAttributeProvider cu)
 	{
 		BindAsAttribute rv;
@@ -2641,16 +2629,6 @@ public partial class Generator : IMemberGatherer {
 		return AttributeManager.HasAttribute<ProtocolAttribute> (type);
 	}
 
-	public bool Protocolize (ICustomAttributeProvider provider)
-	{
-		var attribs = AttributeManager.GetCustomAttributes<ProtocolizeAttribute> (provider);
-		if (attribs is null || attribs.Length == 0)
-			return false;
-
-		var attrib = attribs [0];
-		return CurrentPlatform.GetXamcoreVersion () >= attrib.Version;
-	}
-
 	public string MakeSignature (MemberInformation minfo, bool is_async, ParameterInfo [] parameters, string extra = "", bool alreadyPreserved = false)
 	{
 		var mi = minfo.Method;
@@ -2664,20 +2642,12 @@ public partial class Generator : IMemberGatherer {
 		if (!minfo.is_ctor && !is_async) {
 			var prefix = "";
 			if (!BindThirdPartyLibrary) {
-				var hasReturnTypeProtocolize = Protocolize (minfo.Method.ReturnParameter);
-				if (hasReturnTypeProtocolize) {
-					if (!IsProtocol (minfo.Method.ReturnType)) {
-						ErrorHelper.Warning (1108, minfo.Method.DeclaringType, minfo.Method, minfo.Method.ReturnType.FullName);
-					} else {
-						prefix = "I";
-					}
-				}
 				if (minfo.Method.ReturnType.IsArray) {
 					var et = minfo.Method.ReturnType.GetElementType ();
 					if (IsModel (et))
 						ErrorHelper.Warning (1109, minfo.Method.DeclaringType, minfo.Method.Name, et, et.Namespace, et.Name);
 				}
-				if (IsModel (minfo.Method.ReturnType) && !hasReturnTypeProtocolize)
+				if (IsModel (minfo.Method.ReturnType))
 					ErrorHelper.Warning (1107, minfo.Method.DeclaringType, minfo.Method.Name, minfo.Method.ReturnType, minfo.Method.ReturnType.Namespace, minfo.Method.ReturnType.Name);
 			}
 
@@ -2759,23 +2729,16 @@ public partial class Generator : IMemberGatherer {
 			if (pari == parCount - 1 && parType.IsArray && (AttributeManager.HasAttribute<ParamsAttribute> (pi) || AttributeManager.HasAttribute<ParamArrayAttribute> (pi))) {
 				sb.Append ("params ");
 			}
-			var protocolized = false;
-			if (!BindThirdPartyLibrary && Protocolize (pi)) {
-				if (!AttributeManager.HasAttribute<ProtocolAttribute> (parType)) {
-					Console.WriteLine ("Protocolized attribute for type that does not have a [Protocol] for {0}'s parameter {1}", mi, pi);
-				}
-				protocolized = true;
-			}
 
 			var bindAsAtt = GetBindAsAttribute (pi);
 			if (bindAsAtt is not null) {
 				PrintBindAsAttribute (pi, sb);
 				var bt = bindAsAtt.Type;
-				sb.Append (TypeManager.FormatType (bt.DeclaringType, bt, protocolized));
+				sb.Append (TypeManager.FormatType (bt.DeclaringType, bt));
 				if (!bt.IsValueType && AttributeManager.HasAttribute<NullAllowedAttribute> (pi))
 					sb.Append ('?');
 			} else {
-				sb.Append (TypeManager.FormatType (declaringType, parType, protocolized));
+				sb.Append (TypeManager.FormatType (declaringType, parType));
 				// some `IntPtr` are decorated with `[NullAttribute]`
 				if (!parType.IsValueType && AttributeManager.HasAttribute<NullAllowedAttribute> (pi))
 					sb.Append ('?');
@@ -2830,9 +2793,6 @@ public partial class Generator : IMemberGatherer {
 			// protocol support means we can return interfaces and, as far as .NET knows, they might not be NSObject
 			if (IsProtocolInterface (mi.ReturnType)) {
 				cast_a = " Runtime.GetINativeObject<" + TypeManager.FormatType (mi.DeclaringType, mi.ReturnType) + "> (";
-				cast_b = ", false)!";
-			} else if (minfo is not null && minfo.protocolize) {
-				cast_a = " Runtime.GetINativeObject<" + TypeManager.FormatType (mi.DeclaringType, mi.ReturnType.Namespace, FindProtocolInterface (mi.ReturnType, mi)) + "> (";
 				cast_b = ", false)!";
 			} else if (minfo is not null && minfo.is_forced) {
 				cast_a = " Runtime.GetINativeObject<" + TypeManager.FormatType (declaringType, mi.ReturnType) + "> (";
@@ -2890,9 +2850,6 @@ public partial class Generator : IMemberGatherer {
 				cast_b += "))";
 			} else if (etype == TypeCache.System_String) {
 				cast_a = "CFArray.StringArrayFromHandle (";
-				cast_b = ")!";
-			} else if (minfo is not null && minfo.protocolize) {
-				cast_a = "CFArray.ArrayFromHandle<global::" + etype.Namespace + ".I" + etype.Name + ">(";
 				cast_b = ")!";
 			} else if (etype == TypeCache.Selector) {
 				exceptions.Add (ErrorHelper.CreateError (1066, mai.Type.FullName, mi.DeclaringType.FullName, mi.Name));
@@ -3382,9 +3339,8 @@ public partial class Generator : IMemberGatherer {
 
 		foreach (var pi in mi.GetParameters ()) {
 			var safe_name = pi.Name.GetSafeParamName ();
-			bool protocolize = Protocolize (pi);
 			if (!BindThirdPartyLibrary) {
-				if (!mi.IsSpecialName && IsModel (pi.ParameterType) && !protocolize) {
+				if (!mi.IsSpecialName && IsModel (pi.ParameterType)) {
 					// don't warn on obsoleted API, there's likely a new version that fix this
 					// any no good reason for using the obsolete API anyway
 					if (!AttributeManager.HasAttribute<ObsoleteAttribute> (mi) && !AttributeManager.HasAttribute<ObsoleteAttribute> (mi.DeclaringType))
@@ -3393,13 +3349,6 @@ public partial class Generator : IMemberGatherer {
 			}
 
 			var needs_null_check = ParameterNeedsNullCheck (pi, mi, propInfo);
-			if (protocolize) {
-				print ("if ({0} is not null) {{", safe_name);
-				print ("\tif (!({0} is NSObject))\n", safe_name);
-				print ("\t\tthrow new ArgumentException (\"The object passed of type \" + {0}.GetType () + \" does not derive from NSObject\");", safe_name);
-				print ("}");
-			}
-
 			var cap = propInfo?.SetMethod == mi ? (ICustomAttributeProvider) propInfo : (ICustomAttributeProvider) pi;
 			var bind_as = GetBindAsAttribute (cap);
 			var pit = bind_as is null ? pi.ParameterType : bind_as.Type;
@@ -3549,8 +3498,6 @@ public partial class Generator : IMemberGatherer {
 				print ("IntPtr ret_alloced = Marshal.AllocHGlobal (Marshal.SizeOf<{0}> () + {1});", TypeManager.FormatType (mi.DeclaringType, mi.ReturnType), align.Align);
 				print ("IntPtr aligned_ret = new IntPtr (((nint) (ret_alloced + {0}) >> {1}) << {1});", align.Align - 1, align.Bits);
 				print ("bool aligned_assigned = false;");
-			} else if (minfo.protocolize) {
-				print ("{0} ret;", TypeManager.FormatType (mi.DeclaringType, mi.ReturnType.Namespace, FindProtocolInterface (mi.ReturnType, mi)));
 			} else if (minfo.is_bindAs) {
 				var bindAsAttrib = GetBindAsAttribute (minfo.mi);
 				// tricky, e.g. when an nullable `NSNumber[]` is bound as a `float[]`, since FormatType and bindAsAttrib have not clue about the original nullability 
@@ -3862,7 +3809,6 @@ public partial class Generator : IMemberGatherer {
 		var minfo = new MemberInformation (this, this, pi, type, is_interface_impl);
 		var mod = minfo.GetVisibility ();
 		Type inlinedType = pi.DeclaringType == type ? null : type;
-		minfo.protocolize = Protocolize (pi);
 		GetAccessorInfo (pi, out var getter, out var setter, out var generate_getter, out var generate_setter);
 
 		var nullable = !pi.PropertyType.IsValueType && AttributeManager.HasAttribute<NullAllowedAttribute> (pi);
@@ -3886,7 +3832,7 @@ public partial class Generator : IMemberGatherer {
 		if (!BindThirdPartyLibrary) {
 			var elType = pi.PropertyType.IsArray ? pi.PropertyType.GetElementType () : pi.PropertyType;
 
-			if (IsModel (elType) && !minfo.protocolize) {
+			if (IsModel (elType)) {
 				ErrorHelper.Warning (1110, pi.DeclaringType, pi.Name, pi.PropertyType, pi.PropertyType.Namespace, pi.PropertyType.Name);
 			}
 		}
@@ -3898,7 +3844,7 @@ public partial class Generator : IMemberGatherer {
 			print ("{0} {1}{2}{3} {4} {{",
 				   mod,
 				   minfo.GetModifiers (),
-				   (minfo.protocolize ? "I" : "") + TypeManager.FormatType (pi.DeclaringType, pi.PropertyType),
+				   TypeManager.FormatType (pi.DeclaringType, pi.PropertyType),
 				   nullable ? "?" : String.Empty,
 					pi.Name.GetSafeParamName ());
 			indent++;
@@ -3919,7 +3865,7 @@ public partial class Generator : IMemberGatherer {
 					else if (pi.PropertyType.IsValueType)
 						print ("return ({0}) ({1});", TypeManager.FormatType (pi.DeclaringType, pi.PropertyType), wrap);
 					else
-						print ("return ({0} as {1}{2})!;", wrap, minfo.protocolize ? "I" : String.Empty, TypeManager.FormatType (pi.DeclaringType, pi.PropertyType));
+						print ("return ({0} as {1})!;", wrap, TypeManager.FormatType (pi.DeclaringType, pi.PropertyType));
 				}
 				indent--;
 				print ("}");
@@ -3934,7 +3880,7 @@ public partial class Generator : IMemberGatherer {
 
 				var is_protocol_wrapper = IsProtocolInterface (pi.PropertyType, false);
 
-				if (minfo.protocolize || is_protocol_wrapper) {
+				if (is_protocol_wrapper) {
 					print ("var rvalue = value as NSObject;");
 					print ("if (!(value is null) && rvalue is null)");
 					print ("\tthrow new ArgumentException (\"The object passed of type \" + value.GetType () + \" does not derive from NSObject\");");
@@ -3946,7 +3892,7 @@ public partial class Generator : IMemberGatherer {
 					if (TypeManager.IsArrayOfWrappedType (pi.PropertyType))
 						print ("{0} = NSArray.FromNSObjects (value);", wrap);
 					else
-						print ("{0} = {1}value;", wrap, minfo.protocolize || is_protocol_wrapper ? "r" : "");
+						print ("{0} = {1}value;", wrap, is_protocol_wrapper ? "r" : "");
 				}
 				indent--;
 				print ("}");
@@ -3980,9 +3926,7 @@ public partial class Generator : IMemberGatherer {
 		PrintAttributes (pi, preserve: true, advice: true, bindAs: true);
 
 		string propertyTypeName;
-		if (minfo.protocolize) {
-			propertyTypeName = FindProtocolInterface (pi.PropertyType, pi);
-		} else if (minfo.is_bindAs) {
+		if (minfo.is_bindAs) {
 			var bindAsAttrib = GetBindAsAttribute (minfo.mi);
 			propertyTypeName = TypeManager.FormatType (bindAsAttrib.Type.DeclaringType, bindAsAttrib.Type);
 			// it remains nullable only if the BindAs type can be null (i.e. a reference type)
@@ -6747,11 +6691,8 @@ public partial class Generator : IMemberGatherer {
 			return false;
 
 		Type protocolType;
-		if (Protocolize (pi)) {
-			protocolType = pi.PropertyType;
-		} else if (!IsProtocolInterface (pi.DeclaringType, true, out protocolType)) {
+		if (!IsProtocolInterface (pi.PropertyType, true, out protocolType))
 			return false;
-		}
 
 		return bta.Events.Any (x => x.Name == protocolType.Name);
 	}
@@ -6866,16 +6807,14 @@ public partial class Generator : IMemberGatherer {
 
 	string RenderSingleParameter (ParameterInfo p, bool removeRefTypes)
 	{
-		var protocolized = Protocolize (p);
-		var prefix = protocolized ? "I" : "";
 		var pt = p.ParameterType;
 
 		string name;
 		if (pt.IsByRef) {
 			pt = pt.GetElementType ();
-			name = (removeRefTypes ? "" : (p.IsOut ? "out " : "ref ")) + prefix + TypeManager.RenderType (pt, p);
+			name = (removeRefTypes ? "" : (p.IsOut ? "out " : "ref ")) + TypeManager.RenderType (pt, p);
 		} else
-			name = prefix + TypeManager.RenderType (pt, p);
+			name = TypeManager.RenderType (pt, p);
 		if (!pt.IsValueType && AttributeManager.HasAttribute<NullAllowedAttribute> (p))
 			name += "?";
 		return name;

--- a/src/bgen/Models/MemberInformation.cs
+++ b/src/bgen/Models/MemberInformation.cs
@@ -38,7 +38,6 @@ public class MemberInformation {
 	public bool is_ctor;
 	public bool is_return_release;
 	public bool is_type_sealed;
-	public bool protocolize;
 	public string? selector;
 	public string? wrap_method;
 	public string is_forced_owns;

--- a/src/bgen/TypeManager.cs
+++ b/src/bgen/TypeManager.cs
@@ -167,11 +167,6 @@ public class TypeManager {
 		return FormatTypeUsedIn (usedIn?.Namespace, type);
 	}
 
-	public string FormatType (Type? usedIn, Type type, bool protocolized)
-	{
-		return FormatTypeUsedIn (usedIn?.Namespace, type, protocolized);
-	}
-
 	public string FormatType (Type? usedIn, string @namespace, string name)
 	{
 		string tname;
@@ -183,7 +178,7 @@ public class TypeManager {
 		return tname;
 	}
 
-	public string FormatTypeUsedIn (string? usedInNamespace, Type? type, bool protocolized = false)
+	public string FormatTypeUsedIn (string? usedInNamespace, Type? type)
 	{
 		if (type is null)
 			throw new BindingException (1065, true);
@@ -231,7 +226,6 @@ public class TypeManager {
 		}
 
 
-		var interfaceTag = protocolized == true ? "I" : "";
 		string tname;
 		// we are adding the usage of ReflectedType just for those cases in which we have nested enums/classes, this soluction does not
 		// work with nested/nested/nested classes. But we are not writing a general solution because:
@@ -240,13 +234,13 @@ public class TypeManager {
 		//    so we only solve the problem we have, no more.
 		var parentClass = (type.ReflectedType is null) ? String.Empty : type.ReflectedType.Name + ".";
 		if (typesThatMustAlwaysBeGloballyNamed.Contains (type.Name))
-			tname = $"global::{type.Namespace}.{parentClass}{interfaceTag}{type.Name}";
+			tname = $"global::{type.Namespace}.{parentClass}{type.Name}";
 		else if ((usedInNamespace is not null && type.Namespace == usedInNamespace) ||
 				 BindingTouch.NamespaceCache.StandardNamespaces.Contains (type.Namespace ?? String.Empty) ||
 				 string.IsNullOrEmpty (type.FullName))
-			tname = interfaceTag + type.Name;
+			tname = type.Name;
 		else
-			tname = $"global::{type.Namespace}.{parentClass}{interfaceTag}{type.Name}";
+			tname = $"global::{type.Namespace}.{parentClass}{type.Name}";
 
 		var targs = type.GetGenericArguments ();
 		if (targs.Length > 0) {

--- a/src/classkit.cs
+++ b/src/classkit.cs
@@ -407,9 +407,9 @@ namespace ClassKit {
 		[NullAllowed, Export ("runningActivity", ArgumentSemantic.Strong)]
 		CLSActivity RunningActivity { get; }
 
-		[Wrap ("WeakDelegate"), Protocolize]
+		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		CLSDataStoreDelegate Delegate { get; set; }
+		ICLSDataStoreDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		NSObject WeakDelegate { get; set; }

--- a/src/contactsui.cs
+++ b/src/contactsui.cs
@@ -238,8 +238,7 @@ namespace ContactsUI {
 		string [] DisplayedKeys { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
-		[Protocolize]
-		CNContactPickerDelegate Delegate { get; set; }
+		ICNContactPickerDelegate Delegate { get; set; }
 
 		[Export ("showRelativeToRect:ofView:preferredEdge:")]
 		void Show (CGRect positioningRect, NSView positioningView, NSRectEdge preferredEdge);

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -480,8 +480,7 @@ namespace CoreAnimation {
 		NSObject WeakDelegate { get; [PostSnippet (@"SetCALayerDelegate (value as CALayerDelegate);", Optimizable = true)] set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		CALayerDelegate Delegate { get; set; }
+		ICALayerDelegate Delegate { get; set; }
 
 		[Export ("shadowColor")]
 		[NullAllowed]
@@ -1063,6 +1062,8 @@ namespace CoreAnimation {
 		[Export ("allowsFontSubpixelQuantization")]
 		bool AllowsFontSubpixelQuantization { get; set; }
 	}
+
+	interface ICALayerDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -141,22 +141,21 @@ namespace CoreBluetooth {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		CBCentralManagerDelegate Delegate { get; set; }
+		ICBCentralManagerDelegate Delegate { get; set; }
 
 		[Export ("initWithDelegate:queue:")]
 		[PostGet ("WeakDelegate")]
-		NativeHandle Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue);
+		NativeHandle Constructor ([NullAllowed] ICBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue);
 
 		[DesignatedInitializer]
 		[MacCatalyst (13, 1)]
 		[Export ("initWithDelegate:queue:options:")]
 		[PostGet ("WeakDelegate")]
-		NativeHandle Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor ([NullAllowed] ICBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
 
 		[MacCatalyst (13, 1)]
 		[Wrap ("this (centralDelegate, queue, options.GetDictionary ())")]
-		NativeHandle Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, CBCentralInitOptions options);
+		NativeHandle Constructor ([NullAllowed] ICBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, CBCentralInitOptions options);
 
 		[Export ("scanForPeripheralsWithServices:options:"), Internal]
 		void ScanForPeripherals ([NullAllowed] NSArray serviceUUIDs, [NullAllowed] NSDictionary options);
@@ -327,6 +326,8 @@ namespace CoreBluetooth {
 		[Field ("CBCentralManagerRestoredStateScanOptionsKey")]
 		NSString ScanOptionsKey { get; }
 	}
+
+	interface ICBCentralManagerDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -552,8 +553,7 @@ namespace CoreBluetooth {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		CBPeripheralDelegate Delegate { get; set; }
+		ICBPeripheralDelegate Delegate { get; set; }
 
 		[Export ("readRSSI")]
 		void ReadRSSI ();
@@ -606,6 +606,8 @@ namespace CoreBluetooth {
 		[Export ("ancsAuthorized")]
 		bool AncsAuthorized { get; }
 	}
+
+	interface ICBPeripheralDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -903,7 +905,7 @@ namespace CoreBluetooth {
 		[MacCatalyst (13, 1)]
 		[Export ("initWithDelegate:queue:")]
 		[PostGet ("WeakDelegate")]
-		NativeHandle Constructor ([NullAllowed][Protocolize] CBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue);
+		NativeHandle Constructor ([NullAllowed] ICBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue);
 
 		[NoTV]
 		[NoWatch]
@@ -911,12 +913,11 @@ namespace CoreBluetooth {
 		[DesignatedInitializer]
 		[Export ("initWithDelegate:queue:options:")]
 		[PostGet ("WeakDelegate")]
-		NativeHandle Constructor ([NullAllowed][Protocolize] CBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
+		NativeHandle Constructor ([NullAllowed] ICBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
 
 		[NullAllowed]
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		CBPeripheralManagerDelegate Delegate { get; set; }
+		ICBPeripheralManagerDelegate Delegate { get; set; }
 
 		[NullAllowed]
 		[Export ("delegate", ArgumentSemantic.Weak)]
@@ -981,6 +982,8 @@ namespace CoreBluetooth {
 		CBPeripheralManagerAuthorizationStatus AuthorizationStatus { get; }
 #endif // !NET
 	}
+
+	interface ICBPeripheralManagerDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -569,8 +569,7 @@ namespace CoreData {
 		NativeHandle Constructor (NSFetchRequest fetchRequest, NSManagedObjectContext context, [NullAllowed] string sectionNameKeyPath, [NullAllowed] string name);
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSFetchedResultsControllerDelegate Delegate { get; set; }
+		INSFetchedResultsControllerDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -631,6 +630,8 @@ namespace CoreData {
 		[Export ("deleteCacheWithName:")]
 		void DeleteCache ([NullAllowed] string name);
 	}
+
+	interface INSFetchedResultsControllerDelegate { }
 
 	[NoMac]
 	[MacCatalyst (13, 1)]

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -229,8 +229,7 @@ namespace CoreLocation {
 	[BaseType (typeof (NSObject), Delegates = new string [] { "WeakDelegate" }, Events = new Type [] { typeof (CLLocationManagerDelegate) })]
 	partial interface CLLocationManager {
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		CLLocationManagerDelegate Delegate { get; set; }
+		ICLLocationManagerDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -585,6 +584,8 @@ namespace CoreLocation {
 		[Export ("requestHistoricalLocationsWithPurposeKey:sampleCount:completionHandler:")]
 		void RequestHistoricalLocations (string purposeKey, nint sampleCount, RequestHistoricalLocationsCompletionHandler handler);
 	}
+
+	interface ICLLocationManagerDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]

--- a/src/eventkitui.cs
+++ b/src/eventkitui.cs
@@ -40,9 +40,10 @@ namespace EventKitUI {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		EKEventViewDelegate Delegate { get; set; }
+		IEKEventViewDelegate Delegate { get; set; }
 	}
+
+	interface IEKEventViewDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -67,8 +68,7 @@ namespace EventKitUI {
 		NSObject WeakEditViewDelegate { get; set; }
 
 		[Wrap ("WeakEditViewDelegate")]
-		[Protocolize]
-		EKEventEditViewDelegate EditViewDelegate { get; set; }
+		IEKEventEditViewDelegate EditViewDelegate { get; set; }
 
 		[Export ("eventStore")]
 		EKEventStore EventStore { get; set; }
@@ -80,6 +80,8 @@ namespace EventKitUI {
 		[Export ("cancelEditing")]
 		void CancelEditing ();
 	}
+
+	interface IEKEventEditViewDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -120,8 +122,7 @@ namespace EventKitUI {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		EKCalendarChooserDelegate Delegate { get; set; }
+		IEKCalendarChooserDelegate Delegate { get; set; }
 
 		[Export ("showsDoneButton")]
 		bool ShowsDoneButton { get; set; }
@@ -133,6 +134,8 @@ namespace EventKitUI {
 		[Export ("selectedCalendars", ArgumentSemantic.Copy)]
 		NSSet SelectedCalendars { get; set; }
 	}
+
+	interface IEKCalendarChooserDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]

--- a/src/externalaccessory.cs
+++ b/src/externalaccessory.cs
@@ -56,8 +56,7 @@ namespace ExternalAccessory {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		EAAccessoryDelegate Delegate { get; set; }
+		IEAAccessoryDelegate Delegate { get; set; }
 
 		[Deprecated (PlatformName.iOS, 13, 0)]
 		[Deprecated (PlatformName.TvOS, 13, 0)]
@@ -67,6 +66,8 @@ namespace ExternalAccessory {
 		[Export ("dockType")]
 		string DockType { get; }
 	}
+
+	interface IEAAccessoryDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -210,8 +211,7 @@ namespace ExternalAccessory {
 		[MacCatalyst (13, 1)]
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		EAWiFiUnconfiguredAccessoryBrowserDelegate Delegate { get; set; }
+		IEAWiFiUnconfiguredAccessoryBrowserDelegate Delegate { get; set; }
 
 		[Export ("unconfiguredAccessories", ArgumentSemantic.Copy)]
 		NSSet UnconfiguredAccessories { get; }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -978,8 +978,7 @@ namespace Foundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSCacheDelegate Delegate { get; set; }
+		INSCacheDelegate Delegate { get; set; }
 
 		[Export ("totalCostLimit")]
 		nuint TotalCostLimit { get; set; }
@@ -990,6 +989,8 @@ namespace Foundation {
 		[Export ("evictsObjectsWithDiscardedContent")]
 		bool EvictsObjectsWithDiscardedContent { get; set; }
 	}
+
+	interface INSCacheDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -2763,6 +2764,8 @@ namespace Foundation {
 
 	interface INSMutableCopying { }
 
+	interface INSKeyedArchiverDelegate { }
+
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -2782,6 +2785,8 @@ namespace Foundation {
 		[Export ("archiver:willReplaceObject:withObject:"), EventArgs ("NSArchiveReplace")]
 		void ReplacingObject (NSKeyedArchiver archiver, NSObject oldObject, NSObject newObject);
 	}
+
+	interface INSKeyedUnarchiverDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -2871,8 +2876,7 @@ namespace Foundation {
 		NSPropertyListFormat PropertyListFormat { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSKeyedArchiverDelegate Delegate { get; set; }
+		INSKeyedArchiverDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -2979,8 +2983,7 @@ namespace Foundation {
 		void FinishDecoding ();
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSKeyedUnarchiverDelegate Delegate { get; set; }
+		INSKeyedUnarchiverDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -3081,8 +3084,7 @@ namespace Foundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSMetadataQueryDelegate Delegate { get; set; }
+		INSMetadataQueryDelegate Delegate { get; set; }
 
 		[Export ("predicate", ArgumentSemantic.Copy)]
 		[NullAllowed] // by default this property is null
@@ -3904,6 +3906,8 @@ namespace Foundation {
 		[Field ("NSMetadataQueryUpdateRemovedItemsKey")]
 		NSString QueryUpdateRemovedItemsKey { get; }
 	}
+
+	interface INSMetadataQueryDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -5892,8 +5896,7 @@ namespace Foundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSUserActivityDelegate Delegate { get; set; }
+		INSUserActivityDelegate Delegate { get; set; }
 
 		[Export ("addUserInfoEntriesFromDictionary:")]
 		void AddUserInfoEntries (NSDictionary otherDictionary);
@@ -6029,6 +6032,8 @@ namespace Foundation {
 		[Field ("NSUserActivityTypeBrowsingWeb")]
 		NSString BrowsingWeb { get; }
 	}
+
+	interface INSUserActivityDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[Protocol, Model]
@@ -7389,21 +7394,21 @@ namespace Foundation {
 		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'NSUrlSession' instead.")]
 		[Export ("connectionWithRequest:delegate:")]
 		[Static]
-		NSUrlConnection FromRequest (NSUrlRequest request, [NullAllowed, Protocolize] NSUrlConnectionDelegate connectionDelegate);
+		NSUrlConnection FromRequest (NSUrlRequest request, [NullAllowed] INSUrlConnectionDelegate connectionDelegate);
 
 		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'NSUrlSession' instead.")]
 		[Deprecated (PlatformName.TvOS, 9, 0, message: "Use 'NSUrlSession' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSUrlSession' instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'NSUrlSession' instead.")]
 		[Export ("initWithRequest:delegate:")]
-		NativeHandle Constructor (NSUrlRequest request, [NullAllowed, Protocolize] NSUrlConnectionDelegate connectionDelegate);
+		NativeHandle Constructor (NSUrlRequest request, [NullAllowed] INSUrlConnectionDelegate connectionDelegate);
 
 		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'NSUrlSession' instead.")]
 		[Deprecated (PlatformName.TvOS, 9, 0, message: "Use 'NSUrlSession' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSUrlSession' instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'NSUrlSession' instead.")]
 		[Export ("initWithRequest:delegate:startImmediately:")]
-		NativeHandle Constructor (NSUrlRequest request, [NullAllowed, Protocolize] NSUrlConnectionDelegate connectionDelegate, bool startImmediately);
+		NativeHandle Constructor (NSUrlRequest request, [NullAllowed] INSUrlConnectionDelegate connectionDelegate, bool startImmediately);
 
 		[Export ("start")]
 		void Start ();
@@ -7458,6 +7463,8 @@ namespace Foundation {
 		[Async (ResultTypeName = "NSUrlAsyncResult", MethodName = "SendRequestAsync")]
 		void SendAsynchronousRequest (NSUrlRequest request, NSOperationQueue queue, NSUrlConnectionDataResponse completionHandler);
 	}
+
+	interface INSUrlConnectionDelegate { }
 
 	[BaseType (typeof (NSObject), Name = "NSURLConnectionDelegate")]
 	[Model]
@@ -7707,8 +7714,7 @@ namespace Foundation {
 		NSObject WeakDelegate { get; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSUrlSessionDelegate Delegate { get; }
+		INSUrlSessionDelegate Delegate { get; }
 
 		[Export ("configuration", ArgumentSemantic.Copy)]
 		NSUrlSessionConfiguration Configuration { get; }
@@ -8937,8 +8943,7 @@ namespace Foundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSStreamDelegate Delegate { get; set; }
+		INSStreamDelegate Delegate { get; set; }
 
 #if NET
 		[Abstract]
@@ -9063,6 +9068,8 @@ namespace Foundation {
 		[Static, Export ("getStreamsToHostWithName:port:inputStream:outputStream:")]
 		void GetStreamsToHost (string hostname, nint port, out NSInputStream inputStream, out NSOutputStream outputStream);
 	}
+
+	interface INSStreamDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -11538,8 +11545,7 @@ namespace Foundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSNetServiceDelegate Delegate { get; set; }
+		INSNetServiceDelegate Delegate { get; set; }
 
 #if NET
 		[Export ("scheduleInRunLoop:forMode:")]
@@ -11631,6 +11637,8 @@ namespace Foundation {
 		bool IncludesPeerToPeer { get; set; }
 	}
 
+	interface INSNetServiceDelegate { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[Model, BaseType (typeof (NSObject))]
@@ -11678,8 +11686,7 @@ namespace Foundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSNetServiceBrowserDelegate Delegate { get; set; }
+		INSNetServiceBrowserDelegate Delegate { get; set; }
 
 #if NET
 		[Export ("scheduleInRunLoop:forMode:")]
@@ -11719,6 +11726,8 @@ namespace Foundation {
 		[Export ("includesPeerToPeer")]
 		bool IncludesPeerToPeer { get; set; }
 	}
+
+	interface INSNetServiceBrowserDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -12837,8 +12846,7 @@ namespace Foundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate"), NullAllowed]
-		[Protocolize]
-		NSPortDelegate Delegate { get; set; }
+		INSPortDelegate Delegate { get; set; }
 
 		[Export ("scheduleInRunLoop:forMode:")]
 		void ScheduleInRunLoop (NSRunLoop runLoop, NSString runLoopMode);
@@ -12861,6 +12869,8 @@ namespace Foundation {
 		bool SendBeforeDate (NSDate limitDate, nuint msgID, [NullAllowed] NSMutableArray components, [NullAllowed] NSPort receivePort, nuint headerSpaceReserved);
 #pragma warning restore 618
 	}
+
+	interface INSPortDelegate { }
 
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
@@ -12960,9 +12970,10 @@ namespace Foundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate"), NullAllowed]
-		[Protocolize]
-		NSMachPortDelegate Delegate { get; set; }
+		INSMachPortDelegate Delegate { get; set; }
 	}
+
+	interface INSMachPortDelegate { }
 
 	[Model, BaseType (typeof (NSPortDelegate))]
 	[Protocol]
@@ -13418,17 +13429,16 @@ namespace Foundation {
 	interface NSFileCoordinator {
 		[Static, Export ("addFilePresenter:")]
 		[PostGet ("FilePresenters")]
-		void AddFilePresenter ([Protocolize] NSFilePresenter filePresenter);
+		void AddFilePresenter (INSFilePresenter filePresenter);
 
 		[Static]
 		[Export ("removeFilePresenter:")]
 		[PostGet ("FilePresenters")]
-		void RemoveFilePresenter ([Protocolize] NSFilePresenter filePresenter);
+		void RemoveFilePresenter (INSFilePresenter filePresenter);
 
 		[Static]
 		[Export ("filePresenters", ArgumentSemantic.Copy)]
-		[Protocolize]
-		NSFilePresenter [] FilePresenters { get; }
+		INSFilePresenter [] FilePresenters { get; }
 
 		[DesignatedInitializer]
 		[Export ("initWithFilePresenter:")]
@@ -13626,9 +13636,8 @@ namespace Foundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
 		[NullAllowed]
-		NSFileManagerDelegate Delegate { get; set; }
+		INSFileManagerDelegate Delegate { get; set; }
 
 		[Export ("setAttributes:ofItemAtPath:error:")]
 		bool SetAttributes (NSDictionary attributes, string path, out NSError error);
@@ -13821,6 +13830,8 @@ namespace Foundation {
 		[Async, Export ("getFileProviderServicesForItemAtURL:completionHandler:")]
 		void GetFileProviderServices (NSUrl url, Action<NSDictionary<NSString, NSFileProviderService>, NSError> completionHandler);
 	}
+
+	interface INSFileManagerDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -15332,9 +15343,10 @@ namespace Foundation {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		NSConnectionDelegate Delegate { get; set; }
+		INSConnectionDelegate Delegate { get; set; }
 	}
+
+	interface INSConnectionDelegate { }
 
 	[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'NSXpcConnection' instead.")]
 	[NoMacCatalyst]
@@ -15901,8 +15913,7 @@ namespace Foundation {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		NSUserNotificationCenterDelegate Delegate { get; set; }
+		INSUserNotificationCenterDelegate Delegate { get; set; }
 
 		[Export ("scheduledNotifications", ArgumentSemantic.Copy)]
 		NSUserNotification [] ScheduledNotifications { get; set; }
@@ -15930,6 +15941,8 @@ namespace Foundation {
 		[PostGet ("DeliveredNotifications")]
 		void RemoveAllDeliveredNotifications ();
 	}
+
+	interface INSUserNotificationCenterDelegate { }
 
 	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	[BaseType (typeof (NSObject))]

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -73,6 +73,8 @@ namespace GameKit {
 	interface UIWindow {}
 #endif
 
+	interface IGKVoiceChatClient { }
+
 	[NoMac]
 	[NoWatch] // only exposed thru GKVoiceChatService (not in 3.0)
 	[NoTV]
@@ -122,8 +124,7 @@ namespace GameKit {
 
 		[NullAllowed] // by default this property is null
 		[Export ("client", ArgumentSemantic.Assign)]
-		[Protocolize]
-		GKVoiceChatClient Client { get; set; }
+		IGKVoiceChatClient Client { get; set; }
 
 		[Export ("startVoiceChatWithParticipantID:error:")]
 		bool StartVoiceChat (string participantID, out NSError error);
@@ -185,8 +186,7 @@ namespace GameKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		GKSessionDelegate Delegate { get; set; }
+		IGKSessionDelegate Delegate { get; set; }
 
 		[Export ("sessionID")]
 		string SessionID { get; }
@@ -767,6 +767,8 @@ namespace GameKit {
 		UIViewController ChallengeComposeController ([NullAllowed] string message, [NullAllowed] GKPlayer [] players, [NullAllowed] GKChallengeComposeHandler completionHandler);
 	}
 
+	interface IGKLeaderboardViewControllerDelegate { }
+
 	[NoWatch]
 	[NoTV]
 	[NoMacCatalyst]
@@ -800,8 +802,7 @@ namespace GameKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		GKLeaderboardViewControllerDelegate Delegate { get; set; }
+		IGKLeaderboardViewControllerDelegate Delegate { get; set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("category",
@@ -933,11 +934,11 @@ namespace GameKit {
 
 		[MacCatalyst (13, 1)]
 		[Export ("registerListener:")]
-		void RegisterListener ([Protocolize] GKLocalPlayerListener listener);
+		void RegisterListener (IGKLocalPlayerListener listener);
 
 		[MacCatalyst (13, 1)]
 		[Export ("unregisterListener:")]
-		void UnregisterListener ([Protocolize] GKLocalPlayerListener listener);
+		void UnregisterListener (IGKLocalPlayerListener listener);
 
 		[MacCatalyst (13, 1)]
 		[Export ("unregisterAllListeners")]
@@ -1096,8 +1097,7 @@ namespace GameKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		GKMatchDelegate Delegate { get; set; }
+		IGKMatchDelegate Delegate { get; set; }
 
 		[Export ("expectedPlayerCount")]
 		nint ExpectedPlayerCount { get; }
@@ -1148,6 +1148,8 @@ namespace GameKit {
 		[Export ("sendData:toPlayers:dataMode:error:")]
 		bool SendData (NSData data, GKPlayer [] players, GKMatchSendDataMode mode, out NSError error);
 	}
+
+	interface IGKMatchDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -1496,8 +1498,7 @@ namespace GameKit {
 
 		[NullAllowed]
 		[Wrap ("WeakMatchmakerDelegate")]
-		[Protocolize]
-		GKMatchmakerViewControllerDelegate MatchmakerDelegate { get; set; }
+		IGKMatchmakerViewControllerDelegate MatchmakerDelegate { get; set; }
 
 		[Export ("matchRequest", ArgumentSemantic.Strong)]
 		GKMatchRequest MatchRequest { get; }
@@ -1552,6 +1553,8 @@ namespace GameKit {
 		[Export ("canStartWithMinimumPlayers")]
 		bool CanStartWithMinimumPlayers { get; set; }
 	}
+
+	interface IGKMatchmakerViewControllerDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -1821,6 +1824,8 @@ namespace GameKit {
 		NSNumber RarityPercent { get; }
 	}
 
+	interface IGKAchievementViewControllerDelegate { }
+
 	[NoWatch]
 	[NoTV]
 	[NoMacCatalyst]
@@ -1857,8 +1862,7 @@ namespace GameKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		GKAchievementViewControllerDelegate Delegate { get; set; }
+		IGKAchievementViewControllerDelegate Delegate { get; set; }
 	}
 
 	[NoiOS]
@@ -1908,8 +1912,7 @@ namespace GameKit {
 		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Deprecated (PlatformName.MacCatalyst, 13, 1)]
 		[Wrap ("WeakComposeViewDelegate")]
-		[Protocolize]
-		GKFriendRequestComposeViewControllerDelegate ComposeViewDelegate { get; set; }
+		IGKFriendRequestComposeViewControllerDelegate ComposeViewDelegate { get; set; }
 
 		[Export ("maxNumberOfRecipients")]
 		[Static]
@@ -1930,6 +1933,8 @@ namespace GameKit {
 		[Export ("setMessage:")]
 		void SetMessage ([NullAllowed] string message);
 	}
+
+	interface IGKFriendRequestComposeViewControllerDelegate { }
 
 	[NoWatch]
 	[NoTV]
@@ -1995,6 +2000,8 @@ namespace GameKit {
 		NSDate TimeoutDate { get; }
 	}
 
+	interface IGKTurnBasedEventHandlerDelegate { }
+
 	[NoTV]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -2045,8 +2052,7 @@ namespace GameKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		GKTurnBasedEventHandlerDelegate Delegate { get; set; }
+		IGKTurnBasedEventHandlerDelegate Delegate { get; set; }
 
 		[Export ("sharedTurnBasedEventHandler"), Static]
 		GKTurnBasedEventHandler SharedTurnBasedEventHandler { get; }
@@ -2267,9 +2273,10 @@ namespace GameKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		GKTurnBasedMatchmakerViewControllerDelegate Delegate { get; set; }
+		IGKTurnBasedMatchmakerViewControllerDelegate Delegate { get; set; }
 	}
+
+	interface IGKTurnBasedMatchmakerViewControllerDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -2434,8 +2441,7 @@ namespace GameKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		GKGameCenterControllerDelegate Delegate { get; set; }
+		IGKGameCenterControllerDelegate Delegate { get; set; }
 
 		[Deprecated (PlatformName.iOS, 14, 0, message: "Use '.ctor (GKGameCenterViewControllerState)' instead.")]
 		[Deprecated (PlatformName.TvOS, 14, 0, message: "Use '.ctor (GKGameCenterViewControllerState)' instead.")]
@@ -2471,6 +2477,8 @@ namespace GameKit {
 		string LeaderboardIdentifier { get; set; }
 	}
 
+	interface IGKGameCenterControllerDelegate { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[Model]
@@ -2495,12 +2503,13 @@ namespace GameKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		GKChallengeEventHandlerDelegate Delegate { get; set; }
+		IGKChallengeEventHandlerDelegate Delegate { get; set; }
 
 		[Export ("challengeEventHandler"), Static]
 		GKChallengeEventHandler Instance { get; }
 	}
+
+	interface IGKChallengeEventHandlerDelegate { }
 
 	[NoWatch]
 	[NoTV]
@@ -2614,6 +2623,8 @@ namespace GameKit {
 		[NullAllowed]
 		NSDate ReplyDate { get; }
 	}
+
+	interface IGKLocalPlayerListener { }
 
 	[MacCatalyst (13, 1)]
 	[Model, Protocol, BaseType (typeof (NSObject))]
@@ -2901,6 +2912,8 @@ namespace GameKit {
 	[Protocol]
 	interface GKViewController {
 	}
+
+	interface IGKSessionDelegate { }
 
 	[NoTV]
 	[NoWatch] // only exposed thru GKSession (not in 3.0)

--- a/src/glkit.cs
+++ b/src/glkit.cs
@@ -575,8 +575,7 @@ namespace GLKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		GLKViewDelegate Delegate { get; set; }
+		IGLKViewDelegate Delegate { get; set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("context", ArgumentSemantic.Retain)]
@@ -618,6 +617,8 @@ namespace GLKit {
 		[Export ("deleteDrawable")]
 		void DeleteDrawable ();
 	}
+
+	interface IGLKViewDelegate { }
 
 	[NoMac]
 	[Deprecated (PlatformName.iOS, 12, 0, message: "Use 'Metal' instead.")]
@@ -674,13 +675,14 @@ namespace GLKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		GLKViewControllerDelegate Delegate { get; set; }
+		IGLKViewControllerDelegate Delegate { get; set; }
 
 		// Pseudo-documented, if the user overrides it, call this instead of the delegate method
 		[Export ("update")]
 		void Update ();
 	}
+
+	interface IGLKViewControllerDelegate { }
 
 	[NoMac]
 	[Deprecated (PlatformName.iOS, 12, 0, message: "Use 'Metal' instead.")]

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -3581,8 +3581,7 @@ namespace HealthKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		HKWorkoutSessionDelegate Delegate { get; set; }
+		IHKWorkoutSessionDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		NSObject WeakDelegate { get; set; }
@@ -3675,6 +3674,8 @@ namespace HealthKit {
 		[Async]
 		void StopMirroringToCompanionDevice (Action<bool, NSError> completion);
 	}
+
+	interface IHKWorkoutSessionDelegate { }
 
 	[Mac (13, 0)]
 	[iOS (17, 0)]

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -32,8 +32,7 @@ namespace HomeKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		HMHomeManagerDelegate Delegate { get; set; }
+		IHMHomeManagerDelegate Delegate { get; set; }
 
 		[Deprecated (PlatformName.MacOSX, 13, 0, message: "No longer supported.")]
 		[Deprecated (PlatformName.iOS, 16, 1, message: "No longer supported.")]
@@ -75,6 +74,8 @@ namespace HomeKit {
 		[Export ("authorizationStatus")]
 		HMHomeManagerAuthorizationStatus AuthorizationStatus { get; }
 	}
+
+	interface IHMHomeManagerDelegate { }
 
 	[MacCatalyst (14, 0)]
 	[Model, Protocol]
@@ -130,8 +131,7 @@ namespace HomeKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		HMAccessoryDelegate Delegate { get; set; }
+		IHMAccessoryDelegate Delegate { get; set; }
 
 		[Export ("reachable")]
 		bool Reachable { [Bind ("isReachable")] get; }
@@ -208,6 +208,8 @@ namespace HomeKit {
 		bool SupportsIdentify { get; }
 	}
 
+	interface IHMAccessoryDelegate { }
+
 	[MacCatalyst (14, 0)]
 	[Model, Protocol]
 	[BaseType (typeof (NSObject))]
@@ -256,8 +258,7 @@ namespace HomeKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		HMAccessoryBrowserDelegate Delegate { get; set; }
+		IHMAccessoryBrowserDelegate Delegate { get; set; }
 
 		[Export ("discoveredAccessories", ArgumentSemantic.Copy)]
 		HMAccessory [] DiscoveredAccessories { get; }
@@ -268,6 +269,8 @@ namespace HomeKit {
 		[Export ("stopSearchingForNewAccessories")]
 		void StopSearchingForNewAccessories ();
 	}
+
+	interface IHMAccessoryBrowserDelegate { }
 
 	[NoTV]
 	[NoMacCatalyst]
@@ -581,8 +584,7 @@ namespace HomeKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		HMHomeDelegate Delegate { get; set; }
+		IHMHomeDelegate Delegate { get; set; }
 
 		[Export ("name")]
 		string Name { get; }
@@ -819,6 +821,8 @@ namespace HomeKit {
 		[Export ("supportsAddingNetworkRouter")]
 		bool SupportsAddingNetworkRouter { get; }
 	}
+
+	interface IHMHomeDelegate { }
 
 	[MacCatalyst (14, 0)]
 	[Model, Protocol]

--- a/src/imagekit.cs
+++ b/src/imagekit.cs
@@ -87,8 +87,7 @@ namespace ImageKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		IKCameraDeviceViewDelegate Delegate { get; set; }
+		IIKCameraDeviceViewDelegate Delegate { get; set; }
 
 		[Export ("cameraDevice", ArgumentSemantic.Assign)]
 		ICCameraDevice CameraDevice { get; set; }
@@ -184,6 +183,8 @@ namespace ImageKit {
 		void SetShowStatusInfoAsWindowSubtitle (bool value);
 	}
 
+	interface IIKCameraDeviceViewDelegate { }
+
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -207,8 +208,7 @@ namespace ImageKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		IKDeviceBrowserViewDelegate Delegate { get; set; }
+		IIKDeviceBrowserViewDelegate Delegate { get; set; }
 
 		[Export ("displaysLocalCameras")]
 		bool DisplaysLocalCameras { get; set; }
@@ -228,6 +228,8 @@ namespace ImageKit {
 		[Export ("selectedDevice")]
 		ICDevice SelectedDevice { get; }
 	}
+
+	interface IIKDeviceBrowserViewDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -431,8 +433,7 @@ namespace ImageKit {
 		NSObject WeakDataSource { get; set; }
 
 		[Wrap ("WeakDataSource")]
-		[Protocolize]
-		IKImageBrowserDataSource DataSource { get; set; }
+		IIKImageBrowserDataSource DataSource { get; set; }
 
 		[Export ("reloadData")]
 		void ReloadData ();
@@ -441,8 +442,7 @@ namespace ImageKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		IKImageBrowserDelegate Delegate { get; set; }
+		IIKImageBrowserDelegate Delegate { get; set; }
 
 		//@category IKImageBrowserView (IKAppearance)
 		[Export ("cellsStyleMask")]
@@ -458,7 +458,7 @@ namespace ImageKit {
 		CALayer ForegroundLayer { get; set; }
 
 		[Export ("newCellForRepresentedItem:")]
-		IKImageBrowserCell NewCell ([Protocolize] IKImageBrowserItem representedItem);
+		IKImageBrowserCell NewCell (IIKImageBrowserItem representedItem);
 
 		[Export ("cellForItemAtIndex:")]
 		IKImageBrowserCell GetCellAt (nint itemIndex);
@@ -539,8 +539,7 @@ namespace ImageKit {
 
 		//@category IKImageBrowserView (IKDragNDrop)
 		[Export ("draggingDestinationDelegate", ArgumentSemantic.Weak)]
-		[Protocolize]
-		NSDraggingDestination DraggingDestinationDelegate { get; set; }
+		INSDraggingDestination DraggingDestinationDelegate { get; set; }
 
 		[Export ("indexAtLocationOfDroppedItem")]
 		nint GetIndexAtLocationOfDroppedItem ();
@@ -573,6 +572,8 @@ namespace ImageKit {
 		[Field ("IKImageBrowserCellsSubtitleAttributesKey")]
 		NSString CellsSubtitleAttributesKey { get; }
 	}
+
+	interface IIKImageBrowserDataSource { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -698,6 +699,8 @@ namespace ImageKit {
 
 	interface IIKImageBrowserItem { }
 
+	interface IIKImageBrowserDelegate { }
+
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol (IsInformal = true)]
@@ -723,8 +726,7 @@ namespace ImageKit {
 		IKImageEditPanel SharedPanel { get; }
 
 		[Export ("dataSource", ArgumentSemantic.Assign), NullAllowed]
-		[Protocolize]
-		IKImageEditPanelDataSource DataSource { get; set; }
+		IIKImageEditPanelDataSource DataSource { get; set; }
 
 #if !XAMCORE_5_0
 		[Obsolete ("Use the 'FilterArray' property instead.")]
@@ -738,6 +740,8 @@ namespace ImageKit {
 		[Export ("reloadData")]
 		void ReloadData ();
 	}
+
+	interface IIKImageEditPanelDataSource { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -977,8 +981,7 @@ namespace ImageKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		IKSaveOptionsDelegate Delegate { get; set; }
+		IIKSaveOptionsDelegate Delegate { get; set; }
 
 		[Export ("initWithImageProperties:imageUTType:")]
 		NativeHandle Constructor (NSDictionary imageProperties, string imageUTType);
@@ -993,6 +996,8 @@ namespace ImageKit {
 		[Export ("rememberLastSetting")]
 		bool RememberLastSetting { get; set; }
 	}
+
+	interface IIKSaveOptionsDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -1011,8 +1016,7 @@ namespace ImageKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		IKScannerDeviceViewDelegate Delegate { get; set; }
+		IIKScannerDeviceViewDelegate Delegate { get; set; }
 
 		[Export ("scannerDevice", ArgumentSemantic.Assign)]
 		ICScannerDevice ScannerDevice { get; set; }
@@ -1051,6 +1055,8 @@ namespace ImageKit {
 		NSUrl PostProcessApplication { get; set; }
 	}
 
+	interface IIKScannerDeviceViewDelegate { }
+
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -1084,7 +1090,7 @@ namespace ImageKit {
 		double AutoPlayDelay { get; set; }
 
 		[Export ("runSlideshowWithDataSource:inMode:options:")]
-		void RunSlideshow ([Protocolize] IKSlideshowDataSource dataSource, string slideshowMode, NSDictionary slideshowOptions);
+		void RunSlideshow (IIKSlideshowDataSource dataSource, string slideshowMode, NSDictionary slideshowOptions);
 
 		[Export ("stopSlideshow:")]
 		void StopSlideshow (NSObject sender);
@@ -1151,6 +1157,8 @@ namespace ImageKit {
 		[Field ("IK_PhotosBundleIdentifier")]
 		NSString PhotosBundleIdentifier { get; }
 	}
+
+	interface IIKSlideshowDataSource { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -454,8 +454,7 @@ namespace MapKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		MKMapViewDelegate Delegate { get; set; }
+		IMKMapViewDelegate Delegate { get; set; }
 
 		[Export ("mapType")]
 		MKMapType MapType { get; set; }
@@ -761,6 +760,8 @@ namespace MapKit {
 		NSString ClusterAnnotationViewReuseIdentifier { get; }
 	}
 
+	interface IMKMapViewDelegate { }
+
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -985,8 +986,7 @@ namespace MapKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		MKReverseGeocoderDelegate Delegate { get; set; }
+		IMKReverseGeocoderDelegate Delegate { get; set; }
 
 #if !XAMCORE_5_0
 		[Obsolete ("Use the 'Coordinate' property instead.")]
@@ -1009,6 +1009,8 @@ namespace MapKit {
 		[Export ("placemark")]
 		MKPlacemark Placemark { get; }
 	}
+
+	interface IMKReverseGeocoderDelegate { }
 
 #pragma warning disable 618
 	[NoMac]
@@ -2039,8 +2041,7 @@ namespace MapKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		MKLocalSearchCompleterDelegate Delegate { get; set; }
+		IMKLocalSearchCompleterDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		NSObject WeakDelegate { get; set; }
@@ -2064,6 +2065,8 @@ namespace MapKit {
 		[NullAllowed, Export ("pointOfInterestFilter", ArgumentSemantic.Copy)]
 		MKPointOfInterestFilter PointOfInterestFilter { get; set; }
 	}
+
+	interface IMKLocalSearchCompleterDelegate { }
 
 	[NoWatch]
 	[NoWatch]

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -414,8 +414,7 @@ namespace MediaPlayer {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		MPMediaPickerControllerDelegate Delegate { get; set; }
+		IMPMediaPickerControllerDelegate Delegate { get; set; }
 
 		[Export ("allowsPickingMultipleItems")]
 		bool AllowsPickingMultipleItems { get; set; }
@@ -431,6 +430,8 @@ namespace MediaPlayer {
 		[Export ("showsItemsWithProtectedAssets")]
 		bool ShowsItemsWithProtectedAssets { get; set; }
 	}
+
+	interface IMPMediaPickerControllerDelegate { }
 
 	[NoTV]
 	[NoMac]
@@ -1762,6 +1763,8 @@ namespace MediaPlayer {
 	interface IMPPlayableContentDataSource {
 	}
 
+	interface IMPPlayableContentDelegate { }
+
 	[NoMac]
 	[NoTV]
 	[NoWatch]
@@ -1814,16 +1817,14 @@ namespace MediaPlayer {
 		NSObject WeakDataSource { get; set; }
 
 		[Wrap ("WeakDataSource")]
-		[Protocolize]
-		MPPlayableContentDataSource DataSource { get; set; }
+		IMPPlayableContentDataSource DataSource { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Weak)]
 		[NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		MPPlayableContentDelegate Delegate { get; set; }
+		IMPPlayableContentDelegate Delegate { get; set; }
 
 		[Export ("beginUpdates")]
 		void BeginUpdates ();

--- a/src/messageui.cs
+++ b/src/messageui.cs
@@ -27,8 +27,7 @@ namespace MessageUI {
 		NSObject WeakMailComposeDelegate { get; set; }
 
 		[Wrap ("WeakMailComposeDelegate")]
-		[Protocolize]
-		MFMailComposeViewControllerDelegate MailComposeDelegate { get; set; }
+		IMFMailComposeViewControllerDelegate MailComposeDelegate { get; set; }
 
 		[Export ("setSubject:")]
 		void SetSubject (string subject);
@@ -53,6 +52,8 @@ namespace MessageUI {
 		void SetPreferredSendingEmailAddress (string emailAddress);
 	}
 
+	interface IMFMailComposeViewControllerDelegate { }
+
 #if XAMCORE_3_0
 	[BaseType (typeof (NSObject))]
 #else
@@ -76,8 +77,7 @@ namespace MessageUI {
 		NSObject WeakMessageComposeDelegate { get; set; }
 
 		[Wrap ("WeakMessageComposeDelegate")]
-		[Protocolize]
-		MFMessageComposeViewControllerDelegate MessageComposeDelegate { get; set; }
+		IMFMessageComposeViewControllerDelegate MessageComposeDelegate { get; set; }
 
 		[NullAllowed]
 		[Export ("recipients", ArgumentSemantic.Copy)]
@@ -146,6 +146,8 @@ namespace MessageUI {
 		[Export ("setUPIVerificationCodeSendCompletion:")]
 		void SetUpiVerificationCodeSendCompletion (Action<bool> completion);
 	}
+
+	interface IMFMessageComposeViewControllerDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]

--- a/src/metalkit.cs
+++ b/src/metalkit.cs
@@ -45,8 +45,7 @@ namespace MetalKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		MTKViewDelegate Delegate { get; set; }
+		IMTKViewDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		NSObject WeakDelegate { get; set; }
@@ -145,6 +144,8 @@ namespace MetalKit {
 		[Export ("depthStencilStorageMode", ArgumentSemantic.Assign)]
 		MTLStorageMode DepthStencilStorageMode { get; set; }
 	}
+
+	interface IMTKViewDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[Protocol, Model]

--- a/src/multipeerconnectivity.cs
+++ b/src/multipeerconnectivity.cs
@@ -75,8 +75,7 @@ namespace MultipeerConnectivity {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		MCSessionDelegate Delegate { get; set; }
+		IMCSessionDelegate Delegate { get; set; }
 
 		[Export ("myPeerID")]
 		MCPeerID MyPeerID { get; }
@@ -109,6 +108,8 @@ namespace MultipeerConnectivity {
 
 		#endregion
 	}
+
+	interface IMCSessionDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -158,8 +159,7 @@ namespace MultipeerConnectivity {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		MCNearbyServiceAdvertiserDelegate Delegate { get; set; }
+		IMCNearbyServiceAdvertiserDelegate Delegate { get; set; }
 
 		[Export ("myPeerID")]
 		MCPeerID MyPeerID { get; }
@@ -173,6 +173,8 @@ namespace MultipeerConnectivity {
 	}
 
 	delegate void MCNearbyServiceAdvertiserInvitationHandler (bool accept, [NullAllowed] MCSession session);
+
+	interface IMCNearbyServiceAdvertiserDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -210,8 +212,7 @@ namespace MultipeerConnectivity {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		MCNearbyServiceBrowserDelegate Delegate { get; set; }
+		IMCNearbyServiceBrowserDelegate Delegate { get; set; }
 
 		[Export ("myPeerID")]
 		MCPeerID MyPeerID { get; }
@@ -259,8 +260,7 @@ namespace MultipeerConnectivity {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		MCBrowserViewControllerDelegate Delegate { get; set; }
+		IMCBrowserViewControllerDelegate Delegate { get; set; }
 
 		[Export ("minimumNumberOfPeers", ArgumentSemantic.Assign)]
 		nuint MinimumNumberOfPeers { get; set; }
@@ -277,6 +277,8 @@ namespace MultipeerConnectivity {
 		[Export ("session")]
 		MCSession Session { get; }
 	}
+
+	interface IMCBrowserViewControllerDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -321,8 +323,7 @@ namespace MultipeerConnectivity {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		MCAdvertiserAssistantDelegate Delegate { get; set; }
+		IMCAdvertiserAssistantDelegate Delegate { get; set; }
 
 		[Export ("start")]
 		void Start ();
@@ -330,6 +331,8 @@ namespace MultipeerConnectivity {
 		[Export ("stop")]
 		void Stop ();
 	}
+
+	interface IMCAdvertiserAssistantDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -305,6 +305,8 @@ namespace PassKit {
 	delegate void PKPaymentShippingAddressSelected (PKPaymentAuthorizationStatus status, PKShippingMethod [] shippingMethods, PKPaymentSummaryItem [] summaryItems);
 	delegate void PKPaymentShippingMethodSelected (PKPaymentAuthorizationStatus status, PKPaymentSummaryItem [] summaryItems);
 
+	interface IPKPaymentAuthorizationViewControllerDelegate { }
+
 	[Mac (11, 0)]
 	[MacCatalyst (13, 1)]
 	[Protocol, Model]
@@ -416,8 +418,7 @@ namespace PassKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		PKPaymentAuthorizationViewControllerDelegate Delegate { get; set; }
+		IPKPaymentAuthorizationViewControllerDelegate Delegate { get; set; }
 
 		[Static, Export ("canMakePayments")]
 		bool CanMakePayments { get; }
@@ -758,9 +759,10 @@ namespace PassKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		PKAddPassesViewControllerDelegate Delegate { get; set; }
+		IPKAddPassesViewControllerDelegate Delegate { get; set; }
 	}
+
+	interface IPKAddPassesViewControllerDelegate { }
 
 	[NoMac] // under `TARGET_OS_IPHONE`
 	[NoWatch]
@@ -867,8 +869,8 @@ namespace PassKit {
 #endif
 
 		[Wrap ("WeakDelegate")]
-		[NullAllowed, Protocolize]
-		PKAddPaymentPassViewControllerDelegate Delegate { get; set; }
+		[NullAllowed]
+		IPKAddPaymentPassViewControllerDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		NSObject WeakDelegate { get; set; }

--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -1356,8 +1356,7 @@ namespace PdfKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		PdfDocumentDelegate Delegate { get; set; }
+		IPdfDocumentDelegate Delegate { get; set; }
 
 		[Export ("dataRepresentation")]
 		[return: NullAllowed]
@@ -1488,6 +1487,8 @@ namespace PdfKit {
 		NSPrintOperation GetPrintOperation ([NullAllowed] NSPrintInfo printInfo, PdfPrintScalingMode scaleMode, bool doRotate);
 #pragma warning restore
 	}
+
+	interface IPdfDocumentDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject), Name = "PDFDocumentDelegate")]
@@ -1968,8 +1969,7 @@ namespace PdfKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		PdfViewDelegate Delegate { get; set; }
+		IPdfViewDelegate Delegate { get; set; }
 
 		[Export ("scaleFactor")]
 		nfloat ScaleFactor { get; set; }
@@ -2194,6 +2194,8 @@ namespace PdfKit {
 		[Export ("PDFAnnotationHit")]
 		PdfAnnotation AnnotationHit { get; }
 	}
+
+	interface IPdfViewDelegate { }
 
 	//Verify delegate methods.  There are default actions (not just return null ) that should occur
 	//if the delegate does not implement the method.

--- a/src/photos.cs
+++ b/src/photos.cs
@@ -1081,6 +1081,8 @@ namespace Photos {
 
 	}
 
+	interface IPHPhotoLibraryChangeObserver { }
+
 	[MacCatalyst (13, 1)]
 	[Protocol]
 	[Model]
@@ -1151,10 +1153,10 @@ namespace Photos {
 		bool PerformChangesAndWait (Action changeHandler, out NSError error);
 
 		[Export ("registerChangeObserver:")]
-		void RegisterChangeObserver ([Protocolize] PHPhotoLibraryChangeObserver observer);
+		void RegisterChangeObserver (IPHPhotoLibraryChangeObserver observer);
 
 		[Export ("unregisterChangeObserver:")]
-		void UnregisterChangeObserver ([Protocolize] PHPhotoLibraryChangeObserver observer);
+		void UnregisterChangeObserver (IPHPhotoLibraryChangeObserver observer);
 
 		[TV (13, 0), iOS (13, 0)]
 		[MacCatalyst (13, 1)]

--- a/src/photosui.cs
+++ b/src/photosui.cs
@@ -76,8 +76,7 @@ namespace PhotosUI {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		PHLivePhotoViewDelegate Delegate { get; set; }
+		IPHLivePhotoViewDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		NSObject WeakDelegate { get; set; }
@@ -127,6 +126,8 @@ namespace PhotosUI {
 		[Export ("contentsRect", ArgumentSemantic.Assign)]
 		CGRect ContentsRect { get; set; }
 	}
+
+	interface IPHLivePhotoViewDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[Protocol, Model]

--- a/src/pushkit.cs
+++ b/src/pushkit.cs
@@ -38,8 +38,7 @@ namespace PushKit {
 	[DisableDefaultCtor]
 	interface PKPushRegistry {
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		PKPushRegistryDelegate Delegate { get; set; }
+		IPKPushRegistryDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Weak)]
 		[NullAllowed]
@@ -81,6 +80,8 @@ namespace PushKit {
 		[Field ("PKPushTypeFileProvider")]
 		NSString FileProvider { get; }
 	}
+
+	interface IPKPushRegistryDelegate { }
 
 	[Watch (6, 0)]
 	[MacCatalyst (13, 1)]

--- a/src/quicklook.cs
+++ b/src/quicklook.cs
@@ -59,27 +59,24 @@ namespace QuickLook {
 		NSObject WeakDataSource { get; set; }
 
 		[Wrap ("WeakDataSource")]
-		[Protocolize]
-		QLPreviewControllerDataSource DataSource { get; set; }
+		IQLPreviewControllerDataSource DataSource { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		QLPreviewControllerDelegate Delegate { get; set; }
+		IQLPreviewControllerDelegate Delegate { get; set; }
 
 		[Export ("currentPreviewItemIndex")]
 		nint CurrentPreviewItemIndex { get; set; }
 
 		[Export ("currentPreviewItem")]
-		[Protocolize]
 		[NullAllowed]
-		QLPreviewItem CurrentPreviewItem { get; }
+		IQLPreviewItem CurrentPreviewItem { get; }
 
 		[Static]
 		[Export ("canPreviewItem:")]
-		bool CanPreviewItem ([Protocolize] QLPreviewItem item);
+		bool CanPreviewItem (IQLPreviewItem item);
 
 		[Export ("reloadData")]
 		void ReloadData ();
@@ -87,6 +84,8 @@ namespace QuickLook {
 		[Export ("refreshCurrentPreviewItem")]
 		void RefreshCurrentPreviewItem ();
 	}
+
+	interface IQLPreviewControllerDataSource { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -100,8 +99,7 @@ namespace QuickLook {
 
 		[Abstract]
 		[Export ("previewController:previewItemAtIndex:")]
-		[return: Protocolize]
-		QLPreviewItem GetPreviewItem (QLPreviewController controller, nint index);
+		IQLPreviewItem GetPreviewItem (QLPreviewController controller, nint index);
 	}
 
 	[NoMac]
@@ -113,6 +111,8 @@ namespace QuickLook {
 		UpdateContents,
 		CreateCopy,
 	}
+
+	interface IQLPreviewControllerDelegate { }
 
 	[NoMac]
 	[MacCatalyst (13, 1)]
@@ -127,17 +127,17 @@ namespace QuickLook {
 		void DidDismiss (QLPreviewController controller);
 
 		[Export ("previewController:shouldOpenURL:forPreviewItem:"), DelegateName ("QLOpenUrl"), DefaultValue (false)]
-		bool ShouldOpenUrl (QLPreviewController controller, NSUrl url, [Protocolize] QLPreviewItem item);
+		bool ShouldOpenUrl (QLPreviewController controller, NSUrl url, IQLPreviewItem item);
 
 #if !MONOMAC
 		// UIView and UIImage do not exists in MonoMac
 
 		[Export ("previewController:frameForPreviewItem:inSourceView:"), DelegateName ("QLFrame"), DefaultValue (typeof (CGRect))]
-		CGRect FrameForPreviewItem (QLPreviewController controller, [Protocolize] QLPreviewItem item, ref UIView view);
+		CGRect FrameForPreviewItem (QLPreviewController controller, IQLPreviewItem item, ref UIView view);
 
 		[Export ("previewController:transitionImageForPreviewItem:contentRect:"), DelegateName ("QLTransition"), DefaultValue (null)]
 		[return: NullAllowed]
-		UIImage TransitionImageForPreviewItem (QLPreviewController controller, [Protocolize] QLPreviewItem item, CGRect contentRect);
+		UIImage TransitionImageForPreviewItem (QLPreviewController controller, IQLPreviewItem item, CGRect contentRect);
 
 		[MacCatalyst (13, 1)]
 		[Export ("previewController:transitionViewForPreviewItem:"), DelegateName ("QLTransitionView"), DefaultValue (null)]

--- a/src/quicklookUI.cs
+++ b/src/quicklookUI.cs
@@ -19,6 +19,8 @@ namespace QuickLookUI {
 		Compact = 1
 	}
 
+	interface IQLPreviewPanelDataSource { }
+
 	[BaseType (typeof (NSObject))]
 	[Protocol, Model]
 	interface QLPreviewPanelDataSource {
@@ -28,9 +30,10 @@ namespace QuickLookUI {
 
 		[Export ("previewPanel:previewItemAtIndex:")]
 		[Abstract]
-		[return: Protocolize]
-		QLPreviewItem PreviewItemAtIndex (QLPreviewPanel panel, nint index);
+		IQLPreviewItem PreviewItemAtIndex (QLPreviewPanel panel, nint index);
 	}
+
+	interface IQLPreviewPanelDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Protocol, Model]
@@ -39,10 +42,10 @@ namespace QuickLookUI {
 		bool HandleEvent (QLPreviewPanel panel, NSEvent theEvent);
 
 		[Export ("previewPanel:sourceFrameOnScreenForPreviewItem:")]
-		CGRect SourceFrameOnScreenForPreviewItem (QLPreviewPanel panel, [Protocolize] QLPreviewItem item);
+		CGRect SourceFrameOnScreenForPreviewItem (QLPreviewPanel panel, IQLPreviewItem item);
 
 		[Export ("previewPanel:transitionImageForPreviewItem:contentRect:")]
-		NSObject TransitionImageForPreviewItem (QLPreviewPanel panel, [Protocolize] QLPreviewItem item, CGRect contentRect);
+		NSObject TransitionImageForPreviewItem (QLPreviewPanel panel, IQLPreviewItem item, CGRect contentRect);
 	}
 
 	interface IQLPreviewItem { }
@@ -92,15 +95,13 @@ namespace QuickLookUI {
 
 		[Wrap ("WeakDataSource")]
 		[NullAllowed]
-		[Protocolize]
-		QLPreviewPanelDataSource DataSource { get; set; }
+		IQLPreviewPanelDataSource DataSource { get; set; }
 
 		[Export ("currentPreviewItemIndex")]
 		nint CurrentPreviewItemIndex { get; set; }
 
 		[Export ("currentPreviewItem")]
-		[Protocolize]
-		QLPreviewItem CurrentPreviewItem { get; }
+		IQLPreviewItem CurrentPreviewItem { get; }
 
 		[Export ("displayState", ArgumentSemantic.Retain)]
 		NSObject DisplayState { get; set; }
@@ -111,8 +112,7 @@ namespace QuickLookUI {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		QLPreviewPanelDelegate Delegate { get; set; }
+		IQLPreviewPanelDelegate Delegate { get; set; }
 
 		[Export ("inFullScreenMode")]
 		bool InFullScreenMode { [Bind ("isInFullScreenMode")] get; }

--- a/src/safariservices.cs
+++ b/src/safariservices.cs
@@ -115,8 +115,7 @@ namespace SafariServices {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		SFSafariViewControllerDelegate Delegate { get; set; }
+		ISFSafariViewControllerDelegate Delegate { get; set; }
 
 		[MacCatalyst (13, 1)]
 		[NullAllowed]
@@ -141,6 +140,8 @@ namespace SafariServices {
 		[Export ("prewarmConnectionsToURLs:")]
 		SFSafariViewControllerPrewarmingToken PrewarmConnections (NSUrl [] urls);
 	}
+
+	interface ISFSafariViewControllerDelegate { }
 
 	[NoMac]
 	[MacCatalyst (13, 1)]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -714,8 +714,7 @@ namespace SceneKit {
 	interface SCNCameraController {
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
-		[Protocolize]
-		SCNCameraControllerDelegate Delegate { get; set; }
+		ISCNCameraControllerDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("pointOfView", ArgumentSemantic.Retain)]
 		SCNNode PointOfView { get; set; }
@@ -1906,8 +1905,7 @@ namespace SceneKit {
 		[NoWatch]
 		[MacCatalyst (13, 1)]
 		[Wrap ("WeakRendererDelegate")]
-		[Protocolize]
-		SCNNodeRendererDelegate RendererDelegate { get; set; }
+		ISCNNodeRendererDelegate RendererDelegate { get; set; }
 
 		[Static, Export ("node")]
 		SCNNode Create ();
@@ -2402,6 +2400,8 @@ namespace SceneKit {
 		//void Rotate (Quaternion worldRotation, NVector3 worldTarget);
 	}
 
+	interface ISCNNodeRendererDelegate { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -2487,8 +2487,7 @@ namespace SceneKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		SCNProgramDelegate Delegate { get; set; }
+		ISCNProgramDelegate Delegate { get; set; }
 
 		[Static, Export ("program")]
 		SCNProgram Create ();
@@ -2528,6 +2527,8 @@ namespace SceneKit {
 		[Export ("library", ArgumentSemantic.Retain)]
 		IMTLLibrary Library { get; set; }
 	}
+
+	interface ISCNProgramDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -3055,8 +3056,7 @@ namespace SceneKit {
 		NSObject WeakSceneRendererDelegate { get; set; }
 
 		[Wrap ("WeakSceneRendererDelegate")]
-		[Protocolize]
-		SCNSceneRendererDelegate SceneRendererDelegate { get; set; }
+		ISCNSceneRendererDelegate SceneRendererDelegate { get; set; }
 
 		[Abstract]
 		[Export ("playing")]
@@ -3301,6 +3301,8 @@ namespace SceneKit {
 		[Export ("workingColorSpace")]
 		CGColorSpace WorkingColorSpace { get; }
 	}
+
+	interface ISCNSceneRendererDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[Protocol, Model]
@@ -4389,8 +4391,7 @@ namespace SceneKit {
 		NSObject WeakContactDelegate { get; set; }
 
 		[Wrap ("WeakContactDelegate")]
-		[Protocolize]
-		SCNPhysicsContactDelegate ContactDelegate { get; set; }
+		ISCNPhysicsContactDelegate ContactDelegate { get; set; }
 
 		[Export ("addBehavior:")]
 		void AddBehavior (SCNPhysicsBehavior behavior);
@@ -4526,6 +4527,8 @@ namespace SceneKit {
 		[Export ("sweepTestFraction")]
 		nfloat SweepTestFraction { get; }
 	}
+
+	interface ISCNPhysicsContactDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[Protocol, Model]

--- a/src/scriptingbridge.cs
+++ b/src/scriptingbridge.cs
@@ -144,8 +144,7 @@ namespace ScriptingBridge {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		SBApplicationDelegate Delegate { get; set; }
+		ISBApplicationDelegate Delegate { get; set; }
 
 		[Export ("launchFlags")]
 		LSLaunchFlags LaunchFlags { get; set; }
@@ -156,6 +155,8 @@ namespace ScriptingBridge {
 		[Export ("timeout")]
 		nint Timeout { get; set; }
 	}
+
+	interface ISBApplicationDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -642,8 +642,7 @@ namespace SpriteKit {
 
 		[MacCatalyst (13, 1)]
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		SKSceneDelegate Delegate { get; set; }
+		ISKSceneDelegate Delegate { get; set; }
 
 		[MacCatalyst (13, 1)]
 		[Export ("audioEngine", ArgumentSemantic.Retain)]
@@ -657,6 +656,8 @@ namespace SpriteKit {
 		[NullAllowed, Export ("listener", ArgumentSemantic.Weak)]
 		SKNode Listener { get; set; }
 	}
+
+	interface ISKSceneDelegate { }
 
 	[MacCatalyst (13, 1)]
 	[Protocol, Model]
@@ -2747,6 +2748,8 @@ namespace SpriteKit {
 
 	}
 
+	interface ISKPhysicsContactDelegate { }
+
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -2780,8 +2783,7 @@ namespace SpriteKit {
 		NSObject WeakContactDelegate { get; set; }
 
 		[Wrap ("WeakContactDelegate")]
-		[Protocolize]
-		SKPhysicsContactDelegate ContactDelegate { get; set; }
+		ISKPhysicsContactDelegate ContactDelegate { get; set; }
 
 		[Export ("addJoint:")]
 		void AddJoint (SKPhysicsJoint joint);

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -268,10 +268,10 @@ namespace StoreKit {
 		void FinishTransaction (SKPaymentTransaction transaction);
 
 		[Export ("addTransactionObserver:")]
-		void AddTransactionObserver ([Protocolize] SKPaymentTransactionObserver observer);
+		void AddTransactionObserver (ISKPaymentTransactionObserver observer);
 
 		[Export ("removeTransactionObserver:")]
-		void RemoveTransactionObserver ([Protocolize] SKPaymentTransactionObserver observer);
+		void RemoveTransactionObserver (ISKPaymentTransactionObserver observer);
 
 		[Export ("transactions")]
 		SKPaymentTransaction [] Transactions { get; }
@@ -538,8 +538,7 @@ namespace StoreKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		SKRequestDelegate Delegate { get; set; }
+		ISKRequestDelegate Delegate { get; set; }
 
 		[Export ("cancel")]
 		void Cancel ();
@@ -547,6 +546,8 @@ namespace StoreKit {
 		[Export ("start")]
 		void Start ();
 	}
+
+	interface ISKRequestDelegate { }
 
 	[Watch (6, 2)]
 	[MacCatalyst (13, 1)]
@@ -608,8 +609,7 @@ namespace StoreKit {
 
 		[Wrap ("WeakDelegate")]
 		[New]
-		[Protocolize]
-		SKProductsRequestDelegate Delegate { get; set; }
+		ISKProductsRequestDelegate Delegate { get; set; }
 	}
 
 	[Watch (6, 2)]
@@ -622,6 +622,8 @@ namespace StoreKit {
 		[Export ("invalidProductIdentifiers")]
 		string [] InvalidProducts { get; }
 	}
+
+	interface ISKProductsRequestDelegate { }
 
 	[Watch (6, 2)]
 	[MacCatalyst (13, 1)]
@@ -652,8 +654,7 @@ namespace StoreKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		SKStoreProductViewControllerDelegate Delegate { get; set; }
+		ISKStoreProductViewControllerDelegate Delegate { get; set; }
 
 		[Export ("loadProductWithParameters:completionBlock:")]
 		[Internal]
@@ -676,6 +677,8 @@ namespace StoreKit {
 		[Wrap ("LoadProduct (parameters.GetDictionary ()!, impression, callback)")]
 		void LoadProduct (StoreProductParameters parameters, SKAdImpression impression, [NullAllowed] Action<bool, NSError> callback);
 	}
+
+	interface ISKStoreProductViewControllerDelegate { }
 
 	[Mac (11, 0), NoTV, NoWatch]
 	[MacCatalyst (13, 1)]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -619,13 +619,14 @@ namespace UIKit {
 		double UpdateInterval { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIAccelerometerDelegate Delegate { get; set; }
+		IUIAccelerometerDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
 		NSObject WeakDelegate { get; set; }
 	}
+
+	interface IUIAccelerometerDelegate { }
 
 	[NoTV, NoWatch]
 	[MacCatalyst (13, 1)]
@@ -1401,8 +1402,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIActionSheetDelegate Delegate { get; set; }
+		IUIActionSheetDelegate Delegate { get; set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("title", ArgumentSemantic.Copy)]
@@ -1830,8 +1830,7 @@ namespace UIKit {
 		NativeHandle Constructor ([NullAllowed] string title, [NullAllowed] string message, [NullAllowed] IUIAlertViewDelegate viewDelegate, [NullAllowed] string cancelButtonTitle, IntPtr otherButtonTitles, IntPtr mustBeNull, IntPtr mustAlsoBeNull);
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIAlertViewDelegate Delegate { get; set; }
+		IUIAlertViewDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -2300,8 +2299,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIApplicationDelegate Delegate { get; set; }
+		IUIApplicationDelegate Delegate { get; set; }
 
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use UIView's 'UserInteractionEnabled' property instead.")]
 		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use UIView's 'UserInteractionEnabled' property instead.")]
@@ -3435,6 +3433,8 @@ namespace UIKit {
 		CGRect ConvertRectFromCoordinateSpace (CGRect rect, IUICoordinateSpace coordinateSpace);
 	}
 
+	interface IUIApplicationDelegate { }
+
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[NoMac, NoWatch]
@@ -4177,15 +4177,13 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UICollectionViewDelegate Delegate { get; set; }
+		IUICollectionViewDelegate Delegate { get; set; }
 
 		[Export ("dataSource", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDataSource { get; set; }
 
 		[Wrap ("WeakDataSource")]
-		[Protocolize]
-		UICollectionViewDataSource DataSource { get; set; }
+		IUICollectionViewDataSource DataSource { get; set; }
 
 		[Export ("backgroundView", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -4468,6 +4466,8 @@ namespace UIKit {
 
 	}
 
+	interface IUICollectionViewDataSource { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -4506,6 +4506,8 @@ namespace UIKit {
 		[Export ("collectionView:indexPathForIndexTitle:atIndex:")]
 		NSIndexPath GetIndexPath (UICollectionView collectionView, string title, nint atIndex);
 	}
+
+	interface IUICollectionViewDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -6094,8 +6096,7 @@ namespace UIKit {
 		NSObject WeakCollisionDelegate { get; set; }
 
 		[Wrap ("WeakCollisionDelegate")]
-		[Protocolize]
-		UICollisionBehaviorDelegate CollisionDelegate { get; set; }
+		IUICollisionBehaviorDelegate CollisionDelegate { get; set; }
 
 		[Export ("addItem:")]
 		void AddItem (IUIDynamicItem dynamicItem);
@@ -6123,6 +6124,8 @@ namespace UIKit {
 		[Export ("removeAllBoundaries")]
 		void RemoveAllBoundaries ();
 	}
+
+	interface IUICollisionBehaviorDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -6271,6 +6274,8 @@ namespace UIKit {
 
 	}
 
+	interface IUIDynamicAnimatorDelegate { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -6311,8 +6316,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIDynamicAnimatorDelegate Delegate { get; set; }
+		IUIDynamicAnimatorDelegate Delegate { get; set; }
 
 		[Export ("addBehavior:")]
 		[PostGet ("Behaviors")]
@@ -6963,8 +6967,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIGestureRecognizerDelegate Delegate { get; set; }
+		IUIGestureRecognizerDelegate Delegate { get; set; }
 
 		[Export ("enabled")]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
@@ -7106,6 +7109,8 @@ namespace UIKit {
 		[Export ("pressesCancelled:withEvent:")]
 		void PressesCancelled (NSSet<UIPress> presses, UIPressesEvent evt);
 	}
+
+	interface IUIGestureRecognizerDelegate { }
 
 	[NoWatch]
 	[NoMac]
@@ -7834,16 +7839,14 @@ namespace UIKit {
 		NSObject WeakInputDelegate { get; set; }
 
 		[Wrap ("WeakInputDelegate")]
-		[Protocolize]
-		UITextInputDelegate InputDelegate { get; set; }
+		IUITextInputDelegate InputDelegate { get; set; }
 
 		[Abstract]
 		[Export ("tokenizer")]
 		NSObject WeakTokenizer { get; }
 
 		[Wrap ("WeakTokenizer")]
-		[Protocolize]
-		UITextInputTokenizer Tokenizer { get; }
+		IUITextInputTokenizer Tokenizer { get; }
 
 		[Export ("textInputView")]
 		UIView TextInputView { get; }
@@ -8046,6 +8049,8 @@ namespace UIKit {
 		[Export ("trailingBarButtonGroups", ArgumentSemantic.Copy), NullAllowed]
 		UIBarButtonItemGroup [] TrailingBarButtonGroups { get; set; }
 	}
+
+	interface IUITextInputTokenizer { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -10426,8 +10431,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIDocumentInteractionControllerDelegate Delegate { get; set; }
+		IUIDocumentInteractionControllerDelegate Delegate { get; set; }
 
 		// default value is null but it cannot be set back to null
 		// NSInternalInconsistencyException Reason: UIDocumentInteractionController: invalid scheme (null).  Only the file scheme is supported.
@@ -10472,6 +10476,8 @@ namespace UIKit {
 		[Export ("gestureRecognizers")]
 		UIGestureRecognizer [] GestureRecognizers { get; }
 	}
+
+	interface IUIDocumentInteractionControllerDelegate { }
 
 	[NoTV, NoWatch]
 	[MacCatalyst (13, 1)]
@@ -10839,8 +10845,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UINavigationBarDelegate Delegate { get; set; }
+		IUINavigationBarDelegate Delegate { get; set; }
 
 		[Appearance]
 		[Export ("translucent", ArgumentSemantic.Assign)]
@@ -10986,6 +10991,8 @@ namespace UIKit {
 		[Export ("behavioralStyle", ArgumentSemantic.Assign)]
 		UIBehavioralStyle BehavioralStyle { get; }
 	}
+
+	interface IUINavigationBarDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -11287,8 +11294,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UINavigationControllerDelegate Delegate { get; set; }
+		IUINavigationControllerDelegate Delegate { get; set; }
 
 		[Field ("UINavigationControllerHideShowBarDuration")]
 		nfloat HideShowBarDuration { get; }
@@ -11332,6 +11338,8 @@ namespace UIKit {
 		[Export ("barHideOnTapGestureRecognizer", ArgumentSemantic.UnsafeUnretained)]
 		UITapGestureRecognizer BarHideOnTapGestureRecognizer { get; }
 	}
+
+	interface IUINavigationControllerDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -11502,15 +11510,13 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIPageViewControllerDelegate Delegate { get; set; }
+		IUIPageViewControllerDelegate Delegate { get; set; }
 
 		[Export ("dataSource", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDataSource { get; set; }
 
 		[Wrap ("WeakDataSource")]
-		[Protocolize]
-		UIPageViewControllerDataSource DataSource { get; set; }
+		IUIPageViewControllerDataSource DataSource { get; set; }
 
 		[Export ("transitionStyle")]
 		UIPageViewControllerTransitionStyle TransitionStyle { get; }
@@ -11546,6 +11552,8 @@ namespace UIKit {
 		NSString OptionInterPageSpacingKey { get; }
 	}
 
+	interface IUIPageViewControllerDelegate { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -11578,6 +11586,8 @@ namespace UIKit {
 		[DefaultValue (UIInterfaceOrientation.Portrait)]
 		UIInterfaceOrientation GetPreferredInterfaceOrientationForPresentation (UIPageViewController pageViewController);
 	}
+
+	interface IUIPageViewControllerDataSource { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -11888,8 +11898,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIPickerViewDelegate Delegate { get; set; }
+		IUIPickerViewDelegate Delegate { get; set; }
 
 		[Deprecated (PlatformName.iOS, 13, 0)]
 		[Deprecated (PlatformName.MacCatalyst, 13, 1)]
@@ -11934,6 +11943,8 @@ namespace UIKit {
 		[Export ("tableView:cellForRowAtIndexPath:")]
 		UITableViewCell GetCell (UITableView tableView, NSIndexPath indexPath);
 	}
+
+	interface IUIPickerViewDelegate { }
 
 	[NoTV, NoWatch]
 	[MacCatalyst (13, 1)]
@@ -12079,8 +12090,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIAdaptivePresentationControllerDelegate Delegate { get; set; }
+		IUIAdaptivePresentationControllerDelegate Delegate { get; set; }
 
 		[Deprecated (PlatformName.iOS, 17, 0, message: "Use the 'TraitOverrides' property instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 17, 0, message: "Use the 'TraitOverrides' property instead.")]
@@ -12798,8 +12808,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIScrollViewDelegate Delegate { get; set; }
+		IUIScrollViewDelegate Delegate { get; set; }
 
 		[Export ("bounces")]
 		bool Bounces { get; set; }
@@ -12949,6 +12958,8 @@ namespace UIKit {
 		bool AllowsKeyboardScrolling { get; set; }
 	}
 
+	interface IUIScrollViewDelegate { }
+
 	[NoMac, NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -13041,8 +13052,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UISearchBarDelegate Delegate { get; set; }
+		IUISearchBarDelegate Delegate { get; set; }
 
 		[Export ("text", ArgumentSemantic.Copy)]
 		[NullAllowed]
@@ -13209,6 +13219,8 @@ namespace UIKit {
 		new bool LookToDictateEnabled { [Bind ("isLookToDictateEnabled")] get; set; }
 	}
 
+	interface IUISearchBarDelegate { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (UIBarPositioningDelegate))]
@@ -13296,8 +13308,7 @@ namespace UIKit {
 		NSObject WeakSearchResultsUpdater { get; set; }
 
 		[Wrap ("WeakSearchResultsUpdater")]
-		[Protocolize]
-		UISearchResultsUpdating SearchResultsUpdater { get; set; }
+		IUISearchResultsUpdating SearchResultsUpdater { get; set; }
 
 		[Export ("active", ArgumentSemantic.UnsafeUnretained)]
 		bool Active { [Bind ("isActive")] get; set; }
@@ -13306,8 +13317,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UISearchControllerDelegate Delegate { get; set; }
+		IUISearchControllerDelegate Delegate { get; set; }
 
 		[Deprecated (PlatformName.iOS, 12, 0, message: "Use 'ObscuresBackgroundDuringPresentation' instead.")]
 		[NoTV]
@@ -13377,6 +13387,8 @@ namespace UIKit {
 
 	}
 
+	interface IUISearchControllerDelegate { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[Protocol, Model]
@@ -13422,8 +13434,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UISearchDisplayDelegate Delegate { get; set; }
+		IUISearchDisplayDelegate Delegate { get; set; }
 
 		[Export ("active")]
 		bool Active { [Bind ("isActive")] get; set; }
@@ -13445,16 +13456,14 @@ namespace UIKit {
 		NSObject SearchResultsWeakDataSource { get; set; }
 
 		[Wrap ("SearchResultsWeakDataSource")]
-		[Protocolize]
-		UITableViewDataSource SearchResultsDataSource { get; set; }
+		IUITableViewDataSource SearchResultsDataSource { get; set; }
 
 		[Export ("searchResultsDelegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
 		NSObject SearchResultsWeakDelegate { get; set; }
 
 		[Wrap ("SearchResultsWeakDelegate")]
-		[Protocolize]
-		UITableViewDelegate SearchResultsDelegate { get; set; }
+		IUITableViewDelegate SearchResultsDelegate { get; set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("searchResultsTitle", ArgumentSemantic.Copy)]
@@ -13466,6 +13475,8 @@ namespace UIKit {
 		[Export ("navigationItem")]
 		UINavigationItem NavigationItem { get; }
 	}
+
+	interface IUISearchDisplayDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -13534,6 +13545,8 @@ namespace UIKit {
 		[Deprecated (PlatformName.MacCatalyst, 13, 1)]
 		bool ShouldReloadForSearchScope (UISearchDisplayController controller, nint forSearchOption);
 	}
+
+	interface IUISearchResultsUpdating { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -13966,8 +13979,7 @@ namespace UIKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		UITabBarDelegate Delegate { get; set; }
+		IUITabBarDelegate Delegate { get; set; }
 
 		[Export ("items", ArgumentSemantic.Copy)]
 		[NullAllowed]
@@ -14117,13 +14129,14 @@ namespace UIKit {
 		UITabBar TabBar { get; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UITabBarControllerDelegate Delegate { get; set; }
+		IUITabBarControllerDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
 		NSObject WeakDelegate { get; set; }
 	}
+
+	interface IUITabBarDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -14154,6 +14167,8 @@ namespace UIKit {
 		[Export ("tabBar:didEndCustomizingItems:changed:"), EventArgs ("UITabBarFinalItems")]
 		void DidEndCustomizingItems (UITabBar tabbar, UITabBarItem [] items, bool changed);
 	}
+
+	interface IUITabBarControllerDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -14350,8 +14365,7 @@ namespace UIKit {
 		NSObject WeakDataSource { get; set; }
 
 		[Wrap ("WeakDataSource")]
-		[Protocolize]
-		UITableViewDataSource DataSource { get; set; }
+		IUITableViewDataSource DataSource { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[New]
@@ -14360,8 +14374,7 @@ namespace UIKit {
 
 		[Wrap ("WeakDelegate")]
 		[New]
-		[Protocolize]
-		UITableViewDelegate Delegate { get; set; }
+		IUITableViewDelegate Delegate { get; set; }
 
 		[Export ("rowHeight")]
 		nfloat RowHeight { get; set; }
@@ -15192,6 +15205,8 @@ namespace UIKit {
 		UIRefreshControl RefreshControl { get; set; }
 	}
 
+	interface IUITableViewDataSource { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -15240,6 +15255,8 @@ namespace UIKit {
 		[Export ("tableView:moveRowAtIndexPath:toIndexPath:")]
 		void MoveRow (UITableView tableView, NSIndexPath sourceIndexPath, NSIndexPath destinationIndexPath);
 	}
+
+	interface IUITableViewDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -15633,8 +15650,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UITextFieldDelegate Delegate { get; set; }
+		IUITextFieldDelegate Delegate { get; set; }
 
 		[Export ("background", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -15751,6 +15767,8 @@ namespace UIKit {
 		NSObject InteractionState { get; set; }
 	}
 
+	interface IUITextFieldDelegate { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -15842,8 +15860,7 @@ namespace UIKit {
 
 		[Wrap ("WeakDelegate")]
 		[New]
-		[Protocolize]
-		UITextViewDelegate Delegate { get; set; }
+		IUITextViewDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[New]
@@ -15956,6 +15973,8 @@ namespace UIKit {
 		[Export ("borderStyle", ArgumentSemantic.Assign)]
 		UITextViewBorderStyle BorderStyle { get; set; }
 	}
+
+	interface IUITextViewDelegate { }
 
 	[BaseType (typeof (UIScrollViewDelegate))]
 	[NoMac, NoWatch]
@@ -16120,8 +16139,7 @@ namespace UIKit {
 		UIToolbarAppearance CompactScrollEdgeAppearance { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIToolbarDelegate Delegate { get; set; }
+		IUIToolbarDelegate Delegate { get; set; }
 	}
 
 	interface IUITimingCurveProvider { }
@@ -16142,6 +16160,8 @@ namespace UIKit {
 		[NullAllowed, Export ("springTimingParameters")]
 		UISpringTimingParameters SpringTimingParameters { get; }
 	}
+
+	interface IUIToolbarDelegate { }
 
 	[NoTV, NoWatch]
 	[MacCatalyst (13, 1)]
@@ -16251,9 +16271,8 @@ namespace UIKit {
 		bool CanEditVideoAtPath (string path);
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
 		// id<UINavigationControllerDelegate, UIVideoEditorControllerDelegate>
-		UIVideoEditorControllerDelegate Delegate { get; set; }
+		IUIVideoEditorControllerDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -16268,6 +16287,8 @@ namespace UIKit {
 		[Export ("videoQuality")]
 		UIImagePickerControllerQualityType VideoQuality { get; set; }
 	}
+
+	interface IUIVideoEditorControllerDelegate { }
 
 	// id<UINavigationControllerDelegate, UIVideoEditorControllerDelegate>
 	[BaseType (typeof (UINavigationControllerDelegate))]
@@ -17581,8 +17602,7 @@ namespace UIKit {
 		NSObject WeakTransitioningDelegate { get; set; }
 
 		[Wrap ("WeakTransitioningDelegate")]
-		[Protocolize]
-		UIViewControllerTransitioningDelegate TransitioningDelegate { get; set; }
+		IUIViewControllerTransitioningDelegate TransitioningDelegate { get; set; }
 
 		[NoTV]
 		[MacCatalyst (13, 1)]
@@ -18311,6 +18331,8 @@ namespace UIKit {
 	}
 	interface IUIViewControllerInteractiveTransitioning { }
 
+	interface IUIViewControllerTransitioningDelegate { }
+
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[Model, BaseType (typeof (NSObject))]
@@ -18501,8 +18523,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIWebViewDelegate Delegate { get; set; }
+		IUIWebViewDelegate Delegate { get; set; }
 
 		[Export ("loadRequest:")]
 		void LoadRequest (NSUrlRequest r);
@@ -18585,6 +18606,8 @@ namespace UIKit {
 		[Export ("allowsLinkPreview")]
 		bool AllowsLinkPreview { get; set; }
 	}
+
+	interface IUIWebViewDelegate { }
 
 	[NoMacCatalyst, NoWatch]
 	[NoTV]
@@ -18861,8 +18884,7 @@ namespace UIKit {
 		UIViewController [] ViewControllers { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UISplitViewControllerDelegate Delegate { get; set; }
+		IUISplitViewControllerDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -18962,6 +18984,8 @@ namespace UIKit {
 		[Export ("primaryBackgroundStyle", ArgumentSemantic.Assign)]
 		UISplitViewControllerBackgroundStyle PrimaryBackgroundStyle { get; set; }
 	}
+
+	interface IUISplitViewControllerDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -19323,8 +19347,7 @@ namespace UIKit {
 		UIView [] PassthroughViews { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIPopoverControllerDelegate Delegate { get; set; }
+		IUIPopoverControllerDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -19358,6 +19381,8 @@ namespace UIKit {
 		[Export ("backgroundColor", ArgumentSemantic.Copy)]
 		UIColor BackgroundColor { get; set; }
 	}
+
+	interface IUIPopoverControllerDelegate { }
 
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
@@ -19395,8 +19420,7 @@ namespace UIKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		UIPopoverPresentationControllerDelegate Delegate { get; set; }
+		IUIPopoverPresentationControllerDelegate Delegate { get; set; }
 
 		[Export ("permittedArrowDirections", ArgumentSemantic.UnsafeUnretained)]
 		UIPopoverArrowDirection PermittedArrowDirections { get; set; }
@@ -19441,6 +19465,8 @@ namespace UIKit {
 		[NullAllowed]
 		IUIPopoverPresentationControllerSourceItem SourceItem { get; set; }
 	}
+
+	interface IUIAdaptivePresentationControllerDelegate { }
 
 	[NoWatch]
 	[MacCatalyst (13, 1)]
@@ -19494,6 +19520,8 @@ namespace UIKit {
 		[Export ("presentationControllerDidAttemptToDismiss:")]
 		void DidAttemptToDismiss (UIPresentationController presentationController);
 	}
+
+	interface IUIPopoverPresentationControllerDelegate { }
 
 	[NoTV, NoWatch]
 	[MacCatalyst (13, 1)]
@@ -19599,8 +19627,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIPrinterPickerControllerDelegate Delegate { get; set; }
+		IUIPrinterPickerControllerDelegate Delegate { get; set; }
 
 		[Static, Export ("printerPickerControllerWithInitiallySelectedPrinter:")]
 		UIPrinterPickerController FromPrinter ([NullAllowed] UIPrinter printer);
@@ -19620,6 +19647,8 @@ namespace UIKit {
 		[Export ("dismissAnimated:")]
 		void Dismiss (bool animated);
 	}
+
+	interface IUIPrinterPickerControllerDelegate { }
 
 	[NoTV, NoWatch]
 	[MacCatalyst (13, 1)]
@@ -19717,6 +19746,8 @@ namespace UIKit {
 		UIPrintFormatter [] PrintFormattersForPage (nint index);
 	}
 
+	interface IUIPrintInteractionControllerDelegate { }
+
 	[NoTV, NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -19766,8 +19797,7 @@ namespace UIKit {
 	[DisableDefaultCtor]
 	interface UIPrintInteractionController {
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIPrintInteractionControllerDelegate Delegate { get; set; }
+		IUIPrintInteractionControllerDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Assign)]
 		[NullAllowed]
@@ -20644,8 +20674,7 @@ namespace UIKit {
 		NativeHandle Constructor (NSUrl url, UIDocumentPickerMode mode);
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIDocumentMenuDelegate Delegate { get; set; }
+		IUIDocumentMenuDelegate Delegate { get; set; }
 
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -20654,6 +20683,8 @@ namespace UIKit {
 		[Async]
 		void AddOption (string title, [NullAllowed] UIImage image, UIDocumentMenuOrder order, Action completionHandler);
 	}
+
+	interface IUIDocumentMenuDelegate { }
 
 	[NoWatch]
 	[NoTV]
@@ -20727,8 +20758,7 @@ namespace UIKit {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIDocumentPickerDelegate Delegate { get; set; }
+		IUIDocumentPickerDelegate Delegate { get; set; }
 
 		[Deprecated (PlatformName.iOS, 14, 0)]
 		[Deprecated (PlatformName.MacCatalyst, 14, 0)]
@@ -20749,6 +20779,8 @@ namespace UIKit {
 		[NullAllowed, Export ("directoryURL", ArgumentSemantic.Copy)]
 		NSUrl DirectoryUrl { get; set; }
 	}
+
+	interface IUIDocumentPickerDelegate { }
 
 	[NoWatch]
 	[NoTV]

--- a/src/watchkit.cs
+++ b/src/watchkit.cs
@@ -913,8 +913,7 @@ namespace WatchKit {
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		[Protocolize]
-		WKExtensionDelegate Delegate { get; set; }
+		IWKExtensionDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		NSObject WeakDelegate { get; set; }
@@ -982,6 +981,8 @@ namespace WatchKit {
 		[Notification, Field ("WKApplicationDidEnterBackgroundNotification")]
 		NSString DidEnterBackgroundNotification { get; }
 	}
+
+	interface IWKExtensionDelegate { }
 
 	[NoiOS]
 	[Protocol]

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -1154,6 +1154,8 @@ namespace WebKit {
 	partial interface DomEntityReference {
 	}
 
+	interface IDomEventTarget { }
+
 	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "No longer supported.")]
 	[BaseType (typeof (NSObject), Name = "DOMEventTarget")]
@@ -1182,12 +1184,10 @@ namespace WebKit {
 		string Type { get; }
 
 		[Export ("target", ArgumentSemantic.Retain)]
-		[Protocolize]
-		DomEventTarget Target { get; }
+		IDomEventTarget Target { get; }
 
 		[Export ("currentTarget", ArgumentSemantic.Retain)]
-		[Protocolize]
-		DomEventTarget CurrentTarget { get; }
+		IDomEventTarget CurrentTarget { get; }
 
 		[Export ("eventPhase")]
 		DomEventPhase EventPhase { get; }
@@ -1202,8 +1202,7 @@ namespace WebKit {
 		UInt64 TimeStamp { get; }
 
 		[Export ("srcElement", ArgumentSemantic.Retain)]
-		[Protocolize]
-		DomEventTarget SourceElement { get; }
+		IDomEventTarget SourceElement { get; }
 
 		[Export ("returnValue")]
 		bool ReturnValue { get; set; }
@@ -1381,13 +1380,13 @@ namespace WebKit {
 #if !XAMCORE_3_0
 		[Obsolete ("Use the constructor instead.")]
 		[Export ("initMouseEvent:canBubble:cancelable:view:detail:screenX:screenY:clientX:clientY:ctrlKey:altKey:shiftKey:metaKey:button:relatedTarget:")]
-		void InitEvent (string eventType, bool canBubble, bool cancelable, DomAbstractView view, int /* int, not NSInteger */ detail, int /* int, not NSInteger */ screenX, int /* int, not NSInteger */ screenY, int /* int, not NSInteger */ clientX, int /* int, not NSInteger */ clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, ushort button, [Protocolize] DomEventTarget relatedTarget);
+		void InitEvent (string eventType, bool canBubble, bool cancelable, DomAbstractView view, int /* int, not NSInteger */ detail, int /* int, not NSInteger */ screenX, int /* int, not NSInteger */ screenY, int /* int, not NSInteger */ clientX, int /* int, not NSInteger */ clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, ushort button, IDomEventTarget relatedTarget);
 #endif
 #if !XAMCORE_3_0
 		[Sealed] // Just to avoid the duplicate selector error
 #endif
 		[Export ("initMouseEvent:canBubble:cancelable:view:detail:screenX:screenY:clientX:clientY:ctrlKey:altKey:shiftKey:metaKey:button:relatedTarget:")]
-		NativeHandle Constructor (string eventType, bool canBubble, bool cancelable, DomAbstractView view, int /* int, not NSInteger */ detail, int /* int, not NSInteger */ screenX, int /* int, not NSInteger */ screenY, int /* int, not NSInteger */ clientX, int /* int, not NSInteger */ clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, ushort button, [Protocolize] DomEventTarget relatedTarget);
+		NativeHandle Constructor (string eventType, bool canBubble, bool cancelable, DomAbstractView view, int /* int, not NSInteger */ detail, int /* int, not NSInteger */ screenX, int /* int, not NSInteger */ screenY, int /* int, not NSInteger */ clientX, int /* int, not NSInteger */ clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, ushort button, IDomEventTarget relatedTarget);
 
 		[Export ("screenX")]
 		int ScreenX { get; } /* int, not NSInteger */
@@ -1417,8 +1416,7 @@ namespace WebKit {
 		ushort Button { get; }
 
 		[Export ("relatedTarget", ArgumentSemantic.Retain)]
-		[Protocolize]
-		DomEventTarget RelatedTarget { get; }
+		IDomEventTarget RelatedTarget { get; }
 
 		[Export ("offsetX")]
 		int OffsetX { get; } /* int, not NSInteger */
@@ -1895,8 +1893,7 @@ namespace WebKit {
 		NSData Data { get; }
 
 		[Export ("representation")]
-		[Protocolize]
-		WebDocumentRepresentation Representation { get; }
+		IWebDocumentRepresentation Representation { get; }
 
 		[Export ("webFrame")]
 		WebFrame WebFrame { get; }
@@ -1937,6 +1934,8 @@ namespace WebKit {
 		[Export ("addSubresource:")]
 		void AddSubresource (WebResource subresource);
 	}
+
+	interface IWebDocumentRepresentation { }
 
 	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "No longer supported.")]
@@ -2012,6 +2011,8 @@ namespace WebKit {
 	[BaseType (typeof (NSUrlDownload))]
 	partial interface WebDownload {
 	}
+
+	interface IWebDownloadDelegate { }
 
 	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "No longer supported.")]
@@ -2095,6 +2096,8 @@ namespace WebKit {
 		[Export ("javaScriptContext", ArgumentSemantic.Strong)]
 		JSContext JavaScriptContext { get; }
 	}
+
+	interface IWebFrameLoadDelegate { }
 
 	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "No longer supported.")]
@@ -2282,6 +2285,8 @@ namespace WebKit {
 
 	interface IWebOpenPanelResultListener { }
 
+	interface IWebPolicyDelegate { }
+
 	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "No longer supported.")]
 	[BaseType (typeof (NSObject))]
@@ -2461,6 +2466,8 @@ namespace WebKit {
 		string FrameName { get; }
 	}
 
+	interface IWebResourceLoadDelegate { }
+
 	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "No longer supported.")]
 	[BaseType (typeof (NSObject))]
@@ -2494,6 +2501,8 @@ namespace WebKit {
 		[Export ("webView:plugInFailedWithError:dataSource:"), EventArgs ("WebResourcePluginError")]
 		void OnPlugInFailed (WebView sender, NSError error, WebDataSource dataSource);
 	}
+
+	interface IWebUIDelegate { }
 
 	[NoiOS, NoTV, NoWatch, NoMacCatalyst]
 	[Deprecated (PlatformName.MacOSX, 10, 14, message: "No longer supported.")]
@@ -2816,36 +2825,31 @@ namespace WebKit {
 		NSObject WeakResourceLoadDelegate { get; set; }
 
 		[Wrap ("WeakResourceLoadDelegate")]
-		[Protocolize]
-		WebResourceLoadDelegate ResourceLoadDelegate { get; set; }
+		IWebResourceLoadDelegate ResourceLoadDelegate { get; set; }
 
 		[Export ("downloadDelegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDownloadDelegate { get; set; }
 
 		[Wrap ("WeakDownloadDelegate")]
-		[Protocolize]
-		WebDownloadDelegate DownloadDelegate { get; set; }
+		IWebDownloadDelegate DownloadDelegate { get; set; }
 
 		[Export ("frameLoadDelegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakFrameLoadDelegate { get; set; }
 
 		[Wrap ("WeakFrameLoadDelegate")]
-		[Protocolize]
-		WebFrameLoadDelegate FrameLoadDelegate { get; set; }
+		IWebFrameLoadDelegate FrameLoadDelegate { get; set; }
 
 		[Export ("UIDelegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakUIDelegate { get; set; }
 
 		[Wrap ("WeakUIDelegate")]
-		[Protocolize]
-		WebUIDelegate UIDelegate { get; set; }
+		IWebUIDelegate UIDelegate { get; set; }
 
 		[Export ("policyDelegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakPolicyDelegate { get; set; }
 
 		[Wrap ("WeakPolicyDelegate")]
-		[Protocolize]
-		WebPolicyDelegate PolicyDelegate { get; set; }
+		IWebPolicyDelegate PolicyDelegate { get; set; }
 
 		[Export ("textSizeMultiplier")]
 		float TextSizeMultiplier { get; set; } /* float, not CGFloat */
@@ -4646,6 +4650,8 @@ namespace WebKit {
 		void NavigationResponseDidBecomeDownload (WKWebView webView, WKNavigationResponse navigationResponse, WKDownload download);
 	}
 
+	interface IWKNavigationDelegate { }
+
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
 	interface WKNavigationResponse {
@@ -5094,6 +5100,8 @@ namespace WebKit {
 		void WillDismissEditMenu (WKWebView webView, IUIEditMenuInteractionAnimating animator);
 	}
 
+	interface IWKUIDelegate { }
+
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
 	interface WKUserContentController : NSSecureCoding {
@@ -5108,7 +5116,7 @@ namespace WebKit {
 		void RemoveAllUserScripts ();
 
 		[Export ("addScriptMessageHandler:name:")]
-		void AddScriptMessageHandler ([Protocolize] WKScriptMessageHandler scriptMessageHandler, string name);
+		void AddScriptMessageHandler (IWKScriptMessageHandler scriptMessageHandler, string name);
 
 		[Mac (11, 0), iOS (14, 0)]
 		[MacCatalyst (14, 0)]
@@ -5210,16 +5218,14 @@ namespace WebKit {
 		NSObject WeakNavigationDelegate { get; set; }
 
 		[Wrap ("WeakNavigationDelegate")]
-		[Protocolize]
-		WKNavigationDelegate NavigationDelegate { get; set; }
+		IWKNavigationDelegate NavigationDelegate { get; set; }
 
 		[Export ("UIDelegate", ArgumentSemantic.Weak)]
 		[NullAllowed]
 		NSObject WeakUIDelegate { get; set; }
 
 		[Wrap ("WeakUIDelegate")]
-		[Protocolize]
-		WKUIDelegate UIDelegate { get; set; }
+		IWKUIDelegate UIDelegate { get; set; }
 
 		[Export ("backForwardList", ArgumentSemantic.Strong)]
 		WKBackForwardList BackForwardList { get; }

--- a/tests/generator/NSApplicationPublicEnsureMethods.cs
+++ b/tests/generator/NSApplicationPublicEnsureMethods.cs
@@ -22,6 +22,8 @@ namespace Test {
 		ISharedDelegate Delegate { get; set; }
 	}
 
+	public interface ISharedDelegate {}
+
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/tests/generator/NSApplicationPublicEnsureMethods.cs
+++ b/tests/generator/NSApplicationPublicEnsureMethods.cs
@@ -19,8 +19,7 @@ namespace Test {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		SharedDelegate Delegate { get; set; }
+		ISharedDelegate Delegate { get; set; }
 	}
 
 	[BaseType (typeof (NSObject))]

--- a/tests/generator/NSApplicationPublicEnsureMethods.cs
+++ b/tests/generator/NSApplicationPublicEnsureMethods.cs
@@ -22,7 +22,7 @@ namespace Test {
 		ISharedDelegate Delegate { get; set; }
 	}
 
-	public interface ISharedDelegate {}
+	public interface ISharedDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]

--- a/tests/generator/bug24078-ignore-methods-events.cs
+++ b/tests/generator/bug24078-ignore-methods-events.cs
@@ -17,8 +17,7 @@ namespace Test {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		UIPopoverPresentationControllerDelegate Delegate { get; set; }
+		IUIPopoverPresentationControllerDelegate Delegate { get; set; }
 	}
 
 	[Protocol, Model]

--- a/tests/generator/bug24078-ignore-methods-events.cs
+++ b/tests/generator/bug24078-ignore-methods-events.cs
@@ -20,6 +20,8 @@ namespace Test {
 		IUIPopoverPresentationControllerDelegate Delegate { get; set; }
 	}
 
+	public interface IUIPopoverPresentationControllerDelegate {}
+
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	public partial interface UIPopoverPresentationControllerDelegate {

--- a/tests/generator/bug24078-ignore-methods-events.cs
+++ b/tests/generator/bug24078-ignore-methods-events.cs
@@ -20,7 +20,7 @@ namespace Test {
 		IUIPopoverPresentationControllerDelegate Delegate { get; set; }
 	}
 
-	public interface IUIPopoverPresentationControllerDelegate {}
+	public interface IUIPopoverPresentationControllerDelegate { }
 
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]

--- a/tests/generator/bug37527-wrong-property.cs
+++ b/tests/generator/bug37527-wrong-property.cs
@@ -12,7 +12,7 @@ namespace Test {
 	[Protocol]
 	public interface SharedDelegate {
 	}
-	public interface ISharedDelegate {}
+	public interface ISharedDelegate { }
 
 	[BaseType (typeof (NSObject), Delegates = new string [] { "WeakDelegate" }, Events = new Type [] { typeof (SharedDelegate) })]
 	public interface TestWrongPropertyName {

--- a/tests/generator/bug37527-wrong-property.cs
+++ b/tests/generator/bug37527-wrong-property.cs
@@ -19,7 +19,6 @@ namespace Test {
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
-		[Protocolize]
-		SharedDelegate TestProperty { get; set; }
+		ISharedDelegate TestProperty { get; set; }
 	}
 }

--- a/tests/generator/bug37527-wrong-property.cs
+++ b/tests/generator/bug37527-wrong-property.cs
@@ -12,6 +12,7 @@ namespace Test {
 	[Protocol]
 	public interface SharedDelegate {
 	}
+	public interface ISharedDelegate {}
 
 	[BaseType (typeof (NSObject), Delegates = new string [] { "WeakDelegate" }, Events = new Type [] { typeof (SharedDelegate) })]
 	public interface TestWrongPropertyName {


### PR DESCRIPTION
Remove support for the Protocolize attribute from the generator, and remove
all usages of it in our api definitions - just use the protocol interface.

The Protocolize attribute was used to support binding stuff using the Model
class with Classic Xamarin code + and binding stuff using the protocol
interface with Unified Xamarin code, using the same source code.

Classic Xamarin has been dead for quite a few years ago now though, so there's
no need to keep his code around anymore, we can just upgrade the api
definitions to use the protocol interface directly.

Fixes https://github.com/xamarin/xamarin-macios/issues/14585.