### PR TITLE
[CI] Fix the comments by using the variable from the checkout template.

### DIFF
--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -229,6 +229,6 @@ steps:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     TEST_BOT: $(Agent.Name)
     ${{ if eq(parameters.repositoryAlias, 'self') }}:
-      COMMENT_HASH: $(GIT_HASH)
+      COMMENT_HASH: $(fix_commit.GIT_HASH)
     ${{ else }}:
       COMMENT_HASH: $(Build.SourceVersion)

--- a/tools/devops/automation/templates/mac/stage.yml
+++ b/tools/devops/automation/templates/mac/stage.yml
@@ -66,7 +66,6 @@ stages:
 
     variables:
       PR_ID: $[ stageDependencies.configure_build.configure.outputs['labels.pr_number'] ]
-      GIT_HASH: $[ stageDependencies.build_macos_tests.build.outputs['fix_commit.GIT_HASH'] ]
 
     steps:
     - template: build.yml

--- a/tools/devops/automation/templates/tests/publish-html.yml
+++ b/tools/devops/automation/templates/tests/publish-html.yml
@@ -97,7 +97,7 @@ steps:
     TESTS_SUMMARY: $(TEST_SUMMARY_PATH)
     ACCESSTOKEN: $(System.AccessToken)
     ${{ if eq(parameters.repositoryAlias, 'self') }}:
-      COMMENT_HASH: $(GIT_HASH)
+      COMMENT_HASH: $(fix_commit.GIT_HASH)
     ${{ else }}:
       COMMENT_HASH: $(Build.SourceVersion)
   displayName: 'Add summaries'

--- a/tools/devops/automation/templates/tests/publish-results.yml
+++ b/tools/devops/automation/templates/tests/publish-results.yml
@@ -79,7 +79,6 @@ stages:
     displayName: 'GitHub comment - Publish results'
     timeoutInMinutes: 30
     variables:
-      GIT_HASH: $[ stageDependencies.build_packages.build.outputs['fix_commit.GIT_HASH'] ]
       DEPENDENCIES: $[ convertToJson(dependencies) ]
       STAGE_DEPENDENCIES: $[ convertToJson(stageDependencies) ]
     pool:
@@ -100,9 +99,6 @@ stages:
     condition: eq(stageDependencies.configure_build.configure.outputs['labels.skip_all_tests'], 'True')
     displayName: 'GitHub comment - Skipped tests'
     timeoutInMinutes: 30
-
-    variables:
-      GIT_HASH: $[ stageDependencies.build_packages.build.outputs['fix_commit.GIT_HASH'] ]
 
     pool:
       vmImage: 'windows-latest'
@@ -130,6 +126,6 @@ stages:
         GITHUB_TOKEN: $(GitHub.Token)
         ACCESSTOKEN: $(System.AccessToken)
         ${{ if eq(parameters.repositoryAlias, 'self') }}:
-          COMMENT_HASH: $(GIT_HASH)
+          COMMENT_HASH: $(fix_commit.GIT_HASH)
         ${{ else }}:
           COMMENT_HASH: $(Build.SourceVersion)


### PR DESCRIPTION
There is no need to pass the GIT_HASH variable from job to job since it is calculated by the checkout template in the fix_commit step. We just need to update the variables usage.