### PR TITLE
[release/8.0.1xx] Fix sending MidiPacket when MidiPacket has been created using a point.

### DIFF
--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -926,7 +926,7 @@ namespace CoreMidi {
 				dest += 8;
 				Marshal.WriteInt16 (buffer, dest, (short) packet_size);
 				dest += 2;
-				if (packet.ByteArray is null) {
+				if (packet.ByteArray is null || packet.ByteArray.Length < 1) {
 					Buffer.MemoryCopy ((void*) packet.BytePointer, (void*) (buffer + dest), packet_size, packet_size);
 				} else {
 					Marshal.Copy (packet.ByteArray, packet.start, buffer + dest, packet_size);

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -39,6 +39,7 @@
 #nullable enable
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using ObjCRuntime;
@@ -770,7 +771,7 @@ namespace CoreMidi {
 #if !COREBUILD
 		public long TimeStamp;
 		IntPtr byteptr;
-		byte [] bytes = Array.Empty<byte> ();
+		byte []? bytes;
 		int start;
 		public ushort Length;
 
@@ -826,7 +827,7 @@ namespace CoreMidi {
 			byteptr = IntPtr.Zero;
 		}
 
-		internal byte [] ByteArray {
+		internal byte []? ByteArray {
 			get { return bytes; }
 		}
 
@@ -926,7 +927,7 @@ namespace CoreMidi {
 				dest += 8;
 				Marshal.WriteInt16 (buffer, dest, (short) packet_size);
 				dest += 2;
-				if (packet.ByteArray is null || packet.ByteArray.Length < 1) {
+				if (packet.ByteArray is null) {
 					Buffer.MemoryCopy ((void*) packet.BytePointer, (void*) (buffer + dest), packet_size, packet_size);
 				} else {
 					Marshal.Copy (packet.ByteArray, packet.start, buffer + dest, packet_size);

--- a/tests/monotouch-test/CoreMidi/MidiClientTest.cs
+++ b/tests/monotouch-test/CoreMidi/MidiClientTest.cs
@@ -1,0 +1,47 @@
+//
+// Unit tests for MidiClient
+//
+// Authors:
+//	Rolf Bjarne Kvinge <rolf@xamarin.com>
+//
+// Copyright 2023 Microsoft Corp. All rights reserved.
+//
+
+#if !__TVOS__ && !__WATCHOS__
+using System;
+using System.Diagnostics;
+
+using CoreMidi;
+using Foundation;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreMidi {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class MidiClientTest {
+		[Test]
+		public void SendTest ()
+		{
+			if (Midi.DestinationCount <= 0)
+				Assert.Inconclusive ("No Midi Destinations");
+
+			using var ep = MidiEndpoint.GetDestination (0);
+			Assert.NotNull (ep, "EndPoint");
+
+			var mevent = new byte[] { 0x90, 0x40, 0x70 };
+			using var client = new MidiClient ($"outputclient-{Process.GetCurrentProcess ().Id}");
+			using var port = client.CreateOutputPort ($"outputport-{Process.GetCurrentProcess ().Id}");
+			unsafe {
+				fixed (byte* meventPtr = mevent) {
+					using var packet1 = new MidiPacket (0, (ushort) mevent.Length, (IntPtr) meventPtr);
+					using var packet2 = new MidiPacket (0, mevent);
+					using var packet3 = new MidiPacket (0, mevent, 0, mevent.Length);
+					var packets = new MidiPacket [] { packet1, packet2, packet3 };
+					port.Send (ep, packets);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/tests/monotouch-test/CoreMidi/MidiClientTest.cs
+++ b/tests/monotouch-test/CoreMidi/MidiClientTest.cs
@@ -29,7 +29,7 @@ namespace MonoTouchFixtures.CoreMidi {
 			using var ep = MidiEndpoint.GetDestination (0);
 			Assert.NotNull (ep, "EndPoint");
 
-			var mevent = new byte[] { 0x90, 0x40, 0x70 };
+			var mevent = new byte [] { 0x90, 0x40, 0x70 };
 			using var client = new MidiClient ($"outputclient-{Process.GetCurrentProcess ().Id}");
 			using var port = client.CreateOutputPort ($"outputport-{Process.GetCurrentProcess ().Id}");
 			unsafe {


### PR DESCRIPTION
Fix sending MidiPacket when MidiPacket has been created using a pointer to a byte[] rather than a byte[] passed as a reference.
MidiPacket.bytes is intiailized to a Array.Empty<byte> so it is never null, and so packet.BytePointer is never used.
We therefore need to check for ByteArray.Length being 0.
Midipacket.bytes is never 0 when intiailized to a 0 length byte[] as that constructor checked for 0 length byte[]


Backport of #18981
