### PR TITLE
NativeAOT: Exclude pdbs from NativeAOT app bundles

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1379,9 +1379,10 @@
 		AfterTargets="_LinkNativeExecutable"
 		BeforeTargets="CopyFilesToPublishDirectory">
 		<ItemGroup>
-			<!-- We don't ship assemblies with NativeAOT -->
-			<!-- Exclude assemblies explicitly until https://github.com/dotnet/runtime/issues/87187 is not resolved -->
+			<!-- We don't ship assemblies and pdbs with NativeAOT -->
+			<!-- Exclude assemblies and pdbs explicitly until https://github.com/dotnet/runtime/issues/87187 is not resolved -->
 			<ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.Extension)' == '.dll'" />
+			<ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.Extension)' == '.pdb'" />
 		</ItemGroup>
 	</Target>
 

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1078,7 +1078,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", false)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", true)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", false)]
-		// [TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", true)]  See: https://github.com/xamarin/xamarin-macios/issues/20903
+		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", true)]
 		// [TestCase ("MacCatalyst", "")] - No extension support yet
 		public void BuildProjectsWithExtensions (ApplePlatform platform, string runtimeIdentifier, bool isNativeAot)
 		{
@@ -1113,7 +1113,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", false)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", true)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", false)]
-		// [TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", true)] See: https://github.com/xamarin/xamarin-macios/issues/20903
+		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", true)]
 		// [TestCase ("MacCatalyst", "")] - No extension support yet
 		public void BuildProjectsWithExtensionsAndFrameworks (ApplePlatform platform, string runtimeIdentifier, bool isNativeAot)
 		{
@@ -1742,11 +1742,11 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS, "ios-arm64", "Release")]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", "Debug")]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", "Release")]
-		// [TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64", "Debug")] // See: https://github.com/xamarin/xamarin-macios/issues/20903
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64", "Debug")]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64", "Release")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", "Debug")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", "Release")]
-		// [TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64", "Debug")] // See: https://github.com/xamarin/xamarin-macios/issues/20903
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64", "Debug")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64", "Release")]
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64", "Debug")]
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64", "Release")]


### PR DESCRIPTION
### Description

Previously we were including .pdbs in NativeAOT debug bundles, which was causing issues with debug builds of universal apps (during app bundle merging). This does not seem to be required, as in debug builds NativeAOT compiler uses information from pdbs to provide more data about the managed code during native debugging (like line numbers in stack traces, etc), embedding it into the native image, and does not require presence of said files during runtime.

### Changes

- This PR excludes pdbs from NativeAOT app bundles by removing them from `ResolvedFileToPublish` item group.
- The relevant unit tests are reenabled.

---
Fixes https://github.com/xamarin/xamarin-macios/issues/20903