### PR TITLE
[release/9.0.1xx-rc1] Fix calculating the branch name if BRANCH_NAME isn't set.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -59,7 +59,7 @@ PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 ifneq ($(BUILD_SOURCEBRANCH),)
 # BUILD_SOURCEBRANCH is set in Azure DevOps, so use that value if it exists
 # it seems to always start with refs/heads/, so strip off that first.
-CURRENT_BRANCH:=${BUILD_SOURCEBRANCH#refs\/heads\/}
+CURRENT_BRANCH:=$(subst refs/heads,,${BUILD_SOURCEBRANCH})
 else ifeq ($(BRANCH_NAME),)
 # BRANCH_NAME is set in Jenkins, so this is for local builds.
 CURRENT_BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)

--- a/Make.config
+++ b/Make.config
@@ -56,7 +56,11 @@ PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 # This is done in Make.versions, not here.
 #
 
-ifeq ($(BRANCH_NAME),)
+ifneq ($(BUILD_SOURCEBRANCH),)
+# BUILD_SOURCEBRANCH is set in Azure DevOps, so use that value if it exists
+# it seems to always start with refs/heads/, so strip off that first.
+CURRENT_BRANCH:=${BUILD_SOURCEBRANCH#refs\/heads\/}
+else ifeq ($(BRANCH_NAME),)
 # BRANCH_NAME is set in Jenkins, so this is for local builds.
 CURRENT_BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
 else

--- a/Make.config
+++ b/Make.config
@@ -59,7 +59,7 @@ PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 ifneq ($(BUILD_SOURCEBRANCH),)
 # BUILD_SOURCEBRANCH is set in Azure DevOps, so use that value if it exists
 # it seems to always start with refs/heads/, so strip off that first.
-CURRENT_BRANCH:=$(subst refs/heads,,${BUILD_SOURCEBRANCH})
+CURRENT_BRANCH:=$(subst refs/heads/,,${BUILD_SOURCEBRANCH})
 else ifeq ($(BRANCH_NAME),)
 # BRANCH_NAME is set in Jenkins, so this is for local builds.
 CURRENT_BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
BRANCH_NAME is the variable Jenkins used, so add support for the variable
Azure DevOps uses (BUILD_SOURCEBRANCH).


Backport of #21114
