### PR TITLE
[release/9.0.1xx-rc1] [dotnet] Make the RelativeMlaunchPath and XamarinRelativeSdkRootDirectory properties public.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -23,7 +23,10 @@
 		<UsingAppleNETSdk>true</UsingAppleNETSdk>
 		<!-- This is the location of the Microsoft.<platform>.Sdk NuGet (/usr/local/share/dotnet/sdk/<version>/Sdks/Microsoft.[iOS/tvOS/watchOS/macOS].Sdk) on the platform the build is running from (Mac or Win) -->
 		<_XamarinSdkRootDirectory>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..'))\</_XamarinSdkRootDirectory>
-		<_XamarinRelativeSdkRootDirectory>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::MakeRelative('$(NetCoreRoot)', '$(_XamarinSdkRootDirectory)'))))</_XamarinRelativeSdkRootDirectory>
+		<!-- We used to use '_XamarinRelativeSdkRootDirectory' as the property name, but we've made it public, so it's XamarinRelativeSdkRootDirectory now, but keep setting/supporting the underscored version for a while -->
+		<XamarinRelativeSdkRootDirectory Condition="'$(XamarinRelativeSdkRootDirectory)' == '' And '$(_XamarinRelativeSdkRootDirectory)' != ''">$(_XamarinRelativeSdkRootDirectory)</XamarinRelativeSdkRootDirectory>
+		<XamarinRelativeSdkRootDirectory Condition="'$(XamarinRelativeSdkRootDirectory)' == ''">$([MSBuild]::EnsureTrailingSlash($([MSBuild]::MakeRelative('$(NetCoreRoot)', '$(_XamarinSdkRootDirectory)'))))</XamarinRelativeSdkRootDirectory>
+		<_XamarinRelativeSdkRootDirectory Condition="'$(_XamarinRelativeSdkRootDirectory)' == ''">$(XamarinRelativeSdkRootDirectory)</_XamarinRelativeSdkRootDirectory>
 		<!-- This is the location of the Microsoft.<platform>.Sdk NuGet on macOS, this value will be overriden from Windows  -->
 		<_XamarinSdkRootDirectoryOnMac>$(_XamarinSdkRootDirectory)</_XamarinSdkRootDirectoryOnMac>
 		<_XamarinTaskAssembly Condition="'$(_PlatformName)' != 'macOS'">$(_XamarinSdkRootDirectory)\tools\msbuild\iOS\Xamarin.iOS.Tasks.dll</_XamarinTaskAssembly>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2165,7 +2165,7 @@
 		<!-- We used to use '_RelativeMlaunchPath' as the property name, but we've made it public, so it's RelativeMlaunchPath now, but keep setting/supporting the underscored version for a while -->
 		<RelativeMlaunchPath Condition="'$(RelativeMlaunchPath)' == '' And '$(_RelativeMlaunchPath)' != ''">$(_RelativeMlaunchPath)</RelativeMlaunchPath>
 		<RelativeMlaunchPath Condition="'$(RelativeMlaunchPath)' == ''">$(XamarinRelativeSdkRootDirectory)tools\bin\mlaunch</RelativeMlaunchPath>
-		<_RelativeMlaunchPath Condition="'$(_RelativeMlaunchPath)' == ''">$(_RelativeMlaunchPath)</_RelativeMlaunchPath>
+		<_RelativeMlaunchPath Condition="'$(_RelativeMlaunchPath)' == ''">$(RelativeMlaunchPath)</_RelativeMlaunchPath>
 	</PropertyGroup>
 
 	<Target Name="ComputeMlaunchInstallArguments" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest;_ComputeMlaunchInstallArguments" />

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2162,7 +2162,10 @@
 		<MlaunchPath Condition="'$(MlaunchPath)' == ''">$(_XamarinSdkRootDirectory)tools\bin\mlaunch</MlaunchPath>
 		<_MlaunchPath Condition="'$(_MlaunchPath)' == ''">$(MlaunchPath)</_MlaunchPath>
 		<!-- this is the path to mlaunch relative to the root of the .NET installation -->
-		<_RelativeMlaunchPath Condition="'$(_RelativeMlaunchPath)' == ''">$(_XamarinRelativeSdkRootDirectory)tools\bin\mlaunch</_RelativeMlaunchPath>
+		<!-- We used to use '_RelativeMlaunchPath' as the property name, but we've made it public, so it's RelativeMlaunchPath now, but keep setting/supporting the underscored version for a while -->
+		<RelativeMlaunchPath Condition="'$(RelativeMlaunchPath)' == '' And '$(_RelativeMlaunchPath)' != ''">$(_RelativeMlaunchPath)</RelativeMlaunchPath>
+		<RelativeMlaunchPath Condition="'$(RelativeMlaunchPath)' == ''">$(XamarinRelativeSdkRootDirectory)tools\bin\mlaunch</RelativeMlaunchPath>
+		<_RelativeMlaunchPath Condition="'$(_RelativeMlaunchPath)' == ''">$(_RelativeMlaunchPath)</_RelativeMlaunchPath>
 	</PropertyGroup>
 
 	<Target Name="ComputeMlaunchInstallArguments" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest;_ComputeMlaunchInstallArguments" />


### PR DESCRIPTION
When VS (Windows) needs to figure out where the iOS SDK is located on disk on
the Mac machine, the project is evaluated and
the`_XamarinRelativeSdkRootDirectory` property is read. Unfortunately an
MSBuild optimization recently occurred in VS, where they don't keep
underscored properties around after the build, and thus the property XVS needs
to inspect isn't there anymore.

So make `_XamarinRelativeSdkRootDirectory` and `_RelativeMlaunchPath` public
properties by removing the underscore.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2220369.


Backport of #21074
