### PR TITLE
[dotnet] Embrace trimming.

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/csharp/MacCatalystApp1.csproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/csharp/MacCatalystApp1.csproj
@@ -11,6 +11,12 @@
     <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MacCatalystApp1</RootNamespace>
     <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>
+
+    <!--
+      Enable full trimming in Release mode.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
+    -->
+    <TrimMode Condition="'$(Configuration)' == 'Release'">full</TrimMode>
   </PropertyGroup>
 
   <!-- Notes about the values set below:

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/csharp/MacCatalystBinding1.csproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/csharp/MacCatalystBinding1.csproj
@@ -5,6 +5,12 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
+
+    <!--
+      Enable trim analyzers for class libraries.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
+    -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/csharp/MacCatalystLib1.csproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/csharp/MacCatalystLib1.csproj
@@ -4,5 +4,11 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MacCatalystLib1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
+
+    <!--
+      Enable trim analyzers for class libraries.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
+    -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/iOSTabbedApp1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/iOSTabbedApp1.csproj
@@ -6,5 +6,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>
+
+    <!--
+      Enable full trimming in Release mode.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
+    -->
+    <TrimMode Condition="'$(Configuration)' == 'Release'">full</TrimMode>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/csharp/iOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/csharp/iOSApp1.csproj
@@ -6,5 +6,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>
+
+    <!--
+      Enable full trimming in Release mode.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
+    -->
+    <TrimMode Condition="'$(Configuration)' == 'Release'">full</TrimMode>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/csharp/iOSBinding1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/csharp/iOSBinding1.csproj
@@ -5,6 +5,12 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
+
+    <!--
+      Enable trim analyzers for class libraries.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
+    -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/csharp/iOSLib1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/csharp/iOSLib1.csproj
@@ -4,5 +4,11 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSLib1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
+
+    <!--
+      Enable trim analyzers for class libraries.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
+    -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/csharp/macOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/csharp/macOSApp1.csproj
@@ -6,5 +6,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>
+
+    <!--
+      Enable full trimming in Release mode.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
+    -->
+    <TrimMode Condition="'$(Configuration)' == 'Release'">full</TrimMode>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macosbinding/csharp/macOSBinding1.csproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macosbinding/csharp/macOSBinding1.csproj
@@ -5,6 +5,12 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
+
+    <!--
+      Enable trim analyzers for class libraries.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
+    -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/csharp/macOSLib1.csproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/csharp/macOSLib1.csproj
@@ -4,5 +4,11 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">macOSLib1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
+
+    <!--
+      Enable trim analyzers for class libraries.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
+    -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/csharp/tvOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/csharp/tvOSApp1.csproj
@@ -6,5 +6,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>
+
+    <!--
+      Enable full trimming in Release mode.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
+    -->
+    <TrimMode Condition="'$(Configuration)' == 'Release'">full</TrimMode>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvosbinding/csharp/tvOSBinding1.csproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvosbinding/csharp/tvOSBinding1.csproj
@@ -5,6 +5,12 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
+
+    <!--
+      Enable trim analyzers for class libraries.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
+    -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/csharp/tvOSLib1.csproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/csharp/tvOSLib1.csproj
@@ -4,5 +4,11 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">tvOSLib1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
+
+    <!--
+      Enable trim analyzers for class libraries.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
+    -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -40,15 +40,6 @@
 		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_UseNativeAot)' == 'true'">false</UseMonoRuntime>
 		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == ''">true</UseMonoRuntime>
 
-		<!--
-			With NativeAOT we want to suppress trim warnings coming from ILLink and enable them only for ILC.
-			For this reason, in case of NativeAOT, we set SuppressTrimAnalysisWarnings to true by default and store the overwriten default in
-			_OriginalSuppressTrimAnalysisWarnings property, which is later used to properly configure warning suppression for ILC.
-		-->
-		<_OriginalSuppressTrimAnalysisWarnings>$(SuppressTrimAnalysisWarnings)</_OriginalSuppressTrimAnalysisWarnings>
-		<SuppressTrimAnalysisWarnings Condition="'$(_UseNativeAot)' == 'true'">true</SuppressTrimAnalysisWarnings>
-		<SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == ''">true</SuppressTrimAnalysisWarnings>
-
 		<AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)Microsoft.$(_PlatformName).Sdk.targets</AfterMicrosoftNETSdkTargets>
 
 		<!-- _XamarinSdkRoot is used by the existing MSBuild targets files -->
