### PR TITLE
[tests] Fix BuildBindingsTest expectations.

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -190,8 +190,10 @@ namespace Xamarin.Tests {
 			// Verify that there's one resource in the binding assembly, and its name
 			var ad = AssemblyDefinition.ReadAssembly (asm, new ReaderParameters { ReadingMode = ReadingMode.Deferred });
 			Assert.That (ad.MainModule.Resources.Count, Is.EqualTo (0), "no embedded resources");
-			var resourceBundle = Path.Combine (project_dir, "bin", "Debug", platform.ToFramework (), assemblyName + ".resources.zip");
-			Assert.That (resourceBundle, Does.Exist, "Bundle existence");
+			var resourceBundle = Path.Combine (project_dir, "bin", "Debug", platform.ToFramework (), assemblyName + ".resources");
+			var resourceZip = resourceBundle + ".zip";
+			if (!Directory.Exists (resourceBundle) && !File.Exists (resourceZip))
+				Assert.Fail ($"Neither the sidecar {resourceBundle} or the zipped sidecar {resourceZip} exists.");
 		}
 
 		[TestCase (ApplePlatform.iOS)]


### PR DESCRIPTION
Fix BuildBindingsTest expectations to expect the resources in either a sidecar or a zipped sidecar.

Fixes this test failure:

    Xamarin.Tests.DotNetProjectTest.BuildBindingsTest(TVOS): Bundle existence
    Expected: file or directory exists
    But was: "/Users/builder/azdo/_work/1/s/xamarin-macios/tests/bindings-test/dotnet/tvOS/bin/Debug/net8.0-tvos/bindings-test.resources.zip"