### PR TITLE
[CI] Do not export test matrix.

### DIFF
--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -81,7 +81,6 @@ steps:
     # compress the json to remove any newlines, because we can't set the variable below if the json has any newlines
     Write-Host "$testMatrix"
     $testMatrix = $testMatrix | ConvertFrom-Json | ConvertTo-Json -Compress
-    Write-Host "##vso[task.setvariable variable=TEST_MATRIX;isOutput=true]$testMatrix"
     # update the config file so that we do not recalculate the matrix in other pipelines
     Edit-BuildConfiguration -ConfigKey TEST_MATRIX -ConfigValue $testMatrix -ConfigFile $Env:CONFIG_PATH
     #CONFIG_PATH


### PR DESCRIPTION
The pwsh used on windows is based on dotnet framework. Dotnet framework has a limit in the size of the env that can be passed to a child process. We are very close to reach the limit, but after #21009 we can ignore that env variable since it is parsed from the args.

This is just needed for the ci pipeline because the issues are going to have are related with the vsdrops task used to upload nuget results etc..