### PR TITLE
[devops] Fully disable CodeQL, it crashes on x64 as well.

### DIFF
--- a/tools/devops/automation/scripts/disable-codeql-arm64.sh
+++ b/tools/devops/automation/scripts/disable-codeql-arm64.sh
@@ -1,12 +1,8 @@
 #!/bin/bash -eux
 
-if [[ $(sysctl -n hw.optional.arm64 2>/dev/null) != '1' ]]; then
-  echo "Not running on arm64, nothing to do"
-  exit 0
-fi
-
 # CodeQL inserts a dylib (using DYLD_INSERT_LIBRARIES) that causes Mono to crash.
 # https://twcdot.visualstudio.com/Data/_workitems/edit/116722
+# https://dev.azure.com/twcdot/Data/_workitems/edit/137330
 # So unset DYLD_INSERT_LIBRARIES.
 set -x
 echo "##vso[task.setvariable variable=DYLD_INSERT_LIBRARIES]"


### PR DESCRIPTION
Ref: https://dev.azure.com/twcdot/Data/_workitems/edit/137330