### PR TITLE
NativeAOT: Reenable failing networking tests on tvOS/x64 with NativeAOT

### DIFF
--- a/tests/monotouch-test/Network/NWConnectionGroupTest.cs
+++ b/tests/monotouch-test/Network/NWConnectionGroupTest.cs
@@ -92,7 +92,6 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void TryReinsertExtractedConnectionTest ()
 		{
-			global::MonoTests.System.Net.Http.MessageHandlerTest.CheckTVOSNativeAotFailure ();
 			TestRuntime.AssertXcodeVersion (13, 0);
 			Assert.DoesNotThrow (() => {
 				var conn = connectionGroup.ExtractConnection (endpoint, new NWProtocolTcpOptions ());

--- a/tests/monotouch-test/Network/NWProtocolOptionsTest.cs
+++ b/tests/monotouch-test/Network/NWProtocolOptionsTest.cs
@@ -61,7 +61,6 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void SetIPLocalAddressPreference ()
 		{
-			global::MonoTests.System.Net.Http.MessageHandlerTest.CheckTVOSNativeAotFailure ();
 			TestRuntime.AssertXcodeVersion (11, 0);
 
 			foreach (var ipOption in new [] { NWIPLocalAddressPreference.Default, NWIPLocalAddressPreference.Stable, NWIPLocalAddressPreference.Temporary }) {

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -52,13 +52,6 @@ namespace MonoTests.System.Net.Http {
 			throw new NotImplementedException ($"Unknown handler type: {handler_type}");
 		}
 
-		public static void CheckTVOSNativeAotFailure ()
-		{
-#if NATIVEAOT && __TVOS__
-			if (TestRuntime.IsSimulator && !TestRuntime.IsARM64)
-				Assert.Ignore ("Causes hangs on tvossimulator-x64 with NativeAOT: https://github.com/xamarin/xamarin-macios/issues/20972");
-#endif
-		}
 
 		[Test]
 #if !__WATCHOS__
@@ -71,7 +64,6 @@ namespace MonoTests.System.Net.Http {
 		[TestCase (typeof (NSUrlSessionHandler))]
 		public void DnsFailure (Type handlerType)
 		{
-			CheckTVOSNativeAotFailure ();
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
@@ -458,7 +450,6 @@ namespace MonoTests.System.Net.Http {
 		[TestCase (typeof (NSUrlSessionHandler))]
 		public void RejectSslCertificatesServicePointManager (Type handlerType)
 		{
-			CheckTVOSNativeAotFailure ();
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 9, throwIfOtherPlatform: false);
 			TestRuntime.AssertSystemVersion (ApplePlatform.iOS, 7, 0, throwIfOtherPlatform: false);
 
@@ -856,8 +847,6 @@ namespace MonoTests.System.Net.Http {
 		[TestCase (typeof (SocketsHttpHandler))]
 		public void UpdateRequestUriAfterRedirect (Type handlerType)
 		{
-			CheckTVOSNativeAotFailure ();
-
 			// https://github.com/xamarin/xamarin-macios/issues/20629
 
 			var done = TestRuntime.TryRunAsync (TimeSpan.FromSeconds (30), async () => {
@@ -883,8 +872,6 @@ namespace MonoTests.System.Net.Http {
 		[TestCase (typeof (SocketsHttpHandler))]
 		public void RequestUriNotUpdatedIfNotRedirect (Type handlerType)
 		{
-			CheckTVOSNativeAotFailure ();
-
 			// https://github.com/xamarin/xamarin-macios/issues/20629
 
 			var done = TestRuntime.TryRunAsync (TimeSpan.FromSeconds (30), async () => {


### PR DESCRIPTION
This PR reenables failing tests on tvOS/x64 with NativeAOT as the dotnet/runtime fix became available in: https://github.com/dotnet/runtime/commit/cd064dd8cce624a541b5c966d9449aa5df4072b3 and got merged in to the xamarin net9.0 branch.

The tests were previously disabled in: https://github.com/xamarin/xamarin-macios/pull/20949

---
Fixes: https://github.com/xamarin/xamarin-macios/issues/20972