### PR TITLE
[src] Fix accidental xml documentation comments.

### DIFF
--- a/src/OpenGL/OpenTK/Math/Matrix4.cs
+++ b/src/OpenGL/OpenTK/Math/Matrix4.cs
@@ -471,7 +471,7 @@ namespace OpenTK {
 		/// <param name="height">The height of the projection volume.</param>
 		/// <param name="zNear">The near edge of the projection volume.</param>
 		/// <param name="zFar">The far edge of the projection volume.</param>
-		/// <rereturns>The resulting Matrix4 instance.</rereturns>
+		/// <returns>The resulting Matrix4 instance.</rereturns>
 		public static Matrix4 CreateOrthographic (float width, float height, float zNear, float zFar)
 		{
 			Matrix4 result;

--- a/src/OpenGL/OpenTK/Math/Matrix4d.cs
+++ b/src/OpenGL/OpenTK/Math/Matrix4d.cs
@@ -471,7 +471,7 @@ namespace OpenTK {
 		/// <param name="height">The height of the projection volume.</param>
 		/// <param name="zNear">The near edge of the projection volume.</param>
 		/// <param name="zFar">The far edge of the projection volume.</param>
-		/// <rereturns>The resulting Matrix4d instance.</rereturns>
+		/// <returns>The resulting Matrix4d instance.</returns>
 		public static Matrix4d CreateOrthographic (double width, double height, double zNear, double zFar)
 		{
 			Matrix4d result;

--- a/src/SceneKit/SCNMatrix4.cs
+++ b/src/SceneKit/SCNMatrix4.cs
@@ -580,7 +580,7 @@ namespace SceneKit {
 		/// <param name="height">The height of the projection volume.</param>
 		/// <param name="zNear">The near edge of the projection volume.</param>
 		/// <param name="zFar">The far edge of the projection volume.</param>
-		/// <rereturns>The resulting SCNMatrix4 instance.</rereturns>
+		/// <returns>The resulting SCNMatrix4 instance.</returns>
 		public static SCNMatrix4 CreateOrthographic (pfloat width, pfloat height, pfloat zNear, pfloat zFar)
 		{
 			SCNMatrix4 result;

--- a/src/SceneKit/SCNMatrix4_dotnet.cs
+++ b/src/SceneKit/SCNMatrix4_dotnet.cs
@@ -647,7 +647,7 @@ namespace SceneKit {
 		/// <param name="height">The height of the projection volume.</param>
 		/// <param name="zNear">The near edge of the projection volume.</param>
 		/// <param name="zFar">The far edge of the projection volume.</param>
-		/// <rereturns>The resulting SCNMatrix4 instance.</rereturns>
+		/// <returns>The resulting SCNMatrix4 instance.</returns>
 		public static SCNMatrix4 CreateOrthographic (pfloat width, pfloat height, pfloat zNear, pfloat zFar)
 		{
 			SCNMatrix4 result;
@@ -777,7 +777,7 @@ namespace SceneKit {
 #region CreatePerspectiveOffCenter
 
 		/// <summary>
-		/// Creates an perspective projection matrix.
+		/// Creates a perspective projection matrix.
 		/// </summary>
 		/// <param name="left">Left edge of the view frustum</param>
 		/// <param name="right">Right edge of the view frustum</param>
@@ -818,7 +818,7 @@ namespace SceneKit {
 		}
 
 		/// <summary>
-		/// Creates an perspective projection matrix.
+		/// Creates a perspective projection matrix.
 		/// </summary>
 		/// <param name="left">Left edge of the view frustum</param>
 		/// <param name="right">Right edge of the view frustum</param>
@@ -849,7 +849,7 @@ namespace SceneKit {
 		/// <summary>
 		/// Build a scaling matrix
 		/// </summary>
-		/// <param name="scale">Single scale factor for x,y and z axes</param>
+		/// <param name="scale">Single scale factor for x, y and z axes</param>
 		/// <returns>A scaling matrix</returns>
 		public static SCNMatrix4 Scale (pfloat scale)
 		{
@@ -859,7 +859,7 @@ namespace SceneKit {
 		/// <summary>
 		/// Build a scaling matrix
 		/// </summary>
-		/// <param name="scale">Scale factors for x,y and z axes</param>
+		/// <param name="scale">Scale factors for x, y and z axes</param>
 		/// <returns>A scaling matrix</returns>
 		public static SCNMatrix4 Scale (SCNVector3 scale)
 		{
@@ -1147,7 +1147,7 @@ namespace SceneKit {
 		/// Calculate the inverse of the given matrix
 		/// </summary>
 		/// <param name="matrix">The matrix to invert</param>
-		/// <returns>The inverse of the given matrix if it has one, or the input if it is singular</returns>
+		/// <returns>The inverse of the given matrix if it has one.</returns>
 		/// <exception cref="InvalidOperationException">Thrown if the SCNMatrix4 is singular.</exception>
 		public static SCNMatrix4 Invert (SCNMatrix4 matrix)
 		{

--- a/src/SceneKit/SCNVector3.cs
+++ b/src/SceneKit/SCNVector3.cs
@@ -238,7 +238,7 @@ namespace SceneKit {
 		public static readonly SCNVector3 UnitY = new SCNVector3 (0, 1, 0);
 
 		/// <summary>
-		/// /// Defines a unit-length SCNVector3 that points towards the Z-axis.
+		/// Defines a unit-length SCNVector3 that points towards the Z-axis.
 		/// </summary>
 		public static readonly SCNVector3 UnitZ = new SCNVector3 (0, 0, 1);
 
@@ -733,10 +733,10 @@ namespace SceneKit {
 		#region Transform
 
 #if NET
-        /// <summary>Transform a direction vector by the given Matrix
-        /// Assumes the matrix has a right-most column of (0,0,0,1), that is the translation part is ignored.
-        /// </summary>
-        /// <param name="vec">The column vector to transform</param>
+		/// <summary>Transform a direction vector by the given Matrix
+		/// Assumes the matrix has a right-most column of (0,0,0,1), that is the translation part is ignored.
+		/// </summary>
+		/// <param name="vec">The column vector to transform</param>
 		/// <param name="mat">The desired transformation</param>
 		/// <returns>The transformed vector</returns>
 #else
@@ -754,14 +754,14 @@ namespace SceneKit {
 		}
 
 #if NET
-        /// <summary>Transform a direction vector by the given Matrix
-        /// Assumes the matrix has a right-most column of (0,0,0,1), that is the translation part is ignored.
-        /// </summary>
-        /// <param name="vec">The column vector to transform</param>
+		/// <summary>Transform a direction vector by the given matrix.
+		/// Assumes the matrix has a right-most column of (0,0,0,1), that is the translation part is ignored.
+		/// </summary>
+		/// <param name="vec">The column vector to transform</param>
 		/// <param name="mat">The desired transformation</param>
 		/// <param name="result">The transformed vector</param>
 #else
-		/// <summary>Transform a direction vector by the given Matrix
+		/// <summary>Transform a direction vector by the given matrix.
 		/// Assumes the matrix has a bottom row of (0,0,0,1), that is the translation part is ignored.
 		/// </summary>
 		/// <param name="vec">The row vector to transform</param>

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -1854,7 +1854,7 @@ namespace CoreAnimation {
 		[Export ("seed")]
 		int Seed { get; set; } // unsigned int
 
-		/** `emitterShape' values. **/
+		/* `emitterShape' values. */
 		[Field ("kCAEmitterLayerPoint")]
 		NSString ShapePoint { get; }
 
@@ -1873,7 +1873,7 @@ namespace CoreAnimation {
 		[Field ("kCAEmitterLayerSphere")]
 		NSString ShapeSphere { get; }
 
-		/** `emitterMode' values. **/
+		/* `emitterMode' values. */
 		[Field ("kCAEmitterLayerPoints")]
 		NSString ModePoints { get; }
 
@@ -1886,7 +1886,7 @@ namespace CoreAnimation {
 		[Field ("kCAEmitterLayerVolume")]
 		NSString ModeVolume { get; }
 
-		/** `renderOrder' values. **/
+		/*  `renderOrder' values. */
 		[Field ("kCAEmitterLayerUnordered")]
 		NSString RenderUnordered { get; }
 

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -2487,8 +2487,6 @@ namespace HealthKit {
 	[Mac (13, 0)]
 	[MacCatalyst (13, 1)]
 	enum HKCategoryTypeIdentifier {
-		/**** HKCategoryType Identifiers ****/
-
 		[Field ("HKCategoryTypeIdentifierSleepAnalysis")]
 		SleepAnalysis,
 
@@ -2810,8 +2808,6 @@ namespace HealthKit {
 	[Mac (13, 0)]
 	[MacCatalyst (13, 1)]
 	enum HKCharacteristicTypeIdentifier {
-		/**** HKCharacteristicType Identifiers ****/
-
 		[Field ("HKCharacteristicTypeIdentifierBiologicalSex")]
 		BiologicalSex,
 


### PR DESCRIPTION
In C# there are two ways to specify that a comment is an xml documentation comment:

1. The single-line '///''
2. The multi-line '/** ... **/'

TIL about the second one, when my upcoming tool to migrate API documentation
to xml comments complained that these members already had an xml comment.

This seems entirely accidental, so just remove/rewrite these few comments.

Also fix a few other typos, grammar mistakes, etc.