### PR TITLE
[LockedCameraCapture] Don't bind this framework.

### DIFF
--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-LockedCameraCapture.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-LockedCameraCapture.ignore
@@ -1,3 +1,4 @@
+# This is a Swift-only frameworks, with only version APIs available in Objective-C, so we're not binding it in Objective-C
 !missing-field! LockedCameraCaptureVersionNumber not bound
 !missing-field! LockedCameraCaptureVersionString not bound
 !missing-field! NSUserActivityTypeLockedCameraCapture not bound

--- a/tests/xtro-sharpie/iOS-LockedCameraCapture.ignore
+++ b/tests/xtro-sharpie/iOS-LockedCameraCapture.ignore
@@ -1,3 +1,4 @@
+# This is a Swift-only frameworks, with only version APIs available in Objective-C, so we're not binding it in Objective-C
 !missing-field! LockedCameraCaptureVersionNumber not bound
 !missing-field! LockedCameraCaptureVersionString not bound
 !missing-field! NSUserActivityTypeLockedCameraCapture not bound


### PR DESCRIPTION
For all intents and purposes it's Swift only.