### PR TITLE
[CoreMidi] Obsolete the MidiPacket.Bytes property.

### DIFF
--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -40,6 +40,7 @@
 #nullable enable
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using ObjCRuntime;

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -835,6 +835,9 @@ namespace CoreMidi {
 			get { return byteptr; }
 		}
 
+#if !XAMCORE_5_0
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("This property may return a pointer to a managed object, and this pointer is never safe to use. Use ByteArray or BytePointer instead.")]
 		public IntPtr Bytes {
 			get {
 				if (bytes is null || bytes.Length < 1)
@@ -846,6 +849,7 @@ namespace CoreMidi {
 				}
 			}
 		}
+#endif
 
 		internal static int GetPacketLength (int payload_length)
 		{


### PR DESCRIPTION
It's inherently unsafe, because it may return a pointer to inside a managed
array - which points to random memory if the GC collects or moves the array.

So obsolete the property, and remove it for XAMCORE_5_0.