### PR TITLE
[msbuild] Adjust error message when we can't find Xcode to not talk about VS. Fixes #19818.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -165,6 +165,12 @@
         <comment>The following are literal names and should not be translated: Xcode, Apple SDK, Visual Studio
 {0} - The selected Xcode / Apple SDK directory.</comment>
     </data>
+
+    <data name="E0044v2" xml:space="preserve">
+        <value>Could not find a valid Xcode app bundle at '{0}'. Please verify that 'xcode-select -p' points to your Xcode installation. For more information see https://aka.ms/macios-missing-xcode.
+        </value>
+        <comment>The following are literal names and should not be translated: Xcode</comment>
+    </data>
     
     <data name="E0045" xml:space="preserve">
         <value>Could not find valid a usable Xcode developer path

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocationCore.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocationCore.cs
@@ -235,14 +235,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var currentSdk = CurrentSdk;
 			if (!currentSdk.IsInstalled) {
-				string ideSdkPath;
-				if (string.IsNullOrEmpty (SessionId))
-					// SessionId is only and always defined on windows.
-					// We can't check 'Environment.OSVersion.Platform' since the base tasks are always executed on the Mac.
-					ideSdkPath = "(Projects > SDK Locations > Apple > Apple SDK)";
-				else
-					ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
-				Log.LogError (MSBStrings.E0044, AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
+				Log.LogError (MSBStrings.E0044v2 /* Could not find a valid Xcode app bundle at '{0}'. Please verify that 'xcode-select -p' points to your Xcode installation. For more information see https://aka.ms/macios-missing-xcode. */, AppleSdkSettings.InvalidDeveloperRoot);
 				return false;
 			}
 			Log.LogMessage (MessageImportance.Low, "DeveloperRoot: {0}", currentSdk.DeveloperRoot);


### PR DESCRIPTION
Some people may use VSCode, or the command line, and talking about VS is confusing.

Fixes https://github.com/xamarin/xamarin-macios/issues/19818.