### PR TITLE
[Tests] Make the test FindMissingObsoleteAttributes usable.

### DIFF
--- a/tests/cecil-tests/ApiAvailabilityTest.cs
+++ b/tests/cecil-tests/ApiAvailabilityTest.cs
@@ -16,14 +16,15 @@ namespace Cecil.Tests {
 	[TestFixture]
 	public class ApiAvailabilityTest {
 
-		public record ObsoletedFailure  : IComparable {
+		public record ObsoletedFailure : IComparable {
 
 			public string Key { get; }
-			public ICustomAttributeProvider Api {get;}
+			public ICustomAttributeProvider Api { get; }
 			public OSPlatformAttributes [] Obsoleted { get; }
 			public OSPlatformAttributes [] Supported { get; }
 
-			public ObsoletedFailure (string key, ICustomAttributeProvider api, OSPlatformAttributes [] obsoleted, OSPlatformAttributes [] supported) {
+			public ObsoletedFailure (string key, ICustomAttributeProvider api, OSPlatformAttributes [] obsoleted, OSPlatformAttributes [] supported)
+			{
 				Key = key;
 				Api = api;
 				Obsoleted = obsoleted;
@@ -33,7 +34,8 @@ namespace Cecil.Tests {
 			public override string ToString ()
 				=> $"{Key}: {Api} is obsoleted on {string.Join (", ", Obsoleted.Select (v => v.Platform))} but not on {string.Join (", ", Supported.Select (v => v.Platform))}";
 
-			public int CompareTo (object? obj) {
+			public int CompareTo (object? obj)
+			{
 				if (obj is not ObsoletedFailure other)
 					return -1;
 				return Key.CompareTo (other.Key);

--- a/tests/cecil-tests/ApiAvailabilityTest.cs
+++ b/tests/cecil-tests/ApiAvailabilityTest.cs
@@ -15,6 +15,32 @@ using Xamarin.Tests;
 namespace Cecil.Tests {
 	[TestFixture]
 	public class ApiAvailabilityTest {
+
+		public record ObsoletedFailure  : IComparable {
+
+			public string Key { get; }
+			public ICustomAttributeProvider Api {get;}
+			public OSPlatformAttributes [] Obsoleted { get; }
+			public OSPlatformAttributes [] Supported { get; }
+
+			public ObsoletedFailure (string key, ICustomAttributeProvider api, OSPlatformAttributes [] obsoleted, OSPlatformAttributes [] supported) {
+				Key = key;
+				Api = api;
+				Obsoleted = obsoleted;
+				Supported = supported;
+			}
+
+			public override string ToString ()
+				=> $"{Key}: {Api} is obsoleted on {string.Join (", ", Obsoleted.Select (v => v.Platform))} but not on {string.Join (", ", Supported.Select (v => v.Platform))}";
+
+			public int CompareTo (object? obj) {
+				if (obj is not ObsoletedFailure other)
+					return -1;
+				return Key.CompareTo (other.Key);
+			}
+
+		}
+
 		// This test will flag any API that's only obsoleted on some platforms.
 		[Test]
 		public void FindMissingObsoleteAttributes ()
@@ -23,7 +49,7 @@ namespace Cecil.Tests {
 
 			var harvestedInfo = Helper.MappedNetApi;
 
-			var failures = new Dictionary<string, (string Key, ICustomAttributeProvider Api, OSPlatformAttributes [] Obsoleted, OSPlatformAttributes [] Supported)> ();
+			var failures = new Dictionary<string, ObsoletedFailure> ();
 			var mismatchedObsoleteMessages = new List<string> ();
 			foreach (var kvp in harvestedInfo) {
 				var attributes = kvp.Value.Select (v => v.Api.GetAvailabilityAttributes (v.Platform) ?? new OSPlatformAttributes (v.Api, v.Platform) ?? new OSPlatformAttributes (v.Api, v.Platform)).ToArray ();
@@ -42,7 +68,7 @@ namespace Cecil.Tests {
 				if (!notObsoletedNorUnsupported.Any ())
 					continue;
 
-				var failure = (kvp.Key, kvp.Value.First ().Api, obsoleted, notObsoletedNorUnsupported);
+				var failure = new ObsoletedFailure (kvp.Key, kvp.Value.First ().Api, obsoleted, notObsoletedNorUnsupported);
 				failures [failure.Key] = failure;
 
 				var obsoleteMessages = obsoleted.Select (v => v.Obsoleted?.Message).Distinct ().ToArray ();

--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -50,7 +50,7 @@ namespace Cecil.Tests {
 			AssertFailures<string> (currentFailures, knownFailures, nameOfKnownFailureSet, message, (v) => v);
 		}
 
-		public static void AssertFailures<T> (Dictionary<string, T> currentFailures, HashSet<string> knownFailures, string nameOfKnownFailureSet, string message, Func<T, string> failureToString) where T : notnull
+		public static void AssertFailures<T> (Dictionary<string, T> currentFailures, HashSet<string> knownFailures, string nameOfKnownFailureSet, string message, Func<T, string> failureToString) where T : notnull, IComparable
 		{
 			var newFailures = currentFailures.Where (v => !knownFailures.Contains (v.Key)).Select (v => v.Value).ToArray ();
 			var fixedFailures = knownFailures.Except (currentFailures.Select (v => v.Key).ToHashSet ());


### PR DESCRIPTION
The ToString of a named tuple does not make sense for a human, this tests, while it does find issues with the API, it does not help the developer to find the real reason.

This PR has 2 important fixes.

1. Add a generic constrain to the Assert.Failures. The developer that wrote the code got lucky and always used T that are IComparable. I mean lucky, because the OrderBy from Linq needs T to be IComparable, and I am surprise we never got a rutime error with the test.
2. Use a record type with a reasonable ToString.

The following gist contains a diff between the output with the fix and without it.

https://gist.github.com/mandel-macaque/ee1adab1bf0568a6e95d47e7f3b7970a

The diff is:

New code:

```
AVFoundation.AVAudioSessionRouteSharingPolicy AVFoundation.AVAudioSessionRouteSharingPolicy::LongForm: AVFoundation.AVAudioSessionRouteSharingPolicy AVFoundation.AVAudioSessionRouteSharingPolicy::LongForm is obsoleted on MacOSX but not on iOS, TVOS, MacCatalyst
```

Old code:
```
(AVFoundation.AVAudioSessionRouteSharingPolicy AVFoundation.AVAudioSessionRouteSharingPolicy::LongForm, AVFoundation.AVAudioSessionRouteSharingPolicy AVFoundation.AVAudioSessionRouteSharingPolicy::LongForm, Cecil.Tests.OSPlatformAttributes[], Cecil.Tests.OSPlatformAttributes[])
```