### PR TITLE
[net9.0] Drop support for .NET 7.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -640,8 +640,7 @@ $(TOP)/dotnet.config: $(TOP)/eng/Versions.props $(TOP)/Build.props
 	$(Q) grep MicrosoftDotnetSdkInternalPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftDotnetSdkInternalPackageVersion>//g' -e 's/[ \t]*/DOTNET_VERSION=/' >> $@.tmp
 	$(Q) grep MicrosoftNETCoreAppRefPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftNETCoreAppRefPackageVersion>//g' -e 's/[ \t]*/BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION=/' >> $@.tmp
 	$(Q) grep "<$$(grep EmscriptenWorkloadVersion $(TOP)/eng/Versions.props | sed -e 's_.*>$$[\(]\(.*\)[\)]<.*_\1_')>" $(TOP)/eng/Versions.props | sed -e 's/.*>\(.*\)<.*/EMSCRIPTEN_MANIFEST_PACKAGE_VERSION=\1/' >> $@.tmp
-	$(Q) $(foreach platform,$(ALL_DOTNET_PLATFORMS),grep '<Microsoft$(platform)SdkPackageVersion>' $(TOP)/eng/Versions.props | sed -e 's/<*\/*Microsoft$(platform)SdkPackageVersion>//g' -e 's/[ \t]*/NET7_$(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION_NO_METADATA=/' >> $@.tmp &&) true
-	$(Q) $(foreach platform,$(ALL_DOTNET_PLATFORMS),grep '<Microsoft$(platform)Sdknet80PackageVersion>' $(TOP)/eng/Versions.props | sed -e 's/<*\/*Microsoft$(platform)Sdknet80PackageVersion>//g' -e 's/[ \t]*/NET8_$(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION_NO_METADATA=/' >> $@.tmp &&) true
+	$(Q) $(foreach platform,$(ALL_DOTNET_PLATFORMS),grep '<Microsoft$(platform)SdkPackageVersion>' $(TOP)/eng/Versions.props | sed -e 's/<*\/*Microsoft$(platform)SdkPackageVersion>//g' -e 's/[ \t]*/NET8_$(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION_NO_METADATA=/' >> $@.tmp &&) true
 	$(Q) mv $@.tmp $@
 
 $(TOP)/Build.props: Make.config
@@ -691,7 +690,7 @@ export PATH := $(DOTNET_DIR):$(PATH)
 DOTNET=$(DOTNET_DIR)/dotnet
 DOTNET_BCL_DIR:=$(abspath $(TOP)/packages/microsoft.netcore.app.ref/$(DOTNET_BCL_VERSION)/ref/$(DOTNET_TFM))
 ifneq ($(DOTNET_BCL_DIR),$(shell ls -1d $(DOTNET_BCL_DIR) 2>/dev/null))
-DOTNET_BCL_DIR:=$(abspath $(TOP)/packages/microsoft.netcore.app.ref/$(DOTNET_BCL_VERSION)/ref/net7.0)
+DOTNET_BCL_DIR:=$(abspath $(TOP)/packages/microsoft.netcore.app.ref/$(DOTNET_BCL_VERSION)/ref/net8.0)
 endif
 
 # The sdk version band has the last two digits set to 0: https://github.com/dotnet/sdk/blob/22c4860dcb2cf6b123dd641cc4a87a50380759d5/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs#L52-L53

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -172,12 +172,12 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call SupportedTargetPlatforms,$(
 define WorkloadTargets
 Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.json: Makefile $(TOP)/Make.config.inc $(GIT_DIRECTORY)/HEAD $(GIT_DIRECTORY)/index Makefile generate-workloadmanifest-json.csharp | Workloads/Microsoft.NET.Sdk.$(1)
 	$$(Q) rm -f $$@.tmp
-	$$(Q_GEN) ./generate-workloadmanifest-json.csharp "$(1)" "$(3)" "$(5)" "$(6)" "$$(DOTNET_$(4)_RUNTIME_IDENTIFIERS)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)"
+	$$(Q_GEN) ./generate-workloadmanifest-json.csharp "$(1)" "$(3)" "$(5)" "$$(DOTNET_$(4)_RUNTIME_IDENTIFIERS)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)"
 	$$(Q) mv $$@.tmp $$@
 
 Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.targets: Makefile $(TOP)/Make.config.inc $(TOP)/.git/HEAD $(TOP)/.git/index Makefile generate-workloadmanifest-targets.csharp | Workloads/Microsoft.NET.Sdk.$(1)
 	$$(Q) rm -f $$@.tmp
-	$$(Q_GEN) ./generate-workloadmanifest-targets.csharp "$(1)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)" "$(DOTNET_TFM)" "net7.0 net8.0"
+	$$(Q_GEN) ./generate-workloadmanifest-targets.csharp "$(1)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)" "$(DOTNET_TFM)" "net8.0"
 	$$(Q) mv $$@.tmp $$@
 
 Workloads/Microsoft.NET.Sdk.$(1)/LICENSE: $(TOP)/LICENSE | Workloads/Microsoft.NET.Sdk.$(1)
@@ -191,7 +191,7 @@ LOCAL_WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.json
 LOCAL_WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.targets
 LOCAL_WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/LICENSE
 endef
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform),$(shell echo $(platform) | tr A-Z a-z),$($(platform)_NUGET_VERSION_NO_METADATA),$(shell echo $(platform) | tr a-z A-Z),$(NET7_$(platform)_NUGET_VERSION_NO_METADATA),$(NET8_$(platform)_NUGET_VERSION_NO_METADATA))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform),$(shell echo $(platform) | tr A-Z a-z),$($(platform)_NUGET_VERSION_NO_METADATA),$(shell echo $(platform) | tr a-z A-Z),$(NET8_$(platform)_NUGET_VERSION_NO_METADATA))))
 
 # Always use the commit distance as the third number in the VS component version, as it should always increase across all branches.
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).$($(shell echo $(platform) | tr a-z A-Z)_NUGET_COMMIT_DISTANCE).0))

