### PR TITLE
[tests] Verify that we have a remote connection in tests that require a remote connection.

### DIFF
--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -99,4 +99,8 @@
 			<Output TaskParameter="OutputFile" ItemName="FileWrites" />
 		</Zip>
 	</Target>
+
+	<Target Name="VerifyRemoteConnection" AfterTargets="SayHello" Condition="'$(EnsureRemoteConnection)' == 'true'">
+		<Error Condition="'$(IsMacEnabled)' != 'true'" Text="Unable to connect to the remote Mac. Please examine the output of the SayHello target to figure out what happened." />
+	</Target>
 </Project>

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -234,6 +234,9 @@ namespace Xamarin.Tests {
 			properties ["ServerAddress"] = Environment.GetEnvironmentVariable ("MAC_AGENT_IP") ?? string.Empty;
 			properties ["ServerUser"] = Environment.GetEnvironmentVariable ("MAC_AGENT_USER") ?? string.Empty;
 			properties ["ServerPassword"] = Environment.GetEnvironmentVariable ("XMA_PASSWORD") ?? string.Empty;
+
+			if (!string.IsNullOrEmpty (properties ["ServerUser"]))
+				properties ["EnsureRemoteConnection"] = "true";
 		}
 	}
 }


### PR DESCRIPTION
By default, the build will just continue if a remote connection couldn't be
established. For tests that require a remote connection, this often results in
weird errors later on in the build, so improve this by immediately verifying
that we were able to establish a remote connection and telling the developer
where to look for more information.