### PR TITLE
[monotouch-test] Remove ignore for Mac Catalyst.

### DIFF
--- a/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureMetadataOutputTest.cs
@@ -38,13 +38,13 @@ namespace MonoTouchFixtures.AVFoundation {
 				if (TestRuntime.CheckSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false))
 					Assert.AreEqual (new CGRect (0, 0, 1, 1), obj.RectOfInterest, "RectOfInterest");
 
-#if !__MACCATALYST__ // https://github.com/xamarin/maccore/issues/2345
-				obj.WeakMetadataObjectTypes = null;
-				Assert.AreEqual (AVMetadataObjectType.None, obj.MetadataObjectTypes, "MetadataObjectTypes");
-				obj.MetadataObjectTypes = AVMetadataObjectType.None;
-				Assert.AreEqual (AVMetadataObjectType.None, obj.MetadataObjectTypes, "MetadataObjectTypes");
-				obj.SetDelegate (null, null);
-#endif // !__MACCATALYST__
+				if (TestRuntime.CheckXcodeVersion (13, 0)) {
+					obj.WeakMetadataObjectTypes = null;
+					Assert.AreEqual (AVMetadataObjectType.None, obj.MetadataObjectTypes, "MetadataObjectTypes");
+					obj.MetadataObjectTypes = AVMetadataObjectType.None;
+					Assert.AreEqual (AVMetadataObjectType.None, obj.MetadataObjectTypes, "MetadataObjectTypes");
+					obj.SetDelegate (null, null);
+				}
 			}
 		}
 


### PR DESCRIPTION
Apple says the bug on their side causing a runtime crash has been fixed since
macOS 12, so unignore the code and add a version check for macOS 12.

Fixes https://github.com/xamarin/maccore/issues/2345.