### PR TITLE
[CoreFoundation] Implement Xcode 16.0 beta 1-6 changes.

### DIFF
--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreFoundation.ignore
@@ -7,3 +7,4 @@
 !missing-field! kCFURLVolumeAvailableCapacityForImportantUsageKey not bound
 !missing-field! kCFURLVolumeAvailableCapacityForOpportunisticUsageKey not bound
 !missing-pinvoke! CFCopyHomeDirectoryURL is not bound
+!missing-field! kCFURLFileProtectionCompleteWhenUserInactive not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreFoundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreFoundation.todo
@@ -1,7 +1,0 @@
-!missing-field! kCFURLFileProtectionCompleteWhenUserInactive not bound
-!missing-field! kCFNumberFormatterMinGroupingDigits not bound
-!missing-pinvoke! CFAttributedStringGetBidiLevelsAndResolvedDirections is not bound
-!missing-pinvoke! CFAllocatorAllocateBytes is not bound
-!missing-pinvoke! CFAllocatorAllocateTyped is not bound
-!missing-pinvoke! CFAllocatorReallocateBytes is not bound
-!missing-pinvoke! CFAllocatorReallocateTyped is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-CoreFoundation.ignore
@@ -141,6 +141,7 @@
 !missing-field! kCFNumberFormatterMaxIntegerDigits not bound
 !missing-field! kCFNumberFormatterMaxSignificantDigits not bound
 !missing-field! kCFNumberFormatterMinFractionDigits not bound
+!missing-field! kCFNumberFormatterMinGroupingDigits not bound
 !missing-field! kCFNumberFormatterMinIntegerDigits not bound
 !missing-field! kCFNumberFormatterMinSignificantDigits not bound
 !missing-field! kCFNumberFormatterMinusSign not bound
@@ -305,11 +306,15 @@
 !missing-field! kCFURLVolumeURLKey not bound
 !missing-field! kCFURLVolumeUUIDStringKey not bound
 !missing-pinvoke! CFAbsoluteTimeGetCurrent is not bound
+!missing-pinvoke! CFAllocatorAllocateBytes is not bound
+!missing-pinvoke! CFAllocatorAllocateTyped is not bound
 !missing-pinvoke! CFAllocatorCreate is not bound
 !missing-pinvoke! CFAllocatorGetContext is not bound
 !missing-pinvoke! CFAllocatorGetDefault is not bound
 !missing-pinvoke! CFAllocatorGetPreferredSizeForSize is not bound
 !missing-pinvoke! CFAllocatorReallocate is not bound
+!missing-pinvoke! CFAllocatorReallocateBytes is not bound
+!missing-pinvoke! CFAllocatorReallocateTyped is not bound
 !missing-pinvoke! CFAllocatorSetDefault is not bound
 !missing-pinvoke! CFArrayAppendArray is not bound
 !missing-pinvoke! CFArrayAppendValue is not bound
@@ -339,6 +344,7 @@
 !missing-pinvoke! CFAttributedStringGetAttributeAndLongestEffectiveRange is not bound
 !missing-pinvoke! CFAttributedStringGetAttributes is not bound
 !missing-pinvoke! CFAttributedStringGetAttributesAndLongestEffectiveRange is not bound
+!missing-pinvoke! CFAttributedStringGetBidiLevelsAndResolvedDirections is not bound
 !missing-pinvoke! CFAttributedStringGetLength is not bound
 !missing-pinvoke! CFAttributedStringGetMutableString is not bound
 !missing-pinvoke! CFAttributedStringGetString is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreFoundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreFoundation.todo
@@ -1,6 +1,0 @@
-!missing-field! kCFNumberFormatterMinGroupingDigits not bound
-!missing-pinvoke! CFAttributedStringGetBidiLevelsAndResolvedDirections is not bound
-!missing-pinvoke! CFAllocatorAllocateBytes is not bound
-!missing-pinvoke! CFAllocatorAllocateTyped is not bound
-!missing-pinvoke! CFAllocatorReallocateBytes is not bound
-!missing-pinvoke! CFAllocatorReallocateTyped is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreFoundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreFoundation.todo
@@ -1,6 +1,0 @@
-!missing-field! kCFNumberFormatterMinGroupingDigits not bound
-!missing-pinvoke! CFAttributedStringGetBidiLevelsAndResolvedDirections is not bound
-!missing-pinvoke! CFAllocatorAllocateBytes is not bound
-!missing-pinvoke! CFAllocatorAllocateTyped is not bound
-!missing-pinvoke! CFAllocatorReallocateBytes is not bound
-!missing-pinvoke! CFAllocatorReallocateTyped is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreFoundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreFoundation.todo
@@ -1,6 +1,0 @@
-!missing-field! kCFNumberFormatterMinGroupingDigits not bound
-!missing-pinvoke! CFAttributedStringGetBidiLevelsAndResolvedDirections is not bound
-!missing-pinvoke! CFAllocatorAllocateBytes is not bound
-!missing-pinvoke! CFAllocatorAllocateTyped is not bound
-!missing-pinvoke! CFAllocatorReallocateBytes is not bound
-!missing-pinvoke! CFAllocatorReallocateTyped is not bound


### PR DESCRIPTION
Note: there we no changes in beta 1, beta 2, beta 3, beta 4 or beta 6.

Additionally, none of the added APIs are APIs we'll bind for now, they're
rather specialized.