### PR TITLE
[msbuild] Version the Xamarin.Localization.MSBuild assembly. Fixes #20062.

### DIFF
--- a/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
@@ -39,6 +39,9 @@
       <Reference Include="Microsoft.Build.Utilities.Core">
           <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.Utilities.Core.dll</HintPath>
       </Reference>
+      <Compile Include="..\..\Versions.g.cs">
+         <Link>Versions.g.cs</Link>
+      </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/msbuild/Xamarin.Localization.MSBuild/Properties/AssemblyInfo.cs
+++ b/msbuild/Xamarin.Localization.MSBuild/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyCompanyAttribute ("Microsoft Corp.")]
+[assembly: AssemblyFileVersionAttribute (VersionConstants.XamarinIOSVersion)]
+[assembly: AssemblyInformationalVersionAttribute (VersionConstants.XamarinIOSVersion + "." + VersionConstants.NuGetPrereleaseIdentifier + "+" + VersionConstants.NuGetBuildMetadata)]
+[assembly: AssemblyProductAttribute ("Xamarin.Localization.MSBuild")]
+[assembly: AssemblyTitleAttribute ("Xamarin.Localization.MSBuild")]
+[assembly: AssemblyVersionAttribute (VersionConstants.XamarinIOSVersion)]

--- a/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
+++ b/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
@@ -27,6 +28,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Versions.g.cs">
+      <Link>Versions.g.cs</Link>
+    </Compile>
     <EmbeddedResource Include="TranslatedAssemblies/MSBStrings.cs.resx">
       <Link>MSBStrings.cs.resx</Link>
       <ManifestResourceName>Xamarin.Localization.MSBuild.MSBStrings.cs</ManifestResourceName>

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -85,9 +85,6 @@
     <Compile Include="..\..\tools\common\NullableAttributes.cs">
       <Link>external\NullableAttributes.cs</Link>
     </Compile>
-    <Compile Include="..\Versions.g.cs">
-      <Link>Versions.g.cs</Link>
-    </Compile>
     <Compile Remove="Errors.designer.cs" /> <!-- The 'CoreResGen' target will add it again from the EmbeddedResource item, this avoids a warning about the file being compiled twice -->
     <Compile Include="..\..\tools\common\SdkVersions.cs">
       <Link>external\SdkVersions.cs</Link>

--- a/tools/devops/automation/templates/build/api-diff-process-results.yml
+++ b/tools/devops/automation/templates/build/api-diff-process-results.yml
@@ -69,7 +69,7 @@ steps:
       Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
       $vsdropsChangeDetectionPrefix = "https://vsdrop.corp.microsoft.com/file/v1/xamarin-macios/detected-changes/$Env:BUILD_BUILDNUMBER/$Env:BUILD_BUILDID-$Env:SYSTEM_JOBATTEMPT/;/"
 
-      $rootDirectory = Join-Path "$Env:BUILD_ARTIFACTSTAGINGDIRECTORY" "change-detection" "results"
+      $rootDirectory = Join-Path "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY" "change-detection" "results"
 
       $inputContentsPath = Join-Path -Path $rootDirectory -ChildPath "gh-comment.md"
       if (Test-Path $inputContentsPath -PathType leaf) {


### PR DESCRIPTION
Version the Xamarin.Localization.MSBuild assembly correctly (instead of
hardcoding a 1.0.0 version - implicitly so because no version was set), so
that we can load multiple versions of the assembly into the same process.

Fixes https://github.com/xamarin/xamarin-macios/issues/20062.