### PR TITLE
[dotnet] Don't build library projects multiple times for universal apps.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -154,6 +154,11 @@
 		<_OriginalAggressiveAttributeTrimming>$(_AggressiveAttributeTrimming)</_OriginalAggressiveAttributeTrimming>
 		<_AggressiveAttributeTrimming Condition="'$(_UseNativeAot)' == 'true'">false</_AggressiveAttributeTrimming>
 		<_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
+
+		<!-- This property is also defined in Xamarin.Shared.props, but that file is imported too late for us to use the definition, and we can't remove it from Xamarin.Shared.props quite yet, because that would break legacy
+			 (in other words: once we drop support for legacy Xamarin, we can remove the other definition) -->
+		<_CanOutputAppBundle Condition="'$(_CanOutputAppBundle)' == '' And ('$(OutputType)' == 'Exe' Or '$(IsAppExtension)' == 'true' Or '$(IsWatchApp)' == 'true')">true</_CanOutputAppBundle>
+		<_CanOutputAppBundle Condition="'$(_CanOutputAppBundle)' == ''">false</_CanOutputAppBundle>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -179,7 +184,15 @@
 	</PropertyGroup>
 
 	<!-- Inject our custom logic into *DependsOn variables -->
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(_CanOutputAppBundle)' != 'true'">
+		<BuildDependsOn>
+			BuildOnlySettings;
+			_CollectBundleResources;
+			_PackLibraryResources;
+			$(BuildDependsOn);
+		</BuildDependsOn>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(_CanOutputAppBundle)' == 'true'">
 		<!-- single-rid build -->
 		<BuildDependsOn Condition="'$(RuntimeIdentifiers)' == '' And '$(_IsMultiRidBuild)' != 'true'">
 			_WarnRuntimeIdentifiersClash;
@@ -314,7 +327,18 @@
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_RunRidSpecificBuild" Condition="'$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' == ''" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName">
+	<PropertyGroup>
+		<!-- The dependencies on BuildOnlySettings and ResolveReferences are so that we build any project references before running the RID-specific builds -->
+		<_RunRidSpecificBuildDependsOn>
+			$(_RunRidSpecificBuildDependsOn);
+			BuildOnlySettings;
+			ResolveReferences;
+			_DetectSdkLocations;
+			_GenerateBundleName;
+		</_RunRidSpecificBuildDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_RunRidSpecificBuild" Condition="'$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' == ''" DependsOnTargets="$(_RunRidSpecificBuildDependsOn)">
 		<ItemGroup>
 			<!-- Convert RuntimeIdentifiers (a property) to an item group -->
 			<_RuntimeIdentifiersAsItems Include="$(RuntimeIdentifiers)" Condition=" '$(RuntimeIdentifiers)' != '' " />
@@ -342,7 +366,9 @@
 		<Error Condition="@(_RuntimeIdentifierDistinctPlatforms->Count()) > 1" Text="Building for all the runtime identifiers '$(RuntimeIdentifiers)' at the same time isn't possible, because they represent different platform variations." />
 
 		<PropertyGroup>
+			<!-- We disable building project references (BuildProjectReferences=false), because project references aren't RID-specific, so we build them (once) before running _RunRidSpecificBuild target, so that we don't have to build them once per RID -->
 			<_RidSpecificProperties>
+				BuildProjectReferences=false;
 				_IsMultiRidBuild=true;
 				RuntimeIdentifiers=;
 				_ProcessedBundleResourcesPath=$(_ProcessedBundleResourcesPath);

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1904,7 +1904,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</_UnpackLibraryResourcesDependsOn>
 	</PropertyGroup>
 
-	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true' And '$(_IsMultiRidBuild)' != 'true'" DependsOnTargets="$(_UnpackLibraryResourcesDependsOn)"
+	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="$(_UnpackLibraryResourcesDependsOn)"
 		Inputs="@(_UnpackLibraryResourceItems)"
 		Outputs="@(_UnpackLibraryResourceItems->'$(_StampDirectory)%(StampFile)')">
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true'" Directories="$(_StampDirectory)" />

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1894,7 +1894,17 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_DetectBuildType;_CollectBundleResources;_PrepareUnpackLibraryResources"
+	<PropertyGroup>
+		<_UnpackLibraryResourcesDependsOn>
+			BuildOnlySettings;
+			ResolveReferences;
+			_DetectBuildType;
+			_CollectBundleResources;
+			_PrepareUnpackLibraryResources;
+		</_UnpackLibraryResourcesDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true' And '$(_IsMultiRidBuild)' != 'true'" DependsOnTargets="$(_UnpackLibraryResourcesDependsOn)"
 		Inputs="@(_UnpackLibraryResourceItems)"
 		Outputs="@(_UnpackLibraryResourceItems->'$(_StampDirectory)%(StampFile)')">
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true'" Directories="$(_StampDirectory)" />


### PR DESCRIPTION
Currently for universal apps we build the project once for each RuntimeIdentifier,
and each time we end up building any referenced projects as well.

It's not necessary to build referenced (library) projects on a per-RID basis, because
the RID isn't taken into account.

So optimize this:

1. Build project references in the containing build, before the RID-specific build.
   This is accomplished by adding a dependency on the ResolveReferences target (which
   also needs the BuildOnlySettings target to run first in order to actually build
   any referenced projects).

2. Set "BuildProjectReferences=false" when running the RID-specific build, so
   that any project references aren't built.

3. Also change how we override the BuildDependsOn property: we now have special
   logic for library projects, where we don't do any kind of app-building stuff,
   we only deal with resources.

4. This required adding another target dependency for _UnpackLibraryResources:
   it now depends on the BuildOnlySettings target as well (for the same reason as
   in point 1).