### PR TITLE
[actions] Give pull-requests:write permissions to the changelog editor/creator.

### DIFF
--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -10,6 +10,7 @@ jobs:
     # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:
       issues: write
+      pull-requests: write
       contents: read
     if: github.actor == 'dotnet-maestro[bot]'
 


### PR DESCRIPTION
Hopefully fixes a permission error:

    response: {
    Error: Unhandled error: HttpError: Resource not accessible by integration
       url: 'https://api.github.com/repos/xamarin/xamarin-macios/issues/20075/comments',