### PR TITLE
[release/8.0.1xx-xcode15.4] Bump maccore to get the new testing certificate excusions.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 05609a34411fc8a0bc5224dabd2e6897e65167cf
+NEEDED_MACCORE_VERSION := d3ed4b343e2f39f7afc5d54b30aab74895a13dca
 NEEDED_MACCORE_BRANCH := main
 
 MACCORE_DIRECTORY := maccore

--- a/tools/devops/governance/CredScanSuppressions.json
+++ b/tools/devops/governance/CredScanSuppressions.json
@@ -850,11 +850,11 @@
             "_justification": "External repo dependency, mono."
         },
         {
-            "file": "maccore\\tools\\provisioning-profiles\\certificates-and-profiles\\developer-id-application-luis-aguilera-aug-2024.p12",
+            "file": "maccore\\tools\\provisioning-profiles\\certificates-and-profiles\\developer-id-application-luis-aguilera-jul-2029.p12",
             "_justification": "Testing certificate."
         },
         {
-            "file": "maccore\\tools\\provisioning-profiles\\certificates-and-profiles\\developer-id-installer-luis-aguilera-aug-2024.p12",
+            "file": "maccore\\tools\\provisioning-profiles\\certificates-and-profiles\\developer-id-installer-luis-aguilera-jul-2029.p12",
             "_justification": "Testing certificate."
         },
         {


### PR DESCRIPTION
This is mainly to update the suppression files.

Diff: https://github.com/xamarin/maccore/compare/05609a34411fc8a0bc5224dabd2e6897e65167cf..d3ed4b343e2f39f7afc5d54b30aab74895a13dca