### PR TITLE
Do not enable dedup when targeting `maccatalyst-x64`

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1100,8 +1100,13 @@
 			<_AOTInputDirectory>$(_IntermediateNativeLibraryDir)aot-input/</_AOTInputDirectory>
 			<_AOTOutputDirectory>$(_IntermediateNativeLibraryDir)aot-output/</_AOTOutputDirectory>
 
-			<!-- Enable dedup optimization whenever we run AOT compiler -->
-			<_IsDedupEnabled Condition="'$(_IsDedupEnabled)' == '' And '$(_RunAotCompiler)' == 'true' And '$(IsMacEnabled)' == 'true'">true</_IsDedupEnabled>
+			<!-- 
+				Enable dedup optimization whenever we run AOT compiler
+				The only exception is maccatalyst-x64 which uses AOT when the interpreter is also enabled.
+				In such setup, during runtime, AOT images are loaded but marked as unusuable as they are compiled with `full` compiler switch and the code fallsback to interpreter.
+				Dedup AOT image is specially handled by the AOT runtime and it is not allowed to have it marked as unusuable.
+			-->
+			<_IsDedupEnabled Condition="'$(_IsDedupEnabled)' == '' And '$(_RunAotCompiler)' == 'true' And '$(IsMacEnabled)' == 'true' And '$(RuntimeIdentifier)' != 'maccatalyst-x64'">true</_IsDedupEnabled>
 			<_DedupAssembly Condition="'$(_IsDedupEnabled)' == 'true'">$(IntermediateOutputPath)aot-instances.dll</_DedupAssembly>
 
 			<!-- default to 'static' for Mac Catalyst to work around https://github.com/xamarin/xamarin-macios/issues/14686 -->

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1984,7 +1984,18 @@ namespace Xamarin.Tests {
 			DotNet.AssertBuild (project_path, properties);
 
 			var objDir = GetObjDir (project_path, platform, runtimeIdentifiers);
-			Assert.True (FindAOTedAssemblyFile (objDir, "aot-instances.dll"), "Dedup optimization should be always enabled for AOT compilation");
+			if (platform == ApplePlatform.MacCatalyst)
+			{
+				var objDirMacCatalystArm64 = Path.Combine (objDir, "maccatalyst-arm64");
+				Assert.True (FindAOTedAssemblyFile (objDirMacCatalystArm64, "aot-instances.dll"), $"Dedup optimization should be enabled for AOT compilation on: {platform} with RID: maccatalyst-arm64");
+
+				var objDirMacCatalystx64 = Path.Combine (objDir, "maccatalyst-x64");
+				Assert.False (FindAOTedAssemblyFile (objDirMacCatalystx64, "aot-instances.dll"), $"Dedup optimization should not be enabled for AOT compilation on: {platform} with RID: maccatalyst-x64");
+			}
+			else
+			{
+				Assert.True (FindAOTedAssemblyFile (objDir, "aot-instances.dll"), $"Dedup optimization should be enabled for AOT compilation on: {platform} with RID: {runtimeIdentifiers}");
+			}
 
 			var appExecutable = GetNativeExecutable (platform, appPath);
 

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1984,16 +1984,13 @@ namespace Xamarin.Tests {
 			DotNet.AssertBuild (project_path, properties);
 
 			var objDir = GetObjDir (project_path, platform, runtimeIdentifiers);
-			if (platform == ApplePlatform.MacCatalyst)
-			{
+			if (platform == ApplePlatform.MacCatalyst) {
 				var objDirMacCatalystArm64 = Path.Combine (objDir, "maccatalyst-arm64");
 				Assert.True (FindAOTedAssemblyFile (objDirMacCatalystArm64, "aot-instances.dll"), $"Dedup optimization should be enabled for AOT compilation on: {platform} with RID: maccatalyst-arm64");
 
 				var objDirMacCatalystx64 = Path.Combine (objDir, "maccatalyst-x64");
 				Assert.False (FindAOTedAssemblyFile (objDirMacCatalystx64, "aot-instances.dll"), $"Dedup optimization should not be enabled for AOT compilation on: {platform} with RID: maccatalyst-x64");
-			}
-			else
-			{
+			} else {
 				Assert.True (FindAOTedAssemblyFile (objDir, "aot-instances.dll"), $"Dedup optimization should be enabled for AOT compilation on: {platform} with RID: {runtimeIdentifiers}");
 			}
 


### PR DESCRIPTION
## Description

This is a follow-up PR to: https://github.com/xamarin/xamarin-macios/pull/20936

We should not enable dedup when targeting `maccatalyst-x64` because in case when the project file specifies `MtouchInterpreter=all,-System.Private.CoreLib`, the build will run the full AOT compiler with interpreter enabled. 

In this setup the runtime is configured to run in interp only mode: https://github.com/xamarin/xamarin-macios/blob/97a91cc4e3bf7cf8a4c657ca00ece620f2e28e91/tools/common/Target.cs#L812-L813

which means that during runtime, AOT images will be ignored - aot runtime will load them but mark them as unusuable since they are compiled with `full` compiler switch and the code falls back to interpreter (ref: https://github.com/dotnet/runtime/blob/efebf202a4a9bd78702bf4bf28a027f093e15d89/src/mono/mono/mini/aot-runtime.c#L2131-L2148 )

This is problematic for the `aot-instances` container image, which has a special handling at the runtime and does not accept it to be marked as unusable (we might want to revisit this in the future): 
https://github.com/dotnet/runtime/blob/efebf202a4a9bd78702bf4bf28a027f093e15d89/src/mono/mono/mini/aot-runtime.c#L2527-L2529

## Changes

This PR disables dedup optimization when targeting `maccatalyst-x64` and updates the required tests to match the behavior.

---

Backports:

- [x] https://github.com/xamarin/xamarin-macios/pull/20946
- [x] Original reenabling of dedup for .NET 9 already includes these changes: https://github.com/xamarin/xamarin-macios/pull/20941
