### PR TITLE
[tools] Add OS check to fix availability warnings.

### DIFF
--- a/tools/common/PathUtils.cs
+++ b/tools/common/PathUtils.cs
@@ -291,6 +291,11 @@ namespace Xamarin.Utils {
 
 		static bool IsLongPathsEnabledRegistry {
 			get {
+#if NET
+				if (!OperatingSystem.IsWindows ())
+					return false;
+#endif
+
 				using (var fileSystemKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey (WINDOWS_FILE_SYSTEM_REGISTRY_KEY)) {
 					if (fileSystemKey is null)
 						return false;


### PR DESCRIPTION
Fixes:

    xamarin-macios/tools/common/PathUtils.cs(297,34): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.GetValue(string?, object?)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
    xamarin-macios/tools/common/PathUtils.cs(294,32): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.OpenSubKey(string)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
    xamarin-macios/tools/common/PathUtils.cs(294,32): warning CA1416: This call site is reachable on all platforms. 'Registry.LocalMachine' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)