### PR TITLE
[CI] Remove all references to the tests in the build pipelines.

### DIFF
--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -1,12 +1,4 @@
 parameters:
-- name: runTests
-  type: boolean
-  default: true
-
-- name: runDeviceTests
-  type: boolean
-  default: true
-
 - name: vsdropsPrefix
   type: string
 
@@ -52,7 +44,6 @@ steps:
     isPR: ${{ parameters.isPR }}
     repositoryAlias: ${{ parameters.repositoryAlias }}
     commit: ${{ parameters.commit }}
-    runDeviceTests: ${{ parameters.runDeviceTests }}
     vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
     keyringPass: ${{ parameters.keyringPass }}
     gitHubToken: ${{ parameters.gitHubToken }}

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -1,16 +1,8 @@
 # template that contains all the different steps to create a pkgs, publish the results and provide feedback to the
 # developers in github.
 parameters:
-- name: runTests
-  type: boolean
-  default: true
-
 - name: vsdropsPrefix
   type: string
-
-- name: runDeviceTests
-  type: boolean
-  default: true
 
 - name: keyringPass
   type: string
@@ -103,8 +95,6 @@ jobs:
       isPR: ${{ parameters.isPR }}
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
-      runTests: ${{ parameters.runTests }}
-      runDeviceTests: ${{ parameters.runDeviceTests }}
       vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
       keyringPass: ${{ parameters.keyringPass }}
       gitHubToken: ${{ parameters.gitHubToken }}

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -1,8 +1,4 @@
 parameters:
-- name: runDeviceTests
-  type: boolean
-  default: true
-
 - name: vsdropsPrefix
   type: string
 

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -12,30 +12,10 @@ parameters:
   - ci
   - automatic
 
-- name: runTests
-  type: boolean
-  default: true
-
-- name: runDeviceTests
-  type: boolean
-  default: false
-
-- name: runOldMacOSTests
-  type: boolean
-  default: true
-
-- name: runWindowsIntegration
-  type: boolean
-  default: true
-
 - name: runGovernanceTests
   type: boolean
   default: true
 
-- name: runSamples
-  type: boolean
-  default: false
-  
 - name: enableLegacySigning
   type: boolean
   default: true
@@ -46,7 +26,7 @@ parameters:
 
 - name: forceInsertion
   type: boolean
-  default: false 
+  default: false
 
 - name: skipESRP
   type: boolean
@@ -362,7 +342,7 @@ stages:
         testsLabels: '--label=skip-all-tests,run-ios-tests,run-ios-simulator-tests,run-tvos-tests,run-watchos-tests,run-mac-tests,run-maccatalyst-tests,run-dotnet-tests,run-system-permission-tests,run-legacy-xamarin-tests'
         statusContext: 'VSTS: simulator tests' 
         uploadArtifacts: true
-        
+
 - stage: build_packages
   displayName: '${{ parameters.stageDisplayNamePrefix }}Build'
   dependsOn: [ configure_build ]
@@ -375,8 +355,6 @@ stages:
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
       vsdropsPrefix: ${{ variables.vsdropsPrefix }}
-      runTests: ${{ and(parameters.runTests, ne(variables['Build.Reason'], 'Schedule'))}}
-      runDeviceTests: ${{ and(parameters.runDeviceTests, ne(variables['Build.Reason'], 'Schedule')) }}
       keyringPass: $(pass--lab--mac--builder--keychain)
       gitHubToken: $(Github.Token)
       xqaCertPass: $(xqa--certificates--password)
@@ -479,112 +457,3 @@ stages:
         gitHubToken: $(Github.Token)
         xqaCertPass: $(xqa--certificates--password)
         pool: ${{ parameters.pool }}
