### PR TITLE
[CoreGraphics] Bind the CGSession API.

### DIFF
--- a/src/CoreGraphics/CGSession.cs
+++ b/src/CoreGraphics/CGSession.cs
@@ -1,0 +1,58 @@
+#if NET
+#if __MACOS__ || __MACCATALYST__
+
+using System.Runtime.InteropServices;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace CoreGraphics {
+
+	[SupportedOSPlatform ("maccatalyst")]
+	[SupportedOSPlatform ("macos")]
+	[UnsupportedOSPlatform ("ios")]
+	[UnsupportedOSPlatform ("tvos")]
+	public static class CGSession {
+		[DllImport (Constants.CoreGraphicsLibrary)]
+		extern static /* CFDictionaryRef __nullable */ IntPtr CGSessionCopyCurrentDictionary ();
+
+		/// <summary>Get the properties for the current window server session.</summary>
+		/// <returns>The properties for the current window server session.</returns>
+		/// <remarks>Returns null if the caller is not running in a Quartz GUI session or the window server is disabled.</remarks>
+		public static CGSessionProperties? GetProperties ()
+		{
+			var handle = CGSessionCopyCurrentDictionary ();
+			if (handle == IntPtr.Zero)
+				return null;
+			var dict = Runtime.GetNSObject<NSDictionary> (handle, owns: true);
+			return new CGSessionProperties (dict);
+		}
+	}
+
+	// This looks like it should be in an api definition bound using [Field] attributes,
+	// but these aren't actual native fields, in the headers they're declared as constants:
+	//     #define kCGSession*Key @"SomeStringValue"
+	[SupportedOSPlatform ("maccatalyst")]
+	[SupportedOSPlatform ("macos")]
+	[UnsupportedOSPlatform ("ios")]
+	[UnsupportedOSPlatform ("tvos")]
+	public static class CGSessionKeys {
+		/// <summary>A key for the user ID for the session's current user.</summary>
+		public static NSString UserIdKey { get => (NSString) "kCGSSessionUserIDKey"; }
+
+		/// <summary>A key for the short user name for the session's current user.</summary>
+		public static NSString UserNameKey { get => (NSString) "kCGSSessionUserNameKey"; }
+
+		/// <summary>A key for the set of hardware composing a console for the session's current user.</summary>
+		public static NSString ConsoleSetKey { get => (NSString) "kCGSSessionConsoleSetKey"; }
+
+		/// <summary>A key for indicating whether the session's on a console.</summary>
+		public static NSString OnConsoleKey { get => (NSString) "kCGSSessionOnConsoleKey"; }
+
+		/// <summary>A key for indicating whether the session's login operation has been don</summary>
+		public static NSString LoginDoneKey { get => (NSString) "kCGSessionLoginDoneKey"; }
+	}
+}
+
+#endif // __MACOS__ || __MACCATALYST__
+#endif // NET

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -504,4 +504,16 @@ namespace CoreGraphics {
 		[Field ("kCGDisplayStreamYCbCrMatrix_SMPTE_240M_1995")]
 		NSString Smpte_240M_1995 { get; }
 	}
+
+#if NET
+	[NoiOS, NoTV, NoWatch, MacCatalyst (13, 1)]
+	[StrongDictionary ("CGSessionKeys")]
+	interface CGSessionProperties {
+		uint UserId { get; }
+		string UserName { get; }
+		uint ConsoleSet { get; }
+		bool OnConsole { get; }
+		bool LoginDone { get; }
+	}
+#endif
 }

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -546,6 +546,7 @@ COREGRAPHICS_SOURCES = \
 	CoreGraphics/CGPDFStream.cs \
 	CoreGraphics/CGPDFString.cs \
 	CoreGraphics/CGPdfTagType.cs \
+	CoreGraphics/CGSession.cs \
 	CoreGraphics/CGShading.cs \
 	CoreGraphics/NativeDrawingMethods.cs \
 

