### PR TITLE
[AVFoundation] Fix delegate signature for AVAudioSourceNode callbacks.

### DIFF
--- a/src/AVFoundation/AVAudioSourceNode.cs
+++ b/src/AVFoundation/AVAudioSourceNode.cs
@@ -111,9 +111,9 @@ namespace AVFoundation {
 		{
 			AVAudioSourceNodeRenderHandlerRaw rv = (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData) => {
 				unsafe {
-					byte* isSilencePtr = (byte *) isSilence;
+					byte* isSilencePtr = (byte*) isSilence;
 					bool isSilenceBool = (*isSilencePtr) != 0;
-					AudioTimeStamp timestampValue = *(AudioTimeStamp *) timestamp;
+					AudioTimeStamp timestampValue = *(AudioTimeStamp*) timestamp;
 					var buffers = new AudioBuffers (outputData);
 					return receiverHandler (isSilenceBool, timestampValue, frameCount, ref buffers);
 				}
@@ -131,10 +131,10 @@ namespace AVFoundation {
 		{
 			AVAudioSourceNodeRenderHandlerRaw rv = (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData) => {
 				unsafe {
-					byte* isSilencePtr = (byte *) isSilence;
+					byte* isSilencePtr = (byte*) isSilence;
 					bool isSilenceBool = (*isSilencePtr) != 0;
 					var buffers = new AudioBuffers (outputData);
-					var rv = receiverHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void *) timestamp), frameCount, ref buffers);
+					var rv = receiverHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void*) timestamp), frameCount, ref buffers);
 					*isSilencePtr = isSilenceBool.AsByte ();
 					return rv;
 				}
@@ -151,10 +151,10 @@ namespace AVFoundation {
 #endif // !XAMCORE_5_0
 			AVAudioSourceNodeRenderHandlerRaw rv = (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData) => {
 				unsafe {
-					byte* isSilencePtr = (byte *) isSilence;
+					byte* isSilencePtr = (byte*) isSilence;
 					bool isSilenceBool = (*isSilencePtr) != 0;
 					var buffers = new AudioBuffers (outputData);
-					var rv = receiverHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void *) timestamp), frameCount, buffers);
+					var rv = receiverHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void*) timestamp), frameCount, buffers);
 					*isSilencePtr = isSilenceBool.AsByte ();
 					return rv;
 				}

--- a/src/AVFoundation/AVAudioSourceNode.cs
+++ b/src/AVFoundation/AVAudioSourceNode.cs
@@ -27,7 +27,7 @@ namespace AVFoundation {
 	//
 
 	/// <summary>The delegate that will be called in a callback from <see cref="T:AudioToolbox.AVAudioSourceNode" />.</summary>
-	/// <returns>An OSStatus result code. Return 0 to indicate success.</summary>
+	/// <returns>An OSStatus result code. Return 0 to indicate success.</returns>
 	/// <param name="isSilence">Indicates whether the supplied audio data only contains silence.</param>
 	/// <param name="timestamp">The timestamp the audio renders (HAL time).</param>
 	/// <param name="frameCount">The number of frames of audio to supply.</param>
@@ -54,15 +54,15 @@ namespace AVFoundation {
 #if !XAMCORE_5_0 && NET
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use the overload that takes a delegate that does not take a 'ref AudioBuffers' instead. Assigning a value to the 'inputData' parameter in the callback has no effect.")]
-		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler receiverHandler)
-			: this (GetHandler (receiverHandler))
+		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler renderHandler)
+			: this (GetHandler (renderHandler))
 		{
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use the overload that takes a delegate that does not take a 'ref AudioBuffers' instead. Assigning a value to the 'inputData' parameter in the callback has no effect.")]
-		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler receiverHandler)
-			: this (format, GetHandler (receiverHandler))
+		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler)
+			: this (format, GetHandler (renderHandler))
 		{
 		}
 #endif // !XAMCORE_5_0
