### PR TITLE
[src] Remove the UnifiedInternal attribute.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -2472,11 +2472,11 @@ namespace AVFoundation {
 		[Field ("AVAudioSessionPortVirtual")]
 		NSString PortVirtual { get; }
 
-		[UnifiedInternal, Field ("AVAudioSessionLocationUpper")]
-		NSString LocationUpper { get; }
+		[Internal, Field ("AVAudioSessionLocationUpper")]
+		NSString LocationUpper_ { get; }
 
-		[UnifiedInternal, Field ("AVAudioSessionLocationLower")]
-		NSString LocationLower { get; }
+		[Internal, Field ("AVAudioSessionLocationLower")]
+		NSString LocationLower_ { get; }
 
 		[NoMac]
 		[MacCatalyst (13, 1)]
@@ -2560,17 +2560,17 @@ namespace AVFoundation {
 		[Export ("maximumOutputNumberOfChannels")]
 		nint MaximumOutputNumberOfChannels { get; }
 
-		[UnifiedInternal, Field ("AVAudioSessionOrientationTop")]
-		NSString OrientationTop { get; }
+		[Internal, Field ("AVAudioSessionOrientationTop")]
+		NSString OrientationTop_ { get; }
 
-		[UnifiedInternal, Field ("AVAudioSessionOrientationBottom")]
-		NSString OrientationBottom { get; }
+		[Internal, Field ("AVAudioSessionOrientationBottom")]
+		NSString OrientationBottom_ { get; }
 
-		[UnifiedInternal, Field ("AVAudioSessionOrientationFront")]
-		NSString OrientationFront { get; }
+		[Internal, Field ("AVAudioSessionOrientationFront")]
+		NSString OrientationFront_ { get; }
 
-		[UnifiedInternal, Field ("AVAudioSessionOrientationBack")]
-		NSString OrientationBack { get; }
+		[Internal, Field ("AVAudioSessionOrientationBack")]
+		NSString OrientationBack_ { get; }
 
 		[MacCatalyst (13, 1)]
 		[Field ("AVAudioSessionOrientationLeft")]
@@ -2580,14 +2580,14 @@ namespace AVFoundation {
 		[Field ("AVAudioSessionOrientationRight")]
 		NSString OrientationRight { get; }
 
-		[UnifiedInternal, Field ("AVAudioSessionPolarPatternOmnidirectional")]
-		NSString PolarPatternOmnidirectional { get; }
+		[Internal, Field ("AVAudioSessionPolarPatternOmnidirectional")]
+		NSString PolarPatternOmnidirectional_ { get; }
 
-		[UnifiedInternal, Field ("AVAudioSessionPolarPatternCardioid")]
-		NSString PolarPatternCardioid { get; }
+		[Internal, Field ("AVAudioSessionPolarPatternCardioid")]
+		NSString PolarPatternCardioid_ { get; }
 
-		[UnifiedInternal, Field ("AVAudioSessionPolarPatternSubcardioid")]
-		NSString PolarPatternSubcardioid { get; }
+		[Internal, Field ("AVAudioSessionPolarPatternSubcardioid")]
+		NSString PolarPatternSubcardioid_ { get; }
 
 		[NoWatch, NoTV, NoMac, iOS (14, 0)]
 		[MacCatalyst (14, 0)]
@@ -2786,23 +2786,23 @@ namespace AVFoundation {
 
 		[NoWatch]
 		[MacCatalyst (13, 1)]
-		[UnifiedInternal, Export ("supportedPolarPatterns"), NullAllowed]
-		NSString [] SupportedPolarPatterns { get; }
+		[Internal, Export ("supportedPolarPatterns"), NullAllowed]
+		NSString [] SupportedPolarPatterns_ { get; }
 
 		[NoWatch]
 		[MacCatalyst (13, 1)]
-		[UnifiedInternal, Export ("selectedPolarPattern", ArgumentSemantic.Copy), NullAllowed]
-		NSString SelectedPolarPattern { get; }
+		[Internal, Export ("selectedPolarPattern", ArgumentSemantic.Copy), NullAllowed]
+		NSString SelectedPolarPattern_ { get; }
 
 		[NoWatch]
 		[MacCatalyst (13, 1)]
-		[UnifiedInternal, Export ("preferredPolarPattern", ArgumentSemantic.Copy), NullAllowed]
-		NSString PreferredPolarPattern { get; }
+		[Internal, Export ("preferredPolarPattern", ArgumentSemantic.Copy), NullAllowed]
+		NSString PreferredPolarPattern_ { get; }
 
 		[NoWatch]
 		[MacCatalyst (13, 1)]
-		[UnifiedInternal, Export ("setPreferredPolarPattern:error:")]
-		bool SetPreferredPolarPattern ([NullAllowed] NSString pattern, out NSError outError);
+		[Internal, Export ("setPreferredPolarPattern:error:")]
+		bool SetPreferredPolarPattern_ ([NullAllowed] NSString pattern, out NSError outError);
 
 	}
 

--- a/src/bgen/AttributeManager.cs
+++ b/src/bgen/AttributeManager.cs
@@ -212,8 +212,6 @@ public class AttributeManager {
 			return typeof (ThreadSafeAttribute);
 		case "TransientAttribute":
 			return typeof (TransientAttribute);
-		case "UnifiedInternalAttribute":
-			return typeof (UnifiedInternalAttribute);
 		case "Visibility":
 			return typeof (Visibility);
 		case "WrapAttribute":

--- a/src/bgen/Attributes.cs
+++ b/src/bgen/Attributes.cs
@@ -246,14 +246,17 @@ public class InternalAttribute : Attribute {
 	public InternalAttribute () { }
 }
 
+#if !XAMCORE_5_0
 // This is a conditional "Internal" method, that flags methods as internal only when
 // compiling with Unified, otherwise, this is ignored.
 //
 // In addition, UnifiedInternal members automatically get an underscore after their name
 // so [UnifiedInternal] void Foo(); becomes "Foo_()"
+[Obsolete ("This attribute no longer has any effect; do no use")]
 public class UnifiedInternalAttribute : Attribute {
 	public UnifiedInternalAttribute () { }
 }
+#endif
 
 // When applied to a method or property, flags the resulting generated code as internal
 public sealed class ProtectedAttribute : Attribute {

--- a/src/bgen/Extensions/ExtensionMethods.cs
+++ b/src/bgen/Extensions/ExtensionMethods.cs
@@ -120,25 +120,17 @@ public static class ReflectionExtensions {
 
 	public static bool IsInternal (this MemberInfo mi, Generator generator)
 	{
-		return generator.AttributeManager.HasAttribute<InternalAttribute> (mi)
-			|| (generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi));
-	}
-
-	public static bool IsUnifiedInternal (this MemberInfo mi, Generator generator)
-	{
-		return (generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi));
+		return generator.AttributeManager.HasAttribute<InternalAttribute> (mi);
 	}
 
 	public static bool IsInternal (this PropertyInfo pi, Generator generator)
 	{
-		return generator.AttributeManager.HasAttribute<InternalAttribute> (pi)
-			|| (generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (pi));
+		return generator.AttributeManager.HasAttribute<InternalAttribute> (pi);
 	}
 
 	public static bool IsInternal (this Type type, Generator generator)
 	{
-		return generator.AttributeManager.HasAttribute<InternalAttribute> (type)
-			|| (generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (type));
+		return generator.AttributeManager.HasAttribute<InternalAttribute> (type);
 	}
 
 	public static List<MethodInfo> GatherMethods (this Type type, BindingFlags flags, Generator generator)

--- a/src/bgen/Models/MemberInformation.cs
+++ b/src/bgen/Models/MemberInformation.cs
@@ -14,7 +14,6 @@ public class MemberInformation {
 	public readonly bool is_abstract;
 	public readonly bool is_protected;
 	public readonly bool is_internal;
-	public readonly bool is_unified_internal;
 	public readonly bool is_override;
 	public readonly bool is_new;
 	public readonly bool is_sealed;
@@ -57,7 +56,6 @@ public class MemberInformation {
 		is_abstract = AttributeManager.HasAttribute<AbstractAttribute> (mi) && mi.DeclaringType == type;
 		is_protected = AttributeManager.HasAttribute<ProtectedAttribute> (mi);
 		is_internal = mi.IsInternal (generator);
-		is_unified_internal = AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi);
 		is_override = AttributeManager.HasAttribute<OverrideAttribute> (mi) || !Generator.MemberBelongsToType (mi.DeclaringType, type);
 		is_new = AttributeManager.HasAttribute<NewAttribute> (mi);
 		is_sealed = AttributeManager.HasAttribute<SealedAttribute> (mi);


### PR DESCRIPTION
Remove support for the UnifiedInternal attribute from the generator, and remove
all usages of it in our api definitions - just use the Internal attribute.

The UnifiedInternal attribute was used to mark something as internal for
Unified Xamarin code, while still keeping it as public in Classic Xamarin
code.

Classic Xamarin has been dead for quite a few years ago now though, so there's
no need to keep his code around anymore.