### PR TITLE
[CoreGraphics] Bind CGEventPostToPid.

### DIFF
--- a/src/CoreGraphics/CGEvent.cs
+++ b/src/CoreGraphics/CGEvent.cs
@@ -489,12 +489,39 @@ namespace CoreGraphics {
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
 		extern static void CGEventPostToPSN (IntPtr processSerialNumber, IntPtr handle);
 
+		/// <summary>Post an event to a specific process</summary>
+		/// <remarks>Deprecated, use <see cref="PostToPid" /> instead.</remarks>
 		public static void PostToPSN (CGEvent evt, IntPtr processSerialNumber)
 		{
 			if (evt is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (evt));
 			
 			CGEventPostToPSN (processSerialNumber, evt.Handle);
+		}
+
+		/// <summary>Post an event to a specific process</summary>
+		/// <remarks>Deprecated, use <see cref="PostToPid" /> instead.</remarks>
+		public void PostToPSN (IntPtr processSerialNumber)
+		{
+			PostToPSN (this, processSerialNumber);
+		}
+
+		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]
+		extern static void CGEventPostToPid (int pid, IntPtr handle);
+
+		/// <summary>Post an event to a specific process</summary>
+		public static void PostToPid (CGEvent evt, int pid)
+		{
+			if (evt is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (evt));
+
+			CGEventPostToPid (pid, evt.Handle);
+		}
+
+		/// <summary>Post an event to a specific process</summary>
+		public void PostToPid (int pid)
+		{
+			PostToPid (this, pid);
 		}
 		
 		[DllImport (Constants.ApplicationServicesCoreGraphicsLibrary)]

--- a/tests/monotouch-test/CoreGraphics/CGEventTests.cs
+++ b/tests/monotouch-test/CoreGraphics/CGEventTests.cs
@@ -68,6 +68,6 @@ namespace MonoTouchFixtures.CoreGraphics {
 
 		[DllImport ("/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices")]
 		static extern int GetProcessForPID (int pid, out IntPtr psn);
-	}
 #endif // __MACOS__ || __MACCATALYST__
 	}
+}

--- a/tests/monotouch-test/CoreGraphics/CGEventTests.cs
+++ b/tests/monotouch-test/CoreGraphics/CGEventTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Foundation;
 #if MONOMAC
 using AppKit;
@@ -40,5 +42,30 @@ namespace MonoTouchFixtures.CoreGraphics {
 			Assert.IsFalse (tapCalled, "tap was mistakenly called.");
 		}
 #endif
+
+		[Test]
+		public void PostToPid ()
+		{
+			var pid = Process.GetCurrentProcess ().Id;
+			using var evt = new CGEvent (null, (ushort) 1, true);
+			evt.PostToPid (pid);
+			CGEvent.PostToPid (evt, pid);
+		}
+
+		[Test]
+		public void PostToPSN ()
+		{
+			var pid = Process.GetCurrentProcess ().Id;
+			Assert.AreEqual (0, GetProcessForPID (pid, out var psn), "GetProcessForPID");
+			using var evt = new CGEvent (null, (ushort) 1, true);
+			unsafe {
+				IntPtr* psnPtr = &psn;
+				evt.PostToPSN ((IntPtr) psnPtr);
+				CGEvent.PostToPSN (evt, (IntPtr) psnPtr);
+			}
+		}
+
+		[DllImport ("/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices")]
+		static extern int GetProcessForPID (int pid, out IntPtr psn);
 	}
 }

--- a/tests/monotouch-test/CoreGraphics/CGEventTests.cs
+++ b/tests/monotouch-test/CoreGraphics/CGEventTests.cs
@@ -70,4 +70,4 @@ namespace MonoTouchFixtures.CoreGraphics {
 		static extern int GetProcessForPID (int pid, out IntPtr psn);
 	}
 #endif // __MACOS__ || __MACCATALYST__
-}
+	}

--- a/tests/monotouch-test/CoreGraphics/CGEventTests.cs
+++ b/tests/monotouch-test/CoreGraphics/CGEventTests.cs
@@ -43,6 +43,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 		}
 #endif
 
+#if __MACOS__ || __MACCATALYST__
 		[Test]
 		public void PostToPid ()
 		{
@@ -68,4 +69,5 @@ namespace MonoTouchFixtures.CoreGraphics {
 		[DllImport ("/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices")]
 		static extern int GetProcessForPID (int pid, out IntPtr psn);
 	}
+#endif // __MACOS__ || __MACCATALYST__
 }

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreGraphics.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreGraphics.ignore
@@ -86,7 +86,6 @@
 !missing-pinvoke! CGDisplayVendorNumber is not bound
 !missing-pinvoke! CGEventCreateScrollWheelEvent2 is not bound
 !missing-pinvoke! CGEventGetTypeID is not bound
-!missing-pinvoke! CGEventPostToPid is not bound
 !missing-pinvoke! CGEventSetDoubleValueField is not bound
 !missing-pinvoke! CGEventSetIntegerValueField is not bound
 !missing-pinvoke! CGEventSourceGetTypeID is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreGraphics.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreGraphics.ignore
@@ -74,7 +74,6 @@
 !missing-pinvoke! CGDisplayVendorNumber is not bound
 !missing-pinvoke! CGEventCreateScrollWheelEvent2 is not bound
 !missing-pinvoke! CGEventGetTypeID is not bound
-!missing-pinvoke! CGEventPostToPid is not bound
 !missing-pinvoke! CGEventSetDoubleValueField is not bound
 !missing-pinvoke! CGEventSetIntegerValueField is not bound
 !missing-pinvoke! CGEventSourceGetTypeID is not bound

--- a/tests/xtro-sharpie/macOS-CoreGraphics.ignore
+++ b/tests/xtro-sharpie/macOS-CoreGraphics.ignore
@@ -74,7 +74,6 @@
 !missing-pinvoke! CGDisplayVendorNumber is not bound
 !missing-pinvoke! CGEventCreateScrollWheelEvent2 is not bound
 !missing-pinvoke! CGEventGetTypeID is not bound
-!missing-pinvoke! CGEventPostToPid is not bound
 !missing-pinvoke! CGEventSetDoubleValueField is not bound
 !missing-pinvoke! CGEventSetIntegerValueField is not bound
 !missing-pinvoke! CGEventSourceGetTypeID is not bound


### PR DESCRIPTION
Also deprecate CGEventPostToPSN in documentation, but not formally using
attributes, because Apple only documented the deprecation of CGEventPostToPSN
in a header comment, and not their API documentation, nor using attributes.