### PR TITLE
[tests] Fix the InvalidStaticRegistrarValidation test to only run on x64.

### DIFF
--- a/tests/dotnet/UnitTests/RegistrarTest.cs
+++ b/tests/dotnet/UnitTests/RegistrarTest.cs
@@ -3,21 +3,24 @@ using Mono.Cecil;
 namespace Xamarin.Tests {
 	[TestFixture]
 	public class RegistrarTest : TestBaseClass {
-		[TestCase (ApplePlatform.MacCatalyst, true)]
-		[TestCase (ApplePlatform.MacOSX, true)]
-		[TestCase (ApplePlatform.iOS, false)]
-		[TestCase (ApplePlatform.TVOS, false)]
-		public void InvalidStaticRegistrarValidation (ApplePlatform platform, bool validated)
+		// This test does evil things that the AOT runtime complains about, so it only works when not running the AOT compiler (aka x64 when using Mono).
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", true)]
+		[TestCase (ApplePlatform.MacOSX, null, true)]
+		[TestCase (ApplePlatform.iOS, "iossimulator-x64", false)]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64", false)]
+		public void InvalidStaticRegistrarValidation (ApplePlatform platform, string? runtimeIdentifiers, bool validated)
 		{
 			var project = "MyRegistrarApp";
 			var configuration = "Debug";
-			var runtimeIdentifiers = GetDefaultRuntimeIdentifier (platform);
+
+			runtimeIdentifiers ??= GetDefaultRuntimeIdentifier (platform);
+
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
 
 			var projectPath = GetProjectPath (project, platform: platform);
 			Clean (projectPath);
-			var properties = GetDefaultProperties ();
+			var properties = GetDefaultProperties (runtimeIdentifiers);
 			properties ["Registrar"] = "static";
 			// enable the linker (so that the main assembly is modified)
 			properties ["LinkMode"] = "full";


### PR DESCRIPTION
This is because it doesn't work on arm64 - it's trying to verify that we
handle a specific error condition gracefully, but we're rather evil in trying
to trigger the error condition (being kind doesn't trigger the error), and the
AOT compiler detects the same thing we do and errors out before we get a
chance to show our nice error.

In short: make this an x64-only test.