### PR TITLE
[tests] Don't verify that property accessors have xml documentation.

### DIFF
--- a/tests/cecil-tests/Documentation.cs
+++ b/tests/cecil-tests/Documentation.cs
@@ -139,6 +139,9 @@ namespace Cecil.Tests {
 					// It's not possible to add xml documentation to members of delegates, so don't verify those
 					if (IsDelegateType (md.DeclaringType))
 						continue;
+					// It's not possible to add xml documentation to getters/setters (it's added to the property itself), so don't verify those.
+					if (md.IsPropertyAccessor ())
+						continue;
 					name = "M:" + GetDocId (md);
 				} else if (member is PropertyDefinition pd) {
 					name = "P:" + GetDocId (pd);


### PR DESCRIPTION
There's no way to add xml documentation to them.

Partial fix for https://github.com/xamarin/xamarin-macios/issues/20270.