### PR TITLE
[release/9.0.1xx-preview4] [dotnet] Rename the dependency of the latest .NET 8 packs to match the latest .NET 8 stable release.

### DIFF
--- a/dotnet/generate-workloadmanifest-json.csharp
+++ b/dotnet/generate-workloadmanifest-json.csharp
@@ -50,11 +50,11 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"			\"description\": \".NET SDK Workload for building {platform} applications.\",");
 	writer.WriteLine ($"			\"packs\": [");
 	foreach (var tfm in allApiVersions) {
-		writer.WriteLine ($"				\"Microsoft.{platform}.Sdk.{tfm}\",");
+		writer.WriteLine ($"				\"Microsoft.{platform}.Sdk.{(tfm == "net8.0" ? "net8" : tfm)}\",");
 	}
 	if (hasWindows) {
 		foreach (var tfm in allApiVersions) {
-			writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.{tfm}\",");
+			writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.{(tfm == "net8.0" ? "net8" : tfm)}\",");
 		}
 	}
 	writer.WriteLine ($"				\"Microsoft.{platform}.Ref.{currentApiVersion}\",");
@@ -90,7 +90,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 				failed = true;
 			}
 		}
-		writer.WriteLine ($"		\"Microsoft.{platform}.Sdk.{tfm}\": {{");
+		writer.WriteLine ($"		\"Microsoft.{platform}.Sdk.{(tfm == "net8.0" ? "net8" : tfm)}\": {{");
 		writer.WriteLine ($"			\"kind\": \"sdk\",");
 		writer.WriteLine ($"			\"version\": \"{apiVersion}\",");
 		if (tfm == "net8.0") {
@@ -100,7 +100,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 		}
 		writer.WriteLine ($"		}},");
 		if (hasWindows) {
-			writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.{tfm}\": {{");
+			writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.{(tfm == "net8.0" ? "net8" : tfm)}\": {{");
 			writer.WriteLine ($"			\"kind\": \"sdk\",");
 			writer.WriteLine ($"			\"version\": \"{apiVersion}\",");
 			writer.WriteLine ($"			\"alias-to\": {{");

--- a/dotnet/generate-workloadmanifest-targets.csharp
+++ b/dotnet/generate-workloadmanifest-targets.csharp
@@ -54,11 +54,11 @@ using (var writer = new StreamWriter (outputPath)) {
 			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Sdk.{workloadVersion}\" />");
 		} else {
 			writer.WriteLine ($"	<ImportGroup Condition=\" '$(TargetPlatformIdentifier)' == '{platform}' And '$(UsingAppleNETSdk)' != 'true' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '{tfv}'))\">");
-			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Sdk.{workloadVersion}\" />");
+			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Sdk.{(workloadVersion == "net8.0" ? "net8" : tfm)}\" />");
 		}
 
 		if (hasWindows) {
-			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Windows.Sdk.Aliased.{workloadVersion}\" Condition=\" $([MSBuild]::IsOSPlatform('windows'))\" />");
+			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Windows.Sdk.Aliased.{(workloadVersion == "net8.0" ? "net8" : tfm)}\" Condition=\" $([MSBuild]::IsOSPlatform('windows'))\" />");
 		}
 
 		writer.WriteLine ($"	</ImportGroup>");


### PR DESCRIPTION
The latest .NET 8 stable release doesn't support multi targeting yet, so we
need to use pre-multi-targeting pack names to make VS insertions work
correctly.