### PR TITLE
[release/9.0.1xx-preview7] [xcsync] Bump xcsync to 1.0.90

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -20,7 +20,7 @@ endif
 # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.Tools.Mlaunch/versions
 # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.Tools.xcsync/versions
 MLAUNCH_NUGET_VERSION=1.0.142
-XCSYNC_NUGET_VERSION=1.0.86
+XCSYNC_NUGET_VERSION=1.0.90
 
 define CheckVersionTemplate
 check-$(1)::


### PR DESCRIPTION
(cherry picked from commit fb30263d548f98ce489cdccc82bdd80ab1fbd491)