### PR TITLE
[runtime] Fix min OS versions in various compiler and linker arguments.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -448,7 +448,7 @@ DEVICE_OBJC_CFLAGS=$(OBJC_CFLAGS)
 DEVICE_SDK=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$(IOS_SDK_VERSION).sdk
 DEVICE7_CFLAGS= -arch armv7  -mno-thumb -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
 DEVICE7S_CFLAGS=-arch armv7s -mno-thumb -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
-DEVICE64_CFLAGS=-arch arm64             -miphoneos-version-min=7.0                    -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
+DEVICE64_CFLAGS=-arch arm64             -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
 DEVICE7_OBJC_CFLAGS =$(DEVICE7_CFLAGS)  $(DEVICE_OBJC_CFLAGS)
 DEVICE7S_OBJC_CFLAGS=$(DEVICE7S_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 DEVICE64_OBJC_CFLAGS=$(DEVICE64_CFLAGS) $(DEVICE_OBJC_CFLAGS)

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -112,7 +112,7 @@ define NativeCompilationTemplate
 	$$(call Q_2,LD,    [iphoneos]) $(DEVICE_CC) $(DEVICE64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/lib -fapplication-extension
 
 .libs/iphoneos/%$(1).arm64.framework: | .libs/iphoneos
-	$$(call Q_2,LD,    [iphoneos]) $(DEVICE_CC) $(DEVICE64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks -fapplication-extension  -miphoneos-version-min=8.0
+	$$(call Q_2,LD,    [iphoneos]) $(DEVICE_CC) $(DEVICE64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks -fapplication-extension  -miphoneos-version-min=$(MIN_IOS_SDK_VERSION)
 
 ## maccatalyst (ios on macOS / Catalyst)
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -362,10 +362,10 @@ $$(foreach arch,$$($(2)_ARCHITECTURES),$$(eval $$(call LibXamarinArchTemplate,$(
 .libs/$(1)/libxamarin$(4).x86_64.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS)
 .libs/$(1)/libxamarin$(4).x86_64.dylib: $$(x86_64_$(1)$(3)_OBJECTS)
 
-.libs/$(1)/libxamarin$(4).armv7.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS) -miphoneos-version-min=8.0
+.libs/$(1)/libxamarin$(4).armv7.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS) -miphoneos-version-min=$(MIN_IOS_SDK_VERSION)
 .libs/$(1)/libxamarin$(4).armv7.dylib: $$(armv7_$(1)$(3)_OBJECTS)
 
-.libs/$(1)/libxamarin$(4).armv7s.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS) -miphoneos-version-min=8.0
+.libs/$(1)/libxamarin$(4).armv7s.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS) -miphoneos-version-min=$(MIN_IOS_SDK_VERSION)
 .libs/$(1)/libxamarin$(4).armv7s.dylib: $$(armv7s_$(1)$(3)_OBJECTS)
 
 .libs/$(1)/libxamarin$(4).arm64.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS)
@@ -383,10 +383,10 @@ $$(foreach arch,$$($(2)_ARCHITECTURES),$$(eval $$(call LibXamarinArchTemplate,$(
 .libs/$(1)/Xamarin$(4).x86_64.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS)
 .libs/$(1)/Xamarin$(4).x86_64.framework: $$(x86_64_$(1)$(3)_OBJECTS)
 
-.libs/$(1)/Xamarin$(4).armv7.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS) -miphoneos-version-min=8.0
+.libs/$(1)/Xamarin$(4).armv7.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS) -miphoneos-version-min=$(MIN_IOS_SDK_VERSION)
 .libs/$(1)/Xamarin$(4).armv7.framework: $$(armv7_$(1)$(3)_OBJECTS)
 
-.libs/$(1)/Xamarin$(4).armv7s.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS) -miphoneos-version-min=8.0
+.libs/$(1)/Xamarin$(4).armv7s.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS) -miphoneos-version-min=$(MIN_IOS_SDK_VERSION)
 .libs/$(1)/Xamarin$(4).armv7s.framework: $$(armv7s_$(1)$(3)_OBJECTS)
 
 .libs/$(1)/Xamarin$(4).arm64.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS)

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -189,11 +189,11 @@ IOS_DEVICE_ARCHITECTURES+=arm64
 # 4: platform name
 # 5: min version
 # 6: os
-$(eval $(call Template,iphonesimulator,IOSSIMULATOR,$(IOS_SIMULATOR_ARCHITECTURES),iPhoneSimulator,-mios-simulator-version-min=8.0 -isysroot $(SIMULATOR_SDK)))
-$(eval $(call Template,iphoneos,IPHONEOS,$(IOS_DEVICE_ARCHITECTURES),iPhoneOS,-miphoneos-version-min=8.0 -isysroot $(DEVICE_SDK)))
+$(eval $(call Template,iphonesimulator,IOSSIMULATOR,$(IOS_SIMULATOR_ARCHITECTURES),iPhoneSimulator,-mios-simulator-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(SIMULATOR_SDK)))
+$(eval $(call Template,iphoneos,IPHONEOS,$(IOS_DEVICE_ARCHITECTURES),iPhoneOS,-miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK)))
 ifdef INCLUDE_TVOS
