### PR TITLE
[release/7.0.3xx] Use Mono MDK package from download server

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -219,11 +219,10 @@ MONO_HASH := $(NEEDED_MONO_VERSION)
 # Minimum Mono version for building XI/XM
 MIN_MONO_VERSION=6.12.0.179
 MAX_MONO_VERSION=6.12.99
-MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2020-02/185/dffa5ab92245f2419238a35b7c2052e9a24036b4/MonoFramework-MDK-6.12.0.179.macos10.xamarin.universal.pkg
+MIN_MONO_URL=https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-6.12.0.179.macos10.xamarin.universal.pkg
 
 # Minimum Mono version for Xamarin.Mac apps using the system mono
 MIN_XM_MONO_VERSION=6.4.0.94
-MIN_XM_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-06/77/c608cf3eafaea310e11af13cc9380d770112bb83/MonoFramework-MDK-6.4.0.94.macos10.xamarin.universal.pkg
 
 # Minimum CMake version
 MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg


### PR DESCRIPTION
To reduce reliance on xamjenkinsartifact.\r
Also remove MIN_XM_MONO_URL, it is not used anymore.

Backport of #20442.