### PR TITLE
[dotnet] Compute relative paths using absolute paths.

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
+++ b/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props
@@ -20,37 +20,37 @@
 	<ItemGroup Condition="'$(EnableDefault@PLATFORM@Items)' == 'true' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@TARGET_FRAMEWORK_VERSION@')) And '$(CurrentHash)' == '@CURRENT_HASH_LONG@'">
 		<!-- Default plist file inclusion -->
 		<None Include="*.plist">
-			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
+			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(FullPath)'))</Link>
 		</None>
 
 		<!-- Default Asset Catalog file inclusion -->
 		<ImageAsset Include="**\*.xcassets\**\*.*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);**\*.xcassets\**\*.DS_Store">
-			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
+			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(FullPath)'))</Link>
 			<Visible>false</Visible>
 			<IsDefaultItem>true</IsDefaultItem>
 		</ImageAsset>
 
 		<!-- Default Storyboard file inclusion -->
 		<InterfaceDefinition Include="**\*.storyboard;**\*.xib" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
-			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
+			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(FullPath)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
 		</InterfaceDefinition>
 
 		<!-- Default Atlas Texture file inclusion -->
 		<AtlasTexture Include="**\*.atlas\*.png" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
-			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
+			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(FullPath)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
 		</AtlasTexture>
 
 		<!-- Default CoreMLModel inclusion -->
 		<CoreMLModel Include="**\*.mlmodel" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
-			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
+			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(FullPath)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
 		</CoreMLModel>
 
 		<!-- Default Metal inclusion -->
 		<Metal Include="**\*.metal" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" >
-			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
+			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(FullPath)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
 		</Metal>
 
@@ -74,7 +74,7 @@
 			@(Compile);
 			@(EmbeddedResource);
 			" Condition="'$(_ResourcePrefix)' != ''" >
-			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(Identity)'))</Link>
+			<Link>$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(FullPath)'))</Link>
 			<IsDefaultItem>true</IsDefaultItem>
 		</BundleResource>
 	</ItemGroup>


### PR DESCRIPTION
The 'MSBuild::MakeRelative' path takes the current directory into account.

Given the following example:

    $([MSBuild]::MakeRelative('/Users/rolf/testproject/','Info.plist'))

returns:

1. `/Info.plist` if the current directory is the root directory (`/`).
2. `Info.plist` otherwise.

This is a problem, because we specifically look for "Info.plist" during the
build, and if we don't find it, we may end up with this error:

> A bundle identifier is required. Either add an 'ApplicationId' property in the project file, or add a 'CFBundleIdentifier' entry in the project's Info.plist file.

The fix is to instead of use the relative `Info.plist` path in the call to
`[MSBuild]::MakeRelative`, use the full path instead:

    $([MSBuild]::MakeRelative('/Users/rolf/testproject/','/Users/rolf/testproject/Info.plist'))

and that always yields the expected "Info.plist" result.