### PR TITLE
[src] Turn warnings into errors when compiling API definitions.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -84,7 +84,7 @@ DOTNET_REFERENCES = \
 	/r:$(DOTNET_BCL_DIR)/System.Xml.ReaderWriter.dll \
 
 DOTNET_OR_GREATER_DEFINES:=$(foreach version,$(shell seq 6 $(firstword $(subst ., ,$(subst net,,$(DOTNET_TFM))))),/define:NET$(version)_0_OR_GREATER)
-DOTNET_FLAGS=/noconfig /nostdlib+ /deterministic /features:strict /nologo /target:library /debug /unsafe /define:NET /define:NET_TODO /define:XAMCORE_3_0 $(DOTNET_OR_GREATER_DEFINES) $(DOTNET_REFERENCES)
+DOTNET_FLAGS=/warnaserror+ /noconfig /nostdlib+ /deterministic /features:strict /nologo /target:library /debug /unsafe /define:NET /define:NET_TODO /define:XAMCORE_3_0 $(DOTNET_OR_GREATER_DEFINES) $(DOTNET_REFERENCES)
 
 ifeq ($(XCODE_IS_STABLE),true)
 DOTNET_FLAGS+=/define:XCODE_IS_STABLE

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -2794,10 +2794,10 @@ namespace PassKit {
 		PKShareablePassMetadataPreview PreviewWithTemplateIdentifier (string templateIdentifier);
 
 		[NullAllowed, Export ("passThumbnailImage", ArgumentSemantic.Assign)]
-		new CGImage PassThumbnailImage { get; }
+		CGImage PassThumbnailImage { get; }
 
 		[NullAllowed, Export ("localizedDescription", ArgumentSemantic.Strong)]
-		new string LocalizedDescription { get; }
+		string LocalizedDescription { get; }
 
 		[NullAllowed, Export ("ownerDisplayName", ArgumentSemantic.Strong)]
 		string OwnerDisplayName { get; set; }


### PR DESCRIPTION
Also fix a couple of compiler warnings:

    passkit.cs(2797,15): warning CS0109: The member 'PKShareablePassMetadataPreview.PassThumbnailImage' does not hide an accessible member. The new keyword is not required.
    passkit.cs(2800,14): warning CS0109: The member 'PKShareablePassMetadataPreview.LocalizedDescription' does not hide an accessible member. The new keyword is not required.