### PR TITLE
[devops] Don't download artifacts twice, once is enough.

### DIFF
--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -63,17 +63,6 @@ steps:
   displayName: Generate constants files 
   timeoutInMinutes: 15
 
-- bash: |
-    sudo rm -Rf $(Build.SourcesDirectory)/artifacts
-  displayName: "Remove artifacts"
-  condition: always()
-
-- task: DownloadPipelineArtifact@2
-  displayName: Download artifacts
-  inputs:
-    allowFailedBuilds: true
-    path: $(Build.SourcesDirectory)/artifacts
-
 - pwsh: >-
     ./set_xtro_workloads.ps1
     -WorkloadPath "$(Build.SourcesDirectory)/artifacts/${{ parameters.uploadPrefix }}WorkloadRollback/WorkloadRollback.json"


### PR DESCRIPTION
This saves 3-5 minutes for every test run.

![Screenshot 2024-01-12 at 09 32 42 copy](https://github.com/xamarin/xamarin-macios/assets/249268/a0f9a9fc-3c6b-4156-a252-a31237852c81)
