### PR TITLE
[UIKit] Remove presnippet for UITextView.TypingAttributes. Fixes #12709.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -15912,14 +15912,35 @@ namespace UIKit {
 		[Export ("clearsOnInsertion")]
 		bool ClearsOnInsertion { get; set; }
 
+#if !XAMCORE_5_0
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use 'TypingAttributes2' instead, because this property will return null instead of an empty dictionary.")]
+#endif
 		[NullAllowed] // by default this property is null
 		[Export ("typingAttributes", ArgumentSemantic.Copy)]
 		NSDictionary TypingAttributes {
+#if !XAMCORE_5_0
 			// this avoids a crash (see unit tests) and behave like UITextField does (return null)
+			// however, it's un-intuitive and causes other problems (https://github.com/xamarin/xamarin-macios/issues/12709), so remove it the next time we can make a breaking change.
 			[PreSnippet ("if (SelectedRange.Length == 0) return null;", Optimizable = true)]
+#endif
 			get;
 			set;
 		}
+
+#if !XAMCORE_6_0
+		[NullAllowed] // by default this property is null
+		[Export ("typingAttributes", ArgumentSemantic.Copy)]
+#if XAMCORE_5_0
+		[Obsolete ("Use 'TypingAttributes' instead.")
+		[EditorBrowsable (EditorBrowsableState.Never)]
+#endif
+		[Sealed]
+		NSDictionary TypingAttributes2 {
+			get;
+			set;
+		}
+#endif // XAMCORE_6_0
 
 		[Export ("selectable")]
 		bool Selectable { [Bind ("isSelectable")] get; set; }

--- a/tests/monotouch-test/UIKit/TextViewTest.cs
+++ b/tests/monotouch-test/UIKit/TextViewTest.cs
@@ -31,6 +31,11 @@ namespace MonoTouchFixtures.UIKit {
 		{
 			using (UITextView tv = new UITextView ()) {
 				Assert.That (tv.SelectedRange.Length, Is.EqualTo ((nint) 0), "SelectedRange");
+#if XAMCORE_5_0
+				Assert.IsNotNull (tv.TypingAttributes, "default");
+				tv.TypingAttributes = new NSDictionary ();
+				Assert.IsNotNull (tv.TypingAttributes, "assigned");
+#else
 				Assert.IsNull (tv.TypingAttributes, "default");
 				// ^ without a [PreSnippet] attribute this would crash like:
 				// 7   monotouchtest                 	0x00006340 mono_sigill_signal_handler + 64
@@ -40,8 +45,22 @@ namespace MonoTouchFixtures.UIKit {
 				tv.TypingAttributes = new NSDictionary ();
 				// Assert.IsNotNull (tv.TypingAttributes, "assigned");
 				// ^ this would still crash
+#endif
 			}
 		}
+
+#if !XAMCORE_6_0
+		[Test]
+		public void EmptySelection2 ()
+		{
+			using (UITextView tv = new UITextView ()) {
+				Assert.That (tv.SelectedRange.Length, Is.EqualTo ((nint) 0), "SelectedRange");
+				Assert.IsNotNull (tv.TypingAttributes2, "default");
+				tv.TypingAttributes = new NSDictionary ();
+				Assert.IsNotNull (tv.TypingAttributes2, "assigned");
+			}
+		}
+#endif // !XAMCORE_6_0
 
 		[Test]
 		public void NonEmptySelection ()


### PR DESCRIPTION
Apparently, in earlier versions of iOS, returning an empty dictionary from
UITextView.TypingAttributes would crash, so we added a workaround where we'd
return null instead of an empty dictionary.

However, I can't reproduce any such crashes anymore, and this workaround is
causing other problems, so remove it.

But do this in a backwards compatible way (just in case the removal ends up
crashing apps after all):

* Add a new TypingAttributes2 binding with the behavior we want (a better name
  wouldn't be unwelcome!)
* Mark the existing TypingAttributes as obsolete, pointing to
  TypingAttributes2.
* Make the TypingAttributes property behave as we want in XAMCORE_5_0, and at
  that point  mark TypingAttributes2 as obsolete and point back to
  TypingAttributes.
* Remove TypingAttributes2 in XAMCORE_6_0.

Note: the presnippet attribute to avoid the crash was introduced in 2013:
https://github.com/xamarin/maccore/commit/5adb7c8608934413768f000a04f7dd6fddef7eca,
and our current minimum iOS version (iOS 11), was launched in 2017, so most
likely (aka hopefully) the crash was fixed in an iOS version earlier than the
earliest we support.

Fixes https://github.com/xamarin/xamarin-macios/issues/12709.