### PR TITLE
[msbuild] Handle backslash characters better on Windows in the ParseBundlerArguments task.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ParseBundlerArgumentsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ParseBundlerArgumentsTaskBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -81,7 +82,19 @@ namespace Xamarin.MacDev.Tasks {
 				NoDSymUtil = "false";
 
 			if (!string.IsNullOrEmpty (ExtraArgs)) {
-				var args = CommandLineArgumentBuilder.Parse (ExtraArgs);
+				var extraArgs = ExtraArgs;
+				if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
+					// The backslash character is pretty common on Windows (since it's a path separator),
+					// but the argument parser will treat it as an escape character, and just skip it.
+					// This is obviously wrong, so just replace backslashes with forward slashes, which
+					// should work just as well on Windows, and will also be parsed correctly.
+					// The downside is that now there's no way to escape characters, but that should be a
+					// very rare problem (much rarer than backslash characters), and there are other
+					// ways around the problem (set the actual target property instead of going through
+					// the MtouchExtraArgs property for instance):
+					extraArgs = extraArgs.Replace ('\\', '/');
+				}
+				var args = CommandLineArgumentBuilder.Parse (extraArgs);
 				List<string> xml = null;
 				List<string> customLinkFlags = null;
 				var aot = new List<ITaskItem> ();

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ParseBundlerArgumentsTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ParseBundlerArgumentsTests.cs
@@ -175,7 +175,13 @@ namespace Xamarin.MacDev.Tasks {
 		[TestCase ("-xml:dummy", null, "dummy")]
 		[TestCase ("/xml:dummy", null, "dummy")]
 		[TestCase ("/xml:dummy1 /xml:dummy2", null, "dummy1;dummy2")]
+		[TestCase ("/xml:/path/a /xml:/path/b", null, "/path/a;/path/b")]
 		public void XmlDefinitions (string input, string existing, string output)
+		{
+			XmlDefinitionsTest (input, existing, output);
+		}
+
+		void XmlDefinitionsTest (string input, string existing, string output)
 		{
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			if (existing is not null)
@@ -183,6 +189,14 @@ namespace Xamarin.MacDev.Tasks {
 			task.ExtraArgs = input;
 			Assert.IsTrue (task.Execute (), input);
 			Assert.AreEqual (output, string.Join (";", task.XmlDefinitions.Select (v => v.ItemSpec).ToArray ()), output);
+		}
+
+		[TestCase ("/xml:\\path\\a /xml:/path/b", null, "/path/a;/path/b")]
+		public void XmlDefinitionsWindows (string input, string existing, string output)
+		{
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+				Assert.Ignore ("This test is only applicable on Windows");
+			XmlDefinitionsTest (input, existing, output);
 		}
 
 		[TestCase ("--custom_bundle_name", "")]


### PR DESCRIPTION
The backslash character is pretty common on Windows (since it's a path separator),
but the argument parser will treat it as an escape character, and just skip it.
This is obviously wrong, so just replace backslashes with forward slashes, which
should work just as well on Windows, and will also be parsed correctly.
The downside is that now there's no way to escape characters, but that should be a
very rare problem (much rarer than backslash characters), and there are other
ways around the problem (set the actual target property instead of going through
the MtouchExtraArgs property for instance):