### PR TITLE
[release/8.0.1xx-xcode15.0] [dotnet] Rename packs to contain target framework.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -801,6 +801,7 @@ endif
 
 # Create variables prefixed with the correctly cased platform name from the upper-cased platform name. This simplifies code in a few areas (whenever we foreach over DOTNET_PLATFORMS).
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval DOTNET_$(platform)_RUNTIME_IDENTIFIERS:=$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS)))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_NUGET_OS_VERSION:=$($(shell echo $(platform) | tr a-z A-Z)_NUGET_OS_VERSION)))
 
 # Create a variable with all the runtime identifiers
 DOTNET_RUNTIME_IDENTIFIERS=$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS))
@@ -847,10 +848,10 @@ DOTNET_macOS_SDK_PLATFORMS=mac
 DOTNET_MacCatalyst_SDK_PLATFORMS=maccatalyst
 
 # Misc other computed variables
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(shell echo $(platform) | tr a-z A-Z)_NUGET_SDK_NAME=Microsoft.$(platform).Sdk))
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(shell echo $(platform) | tr a-z A-Z)_NUGET_REF_NAME=Microsoft.$(platform).Ref))
-$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS),$(eval $(rid)_NUGET_RUNTIME_NAME=Microsoft.$(platform).Runtime.$(rid))))
-$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(eval $(shell echo $(platform) | tr a-z A-Z)_NUGET_WINDOWS_SDK_NAME=Microsoft.$(platform).Windows.Sdk))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(shell echo $(platform) | tr a-z A-Z)_NUGET_SDK_NAME=Microsoft.$(platform).Sdk.$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION)))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(shell echo $(platform) | tr a-z A-Z)_NUGET_REF_NAME=Microsoft.$(platform).Ref.$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION)))
+$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS),$(eval $(rid)_NUGET_RUNTIME_NAME=Microsoft.$(platform).Runtime.$(rid).$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION))))
+$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(eval $(shell echo $(platform) | tr a-z A-Z)_NUGET_WINDOWS_SDK_NAME=Microsoft.$(platform).Windows.Sdk.$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION)))
 
 # Create variables prefixed with the correctly cased platform name from the upper-cased platform name. This simplifies code in a few areas (whenever we foreach over DOTNET_PLATFORMS).
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_NUGET_SDK_NAME:=$($(shell echo $(platform) | tr a-z A-Z)_NUGET_SDK_NAME)))

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -119,6 +119,7 @@ targets/Microsoft.$(1).Sdk.Versions.props: targets/Microsoft.Sdk.Versions.templa
 		-e 's/@DOTNET_TFM@/$(DOTNET_TFM)/g' \
 		-e 's/@RUNTIME_PACK_RUNTIME_IDENTIFIERS@/$(4)/g' \
 		-e 's/@XCODE_IS_PREVIEW@/$(XCODE_IS_PREVIEW)/g' \
+		-e 's/@NUGET_OS_VERSION@/$$($(2)_NUGET_OS_VERSION)/g' \
 		$$< > $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 
@@ -144,6 +145,7 @@ Microsoft.$1.Sdk/targets/Microsoft.$1.Sdk.DefaultItems.props: targets/Microsoft.
 	$$(Q_GEN) sed \
 		-e "s/@PLATFORM@/$1/g" \
 		-e "s/@TARGET_FRAMEWORK_VERSION@/$(subst net,,$(DOTNET_TFM))/g" \
+		-e "s/@CURRENT_HASH_LONG@/$$(CURRENT_HASH_LONG)/g" \
 		$$< > $$@
 endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call DefaultItems,$(platform))))
