### PR TITLE
[cecil-tests] Add new test to verify that we don't have any MarshalAs attributes.

### DIFF
--- a/tests/cecil-tests/BlittablePInvokes.KnownFailures.cs
+++ b/tests/cecil-tests/BlittablePInvokes.KnownFailures.cs
@@ -16,6 +16,45 @@ using Xamarin.Utils;
 
 namespace Cecil.Tests {
 	public partial class BlittablePInvokes {
+#if XAMCORE_5_0
+		static HashSet<string> knownFailuresMarshalAs = new (); // shouldn't have any failures here in XAMCORE_5_0.
+#else
+		static HashSet<string> knownFailuresMarshalAs = new HashSet<string> {
+			"For the method ImageIO.CGImageMetadataTagBlock::EndInvoke(System.IAsyncResult) the return type has a [MarshalAs] attribute",
+			"For the method ImageIO.CGImageMetadataTagBlock::Invoke(Foundation.NSString,ImageIO.CGImageMetadataTag) the return type has a [MarshalAs] attribute",
+			"For the method Network.NWFramerParseCompletionDelegate::BeginInvoke(System.Memory`1<System.Byte>,System.Boolean,System.AsyncCallback,System.Object) the parameter #1 (isCompleted) has a [MarshalAs] attribute",
+			"For the method Network.NWFramerParseCompletionDelegate::Invoke(System.Memory`1<System.Byte>,System.Boolean) the parameter #1 (isCompleted) has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorAudioDependencyInfo.IsIndependentlyDecodable has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorChunkInfo.HasUniformFormatDescriptions has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorChunkInfo.HasUniformSampleDurations has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorChunkInfo.HasUniformSampleSizes has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorDependencyInfo.DependsOnOthers has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorDependencyInfo.HasDependentSamples has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorDependencyInfo.HasRedundantCoding has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorDependencyInfo.IndicatesWhetherItDependsOnOthers has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorDependencyInfo.IndicatesWhetherItHasDependentSamples has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorDependencyInfo.IndicatesWhetherItHasRedundantCoding has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorSyncInfo.IsDroppable has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorSyncInfo.IsFullSync has a [MarshalAs] attribute",
+			"The field AVFoundation.AVSampleCursorSyncInfo.IsPartialSync has a [MarshalAs] attribute",
+			"The field CoreMidi.MidiCIDeviceIdentification.Family has a [MarshalAs] attribute",
+			"The field CoreMidi.MidiCIDeviceIdentification.Manufacturer has a [MarshalAs] attribute",
+			"The field CoreMidi.MidiCIDeviceIdentification.ModelNumber has a [MarshalAs] attribute",
+			"The field CoreMidi.MidiCIDeviceIdentification.Reserved has a [MarshalAs] attribute",
+			"The field CoreMidi.MidiCIDeviceIdentification.RevisionLevel has a [MarshalAs] attribute",
+			"The field GameController.GCDualSenseAdaptiveTriggerPositionalAmplitudes.Values has a [MarshalAs] attribute",
+			"The field GameController.GCDualSenseAdaptiveTriggerPositionalResistiveStrengths.Values has a [MarshalAs] attribute",
+			"The field GameController.GCExtendedGamepadSnapshotData.LeftThumbstickButton has a [MarshalAs] attribute",
+			"The field GameController.GCExtendedGamepadSnapshotData.RightThumbstickButton has a [MarshalAs] attribute",
+			"The field GameController.GCExtendedGamepadSnapshotData.SupportsClickableThumbsticks has a [MarshalAs] attribute",
+			"The field GLKit.GLKVertexAttributeParameters.Normalized has a [MarshalAs] attribute",
+			"The field Metal.MTLQuadTessellationFactorsHalf.EdgeTessellationFactor has a [MarshalAs] attribute",
+			"The field Metal.MTLQuadTessellationFactorsHalf.InsideTessellationFactor has a [MarshalAs] attribute",
+			"The field Metal.MTLTriangleTessellationFactorsHalf.EdgeTessellationFactor has a [MarshalAs] attribute",
+			"The field ObjCRuntime.Class/objc_attribute_prop.name has a [MarshalAs] attribute",
+			"The field ObjCRuntime.Class/objc_attribute_prop.value has a [MarshalAs] attribute",
+		};
+#endif
 		static HashSet<string> knownFailuresPInvokes = new HashSet<string> {
 			"AVFoundation.AVSampleCursorAudioDependencyInfo ObjCRuntime.Messaging::AVSampleCursorAudioDependencyInfo_objc_msgSend(System.IntPtr,System.IntPtr)",
 			"AVFoundation.AVSampleCursorAudioDependencyInfo ObjCRuntime.Messaging::AVSampleCursorAudioDependencyInfo_objc_msgSendSuper(System.IntPtr,System.IntPtr)",

--- a/tests/cecil-tests/BlittablePInvokes.cs
+++ b/tests/cecil-tests/BlittablePInvokes.cs
@@ -205,6 +205,63 @@ namespace Cecil.Tests {
 			}
 		}
 
+		public record NoMarshalAsFailure : IComparable {
+			public string Message { get; }
+			public string Location { get; }
+
+			public NoMarshalAsFailure (string message, string location)
+			{
+				Message = message;
+				Location = location;
+			}
+
+			public override string ToString ()
+			{
+				if (string.IsNullOrEmpty (Location))
+					return Message;
+				return $"{Message} at {Location}";
+			}
+
+			public int CompareTo (object? obj)
+			{
+				if (obj is NoMarshalAsFailure other)
+					return ToString ().CompareTo (other.ToString ());
+				return -1;
+			}
+		}
+
+		[Test]
+		public void NoMarshalAsAttributes ()
+		{
+			var failures = new Dictionary<string, NoMarshalAsFailure> ();
+			var marshalProviders = new List<IMarshalInfoProvider> ();
+			foreach (var info in Helper.NetPlatformImplementationAssemblyDefinitions) {
+				var assembly = info.Assembly;
+				foreach (var field in assembly.EnumerateFields ()) {
+					if (field.HasMarshalInfo) {
+						var failure = new NoMarshalAsFailure ($"The field {field.DeclaringType.FullName}.{field.Name} has a [MarshalAs] attribute", "");
+						failures [failure.Message] = failure;
+					}
+				}
+
+				foreach (var method in assembly.EnumerateMethods ()) {
+					if (method.HasParameters) {
+						foreach (var p in method.Parameters) {
+							if (p.HasMarshalInfo) {
+								var failure = new NoMarshalAsFailure ($"For the method {method.RenderMethod ()} the parameter #{p.Index} ({p.Name}) has a [MarshalAs] attribute", method.RenderLocation ());
+								failures [failure.Message] = failure;
+							}
+						}
+					}
+					if (method.MethodReturnType.HasMarshalInfo) {
+						var failure = new NoMarshalAsFailure ($"For the method {method.RenderMethod ()} the return type has a [MarshalAs] attribute", method.RenderLocation ());
+						failures [failure.Message] = failure;
+					}
+				}
+			}
+			Helper.AssertFailures (failures, knownFailuresMarshalAs, nameof (knownFailuresMarshalAs), "APIs with [MarshalAs] attributes.", (v) => $"{v.Location}: {v.Message}");
+		}
+
 		[Test]
 		public void CheckForNonBlittablePInvokes ()
 		{

--- a/tests/cecil-tests/Helper.cs
+++ b/tests/cecil-tests/Helper.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml;
 
 using NUnit.Framework;
@@ -547,6 +548,33 @@ namespace Cecil.Tests {
 			var rv = new TestFixtureData (path);
 			rv.SetArgDisplayNames (Path.GetFileName (path));
 			return rv;
+		}
+
+		// This method renders a string that sorts well - methods in the same
+		// type are sorted next to eachother (the default MethodDefinition.FullName
+		// implementation starts with the return type, so sorting the results
+		// yields ugly results).
+		public static string RenderMethod (this MethodDefinition method)
+		{
+			var sb = new StringBuilder ();
+			sb.Append (method.DeclaringType.FullName);
+			sb.Append ("::");
+			sb.Append (method.Name);
+			sb.Append ('(');
+			if (method.HasParameters) {
+				for (var i = 0; i < method.Parameters.Count; i++) {
+					if (i > 0)
+						sb.Append (',');
+					var pType = method.Parameters [i].ParameterType;
+					sb.Append (pType.FullName);
+				}
+			}
+			sb.Append (')');
+			if (method.IsOperator ()) {
+				sb.Append ("->");
+				sb.Append (method.ReturnType.FullName);
+			}
+			return sb.ToString ();
 		}
 
 		public static string RenderLocation (this IMemberDefinition? member, Instruction? instruction = null)


### PR DESCRIPTION
This is mostly to ensure that in XAMCORE_5_0 we fix all APIs with MarshalAs
attributes, because in order to not break binary compatibility, we can't fix
all of these failures right now.

Additionally it ensures we don't add more APIs with MarshalAs attributes.