### PR TITLE
[tests] Fix detecting exposed members

### DIFF
--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -1165,7 +1165,14 @@ namespace GeneratorTests {
 			bgen.AssertNoMethod ("NS.Whatever", "set_IPropAOpt", parameterTypes: "Foundation.NSObject");
 			bgen.AssertMethod ("NS.Whatever", "set_IPropBOpt", parameterTypes: "Foundation.NSObject");
 			bgen.AssertNoMethod ("NS.Whatever", "get_IPropBOpt");
-			bgen.AssertPublicMethodCount ("NS.Whatever", 9); // 6 accessors + 2 constructors + ClassHandle getter
+			bgen.AssertMethod ("NS.Whatever", ".ctor");
+			bgen.AssertMethod ("NS.Whatever", ".ctor", parameterTypes: "Foundation.NSObjectFlag");
+#if NET
+			bgen.AssertMethod ("NS.Whatever", ".ctor", parameterTypes: "ObjCRuntime.NativeHandle");
+#else
+			bgen.AssertMethod ("NS.Whatever", ".ctor", parameterTypes: "System.IntPtr");
+#endif
+			bgen.AssertPublicMethodCount ("NS.Whatever", 10); // 6 accessors + 3 constructors + ClassHandle getter
 
 			bgen.AssertMethod ("NS.IIProtocol", "get_IPropA");
 			bgen.AssertNoMethod ("NS.IIProtocol", "set_IPropA", parameterTypes: "Foundation.NSObject");

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -319,12 +319,12 @@ namespace Xamarin.Tests {
 
 			var t = assembly.MainModule.Types.First ((v) => v.FullName == typename);
 			var actual = t.Methods.Where ((v) => {
-				if (v.IsPrivate || v.IsFamily || v.IsFamilyAndAssembly)
+				if (v.IsPrivate || v.IsAssembly || v.IsFamilyAndAssembly)
 					return false;
 				return true;
 			});
 			if (actual.Count () != count) {
-				Assert.Fail ($"Expected {count} publicly accessible method(s) in {typename}, found {actual} publicly accessible method(s): {message}\n\t{string.Join ("\n\t", actual.Select (v => v.FullName).OrderBy (v => v))}");
+				Assert.Fail ($"Expected {count} publicly accessible method(s) in {typename}, found {actual.Count ()} publicly accessible method(s): {message}\n\t{string.Join ("\n\t", actual.Select (v => v.FullName).OrderBy (v => v))}");
 			}
 		}
 


### PR DESCRIPTION
The enum value MethodAttributes.IsFamily is 'internal' in C#, which is not exposed
outside an assembly, so don't count such members as exposed. On the other hand, MethodAttributes.IsAssembly
is 'protected' in C#, which *is* exposed, so these members are included.

Update tests accordingly.