### PR TITLE
[src/tools] Propagate the BackwardsCompatibleCodeGeneration field from Protocol attributes in bindings to the generated code.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -4879,11 +4879,13 @@ public partial class Generator : IMemberGatherer {
 		WriteDocumentation (type);
 
 		PrintAttributes (type, platform: true, preserve: true, advice: true);
-		print ("[Protocol (Name = \"{1}\", WrapperType = typeof ({0}Wrapper){2}{3})]",
+		print ("[Protocol (Name = \"{1}\", WrapperType = typeof ({0}Wrapper){2}{3}{4})]",
 			   TypeName,
 			   protocol_name,
 			   protocolAttribute.IsInformal ? ", IsInformal = true" : string.Empty,
-			   protocolAttribute.FormalSince is not null ? $", FormalSince = \"{protocolAttribute.FormalSince}\"" : string.Empty);
+			   protocolAttribute.FormalSince is not null ? $", FormalSince = \"{protocolAttribute.FormalSince}\"" : string.Empty,
+			   backwardsCompatibleCodeGeneration ? string.Empty : ", BackwardsCompatibleCodeGeneration = false"
+			   );
 
 		var sb = new StringBuilder ();
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1427,6 +1427,11 @@ namespace Registrar {
 						throw ErrorHelper.CreateError (4147, Errors.MT4147, "ProtocolAttribute", type.FullName);
 					rv.FormalSinceVersion = version;
 					break;
+#if !XAMCORE_5_0
+				case "BackwardsCompatibleCodeGeneration":
+					rv.BackwardsCompatibleCodeGeneration = (bool) prop.Argument.Value;
+					break;
+#endif
 				default:
 					throw ErrorHelper.CreateError (4147, Errors.MT4147, "ProtocolAttribute", type.FullName);
 				}
@@ -5790,6 +5795,9 @@ namespace Registrar {
 		public string Name { get; set; }
 		public bool IsInformal { get; set; }
 		public Version FormalSinceVersion { get; set; }
+#if !XAMCORE_5_0
+		public bool BackwardsCompatibleCodeGeneration { get; set; }
+#endif
 	}
 
 	class BlockProxyAttribute : Attribute {


### PR DESCRIPTION
Also fix the MustSetBackwardsCompatibleCodeGenerationToFalse test to skip
protocols that actually set BackwardsCompatibleCodeGeneration=false.