### PR TITLE
[msbuild] Update values we put in the generated Info.plist for Xcode archives.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1572,4 +1572,10 @@
         <value>The app bundle '{0}' contains a subdirectory named 'Resources'. This is not allowed on this platform. Typically resource files should be in the root directory of the app bundle (or a custom subdirectory, but named anything other than 'Resources').</value>
         <comment>0: a path</comment>
     </data>
+
+    <data name="E7124" xml:space="preserve">
+        <value>Can't compute the architecture for the archive for the RuntimeIdentifier '{0}' (unknown value)</value>
+        <comment>RuntimeIdentifier: don't translate (it's the name of a MSBuild property)</comment>
+    </data>
+
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
@@ -190,7 +190,7 @@ namespace Xamarin.MacDev.Tasks {
 				//arInfo.Add ("AppStoreFileSize", new PNumber (65535));
 				var props = new PDictionary ();
 				props.Add ("ApplicationPath", new PString (string.Format ("Applications/{0}", Path.GetFileName (AppBundleDir.ItemSpec))));
-				if (!string.IsNullOrEmpty (RuntimeIdentifiers)) {
+				if (!string.IsNullOrEmpty (RuntimeIdentifiers) && IsDotNet) {
 					var rids = RuntimeIdentifiers.Split (new char [] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 					var array = new PArray ();
 					foreach (var rid in rids) {

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
@@ -42,7 +42,7 @@ namespace Xamarin.MacDev.Tasks {
 
 		public string ProjectTypeGuids { get; set; }
 
-		public string SolutionPath { get; set; }
+		public string RuntimeIdentifiers { get; set; }
 
 		public string SigningKey { get; set; }
 
@@ -190,6 +190,23 @@ namespace Xamarin.MacDev.Tasks {
 				//arInfo.Add ("AppStoreFileSize", new PNumber (65535));
 				var props = new PDictionary ();
 				props.Add ("ApplicationPath", new PString (string.Format ("Applications/{0}", Path.GetFileName (AppBundleDir.ItemSpec))));
+				if (!string.IsNullOrEmpty (RuntimeIdentifiers)) {
+					var rids = RuntimeIdentifiers.Split (new char [] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+					var array = new PArray ();
+					foreach (var rid in rids) {
+						string architecture;
+						if (rid.EndsWith ("-x64", StringComparison.Ordinal)) {
+							architecture = "x86_64";
+						} else if (rid.EndsWith ("-arm64", StringComparison.Ordinal)) {
+							architecture = "arm64";
+						} else {
+							Log.LogError (MSBStrings.E7124 /* Can't compute the architecture for the archive for the RuntimeIdentifier '{0}' (unknown value) */, rid);
+							continue;
+						}
+						array.Add (new PString (architecture));
+					}
+					props.Add ("Architectures", array);
+				}
 				props.Add ("CFBundleIdentifier", new PString (plist.GetCFBundleIdentifier ()));
 
 				var version = plist.GetCFBundleShortVersionString ();
@@ -220,17 +237,13 @@ namespace Xamarin.MacDev.Tasks {
 				arInfo.Add ("ArchiveVersion", new PNumber (2));
 				arInfo.Add ("CreationDate", new PDate (Now.ToUniversalTime ()));
 				arInfo.Add ("Name", new PString (plist.GetCFBundleName () ?? plist.GetCFBundleDisplayName ()));
+				arInfo.Add ("SchemeName", new PString (plist.GetCFBundleName () ?? plist.GetCFBundleDisplayName ()));
 
 				if (!string.IsNullOrEmpty (ProjectGuid))
 					arInfo.Add ("ProjectGuid", new PString (ProjectGuid));
 
 				if (!string.IsNullOrEmpty (ProjectTypeGuids))
 					arInfo.Add ("ProjectTypeGuids", new PString (ProjectTypeGuids));
-
-				if (!string.IsNullOrEmpty (SolutionPath)) {
-					arInfo.Add ("SolutionName", new PString (Path.GetFileNameWithoutExtension (SolutionPath)));
-					arInfo.Add ("SolutionPath", new PString (SolutionPath));
-				}
 
 				if (!string.IsNullOrEmpty (InsightsApiKey))
 					arInfo.Add ("InsightsApiKey", new PString (InsightsApiKey));

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Archive.cs
@@ -44,6 +44,8 @@ namespace Xamarin.MacDev.Tasks {
 
 		public string RuntimeIdentifiers { get; set; }
 
+		public string SolutionPath { get; set; }
+
 		public string SigningKey { get; set; }
 
 		public ITaskItem [] WatchAppReferences { get; set; }
@@ -244,6 +246,11 @@ namespace Xamarin.MacDev.Tasks {
 
 				if (!string.IsNullOrEmpty (ProjectTypeGuids))
 					arInfo.Add ("ProjectTypeGuids", new PString (ProjectTypeGuids));
+
+				if (!string.IsNullOrEmpty (SolutionPath)) {
+					arInfo.Add ("SolutionName", new PString (Path.GetFileNameWithoutExtension (SolutionPath)));
+					arInfo.Add ("SolutionPath", new PString (SolutionPath));
+				}
 
 				if (!string.IsNullOrEmpty (InsightsApiKey))
 					arInfo.Add ("InsightsApiKey", new PString (InsightsApiKey));

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2919,7 +2919,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ProjectName="$(MSBuildProjectName)"
 			ProjectTypeGuids="$(ProjectTypeGuids)"
 			SigningKey="$(_CodeSigningKey)"
-			SolutionPath="$(SolutionPath)"
+			RuntimeIdentifiers="$(RuntimeIdentifiers);$(RuntimeIdentifier)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			WatchAppReferences="@(_ResolvedWatchAppReferences)"
 			>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2919,6 +2919,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ProjectName="$(MSBuildProjectName)"
 			ProjectTypeGuids="$(ProjectTypeGuids)"
 			SigningKey="$(_CodeSigningKey)"
+			SolutionPath="$(SolutionPath)"
 			RuntimeIdentifiers="$(RuntimeIdentifiers);$(RuntimeIdentifier)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			WatchAppReferences="@(_ResolvedWatchAppReferences)"


### PR DESCRIPTION
* Set the Architectures array, which Xcode does. This requires passing RuntimeIdentifier(s)
  to the task, so do that.
* Set SchemeName, which Xcode does.

This is a partial fix for https://github.com/xamarin/xamarin-macios/issues/20714.