### PR TITLE
[maestro] Add a subscription to 'Microsoft.DotNet.SharedFramework.Sdk'.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -74,7 +74,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>51321b7e150a2f426cb9e1334687bdfab68ec323</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="9.0.0-beta.24408.2">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="9.0.0-beta.24408.2" Pinned="true">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>60ae233c3d77f11c5fdb53e570b64d503b13ba59</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -70,6 +70,10 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="8.0.0-beta.24413.2">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>51321b7e150a2f426cb9e1334687bdfab68ec323</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="9.0.0-beta.24408.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>60ae233c3d77f11c5fdb53e570b64d503b13ba59</Sha>


### PR DESCRIPTION
This way the dependency is automatically bumped and we're not left in the stone age.