### PR TITLE
[devops] Add a 30-minute timeout for the .NET tests on Windows

### DIFF
--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -165,6 +165,7 @@ steps:
         "--logger:html;LogFileName=$(Build.SourcesDirectory)/xamarin-macios/jenkins-results/windows-dotnet-tests.html" `
         "-bl:$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/run-dotnet-tests.binlog"
   displayName: 'Run .NET tests'
+  timeoutInMinutes: 30
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1


### PR DESCRIPTION
This prevents it from taking 16 hours if something goes wrong.