### PR TITLE
[tests] Improve running bgen tests from the terminal.

### DIFF
--- a/tests/bgen/Makefile
+++ b/tests/bgen/Makefile
@@ -2,4 +2,4 @@ TOP=../..
 include $(TOP)/Make.config
 
 run-tests run-unit-tests:
-	$(DOTNET) test $(TEST_FILTER)
+	$(Q) $(DOTNET) test $(TEST_FILTER) bgen-tests.csproj


### PR DESCRIPTION
Make it appropriately quiet, and pass the project.

This makes the run-tests target work when there's also a .sln in the same
directory (which gets created automatically when opening the project in
VSCode).