@@ -70,44 +70,44 @@ namespace AVFoundation {
 #if !NET
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use the overload that takes a delegate that does not take a 'ref AudioBuffers' instead. Assigning a value to the 'inputData' parameter in the callback has no effect.")]
-		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler2 receiverHandler)
-			: this (GetHandler (receiverHandler))
+		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler2 renderHandler)
+			: this (GetHandler (renderHandler))
 		{
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use the overload that takes a delegate that does not take a 'ref AudioBuffers' instead. Assigning a value to the 'inputData' parameter in the callback has no effect.")]
-		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 receiverHandler)
-			: this (format, GetHandler (receiverHandler))
+		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 renderHandler)
+			: this (format, GetHandler (renderHandler))
 		{
 		}
 #endif // !NET
 
 		/// <summary>Creates an <see cref="T:AudioToolbox.AVAudioSourceNode" /> with the specified callback to render audio.</summary>
-		/// <param name="receiverHandler">The callback that will be called to supply audio data.</param>
+		/// <param name="renderHandler">The callback that will be called to supply audio data.</param>
 #if XAMCORE_5_0
-		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler receiverHandler)
+		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler renderHandler)
 #else
-		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler3 receiverHandler)
+		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler3 renderHandler)
 #endif // XAMCORE_5_0
-			: this (GetHandler (receiverHandler))
+			: this (GetHandler (renderHandler))
 		{
 		}
 
 		/// <summary>Creates an <see cref="T:AudioToolbox.AVAudioSourceNode" /> with the specified callback to render audio.</summary>
 		/// <param name="format">The format of the PCM audio data the callback supplies.</param>
-		/// <param name="receiverHandler">The callback that will be called to supply audio data.</param>
+		/// <param name="renderHandler">The callback that will be called to supply audio data.</param>
 #if XAMCORE_5_0
-		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler receiverHandler)
+		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler)
 #else
-		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler3 receiverHandler)
+		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler3 renderHandler)
 #endif // XAMCORE_5_0
-			: this (format, GetHandler (receiverHandler))
+			: this (format, GetHandler (renderHandler))
 		{
 		}
 
 #if !NET
-		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler receiverHandler)
+		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler renderHandler)
 		{
 			AVAudioSourceNodeRenderHandlerRaw rv = (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData) => {
 				unsafe {
@@ -115,7 +115,7 @@ namespace AVFoundation {
 					bool isSilenceBool = (*isSilencePtr) != 0;
 					AudioTimeStamp timestampValue = *(AudioTimeStamp*) timestamp;
 					var buffers = new AudioBuffers (outputData);
-					return receiverHandler (isSilenceBool, timestampValue, frameCount, ref buffers);
+					return renderHandler (isSilenceBool, timestampValue, frameCount, ref buffers);
 				}
 			};
 			return rv;
@@ -124,9 +124,9 @@ namespace AVFoundation {
 
 #if !XAMCORE_5_0
 #if NET
-		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler receiverHandler)
+		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler renderHandler)
 #else
-		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler2 receiverHandler)
+		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler2 renderHandler)
 #endif // NET
 		{
 			AVAudioSourceNodeRenderHandlerRaw rv = (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData) => {
@@ -134,7 +134,7 @@ namespace AVFoundation {
 					byte* isSilencePtr = (byte*) isSilence;
 					bool isSilenceBool = (*isSilencePtr) != 0;
 					var buffers = new AudioBuffers (outputData);
-					var rv = receiverHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void*) timestamp), frameCount, ref buffers);
+					var rv = renderHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void*) timestamp), frameCount, ref buffers);
 					*isSilencePtr = isSilenceBool.AsByte ();
 					return rv;
 				}
@@ -144,9 +144,9 @@ namespace AVFoundation {
 #endif // !XAMCORE_5_0
 
 #if XAMCORE_5_0
-		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler receiverHandler)
+		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler renderHandler)
 #else