@@ -169,14 +171,12 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call SupportedTargetPlatforms,$(
 define WorkloadTargets
 Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.json: Makefile $(TOP)/Make.config.inc $(TOP)/.git/HEAD $(TOP)/.git/index Makefile generate-workloadmanifest-json.csharp | Workloads/Microsoft.NET.Sdk.$(1)
 	$$(Q) rm -f $$@.tmp
-	$$(Q_GEN) ./generate-workloadmanifest-json.csharp "$(1)" "$(3)" "$(5)" "$$(DOTNET_$(4)_RUNTIME_IDENTIFIERS)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)"
+	$$(Q_GEN) ./generate-workloadmanifest-json.csharp "$(1)" "$(3)" "$(5)" "$$(DOTNET_$(4)_RUNTIME_IDENTIFIERS)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)" "$(DOTNET_TFM)_$$($(4)_NUGET_OS_VERSION)"
 	$$(Q) mv $$@.tmp $$@
 
 Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.targets: Workloads/WorkloadManifest.$(1).template.targets Makefile $(TOP)/Make.config.inc $(TOP)/.git/HEAD $(TOP)/.git/index | Workloads/Microsoft.NET.Sdk.$(1)
 	$$(Q) rm -f $$@.tmp
-	$$(Q_GEN) sed \
-		-e "s/@NUGET_VERSION_NO_METADATA@/$3/g" \
-		$$< > $$@.tmp
+	$$(Q_GEN) ./generate-workloadmanifest-targets.csharp "$(1)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)" "$(DOTNET_TFM)_$$($(4)_NUGET_OS_VERSION)" "net7.0" "$(DEFAULT_TARGET_PLATFORM_VERSION_$(4))"
 	$$(Q) mv $$@.tmp $$@
 
 Workloads/Microsoft.NET.Sdk.$(1)/LICENSE: $(TOP)/LICENSE | Workloads/Microsoft.NET.Sdk.$(1)
@@ -226,6 +226,13 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call NupkgDefinition,$(platform)
 
 # Create the nuget in a temporary directory (nupkgs/)
 define CreateNuGetTemplate
+nupkgs/$(1)$(4).$(DOTNET_TFM)_$($(6)_NUGET_OS_VERSION).$(2).nupkg: $(TEMPLATED_FILES) $(WORKLOAD_TARGETS) $(3) package/$(1)/package.csproj $(wildcard package/*.csproj) $(wildcard $(DOTNET_DESTDIR)/$(1)/* $(DOTNET_DESTDIR)/$(1)/*/* $(DOTNET_DESTDIR)/$(1)/*/*/* $(DOTNET_DESTDIR)/$(1)/*/*/*/*) .stamp-workaround-for-maccore-issue-2427
+	@# Delete any versions of the nuget we're building
+	$$(Q) rm -f nupkgs/$(1).*.nupkg
+	$$(Q_PACK) $(DOTNET) pack package/$(1)/package.csproj -p:VersionBand=$(5) --output "$$(dir $$@)" $(DOTNET_PACK_VERBOSITY) "/bl:$$@.binlog" /p:PackageOSTargetVersion=$(DOTNET_TFM)_$($(6)_NUGET_OS_VERSION)
+endef
+
+define CreateNuGetTemplateNoTargetFramework
 nupkgs/$(1)$(4).$(2).nupkg: $(TEMPLATED_FILES) $(WORKLOAD_TARGETS) $(3) package/$(1)/package.csproj $(wildcard package/*.csproj) $(wildcard $(DOTNET_DESTDIR)/$(1)/* $(DOTNET_DESTDIR)/$(1)/*/* $(DOTNET_DESTDIR)/$(1)/*/*/* $(DOTNET_DESTDIR)/$(1)/*/*/*/*) .stamp-workaround-for-maccore-issue-2427
 	@# Delete any versions of the nuget we're building
 	$$(Q) rm -f nupkgs/$(1).*.nupkg
@@ -236,16 +243,16 @@ define CreateWindowsNuGetTemplate
 nupkgs/$$($(6)_NUGET_WINDOWS_SDK_NAME).$(2).nupkg: $(3) $(WORKLOAD_TARGETS) package/$(1)/package.csproj $(wildcard package/*.csproj) $(wildcard $(DOTNET_DESTDIR)/$(1)/* $(DOTNET_DESTDIR)/$(1)/*/* $(DOTNET_DESTDIR)/$(1)/*/*/* $(DOTNET_DESTDIR)/$(1)/*/*/*/*) .stamp-workaround-for-maccore-issue-2427
 	@# Delete any versions of the nuget we're building
 	$$(Q) rm -f nupkgs/$(1).*.nupkg
-	$$(Q_PACK) $(DOTNET) pack package/$(1)/package.csproj --output "$$(dir $$@)" $(DOTNET_PACK_VERBOSITY) "/bl:$$@.binlog"
+	$$(Q_PACK) $(DOTNET) pack package/$(1)/package.csproj --output "$$(dir $$@)" $(DOTNET_PACK_VERBOSITY) "/bl:$$@.binlog" /p:PackageOSTargetVersion=$(DOTNET_TFM)_$($(6)_NUGET_OS_VERSION)
 endef
 
 # Create the NuGet packaging targets. It's amazing what make allows you to do...
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Sdk,$($(platform)_NUGET_VERSION_NO_METADATA),$($(platform)_NUGET_TARGETS),,$(DOTNET_VERSION_BAND))))
-$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(eval $(call CreateWindowsNuGetTemplate,Microsoft.$(platform).Windows.Sdk,$(IOS_WINDOWS_NUGET_VERSION_NO_METADATA),$($(platform)_WINDOWS_NUGET_TARGETS),,$(DOTNET_VERSION_BAND),$(platform))))
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Ref,$($(platform)_NUGET_VERSION_NO_METADATA),,,$(DOTNET_VERSION_BAND))))
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Templates,$($(platform)_NUGET_VERSION_NO_METADATA),,,$(DOTNET_VERSION_BAND))))
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.NET.Sdk.$(platform),$($(platform)_NUGET_VERSION_NO_METADATA),,.Manifest-$(MACIOS_MANIFEST_VERSION_BAND),$(MACIOS_MANIFEST_VERSION_BAND))))
-$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Runtime.$(rid),$($(platform)_NUGET_VERSION_NO_METADATA),,,$(DOTNET_VERSION_BAND)))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Sdk,$($(platform)_NUGET_VERSION_NO_METADATA),$($(platform)_NUGET_TARGETS),,$(DOTNET_VERSION_BAND),$(platform))))
+$(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(eval $(call CreateWindowsNuGetTemplate,Microsoft.$(platform).Windows.Sdk,$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_WINDOWS_NUGET_VERSION_NO_METADATA),$($(platform)_WINDOWS_NUGET_TARGETS),,$(DOTNET_VERSION_BAND),$(platform))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Ref,$($(platform)_NUGET_VERSION_NO_METADATA),,,$(DOTNET_VERSION_BAND),$(platform))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplateNoTargetFramework,Microsoft.$(platform).Templates,$($(platform)_NUGET_VERSION_NO_METADATA),,,$(DOTNET_VERSION_BAND),$(platform))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplateNoTargetFramework,Microsoft.NET.Sdk.$(platform),$($(platform)_NUGET_VERSION_NO_METADATA),,.Manifest-$(MACIOS_MANIFEST_VERSION_BAND),$(MACIOS_MANIFEST_VERSION_BAND),$(platform))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Runtime.$(rid),$($(platform)_NUGET_VERSION_NO_METADATA),,,$(DOTNET_VERSION_BAND),$(platform)))))
 
 # Copy the nuget from the temporary directory into the final directory
 $(DOTNET_NUPKG_DIR)/%.nupkg: nupkgs/%.nupkg | $(DOTNET_NUPKG_DIR)
@@ -319,8 +326,8 @@ define CreatePackage
 $(TMP_PKG_DIR)/Microsoft.$1.Workload.$2.pkg: $($(1)_NUGET_TARGETS) $(WORKLOAD_TARGETS) Makefile | $(TMP_PKG_DIR)
 	$$(Q) rm -f $$@
 	$$(Q) rm -rf tmpdir/Microsoft.NET.Sdk.$1.$2/
-	$$(Q) mkdir -p tmpdir/Microsoft.NET.Sdk.$1.$2/usr/local/share/dotnet/sdk-manifests/$(MACIOS_MANIFEST_VERSION_BAND)/
-	$$(Q) $$(CP) -r Workloads/Microsoft.NET.Sdk.$1 tmpdir/Microsoft.NET.Sdk.$1.$2/usr/local/share/dotnet/sdk-manifests/$(MACIOS_MANIFEST_VERSION_BAND)/microsoft.net.sdk.$3
+	$$(Q) mkdir -p tmpdir/Microsoft.NET.Sdk.$1.$2/usr/local/share/dotnet/sdk-manifests/$(MACIOS_MANIFEST_VERSION_BAND)/microsoft.net.sdk.$3
+	$$(Q) $$(CP) -r Workloads/Microsoft.NET.Sdk.$1 tmpdir/Microsoft.NET.Sdk.$1.$2/usr/local/share/dotnet/sdk-manifests/$(MACIOS_MANIFEST_VERSION_BAND)/microsoft.net.sdk.$3/$2
 	$$(Q_GEN) pkgbuild --quiet --version '$2' --root tmpdir/Microsoft.NET.Sdk.$1.$2 --component-plist PackageInfo.plist  --install-location / --identifier com.microsoft.net.$3.workload.pkg $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 
@@ -328,18 +335,18 @@ $(TMP_PKG_DIR)/Microsoft.$1.Workload.$2.pkg: $($(1)_NUGET_TARGETS) $(WORKLOAD_TA
 $(TMP_PKG_DIR)/$($(1)_NUGET_SDK_NAME).$2.pkg: $(SDK_PACKS_$(4)) | $(TMP_PKG_DIR)
 	$$(Q) rm -f $$@
 	$$(Q) rm -rf tmpdir/Microsoft.$1.Sdk.$2/
-	$$(Q) mkdir -p tmpdir/Microsoft.$1.Sdk.$2/usr/local/share/dotnet/packs/Microsoft.$1.Sdk/$2/
-	$$(Q) $$(CP) -r $(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/ tmpdir/Microsoft.$1.Sdk.$2/usr/local/share/dotnet/packs/Microsoft.$1.Sdk/$2/
-	$$(Q_GEN) pkgbuild --quiet --version '$2' --root tmpdir/Microsoft.$1.Sdk.$2 --component-plist PackageInfo.plist --install-location / --identifier com.microsoft.net.$3.sdk.pkg $$@.tmp
+	$$(Q) mkdir -p tmpdir/Microsoft.$1.Sdk.$2/usr/local/share/dotnet/packs/$($(1)_NUGET_SDK_NAME)/$2/
+	$$(Q) $$(CP) -r $(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/ tmpdir/Microsoft.$1.Sdk.$2/usr/local/share/dotnet/packs/$($(1)_NUGET_SDK_NAME)/$2/
+	$$(Q_GEN) pkgbuild --quiet --version '$2' --root tmpdir/Microsoft.$1.Sdk.$2 --component-plist PackageInfo.plist --install-location / --identifier com.microsoft.net.$3.sdk.$(DOTNET_TFM)_$$($(1)_NUGET_OS_VERSION).pkg $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 
 # The ref package
 $(TMP_PKG_DIR)/$($(1)_NUGET_REF_NAME).$2.pkg: $(REF_PACKS_$(4)) | $(TMP_PKG_DIR)
 	$$(Q) rm -f $$@
 	$$(Q) rm -rf tmpdir/Microsoft.$1.Ref.$2/
-	$$(Q) mkdir -p tmpdir/Microsoft.$1.Ref.$2/usr/local/share/dotnet/packs/Microsoft.$1.Ref/$2/
-	$$(Q_GEN) pkgbuild --quiet --version '$2' --root tmpdir/Microsoft.$1.Ref.$2 --component-plist PackageInfo.plist --install-location / --identifier com.microsoft.net.$3.ref.pkg $$@.tmp
-	$$(Q) $$(CP) -r $(DOTNET_DESTDIR)/$($(1)_NUGET_REF_NAME)/ tmpdir/Microsoft.$1.Ref.$2/usr/local/share/dotnet/packs/Microsoft.$1.Ref/$2/
+	$$(Q) mkdir -p tmpdir/Microsoft.$1.Ref.$2/usr/local/share/dotnet/packs/$($(1)_NUGET_REF_NAME)/$2/
+	$$(Q) $$(CP) -r $(DOTNET_DESTDIR)/$($(1)_NUGET_REF_NAME)/ tmpdir/Microsoft.$1.Ref.$2/usr/local/share/dotnet/packs/$($(1)_NUGET_REF_NAME)/$2/
+	$$(Q_GEN) pkgbuild --quiet --version '$2' --root tmpdir/Microsoft.$1.Ref.$2 --component-plist PackageInfo.plist --install-location / --identifier com.microsoft.net.$3.ref.$(DOTNET_TFM)_$$($(1)_NUGET_OS_VERSION).pkg $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 
 # The templates package

--- a/dotnet/generate-workloadmanifest-json.csharp
+++ b/dotnet/generate-workloadmanifest-json.csharp
@@ -5,18 +5,15 @@
 using System.IO;
 using System.Xml;
 
-var args = Environment.GetCommandLineArgs ();
-var expectedArgumentCount = 6;
-if (args.Length != expectedArgumentCount + 3 /* 2 default arguments (executable + script) + 'expectedArgumentCount' arguments we're interested in */) {
-	// first arg is "/Library/Frameworks/Mono.framework/Versions/4.8.0/lib/mono/4.5/csharp.exe"
-	// second arg the script itself
-	// then comes the ones we care about
-	Console.WriteLine ($"Need {expectedArgumentCount} arguments, got {args.Length - 3}");
+var args = Args;
+var expectedArgumentCount = 7;
+if (args.Length != expectedArgumentCount) {
+	Console.WriteLine ($"Need {expectedArgumentCount} arguments, got {args.Length}");
 	Environment.Exit (1);
 	return;
 }
 
-var argumentIndex = 3;
+var argumentIndex = 0;
 var platform = args [argumentIndex++];
 var version = args [argumentIndex++];
 var net7Version = args [argumentIndex++];
@@ -24,9 +21,11 @@ var runtimeIdentifiers = args [argumentIndex++].Split (new char [] { ' ' }, Stri
 var outputPath = args [argumentIndex++];
 var windowsPlatforms = args [argumentIndex++].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 var hasWindows = Array.IndexOf (windowsPlatforms, platform) >= 0;
+var currentApiVersion = args [argumentIndex++];
 
 var platformLowerCase = platform.ToLowerInvariant ();
 
+var tfm = currentApiVersion;
 using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"{{");
 	writer.WriteLine ($"	\"version\": \"{version}\",");
@@ -34,15 +33,15 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"		\"{platformLowerCase}\": {{");
 	writer.WriteLine ($"			\"description\": \".NET SDK Workload for building {platform} applications.\",");
 	writer.WriteLine ($"			\"packs\": [");
-	writer.WriteLine ($"				\"Microsoft.{platform}.Sdk.net8\",");
+	writer.WriteLine ($"				\"Microsoft.{platform}.Sdk.{tfm}\",");
 	writer.WriteLine ($"				\"Microsoft.{platform}.Sdk.net7\",");
 	if (hasWindows) {
-		writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.net8\",");
+		writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.{tfm}\",");
 		writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.net7\",");
 	}
