### PR TITLE
[bgen] Generate xml documentation for generated default constructors.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -5641,6 +5641,9 @@ public partial class Generator : IMemberGatherer {
 					var is32BitNotSupported = Is64BitiOSOnly (type);
 					if (external) {
 						if (!disable_default_ctor) {
+							if (BindingTouch.SupportsXmlDocumentation) {
+								sw.WriteLine ($"\t\t/// <summary>Creates a new <see cref=\"{class_name.Replace ('<', '{').Replace ('>', '}')}\" /> with default values.</summary>");
+							}
 							GeneratedCode (sw, 2);
 							if (AttributeManager.HasAttribute<DesignatedDefaultCtorAttribute> (type))
 								sw.WriteLine ("\n\n[DesignatedInitializer]");
@@ -5665,6 +5668,9 @@ public partial class Generator : IMemberGatherer {
 						}
 					} else {
 						if (!disable_default_ctor) {
+							if (BindingTouch.SupportsXmlDocumentation) {
+								sw.WriteLine ($"\t\t/// <summary>Creates a new <see cref=\"{class_name.Replace ('<', '{').Replace ('>', '}')}\" /> with default values.</summary>");
+							}
 							GeneratedCode (sw, 2);
 							if (AttributeManager.HasAttribute<DesignatedDefaultCtorAttribute> (type))
 								sw.WriteLine ("\t\t[DesignatedInitializer]");

--- a/tests/generator/ExpectedXmlDocs.MacCatalyst.xml
+++ b/tests/generator/ExpectedXmlDocs.MacCatalyst.xml
@@ -87,6 +87,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.Notification1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.Notification1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.Notification1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -244,6 +247,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.T1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -301,6 +307,11 @@
                 </para>
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor(System.String)">
+            <summary>
+            Summary for T2.#ctor(String)
+            </summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method
@@ -339,6 +350,9 @@
                 This value contains the pointer to the Objective-C class.
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TG1`2.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.TG1`2" /> with default values.</summary>
         </member>
         <member name="M:XmlDocumentation.TG1`2.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>

--- a/tests/generator/ExpectedXmlDocs.iOS.legacy.xml
+++ b/tests/generator/ExpectedXmlDocs.iOS.legacy.xml
@@ -87,6 +87,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.Notification1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.Notification1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.Notification1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -244,6 +247,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.T1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -301,6 +307,11 @@
                 </para>
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor(System.String)">
+            <summary>
+            Summary for T2.#ctor(String)
+            </summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method
@@ -339,6 +350,9 @@
                 This value contains the pointer to the Objective-C class.
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TG1`2.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.TG1`2" /> with default values.</summary>
         </member>
         <member name="M:XmlDocumentation.TG1`2.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
@@ -420,6 +434,9 @@
                 This value contains the pointer to the Objective-C class.
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TypeWithApparance.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.TypeWithApparance" /> with default values.</summary>
         </member>
         <member name="M:XmlDocumentation.TypeWithApparance.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>

--- a/tests/generator/ExpectedXmlDocs.iOS.xml
+++ b/tests/generator/ExpectedXmlDocs.iOS.xml
@@ -87,6 +87,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.Notification1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.Notification1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.Notification1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -244,6 +247,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.T1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -301,6 +307,11 @@
                 </para>
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor(System.String)">
+            <summary>
+            Summary for T2.#ctor(String)
+            </summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method
@@ -339,6 +350,9 @@
                 This value contains the pointer to the Objective-C class.
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TG1`2.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.TG1`2" /> with default values.</summary>
         </member>
         <member name="M:XmlDocumentation.TG1`2.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
@@ -420,6 +434,9 @@
                 This value contains the pointer to the Objective-C class.
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TypeWithApparance.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.TypeWithApparance" /> with default values.</summary>
         </member>
         <member name="M:XmlDocumentation.TypeWithApparance.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>

--- a/tests/generator/ExpectedXmlDocs.macOS.legacy.xml
+++ b/tests/generator/ExpectedXmlDocs.macOS.legacy.xml
@@ -87,6 +87,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.Notification1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.Notification1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.Notification1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -244,6 +247,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.T1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -301,6 +307,11 @@
                 </para>
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor(System.String)">
+            <summary>
+            Summary for T2.#ctor(String)
+            </summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method
@@ -339,6 +350,9 @@
                 This value contains the pointer to the Objective-C class.
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TG1`2.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.TG1`2" /> with default values.</summary>
         </member>
         <member name="M:XmlDocumentation.TG1`2.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>

--- a/tests/generator/ExpectedXmlDocs.macOS.xml
+++ b/tests/generator/ExpectedXmlDocs.macOS.xml
@@ -87,6 +87,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.Notification1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.Notification1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.Notification1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -244,6 +247,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.T1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -301,6 +307,11 @@
                 </para>
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor(System.String)">
+            <summary>
+            Summary for T2.#ctor(String)
+            </summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method
@@ -339,6 +350,9 @@
                 This value contains the pointer to the Objective-C class.
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TG1`2.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.TG1`2" /> with default values.</summary>
         </member>
         <member name="M:XmlDocumentation.TG1`2.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>

--- a/tests/generator/ExpectedXmlDocs.tvOS.legacy.xml
+++ b/tests/generator/ExpectedXmlDocs.tvOS.legacy.xml
@@ -87,6 +87,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.Notification1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.Notification1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.Notification1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -244,6 +247,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.T1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -301,6 +307,11 @@
                 </para>
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor(System.String)">
+            <summary>
+            Summary for T2.#ctor(String)
+            </summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method
@@ -339,6 +350,9 @@
                 This value contains the pointer to the Objective-C class.
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TG1`2.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.TG1`2" /> with default values.</summary>
         </member>
         <member name="M:XmlDocumentation.TG1`2.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>

--- a/tests/generator/ExpectedXmlDocs.tvOS.xml
+++ b/tests/generator/ExpectedXmlDocs.tvOS.xml
@@ -87,6 +87,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.Notification1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.Notification1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.Notification1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -244,6 +247,9 @@
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.T1" /> with default values.</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
             <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -301,6 +307,11 @@
                 </para>
             </remarks>
         </member>
+        <member name="M:XmlDocumentation.T1.#ctor(System.String)">
+            <summary>
+            Summary for T2.#ctor(String)
+            </summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method
@@ -339,6 +350,9 @@
                 This value contains the pointer to the Objective-C class.
                 It is similar to calling the managed <see cref="M:ObjCRuntime.Class.GetHandle(System.String)" /> or the native <see href="https://developer.apple.com/documentation/objectivec/1418952-objc_getclass">objc_getClass</see> method with the type name.
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TG1`2.#ctor">
+            <summary>Creates a new <see cref="T:XmlDocumentation.TG1`2" /> with default values.</summary>
         </member>
         <member name="M:XmlDocumentation.TG1`2.#ctor(Foundation.NSObjectFlag)">
             <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>

--- a/tests/generator/tests/xmldocs.cs
+++ b/tests/generator/tests/xmldocs.cs
@@ -11,6 +11,12 @@ namespace XmlDocumentation {
 	[BaseType (typeof (NSObject))]
 	interface T1 : P1 {
 		/// <summary>
+		/// Summary for T2.#ctor(String)
+		/// </summary>
+		[Export ("initWithString:")]
+		IntPtr Constructor (string p);
+
+		/// <summary>
 		/// Summary for T1.Method
 		/// </summary>
 		[Export ("method")]


### PR DESCRIPTION
This was mostly copied from the existing API documentation.

Partial fix for https://github.com/xamarin/xamarin-macios/issues/20270.