### PR TITLE
[msbuild] Make the level of parallelism in the codesign task configureable.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1545,4 +1545,13 @@
             {0}: the path to a file
         </comment>
     </data>
+
+    <data name="W7121" xml:space="preserve">
+        <value>Unable to parse the value '{0}' for the property 'MaxDegreeOfParallelism'. Falling back to the default value (number of processors / 2).</value>
+        <comment>
+            {0}: a developer-supplied property value.
+            MaxDegreeOfParallelism: name of the property (do not translate)
+        </comment>
+    </data>
+
 </root>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2257,6 +2257,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<Codesign
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
+			MaxDegreeOfParallelism="$(CodesignMaxDegreeOfParallelism)"
 			Resources="@(_ComputedCodesignItems)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"


### PR DESCRIPTION
We currently have an issue with codesigning duplicated files in parallel
(#20193). The proper fix is somewhat complex, so this implements a simple
workaround for customers, where they can just disable parallelism if they run
into this problem (and since it's simple, it's easier to backport too).

Additionally, it's not a bad idea to be able to configure the level of parallelism.

Ref: #20193.