### PR TITLE
[xharness] Execute 'dotnet restore' before 'dotnet build'.

### DIFF
--- a/tests/xharness/Jenkins/TestTasks/BuildProjectTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/BuildProjectTask.cs
@@ -15,7 +15,7 @@ namespace Xharness.Jenkins.TestTasks {
 		{
 		}
 
-		public virtual bool RestoreNugets {
+		public bool RestoreNugets {
 			get => BuildProject.RestoreNugets;
 			set => BuildProject.RestoreNugets = value;
 		}

--- a/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
@@ -15,17 +15,6 @@ namespace Xharness.Jenkins.TestTasks {
 			}
 		}
 
-		public override bool RestoreNugets {
-			get {
-				if (TestProject.IsDotNetProject) // 'dotnet build' will restore
-					return false;
-				if (TestProject.TestPlatform == TestPlatform.MacCatalyst)
-					return false; // we have to do 'msbuild /r'
-				return base.RestoreNugets;
-			}
-			set => base.RestoreNugets = value;
-		}
-
 		public override void SetEnvironmentVariables (Process process)
 		{
 			base.SetEnvironmentVariables (process);


### PR DESCRIPTION
The main reason is that NuGet isn't safe to execute in parallel, so we need to
serially restore all projects, before they can be built in parallel.

This hopefully fixes a problem where the build would randomly fail because
NuGet would corrupt the packages folder when executed in parallel.