### PR TITLE
[Foundation] Fix hack in NSUrlSessionHandler to avoid a deadlock.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -977,8 +977,7 @@ namespace Foundation {
 
 					inflight.ResponseSent = true;
 
-					// EVIL HACK: having TrySetResult inline was blocking the request from completing
-					Task.Run (() => inflight.CompletionSource.TrySetResult (httpResponse!));
+					inflight.CompletionSource.TrySetResult (httpResponse!);
 				}
 			}
 
@@ -1134,7 +1133,7 @@ namespace Foundation {
 			public readonly object Lock = new object ();
 			public string RequestUrl { get; set; }
 
-			public TaskCompletionSource<HttpResponseMessage> CompletionSource { get; } = new TaskCompletionSource<HttpResponseMessage> ();
+			public TaskCompletionSource<HttpResponseMessage> CompletionSource { get; } = new TaskCompletionSource<HttpResponseMessage> (TaskCreationOptions.RunContinuationsAsynchronously);
 			public CancellationToken CancellationToken { get; set; }
 			public CancellationTokenSource CancellationTokenSource { get; } = new CancellationTokenSource ();
 			public NSUrlSessionDataTaskStream Stream { get; } = new NSUrlSessionDataTaskStream ();


### PR DESCRIPTION
Calling [Try]SetResult on a default TaskCompletionSource will call any
continuations on the same thread.

This can lead to deadlocks (thus the hack to run TrySetResult in a background
thread), so avoid it by configuring the TaskCompletionSource to call
continutations asynchronously.

Ref: https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/