### PR TITLE
[bgen] Fix support for ErrorDomain enums in third-party bindings.

### DIFF
--- a/src/Resources.Designer.cs
+++ b/src/Resources.Designer.cs
@@ -971,6 +971,15 @@ namespace bgen {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Missing value for the &apos;LibraryName&apos; property for the &apos;[ErrorDomain]&apos; attribute for {0} (e.g. &apos;[ErrorDomain (&quot;MyDomain&quot;, LibraryName = &quot;__Internal&quot;)]&apos;).
+        /// </summary>
+        internal static string BI1087 {
+            get {
+                return ResourceManager.GetString("BI1087", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Trying to use a string as a [Target].
         /// </summary>
         internal static string BI1101 {

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -539,6 +539,10 @@
 		<value>Found {0} {1} attributes on the module {2}. At most one was expected.</value>
 	</data>
 
+	<data name="BI1087" xml:space="preserve">
+		<value>Missing value for the 'LibraryName' property for the '[ErrorDomain]' attribute for {0} (e.g. '[ErrorDomain ("MyDomain", LibraryName = "__Internal")]')</value>
+	</data>
+
 	<data name="BI1101" xml:space="preserve">
 		<value>Trying to use a string as a [Target]</value>
 	</data>

--- a/src/bgen/Attributes.cs
+++ b/src/bgen/Attributes.cs
@@ -835,7 +835,14 @@ public class ErrorDomainAttribute : Attribute {
 		ErrorDomain = domain;
 	}
 
+	public ErrorDomainAttribute (string domain, string libraryName)
+	{
+		ErrorDomain = domain;
+		LibraryName = libraryName;
+	}
+
 	public string ErrorDomain { get; set; }
+	public string LibraryName { get; set; }
 }
 
 [AttributeUsage (AttributeTargets.Field)]

--- a/src/bgen/Enums.cs
+++ b/src/bgen/Enums.cs
@@ -135,10 +135,16 @@ public partial class Generator {
 			print ("static {1} partial class {0}Extensions {{", type.Name, visibility);
 			indent++;
 
-			var field = fields.FirstOrDefault ();
-			var fieldAttr = field.Value;
+			if (error is not null) {
+				if (!TryComputeLibraryName (error.LibraryName, type, out library_name, out var _))
+					throw ErrorHelper.CreateError (1087, /* Missing value for the 'LibraryName' property for the '[ErrorDomain]' attribute for {0} (e.g. '[ErrorDomain ("MyDomain", LibraryName = "__Internal")]') */ type.FullName);
+			} else {
+				var field = fields.FirstOrDefault ();
+				var fieldAttr = field.Value;
 
-			ComputeLibraryName (fieldAttr, type, field.Key?.Name, out library_name, out string library_path);
+				if (!TryComputeLibraryName (fieldAttr?.LibraryName, type, out library_name, out var _))
+					throw ErrorHelper.CreateError (1042, /* Missing '[Field (LibraryName=value)]' for {0} (e.g."__Internal") */ type.FullName + "." + field.Key?.Name);
+			}
 		}
 
 		if (error is not null) {

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -1413,6 +1413,13 @@ namespace GeneratorTests {
 			Assert.That (failures, Is.Empty, "Failures");
 		}
 
+		[Test]
+		[TestCase (Profile.iOS)]
+		public void ErrorDomain (Profile profile)
+		{
+			BuildFile (profile, true, true, "tests/errordomain.cs");
+		}
+
 #if !NET
 		[Ignore ("This only applies to .NET")]
 #endif

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -974,5 +974,19 @@ namespace BI1066Errors
 			bgen.AssertExecuteError ("build");
 			bgen.AssertError (1018, "No [Export] attribute on property Test.NSTextInputClient.SelectedRange");
 		}
+
+		[Test]
+		[TestCase (Profile.iOS)]
+		public void ErrorDomain_NoLibraryName (Profile profile)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (profile.AsPlatform ());
+			var bgen = new BGenTool ();
+			bgen.Profile = profile;
+			bgen.ProcessEnums = true;
+			bgen.Defines = BGenTool.GetDefaultDefines (profile);
+			bgen.CreateTemporaryBinding (File.ReadAllText (Path.Combine (Configuration.SourceRoot, "tests", "generator", "tests", "errordomain-nolibraryname.cs")));
+			bgen.AssertExecuteError ("build");
+			bgen.AssertError (1087, "Missing value for the 'LibraryName' property for the '[ErrorDomain]' attribute for ErrorDomainNS.EWithDomain (e.g. '[ErrorDomain (\"MyDomain\", LibraryName = \"__Internal\")]')");
+		}
 	}
 }

--- a/tests/generator/tests/errordomain-nolibraryname.cs
+++ b/tests/generator/tests/errordomain-nolibraryname.cs
@@ -1,0 +1,9 @@
+using System;
+using Foundation;
+
+namespace ErrorDomainNS {
+	[ErrorDomain ("ETheDomain")]
+	enum EWithDomain {
+		ErrorA,
+	}
+}

--- a/tests/generator/tests/errordomain.cs
+++ b/tests/generator/tests/errordomain.cs
@@ -1,0 +1,9 @@
+using System;
+using Foundation;
+
+namespace ErrorDomainNS {
+	[ErrorDomain ("ETheDomain", LibraryName = "__Internal")]
+	enum EWithDomain {
+		ErrorA,
+	}
+}


### PR DESCRIPTION
The generator needs a library name for the generated `_domain` field.

Here's an example for the generated `ARErrorCodeExtensions` class ("ARKit" is
the library name):

```cs
[Field ("ARErrorDomain", "ARKit")]
static NSString? _domain;
```

In order to find the library name, the generator would look at the first enum
field with a `[Field]` attribute, and get the `LibraryName` property from that
`[Field]` attribute. Unfortunately error enums don't necessarily have `[Field]`
attributes on their enum fields. This works fine for our own bindings, because
the generator will fall back to the enum's namespace, but for third-party
bindings this would be the result:

> error BI1042: bgen: Missing '[Field (LibraryName=value)]' for ErrorDomainNS.EWithDomain. (e.g."__Internal")

Note that the error message is rather confusing: it's trying to report a
missing `LibraryName` property for a `[Field]` attribute, but there's no `[Field]`
attribute anywhere in the enum in question.

So fix this by:

* Adding the `LibraryName` property on the `[ErrorDomain]` attribute.
* Implement support for looking at this new property in the generator.
* Report a better error if it's not there.