### PR TITLE
[release/8.0.1xx-xcode15.4] [bgen] Fully qualify the RequiredMember and OptionalMember attributes. Fixes #21073.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -3926,9 +3926,9 @@ public partial class Generator : IMemberGatherer {
 
 #if NET
 		if (minfo.is_protocol_member_required.Value) {
-			print ("[RequiredMember]");
+			print ("[global::Foundation.RequiredMember]");
 		} else {
-			print ("[OptionalMember]");
+			print ("[global::Foundation.OptionalMember]");
 		}
 #endif
 	}


### PR DESCRIPTION
There's a `System.Runtime.CompilerServices.RequiredMemberAttribute` type,
which may lead to ambiguous type references otherwise.

Fixes https://github.com/xamarin/xamarin-macios/issues/21073.


Backport of #21076
