### PR TITLE
[HealthKit] Make P/Invokes have blittable signatures.

### DIFF
--- a/tests/cecil-tests/BlittablePInvokes.KnownFailures.cs
+++ b/tests/cecil-tests/BlittablePInvokes.KnownFailures.cs
@@ -368,7 +368,6 @@ namespace Cecil.Tests {
 			"System.Boolean GameController.GCGamepadSnapshot::GCGamepadSnapShotDataV100FromNSData(GameController.GCGamepadSnapShotDataV100&,System.IntPtr)",
 			"System.Boolean GameController.GCMicroGamepadSnapshot::GCMicroGamepadSnapshotDataFromNSData(GameController.GCMicroGamepadSnapshotData&,System.IntPtr)",
 			"System.Boolean GameController.GCMicroGamepadSnapshot::GCMicroGamepadSnapShotDataV100FromNSData(GameController.GCMicroGamepadSnapShotDataV100&,System.IntPtr)",
-			"System.Boolean HealthKit.HKAppleWalkingSteadiness::HKAppleWalkingSteadinessClassificationForQuantity(System.IntPtr,System.IntPtr&,System.IntPtr&)",
 			"System.Boolean MapKit.MKMapRect::Intersects(MapKit.MKMapRect,MapKit.MKMapRect)",
 			"System.Boolean MapKit.MKMapRect::MKMapRectContainsPoint(MapKit.MKMapRect,MapKit.MKMapPoint)",
 			"System.Boolean MapKit.MKMapRect::MKMapRectContainsRect(MapKit.MKMapRect,MapKit.MKMapRect)",

--- a/tests/cecil-tests/BlittablePInvokes.KnownFailures.cs
+++ b/tests/cecil-tests/BlittablePInvokes.KnownFailures.cs
@@ -368,6 +368,7 @@ namespace Cecil.Tests {
 			"System.Boolean GameController.GCGamepadSnapshot::GCGamepadSnapShotDataV100FromNSData(GameController.GCGamepadSnapShotDataV100&,System.IntPtr)",
 			"System.Boolean GameController.GCMicroGamepadSnapshot::GCMicroGamepadSnapshotDataFromNSData(GameController.GCMicroGamepadSnapshotData&,System.IntPtr)",
 			"System.Boolean GameController.GCMicroGamepadSnapshot::GCMicroGamepadSnapShotDataV100FromNSData(GameController.GCMicroGamepadSnapShotDataV100&,System.IntPtr)",
+			"System.Boolean HealthKit.HKAppleWalkingSteadiness::HKAppleWalkingSteadinessClassificationForQuantity(System.IntPtr,System.IntPtr&,System.IntPtr&)",
 			"System.Boolean MapKit.MKMapRect::Intersects(MapKit.MKMapRect,MapKit.MKMapRect)",
 			"System.Boolean MapKit.MKMapRect::MKMapRectContainsPoint(MapKit.MKMapRect,MapKit.MKMapPoint)",
 			"System.Boolean MapKit.MKMapRect::MKMapRectContainsRect(MapKit.MKMapRect,MapKit.MKMapRect)",


### PR DESCRIPTION
Also fix a bug where we'd only return the error from
HKAppleWalkingSteadinessClassificationForQuantity if the P/Invoke _succeeded_
(in which case there wouldn't be an error of course). Instead always create an
NSError from the error output.

Contributes towards #15684.