### PR TITLE
[bgen] Provide correct initialization for AudioBuffers.

### DIFF
--- a/src/bgen/Models/MarshalTypeList.cs
+++ b/src/bgen/Models/MarshalTypeList.cs
@@ -76,7 +76,7 @@ public class MarshalTypeList : List<MarshalType> {
 		Add (typeCache.SecProtocolOptions);
 		Add (typeCache.SecProtocolMetadata);
 		Add (typeCache.SecAccessControl);
-		Add (typeCache.AudioBuffers);
+		Add (new MarshalType (typeCache.AudioBuffers, create: "new global::AudioToolbox.AudioBuffers (", closingCreate: ", false)"));
 		if (frameworks.HaveAudioUnit) {
 			Add (typeCache.AURenderEventEnumerator);
 		}


### PR DESCRIPTION
Fixes this warning:

    The type AudioToolbox.AudioBuffers does not have a constructor that takes two (ObjCRuntime.NativeHandle, bool) arguments but a constructor that takes two (System.IntPtr, bool) parameters was found (and will be used instead). It's highly recommended to change the signature of the (System.IntPtr, bool) constructor to be (ObjCRuntime.NativeHandle, bool).

which comes from here:

    at ObjCRuntime.Runtime.GetIntPtr_BoolConstructor(Type type) in xamarin-macios/src/ObjCRuntime/Runtime.cs:line 1754
    at ObjCRuntime.Runtime.ConstructINativeObject[AudioBuffers](IntPtr ptr, Boolean owns, Type type, MissingCtorResolution missingCtorResolution, IntPtr sel, RuntimeMethodHandle method_handle) in xamarin-macios/src/ObjCRuntime/Runtime.cs:line 1607
    at ObjCRuntime.Runtime.GetINativeObject[AudioBuffers](IntPtr ptr, Boolean forced_type, Type implementation, Boolean owns, IntPtr sel, RuntimeMethodHandle method_handle) in xamarin-macios/src/ObjCRuntime/Runtime.cs:line 2118
    at ObjCRuntime.Runtime.GetINativeObject[AudioBuffers](IntPtr ptr, Boolean forced_type, Type implementation, Boolean owns) in xamarin-macios/src/ObjCRuntime/Runtime.cs:line 2062
    at ObjCRuntime.Runtime.GetINativeObject[AudioBuffers](IntPtr ptr, Boolean forced_type, Boolean owns) in xamarin-macios/src/ObjCRuntime/Runtime.cs:line 2057
    at ObjCRuntime.Runtime.GetINativeObject[AudioBuffers](IntPtr ptr, Boolean owns) in xamarin-macios/src/ObjCRuntime/Runtime.cs:line 2052
    at ObjCRuntime.Trampolines.SDAVAudioSourceNodeRenderHandler.Invoke(IntPtr block, Byte* isSilence, AudioTimeStamp* timestamp, UInt32 frameCount, NativeHandle* outputData) in xamarin-macios/src/build/dotnet/ios/generated-sources/ObjCRuntime/Trampolines.g.cs:line 526