### PR TITLE
[dotnet] Differentiate between "OS version we support as TargetPlatformVersion" and "OS version we support or have supported".

### DIFF
--- a/builds/Versions-MacCatalyst.plist.in
+++ b/builds/Versions-MacCatalyst.plist.in
@@ -27,6 +27,32 @@
 			<string>17.2</string>
 		</array>
 	</dict>
+	<key>SupportedTargetPlatformVersions</key>
+	<dict>
+		<key>MacCatalyst</key>
+		<array>
+			<!-- When an entry is added to KnownVersions, an entry must be added here too -->
+			<!-- However, versions are never removed from this array -->
+			<!-- The values here are used to generate the MACCATALYSTX_Y_OR_GREATER conditional compilation symbols, and those must be generated even for old OS versions -->
+			<string>13.1</string>
+			<string>13.2</string>
+			<string>13.3</string>
+			<string>13.4</string>
+			<string>13.5</string>
+			<string>14.2</string>
+			<string>14.3</string>
+			<string>14.4</string>
+			<string>14.5</string>
+			<string>15.0</string>
+			<string>15.2</string>
+			<string>15.4</string>
+			<string>16.1</string>
+			<string>16.2</string>
+			<string>16.4</string>
+			<string>17.0</string>
+			<string>17.2</string>
+		</array>
+	</dict>
 	<key>MacCatalystVersionMap</key>
 	<dict>
 		<key>13.1</key>

--- a/builds/Versions-iOS.plist.in
+++ b/builds/Versions-iOS.plist.in
@@ -42,6 +42,51 @@
 			<string>17.2</string>
 		</array>
 	</dict>
+	<key>SupportedTargetPlatformVersions</key>
+	<dict>
+		<key>iOS</key>
+		<array>
+			<!-- When an entry is added to KnownVersions, an entry must be added here too -->
+			<!-- However, versions are never removed from this array -->
+			<!-- The values here are used to generate the IOSX_Y_OR_GREATER conditional compilation symbols, and those must be generated even for old OS versions -->
+			<string>10.0</string>
+			<string>10.1</string>
+			<string>10.2</string>
+			<string>11.0</string>
+			<string>11.0</string>
+			<string>11.1</string>
+			<string>11.2</string>
+			<string>11.3</string>
+			<string>11.4</string>
+			<string>12.0</string>
+			<string>12.1</string>
+			<string>12.2</string>
+			<string>12.3</string>
+			<string>12.4</string>
+			<string>13.0</string>
+			<string>13.1</string>
+			<string>13.2</string>
+			<string>13.3</string>
+			<string>13.4</string>
+			<string>13.5</string>
+			<string>13.6</string>
+			<string>14.0</string>
+			<string>14.1</string>
+			<string>14.2</string>
+			<string>14.3</string>
+			<string>14.4</string>
+			<string>14.5</string>
+			<string>15.0</string>
+			<string>15.2</string>
+			<string>15.4</string>
+			<string>16.0</string>
+			<string>16.1</string>
+			<string>16.2</string>
+			<string>16.4</string>
+			<string>17.0</string>
+			<string>17.2</string>
+		</array>
+	</dict>
 	<key>RecommendedXcodeVersion</key>
 	<string>@XCODE_VERSION@</string>
 	<key>MinExtensionVersion</key>

--- a/builds/Versions-macOS.plist.in
+++ b/builds/Versions-macOS.plist.in
@@ -26,6 +26,30 @@
 			<string>14.2</string>
 		</array>
 	</dict>
+	<key>SupportedTargetPlatformVersions</key>
+	<dict>
+		<key>macOS</key>
+		<array>
+			<!-- When an entry is added to KnownVersions, an entry must be added here too -->
+			<!-- However, versions are never removed from this array -->
+			<!-- The values here are used to generate the MACOSX_Y_OR_GREATER conditional compilation symbols, and those must be generated even for old OS versions -->
+			<string>10.14</string>
+			<string>10.15</string>
+			<string>10.16</string>
+			<string>11.0</string>
+			<string>11.1</string>
+			<string>11.2</string>
+			<string>11.3</string>
+			<string>12.0</string>
+			<string>12.1</string>
+			<string>12.3</string>
+			<string>13.0</string>
+			<string>13.1</string>
+			<string>13.3</string>
+			<string>14.0</string>
+			<string>14.2</string>
+		</array>
+	</dict>
 	<key>RecommendedXcodeVersion</key>
 	<string>@XCODE_VERSION@</string>
 	<key>MinExtensionVersion</key>

