### PR TITLE
Revert "[ci] Improve maestro artifact publishing (#20665)"

### DIFF
--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -53,6 +53,7 @@
   <!-- it overwrites packageType -->
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" Condition="'$(PackageType)' != 'Template'" />
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetSharedFrameworkTaskFile)" Condition="'$(PackageType)' != 'Template'" />
+  <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
 
   <Target Name="_GenerateFrameworkListFile" Condition=" '$(_CreateFrameworkList)' == 'true' Or '$(_CreateRuntimeList)' == 'true' ">
     <!-- https://github.com/dotnet/runtime/blob/0647ec314948904319da5eb15e9931f7c85ed1e2/src/installer/pkg/projects/Directory.Build.targets#L281 -->
@@ -112,26 +113,15 @@
     </Content>
   </ItemGroup>
 
-  <!-- https://github.com/dotnet/arcade/blob/efc3da96e5ac110513e92ebd9ef87c73f44d8540/Documentation/DependencyFlowOnboardingWithoutArcade.md -->
-  <Target Name="PushManifestToBuildAssetRegistry" >
-    <PropertyGroup>
-      <ArtifactsLogDir>$(BarManifestOutputPath)</ArtifactsLogDir>
-      <AssetManifestFileName>Assets.xml</AssetManifestFileName>
-      <AssetManifestPath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName)</AssetManifestPath>
-    </PropertyGroup>
-
-    <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
-
+  <Target Name="GenerateBuildAssetRegistryManifest" >
     <ItemGroup>
-      <ItemsToPush Include="$(NupkgPath)\*.nupkg" />
+      <BuildArtifacts Include="$(NupkgPath)\Microsoft*.$(_PlatformName).*.nupkg" />
     </ItemGroup>
 
-    <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />
-
-    <Message Text="Publishing %(ItemsToPush.Identity)" Importance="normal" />
+    <Error Condition="'@(BuildArtifacts)' == ''" Text="No packages to create manifest from." />
 
     <ItemGroup>
-      <ManifestBuildData Include="InitialAssetsLocation=" />
+      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
       <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
       <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
@@ -140,25 +130,31 @@
       <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
     </ItemGroup>
 
-    <PushToAzureDevOpsArtifacts
-        ItemsToPush="@(ItemsToPush)"
-        ManifestBuildData="@(ManifestBuildData)"
-        ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"
-        ManifestBranch="$(BUILD_SOURCEBRANCH)"
-        ManifestBuildId="$(BUILD_BUILDNUMBER)"
-        ManifestCommit="$(BUILD_SOURCEVERSION)"
-        AssetManifestPath="$(AssetManifestPath)"
+    <GenerateBuildManifest
+        Artifacts="@(BuildArtifacts)"
+        OutputPath="$(BarManifestOutputPath)\AssetManifest.xml"
+        BuildId="$(BUILD_BUILDNUMBER)"
+        BuildData="@(ManifestBuildData)"
+        RepoUri="$(BUILD_REPOSITORY_URI)"
+        RepoBranch="$(BUILD_SOURCEBRANCH)"
+        RepoCommit="$(BUILD_SOURCEVERSION)"
         PublishingVersion="3" />
+  </Target>
+
+  <Target Name="PushManifestToBuildAssetRegistry" >
+    <PropertyGroup>
+      <VersionPrefix>1.0.0</VersionPrefix>
+    </PropertyGroup>
 
     <MSBuild
         Targets="Restore"
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(_RepositoryPath);VersionPrefix=$(_PackageVersion);NuGetPackageRoot=$(_RepositoryPath)\packages\"
+        Properties="Configuration=$(Configuration);RepoRoot=$(_RepositoryPath);VersionPrefix=$(VersionPrefix);NuGetPackageRoot=$(_RepositoryPath)\packages\"
     />
 
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(_RepositoryPath);VersionPrefix=$(_PackageVersion);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net;NuGetPackageRoot=$(_RepositoryPath)\packages\"
+        Properties="Configuration=$(Configuration);RepoRoot=$(_RepositoryPath);VersionPrefix=$(VersionPrefix);ManifestsPath=$(BarManifestOutputPath);MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com;NuGetPackageRoot=$(_RepositoryPath)\packages\"
     />
   </Target>
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -70,9 +70,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="8.0.0-beta.24225.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.21212.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>67d23f4ba1813b315e7e33c71d18b63475f5c5f8</Sha>
+      <Sha>db49d790a4bfa977a9ed7436bf2aa242cefae45e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-alpha.1.21601.1">
       <Uri>https://github.com/dotnet/templating</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <MicrosoftDotnetSdkInternalPackageVersion>8.0.107-servicing.24324.1</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>8.0.5</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETILLinkPackageVersion>8.0.0-rtm.23524.7</MicrosoftNETILLinkPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>8.0.0-beta.24225.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>8.0.5</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>8.0.0-rtm.23511.3</MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>
     <MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>8.0.0</MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -45,11 +45,6 @@ parameters:
   displayName: 'Push Nugets (dotnet)'
   default: true
 
