### PR TITLE
[runtime] Fix memory leak with BlockLiteral descriptors. Fixes #20503.

### DIFF
--- a/runtime/shared.m
+++ b/runtime/shared.m
@@ -167,7 +167,8 @@ xamarin_dispose_helper (void *a)
 	struct Block_literal *bl = (struct Block_literal *) a;
 	xamarin_gchandle_free (bl->global_handle);
 	bl->global_handle = INVALID_GCHANDLE;
-	if (atomic_fetch_sub (&bl->descriptor->ref_count, 1) == 0) {
+	// atomic_fetch_sub returns the original value before the subtraction
+	if (atomic_fetch_sub (&bl->descriptor->ref_count, 1) == 1) {
 		free (bl->descriptor); // allocated using Marshal.AllocHGlobal.
 	}
 	bl->descriptor = NULL;

--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -370,6 +370,7 @@ namespace ObjCRuntime {
 				// CS0420: A volatile field references will not be treated as volatile
 				// Documentation says: "A volatile field should not normally be passed using a ref or out parameter, since it will not be treated as volatile within the scope of the function. There are exceptions to this, such as when calling an interlocked API."
 				// So ignoring the warning, since it's a documented exception.
+				// Interlocked.Decrement returns the new value after the subtraction
 				var rc = Interlocked.Decrement (ref xblock_descriptor->ref_count);
 #pragma warning restore 420
 


### PR DESCRIPTION
We're using two different functions to atomically decrement a reference count,
the native `atomic_fetch_sub` and the managed `Interlocked.Decrement`.

Unfortunately the return value is not the same: `atomic_fetch_sub` returns the
original value before the subtraction, while `Interlocked.Decrement` returns
the subtracted value, while our code assumed the functions behaved the same.
This resulted in a memory leak, because we'd incorrectly expect `0` to be
returned from `atomic_fetch_sub` when the reference count reaches zero, and
thus not detect when the descriptor a block should be freed.

The fix is to update the expected return value from `atomic_fetch_sub` to be
`1` instead of `0`.

Fixes https://github.com/xamarin/xamarin-macios/issues/20503.