### PR TITLE
[AppKit] Create a better binding for [NSEvent eventWithGCEvent:].

### DIFF
--- a/src/AppKit/NSEvent.cs
+++ b/src/AppKit/NSEvent.cs
@@ -13,6 +13,15 @@ namespace AppKit {
 	[DebuggerTypeProxy (typeof (NSEvent.NSEventDebuggerProxy))]
 	public partial class NSEvent {
 
+		/// <summary>Create a new <see cref="AppKit.NSEvent" /> using the specified <see cref="CoreGraphics.CGEvent" />.</summary>
+		/// <param name="event">The <see cref="CoreGraphics.CGEvent" /> that will be wrapped.</param>
+		/// <returns>The newly created <see cref="AppKit.NSEvent" />.</returns>
+		/// <remarks>This method will return null if there's no corresponding Cocoa event.</remarks>
+		public static NSEvent? Create (CGEvent @event)
+		{
+			return EventWithCGEvent (@event.GetNonNullHandle (nameof (@event)));
+		}
+
 		class NSEventDebuggerProxy {
 			NSEvent target;
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -7956,6 +7956,10 @@ namespace AppKit {
 
 		[Static]
 		[Export ("eventWithCGEvent:")]
+		[Obsolete ("Use 'Create (CGEvent)' instead.")]
+#if XAMCORE_5_0
+		[Internal]
+#endif
 		NSEvent EventWithCGEvent (IntPtr cgEventPtr);
 
 		[Export ("magnification")]

--- a/tests/monotouch-test/AppKit/NSEvent.cs
+++ b/tests/monotouch-test/AppKit/NSEvent.cs
@@ -1,0 +1,23 @@
+#if __MACOS__
+using NUnit.Framework;
+using System;
+
+using AppKit;
+using CoreGraphics;
+using Foundation;
+using ObjCRuntime;
+
+namespace Xamarin.Mac.Tests {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NSEventTests {
+		[Test]
+		public void Create ()
+		{
+			using var cgevent = new CGEvent (null, (ushort) 1, true);
+			using var nsevent = NSEvent.Create (cgevent);
+			Assert.AreEqual ((int) cgevent.EventType, (int) nsevent.Type, "[Event]Type");
+		}
+	}
+}
+#endif // __MACOS__


### PR DESCRIPTION
Create a better binding for `[NSEvent eventWithGCEvent:]` by binding it as
`NSEvent.Create(CGEvent)` instead of `NSEvent.EventWithGCEvent(IntPtr)`.

Partial fix for https://github.com/xamarin/xamarin-macios/issues/12650.