### PR TITLE
Revert "Update to use System.AccessToken"

### DIFF
--- a/tools/devops/automation/publish-pr-html-results.yml
+++ b/tools/devops/automation/publish-pr-html-results.yml
@@ -54,7 +54,7 @@ variables:
 - name: GitHub.Token                                          # Override the GitHub.Token setting defined in the Xamarin Release group
   value: $(github--pat--vs-mobiletools-engineering-service2)  # Use a token dedicated to critical production workflows and help avoid GitHub throttling
 - name: AzDoBuildAccess.Token
-  value: $(System.AccessToken)
+  value: $(pat--xamarinc--build-access)
 - name: system.debug
   value: true
 

--- a/tools/devops/automation/templates/variables.yml
+++ b/tools/devops/automation/templates/variables.yml
@@ -12,7 +12,7 @@ variables:
 - name: GitHub.Token                                          # Override the GitHub.Token setting defined in the Xamarin Release group
   value: $(github--pat--vs-mobiletools-engineering-service2)  # Use a token dedicated to critical production workflows and help avoid GitHub throttling
 - name: AzDoBuildAccess.Token
-  value: $(System.AccessToken)
+  value: $(pat--xamarinc--build-access)
 - name: system.debug
   value: false
 - name: SigningKeychain

--- a/tools/devops/automation/vs-insertion.yml
+++ b/tools/devops/automation/vs-insertion.yml
@@ -40,7 +40,7 @@ variables:
 - name: GitHub.Token                                          # Override the GitHub.Token setting defined in the Xamarin Release group
   value: $(github--pat--vs-mobiletools-engineering-service2)  # Use a token dedicated to critical production workflows and help avoid GitHub throttling
 - name: AzDoBuildAccess.Token
-  value: $(System.AccessToken)
+  value: $(pat--xamarinc--build-access)
 - name: system.debug
   value: true
 


### PR DESCRIPTION
Reverts xamarin/xamarin-macios#20476

Usage of `System.AccessToken` in this instance fails with `needs Edit build quality permissions`.