### PR TITLE
[devops] There's no reason for the macOS tests to take more than two hours, so adjust timeout accordingly.

### DIFF
--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -48,7 +48,7 @@ stages:
   jobs:
   - job: run_tests
     displayName: 'macOS tests'
-    timeoutInMinutes: 1000
+    timeoutInMinutes: 120
     workspace:
       clean: all
 


### PR DESCRIPTION
16.6666 hours is *way* too much.