### PR TITLE
[AVFoundation] Obsolete AVSpeechSynthesizer.WriteUtteranceAsync. Fixes #20338.

### DIFF
--- a/src/AVFoundation/AVSpeechSynthesizer.cs
+++ b/src/AVFoundation/AVSpeechSynthesizer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+
+using ObjCRuntime;
+
+#nullable enable
+
+namespace AVFoundation {
+
+	public partial class AVSpeechSynthesizer {
+#if !XAMCORE_5_0
+#if NET
+		[SupportedOSPlatform ("tvos13.0")]
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("maccatalyst")]
+		[SupportedOSPlatform ("macos")]
+#endif
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		[Obsolete ("Do not use this API, it doesn't work correctly. Use the non-Async version (WriteUtterance) instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public unsafe virtual Task<AVAudioBuffer> WriteUtteranceAsync (AVSpeechUtterance utterance)
+		{
+			var tcs = new TaskCompletionSource<AVAudioBuffer> ();
+			WriteUtterance(utterance, (obj_) => {
+				tcs.SetResult (obj_!);
+			});
+			return tcs.Task;
+		}
+#endif
+	}
+}

--- a/src/AVFoundation/AVSpeechSynthesizer.cs
+++ b/src/AVFoundation/AVSpeechSynthesizer.cs
@@ -24,7 +24,7 @@ namespace AVFoundation {
 		public unsafe virtual Task<AVAudioBuffer> WriteUtteranceAsync (AVSpeechUtterance utterance)
 		{
 			var tcs = new TaskCompletionSource<AVAudioBuffer> ();
-			WriteUtterance(utterance, (obj_) => {
+			WriteUtterance (utterance, (obj_) => {
 				tcs.SetResult (obj_!);
 			});
 			return tcs.Task;

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -14530,7 +14530,6 @@ namespace AVFoundation {
 		[Export ("speakUtterance:")]
 		void SpeakUtterance (AVSpeechUtterance utterance);
 
-		[Async]
 		[Watch (6, 0), TV (13, 0), iOS (13, 0)]
 		[MacCatalyst (13, 1)]
 		[Export ("writeUtterance:toBufferCallback:")]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -291,6 +291,7 @@ AVFOUNDATION_SOURCES = \
 	AVFoundation/AVPlayerLayer.cs \
 	AVFoundation/AVPlayerViewController.cs \
 	AVFoundation/AVSampleBufferExtensions.cs \
+	AVFoundation/AVSpeechSynthesizer.cs \
 	AVFoundation/AVTextStyleRule.cs \
 	AVFoundation/Events.cs \
 	AVFoundation/AVPlayerLooper.cs \


### PR DESCRIPTION
The callback may be called multiple times, which means the async version won't
work correctly.

So obsolete and hide the Async binding for now, and remove in XAMCORE_5_0.

References:
* https://discord.com/channels/732297728826277939/732297808148824115/1219903715939582022
* https://developer.apple.com/documentation/avfaudio/avspeechsynthesizer/3141659-writeutterance?language=objc

Fixes https://github.com/xamarin/xamarin-macios/issues/20338.