### PR TITLE
[ObjCRuntime] Fix string comparison to be ordinal.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2445,7 +2445,7 @@ namespace ObjCRuntime {
 					byte b = c [i];
 					if (b > 0x7F) {
 						// This string is a multibyte UTF8 string, so go the slow route and convert it to a managed string before comparison
-						return string.Equals (Marshal.PtrToStringUTF8 (utf8), str);
+						return string.Equals (Marshal.PtrToStringUTF8 (utf8), str, StringComparison.Ordinal);
 					}
 					if (b != (short) str [i])
 						return false;


### PR DESCRIPTION
There's no change in behavior, because string.Equals(string,string) already does ordinal comparison, but:

* "Use overloads that explicitly specify the string comparison rules for string operations.""
* "Use an overload of the String.Equals method to test whether two strings are equal."

Ref: https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings