### PR TITLE
[devops] Add a timeout to the 'undo GitHub merge' step.

### DIFF
--- a/tools/devops/automation/templates/common/checkout.yml
+++ b/tools/devops/automation/templates/common/checkout.yml
@@ -26,6 +26,7 @@ steps:
   name: fix_commit
   displayName: "Undo Github merge"
   workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts
+  timeoutInMinutes: 15
 
 - checkout: maccore
   clean: true


### PR DESCRIPTION
It shouldn't take more than a few minutes to undo the GitHub merge.