### PR TITLE
[builds] Create a separate Versions.plist.in for each .NET platform.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -1136,18 +1136,13 @@ DOTNET_COMMON_TARGETS = \
 	$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(DOTNET_DESTDIR)/$($(platform)_NUGET_SDK_NAME)/Versions.plist) \
 	$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(DOTNET_DESTDIR)/$($(platform)_NUGET_SDK_NAME)/tools/buildinfo) \
 
-$(DOTNET_DESTDIR)/$(MACOS_NUGET_SDK_NAME)/Versions.plist: $(TOP)/Versions-mac.plist.in Makefile $(TOP)/Make.config $(TOP)/versions-check.csharp | $(DOTNET_DESTDIR)/$(MACOS_NUGET_SDK_NAME)
-	$(Q) $(TOP)/versions-check.csharp $< "$(DOTNET_MIN_IOS_SDK_VERSION)" "$(MAX_IOS_DEPLOYMENT_TARGET)" "$(DOTNET_MIN_TVOS_SDK_VERSION)" "$(MAX_TVOS_DEPLOYMENT_TARGET)" "$(MIN_WATCH_OS_VERSION)" "$(MAX_WATCH_DEPLOYMENT_TARGET)" "$(DOTNET_MIN_MACOS_SDK_VERSION)" "$(MACOS_SDK_VERSION)" "$(DOTNET_MIN_MACCATALYST_SDK_VERSION)" "$(MACCATALYST_SDK_VERSION)"
-	$(Q_GEN) sed -e 's/@XCODE_VERSION@/$(XCODE_VERSION)/g' -e "s/@MONO_VERSION@/$(DOTNET_VERSION)/g" -e "s/@MIN_XM_MONO_VERSION@//g" $< > $@.tmp
-	$(Q) mv $@.tmp $@
-
 define VersionInfo
-$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/Versions.plist: $(TOP)/Versions-ios.plist.in Makefile $(TOP)/Make.config $(TOP)/versions-check.csharp | $(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)
+$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/Versions.plist: $(TOP)/builds/Versions-$(1).plist.in Makefile $(TOP)/Make.config $(TOP)/versions-check.csharp | $(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)
 	$$(Q) $(TOP)/versions-check.csharp $$< "$(DOTNET_MIN_IOS_SDK_VERSION)" "$(MAX_IOS_DEPLOYMENT_TARGET)" "$(DOTNET_MIN_TVOS_SDK_VERSION)" "$(MAX_TVOS_DEPLOYMENT_TARGET)" "$(MIN_WATCH_OS_VERSION)" "$(MAX_WATCH_DEPLOYMENT_TARGET)" "$(DOTNET_MIN_MACOS_SDK_VERSION)" "$(MACOS_SDK_VERSION)" "$(DOTNET_MIN_MACCATALYST_SDK_VERSION)" "$(MACCATALYST_SDK_VERSION)"
 	$$(Q_GEN) sed -e 's/@XCODE_VERSION@/$(XCODE_VERSION)/g' -e "s/@MONO_VERSION@/$(DOTNET_VERSION)/g" $$< > $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 endef
