### PR TITLE
[tests] Add infrastructure to run tests on Windows that need a remote Mac. Fixes #13924.

### DIFF
--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -62,9 +62,9 @@ namespace Xamarin.Tests {
 			return Execute ("restore", project, properties, false);
 		}
 
-		public static ExecutionResult AssertBuild (string project, Dictionary<string, string>? properties = null, TimeSpan? timeout = null, bool? quiet = null)
+		public static ExecutionResult AssertBuild (string project, Dictionary<string, string>? properties = null, TimeSpan? timeout = null)
 		{
-			return Execute ("build", project, properties, true, timeout: timeout, quiet: quiet);
+			return Execute ("build", project, properties, true, timeout: timeout);
 		}
 
 		public static ExecutionResult AssertBuildFailure (string project, Dictionary<string, string>? properties = null)
@@ -113,7 +113,7 @@ namespace Xamarin.Tests {
 			return new ExecutionResult (output, output, rv.ExitCode);
 		}
 
-		public static ExecutionResult Execute (string verb, string project, Dictionary<string, string>? properties, bool assert_success = true, string? target = null, bool? msbuildParallelism = null, TimeSpan? timeout = null, bool? quiet = null)
+		public static ExecutionResult Execute (string verb, string project, Dictionary<string, string>? properties, bool assert_success = true, string? target = null, bool? msbuildParallelism = null, TimeSpan? timeout = null)
 		{
 			if (!File.Exists (project))
 				throw new FileNotFoundException ($"The project file '{project}' does not exist.");
@@ -188,8 +188,7 @@ namespace Xamarin.Tests {
 
 				// Work around https://github.com/dotnet/msbuild/issues/8845
 				args.Add ("/v:diag");
-				if (quiet != false)
-					args.Add ("/consoleloggerparameters:Verbosity=Quiet");
+				args.Add ("/consoleloggerparameters:Verbosity=Quiet");
 				// vb does not have preview lang, so we force it to latest
 				if (project.EndsWith (".vbproj", StringComparison.OrdinalIgnoreCase))
 					args.Add ("/p:LangVersion=latest");

--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -69,4 +69,34 @@
 	<Import Project="$(MSBuildThisFileDirectory)/../nunit.framework.targets" Condition="'$(ExcludeNUnitLiteReference)' != 'true'" />
 
 	<Import Project="$(GeneratedProjectFile)" Condition="'$(GeneratedProjectFile)' != ''" />
+
+	<!--
+		This is a helper target for our tests to zip up the app bundle.
+		This is useful when building remotely, and we want to inspect the results on Windows:
+		we build on the Mac, zip up the resulting app bundle, transfer the zip file to Windows where the test is executing, and inspect the zip file there
+	-->
+	<Target Name="CompressAppBundle" AfterTargets="Codesign" Condition="'$(IsMacEnabled)' == 'true' And '$(CopyAppBundleToWindows)' == 'true'">
+		<PropertyGroup>
+			<DirectoryToCompress Condition="'$(DirectoryToCompress)' == ''">$(_AppBundlePath)</DirectoryToCompress>
+			<CompressedName Condition="'$(CompressedName)' == ''">AppBundle.zip</CompressedName>
+			<CompressedPath Condition="'$(CompressedPath)' == ''">$(DeviceSpecificIntermediateOutputPath)$(CompressedName)</CompressedPath>
+		</PropertyGroup>
+
+		<MakeDir SessionId="$(BuildSessionId)" Directories="$([System.IO.Path]::GetDirectoryName('$(CompressedPath)'))" />
+		<Delete SessionId="$(BuildSessionId)" Files="$(CompressedPath)" />
+
+		<Zip
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			ToolExe="$(ZipExe)"
+			ToolPath="$(ZipPath)"
+			Recursive="true"
+			Symlinks="true"
+			Sources="$(DirectoryToCompress)"
+			OutputFile="$(CompressedPath)"
+			WorkingDirectory="$(DirectoryToCompress)"
+			>
+			<Output TaskParameter="OutputFile" ItemName="FileWrites" />
+		</Zip>
+	</Target>
 </Project>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -855,20 +855,6 @@ namespace Xamarin.Tests {
 				Assert.Fail ($"Could not find either BindingWithDefaultCompileInclude.resources.zip or BindingWithDefaultCompileInclude.resources in {bindir}");
 		}
 
-		void AssertThatLinkerExecuted (ExecutionResult result)
-		{
-			var output = BinLog.PrintToString (result.BinLogPath);
-			Assert.That (output, Does.Contain ("Building target \"_RunILLink\" completely."), "Linker did not executed as expected.");
-			Assert.That (output, Does.Contain ("LinkerConfiguration:"), "Custom steps did not run as expected.");
-		}
-
-		void AssertThatLinkerDidNotExecute (ExecutionResult result)
-		{
-			var output = BinLog.PrintToString (result.BinLogPath);
-			Assert.That (output, Does.Not.Contain ("Building target \"_RunILLink\" completely."), "Linker did not executed as expected.");
-			Assert.That (output, Does.Not.Contain ("LinkerConfiguration:"), "Custom steps did not run as expected.");
-		}
-
 		void AssertAppContents (ApplePlatform platform, string app_directory)
 		{
 			var info_plist_path = GetInfoPListPath (platform, app_directory);

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -450,5 +450,20 @@ namespace Xamarin.Tests {
 
 			Assert.Fail ($"Failure when comparing {type} messages:\n{string.Join ("\n", failures)}\n\tAll {type}s:\n\t\t{string.Join ("\n\t\t", actualMessages.Select (v => v.Message?.TrimEnd ()))}");
 		}
+
+		public void AssertThatLinkerExecuted (ExecutionResult result)
+		{
+			var output = BinLog.PrintToString (result.BinLogPath);
+			Assert.That (output, Does.Contain ("Building target \"_RunILLink\" completely."), "Linker did not executed as expected.");
+			Assert.That (output, Does.Contain ("LinkerConfiguration:"), "Custom steps did not run as expected.");
+		}
+
+		public void AssertThatLinkerDidNotExecute (ExecutionResult result)
+		{
+			var output = BinLog.PrintToString (result.BinLogPath);
+			Assert.That (output, Does.Not.Contain ("Building target \"_RunILLink\" completely."), "Linker did not executed as expected.");
+			Assert.That (output, Does.Not.Contain ("LinkerConfiguration:"), "Custom steps did not run as expected.");
+		}
+
 	}
 }

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -6,9 +6,10 @@ using System.IO.Compression;
 #nullable enable
 
 namespace Xamarin.Tests {
-	[Category ("Windows")]
+	[TestFixture]
 	public class WindowsTest : TestBaseClass {
 
+		[Category ("Windows")]
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		public void BundleStructureWithHotRestart (ApplePlatform platform, string runtimeIdentifiers)
 		{

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -173,7 +173,7 @@ namespace Xamarin.Tests {
 			// Copy the app bundle to Windows so that we can inspect the results.
 			properties ["CopyAppBundleToWindows"] = "true";
 
-			var result = DotNet.AssertBuild (project_path, properties, quiet: false, timeout: TimeSpan.FromMinutes (15));
+			var result = DotNet.AssertBuild (project_path, properties, timeout: TimeSpan.FromMinutes (15));
 			AssertThatLinkerExecuted (result);
 
 			var objDir = GetObjDir (project_path, platform, runtimeIdentifiers, configuration);

--- a/tests/dotnet/Windows/collect-binlogs.sh
+++ b/tests/dotnet/Windows/collect-binlogs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eux
+
+# Creates a zip file with all relevant log files from the Mac.
+# Zip file: ~/remote_build_testing/windows-remote-logs.zip
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+TOPLEVEL="$(git rev-parse --show-toplevel)"
+
+# Collect and zip up all the binlogs
+mkdir -p ~/remote_build_testing/binlogs
+rsync -av --prune-empty-dirs --include '*/' --include '*.binlog' --exclude '*' "$TOPLEVEL/.." ~/remote_build_testing/binlogs
+
+rm -f ~/remote_build_testing/windows-remote-logs.zip
+zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/remote_build_testing/binlogs
+
+# Zip up all the logs in ~/Library/Logs/Xamarin.Messaging*
+if ls ~/Library/Logs/Xamarin.Messaging* >& /dev/null ; then
+	zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/Library/Logs/Xamarin.Messaging*
+else
+	echo "No logs in ~/Library/Logs/Xamarin.Messaging"
+fi

--- a/tools/devops/automation/scripts/MaciosCI.psd1
+++ b/tools/devops/automation/scripts/MaciosCI.psd1
@@ -72,6 +72,7 @@ NestedModules = @(
                'Artifacts.psm1', 
                'GitHub.psm1', 
                'MLaunch.psm1', 
+               'RemoteMac.psm1', 
                'StaticPages.psm1', 
                'System.psm1', 
                'TestResults.psm1',

--- a/tools/devops/automation/scripts/RemoteMac.psm1
+++ b/tools/devops/automation/scripts/RemoteMac.psm1
@@ -1,0 +1,65 @@
+<#
+    .SYNOPSIS
+        Executes a command on a remote machine using scp
+#>
+
+function Invoke-SshCommand {
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $RemoteHost,
+
+        [Parameter(Mandatory)]
+        [string]
+        $RemoteUserName,
+
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]]
+        $CommandArguments
+    )
+
+    $cmd = "ssh -v -i `"$Env:ID_RSA_PATH`" -o StrictHostKeyChecking=no `"$($RemoteUserName)@$($RemoteHost)`" $CommandArguments"
+    Write-Host "Executing: $cmd"
+
+    ssh -v -i "$Env:ID_RSA_PATH" -o StrictHostKeyChecking=no "$($RemoteUserName)@$($RemoteHost)" @CommandArguments
+
+    if ($LastExitCode -ne 0) {
+        throw [System.Exception]::new("Failed to execute ssh command '$cmd', exit code: $LastExitCode")
+    }
+}
+
+<#
+    .SYNOPSIS
+        Uploads a file or directory to a remote machine using scp
+#>
+function Invoke-SshDownload {
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $RemoteHost,
+
+        [Parameter(Mandatory)]
+        [string]
+        $RemoteUserName,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Source,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Target
+    )
+
+    $cmd = "scp -v -i $Env:ID_RSA_PATH -o StrictHostKeyChecking=no $($RemoteUserName)@$($RemoteHost):$Source $Target"
+    Write-Host "Executing: $cmd"
+
+    scp -v -i "$Env:ID_RSA_PATH" -o StrictHostKeyChecking=no "$($RemoteUserName)@$($RemoteHost):$Source" $Target
+
+    if ($LastExitCode -ne 0) {
+        throw [System.Exception]::new("Failed to execute scp command '$cmd', exit code: $LastExitCode")
+    }
+}
+
+Export-ModuleMember -Function Invoke-SshCommand
+Export-ModuleMember -Function Invoke-SshDownload

--- a/tools/devops/automation/scripts/fetch-remote-binlogs.ps1
+++ b/tools/devops/automation/scripts/fetch-remote-binlogs.ps1
@@ -1,0 +1,25 @@
+Import-Module "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY/xamarin-macios/tools/devops/automation/scripts/MaciosCI.psd1"
+
+# Zip up all the binlogs into one file
+Invoke-SshCommand `
+  -RemoteHost "$Env:MAC_AGENT_IP" `
+  -RemoteUserName "$Env:MAC_AGENT_USER" `
+  -- `
+  "$Env:MAC_AGENT_BUILD_SOURCESDIRECTORY/xamarin-macios/tests/dotnet/Windows/collect-binlogs.sh"
+
+New-Item -Path "$Env:BUILD_ARTIFACTSTAGINGDIRECTORY" -Name "windows-binlogs" -ItemType "directory"
+New-Item -Path "$Env:BUILD_ARTIFACTSTAGINGDIRECTORY\windows-binlogs" -Name "windows-remote-logs.zip" -ItemType "file" -Value "zip"
+
+# Check file existence
+Invoke-SshCommand `
+  -RemoteHost "$Env:MAC_AGENT_IP" `
+  -RemoteUserName "$Env:MAC_AGENT_USER" `
+  -- `
+  ls -la "/Users/$Env:MAC_AGENT_USER/remote_build_testing/windows-remote-logs.zip"
+
+# Copy the zip from the remote Mac to this machine
+Invoke-SshDownload `
+  -RemoteHost "$Env:MAC_AGENT_IP" `
+  -RemoteUserName "$Env:MAC_AGENT_USER" `
+  -Source "/Users/$Env:MAC_AGENT_USER/remote_build_testing/windows-remote-logs.zip" `
+  -Target "$Env:BUILD_ARTIFACTSTAGINGDIRECTORY\windows-binlogs\windows-remote-logs.zip"

--- a/tools/devops/automation/scripts/prepare-for-remote-tests.sh
+++ b/tools/devops/automation/scripts/prepare-for-remote-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eux
+
+# I've seen machines with more than 1gb of Xamarin.Messaging logs, so clean that up.
+if du -hs ~/Library/Logs/Xamarin.Messaging*; then
+	rm -rf ~/Library/Logs/Xamarin.Messaging*
+fi
+
+# Make sure we don't have any old stuff installed
+if du -hs ~/Library/Caches/Xamarin; then
+	rm -rf ~/Library/Caches/Xamarin
+fi
+
+# Install the local .NET we're using into XMA's directory
+# (we can't point XMA to our local directory)
+mkdir -p ~/Library/Caches/Xamarin/XMA/SDKs
+cp -cRH "$BUILD_SOURCESDIRECTORY"/xamarin-macios/builds/downloads/dotnet ~/Library/Caches/Xamarin/XMA/SDKs

--- a/tools/devops/automation/scripts/run-remote-windows-tests.ps1
+++ b/tools/devops/automation/scripts/run-remote-windows-tests.ps1
@@ -1,0 +1,17 @@
+$Env:DOTNET = "$Env:BUILD_SOURCESDIRECTORY\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe"
+$Env:ServerAddress = $Env:MAC_AGENT_IP
+$Env:ServerUser = $Env:MAC_AGENT_USER
+$Env:ServerPassword = $Env:XMA_PASSWORD
+$Env:_DotNetRootRemoteDirectory = "/Users/$Env:MAC_AGENT_USER/Library/Caches/Xamarin/XMA/SDKs/dotnet/"
+
+& $Env:DOTNET `
+    test `
+    "$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/tests/dotnet/UnitTests/DotNetUnitTests.csproj" `
+    --filter Category=RemoteWindows `
+    --verbosity quiet `
+    --settings $Env:BUILD_SOURCESDIRECTORY/xamarin-macios/tests/dotnet/Windows/config.runsettings `
+    "--results-directory:$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows-remote-tests/" `
+    "--logger:console;verbosity=detailed" `
+    "--logger:trx;LogFileName=$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows-remote-dotnet-tests.trx" `
+    "--logger:html;LogFileName=$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows-remote-dotnet-tests.html" `
+    "-bl:$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/tests/dotnet/Windows/windows-remote-dotnet-tests.binlog"

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -199,6 +199,14 @@ steps:
   env:
     XMA_PASSWORD: $(XMA.Password)
 
+- pwsh: $(Build.SourcesDirectory)\xamarin-macios\tools\devops\automation\scripts\fetch-remote-binlogs.ps1
+  displayName: 'Fetch remote binlogs'
+  timeoutInMinutes: 5
+  condition: always()
+  continueOnError: true
+  env:
+    XMA_PASSWORD: $(XMA.Password)
+
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\\xamarin-macios\\tools\\devops\\automation\\scripts\\MaciosCI.psd1
     $configFile = "$(Build.SourcesDirectory)\\artifacts\\${{ parameters.uploadPrefix }}build-configuration\\configuration.json"

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -233,6 +233,8 @@ steps:
     Write-Host "Mac agent pool: $Env:MAC_AGENT_POOL"
     Write-Host "Mac agent name: $Env:MAC_AGENT_NAME"
     Write-Host "Mac agent IP: $Env:MAC_AGENT_IP"
+    Write-Host "Mac agent SYSTEM_DEFAULTWORKINGDIRECTORY: $Env:MAC_AGENT_SYSTEM_DEFAULTWORKINGDIRECTORY"
+    Write-Host "Mac agent BUILD_SOURCESDIRECTORY: $Env:MAC_AGENT_BUILD_SOURCESDIRECTORY"
   displayName: Run tests
 
 # Upload all the binlogs

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -193,6 +193,12 @@ steps:
   displayName: 'Run .NET tests'
   timeoutInMinutes: 30
 
+- pwsh: $(Build.SourcesDirectory)\xamarin-macios\tools\devops\automation\scripts\run-remote-windows-tests.ps1
+  displayName: 'Run .NET tests remotely'
+  timeoutInMinutes: 120
+  env:
+    XMA_PASSWORD: $(XMA.Password)
+
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\\xamarin-macios\\tools\\devops\\automation\\scripts\\MaciosCI.psd1
     $configFile = "$(Build.SourcesDirectory)\\artifacts\\${{ parameters.uploadPrefix }}build-configuration\\configuration.json"

--- a/tools/devops/automation/templates/windows/reserve-mac.yml
+++ b/tools/devops/automation/templates/windows/reserve-mac.yml
@@ -38,6 +38,8 @@ steps:
     echo "##vso[task.setvariable variable=AGENT_NAME;isOutput=true]$(Agent.Name)"
     echo "##vso[task.setvariable variable=AGENT_POOL;isOutput=true]${{ parameters.macPool }}"
     echo "##vso[task.setvariable variable=AGENT_IP;isOutput=true]$macip"
+    echo "##vso[task.setvariable variable=AGENT_SYSTEM_DEFAULTWORKINGDIRECTORY;isOutput=true]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY"
+    echo "##vso[task.setvariable variable=AGENT_BUILD_SOURCESDIRECTORY;isOutput=true]$Env:BUILD_SOURCESDIRECTORY"
   name: macInfo
   displayName: Set agent information
 

--- a/tools/devops/automation/templates/windows/reserve-mac.yml
+++ b/tools/devops/automation/templates/windows/reserve-mac.yml
@@ -98,3 +98,7 @@ steps:
   timeoutInMinutes: 45
   env:
     MACIOS_UPLOAD_PREFIX: ${{ parameters.uploadPrefix }}
+
+- bash: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/prepare-for-remote-tests.sh
+  displayName: 'Prepare for remote tests'
+  continueOnError: true

--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -89,6 +89,8 @@ stages:
       MAC_AGENT_NAME: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_NAME'] ]
       MAC_AGENT_POOL: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_POOL'] ]
       MAC_AGENT_IP: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_IP'] ]
+      MAC_AGENT_SYSTEM_DEFAULTWORKINGDIRECTORY: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_SYSTEM_DEFAULTWORKINGDIRECTORY'] ]
+      MAC_AGENT_BUILD_SOURCESDIRECTORY: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_BUILD_SOURCESDIRECTORY'] ]
 
     steps:
     - template: build.yml

--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -86,6 +86,7 @@ stages:
       - agent.os -equals Windows_NT
 
     variables:
+      DOTNET_IOS_RUNTIME_IDENTIFIERS:  $[ stageDependencies.configure_build.configure.outputs['configure_platforms.DOTNET_IOS_RUNTIME_IDENTIFIERS'] ]
       MAC_AGENT_NAME: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_NAME'] ]
       MAC_AGENT_POOL: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_POOL'] ]
       MAC_AGENT_IP: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_IP'] ]

--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -92,6 +92,7 @@ stages:
       MAC_AGENT_IP: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_IP'] ]
       MAC_AGENT_SYSTEM_DEFAULTWORKINGDIRECTORY: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_SYSTEM_DEFAULTWORKINGDIRECTORY'] ]
       MAC_AGENT_BUILD_SOURCESDIRECTORY: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_BUILD_SOURCESDIRECTORY'] ]
+      MAC_AGENT_USER: builder
 
     steps:
     - template: build.yml


### PR DESCRIPTION
Also add a single test that builds a simple project remotely.

This PR might be best reviewed commit-by-commit.

Fixes https://github.com/xamarin/xamarin-macios/issues/13924.