### PR TITLE
[release/8.0.1xx-xcode15.1] [AppKit] Fix binding for NSFontDescriptor.Create. Fixes #19659.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -7086,9 +7086,20 @@ namespace AppKit {
 		[Export ("requiresFontAssetRequest")]
 		bool RequiresFontAssetRequest { get; }
 
-		[Export ("fontDescriptorWithDesign:")]
+#if XAMCORE_5_0
+		[Wrap ("Create (design.GetConstant ()!)")]
+#else
+		[Wrap ("Create (design.GetConstant ()!)", IsVirtual = true)]
+#endif
 		[return: NullAllowed]
 		NSFontDescriptor Create (NSFontDescriptorSystemDesign design);
+
+#if !XAMCORE_5_0
+		[Sealed]
+#endif
+		[Export ("fontDescriptorWithDesign:")]
+		[return: NullAllowed]
+		NSFontDescriptor Create (NSString design);
 
 		[Mac (11, 0)]
 		[Static]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -7094,9 +7094,6 @@ namespace AppKit {
 		[return: NullAllowed]
 		NSFontDescriptor Create (NSFontDescriptorSystemDesign design);
 
-#if !XAMCORE_5_0
-		[Sealed]
-#endif
 		[Export ("fontDescriptorWithDesign:")]
 		[return: NullAllowed]
 		NSFontDescriptor Create (NSString design);


### PR DESCRIPTION
[NSFontDescriptor fontDescriptorWithDesign:] takes an NSString, not the enum
value, so use BindAs to bind correctly.

Fixes https://github.com/xamarin/xamarin-macios/issues/19659.


Backport of #19663
