### PR TITLE
fix: `Assembly.GetManifestResourceNames()` may return an empty string

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs
@@ -251,6 +251,8 @@ namespace Xamarin.MacDev.Tasks {
 			}
 
 			foreach (var resourceName in assembly.GetManifestResourceNames ()) {
+	            if (string.IsNullOrEmpty(resourceName))
+	                continue;
 				var info = assembly.GetManifestResourceInfo (resourceName);
 				if (!info.ResourceLocation.HasFlag (ResourceLocation.Embedded))
 					continue;


### PR DESCRIPTION
This change avoids the `UnpackLibraryResources` task to fail :
```
/usr/local/share/dotnet/packs/Microsoft.iOS.Sdk.net8.0_17.5/17.5.8020/tools/msbuild/iOS/Xamarin.Shared.targets(1985,3): error MSB4018: System.ArgumentException: Value does not fall within the expected range. (Parameter 'resourceName') 
/usr/local/share/dotnet/packs/Microsoft.iOS.Sdk.net8.0_17.5/17.5.8020/tools/msbuild/iOS/Xamarin.Shared.targets(1985,3): error MSB4018:    at System.Reflection.TypeLoading.Ecma.EcmaAssembly.GetManifestResourceInfo(String resourceName)
/usr/local/share/dotnet/packs/Microsoft.iOS.Sdk.net8.0_17.5/17.5.8020/tools/msbuild/iOS/Xamarin.Shared.targets(1985,3): error MSB4018:    at Xamarin.MacDev.Tasks.UnpackLibraryResources.GetAssemblyManifestResources(String fileName)+MoveNext() in /Users/builder/azdo/_work/1/s/xamarin-macios/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs:line 254
```

This can happen when assemblies have an invalid resource list, where resources can be created with an empty name.