### PR TITLE
[msbuild] Add more diagnostic output to FindItemWithLogicalName.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -713,6 +713,11 @@
 {1} - The location the file was found.</comment>
     </data>
     
+    <data name="M0149b" xml:space="preserve">
+        <value>Discarded '{0}' with logical name '{1}' because the logical name does not match '{2}'</value>
+        <comment>{0} - A path to a file.</comment>
+    </data>
+
     <data name="E0150" xml:space="preserve">
         <value>  AssemblyPath cannot be null or empty
         </value>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FindItemWithLogicalName.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FindItemWithLogicalName.cs
@@ -44,6 +44,7 @@ namespace Xamarin.MacDev.Tasks {
 						Item = item;
 						break;
 					}
+					Log.LogMessage (MessageImportance.Low, MSBStrings.M0149b /* "Discarded '{0}' with logical name '{1}' because the logical name does not match '{2}'" */, item.ItemSpec, logical, LogicalName);
 				}
 			}
 


### PR DESCRIPTION
I've seen multiple cases of the following error:

>  A bundle identifier is required. Either add an 'ApplicationId' property in the project file, or add a 'CFBundleIdentifier' entry in the project's Info.plist file.

In all cases this has been been because the build fails to find Info.plist,
when it's actually there.

One source of this problem was found and fixed with #20374, but that's not the
problem in other scenarios.

So I'm adding a bit more diagnostic output to the FindItemWithLogicalName
task, to try to track down why the task fails to find `Info.plist`.