### PR TITLE
[release/8.0.1xx-xcode15.1] [GameController] GCMouse doesn't conform to NSCoding/NSSecureCoding.

### DIFF
--- a/src/GameController/GCMouse.cs
+++ b/src/GameController/GCMouse.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+using System;
+
+using ObjCRuntime;
+using Foundation;
+
+namespace GameController {
+
+#if !XAMCORE_5_0
+	// The GCMouse doesn't conform to NSCoding/NSSecureCoding, but it probably did in an early beta, which is why we declared it as such.
+	public partial class GCMouse : INSCoding, INSSecureCoding {
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public GCMouse (NSCoder coder) : base (NSObjectFlag.Empty)
+		{
+			if (IsDirectBinding) {
+				InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle ("initWithCoder:"), coder.Handle), "initWithCoder:");
+			} else {
+				InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper_IntPtr (this.SuperHandle, Selector.GetHandle ("initWithCoder:"), coder.Handle), "initWithCoder:");
+			}
+		}
+
+		[Export ("encodeWithCoder:")]
+		[SupportedOSPlatform ("ios14.0")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("tvos14.0")]
+		[SupportedOSPlatform ("maccatalyst")]
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public virtual void EncodeTo (NSCoder encoder)
+		{
+			var encoder__handle__ = encoder!.GetNonNullHandle (nameof (encoder));
+			if (IsDirectBinding) {
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, Selector.GetHandle ("encodeWithCoder:"), encoder__handle__);
+			} else {
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.SuperHandle, Selector.GetHandle ("encodeWithCoder:"), encoder__handle__);
+			}
+		}
+	}
+#endif // !XAMCORE_5_0
+}

--- a/src/GameController/GCMouse.cs
+++ b/src/GameController/GCMouse.cs
@@ -1,6 +1,8 @@
 #nullable enable
 
 using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 using ObjCRuntime;
 using Foundation;
@@ -22,20 +24,30 @@ namespace GameController {
 		}
 
 		[Export ("encodeWithCoder:")]
+#if NET
 		[SupportedOSPlatform ("ios14.0")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos14.0")]
 		[SupportedOSPlatform ("maccatalyst")]
+#endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		public virtual void EncodeTo (NSCoder encoder)
 		{
 			var encoder__handle__ = encoder!.GetNonNullHandle (nameof (encoder));
+#if NET
 			if (IsDirectBinding) {
 				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, Selector.GetHandle ("encodeWithCoder:"), encoder__handle__);
 			} else {
 				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.SuperHandle, Selector.GetHandle ("encodeWithCoder:"), encoder__handle__);
 			}
+#else
+			if (IsDirectBinding) {
+				global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle ("encodeWithCoder:"), encoder__handle__);
+			} else {
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_IntPtr (this.SuperHandle, Selector.GetHandle ("encodeWithCoder:"), encoder__handle__);
+			}
+#endif
 		}
 	}
 #endif // !XAMCORE_5_0

--- a/src/GameController/GCMouse.cs
+++ b/src/GameController/GCMouse.cs
@@ -23,7 +23,6 @@ namespace GameController {
 			}
 		}
 
-		[Export ("encodeWithCoder:")]
 #if NET
 		[SupportedOSPlatform ("ios14.0")]
 		[SupportedOSPlatform ("macos")]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -910,6 +910,7 @@ GAMECONTROLLER_SOURCES = \
 	GameController/GCExtendedGamepadSnapshot.cs \
 	GameController/GCGamepadSnapshot.cs \
 	GameController/GCMicroGamepadSnapshot.cs \
+	GameController/GCMouse.cs \
 
 # GameKit
 

--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -876,7 +876,7 @@ namespace GameController {
 	[Mac (11, 0), iOS (14, 0), TV (14, 0)]
 	[MacCatalyst (14, 0)]
 	[BaseType (typeof (NSObject))]
-	interface GCMouse : GCDevice, NSSecureCoding, NSCoding {
+	interface GCMouse : GCDevice {
 		[NullAllowed, Export ("mouseInput", ArgumentSemantic.Strong)]
 		GCMouseInput MouseInput { get; }
 


### PR DESCRIPTION
GCMouse doesn't conform to NSCoding/NSSecureCoding, so fix the API definition.
Since this would be a breaking change, also add compat code to preserve binary
compatibility.

Fixes this test:

    Introspection.MacApiSelectorTest
        [FAIL] InstanceMethods :   1 errors found in 33428 instance selector validated:
            Selector not found for GameController.GCMouse : encodeWithCoder: in Void EncodeTo(Foundation.NSCoder) on GameController.GCMouse
                Expected: 0
                But was:  1
        [FAIL] Selector not found for GameController.GCMouse : encodeWithCoder: in Void EncodeTo(Foundation.NSCoder) on GameController.GCMouse
             at Introspection.ApiSelectorTest.InstanceMethods() in /Users/rolf/work/maccore/net9.0/xamarin-macios/tests/introspection/ApiSelectorTest.cs:line 1121


Backport of #20641
