### PR TITLE
[msbuild] Use _DotNetRootRemoteDirectory if it's set in the FindILLink and FindAotCompiler tasks.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1146,6 +1146,7 @@
 	<Target Name="_FindAotCompiler" DependsOnTargets="_ComputeVariables">
 		<PropertyGroup>
 			<_XamarinAOTCompilerCachePath>$(DeviceSpecificIntermediateOutputPath)aot-compiler-path-$(NETCoreSdkVersion).txt</_XamarinAOTCompilerCachePath>
+			<_DotNetRootRemotePath Condition="'$(_DotNetRootRemoteDirectory)' != '' And '$(_DotNetRootRemotePath)' == ''">$(_DotNetRootRemoteDirectory)/dotnet</_DotNetRootRemotePath>
 		</PropertyGroup>
 
 		<!-- This task does not take a SessionId because we cache the path on Windows for remote builds to avoid a round-trip -->
@@ -1159,6 +1160,7 @@
 		<FindAotCompiler
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '$(_RunAotCompiler)' == 'true' And '$(_XamarinAOTCompiler)' == ''"
+			DotNetPath="$(_DotNetRootRemotePath)"
 			KeepTemporaryOutput="$(FindAotCompilerKeepKeepTemporaryOutput)"
 			MonoAotCrossCompiler="@(MonoAotCrossCompiler)"
 			RuntimeIdentifier="$(RuntimeIdentifier)"

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinBuildTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinBuildTask.cs
@@ -18,6 +18,8 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public string RuntimeIdentifier { get; set; }
 
+		public string DotNetPath { get; set; }
+
 		/// <summary>
 		/// Runs the target passed in computeValueTarget and returns its result.
 		/// The target must write the result into a text file using $(OutputFilePath) as path.
@@ -40,7 +42,7 @@ namespace Xamarin.MacDev.Tasks {
 ";
 			File.WriteAllText (projectPath, csproj);
 
-			var dotnetPath = this.GetDotNetPath ();
+			var dotnetPath = !string.IsNullOrEmpty (DotNetPath) ? DotNetPath : this.GetDotNetPath ();
 			var environment = default (Dictionary<string, string>);
 			var customHome = Environment.GetEnvironmentVariable ("DOTNET_CUSTOM_HOME");
 

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -308,6 +308,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 	<Target Name="_FindILLink" DependsOnTargets="_ComputeVariables">
 		<PropertyGroup>
 			<_RemoteILLinkCachePath>$(DeviceSpecificIntermediateOutputPath)remote-illink-path-$(NETCoreSdkVersion).txt</_RemoteILLinkCachePath>
+			<_DotNetRootRemotePath Condition="'$(_DotNetRootRemoteDirectory)' != '' And '$(_DotNetRootRemotePath)' == ''">$(_DotNetRootRemoteDirectory)/dotnet</_DotNetRootRemotePath>
 		</PropertyGroup>
 
 		<!-- This task does not take a SessionId because we cache the path on Windows for remote builds to avoid a round-trip -->
@@ -321,6 +322,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 		<FindILLink
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '$(_RemoteILLinkPath)' == ''"
+			DotNetPath="$(_DotNetRootRemotePath)"
 			KeepTemporaryOutput="$(FindILLinkKeepKeepTemporaryOutput)"
 			RuntimeIdentifier="$(RuntimeIdentifier)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
@@ -351,6 +353,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 			<TrimmerDefaultAction Condition="'$(TrimmerDefaultAction)' == ''">$(_TrimmerDefaultAction)</TrimmerDefaultAction>
 
 			<_RemoteExtraTrimmerArgs Condition="'$(_ExtraTrimmerArgs)' != ''">$(_ExtraTrimmerArgs.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)'))</_RemoteExtraTrimmerArgs>
+			<_DotNetRootRemotePath Condition="'$(_DotNetRootRemoteDirectory)' != '' And '$(_DotNetRootRemotePath)' == ''">$(_DotNetRootRemoteDirectory)/dotnet</_DotNetRootRemotePath>
 		</PropertyGroup>
 
 		<!-- Include Debug symbols as input so those are copied to the server -->
@@ -397,6 +400,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 				ILLinkPath="$(_RemoteILLinkPath)"
 				LinkerItemsDirectory="$(_LinkerItemsDirectory)"
 				DebugSymbols="@(_ILLinkDebugSymbols)"
+				DotNetPath="$(_DotNetRootRemotePath)"
 				ContinueOnError="ErrorAndContinue">
 			<Output TaskParameter="ExitCode" PropertyName="_ILLinkExitCode" />
 			<Output TaskParameter="LinkedItems" ItemName="_XamarinLinkedItems" />

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/ILLinkBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/ILLinkBase.cs
@@ -24,10 +24,15 @@ namespace Xamarin.iOS.Tasks {
 		[Output]
 		public ITaskItem [] LinkedItems { get; set; } = Array.Empty<ITaskItem> ();
 
+		public string DotNetPath { get; set; } = string.Empty;
+
 		public override bool Execute ()
 		{
 			if (this.ShouldExecuteRemotely (SessionId))
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+
+			if (!string.IsNullOrEmpty (DotNetPath))
+				Environment.SetEnvironmentVariable ("DOTNET_HOST_PATH", DotNetPath);
 
 			var result = base.Execute ();
 


### PR DESCRIPTION
This is used when running remote tests from the command line.