### PR TITLE
[devops] Make agent log gathering more resilient.

### DIFF
--- a/tools/devops/automation/scripts/generate_agent_logs.ps1
+++ b/tools/devops/automation/scripts/generate_agent_logs.ps1
@@ -21,21 +21,28 @@ param
 # the build started
 
 # User name can be anything. It is the personal access token (PAT) token that matters.
-$user= "AnyUser"
-$base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $user, $VstsToken)))
-$headers = @{Authorization = "Basic {0}" -f $base64AuthInfo}
+try {
+  $user= "AnyUser"
+  $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $user, $VstsToken)))
+  $headers = @{Authorization = "Basic {0}" -f $base64AuthInfo}
 
-# get the url of the build
-$url= $Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI + "$Env:SYSTEM_TEAMPROJECT/_apis/build/builds/" + $Env:BUILD_BUILDID + "?api-version=5.1"
-$buildPipeline= Invoke-RestMethod -Uri $url -Headers $headers -Method Get
+  # get the url of the build
+  $url= $Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI + "$Env:SYSTEM_TEAMPROJECT/_apis/build/builds/" + $Env:BUILD_BUILDID + "?api-version=5.1"
+  $buildPipeline= Invoke-RestMethod -Uri $url -Headers $headers -Method Get
 
-$start=[DateTime]::Parse($buildPipeline.startTime).ToString("yyyy-MM-dd HH:mm:ss")
+  $start=[DateTime]::Parse($buildPipeline.startTime).ToString("yyyy-MM-dd HH:mm:ss")
 
-$end=Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-Write-Host "end time: $end"
+  $end=Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+  Write-Host "end time: $end"
 
-if (-not $Predicate) {
-  log show --style $Style --start "$start" --end "$end" > $Output
-} else {
-  log show --predicate $Predicate --style $Style --start "$start" --end "$end" > $Output
+  if (-not $Predicate) {
+    log show --style $Style --start "$start" --end "$end" > $Output
+  } else {
+    log show --predicate $Predicate --style $Style --start "$start" --end "$end" > $Output
+  }
+} catch {
+    Write-Host "Exception occurred: $_"
+    # Create the output file, because we later try to upload it as an artifact, and *not* uploading
+    # if there's *no* file is much harder than just creating the file.
+    New-Item -Path $Output -Value "$_"
 }


### PR DESCRIPTION
Sometimes gathering logs fail:

    ========================== Starting Command Output ===========================
    /usr/local/bin/pwsh -NoLogo -NoProfile -NonInteractive -Command . '/Users/builder/azdo/_work/_temp/d21eee53-34e9-41e1-bfb3-335bf6a0c07f.ps1'
    Build pipeline start time:
    generate_agent_logs.ps1: /Users/builder/azdo/_work/_temp/d21eee53-34e9-41e1-bfb3-335bf6a0c07f.ps1:3
    Line |
       3 |  /Users/builder/azdo/_work/2/s/xamarin-macios/tools/devops/automation/ …
         |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         | Exception calling "Parse" with "1" argument(s): "String '' was not
         | recognized as a valid DateTime."

    ##[error]PowerShell exited with code '1'.
    Finishing: Gathering agent logs

Which isn't a big problem, except that the later "Publish Artifacts: Agent
logs" step fails even though "continueOnError: true" if the file doesn't
exist.

So hack this by swallowing any errors in the log gathering phase, but ensuring
that the expected output file exists at the end even if something went wrong.