### PR TITLE
[bgen] Generate xml documentation for the generated ClassHandle property.

### DIFF
--- a/src/bgen/BindingTouch.cs
+++ b/src/bgen/BindingTouch.cs
@@ -68,6 +68,8 @@ public class BindingTouch : IDisposable {
 	bool supportsXmlDocumentation = true;
 	List<string> references = new List<string> ();
 
+	public bool SupportsXmlDocumentation { get => supportsXmlDocumentation; }
+
 	public MetadataLoadContext? universe;
 	public Frameworks? Frameworks;
 

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -5594,6 +5594,15 @@ public partial class Generator : IMemberGatherer {
 
 			if (!is_static_class && !is_partial) {
 				if (!is_model && !external) {
+					if (BindingTouch.SupportsXmlDocumentation) {
+						print ("/// <summary>The Objective-C class handle for this class.</summary>");
+						print ("/// <value>The pointer to the Objective-C class.</value>");
+						print ("/// <remarks>");
+						print ("///     Each managed class mirrors an unmanaged Objective-C class.");
+						print ("///     This value contains the pointer to the Objective-C class.");
+						print ("///     It is similar to calling the managed <see cref=\"ObjCRuntime.Class.GetHandle(string)\" /> or the native <see href=\"https://developer.apple.com/documentation/objectivec/1418952-objc_getclass\">objc_getClass</see> method with the type name.");
+						print ("/// </remarks>");
+					}
 					print ("public {1} {2} ClassHandle {{ get {{ return class_ptr; }} }}\n", objc_type_name, TypeName == "NSObject" ? "virtual" : "override", NativeHandleType);
 				}
 

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -1502,6 +1502,15 @@ namespace GeneratorTests {
             Summary for T1
             </summary>
         </member>
+        <member name=""P:XmlDocumentation.T1.ClassHandle"">
+            <summary>The Objective-C class handle for this class.</summary>
+            <value>The pointer to the Objective-C class.</value>
+            <remarks>
+                Each managed class mirrors an unmanaged Objective-C class.
+                This value contains the pointer to the Objective-C class.
+                It is similar to calling the managed <see cref=""M:ObjCRuntime.Class.GetHandle(System.String)"" /> or the native <see href=""https://developer.apple.com/documentation/objectivec/1418952-objc_getclass"">objc_getClass</see> method with the type name.
+            </remarks>
+        </member>
         <member name=""M:XmlDocumentation.T1.Method"">
             <summary>
             Summary for T1.Method
@@ -1531,6 +1540,15 @@ namespace GeneratorTests {
             <summary>
             Summary for TG1
             </summary>
+        </member>
+        <member name=""P:XmlDocumentation.TG1`2.ClassHandle"">
+            <summary>The Objective-C class handle for this class.</summary>
+            <value>The pointer to the Objective-C class.</value>
+            <remarks>
+                Each managed class mirrors an unmanaged Objective-C class.
+                This value contains the pointer to the Objective-C class.
+                It is similar to calling the managed <see cref=""M:ObjCRuntime.Class.GetHandle(System.String)"" /> or the native <see href=""https://developer.apple.com/documentation/objectivec/1418952-objc_getclass"">objc_getClass</see> method with the type name.
+            </remarks>
         </member>
         <member name=""M:XmlDocumentation.TG1`2.TGMethod"">
             <summary>


### PR DESCRIPTION
This was mostly copied from the existing API documentation.

Partial fix for https://github.com/xamarin/xamarin-macios/issues/20270.