### PR TITLE
[dotnet] Show a better error when using a .NET framework version we don't support yet.

### DIFF
--- a/dotnet/generate-workloadmanifest-targets.csharp
+++ b/dotnet/generate-workloadmanifest-targets.csharp
@@ -66,8 +66,10 @@ using (var writer = new StreamWriter (outputPath)) {
 	}
 
 	var earliestSupportedTFV = supportedTFVs.Select (v => Version.Parse (v)).OrderBy (v => v).First ();
+	var latestSupportedTFV = supportedTFVs.Select (v => Version.Parse (v)).OrderBy (v => v).Last ();
 	writer.WriteLine ($"	<ImportGroup Condition=\" '$(TargetPlatformIdentifier)' == '{platform}' And '$(UsingAppleNETSdk)' != 'true'\">");
 	writer.WriteLine ($"		<Import Project=\"Sdk-eol.props\" Sdk=\"Microsoft.{platform}.Sdk.{tfm}\" Condition=\" $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '{earliestSupportedTFV}'))\" />");
+	writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Sdk.{tfm}\" Condition=\" $([MSBuild]::VersionGreaterThan($(TargetFrameworkVersion), '{latestSupportedTFV}'))\" />");
 	writer.WriteLine ($"	</ImportGroup>");
 	writer.WriteLine ();
 	writer.WriteLine ($"	<ItemGroup Condition=\" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) \">");

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1150,6 +1150,36 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64")]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
+		public void BuildNetFutureApp (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			// Builds an app with a higher .NET version than we support (for instance 'net9.0-ios' when we support 'net8.0-ios')
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var majorNetVersion = Version.Parse (Configuration.DotNetTfm.Replace ("net", "")).Major;
+			var netVersion = $"net{majorNetVersion + 1}.0";
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, netVersion: netVersion);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			var targetFramework = platform.ToFramework (netVersion);
+			properties ["TargetFramework"] = targetFramework;
+			properties ["ExcludeNUnitLiteReference"] = "true";
+			properties ["ExcludeTouchUnitReference"] = "true";
+
+			var result = DotNet.AssertBuildFailure (project_path, properties);
+			var errors = BinLog.GetBuildLogErrors (result.BinLogPath).ToList ();
+
+			AssertErrorMessages (errors,
+				$"The current .NET SDK does not support targeting .NET {majorNetVersion + 1}.0.  Either target .NET {majorNetVersion}.0 or lower, or use a version of the .NET SDK that supports .NET {majorNetVersion + 1}.0. Download the .NET SDK from https://aka.ms/dotnet/download");
+		}
+
+		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
+		[TestCase (ApplePlatform.iOS, "ios-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
 		public void BuildNet7_0App (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "Net7_0SimpleApp";


### PR DESCRIPTION
If a project tried to use a .NET 9 project (say TargetFramework=net9.0-ios), then
we used to show these rather unhelpful errors:

    error NETSDK1147: The target platform identifier ios was not recognized.

The underlying problem is that we don't support .NET 9 yet, so with this fix we now show:

    error NETSDK1202: The current .NET SDK does not support targeting .NET 9.0. Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 9.0. Download the .NET SDK from https://aka.ms/dotnet/download

which is much more helpful.

This is accomplished by loading our workload even when using newer .NET
versions we don't support, because the .NET build logic will show the better
error later on.