-		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler3 receiverHandler)
+		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler3 renderHandler)
 		{
 #endif // !XAMCORE_5_0
 			AVAudioSourceNodeRenderHandlerRaw rv = (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData) => {
@@ -154,7 +154,7 @@ namespace AVFoundation {
 					byte* isSilencePtr = (byte*) isSilence;
 					bool isSilenceBool = (*isSilencePtr) != 0;
 					var buffers = new AudioBuffers (outputData);
-					var rv = receiverHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void*) timestamp), frameCount, buffers);
+					var rv = renderHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void*) timestamp), frameCount, buffers);
 					*isSilencePtr = isSilenceBool.AsByte ();
 					return rv;
 				}

--- a/src/AVFoundation/AVAudioSourceNode.cs
+++ b/src/AVFoundation/AVAudioSourceNode.cs
@@ -1,0 +1,165 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+using AudioToolbox;
+using ObjCRuntime;
+
+namespace AVFoundation {
+
+	// This is messy...
+	// * The good delegate is:
+	//   - AVAudioSourceNodeRenderHandler in XAMCORE_5_0
+	//   - AVAudioSourceNodeRenderHandler3 otherwise
+	// * There are two legacy delegates:
+	//   - AVAudioSourceNodeRenderHandler in .NET and legacy Xamarin
+	//   - AVAudioSourceNodeRenderHandler2 in legacy Xamarin.
+	//
+	// History of mistakes:
+	//
+	// 1. We first bound this using AVAudioSourceNodeRenderHandler (legacy Xamarin version), which was wrong.
+	// 2. We then found the mistake, and bound it as AVAudioSourceNodeRenderHandler2 in legacy Xamarin, removed the initial version in .NET, and named it AVAudioSourceNodeRenderHandler in .NET.
+	//    * However, we failed to write tests, so this delegate was broken too.
+	// 3. Finally we got a customer report, and realized the new delegate was broken too. So now there are two broken delegates, and one working (AVAudioSourceNodeRenderHandler3 in .NET and legacy Xamarin, named as AVAudioSourceNodeRenderHandler in XAMCORE_5_0).
+	//    * And tests were added too.
+	//
+	// Note: broken = made to work with a workaround, which makes this even messier.
+	//
+
+	/// <summary>The delegate that will be called in a callback from <see cref="T:AudioToolbox.AVAudioSourceNode" />.</summary>
+	/// <returns>An OSStatus result code. Return 0 to indicate success.</summary>
+	/// <param name="isSilence">Indicates whether the supplied audio data only contains silence.</param>
+	/// <param name="timestamp">The timestamp the audio renders (HAL time).</param>
+	/// <param name="frameCount">The number of frames of audio to supply.</param>
+	/// <param name="outputData">The <see cref="T:AudioToolbox.AudioBuffers" /> that contains the supplied audio data when the callback returns.</param>
+#if XAMCORE_5_0
+	public delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, AudioBuffers outputData);
+#else
+	public delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler3 (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, AudioBuffers outputData);
+#endif
+
+#if !XAMCORE_5_0
+#if NET
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	public delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
+#else
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	public delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	public delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler2 (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
+#endif // NET
+#endif // XAMCORE_5_0
+
+	public partial class AVAudioSourceNode {
+#if !XAMCORE_5_0 && NET
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use the overload that takes a delegate that does not take a 'ref AudioBuffers' instead. Assigning a value to the 'inputData' parameter in the callback has no effect.")]
+		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler receiverHandler)
+			: this (GetHandler (receiverHandler))
+		{
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use the overload that takes a delegate that does not take a 'ref AudioBuffers' instead. Assigning a value to the 'inputData' parameter in the callback has no effect.")]
+		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler receiverHandler)
+			: this (format, GetHandler (receiverHandler))
+		{
+		}
+#endif // !XAMCORE_5_0
+
+#if !NET
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use the overload that takes a delegate that does not take a 'ref AudioBuffers' instead. Assigning a value to the 'inputData' parameter in the callback has no effect.")]
+		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler2 receiverHandler)
+			: this (GetHandler (receiverHandler))
+		{
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use the overload that takes a delegate that does not take a 'ref AudioBuffers' instead. Assigning a value to the 'inputData' parameter in the callback has no effect.")]
+		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 receiverHandler)
+			: this (format, GetHandler (receiverHandler))
+		{
+		}
+#endif // !NET
+
+		/// <summary>Creates an <see cref="T:AudioToolbox.AVAudioSourceNode" /> with the specified callback to render audio.</summary>
+		/// <param name="receiverHandler">The callback that will be called to supply audio data.</param>
+#if XAMCORE_5_0
+		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler receiverHandler)
+#else
+		public AVAudioSourceNode (AVAudioSourceNodeRenderHandler3 receiverHandler)
+#endif // XAMCORE_5_0
+			: this (GetHandler (receiverHandler))
+		{
+		}
+
+		/// <summary>Creates an <see cref="T:AudioToolbox.AVAudioSourceNode" /> with the specified callback to render audio.</summary>
+		/// <param name="format">The format of the PCM audio data the callback supplies.</param>
+		/// <param name="receiverHandler">The callback that will be called to supply audio data.</param>
+#if XAMCORE_5_0
+		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler receiverHandler)
+#else
+		public AVAudioSourceNode (AVAudioFormat format, AVAudioSourceNodeRenderHandler3 receiverHandler)
+#endif // XAMCORE_5_0
+			: this (format, GetHandler (receiverHandler))
+		{
+		}
+
+#if !NET
+		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler receiverHandler)
+		{
+			AVAudioSourceNodeRenderHandlerRaw rv = (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData) => {
+				unsafe {
+					byte* isSilencePtr = (byte *) isSilence;
+					bool isSilenceBool = (*isSilencePtr) != 0;
+					AudioTimeStamp timestampValue = *(AudioTimeStamp *) timestamp;
+					var buffers = new AudioBuffers (outputData);
+					return receiverHandler (isSilenceBool, timestampValue, frameCount, ref buffers);
+				}
+			};
+			return rv;
+		}
+#endif // !NET
+
+#if !XAMCORE_5_0
+#if NET
+		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler receiverHandler)
+#else
+		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler2 receiverHandler)
+#endif // NET
+		{
+			AVAudioSourceNodeRenderHandlerRaw rv = (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData) => {
+				unsafe {
+					byte* isSilencePtr = (byte *) isSilence;
+					bool isSilenceBool = (*isSilencePtr) != 0;
+					var buffers = new AudioBuffers (outputData);
+					var rv = receiverHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void *) timestamp), frameCount, ref buffers);
+					*isSilencePtr = isSilenceBool.AsByte ();
+					return rv;
+				}
+			};
+			return rv;
+		}
+#endif // !XAMCORE_5_0
+
+#if XAMCORE_5_0
+		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler receiverHandler)
+#else
+		static AVAudioSourceNodeRenderHandlerRaw GetHandler (AVAudioSourceNodeRenderHandler3 receiverHandler)
+		{
+#endif // !XAMCORE_5_0
+			AVAudioSourceNodeRenderHandlerRaw rv = (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData) => {
+				unsafe {
+					byte* isSilencePtr = (byte *) isSilence;
+					bool isSilenceBool = (*isSilencePtr) != 0;
+					var buffers = new AudioBuffers (outputData);
+					var rv = receiverHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void *) timestamp), frameCount, buffers);
+					*isSilencePtr = isSilenceBool.AsByte ();
+					return rv;
+				}
+			};
+			return rv;
+		}
+	}
+}