-$(eval $(call Template,tvsimulator,TVSIMULATOR,x86_64 arm64,AppleTVSimulator,-mtvos-simulator-version-min=9.0 -isysroot $(SIMULATORTV_SDK)))
-$(eval $(call Template,tvos,TVOS,arm64,AppleTVOS,-mtvos-version-min=9.0 -isysroot $(DEVICETV_SDK)))
+$(eval $(call Template,tvsimulator,TVSIMULATOR,x86_64 arm64,AppleTVSimulator,-mtvos-simulator-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(SIMULATORTV_SDK)))
+$(eval $(call Template,tvos,TVOS,arm64,AppleTVOS,-mtvos-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(DEVICETV_SDK)))
 endif
 ifdef INCLUDE_WATCH
 ifdef WATCHOS_SUPPORTS_32BIT_SIMULATOR_ARCHITECTURES

--- a/tests/test-libraries/frameworks/Makefile
+++ b/tests/test-libraries/frameworks/Makefile
@@ -19,10 +19,10 @@ XPCSERVICES=XpcServiceE CompressedXpcServiceF XpcServiceG CompressedXpcServiceH
 # a few lookup tables, because the data we have is not always in the format we need it
 
 COMMON_DYLIB_ARGS=-g -dynamiclib -gdwarf-2 -fms-extensions shared.c -Wall -framework Foundation -lz
-iphonesimulator_DYLIB_FLAGS=$(COMMON_DYLIB_ARGS) -mios-simulator-version-min=8.0 -isysroot $(SIMULATOR_SDK)
-iphoneos_DYLIB_FLAGS=$(COMMON_DYLIB_ARGS) -miphoneos-version-min=8.0 -isysroot $(DEVICE_SDK)
-tvsimulator_DYLIB_FLAGS=$(COMMON_DYLIB_ARGS) -mtvos-simulator-version-min=9.0 -isysroot $(SIMULATORTV_SDK)
-tvos_DYLIB_FLAGS=$(COMMON_DYLIB_ARGS) -mtvos-version-min=9.0 -isysroot $(DEVICETV_SDK)
+iphonesimulator_DYLIB_FLAGS=$(COMMON_DYLIB_ARGS) -mios-simulator-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(SIMULATOR_SDK)
+iphoneos_DYLIB_FLAGS=$(COMMON_DYLIB_ARGS) -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK)
+tvsimulator_DYLIB_FLAGS=$(COMMON_DYLIB_ARGS) -mtvos-simulator-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(SIMULATORTV_SDK)
+tvos_DYLIB_FLAGS=$(COMMON_DYLIB_ARGS) -mtvos-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(DEVICETV_SDK)
 maccatalyst_DYLIB_FLAGS=$(COMMON_DYLIB_ARGS) $(MACCATALYST_COMMON_CFLAGS)
 mac_DYLIB_FLAGS=$(COMMON_DYLIB_ARGS) -mmacosx-version-min=$(MIN_OSX_VERSION_FOR_MAC) -isysroot $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(OSX_SDK_VERSION).sdk
 

--- a/tests/test-libraries/libraries/Makefile
+++ b/tests/test-libraries/libraries/Makefile
@@ -9,10 +9,10 @@ NO_INSTALL_NAME_TOOL_SkipInstallNameTool=1
 # a few lookup tables, because the data we have is not always in the format we need it
 
 COMMON_ARGS=-g -gdwarf-2 -fms-extensions shared.c -Wall
-iphonesimulator_COMPILER_FLAGS=$(COMMON_ARGS) -mios-simulator-version-min=8.0 -isysroot $(SIMULATOR_SDK)
-iphoneos_COMPILER_FLAGS=$(COMMON_ARGS) -miphoneos-version-min=8.0 -isysroot $(DEVICE_SDK)
-tvsimulator_COMPILER_FLAGS=$(COMMON_ARGS) -mtvos-simulator-version-min=9.0 -isysroot $(SIMULATORTV_SDK)
-tvos_COMPILER_FLAGS=$(COMMON_ARGS) -mtvos-version-min=9.0 -isysroot $(DEVICETV_SDK)
+iphonesimulator_COMPILER_FLAGS=$(COMMON_ARGS) -mios-simulator-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(SIMULATOR_SDK)
+iphoneos_COMPILER_FLAGS=$(COMMON_ARGS) -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK)
+tvsimulator_COMPILER_FLAGS=$(COMMON_ARGS) -mtvos-simulator-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(SIMULATORTV_SDK)
+tvos_COMPILER_FLAGS=$(COMMON_ARGS) -mtvos-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(DEVICETV_SDK)
 maccatalyst_COMPILER_FLAGS=$(COMMON_ARGS) $(MACCATALYST_COMMON_CFLAGS)
 mac_COMPILER_FLAGS=$(COMMON_ARGS) -mmacosx-version-min=$(MIN_OSX_VERSION_FOR_MAC) -isysroot $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(OSX_SDK_VERSION).sdk
 


### PR DESCRIPTION
Once upon a time we needed to special case a higher min OS version that the
min OS version we supported for certain compiler/linker arguments, because we
used features not supported in the min OS version we supported.

That time has passed; in all cases our min OS version is now higher than the
special-cased min OS versions passed to native compilers/linkers, so we can
just use the actual min OS version we support.