--- a/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
+++ b/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
@@ -13,6 +13,15 @@ namespace MonoTouchFixtures.CoreVideo {
 	[Preserve (AllMembers = true)]
 	public class CVDisplayLinkTest {
 
+		void IgnoreIfLockedScreen ()
+		{
+			var props = CGSession.GetProperties ();
+			var value = props.Dictionary [(NSString) "CGSSessionScreenIsLocked"]; // This key isn't documented, so no binding for it.
+			var isLocked = (value as NSNumber)?.BoolValue;
+			if (isLocked == true)
+				Assert.Ignore ("The screen is locked.");
+		}
+
 		[Test]
 		public void CreateFromDisplayIdValidIdTest ()
 		{
@@ -61,6 +70,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		public void DefaultConstructorTest ()
 		{
 			TestRuntime.AssertNotVSTS ();
+			IgnoreIfLockedScreen ();
 			Assert.DoesNotThrow (() => {
 				using var displayLink = new CVDisplayLink ();
 			});
@@ -70,6 +80,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		public void SetCurrentDisplayOpenGLTest ()
 		{
 			TestRuntime.AssertNotVSTS ();
+			IgnoreIfLockedScreen ();
 			Assert.DoesNotThrow (() => {
 				using var displayLink = new CVDisplayLink ();
 				displayLink.SetCurrentDisplay (CGDisplay.MainDisplayID);
@@ -80,6 +91,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		public void GetCurrentDisplayTest ()
 		{
 			TestRuntime.AssertNotVSTS ();
+			IgnoreIfLockedScreen ();
 			Assert.DoesNotThrow (() => {
 				using var displayLink = new CVDisplayLink ();
 				Assert.AreEqual (CGDisplay.MainDisplayID, displayLink.GetCurrentDisplay ());
@@ -100,6 +112,7 @@ namespace MonoTouchFixtures.CoreVideo {
 		{
 			TestRuntime.AssertNotVSTS ();
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 12, 0);
+			IgnoreIfLockedScreen ();
 			var outTime = new CVTimeStamp {
 				Version = 0,
 				Flags = (1L << 0) | (1L << 1), // kCVTimeStampVideoTimeValid | kCVTimeStampHostTimeValid

--- a/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
+++ b/tests/monotouch-test/CoreVideo/CVDisplayLinkTest.cs
@@ -15,11 +15,13 @@ namespace MonoTouchFixtures.CoreVideo {
 
 		void IgnoreIfLockedScreen ()
 		{
+#if NET
 			var props = CGSession.GetProperties ();
 			var value = props.Dictionary [(NSString) "CGSSessionScreenIsLocked"]; // This key isn't documented, so no binding for it.
 			var isLocked = (value as NSNumber)?.BoolValue;
 			if (isLocked == true)
 				Assert.Ignore ("The screen is locked.");
+#endif
 		}
 
 		[Test]

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreGraphics.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreGraphics.ignore
@@ -90,7 +90,6 @@
 !missing-pinvoke! CGReleaseDisplayFadeReservation is not bound
 !missing-pinvoke! CGRequestScreenCaptureAccess is not bound
 !missing-pinvoke! CGRestorePermanentDisplayConfiguration is not bound
-!missing-pinvoke! CGSessionCopyCurrentDictionary is not bound
 !missing-pinvoke! CGSetDisplayTransferByByteTable is not bound
 !missing-pinvoke! CGSetDisplayTransferByTable is not bound
 !missing-pinvoke! CGWarpMouseCursorPosition is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreGraphics.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreGraphics.ignore
@@ -87,7 +87,6 @@
 !missing-pinvoke! CGPSConverterIsConverting is not bound
 !missing-pinvoke! CGReleaseDisplayFadeReservation is not bound
 !missing-pinvoke! CGRestorePermanentDisplayConfiguration is not bound
-!missing-pinvoke! CGSessionCopyCurrentDictionary is not bound
 !missing-pinvoke! CGSetDisplayTransferByByteTable is not bound
 !missing-pinvoke! CGSetDisplayTransferByTable is not bound
 !missing-pinvoke! CGWarpMouseCursorPosition is not bound


### PR DESCRIPTION
And use it to ignore a few tests that fail when the screen is locked.