### PR TITLE
[CoreTelephony] Implement Xcode 16.0 beta 1, beta 2 and beta 3 changes.

### DIFF
--- a/src/coretelephony.cs
+++ b/src/coretelephony.cs
@@ -228,8 +228,6 @@ namespace CoreTelephony {
 	partial interface CTSubscriber {
 		[Export ("carrierToken")]
 		[NullAllowed]
-		[Deprecated (PlatformName.iOS, 11, 0)]
-		[Deprecated (PlatformName.MacCatalyst, 13, 1)]
 		NSData CarrierToken { get; }
 
 		[iOS (12, 1)]
@@ -244,6 +242,14 @@ namespace CoreTelephony {
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
 		ICTSubscriberDelegate Delegate { get; set; }
+
+		// available since iOS 6 according to the headers
+		[Export ("refreshCarrierToken")]
+		bool RefreshCarrierToken ();
+
+		[iOS (18, 0)]
+		[Export ("SIMInserted")]
+		bool IsSimInserted { [Bind ("isSIMInserted")] get; }
 	}
 
 	/// <summary>Information on a subscriber to a telephone service.</summary>

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreTelephony.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreTelephony.todo
@@ -1,5 +1,3 @@
-!missing-selector! CTSubscriber::isSIMInserted not bound
-!missing-selector! CTSubscriber::refreshCarrierToken not bound
 !unknown-native-enum! CTCellularDataRestrictedState bound
 !unknown-native-enum! CTCellularPlanProvisioningAddPlanResult bound
 !unknown-type! CTCellularData bound

--- a/tests/xtro-sharpie/iOS-CoreTelephony.todo
+++ b/tests/xtro-sharpie/iOS-CoreTelephony.todo
@@ -1,5 +1,3 @@
-!missing-selector! CTSubscriber::isSIMInserted not bound
-!missing-selector! CTSubscriber::refreshCarrierToken not bound
 !unknown-native-enum! CTCellularDataRestrictedState bound
 !unknown-native-enum! CTCellularPlanProvisioningAddPlanResult bound
 !unknown-type! CTCellularData bound


### PR DESCRIPTION
Note: there were no changes in beta 2 and beta 3.