### PR TITLE
[CI] Bring changes to the CI and fix the simulator install

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 # YAML pipeline build definition
 # https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=13947&view=Tab_Tasks
 #
@@ -5,212 +6,211 @@
 # https://jenkins.internalx.com/view/Xamarin.MaciOS/job/macios/job/main/
 # https://jenkins.internalx.com/view/Xamarin.MaciOS/job/macios/configure
 parameters:
+  - name: provisionatorChannel
+    displayName: Provisionator channel to use
+    type: string
+    default: 'latest'
 
-- name: provisionatorChannel
-  displayName: Provisionator channel to use 
-  type: string
-  default: 'latest'
+  - name: macOSName  # comes from the build agent demand named macOS.Name
+    displayName: Name of the version of macOS to use
+    type: string
+    default: 'Sonoma'
 
-- name: macOSName # comes from the build agent demand named macOS.Name
-  displayName: Name of the version of macOS to use
-  type: string
-  default: 'Sonoma'
+  - name: pool
+    type: string
+    displayName: Bot pool to use
+    default: automatic
+    values:
+      - pr
+      - ci
+      - automatic
 
-- name: pool
-  type: string
-  displayName: Bot pool to use
-  default: automatic
-  values:
-  - pr
-  - ci
-  - automatic
+  - name: runGovernanceTests
+    displayName: Run Governance Checks
+    type: boolean
+    default: true
 
-- name: runGovernanceTests
-  displayName: Run Governance Checks
-  type: boolean
-  default: true
+  - name: forceInsertion
+    displayName: Force Insertion
+    type: boolean
+    default: false
 
-- name: forceInsertion
-  displayName: Force Insertion 
-  type: boolean
-  default: false 
+  - name: skipESRP
+    displayName: Skip ESRP
+    type: boolean
+    default: false  # only to be used when testing the CI and we do not need a signed pkg
 
-- name: skipESRP
-  displayName: Skip ESRP
-  type: boolean
-  default: false # only to be used when testing the CI and we do not need a signed pkg
+  - name: pushNugets
+    type: boolean
+    displayName: 'Push Nugets (dotnet)'
+    default: true
 
-- name: pushNugets
-  type: boolean
-  displayName: 'Push Nugets (dotnet)'
-  default: true
+  - name: pushNugetsToMaestro
+    type: boolean
+    displayName: 'Push Nugets (Maestro)'
+    default: true
 
-- name: pushNugetsToMaestro
-  type: boolean
-  displayName: 'Push Nugets (Maestro)'
-  default: true
+  - name: testConfigurations
+    displayName: Test configurations to run
+    type: object
+    default: []
 
-- name: testConfigurations
-  displayName: Test configurations to run
-  type: object
-  default: []
+  - name: deviceTestsConfigurations
+    displayName: Device test configurations to run
+    type: object
+    default: [
+      {
+        testPrefix: 'iOS64',
+        stageName: 'ios64b_device',
+        displayName: 'iOS64 Device Tests',
+        testPool: 'VSEng-Xamarin-Mac-Devices',
+        testsLabels: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
+        statusContext: 'VSTS: device tests iOS',
+        makeTarget: 'vsts-device-tests',
+        extraBotDemands: [
+          'ios',
+        ]
+      },
+      {
+        testPrefix: 'tvos',
+        stageName: 'tvos_device',
+        displayName: 'tvOS Device Tests',
+        testPool: 'VSEng-Xamarin-Mac-Devices',
+        testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
+        statusContext: 'VSTS: device tests tvOS',
+        makeTarget: 'vsts-device-tests',
+        extraBotDemands: [
+          'tvos',
+        ]
+      }]
 
