### PR TITLE
[tests] Show the binlog we failed to parse.

### DIFF
--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -255,7 +255,7 @@ namespace Xamarin.Tests {
 									msg.AppendLine ($"    {string.Join ($"{Environment.NewLine}        ", error.ToString ().Split ('\n', '\r'))}");
 							}
 						} catch (Exception e) {
-							msg.AppendLine ($"Failed to list errors: {e}");
+							msg.AppendLine ($"Failed to list errors in the binlog {binlogPath}: {e}");
 						}
 #endif
 						Assert.Fail (msg.ToString ());


### PR DESCRIPTION
This makes it easier to find it on disk when something goes wrong.