### PR TITLE
[tests] Ignore the VerifyEveryVisibleMemberIsDocumented test if the Xamarin bits aren't enabled.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -86,6 +86,7 @@ test.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.De
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(platform)_NUGET_REF_NAME=$($(platform)_NUGET_REF_NAME)\\n)" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(rid)_NUGET_RUNTIME_NAME=$($(rid)_NUGET_RUNTIME_NAME)\\n))" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),SUPPORTED_API_VERSIONS_$(platform)='$(SUPPORTED_API_VERSIONS_$(platform))'\\n)" | sed 's/^ //' >> $@
+	@printf "ENABLE_XAMARIN=$(ENABLE_XAMARIN)" >> $@
 
 test-system.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.Details.xml
 	@rm -f $@
@@ -118,6 +119,7 @@ test-system.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Ver
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(platform)_NUGET_REF_NAME=$($(platform)_NUGET_REF_NAME)\\n)" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(rid)_NUGET_RUNTIME_NAME=$($(rid)_NUGET_RUNTIME_NAME)\\n))" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),SUPPORTED_API_VERSIONS_$(platform)='$(SUPPORTED_API_VERSIONS_$(platform))'\\n)" | sed 's/^ //' >> $@
+	@printf "ENABLE_XAMARIN=$(ENABLE_XAMARIN)" >> $@
 
 clean-local::
 	$(Q) $(SYSTEM_XBUILD) /t:Clean /p:Platform=iPhoneSimulator /p:Configuration=$(CONFIG) $(XBUILD_VERBOSITY) tests.sln

--- a/tests/cecil-tests/Documentation.cs
+++ b/tests/cecil-tests/Documentation.cs
@@ -28,6 +28,7 @@ namespace Cecil.Tests {
 		{
 			// We join all the APIs from all the platforms, so we can only run this test when all platforms are enabled.
 			Configuration.IgnoreIfAnyIgnoredPlatforms ();
+			Configuration.IgnoreIfNotXamarinEnabled (); // our tooling to inject docs for Apple APIs lives in maccore, so if we don't do that, we'll get a lot of false positives.
 
 			// Collect everything
 			var xmlMembers = new HashSet<AssemblyApi> ();

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -49,6 +49,7 @@ namespace Xamarin.Tests {
 		public static bool include_dotnet;
 		public static bool include_legacy_xamarin;
 		public static bool iOSSupports32BitArchitectures;
+		public static bool EnableXamarin;
 
 		static Version xcode_version;
 		public static Version XcodeVersion {
@@ -308,6 +309,7 @@ namespace Xamarin.Tests {
 			DotNetExecutable = GetVariable ("DOTNET", null);
 			DotNetTfm = GetVariable ("DOTNET_TFM", null);
 			iOSSupports32BitArchitectures = !string.IsNullOrEmpty (GetVariable ("IOS_SUPPORTS_32BIT_ARCHITECTURES", ""));
+			EnableXamarin = !string.IsNullOrEmpty (GetVariable ("ENABLE_XAMARIN", ""));
 
 			XcodeVersionString = GetXcodeVersion (xcode_root);
 #if MONOMAC
@@ -1155,6 +1157,13 @@ namespace Xamarin.Tests {
 			if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform (platform))
 				return;
 			Assert.Ignore ($"This test is only applicable on {platform}");
+		}
+
+		public static void IgnoreIfNotXamarinEnabled ()
+		{
+			if (EnableXamarin)
+				return;
+			Assert.Ignore ($"This test is only applicable if Xamarin-specific bits are enabled.");
 		}
 
 		public static string GetTestLibraryDirectory (ApplePlatform platform, bool? simulator = null)


### PR DESCRIPTION
Our tool to inject documentation for Apple APIs live in maccore, so if that
part of the build isn't enabled, we'll get a lot of false positives.

Instead just ignore the test if the Xamarin bits (in maccore) aren't enabled.