-	writer.WriteLine ($"				\"Microsoft.{platform}.Ref\",");
+	writer.WriteLine ($"				\"Microsoft.{platform}.Ref.{tfm}\",");
 	foreach (var rid in runtimeIdentifiers) {
-		writer.WriteLine ($"				\"Microsoft.{platform}.Runtime.{rid}\",");
+		writer.WriteLine ($"				\"Microsoft.{platform}.Runtime.{rid}.{tfm}\",");
 	}
 	writer.WriteLine ($"				\"Microsoft.{platform}.Templates.net8\"");
 	writer.WriteLine ($"			],");
@@ -58,12 +57,9 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"		}},");
 	writer.WriteLine ($"	}},");
 	writer.WriteLine ($"	\"packs\": {{");
-	writer.WriteLine ($"		\"Microsoft.{platform}.Sdk.net8\": {{");
+	writer.WriteLine ($"		\"Microsoft.{platform}.Sdk.{tfm}\": {{");
 	writer.WriteLine ($"			\"kind\": \"sdk\",");
 	writer.WriteLine ($"			\"version\": \"{version}\",");
-	writer.WriteLine ($"			\"alias-to\": {{");
-	writer.WriteLine ($"				\"any\": \"Microsoft.{platform}.Sdk\"");
-	writer.WriteLine ($"			}}");
 	writer.WriteLine ($"		}},");
 	writer.WriteLine ($"		\"Microsoft.{platform}.Sdk.net7\": {{");
 	writer.WriteLine ($"			\"kind\": \"sdk\",");
