### PR TITLE
[CI] Allow to execute the push even when we have had warnings.

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -115,7 +115,17 @@ stages:
     - job: push_signed_nugets
       displayName: Push NuGets
       dependsOn: [signing, nuget_convert]
-      condition: "and(eq(dependencies.signing.result, 'Succeeded'),eq(dependencies.nuget_convert.result, 'Succeeded'), ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],''))"
+      condition: and(
+          or(
+            eq(dependencies.signing.result, 'Succeeded'), 
+            eq(dependencies.signing.result, 'SucceededWithIssues')
+          ),
+          or(
+            eq(dependencies.nuget_convert.result, 'Succeeded'), 
+            eq(dependencies.nuget_convert.result, 'SucceededWithIssues')
+          ),
+          ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')
+        )
       variables:
       - name: skipNugetSecurityAnalysis
         value: true


### PR DESCRIPTION
If we get a warning from one of the governance tools, not an error but a warning, we should be allowed to push to the nuget feeds.