### PR TITLE
[tests] Fix misc ARM64 issues when running legacy Xamarin tests.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/EveryFrameworkSmokeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/EveryFrameworkSmokeTest.cs
@@ -26,6 +26,12 @@ namespace Xamarin.Mac.Tests {
 
 			// No bindings for any of these yet
 			switch (libraryName) {
+#if !NET
+			case "QTKitLibrary": // no ARM64 version present
+				if (Runtime.IsARM64CallingConvention)
+					return LoadStatus.Acceptable;
+				break;
+#endif
 			case "CryptoTokenKitLibrary":
 			case "FinderSyncLibrary":
 			case "HypervisorLibrary":

--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -146,6 +146,8 @@ namespace MonoTouchFixtures.Security {
 		public void SslSupportedCiphers ()
 		{
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 8, throwIfOtherPlatform: false);
+			if (Runtime.IsARM64CallingConvention)
+				Assert.Ignore ("This test does not work on ARM64 because SslCipherSuite has the wrong size on ARM64 (the native enum is an ushort on ARM64, even on desktop, while we've defined our enum as uint on macOS and Mac Catalyst)");
 
 			int ssl_client_ciphers = -1;
 			using (var client = new SslContext (SslProtocolSide.Client, SslConnectionType.Stream)) {


### PR DESCRIPTION
We've recently started using more and more ARM64 bots, so these tests are
failing in those cases.

Fixes:

    MonoTouchFixtures.Security.SecureTransportTest
    	[FAIL] SslSupportedCiphers :   3224092716
      Expected: True
      But was:  False
    		  at MonoTouchFixtures.Security.SecureTransportTest.SslSupportedCiphers () [0x000de] in <f08bd76ea2204d929c96e3bd36ae955a>:0

    Xamarin.Mac.Tests.EveryFrameworkSmokeTests
    	[FAIL] ExpectedLibrariesAreLoaded : QTKitLibrary (/System/Library/Frameworks/QTKit.framework/QTKit) failed to load but this was not expected
        		  at Xamarin.Mac.Tests.EveryFrameworkSmokeTests.ExpectedLibrariesAreLoaded () [0x000e6] in <f08bd76ea2204d929c96e3bd36ae955a>:0