### PR TITLE
[net9.0] [dotnet] Fix workload reference to .NET 8 packages.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -108,7 +108,7 @@ print-dotnet-pkg-urls: dotnet-install.sh
 	$(Q) rm -f $@-found-it.stamp
 
 dotnet-install.sh: Makefile
-	$(Q) $(CURL_RETRY) https://dot.net/v1/dotnet-install.sh --output $@.tmp
+	$(Q) $(CURL_RETRY) https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.sh --output $@.tmp
 	$(Q) chmod +x $@.tmp
 	$(Q) mv $@.tmp $@
 

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -108,7 +108,7 @@ print-dotnet-pkg-urls: dotnet-install.sh
 	$(Q) rm -f $@-found-it.stamp
 
 dotnet-install.sh: Makefile
-	$(Q) $(CURL_RETRY) https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.sh --output $@.tmp
+	$(Q) $(CURL_RETRY) https://dot.net/v1/dotnet-install.sh --output $@.tmp
 	$(Q) chmod +x $@.tmp
 	$(Q) mv $@.tmp $@
 

--- a/dotnet/generate-workloadmanifest-json.csharp
+++ b/dotnet/generate-workloadmanifest-json.csharp
@@ -50,11 +50,11 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"			\"description\": \".NET SDK Workload for building {platform} applications.\",");
 	writer.WriteLine ($"			\"packs\": [");
 	foreach (var tfm in allApiVersions) {
-		writer.WriteLine ($"				\"Microsoft.{platform}.Sdk.{tfm}\",");
+		writer.WriteLine ($"				\"Microsoft.{platform}.Sdk.{(tfm == "net8.0" ? "net8" : tfm)}\",");
 	}
 	if (hasWindows) {
 		foreach (var tfm in allApiVersions) {
-			writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.{tfm}\",");
+			writer.WriteLine ($"				\"Microsoft.{platform}.Windows.Sdk.Aliased.{(tfm == "net8.0" ? "net8" : tfm)}\",");
 		}
 	}
 	writer.WriteLine ($"				\"Microsoft.{platform}.Ref.{currentApiVersion}\",");
@@ -90,7 +90,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 				failed = true;
 			}
 		}
-		writer.WriteLine ($"		\"Microsoft.{platform}.Sdk.{tfm}\": {{");
+		writer.WriteLine ($"		\"Microsoft.{platform}.Sdk.{(tfm == "net8.0" ? "net8" : tfm)}\": {{");
 		writer.WriteLine ($"			\"kind\": \"sdk\",");
 		writer.WriteLine ($"			\"version\": \"{apiVersion}\",");
 		if (tfm == "net8.0") {
@@ -100,7 +100,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 		}
 		writer.WriteLine ($"		}},");
 		if (hasWindows) {
-			writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.{tfm}\": {{");
+			writer.WriteLine ($"		\"Microsoft.{platform}.Windows.Sdk.Aliased.{(tfm == "net8.0" ? "net8" : tfm)}\": {{");
 			writer.WriteLine ($"			\"kind\": \"sdk\",");
 			writer.WriteLine ($"			\"version\": \"{apiVersion}\",");
 			writer.WriteLine ($"			\"alias-to\": {{");

--- a/dotnet/generate-workloadmanifest-targets.csharp
+++ b/dotnet/generate-workloadmanifest-targets.csharp
@@ -54,11 +54,11 @@ using (var writer = new StreamWriter (outputPath)) {
 			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Sdk.{workloadVersion}\" />");
 		} else {
 			writer.WriteLine ($"	<ImportGroup Condition=\" '$(TargetPlatformIdentifier)' == '{platform}' And '$(UsingAppleNETSdk)' != 'true' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '{tfv}'))\">");
-			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Sdk.{workloadVersion}\" />");
+			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Sdk.{(workloadVersion == "net8.0" ? "net8" : tfm)}\" />");
 		}
 
 		if (hasWindows) {
-			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Windows.Sdk.Aliased.{workloadVersion}\" Condition=\" $([MSBuild]::IsOSPlatform('windows'))\" />");
+			writer.WriteLine ($"		<Import Project=\"Sdk.props\" Sdk=\"Microsoft.{platform}.Windows.Sdk.Aliased.{(workloadVersion == "net8.0" ? "net8" : tfm)}\" Condition=\" $([MSBuild]::IsOSPlatform('windows'))\" />");
 		}
 
 		writer.WriteLine ($"	</ImportGroup>");


### PR DESCRIPTION
The stable .NET 8 workload we're releasing is calling its Sdk pack 'Microsoft.iOS.Sdk.net8'. This means the pack has to be named the same across everything we're releasing, so special-case the Sdk pack accordingly.

New WorkloadManifest.json:
https://gist.github.com/rolfbjarne/eeee0cee3c6cb328f7853dbe49ed0d50
Diff with previous one:
https://gist.github.com/rolfbjarne/f2c25d2956d39e380e4cc9f922083117


Backport of #20795.