@@ -73,13 +69,13 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"			}}");
 	writer.WriteLine ($"		}},");
 	if (hasWindows) {
-		writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.net8\": {{");
+		writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.{tfm}\": {{");
 		writer.WriteLine ($"			\"kind\": \"sdk\",");
 		writer.WriteLine ($"			\"version\": \"{version}\",");
 		writer.WriteLine ($"			\"alias-to\": {{");
-		writer.WriteLine ($"				\"win-x64\": \"Microsoft.{platform}.Windows.Sdk\",");
-		writer.WriteLine ($"				\"win-x86\": \"Microsoft.{platform}.Windows.Sdk\",");
-		writer.WriteLine ($"				\"win-arm64\": \"Microsoft.{platform}.Windows.Sdk\",");
+		writer.WriteLine ($"				\"win-x64\": \"Microsoft.{platform}.Windows.Sdk.{tfm}\",");
+		writer.WriteLine ($"				\"win-x86\": \"Microsoft.{platform}.Windows.Sdk.{tfm}\",");
+		writer.WriteLine ($"				\"win-arm64\": \"Microsoft.{platform}.Windows.Sdk.{tfm}\",");
 		writer.WriteLine ($"			}}");
 		writer.WriteLine ($"		}},");
 		writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.net7\": {{");
