### PR TITLE
[CI] Disable the governance checks on the tests.

### DIFF
--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -92,6 +92,8 @@ stages:
     displayName: 'T:' 
     timeoutInMinutes: 180
     variables:
+      # disable governance checks in the tests 
+      skipComponentGovernanceDetection: true
       # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
       PR_ID: $[ stageDependencies.configure_build.configure.outputs['labels.pr_number'] ]
       # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it


### PR DESCRIPTION
Disable the autoinjected governance checks in the tests templates since they timeout on the mac.

ref: https://docs.opensource.microsoft.com/tools/cg/index.html