### PR TITLE
[release/8.0.1xx-xcode15.4] [CI] Start the process of cleaning up the config step.

### DIFF
--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -383,7 +383,6 @@ class BuildConfiguration {
         }
 
         $this.StoreParentBuildVariables($configuration)
-        }
 
         # For each .NET platform we support, add a INCLUDE_DOTNET_<platform> variable specifying whether that platform is enabled or not.
         $dotnetPlatforms = $configuration.DOTNET_PLATFORMS.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)

--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -242,6 +242,61 @@ class Vsts {
 
 class BuildConfiguration {
 
+    # list of the default variables we are interested in
+    static [string[]] $defaultBuildVariables = $(
+        "BUILD_BUILDID",
+        "BUILD_BUILDNUMBER",
+        "BUILD_BUILDURI",
+        "BUILD_BINARIESDIRECTORY",
+        "BUILD_DEFINITIONNAME",
+        "BUILD_REASON",
+        "BUILD_REPOSITORY_ID",
+        "BUILD_REPOSITORY_NAME",
+        "BUILD_REPOSITORY_PROVIDER",
+        "BUILD_REPOSITORY_URI",
+        "BUILD_SOURCEBRANCH",
+        "BUILD_SOURCEBRANCHNAME"
+    )
+
+    <#
+        .SYNOPSIS
+            Stores the default variables in the current buld as PARENT_BUILD_* in the
+            configuration object. This allows cacasding pipelines to access the configuration
+            of the pipeline that triggered them.
+    #>
+    [void] StoreParentBuildVariables ([PSCustomObject] $configuration) {
+        Write-Debug ("=> StoreParentBuildVariables")
+        foreach ($buildVariable in [BuildConfiguration]::defaultBuildVariables) {
+            $variableName = "PARENT_BUILD_$buildVariable"
+            $variableValue = [Environment]::GetEnvironmentVariable($buildVariable)
+            if ($variableValue) {
+                Write-Debug "$variableName = $variableValue"
+                $configuration | Add-Member -NotePropertyName $variableName -NotePropertyValue $variableValue
+            } else {
+                Write-Debug "$variableName not found."
+            }
+        }
+    }
+
+    <#
+        .SYNOPSIS
+            Exports the default variables in the current buld as PARENT_BUILD_* from the
+            configuration object.
+    #>
+    [void] ExportParentBuildVariables ([PSCustomObject] $configuration) {
+        Write-Debug ("=> ExportParentBuildVariables")
+        foreach ($buildVariable in [BuildConfiguration]::defaultBuildVariables) {
+            $variableName = "PARENT_BUILD_$buildVariable"
+            $variableValue = $configuration.$variableName
+            if ($variableValue) {
+                Write-Debug "$variableName = $variableValue"
+                Write-Host "##vso[task.setvariable variable=$variableName;isOutput=true]$variableValue"
+            } else {
+                Write-Debug "$variableName not found."
+            }
+        }
+    }
+
     [PSCustomObject] Import([string] $configFile) {
         if (-not (Test-Path -Path $configFile -PathType Leaf)) {
           throw [System.InvalidOperationException]::new("Configuration file $configFile is missing")
@@ -253,31 +308,8 @@ class BuildConfiguration {
           throw [System.InvalidOperationException]::new("Failed to load configuration file $configFile")
         }
 
-        $defaultBuildVariables = @(
-            "BUILD_BUILDID",
-            "BUILD_BUILDNUMBER",
-            "BUILD_BUILDURI",
-            "BUILD_BINARIESDIRECTORY",
-            "BUILD_DEFINITIONNAME",
-            "BUILD_REASON",
-            "BUILD_REPOSITORY_ID",
-            "BUILD_REPOSITORY_NAME",
-            "BUILD_REPOSITORY_PROVIDER",
-            "BUILD_REPOSITORY_URI",
-            "BUILD_SOURCEBRANCH",
-            "BUILD_SOURCEBRANCHNAME"
-        )
-
-        # load the variable name from the parent
-        foreach ($buildVariable in $defaultBuildVariables) {
-            $variableName = "PARENT_BUILD_$buildVariable"
-            $variableValue = $config.$variableName
-            if ($variableValue) {
-                Write-Host "##vso[task.setvariable variable=$variableName;isOutput=true]$variableValue"
-            } else {
-                Write-Debug "Ignoring variable $variableName"
-            }
-        }
+        # load the variables from the config and export them to be accessable from others
+        $this.ExportParentBuildVariables($config)
 
         $dotnetPlatforms = $config.DOTNET_PLATFORMS.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
         Write-Host "##vso[task.setvariable variable=DOTNET_PLATFORMS;isOutput=true]$dotnetPlatforms"
@@ -339,6 +371,7 @@ class BuildConfiguration {
         return $config
     }
 
+
     [PSCustomObject] Create([bool] $addTags, [string] $configFile) {
         # we are going to use a custom object to store all the configuration of the build, this later
         # will be uploaded as an artifact so that it can be easily shared with the cascade pipelines, we will
@@ -349,26 +382,7 @@ class BuildConfiguration {
           DOTNET_PLATFORMS = "$Env:CONFIGURE_PLATFORMS_DOTNET_PLATFORMS"
         }
 
-        $defaultBuildVariables = @(
-            "BUILD_BUILDID",
-            "BUILD_BUILDNUMBER",
-            "BUILD_BUILDURI",
-            "BUILD_BINARIESDIRECTORY",
-            "BUILD_DEFINITIONNAME",
-            "BUILD_REASON",
-            "BUILD_REPOSITORY_ID",
-            "BUILD_REPOSITORY_NAME",
-            "BUILD_REPOSITORY_PROVIDER",
-            "BUILD_REPOSITORY_URI",
-            "BUILD_SOURCEBRANCH",
-            "BUILD_SOURCEBRANCHNAME"
-        )
-
-        # loop over the default build enviroments and add them with a prefix to the configuration objects
-        foreach ($buildVariable in $defaultBuildVariables) {
-            $variableName = "PARENT_BUILD_$buildVariable"
-            $variableValue = [Environment]::GetEnvironmentVariable($buildVariable)
-            $configuration | Add-Member -NotePropertyName $variableName -NotePropertyValue $variableValue
+        $this.StoreParentBuildVariables($configuration)
         }
 
         # For each .NET platform we support, add a INCLUDE_DOTNET_<platform> variable specifying whether that platform is enabled or not.

--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -261,7 +261,7 @@ class BuildConfiguration {
     <#
         .SYNOPSIS
             Stores the default variables in the current buld as PARENT_BUILD_* in the
-            configuration object. This allows cacasding pipelines to access the configuration
+            configuration object. This allows cascading pipelines to access the configuration
             of the pipeline that triggered them.
     #>
     [void] StoreParentBuildVariables ([PSCustomObject] $configuration) {


### PR DESCRIPTION
We want to be able to export and load the variables in the cacading pipelines. The way we have the scripts makes this process very complicated to do. We need to clean up the script. Then export the steps so that we can access them in the following pipelines.

This change is simply refactoring the way we load/export the default VSTS variables in a pipeline.


Backport of #21134
