### PR TITLE
[ObjCRuntime] Suppress trimmer warnings for certain Runtime members.

### DIFF
--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -171,8 +171,17 @@ namespace ObjCRuntime {
 			return path is not null;
 		}
 
+#if NET
+		// Note that this method does not work with NativeAOT, so throw an exception in that case.
+		// IL2026: Using member 'System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyPath(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types and members the loaded assembly depends on might be removed.
+		[UnconditionalSuppressMessage ("", "IL2026", Justification = "The APIs this method tries to access are marked by other means, so this is linker-safe.")]
+#endif
 		static Assembly? ResolvingEventHandler (AssemblyLoadContext sender, AssemblyName assemblyName)
 		{
+			// Note that this method does not work with NativeAOT, so throw an exception in that case.
+			if (IsNativeAOT)
+				throw CreateNativeAOTNotSupportedException ();
+
 			if (xamarin_locate_assembly_resource (assemblyName.Name!, assemblyName.CultureName, assemblyName.Name + ".dll", out var path)) {
 				if (DynamicRegistrationSupported) {
 					return sender.LoadFromAssemblyPath (path);

--- a/tests/dotnet/UnitTests/TrimmerWarningsTest.cs
+++ b/tests/dotnet/UnitTests/TrimmerWarningsTest.cs
@@ -40,7 +40,6 @@ namespace Xamarin.Tests {
 			case ApplePlatform.MacOSX:
 				expectedWarnings = new ExpectedBuildMessage [] {
 					new ExpectedBuildMessage ("src/ObjCRuntime/DynamicRegistrar.cs" /* line 542 */, "Registrar.DynamicRegistrar.HasThisAttributeImpl(MethodBase): Attribute 'System.Runtime.CompilerServices.ExtensionAttribute' is being referenced in code but the trimmer was instructed to remove all instances of this attribute. If the attribute instances are necessary make sure to either remove the trimmer attribute XML portion which removes the attribute instances, or override the removal by using the trimmer XML descriptor to keep the attribute type (which in turn keeps all of its instances)."),
-					new ExpectedBuildMessage ("src/ObjCRuntime/Runtime.CoreCLR.cs" /* line 177 */, "ObjCRuntime.Runtime.ResolvingEventHandler(AssemblyLoadContext, AssemblyName): Using member 'System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyPath(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types and members the loaded assembly depends on might be removed."),
 				};
 				break;
 			case ApplePlatform.MacCatalyst:


### PR DESCRIPTION
Contributes towards #10405.