### PR TITLE
[release/8.0.1xx-xcode15.1] [dotnet] Fix typo causing universal builds to not keep any symbols when stripped. Fixes #19860.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -364,7 +364,7 @@
 			Properties="
 				RuntimeIdentifier=%(_RuntimeIdentifiersAsItems.Identity);
 				_CodesignItemsPath=%(_RuntimeIdentifiersAsItems.RidSpecificCodesignItemsPath);
-				_MtouchSymbolsList=%(_RuntimeIdentifiersAsItems.RidSpecificSymbolsList);
+				_MtouchSymbolsList=%(_RuntimeIdentifiersAsItems.RidSpecificSymbolsListPath);
 				_UserFrameworksWithoutDebugSymbolsPath=%(_RuntimeIdentifiersAsItems.RidSpecificUserFrameworksWithoutDebugSymbolsPath);
 				$(_RidSpecificProperties);
 				">

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -1198,5 +1198,23 @@ namespace Xamarin.Tests {
 
 		[DllImport ("libc")]
 		static extern int sysctlbyname (string name, ref int value, ref IntPtr size, IntPtr zero, IntPtr zeroAgain);
+
+		public static IEnumerable<string> GetNativeSymbols (string file, string arch = null)
+		{
+			var arguments = new List<string> (new [] { "-gUjA", file });
+			if (!string.IsNullOrEmpty (arch)) {
+				arguments.Add ("-arch");
+				arguments.Add (arch);
+			}
+			var symbols = ExecutionHelper.Execute ("nm", arguments, hide_output: true).Split ('\n');
+			return symbols.Where ((v) => {
+				return !v.EndsWith (": no symbols", StringComparison.Ordinal);
+			}).Select ((v) => {
+				var idx = v.LastIndexOf (": ", StringComparison.Ordinal);
+				if (idx <= 0)
+					return v;
+				return v.Substring (idx + 2);
+			});
+		}
 	}
 }

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1593,7 +1593,7 @@ namespace Xamarin.Tests {
 			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
 
 			var symbols = Configuration.GetNativeSymbols (appExecutable);
-			Assert.That (symbols, Does.Contain ("_xamarin_mono_object_retain"), "xamarin_mono_object_retain");
+			Assert.That (symbols, Does.Contain ("_xamarin_release_managed_ref"), "_xamarin_release_managed_ref");
 			switch (platform) {
 			case ApplePlatform.iOS:
 			case ApplePlatform.TVOS:

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1576,7 +1576,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS, "ios-arm64;")]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;")]
-		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64;")]
+		[TestCase (ApplePlatform.TVOS, "tvos-arm64;")]
 		public void StrippedRuntimeIdentifiers (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "MySimpleApp";
@@ -1594,12 +1594,6 @@ namespace Xamarin.Tests {
 
 			var symbols = Configuration.GetNativeSymbols (appExecutable);
 			Assert.That (symbols, Does.Contain ("_xamarin_release_managed_ref"), "_xamarin_release_managed_ref");
-			switch (platform) {
-			case ApplePlatform.iOS:
-			case ApplePlatform.TVOS:
-				Assert.That (symbols, Does.Contain ("_xamarin_UIApplicationMain"), "xamarin_UIApplicationMain");
-				break;
-			}
 		}
 
 	}

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1590,7 +1590,7 @@ namespace Xamarin.Tests {
 			DotNet.AssertBuild (project_path, properties);
 
 			var appExecutable = GetNativeExecutable (platform, appPath);
-			ExecuteWithMagicWordAndAssert (appExecutable);
+			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
 
 			var symbols = Configuration.GetNativeSymbols (appExecutable);
 			Assert.That (symbols, Does.Contain ("_xamarin_mono_object_retain"), "xamarin_mono_object_retain");

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -4715,20 +4715,7 @@ public class TestApp {
 
 		public static IEnumerable<string> GetNativeSymbols (string file, string arch = null)
 		{
-			var arguments = new List<string> (new [] { "-gUjA", file });
-			if (!string.IsNullOrEmpty (arch)) {
-				arguments.Add ("-arch");
-				arguments.Add (arch);
-			}
-			var symbols = ExecutionHelper.Execute ("nm", arguments, hide_output: true).Split ('\n');
-			return symbols.Where ((v) => {
-				return !v.EndsWith (": no symbols", StringComparison.Ordinal);
-			}).Select ((v) => {
-				var idx = v.LastIndexOf (": ", StringComparison.Ordinal);
-				if (idx <= 0)
-					return v;
-				return v.Substring (idx + 2);
-			});
+			return Configuration.GetNativeSymbols (file, arch);
 		}
 
 		static bool? is_apfs;


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/19860.

Backport of #19900.