### PR TITLE
[release/8.0.1xx-xcode15.1] [msbuild] Process custom entitlements as if they came from an Entitlements.plist file.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlementsTaskBase.cs
@@ -241,7 +241,7 @@ namespace Xamarin.MacDev.Tasks {
 			return result;
 		}
 
-		void AddCustomEntitlements (PDictionary dict)
+		void AddCustomEntitlements (PDictionary dict, MobileProvision? profile)
 		{
 			if (CustomEntitlements is null)
 				return;
@@ -280,7 +280,7 @@ namespace Xamarin.MacDev.Tasks {
 					dict [entitlement] = new PBoolean (booleanValue);
 					break;
 				case "string":
-					dict [entitlement] = new PString (value ?? string.Empty);
+					dict [entitlement] = MergeEntitlementString (new PString (value), profile, entitlement == ApplicationIdentifierKey);
 					break;
 				case "stringarray":
 					var arraySeparator = item.GetMetadata ("ArraySeparator");
@@ -289,7 +289,7 @@ namespace Xamarin.MacDev.Tasks {
 					var arrayContent = value.Split (new string [] { arraySeparator }, StringSplitOptions.None);
 					var parray = new PArray ();
 					foreach (var element in arrayContent)
-						parray.Add (new PString (element));
+						parray.Add (MergeEntitlementString (new PString (element), profile, entitlement == ApplicationIdentifierKey));
 					dict [entitlement] = parray;
 					break;
 				default:
@@ -407,7 +407,7 @@ namespace Xamarin.MacDev.Tasks {
 				break;
 			}
 
-			AddCustomEntitlements (entitlements);
+			AddCustomEntitlements (entitlements, profile);
 
 			return entitlements;
 		}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
@@ -44,7 +44,17 @@ namespace Xamarin.MacDev.Tasks {
 			compiledEntitlements = task.CompiledEntitlements.ItemSpec;
 			archivedEntitlements = Path.Combine (AppBundlePath, "archived-expanded-entitlements.xcent");
 
+			DeleteDirectory (Path.Combine (MonoTouchProjectPath, "bin"));
+			DeleteDirectory (Path.Combine (MonoTouchProjectPath, "obj"));
+
 			return task;
+		}
+
+		void DeleteDirectory (string directory)
+		{
+			if (!Directory.Exists (directory))
+				return;
+			Directory.Delete (directory, true);
 		}
 
 		[Test (Description = "Xambug #46298")]
@@ -214,7 +224,7 @@ namespace Xamarin.MacDev.Tasks {
 				new TaskItem ("keychain-access-group", new Dictionary<string, string> { {  "Type", "String" }, { "Value", "$(AppIdentifierPrefix)org.xamarin" } }),
 			};
 			var task = CreateEntitlementsTask (out var compiledEntitlements, out var archivedEntitlements);
-			task.TargetFrameworkMoniker = ".NETCoreApp,Version=v6.0,Profile=maccatalyst";
+			task.TargetFrameworkMoniker = ".NETCoreApp,Version=v6.0,Profile=ios";
 			task.CustomEntitlements = customEntitlements;
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements);
@@ -235,7 +245,7 @@ namespace Xamarin.MacDev.Tasks {
 				new TaskItem ("keychain-access-group", new Dictionary<string, string> { {  "Type", "String" }, { "Value", "$(TeamIdentifierPrefix)org.xamarin" } }),
 			};
 			var task = CreateEntitlementsTask (out var compiledEntitlements, out var archivedEntitlements);
-			task.TargetFrameworkMoniker = ".NETCoreApp,Version=v6.0,Profile=maccatalyst";
+			task.TargetFrameworkMoniker = ".NETCoreApp,Version=v6.0,Profile=ios";
 			task.CustomEntitlements = customEntitlements;
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements);

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
@@ -207,5 +207,46 @@ namespace Xamarin.MacDev.Tasks {
 			Assert.IsFalse (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
 		}
 
+		[Test]
+		public void AppIdentifierPrefix ()
+		{
+			var customEntitlements = new TaskItem [] {
+				new TaskItem ("keychain-access-group", new Dictionary<string, string> { {  "Type", "String" }, { "Value", "$(AppIdentifierPrefix)org.xamarin" } }),
+			};
+			var task = CreateEntitlementsTask (out var compiledEntitlements, out var archivedEntitlements);
+			task.TargetFrameworkMoniker = ".NETCoreApp,Version=v6.0,Profile=maccatalyst";
+			task.CustomEntitlements = customEntitlements;
+			ExecuteTask (task);
+			var compiled = PDictionary.FromFile (compiledEntitlements);
+			Assert.IsFalse (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
+			var kag = ((PString) compiled ["keychain-access-group"]).Value;
+			Assert.That (kag, Is.EqualTo ("32UV7A8CDE.org.xamarin"), "value 1");
+
+			var archived = PDictionary.FromFile (archivedEntitlements);
+			Assert.IsTrue (archived.ContainsKey ("keychain-access-group"), "archived");
+			var archivedKag = ((PString) archived ["keychain-access-group"]).Value;
+			Assert.That (archivedKag, Is.EqualTo ("32UV7A8CDE.org.xamarin"), "archived value 1");
+		}
+
+		[Test]
+		public void TeamIdentifierPrefix ()
+		{
+			var customEntitlements = new TaskItem [] {
+				new TaskItem ("keychain-access-group", new Dictionary<string, string> { {  "Type", "String" }, { "Value", "$(TeamIdentifierPrefix)org.xamarin" } }),
+			};
+			var task = CreateEntitlementsTask (out var compiledEntitlements, out var archivedEntitlements);
+			task.TargetFrameworkMoniker = ".NETCoreApp,Version=v6.0,Profile=maccatalyst";
+			task.CustomEntitlements = customEntitlements;
+			ExecuteTask (task);
+			var compiled = PDictionary.FromFile (compiledEntitlements);
+			Assert.IsFalse (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
+			var kag = ((PString) compiled ["keychain-access-group"]).Value;
+			Assert.That (kag, Is.EqualTo ("Z8CSQKJE7R.org.xamarin"), "value 1");
+
+			var archived = PDictionary.FromFile (archivedEntitlements);
+			Assert.IsTrue (archived.ContainsKey ("keychain-access-group"), "archived");
+			var archivedKag = ((PString) archived ["keychain-access-group"]).Value;
+			Assert.That (archivedKag, Is.EqualTo ("Z8CSQKJE7R.org.xamarin"), "archived value 1");
+		}
 	}
 }


### PR DESCRIPTION
We need to process custom entitlements just like if they came from an
Entitlements.plist file - which means replacing terms such as
`$(AppIdentifierPrefix)` and `$(TeamIdentifierPrefix)` with their correct value
depending on the provisioning profile.

Partial fix for https://github.com/xamarin/xamarin-macios/issues/19903.


Backport of #19942
