### PR TITLE
[devops] Adjust timeouts for remote testing on Macs.

### DIFF
--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -50,7 +50,7 @@ stages:
   - job: mac_reservation
     dependsOn:
     displayName: "Reserve bot for tests"
-    timeoutInMinutes: 1000
+    timeoutInMinutes: 120
     condition: ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')
     workspace:
       clean: all
@@ -75,7 +75,7 @@ stages:
     dependsOn:
     - mac_reservation
     displayName: 'Dotnet tests'
-    timeoutInMinutes: 1000
+    timeoutInMinutes: 120
     condition: ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')
     workspace:
       clean: all


### PR DESCRIPTION
Remote tests on macOS should currently not take more than a couple of hours,
so adjust the timeout accordingly.

This avoids the CI waiting 16 hours before timing out if something goes wrong.