### PR TITLE
[devops] Split the re-enabling of the macOS bot for Windows tests to its own job.

### DIFF
--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -310,17 +310,6 @@ steps:
       COMMENT_HASH: $(Build.SourceVersion)
 
 - pwsh: |
-    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-    $vsts = New-VSTS -Org "devdiv" -Project "DevDiv" -Token $(MacPoolAccessToken)
-
-    # get the pool and the agent objects and disable the bot
-    $pool = $vsts.Pools.GetPool("$Env:MAC_AGENT_POOL")
-    $agent = $vsts.Agents.GetAgent($pool, $Env:MAC_AGENT_NAME)
-    $vsts.Agents.SetEnabled($pool, $agent, $True)
-  displayName: 'Re-enabled macOS bot from pool'
-  condition: always()
-
-- pwsh: |
     Remove-Item "$(ID_RSA_PATH)"
   displayName: "Remove secrets"
   condition: always()

--- a/tools/devops/automation/templates/windows/reenable-mac.yml
+++ b/tools/devops/automation/templates/windows/reenable-mac.yml
@@ -1,0 +1,34 @@
+parameters:
+
+- name: isPR
+  type: boolean
+
+- name: repositoryAlias
+  type: string
+  default: self
+
+- name: commit
+  type: string
+  default: HEAD
+
+steps:
+
+- template: ../common/checkout.yml
+  parameters:
+    isPR: ${{ parameters.isPR }}
+    repositoryAlias: ${{ parameters.repositoryAlias }}
+    commit: ${{ parameters.commit }}
+
+- pwsh: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/show_env.ps1
+  displayName: 'Dump Environment'
+
+- pwsh: |
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
+    $vsts = New-VSTS -Org "devdiv" -Project "DevDiv" -Token $(MacPoolAccessToken)
+
+    # get the pool and the agent objects and disable the bot
+    $pool = $vsts.Pools.GetPool("$Env:MAC_AGENT_POOL")
+    $agent = $vsts.Agents.GetAgent($pool, $Env:MAC_AGENT_NAME)
+    $vsts.Agents.SetEnabled($pool, $agent, $True)
+  displayName: 'Re-enabled macOS bot from pool'
+  condition: always()

--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -49,7 +49,7 @@ stages:
   jobs:
   - job: mac_reservation
     dependsOn:
-    displayName: "Reserve bot for tests"
+    displayName: "Reserve macOS bot for tests"
     timeoutInMinutes: 120
     condition: ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')
     workspace:
@@ -76,7 +76,7 @@ stages:
     - mac_reservation
     displayName: 'Dotnet tests'
     timeoutInMinutes: 120
-    condition: ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')
+    condition: and(succeeded(),ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],''))
     workspace:
       clean: all
 
@@ -103,3 +103,30 @@ stages:
         statusContext: ${{ parameters.statusContext }}
         gitHubToken: ${{ parameters.gitHubToken }}
         xqaCertPass: ${{ parameters.xqaCertPass }}
+
+  - job: mac_reenable
+    dependsOn:
+    - mac_reservation
+    - run_tests
+    displayName: "Re-enable macOS bot for tests"
+    timeoutInMinutes: 120
+    # the condition must be exactly the same as for the mac_reservation job (or if no condition there, then 'always ()')
+    condition: ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')
+    workspace:
+      clean: all
+    pool:
+      name: ${{ parameters.windowsPool }}
+      demands:
+      - agent.os -equals Windows_NT
+
+    steps:
+    - template: reenable-mac.yml
+      parameters:
+        isPR: ${{ parameters.isPR }}
+        repositoryAlias: ${{ parameters.repositoryAlias }}
+        commit: ${{ parameters.commit }}
+
+    variables:
+      MAC_AGENT_NAME: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_NAME'] ]
+      MAC_AGENT_POOL: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_POOL'] ]
+      MAC_AGENT_IP: $[ dependencies.mac_reservation.outputs['macInfo.AGENT_IP'] ]


### PR DESCRIPTION
Split the re-enabling of the macOS bot for the Windows tests to its own job,
so that we can stop running the tests job even if the reservation job failed.