### PR TITLE
[CI] We must pass the signing too in order to be able to push nugets.

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -109,7 +109,7 @@ stages:
     # Check - "xamarin-macios (Prepare Release Push NuGets)"
     - job: push_signed_nugets
       displayName: Push NuGets
-      dependsOn: nuget_convert
+      dependsOn: [signing, nuget_convert]
       condition: "ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')"
       variables:
       - name: skipNugetSecurityAnalysis

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -110,7 +110,7 @@ stages:
     - job: push_signed_nugets
       displayName: Push NuGets
       dependsOn: [signing, nuget_convert]
-      condition: "ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')"
+      condition: "and(or(eq(dependencies.signing.result, 'Succeeded'),eq(dependencies.nuget_convert.result, 'Succeeded')), ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],''))"
       variables:
       - name: skipNugetSecurityAnalysis
         value: true

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -110,7 +110,7 @@ stages:
     - job: push_signed_nugets
       displayName: Push NuGets
       dependsOn: [signing, nuget_convert]
-      condition: "and(or(eq(dependencies.signing.result, 'Succeeded'),eq(dependencies.nuget_convert.result, 'Succeeded')), ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],''))"
+      condition: "and(eq(dependencies.signing.result, 'Succeeded'),eq(dependencies.nuget_convert.result, 'Succeeded'), ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],''))"
       variables:
       - name: skipNugetSecurityAnalysis
         value: true


### PR DESCRIPTION
We need to depend on both stages, else we run as soon as the convert is skipped. Makes no sense but VSTS is like this.

Waiting for https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9845461&view=results