-- name: deviceTestsConfigurations
-  displayName: Device test configurations to run
-  type: object
-  default: [
-    {
-      testPrefix: 'iOS64',
-      stageName: 'ios64b_device',
-      displayName: 'iOS64 Device Tests',
-      testPool: 'VSEng-Xamarin-Mac-Devices',
-      testsLabels: '--label=run-ios-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
-      statusContext: 'VSTS: device tests iOS',
-      makeTarget: 'vsts-device-tests',
-      extraBotDemands: [
-        'ios',
-      ]
-    },
-    {
-      testPrefix: 'tvos',
-      stageName: 'tvos_device',
-      displayName: 'tvOS Device Tests',
-      testPool: 'VSEng-Xamarin-Mac-Devices',
-      testsLabels: '--label=run-tvos-tests,run-non-monotouch-tests,run-monotouch-tests,run-mscorlib-tests',
-      statusContext: 'VSTS: device tests tvOS',
-      makeTarget: 'vsts-device-tests',
-      extraBotDemands: [
-        'tvos',
-      ]
-    }]
-
-- name: macTestsConfigurations
-  displayName: macOS test configurations to run
-  type: object
-  default: [
-    {
-      stageName: 'mac_11_m1',
-      displayName: 'M1 - Mac Big Sur (11)',
-      macPool: 'VSEng-VSMac-Xamarin-Shared',
-      useImage: false,
-      statusContext: 'M1 - Mac Big Sur (11)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals BigSur",
-        "macOS.Architecture -equals arm64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    },
-    {
-      stageName: 'mac_12_m1',
-      displayName: 'M1 - Mac Ventura (12)',
-      macPool: 'VSEng-VSMac-Xamarin-Shared',
-      useImage: false,
-      statusContext: 'M1 - Mac Monterey (12)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals Monterey",
-        "macOS.Architecture -equals arm64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    },
-    {
-      stageName: 'mac_13_m1',
-      displayName: 'M1 - Mac Ventura (13)',
-      macPool: 'VSEng-VSMac-Xamarin-Shared',
-      useImage: false,
-      statusContext: 'M1 - Mac Ventura (13)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals Ventura",
-        "macOS.Architecture -equals arm64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    },
-    {
-      stageName: 'mac_14_x64',
-      displayName: 'X64 - Mac Sonoma (14)',
-      macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted',
-      useImage: false,
-      statusContext: 'X64 - Mac Sonoma (14)',
-      demands: [
-        "Agent.OS -equals Darwin",
-        "macOS.Name -equals Sonoma",
-        "macOS.Architecture -equals x64",
-        "Agent.HasDevices -equals False",
-        "Agent.IsPaired -equals False"
-      ]
-    }]
+  - name: macTestsConfigurations
+    displayName: macOS test configurations to run
+    type: object
+    default: [
+      {
+        stageName: 'mac_11_m1',
+        displayName: 'M1 - Mac Big Sur (11)',
+        macPool: 'VSEng-VSMac-Xamarin-Shared',
+        useImage: false,
+        statusContext: 'M1 - Mac Big Sur (11)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals BigSur",
+          "macOS.Architecture -equals arm64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      },
+      {
+        stageName: 'mac_12_m1',
+        displayName: 'M1 - Mac Ventura (12)',
+        macPool: 'VSEng-VSMac-Xamarin-Shared',
+        useImage: false,
+        statusContext: 'M1 - Mac Monterey (12)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals Monterey",
+          "macOS.Architecture -equals arm64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      },
+      {
+        stageName: 'mac_13_m1',
+        displayName: 'M1 - Mac Ventura (13)',
+        macPool: 'VSEng-VSMac-Xamarin-Shared',
+        useImage: false,
+        statusContext: 'M1 - Mac Ventura (13)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals Ventura",
+          "macOS.Architecture -equals arm64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      },
+      {
+        stageName: 'mac_14_x64',
+        displayName: 'X64 - Mac Sonoma (14)',
+        macPool: 'VSEng-Xamarin-RedmondMacBuildPool-iOS-Untrusted',
+        useImage: false,
+        statusContext: 'X64 - Mac Sonoma (14)',
+        demands: [
+          "Agent.OS -equals Darwin",
+          "macOS.Name -equals Sonoma",
+          "macOS.Architecture -equals x64",
+          "Agent.HasDevices -equals False",
+          "Agent.IsPaired -equals False"
+        ]
+      }]
 
 resources:
   repositories:
-  - repository: self
-    checkoutOptions:
-      submodules: true
+    - repository: self
+      checkoutOptions:
+        submodules: true
 
-  - repository: yaml-templates
-    type: github
-    name: xamarin/yaml-templates
-    ref: refs/heads/main
-    endpoint: xamarin
+    - repository: yaml-templates
+      type: github
+      name: xamarin/yaml-templates
+      ref: refs/heads/main
+      endpoint: xamarin
 
-  - repository: sdk-insertions
-    type: github
-    name: xamarin/sdk-insertions
-    ref: refs/heads/main
-    endpoint: xamarin
+    - repository: sdk-insertions
+      type: github
+      name: xamarin/sdk-insertions
+      ref: refs/heads/main
+      endpoint: xamarin
 
-  - repository: maccore
-    type: github
-    name: xamarin/maccore
-    ref: refs/heads/main
-    endpoint: xamarin
+    - repository: maccore
+      type: github
+      name: xamarin/maccore
+      ref: refs/heads/main
+      endpoint: xamarin
 
-  - repository: release-scripts
-    type: github
-    name: xamarin/release-scripts
-    ref: refs/heads/only_codesign
-    endpoint: xamarin
+    - repository: release-scripts
+      type: github
+      name: xamarin/release-scripts
+      ref: refs/heads/only_codesign
+      endpoint: xamarin
 
-  - repository: CustomPipelineTemplates
-    type: git
-    name: 1ESPipelineTemplates/MicroBuildTemplate
+    - repository: CustomPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/MicroBuildTemplate
 
 variables:
-- ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
-  - template: templates/vsts-variables.yml
-- template: templates/common/vs-release-vars.yml@sdk-insertions
-- template: templates/variables.yml
-- name: MicrobuildConnector
-  value: 'MicroBuild Signing Task (DevDiv)'
-- name: MaciosUploadPrefix
-  value: ''
-- name: DisablePipelineConfigDetector
-  value: true
+  - ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
+      - template: templates/vsts-variables.yml
+  - template: templates/common/vs-release-vars.yml@sdk-insertions
+  - template: templates/variables.yml
+  - name: MicrobuildConnector
+    value: 'MicroBuild Signing Task (DevDiv)'
+  - name: MaciosUploadPrefix
+    value: ''
+  - name: DisablePipelineConfigDetector
+    value: true
 
 trigger:
   branches:
     include:
-    - '*'
+      - '*'
     exclude:
-    - refs/heads/locfiles/*
-    - refs/heads/dev/*
+      - refs/heads/locfiles/*
+      - refs/heads/dev/*
   paths:
     exclude:
-    - .github
-    - docs
-    - CODEOWNERS
-    - ISSUE_TEMPLATE.md
-    - LICENSE
-    - NOTICE.txt
-    - SECURITY.MD
-    - README.md
-    - src/README.md
-    - tools/mtouch/README.md
-    - msbuild/Xamarin.Localization.MSBuild/README.md
+      - .github
+      - docs
+      - CODEOWNERS
+      - ISSUE_TEMPLATE.md
+      - LICENSE
+      - NOTICE.txt
+      - SECURITY.MD
+      - README.md
+      - src/README.md
+      - tools/mtouch/README.md
+      - msbuild/Xamarin.Localization.MSBuild/README.md
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@CustomPipelineTemplates
@@ -237,33 +237,33 @@ extends:
       policheck:
         exclusionsFile: '$(System.DefaultWorkingDirectory)\\xamarin-macios\\tools\\devops\\governance\\PoliCheckExclusions.xml'
       sourceRepositoriesToScan:
-        runInSingleJob: true # run both maccore and macios in the same job
+        runInSingleJob: true  # run both maccore and macios in the same job
         include:
-        - repository: maccore
+          - repository: maccore
         exclude:
-        - repository: yaml-templates
-        - repository: sdk-insertions
-        - repository: release-scripts
+          - repository: yaml-templates
+          - repository: sdk-insertions
+          - repository: release-scripts
     stages:
-    - template: templates/main-stage.yml
-      parameters:
-        xcodeChannel: Beta
-        macOSName: ${{ parameters.macOSName }}
-        isPR: false
-        provisionatorChannel: ${{ parameters.provisionatorChannel }}
-        pool: ${{ parameters.pool }}
-        runGovernanceTests: ${{ parameters.runGovernanceTests }}
-        forceInsertion: ${{ parameters.forceInsertion }}
-        skipESRP: ${{ parameters.skipESRP }}
-        pushNugets: ${{ parameters.pushNugets }}
-        pushNugetsToMaestro: ${{ parameters.pushNugetsToMaestro }}
-        ${{ if ne(length(parameters.testConfigurations), 0)}}:
-          testConfigurations: ${{ parameters.testConfigurations }}
-        deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}
-        macTestsConfigurations: ${{ parameters.macTestsConfigurations }}
-        azureStorage: ${{ variables['azureStorage'] }}
-        azureContainer: ${{ variables['azureContainer'] }}
-        signingSetupSteps:
-        - template: ./templates/sign-and-notarized/setup.yml
-          parameters:
-            isPR: false
+      - template: templates/main-stage.yml
+        parameters:
+          xcodeChannel: Beta
+          macOSName: ${{ parameters.macOSName }}
+          isPR: false
+          provisionatorChannel: ${{ parameters.provisionatorChannel }}
+          pool: ${{ parameters.pool }}
+          runGovernanceTests: ${{ parameters.runGovernanceTests }}
+          forceInsertion: ${{ parameters.forceInsertion }}
+          skipESRP: ${{ parameters.skipESRP }}
+          pushNugets: ${{ parameters.pushNugets }}
+          pushNugetsToMaestro: ${{ parameters.pushNugetsToMaestro }}
+          ${{ if ne(length(parameters.testConfigurations), 0)}}:
+            testConfigurations: ${{ parameters.testConfigurations }}
+          deviceTestsConfigurations: ${{ parameters.deviceTestsConfigurations }}
+          macTestsConfigurations: ${{ parameters.macTestsConfigurations }}
+          azureStorage: ${{ variables['azureStorage'] }}
+          azureContainer: ${{ variables['azureContainer'] }}
+          signingSetupSteps:
+            - template: ./templates/sign-and-notarized/setup.yml
+              parameters:
+                isPR: false

--- a/tools/devops/automation/scripts/bash/install-ios-simulator-simctl.sh
+++ b/tools/devops/automation/scripts/bash/install-ios-simulator-simctl.sh
@@ -7,7 +7,7 @@ SIMULATOR_FILENAME=iOS_18_beta_3_Simulator_Runtime.dmg
 SIMULATOR_VERSION=22A5307f
 
 xcrun simctl runtime list
-if xcrun simctl runtime list|grep iOS.*'('$SIMULATOR_VERSION')'; then
+if xcrun simctl runtime list | grep "iOS.*($SIMULATOR_VERSION)"; then
 	echo "The iOS Simulator runtime $SIMULATOR_VERSION is already installed."
 	exit 0
 fi

--- a/tools/devops/automation/scripts/bash/install-ios-simulator-simctl.sh
+++ b/tools/devops/automation/scripts/bash/install-ios-simulator-simctl.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+
+# this is a workaround for the fact that xcodebuild -downloadPlatform iOS does not work on EO machines
+xcodebuild -runFirstLaunch
+
+SIMULATOR_FILENAME=iOS_18_beta_3_Simulator_Runtime.dmg
+SIMULATOR_VERSION=22A5307f
+
+xcrun simctl runtime list
+if xcrun simctl runtime list|grep iOS.*'('$SIMULATOR_VERSION')'; then
+	echo "The iOS Simulator runtime $SIMULATOR_VERSION is already installed."
+	exit 0
+fi
+
+echo "The iOS Simulator runtime $SIMULATOR_VERSION is not installed, downloading..."
+curl -L -H "Authorization: token $GITHUB_TOKEN" "https://dl.internalx.com/internal-files/xcode.simulator-runtimes/$SIMULATOR_FILENAME" --output "$SIMULATOR_FILENAME"
+
+echo "The iOS Simulator runtime $SIMULATOR_VERSION is not installed, installing..."
+xcrun simctl runtime add "$SIMULATOR_FILENAME"
+
+echo "The iOS Simulator runtime $SIMULATOR_VERSION succesfully installed."
+
+rm -f "$SIMULATOR_FILENAME"

--- a/tools/devops/automation/scripts/generate_agent_logs.ps1
+++ b/tools/devops/automation/scripts/generate_agent_logs.ps1
@@ -35,7 +35,9 @@ $end=Get-Date -Format "yyyy-MM-dd HH:mm:ss"
 Write-Host "end time: $end"
 
 if (-not $Predicate) {
-  log show --style $Style --start "$start" --end "$end" > $Output
+    Write-Host "Executing: log show --style $Style --start `"$start`" --end `"$end`" > $Output"
+    log show --style $Style --start "$start" --end "$end" > $Output
 } else {
-  log show --predicate $Predicate --style $Style --start "$start" --end "$end" > $Output
+    Write-Hos "Executing: log show --predicate $Predicate --style $Style --start `"$start`" --end `"$end`" > $Output"
+    log show --predicate $Predicate --style $Style --start "$start" --end "$end" > $Output
 }

--- a/tools/devops/automation/scripts/generate_agent_logs.ps1
+++ b/tools/devops/automation/scripts/generate_agent_logs.ps1
@@ -41,6 +41,6 @@ if (-not $Predicate) {
     Write-Host "Executing: log show --style $Style --start `"$start`" --end `"$end`" > $Output"
     log show --style $Style --start "$start" --end "$end" > $Output
 } else {
-    Write-Hos "Executing: log show --predicate $Predicate --style $Style --start `"$start`" --end `"$end`" > $Output"
+    Write-Host "Executing: log show --predicate $Predicate --style $Style --start `"$start`" --end `"$end`" > $Output"
     log show --predicate $Predicate --style $Style --start "$start" --end "$end" > $Output
 }

--- a/tools/devops/automation/scripts/generate_agent_logs.ps1
+++ b/tools/devops/automation/scripts/generate_agent_logs.ps1
@@ -32,8 +32,10 @@ $buildPipeline= Invoke-RestMethod -Uri $url -Headers $headers -Method Get
 Write-host "Build pipeline start time: $($buildPipeline.startTime)"
 $start=[DateTime]::Parse($buildPipeline.startTime).ToString("yyyy-MM-dd HH:mm:ss")
 
-$end=Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-Write-Host "end time: $end"
+# hack to get the end time
+$date = Get-Date
+$end=$date.ToString("yyyy-MM-dd HH:mm:ss")
+$start=$date.AddHours(-1).ToString("yyyy-MM-dd HH:mm:ss")
 
 if (-not $Predicate) {
     Write-Host "Executing: log show --style $Style --start `"$start`" --end `"$end`" > $Output"

--- a/tools/devops/automation/scripts/generate_agent_logs.ps1
+++ b/tools/devops/automation/scripts/generate_agent_logs.ps1
@@ -29,6 +29,7 @@ $headers = @{Authorization = "Basic {0}" -f $base64AuthInfo}
 $url= $Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI + "$Env:SYSTEM_TEAMPROJECT/_apis/build/builds/" + $Env:BUILD_BUILDID + "?api-version=5.1"
 $buildPipeline= Invoke-RestMethod -Uri $url -Headers $headers -Method Get
 
+Write-host "Build pipeline start time: $($buildPipeline.startTime)"
 $start=[DateTime]::Parse($buildPipeline.startTime).ToString("yyyy-MM-dd HH:mm:ss")
 
 $end=Get-Date -Format "yyyy-MM-dd HH:mm:ss"

--- a/tools/devops/automation/templates/build/build-pkgs.yml
+++ b/tools/devops/automation/templates/build/build-pkgs.yml
@@ -1,158 +1,159 @@
+# yamllint disable rule:line-length
 parameters:
-- name: vsdropsPrefix
-  type: string
+  - name: vsdropsPrefix
+    type: string
 
-- name: keyringPass
-  type: string
+  - name: keyringPass
+    type: string
 
-- name: gitHubToken
-  type: string
+  - name: gitHubToken
+    type: string
 
-- name: xqaCertPass
-  type: string
+  - name: xqaCertPass
+    type: string
 
-- name: uploadBinlogs
-  type: boolean
-  default: true
+  - name: uploadBinlogs
+    type: boolean
+    default: true
 
-- name: signAndNotarize
-  type: boolean
-  default: true
+  - name: signAndNotarize
+    type: boolean
+    default: true
 
-- name: skipESRP
-  type: boolean
-  default: false # only to be used when testing the CI and we do not need a signed pkg
+  - name: skipESRP
+    type: boolean
+    default: false  # only to be used when testing the CI and we do not need a signed pkg
 
-- name: isPR
-  type: boolean
+  - name: isPR
+    type: boolean
 
-- name: repositoryAlias
-  type: string
-  default: self
+  - name: repositoryAlias
+    type: string
+    default: self
 
-- name: commit
-  type: string
-  default: HEAD
+  - name: commit
+    type: string
+    default: HEAD
 
-- name: uploadPrefix
-  type: string
-  default: '$(MaciosUploadPrefix)'
+  - name: uploadPrefix
+    type: string
+    default: '$(MaciosUploadPrefix)'
 
 steps:
-- template: build.yml
-  parameters:
-    isPR: ${{ parameters.isPR }}
-    repositoryAlias: ${{ parameters.repositoryAlias }}
-    commit: ${{ parameters.commit }}
-    vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
-    keyringPass: ${{ parameters.keyringPass }}
-    gitHubToken: ${{ parameters.gitHubToken }}
-    xqaCertPass: ${{ parameters.xqaCertPass }}
-    buildSteps:
-    # build not signed .pkgs for the SDK
-    - bash: |
-        set -x
-        set -e
-        rm -Rf $(Build.SourcesDirectory)/package/*.pkg
-        rm -Rf $(Build.SourcesDirectory)/package/notarized/*.pkg
-        time make -C $(Build.SourcesDirectory)/xamarin-macios/ package
-      name: packages
-      displayName: 'Build Packages'
-      condition: and(succeeded(), contains(variables['configuration.BuildPkgs'], 'True'))
-      timeoutInMinutes: 180
+  - template: build.yml
+    parameters:
+      isPR: ${{ parameters.isPR }}
+      repositoryAlias: ${{ parameters.repositoryAlias }}
+      commit: ${{ parameters.commit }}
+      vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
+      keyringPass: ${{ parameters.keyringPass }}
+      gitHubToken: ${{ parameters.gitHubToken }}
+      xqaCertPass: ${{ parameters.xqaCertPass }}
+      buildSteps:
+        # build not signed .pkgs for the SDK
+        - bash: |
+            set -x
+            set -e
+            rm -Rf $(Build.SourcesDirectory)/package/*.pkg
+            rm -Rf $(Build.SourcesDirectory)/package/notarized/*.pkg
+            time make -C $(Build.SourcesDirectory)/xamarin-macios/ package
+          name: packages
+          displayName: 'Build Packages'
+          condition: and(succeeded(), contains(variables['configuration.BuildPkgs'], 'True'))
+          timeoutInMinutes: 180
 
-    # build nugets
-    - bash: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/build-nugets.sh
-      displayName: 'Build Nugets'
-      condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'), ne(variables['ENABLE_DOTNET'], ''))
-      timeoutInMinutes: 180
+        # build nugets
+        - bash: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/build-nugets.sh
+          displayName: 'Build Nugets'
+          condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'), ne(variables['ENABLE_DOTNET'], ''))
+          timeoutInMinutes: 180
 
-    - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/generate-workload-rollback.sh
-      name: workload_file
-      displayName: 'Generate "WorkloadRollback.json"'
+        - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/generate-workload-rollback.sh
+          name: workload_file
+          displayName: 'Generate "WorkloadRollback.json"'
 
-    - task: 1ES.PublishPipelineArtifact@1
-      displayName: 'Publish WorkloadRollback.json'
-      inputs:
-        path: $(Build.SourcesDirectory)/WorkloadRollback.json
-        artifact: '${{ parameters.uploadPrefix }}WorkloadRollback'
-      continueOnError: true
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish WorkloadRollback.json'
+          inputs:
+            path: $(Build.SourcesDirectory)/WorkloadRollback.json
+            artifact: '${{ parameters.uploadPrefix }}WorkloadRollback'
+          continueOnError: true
 
-    - bash: |
-        var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=IOS_PACKAGE_VERSION)
-        IOS_PACKAGE_VERSION=${var#*=}
-        IOS_PACKAGE_VERSION=$(echo $IOS_PACKAGE_VERSION | cut -d "+" -f1)
+        - bash: |
+            var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=IOS_PACKAGE_VERSION)
+            IOS_PACKAGE_VERSION=${var#*=}
+            IOS_PACKAGE_VERSION=$(echo $IOS_PACKAGE_VERSION | cut -d "+" -f1)
 
-        var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=MAC_PACKAGE_VERSION)
-        MAC_PACKAGE_VERSION=${var#*=}
-        MAC_PACKAGE_VERSION=$(echo $MAC_PACKAGE_VERSION | cut -d "+" -f1)
+            var=$(make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops print-variable VARIABLE=MAC_PACKAGE_VERSION)
+            MAC_PACKAGE_VERSION=${var#*=}
+            MAC_PACKAGE_VERSION=$(echo $MAC_PACKAGE_VERSION | cut -d "+" -f1)
 
-        PKG_DST="$(Build.SourcesDirectory)/PkgsVersions.json"
+            PKG_DST="$(Build.SourcesDirectory)/PkgsVersions.json"
 
-        echo "{" > $PKG_DST
-        echo "\"iOS\": \"$IOS_PACKAGE_VERSION\"," >>  $PKG_DST
-        echo "\"macOS\": \"$MAC_PACKAGE_VERSION\"" >> $PKG_DST
-        echo "}" >>  $PKG_DST
+            echo "{" > $PKG_DST
+            echo "\"iOS\": \"$IOS_PACKAGE_VERSION\"," >>  $PKG_DST
+            echo "\"macOS\": \"$MAC_PACKAGE_VERSION\"" >> $PKG_DST
+            echo "}" >>  $PKG_DST
 
-        echo "PkgVersions.json file contents:" 
-        echo "$(cat $PKG_DST)"
-      name: pkg_versions_file
-      displayName: 'Generate PkgsVersions.json'
+            echo "PkgVersions.json file contents:"
+            echo "$(cat $PKG_DST)"
+          name: pkg_versions_file
+          displayName: 'Generate PkgsVersions.json'
 
-    - task: 1ES.PublishPipelineArtifact@1
-      displayName: 'Publish PkgsVersions.json'
-      inputs:
-        path: $(Build.SourcesDirectory)/PkgsVersions.json
-        artifact: '${{ parameters.uploadPrefix }}PkgsVersions'
-      continueOnError: true
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish PkgsVersions.json'
+          inputs:
+            path: $(Build.SourcesDirectory)/PkgsVersions.json
+            artifact: '${{ parameters.uploadPrefix }}PkgsVersions'
+          continueOnError: true
 
-    # upload each of the pkgs into the pipeline artifacts
-    - task: 1ES.PublishPipelineArtifact@1
-      displayName: 'Publish Build Artifacts'
-      inputs:
-        path: $(Build.SourcesDirectory)/package
-        artifact: '${{ parameters.uploadPrefix }}not-signed-package'
-      continueOnError: true
+        # upload each of the pkgs into the pipeline artifacts
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish Build Artifacts'
+          inputs:
+            path: $(Build.SourcesDirectory)/package
+            artifact: '${{ parameters.uploadPrefix }}not-signed-package'
+          continueOnError: true
 
-    - bash: |
-        set -x
-        set -e
+        - bash: |
+            set -x
+            set -e
 
-        make -C $(Build.SourcesDirectory)/xamarin-macios/tests package-test-libraries.zip
-      name: introPkg
-      displayName: 'Package test libraries dependencies'
-      continueOnError: true # not a terrible blocking issue
-      timeoutInMinutes: 60
+            make -C $(Build.SourcesDirectory)/xamarin-macios/tests package-test-libraries.zip
+          name: introPkg
+          displayName: 'Package test libraries dependencies'
+          continueOnError: true  # not a terrible blocking issue
+          timeoutInMinutes: 60
 
-    - task: 1ES.PublishPipelineArtifact@1
-      displayName: 'Publish test libraries dependencies'
-      inputs:
-        path: $(Build.SourcesDirectory)/xamarin-macios/tests/package-test-libraries.zip 
-        artifact: '${{ parameters.uploadPrefix }}package-test-libraries'
-      continueOnError: true
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish test libraries dependencies'
+          inputs:
+            path: $(Build.SourcesDirectory)/xamarin-macios/tests/package-test-libraries.zip
+            artifact: '${{ parameters.uploadPrefix }}package-test-libraries'
+          continueOnError: true
 
-    - task: 1ES.PublishPipelineArtifact@1
-      displayName: 'Publish Build.props'
-      inputs:
-        path: $(Build.SourcesDirectory)/xamarin-macios/Build.props
-        artifact: '${{ parameters.uploadPrefix }}Build.props'
-      continueOnError: true
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish Build.props'
+          inputs:
+            path: $(Build.SourcesDirectory)/xamarin-macios/Build.props
+            artifact: '${{ parameters.uploadPrefix }}Build.props'
+          continueOnError: true
 
-    - ${{ if eq(parameters.uploadBinlogs, true) }}:
-      # Copy all the binlogs to a separate directory, keeping directory structure.
-      - script: |
-          set -x
-          mkdir -p $(Build.ArtifactStagingDirectory)/all-binlogs
-          rsync -av --prune-empty-dirs --include '*/' --include '*.binlog' --exclude '*' $(Build.SourcesDirectory)/xamarin-macios $(Build.ArtifactStagingDirectory)/all-binlogs
-        displayName: Copy all binlogs
-        continueOnError: true
-        condition: succeededOrFailed()
+        - ${{ if eq(parameters.uploadBinlogs, true) }}:
+            # Copy all the binlogs to a separate directory, keeping directory structure.
+            - script: |
+                set -x
+                mkdir -p $(Build.ArtifactStagingDirectory)/all-binlogs
+                rsync -av --prune-empty-dirs --include '*/' --include '*.binlog' --exclude '*' $(Build.SourcesDirectory)/xamarin-macios $(Build.ArtifactStagingDirectory)/all-binlogs
+              displayName: Copy all binlogs
+              continueOnError: true
+              condition: succeededOrFailed()
 
-      # Publish all the binlogs we collected in the previous step
-      - task: 1ES.PublishPipelineArtifact@1
-        displayName: 'Publish Artifact: All binlogs'
-        inputs:
-          path: $(Build.ArtifactStagingDirectory)/all-binlogs
-          artifact: '${{ parameters.uploadPrefix }}all-binlogs-$(Build.BuildId)-$(System.StageAttempt)-$(System.JobAttempt)'
-        continueOnError: true
-        condition: succeededOrFailed()
+            # Publish all the binlogs we collected in the previous step
+            - task: 1ES.PublishPipelineArtifact@1
+              displayName: 'Publish Artifact: All binlogs'
+              inputs:
+                path: $(Build.ArtifactStagingDirectory)/all-binlogs
+                artifact: '${{ parameters.uploadPrefix }}all-binlogs-$(Build.BuildId)-$(System.StageAttempt)-$(System.JobAttempt)'
+              continueOnError: true
+              condition: succeededOrFailed()

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -1,101 +1,102 @@
+# yamllint disable rule:line-length
 # template that contains all the different steps to create a pkgs, publish the results and provide feedback to the
 # developers in github.
 parameters:
-- name: vsdropsPrefix
-  type: string
+  - name: vsdropsPrefix
+    type: string
 
-- name: keyringPass
-  type: string
+  - name: keyringPass
+    type: string
 
-- name: gitHubToken
-  type: string
+  - name: gitHubToken
+    type: string
 
-- name: xqaCertPass
-  type: string
+  - name: xqaCertPass
+    type: string
 
-- name: skipESRP
-  type: boolean
-  default: false # only to be used when testing the CI and we do not need a signed pkg
+  - name: skipESRP
+    type: boolean
+    default: false  # only to be used when testing the CI and we do not need a signed pkg
 
-- name: pool
-  type: string
-  default: automatic
+  - name: pool
+    type: string
+    default: automatic
 
-- name: isPR
-  type: boolean
+  - name: isPR
+    type: boolean
 
-- name: repositoryAlias
-  type: string
-  default: self
+  - name: repositoryAlias
+    type: string
+    default: self
 
-- name: commit
-  type: string
-  default: HEAD
+  - name: commit
+    type: string
+    default: HEAD
 
-- name: xcodeChannel
-  type: string
+  - name: xcodeChannel
+    type: string
 
-- name: macOSName
-  type: string
+  - name: macOSName
+    type: string
 
 jobs:
-# This job performs the build of the nuget pkgs and the framework pkgs. There are two interesting dependencies in this job:
-- job: build
-  displayName: 'Build packages'
-  timeoutInMinutes: 1000
-  variables:
-    DOTNET_PLATFORMS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.DOTNET_PLATFORMS'] ]
-    ENABLE_DOTNET: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'] ]
-    INCLUDE_DOTNET_IOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_IOS'] ]
-    INCLUDE_DOTNET_MACCATALYST: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_MACCATALYST'] ]
-    INCLUDE_DOTNET_MACOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_MACOS'] ]
-    INCLUDE_DOTNET_TVOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_TVOS'] ]
-    INCLUDE_LEGACY_IOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_LEGACY_IOS'] ]
-    INCLUDE_LEGACY_MAC: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_LEGACY_MAC'] ]
-    INCLUDE_LEGACY_TVOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_LEGACY_TVOS'] ]
-    INCLUDE_LEGACY_WATCH: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_LEGACY_WATCH'] ]
-    INCLUDE_XAMARIN_LEGACY: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_XAMARIN_LEGACY'] ]
-    ${{ if eq(parameters.pool, 'automatic') }}:
-      AgentPoolComputed: $[ stageDependencies.configure_build.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
-    ${{ if eq(parameters.pool, 'ci') }}:
-      AgentPoolComputed: $(CIBuildPool)
-    ${{ if eq(parameters.pool, 'pr') }}:
-      AgentPoolComputed: $(PRBuildPool)
-    # add all the variables that have been parsed by the configuration step. Could we have a less verbose way??
-    #
-    # build-package
-    # skip-packages
-    # skip-nugets
-    # skip-signing
-    # run-sample-tests
-    BuildPackage: $[ stageDependencies.configure_build.configure.outputs['labels.build_package'] ]
-    SkipPackages: $[ stageDependencies.configure_build.configure.outputs['labels.skip_packages'] ]
-    SkipNugets: $[ stageDependencies.configure_build.configure.outputs['labels.skip_nugets'] ]
-    SkipSigning: $[ stageDependencies.configure_build.configure.outputs['labels.skip_signing'] ]
-    RunSampleTests: $[ stageDependencies.configure_build.configure.outputs['labels.run_sample_tests'] ]
-    SkipApiComparison: $[ stageDependencies.configure_build.configure.outputs['labels.skip_api_comparison'] ]
-    # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
-    PR_ID: $[ stageDependencies.configure_build.configure.outputs['labels.pr_number'] ]
-    # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
-    BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
-    XHARNESS_LABELS: $[ stageDependencies.configure_build.configure.outputs['labels.xharness_labels'] ]
-    RUN_MAC_TESTS: $[ stageDependencies.configure_build.configure.outputs['decisions.RUN_MAC_TESTS'] ]
-  pool:
-    os: macOS
-    name: $(AgentPoolComputed)
-    demands:
-    - Agent.OS -equals Darwin
-    - macOS.Name -equals ${{ parameters.macOSName }}
-    - XcodeChannel -equals ${{ parameters.xcodeChannel }}
+  # This job performs the build of the nuget pkgs and the framework pkgs. There are two interesting dependencies in this job:
+  - job: build
+    displayName: 'Build packages'
+    timeoutInMinutes: 1000
+    variables:
+      DOTNET_PLATFORMS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.DOTNET_PLATFORMS'] ]
+      ENABLE_DOTNET: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.ENABLE_DOTNET'] ]
+      INCLUDE_DOTNET_IOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_IOS'] ]
+      INCLUDE_DOTNET_MACCATALYST: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_MACCATALYST'] ]
+      INCLUDE_DOTNET_MACOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_MACOS'] ]
+      INCLUDE_DOTNET_TVOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_TVOS'] ]
+      INCLUDE_LEGACY_IOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_LEGACY_IOS'] ]
+      INCLUDE_LEGACY_MAC: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_LEGACY_MAC'] ]
+      INCLUDE_LEGACY_TVOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_LEGACY_TVOS'] ]
+      INCLUDE_LEGACY_WATCH: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_LEGACY_WATCH'] ]
+      INCLUDE_XAMARIN_LEGACY: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_XAMARIN_LEGACY'] ]
+      ${{ if eq(parameters.pool, 'automatic') }}:
+        AgentPoolComputed: $[ stageDependencies.configure_build.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
+      ${{ if eq(parameters.pool, 'ci') }}:
+        AgentPoolComputed: $(CIBuildPool)
+      ${{ if eq(parameters.pool, 'pr') }}:
+        AgentPoolComputed: $(PRBuildPool)
+      # add all the variables that have been parsed by the configuration step. Could we have a less verbose way??
+      #
+      # build-package
+      # skip-packages
+      # skip-nugets
+      # skip-signing
+      # run-sample-tests
+      BuildPackage: $[ stageDependencies.configure_build.configure.outputs['labels.build_package'] ]
+      SkipPackages: $[ stageDependencies.configure_build.configure.outputs['labels.skip_packages'] ]
+      SkipNugets: $[ stageDependencies.configure_build.configure.outputs['labels.skip_nugets'] ]
+      SkipSigning: $[ stageDependencies.configure_build.configure.outputs['labels.skip_signing'] ]
+      RunSampleTests: $[ stageDependencies.configure_build.configure.outputs['labels.run_sample_tests'] ]
+      SkipApiComparison: $[ stageDependencies.configure_build.configure.outputs['labels.skip_api_comparison'] ]
+      # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
+      PR_ID: $[ stageDependencies.configure_build.configure.outputs['labels.pr_number'] ]
+      # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
+      BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+      XHARNESS_LABELS: $[ stageDependencies.configure_build.configure.outputs['labels.xharness_labels'] ]
+      RUN_MAC_TESTS: $[ stageDependencies.configure_build.configure.outputs['decisions.RUN_MAC_TESTS'] ]
+    pool:
+      os: macOS
+      name: $(AgentPoolComputed)
+      demands:
+        - Agent.OS -equals Darwin
+        - macOS.Name -equals ${{ parameters.macOSName }}
+        - XcodeChannel -equals ${{ parameters.xcodeChannel }}
 
-  steps:
-  - template: build-pkgs.yml
-    parameters:
-      isPR: ${{ parameters.isPR }}
-      repositoryAlias: ${{ parameters.repositoryAlias }}
-      commit: ${{ parameters.commit }}
-      vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
-      keyringPass: ${{ parameters.keyringPass }}
-      gitHubToken: ${{ parameters.gitHubToken }}
-      xqaCertPass: ${{ parameters.xqaCertPass }}
-      skipESRP: ${{ parameters.skipESRP }}
+    steps:
+      - template: build-pkgs.yml
+        parameters:
+          isPR: ${{ parameters.isPR }}
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+          vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
+          keyringPass: ${{ parameters.keyringPass }}
+          gitHubToken: ${{ parameters.gitHubToken }}
+          xqaCertPass: ${{ parameters.xqaCertPass }}
+          skipESRP: ${{ parameters.skipESRP }}

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -172,17 +172,11 @@ steps:
       - bash: $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators --ignore-shellcheck --ignore-yamllint
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
-      - bash: |
-          curl -L -H "Authorization: token ${{ parameters.gitHubToken }}" https://dl.internalx.com/internal-files/xcode.simulator-runtimes/iOS_18_beta_3_Simulator_Runtime.dmg --output iOS_18_beta_3_Simulator_Runtime.dmg
-        workingDirectory: "$(Build.ArtifactStagingDirectory)"
-        displayName: 'Download simulator runtime'
-
-      - bash: |
-           # this is a workaround for the fact that xcodebuild -downloadPlatform iOS does not work on EO machines
-           xcodebuild -runFirstLaunch 
-           xcrun simctl runtime add "iOS_18_beta_3_Simulator_Runtime.dmg"
+      - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/install-ios-simulator-simctl.sh
         workingDirectory: "$(Build.ArtifactStagingDirectory)"
         displayName: 'Provision simulators (simctl)'
+        env:
+          GITHUB_TOKEN: ${{ parameters.gitHubToken }}
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we
   # are using the cache. Mono does not get bump a lot of times if any (after dotnet)

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -159,8 +159,14 @@ steps:
     AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_P12: ${{ parameters.xqaCertPass }}
     AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_2_P12: ${{ parameters.xqaCertPass }}
 
-- bash: $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators --ignore-shellcheck --ignore-yamllint
-  displayName: 'Provision simulators'
+# only install all the simulators when working on a PR, EO machines do not allow use to perform this step 
+- ${{ if parameters.isPR }}:
+  - bash: $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators --ignore-shellcheck --ignore-yamllint
+    displayName: 'Provision simulators'
+- ${{ else }}:
+  - bash: |
+      xcodebuild -downloadPlatform iOS
+    displayName: 'Provision simulators'
 
 # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we 
 # are using the cache. Mono does not get bump a lot of times if any (after dotnet)

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -1,236 +1,237 @@
+# yamllint disable rule:line-length
 parameters:
-- name: vsdropsPrefix
-  type: string
+  - name: vsdropsPrefix
+    type: string
 
-- name: keyringPass
-  type: string
+  - name: keyringPass
+    type: string
 
-- name: gitHubToken
-  type: string
+  - name: gitHubToken
+    type: string
 
-- name: xqaCertPass
-  type: string
+  - name: xqaCertPass
+    type: string
 
-- name: isPR
-  type: boolean
-  default: false
+  - name: isPR
+    type: boolean
+    default: false
 
-- name: repositoryAlias
-  type: string
-  default: self
+  - name: repositoryAlias
+    type: string
+    default: self
 
-- name: commit
-  type: string
-  default: HEAD
+  - name: commit
+    type: string
+    default: HEAD
 
-- name: buildSteps 
-  type: stepList 
-  default: []
+  - name: buildSteps
+    type: stepList
+    default: []
 
-- name: makeParallelism
-  type: string
-  default: '8'
+  - name: makeParallelism
+    type: string
+    default: '8'
 
-- name: uploadPrefix
-  type: string
-  default: '$(MaciosUploadPrefix)'
+  - name: uploadPrefix
+    type: string
+    default: '$(MaciosUploadPrefix)'
 
-- name: retryCount
-  type: number
-  default: 3
+  - name: retryCount
+    type: number
+    default: 3
 
-- name: use1ES
-  type: boolean
-  default: true
+  - name: use1ES
+    type: boolean
+    default: true
 
 steps:
 
-- template: ../common/checkout.yml
-  parameters:
-    isPR: ${{ parameters.isPR }}
-    repositoryAlias: ${{ parameters.repositoryAlias }}
-    commit: ${{ parameters.commit }}
+  - template: ../common/checkout.yml
+    parameters:
+      isPR: ${{ parameters.isPR }}
+      repositoryAlias: ${{ parameters.repositoryAlias }}
+      commit: ${{ parameters.commit }}
 
-- template: ../common/setup.yml
-  parameters:
-    keyringPass: ${{ parameters.keyringPass }}
+  - template: ../common/setup.yml
+    parameters:
+      keyringPass: ${{ parameters.keyringPass }}
 
-- template: install-certificates.yml@yaml-templates
-  parameters:
-    DeveloperIdApplication: $(developer-id-application)
-    DeveloperIdInstaller: $(developer-id-installer)
-    IphoneDeveloper: $(iphone-developer)
-    MacDeveloper: $(mac-developer)
-    HostedMacKeychainPassword: ${{ parameters.keyringPass }}
+  - template: install-certificates.yml@yaml-templates
+    parameters:
+      DeveloperIdApplication: $(developer-id-application)
+      DeveloperIdInstaller: $(developer-id-installer)
+      IphoneDeveloper: $(iphone-developer)
+      MacDeveloper: $(mac-developer)
+      HostedMacKeychainPassword: ${{ parameters.keyringPass }}
 
-- task: xamops.azdevex.provisionator-task.provisionator@2
-  displayName: 'Provision Brew components'
-  inputs:
-    provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/provision-brew-packages.csx
-    provisioning_extra_args: '-vvvv'
-    github_token: ${{ parameters.gitHubToken }}
-  timeoutInMinutes: 30
-  enabled: true
-  continueOnError: true # brew installation can be temperamental, and things usually work even if the installation fail.
-
-- bash: |
-    make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops build-provisioning.csx
-  displayName: 'Generate provisionator files.'
-
-- task: xamops.azdevex.provisionator-task.provisionator@2
-  displayName: 'Provision Products & Frameworks'
-  inputs:
-    provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/build-provisioning.csx
-    provisioning_extra_args: '-vvvv'
-    github_token: ${{ parameters.gitHubToken }}
-  timeoutInMinutes: 250
-  retryCountOnTaskFailure: ${{ parameters.retryCount }} # mono does give issues sometimes to download, we will retry
-
-# Use the env variables that were set by the label parsing in the configure step
-# print some useful logging to allow to know what is going on AND allow make some
-# choices, there are labels that contradict each other (skip-package vs build-packages)
-# we use warnings for those case we are not sure about.
-- task: PowerShell@2
-  name: configuration
-  displayName: "Parse PR labels"
-  timeoutInMinutes: 5
-  inputs:
-    filePath: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/parse_pr_labels.ps1
-    arguments: -XamarinTop "$(Build.SourcesDirectory)/xamarin-macios/" -BuildReason "$(Build.Reason)"
-
-- ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
-  - task: PowerShell@2
-    displayName: Setup Private Feeds Credentials
+  - task: xamops.azdevex.provisionator-task.provisionator@2
+    displayName: 'Provision Brew components'
     inputs:
-      filePath: $(System.DefaultWorkingDirectory)/xamarin-macios/eng/common/SetupNugetSources.ps1
-      arguments: -ConfigFile $(System.DefaultWorkingDirectory)/xamarin-macios/NuGet.config -Password $Env:Token
+      provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/provision-brew-packages.csx
+      provisioning_extra_args: '-vvvv'
+      github_token: ${{ parameters.gitHubToken }}
+    timeoutInMinutes: 30
+    enabled: true
+    continueOnError: true  # brew installation can be temperamental, and things usually work even if the installation fail.
+
+  - bash: |
+      make -C $(Build.SourcesDirectory)/xamarin-macios/tools/devops build-provisioning.csx
+    displayName: 'Generate provisionator files.'
+
+  - task: xamops.azdevex.provisionator-task.provisionator@2
+    displayName: 'Provision Products & Frameworks'
+    inputs:
+      provisioning_script: $(Build.SourcesDirectory)/xamarin-macios/tools/devops/build-provisioning.csx
+      provisioning_extra_args: '-vvvv'
+      github_token: ${{ parameters.gitHubToken }}
+    timeoutInMinutes: 250
+    retryCountOnTaskFailure: ${{ parameters.retryCount }}  # mono does give issues sometimes to download, we will retry
+
+  # Use the env variables that were set by the label parsing in the configure step
+  # print some useful logging to allow to know what is going on AND allow make some
+  # choices, there are labels that contradict each other (skip-package vs build-packages)
+  # we use warnings for those case we are not sure about.
+  - task: PowerShell@2
+    name: configuration
+    displayName: "Parse PR labels"
+    timeoutInMinutes: 5
+    inputs:
+      filePath: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/parse_pr_labels.ps1
+      arguments: -XamarinTop "$(Build.SourcesDirectory)/xamarin-macios/" -BuildReason "$(Build.Reason)"
+
+  - ${{ if contains(variables['Build.DefinitionName'], 'private') }}:
+      - task: PowerShell@2
+        displayName: Setup Private Feeds Credentials
+        inputs:
+          filePath: $(System.DefaultWorkingDirectory)/xamarin-macios/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(System.DefaultWorkingDirectory)/xamarin-macios/NuGet.config -Password $Env:Token
+        env:
+          Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
+      - bash: |
+          set -x
+          set -e
+          ARGS="--azure-feed \"https://dotnetclimsrc.blob.core.windows.net/dotnet\" -FeedCredential $CREDENTIALS"
+          echo "##vso[task.setvariable variable=DOTNET_INSTALL_EXTRA_ARGS]$ARGS"
+        env:
+          CREDENTIALS: $(dotnetclimsrc-read-sas-token)
+        displayName: "Configure install extra args"
+        timeoutInMinutes: 5
+
+  - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/configure-build.sh
     env:
-      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      ${{ if eq(parameters.isPR, true) }}:
+        IsPR: 'True'
+      ${{ else }}:
+        IsPR: 'False'
+    displayName: "Configure build"
+    workingDirectory: "$(Build.SourcesDirectory)/xamarin-macios"
+    timeoutInMinutes: 5
 
   - bash: |
       set -x
       set -e
-      ARGS="--azure-feed \"https://dotnetclimsrc.blob.core.windows.net/dotnet\" -FeedCredential $CREDENTIALS"
-      echo "##vso[task.setvariable variable=DOTNET_INSTALL_EXTRA_ARGS]$ARGS"
-    env:
-      CREDENTIALS: $(dotnetclimsrc-read-sas-token)
-    displayName: "Configure install extra args"
+      cat configure.inc
+    displayName: "Print configuration"
+    workingDirectory: "$(Build.SourcesDirectory)/xamarin-macios"
     timeoutInMinutes: 5
 
-- bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/configure-build.sh
-  env:
-    ${{ if eq(parameters.isPR, true) }}:
-      IsPR: 'True'
-    ${{ else }}:
-      IsPR: 'False'
-  displayName: "Configure build"
-  workingDirectory: "$(Build.SourcesDirectory)/xamarin-macios"
-  timeoutInMinutes: 5
-
-- bash: |
-    set -x
-    set -e
-    cat configure.inc
-  displayName: "Print configuration"
-  workingDirectory: "$(Build.SourcesDirectory)/xamarin-macios"
-  timeoutInMinutes: 5
-
-# Make sure we have the right maccore hash checked out before we try to add
-# the provisioning profiles.
-- bash: |
-    set -ex
-    time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset
-  name: resetDependencies
-  displayName: 'Reset dependencies'
-  timeoutInMinutes: 10
-
-# We'll need these profiles to build the hot restart prebuilt app during the build
-# (it's built for device, and thus needs a certificate available so that the app can be signed).
-- bash: ./install-qa-provisioning-profiles.sh -v
-  displayName: 'Add build provisioning profiles'
-  timeoutInMinutes: 30
-  continueOnError: true # should not stop the build
-  workingDirectory: $(Build.SourcesDirectory)/maccore/tools
-  env:
-    AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
-    AUTH_TOKEN_LA_DEV_APPLE_P12: ${{ parameters.xqaCertPass }}
-    AUTH_TOKEN_LA_DISTR_APPLE_P12: ${{ parameters.xqaCertPass }}
-    AUTH_TOKEN_LA_MAC_INSTALLER_DISTR_P12: ${{ parameters.xqaCertPass }}
-    AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_P12: ${{ parameters.xqaCertPass }}
-    AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_2_P12: ${{ parameters.xqaCertPass }}
-
-# only install all the simulators when working on a PR, EO machines do not allow use to perform this step 
-- ${{ if parameters.isPR }}:
-  - bash: $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators --ignore-shellcheck --ignore-yamllint
-    displayName: 'Provision simulators'
-- ${{ else }}:
+  # Make sure we have the right maccore hash checked out before we try to add
+  # the provisioning profiles.
   - bash: |
-      xcodebuild -downloadPlatform iOS
-    displayName: 'Provision simulators'
+      set -ex
+      time make -C $(Build.SourcesDirectory)/xamarin-macios/ reset
+    name: resetDependencies
+    displayName: 'Reset dependencies'
+    timeoutInMinutes: 10
 
-# downloding mono takes time and has been shown to be problematic when we have network issues. This is why we 
-# are using the cache. Mono does not get bump a lot of times if any (after dotnet)
+  # We'll need these profiles to build the hot restart prebuilt app during the build
+  # (it's built for device, and thus needs a certificate available so that the app can be signed).
+  - bash: ./install-qa-provisioning-profiles.sh -v
+    displayName: 'Add build provisioning profiles'
+    timeoutInMinutes: 30
+    continueOnError: true  # should not stop the build
+    workingDirectory: $(Build.SourcesDirectory)/maccore/tools
+    env:
+      AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
+      AUTH_TOKEN_LA_DEV_APPLE_P12: ${{ parameters.xqaCertPass }}
+      AUTH_TOKEN_LA_DISTR_APPLE_P12: ${{ parameters.xqaCertPass }}
+      AUTH_TOKEN_LA_MAC_INSTALLER_DISTR_P12: ${{ parameters.xqaCertPass }}
+      AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_P12: ${{ parameters.xqaCertPass }}
+      AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_2_P12: ${{ parameters.xqaCertPass }}
 
-- bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/export-mono-filenames.sh
-  displayName: "Export mono download filenames"
-  workingDirectory: "$(Build.SourcesDirectory)/xamarin-macios"
-  timeoutInMinutes: 5
+  # only install all the simulators when working on a PR, EO machines do not allow use to perform this step
+  - ${{ if parameters.isPR }}:
+      - bash: $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators --ignore-shellcheck --ignore-yamllint
+        displayName: 'Provision simulators (system-dependencies.sh)'
+  - ${{ else }}:
+      - bash: |
+          xcodebuild -downloadPlatform iOS
+        displayName: 'Provision simulators (xcodebuild)'
 
-- task: Cache@2
-  displayName: 'Cache iOS Mono download'
-  inputs:
-    key: "$(MONO_IOS_FILENAME)"
-    path: "$(Build.SourcesDirectory)/xamarin-macios/builds/downloads/$(MONO_IOS_FILENAME)"
+  # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we
+  # are using the cache. Mono does not get bump a lot of times if any (after dotnet)
 
-- task: Cache@2
-  displayName: 'Cache macOS Mono download'
-  inputs:
-    key: "$(MONO_MAC_FILENAME)"
-    path: "$(Build.SourcesDirectory)/xamarin-macios/builds/downloads/$(MONO_MAC_FILENAME)"
+  - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/export-mono-filenames.sh
+    displayName: "Export mono download filenames"
+    workingDirectory: "$(Build.SourcesDirectory)/xamarin-macios"
+    timeoutInMinutes: 5
 
-- task: Cache@2
-  displayName: 'Cache MacCatalsyt Mono download'
-  inputs:
-    key: "$(MONO_MACCATALYST_FILENAME)"
-    path: "$(Build.SourcesDirectory)/xamarin-macios/builds/downloads/$(MONO_MACCATALYST_FILENAME)"
+  - task: Cache@2
+    displayName: 'Cache iOS Mono download'
+    inputs:
+      key: "$(MONO_IOS_FILENAME)"
+      path: "$(Build.SourcesDirectory)/xamarin-macios/builds/downloads/$(MONO_IOS_FILENAME)"
 
-# Actual build of the project
-- bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/build-macios.sh
-  name: build
-  workingDirectory: "$(Build.SourcesDirectory)/xamarin-macios"
-  displayName: 'Build'
-  timeoutInMinutes: 180
-  env:
-    MAKE_PARALLELISM: ${{ parameters.makeParallelism }}
+  - task: Cache@2
+    displayName: 'Cache macOS Mono download'
+    inputs:
+      key: "$(MONO_MAC_FILENAME)"
+      path: "$(Build.SourcesDirectory)/xamarin-macios/builds/downloads/$(MONO_MAC_FILENAME)"
 
-- ${{ each step in parameters.buildSteps }}:
-  - ${{ each pair in step }}:
-      ${{ pair.key }}: ${{ pair.value }}
+  - task: Cache@2
+    displayName: 'Cache MacCatalsyt Mono download'
+    inputs:
+      key: "$(MONO_MACCATALYST_FILENAME)"
+      path: "$(Build.SourcesDirectory)/xamarin-macios/builds/downloads/$(MONO_MACCATALYST_FILENAME)"
 
-# clean the bot after we use it
-- template: ../common/teardown.yml
-  parameters:
-    keyringPass: ${{ parameters.keyringPass }}
-    use1ES: ${{ parameters.use1ES }}
+  # Actual build of the project
+  - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/build-macios.sh
+    name: build
+    workingDirectory: "$(Build.SourcesDirectory)/xamarin-macios"
+    displayName: 'Build'
+    timeoutInMinutes: 180
+    env:
+      MAKE_PARALLELISM: ${{ parameters.makeParallelism }}
 
-# if we failed, write a comment and set the pipeline to failure. In this case, we do not want to hide the fact that we failed but we also want
-# to write a comment.
-- pwsh: |
-    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-    $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token) -Hash $Env:COMMENT_HASH
-    $githubComments.NewCommentFromMessage("Build failed", ":fire:", "Build failed for the job '$(System.JobDisplayName)'")
-  condition: failed()
-  displayName: 'Report build failure'
-  env:
-    ${{ if eq(parameters.repositoryAlias, 'self') }}:
-      COMMENT_HASH: $(fix_commit.GIT_HASH)
-    ${{ else }}:
-      COMMENT_HASH: $(Build.SourceVersion)
+  - ${{ each step in parameters.buildSteps }}:
+      - ${{ each pair in step }}:
+          ${{ pair.key }}: ${{ pair.value }}
 
-# Upload any crash reports that occurred during the build. This is helpful if we want to file issues about dotnet/csc crashing during the build.
-- bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/collect-and-upload-crash-reports.sh
-  displayName: 'Collect and upload crash reports'
-  condition: always() # who knows when crash reports can end up being useful
-  continueOnError: true
-  env:
-    MACIOS_UPLOAD_PREFIX: ${{ parameters.uploadPrefix }}
+  # clean the bot after we use it
+  - template: ../common/teardown.yml
+    parameters:
+      keyringPass: ${{ parameters.keyringPass }}
+      use1ES: ${{ parameters.use1ES }}
+
+  # if we failed, write a comment and set the pipeline to failure. In this case, we do not want to hide the fact that we failed but we also want
+  # to write a comment.
+  - pwsh: |
+      Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
+      $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token) -Hash $Env:COMMENT_HASH
+      $githubComments.NewCommentFromMessage("Build failed", ":fire:", "Build failed for the job '$(System.JobDisplayName)'")
+    condition: failed()
+    displayName: 'Report build failure'
+    env:
+      ${{ if eq(parameters.repositoryAlias, 'self') }}:
+        COMMENT_HASH: $(fix_commit.GIT_HASH)
+      ${{ else }}:
+        COMMENT_HASH: $(Build.SourceVersion)
+
+  # Upload any crash reports that occurred during the build. This is helpful if we want to file issues about dotnet/csc crashing during the build.
+  - bash: $(System.DefaultWorkingDirectory)/xamarin-macios/tools/devops/automation/scripts/bash/collect-and-upload-crash-reports.sh
+    displayName: 'Collect and upload crash reports'
+    condition: always()  # who knows when crash reports can end up being useful
+    continueOnError: true
+    env:
+      MACIOS_UPLOAD_PREFIX: ${{ parameters.uploadPrefix }}

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -173,9 +173,7 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
-           ls /Library/Developer/CoreSimulator/Profiles/Runtimes
-           rm -Rf /Library/Developer/CoreSimulator/Profiles/Runtimes/*
-           xcodebuild -downloadPlatform iOS
+           xcodebuild -verbose -downloadPlatform iOS
         displayName: 'Provision simulators (xcoebuild)'
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -160,25 +160,19 @@ steps:
       AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_P12: ${{ parameters.xqaCertPass }}
       AUTH_TOKEN_VSENG_XAMARIN_MAC_DEVICES_2_P12: ${{ parameters.xqaCertPass }}
 
+  - bash: |
+       set -x
+       set -e
+       rm -rf ~/Library/Developer/Xcode/DerivedData/*
+       rm -rf ~/Library/Caches/com.apple.dt.Xcode
+    displayName: 'Clear Xcode cache'
+
   # only install all the simulators when working on a PR, EO machines do not allow use to perform this step
   - ${{ if parameters.isPR }}:
       - bash: $(Build.SourcesDirectory)/xamarin-macios/system-dependencies.sh --provision-simulators --ignore-shellcheck --ignore-yamllint
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
-           # This is a workaround for a bug in Xcode 15 where we need to open the platforms panel for it to register the simulators.
-           echo "Executing 'open xcpref://Xcode.PreferencePane.Platforms'"
-           echo "Killing Xcode"
-           pkill -9 "Xcode" || echo "Xcode was not running."
-
-           echo "Opening Xcode preferences panel"
-           open xcpref://Xcode.PreferencePane.Platforms
-           echo "waiting 10 secs for Xcode to open the preferences panel"
-           sleep 10
-           echo "Killing Xcode"
-           pkill -9 "Xcode" || echo "Xcode was not running."
-           echo "Executed 'open xcpref://Xcode.PreferencePane.Platforms'"
-
            xcodebuild -downloadPlatform iOS
         displayName: 'Provision simulators (xcoebuild)'
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -172,22 +172,8 @@ steps:
 
       - bash: |
            curl -o ios.dmg https://devimages-cdn.apple.com/downloads/xcode/simulators/com.apple.pkg.iPhoneSimulatorSDK12_4-12.4.1.1568665771.dmg
-        displayName: 'Test image download'
-
-      - bash: |
-          set -x
-          echo "xcode-select path"
-          xcode-select -p
-          echo "xcodebuild version"
-          xcodebuild -version
-          echo  "First run needed"
-          xcodebuild -checkFirstLaunchStatus
-          xcodebuild -runFirstLaunch
-          echo "Show SDKs"
-          xcodebuild -showsdks
-          echo "Downloading simulators"
-          xcodebuild -verbose -downloadPlatform iOS
-        displayName: 'Provision simulators (xcodebuild)'
+           xcrun simctl runtime add "ios.dmg"
+        displayName: 'Download and install iOS simulator'
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we
   # are using the cache. Mono does not get bump a lot of times if any (after dotnet)

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -166,6 +166,20 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
+           # This is a workaround for a bug in Xcode 15 where we need to open the platforms panel for it to register the simulators.
+           echo "Executing 'open xcpref://Xcode.PreferencePane.Platforms'"
+           echo "Killing Xcode"
+           pkill -9 "Xcode" || echo "Xcode was not running."
+
+           echo "Opening Xcode preferences panel"
+           open xcpref://Xcode.PreferencePane.Platforms
+           echo "waiting 10 secs for Xcode to open the preferences panel"
+           sleep 10
+           echo "Killing Xcode"
+           pkill -9 "Xcode" || echo "Xcode was not running."
+           echo "Executed 'open xcpref://Xcode.PreferencePane.Platforms'"
+
+           echo "Finished installing Xcode platforms"
            xcodebuild -downloadPlatform iOS
         displayName: 'Provision simulators (xcoebuild)'
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -173,7 +173,7 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
-           xcodebuild -downloadAllPlatforms
+           xcodebuild -downloadPlatform iOS
         displayName: 'Provision simulators (xcoebuild)'
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -173,7 +173,7 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
-           xcodebuild -downloadPlatform iOS
+           xcodebuild -downloadAllPlatforms
         displayName: 'Provision simulators (xcoebuild)'
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -166,9 +166,18 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
+          set -x
+          echo "xcode-select path"
           xcode-select -p
+          echo "xcodebuild version"
+          xcodebuild -version
+          echo  "First run needed"
+          xcodebuild -checkFirstLaunchStatus
           xcodebuild -runFirstLaunch
-          xcodebuild -downloadPlatform iOS
+          echo "Show SDKs"
+          xcodebuild -showsdks
+          echo "Downloading simulators"
+          xcodebuild -verbose -downloadPlatform iOS
         displayName: 'Provision simulators (xcodebuild)'
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -173,6 +173,8 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
+           ls /Library/Developer/CoreSimulator/Profiles/Runtimes
+           rm -Rf /Library/Developer/CoreSimulator/Profiles/Runtimes/*
            xcodebuild -downloadPlatform iOS
         displayName: 'Provision simulators (xcoebuild)'
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -166,14 +166,8 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
-           curl -o index.xml https://devimages-cdn.apple.com/downloads/xcode/simulators/index2.dvtdownloadableindex
-           cat index.xml
-        displayName: 'Test index download'
-
-      - bash: |
-           curl -o ios.dmg https://devimages-cdn.apple.com/downloads/xcode/simulators/com.apple.pkg.iPhoneSimulatorSDK12_4-12.4.1.1568665771.dmg
-           xcrun simctl runtime add "ios.dmg"
-        displayName: 'Download and install iOS simulator'
+           xcodebuild -downloadPlatform iOS
+        displayName: 'Provision simulators (xcoebuild)'
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we
   # are using the cache. Mono does not get bump a lot of times if any (after dotnet)

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -166,6 +166,8 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
+          xcode-select -p
+          xcodebuild -runFirstLaunch
           xcodebuild -downloadPlatform iOS
         displayName: 'Provision simulators (xcodebuild)'
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -173,7 +173,7 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
-          curl -o iOS_18_beta_3_Simulator_Runtime.dmg https://dalexsotofiles.blob.core.windows.net/xcode/iOS_18_beta_3_Simulator_Runtime.dmg
+          curl -o iOS_18_beta_3_Simulator_Runtime.dmg https://dl.internalx.com/internal-files/xcode.simulator-runtimes/iOS_18_beta_3_Simulator_Runtime.dmg
         workingDirectory: "$(Build.ArtifactStagingDirectory)"
         displayName: 'Download simulator runtime'
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -182,7 +182,7 @@ steps:
            xcodebuild -runFirstLaunch 
            xcrun simctl runtime add "iOS_18_beta_3_Simulator_Runtime.dmg"
         workingDirectory: "$(Build.ArtifactStagingDirectory)"
-        displayName: 'Provision simulators (xcodebuild)'
+        displayName: 'Provision simulators (simctl)'
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we
   # are using the cache. Mono does not get bump a lot of times if any (after dotnet)

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -173,7 +173,15 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
-           xcodebuild -verbose -downloadPlatform iOS || true
+          curl -o iOS_18_beta_3_Simulator_Runtime.dmg https://dalexsotofiles.blob.core.windows.net/xcode/iOS_18_beta_3_Simulator_Runtime.dmg
+        workingDirectory: "$(Build.ArtifactStagingDirectory)"
+        displayName: 'Download simulator runtime'
+
+      - bash: |
+           # this is a workaround for the fact that xcodebuild -downloadPlatform iOS does not work on EO machines
+           xcodebuild -runFirstLaunch 
+           xcrun simctl runtime add "iOS_18_beta_3_Simulator_Runtime.dmg"
+        workingDirectory: "$(Build.ArtifactStagingDirectory)"
         displayName: 'Provision simulators (xcoebuild)'
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -173,7 +173,7 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
-          curl -o iOS_18_beta_3_Simulator_Runtime.dmg https://dl.internalx.com/internal-files/xcode.simulator-runtimes/iOS_18_beta_3_Simulator_Runtime.dmg
+          curl -L -H "Authorization: token $(github-pat)" https://dl.internalx.com/internal-files/xcode.simulator-runtimes/iOS_18_beta_3_Simulator_Runtime.dmg --output iOS_18_beta_3_Simulator_Runtime.dmg
         workingDirectory: "$(Build.ArtifactStagingDirectory)"
         displayName: 'Download simulator runtime'
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -166,6 +166,15 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
+           curl -o index.xml https://devimages-cdn.apple.com/downloads/xcode/simulators/index2.dvtdownloadableindex
+           cat index.xml
+        displayName: 'Test index download'
+
+      - bash: |
+           curl -o ios.dmg https://devimages-cdn.apple.com/downloads/xcode/simulators/com.apple.pkg.iPhoneSimulatorSDK12_4-12.4.1.1568665771.dmg
+        displayName: 'Test image download'
+
+      - bash: |
           set -x
           echo "xcode-select path"
           xcode-select -p

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -173,7 +173,7 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
-           xcodebuild -verbose -downloadPlatform iOS
+           xcodebuild -verbose -downloadPlatform iOS || true
         displayName: 'Provision simulators (xcoebuild)'
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -173,7 +173,7 @@ steps:
         displayName: 'Provision simulators (system-dependencies.sh)'
   - ${{ else }}:
       - bash: |
-          curl -L -H "Authorization: token $(github-pat)" https://dl.internalx.com/internal-files/xcode.simulator-runtimes/iOS_18_beta_3_Simulator_Runtime.dmg --output iOS_18_beta_3_Simulator_Runtime.dmg
+          curl -L -H "Authorization: token ${{ parameters.gitHubToken }}" https://dl.internalx.com/internal-files/xcode.simulator-runtimes/iOS_18_beta_3_Simulator_Runtime.dmg --output iOS_18_beta_3_Simulator_Runtime.dmg
         workingDirectory: "$(Build.ArtifactStagingDirectory)"
         displayName: 'Download simulator runtime'
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -182,7 +182,7 @@ steps:
            xcodebuild -runFirstLaunch 
            xcrun simctl runtime add "iOS_18_beta_3_Simulator_Runtime.dmg"
         workingDirectory: "$(Build.ArtifactStagingDirectory)"
-        displayName: 'Provision simulators (xcoebuild)'
+        displayName: 'Provision simulators (xcodebuild)'
 
   # downloding mono takes time and has been shown to be problematic when we have network issues. This is why we
   # are using the cache. Mono does not get bump a lot of times if any (after dotnet)

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -179,7 +179,6 @@ steps:
            pkill -9 "Xcode" || echo "Xcode was not running."
            echo "Executed 'open xcpref://Xcode.PreferencePane.Platforms'"
 
-           echo "Finished installing Xcode platforms"
            xcodebuild -downloadPlatform iOS
         displayName: 'Provision simulators (xcoebuild)'
 

--- a/tools/devops/automation/templates/common/mac-agent-logs.yml
+++ b/tools/devops/automation/templates/common/mac-agent-logs.yml
@@ -14,7 +14,7 @@ parameters:
 
 - name: predicate
   type: string
-  default: ''
+  default: 'default'
 
 - name: style
   type: string

--- a/tools/devops/automation/templates/common/mac-agent-logs.yml
+++ b/tools/devops/automation/templates/common/mac-agent-logs.yml
@@ -14,7 +14,7 @@ parameters:
 
 - name: predicate
   type: string
-  default: 'default'
+  default: ''
 
 - name: style
   type: string

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -1,444 +1,444 @@
+# yamllint disable rule:line-length
 parameters:
+  - name: provisionatorChannel
+    type: string
+    default: 'latest'
 
-- name: provisionatorChannel
-  type: string
-  default: 'latest'
+  - name: pool
+    type: string
+    default: automatic
+    values:
+      - pr
+      - ci
+      - automatic
 
-- name: pool
-  type: string
-  default: automatic
-  values:
-  - pr
-  - ci
-  - automatic
+  - name: runGovernanceTests
+    type: boolean
+    default: true
 
-- name: runGovernanceTests
-  type: boolean
-  default: true
+  - name: enableLegacySigning
+    type: boolean
+    default: true
 
-- name: enableLegacySigning
-  type: boolean
-  default: true
+  - name: forceInsertion
+    type: boolean
+    default: false
 
-- name: forceInsertion
-  type: boolean
-  default: false
+  - name: skipESRP
+    type: boolean
+    default: false # only to be used when testing the CI and we do not need a signed pkg
 
-- name: skipESRP
-  type: boolean
-  default: false # only to be used when testing the CI and we do not need a signed pkg
+  - name: pushNugets
+    type: boolean
+    default: true # default to true until otherwhise
 
-- name: pushNugets
-  type: boolean
-  default: true # default to true until otherwhise
+  - name: pushNugetsToMaestro
+    type: boolean
+    default: true
 
-- name: pushNugetsToMaestro
-  type: boolean
-  default: true
+  - name: isPR
+    type: boolean
 
-- name: isPR
-  type: boolean
+  - name: repositoryAlias
+    type: string
+    default: self
 
-- name: repositoryAlias
-  type: string
-  default: self
+  - name: commit
+    type: string
+    default: HEAD
 
-- name: commit
-  type: string
-  default: HEAD
+  - name: xcodeChannel
+    type: string
 
-- name: xcodeChannel
-  type: string
+  - name: macOSName
+    type: string
 
-- name: macOSName
-  type: string
+  # Ideally we should read/get the list of platforms from somewhere else, instead of hardcoding them here.
+  # Note that this is _all_ the platforms we support (not just the enabled ones).
+  - name: supportedPlatforms
+    type: object
+    default: [
+      {
+        platform: iOS,
+        isDotNetPlatform: true,
+        isLegacyPlatform: true
+      },
+      {
+        platform: macOS,
+        isDotNetPlatform: true,
+        isLegacyPlatform: true
+      },
+      {
+        platform: tvOS,
+        isDotNetPlatform: true,
+        isLegacyPlatform: true
+      },
+      {
+        platform: watchOS,
+        isDotNetPlatform: false,
+        isLegacyPlatform: true
+      },
+      {
+        platform: MacCatalyst,
+        isDotNetPlatform: true,
+        isLegacyPlatform: false
+      },
+      {
+        # when running platform-specific test runs, we also need a special test run that executes tests that only runs when multiple platforms are enabled
+        platform: Multiple,
+        isDotNetPlatform: true,
+        isLegacyPlatform: true
+      }
+    ]
 
-# Ideally we should read/get the list of platforms from somewhere else, instead of hardcoding them here.
-# Note that this is _all_ the platforms we support (not just the enabled ones).
-- name: supportedPlatforms
-  type: object
-  default: [
-    {
-      platform: iOS,
-      isDotNetPlatform: true,
-      isLegacyPlatform: true
-    },
-    {
-      platform: macOS,
-      isDotNetPlatform: true,
-      isLegacyPlatform: true
-    },
-    {
-      platform: tvOS,
-      isDotNetPlatform: true,
-      isLegacyPlatform: true
-    },
-    {
-      platform: watchOS,
-      isDotNetPlatform: false,
-      isLegacyPlatform: true
-    },
-    {
-      platform: MacCatalyst,
-      isDotNetPlatform: true,
-      isLegacyPlatform: false
-    },
-    {
-      # when running platform-specific test runs, we also need a special test run that executes tests that only runs when multiple platforms are enabled
-      platform: Multiple,
-      isDotNetPlatform: true,
-      isLegacyPlatform: true
-    }
-  ]
+  - name: testConfigurations
+    type: object
+    default: [
+      # Disabled by default #
+      # {
+      #   label: bcl,
+      #   splitByPlatforms: false,
+      # },
+      {
+        label: cecil,
+        splitByPlatforms: false,
+        containsDotNetTests: true,
+        containsLegacyTests: false,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: dotnettests,
+        splitByPlatforms: true,
+        containsDotNetTests: true,
+        containsLegacyTests: false,
+        needsMultiplePlatforms: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: fsharp,
+        splitByPlatforms: false,
+        containsDotNetTests: true,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: framework,
+        splitByPlatforms: false,
+        containsDotNetTests: true,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: generator,
+        splitByPlatforms: false,
+        containsDotNetTests: true,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: interdependent-binding-projects,
+        splitByPlatforms: false,
+        containsDotNetTests: true,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: install-source,
+        splitByPlatforms: false,
+        containsDotNetTests: false,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: introspection,
+        splitByPlatforms: false,
+        containsDotNetTests: true,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: linker,
+        splitByPlatforms: false,
+        containsDotNetTests: true,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: mac-binding-project,
+        splitByPlatforms: false,
+        containsDotNetTests: false,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: mmp,
+        splitByPlatforms: false,
+        containsDotNetTests: false,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: mononative,
+        splitByPlatforms: false,
+        containsDotNetTests: false,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: monotouch,
+        splitByPlatforms: true,
+        containsDotNetTests: true,
+        containsLegacyTests: true,
+        needsMultiplePlatforms: false,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: msbuild,
+        splitByPlatforms: false,
+        containsDotNetTests: true,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: mtouch,
+        splitByPlatforms: false,
+        containsDotNetTests: false,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: xammac,
+        splitByPlatforms: false,
+        containsDotNetTests: false,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: xcframework,
+        splitByPlatforms: false,
+        containsDotNetTests: true,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+      {
+        label: xtro,
+        splitByPlatforms: false,
+        containsDotNetTests: true,
+        containsLegacyTests: true,
+        testPrefix: 'simulator_tests',
+      },
+    ]
 
-- name: testConfigurations
-  type: object
-  default: [
-    # Disabled by default #
-    # {
-    #   label: bcl,
-    #   splitByPlatforms: false,
-    # },
-    {
-      label: cecil,
-      splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: false,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: dotnettests,
-      splitByPlatforms: true,
-      containsDotNetTests: true,
-      containsLegacyTests: false,
-      needsMultiplePlatforms: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: fsharp,
-      splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: framework,
-      splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: generator,
-      splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: interdependent-binding-projects,
-      splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: install-source,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: introspection,
-      splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: linker,
-      splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: mac-binding-project,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: mmp,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: mononative,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: monotouch,
-      splitByPlatforms: true,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      needsMultiplePlatforms: false,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: msbuild,
-      splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: mtouch,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: xammac,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: xcframework,
-      splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: xtro,
-      splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-  ]
+  - name: deviceTestsConfigurations
+    type: object
 
-- name: deviceTestsConfigurations
-  type: object
+  - name: macTestsConfigurations
+    type: object
 
-- name: macTestsConfigurations
-  type: object
+  - name: signingSetupSteps
+    type: stepList
+    default: []
 
-- name: signingSetupSteps
-  type: stepList
-  default: []
+  - name: legacyPackageJobs
+    type: object
+    default: [
+      {
+        job: 'xamarin_ios_sign_notarize',
+        name: 'Xamarin.iOS',
+        pattern: 'xamarin.ios-*',
+        conditionVariable: "INCLUDE_LEGACY_IOS",
+      },
+      {
+        job: 'xamarin_mac_sing_notarie',
+        name: 'Xamarin.Mac',
+        pattern: 'xamarin.mac-*',
+        conditionVariable: "INCLUDE_LEGACY_MAC",
+      }
+    ]
 
-- name: legacyPackageJobs
-  type: object
-  default: [
-    {
-      job: 'xamarin_ios_sign_notarize',
-      name: 'Xamarin.iOS',
-      pattern: 'xamarin.ios-*',
-      conditionVariable: "INCLUDE_LEGACY_IOS",
-    },
-    {
-      job: 'xamarin_mac_sing_notarie',
-      name: 'Xamarin.Mac',
-      pattern: 'xamarin.mac-*',
-      conditionVariable: "INCLUDE_LEGACY_MAC",
-    }
-  ]
+  - name: azureStorage
+    type: string
 
-- name: azureStorage
-  type: string
+  - name: azureContainer
+    type: string
 
-- name: azureContainer
-  type: string
+  - name: stageDisplayNamePrefix
+    type: string
+    default: ''
 
-- name: stageDisplayNamePrefix
-  type: string
-  default: ''
+  - name: dependsOn
+    type: string
+    default: ''
 
-- name: dependsOn
-  type: string
-  default: ''
-
-- name: dependsOnResult
-  type: string
-  default: ''
+  - name: dependsOnResult
+    type: string
+    default: ''
 
 stages:
 
-- ${{ if eq(parameters.runGovernanceTests, true) }}:
-  - template: ./governance/stage.yml
-    parameters:
-      isPR: ${{ parameters.isPR }}
-      repositoryAlias: ${{ parameters.repositoryAlias }}
-      commit: ${{ parameters.commit }}
-      stageDisplayNamePrefix: ${{ parameters.stageDisplayNamePrefix }}
-
-- ${{ if parameters.isPR }}:
-  - stage: clean
-    displayName: '${{ parameters.stageDisplayNamePrefix }}Clean up'
-    dependsOn: []
-    jobs:
-    - job:
-      displayName: 'Clean comments'
-      pool:
-        name: AzurePipelines-EO
-        demands:
-        - ImageOverride -equals 1ESPT-Windows2022
-
-      steps:
-      - template: ./common/clean.yml
-
-- stage: configure_build
-  displayName: '${{ parameters.stageDisplayNamePrefix }}Configure'
-  dependsOn: ${{ parameters.dependsOn }}
-  ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
-    condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
-  jobs:
-  - ${{ if eq(parameters.pool, 'automatic') }}:
-    - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
-      pool: # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
-        name: AzurePipelines-EO
-        demands:
-        - ImageOverride -equals 1ESPT-Windows2022
-      steps:
-      - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-
-      # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-      - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
+  - ${{ if eq(parameters.runGovernanceTests, true) }}:
+      - template: ./governance/stage.yml
         parameters:
-          agentPoolPR: $(PRBuildPool)
-          agentPoolPRUrl: $(PRBuildPoolUrl)
-          agentPoolCI: $(CIBuildPool)
-          agentPoolCIUrl: $(CIBuildPoolUrl)
+          isPR: ${{ parameters.isPR }}
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+          stageDisplayNamePrefix: ${{ parameters.stageDisplayNamePrefix }}
 
-  - job: configure
-    displayName: 'Configure build'
-    pool:
-      name: AzurePipelines-EO
-      demands:
-      - ImageOverride -equals 1ESPT-Windows2022
+  - ${{ if parameters.isPR }}:
+      - stage: clean
+        displayName: '${{ parameters.stageDisplayNamePrefix }}Clean up'
+        dependsOn: []
+        jobs:
+          - job:
+            displayName: 'Clean comments'
+            pool:
+              name: AzurePipelines-EO
+              demands:
+                - ImageOverride -equals 1ESPT-Windows2022
 
-    variables:
-      isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
-      isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
-      BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+            steps:
+              - template: ./common/clean.yml
 
-    steps:
-    - template: common/configure.yml
-      parameters: 
-        repositoryAlias: ${{ parameters.repositoryAlias }}
-        commit: ${{ parameters.commit }}
-        testConfigurations: ${{ parameters.testConfigurations }}
-        supportedPlatforms: ${{ parameters.supportedPlatforms }}
-        testsLabels: '--label=skip-all-tests,run-ios-tests,run-ios-simulator-tests,run-tvos-tests,run-watchos-tests,run-mac-tests,run-maccatalyst-tests,run-dotnet-tests,run-system-permission-tests,run-legacy-xamarin-tests'
-        statusContext: 'VSTS: simulator tests' 
-        uploadArtifacts: true
-        use1ES: true
+  - stage: configure_build
+    displayName: '${{ parameters.stageDisplayNamePrefix }}Configure'
+    dependsOn: ${{ parameters.dependsOn }}
+    ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
+      condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
+    jobs:
+      - ${{ if eq(parameters.pool, 'automatic') }}:
+          - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
+            pool:  # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
+              name: AzurePipelines-EO
+              demands:
+                - ImageOverride -equals 1ESPT-Windows2022
+            steps:
+              - checkout: none  # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
 
-- stage: build_packages
-  displayName: '${{ parameters.stageDisplayNamePrefix }}Build'
-  dependsOn: [ configure_build ]
-  jobs:
-  - template: ./build/build-stage.yml
-    parameters:
-      xcodeChannel: ${{ parameters.xcodeChannel }}
-      macOSName: ${{ parameters.macOSName }}
-      isPR: ${{ parameters.isPR }}
-      repositoryAlias: ${{ parameters.repositoryAlias }}
-      commit: ${{ parameters.commit }}
-      vsdropsPrefix: ${{ variables.vsdropsPrefix }}
-      keyringPass: $(pass--lab--mac--builder--keychain)
-      gitHubToken: $(Github.Token)
-      xqaCertPass: $(xqa--certificates--password)
-      skipESRP: ${{ parameters.skipESRP }}
-      pool: ${{ parameters.pool }}
+              # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
+              - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
+                parameters:
+                  agentPoolPR: $(PRBuildPool)
+                  agentPoolPRUrl: $(PRBuildPoolUrl)
+                  agentPoolCI: $(CIBuildPool)
+                  agentPoolCIUrl: $(CIBuildPoolUrl)
 
-- stage: build_macos_tests
-  displayName: '${{ parameters.stageDisplayNamePrefix }}Build macOS tests'
-  dependsOn: [ configure_build ]
-  jobs:
-  - template: ./build/build-mac-tests-stage.yml
-    parameters:
-      xcodeChannel: ${{ parameters.xcodeChannel }}
-      macOSName: ${{ parameters.macOSName }}
-      isPR: ${{ parameters.isPR }}
-      repositoryAlias: ${{ parameters.repositoryAlias }}
-      commit: ${{ parameters.commit }}
-      vsdropsPrefix: ${{ variables.vsdropsPrefix }}
-      keyringPass: $(pass--lab--mac--builder--keychain)
-      gitHubToken: $(Github.Token)
-      xqaCertPass: $(xqa--certificates--password)
-      pool: ${{ parameters.pool }}
+      - job: configure
+        displayName: 'Configure build'
+        pool:
+          name: AzurePipelines-EO
+          demands:
+            - ImageOverride -equals 1ESPT-Windows2022
 
-- stage: prepare_packages_legacy
-  displayName: '${{ parameters.stageDisplayNamePrefix }}Prepare legacy packages'
-  condition: and(eq(dependencies.build_packages.result, 'Succeeded'), eq('${{ parameters.enableLegacySigning }}', true))
-  dependsOn:
-  - build_packages
-  - configure_build
-  jobs:
-  - template: ./sign-and-notarized/prepare-pkg-stage.yml
-    parameters:
-      isPR: ${{ parameters.isPR }}
-      repositoryAlias: ${{ parameters.repositoryAlias }}
-      commit: ${{ parameters.commit }}
-      signingSetupSteps: ${{ parameters.signingSetupSteps }}
-      keyringPass: $(pass--lab--mac--builder--keychain)
-      skipESRP: ${{ parameters.skipESRP }}
-      packages: ${{ parameters.legacyPackageJobs }}
+        variables:
+          isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+          isScheduled: $[eq(variables['Build.Reason'], 'Schedule')]
+          BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
-# .NET Release Prep and VS Insertion Stages, only execute them when the build comes from an official branch and is not a schedule build from OneLoc
-# setting the stage at this level makes the graph of the UI look better, else the lines overlap and is not clear.
-- ? ${{ if
-      and(
-        ne(variables['Build.Reason'], 'Schedule'),
-        or(
-          eq(variables['Build.SourceBranch'], 'refs/heads/main'),
-          startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'),
-          startsWith(variables['Build.SourceBranch'], 'refs/heads/release-test/'),
-          eq(variables['Build.SourceBranch'], 'refs/heads/net7.0'),
-          eq(variables['Build.SourceBranch'], 'refs/heads/net8.0'),
-          eq(variables['Build.SourceBranch'], 'refs/heads/net9.0'),
-          eq(parameters.forceInsertion, true)
+        steps:
+          - template: common/configure.yml
+            parameters:
+              repositoryAlias: ${{ parameters.repositoryAlias }}
+              commit: ${{ parameters.commit }}
+              testConfigurations: ${{ parameters.testConfigurations }}
+              supportedPlatforms: ${{ parameters.supportedPlatforms }}
+              testsLabels: '--label=skip-all-tests,run-ios-tests,run-ios-simulator-tests,run-tvos-tests,run-watchos-tests,run-mac-tests,run-maccatalyst-tests,run-dotnet-tests,run-system-permission-tests,run-legacy-xamarin-tests'
+              statusContext: 'VSTS: simulator tests'
+              uploadArtifacts: true
+              use1ES: true
+
+  - stage: build_packages
+    displayName: '${{ parameters.stageDisplayNamePrefix }}Build'
+    dependsOn: [configure_build]
+    jobs:
+      - template: ./build/build-stage.yml
+        parameters:
+          xcodeChannel: ${{ parameters.xcodeChannel }}
+          macOSName: ${{ parameters.macOSName }}
+          isPR: ${{ parameters.isPR }}
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+          vsdropsPrefix: ${{ variables.vsdropsPrefix }}
+          keyringPass: $(pass--lab--mac--builder--keychain)
+          gitHubToken: $(Github.Token)
+          xqaCertPass: $(xqa--certificates--password)
+          skipESRP: ${{ parameters.skipESRP }}
+          pool: ${{ parameters.pool }}
+
+  - stage: build_macos_tests
+    displayName: '${{ parameters.stageDisplayNamePrefix }}Build macOS tests'
+    dependsOn: [configure_build]
+    jobs:
+      - template: ./build/build-mac-tests-stage.yml
+        parameters:
+          xcodeChannel: ${{ parameters.xcodeChannel }}
+          macOSName: ${{ parameters.macOSName }}
+          isPR: ${{ parameters.isPR }}
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+          vsdropsPrefix: ${{ variables.vsdropsPrefix }}
+          keyringPass: $(pass--lab--mac--builder--keychain)
+          gitHubToken: $(Github.Token)
+          xqaCertPass: $(xqa--certificates--password)
+          pool: ${{ parameters.pool }}
+
+  - stage: prepare_packages_legacy
+    displayName: '${{ parameters.stageDisplayNamePrefix }}Prepare legacy packages'
+    condition: and(eq(dependencies.build_packages.result, 'Succeeded'), eq('${{ parameters.enableLegacySigning }}', true))
+    dependsOn:
+      - build_packages
+      - configure_build
+    jobs:
+      - template: ./sign-and-notarized/prepare-pkg-stage.yml
+        parameters:
+          isPR: ${{ parameters.isPR }}
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+          signingSetupSteps: ${{ parameters.signingSetupSteps }}
+          keyringPass: $(pass--lab--mac--builder--keychain)
+          skipESRP: ${{ parameters.skipESRP }}
+          packages: ${{ parameters.legacyPackageJobs }}
+
+  # .NET Release Prep and VS Insertion Stages, only execute them when the build comes from an official branch and is not a schedule build from OneLoc
+  # setting the stage at this level makes the graph of the UI look better, else the lines overlap and is not clear.
+  - ? ${{ if
+        and(
+          ne(variables['Build.Reason'], 'Schedule'),
+          or(
+            eq(variables['Build.SourceBranch'], 'refs/heads/main'),
+            startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'),
+            startsWith(variables['Build.SourceBranch'], 'refs/heads/release-test/'),
+            eq(variables['Build.SourceBranch'], 'refs/heads/net7.0'),
+            eq(variables['Build.SourceBranch'], 'refs/heads/net8.0'),
+            eq(variables['Build.SourceBranch'], 'refs/heads/net9.0'),
+            eq(parameters.forceInsertion, true)
+          )
         )
-      )
-    }}
-  : - template: ./release/vs-insertion-prep.yml
-      parameters:
-        buildStage: build_packages
-        dependsOn: [ build_packages, configure_build ]
-        stageDisplayNamePrefix: ${{ parameters.stageDisplayNamePrefix }}
-        isPR: ${{ parameters.isPR }}
-        repositoryAlias: ${{ parameters.repositoryAlias }}
-        commit: ${{ parameters.commit }}
-        pushNugets: ${{ parameters.pushNugets }}
-        pushNugetsToMaestro: ${{ parameters.pushNugetsToMaestro }}
+      }}
+    : - template: ./release/vs-insertion-prep.yml
+        parameters:
+          buildStage: build_packages
+          dependsOn: [build_packages, configure_build]
+          stageDisplayNamePrefix: ${{ parameters.stageDisplayNamePrefix }}
+          isPR: ${{ parameters.isPR }}
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+          pushNugets: ${{ parameters.pushNugets }}
+          pushNugetsToMaestro: ${{ parameters.pushNugetsToMaestro }}
 
-- stage: funnel
-  displayName: '${{ parameters.stageDisplayNamePrefix }}Collect signed artifacts'
-  condition: and(eq(dependencies.prepare_packages_legacy.result, 'Succeeded'), eq('${{ parameters.enableLegacySigning }}', true))
-  dependsOn:
-  - prepare_packages_legacy
-  - configure_build
-  jobs:
-  - template: ./sign-and-notarized/funnel.yml
-    parameters:
-      isPR: ${{ parameters.isPR }}
-      repositoryAlias: ${{ parameters.repositoryAlias }}
-      commit: ${{ parameters.commit }}
-      azureStorage:  ${{ parameters.azureStorage }}
-      azureContainer: ${{ parameters.azureContainer }}
-      packages: # flatten the pkgs for the parameter
-      - ${{ each pkg in parameters.legacyPackageJobs }}:
-        - ${{ pkg }}
+  - stage: funnel
+    displayName: '${{ parameters.stageDisplayNamePrefix }}Collect signed artifacts'
+    condition: and(eq(dependencies.prepare_packages_legacy.result, 'Succeeded'), eq('${{ parameters.enableLegacySigning }}', true))
+    dependsOn:
+      - prepare_packages_legacy
+      - configure_build
+    jobs:
+      - template: ./sign-and-notarized/funnel.yml
+        parameters:
+          isPR: ${{ parameters.isPR }}
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+          azureStorage: ${{ parameters.azureStorage }}
+          azureContainer: ${{ parameters.azureContainer }}
+          packages:  # flatten the pkgs for the parameter
+            - ${{ each pkg in parameters.legacyPackageJobs }}:
+                - ${{ pkg }}


### PR DESCRIPTION
There seems to be several problems with the xcode16 branch:

1. There was a merge issue and the ci broke were we were trying to use the sh to install the runtimes.
2. xcodebuild on xcode16 when using EO machines cannot install the needed simulator runtime.

The PR seems to have some noise because there is a back port missing where we fixed a number of yaml lint issues. The important change is at 'Provision simulators (xcodebuild)' (will add a comment). We had to do a few things:

1. Upload the needed runtime to an internal url.
2. Use simctl to add the runtime, which works as opposed to xcodebuild.

This PR unblocks the CI as seen here: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9918721&view=logs&j=600d49c6-e96b-5e8b-2c3a-9f351e2e5848&t=80a136b1-24dd-5d7f-8552-895fbffe54ed