--- a/builds/Versions-tvOS.plist.in
+++ b/builds/Versions-tvOS.plist.in
@@ -37,6 +37,46 @@
 			<string>17.2</string>
 		</array>
 	</dict>
+	<key>SupportedTargetPlatformVersions</key>
+	<dict>
+		<key>tvOS</key>
+		<array>
+			<!-- When an entry is added to KnownVersions, an entry must be added here too -->
+			<!-- However, versions are never removed from this array -->
+			<!-- The values here are used to generate the TVOSX_Y_OR_GREATER conditional compilation symbols, and those must be generated even for old OS versions -->
+			<string>10.0</string>
+			<string>10.1</string>
+			<string>10.2</string>
+			<string>11.0</string>
+			<string>11.0</string>
+			<string>11.1</string>
+			<string>11.2</string>
+			<string>11.3</string>
+			<string>11.4</string>
+			<string>12.0</string>
+			<string>12.1</string>
+			<string>12.2</string>
+			<string>12.3</string>
+			<string>12.4</string>
+			<string>13.0</string>
+			<string>13.2</string>
+			<string>13.3</string>
+			<string>13.4</string>
+			<string>14.0</string>
+			<string>14.2</string>
+			<string>14.3</string>
+			<string>14.4</string>
+			<string>14.5</string>
+			<string>15.0</string>
+			<string>15.2</string>
+			<string>15.4</string>
+			<string>16.0</string>
+			<string>16.1</string>
+			<string>16.4</string>
+			<string>17.0</string>
+			<string>17.2</string>
+		</array>
+	</dict>
 	<key>RecommendedXcodeVersion</key>
 	<string>@XCODE_VERSION@</string>
 	<key>MinExtensionVersion</key>

--- a/dotnet/generate-target-platforms.csharp
+++ b/dotnet/generate-target-platforms.csharp
@@ -20,7 +20,8 @@ var plistPath = $"../builds/Versions-{platform}.plist.in"
 
 var doc = new XmlDocument ();
 doc.Load (plistPath);
-var nodes = doc.SelectNodes ($"/plist/dict/key[text()='KnownVersions']/following-sibling::dict[1]/key[text()='{platform}']/following-sibling::array[1]/string");
+var knownVersions = doc.SelectNodes ($"/plist/dict/key[text()='KnownVersions']/following-sibling::dict[1]/key[text()='{platform}']/following-sibling::array[1]/string").Cast<XmlNode> ().Select (v => v.InnerText).ToArray ();
+var supportedTargetPlatformVersions = doc.SelectNodes ($"/plist/dict/key[text()='SupportedTargetPlatformVersions']/following-sibling::dict[1]/key[text()='{platform}']/following-sibling::array[1]/string").Cast<XmlNode> ().Select (v => v.InnerText).ToArray ();
 
 var minSdkVersionName = $"DOTNET_MIN_{platform.ToUpper ()}_SDK_VERSION";
 var minSdkVersionString = File.ReadAllLines ("../Make.config").Single (v => v.StartsWith (minSdkVersionName + "=", StringComparison.Ordinal)).Substring (minSdkVersionName.Length + 1);
@@ -32,11 +33,11 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ("<Project>");
 	writer.WriteLine ("\t<ItemGroup>");
 
