### PR TITLE
Upgrade NuGetAuthenticate task to version 1

### DIFF
--- a/tools/devops/automation/templates/release/auth-feed.yml
+++ b/tools/devops/automation/templates/release/auth-feed.yml
@@ -3,7 +3,7 @@ parameters:
   type: string  
 
 steps:
-- task: NuGetAuthenticate@0
+- task: NuGetAuthenticate@1
   displayName: 'Authenticate dotnet-tool feed'
   inputs:
     nuGetServiceConnections: ${{ parameters.serviceConnection }}


### PR DESCRIPTION
The AzDo Task 'NuGet authenticate' version 0 (NuGetAuthenticate@0) is deprecated. This task will be removed. From January 31, 2024, onwards it may no longer be available. 

