### PR TITLE
[ObjCRuntime] Suppress trimmer warnings for certain DynamicRegistrar members.

### DIFF
--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -661,6 +661,10 @@ namespace Registrar {
 			return mi.ReturnTypeCustomAttributes.IsDefined (typeof (ReleaseAttribute), false);
 		}
 
+#if NET
+		// IL2025: Attribute 'System.Runtime.CompilerServices.ExtensionAttribute' is being referenced in code but the trimmer was instructed to remove all instances of this attribute. If the attribute instances are necessary make sure to either remove the trimmer attribute XML portion which removes the attribute instances, or override the removal by using the trimmer XML descriptor to keep the attribute type (which in turn keeps all of its instances).
+		[UnconditionalSuppressMessage ("", "IL2045", Justification = "The Extension attribute is manually preserved.")]
+#endif
 		public static bool HasThisAttributeImpl (MethodBase method)
 		{
 			var mi = method as MethodInfo;

--- a/tests/dotnet/UnitTests/TrimmerWarningsTest.cs
+++ b/tests/dotnet/UnitTests/TrimmerWarningsTest.cs
@@ -34,17 +34,14 @@ namespace Xamarin.Tests {
 			case ApplePlatform.TVOS:
 				expectedWarnings = new ExpectedBuildMessage [] {
 					new ExpectedBuildMessage ("src/ObjCRuntime/Blocks.cs" /* line 313 */, "ObjCRuntime.BlockLiteral.SetupBlock(Delegate, Delegate): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'. The return value of method 'ObjCRuntime.MonoPInvokeCallbackAttribute.DelegateType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."),
-					new ExpectedBuildMessage ("src/ObjCRuntime/DynamicRegistrar.cs" /* line 542 */, "Registrar.DynamicRegistrar.HasThisAttributeImpl(MethodBase): Attribute 'System.Runtime.CompilerServices.ExtensionAttribute' is being referenced in code but the trimmer was instructed to remove all instances of this attribute. If the attribute instances are necessary make sure to either remove the trimmer attribute XML portion which removes the attribute instances, or override the removal by using the trimmer XML descriptor to keep the attribute type (which in turn keeps all of its instances)."),
 				};
 				break;
 			case ApplePlatform.MacOSX:
 				expectedWarnings = new ExpectedBuildMessage [] {
-					new ExpectedBuildMessage ("src/ObjCRuntime/DynamicRegistrar.cs" /* line 542 */, "Registrar.DynamicRegistrar.HasThisAttributeImpl(MethodBase): Attribute 'System.Runtime.CompilerServices.ExtensionAttribute' is being referenced in code but the trimmer was instructed to remove all instances of this attribute. If the attribute instances are necessary make sure to either remove the trimmer attribute XML portion which removes the attribute instances, or override the removal by using the trimmer XML descriptor to keep the attribute type (which in turn keeps all of its instances)."),
 				};
 				break;
 			case ApplePlatform.MacCatalyst:
 				expectedWarnings = new ExpectedBuildMessage [] {
-					new ExpectedBuildMessage ("src/ObjCRuntime/DynamicRegistrar.cs" /* line 542 */, "Registrar.DynamicRegistrar.HasThisAttributeImpl(MethodBase): Attribute 'System.Runtime.CompilerServices.ExtensionAttribute' is being referenced in code but the trimmer was instructed to remove all instances of this attribute. If the attribute instances are necessary make sure to either remove the trimmer attribute XML portion which removes the attribute instances, or override the removal by using the trimmer XML descriptor to keep the attribute type (which in turn keeps all of its instances)."),
 				};
 				break;
 			default:


### PR DESCRIPTION
Contributes towards #10405.