### PR TITLE
[mtouch] Remove packages.config, doesn't seem to be used anymore.

### DIFF
--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -521,7 +521,6 @@
     <None Include="..\..\docs\website\mtouch-errors.md">
       <Link>docs\website\mtouch-errors.md</Link>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Errors.resx">

--- a/tools/mtouch/packages.config
+++ b/tools/mtouch/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.DiaSymReader.Pdb2Pdb" version="1.1.0-beta2-19521-03" targetFramework="net46" />
-  <package id="XliffTasks" version="1.0.0-beta.20078.1" targetFramework="net46" />
-</packages>


### PR DESCRIPTION
The packages in packages.config for mtouch don't seem be used anymore (the
localization process for mtouch doesn't use the xliff localization workflow
anymore), so just remove the file.