### PR TITLE
[release/8.0.1xx-xcode15.1] [dotnet-linker] Add ProcessExportedFields to the list of steps we execute. Fixes #20061.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -654,6 +654,7 @@
 			<!-- This would not be needed if LinkContext.GetAssemblies () was exposed to us. -->
 			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="MarkStep" Type="Xamarin.Linker.CollectAssembliesStep" />
 			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="MarkStep" Type="MonoTouch.Tuner.CoreTypeMapStep" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="MarkStep" Type="MonoTouch.Tuner.ProcessExportedFields" />
 			<!-- The final decision to remove/keep the dynamic registrar must be done before the linking step -->
 			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="MarkStep" Type="MonoTouch.Tuner.RegistrarRemovalTrackingStep" />
 			<!-- TODO: these steps should probably run after mark. -->

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -18,6 +18,12 @@ namespace Bindings.Test {
 	}
 #endif
 
+	[Static]
+	interface Globals {
+		[Field ("x_GlobalString", "__Internal")]
+		NSString GlobalString { get; }
+	}
+
 	[BaseType (typeof (NSObject))]
 	public interface UltimateMachine {
 		[Export ("getAnswer")]

--- a/tests/bindings-test/RuntimeTest.cs
+++ b/tests/bindings-test/RuntimeTest.cs
@@ -13,6 +13,12 @@ namespace Xamarin.Tests {
 	[Preserve (AllMembers = true)]
 	public class RuntimeTest {
 		[Test]
+		public void GlobalStringTest ()
+		{
+			Assert.AreEqual ("There's nothing cruvus here!", (string) Globals.GlobalString, "Global string");
+		}
+
+		[Test]
 		public void WrapperTypeLookupTest ()
 		{
 			using (var assigner = new MyProtocolAssigner ()) {

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -7,6 +7,8 @@
 #include <zlib.h>
 #include "libtest.h"
 
+NSString *x_GlobalString = @"There's nothing cruvus here!";
+
 int
 theUltimateAnswer ()
 {

--- a/tests/test-libraries/rename.h
+++ b/tests/test-libraries/rename.h
@@ -72,6 +72,7 @@
 	#define x_SCNMatrix4MakeTranslation object_x_SCNMatrix4MakeTranslation
 	#define x_SCNMatrix4MakeScale       object_x_SCNMatrix4MakeScale
 	#define x_SCNMatrix4Translate       object_x_SCNMatrix4Translate
+	#define x_GlobalString				object_x_GlobalString
 #elif PREFIX == 2
 	#define theUltimateAnswer ar_theUltimateAnswer
 	#define useZLib           ar_useZLib
@@ -145,6 +146,7 @@
 	#define x_SCNMatrix4MakeTranslation ar_x_SCNMatrix4MakeTranslation
 	#define x_SCNMatrix4MakeScale       ar_x_SCNMatrix4MakeScale
 	#define x_SCNMatrix4Translate       ar_x_SCNMatrix4Translate
+	#define x_GlobalString					ar_x_GlobalString
 #else
 // keep original names
 #endif

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -183,6 +183,9 @@
     <Compile Include="..\linker\MonoTouch.Tuner\PreserveSmartEnumConversions.cs">
       <Link>external\tools\linker\MonoTouch.Tuner\PreserveSmartEnumConversions.cs</Link>
     </Compile>
+    <Compile Include="..\linker\MonoTouch.Tuner\ProcessExportedFields.cs">
+      <Link>external\tools\linker\MonoTouch.Tuner\ProcessExportedFields.cs</Link>
+    </Compile>
     <Compile Include="..\linker\MobileExtensions.cs">
       <Link>external\tools\linker\MobileExtensions.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/20061.


Backport of #20066
