### PR TITLE
Add UseInterpreter as part of the check for DynamicCodeSupport

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -143,7 +143,7 @@
 		<VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == '' And '$(_BundlerDebug)' != 'true'">false</VerifyDependencyInjectionOpenGenericServiceTrimmability>
 		<VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == ''">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
 		<!-- This should be set by dotnet/sdk instead, once https://github.com/dotnet/sdk/issues/25392 gets resolved.  -->
-		<DynamicCodeSupport Condition="'$(DynamicCodeSupport)' == '' And ( '$(MtouchInterpreter)' == '' And '$(UseInterpreter)' == 'false' ) And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'MacCatalyst')">false</DynamicCodeSupport>
+		<DynamicCodeSupport Condition="'$(DynamicCodeSupport)' == '' And ( '$(MtouchInterpreter)' == '' And '$(UseInterpreter)' != 'true' ) And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'MacCatalyst')">false</DynamicCodeSupport>
 
 		<!-- We don't need to generate reference assemblies for apps or app extensions -->
 		<ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' And ('$(OutputType)' == 'Exe' Or '$(IsAppExtension)' == 'true')">false</ProduceReferenceAssembly>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -143,7 +143,7 @@
 		<VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == '' And '$(_BundlerDebug)' != 'true'">false</VerifyDependencyInjectionOpenGenericServiceTrimmability>
 		<VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == ''">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
 		<!-- This should be set by dotnet/sdk instead, once https://github.com/dotnet/sdk/issues/25392 gets resolved.  -->
-		<DynamicCodeSupport Condition="'$(DynamicCodeSupport)' == '' And '$(MtouchInterpreter)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'MacCatalyst')">false</DynamicCodeSupport>
+		<DynamicCodeSupport Condition="'$(DynamicCodeSupport)' == '' And ( '$(MtouchInterpreter)' == '' And '$(UseInterpreter)' == 'false' ) And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'MacCatalyst')">false</DynamicCodeSupport>
 
 		<!-- We don't need to generate reference assemblies for apps or app extensions -->
 		<ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' And ('$(OutputType)' == 'Exe' Or '$(IsAppExtension)' == 'true')">false</ProduceReferenceAssembly>


### PR DESCRIPTION
fixes: https://github.com/dotnet/maui/issues/23577

## Cause:
   `MtouchInterpreter` is set as https://github.com/xamarin/xamarin-macios/blob/d1ec7a793f46f615f5f08f0a60f4c6daa6a1b671/msbuild/Xamarin.Shared/Xamarin.Shared.props#L308
   `DynamicCodeSupport` is set by https://github.com/xamarin/xamarin-macios/blob/d1ec7a793f46f615f5f08f0a60f4c6daa6a1b671/dotnet/targets/Xamarin.Shared.Sdk.targets#L146
   `Xamarin.Shared.Sdk.targets` is imported *before* `Xamarin.Shared.props` as shown below (courtesy of @ivanpovazan)
<img src="https://github.com/user-attachments/assets/c97b7f01-2372-4f9d-bedf-83060eed1c50">
 
   so unless the value of `MtouchInterpreter` is set in the project, it's value will be empty when the `DynamicCodeSupport` property is evaluated.

## Resolution:
To minimize the impact of this change, until it can be investigated more fully, the value of `MtouchInterpreter` is evaluated as https://github.com/xamarin/xamarin-macios/blob/d1ec7a793f46f615f5f08f0a60f4c6daa6a1b671/msbuild/Xamarin.Shared/Xamarin.Shared.props#L308
So adding `( '$(MtouchInterpreter)' == '' And '$(UseInterpreter)' == 'false' )` to the definition of `DynamicCodeSupport` to match the `MtouchInterpreter` definition.

A further fix might be to either:
1. Reorder the imports so that the props are included before the targets, although the ramifications of that change could be significant
2. Move the definition of `DynamicCodeSupport` to `Xamarin.Shared.props`. This at first glance seems to be less significant than 1) but would need review and testing. 