@@ -92,12 +88,12 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 		writer.WriteLine ($"			}}");
 		writer.WriteLine ($"		}},");
 	}
-	writer.WriteLine ($"		\"Microsoft.{platform}.Ref\": {{");
+	writer.WriteLine ($"		\"Microsoft.{platform}.Ref.{tfm}\": {{");
 	writer.WriteLine ($"			\"kind\": \"framework\",");
 	writer.WriteLine ($"			\"version\": \"{version}\"");
 	writer.WriteLine ($"		}},");
 	foreach (var rid in runtimeIdentifiers) {
-		writer.WriteLine ($"		\"Microsoft.{platform}.Runtime.{rid}\": {{");
+		writer.WriteLine ($"		\"Microsoft.{platform}.Runtime.{rid}.{tfm}\": {{");
 		writer.WriteLine ($"			\"kind\": \"framework\",");
 		writer.WriteLine ($"			\"version\": \"{version}\"");
 		writer.WriteLine ($"		}},");

--- a/dotnet/generate-workloadmanifest-targets.csharp
+++ b/dotnet/generate-workloadmanifest-targets.csharp
@@ -1,0 +1,68 @@
+#!/usr/bin/env /Library/Frameworks/Mono.framework/Commands/csharp -s
+
+// arguments are: <platform> <outputPath>
+
+using System.IO;
+using System.Xml;
+
+var args = Args;
+var expectedArgumentCount = 6;
+if (args.Length != expectedArgumentCount) {
+	Console.WriteLine ($"Need {expectedArgumentCount} arguments, got {args.Length}");
+	Environment.Exit (1);
+	return;
+}
+
+var argumentIndex = 0;
+var platform = args [argumentIndex++];
+var outputPath = args [argumentIndex++];
+var windowsPlatforms = args [argumentIndex++].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+var hasWindows = Array.IndexOf (windowsPlatforms, platform) >= 0;
+var currentApiVersion = args [argumentIndex++];
+var olderApiVersions = args [argumentIndex++];
+var defaultApiVersion = args [argumentIndex++];
+
+var platformLowerCase = platform.ToLowerInvariant ();
+var tfm = currentApiVersion;
+
+var supportedTFMs = new List<string> ();
+supportedTFMs.Add (currentApiVersion);
+supportedTFMs.AddRange (olderApiVersions.Split (' '));
+
+using (var writer = new StreamWriter (outputPath)) {
+	writer.WriteLine ($"<Project>");
+	writer.WriteLine ($"	<ImportGroup Condition=\" '$(TargetPlatformIdentifier)' == '{platform}' \">");
+	foreach (var tfm in supportedTFMs) {
+		var tfv = tfm.Replace ("net", "");
+		var sep = tfv.IndexOfAny (new char [] { '-', '_' });
+		if (sep >= 0)
+			tfv = tfv.Substring (0, sep);
+		var workloadVersion = tfm;
+		if (tfv [0] == '7')
+			workloadVersion = tfm.Replace (".0", "");
+		writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Sdk.{workloadVersion}\" Condition=\" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '{tfv}'))\" />");
+	}
+	if (hasWindows) {
+		writer.WriteLine ();
+		foreach (var tfm in supportedTFMs) {
+			var tfv = tfm.Replace ("net", "");
+			var sep = tfv.IndexOfAny (new char [] { '-', '_' });
+			if (sep >= 0)
+				tfv = tfv.Substring (0, tfv.IndexOfAny (new char [] { '-', '_' }));
+			var workloadVersion = tfm;
+			if (tfv [0] == '7')
+				workloadVersion = tfm.Replace (".0", "");
+			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Windows.Sdk.Aliased.{workloadVersion}\" Condition=\" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '{tfv}')) And $([MSBuild]::IsOSPlatform('windows'))\" />");
+		}
+	}
+	writer.WriteLine ($"	</ImportGroup>");
+	writer.WriteLine ();
+	writer.WriteLine ($"	<ItemGroup Condition=\" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) \">");
+	writer.WriteLine ($"		<SdkSupportedTargetPlatformIdentifier Include=\"{platformLowerCase}\" DisplayName=\"{platform}\" />");
+	writer.WriteLine ($"	</ItemGroup>");
+
+	writer.WriteLine ($"</Project>");
+	writer.WriteLine ();
+}
+
+Environment.Exit (0);

