### PR TITLE
[GitOps] Add an opt-out for automated comments for need-* labels.

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -78,27 +78,48 @@ configuration:
       - addReply:
           reply: This issue is being closed due to inactivity. If this issue is still affecting you, please follow the steps above to use the VS Feedback Tool to report the issue.
       - closeIssue
+
     eventResponderTasks:
+
     - if:
       - payloadType: Issues
       - labelAdded:
           label: need-info
       then:
-      - addReply:
-          reply: Hi @${issueAuthor}. We have added the "need-info" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
-      description: 
+      - if:
+          - not:
+              hasLabel: no-auto-reply
+          then:
+            - addReply:
+                reply: Hi @${issueAuthor}. We have added the "need-info" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
+      - if:
+          - hasLabel: no-auto-reply
+        then:
+          removeLabel:
+            label: no-auto-reply
+      description: "Add comment asking for info when the 'need-info' label is added to an issue."
+
     - if:
       - payloadType: Issues
       - labelAdded:
           label: need-repro
       then:
-      - addReply:
-          reply: >-
-            Hi @${issueAuthor}. We have added the "need-repro" label to this issue, which indicates that we require steps and sample code to reproduce the issue before we can take further action. Please try to create a minimal sample project/solution or code samples which reproduce the issue, ideally as a GitHub repo that we can clone. See more details about creating repros here: https://github.com/xamarin/xamarin-macios/blob/main/docs/bug-repro.md
+      - if:
+          - not:
+              hasLabel: no-auto-reply
+        then:
+          - addReply:
+              reply: >-
+                Hi @${issueAuthor}. We have added the "need-repro" label to this issue, which indicates that we require steps and sample code to reproduce the issue before we can take further action. Please try to create a minimal sample project/solution or code samples which reproduce the issue, ideally as a GitHub repo that we can clone. See more details about creating repros here: https://github.com/xamarin/xamarin-macios/blob/main/docs/bug-repro.md
 
+                This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
+      - if:
+          - hasLabel: no-auto-reply
+        then:
+          removeLabel:
+            label: no-auto-reply
+      description: "Add comment asking for info when the 'need-repro' label is added to an issue."
 
-            This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
-      description: 
     - if:
       - payloadType: Issue_Comment
       - isAction:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -115,9 +115,9 @@ configuration:
               This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
       - if:
         - hasLabel: no-auto-reply
-      then:
-      - removeLabel:
-          label: no-auto-reply
+        then:
+        - removeLabel:
+            label: no-auto-reply
       description: "Add comment asking for info when the 'need-repro' label is added to an issue."
 
     - if:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -87,16 +87,16 @@ configuration:
           label: need-info
       then:
       - if:
-          - not:
-              hasLabel: no-auto-reply
-          then:
-            - addReply:
-                reply: Hi @${issueAuthor}. We have added the "need-info" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
-      - if:
-          - hasLabel: no-auto-reply
+        - not:
+            hasLabel: no-auto-reply
         then:
-          removeLabel:
-            label: no-auto-reply
+        - addReply:
+            reply: Hi @${issueAuthor}. We have added the "need-info" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
+      - if:
+        - hasLabel: no-auto-reply
+      then:
+        removeLabel:
+          label: no-auto-reply
       description: "Add comment asking for info when the 'need-info' label is added to an issue."
 
     - if:
@@ -105,19 +105,19 @@ configuration:
           label: need-repro
       then:
       - if:
-          - not:
-              hasLabel: no-auto-reply
+        - not:
+            hasLabel: no-auto-reply
         then:
-          - addReply:
-              reply: >-
-                Hi @${issueAuthor}. We have added the "need-repro" label to this issue, which indicates that we require steps and sample code to reproduce the issue before we can take further action. Please try to create a minimal sample project/solution or code samples which reproduce the issue, ideally as a GitHub repo that we can clone. See more details about creating repros here: https://github.com/xamarin/xamarin-macios/blob/main/docs/bug-repro.md
+        - addReply:
+            reply: >-
+              Hi @${issueAuthor}. We have added the "need-repro" label to this issue, which indicates that we require steps and sample code to reproduce the issue before we can take further action. Please try to create a minimal sample project/solution or code samples which reproduce the issue, ideally as a GitHub repo that we can clone. See more details about creating repros here: https://github.com/xamarin/xamarin-macios/blob/main/docs/bug-repro.md
 
-                This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
+              This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
       - if:
