### PR TITLE
[release/8.0.1xx-xcode15.1] [msbuild] Correctly add custom entitlements to the archived entitlements.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlementsTaskBase.cs
@@ -412,7 +412,7 @@ namespace Xamarin.MacDev.Tasks {
 			return entitlements;
 		}
 
-		static PDictionary GetArchivedExpandedEntitlements (PDictionary template, PDictionary compiled)
+		PDictionary GetArchivedExpandedEntitlements (PDictionary template, PDictionary compiled)
 		{
 			var allowed = new HashSet<string> ();
 
@@ -420,6 +420,9 @@ namespace Xamarin.MacDev.Tasks {
 			allowed.Add ("com.apple.developer.icloud-container-environment");
 			foreach (var item in template)
 				allowed.Add (item.Key!);
+			// also allow any custom entitlements
+			foreach (var item in CustomEntitlements)
+				allowed.Add (item.ItemSpec);
 
 			// now we duplicate the allowed keys from the compiled xcent file
 			var archived = new PDictionary ();

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
@@ -50,7 +50,7 @@ namespace Xamarin.MacDev.Tasks {
 		[Test (Description = "Xambug #46298")]
 		public void ValidateEntitlement ()
 		{
-			var task = CreateEntitlementsTask (out var compiledEntitlements);
+			var task = CreateEntitlementsTask (out var compiledEntitlements, out var archivedEntitlements);
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements);
 			Assert.IsTrue (compiled.Get<PBoolean> (EntitlementKeys.GetTaskAllow).Value, "#1");
@@ -60,6 +60,9 @@ namespace Xamarin.MacDev.Tasks {
 			Assert.AreEqual ("Z8CSQKJE7R.*", compiled.GetPassBookIdentifiers ().ToStringArray ().First (), "#5");
 			Assert.AreEqual ("Z8CSQKJE7R.com.xamarin.MySingleView", compiled.GetUbiquityKeyValueStore (), "#6");
 			Assert.AreEqual ("32UV7A8CDE.com.xamarin.MySingleView", compiled.GetKeychainAccessGroups ().ToStringArray ().First (), "#7");
+
+			var archived = PDictionary.FromFile (archivedEntitlements);
+			Assert.IsTrue (compiled.ContainsKey ("application-identifier"), "archived");
 		}
 
 		[TestCase ("Invalid", null, "Unknown type 'Invalid' for the entitlement 'com.xamarin.custom.entitlement' specified in the CustomEntitlements item group. Expected 'Remove', 'Boolean', 'String', or 'StringArray'.")]
@@ -187,8 +190,7 @@ namespace Xamarin.MacDev.Tasks {
 			Assert.IsTrue (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
 			Assert.IsFalse (compiled.Get<PBoolean> (EntitlementKeys.AllowExecutionOfJitCode).Value, "#2");
 
-			var archived = PDictionary.FromFile (archivedEntitlements);
-			Assert.IsTrue (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "archived");
+			Assert.That (archivedEntitlements, Does.Not.Exist, "No archived entitlements");
 		}
 
 		[Test]

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
@@ -25,6 +25,11 @@ namespace Xamarin.MacDev.Tasks {
 	public class CompileEntitlementsTaskTests : TestBase {
 		CustomCompileEntitlements CreateEntitlementsTask (out string compiledEntitlements)
 		{
+			return CreateEntitlementsTask (out compiledEntitlements, out var _);
+		}
+
+		CustomCompileEntitlements CreateEntitlementsTask (out string compiledEntitlements, out string archivedEntitlements)
+		{
 			var task = CreateTask<CustomCompileEntitlements> ();
 
 			task.AppBundleDir = AppBundlePath;
@@ -37,6 +42,7 @@ namespace Xamarin.MacDev.Tasks {
 			task.TargetFrameworkMoniker = "Xamarin.iOS,v1.0";
 
 			compiledEntitlements = task.CompiledEntitlements.ItemSpec;
+			archivedEntitlements = Path.Combine (AppBundlePath, "archived-expanded-entitlements.xcent");
 
 			return task;
 		}
@@ -173,13 +179,16 @@ namespace Xamarin.MacDev.Tasks {
 			var customEntitlements = new TaskItem [] {
 				new TaskItem ("com.apple.security.cs.allow-jit", new Dictionary<string, string> { {  "Type", "Boolean" }, { "Value", "false" } }),
 			};
-			var task = CreateEntitlementsTask (out var compiledEntitlements);
+			var task = CreateEntitlementsTask (out var compiledEntitlements, out var archivedEntitlements);
 			task.TargetFrameworkMoniker = ".NETCoreApp,Version=v6.0,Profile=maccatalyst";
 			task.CustomEntitlements = customEntitlements;
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements);
 			Assert.IsTrue (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
 			Assert.IsFalse (compiled.Get<PBoolean> (EntitlementKeys.AllowExecutionOfJitCode).Value, "#2");
+
+			var archived = PDictionary.FromFile (archivedEntitlements);
+			Assert.IsTrue (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "archived");
 		}
 
 		[Test]


### PR DESCRIPTION
Otherwise custom entitlements won't end up in the archived entitlements (as
they should, just as if they were provided in an Entitlements.plist file).

Partial fix for https://github.com/xamarin/xamarin-macios/issues/19903.


Backport of #19920
