### PR TITLE
Revert "Migrate Messaging Build agent to .NET 8 (#20705)"

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -108,7 +108,7 @@
     <FirstParty Include="Broker.exe" />
     <FirstParty Include="Broker.resources.dll" />
     <!-- Build.zip -->
-    <FirstParty Include="Build.dll" />
+    <FirstParty Include="Build.exe" />
     <FirstParty Include="Microsoft.Build*.dll" />
     <FirstParty Include="Microsoft.NET.StringTools.dll" />
     <FirstParty Include="System.IO.Abstractions.dll" />

--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -11,7 +11,7 @@
 			enclosed in brackets.
 
 		-->
-		<MessagingVersion>[2.0.28]</MessagingVersion>
+		<MessagingVersion>[1.14.6]</MessagingVersion>
 		<HotRestartVersion>[1.1.7]</HotRestartVersion>
 	</PropertyGroup>
 	<Import Project="$(MSBuildThisFileDirectory)../Directory.Build.props" />

--- a/msbuild/ILMerge.targets
+++ b/msbuild/ILMerge.targets
@@ -42,7 +42,6 @@
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.ComponentModel.Composition'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Diagnostics.Tracer'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Net.Mqtt'" />
-      <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Net.Mqtt.Server'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Reactive'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Security.Cryptography.ProtectedData'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Text.Encoding.CodePages'" />

--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -491,9 +491,9 @@ DOTNET_IOS_WINDOWS_OUTPUT_FILES =                                \
 	iSign.Core.pdb                                               \
 	Xamarin.iOS.Windows.Client.pdb                               \
 	Broker.zip                                                   \
+	Build.zip                                                    \
 
 DOTNET_IOS_WINDOWS_FILES = $(IOS_WINDOWS_TARGETS) $(foreach file,$(DOTNET_IOS_WINDOWS_OUTPUT_FILES),Xamarin.iOS.Tasks.Windows/bin/$(CONFIG)/$(TARGETFRAMEWORK)/$(WINDOWSRUNTIMEIDENTIFIER)/$(file))
-DOTNET_IOS_WINDOWS_FILES += Messaging/Xamarin.Messaging.Build/obj/$(CONFIG)/Build.zip
 DOTNET_IOS_WINDOWS_MOBILEDEVICE_TOOLS_X86 = $(foreach file,$(IOS_WINDOWS_MOBILEDEVICE_TOOLS),Xamarin.iOS.Tasks.Windows/bin/$(CONFIG)/$(TARGETFRAMEWORK)/$(WINDOWSRUNTIMEIDENTIFIER)/imobiledevice-x86/$(file).*)
 DOTNET_IOS_WINDOWS_MOBILEDEVICE_TOOLS_X64 = $(foreach file,$(IOS_WINDOWS_MOBILEDEVICE_TOOLS),Xamarin.iOS.Tasks.Windows/bin/$(CONFIG)/$(TARGETFRAMEWORK)/$(WINDOWSRUNTIMEIDENTIFIER)/imobiledevice-x64/$(file).*)
 

--- a/msbuild/Messaging/Xamarin.Messaging.Build/BuildAgent.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/BuildAgent.cs
@@ -49,6 +49,9 @@ namespace Xamarin.Messaging.Build {
 				.ConfigureAwait (continueOnCapturedContext: false);
 			await TryRegisterHandlerAsync (new GetItemMessageHandler ())
 			   .ConfigureAwait (continueOnCapturedContext: false);
+
+			await TryRegisterHandlerAsync (new VerifyXcodeVersionMessageHandler ())
+				.ConfigureAwait (continueOnCapturedContext: false);
 			await TryRegisterHandlerAsync (new GetUniversalTargetIdentifierMessageHandler ())
 				.ConfigureAwait (continueOnCapturedContext: false);
 		}

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/CopyItemMessageHandler.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/CopyItemMessageHandler.cs
@@ -17,13 +17,10 @@ namespace Xamarin.Messaging.Build {
 					message.SessionId,
 					PlatformPath.GetPathForCurrentPlatform (message.ItemSpec)));
 
-				if (File.Exists (targetPath)) {
+				if (File.Exists (targetPath))
 					File.Delete (targetPath);
-				} else {
-					var directoryName = Path.GetDirectoryName (targetPath);
-					if (directoryName is not null && !Directory.Exists (directoryName))
-						Directory.CreateDirectory (directoryName);
-				}
+				else if (!Directory.Exists (Path.GetDirectoryName (targetPath)))
+					Directory.CreateDirectory (Path.GetDirectoryName (targetPath));
 
 				using (var file = File.Create (targetPath))
 				using (var stream = new MemoryStream (message.Content))

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>Build</AssemblyName>
     <NoWarn>$(NoWarn);NU1603</NoWarn> <!-- Xamarin.Messaging.Build.Common 1.6.24 depends on Merq (>= 1.1.0) but Merq 1.1.0 was not found. An approximate best match of Merq 1.1.4 was resolved. -->
