### PR TITLE
[devops] Remove logic to detect if the tests failed to build before reporting results.

### DIFF
--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -253,7 +253,18 @@ class GitHubComments {
     }
 
     static [bool] IsPR() {
-        return $Env:BUILD_REASON -eq "PullRequest"
+        if ($Env:BUILD_REASON -eq "PullRequest") {
+            return $true;
+        }
+
+        if (($Env:BUILD_REASON -eq "ResourceTrigger")) {
+            $sourceBranch = $Env:BUILD_SOURCEBRANCH
+            if ($sourceBranch.StartsWith("refs/pull/") -and $sourceBranch.EndsWith("/merge")) {
+                return $true
+            }
+        }
+
+        return $false
     }
 
     static [string] GetPRID() {

--- a/tools/devops/automation/scripts/TestResults.Tests.ps1
+++ b/tools/devops/automation/scripts/TestResults.Tests.ps1
@@ -546,29 +546,5 @@ Describe "TestResults tests" {
 [comment]: <> (This is a test result report added by Azure DevOps)
 "
         }
-
-        It "computes the right summary with build failure" {
-            $VerbosePreference = "Continue"
-            $Env:MyVerbosePreference = 'Continue'
-
-
-            $parallelResults = New-ParallelTestsResults -Path "path" -StageDependencies "$stageDependenciesWithBuildFailure" -Context "context" -VSDropsIndex "vsdropsIndex"
-
-            $parallelResults.IsSuccess() | Should -Be $false
-
-            $sb = [System.Text.StringBuilder]::new()
-            $parallelResults.WriteComment($sb)
-
-            $content = $sb.ToString()
-
-            Write-Host $content.Replace("&$", "&``$")
-
-            $content | Should -Be "# :x: Build failure :x:
-
-Build result: [Failed](/_build/index?buildId=)
-
-[comment]: <> (This is a test result report added by Azure DevOps)
-"
-        }
     }
 }

--- a/tools/devops/automation/scripts/TestResults.psm1
+++ b/tools/devops/automation/scripts/TestResults.psm1
@@ -478,13 +478,6 @@ function New-ParallelTestsResults {
 
     $stageDep = $StageDependencies | ConvertFrom-Json -AsHashtable
 
-    $buildResult = $stageDep.build_macos_tests.build_macos_tests_job.result
-    Write-Host "Build result: $buildResult"
-    if ($buildResult -ne "Succeeded") {
-        Write-Host "Build did not succeed: $buildResult"
-        return [ParallelTestsResults]::new($buildResult)
-    }
-
     $matrix = $stageDep.configure_build.configure.outputs["test_matrix.TEST_MATRIX"] | ConvertFrom-Json -AsHashtable
     $suites = [System.Collections.SortedList]::new()
     foreach ($title in $matrix.Keys) {


### PR DESCRIPTION
This check is redundant now, because the post-build test pipeline just won't
run in this case.

This fixes an issue where the GitHub comment reports 0 tests passing, because
we'd detect that the tests failed to build even when they didn't.