### PR TITLE
[release/9.0.1xx-preview6] [CI] Fix credscan in the sign step

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -54,6 +54,7 @@ stages:
     parameters:
       use1ESTemplate: true
       enabledCredScan: false
+      checkoutType: self
       signedArtifactName: '${{ parameters.uploadPrefix }}nuget-signed'
       artifactName: '${{ parameters.uploadPrefix }}not-signed-package'
       signType: Real


### PR DESCRIPTION
Fixes 

> "PowerArgs.ValidationArgException: File not found - D:\a\_work\1\s\xamarin-macios\tools\devops\governance\CredScanSuppressions.csk"

<img width="648" alt="IMG_2524" src="https://github.com/xamarin/xamarin-macios/assets/204671/73aefc4a-3c96-45f6-a2d8-3ae277e63fdd">


The real issue is that the file does indeed not exist but in reality it is looking for 'CredScanSuppressions.json' which does not exist because there is not checkout of the repo happening when this step is run.