### PR TITLE
[release/8.0.1xx] GITHUB_TOKEN read-only change: Include permissions block

### DIFF
--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   setupBackport:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
     if: github.event.issue.pull_request != '' && startswith(github.event.comment.body, '/sudo backport')
     outputs:
       target_branch: ${{ steps.parse_comment.outputs.target_branch }}


### PR DESCRIPTION
Provide permission block to allow GITHUB_TOKEN access to continue working after 2024-02-01
Guidance: https://docs.opensource.microsoft.com/github/apps/permission-changes/

Not sure if any other GitHub action yaml files under .github/workflows also need to be updated


Backport of #19969
