### PR TITLE
[tests] Use the default RuntimeIdentifier in MyCatalystApp

### DIFF
--- a/tests/dotnet/MyCatalystApp/MyCatalystApp.csproj
+++ b/tests/dotnet/MyCatalystApp/MyCatalystApp.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
-		<RuntimeIdentifier>maccatalyst-x64</RuntimeIdentifier>
 		<OutputType>Exe</OutputType>
 
 		<ApplicationTitle>MyCatalystApp</ApplicationTitle>


### PR DESCRIPTION
The default RuntimeIdentifier for Mac Catalyst is maccatalyst-arm64 if running
on an ARM64 machine, which is what our unit tests assume. Hardcoding the
RuntimeIdentifier in the project file prevents the default from being used,
and makes the unit tests fail when running on an ARM64 machine.