### PR TITLE
[net9.0] [maestro] Depend on 'VS.Tools.Net.Core.SDK.Resolver' instead of 'Microsoft.Dotnet.Sdk.Internal'.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -636,7 +636,7 @@ ALL_DOTNET_PLATFORMS=iOS macOS tvOS MacCatalyst
 -include $(TOP)/dotnet.config
 $(TOP)/dotnet.config: $(TOP)/eng/Versions.props $(TOP)/Build.props
 	$(Q) rm -f $@.tmp
-	$(Q) grep VSToolsNetCoreSDKResolverPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*VSToolsNetCoreSDKResolverPackageVersion>//g' -e 's/[ \t]*/DOTNET_VERSION=/' >> $@.tmp
+	$(Q) grep '<VSToolsNetCoreSDKResolverPackageVersion>' $(TOP)/eng/Versions.props | sed -e 's/<*\/*VSToolsNetCoreSDKResolverPackageVersion>//g' -e 's/[ \t]*/DOTNET_VERSION=/' >> $@.tmp
 	$(Q) grep MicrosoftNETCoreAppRefPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftNETCoreAppRefPackageVersion>//g' -e 's/[ \t]*/BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION=/' >> $@.tmp
 	$(Q) grep "<$$(grep EmscriptenWorkloadVersion $(TOP)/eng/Versions.props | sed -e 's_.*>$$[\(]\(.*\)[\)]<.*_\1_')>" $(TOP)/eng/Versions.props | sed -e 's/.*>\(.*\)<.*/EMSCRIPTEN_MANIFEST_PACKAGE_VERSION=\1/' >> $@.tmp
 	$(Q) $(foreach platform,$(ALL_DOTNET_PLATFORMS),grep '<Microsoft$(platform)SdkPackageVersion>' $(TOP)/eng/Versions.props | sed -e 's/<*\/*Microsoft$(platform)SdkPackageVersion>//g' -e 's/[ \t]*/NET8_$(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION_NO_METADATA=/' >> $@.tmp &&) true

--- a/Make.config
+++ b/Make.config
@@ -636,7 +636,7 @@ ALL_DOTNET_PLATFORMS=iOS macOS tvOS MacCatalyst
 -include $(TOP)/dotnet.config
 $(TOP)/dotnet.config: $(TOP)/eng/Versions.props $(TOP)/Build.props
 	$(Q) rm -f $@.tmp
-	$(Q) grep MicrosoftDotnetSdkInternalPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftDotnetSdkInternalPackageVersion>//g' -e 's/[ \t]*/DOTNET_VERSION=/' >> $@.tmp
+	$(Q) grep VSToolsNetCoreSDKResolverPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*VSToolsNetCoreSDKResolverPackageVersion>//g' -e 's/[ \t]*/DOTNET_VERSION=/' >> $@.tmp
 	$(Q) grep MicrosoftNETCoreAppRefPackageVersion $(TOP)/eng/Versions.props | sed -e 's/<*\/*MicrosoftNETCoreAppRefPackageVersion>//g' -e 's/[ \t]*/BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION=/' >> $@.tmp
 	$(Q) grep "<$$(grep EmscriptenWorkloadVersion $(TOP)/eng/Versions.props | sed -e 's_.*>$$[\(]\(.*\)[\)]<.*_\1_')>" $(TOP)/eng/Versions.props | sed -e 's/.*>\(.*\)<.*/EMSCRIPTEN_MANIFEST_PACKAGE_VERSION=\1/' >> $@.tmp
 	$(Q) $(foreach platform,$(ALL_DOTNET_PLATFORMS),grep '<Microsoft$(platform)SdkPackageVersion>' $(TOP)/eng/Versions.props | sed -e 's/<*\/*Microsoft$(platform)SdkPackageVersion>//g' -e 's/[ \t]*/NET8_$(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_VERSION_NO_METADATA=/' >> $@.tmp &&) true
@@ -713,7 +713,7 @@ EMSCRIPTEN_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_
 # It should typically be $(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT), unless we decide to hardcode it to something else
 MACIOS_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT)
 
