### PR TITLE
[msbuild] Use the fully resolved path when computing the relative path for the LogicalName property. Fixes #20330.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ACTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ACTool.cs
@@ -165,11 +165,12 @@ namespace Xamarin.MacDev.Tasks {
 					if (path.EndsWith ("partial-info.plist", StringComparison.Ordinal))
 						continue;
 
-					var vpath = PathUtils.AbsoluteToRelative (pwd, PathUtils.ResolveSymbolicLinks (path));
+					var resolvedPath = PathUtils.ResolveSymbolicLinks (path);
+					var vpath = PathUtils.AbsoluteToRelative (pwd, resolvedPath);
 					var item = new TaskItem (vpath);
 
 					// Note: the intermediate bundle dir functions as a top-level bundle dir
-					var logicalName = PathUtils.AbsoluteToRelative (intermediateBundleDir, path);
+					var logicalName = PathUtils.AbsoluteToRelative (intermediateBundleDir, resolvedPath);
 
 					if (logicalName.StartsWith ("../OnDemandResources/", StringComparison.Ordinal)) {
 						logicalName = logicalName.Substring (3);


### PR DESCRIPTION
This fixes an issue where we'd compute a LogicalName property that was outside
of the app bundle, resulting in broken resources in the app bundle (in
particular the app icon would be missing).

So instead of something like this:

    LogicalName: ../../../../../../../../../tmp/testapp/obj/Debug/net8.0-ios/iossimulator-arm64/actool/bundle/Assets.car

we'll now get:

    LogicalName: Assets.car

and the icons will be correctly embedded in the app bundle.

Fixes https://github.com/xamarin/xamarin-macios/issues/20330.