### PR TITLE
[monotouch-test] Fix a variety of compiler warnings.

### DIFF
--- a/tests/bindings-test/Messaging.cs
+++ b/tests/bindings-test/Messaging.cs
@@ -5,6 +5,7 @@ namespace ObjCRuntime {
 	static class Messaging {
 		internal const string LIBOBJC_DYLIB = "/usr/lib/libobjc.dylib";
 
+		[StructLayout (LayoutKind.Sequential)]
 		public struct objc_super {
 			public IntPtr Handle;
 			public IntPtr SuperHandle;

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -43,6 +43,8 @@ using NUnit.Framework;
 using NativeHandle = System.IntPtr;
 #endif
 
+#nullable enable
+
 partial class TestRuntime {
 
 	[DllImport (Constants.CoreFoundationLibrary)]
@@ -91,7 +93,7 @@ partial class TestRuntime {
 	[System.Runtime.InteropServices.DllImport ("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
 	static extern int Gestalt (int selector, out int result);
 
-	static Version version;
+	static Version? version;
 
 	public static Version OSXVersion {
 		get {
@@ -190,10 +192,9 @@ partial class TestRuntime {
 
 	public static void AssertDesktop (string message = "This test only runs on Desktops (macOS or MacCatalyst).")
 	{
-#if __MACOS__ || __MACCATALYST__
-		return;
-#endif
+#if !(__MACOS__ || __MACCATALYST__)
 		NUnit.Framework.Assert.Ignore (message);
+#endif
 	}
 
 	public static void AssertNotDesktop (string message = "This test does not run on Desktops (macOS or MacCatalyst).")
@@ -1437,7 +1438,7 @@ partial class TestRuntime {
 #else
 		const string fieldName = "flags";
 #endif
-		return (byte) typeof (NSObject).GetField (fieldName, BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic).GetValue (obj);
+		return (byte) typeof (NSObject).GetField (fieldName, BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic)!.GetValue (obj)!;
 	}
 
 	// Determine if linkall was enabled by checking if an unused class in this assembly is still here.

--- a/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioFormatTest.cs
@@ -29,7 +29,9 @@ namespace MonoTouchFixtures.AVFoundation {
 		public void TestEqualOperatorSameInstace ()
 		{
 			using (var format = new AVAudioFormat ())
+#pragma warning disable CS1718 // warning CS1718: Comparison made to same variable; did you mean to compare something else?
 				Assert.IsTrue (format == format, "format == format");
+#pragma warning restore
 		}
 
 		[Test]

--- a/tests/monotouch-test/AudioUnit/AUParameterNodeTest.cs
+++ b/tests/monotouch-test/AudioUnit/AUParameterNodeTest.cs
@@ -69,7 +69,6 @@ namespace monotouchtest {
 		{
 			TestRuntime.AssertXcodeVersion (7, 0);
 
-			const ulong address = 0;
 			const float newValue = 10f;
 
 			bool recordingObserverInvoked = false;

--- a/tests/monotouch-test/CoreFoundation/DispatchBlockTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchBlockTests.cs
@@ -140,6 +140,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 				db.Cancel ();
 				Assert.AreNotEqual ((nint) 0, db.TestCancel (), "TestCancel 2");
 				Assert.IsTrue (db.Cancelled, "Cancelled 2");
+				Assert.IsFalse (called, "Called"); // The dispatch block was never submitted to a dispatch queue, so it shouldn't have executed.
 			}
 		}
 

--- a/tests/monotouch-test/CoreFoundation/NetworkTest.cs
+++ b/tests/monotouch-test/CoreFoundation/NetworkTest.cs
@@ -66,7 +66,9 @@ namespace MonoTouchFixtures.CoreFoundation {
 			if (PlatformCFNetwork.GetProxiesForUri (uri, settings).Length <= 1)
 				Assert.Ignore ("Only run when proxy is configured.");
 
+#pragma warning disable SYSLIB0014 // warning SYSLIB0014: 'WebRequest.CreateHttp(Uri)' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.' 
 			var req = WebRequest.CreateHttp (uri);
+#pragma warning restore
 			using (var rsp = req.GetResponse ())
 			using (var str = new StreamReader (rsp.GetResponseStream ()))
 				Console.WriteLine (str.ReadToEnd ());

--- a/tests/monotouch-test/CoreGraphics/CGEventTests.cs
+++ b/tests/monotouch-test/CoreGraphics/CGEventTests.cs
@@ -27,7 +27,6 @@ namespace MonoTouchFixtures.CoreGraphics {
 		public void CreateTap ()
 		{
 			tapCalled = false;
-			var psn = (IntPtr) 2; // kCurrentProcess
 			using var tapPort = CGEvent.CreateTap (CGEventTapLocation.AnnotatedSession, CGEventTapPlacement.HeadInsert, CGEventTapOptions.Default, CGEventMask.KeyDown, callBack, IntPtr.Zero);
 			Assert.IsFalse (tapCalled, "tap was mistakenly called.");
 		}

--- a/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
+++ b/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
@@ -3,7 +3,6 @@ using System;
 using CoreGraphics;
 using Foundation;
 using NUnit.Framework;
-using Foundation;
 using ObjCRuntime;
 using CoreVideo;
 using Xamarin.Utils;

--- a/tests/monotouch-test/Foundation/CoderTest.cs
+++ b/tests/monotouch-test/Foundation/CoderTest.cs
@@ -23,7 +23,6 @@ namespace MonoTouchFixtures.Foundation {
 		{
 			var buffer = new byte [] { 3, 14, 15 };
 			var obj = new NSString ();
-			byte [] data;
 			var ptr = Marshal.AllocHGlobal (buffer.Length);
 
 			for (int i = 0; i < buffer.Length; i++)

--- a/tests/monotouch-test/Foundation/NSDictionaryTest.cs
+++ b/tests/monotouch-test/Foundation/NSDictionaryTest.cs
@@ -219,7 +219,6 @@ namespace MonoTouchFixtures.Foundation {
 			IntPtr objptr;
 			IntPtr keyptr;
 
-			NSString obj, key;
 			NSString v;
 
 			try {

--- a/tests/monotouch-test/Foundation/NSMutableDictionaryTest.cs
+++ b/tests/monotouch-test/Foundation/NSMutableDictionaryTest.cs
@@ -19,7 +19,6 @@ namespace monotouchtest {
 			IntPtr objptr;
 			IntPtr keyptr;
 
-			NSString obj, key;
 			NSString v;
 
 			try {

--- a/tests/monotouch-test/Foundation/NSOperatingSystemVersionTest.cs
+++ b/tests/monotouch-test/Foundation/NSOperatingSystemVersionTest.cs
@@ -13,7 +13,7 @@ namespace MonoTouchFixtures.Foundation {
 
 		// IEqual Tests
 
-		public static IEnumerable<(NSOperatingSystemVersion, NSOperatingSystemVersion, bool)> VersionCasesEqual {
+		public static IEnumerable<(NSOperatingSystemVersion VersionOne, NSOperatingSystemVersion VersionTwo, bool Result)> VersionCasesEqual {
 			get {
 				yield return (VersionOne: new NSOperatingSystemVersion (major: (nint) 1), VersionTwo: new NSOperatingSystemVersion (major: (nint) 1), Result: true);
 				yield return (VersionOne: new NSOperatingSystemVersion (major: (nint) 1), VersionTwo: new NSOperatingSystemVersion (major: (nint) 2), Result: false);
@@ -36,12 +36,12 @@ namespace MonoTouchFixtures.Foundation {
 
 		// Object Equal Tests
 
-		public static IEnumerable<(Object, bool)> VersionCasesObjectEqual {
+		public static IEnumerable<(Object VersionOne, bool Result)> VersionCasesObjectEqual {
 			get {
 				yield return (VersionOne: new NSOperatingSystemVersion (major: (nint) 1, minor: (nint) 2, patchVersion: (nint) 3), Result: true);
 				yield return (VersionOne: new NSOperatingSystemVersion (major: (nint) 2), Result: false);
-				yield return ("hello", Result: false);
-				yield return (null, Result: false);
+				yield return (VersionOne: "hello", Result: false);
+				yield return (VersionOne: null, Result: false);
 			}
 		}
 
@@ -54,12 +54,12 @@ namespace MonoTouchFixtures.Foundation {
 
 		// Object Compare Tests
 
-		public static IEnumerable<(Object, int)> VersionCasesObjectCompare {
+		public static IEnumerable<(Object VersionOne, int Result)> VersionCasesObjectCompare {
 			get {
 				yield return (VersionOne: new NSOperatingSystemVersion (major: (nint) 1, minor: (nint) 2, patchVersion: (nint) 3), Result: 0);
 				yield return (VersionOne: new NSOperatingSystemVersion (major: (nint) 2), Result: -1);
-				yield return ("hello", Result: 1);
-				yield return (null, Result: 1);
+				yield return (VersionOne: "hello", Result: 1);
+				yield return (VersionOne: null, Result: 1);
 			}
 		}
 
@@ -104,7 +104,7 @@ namespace MonoTouchFixtures.Foundation {
 
 		// ICompare Tests
 
-		public static IEnumerable<(NSOperatingSystemVersion, NSOperatingSystemVersion, int)> VersionCasesCompare {
+		public static IEnumerable<(NSOperatingSystemVersion VersionOne, NSOperatingSystemVersion VersionTwo, int Result)> VersionCasesCompare {
 			get {
 				yield return (VersionOne: new NSOperatingSystemVersion (major: (nint) 1), VersionTwo: new NSOperatingSystemVersion (major: (nint) 1), Result: 0);
 				yield return (VersionOne: new NSOperatingSystemVersion (major: (nint) 1), VersionTwo: new NSOperatingSystemVersion (major: (nint) 2), Result: -1);

--- a/tests/monotouch-test/Foundation/NSTextListTest.cs
+++ b/tests/monotouch-test/Foundation/NSTextListTest.cs
@@ -25,7 +25,6 @@ namespace MonoTouchFixtures.Foundation {
 		[TestCase ("•")]
 		public void Constructor_CustomFormat (string format)
 		{
-			bool makeUnorderedList = false;
 			var textList = new NSTextList (format);
 			Assert.AreEqual (format, textList.CustomMarkerFormat, "CustomMarkerFormat");
 #if NET
@@ -40,7 +39,6 @@ namespace MonoTouchFixtures.Foundation {
 		[TestCase ("•", NSTextListOptions.PrependEnclosingMarker)]
 		public void Constructor_CustomFormat_2 (string format, NSTextListOptions options)
 		{
-			bool makeUnorderedList = false;
 			var textList = new NSTextList (format, options);
 			Assert.AreEqual (format, textList.CustomMarkerFormat, "CustomMarkerFormat");
 #if NET
@@ -56,7 +54,6 @@ namespace MonoTouchFixtures.Foundation {
 		[TestCase (NSTextListMarkerFormats.Box, NSTextListOptions.PrependEnclosingMarker)]
 		public void Constructor_TypedFormat_2 (NSTextListMarkerFormats format, NSTextListOptions options)
 		{
-			bool makeUnorderedList = false;
 			var textList = new NSTextList (format, options);
 			Assert.AreEqual ((string) format.GetConstant ()!, textList.CustomMarkerFormat, "CustomMarkerFormat");
 #if NET
@@ -71,7 +68,6 @@ namespace MonoTouchFixtures.Foundation {
 		[TestCase (NSTextListMarkerFormats.Diamond)]
 		public void Constructor_TypedFormat (NSTextListMarkerFormats format)
 		{
-			bool makeUnorderedList = false;
 			var textList = new NSTextList (format);
 			Assert.AreEqual ((string) format.GetConstant ()!, textList.CustomMarkerFormat, "CustomMarkerFormat");
 #if NET

--- a/tests/monotouch-test/Foundation/UrlTest.cs
+++ b/tests/monotouch-test/Foundation/UrlTest.cs
@@ -295,7 +295,9 @@ namespace MonoTouchFixtures.Foundation {
 		{
 			string bad = "Server 1/Custom View/Analog Schedule!@#$%^&&%$#@";
 
+#pragma warning disable SYSLIB0013 // warning SYSLIB0013: 'Uri.EscapeUriString(string)' is obsolete: 'Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components instead.'
 			string bad_url = Uri.EscapeUriString (bad);
+#pragma warning restore
 			if (TestRuntime.CheckXcodeVersion (15, 0)) {
 				using (var url = NSUrl.FromString (bad_url))
 					Assert.NotNull (bad_url, "bad");
@@ -313,7 +315,9 @@ namespace MonoTouchFixtures.Foundation {
 		public void TestEqualOperatorSameInstace ()
 		{
 			using (var url = NSUrl.FromString ("http://www.xamarin.com"))
+#pragma warning disable CS1718 // warning CS1718: Comparison made to same variable; did you mean to compare something else?
 				Assert.IsTrue (url == url);
+#pragma warning restore
 
 		}
 

--- a/tests/monotouch-test/MetalPerformanceShaders/MnistTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MnistTest.cs
@@ -91,7 +91,7 @@ namespace MonoTouchFixtures.MetalPerformanceShadersGraph {
 				completed = true;
 			});
 
-			Assert.IsTrue (TestRuntime.RunAsync (TimeSpan.FromSeconds (30), async () => {
+			Assert.IsTrue (TestRuntime.RunAsync (TimeSpan.FromSeconds (30), () => {
 			}, () => completed), "Completion");
 
 			// Don't need to commit since EncodeTrainingBatch oddly does that

--- a/tests/monotouch-test/Network/NWBrowserTest.cs
+++ b/tests/monotouch-test/Network/NWBrowserTest.cs
@@ -91,7 +91,7 @@ namespace MonoTouchFixtures.Network {
 			var changesEvent = new AutoResetEvent (false);
 			var browserReady = new AutoResetEvent (false);
 			var finalEvent = new AutoResetEvent (false);
-			TestRuntime.RunAsync (TimeSpan.FromSeconds (30), async () => {
+			TestRuntime.RunAsync (TimeSpan.FromSeconds (30), () => {
 				// start the browser, before the listener
 				browser.SetStateChangesHandler ((st, er) => {
 					// assert here with a `st` of `Fail`

--- a/tests/monotouch-test/Network/NWPathMonitorTest.cs
+++ b/tests/monotouch-test/Network/NWPathMonitorTest.cs
@@ -28,7 +28,7 @@ namespace monotouchtest.Network {
 			NWPath finalPath = null;
 			bool isPathUpdated = false;
 
-			TestRuntime.RunAsync (TimeSpan.FromSeconds (30), async () => {
+			TestRuntime.RunAsync (TimeSpan.FromSeconds (30), () => {
 
 				monitor.SnapshotHandler = ((path) => {
 					if (path is not null) {

--- a/tests/monotouch-test/ObjCRuntime/ClassTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ClassTest.cs
@@ -119,7 +119,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		class DirtyType : NSObject {
-			public void MarkDirty ()
+			public new void MarkDirty ()
 			{
 				base.MarkDirty ();
 			}

--- a/tests/monotouch-test/ObjCRuntime/DisposableObjectTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/DisposableObjectTest.cs
@@ -18,12 +18,12 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			public Subclassed (NativeHandle handle, bool owns) : base (handle, owns) { }
 			public Subclassed (NativeHandle handle, bool owns, bool verify) : base (handle, owns, verify) { }
 
-			public NativeHandle Handle {
+			public new NativeHandle Handle {
 				get => base.Handle;
 				set => base.Handle = value;
 			}
 
-			public bool Owns { get => base.Owns; }
+			public new bool Owns { get => base.Owns; }
 		}
 
 		[Test]

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -272,7 +272,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 
 			[Export ("release")]
-			new void Release ()
+			void Release ()
 			{
 				if (enabled)
 					deallocated ();

--- a/tests/monotouch-test/SceneKit/SCNMatrixTest.cs
+++ b/tests/monotouch-test/SceneKit/SCNMatrixTest.cs
@@ -1155,7 +1155,7 @@ namespace MonoTouchFixtures.SceneKit {
 		}
 
 		[Test]
-		public void ToString ()
+		public void ToStringTest ()
 		{
 			var matrix = new SCNMatrix4 (
 				new SCNVector4 (11, 12, 13, 14),

--- a/tests/monotouch-test/SceneKit/StructTest.cs
+++ b/tests/monotouch-test/SceneKit/StructTest.cs
@@ -45,7 +45,6 @@ namespace MonoTouchFixtures.SceneKit {
 		[Test]
 		public void Vector ()
 		{
-			var v = new SCNVector4 ();
 			var u = SCNVector4.UnitX;
 			u.X = 2;
 			Assert.That (SCNVector4.UnitX, Is.Not.EqualTo (u), "UnitX");

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -465,7 +465,6 @@ namespace MonoTouchFixtures.Security {
 		[Test]
 		public void GenerateKeyPairTest ()
 		{
-			NSError error;
 			SecKey private_key;
 			SecKey public_key;
 			var att = new SecPublicPrivateKeyAttrs ();

--- a/tests/monotouch-test/SpriteKit/UniformTest.cs
+++ b/tests/monotouch-test/SpriteKit/UniformTest.cs
@@ -46,10 +46,10 @@ namespace MonoTouchFixtures.SpriteKit {
 			Matrix2 M2;
 			Matrix3 M3;
 			Matrix4 M4;
-#endif
 			MatrixFloat2x2 M2x2;
 			MatrixFloat3x3 M3x3;
 			MatrixFloat4x4 M4x4;
+#endif
 
 			using (var obj = new SKUniform ("name")) {
 #if !NET
@@ -146,7 +146,6 @@ namespace MonoTouchFixtures.SpriteKit {
 				Asserts.AreEqual (V4, obj.FloatVector4Value, "7 FloatVector4Value");
 			}
 
-#if !NET
 			using (var obj = new SKUniform ("name", M2)) {
 				Asserts.AreEqual (M2, obj.FloatMatrix2Value, "8 FloatMatrix2Value");
 				Asserts.AreEqual (M2, MatrixFloat2x2.Transpose (CFunctions.GetMatrixFloat2x2 (obj, "matrixFloat2x2Value")), "8b FloatMatrix2Value");
@@ -161,7 +160,6 @@ namespace MonoTouchFixtures.SpriteKit {
 				Asserts.AreEqual (M4, obj.FloatMatrix4Value, "10 FloatMatrix4Value");
 				Asserts.AreEqual (M4, MatrixFloat4x4.Transpose (CFunctions.GetMatrixFloat4x4 (obj, "matrixFloat4x4Value")), "10b FloatMatrix4Value");
 			}
-#endif
 
 			using (var obj = new SKUniform ("name", M2x2)) {
 				Asserts.AreEqual (M2x2, obj.MatrixFloat2x2Value, "11 MatrixFloat2x2Value");

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -458,7 +458,6 @@ namespace MonoTests.System.Net.Http {
 #endif
 
 			bool validationCbWasExecuted = false;
-			bool customValidationCbWasExecuted = false;
 			bool invalidServicePointManagerCbWasExcuted = false;
 			Type expectedExceptionType = null;
 			HttpResponseMessage result = null;
@@ -580,6 +579,7 @@ namespace MonoTests.System.Net.Http {
 				}
 			}
 			Assert.IsNull (ex);
+			Assert.IsTrue (servicePointManagerCbWasExcuted, "Executed");
 		}
 
 #if NET

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -538,7 +538,7 @@ namespace MonoTests.System.Net.Http {
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
-			bool servicePointManagerCbWasExcuted = false;
+			// bool servicePointManagerCbWasExcuted = false;
 
 			var handler = GetHandler (handlerType);
 			if (handler is NSUrlSessionHandler ns) {
@@ -547,12 +547,12 @@ namespace MonoTests.System.Net.Http {
 #else
 				ns.TrustOverride += (a, b) => {
 #endif
-					servicePointManagerCbWasExcuted = true;
+					// servicePointManagerCbWasExcuted = true;
 					return true;
 				};
 			} else {
 				ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => {
-					servicePointManagerCbWasExcuted = true;
+					// servicePointManagerCbWasExcuted = true;
 					return true;
 				};
 			}
@@ -579,7 +579,7 @@ namespace MonoTests.System.Net.Http {
 				}
 			}
 			Assert.IsNull (ex);
-			Assert.IsTrue (servicePointManagerCbWasExcuted, "Executed");
+			// Assert.IsTrue (servicePointManagerCbWasExcuted, "Executed");
 		}
 
 #if NET

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -90,8 +90,6 @@ namespace MonoTests.System.Net.Http {
 		}
 
 		public static class Httpbin {
-			static bool? isHttpbinDown;
-
 			public static string Url => AssertNetworkConnection ("https://httpbin.org");
 			public static Uri Uri => new Uri ($"{Url}");
 			public static string DeleteUrl => $"{Url}/delete";


### PR DESCRIPTION
Fix a variety of compiler warnings:

* Unused variables.
* Nullability issues.
* Unreachable code.
* Duplicated using statements.
* Unnecessary 'async' modifiers.
* Ignored warnings when the code is correct as-is.
* Misc other issues.