### PR TITLE
[MSBuild] Fix nullability that broke main.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/BundleResource.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/BundleResource.cs
@@ -24,8 +24,13 @@ namespace Xamarin.MacDev {
 			"_CodeSignature",
 		}, StringComparer.OrdinalIgnoreCase);
 
-		public static bool IsIllegalName (string name, [NotNullWhen (true)] out string? illegal)
+		public static bool IsIllegalName (string? name, [NotNullWhen (true)] out string? illegal)
 		{
+			if (name is null) {
+				illegal = null;
+				return false;
+			}
+
 			if (illegalFileNames.Contains (name)) {
 				illegal = name;
 				return true;

--- a/msbuild/Xamarin.MacDev.Tasks/BundleResource.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/BundleResource.cs
@@ -24,13 +24,8 @@ namespace Xamarin.MacDev {
 			"_CodeSignature",
 		}, StringComparer.OrdinalIgnoreCase);
 
-		public static bool IsIllegalName (string? name, [NotNullWhen (true)] out string? illegal)
+		public static bool IsIllegalName (string name, [NotNullWhen (true)] out string? illegal)
 		{
-			if (name is null) {
-				illegal = null;
-				return true;
-			}
-
 			if (illegalFileNames.Contains (name)) {
 				illegal = name;
 				return true;

--- a/msbuild/Xamarin.MacDev.Tasks/BundleResource.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/BundleResource.cs
@@ -28,7 +28,7 @@ namespace Xamarin.MacDev {
 		{
 			if (name is null) {
 				illegal = null;
-				return false;
+				return true;
 			}
 
 			if (illegalFileNames.Contains (name)) {

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectBundleResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectBundleResources.cs
@@ -71,7 +71,6 @@ namespace Xamarin.MacDev.Tasks {
 				var logicalName = BundleResource.GetLogicalName (ProjectDir, prefixes, item, !string.IsNullOrEmpty (SessionId));
 				// We need a physical path here, ignore the Link element
 				var path = item.GetMetadata ("FullPath");
-				string illegal;
 
 				if (!File.Exists (path)) {
 					Log.LogError (MSBStrings.E0099, logicalName, path);
@@ -88,7 +87,7 @@ namespace Xamarin.MacDev.Tasks {
 					continue;
 				}
 
-				if (BundleResource.IsIllegalName (logicalName, out illegal)) {
+				if (BundleResource.IsIllegalName (logicalName, out var illegal)) {
 					Log.LogError (null, null, null, item.ItemSpec, 0, 0, 0, 0, MSBStrings.E0102, illegal);
 					continue;
 				}


### PR DESCRIPTION
Fix nullability by allowing the method to take a null string. Return that a null string is an illegal name.