### PR TITLE
[tests] Correctly run the VerifyRemoteConnection target.

### DIFF
--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -128,7 +128,7 @@
 		</Zip>
 	</Target>
 
-	<Target Name="VerifyRemoteConnection" AfterTargets="SayHello" Condition="'$(EnsureRemoteConnection)' == 'true'">
+	<Target Name="VerifyRemoteConnection" AfterTargets="_SayHello" Condition="'$(EnsureRemoteConnection)' == 'true'">
 		<Error Condition="'$(IsMacEnabled)' != 'true'" Text="Unable to connect to the remote Mac. Please examine the output of the SayHello target to figure out what happened." />
 	</Target>
 </Project>


### PR DESCRIPTION
There's no target named `SayHello`, the correct name is `_SayHello` (where we
establish a connection to the remote mac).