### PR TITLE
[CI] Simplify the split of the pipelines via extensions

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -4,256 +4,33 @@
 # YAML build pipeline based on the Jenkins multi-stage (main branch) build workflow
 # https://jenkins.internalx.com/view/Xamarin.MaciOS/job/macios/job/main/
 # https://jenkins.internalx.com/view/Xamarin.MaciOS/job/macios/configure
-#
-parameters:
-
-- name: provisionatorChannel
-  displayName: Provisionator channel to use 
-  type: string
-  default: 'latest'
-
-- name: macOSName # comes from the build agent demand named macOS.Name
-  displayName: Name of the version of macOS to use
-  type: string
-  default: 'Sonoma'
-
-- name: pool
-  type: string
-  displayName: Bot pool to use
-  default: automatic
-  values:
-  - pr
-  - ci
-  - automatic
-
-- name: runTests
-  displayName: Run Simulator Tests
-  type: boolean
-  default: true
-
-- name: runDeviceTests
-  displayName: Run Device Tests 
-  type: boolean
-  default: false
-
-- name: runOldMacOSTests
-  displayName: Run Tests on older macOS versions 
-  type: boolean
-  default: true
-
-- name: runWindowsIntegration
-  displayName: Run Windows integration tests
-  type: boolean
-  default: true
-
-- name: runGovernanceTests
-  displayName: Run Governance Checks
-  type: boolean
-  default: true
-
-- name: runSamples
-  displayName: Run Samples
-  type: boolean
-  default: false
-  
-- name: enableAPIDiff
-  displayName: Enable API diff generation
-  type: boolean
-  default: true
-
-- name: forceInsertion
-  displayName: Force Insertion 
-  type: boolean
-  default: false 
-
-- name: skipESRP
-  displayName: Skip ESRP
-  type: boolean
-  default: false # only to be used when testing the CI and we do not need a signed pkg
-
-- name: testConfigurations
-  displayName: Test configurations to run
-  type: object
-  default: []
-
-- name: deviceTestsConfigurations
-  displayName: Device test configurations to run
-  type: object
-  default: [
-    {
-      testPrefix: 'iOS64',
-      stageName: 'ios64b_device',
-      displayName: 'iOS64 Device Tests',
-      testPool: 'VSEng-Xamarin-Mac-Devices',
-      useXamarinStorage: false,
-      testsLabels: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
-      statusContext: 'VSTS: device tests iOS',
-      makeTarget: 'vsts-device-tests',
-      extraBotDemands: [
-        'ios',
-      ]
-    },
-    {
-      testPrefix: 'tvos',
-      stageName: 'tvos_device',
-      displayName: 'tvOS Device Tests',
-      testPool: 'VSEng-Xamarin-Mac-Devices',
-      useXamarinStorage: false,
-      testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
-      statusContext: 'VSTS: device tests tvOS',
-      makeTarget: 'vsts-device-tests',
-      extraBotDemands: [
-        'tvos',
-      ]
-    }]
-
-- name: macTestsConfigurations
-  displayName: macOS test configurations to run
-  type: object
-  default: [
-    {
-      stageName: 'mac_11_m1',
-      displayName: 'M1 - Mac Big Sur (11)',
-      macPool: 'VSEng-VSMac-Xamarin-Shared',
-      useImage: false,
-      statusContext: 'M1 - Mac Big Sur (11)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals BigSur",
-        "macOS.Architecture -equals arm64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    },
-    {
-      stageName: 'mac_12_m1',
-      displayName: 'M1 - Mac Ventura (12)',
-      macPool: 'VSEng-VSMac-Xamarin-Shared',
-      useImage: false,
-      statusContext: 'M1 - Mac Monterey (12)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals Monterey",
-        "macOS.Architecture -equals arm64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    },
-    {
-      stageName: 'mac_13_m1',
-      displayName: 'M1 - Mac Ventura (13)',
-      macPool: 'VSEng-VSMac-Xamarin-Shared',
-      useImage: false,
-      statusContext: 'M1 - Mac Ventura (13)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals Ventura",
-        "macOS.Architecture -equals arm64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    },
-    {
-      stageName: 'mac_14_x64',
-      displayName: 'X64 - Mac Sonoma (14)',
-      macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted',
-      useImage: false,
-      statusContext: 'X64 - Mac Sonoma (14)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals Sonoma",
-        "macOS.Architecture -equals x64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    }]
-
-resources:
-  repositories:
-  - repository: self
-    checkoutOptions:
-      submodules: true
-
-  - repository: yaml-templates
-    type: github
-    name: xamarin/yaml-templates
-    ref: refs/heads/main
-    endpoint: xamarin
-
-  - repository: sdk-insertions
-    type: github
-    name: xamarin/sdk-insertions
-    ref: refs/heads/main
-    endpoint: xamarin
-
-  - repository: maccore
-    type: github
-    name: xamarin/maccore
-    ref: refs/heads/main
-    endpoint: xamarin
-
-  - repository: release-scripts
-    type: github
-    name: xamarin/release-scripts
-    ref: refs/heads/only_codesign
-    endpoint: xamarin
-
-variables:
-- ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
-  - template: templates/vsts-variables.yml
-- template: templates/variables.yml
-- name: MicrobuildConnector
-  value: 'MicroBuild Signing Task (DevDiv)'
-- name: MaciosUploadPrefix
-  value: ''
-- name: DisablePipelineConfigDetector
-  value: true
 
 trigger:
   branches:
     include:
-    - '*'
+      - '*'
     exclude:
-    - refs/heads/locfiles/*
-    - refs/heads/dev/*
+      - refs/heads/locfiles/*
+      - refs/heads/dev/*
   paths:
     exclude:
-    - .github
-    - docs
-    - CODEOWNERS
-    - ISSUE_TEMPLATE.md
-    - LICENSE
-    - NOTICE.txt
-    - SECURITY.MD
-    - README.md
-    - src/README.md
-    - tools/mtouch/README.md
-    - msbuild/Xamarin.Localization.MSBuild/README.md
+      - .github
+      - docs
+      - CODEOWNERS
+      - ISSUE_TEMPLATE.md
+      - LICENSE
+      - NOTICE.txt
+      - SECURITY.MD
+      - README.md
+      - src/README.md
+      - tools/mtouch/README.md
+      - msbuild/Xamarin.Localization.MSBuild/README.md
 
-stages:
-- template: templates/main-stage.yml
+extends:
+  template: templates/pipelines/build-pipeline.yml
   parameters:
-    xcodeChannel: Stable
-    macOSName: ${{ parameters.macOSName }}
     isPR: false
-    provisionatorChannel: ${{ parameters.provisionatorChannel }}
-    pool: ${{ parameters.pool }}
-    runTests: ${{ parameters.runTests }}
-    runDeviceTests: ${{ parameters.runDeviceTests }}
-    runOldMacOSTests: ${{ parameters.runOldMacOSTests }}
-    runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
-    runGovernanceTests: ${{ parameters.runGovernanceTests }}
-    runSamples: ${{ parameters.runSamples }}
-    enableAPIDiff: ${{ parameters.enableAPIDiff }}
-    forceInsertion: ${{ parameters.forceInsertion }}
-    skipESRP: ${{ parameters.skipESRP }}
-    ${{ if ne(length(parameters.testConfigurations), 0)}}:
-      testConfigurations: ${{ parameters.testConfigurations }}
-    deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}
-    macTestsConfigurations: ${{ parameters.macTestsConfigurations }}
-    azureStorage: ${{ variables['azureStorage'] }}
-    azureContainer: ${{ variables['azureContainer'] }}
-    signingSetupSteps:
-    - template: ./templates/sign-and-notarized/setup.yml
-      parameters:
-        isPR: false
+    signingSetupSteps: 
+      - template: ./templates/sign-and-notarized/setup.yml
+        parameters:
+          isPR: false

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -4,193 +4,6 @@
 # YAML build pipeline based on the Jenkins multi-stage (main branch) build workflow
 # https://jenkins.internalx.com/view/Xamarin.MaciOS/job/macios/job/main/
 # https://jenkins.internalx.com/view/Xamarin.MaciOS/job/macios/configure
-#
-parameters:
-
-- name: provisionatorChannel
-  displayName: Provisionator channel to use 
-  type: string
-  default: 'latest'
-
-- name: macOSName # comes from the build agent demand named macOS.Name
-  displayName: Name of the version of macOS to use
-  type: string
-  default: 'Sonoma'
-
-- name: pool
-  type: string
-  displayName: Bot pool to use
-  default: automatic
-  values:
-  - pr
-  - ci
-  - automatic
-
-- name: runTests
-  displayName: Run Simulator Tests
-  type: boolean
-  default: true
-
-- name: runOldMacOSTests
-  displayName: Run Tests on older macOS versions 
-  type: boolean
-  default: true
-
-- name: runWindowsIntegration
-  displayName: Run Windows integration tests
-  type: boolean
-  default: true
-
-- name: runGovernanceTests
-  displayName: Run Governance Checks
-  type: boolean
-  default: true
-
-- name: runSamples
-  displayName: Run Samples
-  type: boolean
-  default: false
-  
-- name: enableAPIDiff
-  displayName: Enable API diff generation
-  type: boolean
-  default: true
-
-- name: testConfigurations
-  displayName: Test configurations to run
-  type: object
-  default: []
-
-- name: deviceTestsConfigurations
-  displayName: Device test configurations to run
-  type: object
-  default: [
-    {
-      testPrefix: 'iOS64',
-      stageName: 'ios64b_device',
-      displayName: 'iOS64 Device Tests',
-      testPool: 'VSEng-Xamarin-Mac-Devices',
-      useXamarinStorage: false,
-      testsLabels: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
-      statusContext: 'VSTS: device tests iOS',
-      makeTarget: 'vsts-device-tests',
-      extraBotDemands: [
-        'ios',
-      ]
-    },
-    {
-      testPrefix: 'tvos',
-      stageName: 'tvos_device',
-      displayName: 'tvOS Device Tests',
-      testPool: 'VSEng-Xamarin-Mac-Devices',
-      useXamarinStorage: false,
-      testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
-      statusContext: 'VSTS: device tests tvOS',
-      makeTarget: 'vsts-device-tests',
-      extraBotDemands: [
-        'tvos',
-      ]
-    }]
-
-- name: macTestsConfigurations
-  displayName: macOS test configurations to run
-  type: object
-  default: [
-    {
-      stageName: 'mac_11_m1',
-      displayName: 'M1 - Mac Big Sur (11)',
-      macPool: 'VSEng-VSMac-Xamarin-Shared',
-      useImage: false,
-      statusContext: 'M1 - Mac Big Sur (11)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals BigSur",
-        "macOS.Architecture -equals arm64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    },
-    {
-      stageName: 'mac_12_m1',
-      displayName: 'M1 - Mac Ventura (12)',
-      macPool: 'VSEng-VSMac-Xamarin-Shared',
-      useImage: false,
-      statusContext: 'M1 - Mac Monterey (12)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals Monterey",
-        "macOS.Architecture -equals arm64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    },
-    {
-      stageName: 'mac_13_m1',
-      displayName: 'M1 - Mac Ventura (13)',
-      macPool: 'VSEng-VSMac-Xamarin-Shared',
-      useImage: false,
-      statusContext: 'M1 - Mac Ventura (13)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals Ventura",
-        "macOS.Architecture -equals arm64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    },
-    {
-      stageName: 'mac_14_x64',
-      displayName: 'X64 - Mac Sonoma (14)',
-      macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted',
-      useImage: false,
-      statusContext: 'X64 - Mac Sonoma (14)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals Sonoma",
-        "macOS.Architecture -equals x64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    }]
-
-resources:
-  repositories:
-  - repository: self
-    checkoutOptions:
-      submodules: true
-
-  - repository: yaml-templates
-    type: github
-    name: xamarin/yaml-templates
-    ref: refs/heads/main
-    endpoint: xamarin
-
-  - repository: sdk-insertions
-    type: github
-    name: xamarin/sdk-insertions
-    ref: refs/heads/main
-    endpoint: xamarin
-
-  - repository: maccore
-    type: github
-    name: xamarin/maccore
-    ref: refs/heads/main
-    endpoint: xamarin
-
-  - repository: release-scripts
-    type: github
-    name: xamarin/release-scripts
-    ref: refs/heads/only_codesign
-    endpoint: xamarin
-
-variables:
-- template: templates/variables.yml
-- name: MicrobuildConnector
-  value: ''
-- name: MaciosUploadPrefix
-  value: ''
-- name: Packaging.EnableSBOMSigning
-  value: false
 
 trigger: none
 
@@ -198,45 +11,26 @@ pr:
   autoCancel: true
   branches:
     include:
-    - '*'  # yes, you do need the quote, * has meaning in yamls
+      - '*'  # yes, you do need the quote, * has meaning in yamls
   paths:
     exclude:
-    - .github
-    - docs
-    - CODEOWNERS
-    - ISSUE_TEMPLATE.md
-    - LICENSE
-    - NOTICE.txt
-    - SECURITY.MD
-    - README.md
-    - src/README.md
-    - tools/mtouch/README.md
-    - msbuild/Xamarin.Localization.MSBuild/README.md
+      - .github
+      - docs
+      - CODEOWNERS
+      - ISSUE_TEMPLATE.md
+      - LICENSE
+      - NOTICE.txt
+      - SECURITY.MD
+      - README.md
+      - src/README.md
+      - tools/mtouch/README.md
+      - msbuild/Xamarin.Localization.MSBuild/README.md
 
-stages:
-- template: templates/main-stage.yml
+extends:
+  template: templates/pipelines/build-pipeline.yml
   parameters:
-    xcodeChannel: Stable
-    macOSName: ${{ parameters.macOSName }}
     isPR: true
-    provisionatorChannel: ${{ parameters.provisionatorChannel }}
-    pool: ${{ parameters.pool }}
-    runTests: ${{ parameters.runTests }}
-    runDeviceTests: false
-    runOldMacOSTests: ${{ parameters.runOldMacOSTests }}
-    runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
-    runGovernanceTests: ${{ parameters.runGovernanceTests }}
-    runSamples: ${{ parameters.runSamples }}
-    enableAPIDiff: ${{ parameters.enableAPIDiff }}
-    forceInsertion: false
-    skipESRP: true
-    ${{ if ne(length(parameters.testConfigurations), 0)}}:
-      testConfigurations: ${{ parameters.testConfigurations }}
-    deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}
-    macTestsConfigurations: ${{ parameters.macTestsConfigurations }}
-    azureStorage: ${{ variables['azureStorage'] }}
-    azureContainer: ${{ variables['azureContainer'] }}
-    signingSetupSteps:
-    - template: ./templates/sign-and-notarized/setup.yml
-      parameters:
-        isPR: true
+    signingSetupSteps: 
+      - template: ./templates/sign-and-notarized/setup.yml
+        parameters:
+          isPR: true

--- a/tools/devops/automation/templates/pipelines/build-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/build-pipeline.yml
@@ -229,7 +229,7 @@ stages:
   parameters:
     xcodeChannel: Stable
     macOSName: ${{ parameters.macOSName }}
-    isPR: false
+    isPR: ${{ parameters.isPR }}
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}
     runTests: ${{ parameters.runTests }}

--- a/tools/devops/automation/templates/pipelines/build-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/build-pipeline.yml
@@ -1,0 +1,250 @@
+# template that can be extended by pipelines that will be used to build the project. This
+# allows to share te parameters and resources. 
+
+parameters:
+
+- name: provisionatorChannel
+  displayName: Provisionator channel to use 
+  type: string
+  default: 'latest'
+
+- name: macOSName # comes from the build agent demand named macOS.Name
+  displayName: Name of the version of macOS to use
+  type: string
+  default: 'Sonoma'
+
+- name: pool
+  type: string
+  displayName: Bot pool to use
+  default: automatic
+  values:
+  - pr
+  - ci
+  - automatic
+
+- name: runTests
+  displayName: Run Simulator Tests
+  type: boolean
+  default: true
+
+- name: runDeviceTests
+  displayName: Run Device Tests 
+  type: boolean
+  default: false
+
+- name: runOldMacOSTests
+  displayName: Run Tests on older macOS versions 
+  type: boolean
+  default: true
+
+- name: runWindowsIntegration
+  displayName: Run Windows integration tests
+  type: boolean
+  default: true
+
+- name: runGovernanceTests
+  displayName: Run Governance Checks
+  type: boolean
+  default: true
+
+- name: runSamples
+  displayName: Run Samples
+  type: boolean
+  default: false
+  
+- name: enableAPIDiff
+  displayName: Enable API diff generation
+  type: boolean
+  default: true
+
+- name: forceInsertion
+  displayName: Force Insertion 
+  type: boolean
+  default: false 
+
+- name: skipESRP
+  displayName: Skip ESRP
+  type: boolean
+  default: false # only to be used when testing the CI and we do not need a signed pkg
+
+- name: isPR
+  displayName: Is PR build
+  type: boolean
+  default: false
+
+- name: signingSetupSteps
+  type: stepList
+  default: []
+
+- name: testConfigurations
+  displayName: Test configurations to run
+  type: object
+  default: []
+
+- name: deviceTestsConfigurations
+  displayName: Device test configurations to run
+  type: object
+  default: [
+    {
+      testPrefix: 'iOS64',
+      stageName: 'ios64b_device',
+      displayName: 'iOS64 Device Tests',
+      testPool: 'VSEng-Xamarin-Mac-Devices',
+      useXamarinStorage: false,
+      testsLabels: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
+      statusContext: 'VSTS: device tests iOS',
+      makeTarget: 'vsts-device-tests',
+      extraBotDemands: [
+        'ios',
+      ]
+    },
+    {
+      testPrefix: 'tvos',
+      stageName: 'tvos_device',
+      displayName: 'tvOS Device Tests',
+      testPool: 'VSEng-Xamarin-Mac-Devices',
+      useXamarinStorage: false,
+      testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
+      statusContext: 'VSTS: device tests tvOS',
+      makeTarget: 'vsts-device-tests',
+      extraBotDemands: [
+        'tvos',
+      ]
+    }]
+
+- name: macTestsConfigurations
+  displayName: macOS test configurations to run
+  type: object
+  default: [
+    {
+      stageName: 'mac_11_m1',
+      displayName: 'M1 - Mac Big Sur (11)',
+      macPool: 'VSEng-VSMac-Xamarin-Shared',
+      useImage: false,
+      statusContext: 'M1 - Mac Big Sur (11)',
+      demands: [
+        "Agent.OS -equals Darwin",
+        "macOS.Name -equals BigSur",
+        "macOS.Architecture -equals arm64",
+        "Agent.HasDevices -equals False",
+        "Agent.IsPaired -equals False"
+      ]
+    },
+    {
+      stageName: 'mac_12_m1',
+      displayName: 'M1 - Mac Ventura (12)',
+      macPool: 'VSEng-VSMac-Xamarin-Shared',
+      useImage: false,
+      statusContext: 'M1 - Mac Monterey (12)',
+      demands: [
+        "Agent.OS -equals Darwin",
+        "macOS.Name -equals Monterey",
+        "macOS.Architecture -equals arm64",
+        "Agent.HasDevices -equals False",
+        "Agent.IsPaired -equals False"
+      ]
+    },
+    {
+      stageName: 'mac_13_m1',
+      displayName: 'M1 - Mac Ventura (13)',
+      macPool: 'VSEng-VSMac-Xamarin-Shared',
+      useImage: false,
+      statusContext: 'M1 - Mac Ventura (13)',
+      demands: [
+        "Agent.OS -equals Darwin",
+        "macOS.Name -equals Ventura",
+        "macOS.Architecture -equals arm64",
+        "Agent.HasDevices -equals False",
+        "Agent.IsPaired -equals False"
+      ]
+    },
+    {
+      stageName: 'mac_14_x64',
+      displayName: 'X64 - Mac Sonoma (14)',
+      macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted',
+      useImage: false,
+      statusContext: 'X64 - Mac Sonoma (14)',
+      demands: [
+        "Agent.OS -equals Darwin",
+        "macOS.Name -equals Sonoma",
+        "macOS.Architecture -equals x64",
+        "Agent.HasDevices -equals False",
+        "Agent.IsPaired -equals False"
+      ]
+    }]
+
+resources:
+  repositories:
+  - repository: self
+    checkoutOptions:
+      submodules: true
+
+  - repository: yaml-templates
+    type: github
+    name: xamarin/yaml-templates
+    ref: refs/heads/main
+    endpoint: xamarin
+
+  - repository: sdk-insertions
+    type: github
+    name: xamarin/sdk-insertions
+    ref: refs/heads/main
+    endpoint: xamarin
+
+  - repository: maccore
+    type: github
+    name: xamarin/maccore
+    ref: refs/heads/main
+    endpoint: xamarin
+
+  - repository: release-scripts
+    type: github
+    name: xamarin/release-scripts
+    ref: refs/heads/only_codesign
+    endpoint: xamarin
+
+
+variables:
+- ${{ if eq(parameters.isPR, false) }}:
+  - ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
+    - template: ../vsts-variables.yml
+  - template: ../variables.yml
+  - name: MicrobuildConnector
+    value: 'MicroBuild Signing Task (DevDiv)'
+  - name: MaciosUploadPrefix
+    value: ''
+  - name: DisablePipelineConfigDetector
+    value: true
+- ${{ else }}:
+  - template: ../variables.yml
+  - name: MicrobuildConnector
+    value: ''
+  - name: MaciosUploadPrefix
+    value: ''
+  - name: Packaging.EnableSBOMSigning
+    value: false
+
+stages:
+- template: ../main-stage.yml
+  parameters:
+    xcodeChannel: Stable
+    macOSName: ${{ parameters.macOSName }}
+    isPR: false
+    provisionatorChannel: ${{ parameters.provisionatorChannel }}
+    pool: ${{ parameters.pool }}
+    runTests: ${{ parameters.runTests }}
+    runDeviceTests: ${{ parameters.runDeviceTests }}
+    runOldMacOSTests: ${{ parameters.runOldMacOSTests }}
+    runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
+    runGovernanceTests: ${{ parameters.runGovernanceTests }}
+    runSamples: ${{ parameters.runSamples }}
+    enableAPIDiff: ${{ parameters.enableAPIDiff }}
+    forceInsertion: ${{ parameters.forceInsertion }}
+    skipESRP: ${{ parameters.skipESRP }}
+    ${{ if ne(length(parameters.testConfigurations), 0)}}:
+      testConfigurations: ${{ parameters.testConfigurations }}
+    deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}
+    macTestsConfigurations: ${{ parameters.macTestsConfigurations }}
+    azureStorage: ${{ variables['azureStorage'] }}
+    azureContainer: ${{ variables['azureContainer'] }}
+    signingSetupSteps: ${{ parameters.signingSetupSteps }}


### PR DESCRIPTION
Make the live of the mantianers better by using inheritance for the build pipelines. This later will make the move to the 1ES template easier since we refactored the yaml of the pipelines to be as small as possible.