### PR TITLE
[tests] Ignore the MessageHandlerTest.GHIssue16339 test if we're in CI and have a bad network.

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -817,6 +817,7 @@ namespace MonoTests.System.Net.Http {
 
 				for (var i = 0; i < iterations; i++) {
 					var rsp = delegatingHandler.Responses [i];
+					TestRuntime.IgnoreInCIIfBadNetwork (rsp.StatusCode);
 					Assert.IsTrue (delegatingHandler.IsCompleted (i), $"Completed #{i}");
 					Assert.AreEqual ("OK", rsp.ReasonPhrase, $"ReasonPhrase #{i}");
 					Assert.AreEqual (HttpStatusCode.OK, rsp.StatusCode, $"StatusCode #{i}");


### PR DESCRIPTION
Fixes this test failure:

    MonoTests.System.Net.Http.MessageHandlerTest.GHIssue16339
    	[FAIL] GHIssue16339() :   ReasonPhrase #1
      Expected string length 2 but was 11. Strings differ at index 0.
      Expected: "OK"
      But was:  "Bad Gateway"