### PR TITLE
[tools] Create a binlog when building dotnet-linker.

### DIFF
--- a/tools/dotnet-linker/Makefile
+++ b/tools/dotnet-linker/Makefile
@@ -20,7 +20,7 @@ dotnet-linker.csproj.inc: dotnet-linker.csproj
 -include dotnet-linker.csproj.inc
 
 $(BUILD_DIR)/dotnet-linker%dll $(BUILD_DIR)/dotnet-linker%pdb: Makefile $(dotnet_linker_dependencies)
-	$(Q_DOTNET_BUILD) $(DOTNET) build dotnet-linker.csproj $(DOTNET_BUILD_VERBOSITY)
+	$(Q_DOTNET_BUILD) $(DOTNET) build dotnet-linker.csproj /bl:dotnet-linker.binlog $(DOTNET_BUILD_VERBOSITY)
 	$(Q) touch $(BUILD_DIR)/dotnet-linker.dll $(BUILD_DIR)/dotnet-linker.pdb
 
 define InstallTemplate


### PR DESCRIPTION
Makes diagnosing build issues much easier.