### PR TITLE
[ci] Update post-build pipeline triggers

### DIFF
--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -34,8 +34,7 @@ resources:
     source: xamarin-macios-ci
     trigger:
       branches:
-      - release/*
-      - net7.0
+      - release/8*
       - net8.0
       - release-test/* # this is for testing the release pipeline on branches without GitHub's branch protection (so we can automate tests without requiring commits to go through pull requests, etc.).
       stages:


### PR DESCRIPTION
This post-build pipeline should only run against net8.0 servicing
branches that don't have the commit (2abbaf900b) that moved maestro
publishing into the regular build pipeline.