### PR TITLE
[dotnet] Throw an exception if the developer tries to use server garbage collection. Fixes #16853.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2124,6 +2124,12 @@
 		<Error Condition="'$(_IsValidRuntimeIdentifier)' != 'true'" Text="The RuntimeIdentifier '$(RuntimeIdentifier)' is invalid." />
 	</Target>
 
+	<Target Name="_ValidateGarbageCollector"
+		Condition="'$(ServerGarbageCollection)' == 'true'"
+		BeforeTargets="Build;ResolvedFrameworkReference;ResolveRuntimePackAssets">
+		<Error Text=".NET for $(_PlatformName) does not support server garbage collection. Please don't set the 'ServerGarbageCollection' property." />
+	</Target>
+
 	<!-- This target can be removed in .NET 9 (when we stop supporting the compat logic to make the invalid TPV just a warning instead of an error) -->
 	<Target Name="_XamarinValidateTargetPlatformVersion"
 		BeforeTargets="Build;ResolvedFrameworkReference;ResolveRuntimePackAssets"

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -83,6 +83,20 @@ namespace ObjCRuntime {
 		}
 #pragma warning restore 649
 
+#if __TVOS__
+		internal const string PlatformName = "tvOS";
+#elif __WATCHOS__
+		internal const string PlatformName = "watchOS";
+#elif __MACCATALYST__
+		internal const string PlatformName = "Mac Catalyst";
+#elif __IOS__
+		internal const string PlatformName = "iOS";
+#elif __MACOS__
+		internal const string PlatformName = "macOS";
+#else
+#error Undetermined platform name
+#endif
+
 		[Flags]
 		internal enum MTTypeFlags : uint {
 			None = 0,
@@ -358,6 +372,14 @@ namespace ObjCRuntime {
 				NSLog (msg);
 				throw ErrorHelper.CreateError (8010, msg);
 			}
+
+#if NET
+			if (System.Runtime.GCSettings.IsServerGC) {
+				var msg = $".NET for {PlatformName} does not support server garbage collection.";
+				NSLog (msg);
+				throw ErrorHelper.CreateError (8057, msg);
+			}
+#endif
 
 #if NET
 			if (options->RegistrationMap is not null && options->RegistrationMap->classHandles is not null) {

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -4257,5 +4257,14 @@ namespace Xamarin.Bundler {
                 return ResourceManager.GetString("MX8056", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .NET for {0} does not support server garbage collection..
+        /// </summary>
+        public static string MX8057 {
+            get {
+                return ResourceManager.GetString("MX8057", resourceCulture);
+            }
+        }
     }
 }

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -2266,4 +2266,9 @@
 	<data name="MX8056" xml:space="preserve">
 		<value>Failed to marshal the Objective-C object 0x{0} (type: {1}). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance of generic type {2}.</value>
 	</data>
+
+	<data name="MX8057" xml:space="preserve">
+		<value>.NET for {0} does not support server garbage collection.</value>
+		<comment>{0}: the platform (iOS, macOS, etc.)</comment>
+	</data>
 </root>


### PR DESCRIPTION
Our runtime doesn't support server garbage collection:

https://github.com/xamarin/xamarin-macios/blob/main/runtime/coreclr-bridge.m#L203-L210

Fixes https://github.com/xamarin/xamarin-macios/issues/16853.