### PR TITLE
[github] Make it possible to drop files in the "Additional Logs" field. Fixes #21243.

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-building-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/01-building-an-application.yml
@@ -65,7 +65,6 @@ body:
     attributes:
       label: Build logs
       description: Please get an [MSBuild binlogs](https://github.com/xamarin/xamarin-macios/wiki/Diagnosis#build-logs) and attach it here (zipped, since GitHub doesn't allow attachment of .binlog files)
-      render: shell
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/02-running-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/02-running-an-application.yml
@@ -65,7 +65,6 @@ body:
     attributes:
       label: Relevant logs
       description: Please copy and paste any (short!) relevant logs. Longer logs can be attached as .txt or .zip files. This is likely either the Application Output from the IDE, a [crash report](https://github.com/xamarin/xamarin-macios/wiki/Diagnosis#crash-reports) or the [device log](https://support.apple.com/en-in/guide/console/cnsl1012/mac) (or all of these).
-      render: shell
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/03-api.yml
+++ b/.github/ISSUE_TEMPLATE/03-api.yml
@@ -75,7 +75,6 @@ body:
     attributes:
       label: Relevant log output
       description: Please copy and paste any (short!) relevant log output. Longer logs can be attached as .txt or .zip files.
-      render: shell
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/04-bindings.yml
+++ b/.github/ISSUE_TEMPLATE/04-bindings.yml
@@ -66,7 +66,6 @@ body:
     attributes:
       label: Build logs
       description: Please get an [MSBuild binlogs](https://github.com/xamarin/xamarin-macios/wiki/Diagnosis#build-logs) and attach it here (zipped, since GitHub doesn't allow attachment of .binlog files)
-      render: shell
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/05-other.yml
+++ b/.github/ISSUE_TEMPLATE/05-other.yml
@@ -65,7 +65,6 @@ body:
     attributes:
       label: Relevant log output
       description: Please copy and paste any (short!) relevant log output. Longer logs can be attached as .txt or .zip files. For build logs please provide an [MSBuild binlog](https://github.com/xamarin/xamarin-macios/wiki/Diagnosis#build-logs).
-      render: shell
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
GitHub won't allow dropping files into a field where 'render: shell'
(presumably because that means the field will automatically become a fenced
block in the final issue), so just remove the 'render' property (this way it
matches all the other input fields).

Fixes https://github.com/xamarin/xamarin-macios/issues/21243.