### PR TITLE
[tests] Fix ignoring members based on OSPlatformAttributes.

### DIFF
--- a/tests/introspection/ApiBaseTest.cs
+++ b/tests/introspection/ApiBaseTest.cs
@@ -196,7 +196,16 @@ namespace Introspection {
 		public bool MemberHasObsolete (MemberInfo member)
 		{
 #if NET
-			return member.GetCustomAttributes<ObsoletedOSPlatformAttribute> (false).Any ();
+			return TestRuntime.HasOSPlatformAttributeForCurrentPlatform<ObsoletedOSPlatformAttribute> (member);
+#else
+			return member.GetCustomAttribute<ObsoleteAttribute> () is not null;
+#endif
+		}
+
+		public bool MemberHasUnsupported (MemberInfo member)
+		{
+#if NET
+			return TestRuntime.HasOSPlatformAttributeForCurrentPlatform<UnsupportedOSPlatformAttribute> (member);
 #else
 			return member.GetCustomAttribute<ObsoleteAttribute> () is not null;
 #endif

--- a/tests/introspection/ApiSignatureTest.cs
+++ b/tests/introspection/ApiSignatureTest.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Reflection;
 using System.Text;
 using NUnit.Framework;
@@ -864,10 +865,15 @@ namespace Introspection {
 				case "AdviceAttribute":
 				case "ObsoletedAttribute":
 				case "DeprecatedAttribute":
-				case "UnsupportedOSPlatformAttribute":
 					return true;
 				}
 			}
+
+#if NET
+			if (TestRuntime.HasOSPlatformAttributeForCurrentPlatform<UnsupportedOSPlatformAttribute> (mi))
+				return true;
+#endif
+
 			return false;
 		}
 


### PR DESCRIPTION
We were ignorning members based on whether a member had
ObsoletedOSPlatformAttribute/UnavailableOSPlatformAttribute, not taking into
account that the attribute might not apply to the current platform.

So implement logic to only take into account
[Obsoleted|Unavailable]OSPlatformAttributes for the current platform.