### PR TITLE
[devops] Only fetch the exact remote branches we need to undo the GitHub merge.

### DIFF
--- a/tools/devops/automation/scripts/undo_github_merge.ps1
+++ b/tools/devops/automation/scripts/undo_github_merge.ps1
@@ -11,7 +11,7 @@ param
 if($IsPr.ToLower() -eq "true") {
     Write-Host "Working on a PR, Undoing the github merge with main."
 
-    git config remote.origin.fetch '+refs/pull/$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/*:refs/remotes/origin/pull/$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/*'
+    git config remote.origin.fetch "+refs/pull/$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/*:refs/remotes/origin/pull/$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/*"
     git fetch origin
 
     $branch="$SourceBranch".Replace("merge", "head")

--- a/tools/devops/automation/scripts/undo_github_merge.ps1
+++ b/tools/devops/automation/scripts/undo_github_merge.ps1
@@ -11,7 +11,7 @@ param
 if($IsPr.ToLower() -eq "true") {
     Write-Host "Working on a PR, Undoing the github merge with main."
 
-    git config remote.origin.fetch '+refs/pull/$($Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)/*:refs/remotes/origin/pull/$($Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)/*'
+    git config remote.origin.fetch '+refs/pull/$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/*:refs/remotes/origin/pull/$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/*'
     git fetch origin
 
     $branch="$SourceBranch".Replace("merge", "head")

--- a/tools/devops/automation/scripts/undo_github_merge.ps1
+++ b/tools/devops/automation/scripts/undo_github_merge.ps1
@@ -11,7 +11,7 @@ param
 if($IsPr.ToLower() -eq "true") {
     Write-Host "Working on a PR, Undoing the github merge with main."
 
-    git config remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
+    git config remote.origin.fetch '+refs/pull/$($Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)/*:refs/remotes/origin/pull/$($Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)/*'
     git fetch origin
 
     $branch="$SourceBranch".Replace("merge", "head")

--- a/tools/devops/automation/scripts/undo_github_merge.ps1
+++ b/tools/devops/automation/scripts/undo_github_merge.ps1
@@ -11,8 +11,11 @@ param
 if($IsPr.ToLower() -eq "true") {
     Write-Host "Working on a PR, Undoing the github merge with main."
 
-    git config remote.origin.fetch "+refs/pull/$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/*:refs/remotes/origin/pull/$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/*"
-    git fetch origin
+    $refspec="+refs/pull/$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/*:refs/remotes/origin/pull/$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/*"
+
+    Write-Host "Refspec: $refspec"
+
+    git fetch origin "$refspec"
 
     $branch="$SourceBranch".Replace("merge", "head")
     $branch=$branch.Replace("refs", "origin")


### PR DESCRIPTION
This will typically save between 1 and 2 minutes for every test run.

But potentially much more if GitHub happens to be slow:

```
[...]
Working on a PR, Undoing the github merge with main.
##[error]The task has timed out.
[...]
```