--- a/dotnet/package/microsoft.ref.csproj
+++ b/dotnet/package/microsoft.ref.csproj
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageId>Microsoft.$(_PlatformName).Ref</PackageId>
+    <PackageId>Microsoft.$(_PlatformName).Ref.$(PackageOSTargetVersion)</PackageId>
     <Description>Microsoft $(_PlatformName) reference assemblies. Please do not reference directly.</Description>
     <_CreateFrameworkList>true</_CreateFrameworkList>
   </PropertyGroup>

--- a/dotnet/package/microsoft.runtime.csproj
+++ b/dotnet/package/microsoft.runtime.csproj
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageId>Microsoft.$(_PlatformName).Runtime.$(_RuntimeIdentifier)</PackageId>
+    <PackageId>Microsoft.$(_PlatformName).Runtime.$(_RuntimeIdentifier).$(PackageOSTargetVersion)</PackageId>
     <Description>Microsoft $(_PlatformName) runtime pack for $(_RuntimeIdentifier). Please do not reference directly.</Description>
     <_CreateRuntimeList>true</_CreateRuntimeList>
   </PropertyGroup>

--- a/dotnet/package/microsoft.sdk.csproj
+++ b/dotnet/package/microsoft.sdk.csproj
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <PackageId>Microsoft.$(_PlatformName).Sdk</PackageId>
-    <PackageId Condition="'$(IsWindowsPack)' == 'true'">Microsoft.$(_PlatformName).Windows.Sdk</PackageId>
+    <PackageId>Microsoft.$(_PlatformName).Sdk.$(PackageOSTargetVersion)</PackageId>
+    <PackageId Condition="'$(IsWindowsPack)' == 'true'">Microsoft.$(_PlatformName).Windows.Sdk.$(PackageOSTargetVersion)</PackageId>
     <Description>Managed Tools and Bindings for the $(_PlatformName) SDK</Description>
   </PropertyGroup>
   <Import Project="common.csproj" />