-
-# Test stages
-
-# always run simulator tests
-- template: ./tests/stage.yml
-  parameters:
-    xcodeChannel: ${{ parameters.xcodeChannel }}
-    macOSName: ${{ parameters.macOSName }}
-    isPR: ${{ parameters.isPR }}
-    repositoryAlias: ${{ parameters.repositoryAlias }}
-    commit: ${{ parameters.commit }}
-    testConfigurations: ${{ parameters.testConfigurations }}
-    supportedPlatforms: ${{ parameters.supportedPlatforms }}
-    stageName: 'simulator_tests'
-    displayName: '${{ parameters.stageDisplayNamePrefix }}Simulator tests'
-    testPool: '' # use the default
-    useXamarinStorage: false
-    statusContext: 'VSTS: simulator tests'
-    makeTarget: 'jenkins'
-    vsdropsPrefix: ${{ variables.vsdropsPrefix }}
-    keyringPass: $(pass--lab--mac--builder--keychain)
-    gitHubToken: $(Github.Token)
-    xqaCertPass: $(xqa--certificates--password)
-    condition: ${{ parameters.runTests }}
-
-- template: ./tests/publish-results.yml
-  parameters:
-    displayName: '${{ parameters.stageDisplayNamePrefix }}Publish Test Results'
-    stageName: 'publish_test_results'
-    statusContext: 'VSTS: test results'
-    vsdropsPrefix: ${{ variables.vsdropsPrefix }}
-    condition: ${{ parameters.runTests }}
-    testConfigurations: ${{ parameters.testConfigurations }}
-    supportedPlatforms: ${{ parameters.supportedPlatforms }}
-    isPR: ${{ parameters.isPR }}
-    repositoryAlias: ${{ parameters.repositoryAlias }}
-    commit: ${{ parameters.commit }}
-
-# devices are optional and will only be ran when we set them OR in CI
-# Disabled since they are broken after the device lab moved from BOS to SEA
-# - ${{ if eq(parameters.runDeviceTests, true) }}:
-#   - ${{ if and(ne(variables['Build.Reason'], 'Schedule'), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual'))) }}:
-#     - ${{ each config in parameters.deviceTestsConfigurations }}:
-#       - template: ./tests/stage.yml
-#         parameters:
-#           xcodeChannel: ${{ parameters.xcodeChannel }}
-#           isPR: ${{ parameters.isPR }}
-#           repositoryAlias: ${{ parameters.repositoryAlias }}
-#           commit: ${{ parameters.commit }}
-#           testPrefix: ${{ config.testPrefix }} 
-#           stageName: ${{ config.stageName }} 
-#           displayName: '${{ parameters.stageDisplayNamePrefix }}${{ config.displayName }}'
-#           testPool: ${{ config.testPool }} 
-#           useXamarinStorage: ${{ config.useXamarinStorage }} 
-#           testsLabels: ${{ config.testsLabels }} 
-#           statusContext: ${{ config.statusContext }} 
-#           extraBotDemands: ${{ config.extraBotDemands }} 
-#           makeTarget: ${{ config.makeTarget }} 
-#           vsdropsPrefix: ${{ variables.vsdropsPrefix }}
-#           keyringPass: $(pass-XamarinQA-bot-login) 
-#           gitHubToken: $(Github.Token)
-#           xqaCertPass: $(xqa--certificates--password)
-#           condition: ${{ parameters.runDeviceTests }}
-#           parseLabels: false
-
-- ${{ if eq(parameters.runOldMacOSTests, true) }}:
-  - ${{ each config in parameters.macTestsConfigurations }}:
-    - template: ./mac/stage.yml
-      parameters:
-        isPR: ${{ parameters.isPR }}
-        repositoryAlias: ${{ parameters.repositoryAlias }}
-        commit: ${{ parameters.commit }}
-        stageName: ${{ config.stageName }}
-        displayName: ' ${{ parameters.stageDisplayNamePrefix }}${{ config.displayName }}'
-        macPool: ${{ config.macPool }}
-        useImage: ${{ config.useImage }}
-        statusContext: ${{ config.statusContext }}
-        keyringPass: $(pass--lab--mac--builder--keychain)
-        demands: ${{ config.demands }}
-
-- ${{ if eq(parameters.runWindowsIntegration, true) }}:
-  - template: ./windows/stage.yml
-    parameters:
-      isPR: ${{ parameters.isPR }}
-      repositoryAlias: ${{ parameters.repositoryAlias }}
-      commit: ${{ parameters.commit }}
-      stageName: windows_integration
-      displayName: '${{ parameters.stageDisplayNamePrefix }}Windows Integration Tests'
-      pool: 'VSEng-Xamarin-Mac-Devices' # currently ignored until the VS team provides a real one
-      statusContext: 'Windows Integration Tests'
-      gitHubToken: $(Github.Token)
-      xqaCertPass: $(xqa--certificates--password)
-
-- ${{ if eq(parameters.runSamples, true) }}:
-  # TODO: Not the real step
-  - stage: sample_testing
-    displayName: '${{ stageDisplayNamePrefix }}Sample testing'
-    dependsOn:
-    - build_packages
-    condition: and(succeeded(), contains (stageDependencies.build_packages.build.outputs['configuration.RunSampleTests'], 'True'))
-    jobs:
-    - job: sample_testing
-      pool:
-        vmImage: ubuntu-latest
-      steps:
-      # TODO: do parse labels
-      - bash: |
-          echo "Samples!"
-        displayName: 'Sample testing'

--- a/tools/devops/automation/templates/pipelines/build-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/build-pipeline.yml
@@ -22,36 +22,11 @@ parameters:
   - ci
   - automatic
 
-- name: runTests
-  displayName: Run Simulator Tests
-  type: boolean
-  default: true
-
-- name: runDeviceTests
-  displayName: Run Device Tests 
-  type: boolean
-  default: false
-
-- name: runOldMacOSTests
-  displayName: Run Tests on older macOS versions 
-  type: boolean
-  default: true
-
-- name: runWindowsIntegration
-  displayName: Run Windows integration tests
-  type: boolean
-  default: true
-
 - name: runGovernanceTests
   displayName: Run Governance Checks
   type: boolean
   default: true
 
-- name: runSamples
-  displayName: Run Samples
-  type: boolean
-  default: false
-  
 - name: enableAPIDiff
   displayName: Enable API diff generation
   type: boolean
@@ -240,12 +215,7 @@ stages:
     isPR: ${{ parameters.isPR }}
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     pool: ${{ parameters.pool }}
-    runTests: ${{ parameters.runTests }}
-    runDeviceTests: ${{ parameters.runDeviceTests }}
-    runOldMacOSTests: ${{ parameters.runOldMacOSTests }}
-    runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
     runGovernanceTests: ${{ parameters.runGovernanceTests }}
-    runSamples: ${{ parameters.runSamples }}
     enableAPIDiff: ${{ parameters.enableAPIDiff }}
     forceInsertion: ${{ parameters.forceInsertion }}
     skipESRP: ${{ parameters.skipESRP }}


### PR DESCRIPTION
There are now two post build pipelines that run the tests when a new build has complited building the nuget packages and dependencies. This allows the project to have a cleaner build pipeline to onboard on the 1ES template.