### PR TITLE
[release/8.0.1xx-xcode15.1] [msbuild] Take the CustomEntitlements item group into account in DetectSigningIdentity.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSigningIdentityTaskBase.cs
@@ -108,6 +108,8 @@ namespace Xamarin.MacDev.Tasks {
 
 		public string CodesignRequireProvisioningProfile { get; set; }
 
+		public ITaskItem [] CustomEntitlements { get; set; } = Array.Empty<ITaskItem> ();
+
 		public string Keychain { get; set; }
 
 		public string SigningKey { get; set; }
@@ -175,10 +177,13 @@ namespace Xamarin.MacDev.Tasks {
 		}
 
 		bool? hasEntitlements;
-		bool HasEntitlements {
+		public bool HasEntitlements {
 			get {
 				if (!hasEntitlements.HasValue) {
-					if (string.IsNullOrEmpty (CodesignEntitlements?.ItemSpec)) {
+					if (CustomEntitlements.Any ()) {
+						// If we have custom entitlements, then we have entitlements.
+						hasEntitlements = true;
+					} else if (string.IsNullOrEmpty (CodesignEntitlements?.ItemSpec)) {
 						// If no CodesignEntitlements was specified, we don't have any entitlements
 						hasEntitlements = false;
 					} else {

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1810,6 +1810,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleName="$(_AppBundleName)"
 			BundleIdentifier="$(_BundleIdentifier)"
+			CustomEntitlements="@(CustomEntitlements)"
 			Keychain="$(CodesignKeychain)"
 			RequireCodeSigning="$(_RequireCodeSigning)"
 			SdkIsSimulator="$(_SdkIsSimulator)"

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
 
@@ -39,6 +40,7 @@ namespace Xamarin.MacDev.Tasks {
 			Assert.AreEqual ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate", task.DetectedCodesignAllocate, "DetectedCodesignAllocate");
 			Assert.AreEqual ("Any", task.DetectedDistributionType, "DetectedDistributionType");
 			Assert.IsNull (task.DetectedProvisioningProfile, "DetectedProvisioningProfile");
+			Assert.IsFalse (task.HasEntitlements, "HasEntitlements");
 		}
 
 		const string EmptyEntitlements1 = @"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -131,6 +133,22 @@ namespace Xamarin.MacDev.Tasks {
 				Assert.IsNull (task.DetectedProvisioningProfile, "DetectedProvisioningProfile");
 			}
 			Assert.AreEqual ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate", task.DetectedCodesignAllocate, "DetectedCodesignAllocate");
+		}
+
+		[Test]
+		public void CustomEntitlements ()
+		{
+			var dir = Cache.CreateTemporaryDirectory ();
+			var task = CreateTask (dir);
+			task.CustomEntitlements = new ITaskItem [] { new TaskItem ("keychain-access-group") };
+			ExecuteTask (task);
+
+			Assert.IsNull (task.DetectedAppId, "DetectedAppId");
+			Assert.AreEqual ("-", task.DetectedCodeSigningKey, "DetectedCodeSigningKey");
+			Assert.AreEqual ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate", task.DetectedCodesignAllocate, "DetectedCodesignAllocate");
+			Assert.AreEqual ("Any", task.DetectedDistributionType, "DetectedDistributionType");
+			Assert.IsNull (task.DetectedProvisioningProfile, "DetectedProvisioningProfile");
+			Assert.IsTrue (task.HasEntitlements, "HasEntitlements");
 		}
 	}
 }


### PR DESCRIPTION
Take the CustomEntitlements item group into account in DetectSigningIdentity
when determining whether the app has entitlements (and would thus require a
provisioning profile).

Partial fix for https://github.com/xamarin/xamarin-macios/issues/19903.


Backport of #19919
