### PR TITLE
[Foundation] Make the generic collection classes' generic GetEnumerator methods public.

### DIFF
--- a/src/Foundation/NSArray.cs
+++ b/src/Foundation/NSArray.cs
@@ -476,7 +476,9 @@ namespace Foundation {
 			return ToArray<NSObject> ();
 		}
 
-		IEnumerator<NSObject> IEnumerable<NSObject>.GetEnumerator ()
+		/// <summary>Returns an enumerator that iterates through the array.</summary>
+		/// <returns>An enumerator that can be used to iterate through the array.</returns>
+		public IEnumerator<NSObject> GetEnumerator ()
 		{
 			return new NSFastEnumerator<NSObject> (this);
 		}

--- a/src/Foundation/NSArray_1.cs
+++ b/src/Foundation/NSArray_1.cs
@@ -77,7 +77,9 @@ namespace Foundation {
 		}
 
 		#region IEnumerable<TKey>
-		IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator ()
+		/// <summary>Returns an enumerator that iterates through the array.</summary>
+		/// <returns>An enumerator that can be used to iterate through the array.</returns>
+		public new IEnumerator<TKey> GetEnumerator ()
 		{
 			return new NSFastEnumerator<TKey> (this);
 		}

--- a/src/Foundation/NSDictionary.cs
+++ b/src/Foundation/NSDictionary.cs
@@ -395,6 +395,8 @@ namespace Foundation {
 			return GetEnumerator ();
 		}
 
