### PR TITLE
[dotnet] Automatically link with the Security framework. Fixes #20406.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1492,6 +1492,9 @@
 			<!-- CFNetwork is required by xamarin_start_wwan -->
 			<_NativeExecutableFrameworks Include="CFNetwork" Condition="'$(_PlatformName)' == 'iOS'" />
 
+			<!-- libSystem.Security.Cryptography.Native.Apple.a requires the Security framework -->
+			<_NativeExecutableFrameworks Include="Security" />
+
 			<!-- Mono requires zlib, iconv, and the "Compression framework" -->
 			<_MainLinkerFlags Include="-lz" />
 			<_MainLinkerFlags Include="-liconv" />


### PR DESCRIPTION
It seems we might not always link with the Security framework by default, so
link with it explicitly.

Fixes https://github.com/xamarin/xamarin-macios/issues/20406.