### PR TITLE
[maestro] Rearrange lines to try to have fewer merge conflicts.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,6 +2,7 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- Versions updated by maestro -->
+    <MicrosoftDotNetCecilPackageVersion>0.11.4-alpha.23509.2</MicrosoftDotNetCecilPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>8.0.108-servicing.24367.6</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>8.0.7</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETILLinkPackageVersion>8.0.0-rtm.23524.7</MicrosoftNETILLinkPackageVersion>
@@ -10,7 +11,6 @@
     <MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>8.0.0-rtm.23511.3</MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>
     <MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>8.0.0</MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
-    <MicrosoftDotNetCecilPackageVersion>0.11.4-alpha.23509.2</MicrosoftDotNetCecilPackageVersion>
     <MicrosoftDotNetXHarnessiOSSharedPackageVersion>9.0.0-prerelease.24379.1</MicrosoftDotNetXHarnessiOSSharedPackageVersion>
     <!-- Manually updated versions -->
     <Emscriptennet7WorkloadVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100Version)</Emscriptennet7WorkloadVersion>


### PR DESCRIPTION
The `MicrosoftDotNetXHarnessiOSSharedPackageVersion` value is bumped in `main`,
while `MicrosoftDotNetCecilPackageVersion` is bumped in `netX.Y` branches.

If both lines are next to eachother, and they've each been updated in their
respective branches, then merging `main` into `netX.Y` will result in a merge
failure.

Merge conflicts get old rather fast, so try to avoid this by rearranging these
lines a bit.