### PR TITLE
[tests] Adjust MessageHandlerTest.GHIssue16339 slightly.

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -818,7 +818,6 @@ namespace MonoTests.System.Net.Http {
 				for (var i = 0; i < iterations; i++) {
 					var rsp = delegatingHandler.Responses [i];
 					Assert.IsTrue (delegatingHandler.IsCompleted (i), $"Completed #{i}");
-					Assert.IsTrue (rsp.IsSuccessStatusCode, $"IsSuccessStatusCode #{i}");
 					Assert.AreEqual ("OK", rsp.ReasonPhrase, $"ReasonPhrase #{i}");
 					Assert.AreEqual (HttpStatusCode.OK, rsp.StatusCode, $"StatusCode #{i}");
 


### PR DESCRIPTION
We've recently had a few test failures like this:

    MonoTests.System.Net.Http.MessageHandlerTest.GHIssue16339
     	[FAIL] GHIssue16339() :   IsSuccessStatusCode #1
       Expected: True
       But was:  False

which doesn't provide much info into what went wrong.

It turns out this particular assert for IsSuccessStatusCode is redundant,
because we assert on the exact StatusCode a bit later, and if that assert
fails, we'll know a bit more.

So just remove this redundant assert for IsSuccessStatusCode.