### PR TITLE
[release/8.0.1xx-xcode15.1] [CI] Use the prefix in the artifact name, not the file.

### DIFF
--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -176,7 +176,7 @@ steps:
 
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\\xamarin-macios\\tools\\devops\\automation\\scripts\\MaciosCI.psd1
-    $configFile = "$(Build.SourcesDirectory)\\artifacts\\build-configuration\\${{ parameters.uploadPrefix }}configuration.json"
+    $configFile = "$(Build.SourcesDirectory)\\artifacts\\${{ parameters.uploadPrefix }}build-configuration\\configuration.json"
     $config = Import-BuildConfiguration -ConfigFile $configFile
     $config | Write-Host
   name: configuration


### PR DESCRIPTION
The prefix goes in the container, not the file.


Backport of #19896
