### PR TITLE
[ci] Use new connection for pair-to-mac keyvault

### DIFF
--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -110,7 +110,7 @@ steps:
 
 - task: AzureKeyVault@2
   inputs:
-    azureSubscription: 'Xamarin - R&D - XamarinSecurity'
+    azureSubscription: 'Xamarin - SDK Engineering - macios-team-pair-to-mac-ci'
     KeyVaultName: 'xamarin-ios-vault'
     SecretsFilter: 'RemoteMacIdRsa'
   displayName: 'Download id_rsa'

--- a/tools/devops/automation/templates/windows/reenable-mac.yml
+++ b/tools/devops/automation/templates/windows/reenable-mac.yml
@@ -24,7 +24,7 @@ steps:
 
 - task: AzureKeyVault@2
   inputs:
-    azureSubscription: 'Xamarin - R&D - XamarinSecurity'
+    azureSubscription: 'Xamarin - SDK Engineering - macios-team-pair-to-mac-ci'
     KeyVaultName: 'xamarin-ios-vault'
     SecretsFilter: 'RemoteMacIdRsa'
   displayName: 'Download id_rsa'

--- a/tools/devops/automation/templates/windows/reserve-mac.yml
+++ b/tools/devops/automation/templates/windows/reserve-mac.yml
@@ -91,7 +91,7 @@ steps:
 
 - task: AzureKeyVault@2
   inputs:
-    azureSubscription: 'Xamarin - R&D - XamarinSecurity'
+    azureSubscription: 'Xamarin - SDK Engineering - macios-team-pair-to-mac-ci'
     KeyVaultName: 'xamarin-ios-vault'
     SecretsFilter: 'RemoteMacIdRsaPub'
   displayName: 'Download id_rsa.pub'


### PR DESCRIPTION
The xamarin-ios-vault keyvault has been moved into the Xamarin SDK azure subscription:

https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cd4829e2-e38b-43d2-8316-2f2009f36f97/resourceGroups/macios-team-pair-to-mac-ci/providers/Microsoft.KeyVault/vaults/xamarin-ios-vault/overview