### PR TITLE
[msbuild] Remove usage of GitInfo in Xamarin.Messaging.Build.

### DIFF
--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -564,8 +564,11 @@ Versions.g.cs: Makefile $(TOP)/Make.config.inc
 	$(Q) printf "\\tpublic const string XamarinMacVersion = \"$(MAC_PACKAGE_VERSION)\";\\n" >> $@.tmp
 	$(Q) printf "\\tpublic const string XamarinIOSVersion = \"$(IOS_PACKAGE_VERSION)\";\\n" >> $@.tmp
 	$(Q) echo $(foreach platform,$(ALL_DOTNET_PLATFORMS),"\\tpublic const string Microsoft_$(platform)_Version = \"$($(shell echo $(platform) | tr 'a-z' 'A-Z')_NUGET_VERSION_FULL)\";\\n") >> $@.tmp
+	$(Q) echo $(foreach platform,$(ALL_DOTNET_PLATFORMS),"\\tpublic const string Microsoft_$(platform)_Standard_Version = \"$($(shell echo $(platform) | tr 'a-z' 'A-Z')_NUGET_VERSION_MAJOR).$($(shell echo $(platform) | tr 'a-z' 'A-Z')_NUGET_VERSION_MINOR).0.$($(shell echo $(platform) | tr 'a-z' 'A-Z')_NUGET_VERSION_PATCH)\";\\n") >> $@.tmp
 	$(Q) printf "\\tpublic const string NuGetPrereleaseIdentifier = \"$(NUGET_PRERELEASE_IDENTIFIER)\";\\n" >> $@.tmp
 	$(Q) printf "\\tpublic const string NuGetBuildMetadata = \"$(NUGET_BUILD_METADATA)\";\\n" >> $@.tmp
+	$(Q) printf "\\tpublic const string Branch = \"$(CURRENT_BRANCH)\";\\n" >> $@.tmp
+	$(Q) printf "\\tpublic const string Commit = \"$(CURRENT_HASH)\";\\n" >> $@.tmp
 	$(Q) printf "}\\n" >> $@.tmp
 	$(Q) mv $@.tmp $@
 

--- a/msbuild/Messaging/Xamarin.Messaging.Build/BuildAgent.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/BuildAgent.cs
@@ -90,8 +90,11 @@ namespace Xamarin.Messaging.Build {
 			}
 		}
 
-		string GetVersion () => ThisAssembly.Git.BaseVersion.Major + "." + ThisAssembly.Git.BaseVersion.Minor + "." + ThisAssembly.Git.BaseVersion.Patch + "." + ThisAssembly.Git.Commits;
+		// The version is a bit complicated, because we're building this assembly once, and use it for all our platforms.
+		// And since the platforms don't have the same version between them, there's no single version number that's valid for all platforms...
+		// So we just pick the iOS version, which will always be the correct version for remote Mac builds, because only iOS is supported for that scenario.
+		string GetVersion () => VersionConstants.Microsoft_iOS_Standard_Version;
 
-		string GetInformationalVersion () => GetVersion () + "-" + ThisAssembly.Git.Branch + "+" + ThisAssembly.Git.Commit;
+		string GetInformationalVersion () => GetVersion () + "-" + VersionConstants.Branch + "+" + VersionConstants.Commit;
 	}
 }

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <PackageReference Include="System.IO.Abstractions" Version="6.0.27" />
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilPackageVersion)" />
-    <PackageReference Include="GitInfo" Version="2.2.0" />
     <!-- We only include build assets to get targets related to agent generation, the assemblies come from Xamarin.iOS.Tasks -->
     <PackageReference Include="Xamarin.Messaging.Core" Version="$(MessagingVersion)" IncludeAssets="build" />
   </ItemGroup>


### PR DESCRIPTION
* The calculation GitInfo does is horribly wrong for us - it seems to pick a
  tag the most recent tag and parse it to pick out a version number:
	* This means for any given release it'll use the previous tag - because we
	  don't necessarily tag until after the release build has been committed.
	* It's not a stable version: a build is made (finding one tag), a new tag
	  is pushed, and if the same commit is built, it may find the new tag,
	  thus creating a new version number.
	* We may have multiple tags for any given commit.
	* The version calculation is also wrong: right now it finds the tag
	  `xamarin-ios-15.5.0.5-4407-gd45f4e90a6`, and comes up with the version
	  number 0.5.0.4407.
* I didn't investigate deeply, but GitInfo also touches .git/index and
  .git/HEAD somehow, which causes us to rebuild stuff.
* We already have an established way of calculating version numbers and other
  build related information, so use that after extending it a bit.