### PR TITLE
[CoreGraphics] Bind CGEventTapCreateForPid and misc other improvements.

### DIFF
--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreGraphics.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreGraphics.ignore
@@ -76,7 +76,6 @@
 !missing-pinvoke! CGEventSetDoubleValueField is not bound
 !missing-pinvoke! CGEventSetIntegerValueField is not bound
 !missing-pinvoke! CGEventSourceGetTypeID is not bound
-!missing-pinvoke! CGEventTapCreateForPid is not bound
 !missing-pinvoke! CGGetActiveDisplayList is not bound
 !missing-pinvoke! CGGetDisplaysWithOpenGLDisplayMask is not bound
 !missing-pinvoke! CGGetDisplaysWithPoint is not bound


### PR DESCRIPTION
* Bind CGEventTapCreateForPid.
* Remove an obsolete CGEvent.CreateTap overload from XAMCORE_5_0.
* Unify/deduplicate code to keep track of taps.
* Make TapData disposable to not depend on the GC to come around.
* Add API documentation.