### PR TITLE
Update to use System.AccessToken

### DIFF
--- a/tools/devops/automation/publish-pr-html-results.yml
+++ b/tools/devops/automation/publish-pr-html-results.yml
@@ -54,7 +54,7 @@ variables:
 - name: GitHub.Token                                          # Override the GitHub.Token setting defined in the Xamarin Release group
   value: $(github--pat--vs-mobiletools-engineering-service2)  # Use a token dedicated to critical production workflows and help avoid GitHub throttling
 - name: AzDoBuildAccess.Token
-  value: $(pat--xamarinc--build-access)
+  value: $(System.AccessToken)
 - name: system.debug
   value: true
 

--- a/tools/devops/automation/templates/variables.yml
+++ b/tools/devops/automation/templates/variables.yml
@@ -12,7 +12,7 @@ variables:
 - name: GitHub.Token                                          # Override the GitHub.Token setting defined in the Xamarin Release group
   value: $(github--pat--vs-mobiletools-engineering-service2)  # Use a token dedicated to critical production workflows and help avoid GitHub throttling
 - name: AzDoBuildAccess.Token
-  value: $(pat--xamarinc--build-access)
+  value: $(System.AccessToken)
 - name: system.debug
   value: false
 - name: SigningKeychain

--- a/tools/devops/automation/vs-insertion.yml
+++ b/tools/devops/automation/vs-insertion.yml
@@ -40,7 +40,7 @@ variables:
 - name: GitHub.Token                                          # Override the GitHub.Token setting defined in the Xamarin Release group
   value: $(github--pat--vs-mobiletools-engineering-service2)  # Use a token dedicated to critical production workflows and help avoid GitHub throttling
 - name: AzDoBuildAccess.Token
-  value: $(pat--xamarinc--build-access)
+  value: $(System.AccessToken)
 - name: system.debug
   value: true
 


### PR DESCRIPTION
Replace the manually updated PAT `$(pat--xamarinc--build-access)` with the built in `$(System.AccessToken)`.

This PR is untested but from the documentation I have read it should work for requesting anything within the same DevOps tenant and project aka DevDiv.

- [Predefined variables - Azure Pipelines | Microsoft Learn](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)
- [Understand job access tokens - Azure Pipelines | Microsoft Learn](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/access-tokens?view=azure-devops&tabs=yaml#job-authorization-scope)