-          - hasLabel: no-auto-reply
-        then:
-          removeLabel:
-            label: no-auto-reply
+        - hasLabel: no-auto-reply
+      then:
+        removeLabel:
+          label: no-auto-reply
       description: "Add comment asking for info when the 'need-repro' label is added to an issue."
 
     - if:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -95,7 +95,7 @@ configuration:
       - if:
         - hasLabel: no-auto-reply
       then:
-        removeLabel:
+      - removeLabel:
           label: no-auto-reply
       description: "Add comment asking for info when the 'need-info' label is added to an issue."
 
@@ -116,7 +116,7 @@ configuration:
       - if:
         - hasLabel: no-auto-reply
       then:
-        removeLabel:
+      - removeLabel:
           label: no-auto-reply
       description: "Add comment asking for info when the 'need-repro' label is added to an issue."
 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -100,27 +100,6 @@ configuration:
       description: "Add comment asking for info when the 'need-info' label is added to an issue."
 
     - if:
-      - payloadType: Issues
-      - labelAdded:
-          label: need-repro
-      then:
-      - if:
-        - not:
-            hasLabel: no-auto-reply
-        then:
-        - addReply:
-            reply: >-
-              Hi @${issueAuthor}. We have added the "need-repro" label to this issue, which indicates that we require steps and sample code to reproduce the issue before we can take further action. Please try to create a minimal sample project/solution or code samples which reproduce the issue, ideally as a GitHub repo that we can clone. See more details about creating repros here: https://github.com/xamarin/xamarin-macios/blob/main/docs/bug-repro.md
-
-              This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
-      - if:
-        - hasLabel: no-auto-reply
-      then:
-      - removeLabel:
-          label: no-auto-reply
-      description: "Add comment asking for info when the 'need-repro' label is added to an issue."
-
-    - if:
       - payloadType: Issue_Comment
       - isAction:
           action: Created

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -92,6 +92,11 @@ configuration:
         then:
         - addReply:
             reply: Hi @${issueAuthor}. We have added the "need-info" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
+      - if:
+        - hasLabel: no-auto-reply
+        then:
+        - removeLabel:
+            label: no-auto-reply
 
     - if:
       - payloadType: Issue_Comment

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -97,6 +97,28 @@ configuration:
         then:
         - removeLabel:
             label: no-auto-reply
+      description: "Add comment asking for info when the 'need-info' label is added to an issue."
+
+    - if:
+      - payloadType: Issues
+      - labelAdded:
+          label: need-repro
+      then:
+      - if:
+        - not:
+            hasLabel: no-auto-reply
+        then:
+        - addReply:
+            reply: >-
+              Hi @${issueAuthor}. We have added the "need-repro" label to this issue, which indicates that we require steps and sample code to reproduce the issue before we can take further action. Please try to create a minimal sample project/solution or code samples which reproduce the issue, ideally as a GitHub repo that we can clone. See more details about creating repros here: https://github.com/xamarin/xamarin-macios/blob/main/docs/bug-repro.md
+
+              This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
+      - if:
+        - hasLabel: no-auto-reply
+        then:
+        - removeLabel:
+            label: no-auto-reply
+      description: "Add comment asking for info when the 'need-repro' label is added to an issue."
 
     - if:
       - payloadType: Issue_Comment

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -115,9 +115,9 @@ configuration:
               This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
       - if:
         - hasLabel: no-auto-reply
-        then:
-        - removeLabel:
-            label: no-auto-reply
+      then:
+      - removeLabel:
+          label: no-auto-reply
       description: "Add comment asking for info when the 'need-repro' label is added to an issue."
 
     - if:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -92,12 +92,6 @@ configuration:
         then:
         - addReply:
             reply: Hi @${issueAuthor}. We have added the "need-info" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.
-      - if:
-        - hasLabel: no-auto-reply
-      then:
-      - removeLabel:
-          label: no-auto-reply
-      description: "Add comment asking for info when the 'need-info' label is added to an issue."
 
     - if:
       - payloadType: Issue_Comment


### PR DESCRIPTION
Currently a descriptive comment is automatically added to an issue when either
the 'need-info' or the 'need-repro' label is added to an issue, requesting
more info or a test project, respectively, and then when the reporter (or
anyone else) comments something, the `need-info`/`need-repro` label is removed
and a `need-attention` label is added.

However, sometimes this can get repetitive if the reporter replies frequently,
or someone else steps in and answers questions or asks unrelated questions,
and we have to add back the `need-info` or `need-repro` every time.

So add an opt-out: if the label `no-auto-reply` is set, then don't add that
descriptive comment.

The label is single-use: it'll be removed when a `need-info` or `need-repro`
labels is added.