### PR TITLE
[ci] Simplify shipping drop metadata names

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -150,7 +150,7 @@ stages:
 
       - task: DownloadPipelineArtifact@2
         inputs:
-          artifactName: DropMetadata-$(Build.BuildId)-nugets-$(System.JobAttempt)
+          artifactName: DropMetadata-shipping-nugets
           downloadPath: $(Build.StagingDirectory)\metadata
         displayName: Download nugets drop metadata
 


### PR DESCRIPTION
Using the $(System.JobAttempt) variable in the drop metadata artifact
name is problematic. In some cases the drop artifacts created by the
nuget-msi-convert job will be used by a different job, and the job
attempt number will not necessarily match if any jobs are re-ran.