### PR TITLE
[msbuild] Set the working directory before executing 'dotnet build' in the ComputeRemoteGeneratorProperties task.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeRemoteGeneratorProperties.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeRemoteGeneratorProperties.cs
@@ -97,9 +97,11 @@ namespace Xamarin.MacDev.Tasks {
 
 			var arguments = new List<string> ();
 			var environment = default (Dictionary<string, string?>);
+			string? workingDirectory = null;
 
 			if (IsDotNet) {
 				executable = this.GetDotNetPath ();
+				workingDirectory = Path.GetDirectoryName (executable);
 
 				arguments.Add ("build");
 
@@ -121,7 +123,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			arguments.Add (projectPath);
 
-			ExecuteAsync (executable, arguments, environment: environment).Wait ();
+			ExecuteAsync (executable, arguments, workingDirectory: workingDirectory, environment: environment).Wait ();
 			if (!File.Exists (outputFile)) {
 				Log.LogError (MSBStrings.E7120 /* Unable to compute the remote generator properties. Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new and attach the following file: {0} */, binlog);
 				return;


### PR DESCRIPTION
If the project in question needs a custom NuGet.config, this NuGet.config file
will be in a base directory of where the .NET executable is located. I'm not
certain what the current directory is when executing `dotnet` in this task, so
make it explicit in case it's a different path.

This in particular might affect us for remote tests using .NET previews:

    /Users/builder/Library/Caches/Xamarin/mtbs/builds/bindingsframeworktest/8b36a8b30efab69178e7774426ff34b9aded7e20a789eb18f485be2f81a2dccd/obj/Debug/net9.0-ios/ComputeRemoteGeneratorProperties/ComputeRemoteGeneratorProperties.csproj : error NU1102: Unable to find package Microsoft.NET.ILLink.Tasks with version (>= 9.0.0-preview.4.24223.11)
    /Users/builder/Library/Caches/Xamarin/mtbs/builds/bindingsframeworktest/8b36a8b30efab69178e7774426ff34b9aded7e20a789eb18f485be2f81a2dccd/obj/Debug/net9.0-ios/ComputeRemoteGeneratorProperties/ComputeRemoteGeneratorProperties.csproj : error NU1102:   - Found 21 version(s) in nuget.org [ Nearest version: 9.0.0-preview.3.24172.9 ]
      Failed to restore /Users/builder/Library/Caches/Xamarin/mtbs/builds/bindingsframeworktest/8b36a8b30efab69178e7774426ff34b9aded7e20a789eb18f485be2f81a2dccd/obj/Debug/net9.0-ios/ComputeRemoteGeneratorProperties/ComputeRemoteGeneratorProperties.csproj (in 424 ms).