### PR TITLE
[devops] Include the stage attempt in the artifact name for uploaded (bin)logs.

### DIFF
--- a/tools/devops/automation/templates/build/build-mac-tests.yml
+++ b/tools/devops/automation/templates/build/build-mac-tests.yml
@@ -87,6 +87,6 @@ steps:
         displayName: 'Publish Artifact: All binlogs'
         inputs:
           targetPath: $(Build.ArtifactStagingDirectory)/mactests-binlogs
-          artifactName: '${{ parameters.uploadPrefix }}mactests-binlogs-$(Build.BuildId)-$(System.JobAttempt)'
+          artifactName: '${{ parameters.uploadPrefix }}mactests-binlogs-$(Build.BuildId)-$(System.StageAttempt)-$(System.JobAttempt)'
         continueOnError: true
         condition: succeededOrFailed()

--- a/tools/devops/automation/templates/build/build-nugets.yml
+++ b/tools/devops/automation/templates/build/build-nugets.yml
@@ -54,6 +54,6 @@ steps:
   displayName: 'Publish Artifact: build-binlogs'
   inputs:
     targetPath: $(Build.ArtifactStagingDirectory)/build-binlogs
-    artifactName: ${{ parameters.uploadPrefix }}build-binlogs-$(Build.BuildId)-$(System.JobAttempt)
+    artifactName: ${{ parameters.uploadPrefix }}build-binlogs-$(Build.BuildId)-$(System.StageAttempt)-$(System.JobAttempt)
   continueOnError: true
   condition: and(succeededOrFailed(), contains(variables['configuration.BuildNugets'], 'True'), ne(variables['ENABLE_DOTNET'],''))

--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -159,6 +159,6 @@ steps:
         displayName: 'Publish Artifact: All binlogs'
         inputs:
           targetPath: $(Build.ArtifactStagingDirectory)/all-binlogs
-          artifactName: '${{ parameters.uploadPrefix }}all-binlogs-$(Build.BuildId)-$(System.JobAttempt)'
+          artifactName: '${{ parameters.uploadPrefix }}all-binlogs-$(Build.BuildId)-$(System.StageAttempt)-$(System.JobAttempt)'
         continueOnError: true
         condition: succeededOrFailed()

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -201,7 +201,7 @@ steps:
   displayName: 'Publish Artifact: Simulator diagnostic info'
   inputs:
     targetPath: $(System.DefaultWorkingDirectory)/diagnostic-sim-output
-    artifactName: '${{ parameters.uploadPrefix }}diagnostic-simulator-info-$(Build.BuildId)-$(System.JobAttempt)-${{ parameters.labelWithPlatform }}'
+    artifactName: '${{ parameters.uploadPrefix }}diagnostic-simulator-info-$(Build.BuildId)-$(System.StageAttempt)-$(System.JobAttempt)-${{ parameters.labelWithPlatform }}'
   condition: and(eq(variables['system.debug'], true), succeededOrFailed())
   continueOnError: true
 
@@ -312,7 +312,7 @@ steps:
   displayName: 'Publish Artifact: All binlogs'
   inputs:
     targetPath: $(Build.ArtifactStagingDirectory)/all-binlogs
-    artifactName: ${{ parameters.uploadPrefix }}all-binlogs-test-${{ parameters.testPrefix }}-$(Build.BuildId)-$(System.JobAttempt)
+    artifactName: ${{ parameters.uploadPrefix }}all-binlogs-test-${{ parameters.testPrefix }}-$(Build.BuildId)-$(System.StageAttempt)-$(System.JobAttempt)
   continueOnError: true
   condition: succeededOrFailed()
 

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -297,7 +297,7 @@ steps:
   displayName: 'Publish Artifact: Windows binlogs'
   inputs:
     targetPath: $(Build.ArtifactStagingDirectory)/windows-binlogs
-    artifactName: windows-binlogs-test-$(Build.BuildId)-$(System.JobAttempt)
+    artifactName: windows-binlogs-test-$(Build.BuildId)-$(System.StageAttempt)-$(System.StageAttempt)-$(System.JobAttempt)
   continueOnError: true
   condition: succeededOrFailed()
 


### PR DESCRIPTION
The stage attempt number increases every time the entire stage is rerun (which
must happen for the Windows tests stage for instance, but can happen for other
stages as well).