### PR TITLE
[tests] Automatically ignore Windows tests on non-Windows platforms.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -1122,6 +1122,23 @@ namespace Xamarin.Tests {
 				Assert.Ignore ($"This test requires all platforms to be included, but the following platforms aren't included: {string.Join (", ", notIncluded.Select (v => v.AsString ()))}");
 		}
 
+		public static void IgnoreIfNotOnMacOS ()
+		{
+			IgnoreIfNotOn (System.Runtime.InteropServices.OSPlatform.OSX);
+		}
+
+		public static void IgnoreIfNotOnWindows ()
+		{
+			IgnoreIfNotOn (System.Runtime.InteropServices.OSPlatform.Windows);
+		}
+
+		public static void IgnoreIfNotOn (System.Runtime.InteropServices.OSPlatform platform)
+		{
+			if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform (platform))
+				return;
+			Assert.Ignore ($"This test is only applicable on {platform}");
+		}
+
 		public static string GetTestLibraryDirectory (ApplePlatform platform, bool? simulator = null)
 		{
 			string dir;

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -8,27 +8,16 @@ using System.IO.Compression;
 namespace Xamarin.Tests {
 	[Category ("Windows")]
 	public class WindowsTest : TestBaseClass {
-		[Test]
-		public void OnlyOnWindows ()
-		{
-			Assert.True (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform (System.Runtime.InteropServices.OSPlatform.Windows), "On Windows");
-		}
-
-		[Test]
-		[TestCase (ApplePlatform.iOS, "ios-arm64")]
-		public void ConfigurationTestWhileDebugging (ApplePlatform platform, string runtimeIdentifiers)
-		{
-			Configuration.IgnoreIfIgnoredPlatform (platform);
-		}
 
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		public void BundleStructureWithHotRestart (ApplePlatform platform, string runtimeIdentifiers)
 		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.IgnoreIfNotOnWindows ();
+
 			var project = "BundleStructure";
 			var configuration = "Debug";
 			var tmpdir = Cache.CreateTemporaryDirectory ();
-
-			Configuration.IgnoreIfIgnoredPlatform (platform);
 
 			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
 			var project_dir = Path.GetDirectoryName (Path.GetDirectoryName (project_path))!;


### PR DESCRIPTION
This makes it nicer to run 'dotnet test' on macOS, because we won't try to
(and fail to) run any Windows-specific tests.