### PR TITLE
[msbuild] Make the level of parallelism configurable in all tasks that call Parallel.ForEach. Fixes #20210.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1261,6 +1261,7 @@
 			Assemblies="@(_AssembliesToAOT)"
 			AOTCompilerPath="$(_XamarinAOTCompiler)"
 			InputDirectory="$(_AOTInputDirectory)"
+			MaxDegreeOfParallelism="$(AotCompileMaxDegreeOfParallelism)"
 			MinimumOSVersion="$(_MinimumOSVersion)"
 			OutputDirectory="$(_AOTOutputDirectory)\%(_AssembliesToAOT.Arch)"
 			SdkDevPath="$(_SdkDevPath)"

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/AOTCompile.cs
@@ -16,7 +16,7 @@ using Xamarin.Utils;
 #nullable enable
 
 namespace Xamarin.MacDev.Tasks {
-	public class AOTCompile : XamarinTask, ITaskCallback, ICancelableTask {
+	public class AOTCompile : XamarinParallelTask, ITaskCallback, ICancelableTask {
 		public ITaskItem [] AotArguments { get; set; } = Array.Empty<ITaskItem> ();
 
 		[Required]
@@ -314,7 +314,7 @@ namespace Xamarin.MacDev.Tasks {
 				listOfArguments.Add (new (arguments, input));
 			}
 
-			Parallel.ForEach (listOfArguments, (arg) => {
+			ForEach (listOfArguments, (arg) => {
 				ExecuteAsync (AOTCompilerPath, arg.Arguments, sdkDevPath: SdkDevPath, showErrorIfFailure: false /* we show our own error below */)
 					.ContinueWith ((v) => {
 						if (v.Result.ExitCode != 0)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
@@ -17,7 +17,7 @@ using Xamarin.Utils;
 #nullable disable
 
 namespace Xamarin.MacDev.Tasks {
-	public class Codesign : XamarinTask, ITaskCallback, ICancelableTask {
+	public class Codesign : XamarinParallelTask, ITaskCallback, ICancelableTask {
 		const string ToolName = "codesign";
 		const string MacOSDirName = "MacOS";
 		const string CodeSignatureDirName = "_CodeSignature";
@@ -54,10 +54,6 @@ namespace Xamarin.MacDev.Tasks {
 
 		// Can also be specified per resource using the 'CodesignDeep' metadata (yes, the naming difference is correct and due to historical reasons)
 		public bool IsAppExtension { get; set; }
-
-		// How many codesign tasks we execute in parallel. Default is number of processors / 2.
-		// Contrary to many of the other codesigning properties, this can not be set per resource.
-		public string MaxDegreeOfParallelism { get; set; }
 
 		// Can also be specified per resource using the 'CodesignUseHardenedRuntime' metadata
 		public bool UseHardenedRuntime { get; set; }
@@ -103,16 +99,6 @@ namespace Xamarin.MacDev.Tasks {
 		string GetCodesignAllocate (ITaskItem item)
 		{
 			return GetNonEmptyStringOrFallback (item, "CodesignAllocate", CodesignAllocate, "CodesignAllocate", required: true);
-		}
-
-		int GetMaxDegreeOfParallelism ()
-		{
-			if (!string.IsNullOrEmpty (MaxDegreeOfParallelism)) {
-				if (int.TryParse (MaxDegreeOfParallelism, out var max))
-					return max;
-				Log.LogWarning (MSBStrings.W7121 /* Unable to parse the value '{0}' for the property 'MaxDegreeOfParallelism'. Falling back to the default value (number of processors / 2). */, MaxDegreeOfParallelism);
-			}
-			return Math.Max (Environment.ProcessorCount / 2, 1);
 		}
 
 		// 'sortedItems' is sorted by length of path, longest first.
@@ -482,7 +468,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			for (var b = 0; b < buckets.Count; b++) {
 				var bucket = buckets [b];
-				Parallel.ForEach (bucket, new ParallelOptions { MaxDegreeOfParallelism = GetMaxDegreeOfParallelism () }, (item) => {
+				ForEach (bucket, (item) => {
 					Sign (item);
 
 					var files = GetCodesignedFiles (item.Item);

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ScnTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ScnTool.cs
@@ -10,7 +10,7 @@ using Xamarin.Messaging.Build.Client;
 using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks {
-	public class ScnTool : XamarinTask {
+	public class ScnTool : XamarinParallelTask {
 		#region Inputs
 
 		[Required]
@@ -95,7 +95,7 @@ namespace Xamarin.MacDev.Tasks {
 				bundleResources.Add (bundleResource);
 			}
 
-			Parallel.ForEach (listOfArguments, (arg) => {
+			ForEach (listOfArguments, (arg) => {
 				ExecuteAsync ("xcrun", arg.Arguments, sdkDevPath: SdkDevPath).Wait ();
 			});
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/SymbolStrip.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/SymbolStrip.cs
@@ -12,7 +12,7 @@ using Xamarin.Messaging.Build.Client;
 #nullable enable
 
 namespace Xamarin.MacDev.Tasks {
-	public class SymbolStrip : XamarinTask, ITaskCallback {
+	public class SymbolStrip : XamarinParallelTask, ITaskCallback {
 		#region Inputs
 
 		[Required]
@@ -60,7 +60,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
-			Parallel.ForEach (Executable, new ParallelOptions { MaxDegreeOfParallelism = Math.Max (Environment.ProcessorCount / 2, 1) }, (item) => {
+			ForEach (Executable, (item) => {
 				ExecuteStrip (item);
 			});
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinParallelTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinParallelTask.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Xamarin.Localization.MSBuild;
+using Xamarin.Utils;
+
+#nullable enable
+
+namespace Xamarin.MacDev.Tasks {
+	public abstract class XamarinParallelTask : XamarinTask {
+		// How many tasks we execute in parallel. Default is number of processors / 2.
+		public string MaxDegreeOfParallelism { get; set; } = string.Empty;
+
+		int GetMaxDegreeOfParallelism ()
+		{
+			if (!string.IsNullOrEmpty (MaxDegreeOfParallelism)) {
+				if (int.TryParse (MaxDegreeOfParallelism, out var max))
+					return max;
+				Log.LogWarning (MSBStrings.W7121 /* Unable to parse the value '{0}' for the property 'MaxDegreeOfParallelism'. Falling back to the default value (number of processors / 2). */, MaxDegreeOfParallelism);
+			}
+			return Math.Max (Environment.ProcessorCount / 2, 1);
+		}
+
+		protected void ForEach<TSource> (IEnumerable<TSource> source, Action<TSource> body)
+		{
+			var options = new ParallelOptions { MaxDegreeOfParallelism = GetMaxDegreeOfParallelism () };
+			Parallel.ForEach (source, options, body);
+		}
+	}
+}

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1070,6 +1070,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true'"
 			DeviceSpecificIntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			IsWatchApp="$(IsWatchApp)"
+			MaxDegreeOfParallelism="$(ColladaMaxDegreeOfParallelism)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(_ResourcePrefix)"
 			SdkPlatform="$(_SdkPlatform)"
@@ -2771,6 +2772,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true'"
 			Executable="$(_AppContainerDir)%(_NativeStripItems.Identity)"
 			Kind="%(_NativeStripItems.Kind)"
+			MaxDegreeOfParallelism="$(SymbolStripMaxDegreeOfParallelism)"
 			SymbolFile="%(_NativeStripItems.SymbolFile)"
 		/>
 


### PR DESCRIPTION
This deduplicates some code, and also ensures we specifiy a max limit to the
level of parallelism. This fixes an issue in the AOTCompile and ScnTool tasks,
where we'd have no limit, launching as many subprocesses as tasks there are to
execute. In particular for the AOTCompile task, this can put a rather heavy
burden on build machines, slowing everything down to a crawl.

Fixes https://github.com/xamarin/xamarin-macios/issues/20210.