--- a/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
+++ b/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
@@ -17,7 +17,7 @@
 
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@TARGET_FRAMEWORK_VERSION@'))">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@TARGET_FRAMEWORK_VERSION@')) And '$(CurrentHash)' == '@CURRENT_HASH_LONG@'">
 		<!-- Default plist file inclusion -->
 		<None Include="*.plist">
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>

--- a/dotnet/targets/Microsoft.Sdk.Versions.template.props
+++ b/dotnet/targets/Microsoft.Sdk.Versions.template.props
@@ -8,6 +8,8 @@
 		<_PackageVersion>@NUGET_VERSION_FULL@</_PackageVersion>
 		<_DefaultTargetPlatformVersion>@DEFAULT_TARGET_PLATFORM_VERSION@</_DefaultTargetPlatformVersion>
 		<_XamarinIsPreviewRelease>@XCODE_IS_PREVIEW@</_XamarinIsPreviewRelease>
+		<_XamarinDotNetVersion>@DOTNET_TFM@</_XamarinDotNetVersion>
+		<_XamarinPackSuffix>@DOTNET_TFM@_@NUGET_OS_VERSION@</_XamarinPackSuffix>
 	</PropertyGroup>
 
 	<ItemGroup>@VALID_RUNTIME_IDENTIFIERS@
@@ -21,9 +23,9 @@
 			RuntimeFrameworkName="Microsoft.@PLATFORM@"
 			DefaultRuntimeFrameworkVersion="@NUGET_VERSION_NO_METADATA@"
 			LatestRuntimeFrameworkVersion="@NUGET_VERSION_NO_METADATA@"
-			TargetingPackName="Microsoft.@PLATFORM@.Ref"
+			TargetingPackName="Microsoft.@PLATFORM@.Ref.@DOTNET_TFM@_@NUGET_OS_VERSION@"
 			TargetingPackVersion="@NUGET_VERSION_NO_METADATA@"
-			RuntimePackNamePatterns="Microsoft.@PLATFORM@.Runtime.**RID**"
+			RuntimePackNamePatterns="Microsoft.@PLATFORM@.Runtime.**RID**.@DOTNET_TFM@_@NUGET_OS_VERSION@"
 			RuntimePackRuntimeIdentifiers="@RUNTIME_PACK_RUNTIME_IDENTIFIERS@"
 			Profile="@PLATFORM@"
 		/>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -954,7 +954,7 @@
 			<_PackageIdInfix Condition="'$(_XamarinRuntime)' == 'NativeAOT'">NativeAOT.</_PackageIdInfix>
 
 			<_MonoNugetPackageId>Microsoft.NETCore.App.Runtime.$(_PackageIdInfix)$(RuntimeIdentifier)</_MonoNugetPackageId>
-			<_XamarinNugetPackageId>Microsoft.$(_PlatformName).Runtime.$(RuntimeIdentifier)</_XamarinNugetPackageId>
+			<_XamarinNugetPackageId>Microsoft.$(_PlatformName).Runtime.$(RuntimeIdentifier).$(_XamarinPackSuffix)</_XamarinNugetPackageId>
 		</PropertyGroup>
 		<ItemGroup>
 			<!-- Look in the ResolvedFrameworkReference for our Microsoft.* package. This should only find a single package. -->

--- a/release/Makefile
+++ b/release/Makefile
@@ -180,7 +180,17 @@ ifdef INCLUDE_XAMARIN_LEGACY
 	if test -d $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono; then cd $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono     && zip -9 -r $(CURDIR)/bundle.zip .; fi
 endif
 ifdef ENABLE_DOTNET
-	cd $(DOTNET_DESTDIR) && zip -9 -r $(CURDIR)/bundle.zip $(foreach platform,$(DOTNET_PLATFORMS),./Microsoft.$(platform).Ref/ref/)
+	$(foreach platform,$(DOTNET_PLATFORMS),export $(platform)_NUGET_REF_NAME=$($(platform)_NUGET_REF_NAME);) \
+	for platform in $(DOTNET_PLATFORMS); do \
+		cd $(CURDIR); \
+		rm -rf tmpdir; \
+		mkdir -p Microsoft.$$platform.Ref/; \
+		TMPVAR=$${platform}_NUGET_REF_NAME; \
+		$(CP) -r $(DOTNET_DESTDIR)/$${!TMPVAR}/ref Microsoft.$$platform.Ref; \
+		cd tmpdir; \
+		zip -9 -r $(CURDIR)/bundle.zip ./Microsoft.$$platform.Ref/ref/; \
+		rm -rf tmpdir; \
+	done
 endif
 	zip -9 $@ Version Version.rev
 

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -532,9 +532,13 @@ $(APIDIFF_DIR)/references/dotnet/Microsoft.$(1).Ref/ref/$(DOTNET_TFM_REFERENCE)/
 endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call DotNetGenerateReferenceXml,$(platform))))
 
