### PR TITLE
[ObjCRuntime] Allow a null delegate in Runtime.ReleaseBlockWhenDelegateIsCollected. Fixes #20920.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2587,11 +2587,11 @@ namespace ObjCRuntime {
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		static Delegate ReleaseBlockWhenDelegateIsCollected (IntPtr block, Delegate @delegate)
 		{
-			if (@delegate is null)
-				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (@delegate));
-
 			if (block == IntPtr.Zero)
 				return @delegate;
+
+			if (@delegate is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (@delegate));
 
 			if (block_lifetime_table.TryGetValue (@delegate, out var existingCollector)) {
 				existingCollector.Add (block);

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -424,6 +424,8 @@ namespace Bindings.Test {
 		[Export ("setProtocolWithBlockProperties:required:instance:")]
 		void SetProtocolWithBlockProperties (IProtocolWithBlockProperties obj, bool required, bool instance);
 
+		[Export ("nullableCallback:")]
+		bool NullableCallback ([NullAllowed] Action<int> completionHandler);
 	}
 
 	delegate void InnerBlock (int magic_number);

--- a/tests/bindings-test/Messaging.cs
+++ b/tests/bindings-test/Messaging.cs
@@ -13,5 +13,8 @@ namespace ObjCRuntime {
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public extern static void void_objc_msgSend_IntPtr_bool_bool (IntPtr receiver, IntPtr selector, IntPtr a, bool b, bool c);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static byte byte_objc_msgSend_IntPtr (IntPtr receiver, IntPtr selector, IntPtr a);
 	}
 }

--- a/tests/bindings-test/RegistrarBindingTest.cs
+++ b/tests/bindings-test/RegistrarBindingTest.cs
@@ -257,6 +257,7 @@ namespace Xamarin.BindingTests {
 			}
 
 #if NET
+			[BindingImpl (BindingImplOptions.Optimizable)]
 			public bool InvokeNullableCallbackNatively (Action<int>? completionHandler)
 			{
 				byte rv;
@@ -265,7 +266,7 @@ namespace Xamarin.BindingTests {
 				} else {
 					unsafe {
 						delegate* unmanaged<IntPtr, int, void> trampoline = &NullableCallbackHandler;
-						using var block = new BlockLiteral (trampoline, completionHandler, GetType (), nameof (NullableCallbackHandler));
+						using var block = new BlockLiteral (trampoline, completionHandler, typeof (BlockCallbackTester), nameof (NullableCallbackHandler));
 						BlockLiteral* block_ptr = &block;
 						rv = Messaging.byte_objc_msgSend_IntPtr (Handle, Selector.GetHandle ("nullableCallback:"), (IntPtr) block_ptr);
 					}

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -17,6 +17,10 @@ extern "C" {
 int theUltimateAnswer ();
 void useZLib ();
 
+// NS_ASSUME_NONNULL_BEGIN doesn't work
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+
 typedef void (^x_block_callback)();
 void x_call_block (x_block_callback block);
 void* x_call_func_3 (void* (*fptr)(void*, void*, void*), void* p1, void* p2, void* p3);
@@ -237,6 +241,8 @@ typedef void (^outerBlock) (innerBlock callback);
 
 +(void) setProtocolWithBlockProperties: (id<ProtocolWithBlockProperties>) obj required: (bool) required instance: (bool) instance;
 +(int) calledBlockCount;
+
+-(bool) nullableCallback: (void (^ __nullable)(int32_t magic_number))completionHandler;
 @end
 
 @interface FreedNotifier : NSObject {
@@ -293,6 +299,9 @@ typedef void (^outerBlock) (innerBlock callback);
 @property (copy) NSDate* dateValue;
 
 @end
+
+#pragma clang diagnostic pop
+// NS_ASSUME_NONNULL_END
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -812,6 +812,12 @@ static Class _TestClass = NULL;
 	return called_blocks;
 }
 
+-(bool) nullableCallback: (void (^ __nullable)(int32_t magic_number))completionHandler
+{
+	assert (false); // THIS FUNCTION SHOULD BE OVERRIDDEN
+	return false;
+}
+
 static void block_called ()
 {
 #pragma clang diagnostic push


### PR DESCRIPTION
Allow a null delegate in Runtime.ReleaseBlockWhenDelegateIsCollected if the
corresponding native pointer is also null.

Fixes https://github.com/xamarin/xamarin-macios/issues/20920.