### PR TITLE
[ObjCRuntime] Refactor the Block.SetupBlock(Delegate,Delegate) implementation a bit.

### DIFF
--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -304,6 +304,17 @@ namespace ObjCRuntime {
 			if (trampoline is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (trampoline));
 
+			VerifyBlockDelegates (trampoline, userDelegate);
+
+			SetupBlock (trampoline, userDelegate, safe: true);
+		}
+
+#if NET
+		// IL2075: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'. The return value of method 'ObjCRuntime.MonoPInvokeCallbackAttribute.DelegateType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+		[UnconditionalSuppressMessage ("", "IL2075", Justification = "Calling GetMethod('Invoke') on a delegate type will always find something, because the invoke method can't be linked away for a delegate.")]
+#endif
+		void VerifyBlockDelegates (Delegate trampoline, Delegate userDelegate)
+		{
 #if !MONOMAC && !__MACCATALYST__
 			// Check that:
 			// * The trampoline is static
@@ -338,7 +349,7 @@ namespace ObjCRuntime {
 				}
 			}
 #endif
-			SetupBlock (trampoline, userDelegate, safe: true);
+
 		}
 
 		public void CleanupBlock ()

--- a/tests/dotnet/UnitTests/TrimmerWarningsTest.cs
+++ b/tests/dotnet/UnitTests/TrimmerWarningsTest.cs
@@ -28,28 +28,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.TVOS, "tvos-arm64")]
 		public void TrimmerWarningsDynamicRegistrar (ApplePlatform platform, string runtimeIdentifiers)
 		{
-			ExpectedBuildMessage [] expectedWarnings;
-			switch (platform) {
-			case ApplePlatform.iOS:
-			case ApplePlatform.TVOS:
-				expectedWarnings = new ExpectedBuildMessage [] {
-					new ExpectedBuildMessage ("src/ObjCRuntime/Blocks.cs" /* line 313 */, "ObjCRuntime.BlockLiteral.SetupBlock(Delegate, Delegate): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'. The return value of method 'ObjCRuntime.MonoPInvokeCallbackAttribute.DelegateType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."),
-				};
-				break;
-			case ApplePlatform.MacOSX:
-				expectedWarnings = new ExpectedBuildMessage [] {
-				};
-				break;
-			case ApplePlatform.MacCatalyst:
-				expectedWarnings = new ExpectedBuildMessage [] {
-				};
-				break;
-			default:
-				Assert.Fail ($"Unknown platform: {platform}");
-				return;
-			}
-
-			TrimmerWarnings (platform, runtimeIdentifiers, "dynamic", expectedWarnings);
+			TrimmerWarnings (platform, runtimeIdentifiers, "dynamic", Array.Empty<ExpectedBuildMessage> ());
 		}
 
 		void TrimmerWarnings (ApplePlatform platform, string runtimeIdentifiers, string registrar, params ExpectedBuildMessage [] expectedWarnings)


### PR DESCRIPTION
* Extract code the trimmer wants to warn about into a separate method.
* Suppress the trimmer warning we get.

Contributes towards #10405.