### PR TITLE
[release/8.0.xx][CI] Fix the connection used to push nugets.

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -124,7 +124,7 @@ stages:
           command: push
           packagesToPush: '$(Build.SourcesDirectory)/package/*.nupkg'
           nuGetFeedType: external
-          publishFeedCredentials: dnceng-dotnet8
+          publishFeedCredentials: dnceng-dotnetfeeds
 
       - task: DownloadPipelineArtifact@2
         inputs:
@@ -139,7 +139,7 @@ stages:
           command: push
           packagesToPush: '$(Build.SourcesDirectory)/${{ parameters.uploadPrefix }}vs-msi-nugets/*.nupkg'
           nuGetFeedType: external
-          publishFeedCredentials: dnceng-dotnet8
+          publishFeedCredentials: dnceng-dotnetfeeds
 
       - pwsh: |
           mkdir $(Build.SourcesDirectory)/nugets-blob


### PR DESCRIPTION
The connection had a expired pat and does not need to be specific to a dotnet version.