### PR TITLE
[release/8.0.1xx-xcode15.1] [msbuild] Make the level of parallelism in the codesign task configureable.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1533,4 +1533,13 @@
             {0}: the path to an assembly
         </comment>
     </data>
+
+    <data name="W7121" xml:space="preserve">
+        <value>Unable to parse the value '{0}' for the property 'MaxDegreeOfParallelism'. Falling back to the default value (number of processors / 2).</value>
+        <comment>
+            {0}: a developer-supplied property value.
+            MaxDegreeOfParallelism: name of the property (do not translate)
+        </comment>
+    </data>
+
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CodesignTaskBase.cs
@@ -50,6 +50,10 @@ namespace Xamarin.MacDev.Tasks {
 		// Can also be specified per resource using the 'CodesignDeep' metadata (yes, the naming difference is correct and due to historical reasons)
 		public bool IsAppExtension { get; set; }
 
+		// How many codesign tasks we execute in parallel. Default is number of processors / 2.
+		// Contrary to many of the other codesigning properties, this can not be set per resource.
+		public string MaxDegreeOfParallelism { get; set; }
+
 		// Can also be specified per resource using the 'CodesignUseHardenedRuntime' metadata
 		public bool UseHardenedRuntime { get; set; }
 
@@ -94,6 +98,16 @@ namespace Xamarin.MacDev.Tasks {
 		string GetCodesignAllocate (ITaskItem item)
 		{
 			return GetNonEmptyStringOrFallback (item, "CodesignAllocate", CodesignAllocate, "CodesignAllocate", required: true);
+		}
+
+		int GetMaxDegreeOfParallelism ()
+		{
+			if (!string.IsNullOrEmpty (MaxDegreeOfParallelism)) {
+				if (int.TryParse (MaxDegreeOfParallelism, out var max))
+					return max;
+				Log.LogWarning (MSBStrings.W7121 /* Unable to parse the value '{0}' for the property 'MaxDegreeOfParallelism'. Falling back to the default value (number of processors / 2). */, MaxDegreeOfParallelism);
+			}
+			return Math.Max (Environment.ProcessorCount / 2, 1);
 		}
 
 		// 'sortedItems' is sorted by length of path, longest first.
@@ -460,7 +474,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			for (var b = 0; b < buckets.Count; b++) {
 				var bucket = buckets [b];
-				Parallel.ForEach (bucket, new ParallelOptions { MaxDegreeOfParallelism = Math.Max (Environment.ProcessorCount / 2, 1) }, (item) => {
+				Parallel.ForEach (bucket, new ParallelOptions { MaxDegreeOfParallelism = GetMaxDegreeOfParallelism () }, (item) => {
 					Codesign (item);
 
 					var files = GetCodesignedFiles (item.Item);

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2257,6 +2257,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<Codesign
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
+			MaxDegreeOfParallelism="$(CodesignMaxDegreeOfParallelism)"
 			Resources="@(_ComputedCodesignItems)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"


### PR DESCRIPTION
We currently have an issue with codesigning duplicated files in parallel
(#20193). The proper fix is somewhat complex, so this implements a simple
workaround for customers, where they can just disable parallelism if they run
into this problem (and since it's simple, it's easier to backport too).

Additionally, it's not a bad idea to be able to configure the level of parallelism.

Ref: #20193.

Backport of #20242.