--- a/dotnet/generate-workloadmanifest-json.csharp
+++ b/dotnet/generate-workloadmanifest-json.csharp
@@ -6,7 +6,7 @@ using System.IO;
 using System.Xml;
 
 var args = Args;
-var expectedArgumentCount = 7;
+var expectedArgumentCount = 6;
 if (args.Length != expectedArgumentCount) {
 	Console.WriteLine ($"Need {expectedArgumentCount} arguments, got {args.Length}");
 	Environment.Exit (1);
@@ -16,7 +16,6 @@ if (args.Length != expectedArgumentCount) {
 var argumentIndex = 0;
 var platform = args [argumentIndex++];
 var version = args [argumentIndex++];
-var net7Version = args [argumentIndex++];
 var net8Version = args [argumentIndex++];
 var runtimeIdentifiers = args [argumentIndex++].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 var outputPath = args [argumentIndex++];
@@ -34,11 +33,9 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"			\"packs\": [");
 	writer.WriteLine ($"				\"Microsoft.{platform}.Sdk.net9\",");
 	writer.WriteLine ($"				\"Microsoft.{platform}.Sdk.net8\",");
-	writer.WriteLine ($"				\"Microsoft.{platform}.Sdk.net7\",");
 	if (hasWindows) {
 		writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.net9\",");
 		writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.net8\",");
-		writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.net7\",");
 	}
 	writer.WriteLine ($"				\"Microsoft.{platform}.Ref\",");
 	foreach (var rid in runtimeIdentifiers) {
@@ -50,11 +47,9 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	if (platform == "macOS") {
 		writer.WriteLine ($"				\"microsoft-net-runtime-mono-tooling\",");
 		// writer.WriteLine ($"				\"microsoft-net-runtime-mono-tooling-net8\",");
-		writer.WriteLine ($"				\"microsoft-net-runtime-mono-tooling-net7\",");
 	} else {
 		writer.WriteLine ($"				\"microsoft-net-runtime-{platformLowerCase}\",");
 		// writer.WriteLine ($"				\"microsoft-net-runtime-{platformLowerCase}-net8\",");
-		writer.WriteLine ($"				\"microsoft-net-runtime-{platformLowerCase}-net7\",");
 	}
 	writer.WriteLine ($"			]");
 	writer.WriteLine ($"		}},");
@@ -74,13 +69,6 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"				\"any\": \"Microsoft.{platform}.Sdk\"");
 	writer.WriteLine ($"			}}");
 	writer.WriteLine ($"		}},");
-	writer.WriteLine ($"		\"Microsoft.{platform}.Sdk.net7\": {{");
-	writer.WriteLine ($"			\"kind\": \"sdk\",");
-	writer.WriteLine ($"			\"version\": \"{net7Version}\",");
-	writer.WriteLine ($"			\"alias-to\": {{");
-	writer.WriteLine ($"				\"any\": \"Microsoft.{platform}.Sdk\"");
-	writer.WriteLine ($"			}}");
-	writer.WriteLine ($"		}},");
 	if (hasWindows) {
 		writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.net9\": {{");
 		writer.WriteLine ($"			\"kind\": \"sdk\",");
@@ -94,15 +82,6 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 		writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.net8\": {{");
 		writer.WriteLine ($"			\"kind\": \"sdk\",");
 		writer.WriteLine ($"			\"version\": \"{net8Version}\",");
-		writer.WriteLine ($"			\"alias-to\": {{");
-		writer.WriteLine ($"				\"win-x64\": \"Microsoft.{platform}.Windows.Sdk\",");
-		writer.WriteLine ($"				\"win-x86\": \"Microsoft.{platform}.Windows.Sdk\",");
-		writer.WriteLine ($"				\"win-arm64\": \"Microsoft.{platform}.Windows.Sdk\",");
-		writer.WriteLine ($"			}}");
-		writer.WriteLine ($"		}},");
-		writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.net7\": {{");
-		writer.WriteLine ($"			\"kind\": \"sdk\",");
-		writer.WriteLine ($"			\"version\": \"{net7Version}\",");
 		writer.WriteLine ($"			\"alias-to\": {{");
 		writer.WriteLine ($"				\"win-x64\": \"Microsoft.{platform}.Windows.Sdk\",");
 		writer.WriteLine ($"				\"win-x86\": \"Microsoft.{platform}.Windows.Sdk\",");

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,22 +30,22 @@
       <Uri>https://github.com/dotnet/cecil</Uri>
       <Sha>81facb3f6009be2cdce70df30452bb75e9a8f993</Sha>
     </Dependency>
