### PR TITLE
[devops] Always run the step to get the AzDo.BearerToken.

### DIFF
--- a/tools/devops/automation/templates/windows/generate-token.yml
+++ b/tools/devops/automation/templates/windows/generate-token.yml
@@ -10,6 +10,7 @@ steps:
 - task: AzureCLI@2
   displayName: 'AzDO.BearerToken based on service connection'
   enabled: true
+  condition: always()
   inputs:
     azureSubscription: 'DevDiv - SharedUntrustedAgentPool-Manage'
     scriptType: 'pscore'


### PR DESCRIPTION
We need the AzDo.BearerToken in later steps that have the 'always()'
condition, and unless we actually get the AzDo.BearerToken under the same
conditions, those later steps will fail.

One example is if the job was cancelled, or previous steps failed (which is
common when running tests).

Example failure for re-enabling macOS bots:

```
AzDO.BearerToken : The term 'AzDO.BearerToken' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At D:\AzDO\_work\_temp\9b207e8a-c163-4c97-93d3-e7e3bb908583.ps1:6 char:23
+ $azdoBearerToken = "$(AzDO.BearerToken)"
+                       ~~~~~~~~~~~~~~~~
+ CategoryInfo          : ObjectNotFound: (AzDO.BearerToken:String) [], ParentContainsErrorRecordException
+ FullyQualifiedErrorId : CommandNotFoundException
```

This problem causes a lot of bots to end up disabled, because we fail to
re-enable them after using them.