### PR TITLE
[devops] Don't collect (and re-upload) binlogs from artifacts we've downloaded from previous builds.

### DIFF
--- a/tests/dotnet/Windows/collect-binlogs.sh
+++ b/tests/dotnet/Windows/collect-binlogs.sh
@@ -9,7 +9,7 @@ TOPLEVEL="$(git rev-parse --show-toplevel)"
 
 # Collect and zip up all the binlogs
 mkdir -p ~/remote_build_testing/binlogs
-rsync -av --prune-empty-dirs --exclude '*/artifacts/' --include '*/' --include '*.binlog' --exclude '*' "$TOPLEVEL/.." ~/remote_build_testing/binlogs
+rsync -avv --prune-empty-dirs --exclude 'artifacts/' --include '*/' --include '*.binlog' --exclude '*' "$TOPLEVEL/.." ~/remote_build_testing/binlogs
 
 rm -f ~/remote_build_testing/windows-remote-logs.zip
 zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/remote_build_testing/binlogs

--- a/tests/dotnet/Windows/collect-binlogs.sh
+++ b/tests/dotnet/Windows/collect-binlogs.sh
@@ -9,7 +9,7 @@ TOPLEVEL="$(git rev-parse --show-toplevel)"
 
 # Collect and zip up all the binlogs
 mkdir -p ~/remote_build_testing/binlogs
-rsync -av --prune-empty-dirs --include '*/' --include '*.binlog' --exclude '*' "$TOPLEVEL/.." ~/remote_build_testing/binlogs
+rsync -av --prune-empty-dirs --exclude '*/artifacts/' --include '*/' --include '*.binlog' --exclude '*' "$TOPLEVEL/.." ~/remote_build_testing/binlogs
 
 rm -f ~/remote_build_testing/windows-remote-logs.zip
 zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/remote_build_testing/binlogs

--- a/tools/devops/automation/scripts/prepare-for-remote-tests.sh
+++ b/tools/devops/automation/scripts/prepare-for-remote-tests.sh
@@ -10,6 +10,9 @@ if du -hs ~/Library/Caches/Xamarin; then
 	rm -rf ~/Library/Caches/Xamarin
 fi
 
+# Make sure we don't have stuff from earlier builds.
+rm -rf ~/remote_build_testing
+
 # Install the local .NET we're using into XMA's directory
 # (we can't point XMA to our local directory)
 mkdir -p ~/Library/Caches/Xamarin/XMA/SDKs


### PR DESCRIPTION
This fixes an issue where the zip of all the binlogs we'd collect for the
Windows test run also contained all the binlogs from all other jobs completed
at that point (because they were downloaded as artifacts).