### PR TITLE
[mmp] Add PreserveSmartEnumConversionsSubStep to the linker sub steps. Fixes #19712.

### DIFF
--- a/tests/monotouch-test/Vision/VNGetCameraRelativePositionTest.cs
+++ b/tests/monotouch-test/Vision/VNGetCameraRelativePositionTest.cs
@@ -68,20 +68,6 @@ namespace MonoTouchFixtures.Vision {
 			Assert.Null (observationError, $"GetCameraRelativePosition should not return an error {observationError}");
 			Assert.That (modelPositionOut, Is.EqualTo (expectedMatrix), "VNVector3DGetCameraRelativePosition result is not equal to expected matrix");
 		}
-
-		[Test]
-		public void KeepValueMethodsAliveTest ()
-		{
-			// When running the app with the --optimize:all property, the Value extension methods of
-			// the VNHumanBodyPose3DObservationJointName smart enum are linked away and results in a
-			// build failure.
-			// This is https://github.com/xamarin/xamarin-macios/issues/19712
-			// As a temp workaround, this test will ensure that the GetValue method is getting used
-			// to prevent the linker from removing this method.
-
-			var getValue = VNHumanBodyPose3DObservationJointNameExtensions.GetValue ((NSString) "CenterHead");
-			Assert.NotNull (getValue, "VNHumanBodyPose3DObservationJointNameExtensions.GetValue should not return null");
-		}
 	}
 }
 #endif

--- a/tools/mmp/Tuning.mmp.cs
+++ b/tools/mmp/Tuning.mmp.cs
@@ -157,6 +157,7 @@ namespace MonoMac.Tuner {
 			sub.Add (new MarkNSObjects ());
 
 			sub.Add (new CoreRemoveSecurity ());
+			sub.Add (new PreserveSmartEnumConversionsSubStep ());
 
 			return sub;
 		}


### PR DESCRIPTION
Looks like this was substep was only added to mtouch, never to mmp, so let's fix that.

This also makes it possible to remove a test that was only there for the
linker to keep some required methods so that the test app would build
correctly.

Fixes https://github.com/xamarin/xamarin-macios/issues/19712.