### PR TITLE
[msbuild] Show a slightly better warning message when trying to expand TeamIdentifierPrefix/AppIdentifierPrefix without a provisioning profile.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -479,14 +479,12 @@
         </value>
     </data>
     
-    <data name="W0108" xml:space="preserve">
-        <value>Cannot expand $(TeamIdentifierPrefix) in Entitlements.plist without a provisioning profile.
-        </value>
+    <data name="W0108b" xml:space="preserve">
+        <value>Cannot expand $(TeamIdentifierPrefix) in Entitlements.plist without a provisioning profile for key '{0}' with value '{1}'.</value>
     </data>
     
-    <data name="W0109" xml:space="preserve">
-        <value>Cannot expand $(AppIdentifierPrefix) in Entitlements.plist without a provisioning profile.
-        </value>
+    <data name="W0109b" xml:space="preserve">
+        <value>Cannot expand $(AppIdentifierPrefix) in Entitlements.plist without a provisioning profile for key '{0}' with value '{1}'.</value>
     </data>
         
     <data name="W0110" xml:space="preserve">

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs
@@ -138,7 +138,7 @@ namespace Xamarin.MacDev.Tasks {
 			}
 		}
 
-		PString MergeEntitlementString (PString pstr, MobileProvision? profile, bool expandWildcards)
+		PString MergeEntitlementString (PString pstr, MobileProvision? profile, bool expandWildcards, string? key)
 		{
 			string TeamIdentifierPrefix;
 			string AppIdentifierPrefix;
@@ -148,12 +148,12 @@ namespace Xamarin.MacDev.Tasks {
 
 			if (profile is null) {
 				if (!warnedTeamIdentifierPrefix && pstr.Value.Contains ("$(TeamIdentifierPrefix)")) {
-					Log.LogWarning (null, null, null, Entitlements, 0, 0, 0, 0, MSBStrings.W0108);
+					Log.LogWarning (null, null, null, Entitlements, 0, 0, 0, 0, MSBStrings.W0108b /* Cannot expand $(TeamIdentifierPrefix) in Entitlements.plist without a provisioning profile for key '{0}' with value '{1}' */, key, pstr.Value);
 					warnedTeamIdentifierPrefix = true;
 				}
 
 				if (!warnedAppIdentifierPrefix && pstr.Value.Contains ("$(AppIdentifierPrefix)")) {
-					Log.LogWarning (null, null, null, Entitlements, 0, 0, 0, 0, MSBStrings.W0109);
+					Log.LogWarning (null, null, null, Entitlements, 0, 0, 0, 0, MSBStrings.W0109b /* Cannot expand $(AppIdentifierPrefix) in Entitlements.plist without a provisioning profile for key '{0}' with value '{1}' */, key, pstr.Value);
 					warnedAppIdentifierPrefix = true;
 				}
 			}
@@ -198,7 +198,7 @@ namespace Xamarin.MacDev.Tasks {
 			return new PString (expanded);
 		}
 
-		PArray? MergeEntitlementArray (PArray array, MobileProvision? profile)
+		PArray? MergeEntitlementArray (PArray array, MobileProvision? profile, string? key)
 		{
 			var result = new PArray ();
 
@@ -206,11 +206,11 @@ namespace Xamarin.MacDev.Tasks {
 				PObject? value;
 
 				if (item is PDictionary)
-					value = MergeEntitlementDictionary ((PDictionary) item, profile);
+					value = MergeEntitlementDictionary ((PDictionary) item, profile, key);
 				else if (item is PString)
-					value = MergeEntitlementString ((PString) item, profile, false);
+					value = MergeEntitlementString ((PString) item, profile, false, key);
 				else if (item is PArray)
-					value = MergeEntitlementArray ((PArray) item, profile);
+					value = MergeEntitlementArray ((PArray) item, profile, key);
 				else
 					value = item.Clone ();
 
@@ -224,7 +224,7 @@ namespace Xamarin.MacDev.Tasks {
 			return null;
 		}
 
-		PDictionary MergeEntitlementDictionary (PDictionary dict, MobileProvision? profile)
+		PDictionary MergeEntitlementDictionary (PDictionary dict, MobileProvision? profile, string? key)
 		{
 			var result = new PDictionary ();
 
@@ -232,11 +232,11 @@ namespace Xamarin.MacDev.Tasks {
 				PObject? value = item.Value;
 
 				if (value is PDictionary)
-					value = MergeEntitlementDictionary ((PDictionary) value, profile);
+					value = MergeEntitlementDictionary ((PDictionary) value, profile, item.Key);
 				else if (value is PString)
-					value = MergeEntitlementString ((PString) value, profile, false);
+					value = MergeEntitlementString ((PString) value, profile, false, item.Key);
 				else if (value is PArray)
-					value = MergeEntitlementArray ((PArray) value, profile);
+					value = MergeEntitlementArray ((PArray) value, profile, item.Key);
 				else
 					value = value.Clone ();
 
@@ -286,7 +286,7 @@ namespace Xamarin.MacDev.Tasks {
 					dict [entitlement] = new PBoolean (booleanValue);
 					break;
 				case "string":
-					dict [entitlement] = MergeEntitlementString (new PString (value), profile, entitlement == ApplicationIdentifierKey);
+					dict [entitlement] = MergeEntitlementString (new PString (value), profile, entitlement == ApplicationIdentifierKey, entitlement);
 					break;
 				case "stringarray":
 					var arraySeparator = item.GetMetadata ("ArraySeparator");
@@ -295,7 +295,7 @@ namespace Xamarin.MacDev.Tasks {
 					var arrayContent = value.Split (new string [] { arraySeparator }, StringSplitOptions.None);
 					var parray = new PArray ();
 					foreach (var element in arrayContent)
-						parray.Add (MergeEntitlementString (new PString (element), profile, entitlement == ApplicationIdentifierKey));
+						parray.Add (MergeEntitlementString (new PString (element), profile, entitlement == ApplicationIdentifierKey, entitlement));
 					dict [entitlement] = parray;
 					break;
 				default:
@@ -358,11 +358,11 @@ namespace Xamarin.MacDev.Tasks {
 					if (key == "com.apple.developer.icloud-container-environment")
 						value = new PString ("Development");
 					else if (value is PDictionary)
-						value = MergeEntitlementDictionary ((PDictionary) value, profile);
+						value = MergeEntitlementDictionary ((PDictionary) value, profile, key);
 					else if (value is PString)
-						value = MergeEntitlementString ((PString) value, profile, item.Key == ApplicationIdentifierKey);
+						value = MergeEntitlementString ((PString) value, profile, item.Key == ApplicationIdentifierKey, key);
 					else if (value is PArray)
-						value = MergeEntitlementArray ((PArray) value, profile);
+						value = MergeEntitlementArray ((PArray) value, profile, key);
 					else
 						value = value.Clone ();
 
@@ -393,11 +393,11 @@ namespace Xamarin.MacDev.Tasks {
 				}
 
 				if (value is PDictionary)
-					value = MergeEntitlementDictionary ((PDictionary) value, profile);
+					value = MergeEntitlementDictionary ((PDictionary) value, profile, key);
 				else if (value is PString)
-					value = MergeEntitlementString ((PString) value, profile, key == ApplicationIdentifierKey);
+					value = MergeEntitlementString ((PString) value, profile, key == ApplicationIdentifierKey, key);
 				else if (value is PArray)
-					value = MergeEntitlementArray ((PArray) value, profile);
+					value = MergeEntitlementArray ((PArray) value, profile, key);
 				else
 					value = value.Clone ();
 


### PR DESCRIPTION
By including the key and the offending value in the warning message.