### PR TITLE
[devops] Publish Xcode 16 builds (take 2).

### DIFF
--- a/tools/devops/automation/post-build-pipeline.yml
+++ b/tools/devops/automation/post-build-pipeline.yml
@@ -37,7 +37,6 @@ resources:
       - release/8*
       - net8.0
       - release-test/* # this is for testing the release pipeline on branches without GitHub's branch protection (so we can automate tests without requiring commits to go through pull requests, etc.).
-      - xcode16
       stages:
       - prepare_release
 

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -410,6 +410,7 @@ stages:
             eq(variables['Build.SourceBranch'], 'refs/heads/net7.0'),
             eq(variables['Build.SourceBranch'], 'refs/heads/net8.0'),
             eq(variables['Build.SourceBranch'], 'refs/heads/net9.0'),
+            eq(variables['Build.SourceBranch'], 'refs/heads/xcode16'),
             eq(parameters.forceInsertion, true)
           )
         )


### PR DESCRIPTION
This is required to release any previews of our xcode16 bits.