### PR TITLE
[release/8.0.1xx-xcode15.1] Enable dedup optimization in FullAOT mode only 

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1051,8 +1051,9 @@
 
 			<_AOTInputDirectory>$(_IntermediateNativeLibraryDir)aot-input/</_AOTInputDirectory>
 			<_AOTOutputDirectory>$(_IntermediateNativeLibraryDir)aot-output/</_AOTOutputDirectory>
-			<_IsDedupEnabled Condition="'$(_IsDedupEnabled)' == ''">true</_IsDedupEnabled>
-			<_DedupAssembly Condition="'$(_RunAotCompiler)' == 'true' And '$(IsMacEnabled)' == 'true' And '$(_IsDedupEnabled)' == 'true'">$(IntermediateOutputPath)aot-instances.dll</_DedupAssembly>
+			<!-- Enable dedup optimization only in FullAOT mode -->
+			<_IsDedupEnabled Condition="'$(_IsDedupEnabled)' == '' And '$(_RunAotCompiler)' == 'true' And '$(MtouchInterpreter)' == '' And '$(IsMacEnabled)' == 'true'">true</_IsDedupEnabled>
+			<_DedupAssembly Condition="'$(_IsDedupEnabled)' == 'true'">$(IntermediateOutputPath)aot-instances.dll</_DedupAssembly>
 
 			<!-- default to 'static' for Mac Catalyst to work around https://github.com/xamarin/xamarin-macios/issues/14686 -->
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And '$(_PlatformName)' == 'MacCatalyst'">static</_LibMonoLinkMode>
@@ -1174,7 +1175,7 @@
 	</Target>
 
 	<Target Name="_CreateAOTDedupAssembly"
-			Condition="'$(_RunAotCompiler)' == 'true' And '$(IsMacEnabled)' == 'true'"
+			Condition="'$(_IsDedupEnabled)' == 'true'"
 			DependsOnTargets="_ComputeManagedAssemblyToLink"
 			BeforeTargets="PrepareForILLink"
 			Inputs="$(MSBuildThisFileFullPath)"


### PR DESCRIPTION
## Description

This PR enables the dedup optimization in FullAOT mode only. The optimization can only run in FullAOT mode with complete application context. Without it, the AOT compiler may fail to collect all generic instances, and the runtime can't find them as they are searched in the dedup assembly.

## Changes

This PR updates the SDK targets to enable dedup optimization in FullAOT mode only. This change doesn't depend on any runtime changes.

## Verification

This PR also introduces partial AOT tests. They inspect the bundle for `aot-instances.dll`, which shouldn't be generated in a partial AOT compilation setup. Additionally, basic functionality is tested by asserting at app startup.

## Additional notes

This change should be backported to .NET 8 as well.

Fixes https://github.com/dotnet/runtime/issues/99248


Backport of #20687
