### PR TITLE
[dotnet] Force 'AppendRuntimeIdentifierToOutputPath=true' for the inner build of universal apps.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -386,10 +386,12 @@
 		</PropertyGroup>
 
 		<!-- Execute the inner builds -->
+		<!-- We force AppendRuntimeIdentifierToOutputPath=true because otherwise the inner builds might end up writing to the same directory -->
 		<MSBuild
 			Projects="$(MSBuildProjectFile)"
 			Targets="_BuildRidSpecificAppBundle"
 			Properties="
+				AppendRuntimeIdentifierToOutputPath=true;
 				RuntimeIdentifier=%(_RuntimeIdentifiersAsItems.Identity);
 				_CodesignItemsPath=%(_RuntimeIdentifiersAsItems.RidSpecificCodesignItemsPath);
 				_MtouchSymbolsList=%(_RuntimeIdentifiersAsItems.RidSpecificSymbolsListPath);

--- a/tests/dotnet/MySimpleApp/Directory.Build.props
+++ b/tests/dotnet/MySimpleApp/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup Condition="'$(SetAppendRuntimeIdentifierToOutputPathToFalse)' == 'true'">
+		<!-- Used by the AppendRuntimeIdentifierToOutputPath_* tests -->
+		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+	</PropertyGroup>
+	<Import Project="$(MSBuildThisFileDirectory)../../../Directory.Build.props" />
+</Project>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1984,5 +1984,37 @@ namespace Xamarin.Tests {
 				ExecuteWithMagicWordAndAssert (appExecutable);
 			}
 		}
+
+		[Test]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64")]
+		public void AppendRuntimeIdentifierToOutputPath_DisableCommandLine (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["cmdline:AppendRuntimeIdentifierToOutputPath"] = "false";
+			DotNet.AssertBuild (project_path, properties);
+		}
+
+		[Test]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64")]
+		public void AppendRuntimeIdentifierToOutputPath_DisableDirectoryBuildProps (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["SetAppendRuntimeIdentifierToOutputPathToFalse"] = "true";
+			DotNet.AssertBuild (project_path, properties);
+		}
 	}
 }


### PR DESCRIPTION
When building universal apps, each inner build must add the runtime identifier
to the output path, otherwise the inner builds may conflict with eachother,
overwriting eachother's files.

That's bad.

So we explicitly set `AppendRuntimeIdentifierToOutputPath` to `true` when
building inner builds.