### PR TITLE
[dotnet] Show a better error when using a .NET framework version we don't support.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -25,12 +25,14 @@ $(1)_NUGET_TARGETS = \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/data/UnixFilePermissions.xml \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/Sdk/AutoImport.props \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/Sdk/Sdk.props \
+	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/Sdk/Sdk-eol.props \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/targets/Microsoft.$(1).Sdk.ImplicitNamespaceImports.props \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/targets/Microsoft.$(1).Sdk.SupportedTargetPlatforms.props \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/targets/Microsoft.$(1).Sdk.DefaultItems.props \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/targets/Microsoft.$(1).Sdk.props \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/targets/Microsoft.$(1).Sdk.Versions.props \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/targets/Microsoft.$(1).Sdk.targets \
+	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/targets/Microsoft.Sdk.Eol.targets \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/targets/Xamarin.Shared.Sdk.DefaultItems.targets \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/targets/Xamarin.Shared.Sdk.Publish.targets \
 	$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/targets/Xamarin.Shared.Sdk.TargetFrameworkInference.props \

--- a/dotnet/Microsoft.MacCatalyst.Sdk/Sdk/Sdk-eol.props
+++ b/dotnet/Microsoft.MacCatalyst.Sdk/Sdk/Sdk-eol.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<_IsWorkloadEol>true</_IsWorkloadEol>
+	</PropertyGroup>
+	<Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.MacCatalyst.Sdk.props" />
+</Project>

--- a/dotnet/Microsoft.MacCatalyst.Sdk/targets/Microsoft.MacCatalyst.Sdk.props
+++ b/dotnet/Microsoft.MacCatalyst.Sdk/targets/Microsoft.MacCatalyst.Sdk.props
@@ -4,5 +4,6 @@
     <_PlatformName>MacCatalyst</_PlatformName>
   </PropertyGroup>
 
-  <Import Project="Xamarin.Shared.Sdk.props" />
+  <Import Project="Xamarin.Shared.Sdk.props" Condition="'$(_IsWorkloadEol)' != 'true'" />
+  <Import Project="Microsoft.Sdk.Eol.targets" Condition="'$(_IsWorkloadEol)' == 'true'" />
 </Project>

--- a/dotnet/Microsoft.iOS.Sdk/Sdk/Sdk-eol.props
+++ b/dotnet/Microsoft.iOS.Sdk/Sdk/Sdk-eol.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<_IsWorkloadEol>true</_IsWorkloadEol>
+	</PropertyGroup>
+	<Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.iOS.Sdk.props" />
+</Project>

--- a/dotnet/Microsoft.iOS.Sdk/targets/Microsoft.iOS.Sdk.props
+++ b/dotnet/Microsoft.iOS.Sdk/targets/Microsoft.iOS.Sdk.props
@@ -6,5 +6,6 @@
     <CoreiOSSdkDirectory>$(MSBuildThisFileDirectory)..\tools\msbuild\iOS\</CoreiOSSdkDirectory>
   </PropertyGroup>
 
-  <Import Project="Xamarin.Shared.Sdk.props" />
+  <Import Project="Xamarin.Shared.Sdk.props" Condition="'$(_IsWorkloadEol)' != 'true'" />
+  <Import Project="Microsoft.Sdk.Eol.targets" Condition="'$(_IsWorkloadEol)' == 'true'" />
 </Project>

--- a/dotnet/Microsoft.macOS.Sdk/Sdk/Sdk-eol.props
+++ b/dotnet/Microsoft.macOS.Sdk/Sdk/Sdk-eol.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<_IsWorkloadEol>true</_IsWorkloadEol>
+	</PropertyGroup>
+	<Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.macOS.Sdk.props" />
+</Project>

--- a/dotnet/Microsoft.macOS.Sdk/targets/Microsoft.macOS.Sdk.props
+++ b/dotnet/Microsoft.macOS.Sdk/targets/Microsoft.macOS.Sdk.props
@@ -4,5 +4,6 @@
     <_PlatformName>macOS</_PlatformName>
   </PropertyGroup>
 
