### PR TITLE
[src] Remove EventArgs attribute on a category method.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -896,7 +896,7 @@ namespace AppKit {
 	[Category]
 	[BaseType (typeof (NSApplication))]
 	interface NSApplication_NSServicesMenu {
-		[Export ("registerServicesMenuSendTypes:returnTypes:"), EventArgs ("NSApplicationRegister")]
+		[Export ("registerServicesMenuSendTypes:returnTypes:")]
 		void RegisterServicesMenu (string [] sendTypes, string [] returnTypes);
 	}
 


### PR DESCRIPTION
EventArgs does nothing in a category method, so this is effectively removing dead code.