### PR TITLE
[msbuild] Copy extracted files from the DecompressXpcServices target back to Windows.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2078,6 +2078,7 @@
 		<Unzip
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true'"
+			CopyToWindows="true"
 			ZipFilePath="%(_CompressedXpcServices.Identity)"
 			ExtractionPath="%(_CompressedXpcServices.ExtractionPath)"
 			>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Unzip.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Unzip.cs
@@ -22,6 +22,9 @@ namespace Xamarin.MacDev.Tasks {
 	/// This task works on Windows too, but if the task encounters a symlink while extracting, an error will be shown.
 	/// </summary>
 	public class Unzip : XamarinTask, ITaskCallback {
+		// If we should copy the extracted files to Windows (as opposed to just creating an empty output file).
+		public bool CopyToWindows { get; set; }
+
 		[Required]
 		public ITaskItem? ZipFilePath { get; set; }
 
@@ -37,8 +40,15 @@ namespace Xamarin.MacDev.Tasks {
 
 		public override bool Execute ()
 		{
-			if (ShouldExecuteRemotely ())
-				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+			if (ShouldExecuteRemotely ()) {
+				var taskRunner = new TaskRunner (SessionId, BuildEngine4);
+				var rv = taskRunner.RunAsync (this).Result;
+
+				if (rv && CopyToWindows)
+					CopyFilesToWindowsAsync (taskRunner, TouchedFiles).Wait ();
+
+				return rv;
+			}
 
 			return ExecuteLocally ();
 		}
@@ -51,7 +61,12 @@ namespace Xamarin.MacDev.Tasks {
 
 		public bool ShouldCopyToBuildServer (ITaskItem item) => true;
 
-		public bool ShouldCreateOutputFile (ITaskItem item) => true;
+		public bool ShouldCreateOutputFile (ITaskItem item)
+		{
+			if (CopyToWindows)
+				return Array.IndexOf (TouchedFiles, item) == -1;
+			return true;
+		}
 
 		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 
 using Xamarin.Localization.MSBuild;
+using Xamarin.Messaging.Build.Client;
 using Xamarin.Utils;
 using static Xamarin.Bundler.FileCopier;
 
@@ -243,6 +244,14 @@ namespace Xamarin.MacDev.Tasks {
 		protected internal static IEnumerable<ITaskItem> CreateItemsForAllFilesRecursively (IEnumerable<ITaskItem>? directories)
 		{
 			return CreateItemsForAllFilesRecursively (directories?.Select (v => v.ItemSpec));
+		}
+
+		internal async global::System.Threading.Tasks.Task CopyFilesToWindowsAsync (TaskRunner runner, IEnumerable<ITaskItem> items)
+		{
+			foreach (var item in items) {
+				Log.LogMessage (MessageImportance.Low, $"Copying {item.ItemSpec} from the remote Mac to Windows");
+				await runner.GetFileAsync (this, item.ItemSpec).ConfigureAwait (false);
+			}
 		}
 	}
 }


### PR DESCRIPTION
The extracted files show up in the build later on, and if only the 0-length
mirror file exists on Windows, it'll be copied as such to the Mac, producing
incorrect build results.