### PR TITLE
[xma] Updated Xamarin.Messaging

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<MessagingVersion>1.13.1</MessagingVersion>
+		<MessagingVersion>1.13.8</MessagingVersion>
 		<HotRestartVersion>1.1.7</HotRestartVersion>
 	</PropertyGroup>
 	<Import Project="$(MSBuildThisFileDirectory)../Directory.Build.props" />

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Tasks {
 
 			var taskRunner = new TaskRunner (SessionId, BuildEngine4);
 
-			taskRunner.FixReferencedItems (SourceFiles);
+			taskRunner.FixReferencedItems (this, SourceFiles);
 
 			return taskRunner.RunAsync (this).Result;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -123,7 +123,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (ShouldExecuteRemotely ()) {
 				var taskRunner = new TaskRunner (SessionId, BuildEngine4);
 
-				taskRunner.FixReferencedItems (SceneKitAssets);
+				taskRunner.FixReferencedItems (this, SceneKitAssets);
 
 				FixUpRootedPaths (SceneKitAssets);
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DittoTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DittoTaskBase.cs
@@ -71,7 +71,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (ShouldExecuteRemotely ()) {
 				var taskRunner = new TaskRunner (SessionId, BuildEngine4);
 
-				taskRunner.FixReferencedItems (new ITaskItem [] { Source! });
+				taskRunner.FixReferencedItems (this, new ITaskItem [] { Source! });
 
 				return taskRunner.RunAsync (this).Result;
 			}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/SmartCopy.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/SmartCopy.cs
@@ -10,7 +10,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (ShouldExecuteRemotely ()) {
 				var taskRunner = new TaskRunner (SessionId, BuildEngine4);
 
-				taskRunner.FixReferencedItems (SourceFiles);
+				taskRunner.FixReferencedItems (this, SourceFiles);
 
 				return taskRunner.RunAsync (this).Result;
 			}

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/FindWatchOS2AppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/FindWatchOS2AppBundleTaskBase.cs
@@ -30,7 +30,7 @@ namespace Xamarin.iOS.Tasks {
 		{
 			if (ShouldExecuteRemotely ()) {
 				var taskRunner = new TaskRunner (SessionId, BuildEngine4);
-				taskRunner.FixReferencedItems (WatchAppReferences);
+				taskRunner.FixReferencedItems (this, WatchAppReferences);
 				return taskRunner.RunAsync (this).Result;
 			}
 


### PR DESCRIPTION
Changes:

- Updated Xamarin.Messaging to 1.13.8: bring fix for potential NullReferenceException in TaskRunner.FixReferencedItems: https://github.com/xamarin/Xamarin.Messaging/pull/694

- Updated MSBuild tasks that uses TaskRunner.FixReferencedItems from Xamarin.Messaging: update needed to match new Xamarin.Messaging API changes