### PR TITLE
[CI] Use the APIScan dedicated pool.

### DIFF
--- a/tools/devops/automation/templates/governance/stage.yml
+++ b/tools/devops/automation/templates/governance/stage.yml
@@ -26,7 +26,10 @@ stages:
   - job: apiscan
     displayName: 'APIScan:' 
     timeoutInMinutes: 1000
-    pool: MAUI-1ESPT-Windows2022
+    pool:
+      name: MAUI-1ESPT
+      demands:
+      - ImageOverride -equals 1ESPT-Windows2022
 
     strategy:
       matrix: $[ stageDependencies.configure_build.configure.outputs['apiscan_matrix.APISCAN_MATRIX'] ]

--- a/tools/devops/automation/templates/governance/stage.yml
+++ b/tools/devops/automation/templates/governance/stage.yml
@@ -26,7 +26,7 @@ stages:
   - job: apiscan
     displayName: 'APIScan:' 
     timeoutInMinutes: 1000
-    pool: VSEngSS-MicroBuild2022-1ES
+    pool: MAUI-1ESPT-Windows2022
 
     strategy:
       matrix: $[ stageDependencies.configure_build.configure.outputs['apiscan_matrix.APISCAN_MATRIX'] ]


### PR DESCRIPTION
We have split the workloads in two pools:

1. VSEngSS-MicroBuild2022-1ES - Signing dedicated.
2. MAUI-1ESPT-Windows2022 - APIScan dedicated.

This allows to manage machines better and we could request better machines if needed for APIScan.