### PR TITLE
[release/9.0.1xx-preview4] Use legacy mono-sdks from download.mono-project.com

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -610,11 +610,11 @@ XCODE_IOS_ARCHIVE_VERSION=xcode-12D4e
 # Xcode 12.4 Build 12D4e
 XCODE_MACOS_ARCHIVE_VERSION=xcode-12D4e
 MONO_IOS_FILENAME:=ios-release-Darwin-$(MONO_HASH).7z
-MONO_IOS_URL:=https://xamjenkinsartifact.blob.core.windows.net/mono-sdks/$(XCODE_IOS_ARCHIVE_VERSION)/$(MONO_IOS_FILENAME)
+MONO_IOS_URL:=https://download.mono-project.com/mono-sdks/$(XCODE_IOS_ARCHIVE_VERSION)/$(MONO_IOS_FILENAME)
 MONO_MAC_FILENAME:=mac-release-Darwin-$(MONO_HASH).7z
-MONO_MAC_URL:=https://xamjenkinsartifact.blob.core.windows.net/mono-sdks/$(XCODE_MACOS_ARCHIVE_VERSION)/$(MONO_MAC_FILENAME)
+MONO_MAC_URL:=https://download.mono-project.com/mono-sdks/$(XCODE_MACOS_ARCHIVE_VERSION)/$(MONO_MAC_FILENAME)
 MONO_MACCATALYST_FILENAME:=maccat-release-Darwin-$(MONO_HASH).7z
-MONO_MACCATALYST_URL:=https://xamjenkinsartifact.blob.core.windows.net/mono-sdks/$(XCODE_MACOS_ARCHIVE_VERSION)/$(MONO_MACCATALYST_FILENAME)
+MONO_MACCATALYST_URL:=https://download.mono-project.com/mono-sdks/$(XCODE_MACOS_ARCHIVE_VERSION)/$(MONO_MACCATALYST_FILENAME)
 
 # Setup various variables depending on whether mono is downloaded or built from source
 ifeq ($(MONO_BUILD_FROM_SOURCE),)


### PR DESCRIPTION
Backport of #20482.