### PR TITLE
[Tests] Move to use the Helpers method to report MarshalAsTest failures.

### DIFF
--- a/tests/cecil-tests/MarshalAsTest.cs
+++ b/tests/cecil-tests/MarshalAsTest.cs
@@ -15,12 +15,15 @@ namespace Cecil.Tests {
 
 	[TestFixture]
 	public class MarshalAsTest {
+
+		private HashSet<string> knownIssues = new HashSet<string> {};
+
 		[TestCaseSource (typeof (Helper), nameof (Helper.PlatformAssemblyDefinitions))]
 		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformAssemblyDefinitions))]
 		public void TestAssembly (AssemblyInfo info)
 		{
 			var assembly = info.Assembly;
-			var failedMethods = new List<string> ();
+			var failedMethods = new HashSet<string> ();
 			List<string>? failures = null;
 			var checkedTypes = new List<TypeReference> ();
 			foreach (var m in assembly.EnumerateMethods ((m) => m.HasPInvokeInfo)) {
@@ -31,7 +34,7 @@ namespace Cecil.Tests {
 				}
 			}
 
-			Assert.That (failedMethods, Is.Empty, "Methods with bool return type / parameters and no MarshalAs attribute.");
+			Helper.AssertFailures (failedMethods, knownIssues, nameof (MarshalAsTest), "Methods with bool return type / parameters and no MarshalAs attribute.");
 		}
 
 		static void AddFailure (ref List<string>? failures, string failure)

--- a/tests/cecil-tests/MarshalAsTest.cs
+++ b/tests/cecil-tests/MarshalAsTest.cs
@@ -16,7 +16,7 @@ namespace Cecil.Tests {
 	[TestFixture]
 	public class MarshalAsTest {
 
-		private HashSet<string> knownIssues = new HashSet<string> {};
+		private HashSet<string> knownIssues = new HashSet<string> { };
 
 		[TestCaseSource (typeof (Helper), nameof (Helper.PlatformAssemblyDefinitions))]
 		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformAssemblyDefinitions))]

--- a/tests/cecil-tests/MarshalAsTest.cs
+++ b/tests/cecil-tests/MarshalAsTest.cs
@@ -16,7 +16,7 @@ namespace Cecil.Tests {
 	[TestFixture]
 	public class MarshalAsTest {
 
-		private HashSet<string> knownIssues = new HashSet<string> { };
+		HashSet<string> knownIssues = new HashSet<string> { };
 
 		[TestCaseSource (typeof (Helper), nameof (Helper.PlatformAssemblyDefinitions))]
 		[TestCaseSource (typeof (Helper), nameof (Helper.NetPlatformAssemblyDefinitions))]


### PR DESCRIPTION
As with others, make the results more readable, in this case we just need to re-use the already present method.

Diff in the ouputs can be found here:

https://gist.github.com/mandel-macaque/7015b2f9c7dfc857caa72f7c1ea19b0a

In this case we move to have the enumerated list.