### PR TITLE
[AppKit] Fix availability attribute for NSSplitViewItem.CanCollapseFromWindowResize.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -15049,7 +15049,7 @@ namespace AppKit {
 		[Export ("titlebarSeparatorStyle", ArgumentSemantic.Assign)]
 		NSTitlebarSeparatorStyle TitlebarSeparatorStyle { get; set; }
 
-		[Mac (14, 0)]
+		[Mac (10, 14)]
 		[Export ("canCollapseFromWindowResize")]
 		bool CanCollapseFromWindowResize { get; set; }
 


### PR DESCRIPTION
This property is available starting in macOS 10.14, not macOS 14.0.