-- name: pushNugetsToMaestro
-  type: boolean
-  displayName: 'Push Nugets (Maestro)'
-  default: true
-
 - name: testConfigurations
   displayName: Test configurations to run
   type: object
@@ -256,7 +251,6 @@ extends:
         forceInsertion: ${{ parameters.forceInsertion }}
         skipESRP: ${{ parameters.skipESRP }}
         pushNugets: ${{ parameters.pushNugets }}
-        pushNugetsToMaestro: ${{ parameters.pushNugetsToMaestro }}
         ${{ if ne(length(parameters.testConfigurations), 0)}}:
           testConfigurations: ${{ parameters.testConfigurations }}
         deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -246,7 +246,6 @@ extends:
         forceInsertion: ${{ parameters.forceInsertion }}
         skipESRP: ${{ parameters.skipESRP }}
         pushNugets: false
-        pushNugetsToMaestro: false
         ${{ if ne(length(parameters.testConfigurations), 0)}}:
           testConfigurations: ${{ parameters.testConfigurations }}
         deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}

--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -1,6 +1,5 @@
 # YAML pipeline for post build operations. 
 # This pipeline will trigger automatically after successful completion of the `prepare_release` stage against the specified branches.
-# NOTE: This pipeline is now deprecated, maestro publishing has been moved to the "Prepare .NET Release" stage
 
 trigger: none
 pr: none
@@ -34,9 +33,11 @@ resources:
     source: xamarin-macios-ci
     trigger:
       branches:
+      - main
       - release/*
       - net7.0
       - net8.0
+      - net9.0
       - release-test/* # this is for testing the release pipeline on branches without GitHub's branch protection (so we can automate tests without requiring commits to go through pull requests, etc.).
       stages:
       - prepare_release
@@ -110,7 +111,7 @@ jobs:
   # Iterate over each build we pushed and add it to the default channel.
   - powershell: |
       Write-Host "Processing platforms: '$Env:CONFIGURATION_DOTNET_PLATFORMS'"
-      $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
+      $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
       $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
       $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
       $dotnetPlatforms = "$Env:CONFIGURATION_DOTNET_PLATFORMS".Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
@@ -118,7 +119,7 @@ jobs:
       foreach ($platform in $dotnetPlatforms) {
         $envVar = "ENVIRONMENT_REDIRECT_$($platform.ToUpper())_BARBUILDID"
         $barBuildId = [Environment]::GetEnvironmentVariable($envVar)
-        & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $barBuildId --publishing-infra-version 3 --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+        & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $barBuildId --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
         Write-Host "Added $($platform) bar build id: $($barBuildId)"
       }
     displayName: Add builds to default darc channel

--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -33,11 +33,9 @@ resources:
     source: xamarin-macios-ci
     trigger:
       branches:
-      - main
       - release/*
       - net7.0
       - net8.0
-      - net9.0
       - release-test/* # this is for testing the release pipeline on branches without GitHub's branch protection (so we can automate tests without requiring commits to go through pull requests, etc.).
       stages:
       - prepare_release
@@ -111,7 +109,7 @@ jobs:
   # Iterate over each build we pushed and add it to the default channel.
   - powershell: |
       Write-Host "Processing platforms: '$Env:CONFIGURATION_DOTNET_PLATFORMS'"
-      $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
+      $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
       $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
       $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
       $dotnetPlatforms = "$Env:CONFIGURATION_DOTNET_PLATFORMS".Split(' ', [StringSplitOptions]::RemoveEmptyEntries)

--- a/tools/devops/automation/templates/build/build-nugets.yml
+++ b/tools/devops/automation/templates/build/build-nugets.yml
@@ -42,7 +42,7 @@ steps:
     displayName: 'Generate Build Asset Registry Manifest for ${{ platform.platform }}'
     condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'), ne(variables['${{ platform.conditionVariable }}'],''))
 
-- task: PublishPipelineArtifact@1
+- task: 1ES.PublishPipelineArtifact@1
   displayName: 'Publish Artifact: AssetManifests'
   inputs:
     targetPath: $(Build.SourcesDirectory)/xamarin-macios/_build/nupkgs/bar-manifests
@@ -50,7 +50,7 @@ steps:
   continueOnError: true
   condition: and(succeededOrFailed(), contains(variables['configuration.BuildNugets'], 'True'), ne(variables['ENABLE_DOTNET'],''))
 
-- task: PublishPipelineArtifact@1
+- task: 1ES.PublishPipelineArtifact@1
   displayName: 'Publish Artifact: build-binlogs'
   inputs:
     targetPath: $(Build.ArtifactStagingDirectory)/build-binlogs

--- a/tools/devops/automation/templates/build/build-nugets.yml
+++ b/tools/devops/automation/templates/build/build-nugets.yml
@@ -1,0 +1,59 @@
+# all steps that are required to build the nugets
+
+parameters:
+
+- name: dotnetPlatforms
+  type: object
+  default: [
+    {
+      platform: iOS,
+      conditionVariable: "INCLUDE_DOTNET_IOS"
+    },
+    {
+      platform: tvOS,
+      conditionVariable: "INCLUDE_DOTNET_TVOS"
+    },
+    {
+      platform: macOS,
+      conditionVariable: "INCLUDE_DOTNET_MACOS"
+    },
+    {
+      platform: MacCatalyst,
+      conditionVariable: "INCLUDE_DOTNET_MACCATALYST"
+    }]
+
+- name: uploadPrefix
+  type: string
+  default: '$(MaciosUploadPrefix)'
+
+steps:
+
+- bash: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/build-nugets.sh
+  displayName: 'Build Nugets'
+  condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'), ne(variables['ENABLE_DOTNET'],''))
+  continueOnError: true # should not stop the build since is not official just yet.
+  timeoutInMinutes: 180
+
+- ${{ each platform in parameters.dotnetPlatforms }}:
+  - script: >-
+      dotnet build -t:GenerateBuildAssetRegistryManifest /v:n
+      $(Build.SourcesDirectory)/xamarin-macios/dotnet/package/Microsoft.${{ platform.platform }}.Ref/package.csproj
+      -bl:$(Build.ArtifactStagingDirectory)/build-binlogs/generate-bar-manifest-${{ platform.platform }}.binlog
+    displayName: 'Generate Build Asset Registry Manifest for ${{ platform.platform }}'
+    condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'), ne(variables['${{ platform.conditionVariable }}'],''))
+
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish Artifact: AssetManifests'
+  inputs:
+    targetPath: $(Build.SourcesDirectory)/xamarin-macios/_build/nupkgs/bar-manifests
+    artifactName: '${{ parameters.uploadPrefix }}AssetManifests'
+  continueOnError: true
+  condition: and(succeededOrFailed(), contains(variables['configuration.BuildNugets'], 'True'), ne(variables['ENABLE_DOTNET'],''))
+
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish Artifact: build-binlogs'
+  inputs:
+    targetPath: $(Build.ArtifactStagingDirectory)/build-binlogs
+    artifactName: ${{ parameters.uploadPrefix }}build-binlogs-$(Build.BuildId)-$(System.StageAttempt)-$(System.JobAttempt)
+  continueOnError: true
+  condition: and(succeededOrFailed(), contains(variables['configuration.BuildNugets'], 'True'), ne(variables['ENABLE_DOTNET'],''))

--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -62,10 +62,7 @@ steps:
       timeoutInMinutes: 180
 
     # build nugets
-    - bash: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/build-nugets.sh
-      displayName: 'Build Nugets'
-      condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'), ne(variables['ENABLE_DOTNET'], ''))
-      timeoutInMinutes: 180
+    - template: build-nugets.yml
 
     - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/generate-workload-rollback.sh
       name: workload_file

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -32,10 +32,6 @@ parameters:
   type: boolean
   default: true # default to true until otherwhise
 
-- name: pushNugetsToMaestro
-  type: boolean
-  default: true
-
 - name: isPR
   type: boolean
 
@@ -423,7 +419,6 @@ stages:
         repositoryAlias: ${{ parameters.repositoryAlias }}
         commit: ${{ parameters.commit }}
         pushNugets: ${{ parameters.pushNugets }}
-        pushNugetsToMaestro: ${{ parameters.pushNugetsToMaestro }}
 
 - stage: funnel
   displayName: '${{ parameters.stageDisplayNamePrefix }}Collect signed artifacts'

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -32,6 +32,8 @@ parameters:
 stages:
 - stage: prepare_release
   displayName: '${{ parameters.stageDisplayNamePrefix }}Prepare .NET Release'
+  variables:
+  - group: Xamarin Release
   ${{ if parameters.dependsOn }}:
     dependsOn: ${{ parameters.dependsOn }}
     condition: and(

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -21,10 +21,6 @@ parameters:
   type: boolean
   default: true
 
-- name: pushNugetsToMaestro
-  type: boolean
-  default: true
-
 - name: stageDisplayNamePrefix
   type: string
   default: ''
@@ -129,18 +125,7 @@ stages:
           ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')
         )
       variables:
-      - name: skipNugetSecurityAnalysis
-        value: true
-      - name: INCLUDE_DOTNET_IOS
-        value: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_IOS'] ]
-      - name: INCLUDE_DOTNET_MACCATALYST
-        value: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_MACCATALYST'] ]
-      - name: INCLUDE_DOTNET_MACOS
-        value: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_MACOS'] ]
-      - name: INCLUDE_DOTNET_TVOS
-        value: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_TVOS'] ]
-      - ${{ if eq(parameters.isPR, false) }}:
-        - group: Publish-Build-Assets
+        skipNugetSecurityAnalysis: true
       pool:
         name: AzurePipelines-EO
         demands:
@@ -229,48 +214,3 @@ stages:
             inputs:
               artifactName: ${{ parameters.uploadPrefix }}vsdrop-multitarget-signed
               downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
-
-      - script: make -C $(Build.SourcesDirectory)/dotnet version-props
-        displayName: make version props
-
-      - powershell: |
-          $varMap = @{ "INCLUDE_DOTNET_IOS" = "iOS"; "INCLUDE_DOTNET_MACCATALYST" = "MacCatalyst"; "INCLUDE_DOTNET_MACOS" = "macOS"; "INCLUDE_DOTNET_TVOS" = "tvOS" }
-          foreach ($varName in $varMap.Keys) {
-              if ([Environment]::GetEnvironmentVariable($varName)) {
-                  Write-Host "##vso[task.setvariable variable=MaestroProjectPlatformName]$($varMap[$varName])"
-                  exit 0;
-              }
-          }
-        displayName: Set maestro project variable
-
-      - task: DotNetCoreCLI@2
-        displayName: generate and publish BAR manifest
-        inputs:
-          projects: $(Build.SourcesDirectory)/dotnet/package/Microsoft.$(MaestroProjectPlatformName).Ref/package.csproj
-          arguments: >-
-            -t:PushManifestToBuildAssetRegistry
-            -p:BuildAssetRegistryToken=$(MaestroAccessToken)
-            -p:NupkgPath=$(Build.SourcesDirectory)/nugets-blob
-            -bl:$(Build.ArtifactStagingDirectory)/maestro-binlogs/generate-bar-manifest.binlog
-          workingDirectory: $(Build.SourcesDirectory)\..
-        condition: and(succeeded(), eq('${{ parameters.pushNugetsToMaestro }}', 'true'))
-
-      - powershell: |
-          $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
-          $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
-          $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-          & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
-          & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
-        displayName: Add builds to default darc channel
-        # We can't use the global.json located in the root of our repo, because makes it required to use the exact .NET version we're referencing in our eng/Versions.Details.xml file.
-        # So in order to not use it, we set the working directory to the parent directory of xamarin-macios.
-        workingDirectory: $(Build.SourcesDirectory)\..
-        condition: and(succeeded(), eq('${{ parameters.pushNugetsToMaestro }}', 'true'))
-
-      - task: 1ES.PublishPipelineArtifact@1
-        displayName: 'Publish Artifact: maestro-binlogs'
-        inputs:
-          path: $(Build.ArtifactStagingDirectory)/maestro-binlogs
-          artifact: ${{ parameters.uploadPrefix }}maestro-binlogs-$(System.JobAttempt)
-        condition: and(succeededOrFailed(), eq('${{ parameters.pushNugetsToMaestro }}', 'true'))
-        continueOnError: true


### PR DESCRIPTION
This reverts commit 2abbaf900be87eed474f86a6fbeef0c7d92077c3.

These publishing changes were intended for .NET 9.0+, and they require
some additional work to be compatible with stable package versioning.