### PR TITLE
[msbuild] The DTPlatformName is supposed to be 'macosx' for Mac Catalyst.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
@@ -527,7 +527,7 @@ namespace Xamarin.MacDev.Tasks {
 			SetValueIfNotNull (plist, "DTCompiler", sdkSettings.DTCompiler);
 			SetValueIfNotNull (plist, "DTPlatformBuild", dtSettings.DTPlatformBuild);
 			SetValueIfNotNull (plist, "DTSDKBuild", sdkSettings.DTSDKBuild);
-			SetValueIfNotNull (plist, "DTPlatformName", SdkPlatform.ToLowerInvariant ());
+			SetValueIfNotNull (plist, "DTPlatformName", PlatformUtils.GetTargetPlatform (SdkPlatform, IsWatchApp));
 			SetValueIfNotNull (plist, "DTPlatformVersion", dtSettings.DTPlatformVersion);
 			SetValueIfNotNull (plist, "DTSDKName", sdkSettings.CanonicalName);
 			SetValueIfNotNull (plist, "DTXcode", AppleSdkSettings.DTXcode);

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
@@ -138,13 +138,13 @@ namespace Xamarin.MacDev.Tasks {
 		}
 
 		[Test]
-		[TestCase (ApplePlatform.iOS, true)]
-		[TestCase (ApplePlatform.iOS, false)]
-		[TestCase (ApplePlatform.MacCatalyst, false)]
-		[TestCase (ApplePlatform.TVOS, true)]
-		[TestCase (ApplePlatform.TVOS, false)]
-		[TestCase (ApplePlatform.MacOSX, false)]
-		public void XcodeVariables (ApplePlatform platform, bool isSimulator)
+		[TestCase (ApplePlatform.iOS, true, "iphonesimulator")]
+		[TestCase (ApplePlatform.iOS, false, "iphoneos")]
+		[TestCase (ApplePlatform.MacCatalyst, false, "macosx")]
+		[TestCase (ApplePlatform.TVOS, true, "appletvsimulator")]
+		[TestCase (ApplePlatform.TVOS, false, "appletvos")]
+		[TestCase (ApplePlatform.MacOSX, false, "macosx")]
+		public void XcodeVariables (ApplePlatform platform, bool isSimulator, string expectedDTPlatformName)
 		{
 			var task = CreateTask (platform: platform);
 			task.SdkIsSimulator = isSimulator;
@@ -165,6 +165,7 @@ namespace Xamarin.MacDev.Tasks {
 				var value = plist.GetString (variable)?.Value;
 				Assert.That (value, Is.Not.Null.And.Not.Empty, variable);
 			}
+			Assert.AreEqual (expectedDTPlatformName, plist.GetString ("DTPlatformName")?.Value, "Expected DTPlatformName");
 		}
 	}
 }


### PR DESCRIPTION
Change how we compute DTPlatformName so that it's 'macosx' for Mac Catalyst.
The PlatformUtils.GetTargetPlatform returns SdkPlatform for all platforms
except Mac Catalyst, where it returns the same as for macOS (i.e. 'macosx').
It also returns a lowercased value, so we don't need to do that either.

This is a partial fix for https://github.com/xamarin/xamarin-macios/issues/20714.