### PR TITLE
[msbuild] Add support for signing with the placeholder key.

### DIFF
--- a/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
+++ b/msbuild/Xamarin.HotRestart.PreBuilt/Xamarin.PreBuilt.iOS/Xamarin.PreBuilt.iOS.csproj
@@ -14,8 +14,9 @@
     <_LinkMode>None</_LinkMode>
     <UseInterpreter>true</UseInterpreter>
     <MtouchExtraArgs>--registrar:dynamic</MtouchExtraArgs>
-    <!-- disable code signing unless we're building in CI, to avoid requiring code signing during developer builds (who will usually never need the prebuilt app) -->
-    <EnableCodeSigning Condition="'$(BUILD_REVISION)' == ''">false</EnableCodeSigning>
+    <!-- Use a placeholder signing key, which simplifies our build (no need for an actual certificate). -->
+    <!-- The app will have to be signed on the end user machine anyway, so this shouldn't have any real effect. -->
+    <CodesignKey>-</CodesignKey>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.iOS.HotRestart.Application" Version="1.1.5" />

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSigningIdentity.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSigningIdentity.cs
@@ -287,7 +287,7 @@ namespace Xamarin.MacDev.Tasks {
 		void ReportDetectedCodesignInfo ()
 		{
 			Log.LogMessage (MessageImportance.High, MSBStrings.M0125);
-			if (codesignCommonName is not null)
+			if (codesignCommonName is not null || !string.IsNullOrEmpty (DetectedCodeSigningKey))
 				Log.LogMessage (MessageImportance.High, "  Code Signing Key: \"{0}\" ({1})", codesignCommonName, DetectedCodeSigningKey);
 			if (provisioningProfileName is not null)
 				Log.LogMessage (MessageImportance.High, "  Provisioning Profile: \"{0}\" ({1})", provisioningProfileName, DetectedProvisioningProfile);
@@ -572,6 +572,13 @@ namespace Xamarin.MacDev.Tasks {
 
 			identity.BundleId = BundleIdentifier;
 			DetectedAppId = BundleIdentifier; // default value that can be changed below
+
+			// If the developer chooses to use the placeholder codesigning key, accept that.
+			if (SigningKey == "-") {
+				DetectedCodeSigningKey = SigningKey;
+				ReportDetectedCodesignInfo ();
+				return !Log.HasLoggedErrors;
+			}
 
 			if (Platform == ApplePlatform.MacOSX) {
 				if (!RequireCodeSigning || !string.IsNullOrEmpty (DetectedCodeSigningKey)) {


### PR DESCRIPTION
Add support for signing with a placeholder key ("-") from the developer, and
then use this to sign the prebuilt HotRestart app this way.

The app will have to be signed anyway on the end user machine, so this
shouldn't have any real effect.

This simplifies our build (both locally and on bots), because we won't need a
certificate around to do the actual signing.