### PR TITLE
[ci] Use drop service for SDK insertion artifacts

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -140,7 +140,7 @@ resources:
   - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/dev/pjc/v4drop-metadata
+    ref: refs/heads/main
     endpoint: xamarin
 
   - repository: sdk-insertions

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -140,7 +140,7 @@ resources:
   - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/pjc/v4drop-metadata
     endpoint: xamarin
 
   - repository: sdk-insertions

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -23,7 +23,7 @@ parameters:
 
 - name: pushNugetsToMaestro
   type: boolean
-  default: false
+  default: true
 
 - name: stageDisplayNamePrefix
   type: string

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -23,7 +23,7 @@ parameters:
 
 - name: pushNugetsToMaestro
   type: boolean
-  default: true
+  default: false
 
 - name: stageDisplayNamePrefix
   type: string
@@ -75,7 +75,7 @@ stages:
         name: disableCodeQLOnArm64
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v3.yml@yaml-templates
+  - template: nuget-msi-convert/job/v4.yml@yaml-templates
     parameters:
       use1ESTemplate: true
       yamlResourceName: yaml-templates
@@ -87,9 +87,8 @@ stages:
       msiNuGetArtifactName: ${{ parameters.uploadPrefix }}vs-msi-nugets
       binlogsArtifactName: ${{ parameters.uploadPrefix }}nuget-msi-convert-binlogs
       signType: Real
-      useDateTimeVersion: true
       condition: "ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')"
-      setupSteps:
+      preConvertSteps:
       - pwsh: |
           New-Item "$(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/governance" -ItemType Directory -ea 0
           New-Item -Path "$(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/governance" -Name "CredScanSuppressions.json" -Value '{"tool":"Crendential Scanner", "supressions":[]}'
@@ -153,82 +152,23 @@ stages:
 
       - task: DownloadPipelineArtifact@2
         inputs:
-          artifactName: '${{ parameters.uploadPrefix }}nuget-signed'
-          downloadPath: $(Build.SourcesDirectory)/package
-          patterns: |
-            *.nupkg
+          artifactName: DropMetadata-$(Build.BuildId)-nugets-$(System.JobAttempt)
+          downloadPath: $(Build.StagingDirectory)\metadata
+        displayName: Download nugets drop metadata
 
-      - task: 1ES.PublishNuget@1
-        displayName: Publish Nugets package
+      - powershell: |
+          $jsonContent = Get-Content -Path "$(Build.StagingDirectory)\metadata\VSTSDrop.json" -Raw | ConvertFrom-Json
+          $dropPrefix = $jsonContent.VstsDropBuildArtifact.VstsDropUrl -replace 'https://devdiv.artifacts.visualstudio.com/DefaultCollection/_apis/drop/drops/' -replace '/nugets'
+          Write-Host "##vso[task.setvariable variable=ReleaseDropPrefix]$dropPrefix"
+        displayName: Set variable ReleaseDropPrefix
+
+      # Download nugets drop created by nuget-msi-convert/job/v4.yml and publish to maestro
+      - task: ms-vscs-artifact.build-tasks.artifactDropDownloadTask-1.artifactDropDownloadTask@1
+        displayName: Download $(ReleaseDropPrefix)/nugets
         inputs:
-          useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
-          packagesToPush: '$(Build.SourcesDirectory)/package/*.nupkg'
-          packageParentPath: '$(Build.SourcesDirectory)/package'
-          nuGetFeedType: external
-          allowPackageConflicts: true # Optional. NuGetCommand task only.
-          publishPackageMetadata: true # Optional
-          publishFeedCredentials: dnceng-dotnet8
-
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          artifactName: '${{ parameters.uploadPrefix }}vs-msi-nugets'
-          downloadPath: '$(Build.SourcesDirectory)/${{ parameters.uploadPrefix}}vs-msi-nugets'
-          patterns: |
-            *.nupkg
-
-      - task: 1ES.PublishNuget@1
-        displayName: Publish MSI Nugets package
-        inputs:
-          useDotNetTask: false 
-          packagesToPush: '$(Build.SourcesDirectory)/${{ parameters.uploadPrefix }}vs-msi-nugets/*.nupkg'
-          packageParentPath: '$(Build.SourcesDirectory)/${{ parameters.uploadPrefix }}vs-msi-nugets'
-          nuGetFeedType: external
-          allowPackageConflicts: true
-          publishPackageMetadata: true
-          publishFeedCredentials: dnceng-dotnet8
-
-      - pwsh: |
-          mkdir $(Build.SourcesDirectory)/nugets-blob
-          cp $(Build.SourcesDirectory)/package/* $(Build.SourcesDirectory)/nugets-blob
-          cp $(Build.SourcesDirectory)/${{ parameters.uploadPrefix}}vs-msi-nugets/* $(Build.SourcesDirectory)/nugets-blob
-        displayName: "Copy content for the nugets blob."
-
-      - template: templates/common/upload-vs-insertion-artifacts.yml@sdk-insertions
-        parameters:
-          yamlResourceName: yaml-templates
-          githubToken: $(GitHub.Token)
-          githubContext: $(NupkgCommitStatusName)
-          blobName: $(NupkgCommitStatusName)
-          packagePrefix: xamarin-macios
-          artifactsPath: $(Build.SourcesDirectory)/nugets-blob
-
-      - template: templates/common/upload-vs-insertion-artifacts.yml@sdk-insertions
-        parameters:
-          yamlResourceName: yaml-templates
-          githubToken: $(GitHub.Token)
-          githubContext: $(VSDropCommitStatusName)
-          blobName: $(VSDropCommitStatusName)
-          packagePrefix: xamarin-macios
-          artifactsPath: $(Build.SourcesDirectory)/vs-insertion
-          downloadSteps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              artifactName: ${{ parameters.uploadPrefix }}vsdrop-signed
-              downloadPath: $(Build.SourcesDirectory)/vs-insertion
-
-      - template: templates/common/upload-vs-insertion-artifacts.yml@sdk-insertions
-        parameters:
-          yamlResourceName: yaml-templates
-          githubToken: $(GitHub.Token)
-          githubContext: $(MultiTargetVSDropCommitStatusName)
-          blobName: $(MultiTargetVSDropCommitStatusName)
-          packagePrefix: xamarin-macios
-          artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
-          downloadSteps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              artifactName: ${{ parameters.uploadPrefix }}vsdrop-multitarget-signed
-              downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+          dropServiceURI: https://devdiv.artifacts.visualstudio.com/DefaultCollection
+          buildNumber: $(ReleaseDropPrefix)/nugets
+          destinationPath: $(Build.StagingDirectory)\nuget-signed
 
       - script: make -C $(Build.SourcesDirectory)/dotnet version-props
         displayName: make version props
@@ -250,7 +190,7 @@ stages:
           arguments: >-
             -t:PushManifestToBuildAssetRegistry
             -p:BuildAssetRegistryToken=$(MaestroAccessToken)
-            -p:NupkgPath=$(Build.SourcesDirectory)/nugets-blob
+            -p:NupkgPath=$(Build.StagingDirectory)/nuget-signed
             -bl:$(Build.ArtifactStagingDirectory)/maestro-binlogs/generate-bar-manifest.binlog
           workingDirectory: $(Build.SourcesDirectory)\..
         condition: and(succeeded(), eq('${{ parameters.pushNugetsToMaestro }}', 'true'))

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -82,9 +82,6 @@ stages:
       dependsOn: signing
       artifactName: '${{ parameters.uploadPrefix }}nuget-signed'
       propsArtifactName: ${{ parameters.uploadPrefix }}not-signed-package
-      vsDropArtifactName: ${{ parameters.uploadPrefix }}vsdrop-signed
-      vsDropMultiTargetArtifactName: ${{ parameters.uploadPrefix }}vsdrop-multitarget-signed
-      msiNuGetArtifactName: ${{ parameters.uploadPrefix }}vs-msi-nugets
       binlogsArtifactName: ${{ parameters.uploadPrefix }}nuget-msi-convert-binlogs
       signType: Real
       condition: "ne(stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'],'')"
@@ -106,8 +103,9 @@ stages:
         displayName: verify signed msi content
         inputs:
           TargetFolders: |
-            $(Build.StagingDirectory)\bin\manifests
-            $(Build.StagingDirectory)\bin\manifests-multitarget
+            $(Build.ArtifactStagingDirectory)\bin\manifests
+            $(Build.ArtifactStagingDirectory)\bin\manifests-packs
+            $(Build.ArtifactStagingDirectory)\bin\msi-nupkgs
           ExcludeSNVerify: true
           ApprovalListPathForCerts: $(Build.StagingDirectory)\sign-verify\SignVerifyIgnore.txt
 


### PR DESCRIPTION
Context: xamarin/yaml-templates@8759ec9

Steps to upload release artifacts to custom blob storage have been
replaced with azure-artifacts-drop (aka.ms/drop).

A new version of nuget-msi-convert has been added that will create a set
of artifact drops for the following shipping artifacts:
  * nugets
  * vs-components
  * vs-packs

The nugets drop contains all shipping packages that should be pushed to
various feeds or NuGet.org.

The components and packs drops are used for VS insertions.