### PR TITLE
[devops] Copy XMA's NuGet.config to XMA's home directory.

### DIFF
--- a/tests/dotnet/Windows/collect-binlogs.sh
+++ b/tests/dotnet/Windows/collect-binlogs.sh
@@ -34,3 +34,7 @@ else
 fi
 
 ps auxww > ~/remote_build_testing/processes.txt || true
+
+ls -la ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/ >> ~/remote_build_testing/dotnet-debug.txt 2>&1 || true
+cat ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config >> ~/remote_build_testing/dotnet-debug.txt 2>&1 || true
+cat ~/Library/Caches/Xamarin/XMA/SDKs/.home/.nuget/NuGet/NuGet.Config >> ~/remote_build_testing/dotnet-debug.txt 2>&1  || true

--- a/tools/devops/automation/scripts/prepare-for-remote-tests.sh
+++ b/tools/devops/automation/scripts/prepare-for-remote-tests.sh
@@ -5,3 +5,11 @@
 mkdir -p ~/Library/Caches/Xamarin/XMA/SDKs
 cp -cRH "$BUILD_SOURCESDIRECTORY"/xamarin-macios/builds/downloads/dotnet ~/Library/Caches/Xamarin/XMA/SDKs
 sed '/local-tests-feed/d' "$BUILD_SOURCESDIRECTORY"/xamarin-macios/NuGet.config > ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config
+
+mkdir -p ~/Library/Caches/Xamarin/XMA/SDKs/.home/.nuget/NuGet/
+cp ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config ~/Library/Caches/Xamarin/XMA/SDKs/.home/.nuget/NuGet/NuGet.Config
+
+# some diagnostics
+cat ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config
+cd ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/
+./dotnet --info || true


### PR DESCRIPTION
This way we're using the same NuGet configuration even when executing outside
of XMA's .NET directory.

Also collect a bit more diagnostic info.