### PR TITLE
[bgen] Generate xml documentation for the extension class we generate for protocols.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -4888,6 +4888,12 @@ public partial class Generator : IMemberGatherer {
 		include_extensions = optionalInstanceMethods.Any () || optionalInstanceProperties.Any () || requiredInstanceAsyncMethods.Any ();
 		if (include_extensions) {
 			// extension methods
+			if (BindingTouch.SupportsXmlDocumentation) {
+				print ($"/// <summary>Extension methods to the <see cref=\"I{TypeName}\" /> interface to support all the methods from the {protocol_name} protocol.</summary>");
+				print ($"/// <remarks>");
+				print ($"///   <para>The extension methods for <see cref=\"I{TypeName}\" /> interface allow developers to treat instances of the interface as having all the optional methods of the original {protocol_name} protocol. Since the interface only contains the required members, these extension methods allow developers to call the optional members of the protocol.</para>");
+				print ($"/// </remarks>");
+			}
 			PrintAttributes (type, preserve: true, advice: true);
 			print ("{1} unsafe static partial class {0}_Extensions {{", TypeName, class_visibility);
 			indent++;

--- a/tests/generator/ExpectedXmlDocs.MacCatalyst.xml
+++ b/tests/generator/ExpectedXmlDocs.MacCatalyst.xml
@@ -208,6 +208,12 @@
             Summary for PA1.PProperty
             </summary>
         </member>
+        <member name="T:XmlDocumentation.P1_Extensions">
+            <summary>Extension methods to the <see cref="T:XmlDocumentation.IP1" /> interface to support all the methods from the P1 protocol.</summary>
+            <remarks>
+              <para>The extension methods for <see cref="T:XmlDocumentation.IP1" /> interface allow developers to treat instances of the interface as having all the optional methods of the original P1 protocol. Since the interface only contains the required members, these extension methods allow developers to call the optional members of the protocol.</para>
+            </remarks>
+        </member>
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod

--- a/tests/generator/ExpectedXmlDocs.iOS.legacy.xml
+++ b/tests/generator/ExpectedXmlDocs.iOS.legacy.xml
@@ -208,6 +208,12 @@
             Summary for PA1.PProperty
             </summary>
         </member>
+        <member name="T:XmlDocumentation.P1_Extensions">
+            <summary>Extension methods to the <see cref="T:XmlDocumentation.IP1" /> interface to support all the methods from the P1 protocol.</summary>
+            <remarks>
+              <para>The extension methods for <see cref="T:XmlDocumentation.IP1" /> interface allow developers to treat instances of the interface as having all the optional methods of the original P1 protocol. Since the interface only contains the required members, these extension methods allow developers to call the optional members of the protocol.</para>
+            </remarks>
+        </member>
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod

--- a/tests/generator/ExpectedXmlDocs.iOS.xml
+++ b/tests/generator/ExpectedXmlDocs.iOS.xml
@@ -208,6 +208,12 @@
             Summary for PA1.PProperty
             </summary>
         </member>
+        <member name="T:XmlDocumentation.P1_Extensions">
+            <summary>Extension methods to the <see cref="T:XmlDocumentation.IP1" /> interface to support all the methods from the P1 protocol.</summary>
+            <remarks>
+              <para>The extension methods for <see cref="T:XmlDocumentation.IP1" /> interface allow developers to treat instances of the interface as having all the optional methods of the original P1 protocol. Since the interface only contains the required members, these extension methods allow developers to call the optional members of the protocol.</para>
+            </remarks>
+        </member>
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod

--- a/tests/generator/ExpectedXmlDocs.macOS.legacy.xml
+++ b/tests/generator/ExpectedXmlDocs.macOS.legacy.xml
@@ -208,6 +208,12 @@
             Summary for PA1.PProperty
             </summary>
         </member>
+        <member name="T:XmlDocumentation.P1_Extensions">
+            <summary>Extension methods to the <see cref="T:XmlDocumentation.IP1" /> interface to support all the methods from the P1 protocol.</summary>
+            <remarks>
+              <para>The extension methods for <see cref="T:XmlDocumentation.IP1" /> interface allow developers to treat instances of the interface as having all the optional methods of the original P1 protocol. Since the interface only contains the required members, these extension methods allow developers to call the optional members of the protocol.</para>
+            </remarks>
+        </member>
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod

--- a/tests/generator/ExpectedXmlDocs.macOS.xml
+++ b/tests/generator/ExpectedXmlDocs.macOS.xml
@@ -208,6 +208,12 @@
             Summary for PA1.PProperty
             </summary>
         </member>
+        <member name="T:XmlDocumentation.P1_Extensions">
+            <summary>Extension methods to the <see cref="T:XmlDocumentation.IP1" /> interface to support all the methods from the P1 protocol.</summary>
+            <remarks>
+              <para>The extension methods for <see cref="T:XmlDocumentation.IP1" /> interface allow developers to treat instances of the interface as having all the optional methods of the original P1 protocol. Since the interface only contains the required members, these extension methods allow developers to call the optional members of the protocol.</para>
+            </remarks>
+        </member>
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod

--- a/tests/generator/ExpectedXmlDocs.tvOS.legacy.xml
+++ b/tests/generator/ExpectedXmlDocs.tvOS.legacy.xml
@@ -208,6 +208,12 @@
             Summary for PA1.PProperty
             </summary>
         </member>
+        <member name="T:XmlDocumentation.P1_Extensions">
+            <summary>Extension methods to the <see cref="T:XmlDocumentation.IP1" /> interface to support all the methods from the P1 protocol.</summary>
+            <remarks>
+              <para>The extension methods for <see cref="T:XmlDocumentation.IP1" /> interface allow developers to treat instances of the interface as having all the optional methods of the original P1 protocol. Since the interface only contains the required members, these extension methods allow developers to call the optional members of the protocol.</para>
+            </remarks>
+        </member>
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod

--- a/tests/generator/ExpectedXmlDocs.tvOS.xml
+++ b/tests/generator/ExpectedXmlDocs.tvOS.xml
@@ -208,6 +208,12 @@
             Summary for PA1.PProperty
             </summary>
         </member>
+        <member name="T:XmlDocumentation.P1_Extensions">
+            <summary>Extension methods to the <see cref="T:XmlDocumentation.IP1" /> interface to support all the methods from the P1 protocol.</summary>
+            <remarks>
+              <para>The extension methods for <see cref="T:XmlDocumentation.IP1" /> interface allow developers to treat instances of the interface as having all the optional methods of the original P1 protocol. Since the interface only contains the required members, these extension methods allow developers to call the optional members of the protocol.</para>
+            </remarks>
+        </member>
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod


### PR DESCRIPTION
This was mostly copied from the existing API documentation.

Partial fix for https://github.com/xamarin/xamarin-macios/issues/20270.