### PR TITLE
[tools] Ignore a few warnings by default. Fixes #20670.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -613,6 +613,7 @@
 				TargetFramework=$(_ComputedTargetFrameworkMoniker)
 				UseLlvm=$(MtouchUseLlvm)
 				Verbosity=$(_BundlerVerbosity)
+				Warn=$(_BundlerWarn)
 				WarnAsError=$(_BundlerWarnAsError)
 				XamarinNativeLibraryDirectory=$(_XamarinNativeLibraryDirectory)
 				XamarinRuntime=$(_XamarinRuntime)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ParseBundlerArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ParseBundlerArguments.cs
@@ -68,6 +68,9 @@ namespace Xamarin.MacDev.Tasks {
 		public int Verbosity { get; set; }
 
 		[Output]
+		public string Warn { get; set; }
+
+		[Output]
 		public string WarnAsError { get; set; }
 
 		[Output]
@@ -231,6 +234,15 @@ namespace Xamarin.MacDev.Tasks {
 							NoWarn = value;
 						} else {
 							NoWarn += "," + value;
+						}
+						break;
+					case "warn":
+						if (!hasValue)
+							value = "-1"; // all warnings
+						if (string.IsNullOrEmpty (Warn)) {
+							Warn = value;
+						} else {
+							Warn += "," + value;
 						}
 						break;
 					default:

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2039,6 +2039,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<Output TaskParameter="SkipMarkingNSObjectsInUserAssemblies" PropertyName="_SkipMarkingNSObjectsInUserAssemblies" />
 			<Output TaskParameter="Verbosity" PropertyName="_BundlerVerbosity" />
 			<Output TaskParameter="WarnAsError" PropertyName="_BundlerWarnAsError" />
+			<Output TaskParameter="Warn" PropertyName="_BundlerWarn" />
 			<Output TaskParameter="XmlDefinitions" ItemName="_BundlerXmlDefinitions" />
 			<Output TaskParameter="NoStrip" PropertyName="EnableAssemblyILStripping" />
 		</ParseBundlerArguments>

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -1797,5 +1797,18 @@ namespace Xamarin.Bundler {
 
 			return dynamic;
 		}
+
+		static Application ()
+		{
+			SetDefaultHiddenWarnings ();
+		}
+
+		public static void SetDefaultHiddenWarnings ()
+		{
+			// People don't like these warnings (#20670), and they also complicate our tests, so ignore them.
+			ErrorHelper.ParseWarningLevel (ErrorHelper.WarningLevel.Disable, "4178"); // The class '{0}' will not be registered because the {1} framework has been removed from the {2} SDK.
+			ErrorHelper.ParseWarningLevel (ErrorHelper.WarningLevel.Disable, "4189"); // The class '{0}' will not be registered because it has been removed from the {1} SDK.
+			ErrorHelper.ParseWarningLevel (ErrorHelper.WarningLevel.Disable, "4190"); // The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.
+		}
 	}
 }

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -129,6 +129,13 @@ namespace Xamarin.Bundler {
 					throw ErrorHelper.CreateError (26, ex, Errors.MX0026, "--nowarn", ex.Message);
 				}
 			});
+			options.Add ("warn:", "An optional comma-separated list of warning codes to report as warnings (if no warnings are specified all warnings reported).", v => {
+				try {
+					ErrorHelper.ParseWarningLevel (ErrorHelper.WarningLevel.Warning, v);
+				} catch (Exception ex) {
+					throw ErrorHelper.CreateError (26, ex, Errors.MX0026, "--warn", ex.Message);
+				}
+			});
 			options.Add ("coop:", "If the GC should run in cooperative mode.", v => { app.EnableCoopGC = ParseBool (v, "coop"); }, hidden: true);
 			options.Add ("sgen-conc", "Enable the *experimental* concurrent garbage collector.", v => { app.EnableSGenConc = true; });
 			options.Add ("marshal-objectivec-exceptions:", "Specify how Objective-C exceptions should be marshalled. Valid values: default, unwindmanagedcode, throwmanagedexception, abort and disable. The default depends on the target platform (on watchOS the default is 'throwmanagedexception', while on all other platforms it's 'disable').", v => {

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -351,6 +351,13 @@ namespace Xamarin.Linker {
 						throw new InvalidOperationException ($"Invalid Verbosity '{value}' in {linker_file}");
 					Driver.Verbosity += verbosity;
 					break;
+				case "Warn":
+					try {
+						ErrorHelper.ParseWarningLevel (ErrorHelper.WarningLevel.Warning, value);
+					} catch (Exception ex) {
+						throw new InvalidOperationException ($"Invalid Warn '{value}' in {linker_file}", ex);
+					}
+					break;
 				case "WarnAsError":
 					try {
 						ErrorHelper.ParseWarningLevel (ErrorHelper.WarningLevel.Error, value);


### PR DESCRIPTION
Ignore a few warnings by default, when reporting about types that we couldn't register because they're deprecated/removed.

Also add a way to re-enable these warnings.

Fixes https://github.com/xamarin/xamarin-macios/issues/20670.