### PR TITLE
NativeAOT: Fix output dir path for universal apps built with NativeAOT

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -95,6 +95,9 @@
 		<AllowPublishAotWithoutRuntimeIdentifier Condition="'$(AllowPublishAotWithoutRuntimeIdentifier)' == '' And '$(_UseNativeAot)' == 'true'">true</AllowPublishAotWithoutRuntimeIdentifier>
 		<AllowSelfContainedWithoutRuntimeIdentifier Condition="'$(AllowSelfContainedWithoutRuntimeIdentifier)' == ''">true</AllowSelfContainedWithoutRuntimeIdentifier>
 
+		<!-- Prevent .NET from resolving runtime identifier for NativeAOT builds when building universal apps. -->
+		<UseCurrentRuntimeIdentifier Condition="'$(_UseNativeAot)' == 'true' And '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' == ''">false</UseCurrentRuntimeIdentifier>
+
 	</PropertyGroup>
 
 	<!-- Set the default RuntimeIdentifier if not already specified. -->


### PR DESCRIPTION
### Description 

When building universal apps with NativeAOT, the output path for the app bundle (and zipped .ipa) is incorrect when building with NativeAOT.

For example publishing a MAUI template app with NativeAOT gives the following output (notice: `osx-arm64`):
```
Created the package: /Users/ivan/tmp/net9-rc1/MacCatRc1/bin/Release/net9.0-maccatalyst/osx-arm64/publish/MacCatRc1-1.0.pkg
```
and the following output tree:
```
bin/Release 
bin/Release/net9.0-maccatalyst 
bin/Release/net9.0-maccatalyst/maccatalyst-arm64/*
bin/Release/net9.0-maccatalyst/maccatalyst-x64/*
bin/Release/net9.0-maccatalyst/osx-arm64
bin/Release/net9.0-maccatalyst/osx-arm64/MacCatRc1.app/*
bin/Release/net9.0-maccatalyst/osx-arm64/publish/*
```

The problem comes from the fact that .NET SDK for NativeAOT builds will try to resolve `RuntimeIdentifier` when it is not specified in:
https://github.com/dotnet/sdk/blob/58eb155e30a393656dd290486143f02f958898fc/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets#L95-L114

which resolves to `osx-arm64` and gets later used to setup `IntermediateOutputPath` and `OutputPath` in:
https://github.com/dotnet/sdk/blob/58eb155e30a393656dd290486143f02f958898fc/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets#L343-L346
 
However, this shouldn't be done in universal builds, as the outer build does not have the runtime identifier specified and should not be altered.

### Changes

In this PR we are disabling the resolution of the `RuntimeIdentifier` when building universal apps with NativeAOT early in SDK in order to fix the output path.

I also included unit tests to verify the existence of .app bundles. 

### Follow-up

There is an additional issue with Debug builds of universal apps with NativeAOT, where merging PDBs fails, which is reported in: https://github.com/xamarin/xamarin-macios/issues/20903

---
Contributes to: https://github.com/xamarin/xamarin-macios/issues/20903
