### PR TITLE
[devops] Terminate any existing builders and brokers when preparing Macs for remote testing.

### DIFF
--- a/tests/dotnet/Windows/collect-binlogs.sh
+++ b/tests/dotnet/Windows/collect-binlogs.sh
@@ -25,3 +25,12 @@ if ls ~/Library/Logs/Xamarin.Messaging* >& /dev/null ; then
 else
 	echo "No logs in ~/Library/Logs/Xamarin.Messaging"
 fi
+
+# Zip up all the logs in /tmp/com.xamarin.*
+if ls /tmp/com.xamarin.* >& /dev/null ; then
+	zip -9r ~/remote_build_testing/windows-remote-logs.zip /tmp/com.xamarin.*
+else
+	echo "No logs in /tmp/com.xamarin.*"
+fi
+
+ps auxww > ~/remote_build_testing/processes.txt || true

--- a/tools/devops/automation/scripts/clean-for-remote-tests.sh
+++ b/tools/devops/automation/scripts/clean-for-remote-tests.sh
@@ -12,3 +12,9 @@ fi
 
 # Make sure we don't have stuff from earlier builds.
 rm -rf ~/remote_build_testing
+
+# Kill any existing brokers and builders
+ps auxww || true
+pkill -f Broker.exe || true
+pkill -f Build.exe || true
+ps auxww || true


### PR DESCRIPTION
Also collect more logs to help diagnose any transient failures.