### PR TITLE
[CI] Retry tests if on CI.

### DIFF
--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -232,6 +232,7 @@ steps:
 
 - template: ./run-tests.yml
   parameters:
+    isPR: ${{ parameters.isPR }}
     label: ${{ parameters.label }}
     labelWithPlatform: ${{ parameters.labelWithPlatform }}
     statusContext: ${{ parameters.statusContext }}

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -10,6 +10,9 @@ parameters:
 - name: label
   type: string
 
+- name: isPR
+  type: boolean
+
 - name: labelWithPlatform
   type: string
 
@@ -35,6 +38,10 @@ parameters:
 - name: uploadPrefix
   type: string
   default: '$(MaciosUploadPrefix)'
+
+- name: retryCount
+  type: number
+  default: 3
 
 steps:
 - bash: |
@@ -169,6 +176,8 @@ steps:
   displayName: 'Run tests'
   name: runTests # not to be confused with the displayName, this is used to later use the name of the step to access the output variables from an other job
   timeoutInMinutes: 840
+  ${{ if not(parameters.isPR) }}:
+    retryCountOnTaskFailure: ${{ parameters.retryCount }}
 
 # Collect simulator diagnostic logs
 - bash: |


### PR DESCRIPTION
Sometimes we have flaky tests, now that we have the tests splitted, dooing a rerun is not expensive and will allow our CI builds to be greener.

The template now checks if we are on CI and add the new rerun paramter (this was added in 2021).