### PR TITLE
[tests] Ignore trimmer warnings from NUnit.

### DIFF
--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -66,6 +66,28 @@
 		<DefineConstants>$(DefineConstants);NATIVEAOT</DefineConstants>
 	</PropertyGroup>
 
+	<!-- Trimmer options -->
+	<!-- We want to ignore any trimmer warnings from NUnit. We do this by:
+		* Enable all warnings
+		* Turn off all warnings (enabling single-warning mode) for NUnit
+		* Ignore the warning produced when single-warning logic is triggered.
+	-->
+	<PropertyGroup>
+		<!-- We want all the trimmer warnings -->
+		<TrimmerSingleWarn Condition="'$(TrimmerSingleWarn)' == ''">true</TrimmerSingleWarn>
+		<!-- IL2104: Assembly '...' produced trim warnings -->
+		<NoWarn>$(NoWarn);IL2104</NoWarn>
+	</PropertyGroup>
+	<Target Name="IgnoreTrimmerWarningsInNUnit" BeforeTargets="PrepareForILLink">
+		<ItemGroup>
+			<ManagedAssemblyToLink Condition="'%(Filename)' == 'nunit.framework'">
+				<TrimmerSingleWarn>true</TrimmerSingleWarn>
+			</ManagedAssemblyToLink>
+			<!-- The above ItemGroup doesn't work for NativeAOT, so pass the argument manually to ILC: https://github.com/dotnet/runtime/issues/94255 -->
+			<IlcArg Include="--singlewarnassembly:nunit.framework" />
+		</ItemGroup>
+	</Target>
+
 	<ItemGroup>
 		<PackageReference Include="NUnitLite" Version="3.12.0" Condition="'$(ExcludeNUnitLiteReference)' != 'true'" />
 		<ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\external\Touch.Unit\Touch.Client\dotnet\$(_PlatformName)\Touch.Client-$(_PlatformName).dotnet.csproj" Condition="'$(ExcludeTouchUnitReference)' != 'true'" />

--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -195,6 +195,24 @@ namespace Xharness {
 			}
 		}
 
+		public static void AddTopLevelInclude (this XmlDocument csproj, string type, string link, string include, bool prepend = false)
+		{
+			var type_node = csproj.SelectSingleNode ($"//*[local-name() = '{type}']");
+			var item_group = type_node?.ParentNode ?? csproj.SelectSingleNode ($"/Project/*[local-name() = 'ItemGroup'][last()]")!;
+			var node = csproj.CreateElement (type, csproj.GetNamespace ());
+			var include_attribute = csproj.CreateAttribute ("Include");
+			include_attribute.Value = include;
+			node.Attributes.Append (include_attribute);
+			var linkElement = csproj.CreateElement ("Link", csproj.GetNamespace ());
+			linkElement.InnerText = link;
+			node.AppendChild (linkElement);
+			if (prepend) {
+				item_group.PrependChild (node);
+			} else {
+				item_group.AppendChild (node);
+			}
+		}
+
 		// This is an evolved version of https://github.com/dotnet/xharness/blob/b2297d610df1ae15fc7ba8bd8c9bc0a7192aaefa/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs#L1168
 		public static void ResolveAllPaths (this XmlDocument csproj, string project_path, Dictionary<string, string>? variableSubstitution = null)
 		{

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -147,19 +147,19 @@ namespace Xharness {
 						var windows_file = full_path.Replace ('/', '\\');
 
 						if (file.Contains (".xcasset")) {
-							doc.AddInclude ("ImageAsset", file, windows_file, true);
+							doc.AddTopLevelInclude ("ImageAsset", file, windows_file, true);
 							continue;
 						}
 
 						switch (ext.ToLowerInvariant ()) {
 						case ".cs":
-							doc.AddInclude ("Compile", file, windows_file, true);
+							doc.AddTopLevelInclude ("Compile", file, windows_file, true);
 							break;
 						case ".plist":
-							doc.AddInclude ("None", file, windows_file, true);
+							doc.AddTopLevelInclude ("None", file, windows_file, true);
 							break;
 						case ".storyboard":
-							doc.AddInclude ("InterfaceDefinition", file, windows_file, true);
+							doc.AddTopLevelInclude ("InterfaceDefinition", file, windows_file, true);
 							break;
 						case ".gitignore":
 						case ".csproj":


### PR DESCRIPTION
NUnit is not trimmer-safe, and produces a lot of trimmer warnings.

Ideally we'll fix NUnit or come up with an alternative (see #19911), but
that's a significant amount of work.

We also want to turn warnings into errors (to avoid adding more trimmer
warnings by accident).

So we disable trimmer warnings from NUnit. The method is somewhat complex,
because there's no built-in way to ignore warnings for a given assembly, but
both ILC and ILLink provides a way to collapse multiple warnings into a single
warning (with a specific code) on a per assembly basis, and we can levarage
this:

* We enable all warnings for all assemblies (by setting
  `TrimmerSingleWarn=false`).
* We enable the single-warning mode for NUnit only.
* We ask the trimmer to not warn about the specific warning code given for the
  single-warning produced.

The end result is that we won't get any trimmer warnings for NUnit.

An xharness fix was also needed to make xharness not get confused with
ItemGroups inside Targets when cloning project files.

Ref: https://github.com/xamarin/xamarin-macios/issues/19911