+		/// <summary>Returns an enumerator that iterates through the dictionary.</summary>
+		/// <returns>An enumerator that can be used to iterate through the dictionary.</returns>
 		public IEnumerator<KeyValuePair<NSObject, NSObject>> GetEnumerator ()
 		{
 			foreach (var key in Keys) {

--- a/src/Foundation/NSIndexSet.cs
+++ b/src/Foundation/NSIndexSet.cs
@@ -47,6 +47,8 @@ namespace Foundation {
 			}
 		}
 
+		/// <summary>Returns an enumerator that iterates through the set.</summary>
+		/// <returns>An enumerator that can be used to iterate through the set.</returns>
 		public IEnumerator<nuint> GetEnumerator ()
 		{
 			if (this.Count == 0)

--- a/src/Foundation/NSMutableArray_1.cs
+++ b/src/Foundation/NSMutableArray_1.cs
@@ -185,6 +185,8 @@ namespace Foundation {
 		}
 
 		#region IEnumerable<T> implementation
+		/// <summary>Returns an enumerator that iterates through the array.</summary>
+		/// <returns>An enumerator that can be used to iterate through the array.</returns>
 		public IEnumerator<TValue> GetEnumerator ()
 		{
 			return new NSFastEnumerator<TValue> (this);

--- a/src/Foundation/NSMutableDictionary.cs
+++ b/src/Foundation/NSMutableDictionary.cs
@@ -311,6 +311,8 @@ namespace Foundation {
 		#endregion
 
 		#region IEnumerable<K,V>
+		/// <summary>Returns an enumerator that iterates through the dictionary.</summary>
+		/// <returns>An enumerator that can be used to iterate through the dictionary.</returns>
 		public IEnumerator<KeyValuePair<NSObject, NSObject>> GetEnumerator ()
 		{
 			foreach (var key in Keys) {

--- a/src/Foundation/NSMutableOrderedSet_1.cs
+++ b/src/Foundation/NSMutableOrderedSet_1.cs
@@ -157,7 +157,9 @@ namespace Foundation {
 		}
 
 		#region IEnumerable<TKey>
-		IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator ()
+		/// <summary>Returns an enumerator that iterates through the set.</summary>
+		/// <returns>An enumerator that can be used to iterate through the set.</returns>
+		public new IEnumerator<TKey> GetEnumerator ()
 		{
 			return new NSFastEnumerator<TKey> (this);
 		}

--- a/src/Foundation/NSMutableSet_1.cs
+++ b/src/Foundation/NSMutableSet_1.cs
@@ -162,7 +162,9 @@ namespace Foundation {
 		}
 
 		#region IEnumerable<T> implementation
-		IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator ()
+		/// <summary>Returns an enumerator that iterates through the set.</summary>
+		/// <returns>An enumerator that can be used to iterate through the set.</returns>
+		public new IEnumerator<TKey> GetEnumerator ()
 		{
 			return new NSFastEnumerator<TKey> (this);
 		}

--- a/src/Foundation/NSOrderedSet.cs
+++ b/src/Foundation/NSOrderedSet.cs
@@ -72,6 +72,8 @@ namespace Foundation {
 			return (NSOrderedSet) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (class_ptr, Selector.GetHandle (selSetWithArray), a.Handle));
 		}
 
+		/// <summary>Returns an enumerator that iterates through the set.</summary>
+		/// <returns>An enumerator that can be used to iterate through the set.</returns>
 		public IEnumerator<NSObject> GetEnumerator ()
 		{
 			var enumerator = _GetEnumerator ();

--- a/src/Foundation/NSOrderedSet_1.cs
+++ b/src/Foundation/NSOrderedSet_1.cs
@@ -109,7 +109,9 @@ namespace Foundation {
 		}
 
 		#region IEnumerable<TKey>
-		IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator ()
+		/// <summary>Returns an enumerator that iterates through the set.</summary>
+		/// <returns>An enumerator that can be used to iterate through the set.</returns>
+		public new IEnumerator<TKey> GetEnumerator ()
 		{
 			return new NSFastEnumerator<TKey> (this);
 		}

--- a/src/Foundation/NSSet.cs
+++ b/src/Foundation/NSSet.cs
@@ -66,6 +66,8 @@ namespace Foundation {
 		}
 
 		#region IEnumerable<T>
+		/// <summary>Returns an enumerator that iterates through the set.</summary>
+		/// <returns>An enumerator that can be used to iterate through the set.</returns>
 		public IEnumerator<NSObject> GetEnumerator ()
 		{
 			var enumerator = _GetEnumerator ();

--- a/src/Foundation/NSSet_1.cs
+++ b/src/Foundation/NSSet_1.cs
@@ -127,7 +127,9 @@ namespace Foundation {
 		}
 
 		#region IEnumerable<TKey>
-		IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator ()
+		/// <summary>Returns an enumerator that iterates through the set.</summary>
+		/// <returns>An enumerator that can be used to iterate through the set.</returns>
+		public new IEnumerator<TKey> GetEnumerator ()
 		{
 			return new NSFastEnumerator<TKey> (this);
 		}

--- a/tests/monotouch-test/Foundation/NSArray1Test.cs
+++ b/tests/monotouch-test/Foundation/NSArray1Test.cs
@@ -82,6 +82,17 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+		public void IEnumerable1Test_EnumeratorType ()
+		{
+			var myEnumerable = new NSArray<NSNumber> ();
+			foreach (var item in myEnumerable) {
+				// The point of this test is to verify that the compiler finds the correct enumerator (the one returning NSNumbers, and not the one from the non-generic NSSet class returning NSObjects).
+				// This means that we don't have to actually execute this code, it's enough to make it compile.
+				Console.WriteLine (item.LongValue);
+			}
+		}
+
+		[Test]
 		public void FromNSObjectsNullTest ()
 		{
 			var str1 = (NSString) "1";

--- a/tests/monotouch-test/Foundation/NSMutableArray1Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableArray1Test.cs
@@ -233,5 +233,16 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.AreEqual (C, lst.Count, "iterator count");
 			}
 		}
+
+		[Test]
+		public void IEnumerable1Test_EnumeratorType ()
+		{
+			var myEnumerable = new NSMutableArray<NSNumber> ();
+			foreach (var item in myEnumerable) {
+				// The point of this test is to verify that the compiler finds the correct enumerator (the one returning NSNumbers, and not the one from the non-generic NSSet class returning NSObjects).
+				// This means that we don't have to actually execute this code, it's enough to make it compile.
+				Console.WriteLine (item.LongValue);
+			}
+		}
 	}
 }

--- a/tests/monotouch-test/Foundation/NSMutableOrderedSet1Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableOrderedSet1Test.cs
@@ -260,6 +260,17 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+		public void IEnumerable1Test_EnumeratorType ()
+		{
+			var myEnumerable = new NSMutableOrderedSet<NSNumber> ();
+			foreach (var item in myEnumerable) {
+				// The point of this test is to verify that the compiler finds the correct enumerator (the one returning NSNumbers, and not the one from the non-generic NSSet class returning NSObjects).
+				// This means that we don't have to actually execute this code, it's enough to make it compile.
+				Console.WriteLine (item.LongValue);
+			}
+		}
+
+		[Test]
 		public void IEnumerableTest ()
 		{
 			const int C = 16 * 2 + 3; // NSFastEnumerator has a array of size 16, use more than that, and not an exact multiple.

--- a/tests/monotouch-test/Foundation/NSMutableSet1Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableSet1Test.cs
@@ -226,6 +226,17 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+		public void IEnumerable1Test_EnumeratorType ()
+		{
+			var myEnumerable = new NSMutableSet<NSNumber> ();
+			foreach (var item in myEnumerable) {
+				// The point of this test is to verify that the compiler finds the correct enumerator (the one returning NSNumbers, and not the one from the non-generic NSSet class returning NSObjects).
+				// This means that we don't have to actually execute this code, it's enough to make it compile.
+				Console.WriteLine (item.LongValue);
+			}
+		}
+
+		[Test]
 		public void IEnumerableTest ()
 		{
 			const int C = 16 * 2 + 3; // NSFastEnumerator has a array of size 16, use more than that, and not an exact multiple.

--- a/tests/monotouch-test/Foundation/NSOrderedSet1Test.cs
+++ b/tests/monotouch-test/Foundation/NSOrderedSet1Test.cs
@@ -180,6 +180,17 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+		public void IEnumerable1Test_EnumeratorType ()
+		{
+			var myEnumerable = new NSOrderedSet<NSNumber> ();
+			foreach (var item in myEnumerable) {
+				// The point of this test is to verify that the compiler finds the correct enumerator (the one returning NSNumbers, and not the one from the non-generic NSSet class returning NSObjects).
+				// This means that we don't have to actually execute this code, it's enough to make it compile.
+				Console.WriteLine (item.LongValue);
+			}
+		}
+
+		[Test]
 		public void IEnumerableTest ()
 		{
 			const int C = 16 * 2 + 3; // NSFastEnumerator has a array of size 16, use more than that, and not an exact multiple.

--- a/tests/monotouch-test/Foundation/NSSet1Test.cs
+++ b/tests/monotouch-test/Foundation/NSSet1Test.cs
@@ -166,6 +166,17 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+		public void IEnumerable1Test_EnumeratorType ()
+		{
+			var myEnumerable = new NSSet<NSNumber> ();
+			foreach (var item in myEnumerable) {
+				// The point of this test is to verify that the compiler finds the correct enumerator (the one returning NSNumbers, and not the one from the non-generic NSSet class returning NSObjects).
+				// This means that we don't have to actually execute this code, it's enough to make it compile.
+				Console.WriteLine (item.LongValue);
+			}
+		}
+
+		[Test]
 		public void IEnumerableTest ()
 		{
 			const int C = 16 * 2 + 3; // NSFastEnumerator has a array of size 16, use more than that, and not an exact multiple.


### PR DESCRIPTION
When finding an enumerator for the given code:

```cs
var collection = new NSSet<NSNumber> ();
foreach (var item in collection) {
	// ...
}
```

the C# compiler will first look for any `GetEnumerator` methods. The non-generic `NSSet` class defines a `IEnumerator<NSObject> GetEnumerator<NSObject> ()` method, which, since the generic `NSSet<T>` class doesn't define such a method, is selected.

The end result is that the type of the foreach element is `NSObject`
(`GetEnumerator`'s return type') - which is somewhat unexpected:

```cs
var collection = new NSSet<NSNumber> ();
foreach (var item in collection) {
	Console.WriteLine (item.LongValue); // error CS1061: 'NSObject' does not contain a definition for 'LongValue'
}
```

The fix is to define a  `IEnumerator<T> GetEnumerator<T> ()` method in the
generic `NSSet<T>` class, which the C# will find and choose over the base
class' method. Then the type of the foreach element is the correct type, and
the following code works:

```cs
var collection = new NSSet<NSNumber> ();
foreach (var item in collection) {
	Console.WriteLine (item.LongValue); // it works!
}
```

Do this for all our generic collection classes.

Also document these methods + all the other public `GetEnumerator` methods.