### PR TITLE
[CoreBluetooth] Implement Xcode 16.0 beta 1, beta 2 and beta 3 changes.

### DIFF
--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -877,6 +877,10 @@ namespace CoreBluetooth {
 		NSString CharacteristicValidRangeString { get; }
 #endif
 
+		[Watch (11, 0), TV (18, 0), Mac (15, 0), iOS (18, 0), MacCatalyst (18, 0)]
+		[Field ("CBUUIDCharacteristicObservationScheduleString")]
+		NSString CharacteristicObservationScheduleString { get; }
+
 		[MacCatalyst (13, 1)]
 		[Field ("CBUUIDL2CAPPSMCharacteristicString")]
 		NSString L2CapPsmCharacteristicString { get; }

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreBluetooth.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreBluetooth.todo
@@ -1,1 +1,0 @@
-!missing-field! CBUUIDCharacteristicObservationScheduleString not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreBluetooth.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreBluetooth.todo
@@ -1,1 +1,0 @@
-!missing-field! CBUUIDCharacteristicObservationScheduleString not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreBluetooth.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreBluetooth.todo
@@ -1,1 +1,0 @@
-!missing-field! CBUUIDCharacteristicObservationScheduleString not bound

--- a/tests/xtro-sharpie/iOS-CoreBluetooth.todo
+++ b/tests/xtro-sharpie/iOS-CoreBluetooth.todo
@@ -1,1 +1,0 @@
-!missing-field! CBUUIDCharacteristicObservationScheduleString not bound

--- a/tests/xtro-sharpie/macOS-CoreBluetooth.todo
+++ b/tests/xtro-sharpie/macOS-CoreBluetooth.todo
@@ -1,1 +1,0 @@
-!missing-field! CBUUIDCharacteristicObservationScheduleString not bound

--- a/tests/xtro-sharpie/tvOS-CoreBluetooth.todo
+++ b/tests/xtro-sharpie/tvOS-CoreBluetooth.todo
@@ -1,1 +1,0 @@
-!missing-field! CBUUIDCharacteristicObservationScheduleString not bound

--- a/tests/xtro-sharpie/watchOS-CoreBluetooth.todo
+++ b/tests/xtro-sharpie/watchOS-CoreBluetooth.todo
@@ -1,1 +1,0 @@
-!missing-field! CBUUIDCharacteristicObservationScheduleString not bound


### PR DESCRIPTION
Note: there were no changes in beta 2 or beta 3.