### PR TITLE
[src] Fix definition of AVSampleCursorAudioDependencyInfo for Mac Catalyst.

### DIFF
--- a/src/AVFoundation/AVTypes.cs
+++ b/src/AVFoundation/AVTypes.cs
@@ -642,7 +642,7 @@ namespace AVFoundation {
 		public nint PacketRefreshCount;
 	}
 
-#if !XAMCORE_5_0 && !__IOS__ && !__TVOS__
+#if !XAMCORE_5_0 && !(__IOS__ && !__MACCATALYST__) && !__TVOS__
 	[StructLayout (LayoutKind.Sequential)]
 	[NativeName ("AVSampleCursorAudioDependencyInfo")]
 #if COREBUILD

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -5365,7 +5365,7 @@ namespace AVFoundation {
 
 
 		[Export ("currentSampleAudioDependencyInfo")]
-#if XAMCORE_5_0 || IOS || TVOS
+#if XAMCORE_5_0 || (IOS && !__MACCATALYST__) || TVOS
 		AVSampleCursorAudioDependencyInfo CurrentSampleAudioDependencyInfo { get; }
 #else
 		[Internal]

--- a/tests/cecil-tests/BlittablePInvokes.cs
+++ b/tests/cecil-tests/BlittablePInvokes.cs
@@ -268,13 +268,16 @@ namespace Cecil.Tests {
 			var failures = new Dictionary<string, NonBlittablePInvokesFailure> ();
 			var pinvokes = new List<(AssemblyDefinition Assembly, MethodDefinition Method)> ();
 
-			foreach (var info in Helper.NetPlatformImplementationAssemblyDefinitions)
+			var blitCaches = new Dictionary<AssemblyDefinition, Dictionary<string, BlitAndReason>> ();
+			foreach (var info in Helper.NetPlatformImplementationAssemblyDefinitions) {
 				pinvokes.AddRange (AllPInvokes (info.Assembly).Select (v => (info.Assembly, v)));
+
+				blitCaches [info.Assembly] = new Dictionary<string, BlitAndReason> ();
+			}
 
 			Assert.That (pinvokes.Count, Is.GreaterThan (0), "Must have some P/Invokes at least");
 
-			var blitCache = new Dictionary<string, BlitAndReason> ();
-			var results = pinvokes.Select (pi => IsMethodBlittable (pi.Assembly, pi.Method, blitCache)).Where (r => !r.IsBlittable).ToArray ();
+			var results = pinvokes.Select (pi => IsMethodBlittable (pi.Assembly, pi.Method, blitCaches [pi.Assembly])).Where (r => !r.IsBlittable).ToArray ();
 			foreach (var result in results) {
 				failures [result.Method.FullName] = new (result.Method.FullName, result.Method.RenderLocation (), result.Result.ToString ());
 			}


### PR DESCRIPTION
We need the backwards compatible code for the
AVSampleCursorAudioDependencyInfo struct (i.e. use the
AVSampleCursorAudioDependencyInfo_Blittable version), so adjust the ifdefs
accordingly - which wasn't obvious at first, because __IOS__ is defined for
Mac Catalyst.

Also fix the corresponding test, because it would cache the result of
computing whether a struct was blittable or not, but that's not true across
platforms ("AVSampleCursorAudioDependencyInfo" is blittable on iOS, but not on
Mac Catalyst). The result was that the test would incorrectly pass if we
processed Microsoft.iOS.dll before Microsoft.MacCatalyst.dll. The fix is to
cache per platform, instead of using a global cache.