### PR TITLE
[release/9.0.1xx-preview4] [devops] Escape Rosetta when installing powershell.

### DIFF
--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -45,8 +45,13 @@ parameters:
 
 steps:
 - bash: |
+    set -ex
     brew update
-    brew install powershell
+    if [[ "1" == "$(sysctl -n sysctl.proc_translated)" ]]; then
+      arch -arm64 brew install powershell
+    else
+      brew install powershell
+    fi
   displayName: Install powershell
 
 - bash: |


### PR DESCRIPTION
If the script to install powershell is executed with Rosetta, this happens:

    $ arch -x86_64 brew install powershell
    Warning: Not upgrading powershell, the latest version is already installed
    Error: Cannot install under Rosetta 2 in ARM default prefix (/opt/homebrew)!
    To rerun under ARM use:
        arch -arm64 brew install ...
    To install under x86_64, install Homebrew into /usr/local.

which can be seen on the bots:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9496253&view=logs&j=1acdac53-199e-5330-5c52-bf5d9d7be24b&t=ca94b18d-fa43-5a35-82db-a681bd2b1a78.

So escape Rosetta when installing powershell.

Backport of #20530.