### PR TITLE
[tests] Make the 'run-tests' and 'run-unit-tests' targets equivalent.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -131,7 +131,7 @@ clean-local::
 
 ## run targets = build + [install] + exec
 
-run run-all run-tests run-test:
+run run-all run-tests run-test run-unit-tests:
 	$(Q) for subdir in $(SUBDIRS); do \
 		$(MAKE) -C $$subdir run || exit 1; \
 	done

--- a/tests/bgen/Makefile
+++ b/tests/bgen/Makefile
@@ -1,5 +1,5 @@
 TOP=../..
 include $(TOP)/Make.config
 
-run-tests:
+run-tests run-unit-tests:
 	$(DOTNET) test $(TEST_FILTER)

--- a/tests/cecil-tests/Makefile
+++ b/tests/cecil-tests/Makefile
@@ -7,7 +7,7 @@ all-local::
 build:
 	$(Q) $(DOTNET) build $(DOTNET_BUILD_VERBOSITY) /bl
 
-run-tests: build
+run-tests run-unit-tests: build
 	$(DOTNET) test $(abspath $(TOP)/tests/cecil-tests/bin/Debug/$(DOTNET_TFM)/cecil-tests.dll) $(TEST_NAME) '--logger:console;verbosity=detailed'
 
 clean:

--- a/tests/dotnet/Makefile
+++ b/tests/dotnet/Makefile
@@ -4,7 +4,7 @@ include $(TOP)/Make.config
 
 TARGETS += \
 
-run-unit-tests:
+run-tests run-unit-tests:
 	$(MAKE) -C UnitTests $@
 
 all-local:: $(TARGETS)

--- a/tests/dotnet/UnitTests/Makefile
+++ b/tests/dotnet/UnitTests/Makefile
@@ -12,7 +12,7 @@ publish:
 # Example TEST_FILTER:
 #    TEST_FILTER="--filter FullyQualifiedName~BuildMyCocoaApp"
 # Docs: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test#filter-option-details
-run-unit-tests:
+run-tests run-unit-tests:
 	$(DOTNET) test DotNetUnitTests.csproj $(TEST_FILTER)
 
 run-published:

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -8,7 +8,7 @@ build-unit-tests:
 	$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore $(TOP)/src/generator.sln
 	$(SYSTEM_MSBUILD) generator-tests.csproj $(XBUILD_VERBOSITY)
 
-run-unit-tests: build-unit-tests
+run-tests run-unit-tests: build-unit-tests
 	rm -f .failed-stamp
 	$(TOP)/tools/nunit3-console-3.11.1 $(abspath $(TOP)/tests/generator/bin/Debug/generator-tests.dll) "--result=$(abspath $(CURDIR)/TestResult.xml);format=nunit2" $(TEST_FIXTURE) --labels=After || touch $(CURDIR)/.failed-stamp
 	@# Create an html file and tell MonkeyWrench to upload it (if we're running there)

--- a/tests/mtouch/Makefile
+++ b/tests/mtouch/Makefile
@@ -18,7 +18,7 @@ all-local::
 # or multiple tests:
 #     make run-tests TEST_FIXTURE="-test=Xamarin.MTouch.MT1016,Xamarin.MTouch.MT1017"
 
-run-tests: bin/Debug/mtouchtests.dll test.config
+run-tests run-unit-tests: bin/Debug/mtouchtests.dll test.config
 	rm -f .failed-stamp
 	$(TOP)/tools/nunit3-console-3.11.1 "$(abspath $<)" "--result=$(abspath $(CURDIR)/TestResult.xml);format=nunit2" $(TEST_FIXTURE) --labels=After --inprocess || touch $(CURDIR)/.failed-stamp
 	@# Create an html file and tell MonkeyWrench to upload it (if we're running there)

--- a/tools/devops/automation/scripts/Makefile
+++ b/tools/devops/automation/scripts/Makefile
@@ -1,5 +1,5 @@
 TOP=../../../..
 include $(TOP)/Make.config
 
-run-tests:
+run-tests run-unit-tests:
 	$(Q_GEN) pwsh -Command "Install-Module -AcceptLicense -Force -AllowClobber Pester;Invoke-Pester"


### PR DESCRIPTION
I keep forgetting which makefile / test suite uses which run-* target, so just
make both work everywhere.