### PR TITLE
[bgen] Add simple makefile.

### DIFF
--- a/src/bgen/Makefile
+++ b/src/bgen/Makefile
@@ -1,0 +1,8 @@
+TOP=../../
+include $(TOP)/Make.config
+
+all:
+	$(Q) $(MAKE) -C .. install-bgen
+
+run-tests:
+	$(Q) $(MAKE) -C ../../tests/bgen run-tests


### PR DESCRIPTION
Add a simple makefile to the src/bgen directory that only builds and tests
bgen.

This is very useful when working on bgen to make sure your changes are at
building and working.