### PR TITLE
[Tests] Use Assert.Multiple over IsEmpty to get nicer output.

### DIFF
--- a/tests/dotnet/UnitTests/Extensions.cs
+++ b/tests/dotnet/UnitTests/Extensions.cs
@@ -57,6 +57,7 @@ namespace Xamarin.Tests {
 			// Rather than doing an Assert.IsEmpty, which produces a horrendous error message, we'll do an Assert.Multiple which generates a 
 			// nice enumerated output of all the failures.
 			Assert.Multiple (() => {
+					Assert.Fail ($"Root path is {Configuration.SourceRoot}");
 					// fail for each of the new warnings
 					foreach (var evt in newWarnings)
 						Assert.Fail ($"Unexpected warning: {evt.File}:{evt.LineNumber} {evt.Message}");

--- a/tests/dotnet/UnitTests/Extensions.cs
+++ b/tests/dotnet/UnitTests/Extensions.cs
@@ -53,8 +53,18 @@ namespace Xamarin.Tests {
 			}
 			Console.WriteLine ($"If this is expected, here's the updated list of expected warnings:");
 			Console.WriteLine (sb);
-			Assert.That (newWarnings, Is.Empty, "New warnings");
-			Assert.That (missingWarnings, Is.Empty, "Empty warnings");
+
+			// Rather than doing an Assert.IsEmpty, which produces a horrendous error message, we'll do an Assert.Multiple which generates a 
+			// nice enumerated output of all the failures.
+			Assert.Multiple (() => {
+					// fail for each of the new warnings
+					foreach (var evt in newWarnings)
+						Assert.Fail ($"Unexpected warning: {evt.File}:{evt.LineNumber} {evt.Message}");
+
+					// fail for each of the missing warnings
+					foreach (var evt in missingWarnings)
+						Assert.Fail ($"Missing warning: {evt.File}: {evt.Message}");
+			});
 		}
 	}
 


### PR DESCRIPTION
IsEmpty does not provide a formated way to see the errors and makes it really hard to parse the informaiton. Assert.Multiple is much nicer and a better way to get the data.