-$(foreach platform,$(filter-out macOS,$(DOTNET_PLATFORMS)),$(eval $(call VersionInfo,$(platform))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call VersionInfo,$(platform))))
 
 define BuildInfo
 $(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/tools/buildinfo: $(TOP)/Make.config.inc $(GIT_DIRECTORY)/index | $(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/tools

--- a/builds/Versions-MacCatalyst.plist.in
+++ b/builds/Versions-MacCatalyst.plist.in
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MonoVersion</key>
+	<string>@MONO_VERSION@</string>
+	<key>KnownVersions</key>
+	<dict>
+		<key>MacCatalyst</key>
+		<array>
+			<string>13.1</string>
+			<string>13.2</string>
+			<string>13.3</string>
+			<string>13.4</string>
+			<string>13.5</string>
+			<string>14.2</string>
+			<string>14.3</string>
+			<string>14.4</string>
+			<string>14.5</string>
+			<string>15.0</string>
+			<string>15.2</string>
+			<string>15.4</string>
+			<string>16.1</string>
+			<string>16.2</string>
+			<string>16.4</string>
+			<string>17.0</string>
+		</array>
+	</dict>
+	<key>MacCatalystVersionMap</key>
+	<dict>
+		<key>13.1</key>
+		<string>10.15</string>
+		<key>13.2</key>
+		<string>10.15.1</string>
+		<key>13.3</key>
+		<string>10.15.2</string>
+		<key>13.4</key>
+		<string>10.15.4</string>
+		<key>13.5</key>
+		<string>10.15.5</string>
+		<key>14.2</key>
+		<string>11.0</string>
+		<key>14.3</key>
+		<string>11.1</string>
+		<key>14.4</key>
+		<string>11.1</string>
+		<key>14.5</key>
+		<string>11.3</string>
+		<key>15.0</key>
+		<string>12.0</string>
+		<key>15.2</key>
+		<string>12.1</string>
+		<key>15.4</key>
+		<string>12.3</string>
+		<key>16.1</key>
+		<string>13.0</string>
+		<key>16.2</key>
+		<string>13.1</string>
+		<key>16.4</key>
+		<string>13.3</string>
+	</dict>
+	<key>RecommendedXcodeVersion</key>
+	<string>@XCODE_VERSION@</string>
+	<key>MinExtensionVersion</key>
+	<dict>
+	</dict>
+	<key>Features</key>
+	<array>
+		<string>mlaunch-launchdevbundleid</string>
+		<string>mlaunch-observe-extension</string>
+		<string>mlaunch-launch-simulator</string>
+		<string>mlaunch-install-progress</string>
+		<string>mlaunch-watchos-complications</string>
+		<string>mlaunch-wireless-devices</string>
+		<string>http-client-handlers</string>
+		<string>mono-symbol-archive</string>
+		<string>sgen-concurrent-gc</string> <!-- this means experimental support for the concurrent GC -->
+		<string>sgen-concurrent</string> <!-- this means stable support for the concurrent GC -->
+		<string>arm64_32</string>
+		<string>altool</string>
+		<string>maccatalyst</string>
+	</array>
+	<key>Optimizations</key>
+	<dict>
+		<!-- The key is the value to be passed to mtouch. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
+		<key>inline-intptr-size</key>
+		<string>Inline IntPtr.Size</string>
+		<key>inline-runtime-arch</key>
+		<string>Inline NSObject.IsDirectBinding</string>
+		<key>dead-code-elimination</key>
+		<string>Dead code elimination</string>
+		<key>remove-uithread-checks</key>
+		<string>Remove UI thread checks</string>
+	</dict>
+</dict>
+</plist>

--- a/builds/Versions-iOS.plist.in
+++ b/builds/Versions-iOS.plist.in
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MonoVersion</key>
+	<string>@MONO_VERSION@</string>
+	<key>KnownVersions</key>
+	<dict>
+		<key>iOS</key>
+		<array>
+			<string>11.0</string>
+			<string>11.1</string>
+			<string>11.2</string>
+			<string>11.3</string>
+			<string>11.4</string>
+			<string>12.0</string>
+			<string>12.1</string>
+			<string>12.2</string>
+			<string>12.3</string>
+			<string>12.4</string>
+			<string>13.0</string>
+			<string>13.1</string>
+			<string>13.2</string>
+			<string>13.3</string>
+			<string>13.4</string>
+			<string>13.5</string>
+			<string>13.6</string>
+			<string>14.0</string>
+			<string>14.1</string>
+			<string>14.2</string>
+			<string>14.3</string>
+			<string>14.4</string>
+			<string>14.5</string>
+			<string>15.0</string>
+			<string>15.2</string>
+			<string>15.4</string>
+			<string>16.0</string>
+			<string>16.1</string>
+			<string>16.2</string>
+			<string>16.4</string>
+			<string>17.0</string>
+		</array>
+	</dict>
+	<key>RecommendedXcodeVersion</key>
+	<string>@XCODE_VERSION@</string>
+	<key>MinExtensionVersion</key>
+	<dict>
+		<key>iOS</key>
+		<dict>
+			<key>com.apple.ui-services</key>
+			<string>8.0</string>
+			<key>com.apple.services</key>
+			<string>8.0</string>
+			<key>com.apple.keyboard-service</key>
+			<string>8.0</string>
+			<key>com.apple.fileprovider-ui</key>
+			<string>8.0</string>
+			<key>com.apple.fileprovider-nonui</key>
+			<string>8.0</string>
+			<key>com.apple.photo-editing</key>
+			<string>8.0</string>
+			<key>com.apple.share-services</key>
+			<string>8.0</string>
+			<key>com.apple.widget-extension</key>
+			<string>8.0</string>
+			<key>com.apple.watchkit</key>
+			<string>8.2</string>
+			<key>com.apple.AudioUnit-UI</key>
+			<string>8.2</string>
+			<key>com.apple.AudioUnit</key>
+			<string>8.0</string>
+			<key>com.apple.Safari.content-blocker</key>
+			<string>9.0</string>
+			<key>com.apple.Safari.sharedlinks-service</key>
+			<string>9.0</string>
+			<key>com.apple.spotlight.index</key>
+			<string>9.0</string>
+			<key>com.apple.networkextension.packet-tunnel</key>
+			<string>9.0</string>
+			<key>com.apple.callkit.call-directory</key>
+			<string>10.0</string>
+			<key>com.apple.intents-service</key>
+			<string>10.0</string>
+			<key>com.apple.intents-ui-service</key>
+			<string>10.0</string>
+			<key>com.apple.message-payload-provider</key>
+			<string>10.0</string>
+			<key>com.apple.usernotifications.content-extension</key>
+			<string>10.0</string>
+			<key>com.apple.usernotifications.service</key>
+			<string>10.0</string>
+			<key>com.apple.authentication-services-credential-provider-ui</key>
+			<string>12.0</string>
+		</dict>
+	</dict>
+	<key>Features</key>
+	<array>
+		<string>mlaunch-launchdevbundleid</string>
+		<string>mlaunch-observe-extension</string>
+		<string>mlaunch-launch-simulator</string>
+		<string>mlaunch-install-progress</string>
+		<string>mlaunch-watchos-complications</string>
+		<string>mlaunch-wireless-devices</string>
+		<string>http-client-handlers</string>
+		<string>mono-symbol-archive</string>
+		<string>sgen-concurrent-gc</string> <!-- this means experimental support for the concurrent GC -->
+		<string>sgen-concurrent</string> <!-- this means stable support for the concurrent GC -->
+		<string>arm64_32</string>
+		<string>altool</string>
+		<string>maccatalyst</string>
+	</array>
+	<key>Optimizations</key>
+	<dict>
+		<!-- The key is the value to be passed to mtouch. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
+		<key>inline-intptr-size</key>
+		<string>Inline IntPtr.Size</string>
+		<key>inline-runtime-arch</key>
+		<string>Inline NSObject.IsDirectBinding</string>
+		<key>dead-code-elimination</key>
+		<string>Dead code elimination</string>
+		<key>remove-uithread-checks</key>
+		<string>Remove UI thread checks</string>
+	</dict>
+</dict>
+</plist>

--- a/builds/Versions-macOS.plist.in
+++ b/builds/Versions-macOS.plist.in
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MonoVersion</key>
+	<string>@MONO_VERSION@</string>
+	<key>MinimumSystemMono</key>
+	<string>@MIN_XM_MONO_VERSION@</string>
+	<key>KnownVersions</key>
+	<dict>
+		<key>macOS</key>
+		<array>
+			<string>10.15</string>
+			<string>10.16</string>
+			<string>11.0</string>
+			<string>11.1</string>
+			<string>11.2</string>
+			<string>11.3</string>
+			<string>12.0</string>
+			<string>12.1</string>
+			<string>12.3</string>
+			<string>13.0</string>
+			<string>13.1</string>
+			<string>13.3</string>
+			<string>14.0</string>
+		</array>
+	</dict>
+	<key>RecommendedXcodeVersion</key>
+	<string>@XCODE_VERSION@</string>
+	<key>MinExtensionVersion</key>
+	<dict>
+		<key>macOS</key>
+		<dict>
+			<key>com.apple.FinderSync</key>
+			<string>10.10</string>
+			<key>com.apple.share-services</key>
+			<string>10.10</string>
+			<key>com.apple.widget-extension</key>
+			<string>10.10</string>
+			<key>com.apple.networkextension.packet-tunnel</key>
+			<string>10.11</string>
+		</dict>
+	</dict>
+	<key>Features</key>
+	<array>
+		<string>http-client-handlers</string>
+		<string>mono-symbol-archive</string>
+		<string>sgen-concurrent-gc</string> <!-- this means experimental support for the concurrent GC -->
+		<string>sgen-concurrent</string> <!-- this means stable support for the concurrent GC -->
+		<string>link-platform</string>
+		<string>hybrid-aot</string>
+		<string>64-bit-only</string>
+		<string>altool</string>
+	</array>
+	<key>Optimizations</key>
+	<dict>
+		<!-- The key is the value to be passed to mmp. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
+		<key>inline-intptr-size</key>
+		<string>Inline IntPtr.Size</string>
+		<key>inline-runtime-arch</key>
+		<string>Inline Runtime.Arch</string>
+		<key>inline-isdirectbinding</key>
+		<string>Inline NSObject.IsDirectBinding</string>
+		<key>dead-code-elimination</key>
+		<string>Dead code elimination</string>
+		<key>remove-uithread-checks</key>
+		<string>Remove UI thread checks</string>
+	</dict>
+</dict>
+</plist>

--- a/builds/Versions-tvOS.plist.in
+++ b/builds/Versions-tvOS.plist.in
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MonoVersion</key>
+	<string>@MONO_VERSION@</string>
+	<key>KnownVersions</key>
+	<dict>
+		<key>tvOS</key>
+		<array>
+			<string>11.0</string>
+			<string>11.1</string>
+			<string>11.2</string>
+			<string>11.3</string>
+			<string>11.4</string>
+			<string>12.0</string>
+			<string>12.1</string>
+			<string>12.2</string>
+			<string>12.3</string>
+			<string>12.4</string>
+			<string>13.0</string>
+			<string>13.2</string>
+			<string>13.3</string>
+			<string>13.4</string>
+			<string>14.0</string>
+			<string>14.2</string>
+			<string>14.3</string>
+			<string>14.4</string>
+			<string>14.5</string>
+			<string>15.0</string>
+			<string>15.2</string>
+			<string>15.4</string>
+			<string>16.0</string>
+			<string>16.1</string>
+			<string>16.4</string>
+			<string>17.0</string>
+		</array>
+	</dict>
+	<key>RecommendedXcodeVersion</key>
+	<string>@XCODE_VERSION@</string>
+	<key>MinExtensionVersion</key>
+	<dict>
+		<key>tvOS</key>
+		<dict>
+			<key>com.apple.broadcast-services</key>
+			<string>10.0</string>
+			<key>com.apple.tv-services</key>
+			<string>9.0</string>
+		</dict>
+	</dict>
+	<key>Features</key>
+	<array>
+		<string>mlaunch-launchdevbundleid</string>
+		<string>mlaunch-observe-extension</string>
+		<string>mlaunch-launch-simulator</string>
+		<string>mlaunch-install-progress</string>
+		<string>mlaunch-watchos-complications</string>
+		<string>mlaunch-wireless-devices</string>
+		<string>http-client-handlers</string>
+		<string>mono-symbol-archive</string>
+		<string>sgen-concurrent-gc</string> <!-- this means experimental support for the concurrent GC -->
+		<string>sgen-concurrent</string> <!-- this means stable support for the concurrent GC -->
+		<string>arm64_32</string>
+		<string>altool</string>
+		<string>maccatalyst</string>
+	</array>
+	<key>Optimizations</key>
+	<dict>
+		<!-- The key is the value to be passed to mtouch. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
+		<key>inline-intptr-size</key>
+		<string>Inline IntPtr.Size</string>
+		<key>inline-runtime-arch</key>
+		<string>Inline NSObject.IsDirectBinding</string>
+		<key>dead-code-elimination</key>
+		<string>Dead code elimination</string>
+		<key>remove-uithread-checks</key>
+		<string>Remove UI thread checks</string>
+	</dict>
+</dict>
+</plist>

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -161,7 +161,7 @@ endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call ImplicitNamespaceImports,$(platform),$(foreach using,$(DOTNET_$(platform)_GLOBAL_USINGS),\n\t\t<Using Include=\"$(using)\" Platform=\"$(platform)\" \/>))))
 
 define SupportedTargetPlatforms
-Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.SupportedTargetPlatforms.props: $(TOP)/Versions-ios.plist.in $(TOP)/Versions-mac.plist.in Makefile ./generate-target-platforms.csharp Makefile
+Microsoft.$(1).Sdk/targets/Microsoft.$(1).Sdk.SupportedTargetPlatforms.props: $(TOP)/builds/Versions-$(1).plist.in Makefile ./generate-target-platforms.csharp Makefile
 	$(Q) rm -f $$@.tmp
 	$(Q) ./generate-target-platforms.csharp $(1) $$@.tmp
 	$(Q) mv $$@.tmp $$@

--- a/dotnet/generate-target-platforms.csharp
+++ b/dotnet/generate-target-platforms.csharp
@@ -18,7 +18,7 @@ if (args.Length != expectedArgumentCount + 2 /* 2 default arguments (executable 
 
 var platform = args [2];
 var outputPath = args [3];
-var plistPath = platform == "macOS" ? "../Versions-mac.plist.in" : "../Versions-ios.plist.in";
+var plistPath = $"../builds/Versions-{platform}.plist.in"
 
 var doc = new XmlDocument ();
 doc.Load (plistPath);


### PR DESCRIPTION
In .NET the 4 platforms are 4 separate products, so it makes sense that each
Versions.plist only contains information for the corresponding platform.

This means we can share the same logic for all .NET platforms, instead of
having to special-case macOS.

It also decouples legacy logic from .NET logic, which makes it easier to
remove legacy logic when that time comes.