### PR TITLE
[devops] Attempt to fix simulator runtimes disappearing.

### DIFF
--- a/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
+++ b/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
@@ -35,3 +35,17 @@ do
 done < simruntime-duplicated-runtimes.txt
 
 xcrun simctl runtime list -v
+xcrun simctl runtime match list -v
+
+# try to detach all simulator runtimes
+for dir in $(ls -d /Library/Developer/CoreSimulator/Volumes/*); do
+  diskutil eject $dir || true
+done
+# kill the com.apple.CoreSimulator.simdiskimaged service
+sudo launchctl kill 9 system/com.apple.CoreSimulator.simdiskimaged || true
+# kill the com.apple.CoreSimulator.CoreSimulatorService service
+# it seems this service starts the simdiskimaged service if it's not running.
+pkill -9 com.apple.CoreSimulator.CoreSimulatorService || true
+# the disk image service should now restart when needed, and reload the re-attach all the simulator runtimes.
+
+xcrun simctl runtime match list -v

--- a/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
+++ b/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
@@ -43,13 +43,13 @@ xcrun simctl runtime match list -v || true
 
 # try to detach all simulator runtimes
 for dir in /Library/Developer/CoreSimulator/Volumes/*; do
-  diskutil eject "$dir" || true
+  sudo diskutil eject "$dir" || true
 done
 # kill the com.apple.CoreSimulator.simdiskimaged service
 sudo launchctl kill 9 system/com.apple.CoreSimulator.simdiskimaged || true
 # kill the com.apple.CoreSimulator.CoreSimulatorService service
 # it seems this service starts the simdiskimaged service if it's not running.
-pkill -9 com.apple.CoreSimulator.CoreSimulatorService || true
+sudo pkill -9 com.apple.CoreSimulator.CoreSimulatorService || true
 # the disk image service should now restart when needed, and reload the re-attach all the simulator runtimes.
 
 xcrun simctl runtime match list -v || true

--- a/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
+++ b/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
@@ -38,8 +38,8 @@ xcrun simctl runtime list -v
 xcrun simctl runtime match list -v
 
 # try to detach all simulator runtimes
-for dir in $(ls -d /Library/Developer/CoreSimulator/Volumes/*); do
-  diskutil eject $dir || true
+for dir in /Library/Developer/CoreSimulator/Volumes/*; do
+  diskutil eject "$dir" || true
 done
 # kill the com.apple.CoreSimulator.simdiskimaged service
 sudo launchctl kill 9 system/com.apple.CoreSimulator.simdiskimaged || true

--- a/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
+++ b/tools/devops/automation/scripts/bash/clean-simulator-runtime.sh
@@ -8,17 +8,21 @@ IFS=$'\n\t'
 xcrun simctl runtime list -j > simruntime.json
 cat simruntime.json
 
-grep -e '"identifier" : ' -e '"runtimeIdentifier" : ' simruntime.json | tr '\n' ' ' | sed -e 's/,//g' -e 's/"//g' -e 's/runtimeIdentifier : //g' -e $'s/identifier : /@/g' | tr '@' '\n' | awk NF | sed 's/^[[:blank:]]*//' > simruntime-lines.txt
-cat simruntime-lines.txt
+if grep -e '"identifier" : ' -e '"runtimeIdentifier" : ' simruntime.json | tr '\n' ' ' | sed -e 's/,//g' -e 's/"//g' -e 's/runtimeIdentifier : //g' -e $'s/identifier : /@/g' | tr '@' '\n' | awk NF | sed 's/^[[:blank:]]*//' > simruntime-lines.txt; then
+  cat simruntime-lines.txt
+fi
 
-sed -e 's/.*com.apple/com.apple/g' simruntime-lines.txt > simruntime-runtimes.txt
-cat simruntime-runtimes.txt
+if sed -e 's/.*com.apple/com.apple/g' simruntime-lines.txt > simruntime-runtimes.txt; then
+  cat simruntime-runtimes.txt
+fi
 
-sort simruntime-runtimes.txt | uniq -c | sort -n | sed 's/^[[:blank:]]*//' > simruntime-runtimes-by-count.txt
-cat simruntime-runtimes-by-count.txt
+if sort simruntime-runtimes.txt | uniq -c | sort -n | sed 's/^[[:blank:]]*//' > simruntime-runtimes-by-count.txt; then
+  cat simruntime-runtimes-by-count.txt
+fi
 
-grep -v '^1 ' simruntime-runtimes-by-count.txt | sed 's/^[0-9 ]*//' > simruntime-duplicated-runtimes.txt
-cat simruntime-duplicated-runtimes.txt
+if grep -v '^1 ' simruntime-runtimes-by-count.txt | sed 's/^[0-9 ]*//' > simruntime-duplicated-runtimes.txt; then
+  cat simruntime-duplicated-runtimes.txt
+fi
 
 while IFS= read -r simruntime
 do
@@ -32,10 +36,10 @@ do
       echo "    deleted runtime $id"
     fi
   done
-done < simruntime-duplicated-runtimes.txt
+done < simruntime-duplicated-runtimes.txt || true
 
-xcrun simctl runtime list -v
-xcrun simctl runtime match list -v
+xcrun simctl runtime list -v || true
+xcrun simctl runtime match list -v || true
 
 # try to detach all simulator runtimes
 for dir in /Library/Developer/CoreSimulator/Volumes/*; do


### PR DESCRIPTION
Attempt to fix simulator runtimes disappearing by:

* Detaching all the currently loaded runtimes.
* Killing the simdiskimaged and CoreSimulatorService services.

Hopefully this will make the simdiskimaged service restart, and reload the
simulator runtimes.