-    <!-- This is a subscription of the .NET 7 versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.7099">
+    <!-- This is a subscription of the .NET 8 versions of our packages -->
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.2.8011">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c70a2f50f88ee470d197d2b4fff3de5b75237a0d</Sha>
+      <Sha>31515c4d5ccb6fb3ed70874586e9737c0dd2f702</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7099">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="14.2.8011">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c70a2f50f88ee470d197d2b4fff3de5b75237a0d</Sha>
+      <Sha>31515c4d5ccb6fb3ed70874586e9737c0dd2f702</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7099">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="17.2.8011">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c70a2f50f88ee470d197d2b4fff3de5b75237a0d</Sha>
+      <Sha>31515c4d5ccb6fb3ed70874586e9737c0dd2f702</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7099">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.2.8011">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c70a2f50f88ee470d197d2b4fff3de5b75237a0d</Sha>
+      <Sha>31515c4d5ccb6fb3ed70874586e9737c0dd2f702</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Runtime.MonoTargets.Sdk" Version="9.0.0-alpha.1.23556.4">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,15 +15,10 @@
     <!-- Manually updated versions -->
     <Emscriptennet7WorkloadVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100Version)</Emscriptennet7WorkloadVersion>
     <EmscriptenWorkloadVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100Version)</EmscriptenWorkloadVersion>
-    <!-- This is a subscription of the .NET 7 versions of our packages -->
-    <MicrosoftMacCatalystSdkPackageVersion>16.4.7099</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>13.3.7099</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>16.4.7099</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>16.4.7099</MicrosofttvOSSdkPackageVersion>
-    <!-- Currently these must be updated manually, there's no subscription to the .NET 8 versions of our packages -->
-    <MicrosoftMacCatalystSdknet80PackageVersion>17.2.8004</MicrosoftMacCatalystSdknet80PackageVersion>
-    <MicrosoftmacOSSdknet80PackageVersion>14.2.8004</MicrosoftmacOSSdknet80PackageVersion>
-    <MicrosoftiOSSdknet80PackageVersion>17.2.8004</MicrosoftiOSSdknet80PackageVersion>
-    <MicrosofttvOSSdknet80PackageVersion>17.2.8004</MicrosofttvOSSdknet80PackageVersion>
+    <!-- This is a subscription of the .NET 8 versions of our packages -->
+    <MicrosoftMacCatalystSdkPackageVersion>17.2.8011</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.2.8011</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.2.8011</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.2.8011</MicrosofttvOSSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1152,7 +1152,6 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		[Ignore ("Ignore due to issue: https://github.com/xamarin/xamarin-macios/issues/18655")]
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64")]
@@ -1168,21 +1167,10 @@ namespace Xamarin.Tests {
 			Clean (project_path);
 			var properties = GetDefaultProperties (runtimeIdentifiers);
 
-			// This property is needed until https://github.com/xamarin/xamarin-macios/pull/18411 has been merged and we can use the resulting packages.
-			properties ["_RequiresILLinkPack"] = "true";
-
-			var result = DotNet.AssertBuild (project_path, properties);
-			AssertThatLinkerExecuted (result);
-			var infoPlistPath = GetInfoPListPath (platform, appPath);
-			Assert.That (infoPlistPath, Does.Exist, "Info.plist");
-			var infoPlist = PDictionary.FromFile (infoPlistPath)!;
-			Assert.AreEqual ("com.xamarin.mysimpleapp", infoPlist.GetString ("CFBundleIdentifier").Value, "CFBundleIdentifier");
-			Assert.AreEqual ("MySimpleApp", infoPlist.GetString ("CFBundleDisplayName").Value, "CFBundleDisplayName");
-			Assert.AreEqual ("7.0", infoPlist.GetString ("CFBundleVersion").Value, "CFBundleVersion");
-			Assert.AreEqual ("7.0", infoPlist.GetString ("CFBundleShortVersionString").Value, "CFBundleShortVersionString");
-
-			var appExecutable = GetNativeExecutable (platform, appPath);
-			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
+			var result = DotNet.AssertBuildFailure (project_path, properties);
+			var errors = BinLog.GetBuildLogErrors (result.BinLogPath).ToList ();
+			Assert.AreEqual (1, errors.Count, "Error Count");
+			Assert.That (errors [0].Message, Does.Contain ("To build this project, the following workloads must be installed: "), "Error message");
 		}
 
 		[Test]


### PR DESCRIPTION
.NET 7 will be out of support by the time .NET 9 is released, so we can just
drop it already.