### PR TITLE
[GLKit] Make the GLKVertexAttributeParametersFromModelIO P/Invoke have a blittable signature.

### DIFF
--- a/src/GLKit/Defs.cs
+++ b/src/GLKit/Defs.cs
@@ -142,17 +142,47 @@ namespace GLKit {
 	public struct GLKVertexAttributeParameters {
 		public uint Type;
 		public uint Size;
+#if XAMCORE_5_0
+		byte normalized;
+		public bool Normalized {
+			get => normalized != 0;
+			set => normalized = value.AsByte ();
+		}
+#else
 		[MarshalAs (UnmanagedType.I1)]
 		public bool Normalized;
+#endif
 
 #if !COREBUILD
 		[DllImport (Constants.GLKitLibrary, EntryPoint = "GLKVertexAttributeParametersFromModelIO")]
+#if XAMCORE_5_0
 		extern static GLKVertexAttributeParameters FromVertexFormat_ (nuint vertexFormat);
+#else
+		extern static GLKVertexAttributeParametersInternal FromVertexFormat_ (nuint vertexFormat);
+#endif
 
 		public static GLKVertexAttributeParameters FromVertexFormat (MDLVertexFormat vertexFormat)
 		{
+#if XAMCORE_5_0
 			return FromVertexFormat_ ((nuint) (ulong) vertexFormat);
+#else
+			var tmp = FromVertexFormat_ ((nuint) (ulong) vertexFormat);
+			var rv = new GLKVertexAttributeParameters ();
+			rv.Type = tmp.Type;
+			rv.Size = tmp.Size;
+			rv.Normalized = tmp.Normalized != 0;
+			return rv;
+#endif
 		}
 #endif
 	}
+
+#if !XAMCORE_5_0
+	[StructLayout (LayoutKind.Sequential)]
+	struct GLKVertexAttributeParametersInternal {
+		public uint Type;
+		public uint Size;
+		public byte Normalized;
+	}
+#endif // !XAMCORE_5_0
 }

--- a/tests/cecil-tests/BlittablePInvokes.KnownFailures.cs
+++ b/tests/cecil-tests/BlittablePInvokes.KnownFailures.cs
@@ -64,7 +64,6 @@ namespace Cecil.Tests {
 			"AVFoundation.AVSampleCursorSyncInfo ObjCRuntime.Messaging::AVSampleCursorSyncInfo_objc_msgSend(System.IntPtr,System.IntPtr)",
 			"AVFoundation.AVSampleCursorSyncInfo ObjCRuntime.Messaging::AVSampleCursorSyncInfo_objc_msgSendSuper_stret(System.IntPtr,System.IntPtr)",
 			"AVFoundation.AVSampleCursorSyncInfo ObjCRuntime.Messaging::AVSampleCursorSyncInfo_objc_msgSendSuper(System.IntPtr,System.IntPtr)",
-			"GLKit.GLKVertexAttributeParameters GLKit.GLKVertexAttributeParameters::FromVertexFormat_(System.UIntPtr)",
 			"MediaToolbox.MTAudioProcessingTapError MediaToolbox.MTAudioProcessingTap::MTAudioProcessingTapCreate(System.IntPtr,MediaToolbox.MTAudioProcessingTap/Callbacks&,MediaToolbox.MTAudioProcessingTapCreationFlags,System.IntPtr&)",
 			"MediaToolbox.MTAudioProcessingTapError MediaToolbox.MTAudioProcessingTap::MTAudioProcessingTapGetSourceAudio(System.IntPtr,System.IntPtr,System.IntPtr,MediaToolbox.MTAudioProcessingTapFlags&,CoreMedia.CMTimeRange&,System.IntPtr&)",
 			"ObjCRuntime.NativeHandle ObjCRuntime.Messaging::NativeHandle_objc_msgSend_AudioComponentDescription_ref_NativeHandle(System.IntPtr,System.IntPtr,AudioUnit.AudioComponentDescription,ObjCRuntime.NativeHandle*)",


### PR DESCRIPTION
This was complicated a bit because it uses a non-blittable struct we can't
change because it's public API. So introduce an internal temporary blittable
struct.

Contributes towards #15684.