-  <Import Project="Xamarin.Shared.Sdk.props" />
+  <Import Project="Xamarin.Shared.Sdk.props" Condition="'$(_IsWorkloadEol)' != 'true'" />
+  <Import Project="Microsoft.Sdk.Eol.targets" Condition="'$(_IsWorkloadEol)' == 'true'" />
 </Project>

--- a/dotnet/Microsoft.tvOS.Sdk/Sdk/Sdk-eol.props
+++ b/dotnet/Microsoft.tvOS.Sdk/Sdk/Sdk-eol.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<_IsWorkloadEol>true</_IsWorkloadEol>
+	</PropertyGroup>
+	<Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.tvOS.Sdk.props" />
+</Project>

--- a/dotnet/Microsoft.tvOS.Sdk/targets/Microsoft.tvOS.Sdk.props
+++ b/dotnet/Microsoft.tvOS.Sdk/targets/Microsoft.tvOS.Sdk.props
@@ -4,5 +4,6 @@
     <_PlatformName>tvOS</_PlatformName>
   </PropertyGroup>
 
-  <Import Project="Xamarin.Shared.Sdk.props" />
+  <Import Project="Xamarin.Shared.Sdk.props" Condition="'$(_IsWorkloadEol)' != 'true'" />
+  <Import Project="Microsoft.Sdk.Eol.targets" Condition="'$(_IsWorkloadEol)' == 'true'" />
 </Project>

--- a/dotnet/generate-workloadmanifest-targets.csharp
+++ b/dotnet/generate-workloadmanifest-targets.csharp
@@ -39,6 +39,7 @@ using (var writer = new StreamWriter (outputPath)) {
 		var sep = tfv.IndexOfAny (new char [] { '-', '_' });
 		if (sep >= 0)
 			tfv = tfv.Substring (0, sep);
+		supportedTFVs.Add (tfv);
 		var workloadVersion = tfm;
 		if (tfv [0] == '7')
 			workloadVersion = tfm.Replace (".0", "");

--- a/dotnet/generate-workloadmanifest-targets.csharp
+++ b/dotnet/generate-workloadmanifest-targets.csharp
@@ -29,6 +29,8 @@ var supportedTFMs = new List<string> ();
 supportedTFMs.Add (currentApiVersion);
 supportedTFMs.AddRange (olderApiVersions.Split (' '));
 
+var supportedTFVs = new List<string> ();
+
 using (var writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"<Project>");
 	writer.WriteLine ($"	<ImportGroup Condition=\" '$(TargetPlatformIdentifier)' == '{platform}' \">");
@@ -55,6 +57,9 @@ using (var writer = new StreamWriter (outputPath)) {
 			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Windows.Sdk.Aliased.{workloadVersion}\" Condition=\" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '{tfv}')) And $([MSBuild]::IsOSPlatform('windows'))\" />");
 		}
 	}
+	writer.WriteLine ();
+	var earliestSupportedTFV = supportedTFVs.Select (v => Version.Parse (v)).OrderBy (v => v).First ();
+	writer.WriteLine ($"		<Import Project=\"Sdk-eol.props\" Sdk=\"Microsoft.{platform}.Sdk.{tfm}\" Condition=\" $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '{earliestSupportedTFV}'))\" />");
 	writer.WriteLine ($"	</ImportGroup>");
 	writer.WriteLine ();
 	writer.WriteLine ($"	<ItemGroup Condition=\" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) \">");

