### PR TITLE
[devops] Add DevOps' JobAttempt number to the change detection zip file.

### DIFF
--- a/tools/devops/automation/scripts/bash/compare.sh
+++ b/tools/devops/automation/scripts/bash/compare.sh
@@ -52,8 +52,8 @@ RC=0
 ./tools/compare-commits.sh --base="$BASE" "--output-dir=$CHANGE_DETECTION_OUTPUT_DIR" || RC=$?
 
 if test -d "$CHANGE_DETECTION_OUTPUT_DIR"; then
-    rm -f "$CHANGE_DETECTION_OUTPUT_DIR/change-detection.zip"
-    cd "$CHANGE_DETECTION_OUTPUT_DIR" && zip -9r "change-detection.zip" .
+    rm -f "$CHANGE_DETECTION_OUTPUT_DIR/change-detection-$SYSTEM_JOBATTEMPT.zip"
+    cd "$CHANGE_DETECTION_OUTPUT_DIR" && zip -9r "change-detection-$SYSTEM_JOBATTEMPT.zip" .
 fi
 
 exit $RC

--- a/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
+++ b/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
@@ -60,7 +60,7 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: 'Publish change detection artifact'
   inputs:
-    targetPath: '$(Build.ArtifactStagingDirectory)/change-detection/change-detection.zip'
+    targetPath: '$(Build.ArtifactStagingDirectory)/change-detection/change-detection-$(System.JobAttempt).zip'
     artifactName: ${{ parameters.uploadPrefix }}change-detection
   condition: succeededOrFailed() # we always want to upload the zip as an artifact
   continueOnError: true

--- a/tools/devops/automation/templates/build/api-diff-process-results.yml
+++ b/tools/devops/automation/templates/build/api-diff-process-results.yml
@@ -41,7 +41,7 @@ steps:
   - task: DownloadPipelineArtifact@2
     displayName: 'Download change detection artifacts'
     inputs:
-      patterns: '${{ parameters.uploadPrefix }}change-detection/change-detection.zip'
+      patterns: '${{ parameters.uploadPrefix }}change-detection/change-detection-$(System.JobAttempt).zip'
       allowFailedBuilds: true
       path: $(System.DefaultWorkingDirectory)/Artifacts
 
@@ -49,7 +49,7 @@ steps:
   - task: ExtractFiles@1
     displayName: 'Decompress change detection artifacts'
     inputs:
-      archiveFilePatterns: '$(System.DefaultWorkingDirectory)/Artifacts/${{ parameters.uploadPrefix }}change-detection/change-detection.zip'
+      archiveFilePatterns: '$(System.DefaultWorkingDirectory)/Artifacts/${{ parameters.uploadPrefix }}change-detection/change-detection-$(System.JobAttempt).zip'
       destinationFolder: '$(System.DefaultWorkingDirectory)/change-detection'
 
   # Upload the change detection results to vsdrops


### PR DESCRIPTION
Hopefully this fixes an issue rerunning the api diff, where uploading the
change-detection.zip file would fail because it already exists in the artifact.