### PR TITLE
[msbuild] Fix duplicated property declaration.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1904,9 +1904,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<PropertyGroup>
 		<_UnpackLibraryResourcesDependsOn>
 			$(_UnpackLibraryResourcesDependsOn);
+			BuildOnlySettings;
 			ResolveReferences;
 			_DetectBuildType;
-			_CollectBundleResources;
 			_PrepareUnpackLibraryResources;
 			_BeforeUnpackLibraryResources;
 			_ReadUnpackedLibraryResources;
@@ -1924,16 +1924,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			</_UnpackLibraryResourceItems>
 		</ItemGroup>
 	</Target>
-
-	<PropertyGroup>
-		<_UnpackLibraryResourcesDependsOn>
-			BuildOnlySettings;
-			ResolveReferences;
-			_DetectBuildType;
-			_CollectBundleResources;
-			_PrepareUnpackLibraryResources;
-		</_UnpackLibraryResourcesDependsOn>
-	</PropertyGroup>
 
 	<Target Name="_BeforeUnpackLibraryResources"
 		Inputs="@(_UnpackLibraryResourceItems)"


### PR DESCRIPTION
This looks like an incorrect merge conflict resolution: the property
_UnpackLibraryResourcesDependsOn was declared twice, the second time
overwriting the first.

Pick the first declaration, since it's the newest and more complete one
(70a5d0d09ab).