--- a/dotnet/targets/Microsoft.Sdk.Eol.targets
+++ b/dotnet/targets/Microsoft.Sdk.Eol.targets
@@ -1,0 +1,48 @@
+<!--
+***********************************************************************************************
+Microsoft.Sdk.Eol.targets
+
+Imported only when using a .NET version that has reached EOL, contains settings to force the error:
+
+error NETSDK1202: The workload 'ios' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.
+
+Things to note:
+
+* $(WarningsAsErrors) includes NETSDK1202, so that the build stops and we don't run into other (and more confusing) errors.
+* Force $(TargetPlatformVersion) to just be 1.0, to make it past early error messages
+* _ClearMissingWorkloads prevents undesired extra error messages
+
+***********************************************************************************************
+-->
+<Project InitialTargets="_ClearMissingWorkloads">
+	<PropertyGroup>
+		<!-- This is required to let .NET know that our workload handles the current target framework -->
+		<TargetPlatformSupported>true</TargetPlatformSupported>
+
+		<!-- Force NETSDK1202 to be an error (otherwise we run into a less descriptive later on) -->
+		<WarningsAsErrors>$(WarningsAsErrors);NETSDK1202</WarningsAsErrors>
+
+		<!--
+			Fixes this error:
+				error NU1012: Platform version is not present for one or more target frameworks, even though they have specified a platform: net6.0-ios
+			The actual version number doesn't seem to matter, so we're just staying at 1.0 forever.
+		-->
+		<TargetPlatformVersion>1.0</TargetPlatformVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<EolWorkload Include="$(TargetFramework)" Url="https://aka.ms/maui-support-policy" />
+	</ItemGroup>
+
+	<Target Name="_ClearMissingWorkloads">
+		<!--
+			Prevents the error:
+			Microsoft.NET.Sdk.ImportWorkloads.targets(38,5): error NETSDK1147:
+			To build this project, the following workloads must be installed: wasm-tools-net6
+			To install these workloads, run the following command: dotnet workload restore
+		-->
+		<ItemGroup>
+			<MissingWorkloadPack Remove="@(MissingWorkloadPack)" />
+		</ItemGroup>
+	</Target>
+</Project>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1148,36 +1148,6 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
-		[TestCase (ApplePlatform.iOS, "ios-arm64")]
-		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64")]
-		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
-		public void BuildNetFutureApp (ApplePlatform platform, string runtimeIdentifiers)
-		{
-			// Builds an app with a higher .NET version than we support (for instance 'net9.0-ios' when we support 'net8.0-ios')
-			var project = "MySimpleApp";
-			Configuration.IgnoreIfIgnoredPlatform (platform);
-			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
-
-			var majorNetVersion = Version.Parse (Configuration.DotNetTfm.Replace ("net", "")).Major;
-			var netVersion = $"net{majorNetVersion + 1}.0";
-			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, netVersion: netVersion);
-			Clean (project_path);
-			var properties = GetDefaultProperties (runtimeIdentifiers);
-			var targetFramework = platform.ToFramework (netVersion);
-			properties ["TargetFramework"] = targetFramework;
-			properties ["ExcludeNUnitLiteReference"] = "true";
-			properties ["ExcludeTouchUnitReference"] = "true";
-
-			var result = DotNet.AssertBuildFailure (project_path, properties);
-			var errors = BinLog.GetBuildLogErrors (result.BinLogPath).ToList ();
-
-			AssertErrorMessages (errors,
-				$"The current .NET SDK does not support targeting .NET {majorNetVersion + 1}.0.  Either target .NET {majorNetVersion}.0 or lower, or use a version of the .NET SDK that supports .NET {majorNetVersion + 1}.0. Download the .NET SDK from https://aka.ms/dotnet/download");
-		}
-
-		[Test]
 		[Ignore ("Ignore due to issue: https://github.com/xamarin/xamarin-macios/issues/18655")]
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]


### PR DESCRIPTION
If a project tried to use a .NET 6 project (say TargetFramework=net6.0-ios), then
we used to show these rather unhelpful errors:

    error NETSDK1147: To build this project, the following workloads must be installed: wasm-tools-net6
    error NETSDK1147: To install these workloads, run the following command: dotnet workload restore

The underlying problem is that we don't support .NET 6 anymore, so with this fix we now show:

    error NETSDK1202: The workload 'net6.0-ios' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.

which is much more helpful.

References:

* https://github.com/dotnet/sdk/pull/32426
* https://github.com/xamarin/xamarin-android/pull/8047

Fixes https://github.com/xamarin/xamarin-macios/issues/18790.