### PR TITLE
[devops] Clean up temporary files to fix api diff.

### DIFF
--- a/tools/devops/automation/scripts/bash/export-mono-filenames.sh
+++ b/tools/devops/automation/scripts/bash/export-mono-filenames.sh
@@ -23,3 +23,5 @@ MONO_MACCATALYST_FILENAME=$(basename "$MONO_MACCATALYST_FILENAME" ".7z")
 echo "##vso[task.setvariable variable=MONO_IOS_FILENAME;]$MONO_IOS_FILENAME"
 echo "##vso[task.setvariable variable=MONO_MAC_FILENAME;]$MONO_MAC_FILENAME"
 echo "##vso[task.setvariable variable=MONO_MACCATALYST_FILENAME;]$MONO_MACCATALYST_FILENAME"
+
+rm -f "$FILE"


### PR DESCRIPTION
API diff currently fails with:

	** Error: Working directory isn't clean:
	HEAD detached at origin/pull/20587/head
	Untracked files:
	(use "git add <file>..." to include in what will be committed)
	tmp.txt

So clean up after ourselves in a previous step to avoid this.