### PR TITLE
[devops] Append to the agent log, instead of creating the file.

### DIFF
--- a/tools/devops/automation/scripts/generate_agent_logs.ps1
+++ b/tools/devops/automation/scripts/generate_agent_logs.ps1
@@ -46,8 +46,7 @@ try {
       log show --predicate $Predicate --style $Style --start "$start" --end "$end" > $Output
   }
 } catch {
-    Write-Host "Exception occurred: $_"
     # Create the output file, because we later try to upload it as an artifact, and *not* uploading
     # if there's *no* file is much harder than just creating the file.
-    New-Item -Path $Output -Value "$_"
+    Write-Host "Exception occurred: $_" | Tee-Object -FilePath $Output -Append
 }


### PR DESCRIPTION
Append to the agent log, instead of creating the file, when an exception occcurs.

The problem is that creating the file fails if it already exists:

    Exception occurred: Exception calling "Parse" with "1" argument(s): "String '' was not recognized as a valid DateTime."
    New-Item: /Users/builder/azdo/_work/4/s/xamarin-macios/tools/devops/automation/scripts/generate_agent_logs.ps1:52
    Line |
      52 |      New-Item -Path $Output -Value "$_"
         |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         | The file '/Users/builder/azdo/_work/4/s/agent-logs.log' already exists.