--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -16,8 +16,6 @@ using NativeHandle = System.IntPtr;
 #nullable enable
 
 namespace AVFoundation {
-	public delegate int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioToolbox.AudioBuffers outputData);
-
 	partial class AVAudioNode {
 		internal AVAudioNode () { }
 	}

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -15844,12 +15844,9 @@ namespace AVFoundation {
 		[Export ("replacementFormatDescription")]
 		CMFormatDescription ReplacementFormatDescription { get; }
 	}
-#if NET
-	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
-#else
-	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler (bool isSilence, AudioToolbox.AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
-	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandler2 (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers outputData);
-#endif
+
+	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandlerRaw (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData);
+
 	[Watch (6, 0), TV (13, 0), iOS (13, 0)]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (AVAudioNode))]
@@ -15857,19 +15854,11 @@ namespace AVFoundation {
 	interface AVAudioSourceNode : AVAudioMixing {
 		[Export ("initWithRenderBlock:")]
 		[DesignatedInitializer]
-#if NET
-		NativeHandle Constructor (AVAudioSourceNodeRenderHandler renderHandler);
-#else
-		NativeHandle Constructor (AVAudioSourceNodeRenderHandler2 renderHandler);
-#endif
+		NativeHandle Constructor (AVAudioSourceNodeRenderHandlerRaw renderHandler);
 
 		[Export ("initWithFormat:renderBlock:")]
 		[DesignatedInitializer]
-#if NET
-		NativeHandle Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler renderHandler);
-#else
-		NativeHandle Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandler2 renderHandler);
-#endif
+		NativeHandle Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandlerRaw renderHandler);
 	}
 
 	delegate int AVAudioSinkNodeReceiverHandlerRaw (IntPtr timestamp, uint frameCount, IntPtr inputData);

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -15845,6 +15845,12 @@ namespace AVFoundation {
 		CMFormatDescription ReplacementFormatDescription { get; }
 	}
 