-	foreach (XmlNode n in nodes) {
-		var version = n.InnerText;
-		if (Version.Parse (version) < minSdkVersion)
-			continue;
-		writer.WriteLine ($"\t\t<{platform}SdkSupportedTargetPlatformVersion Include=\"{n.InnerText}\" />");
+	foreach (var version in supportedTargetPlatformVersions) {
+		writer.Write ($"\t\t<{platform}SdkSupportedTargetPlatformVersion Include=\"{version}\" ");
+		if (!knownVersions.Contains (version))
+			writer.Write ($"DefineConstantsOnly=\"true\" ");
+		writer.WriteLine ("/>");
 	}
 
 	writer.WriteLine ("\t</ItemGroup>");

--- a/versions-check.csharp
+++ b/versions-check.csharp
@@ -44,6 +44,7 @@ try {
 			// Skip this (iOS/tvOS/watchOS versions for macOS, or vice versa)
 			return;
 		}
+		var versionsHashSet = new HashSet<string> (versions.Cast<XmlNode> ().Select (v => v.InnerText));
 		foreach (XmlNode node in versions) {
 			// Console.WriteLine ($"{product}: checking: {node.InnerText}");
 			var v = node.InnerText;
@@ -66,6 +67,20 @@ try {
 		}
 		if (!foundMin) {
 			Console.Error.WriteLine ($"Could not find the min {product} version {min} in {Path.GetFileName (plistPath)}.");
+			failed = true;
+		}
+
+		var supportedTPVNodes = doc.SelectNodes ($"/plist/dict/key[text()='SupportedTargetPlatformVersions']/following-sibling::dict[1]/key[text()='{product}']/following-sibling::array[1]/string").Cast<XmlNode> ().ToArray ();
+		var supportedTPVs = supportedTPVNodes.Select (v => v.InnerText).ToArray ();
+		if (supportedTPVs?.Any () == true) {
+			var supportedTPVSet = new HashSet<string> (supportedTPVs);
+			var missingTPVs = versionsHashSet.Except (supportedTPVSet);
+			if (missingTPVs.Any ()) {
+				Console.Error.WriteLine ($"The array SupportedTargetPlatformVersions are missing the following entries (they're in the KnownVersions array): {string.Join (", ", missingTPVs)}");
+				failed = true;
+			}
+		} else if (plistPath.Contains ("/builds/")) {
+			Console.Error.WriteLine ($"No SupportedTargetPlatformVersions array found in the plist: {plistPath}");
 			failed = true;
 		}
 	});


### PR DESCRIPTION
The `SdkSupportedTargetPlatformVersion` item group is used for (at least) two things:

1. Generate the `_OR_GREATER` preprocessing symbols:

https://github.com/dotnet/sdk/blob/bfd2919bc446cad68d11de90cec4025d3683591c/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets#L230-L237

2. Validate the TargetPlatformVersion:

https://github.com/dotnet/sdk/blob/bfd2919bc446cad68d11de90cec4025d3683591c/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets#L233-L246

The problem is that these two uses aren't equivalent.

Take for example the following scenario:

We release bindings for iOS 10, and a library developer takes advantage of the
bindings for the new iOS version, while at the same time supporting
multi-targeting to older platforms:

```csharp
    #if IOS10_0_OR_GREATER
        UseNewApi ();
    #else
        UseOldApi ();
    #endif
```

Time passes, iOS 11 comes out, and we stop shipping bindings specifically for
iOS 10 (the APIs themselves would be included in the bindings for iOS 11). The
code above should continue to work, but iOS 10 is not a valid
TargetPlatformVersion anymore. However, with the current situation there's no
way to express this, because the moment we remove the "10.0" version from
SdkSupportedTargetPlatformVersion, the IOS10_0_OR_GREATER define isn't
generated anymore.

We discussed this in a meeting internally, and the suggestion that came up was
to use metadata to handle this situation, and we've decided to add the
"DefineConstantsOnly=true" metadata to items in
SdkSupportedTargetPlatformVersion that are "OS versions we support or have
supported", but not "OS versions we support as TargetPlatformVersion".

Note: we're adding this to .NET 8, but .NET will not understand the new
metadata until .NET 9, which means this won't be a breaking change until .NET
9.

In a different PR I'll add logic to warn if a project uses a
TargetPlatformVersion that is no longer valid (so that people will start
getting a warning in .NET 8 instead of getting surprised by a build error in
.NET 9).

Ref: https://github.com/dotnet/sdk/issues/38016