### PR TITLE
[src] Fix generating bgen.csproj.inc.

### DIFF
--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -14,6 +14,11 @@ $(BUILD_DIR)/generator.csproj.inc: export BUILD_VERBOSITY=$(MSBUILD_VERBOSITY)
 $(BUILD_DIR)/common/bgen.exe: $(generator_dependencies) Makefile.generator $(BUILD_DIR)/generator-frameworks.g.cs
 	$(Q_GEN) $(SYSTEM_MSBUILD) "/bl:$@.binlog" $(XBUILD_VERBOSITY) /p:Configuration=Debug generator.csproj /p:IntermediateOutputPath=$(BUILD_DIR)/IDE/obj/common/ /p:OutputPath=$(BUILD_DIR)/common /restore
 
+# copy generator.csproj to the build dir so that we can use our shared .csproj.inc target from rules.mk to create generator.csproj.inc
+# we need any generated files in this directory to go into the build directory, and the shared target will output the csproj.inc into the same directory as the csproj
+$(DOTNET_BUILD_DIR)/bgen.csproj: $(BUILD_DIR)/generator.csproj | $(BUILD_DIR)
+	$(Q) $(CP) $< $@
+
 # bgen.csproj.inc contains the generator_dependencies variable used to determine if the generator needs to be rebuilt or not.
 $(DOTNET_BUILD_DIR)/bgen.csproj.inc: export BUILD_VERBOSITY=$(MSBUILD_VERBOSITY)
 -include $(DOTNET_BUILD_DIR)/bgen.csproj.inc


### PR DESCRIPTION
The current logic to generate bgen.csproj.inc depends on having bgen.csproj in
the same directory; but in this case we want the bgen.csproj.inc in a
different directory (the temporary build directory).

Work around this by copying bgen.csproj to the temporary build directory.