+	/// <summary>The delegate that will be called in a callback from <see cref="T:AudioToolbox.AVAudioSourceNode" />.</summary>
+	/// <returns>An OSStatus result code. Return 0 to indicate success.</returns>
+	/// <param name="isSilence">Indicates whether the supplied audio data only contains silence. This is a pointer to a <see cref="T:System.Byte" /> value.</param>
+	/// <param name="timestamp">The timestamp the audio renders (HAL time). This is a pointer to an <see cref="T:AudioToolbox.AudioTimeStamp" /> value.</param>
+	/// <param name="frameCount">The number of frames of audio to supply.</param>
+	/// <param name="outputData">The <see cref="T:AudioToolbox.AudioBuffers" /> that contains the supplied audio data when the callback returns. This is a handle for an <see cref="T:AudioToolbox.AudioBuffers" /> value.</param>
 	delegate /* OSStatus */ int AVAudioSourceNodeRenderHandlerRaw (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData);
 
 	[Watch (6, 0), TV (13, 0), iOS (13, 0)]
@@ -15852,10 +15858,15 @@ namespace AVFoundation {
 	[BaseType (typeof (AVAudioNode))]
 	[DisableDefaultCtor]
 	interface AVAudioSourceNode : AVAudioMixing {
+		/// <summary>Creates an <see cref="T:AudioToolbox.AVAudioSourceNode" /> with the specified callback to render audio.</summary>
+		/// <param name="renderHandler">The callback that will be called to supply audio data.</param>
 		[Export ("initWithRenderBlock:")]
 		[DesignatedInitializer]
 		NativeHandle Constructor (AVAudioSourceNodeRenderHandlerRaw renderHandler);
 
+		/// <summary>Creates an <see cref="T:AudioToolbox.AVAudioSourceNode" /> with the specified callback to render audio.</summary>
+		/// <param name="format">The format of the PCM audio data the callback supplies.</param>
+		/// <param name="renderHandler">The callback that will be called to supply audio data.</param>
 		[Export ("initWithFormat:renderBlock:")]
 		[DesignatedInitializer]
 		NativeHandle Constructor (AVAudioFormat format, AVAudioSourceNodeRenderHandlerRaw renderHandler);

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -4538,6 +4538,8 @@ public partial class Generator : IMemberGatherer {
 				if (shortName.StartsWith ("Func<", StringComparison.Ordinal))
 					continue;
 
+				WriteDocumentation (mi.DeclaringType);
+
 				var del = mi.DeclaringType;
 
 				if (AttributeManager.HasAttribute (mi.DeclaringType, "MonoNativeFunctionWrapper"))

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -267,6 +267,7 @@ AVFOUNDATION_SOURCES = \
 	AVFoundation/AVAudioSessionDataSourceDescription.cs \
 	AVFoundation/AVAudioSessionPortDescription.cs \
 	AVFoundation/AVAudioSinkNode.cs \
+	AVFoundation/AVAudioSourceNode.cs \
 	AVFoundation/AVCaptureConnection.cs \
 	AVFoundation/AVCaptureDeviceDiscoverySession.cs \
 	AVFoundation/AVCaptureDeviceInput.cs \

--- a/tests/monotouch-test/AVFoundation/AVAudioSourceNodeTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioSourceNodeTest.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using AudioToolbox;
+using AVFoundation;
+using Foundation;
+
+namespace MonoTouchFixtures.AVFoundation {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class AVAudioSourceNodeTest {
+#if __WATCHOS__
+		[SetUp]
+		public void SetUp ()
+		{
+			// Looks like this test broke in the watchOS simulator, so just skip it there.
+			TestRuntime.AssertNotSimulator ();
+		}
+#endif
+
+		[Test]
+		public void SourceNodeCallback ()
+		{
+			var callbackEvent = new TaskCompletionSource<bool> ();
+			SourceNodeCallbackTest (callbackEvent, () => {
+#if XAMCORE_5_0
+				var handler = new AVAudioSourceNodeRenderHandler ((ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, AudioBuffers buffers) => SourceHandler (ref isSilence, ref timestamp, frameCount, buffers, callbackEvent));
+#else
+				var handler = new AVAudioSourceNodeRenderHandler3 ((ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, AudioBuffers buffers) => SourceHandler (ref isSilence, ref timestamp, frameCount, buffers, callbackEvent));
+#endif
+				return new AVAudioSourceNode (handler);
+			});
+		}
+
+		[Test]
+		public void SourceNodeCallbackRaw ()
+		{
+			var callbackEvent = new TaskCompletionSource<bool> ();
+			SourceNodeCallbackTest (callbackEvent, () => {
+				var handler = new AVAudioSourceNodeRenderHandlerRaw ((IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr buffers) => SourceHandlerRaw (isSilence, timestamp, frameCount, buffers, callbackEvent));
+				return new AVAudioSourceNode (handler);
+			});
+		}
+
+#if !XAMCORE_5_0
+		[Test]
+		public void SourceNodeCallback2 ()
+		{
+			var callbackEvent = new TaskCompletionSource<bool> ();
+			SourceNodeCallbackTest (callbackEvent, () => {
+#if NET
+				var handler = new AVAudioSourceNodeRenderHandler ((ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers buffers) => SourceHandler (ref isSilence, ref timestamp, frameCount, buffers, callbackEvent));
+#else
+				var handler = new AVAudioSourceNodeRenderHandler2 ((ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers buffers) => SourceHandler (ref isSilence, ref timestamp, frameCount, buffers, callbackEvent));
+#endif
+				return new AVAudioSourceNode (handler);
+			});
+		}
+#endif
+
+		void SourceNodeCallbackTest (TaskCompletionSource<bool> callbackEvent, Func<AVAudioSourceNode> createSourceNode)
+		{
+			TestRuntime.AssertNotVirtualMachine ();
+
+#if __MACOS__
+			var defaultCaptureDevice = AVCaptureDevice.GetDefaultDevice (AVMediaTypes.Audio);
+			if (defaultCaptureDevice is null)
+				Assert.Ignore ("The current system doesn't have a microphone.");
+#else
+			using var session = AVAudioSession.SharedInstance ();
+			if (!session.InputAvailable)
+				Assert.Ignore ("The current system doesn't have a microphone.");
+
+			session.SetCategory (AVAudioSessionCategory.PlayAndRecord, AVAudioSessionCategoryOptions.DefaultToSpeaker, out var categoryError);
+			Assert.IsNull (categoryError, "Category Error");
+#if !__WATCHOS__
+			session.SetPreferredSampleRate (48000, out var sampleRateError);
+			Assert.IsNull (sampleRateError, "Sample Rate Error");
+			if (session.MaximumInputNumberOfChannels == 0)
+				Assert.Ignore ("The current system doesn't support any input channels");
+			session.SetPreferredInputNumberOfChannels (1, out var inputChannelCountError);
+			Assert.IsNull (inputChannelCountError, "Input Channel Count Error");
+#endif // !__WATCHOS__
+			session.SetActive (true);
+#endif // __MACOS__
+
+			using var engine = new AVAudioEngine ();
+
+			try {
+				var inputNode = engine.InputNode;
+				var inputFormat = inputNode.GetBusOutputFormat (0);
+				if (inputFormat.SampleRate == 0)
+					Assert.Ignore ("The current system can't record audio.");
+
+				var SourceNode = createSourceNode ();
+				engine.AttachNode (SourceNode);
+				engine.Connect (SourceNode, engine.MainMixerNode, inputFormat);
+				engine.StartAndReturnError (out var error);
+
+				Assert.IsNull (error, "Start error");
+				Assert.True (callbackEvent.Task.Wait (TimeSpan.FromSeconds (5)), "Called back");
+			} finally {
+				engine.Stop ();
+			}
+		}
+
+		int SourceHandler (ref bool isSilence, ref AudioTimeStamp timestamp, uint frameCount, AudioBuffers outputData, TaskCompletionSource<bool> evt)
+		{
+			try {
+				Assert.AreEqual (1, outputData.Count, "Count");
+				Assert.That (((IntPtr) outputData.Handle).ToInt64 (), Is.GreaterThan (1024), "Valid handle");
+				Assert.That (outputData [0].DataByteSize, Is.GreaterThan (1023), "Valid data size");
+				Assert.That (outputData [0].NumberChannels, Is.GreaterThan (0), "NumberChannels");
+				Assert.That (frameCount, Is.GreaterThan (0), "FrameCount");
+
+				evt.TrySetResult (true);
+			} catch (Exception e) {
+				evt.SetException (e);
+			}
+			return 0;
+		}
+
+		static void LogMe (string message)
+		{
+			Console.WriteLine ($"STDOUT: {message}");
+			Console.Error.WriteLine ($"STDERR: {message}");
+			TestRuntime.NSLog ($"NSLOG: {message}");
+			File.AppendAllText ("/tmp/logme.txt", $"{DateTime.Now} {message}\n");
+		}
+
+		unsafe int SourceHandlerRaw (IntPtr isSilence, IntPtr timestamp, uint frameCount, IntPtr outputData, TaskCompletionSource<bool> evt)
+		{
+			int rv = 0;
+			try {
+				byte* isSilencePtr = (byte *) isSilence;
+				bool isSilenceBool = (*isSilencePtr) != 0;
+				var buffers = new AudioBuffers (outputData);
+				rv = SourceHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void *) timestamp), frameCount, buffers, evt);
+				*isSilencePtr = isSilenceBool ? (byte) 1 : (byte) 0;
+			} catch (Exception e) {
+				evt.SetException (e);
+			}
+			return rv;
+		}
+	}
+}

