### PR TITLE
[devops] Simplify logic to provision simulators.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -159,14 +159,8 @@ steps:
     AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_P12: ${{ parameters.xqaCertPass }}
     AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_2_P12: ${{ parameters.xqaCertPass }}
 
-# only install all the simulators when working on a PR, EO machines do not allow use to perform this step 
-- ${{ if parameters.isPR }}:
-  - bash: $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators --ignore-shellcheck --ignore-yamllint
-    displayName: 'Provision simulators'
-- ${{ else }}:
-  - bash: |
-      xcodebuild -downloadPlatform iOS
-    displayName: 'Provision simulators'
+- bash: $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators --ignore-shellcheck --ignore-yamllint
+  displayName: 'Provision simulators'
 
 # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we 
 # are using the cache. Mono does not get bump a lot of times if any (after dotnet)


### PR DESCRIPTION
The system-dependencies.sh script has been updated to install latest and older simulators separately, so --provision-simulators will only provision the latest simulators (using 'xcodebuild -downloadPlatform ...').

This works on all machines, for both PRs and non-PRs, so make it the actual code path in both cases.