### PR TITLE
[xharness] Serialize builds.

### DIFF
--- a/tests/xharness/Jenkins/TestTasks/BuildProject.cs
+++ b/tests/xharness/Jenkins/TestTasks/BuildProject.cs
@@ -47,7 +47,7 @@ namespace Xharness.Jenkins.TestTasks {
 
 		public bool SupportsParallelExecution {
 			get {
-				return Platform.ToString ().StartsWith ("Mac", StringComparison.Ordinal);
+				return false;
 			}
 		}
 

--- a/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/MSBuildTask.cs
@@ -90,5 +90,9 @@ namespace Xharness.Jenkins.TestTasks {
 			environment ["TargetFrameworkFallbackSearchPaths"] = null;
 			environment ["MSBuildExtensionsPathFallbackPathsOverride"] = null;
 		}
+
+		public override bool SupportsParallelExecution {
+			get => false;
+		}
 	}
 }


### PR DESCRIPTION
NuGet isn't parallel-safe, and building any project (in .NET at least) may end
up using NuGet, so just disable parallel building.

This will hopefully fix numerous random build failures on the bots due to
NuGet running into concurrency problems.

Note that test execution is still parallelized.