### PR TITLE
[msbuild] Don't sign the Hot Restart app.

### DIFF
--- a/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
@@ -14,8 +14,8 @@
     <_LinkMode>None</_LinkMode>
     <UseInterpreter>true</UseInterpreter>
     <MtouchExtraArgs>--registrar:dynamic</MtouchExtraArgs>
-    <!-- disable code signing unless we're building in CI, to avoid requiring code signing during developer builds (who will usually never need the prebuilt app) -->
-    <EnableCodeSigning Condition="'$(BUILD_REVISION)' == ''">false</EnableCodeSigning>
+    <!-- Disable code signing, which simplifies our build (no need for a certificate). The app will have to be signed on the end user machine anyway, so this shouldn't have any real effect. -->
+    <EnableCodeSigning>false</EnableCodeSigning>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.iOS.HotRestart.Application" Version="1.1.5" />


### PR DESCRIPTION
The app will have to be signed anyway on the end user machine, so this seems
somewhat redundant.

Not signing would also simplify our build, because we wouldn't need a
certificate around to do the actual signing.