### PR TITLE
[msbuild] Add exception handling in the Copy task to track down random exception on the bots.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Copy.cs
@@ -13,16 +13,23 @@ namespace Microsoft.Build.Tasks {
 		public string SessionId { get; set; } = string.Empty;
 		public override bool Execute ()
 		{
-			if (!this.ShouldExecuteRemotely (SessionId))
-				return base.Execute ();
+			try {
+				if (!this.ShouldExecuteRemotely (SessionId))
+					return base.Execute ();
 
-			var taskRunner = new TaskRunner (SessionId, BuildEngine4);
+				var taskRunner = new TaskRunner (SessionId, BuildEngine4);
 
-			if (SourceFiles?.Any () == true) {
-				taskRunner.FixReferencedItems (this, SourceFiles);
+				if (SourceFiles?.Any () == true) {
+					taskRunner.FixReferencedItems (this, SourceFiles);
+				}
+
+				return taskRunner.RunAsync (this).Result;
+			} catch (Exception ex) {
+				Log.LogError ($"Copy failed due to exception: {ex.Message}");
+				Log.LogError ($"Stack trace:\n{ex.StackTrace}");
+				Log.LogErrorFromException (ex);
+				return false;
 			}
-
-			return taskRunner.RunAsync (this).Result;
 		}
 	}
 }


### PR DESCRIPTION
Ref: https://github.com/xamarin/xamarin-macios/issues/20117