### PR TITLE
Fail the build if global.json was updated.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,12 @@ global.json: $(TOP)/dotnet.config Makefile $(GIT_DIRECTORY)/HEAD $(GIT_DIRECTORY
 		printf "}\n" >> $@
 
 install-hook::
+	$(Q) if ! git diff --exit-code global.json; then \
+		echo "Error: global.json has changed: please commit the changes."; \
+		exit 1; \
+	fi
+
+install-hook::
 	@$(MAKE) check-permissions
 ifdef INCLUDE_IOS
 ifneq ($(findstring $(IOS_DESTDIR)$(MONOTOUCH_PREFIX),$(shell ls -l /Library/Frameworks/Xamarin.iOS.framework/Versions/Current 2>&1)),)


### PR DESCRIPTION
While not strictly necessary for a successful build, the API diff will fail
unless we have the correct global.json contents checked in.