### PR TITLE
[release/7.0.3xx] [actions] Fix permissions for the changelog action after default permissions change.

### DIFF
--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -5,6 +5,12 @@ jobs:
   add-changelog:
     name: Add changelog
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      issues: write
+      contents: read
     if: github.actor == 'dotnet-maestro[bot]'
 
     steps:


### PR DESCRIPTION



Backport of #20073