@@ -10,7 +10,6 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Label="Messaging">

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -878,6 +878,19 @@
         <value>Could not resolve UTI for {0} in catalog {1}</value>
     </data>
 
+    <data name="E0183" xml:space="preserve">
+        <value>An error occurred while trying to verify the compatibility between Xcode and the .NET SDK</value>
+    </data>
+
+    <data name="E0184" xml:space="preserve">
+        <value>The project was built with a version of Xcode ({0}) that is not compatible which may result in unexpected warnings or errors. Please install Xcode '{1}' or visit the documentation to learn more.</value>
+    </data>
+
+    <data name="E0185" xml:space="preserve">
+        <value>An error occurred while trying to verify the compatibility between Xcode and the .NET SDK. Details: {0}
+        </value>
+    </data>
+
     <data name="E0186" xml:space="preserve">
         <value>The provided Archive Path is not from a valid archive file (.xcarchive). Archive Path: '{0}'</value>
     </data>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/VerifyXcodeVersion.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/VerifyXcodeVersion.cs
@@ -1,0 +1,46 @@
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.Localization.MSBuild;
+using Xamarin.MacDev.Tasks;
+using Xamarin.Messaging.Build.Client;
+using Xamarin.Messaging.Build.Contracts;
+using Threading = System.Threading.Tasks;
+
+namespace Xamarin.MacDev.Tasks {
+	public class VerifyXcodeVersion : XamarinTask {
+		public override bool Execute () => ExecuteAsync ().Result;
+
+		async Threading.Task<bool> ExecuteAsync ()
+		{
+			try {
+				var connection = await BuildConnection.GetAsync (BuildEngine4).ConfigureAwait (continueOnCapturedContext: false);
+				var buildClient = connection.GetClient (SessionId) as BuildClient;
+
+				if (!connection.IsConnected || buildClient is null) {
+					Log.LogWarning (MSBStrings.E0179, nameof (VerifyXcodeVersion));
+
+					return true;
+				}
+
+				var xcodeVerificationResult = await buildClient
+					.RunMessagingAsync<VerifyXcodeVersionMessage, VerifyXcodeVersionResult> (new VerifyXcodeVersionMessage ())
+					.ConfigureAwait (continueOnCapturedContext: false);
+
+				if (!xcodeVerificationResult.IsCompatibleVersion) {
+					if (string.IsNullOrEmpty (xcodeVerificationResult.XcodeVersion) || string.IsNullOrEmpty (xcodeVerificationResult.RecommendedXcodeVersion)) {
+						Log.LogWarning (MSBStrings.E0183);
+					} else {
+						Log.LogWarning (MSBStrings.E0184, xcodeVerificationResult.XcodeVersion, xcodeVerificationResult.RecommendedXcodeVersion);
+					}
+				}
+
+				return true;
+			} catch (Exception ex) {
+				Log.LogWarning (MSBStrings.E0185, ex.Message);
+
+				return true;
+			}
+		}
+	}
+}

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -105,6 +105,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.UnpackLibraryResources" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.Unzip" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ValidateAppBundleTask" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.VerifyXcodeVersion" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.WriteAppManifest" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.WriteAssetPackManifest" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.WriteItemsToFile" AssemblyFile="$(_TaskAssemblyName)" />

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.Messaging.Apple.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.Messaging.Apple.targets
@@ -23,6 +23,13 @@
 			<IsRemoteBuild Condition="'$(IsHotRestartBuild)' == 'True'">False</IsRemoteBuild>
 		</PropertyGroup>
 	</Target>
+	
+	<!-- AfterConnect belongs to Xamarin.Messaging.Build.targets -->
+	<Target Name="AfterConnect" Condition="'$(IsRemoteBuild)' == 'true'" DependsOnTargets="_VerifyXcodeVersion" />
+	
+	<Target Name="_VerifyXcodeVersion" Condition="'$(IsRemoteBuild)' == 'true' And '$(IsMacEnabled)' == 'true'">
+		<VerifyXcodeVersion SessionId="$(BuildSessionId)" />
+	</Target>
 
 	<PropertyGroup>
 		<MessagingAppleTargetsImported>True</MessagingAppleTargetsImported>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -29,6 +29,11 @@
     <PackageReference Include="GitInfo" Version="2.2.0" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Messaging\Xamarin.Messaging.Build\Xamarin.Messaging.Build.csproj">
+      <ExcludeAssets>all</ExcludeAssets>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+      <IsAgent>True</IsAgent>
+    </ProjectReference>
     <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This reverts commit f8552e929419ffb609fb6c5d5d6b2e11f93a3a59.

This change is only supposed to be released with .NET 9, and we might
release new .NET 8 updates from main. Thus we need to make sure these
changes are only in the net9.0 branch (they already are).