### PR TITLE
[Tests] Make cecil test failures readable.

### DIFF
--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -70,7 +70,7 @@ namespace Cecil.Tests {
 					Console.WriteLine ($"    {failureToString (failure)}");
 			}
 
-			// Ratehr than doing an Assert.IsEmpty, which produces a horendows error message, we'll do an Assert.Multiple which generates a 
+			// Ratehr than doing an Assert.IsEmpty, which produces a horrendous error message, we'll do an Assert.Multiple which generates a 
 			// nice enumerated output of all the failures.
 			Assert.Multiple (() => {
 				// fail for each of the new failures

--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -50,7 +50,7 @@ namespace Cecil.Tests {
 			AssertFailures<string> (currentFailures, knownFailures, nameOfKnownFailureSet, message, (v) => v);
 		}
 
-		public static void AssertFailures<T> (Dictionary<string, T> currentFailures, HashSet<string> knownFailures, string nameOfKnownFailureSet, string message, Func<T, string> failureToString)
+		public static void AssertFailures<T> (Dictionary<string, T> currentFailures, HashSet<string> knownFailures, string nameOfKnownFailureSet, string message, Func<T, string> failureToString) where T : notnull
 		{
 			var newFailures = currentFailures.Where (v => !knownFailures.Contains (v.Key)).Select (v => v.Value).ToArray ();
 			var fixedFailures = knownFailures.Except (currentFailures.Select (v => v.Key).ToHashSet ());
@@ -70,12 +70,20 @@ namespace Cecil.Tests {
 					Console.WriteLine ($"    {failureToString (failure)}");
 			}
 
-			Assert.IsEmpty (newFailures, $"Failures: {message}");
+			// Ratehr than doing an Assert.IsEmpty, which produces a horendows error message, we'll do an Assert.Multiple which generates a 
+			// nice enumerated output of all the failures.
+			Assert.Multiple (() => {
+				// fail for each of the new failures
+				foreach (var failure in newFailures) {
+					Assert.Fail (failure.ToString ());
+				}
 
-			// The list of known failures often doesn't separate based on platform, which means that we might not see all the known failures
-			// unless we're currently building for all platforms. As such, only verify the list of known failures if we're building for all platforms.
-			if (!Configuration.AnyIgnoredPlatforms ())
-				Assert.IsEmpty (fixedFailures, $"Known failures that aren't failing anymore - remove these from the list of known failures: {message}");
+				// The list of known failures often doesn't separate based on platform, which means that we might not see all the known failures
+				// unless we're currently building for all platforms. As such, only verify the list of known failures if we're building for all platforms.
+				if (!Configuration.AnyIgnoredPlatforms ())
+					Assert.IsEmpty (fixedFailures, $"Known failures that aren't failing anymore - remove these from the list of known failures: {message}");
+			});
+
 		}
 
 		// Enumerates all the methods in the assembly, for all types (including nested types), potentially providing a custom filter function.

--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -70,7 +70,7 @@ namespace Cecil.Tests {
 					Console.WriteLine ($"    {failureToString (failure)}");
 			}
 
-			// Ratehr than doing an Assert.IsEmpty, which produces a horrendous error message, we'll do an Assert.Multiple which generates a 
+			// Rather than doing an Assert.IsEmpty, which produces a horrendous error message, we'll do an Assert.Multiple which generates a 
 			// nice enumerated output of all the failures.
 			Assert.Multiple (() => {
 				// fail for each of the new failures


### PR DESCRIPTION
Using Assert.IsEmpty generates a hideous error message that is not easy for a human to read. Instead of doing IsEmpty, we use the more elegant approach of create a Assert.Multiple wich does a much nicer job when printing the failures.

An full example of the difference can be found here:

https://gist.github.com/mandel-macaque/fd08a17067a3deb28d0bd10b67265628

A small example:

Old output

```
Cecil.Tests.ApiAvailabilityTest.AttributeConsistency(_build/Microsoft.MacCatalyst.Ref/ref/net8.0/Microsoft.MacCatalyst.dll): 2 API with inconsistent availability attributes:
    [FAIL] AVFoundation.AVSampleBufferVideoRenderer.get_HasSufficientMediaDataForReliablePlaybackStart() is marked both supported and obsoleted in the same version (maccatalyst17.0)
    [FAIL] System.Boolean AVFoundation.AVSampleBufferVideoRenderer::HasSufficientMediaDataForReliablePlaybackStart() is marked both supported and obsoleted in the same version (maccatalyst17.0)
Cecil.Tests.ApiAvailabilityTest.FindMissingObsoleteAttributes: Failures: Missing obsolete attributes
Expected: <empty>
But was: < ("AVFoundation.AVAudioSessionRouteSharingPolicy AVFoundation.AVAudioSessionRouteSharingPolicy::LongForm", <AVFoundation.AVAudioSessionRouteSharingPolicy AVFoundation.AVAudioSessionRouteSharingPolicy::LongForm>, < <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >), ("AVFoundation.AVAudioSession.get_InterruptionNotification()", <Foundation.NSString AVFoundation.AVAudioSession::get_InterruptionNotification()>, < <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >), ("AVFoundation.AVAudioSession.get_MediaServicesWereLostNotification()", <Foundation.NSString AVFoundation.AVAudioSession::get_MediaServicesWereLostNotification()>, < <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >), ("AVFoundation.AVAudioSession.get_MediaServicesWereResetNotification()", <Foundation.NSString AVFoundation.AVAudioSession::get_MediaServicesWereResetNotification()>, < <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >), ("AVFoundation.AVCaptureDevice.DevicesWithMediaType(System.String)", <AVFoundation.AVCaptureDevice[] AVFoundation.AVCaptureDevice::DevicesWithMediaType(System.String)>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("AVFoundation.AVCapturePhoto.GetFileDataRepresentation(Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSObject>, Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSObject>, CoreVideo.CVPixelBuffer, AVFoundation.AVDepthData)", <Foundation.NSData AVFoundation.AVCapturePhoto::GetFileDataRepresentation(Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSObject>,Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSObject>,CoreVideo.CVPixelBuffer,AVFoundation.AVDepthData)>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("AVFoundation.AVCapturePhotoOutput.GetDngPhotoDataRepresentation(CoreMedia.CMSampleBuffer, CoreMedia.CMSampleBuffer)", <Foundation.NSData AVFoundation.AVCapturePhotoOutput::GetDngPhotoDataRepresentation(CoreMedia.CMSampleBuffer,CoreMedia.CMSampleBuffer)>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("AVFoundation.AVCapturePhotoOutput.GetJpegPhotoDataRepresentation(CoreMedia.CMSampleBuffer, CoreMedia.CMSampleBuffer)", <Foundation.NSData AVFoundation.AVCapturePhotoOutput::GetJpegPhotoDataRepresentation(CoreMedia.CMSampleBuffer,CoreMedia.CMSampleBuffer)>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("AVFoundation.AVSampleBufferGenerator.CreateSampleBuffer(AVFoundation.AVSampleBufferRequest)", <CoreMedia.CMSampleBuffer AVFoundation.AVSampleBufferGenerator::CreateSampleBuffer(AVFoundation.AVSampleBufferRequest)>, < <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCaptureVideoPreviewLayer::AutomaticallyAdjustsMirroring()", <System.Boolean AVFoundation.AVCaptureVideoPreviewLayer::AutomaticallyAdjustsMirroring()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCaptureVideoPreviewLayer::Mirrored()", <System.Boolean AVFoundation.AVCaptureVideoPreviewLayer::Mirrored()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCaptureVideoPreviewLayer::MirroringSupported()", <System.Boolean AVFoundation.AVCaptureVideoPreviewLayer::MirroringSupported()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCaptureVideoPreviewLayer::OrientationSupported()", <System.Boolean AVFoundation.AVCaptureVideoPreviewLayer::OrientationSupported()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("Foundation.NSString AVFoundation.AVAudioSession::InterruptionNotification()", <Foundation.NSString AVFoundation.AVAudioSession::InterruptionNotification()>, < <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >), ("Foundation.NSString AVFoundation.AVAudioSession::MediaServicesWereLostNotification()", <Foundation.NSString AVFoundation.AVAudioSession::MediaServicesWereLostNotification()>, < <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >), ("Foundation.NSString AVFoundation.AVAudioSession::MediaServicesWereResetNotification()", <Foundation.NSString AVFoundation.AVAudioSession::MediaServicesWereResetNotification()>, < <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCaptureConnection::EnablesVideoStabilizationWhenAvailable()", <System.Boolean AVFoundation.AVCaptureConnection::EnablesVideoStabilizationWhenAvailable()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCaptureConnection::SupportsVideoOrientation()", <System.Boolean AVFoundation.AVCaptureConnection::SupportsVideoOrientation()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCaptureConnection::VideoStabilizationEnabled()", <System.Boolean AVFoundation.AVCaptureConnection::VideoStabilizationEnabled()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("AVFoundation.AVCaptureDevice[] AVFoundation.AVCaptureDevice::Devices()", <AVFoundation.AVCaptureDevice[] AVFoundation.AVCaptureDevice::Devices()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Runtime.InteropServices.NFloat AVFoundation.AVCaptureDevice::DualCameraSwitchOverVideoZoomFactor()", <System.Runtime.InteropServices.NFloat AVFoundation.AVCaptureDevice::DualCameraSwitchOverVideoZoomFactor()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCaptureDevice::FlashActive()", <System.Boolean AVFoundation.AVCaptureDevice::FlashActive()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("CoreMedia.CMVideoDimensions AVFoundation.AVCaptureDeviceFormat::HighResolutionStillImageDimensions()", <CoreMedia.CMVideoDimensions AVFoundation.AVCaptureDeviceFormat::HighResolutionStillImageDimensions()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Runtime.InteropServices.NFloat[] AVFoundation.AVCaptureDeviceFormat::SupportedVideoZoomFactorsForDepthDataDelivery()", <System.Runtime.InteropServices.NFloat[] AVFoundation.AVCaptureDeviceFormat::SupportedVideoZoomFactorsForDepthDataDelivery()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Runtime.InteropServices.NFloat AVFoundation.AVCaptureDeviceFormat::VideoMaxZoomFactorForDepthDataDelivery()", <System.Runtime.InteropServices.NFloat AVFoundation.AVCaptureDeviceFormat::VideoMaxZoomFactorForDepthDataDelivery()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Runtime.InteropServices.NFloat AVFoundation.AVCaptureDeviceFormat::VideoMinZoomFactorForDepthDataDelivery()", <System.Runtime.InteropServices.NFloat AVFoundation.AVCaptureDeviceFormat::VideoMinZoomFactorForDepthDataDelivery()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCaptureDeviceFormat::VideoStabilizationSupported()", <System.Boolean AVFoundation.AVCaptureDeviceFormat::VideoStabilizationSupported()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCapturePhotoOutput::DualCameraDualPhotoDeliveryEnabled()", <System.Boolean AVFoundation.AVCapturePhotoOutput::DualCameraDualPhotoDeliveryEnabled()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCapturePhotoOutput::DualCameraDualPhotoDeliverySupported()", <System.Boolean AVFoundation.AVCapturePhotoOutput::DualCameraDualPhotoDeliverySupported()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCapturePhotoOutput::DualCameraFusionSupported()", <System.Boolean AVFoundation.AVCapturePhotoOutput::DualCameraFusionSupported()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCapturePhotoOutput::IsHighResolutionCaptureEnabled()", <System.Boolean AVFoundation.AVCapturePhotoOutput::IsHighResolutionCaptureEnabled()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCapturePhotoOutput::IsStillImageStabilizationScene()", <System.Boolean AVFoundation.AVCapturePhotoOutput::IsStillImageStabilizationScene()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCapturePhotoOutput::IsStillImageStabilizationSupported()", <System.Boolean AVFoundation.AVCapturePhotoOutput::IsStillImageStabilizationSupported()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCapturePhotoSettings::IsAutoStillImageStabilizationEnabled()", <System.Boolean AVFoundation.AVCapturePhotoSettings::IsAutoStillImageStabilizationEnabled()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("System.Boolean AVFoundation.AVCapturePhotoSettings::IsHighResolutionPhotoEnabled()", <System.Boolean AVFoundation.AVCapturePhotoSettings::IsHighResolutionPhotoEnabled()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >), ("CoreMedia.CMClock AVFoundation.AVCaptureSession::MasterClock()", <CoreMedia.CMClock AVFoundation.AVCaptureSession::MasterClock()>, < <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes>, <Cecil.Tests.OSPlatformAttributes> >, < <Cecil.Tests.OSPlatformAttributes> >) >

```

New output

```
Cecil.Tests.ApiAvailabilityTest.AttributeConsistency(_build/Microsoft.tvOS.Ref/ref/net8.0/Microsoft.tvOS.dll): 2 API with inconsistent availability attributes:
    [FAIL] AVFoundation.AVSampleBufferVideoRenderer.get_HasSufficientMediaDataForReliablePlaybackStart() is marked both supported and obsoleted in the same version (tvos17.0)
    [FAIL] System.Boolean AVFoundation.AVSampleBufferVideoRenderer::HasSufficientMediaDataForReliablePlaybackStart() is marked both supported and obsoleted in the same version (tvos17.0)
Cecil.Tests.AttributeTest.FindSupportedOnElementsThatDoNotExistInThatAssembly: Multiple failures or warnings in test:
1) AVFoundation.AVOutputSettingsAssistant.PresetMVHevc960x960 was not found on tvos despite being declared supported there:
    Assembly ios => Declares (Mentioned: (ios, maccatalyst, tvos, macos) Claimed: (ios, maccatalyst, tvos, macos))
    Assembly maccatalyst => Declares (Mentioned: (ios, maccatalyst, tvos, macos) Claimed: (ios, maccatalyst, tvos, macos))
AVFoundation.AVOutputSettingsAssistant.PresetMVHevc960x960 was not found on macos despite being declared supported there:
    Assembly ios => Declares (Mentioned: (ios, maccatalyst, tvos, macos) Claimed: (ios, maccatalyst, tvos, macos))
    Assembly maccatalyst => Declares (Mentioned: (ios, maccatalyst, tvos, macos) Claimed: (ios, maccatalyst, tvos, macos))
2) AVFoundation.AVOutputSettingsAssistant.PresetMVHevc1440x1440 was not found on tvos despite being declared supported there:
    Assembly ios => Declares (Mentioned: (ios, maccatalyst, tvos, macos) Claimed: (ios, maccatalyst, tvos, macos))
    Assembly maccatalyst => Declares (Mentioned: (ios, maccatalyst, tvos, macos) Claimed: (ios, maccatalyst, tvos, macos))
AVFoundation.AVOutputSettingsAssistant.PresetMVHevc1440x1440 was not found on macos despite being declared supported there:
    Assembly ios => Declares (Mentioned: (ios, maccatalyst, tvos, macos) Claimed: (ios, maccatalyst, tvos, macos))
    Assembly maccatalyst => Declares (Mentioned: (ios, maccatalyst, tvos, macos) Claimed: (ios, maccatalyst, tvos, macos))
3) AVFoundation.AVCapturePhotoCaptureDelegate_Extensions.DidFinishCapturingDeferredPhotoProxy (AVFoundation.IAVCapturePhotoCaptureDelegate, AVFoundation.AVCapturePhotoOutput, AVFoundation.AVCaptureDeferredPhotoProxy, Foundation.NSError) was not found on maccatalyst despite being declared supported there:
    Assembly ios => Declares (Mentioned: (tvos, maccatalyst, macos, ios) Claimed: (ios, maccatalyst))
4) AVFoundation.AVCapturePhotoCaptureDelegate.DidFinishCapturingDeferredPhotoProxy (AVFoundation.AVCapturePhotoOutput, AVFoundation.AVCaptureDeferredPhotoProxy, Foundation.NSError) was not found on maccatalyst despite being declared supported there:
    Assembly ios => Declares (Mentioned: (tvos, maccatalyst, macos, ios) Claimed: (ios, maccatalyst))
5) AVFoundation.AVCaptureResolvedPhotoSettings.DeferredPhotoProxyDimensions was not found on maccatalyst despite being declared supported there:
    Assembly ios => Declares (Mentioned: (tvos, maccatalyst, macos, ios) Claimed: (ios, maccatalyst))
```