### PR TITLE
[runtime] Use strnlen instead of strlen.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -54,11 +54,13 @@ get_stacktrace (void **addresses, int frames)
 	// get the symbols for the addresses
 	char** strs = backtrace_symbols (addresses, frames);
 
+	const int max_symbol_length = 512; // this is just to have a maximum value, so that we can use strnlen instead of strlen
+
 	// compute the total length of all the symbols, adding 1 for every line (for the newline)
 	size_t length = 0;
 	int i;
 	for (i = 0; i < frames; i++)
-		length += strlen (strs [i]) + 1;
+		length += strnlen (strs [i], max_symbol_length) + 1;
 	length++;
 
 	// format the symbols as one long string with newlines
@@ -67,7 +69,7 @@ get_stacktrace (void **addresses, int frames)
 	size_t left = length;
 	for (i = 0; i < frames; i++) {
 		snprintf (buffer, left, "%s\n", strs [i]);
-		size_t slen = strlen (strs [i]) + 1;
+		size_t slen = strnlen (strs [i], max_symbol_length) + 1;
 		left -= slen;
 		buffer += slen;
 	}

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2664,7 +2664,7 @@ xamarin_is_native_library (const char *libraryName)
 	if (xamarin_runtime_libraries == NULL)
 		return false;
 
-	size_t libraryNameLength = strlen (libraryName);
+	size_t libraryNameLength = strnlen (libraryName, 255 /* max length of file name across all relevant file systems currently in use */);
 	// The libraries in xamarin_runtime_libraries are extension-less, so we need to
 	// remove any .dylib extension for the library name we're comparing with too.
 	if (libraryNameLength > 6 && strcmp (libraryName + libraryNameLength - 6, ".dylib") == 0)

--- a/tests/mtouch/MiscTests.cs
+++ b/tests/mtouch/MiscTests.cs
@@ -240,7 +240,7 @@ namespace Xamarin.Tests {
 				"snscanf", "snwscanf", "sprintf", "sprintfa", "sprintfw", "sscanf", "strcat",
 				"strcata", "strcatbuff", "strcatbuffa", "strcatbuffw", "strcatchainw",
 				"strcatn", "strcatna", "strcatnw", "strcatw", "strcpy", "strcpya", "strcpyn",
-				"strcpyna", "strcpynw", "strcpyw", /* "strlen" , */ "strncat", "strncata", "strncatw", // strlen is banned, but we use it a bunch, and so does dotnet/runtime
+				"strcpyna", "strcpynw", "strcpyw", "strlen", "strncat", "strncata", "strncatw",
 				"strncpy", "strncpya", "strncpyw", "strtok", "swprintf", "swscanf", "vsnprintf",
 				"vsprintf", "vswprintf", "wcscat", "wcscpy", "wcslen", "wcsncat", "wcsncpy",
 				"wcstok", "wmemcpy", "wnsprintf", "wnsprintfa", "wnsprintfw", "wscanf", "wsprintf",


### PR DESCRIPTION
Apparently it's safer.