### PR TITLE
[release/7.0.3xx] Avoid passing null to TaskRunner.FixReferencedItems

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Xamarin.Messaging.Build.Client;
 
 namespace Microsoft.Build.Tasks {

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Build.Tasks {
 
 			var taskRunner = new TaskRunner (SessionId, BuildEngine4);
 
-			taskRunner.FixReferencedItems (SourceFiles);
+			if (SourceFiles?.Any () == true) {
+				taskRunner.FixReferencedItems (SourceFiles);
+			}
 
 			return taskRunner.RunAsync (this).Result;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -32,7 +32,7 @@ namespace Xamarin.MacDev.Tasks {
 		public string ResourcePrefix { get; set; }
 
 		[Required]
-		public ITaskItem [] SceneKitAssets { get; set; }
+		public ITaskItem [] SceneKitAssets { get; set; } = Array.Empty<ITaskItem> ();
 
 		[Required]
 		public string SdkDevPath { get; set; }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/SmartCopyTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/SmartCopyTaskBase.cs
@@ -18,7 +18,7 @@ namespace Xamarin.MacDev.Tasks {
 		public ITaskItem DestinationFolder { get; set; }
 
 		[Required]
-		public ITaskItem [] SourceFiles { get; set; }
+		public ITaskItem [] SourceFiles { get; set; } = Array.Empty<ITaskItem> ();
 
 		#endregion
 


### PR DESCRIPTION
Ensure the input properties that are meant to be fixed with the TaskRunner.FixReferencedItems invocation, might never be null

Backport of #19871.