### PR TITLE
[release/9.0.1xx-preview7] Enable dedup only when targeting ARM64 mobile platforms

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1098,7 +1098,7 @@
 				In such setup, during runtime, AOT images are loaded but marked as unusuable as they are compiled with `full` compiler switch and the code fallsback to interpreter.
 				Dedup AOT image is specially handled by the AOT runtime and it is not allowed to have it marked as unusuable.
 			-->
-			<_IsDedupEnabled Condition="'$(_IsDedupEnabled)' == '' And '$(_RunAotCompiler)' == 'true' And '$(IsMacEnabled)' == 'true' And '$(RuntimeIdentifier)' != 'maccatalyst-x64'">true</_IsDedupEnabled>
+			<_IsDedupEnabled Condition="'$(_IsDedupEnabled)' == '' And '$(_RunAotCompiler)' == 'true' And '$(IsMacEnabled)' == 'true' And '$(TargetArchitectures)' == 'ARM64'">true</_IsDedupEnabled>
 			<_DedupAssembly Condition="'$(_IsDedupEnabled)' == 'true'">$(IntermediateOutputPath)aot-instances.dll</_DedupAssembly>
 
 			<!-- default to 'static' for Mac Catalyst to work around https://github.com/xamarin/xamarin-macios/issues/14686 -->


### PR DESCRIPTION
## Description

Previous fix https://github.com/xamarin/xamarin-macios/pull/20941 did not take into account that when we target non arm64 apple mobile platforms we are using `MONO_AOT_MODE_INTERP_ONLY` which cannot use dedup optimization as it discards AOT images during runtime (as noted in: https://github.com/xamarin/xamarin-macios/pull/20945).

## Changes

- Enable dedup only when targeting ARM64
- Fix tests to cover builds for both ARM64 and X64 builds

Finally, the change was tested against MAUI iossimulator-x64 template app