### PR TITLE
[release/8.0.1xx-xcode15.1] Only load default items if the workload we loaded matches exactly.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -144,6 +144,7 @@ Microsoft.$1.Sdk/targets/Microsoft.$1.Sdk.DefaultItems.props: targets/Microsoft.
 	$$(Q_GEN) sed \
 		-e "s/@PLATFORM@/$1/g" \
 		-e "s/@TARGET_FRAMEWORK_VERSION@/$(subst net,,$(DOTNET_TFM))/g" \
+		-e "s/@CURRENT_HASH_LONG@/$$(CURRENT_HASH_LONG)/g" \
 		$$< > $$@
 endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call DefaultItems,$(platform))))

--- a/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
+++ b/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
@@ -17,7 +17,7 @@
 
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@TARGET_FRAMEWORK_VERSION@'))">
+	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@TARGET_FRAMEWORK_VERSION@')) And '$(CurrentHash)' == '@CURRENT_HASH_LONG@'">
 		<!-- Default plist file inclusion -->
 		<None Include="*.plist">
 			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>


### PR DESCRIPTION
The build will load all the AutoImport.props files from all sdk packs (in our
AutoImport.props file we load the Microsoft.Sdk.DefaultItems.props file). This
file is supposed to include all the default items an sdk pack wants to include
by default, properly conditioned so that multiple versions of the sdk pack
don't end up including the same item more than once.

In the past, conditioning on the .NET version worked, because there would only
be one version of a sdk pack installed per .NET version. However this changed
with multi-targeting, now we can have numerous versions of an sdk pack
installed for every .NET version, which means the condition needs to be
updated, on all versions of the sdk pack.

This is already implemented for the `main` and `release/8.0.1xx-xcode15.0`
branches, but we need it in `release/8.0.1xx-xcode15.1`, because `main`
includes a reference to the sdk pack from this branch.