### PR TITLE
[UIKit] Remove UITextAttributes.Dictionary. Fixes #20409.

### DIFF
--- a/src/UIKit/UIBarItem.cs
+++ b/src/UIKit/UIBarItem.cs
@@ -24,8 +24,12 @@ namespace UIKit {
 
 		public void SetTitleTextAttributes (TextAttributes attributes, UIControlState state)
 		{
-			using (var dict = attributes is null ? null : attributes.Dictionary)
-				_SetTitleTextAttributes (dict, state);
+#if XAMCORE_3_0
+			var dict = attributes?.Dictionary;
+#else
+			using var dict = attributes?.ToDictionary ();
+#endif
+			_SetTitleTextAttributes (dict, state);
 		}
 
 		public TextAttributes GetTitleTextAttributes (UIControlState state)
@@ -40,9 +44,12 @@ namespace UIKit {
 			{
 				if (attributes is null)
 					throw new ArgumentNullException ("attributes");
-				using (var dict = attributes.Dictionary) {
-					_SetTitleTextAttributes (dict, state);
-				}
+#if XAMCORE_3_0
+				var dict = attributes.Dictionary;
+#else
+				using var dict = attributes.ToDictionary ();
+#endif
+				_SetTitleTextAttributes (dict, state);
 			}
 
 			public virtual TextAttributes GetTitleTextAttributes (UIControlState state)

--- a/src/UIKit/UISearchBar.cs
+++ b/src/UIKit/UISearchBar.cs
@@ -24,9 +24,12 @@ namespace UIKit {
 			if (attributes is null)
 				throw new ArgumentNullException ("attributes");
 
-			using (var dict = attributes.Dictionary) {
-				_SetScopeBarButtonTitle (dict, state);
-			}
+#if XAMCORE_3_0
+			var dict = attributes.Dictionary;
+#else
+			using var dict = attributes.ToDictionary ();
+#endif
+			_SetScopeBarButtonTitle (dict, state);
 		}
 
 		public TextAttributes GetScopeBarButtonTitleTextAttributes (UIControlState state)
@@ -42,9 +45,12 @@ namespace UIKit {
 				if (attributes is null)
 					throw new ArgumentNullException ("attributes");
 
-				using (var dict = attributes.Dictionary) {
-					_SetScopeBarButtonTitle (dict, state);
-				}
+#if XAMCORE_3_0
+				var dict = attributes.Dictionary;
+#else
+				using var dict = attributes.ToDictionary ();
+#endif
+				_SetScopeBarButtonTitle (dict, state);
 			}
 
 			public TextAttributes GetScopeBarButtonTitleTextAttributes (UIControlState state)

--- a/src/UIKit/UISegmentedControl.cs
+++ b/src/UIKit/UISegmentedControl.cs
@@ -98,9 +98,12 @@ namespace UIKit {
 			if (attributes is null)
 				throw new ArgumentNullException ("attributes");
 
-			using (var dict = attributes.Dictionary) {
-				_SetTitleTextAttributes (dict, state);
-			}
+#if XAMCORE_3_0
+			var dict = attributes.Dictionary;
+#else
+			using var dict = attributes.ToDictionary ();
+#endif
+			_SetTitleTextAttributes (dict, state);
 		}
 
 		public TextAttributes GetTitleTextAttributes (UIControlState state)
@@ -116,9 +119,12 @@ namespace UIKit {
 				if (attributes is null)
 					throw new ArgumentNullException ("attributes");
 
-				using (var dict = attributes.Dictionary) {
-					_SetTitleTextAttributes (dict, state);
-				}
+#if XAMCORE_3_0
+				var dict = attributes.Dictionary;
+#else
+				using var dict = attributes.ToDictionary ();
+#endif
+				_SetTitleTextAttributes (dict, state);
 			}
 
 			public TextAttributes GetTitleTextAttributes (UIControlState state)

--- a/src/UIKit/UITextAttributes.cs
+++ b/src/UIKit/UITextAttributes.cs
@@ -22,13 +22,6 @@ namespace UIKit {
 		public UIColor TextShadowColor;
 		public UIOffset TextShadowOffset;
 
-		// This property is intended for compatibility with UIStringAttributes
-		internal NSDictionary Dictionary {
-			get {
-				return ToDictionary ();
-			}
-		}
-
 		public UITextAttributes ()
 		{
 		}

--- a/tests/monotouch-test/UIKit/StringAttributesTest.cs
+++ b/tests/monotouch-test/UIKit/StringAttributesTest.cs
@@ -142,6 +142,38 @@ namespace MonoTouchFixtures.UIKit {
 			}
 		}
 #endif // !__WATCHOS__
+
+#if !__WATCHOS__
+		[Test]
+		public void PrematureDisposal_SegmentedControl ()
+		{
+			// https://github.com/xamarin/xamarin-macios/issues/20409
+			using var control = new UISegmentedControl ();
+			var attrs = new UIStringAttributes();
+			control.SetTitleTextAttributes (attrs, UIControlState.Normal);
+			control.SetTitleTextAttributes (attrs, UIControlState.Selected);
+		}
+
+		[Test]
+		public void PrematureDisposal_BarItem ()
+		{
+			// https://github.com/xamarin/xamarin-macios/issues/20409
+			using var control = new UIBarItem ();
+			var attrs = new UIStringAttributes();
+			control.SetTitleTextAttributes (attrs, UIControlState.Normal);
+			control.SetTitleTextAttributes (attrs, UIControlState.Selected);
+		}
+
+		[Test]
+		public void PrematureDisposal_SearchBar ()
+		{
+			// https://github.com/xamarin/xamarin-macios/issues/20409
+			using var control = new UISearchBar ();
+			var attrs = new UIStringAttributes();
+			control.SetScopeBarButtonTitle (attrs, UIControlState.Normal);
+			control.SetScopeBarButtonTitle (attrs, UIControlState.Selected);
+		}
+#endif // !__WATCHOS__
 	}
 }
 #endif


### PR DESCRIPTION
The UITextAttributes.Dictionary property is supposed to work like the
UIStringAttributes.Dictionary property, but there's one big difference: the
UITextAttributes version can (and calling code does) be disposed, while the
UIStringAttributes version can't.

This is because the UITextAttributes version creates a new dictionary every
time, while the UIStringAttributes version doesn't.

Since properties shouldn't really do much, it makes sense to remove the
UITextAttributes version, and instead rely on the
UITextAttributes.ToDictionary method, where the difference in behavior is more
obvious.

This required a few changes in calling code, which used either UITextAttributes
or UIStringAttributes using conditional compilation.

Fixes https://github.com/xamarin/xamarin-macios/issues/20409.