### PR TITLE
Fix described in #21132

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -651,7 +651,10 @@ namespace Foundation {
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		public IWebProxy? Proxy {
 			get => null;
-			set => throw new PlatformNotSupportedException ();
+			set {
+				if (value is not null)
+					throw new PlatformNotSupportedException ();
+			} 
 		}
 
 		// There doesn't seem to be a trivial way to specify the protocols to accept (or not)


### PR DESCRIPTION
Before PR
NSUrlSessionHandler.Proxy property throws NSE when client code set any value (including `null`)
![image](https://github.com/user-attachments/assets/bb273910-3519-490f-b5fd-1999327012b3)

After PR
NSUrlSessionHandler.Proxy property throws NSE only when the client code tries to set a value different from `null` (Custom proxy is not supported right now in iOS implementation so setting a value other than null must throws NSE)
![image](https://github.com/user-attachments/assets/4a564785-3e23-469c-ac26-460d028cf770)

The reason behind the change is described in #21132 

PR originally submitted by @adospace in #21137.