### PR TITLE
[build] Parameterize the .NET download script url.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -107,8 +107,10 @@ print-dotnet-pkg-urls: dotnet-install.sh
 	$(Q) if ! test -f $@-found-it.stamp; then echo "No working urls were found."; exit 1; fi
 	$(Q) rm -f $@-found-it.stamp
 
+DOTNET_DOWNLOAD_URL?=https://dot.net/v1/dotnet-install.sh
+
 dotnet-install.sh: Makefile
-	$(Q) $(CURL_RETRY) https://dot.net/v1/dotnet-install.sh --output $@.tmp
+	$(Q) $(CURL_RETRY) $(DOTNET_DOWNLOAD_URL) --output $@.tmp
 	$(Q) chmod +x $@.tmp
 	$(Q) mv $@.tmp $@
 


### PR DESCRIPTION
This way it can easily be overridden when building from the command line (to
provide a different url if the normal url doesn't work for some temporary
reason).