### PR TITLE
[devops] Filter remote macs to arm64 macs

### DIFF
--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -53,6 +53,8 @@ stages:
       demands:
       - agent.os -equals Darwin
       - SSH.Enabled -equals True
+      - macOS.Architecture -equals arm64
+      - macOS.Name -equals Ventura
 
     steps:
     - template: reserve-mac.yml


### PR DESCRIPTION
The arm64 macs are the only ones configured to be used as remote macs.