### PR TITLE
[bgen] Generate Obsolete + EditorBrowsable attributes in a few more cases.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -221,7 +221,7 @@ namespace AVFoundation {
 	}
 
 #if !NET
-	[Obsolete ("Use AVMediaTypes enum values")]
+	[Obsolete ("Use AVMediaTypes enum values.")]
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Static]
@@ -420,7 +420,7 @@ namespace AVFoundation {
 
 #if !NET
 	[NoWatch]
-	[Obsolete ("Use AVMediaCharacteristics enum values")]
+	[Obsolete ("Use AVMediaCharacteristics enum values.")]
 	[BaseType (typeof (NSObject))]
 	[Static]
 	interface AVMediaCharacteristic {
@@ -598,7 +598,7 @@ namespace AVFoundation {
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Static]
-	[Obsolete ("Use AVFileTypes enum values")]
+	[Obsolete ("Use AVFileTypes enum values.")]
 	interface AVFileType {
 		[Field ("AVFileTypeQuickTimeMovie")]
 		NSString QuickTimeMovie { get; }

--- a/src/bgen/Enums.cs
+++ b/src/bgen/Enums.cs
@@ -82,7 +82,6 @@ public partial class Generator {
 			sb.Append ("]");
 			print (sb.ToString ());
 		}
-		PrintObsoleteAttributes (type);
 		CopyNativeName (type);
 
 		var unique_constants = new HashSet<string> ();

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -238,6 +238,24 @@ namespace GeneratorTests {
 			bgen.AssertNoWarnings ();
 		}
 
+		[Test]
+		[TestCase (Profile.iOS)]
+		public void EditorBrowsable (Profile profile)
+		{
+			var bgen = BuildFile (profile, false, true, "tests/editor-browsable.cs");
+			var types = bgen.ApiAssembly.MainModule.Types;
+
+			var hasEditorBrowsableAttribute = new Func<ICustomAttributeProvider, bool> ((ICustomAttributeProvider provider) =>
+			{
+				return provider.CustomAttributes.Any (v => v.AttributeType.Name == "EditorBrowsableAttribute");
+			});
+
+			var strongEnumType = types.Single (v => v.Name == "StrongEnum");
+			Assert.IsTrue (hasEditorBrowsableAttribute (strongEnumType), "StrongEnumType");
+			var objcClassType = types.Single (v => v.Name == "ObjCClass");
+			Assert.IsTrue (hasEditorBrowsableAttribute (objcClassType), "ObjCClass");
+		}
+
 		static string RenderArgument (CustomAttributeArgument arg)
 		{
 			var td = arg.Type.Resolve ();

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -245,8 +245,7 @@ namespace GeneratorTests {
 			var bgen = BuildFile (profile, false, true, "tests/editor-browsable.cs");
 			var types = bgen.ApiAssembly.MainModule.Types;
 
-			var hasEditorBrowsableAttribute = new Func<ICustomAttributeProvider, bool> ((ICustomAttributeProvider provider) =>
-			{
+			var hasEditorBrowsableAttribute = new Func<ICustomAttributeProvider, bool> ((ICustomAttributeProvider provider) => {
 				return provider.CustomAttributes.Any (v => v.AttributeType.Name == "EditorBrowsableAttribute");
 			});
 

--- a/tests/generator/tests/editor-browsable.cs
+++ b/tests/generator/tests/editor-browsable.cs
@@ -1,0 +1,19 @@
+using System;
+using System.ComponentModel;
+
+using Foundation;
+
+namespace EditorBrowsable {
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	enum StrongEnum {
+		[Field ("AField", "__Internal")]
+		A,
+	}
+
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	[BaseType (typeof (NSObject))]
+	interface ObjCClass {
+		[Export ("strongEnumField")]
+		StrongEnum StrongEnumField { get; set; }
+	}
+}


### PR DESCRIPTION
* Forward [Obsolete] from api definition interfaces.
* Generate [EditorBrowsable] whenever an api definition member as either
  [EditorBrowsable] or [Obsolete].