### PR TITLE
[vs-workload.props] Append branch info to VSMAN name

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -205,6 +205,7 @@ $(DOTNET_NUPKG_DIR)/vs-workload.props: Makefile generate-vs-workload.csharp
 		--shorten Microsoft.NET.Sdk.MacCatalyst.Manifest=Microsoft.MacCatalyst.Manifest \
 		--shorten Microsoft.tvOS.Runtime.tvossimulator=Microsoft.tvOS.Runtime \
 		--tfm $(DOTNET_TFM) \
+		--branch-name $(CURRENT_BRANCH) \
 		--output $@.tmp
 	$(Q) mv $@.tmp $@
 

--- a/dotnet/generate-vs-workload.csharp
+++ b/dotnet/generate-vs-workload.csharp
@@ -14,6 +14,7 @@ var shorten = new Dictionary<string, string> ();
 var platforms = new List<(string, string)> ();
 var windowsPlatforms = new List<string> ();
 var tfm = string.Empty;
+var branchName = string.Empty;
 var outputPath = string.Empty;
 
 var args = new Queue<string> (Environment.GetCommandLineArgs ());
@@ -46,6 +47,11 @@ while (args.Any ()) {
 	case "--tfm":
 		tfm = args.Dequeue ();
 		break;
+	case "--branch-name":
+		var fullBranch = args.Dequeue ();
+		fullBranch = fullBranch.Substring (fullBranch.LastIndexOf ('/') + 1);
+		branchName = $".{fullBranch}";
+		break;
 	default:
 		Console.Error.WriteLine ($"Unknown argument: {arg}");
 		Environment.Exit (1);
@@ -58,7 +64,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"<Project>");
 	writer.WriteLine ($"  <PropertyGroup>");
 	var allPlatforms = string.Join (".", platforms.Select (v => v.Item1).OrderBy (v => v));
-	writer.WriteLine ($"    <TargetName>Microsoft.NET.Sdk.{allPlatforms}.Workload.{tfm}</TargetName>");
+	writer.WriteLine ($"    <TargetName>Microsoft.NET.Sdk.{allPlatforms}.Workload.{tfm}{branchName}</TargetName>");
 	// Find the iOS version, otherwise use the version of the first platform listed.
 	var iOSPlatform = platforms.Where (v => v.Item1 == "iOS");
 	var manifestBuildVersion = iOSPlatform.Any () ? iOSPlatform.First ().Item2 : platforms.First ().Item2;


### PR DESCRIPTION
In order to add .NET 9 packs to VS we'll need to provide content from the following three branches:

    release/9.0.1xx-preview
    release/8.0.1xx-xcode15.0
    release/8.0.1xx-xcode15.1

The two release/8.0.1xx-* branches currently produce VS manifests with the same name, and one of them will need to be renamed to allow them to be added side by side to VS.

I believe we only plan on inserting release/8.0.1xx-xcode15.0 into VS as a dependency of release/9.0.1xx-preview*, so we can add branch name info to the manifests generated in this branch to produce a unique manifest.