--- a/tests/monotouch-test/AVFoundation/AVAudioSourceNodeTest.cs
+++ b/tests/monotouch-test/AVFoundation/AVAudioSourceNodeTest.cs
@@ -139,10 +139,10 @@ namespace MonoTouchFixtures.AVFoundation {
 		{
 			int rv = 0;
 			try {
-				byte* isSilencePtr = (byte *) isSilence;
+				byte* isSilencePtr = (byte*) isSilence;
 				bool isSilenceBool = (*isSilencePtr) != 0;
 				var buffers = new AudioBuffers (outputData);
-				rv = SourceHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void *) timestamp), frameCount, buffers, evt);
+				rv = SourceHandler (ref isSilenceBool, ref Unsafe.AsRef<AudioTimeStamp> ((void*) timestamp), frameCount, buffers, evt);
 				*isSilencePtr = isSilenceBool ? (byte) 1 : (byte) 0;
 			} catch (Exception e) {
 				evt.SetException (e);


### PR DESCRIPTION
The signature of the callback provided when creating AVAudioSourceNode instances
was wrong, so the callback would get corrupted data, causing crashes.

Fix the callback to have the right signature (not too difficult), and also make the
existing signature work (a bit more complicated).

Note that this is the second time we've tried to fix the delegate signature for the
AVAudioSourceNode callbacks, but now with tests, so hoping there won't be a third
time.

Fixes https://github.com/xamarin/xamarin-macios/issues/19868.