-$(APIDIFF_DIR)/updated-references/dotnet/%.xml: $(DOTNET_DESTDIR)/%.dll $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/dotnet/$*)
-	$(QF_GEN) $(MONO_API_INFO_EXEC) $(abspath $<) -o $(abspath $(APIDIFF_DIR)/references/dotnet/$*.xml)
+define UpdatedReferences
+$(APIDIFF_DIR)/updated-references/dotnet/Microsoft.$(1).Ref/ref/$(DOTNET_TFM)/Microsoft.$(1).xml: $(DOTNET_DESTDIR)/$($(1)_NUGET_REF_NAME)/ref/$(DOTNET_TFM)/Microsoft.$(1).dll $(MONO_API_INFO)
+	$$(Q) mkdir -p $$(dir $$@) $$(dir $$(APIDIFF_DIR)/references/dotnet/Microsoft.$(1).Ref/ref/$(DOTNET_TFM)/Microsoft.$(1).Ref)
+	$$(QF_GEN) $$(MONO_API_INFO_EXEC) $$(abspath $$<) -o $$(abspath $$(APIDIFF_DIR)/references/dotnet/Microsoft.$(1).Ref/ref/$(DOTNET_TFM)/Microsoft.$(1).xml)
+endef
+
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call UpdatedReferences,$(platform))))
 
 update-tvos-refs: $(TVOS_REFS)
 update-watchos-refs: $(WATCHOS_REFS)


### PR DESCRIPTION
This is the first step towards [multi-targeting support][1]. In order to
support multi-targeting, it must be possible to install several versions of
our packs simultaneously, and that also means that it becomes a lot easier to
visualize and work with the version we want to support if the packs were named
in a helpful way.

In particular, this PR changes the sdk, ref and runtime pack names to contain
the target framework + target platform version.

This will be the new names:

* iOS

    * Microsoft.iOS.Sdk.net8.0_17.0
    * Microsoft.iOS.Ref.net8.0_17.0
    * Microsoft.iOS.Runtime.ios-arm64.net8.0_17.0
    * Microsoft.iOS.Runtime.iossimulator-arm64.net8.0_17.0
    * Microsoft.iOS.Runtime.iossimulator-x64.net8.0_17.0

* tvOS

    * Microsoft.tvOS.Sdk.net8.0_17.0
    * Microsoft.tvOS.Ref.net8.0_17.0
    * Microsoft.tvOS.Runtime.ios-arm64.net8.0_17.0
    * Microsoft.tvOS.Runtime.iossimulator-arm64.net8.0_17.0
    * Microsoft.tvOS.Runtime.iossimulator-x64.net8.0_17.0

* Mac Catalyst

    * Microsoft.MacCatalyst.Sdk.net8.0_17.0
    * Microsoft.MacCatalyst.Ref.net8.0_17.0
    * Microsoft.MacCatalyst.Runtime.maccatalyst-x64.net8.0_17.0
    * Microsoft.MacCatalyst.Runtime.maccatalyst-arm64.net8.0_17.0

* macOS

    * Microsoft.macOS.Sdk.net8.0_14.0
    * Microsoft.macOS.Ref.net8.0_14.0
    * Microsoft.macOS.Runtime.osx-x64.net8.0_14.0
    * Microsoft.macOS.Runtime.osx-arm64.net8.0_14.0

There are two main benefits to renaming the packs:

* It becomes a lot easier to understand which versions we support when we
  support multi-targeting. For example, say we want to support:

	* net8.0-ios17.0
	* net8.0-ios17.0
	* net9.0-ios18.0

    In this case we'd ship packs for `Microsoft.iOS.Sdk.net8.0_17.0`,
    `Microsoft.iOS.Sdk.net8.0_17.0`, `Microsoft.iOS.Sdk.net9.0_18.0` (the
    exact version number for each pack wouldn't be important).

    If we didn't change the pack names, we'd need to track the exact versions
    of the Microsoft.iOS.Sdk pack, mapping them to the correct target
    framework + target platform version we want to support.

* It'll be possible to add maestro subscriptions between versions. Given the
  previous example:

	* net8.0-ios17.0
	* net8.0-ios17.0
	* net9.0-ios18.0

	The branch producing `net9.0-ios8.0` could have a maestro subscription on
	the branches producing `net7.0-ios17.0` and `net7.0-ios17.0`,
	automatically bumping the versions whenever those branches have any
	changes.

	This would be rather annoying to keep track of and bump manually.

[1]: https://github.com/xamarin/xamarin-macios/blob/main/docs/multi-target-framework.md

Backport of #19765.