### PR TITLE
[CI] Split tests to a post-build pipeline.

### DIFF
--- a/tools/devops/automation/run-post-ci-build-tests.yml
+++ b/tools/devops/automation/run-post-ci-build-tests.yml
@@ -1,0 +1,216 @@
+# YAML pipeline for post build operations. 
+# This pipeline will execute the tests for the CI as soon as the workloads have been complited.
+
+trigger: none
+pr: none
+
+parameters:
+
+  - name: provisionatorChannel
+    displayName: Provisionator channel to use 
+    type: string
+    default: 'latest'
+
+  - name: macOSName # comes from the build agent demand named macOS.Name
+    displayName: Name of the version of macOS to use
+    type: string
+    default: 'Sonoma'
+
+  - name: pool
+    type: string
+    displayName: Bot pool to use
+    default: automatic
+    values:
+      - pr
+      - ci
+      - automatic
+
+  - name: runTests
+    displayName: Run Simulator Tests
+    type: boolean
+    default: true
+
+  - name: runDeviceTests
+    displayName: Run Device Tests 
+    type: boolean
+    default: false
+
+  - name: runOldMacOSTests
+    displayName: Run Tests on older macOS versions 
+    type: boolean
+    default: true
+
+  - name: runWindowsIntegration
+    displayName: Run Windows integration tests
+    type: boolean
+    default: true
+
+  - name: runSamples
+    displayName: Run Samples
+    type: boolean
+    default: false
+    
+  - name: testConfigurations
+    displayName: Test configurations to run
+    type: object
+    default: []
+
+  - name: deviceTestsConfigurations
+    displayName: Device test configurations to run
+    type: object
+    default: [
+      {
+        testPrefix: 'iOS64',
+        stageName: 'ios64b_device',
+        displayName: 'iOS64 Device Tests',
+        testPool: 'VSEng-Xamarin-Mac-Devices',
+        useXamarinStorage: false,
+        testsLabels: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
+        statusContext: 'VSTS: device tests iOS',
+        makeTarget: 'vsts-device-tests',
+        extraBotDemands: [
+          'ios',
+        ]
+      },
+      {
+        testPrefix: 'tvos',
+        stageName: 'tvos_device',
+        displayName: 'tvOS Device Tests',
+        testPool: 'VSEng-Xamarin-Mac-Devices',
+        useXamarinStorage: false,
+        testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
+        statusContext: 'VSTS: device tests tvOS',
+        makeTarget: 'vsts-device-tests',
+        extraBotDemands: [
+          'tvos',
+        ]
+      }]
+
+  - name: macTestsConfigurations
+    displayName: macOS test configurations to run
+    type: object
+    default: [
+      {
+        stageName: 'mac_11_m1',
+        displayName: 'M1 - Mac Big Sur (11)',
+        macPool: 'VSEng-VSMac-Xamarin-Shared',
+        useImage: false,
+        statusContext: 'M1 - Mac Big Sur (11)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals BigSur",
+          "macOS.Architecture -equals arm64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      },
+      {
+        stageName: 'mac_12_m1',
+        displayName: 'M1 - Mac Ventura (12)',
+        macPool: 'VSEng-VSMac-Xamarin-Shared',
+        useImage: false,
+        statusContext: 'M1 - Mac Monterey (12)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals Monterey",
+          "macOS.Architecture -equals arm64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      },
+      {
+        stageName: 'mac_13_m1',
+        displayName: 'M1 - Mac Ventura (13)',
+        macPool: 'VSEng-VSMac-Xamarin-Shared',
+        useImage: false,
+        statusContext: 'M1 - Mac Ventura (13)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals Ventura",
+          "macOS.Architecture -equals arm64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      },
+      {
+        stageName: 'mac_14_x64',
+        displayName: 'X64 - Mac Sonoma (14)',
+        macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted',
+        useImage: false,
+        statusContext: 'X64 - Mac Sonoma (14)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals Sonoma",
+          "macOS.Architecture -equals x64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      }]
+
+
+resources:
+  repositories:
+    - repository: self
+      checkoutOptions:
+        submodules: true
+
+    - repository: yaml-templates
+      type: github
+      name: xamarin/yaml-templates
+      ref: refs/heads/main
+      endpoint: xamarin
+
+    - repository: sdk-insertions
+      type: github
+      name: xamarin/sdk-insertions
+      ref: refs/heads/main
+      endpoint: xamarin
+
+    - repository: maccore
+      type: github
+      name: xamarin/maccore
+      ref: refs/heads/main
+      endpoint: xamarin
+
+    - repository: release-scripts
+      type: github
+      name: xamarin/release-scripts
+      ref: refs/heads/only_codesign
+      endpoint: xamarin
+
+  pipelines:
+    - pipeline: macios
+      source: xamarin-macios-ci
+      trigger:
+        stages:
+          - build_packages
+          - build_macos_tests
+
+variables:
+  - ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
+      - template: templates/vsts-variables.yml
+  - template: templates/variables.yml
+  - name: MaciosUploadPrefix
+    value: ''
+  - name: DisablePipelineConfigDetector
+    value: true
+
+stages:
+  - template: templates/tests-stage.yml
+    parameters:
+      xcodeChannel: Stable
+      macOSName: ${{ parameters.macOSName }}
+      isPR: false
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
+      pool: ${{ parameters.pool }}
+      runTests: ${{ parameters.runTests }}
+      runDeviceTests: ${{ parameters.runDeviceTests }}
+      runOldMacOSTests: ${{ parameters.runOldMacOSTests }}
+      runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
+      runSamples: ${{ parameters.runSamples }}
+      ${{ if ne(length(parameters.testConfigurations), 0)}}:
+        testConfigurations: ${{ parameters.testConfigurations }}
+      deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}
+      macTestsConfigurations: ${{ parameters.macTestsConfigurations }}
+      azureStorage: ${{ variables['azureStorage'] }}
+      azureContainer: ${{ variables['azureContainer'] }}

--- a/tools/devops/automation/run-post-pr-build-tests.yml
+++ b/tools/devops/automation/run-post-pr-build-tests.yml
@@ -1,0 +1,217 @@
+# YAML pipeline for post build operations. 
+# This pipeline will execute the tests for the CI on PR as soon as the workloads have been complited.
+
+trigger: none
+pr: none
+
+parameters:
+
+  - name: provisionatorChannel
+    displayName: Provisionator channel to use 
+    type: string
+    default: 'latest'
+
+  - name: macOSName # comes from the build agent demand named macOS.Name
+    displayName: Name of the version of macOS to use
+    type: string
+    default: 'Sonoma'
+
+  - name: pool
+    type: string
+    displayName: Bot pool to use
+    default: automatic
+    values:
+      - pr
+      - ci
+      - automatic
+
+  - name: runTests
+    displayName: Run Simulator Tests
+    type: boolean
+    default: true
+
+  - name: runDeviceTests
+    displayName: Run Device Tests 
+    type: boolean
+    default: false
+
+  - name: runOldMacOSTests
+    displayName: Run Tests on older macOS versions 
+    type: boolean
+    default: true
+
+  - name: runWindowsIntegration
+    displayName: Run Windows integration tests
+    type: boolean
+    default: true
+
+  - name: runSamples
+    displayName: Run Samples
+    type: boolean
+    default: false
+    
+  - name: testConfigurations
+    displayName: Test configurations to run
+    type: object
+    default: []
+
+  - name: deviceTestsConfigurations
+    displayName: Device test configurations to run
+    type: object
+    default: [
+      {
+        testPrefix: 'iOS64',
+        stageName: 'ios64b_device',
+        displayName: 'iOS64 Device Tests',
+        testPool: 'VSEng-Xamarin-Mac-Devices',
+        useXamarinStorage: false,
+        testsLabels: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
+        statusContext: 'VSTS: device tests iOS',
+        makeTarget: 'vsts-device-tests',
+        extraBotDemands: [
+          'ios',
+        ]
+      },
+      {
+        testPrefix: 'tvos',
+        stageName: 'tvos_device',
+        displayName: 'tvOS Device Tests',
+        testPool: 'VSEng-Xamarin-Mac-Devices',
+        useXamarinStorage: false,
+        testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
+        statusContext: 'VSTS: device tests tvOS',
+        makeTarget: 'vsts-device-tests',
+        extraBotDemands: [
+          'tvos',
+        ]
+      }]
+
+  - name: macTestsConfigurations
+    displayName: macOS test configurations to run
+    type: object
+    default: [
+      {
+        stageName: 'mac_11_m1',
+        displayName: 'M1 - Mac Big Sur (11)',
+        macPool: 'VSEng-VSMac-Xamarin-Shared',
+        useImage: false,
+        statusContext: 'M1 - Mac Big Sur (11)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals BigSur",
+          "macOS.Architecture -equals arm64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      },
+      {
+        stageName: 'mac_12_m1',
+        displayName: 'M1 - Mac Ventura (12)',
+        macPool: 'VSEng-VSMac-Xamarin-Shared',
+        useImage: false,
+        statusContext: 'M1 - Mac Monterey (12)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals Monterey",
+          "macOS.Architecture -equals arm64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      },
+      {
+        stageName: 'mac_13_m1',
+        displayName: 'M1 - Mac Ventura (13)',
+        macPool: 'VSEng-VSMac-Xamarin-Shared',
+        useImage: false,
+        statusContext: 'M1 - Mac Ventura (13)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals Ventura",
+          "macOS.Architecture -equals arm64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      },
+      {
+        stageName: 'mac_14_x64',
+        displayName: 'X64 - Mac Sonoma (14)',
+        macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted',
+        useImage: false,
+        statusContext: 'X64 - Mac Sonoma (14)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals Sonoma",
+          "macOS.Architecture -equals x64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      }]
+
+
+resources:
+  repositories:
+    - repository: self
+      checkoutOptions:
+        submodules: true
+
+    - repository: yaml-templates
+      type: github
+      name: xamarin/yaml-templates
+      ref: refs/heads/main
+      endpoint: xamarin
+
+    - repository: sdk-insertions
+      type: github
+      name: xamarin/sdk-insertions
+      ref: refs/heads/main
+      endpoint: xamarin
+
+    - repository: maccore
+      type: github
+      name: xamarin/maccore
+      ref: refs/heads/main
+      endpoint: xamarin
+
+    - repository: release-scripts
+      type: github
+      name: xamarin/release-scripts
+      ref: refs/heads/only_codesign
+      endpoint: xamarin
+
+  pipelines:
+    - pipeline: macios
+      source: xamarin-macios-pr
+      trigger:
+        stages:
+          - build_packages
+          - build_macos_tests
+
+variables:
+  - ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
+      - template: templates/vsts-variables.yml
+  - template: templates/variables.yml
+  - name: MaciosUploadPrefix
+    value: ''
+  - name: DisablePipelineConfigDetector
+    value: true
+
+stages:
+  - template: templates/tests-stage.yml
+    parameters:
+      xcodeChannel: Stable
+      macOSName: ${{ parameters.macOSName }}
+      isPR: true
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
+      pool: ${{ parameters.pool }}
+      runTests: ${{ parameters.runTests }}
+      runDeviceTests: ${{ parameters.runDeviceTests }}
+      runOldMacOSTests: ${{ parameters.runOldMacOSTests }}
+      runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
+      runSamples: ${{ parameters.runSamples }}
+      ${{ if ne(length(parameters.testConfigurations), 0)}}:
+        testConfigurations: ${{ parameters.testConfigurations }}
+      deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}
+      macTestsConfigurations: ${{ parameters.macTestsConfigurations }}
+      azureStorage: ${{ variables['azureStorage'] }}
+      azureContainer: ${{ variables['azureContainer'] }}
+

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -35,11 +35,16 @@ parameters:
   type: string
   default: HEAD
 
+- name: postPipeline
+  type: boolean
+  default: false
+
 stages:
 - stage: ${{ parameters.stageName }}
   displayName: ${{ parameters.displayName }}
   dependsOn:
-  - build_macos_tests
+  - ${{ if eq(parameters.postPipeline, false) }}:
+    - build_macos_tests
   - configure_build
   condition: and(succeeded(), eq(stageDependencies.configure_build.outputs['configure.decisions.RUN_MAC_TESTS'], 'true'))
   variables:

--- a/tools/devops/automation/templates/tests-stage.yml
+++ b/tools/devops/automation/templates/tests-stage.yml
@@ -1,0 +1,391 @@
+parameters:
+
+- name: provisionatorChannel
+  type: string
+  default: 'latest'
+
+- name: pool
+  type: string
+  default: automatic
+  values:
+  - pr
+  - ci
+  - automatic
+
+- name: runTests
+  type: boolean
+  default: true
+
+- name: runDeviceTests
+  type: boolean
+  default: false
+
+- name: runOldMacOSTests
+  type: boolean
+  default: true
+
+- name: runWindowsIntegration
+  type: boolean
+  default: true
+
+- name: runSamples
+  type: boolean
+  default: false
+  
+- name: isPR
+  type: boolean
+
+- name: repositoryAlias
+  type: string
+  default: self
+
+- name: commit
+  type: string
+  default: HEAD
+
+- name: xcodeChannel
+  type: string
+
+- name: macOSName
+  type: string
+
+# Ideally we should read/get the list of platforms from somewhere else, instead of hardcoding them here.
+# Note that this is _all_ the platforms we support (not just the enabled ones).
+- name: supportedPlatforms
+  type: object
+  default: [
+    {
+      platform: iOS,
+      isDotNetPlatform: true,
+      isLegacyPlatform: true
+    },
+    {
+      platform: macOS,
+      isDotNetPlatform: true,
+      isLegacyPlatform: true
+    },
+    {
+      platform: tvOS,
+      isDotNetPlatform: true,
+      isLegacyPlatform: true
+    },
+    {
+      platform: watchOS,
+      isDotNetPlatform: false,
+      isLegacyPlatform: true
+    },
+    {
+      platform: MacCatalyst,
+      isDotNetPlatform: true,
+      isLegacyPlatform: false
+    },
+    {
+      # when running platform-specific test runs, we also need a special test run that executes tests that only runs when multiple platforms are enabled
+      platform: Multiple,
+      isDotNetPlatform: true,
+      isLegacyPlatform: true
+    }
+  ]
+
+- name: testConfigurations
+  type: object
+  default: [
+    # Disabled by default #
+    # {
+    #   label: bcl,
+    #   splitByPlatforms: false,
+    # },
+    {
+      label: cecil,
+      splitByPlatforms: false,
+      containsDotNetTests: true,
+      containsLegacyTests: false,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: dotnettests,
+      splitByPlatforms: true,
+      containsDotNetTests: true,
+      containsLegacyTests: false,
+      needsMultiplePlatforms: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: fsharp,
+      splitByPlatforms: false,
+      containsDotNetTests: true,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: framework,
+      splitByPlatforms: false,
+      containsDotNetTests: true,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: generator,
+      splitByPlatforms: false,
+      containsDotNetTests: true,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: interdependent-binding-projects,
+      splitByPlatforms: false,
+      containsDotNetTests: true,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: install-source,
+      splitByPlatforms: false,
+      containsDotNetTests: false,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: introspection,
+      splitByPlatforms: false,
+      containsDotNetTests: true,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: linker,
+      splitByPlatforms: false,
+      containsDotNetTests: true,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: mac-binding-project,
+      splitByPlatforms: false,
+      containsDotNetTests: false,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: mmp,
+      splitByPlatforms: false,
+      containsDotNetTests: false,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: mononative,
+      splitByPlatforms: false,
+      containsDotNetTests: false,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: monotouch,
+      splitByPlatforms: true,
+      containsDotNetTests: true,
+      containsLegacyTests: true,
+      needsMultiplePlatforms: false,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: msbuild,
+      splitByPlatforms: false,
+      containsDotNetTests: true,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: mtouch,
+      splitByPlatforms: false,
+      containsDotNetTests: false,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: xammac,
+      splitByPlatforms: false,
+      containsDotNetTests: false,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: xcframework,
+      splitByPlatforms: false,
+      containsDotNetTests: true,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+    {
+      label: xtro,
+      splitByPlatforms: false,
+      containsDotNetTests: true,
+      containsLegacyTests: true,
+      testPrefix: 'simulator_tests',
+    },
+  ]
+
+- name: deviceTestsConfigurations
+  type: object
+
+- name: macTestsConfigurations
+  type: object
+
+- name: azureStorage
+  type: string
+
+- name: azureContainer
+  type: string
+
+- name: stageDisplayNamePrefix
+  type: string
+  default: ''
+
+- name: dependsOn
+  type: string
+  default: ''
+
+- name: dependsOnResult
+  type: string
+  default: ''
+
+stages:
+
+- ${{ if parameters.isPR }}:
+  - stage: clean
+    displayName: '${{ parameters.stageDisplayNamePrefix }}Clean up'
+    dependsOn: []
+    jobs:
+    - job:
+      displayName: 'Clean comments'
+      pool:
+        vmImage: windows-latest
+      steps:
+      - template: ./common/clean.yml
+
+- stage: configure_build
+  displayName: '${{ parameters.stageDisplayNamePrefix }}Configure'
+  dependsOn: ${{ parameters.dependsOn }}
+  ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
+    condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
+  jobs:
+  
+  - ${{ if eq(parameters.pool, 'automatic') }}:
+    - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
+      pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
+        vmImage: ubuntu-latest
+      steps:
+      - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
+
+      # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
+      - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
+        parameters:
+          agentPoolPR: $(PRBuildPool)
+          agentPoolPRUrl: $(PRBuildPoolUrl)
+          agentPoolCI: $(CIBuildPool)
+          agentPoolCIUrl: $(CIBuildPoolUrl)
+
+  - job: configure
+    displayName: 'Configure build'
+    pool:
+      vmImage: windows-latest
+
+    variables:
+      isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+      isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+      BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+
+    steps:
+    - template: common/configure.yml
+      parameters: 
+        repositoryAlias: ${{ parameters.repositoryAlias }}
+        commit: ${{ parameters.commit }}
+        testConfigurations: ${{ parameters.testConfigurations }}
+        supportedPlatforms: ${{ parameters.supportedPlatforms }}
+        testsLabels: '--label=skip-all-tests,run-ios-tests,run-ios-simulator-tests,run-tvos-tests,run-watchos-tests,run-mac-tests,run-maccatalyst-tests,run-dotnet-tests,run-system-permission-tests,run-legacy-xamarin-tests'
+        statusContext: 'VSTS: simulator tests' 
+        uploadArtifacts: true
+
+# always run simulator tests
+- template: ./tests/stage.yml
+  parameters:
+    xcodeChannel: ${{ parameters.xcodeChannel }}
+    macOSName: ${{ parameters.macOSName }}
+    isPR: ${{ parameters.isPR }}
+    repositoryAlias: ${{ parameters.repositoryAlias }}
+    commit: ${{ parameters.commit }}
+    testConfigurations: ${{ parameters.testConfigurations }}
+    supportedPlatforms: ${{ parameters.supportedPlatforms }}
+    stageName: 'simulator_tests'
+    displayName: '${{ parameters.stageDisplayNamePrefix }}Simulator tests'
+    testPool: '' # use the default
+    useXamarinStorage: false
+    statusContext: 'VSTS: simulator tests'
+    makeTarget: 'jenkins'
+    vsdropsPrefix: ${{ variables.vsdropsPrefix }}
+    keyringPass: $(pass--lab--mac--builder--keychain)
+    gitHubToken: $(Github.Token)
+    xqaCertPass: $(xqa--certificates--password)
+    condition: ${{ parameters.runTests }}
+    postPipeline: true
+
+- template: ./tests/publish-results.yml
+  parameters:
+    displayName: '${{ parameters.stageDisplayNamePrefix }}Publish Test Results'
+    stageName: 'publish_test_results'
+    statusContext: 'VSTS: test results'
+    vsdropsPrefix: ${{ variables.vsdropsPrefix }}
+    condition: ${{ parameters.runTests }}
+    testConfigurations: ${{ parameters.testConfigurations }}
+    supportedPlatforms: ${{ parameters.supportedPlatforms }}
+    isPR: ${{ parameters.isPR }}
+    repositoryAlias: ${{ parameters.repositoryAlias }}
+    commit: ${{ parameters.commit }}
+    postPipeline: true
+
+- ${{ if eq(parameters.runOldMacOSTests, true) }}:
+  - ${{ each config in parameters.macTestsConfigurations }}:
+    - template: ./mac/stage.yml
+      parameters:
+        isPR: ${{ parameters.isPR }}
+        repositoryAlias: ${{ parameters.repositoryAlias }}
+        commit: ${{ parameters.commit }}
+        stageName: ${{ config.stageName }}
+        displayName: ' ${{ parameters.stageDisplayNamePrefix }}${{ config.displayName }}'
+        macPool: ${{ config.macPool }}
+        useImage: ${{ config.useImage }}
+        statusContext: ${{ config.statusContext }}
+        keyringPass: $(pass--lab--mac--builder--keychain)
+        demands: ${{ config.demands }}
+        postPipeline: true
+
+- ${{ if eq(parameters.runWindowsIntegration, true) }}:
+  - template: ./windows/stage.yml
+    parameters:
+      isPR: ${{ parameters.isPR }}
+      repositoryAlias: ${{ parameters.repositoryAlias }}
+      commit: ${{ parameters.commit }}
+      stageName: windows_integration
+      displayName: '${{ parameters.stageDisplayNamePrefix }}Windows Integration Tests'
+      pool: 'VSEng-Xamarin-Mac-Devices' # currently ignored until the VS team provides a real one
+      statusContext: 'Windows Integration Tests'
+      gitHubToken: $(Github.Token)
+      xqaCertPass: $(xqa--certificates--password)
+      postPipeline: true
+
+- ${{ if eq(parameters.runSamples, true) }}:
+  # TODO: Not the real step
+  - stage: sample_testing
+    displayName: '${{ stageDisplayNamePrefix }}Sample testing'
+    dependsOn:
+    - build_packages
+    condition: and(succeeded(), contains (stageDependencies.build_packages.build.outputs['configuration.RunSampleTests'], 'True'))
+    jobs:
+    - job: sample_testing
+      pool:
+        vmImage: ubuntu-latest
+      steps:
+      # TODO: do parse labels
+      - bash: |
+          echo "Samples!"
+        displayName: 'Sample testing'

--- a/tools/devops/automation/templates/tests/publish-results.yml
+++ b/tools/devops/automation/templates/tests/publish-results.yml
@@ -37,11 +37,16 @@ parameters:
   type: string
   default: HEAD
 
+- name: postPipeline
+  type: boolean
+  default: false
+
 stages:
 - stage: ${{ parameters.stageName }}
   displayName: ${{ parameters.displayName }}
   dependsOn:
-  - build_packages
+  - ${{ if eq(parameters.postPipeline, false) }}:
+    - build_macos_tests
   - configure_build
   - simulator_tests
   condition: and(succeededOrFailed(), ${{ parameters.condition }})

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -76,11 +76,16 @@ parameters:
 - name: macOSName
   type: string
 
+- name: postPipeline
+  type: boolean
+  default: false
+
 stages:
 - stage: ${{ parameters.stageName }}
   displayName: ${{ parameters.displayName }}
   dependsOn:
-  - build_packages
+  - ${{ if eq(parameters.postPipeline, false) }}:
+    - build_macos_tests
   - configure_build
   # we need to have the pkgs built and the device sets to be ran, that is decided via the labels or type of build during the build_packages stage
   condition: and(succeeded(), ${{ parameters.condition }})

--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -38,11 +38,16 @@ parameters:
 - name: xqaCertPass
   type: string
 
+- name: postPipeline
+  type: boolean
+  default: false
+
 stages:
 - stage: ${{ parameters.stageName }}
   displayName: ${{ parameters.displayName }}
   dependsOn:
-  - build_packages
+  - ${{ if eq(parameters.postPipeline, false) }}:
+    - build_macos_tests
   - configure_build
   condition: and(succeeded(), eq(dependencies.configure_build.outputs['configure.decisions.RUN_WINDOWS_TESTS'], 'true'))
 


### PR DESCRIPTION
1Es is problematic and has a lot of issues on how we use the matrix strategies. We have two options, either wait for 1ES to implement the needed changes or move all the tests out to two different pipelines that won't need to be 1ES complient.

In the long run moving out of the build piepline is going to give us more flexibility and will move the project away from depending on a thridparty to fix the yaml issues.

Even when landing this PR we will not have the tests removed, we will do that after we have been able to test that things work as expected.