### PR TITLE
[tests] Collect info about installed XMA build agents to try to track down an installation failure.

### DIFF
--- a/tests/dotnet/Windows/collect-binlogs.sh
+++ b/tests/dotnet/Windows/collect-binlogs.sh
@@ -14,6 +14,11 @@ rsync -avv --prune-empty-dirs --exclude 'artifacts/' --include '*/' --include '*
 rm -f ~/remote_build_testing/windows-remote-logs.zip
 zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/remote_build_testing/binlogs
 
+if test -d ~/Library/Caches/Xamarin/XMA/Agents/Build; then
+	find ~/Library/Caches/Xamarin/XMA/Agents/Build -type f -print0 | xargs -0 shasum -a 256 > ~/remote_build_testing/Agents_Build_Checksums.txt
+	zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/remote_build_testing/Agents_Build_Checksums.txt
+fi
+
 # Zip up all the logs in ~/Library/Logs/Xamarin.Messaging*
 if ls ~/Library/Logs/Xamarin.Messaging* >& /dev/null ; then
 	zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/Library/Logs/Xamarin.Messaging*


### PR DESCRIPTION
Collect info to try to track down this random failure:

	[...]
    [xma][info]: Uploaded Build.zip 100%
    [xma][info]: Successfully copied /tmp/Build-1.13.0.8-992eab55-04bf-44f3-b12d-df4b6ec5efb7/Build.zip
    [xma][info]: Checking integrity of uploaded file /tmp/Build-1.13.0.8-992eab55-04bf-44f3-b12d-df4b6ec5efb7/Build.zip...
    [xma][info]: Executing SSH command: '/usr/bin/shasum -a 256 "/tmp/Build-1.13.0.8-992eab55-04bf-44f3-b12d-df4b6ec5efb7/Build.zip" | awk "{ print $1 }"'
    [xma][info]: Trying to copy to '/tmp/Build-1.13.0.8-992eab55-04bf-44f3-b12d-df4b6ec5efb7/Build.zip' to cache...
    [xma][info]: Executing SSH command: 'mkdir -p "/Users/builder/Library/Caches/Xamarin/XMA/Cache"'
    [xma][info]: Executing SSH command: 'cp -f "/tmp/Build-1.13.0.8-992eab55-04bf-44f3-b12d-df4b6ec5efb7/Build.zip" "/Users/builder/Library/Caches/Xamarin/XMA/Cache/c3cbbdd25de4805022ca502605de17757ace8ffd3d5458dec1142c1f88211587"'
    [xma][info]: Successfully copied '/tmp/Build-1.13.0.8-992eab55-04bf-44f3-b12d-df4b6ec5efb7/Build.zip' to cache
    [xma][info]: Unzipping file '/tmp/Build-1.13.0.8-992eab55-04bf-44f3-b12d-df4b6ec5efb7/Build.zip' to '/Users/builder/Library/Caches/Xamarin/XMA/Agents/Build/1.13.0.8'
    [xma][info]: Executing SSH command: 'ls "/Users/builder/Library/Caches/Xamarin/XMA/Agents/Build/1.13.0.8"'
    [xma][info]: Creating directory '/Users/builder/Library/Caches/Xamarin/XMA/Agents/Build/1.13.0.8' for installation...
    [xma][info]: Executing SSH command: 'mkdir -p "/Users/builder/Library/Caches/Xamarin/XMA/Agents/Build/1.13.0.8"'
    [xma][info]: Executing SSH command: 'unzip -o "/tmp/Build-1.13.0.8-992eab55-04bf-44f3-b12d-df4b6ec5efb7/Build.zip" -d "/Users/builder/Library/Caches/Xamarin/XMA/Agents/Build/1.13.0.8"'
    [xma][info]: Executing SSH command: 'ls "/Users/builder/Library/Caches/Xamarin/XMA/Agents/Build/1.13.0.8"'
    [xma][info]: Executing SSH command: 'find "/Users/builder/Library/Caches/Xamarin/XMA/Agents/Build/1.13.0.8/" -type f | while read line ; do /usr/bin/shasum -a 256 "$line" | awk "{ print $1 }" ; done'
    [xma][warn]: Integrity check failed between source and target content. Source path: d:\azdo\_work\1\s\xamarin-macios\tests\dotnet\windows\bin\dotnet\packs\Microsoft.iOS.Windows.Sdk\17.2.8172-ci.main\tools\msbuild\iOS\Build.zip, Target path: /Users/builder/Library/Caches/Xamarin/XMA/Agents/Build/1.13.0.8
    [xma][err]: Unable to install the Agent 'Build 1.13.0.8'
    [xma][info]: An error occurred while trying to start the Build Agent. Details: Unable to install the Agent 'Build 1.13.0.8'
    exception: An error occurred while installing Build 1.13.0.8