### PR TITLE
[tests] Ignore trailing slashes in NativeReference items. Fixes #15430.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferences.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferences.cs
@@ -295,7 +295,7 @@ namespace Xamarin.MacDev.Tasks {
 			document.LoadXmlWithoutNetworkAccess (manifestContents);
 			foreach (XmlNode referenceNode in document.GetElementsByTagName ("NativeReference")) {
 				ITaskItem t = new TaskItem (r);
-				var name = referenceNode.Attributes ["Name"].Value;
+				var name = referenceNode.Attributes ["Name"].Value.Trim ('\\', '/');
 				switch (Path.GetExtension (name)) {
 				case ".xcframework": {
 					if (!TryResolveXCFramework (Log, TargetFrameworkMoniker, SdkIsSimulator, Architectures, resources, name, GetIntermediateDecompressionDir (resources), createdFiles, out var frameworkPath))

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
@@ -134,7 +134,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_PrepareNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'">
+	<Target Name="_PrepareNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="_SanitizeNativeReferences">
 		<PrepareNativeReferences
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -127,7 +127,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</PropertyGroup>
 	</Target>
 
-	<Target Name="SanitizeNativeReference">
+	<Target Name="_SanitizeNativeReferences">
 		<!-- Remove trailing slashes from native references, so that we treat '.framework' the same as '.framework/'.
 			Ref: https://github.com/xamarin/xamarin-macios/issues/15430
 		-->
@@ -145,7 +145,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		@(NativeReference) are not safe to use as an Input to a task, as frameworks are a directory and will appears unbuilt every time.
 		So we split it into two camps as a prebuild step
 	-->
-	<Target Name="_ExpandNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;SanitizeNativeReference">
+	<Target Name="_ExpandNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;_SanitizeNativeReferences">
 		<ItemGroup>
 			<_XCFrameworkNativeReference Include="@(NativeReference -> '%(Identity)/.')" Condition="'%(Extension)' == '.xcframework'" />
 			<_FrameworkNativeReference Include="@(NativeReference -> '%(Identity)/%(Filename)')" Condition="'%(Extension)' == '.framework'" />

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -127,11 +127,25 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</PropertyGroup>
 	</Target>
 
+	<Target Name="SanitizeNativeReference">
+		<!-- Remove trailing slashes from native references, so that we treat '.framework' the same as '.framework/'.
+			Ref: https://github.com/xamarin/xamarin-macios/issues/15430
+		-->
+		<ItemGroup>
+			<NativeReference>
+				<IdentityWithoutPathSeparatorSuffix>$([System.String]::Copy('%(Identity)').TrimEnd('/').TrimEnd('\'))</IdentityWithoutPathSeparatorSuffix>
+			</NativeReference>
+			<NativeReferenceWithoutPathSeparatorSuffix Include="@(NativeReference->'%(IdentityWithoutPathSeparatorSuffix)')" />
+			<NativeReference Remove="@(NativeReference)" />
+			<NativeReference Include="@(NativeReferenceWithoutPathSeparatorSuffix)" />
+		</ItemGroup>
+	</Target>
+
 	<!--
 		@(NativeReference) are not safe to use as an Input to a task, as frameworks are a directory and will appears unbuilt every time.
 		So we split it into two camps as a prebuild step
 	-->
-	<Target Name="_ExpandNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName">
+	<Target Name="_ExpandNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;SanitizeNativeReference">
 		<ItemGroup>
 			<_XCFrameworkNativeReference Include="@(NativeReference -> '%(Identity)/.')" Condition="'%(Extension)' == '.xcframework'" />
 			<_FrameworkNativeReference Include="@(NativeReference -> '%(Identity)/%(Filename)')" Condition="'%(Extension)' == '.framework'" />

--- a/tests/bindings-framework-test/dotnet/shared.csproj
+++ b/tests/bindings-framework-test/dotnet/shared.csproj
@@ -45,7 +45,7 @@
       <NoDSymUtil>true</NoDSymUtil>
       <NoSymbolStrip>true</NoSymbolStrip>
     </NativeReference>
-    <NativeReference Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\XStaticObjectTest.framework">
+    <NativeReference Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\XStaticObjectTest.framework\">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
       <Frameworks>CoreLocation ModelIO</Frameworks>

--- a/tests/bindings-xcframework-test/dotnet/shared.csproj
+++ b/tests/bindings-xcframework-test/dotnet/shared.csproj
@@ -35,7 +35,7 @@
     <TestLibrariesInput Include="$(TestLibrariesDirectory)\libframework.m" />
     <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\XTest.xcframework" />
 
-    <NativeReference Include="$(TestLibrariesDirectory)\.libs\XTest.xcframework">
+    <NativeReference Include="$(TestLibrariesDirectory)\.libs\XTest.xcframework/">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
       <Frameworks>CoreLocation ModelIO</Frameworks>


### PR DESCRIPTION
A `*.framework/` native reference and a `*.framework` reference are the same
thing, so treat them the same. We accomplish this by removing any trailing
path separators (both windows style and non-windows-style for consistency)
before doing any processing.

Fixes https://github.com/xamarin/xamarin-macios/issues/15430.