### PR TITLE
[dotnet] Limit custom dotnet/runtime selection to the current .NET version.

### DIFF
--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -9,19 +9,16 @@
 		<KnownFrameworkReference Update="Microsoft.NETCore.App.Mono" RuntimeFrameworkVersion="$(CUSTOM_DOTNET_VERSION)" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TRACKING_DOTNET_RUNTIME_SEPARATELY)' != ''">
-		<KnownFrameworkReference Update="Microsoft.NETCore.App">
-			<RuntimeFrameworkVersion>$(MicrosoftNETCoreAppRefPackageVersion)</RuntimeFrameworkVersion>
-		</KnownFrameworkReference>
-	</ItemGroup>
-
 	<Target
 			Name="UpdateKnownRuntimePackWithCustomRuntime"
 			Condition="'$(TRACKING_DOTNET_RUNTIME_SEPARATELY)' != ''"
 			BeforeTargets="ProcessFrameworkReferences">
 		<ItemGroup>
-				<KnownRuntimePack Update="Microsoft.NETCore.App">
-					<LatestRuntimeFrameworkVersion>$(MicrosoftNETCoreAppRefPackageVersion)</LatestRuntimeFrameworkVersion>
+			<KnownFrameworkReference Update="Microsoft.NETCore.App" Condition="'%(TargetFramework)' == 'net$(BundledNETCoreAppTargetFrameworkVersion)'">
+				<RuntimeFrameworkVersion>$(MicrosoftNETCoreAppRefPackageVersion)</RuntimeFrameworkVersion>
+			</KnownFrameworkReference>
+			<KnownRuntimePack Update="Microsoft.NETCore.App"  Condition="'%(TargetFramework)' == 'net$(BundledNETCoreAppTargetFrameworkVersion)'">
+				<LatestRuntimeFrameworkVersion>$(MicrosoftNETCoreAppRefPackageVersion)</LatestRuntimeFrameworkVersion>
 			</KnownRuntimePack>
 		</ItemGroup>
 	</Target>


### PR DESCRIPTION
This way any tests using the previous .NET version still works.