### PR TITLE
[release/8.0.1xx-xcode15.1] [devops] Remove installation of .NET 5.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -59,12 +59,6 @@ steps:
     MacDeveloper: $(mac-developer)
     HostedMacKeychainPassword: ${{ parameters.keyringPass }}
 
-- task: UseDotNet@2
-  inputs:
-    packageType: sdk
-    version: 5.x
-  displayName: 'Install .NET 5.x SDK'
-
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: 'Provision Brew components'
   inputs:


### PR DESCRIPTION
It doesn't look like we need it anymore, and in any case it fails to install on ARM64:

> ##[error]Download URL for .Net Core sdk version 5.0.408 could not be found for the following OS platforms (rid): osx-arm64,osx-arm64

From: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9486716&view=logs&jobId=2ad83a99-f770-5ec5-96c6-63e16b4bb697&j=2ad83a99-f770-5ec5-96c6-63e16b4bb697&t=5c4dfcb8-6d0a-532a-9705-12b94c390bf5


Backport of #20527
