### PR TITLE
[system-dependencies] Split simulator installation.

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -11,6 +11,7 @@ VERBOSE=
 
 OPTIONAL_SHARPIE=1
 OPTIONAL_SIMULATORS=1
+OPTIONAL_OLD_SIMULATORS=1
 
 # parse command-line arguments
 while ! test -z $1; do
@@ -75,6 +76,12 @@ while ! test -z $1; do
 			unset IGNORE_SIMULATORS
 			shift
 			;;
+		--provision-old-simulators)
+			PROVISION_OLD_SIMULATORS=1
+			unset OPTIONAL_OLD_SIMULATORS
+			unset IGNORE_OLD_SIMULATORS
+			shift
+			;;
 		--provision-dotnet)
 			PROVISION_DOTNET=1
 			unset IGNORE_DOTNET
@@ -109,6 +116,8 @@ while ! test -z $1; do
 			unset IGNORE_SHARPIE
 			PROVISION_SIMULATORS=1
 			unset IGNORE_SIMULATORS
+			PROVISION_OLD_SIMULATORS=1
+			unset IGNORE_OLD_SIMULATORS
 			PROVISION_PYTHON3=1
 			unset IGNORE_PYTHON3
 			PROVISION_DOTNET=1
@@ -994,9 +1003,9 @@ function check_objective_sharpie () {
 	fi
 }
 
-function check_simulators ()
+function check_old_simulators ()
 {
-	if test -n "$IGNORE_SIMULATORS"; then return; fi
+	if test -n "$IGNORE_OLD_SIMULATORS"; then return; fi
 
 	local EXTRA_SIMULATORS
 	local XCODE
@@ -1024,7 +1033,7 @@ function check_simulators ()
 
 	if ! FAILED_SIMULATORS=$(make -C tools/siminstaller only-check INSTALL_SIMULATORS="$INSTALL_SIMULATORS" 2>/dev/null); then
 		local action=warn
-		if test -z $OPTIONAL_SIMULATORS; then
+		if test -z $OPTIONAL_OLD_SIMULATORS; then
 			action=fail
 		fi
 		if [[ "$FAILED_SIMULATORS" =~ "Unknown simulators:" ]]; then
@@ -1034,7 +1043,7 @@ function check_simulators ()
 			$action "    and then update the ${COLOR_MAGENTA}MIN_<OS>_SIMULATOR_VERSION${COLOR_RESET} and ${COLOR_MAGENTA}EXTRA_SIMULATORS${COLOR_RESET} variables in Make.config to the earliest available simulators."
 			$action "    Another possibility is that Apple is not shipping any simulators (yet?) for the new version of Xcode (if the previous list shows no simulators)."
 		else
-			if ! test -z $PROVISION_SIMULATORS; then
+			if ! test -z $PROVISION_OLD_SIMULATORS; then
 				if ! make -C tools/siminstaller install-simulators INSTALL_SIMULATORS="$INSTALL_SIMULATORS"; then
 					$action "Failed to install extra simulators."
 				else
@@ -1063,7 +1072,7 @@ check_mono
 check_cmake
 check_7z
 check_objective_sharpie
-check_simulators
+check_old_simulators
 if test -z "$IGNORE_DOTNET"; then
 	ok "Installed .NET SDKs:"
 	(IFS=$'\n'; for i in $(/usr/local/share/dotnet/dotnet --list-sdks); do log "$i"; done)

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -76,6 +76,9 @@ parameters:
   type: number
   default: 3
 
+- name: XcodeChannel
+  type: string
+
 steps:
 
 - template: ../common/checkout.yml
@@ -279,9 +282,18 @@ steps:
 - bash: |
     set -x
     set -e
-    $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators --ignore-shellcheck --ignore-yamllint
+    ARGS=()
+    ARGS+=(--provision-simulators)
+    if [[ "$XCODE_CHANNEL" == "Beta" ]]; then
+      ARGS+=(--provision-old-simulators)
+    fi
+    ARGS+=(--ignore-shellcheck)
+    ARGS+=(--ignore-yamllint)
+    $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh "${ARGS[@]}"
   displayName: 'Provision simulators'
   timeoutInMinutes: 250
+  env:
+    XCODE_CHANNEL: ${{ parameters.XcodeChannel }}
 
 # clean sims incase we were left in a strange state
 - bash: |

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -139,3 +139,4 @@ stages:
         makeTarget: ${{ parameters.makeTarget }}
         gitHubToken: ${{ parameters.gitHubToken }}
         xqaCertPass: ${{ parameters.xqaCertPass }}
+        XcodeChannel: ${{ parameters.XcodeChannel }}


### PR DESCRIPTION
Split installing new and old simulators, so that we can choose to only install
the old simulators if we want so.

And then only install the old simulators when we're doing beta builds, because
that's the only time we need them.