### PR TITLE
[tests] Disable the BCL tests by default.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -346,7 +346,7 @@ runner: $(XHARNESS_EXECUTABLE)
 # installed on the system.
 vsts-device-tests: $(XHARNESS_EXECUTABLE)
 	$(MAKE) -C $(TOP)/builds .stamp-mono-ios-sdk-destdir download -j
-	$(Q) ulimit -n 4096 && $(DOTNET) $< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT) --use-system:true --label=skip-all-tests,run-device-tests,run-bcl-tests --markdown-summary=$(CURDIR)/TestSummary.md $(TESTS_EXTRA_ARGUMENTS) $(TESTS_PERIODIC_COMMAND)
+	$(Q) ulimit -n 4096 && $(DOTNET) $< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT) --use-system:true --label=skip-all-tests,run-device-tests --markdown-summary=$(CURDIR)/TestSummary.md $(TESTS_EXTRA_ARGUMENTS) $(TESTS_PERIODIC_COMMAND)
 
 verify-system-vsmac-xcode-match:
 	@SYSTEM_XCODE=$$(dirname $$(dirname $$(xcode-select -p))); \

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -76,7 +76,7 @@ parameters:
 - name: simTestsConfigurations
   type: object
   default: [
-    'bcl',
+    # disabled by default # 'bcl',
     'cecil',
     'dotnettests',
     'fsharp',


### PR DESCRIPTION
A few facts:

* We very rarely bump Mono (which is really the only time we should run the BCL tests).
* At the moment we're not shipping legacy Xamarin packages from main anymore.
* The BCL tests only apply to legacy Xamarin.

means that there's no need to run the BCL tests on every commit, we can just
run them manually *if* we happen to ever bump Mono again *and* we start
shipping legacy Xamarin packages from main again.