-# Set this to 1 if the Microsoft.NETCore.App.Ref dependency in eng/Version.Details.xml does *not* specify a CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal.
+# Set this to 1 if the Microsoft.NETCore.App.Ref dependency in eng/Version.Details.xml does *not* specify a CoherentParentDependency on VS.Tools.Net.Core.SDK.Resolver.
 TRACKING_DOTNET_RUNTIME_SEPARATELY=
 
 # The location of csc changes depending on whether we're using a preview or a stable/service release :/

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,24 +1,24 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="9.0.100-preview.5.24258.1">
+    <Dependency Name="VS.Tools.Net.Core.SDK.Resolver" Version="9.0.100-preview.5.24262.2">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>05ec25e1549a0653393a4f6782b4af6a0cbfbcf0</Sha>
+      <Sha>1741345c6399ae203d8f259fb12fb873dac5129d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink" Version="9.0.0-alpha.1.23556.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf47d9ff6827a3e1d6f2acbf925cd618418f20dd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="9.0.0-preview.5.24256.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="9.0.0-preview.5.24256.1" CoherentParentDependency="VS.Tools.Net.Core.SDK.Resolver">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>84b33395057737db3ea342a5151feb6b90c1b6f6</Sha>
     </Dependency>
-    <!-- Set TRACKING_DOTNET_RUNTIME_SEPARATELY to something in Make.config if removing the CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal -->
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.5.24256.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <!-- Set TRACKING_DOTNET_RUNTIME_SEPARATELY to something in Make.config if removing the CoherentParentDependency on VS.Tools.Net.Core.SDK.Resolver -->
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.5.24256.1" CoherentParentDependency="VS.Tools.Net.Core.SDK.Resolver">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>84b33395057737db3ea342a5151feb6b90c1b6f6</Sha>
     </Dependency>
     <!-- This is required for our test apps to build; in some cases Microsoft.AspNetCore.App is pulled in, and when building test apps the build needs to be able to resolve that -->
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="9.0.0-preview.5.24256.2" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="9.0.0-preview.5.24256.2" CoherentParentDependency="VS.Tools.Net.Core.SDK.Resolver">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>da3aa27233a2cec2f6780884f71934b2f5e686ce</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,8 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- Versions updated by maestro -->
-    <MicrosoftDotnetSdkInternalPackageVersion>9.0.100-preview.5.24258.1</MicrosoftDotnetSdkInternalPackageVersion>
+    <!-- NOTE: $(VSToolsNetCoreSDKResolverPackageVersion) may be temporary -->
+    <VSToolsNetCoreSDKResolverPackageVersion>9.0.100-preview.5.24262.2</VSToolsNetCoreSDKResolverPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>9.0.0-preview.5.24256.1</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETILLinkPackageVersion>9.0.0-alpha.1.23556.4</MicrosoftNETILLinkPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
@@ -15,6 +16,7 @@
     <!-- Manually updated versions -->
     <Emscriptennet7WorkloadVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100Version)</Emscriptennet7WorkloadVersion>
     <EmscriptenWorkloadVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100Version)</EmscriptenWorkloadVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>$(VSToolsNetCoreSDKResolverPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- This is a subscription of the .NET 8 versions of our packages -->
     <MicrosoftMacCatalystSdkPackageVersion>17.2.8053</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>14.2.8053</MicrosoftmacOSSdkPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.5.24258.1"
+    "version": "9.0.100-preview.5.24262.2"
   }
 }


### PR DESCRIPTION
dotnet/installer is no longer producing a `Microsoft.Dotnet.Sdk.Internal`
"package" for the SDK, which we're using to get the .NET version to provision
.NET.

So use `VS.Tools.Net.Core.SDK.Resolver` instead, as this is a component
inserted into Visual Studio that contains the same version number.

We may have to change this again in the future, as dotnet/installer is in the
process of merging and/or moving to dotnet/sdk.

Ref:

* https://github.com/xamarin/xamarin-android/pull/8949
* [MS Teams thread](https://teams.microsoft.com/l/message/19:afba3d1545dd45d7b79f34c1821f6055@thread.skype/1715789991637?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&parentMessageId=1715789991637&teamName=.NET%20Core%20Eng%20Services%20Partners&channelName=First%20Responders&createdTime=1715789991637)