### PR TITLE
[release/8.0.1xx-xcode15.1] Allow null for CGColorSpace.CreatePattern

### DIFF
--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -261,7 +261,7 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreatePattern (/* CGColorSpaceRef */ IntPtr baseSpace);
 
-		public static CGColorSpace? CreatePattern (CGColorSpace baseSpace)
+		public static CGColorSpace? CreatePattern (CGColorSpace? baseSpace)
 		{
 			var ptr = CGColorSpaceCreatePattern (baseSpace.GetHandle ());
 			return FromHandle (ptr, true);


### PR DESCRIPTION
Per Apple docs for the `CGColorSpaceCreatePattern(CGColorSpaceRef baseSpace)`, the `baseSpace` _should_ be null when creating the color pattern. So, allow `null` here.

Fixes https://github.com/xamarin/xamarin-macios/issues/20293


Backport of #20294
