### PR TITLE
[CoreFoundation] Fix memory leak in CFProxySupport.

### DIFF
--- a/src/CoreFoundation/CFProxySupport.cs
+++ b/src/CoreFoundation/CFProxySupport.cs
@@ -721,9 +721,9 @@ namespace CoreFoundation {
 
 #if NET
 					unsafe {
-					using (var loopSource = new CFRunLoopSource (factory (&ExecutePacCallback, ref clientContext), false))
+					using (var loopSource = new CFRunLoopSource (factory (&ExecutePacCallback, ref clientContext), true))
 #else
-					using (var loopSource = new CFRunLoopSource (factory (ExecutePacCallback, ref clientContext), false))
+					using (var loopSource = new CFRunLoopSource (factory (ExecutePacCallback, ref clientContext), true))
 #endif
 					using (var mode = new NSString ("Xamarin.iOS.Proxy")) {
 
@@ -785,9 +785,9 @@ namespace CoreFoundation {
 
 #if NET
 				unsafe {
-				using (var loopSource = new CFRunLoopSource (factory (&ExecutePacCallback, ref clientContext), false))
+				using (var loopSource = new CFRunLoopSource (factory (&ExecutePacCallback, ref clientContext), true))
 #else
-				using (var loopSource = new CFRunLoopSource (factory (ExecutePacCallback, ref clientContext), false))
+				using (var loopSource = new CFRunLoopSource (factory (ExecutePacCallback, ref clientContext), true))
 #endif
 				using (var mode = new NSString ("Xamarin.iOS.Proxy")) {
 					runLoop.AddSource (loopSource, mode);


### PR DESCRIPTION
The Xcode 16 release notes have this note:

    CFNetwork Resolved Issues

    * Fixed: CFNetworkExecuteProxyAutoConfigurationScript and
      CFNetworkExecuteProxyAutoConfigurationURL have always returned a +1
      retained CF type object, but the function declarations were not
      decorated with the CF_RETURNS_RETAINED attribute until iOS 18, macOS 15,
      tvOS 18, and visionOS 2.

      For C-based languages, the clang static analyzer might note if the
      object is leaked. No source code changes are required, but they are
      encouraged to fix the leak.

      For Swift, this changes the return type of these functions from
      Unmanaged<> to the actual CF type returned, which will require a source
      change to fix when compiling with newer SDKs. However, Swift programs
      compiled with older SDKs will continue to work on the new OSes, though
      the returned CF type object will continue to leak as it did prior to
      this change. (126154509)

So update our code accordingly to take into account that
CFNetworkExecuteProxyAutoConfigurationScript and
CFNetworkExecuteProxyAutoConfigurationURL return retained objects.