### PR TITLE
[CoreFoundation] Fix CFWriteStream.DoGetProperty to actually get the property.

### DIFF
--- a/src/CoreFoundation/CFWriteStream.cs
+++ b/src/CoreFoundation/CFWriteStream.cs
@@ -190,13 +190,13 @@ namespace CoreFoundation {
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
-		extern static /* CFTypeRef */ IntPtr CFWriteStreamSetProperty (/* CFWriteStreamRef */ IntPtr stream, /* CFStringRef */ IntPtr propertyName);
+		extern static /* CFTypeRef */ IntPtr CFWriteStreamCopyProperty (/* CFWriteStreamRef */ IntPtr stream, /* CFStringRef */ IntPtr propertyName);
 
 		protected override IntPtr DoGetProperty (NSString name)
 		{
 			if (name is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (name));
-			return CFWriteStreamSetProperty (Handle, name.Handle);
+			return CFWriteStreamCopyProperty (Handle, name.Handle);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-CoreFoundation.ignore
@@ -857,7 +857,6 @@
 !missing-pinvoke! CFUUIDGetConstantUUIDWithBytes is not bound
 !missing-pinvoke! CFUUIDGetTypeID is not bound
 !missing-pinvoke! CFUUIDGetUUIDBytes is not bound
-!missing-pinvoke! CFWriteStreamCopyProperty is not bound
 !missing-pinvoke! CFWriteStreamCreateWithAllocatedBuffers is not bound
 !missing-pinvoke! CFWriteStreamCreateWithBuffer is not bound
 !missing-pinvoke! CFWriteStreamCreateWithFile is not bound

--- a/tests/xtro-sharpie/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/common-CoreFoundation.ignore
@@ -857,7 +857,6 @@
 !missing-pinvoke! CFUUIDGetConstantUUIDWithBytes is not bound
 !missing-pinvoke! CFUUIDGetTypeID is not bound
 !missing-pinvoke! CFUUIDGetUUIDBytes is not bound
-!missing-pinvoke! CFWriteStreamCopyProperty is not bound
 !missing-pinvoke! CFWriteStreamCreateWithAllocatedBuffers is not bound
 !missing-pinvoke! CFWriteStreamCreateWithBuffer is not bound
 !missing-pinvoke! CFWriteStreamCreateWithFile is not bound


### PR DESCRIPTION
Ref: https://github.com/xamarin/maccore/commit/aa13dcb506f1d18f7b167c10b1438af4eddec666

First line in the description is:

> Fixed CFWriteStream.DoGetProperty to call CFWriteStreamCopyProperty (and not CFReadStreamCopyProperty)

But that's not what the actual change does.. so change it to do the right thing.