### PR TITLE
[siminstaller] Don't use the C# compiler server.

### DIFF
--- a/tools/siminstaller/Makefile
+++ b/tools/siminstaller/Makefile
@@ -9,7 +9,7 @@ install-local:: all-local
 
 # we build using the system .NET, because we might execute before we've downloaded our own version of .NET (i.e. while provisioning dependencies)
 $(EXECUTABLE): $(wildcard *.cs) $(wildcard *.csproj) Makefile
-	$(Q_BUILD) cd $(HOME) && dotnet build $(abspath $(CURDIR))/*.csproj "/bl:$(abspath $@.binlog)" $(DOTNET_BUILD_VERBOSITY)
+	$(Q_BUILD) cd $(HOME) && dotnet build $(abspath $(CURDIR))/*.csproj "/bl:$(abspath $@.binlog)" /p:UseSharedCompilation=false $(DOTNET_BUILD_VERBOSITY)
 	$(Q) touch $@
 
 print-simulators: $(EXECUTABLE)


### PR DESCRIPTION
The C# build server makes trouble for us, because:

* We're using parallel make, and parallel make will start a jobserver, managed
  by file descriptors, where these file descriptors must be closed in all
  subprocesses for make to realize it's done.
* 'dotnet build' might have started a build server
* The build server does not close any file descriptors it may have inherited
  when daemonizing itself.
* Thus the build server (which will still be alive after we're done building)
  might have a file descriptor open which make is waiting for.
* The proper fix is to fix the build server to close its file descriptors.
* The intermediate working is to shut down the build server instead. An
  alternative solution would be to pass /p:UseSharedCompilation=false to
  'dotnet pack' to disable the usage of the build server.
* Note that build server will exit automatically after 10 minutes of idle
  time, so the hang is only a 10 minute delay at works.

For the siminstaller, which builds using the system .NET, the simplest
solution is to just not use the build server.

This fixes a problem where the build would hang for 10 minutes after running
the system dependency check (which builds and runs siminstaller).