### PR TITLE
[tests] Make the simulator the default runtime identifier when running test suites from the command line.

### DIFF
--- a/tests/common/shared-dotnet.mk
+++ b/tests/common/shared-dotnet.mk
@@ -78,9 +78,9 @@ endif
 
 ifeq ($(RID),)
 ifeq ($(PLATFORM),iOS)
-RID=ios-arm64
+RID=iossimulator-arm64
 else ifeq ($(PLATFORM),tvOS)
-RID=tvos-arm64
+RID=tvossimulator-arm64
 else ifeq ($(PLATFORM),MacCatalyst)
 ifeq ($(CONFIG),Release)
 RID=maccatalyst-x64;maccatalyst-arm64


### PR DESCRIPTION
Because simulator is where we most commonly run tests.

And hardcode arm64 - if x64 is ever needed, and I'm bugged enough to add
auto-detection, I'll do it then.