### PR TITLE
[devops] Remove legacy-only test configurations.

### DIFF
--- a/tools/devops/automation/scripts/TestConfiguration.Tests.ps1
+++ b/tools/devops/automation/scripts/TestConfiguration.Tests.ps1
@@ -15,23 +15,17 @@ Describe 'Get-TestConfiguration' {
   {
     "label": "cecil",
     "splitByPlatforms": "false",
-    "containsDotNetTests": "true",
-    "containsLegacyTests": "true",
     "testPrefix": "test-prefix_",
   },
   {
     "label": "dotnettests",
     "splitByPlatforms": "true",
-    "containsDotNetTests": "true",
-    "containsLegacyTests": "false",
     "needsMultiplePlatforms": "true",
     "testPrefix": "test-prefix_",
   },
   {
     "label": "monotouchtest",
     "splitByPlatforms": "true",
-    "containsDotNetTests": "true",
-    "containsLegacyTests": "true",
     "needsMultiplePlatforms": "false",
     "testPrefix": "test-prefix_",
   }
@@ -42,33 +36,18 @@ Describe 'Get-TestConfiguration' {
 [
   {
     "platform": "iOS",
-    "isDotNetPlatform": "true",
-    "isLegacyPlatform": "true"
   },
   {
     "platform": "macOS",
-    "isDotNetPlatform": "true",
-    "isLegacyPlatform": "true"
   },
   {
     "platform": "tvOS",
-    "isDotNetPlatform": "true",
-    "isLegacyPlatform": "true"
-  },
-  {
-    "platform": "watchOS",
-    "isDotNetPlatform": "false",
-    "isLegacyPlatform": "true"
   },
   {
     "platform": "MacCatalyst",
-    "isDotNetPlatform": "true",
-    "isLegacyPlatform": "false"
   },
   {
     "platform": "Multiple",
-    "isDotNetPlatform": "true",
-    "isLegacyPlatform": "true"
   }
 ]
 "@

--- a/tools/devops/automation/scripts/TestConfiguration.psm1
+++ b/tools/devops/automation/scripts/TestConfiguration.psm1
@@ -32,24 +32,6 @@ class TestConfiguration {
             $vars["LABEL"] = $label
             $vars["TESTS_LABELS"] = "$($this.testsLabels),run-$($label)-tests"
             if ($splitByPlatforms -eq "True") {
-                # watchOS is not supported for .NET so it's an outlier.
-                # we're soon removing legacy Xamarin support though, so hard-coding it here is a quick solution
-                # until this code will be removed anyways.
-                if ($config.containsLegacyTests -eq "true") {
-                    Write-Host "Test $label has legacy tests"
-                    $watchConfig = "$($Env:CONFIGURE_PLATFORMS_INCLUDE_WATCH)$($Env:CONFIGURE_PLATFORMS_INCLUDE_XAMARIN_LEGACY)"
-                    if ("$watchConfig" -eq "11") {
-                        Write-Host "Enabling watchOS for $label because watchOS is enabled."
-                        $enabledPlatformsForConfig += "watchOS"
-                    } else {
-                        Write-Host "Not enabling watchOS for $label because watchOS is not enabled ($watchConfig)"
-                        Write-Host "CONFIGURE_PLATFORMS_INCLUDE_WATCH = $($Env:CONFIGURE_PLATFORMS_INCLUDE_WATCH)"
-                        Write-Host "CONFIGURE_PLATFORMS_INCLUDE_XAMARIN_LEGACY = $($Env:CONFIGURE_PLATFORMS_INCLUDE_XAMARIN_LEGACY)"
-                    }
-                } else {
-                    Write-Host "Test $label does not have legacy tests"
-                }
-
                 if ($enabledPlatformsForConfig.Length -eq 0) {
                     Write-Host "No enabled platforms, skipping $label"
                     continue
@@ -69,18 +51,6 @@ class TestConfiguration {
                     $platform = $platformConfig.platform
 
                     $runThisPlatform = $false
-                    $containsDotNetTests = $($config.containsDotNetTests) -eq "true"
-                    $containsLegacyTests = $($config.containsLegacyTests) -eq "true"
-                    $isDotNetPlatform = $($platformConfig.isDotNetPlatform) -eq "true"
-                    $isLegacyPlatform = $($platformConfig.isLegacyPlatform) -eq "true"
-                    if ($containsDotNetTests -and $isDotNetPlatform) {
-                        $runThisPlatform = $true
-                    } elseif ($containsLegacyTests -and $isLegacyPlatform) {
-                        $runThisPlatform = $true
-                    }
-                    if (!$runThisPlatform) {
-                        continue
-                    }
 
                     # create a clone of the general dictionary
                     $platformVars = [ordered]@{}

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -61,33 +61,23 @@ parameters:
       {
         platform: iOS,
         isDotNetPlatform: true,
-        isLegacyPlatform: true
       },
       {
         platform: macOS,
         isDotNetPlatform: true,
-        isLegacyPlatform: true
       },
       {
         platform: tvOS,
         isDotNetPlatform: true,
-        isLegacyPlatform: true
-      },
-      {
-        platform: watchOS,
-        isDotNetPlatform: false,
-        isLegacyPlatform: true
       },
       {
         platform: MacCatalyst,
         isDotNetPlatform: true,
-        isLegacyPlatform: false
       },
       {
         # when running platform-specific test runs, we also need a special test run that executes tests that only runs when multiple platforms are enabled
         platform: Multiple,
         isDotNetPlatform: true,
-        isLegacyPlatform: true
       }
     ]
 
@@ -102,129 +92,63 @@ parameters:
       {
         label: cecil,
         splitByPlatforms: false,
-        containsDotNetTests: true,
-        containsLegacyTests: false,
         testPrefix: 'simulator_tests',
       },
       {
         label: dotnettests,
         splitByPlatforms: true,
-        containsDotNetTests: true,
-        containsLegacyTests: false,
         needsMultiplePlatforms: true,
         testPrefix: 'simulator_tests',
       },
       {
         label: fsharp,
         splitByPlatforms: false,
-        containsDotNetTests: true,
-        containsLegacyTests: true,
         testPrefix: 'simulator_tests',
       },
       {
         label: framework,
         splitByPlatforms: false,
-        containsDotNetTests: true,
-        containsLegacyTests: true,
         testPrefix: 'simulator_tests',
       },
       {
         label: generator,
         splitByPlatforms: false,
-        containsDotNetTests: true,
-        containsLegacyTests: true,
         testPrefix: 'simulator_tests',
       },
       {
         label: interdependent-binding-projects,
         splitByPlatforms: false,
-        containsDotNetTests: true,
-        containsLegacyTests: true,
-        testPrefix: 'simulator_tests',
-      },
-      {
-        label: install-source,
-        splitByPlatforms: false,
-        containsDotNetTests: false,
-        containsLegacyTests: true,
         testPrefix: 'simulator_tests',
       },
       {
         label: introspection,
         splitByPlatforms: false,
-        containsDotNetTests: true,
-        containsLegacyTests: true,
         testPrefix: 'simulator_tests',
       },
       {
         label: linker,
         splitByPlatforms: false,
-        containsDotNetTests: true,
-        containsLegacyTests: true,
-        testPrefix: 'simulator_tests',
-      },
-      {
-        label: mac-binding-project,
-        splitByPlatforms: false,
-        containsDotNetTests: false,
-        containsLegacyTests: true,
-        testPrefix: 'simulator_tests',
-      },
-      {
-        label: mmp,
-        splitByPlatforms: false,
-        containsDotNetTests: false,
-        containsLegacyTests: true,
-        testPrefix: 'simulator_tests',
-      },
-      {
-        label: mononative,
-        splitByPlatforms: false,
-        containsDotNetTests: false,
-        containsLegacyTests: true,
         testPrefix: 'simulator_tests',
       },
       {
         label: monotouch,
         splitByPlatforms: true,
-        containsDotNetTests: true,
-        containsLegacyTests: true,
         needsMultiplePlatforms: false,
         testPrefix: 'simulator_tests',
       },
       {
         label: msbuild,
         splitByPlatforms: false,
-        containsDotNetTests: true,
-        containsLegacyTests: true,
-        testPrefix: 'simulator_tests',
-      },
-      {
-        label: mtouch,
-        splitByPlatforms: false,
-        containsDotNetTests: false,
-        containsLegacyTests: true,
-        testPrefix: 'simulator_tests',
-      },
-      {
-        label: xammac,
-        splitByPlatforms: false,
-        containsDotNetTests: false,
-        containsLegacyTests: true,
         testPrefix: 'simulator_tests',
       },
       {
         label: xcframework,
         splitByPlatforms: false,
-        containsDotNetTests: true,
-        containsLegacyTests: true,
         testPrefix: 'simulator_tests',
       },
       {
         label: xtro,
         splitByPlatforms: false,
-        containsDotNetTests: true,
-        containsLegacyTests: true,
         testPrefix: 'simulator_tests',
       },
     ]

--- a/tools/devops/automation/templates/tests-stage.yml
+++ b/tools/devops/automation/templates/tests-stage.yml
@@ -142,7 +142,6 @@ parameters:
       splitByPlatforms: false,
       testPrefix: 'simulator_tests',
     },
-    },
     {
       label: xcframework,
       splitByPlatforms: false,

--- a/tools/devops/automation/templates/tests-stage.yml
+++ b/tools/devops/automation/templates/tests-stage.yml
@@ -57,33 +57,23 @@ parameters:
     {
       platform: iOS,
       isDotNetPlatform: true,
-      isLegacyPlatform: true
     },
     {
       platform: macOS,
       isDotNetPlatform: true,
-      isLegacyPlatform: true
     },
     {
       platform: tvOS,
       isDotNetPlatform: true,
-      isLegacyPlatform: true
-    },
-    {
-      platform: watchOS,
-      isDotNetPlatform: false,
-      isLegacyPlatform: true
     },
     {
       platform: MacCatalyst,
       isDotNetPlatform: true,
-      isLegacyPlatform: false
     },
     {
       # when running platform-specific test runs, we also need a special test run that executes tests that only runs when multiple platforms are enabled
       platform: Multiple,
       isDotNetPlatform: true,
-      isLegacyPlatform: true
     }
   ]
 
@@ -98,129 +88,69 @@ parameters:
     {
       label: cecil,
       splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: false,
       testPrefix: 'simulator_tests',
     },
     {
       label: dotnettests,
       splitByPlatforms: true,
-      containsDotNetTests: true,
-      containsLegacyTests: false,
       needsMultiplePlatforms: true,
       testPrefix: 'simulator_tests',
     },
     {
       label: fsharp,
       splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
       testPrefix: 'simulator_tests',
     },
     {
       label: framework,
       splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
       testPrefix: 'simulator_tests',
     },
     {
       label: generator,
       splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
       testPrefix: 'simulator_tests',
     },
     {
       label: interdependent-binding-projects,
       splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: install-source,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
       testPrefix: 'simulator_tests',
     },
     {
       label: introspection,
       splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
       testPrefix: 'simulator_tests',
     },
     {
       label: linker,
       splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: mac-binding-project,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
       testPrefix: 'simulator_tests',
     },
     {
       label: mmp,
       splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: mononative,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
       testPrefix: 'simulator_tests',
     },
     {
       label: monotouch,
       splitByPlatforms: true,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
       needsMultiplePlatforms: false,
       testPrefix: 'simulator_tests',
     },
     {
       label: msbuild,
       splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
       testPrefix: 'simulator_tests',
     },
-    {
-      label: mtouch,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
-    },
-    {
-      label: xammac,
-      splitByPlatforms: false,
-      containsDotNetTests: false,
-      containsLegacyTests: true,
-      testPrefix: 'simulator_tests',
     },
     {
       label: xcframework,
       splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
       testPrefix: 'simulator_tests',
     },
     {
       label: xtro,
       splitByPlatforms: false,
-      containsDotNetTests: true,
-      containsLegacyTests: true,
       testPrefix: 'simulator_tests',
     },
   ]


### PR DESCRIPTION
Also simplify some code that checks if we're running a .NET test (which will
always be true now).