### PR TITLE
[devops] Each test run shouldn't take more than a couple of hours, so set 3h as the upper bound.

### DIFF
--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -89,7 +89,7 @@ stages:
   - job: "tests"
     condition: ne(stageDependencies.configure_build.configure.outputs['labels.skip_all_tests'], 'True')
     displayName: 'T:' 
-    timeoutInMinutes: 1000
+    timeoutInMinutes: 180
     variables:
       # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
       PR_ID: $[ stageDependencies.configure_build.configure.outputs['labels.pr_number'] ]


### PR DESCRIPTION
Waiting 16.6 hours for a test run to time out if something goes wrong is way too long.