### PR TITLE
[tests] Don't verify that delegate members have xml documentation.

### DIFF
--- a/tests/cecil-tests/Documentation.cs
+++ b/tests/cecil-tests/Documentation.cs
@@ -129,6 +129,9 @@ namespace Cecil.Tests {
 				string name;
 
 				if (member is MethodDefinition md) {
+					// It's not possible to add xml documentation to members of delegates, so don't verify those
+					if (IsDelegateType (md.DeclaringType))
+						continue;
 					name = "M:" + GetDocId (md);
 				} else if (member is PropertyDefinition pd) {
 					name = "P:" + GetDocId (pd);
@@ -148,6 +151,18 @@ namespace Cecil.Tests {
 			}
 
 			return rv;
+		}
+
+		static bool IsDelegateType (TypeDefinition? type)
+		{
+			while (type is not null) {
+				if (type.Is ("System", "Delegate"))
+					return true;
+
+				type = type.BaseType is not null ? type.BaseType.Resolve () : null;
+			}
+
+			return false;
 		}
 
 		// https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#id-strings


### PR DESCRIPTION
There's no way to add xml documentation to them.

Partial fix for https://github.com/xamarin/xamarin-macios/issues/20270.