### PR TITLE
[CI] Use the default credscan setup except for the exclusion.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -232,9 +232,6 @@ extends:
         enabled: false  # we run our on sbom generation
       credscan:
         suppressionsFile: '$(System.DefaultWorkingDirectory)\\xamarin-macios\\tools\\devops\\governance\\CredScanSuppressions.json'
-        outputFormat: sarif
-        debugMode: false
-        batchSize: 16
       policheck:
         exclusionsFile: '$(System.DefaultWorkingDirectory)\\xamarin-macios\\tools\\devops\\governance\\PoliCheckExclusions.xml'
       sourceRepositoriesToScan:

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -232,9 +232,6 @@ extends:
         enabled: false  # we run our on sbom generation
       credscan:
         suppressionsFile: '$(System.DefaultWorkingDirectory)\\xamarin-macios\\tools\\devops\\governance\\CredScanSuppressions.json'
-        outputFormat: sarif
-        debugMode: false
-        batchSize: 16
       policheck:
         exclusionsFile: '$(System.DefaultWorkingDirectory)\\xamarin-macios\\tools\\devops\\governance\\PoliCheckExclusions.xml'
       sourceRepositoriesToScan:


### PR DESCRIPTION
The configuration was giving issues in one of the jobs with binaries. Using the default fixes the issue.