@@ -171,6 +162,19 @@
 		<TrimMode Condition="'$(_LinkMode)' == 'SdkOnly'">partial</TrimMode>
 		<TrimMode Condition="'$(_LinkMode)' == 'Full'">full</TrimMode>
 		<!-- For None link mode we also need to set TrimMode for all assemblies. This is done later -->
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<!--
+			With NativeAOT we want to suppress trim warnings coming from ILLink and enable them only for ILC.
+			For this reason, in case of NativeAOT, we set SuppressTrimAnalysisWarnings to true by default and store the overwriten default in
+			_OriginalSuppressTrimAnalysisWarnings property, which is later used to properly configure warning suppression for ILC.
+		-->
+		<_OriginalSuppressTrimAnalysisWarnings>$(SuppressTrimAnalysisWarnings)</_OriginalSuppressTrimAnalysisWarnings>
+		<SuppressTrimAnalysisWarnings Condition="'$(_UseNativeAot)' == 'true'">true</SuppressTrimAnalysisWarnings>
+		<!-- Otherwise suppress trimmer warnings unless we're trimming all assemblies -->
+		<SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimMode)' == 'full'">false</SuppressTrimAnalysisWarnings>
+		<SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == ''">true</SuppressTrimAnalysisWarnings>
 	</PropertyGroup>
 
 	<!-- We're never using any app hosts -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -145,6 +145,7 @@
 		<VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == ''">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
 		<!-- This should be set by dotnet/sdk instead, once https://github.com/dotnet/sdk/issues/25392 gets resolved.  -->
 		<DynamicCodeSupport Condition="'$(DynamicCodeSupport)' == '' And '$(MtouchInterpreter)' != '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'MacCatalyst')">false</DynamicCodeSupport>
+		<_ComObjectDescriptorSupport Condition="'$(_ComObjectDescriptorSupport)' == ''">false</_ComObjectDescriptorSupport>
 
 		<!-- We don't need to generate reference assemblies for apps or app extensions -->
 		<ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' And ('$(OutputType)' == 'Exe' Or '$(IsAppExtension)' == 'true')">false</ProduceReferenceAssembly>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -526,6 +526,10 @@
 			<!-- Yep, we want to run ILLink as well, because we need our custom steps to run (NativeAOT sets this to false, so set it back to true) -->
 			<RunILLink Condition="'$(PublishAot)' == 'true'">true</RunILLink>
 
+			<!-- Suppress trimmer warnings unless we're trimming all assemblies -->
+			<SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimMode)' == 'full'">false</SuppressTrimAnalysisWarnings>
+			<SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == ''">true</SuppressTrimAnalysisWarnings>
+
 			<!-- Pass the custom options to our custom steps -->
 			<_CustomLinkerOptionsFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)custom-linker-options.txt'))</_CustomLinkerOptionsFile>
 			<_CustomLinkerOptionsFile Condition="'$(BuildSessionId)' != ''">$(IntermediateOutputPath)custom-linker-options.txt</_CustomLinkerOptionsFile>


### PR DESCRIPTION
As we have solved all trimming warnings in the our workloads, we can now go
all in on trimming.

Early in .NET 6 we hid many trimming warnings as we did not yet plan to solve
them:

    <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>

Ref: https://github.com/xamarin/xamarin-macios/issues/10405

These warnings were not *actionable* at the time for customers, as
many warnings were from our code.

Going forward, let's stop suppressing these warnings if `TrimMode=full`.

We can also enable trimming for new projects:

* `dotnet new ios|tvos|macos|maccatalyst`

These will have the `TrimMode` property set to `Full` by default for `Release`
builds:

```xml
<!--
  Enable full trimming in Release mode.
  To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
-->
<PropertyGroup Condition="'$(Configuration)' == 'Release'">
  <TrimMode>full</TrimMode>
</PropertyGroup>
```

We wouldn't want to do this for existing projects, as they might have existing
code, NuGet packages, etc. where trimming warnings might be present.

We can also improve the templates for class libraries and binding libraries:

* `dotnet new ioslib|iosbinding|tvoslib|tvosbinding|...`

```xml
<!--
  Enable trim analyzers for Android class libraries.
  To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
-->
<IsTrimmable>true</IsTrimmable>
```

This way, new class libraries and binding libraries will be trimmable by
default and be able to react to trimming warnings.

Fixes https://github.com/xamarin/xamarin-macios/issues/10405.

Ref: https://github.com/xamarin/xamarin-android/pull/8805