### PR TITLE
[AudioToolbox] Fix computing array size.

### DIFF
--- a/src/AudioToolbox/AudioConverter.cs
+++ b/src/AudioToolbox/AudioConverter.cs
@@ -653,13 +653,15 @@ namespace AudioToolbox {
 				return null;
 
 			var elementSize = sizeof (AudioFormatType);
-			var data = new AudioFormatType [size / elementSize];
+			var elementCount = size / elementSize;
+			var data = new AudioFormatType [elementCount];
 			fixed (AudioFormatType* ptr = data) {
 				var res = AudioFormatPropertyNative.AudioFormatGetProperty (prop, 0, IntPtr.Zero, ref size, (IntPtr) ptr);
 				if (res != 0)
 					return null;
 
-				Array.Resize (ref data, elementSize);
+				elementCount = size / elementSize;
+				Array.Resize (ref data, elementCount);
 				return data;
 			}
 		}

--- a/tests/monotouch-test/AudioToolbox/AudioConverterTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioConverterTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
@@ -20,6 +21,18 @@ namespace MonoTouchFixtures.AudioToolbox {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class AudioConverterTest {
+
+		[Test]
+		public void Formats ()
+		{
+			var decodeFormats = AudioConverter.DecodeFormats;
+			Assert.NotNull (decodeFormats, "Decode #1");
+			Assert.That (decodeFormats.Length, Is.GreaterThan (10), "Decode Length #1");
+
+			var encodeFormats = AudioConverter.EncodeFormats;
+			Assert.NotNull (encodeFormats, "Encode #1");
+			Assert.That (encodeFormats.Length, Is.GreaterThan (10), "Encode Length #1");
+		}
 
 		[Test]
 		public void Convert ()


### PR DESCRIPTION
When resizing an array to a certain number of elements, we need to compute the
number of elements and use that to resize the array (and not use the size of
each element as the number of elements).

We also need to recompute the number of elements after calling the P/Invoke
(which may have changed the total size) - otherwise resizing the array is
entirely redundant (because the number of elements wouldn't change).