### PR TITLE
[CI] Make the timeout to be closer to reality.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -166,7 +166,7 @@ steps:
   name: build
   workingDirectory: "$(Build.SourcesDirectory)/xamarin-macios"
   displayName: 'Build'
-  timeoutInMinutes: 300
+  timeoutInMinutes: 180
   env:
     MAKE_PARALLELISM: ${{ parameters.makeParallelism }}
 


### PR DESCRIPTION
We are not seeing builds that take longer that 2 hours. Lets try to kill the build in those cases in which something out of the ordinaty happens like in https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8939582