### PR TITLE
[release/9.0.1xx-preview7] Fix .NET 8 dep hashes

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -33,19 +33,19 @@
     <!-- This is a subscription of the .NET 8/Xcode 15.4 versions of our packages -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net8.0_17.5" Version="17.5.8020">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>41fe010737e439bd0161c45ebdb7dee0c3fb4183</Sha>
+      <Sha>700c59ad092ba56a5fc5a71e9aae01b3f4fa25de</Sha>
     </Dependency>
     <Dependency Name="Microsoft.macOS.Sdk.net8.0_14.5" Version="14.5.8020">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>41fe010737e439bd0161c45ebdb7dee0c3fb4183</Sha>
+      <Sha>700c59ad092ba56a5fc5a71e9aae01b3f4fa25de</Sha>
     </Dependency>
     <Dependency Name="Microsoft.iOS.Sdk.net8.0_17.5" Version="17.5.8020">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>41fe010737e439bd0161c45ebdb7dee0c3fb4183</Sha>
+      <Sha>700c59ad092ba56a5fc5a71e9aae01b3f4fa25de</Sha>
     </Dependency>
     <Dependency Name="Microsoft.tvOS.Sdk.net8.0_17.5" Version="17.5.8020">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>41fe010737e439bd0161c45ebdb7dee0c3fb4183</Sha>
+      <Sha>700c59ad092ba56a5fc5a71e9aae01b3f4fa25de</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 8/Xcode 15.0 versions of our packages -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net8.0_17.0" Version="17.0.8523">


### PR DESCRIPTION
17.5.8020 hash is 700c59ad092ba56a5fc5a71e9aae01b3f4fa25de see https://github.com/xamarin/xamarin-macios/commits/release/8.0.1xx-xcode15.4/