### PR TITLE
[net9.0] Revert "Ignore test triggering .NET regression."

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/TrampolineTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/TrampolineTest.cs
@@ -194,9 +194,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
-#if NET
-		[Ignore ("https://github.com/dotnet/runtime/issues/96063")]
-#endif
 		public void FloatingPointStretTrampolineTest ()
 		{
 			CGRect rect, rect2, rect3, rect4;


### PR DESCRIPTION
This reverts commit b0d8122eb749a5f6a63809ed4b3ef6afce70424e.

Fixes https://github.com/xamarin/xamarin-macios/issues/19653.