### PR TITLE
Don't encode underscore in AOT symbol name

### DIFF
--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -959,7 +959,8 @@ namespace Xamarin.Bundler {
 				char c = (char) b;
 				if ((c >= '0' && c <= '9') ||
 					(c >= 'a' && c <= 'z') ||
-					(c >= 'A' && c <= 'Z')) {
+					(c >= 'A' && c <= 'Z') ||
+                    (c == '_')) {
 					sb.Append (c);
 					continue;
 #if NET

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -960,7 +960,7 @@ namespace Xamarin.Bundler {
 				if ((c >= '0' && c <= '9') ||
 					(c >= 'a' && c <= 'z') ||
 					(c >= 'A' && c <= 'Z') ||
-                    (c == '_')) {
+					(c == '_')) {
 					sb.Append (c);
 					continue;
 #if NET


### PR DESCRIPTION
This was an oversight in https://github.com/xamarin/xamarin-macios/commit/4a9bfcb154b7902edde55252b61e9559dee43db0

We need to keep underscore as-is to match what the AOT compiler generates.