### PR TITLE
[release/9.0.1xx-preview7] Link with swift

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1507,6 +1507,8 @@
 		<PropertyGroup>
 			<_ExportedSymbolsFile Condition="'$(_ExportedSymbolsFile)' == '' and '$(_MtouchSymbolsList)' == ''">/dev/null</_ExportedSymbolsFile> <!-- nothing to export -->
 			<_ExportedSymbolsFile Condition="'$(_ExportedSymbolsFile)' == ''">$(_MtouchSymbolsList)</_ExportedSymbolsFile>
+			<!-- Runtime now requires swift https://github.com/dotnet/runtime/commit/2c70e36356e8dfb50e6b32c8b7c9ce1a8e9f1331 -->
+			<LinkWithSwiftSystemLibraries>true</LinkWithSwiftSystemLibraries>
 		</PropertyGroup>
 		<ItemGroup>
 			<_XamarinMainLibraries Include="$(_XamarinNativeLibraryDirectory)/$(_LibXamarinName)" />


### PR DESCRIPTION
The runtime now requires Swift so let's link with it by default
https://github.com/dotnet/runtime/commit/2c70e36356e8dfb50e6b32c8b7c9ce1a8e9f1331

Fixes: https://dev.azure.com/xamarin/public/_build/results?buildId=120547&view=logs&j=71979588-66ac-5e95-831a-69c8cd9b2cd2&t=acd19e4c-afbd-5efc-2769-76bfa657ccbb&l=2196

```
/Users/builder/azdo/_work/1/s/bin/dotnet/packs/Microsoft.MacCatalyst.Sdk.net9.0_17.5/17.5.9217-net9-p7/targets/Xamarin.Shared.Sdk.targets(1634,3): error : clang++ exited with code 1: [/Users/builder/azdo/_work/1/s/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj::TargetFramework=net9.0-maccatalyst]
/Users/builder/azdo/_work/1/s/bin/dotnet/packs/Microsoft.MacCatalyst.Sdk.net9.0_17.5/17.5.9217-net9-p7/targets/Xamarin.Shared.Sdk.targets(1634,3): error : Undefined symbols for architecture x86_64: [/Users/builder/azdo/_work/1/s/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj::TargetFramework=net9.0-maccatalyst]
/Users/builder/azdo/_work/1/s/bin/dotnet/packs/Microsoft.MacCatalyst.Sdk.net9.0_17.5/17.5.9217-net9-p7/targets/Xamarin.Shared.Sdk.targets(1634,3): error :   "_$sSqMa", referenced from: [/Users/builder/azdo/_work/1/s/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj::TargetFramework=net9.0-maccatalyst]
/Users/builder/azdo/_work/1/s/bin/dotnet/packs/Microsoft.MacCatalyst.Sdk.net9.0_17.5/17.5.9217-net9-p7/targets/Xamarin.Shared.Sdk.targets(1634,3): error :       _$s17pal_swiftbindings7encrypt_3key9nonceData9plaintext10cipherText3tag3aadyxm_SRys5UInt8VGA2KSryAJGAlKtKAA22AEADSymmetricAlgorithmRzlF in libSystem.Security.Cryptography.Native.Apple.a(pal_swiftbindings.o) [/Users/builder/azdo/_work/1/s/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj::TargetFramework=net9.0-maccatalyst]
/Users/builder/azdo/_work/1/s/bin/dotnet/packs/Microsoft.MacCatalyst.Sdk.net9.0_17.5/17.5.9217-net9-p7/targets/Xamarin.Shared.Sdk.targets(1634,3): error :   "_$ss5ErrorMp", referenced from: [/Users/builder/azdo/_work/1/s/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj::TargetFramework=net9.0-maccatalyst]
```