### PR TITLE
[dotnet-linker] Fix computing block signatures. Fixes #21008.

### DIFF
--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -204,11 +204,6 @@ namespace ObjCRuntime {
 		}
 #endif // NET
 
-#if NET
-		// Note that the code in this method shouldn't be called when using any static registrar, so throw an exception in that case.
-		// IL2075: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'. The return value of method 'ObjCRuntime.UserDelegateTypeAttribute.UserDelegateType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
-		[UnconditionalSuppressMessage ("", "IL2075", Justification = "The APIs this method tries to access are marked by other means, so this is linker-safe.")]
-#endif
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		void SetupBlock (Delegate trampoline, Delegate target, bool safe)
 		{
@@ -231,6 +226,11 @@ namespace ObjCRuntime {
 			SetupBlockImpl (trampoline, target, safe, System.Text.Encoding.UTF8.GetBytes (signature));
 		}
 
+#if NET
+		// Note that the code in this method shouldn't be called when using any static registrar, so throw an exception in that case.
+		// IL2075: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'. The return value of method 'ObjCRuntime.UserDelegateTypeAttribute.UserDelegateType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+		[UnconditionalSuppressMessage ("", "IL2075", Justification = "The APIs this method tries to access are marked by other means, so this is linker-safe.")]
+#endif
 		static bool TryGetUserDelegateType (MemberInfo provider, MethodInfo noUserDelegateTypeMethod, out MethodInfo userMethod)
 		{
 			var userDelegateType = provider.GetCustomAttribute<UserDelegateTypeAttribute> ()?.UserDelegateType;

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -2697,10 +2697,24 @@ namespace Registrar {
 			case "System.Double": return "d";
 			case "System.Boolean":
 				// map managed 'bool' to ObjC BOOL = 'unsigned char' in OSX and 32bit iOS architectures and 'bool' in 64bit iOS architectures
+#if MTOUCH || MMP || BUNDLER
+				switch (App.Platform) {
+				case ApplePlatform.iOS:
+				case ApplePlatform.WatchOS:
+				case ApplePlatform.TVOS:
+					return Is64Bits ? "B" : "c";
+				case ApplePlatform.MacOSX:
+				case ApplePlatform.MacCatalyst:
+					return IsARM64 ? "B" : "c";
+				default:
+					throw ErrorHelper.CreateError (71, Errors.MX0071, App.Platform, App.ProductName);
+				}
+#else
 #if MONOMAC || __MACCATALYST__
 				return IsARM64 ? "B" : "c";
 #else
 				return Is64Bits ? "B" : "c";
+#endif
 #endif
 			case "System.Void": return "v";
 			case "System.String":

--- a/src/ObjCRuntime/UserDelegateTypeAttribute.cs
+++ b/src/ObjCRuntime/UserDelegateTypeAttribute.cs
@@ -36,7 +36,7 @@ namespace ObjCRuntime {
 	// This attribute is emitted by the generator and used at runtime.
 	// It's not supposed to be used by manually written code.
 	[EditorBrowsable (EditorBrowsableState.Never)]
-	[AttributeUsage (AttributeTargets.Delegate, AllowMultiple = false)]
+	[AttributeUsage (AttributeTargets.Delegate | AttributeTargets.Method, AllowMultiple = false)]
 	public sealed class UserDelegateTypeAttribute : Attribute {
 		public UserDelegateTypeAttribute (Type userDelegateType)
 		{

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -1602,6 +1602,7 @@ public partial class Generator : IMemberGatherer {
 #else
 			print ("[MonoPInvokeCallback (typeof ({0}))]", ti.DelegateName);
 #endif
+			print ("[UserDelegateType (typeof ({0}))]", ti.UserDelegate);
 			print ("internal static unsafe {0} Invoke ({1}) {{", ti.ReturnType, ti.Parameters);
 			indent++;
 			print ("var del = BlockLiteral.GetTarget<{0}> (block);", ti.UserDelegate);

--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -104,7 +104,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		static unsafe string GetBlockSignature (BlockLiteral* block)
 		{
-			var test_block = (TestBlockLiteral *) block;
+			var test_block = (TestBlockLiteral*) block;
 			var signatureUtf8Ptr = test_block->block_descriptor->signature;
 			var signature = Marshal.PtrToStringAuto (signatureUtf8Ptr);
 			return signature;

--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -41,7 +41,12 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		{
 			delegate* unmanaged<IntPtr, byte, void> trampoline = &SignatureTestA;
 			using var block = new BlockLiteral (trampoline, null, typeof (BlocksTest), nameof (SignatureTestA));
-			Assert.AreEqual ("v@?B", GetBlockSignature (&block), "Signature");
+#if __MACOS__ || __MACCATALYST__
+			var boolIsB = Runtime.IsARM64CallingConvention;
+#else
+			var boolIsB = true;
+#endif
+			Assert.AreEqual (boolIsB ? "v@?B" : "v@?c", GetBlockSignature (&block), "Signature");
 		}
 
 		[Test]

--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -43,10 +43,12 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			using var block = new BlockLiteral (trampoline, null, typeof (BlocksTest), nameof (SignatureTestA));
 #if __MACOS__
 			var boolIsB = Runtime.IsARM64CallingConvention;
+#elif __MACCATALYST__
+			var boolIsB = Runtime.IsARM64CallingConvention;
 #else
 			var boolIsB = true;
 #endif
-			Assert.AreEqual (boolIsB ? "v@?B" : "v@?c", GetBlockSignature (&block), "Signature");
+			Assert.AreEqual (boolIsB ? "v@?B" : "v@?c", GetBlockSignature (&block), $"Signature ARM64: {Runtime.IsARM64CallingConvention}");
 		}
 
 		[Test]

--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -41,7 +41,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		{
 			delegate* unmanaged<IntPtr, byte, void> trampoline = &SignatureTestA;
 			using var block = new BlockLiteral (trampoline, null, typeof (BlocksTest), nameof (SignatureTestA));
-#if __MACOS__ || __MACCATALYST__
+#if __MACOS__
 			var boolIsB = Runtime.IsARM64CallingConvention;
 #else
 			var boolIsB = true;

--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -34,6 +34,82 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[DllImport ("/usr/lib/libobjc.dylib")]
 		static extern bool class_addMethod (IntPtr cls, IntPtr name, IntPtr imp, string types);
 
+#if NET
+		[Test]
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		public unsafe void SignatureA ()
+		{
+			delegate* unmanaged<IntPtr, byte, void> trampoline = &SignatureTestA;
+			using var block = new BlockLiteral (trampoline, null, typeof (BlocksTest), nameof (SignatureTestA));
+			Assert.AreEqual ("v@?B", GetBlockSignature (&block), "Signature");
+		}
+
+		[Test]
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		public unsafe void SignatureB ()
+		{
+			delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &SignatureTestB;
+			using var block = new BlockLiteral (trampoline, null, typeof (BlocksTest), nameof (SignatureTestB));
+			Assert.AreEqual ("v@?@", GetBlockSignature (&block), "Signature");
+		}
+
+		[Test]
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		public unsafe void SignatureC ()
+		{
+			delegate* unmanaged<IntPtr, IntPtr, void> trampoline = &SignatureTestC;
+			using var block = new BlockLiteral (trampoline, null, typeof (BlocksTest), nameof (SignatureTestC));
+			// This is the wrong signature, but the registrar has no way of figuring out the correct
+			// one without the UserDelegateType attribute on the target method.
+			Assert.AreEqual ("v@?^v^v", GetBlockSignature (&block), "Signature");
+		}
+
+		[UserDelegateType (typeof (Action<bool>))]
+		[UnmanagedCallersOnly]
+		static void SignatureTestA (IntPtr block, byte value)
+		{
+		}
+
+		[UserDelegateType (typeof (Action<NSError>))]
+		[UnmanagedCallersOnly]
+		static void SignatureTestB (IntPtr block, IntPtr value)
+		{
+		}
+
+		[UnmanagedCallersOnly]
+		static void SignatureTestC (IntPtr block, IntPtr value)
+		{
+		}
+#endif
+
+
+#pragma warning disable 649
+		[StructLayout (LayoutKind.Sequential)]
+		struct TestBlockDescriptor {
+			public IntPtr reserved;
+			public IntPtr size;
+			public IntPtr copy_helper;
+			public IntPtr dispose;
+			public IntPtr signature;
+		}
+		[StructLayout (LayoutKind.Sequential)]
+		unsafe struct TestBlockLiteral {
+			IntPtr isa;
+			int flags;
+			int reserved;
+			IntPtr invoke;
+			public TestBlockDescriptor* block_descriptor;
+		}
+#pragma warning restore 649
+
+		static unsafe string GetBlockSignature (BlockLiteral* block)
+		{
+			var test_block = (TestBlockLiteral *) block;
+			var signatureUtf8Ptr = test_block->block_descriptor->signature;
+			var signature = Marshal.PtrToStringAuto (signatureUtf8Ptr);
+			return signature;
+		}
+
 		[Test]
 		public void TestSetupBlock ()
 		{

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -5716,10 +5716,23 @@ namespace Registrar {
 		}
 
 		// Find the value of the [UserDelegateType] attribute on the specified delegate
+		public TypeReference GetUserDelegateType (MethodReference invokeMethod)
+		{
+			return GetUserDelegateTypeImpl (invokeMethod.Resolve ());
+		}
+
+		// Find the value of the [UserDelegateType] attribute on the specified method
 		TypeReference GetUserDelegateType (TypeReference delegateType)
 		{
-			var delegateTypeDefinition = delegateType.Resolve ();
-			foreach (var attrib in delegateTypeDefinition.CustomAttributes) {
+			return GetUserDelegateTypeImpl (delegateType.Resolve ());
+		}
+
+		// Find the value of the [UserDelegateType] attribute on the specified delegate
+		TypeReference GetUserDelegateTypeImpl (ICustomAttributeProvider provider)
+		{
+			if (provider?.HasCustomAttributes != true)
+				return null;
+			foreach (var attrib in provider.CustomAttributes) {
 				var attribType = attrib.AttributeType;
 				if (!attribType.Is (Namespaces.ObjCRuntime, "UserDelegateTypeAttribute"))
 					continue;
@@ -5728,17 +5741,17 @@ namespace Registrar {
 			return null;
 		}
 
-		MethodDefinition GetDelegateInvoke (TypeReference delegateType)
+		public MethodReference GetDelegateInvoke (TypeReference delegateType)
 		{
 			var td = delegateType.Resolve ();
 			foreach (var method in td.Methods) {
 				if (method.Name == "Invoke")
-					return method;
+					return InflateMethod (delegateType, method);
 			}
 			return null;
 		}
 
-		MethodReference InflateMethod (TypeReference inflatedDeclaringType, MethodDefinition openMethod)
+		public MethodReference InflateMethod (TypeReference inflatedDeclaringType, MethodDefinition openMethod)
 		{
 			if (inflatedDeclaringType is not GenericInstanceType git)
 				return openMethod;
@@ -5767,13 +5780,11 @@ namespace Registrar {
 				// First look for any [UserDelegateType] attributes on the trampoline delegate type.
 				var userDelegateType = GetUserDelegateType (trampolineDelegateType);
 				if (userDelegateType is not null) {
-					var userMethodDefinition = GetDelegateInvoke (userDelegateType);
-					userMethod = InflateMethod (userDelegateType, userMethodDefinition);
+					userMethod = GetDelegateInvoke (userDelegateType);
 					blockSignature = true;
 				} else {
 					// Couldn't find a [UserDelegateType] attribute, use the type of the actual trampoline instead.
-					var userMethodDefinition = GetDelegateInvoke (trampolineDelegateType);
-					userMethod = InflateMethod (trampolineDelegateType, userMethodDefinition);
+					userMethod = GetDelegateInvoke (trampolineDelegateType);
 					blockSignature = false;
 				}
 

--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -1144,12 +1144,20 @@ namespace Xamarin.Linker {
 					return 0;
 				}
 
-				// Calculate the block signature.
+				var userDelegateType = LinkContext.Target.StaticRegistrar.GetUserDelegateType (trampolineMethod);
+				MethodReference userMethod = null;
 				var blockSignature = true;
-				var parameters = new TypeReference [trampolineMethod.Parameters.Count];
+				if (userDelegateType is not null) {
+					userMethod = LinkContext.Target.StaticRegistrar.GetDelegateInvoke (userDelegateType);
+				} else {
+					userMethod = trampolineMethod;
+				}
+
+				// Calculate the block signature.
+				var parameters = new TypeReference [userMethod.Parameters.Count];
 				for (int p = 0; p < parameters.Length; p++)
-					parameters [p] = trampolineMethod.Parameters [p].ParameterType;
-				signature = LinkContext.Target.StaticRegistrar.ComputeSignature (trampolineMethod.DeclaringType, false, trampolineMethod.ReturnType, parameters, trampolineMethod.Resolve (), isBlockSignature: blockSignature);
+					parameters [p] = userMethod.Parameters [p].ParameterType;
+				signature = LinkContext.Target.StaticRegistrar.ComputeSignature (userMethod.DeclaringType, false, userMethod.ReturnType, parameters, userMethod.Resolve (), isBlockSignature: blockSignature);
 
 				sequenceStart = loadType;
 			} catch (Exception e) {


### PR DESCRIPTION
When we compute the signature of a block for Objective-C, we need to use parameters of the user-provided callback (and not the intermediate UnmanagedCallersOnly method) to compute the signature.

This is because the intermediate method's parameters don't have all the information we need to correctly compute the block signature (in particular for the issue in question, the user callback has an `NSError` parameter, while the intermediate method has an `IntPtr` parameter, and these two parameter types show up differently in the block signature).

This is solved by adding the `UserDelegateType` attribute (which was created for exactly this, and it's just in older generated code) to the intermediate method, pointing to a delegate with the correct managed signature.

Fixes https://github.com/xamarin/xamarin-macios/issues/21008.