### PR TITLE
[GitOps] Automatically close inactive community pull requests after 28 days.

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -79,6 +79,39 @@ configuration:
           reply: This issue is being closed due to inactivity. If this issue is still affecting you, please follow the steps above to use the VS Feedback Tool to report the issue.
       - closeIssue
 
+    - description: Add comment letting user know their PR is out of date.
+      frequencies:
+      - weekday:
+          day: Monday
+          time: 0:0
+      filters:
+      - isPullRequest
+      - isOpen
+      - hasLabel:
+          label: community
+      - noActivitySince:
+          days: 21
+      actions:
+      - addReply:
+          reply: Hi @{issueAuthor}. Due to inactivity, we will close this pull request in 7 days.
+
+    - description: Closing out-of-date community PRs.
+      frequencies:
+      - weekday:
+          day: Monday
+          time: 0:0
+      filters:
+      - isPullRequest
+      - isOpen
+      - hasLabel:
+          label: community
+      - noActivitySince:
+          days: 28
+      actions:
+      - closePullRequest
+      - addReply:
+          reply: Hi @{issueAuthor}. This pull request was closed due to inactivity. Please let us know if you'd like to reopen it.
+
     eventResponderTasks:
 
     - if:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -108,9 +108,9 @@ configuration:
       - noActivitySince:
           days: 28
       actions:
-      - closePullRequest
       - addReply:
           reply: Hi @{issueAuthor}. This pull request was closed due to inactivity. Please let us know if you'd like to reopen it.
+      - closePullRequest
 
     eventResponderTasks:
 


### PR DESCRIPTION
For any pull request with the 'community' label:

1. After 21 days of inactivity: give a warning that the pull request is out of date and will be closed.
2. After 28 days of inactivity: close the pull request.

Only check once a week (every Monday - there's no hurry here), so there may be
an additional 6 days until the inactivity workflow is triggered (if the last
action occurred on a Tuesday)

Unanswered question: I'm not sure if the first action will be considered as
some activity, in which case the second action will only happen in 21 + 28
days = 49 days. It doesn't really matter; the important part is that pull
requests are automatically closed after some time (and 49 days - even 55 days
- is still way better than now, which can be years).