### PR TITLE
[Foundation] Use 'Foundation' as the namespace for NSUrlSessionHandler for all platforms.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -52,7 +52,7 @@ using UIKit;
 
 #nullable enable
 
-#if !MONOMAC
+#if !MONOMAC && !XAMCORE_5_0
 namespace System.Net.Http {
 #else
 namespace Foundation {


### PR DESCRIPTION
Use 'Foundation' as the namespace for NSUrlSessionHandler for all platforms
(so that we have the same API across all platforms).

But only in XAMCORE_5_0, since this is a breaking change.