### PR TITLE
[GameplayKit] Remove the bindings for GKHybridStrategist.

### DIFF
--- a/src/GameplayKit/GKHybridStrategist.cs
+++ b/src/GameplayKit/GKHybridStrategist.cs
@@ -22,9 +22,12 @@ namespace GameplayKit {
 #endif
 	[EditorBrowsable (EditorBrowsableState.Never)]
 	public class GKHybridStrategist : NSObject, IGKStrategist {
+		/// <summary>Do not use</summary>
 		public override NativeHandle ClassHandle => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
 		public GKHybridStrategist () : base (NSObjectFlag.Empty) => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		/// <summary>Do not use</summary>
 		protected GKHybridStrategist (NSObjectFlag t) : base (t) => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		/// <summary>Do not use</summary>
 		protected internal GKHybridStrategist (NativeHandle handle) : base (handle) => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
 		public virtual IGKGameModelUpdate GetBestMoveForActivePlayer () => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
 		public virtual nuint Budget {

--- a/src/GameplayKit/GKHybridStrategist.cs
+++ b/src/GameplayKit/GKHybridStrategist.cs
@@ -13,7 +13,7 @@ using NativeHandle = System.IntPtr;
 
 #if !XAMCORE_5_0 && !__MACOS__
 namespace GameplayKit {
-	[Register("GKHybridStrategist", SkipRegistration = true)]
+	[Register ("GKHybridStrategist", SkipRegistration = true)]
 #if NET
 	[UnsupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst")]

--- a/src/GameplayKit/GKHybridStrategist.cs
+++ b/src/GameplayKit/GKHybridStrategist.cs
@@ -1,0 +1,52 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.Versioning;
+
+using Foundation;
+using ObjCRuntime;
+
+#nullable enable
+
+#if !NET
+using NativeHandle = System.IntPtr;
+#endif
+
+#if !XAMCORE_5_0 && !__MACOS__
+namespace GameplayKit {
+	[Register("GKHybridStrategist", SkipRegistration = true)]
+#if NET
+	[UnsupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("maccatalyst")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+#endif
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	public class GKHybridStrategist : NSObject, IGKStrategist {
+		public override NativeHandle ClassHandle => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		public GKHybridStrategist () : base (NSObjectFlag.Empty) => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		protected GKHybridStrategist (NSObjectFlag t) : base (t) => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		protected internal GKHybridStrategist (NativeHandle handle) : base (handle) => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		public virtual IGKGameModelUpdate GetBestMoveForActivePlayer () => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		public virtual nuint Budget {
+			get => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+			set => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		}
+		public virtual nuint ExplorationParameter {
+			get => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+			set => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		}
+		public virtual IGKGameModel? GameModel {
+			get => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+			set => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		}
+		public virtual nuint MaxLookAheadDepth {
+			get => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+			set => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		}
+		public virtual IGKRandom? RandomSource {
+			get => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+			set => throw new PlatformNotSupportedException (Constants.TypeRemovedAllPlatforms);
+		}
+	}
+}
+#endif // !XAMCORE_5_0 && !__MACOS__

--- a/src/ObjCRuntime/ObsoleteConstants.cs
+++ b/src/ObjCRuntime/ObsoleteConstants.cs
@@ -40,5 +40,7 @@ namespace ObjCRuntime {
 		internal const string RemovedFromPassKit = "This API has been removed from the 'PassKit' framework.";
 
 		internal const string NewsstandKitRemoved = "The NewsstandKit framework has been removed from iOS.";
+
+		internal const string TypeRemovedAllPlatforms = "This type has been removed from all platforms.";
 	}
 }

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -952,6 +952,7 @@ GAMEPLAYKIT_SOURCES = \
 	GameplayKit/GKEntity.cs \
 	GameplayKit/GKGameModel.cs \
 	GameplayKit/GKGridGraph.cs \
+	GameplayKit/GKHybridStrategist.cs \
 	GameplayKit/GKObstacleGraph.cs \
 	GameplayKit/GKPath.cs \
 	GameplayKit/GKPolygonObstacle.cs \

--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -1364,20 +1364,6 @@ namespace GameplayKit {
 		bool EnterState (Class stateClass);
 	}
 
-	[NoMac]
-	[MacCatalyst (13, 1)]
-	[BaseType (typeof (NSObject))]
-	interface GKHybridStrategist : GKStrategist {
-		[Export ("budget")]
-		nuint Budget { get; set; }
-
-		[Export ("explorationParameter")]
-		nuint ExplorationParameter { get; set; }
-
-		[Export ("maxLookAheadDepth")]
-		nuint MaxLookAheadDepth { get; set; }
-	}
-
 	[MacCatalyst (13, 1)]
 	[Protocol]
 	interface GKStrategist {

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -138,6 +138,10 @@ namespace Introspection {
 			case "PKIdentityButton":
 				return true;
 #endif
+#if !XAMCORE_5_0
+			case "GKHybridStrategist":
+				return true; // GKHybridStrategist has been removed from our bindings
+#endif
 			}
 
 			switch (type.Namespace) {

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -72,6 +72,11 @@ namespace Introspection {
 			case "CIFilterGenerator":
 				// only present on device :/
 				return TestRuntime.IsSimulatorOrDesktop;
+#if !XAMCORE_5_0
+			case "GKHybridStrategist":
+				// We removed the bindings for this type.
+				return true;
+#endif
 			default:
 				return SkipDueToAttribute (type);
 			}

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-GameplayKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-GameplayKit.ignore
@@ -1,2 +1,0 @@
-## unsorted
-!unknown-type! GKHybridStrategist bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-GameplayKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-GameplayKit.ignore
@@ -1,2 +1,0 @@
-## unsorted
-!unknown-type! GKHybridStrategist bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-GameplayKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-GameplayKit.ignore
@@ -1,2 +1,0 @@
-## unsorted
-!unknown-type! GKHybridStrategist bound

--- a/tests/xtro-sharpie/iOS-GameplayKit.ignore
+++ b/tests/xtro-sharpie/iOS-GameplayKit.ignore
@@ -1,1 +1,0 @@
-!unknown-type! GKHybridStrategist bound

--- a/tests/xtro-sharpie/tvOS-GameplayKit.ignore
+++ b/tests/xtro-sharpie/tvOS-GameplayKit.ignore
@@ -1,1 +1,0 @@
-!unknown-type! GKHybridStrategist bound


### PR DESCRIPTION
The GKHybridStrategist type doesn't exist in iOS. This was probably a type
initially introduced in a beta version, and then removed in a later beta
version, and then we didn't notice.