### PR TITLE
[Foundation] Don't leak exceptions in WrappedNSInputStream.Read.

### DIFF
--- a/src/Foundation/NSExceptionError.cs
+++ b/src/Foundation/NSExceptionError.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.Versioning;
+
+#nullable enable
+
+namespace Foundation {
+#if NET
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("maccatalyst")]
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("tvos")]
+#endif
+	public class NSExceptionError : NSError {
+		Exception exception;
+
+		public Exception Exception { get => exception; }
+
+		public NSExceptionError (Exception exception)
+			: base ((NSString) exception.GetType ().FullName, exception.HResult, GetDictionary (exception))
+		{
+			this.exception = exception;
+		}
+
+		static NSDictionary GetDictionary (Exception e)
+		{
+			var dict = new NSMutableDictionary ();
+			dict [NSError.LocalizedDescriptionKey] = (NSString) e.Message;
+			dict [NSError.LocalizedFailureReasonErrorKey] = (NSString) e.Message;
+			return dict;
+		}
+	}
+}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -826,6 +826,7 @@ FOUNDATION_SOURCES = \
 	Foundation/NSDistributedNotificationCenter.cs \
 	Foundation/NSEnumerator_1.cs \
 	Foundation/NSErrorException.cs \
+	Foundation/NSExceptionError.cs \
 	Foundation/NSExpression.cs \
 	Foundation/NSFastEnumerationState.cs \
 	Foundation/NSFastEnumerator.cs \


### PR DESCRIPTION
We don't want to leak exceptions back to the calling native code in WrappedNSInputStream.Read, because that will likely crash the process.

Example stack trace:

    ObjectDisposed_StreamClosed (System.ObjectDisposedException)
       at System.ThrowHelper.ThrowObjectDisposedException_StreamClosed(String) + 0x3c
       at System.IO.MemoryStream.Read(Byte[], Int32, Int32) + 0x124
       at System.Net.Http.MultipartContent.ContentReadStream.Read(Byte[], Int32, Int32) + 0x78
       at System.Net.Http.NSUrlSessionHandler.WrappedNSInputStream.Read(IntPtr buffer, UIntPtr len) + 0x58
       at MyApp!<BaseAddress>+0x7082f8

Instead return -1 from the Read method, which is documented as an error
condition, and then also return a custom NSError from the Error property -
which is also documented to be where the error is supposed to be surfaced.

Ref: https://developer.apple.com/documentation/foundation/nsinputstream/1411544-read

Ref: https://github.com/xamarin/xamarin-macios/issues/20123.