### PR TITLE
[release/8.0.1xx-xcode15.1] Fix windows integration tests condition

### DIFF
--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -38,7 +38,7 @@ stages:
   dependsOn:
   - build_packages
   - configure_build
-  condition: and(succeeded(), eq(dependencies.build_packages.outputs['configure.decisions.RUN_WINDOWS_TESTS'], 'true'))
+  condition: and(succeeded(), eq(dependencies.configure_build.outputs['configure.decisions.RUN_WINDOWS_TESTS'], 'true'))
 
   jobs:
   - job: mac_reservation


### PR DESCRIPTION
The location of the variable changed when the `configure` jobs were centralized into a single stage.