### PR TITLE
[build] Shutdown/kill any build servers at the end of the build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ else
 	@echo
 endif
 endif
+	$(Q) $(MAKE) -C dotnet shutdown-build-server
 
 .PHONY: package release
 package release:

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -546,4 +546,9 @@ all-hook::
 	$(Q) $(MAKE) shutdown-build-server
 
 shutdown-build-server:
-	$(Q) $(DOTNET) build-server shutdown
+	$(Q) echo "Shutting down build servers:"
+	$(Q) $(DOTNET) build-server shutdown | sed 's/^/    /' || true
+	$(Q) echo "Listing .NET processes still alive:"
+	$(Q) pgrep -lf "^$(DOTNET)" | sed 's/^/    /' || true
+	$(Q) echo "Killing the above mentioned processes."
+	$(Q) pkill -9 -f "^$(DOTNET)" | sed 's/^/    /' || true


### PR DESCRIPTION
This is a log from our bots, note the 14 minute gap just before printing the timing results:

```
[...]
2024-09-27T07:34:00.3958920Z Making install in dotnet
2024-09-27T07:34:01.7633820Z Validated file permissions for Xamarin.Mac.
2024-09-27T07:34:01.7800150Z Validated file permissions for Xamarin.iOS.
2024-09-27T07:34:01.7825300Z
2024-09-27T07:34:01.7872490Z 	Xamarin.iOS has not been installed into your system by 'make install'
2024-09-27T07:34:01.7918570Z 	In order to set the currently built Xamarin.iOS as your system version,
2024-09-27T07:34:01.7965090Z 	execute 'make install-system'.
2024-09-27T07:34:01.7987920Z
2024-09-27T07:34:01.8034290Z 	Xamarin.Mac has not been installed into your system by 'make install'
2024-09-27T07:34:01.8080260Z 	In order to set the currently built Xamarin.Mac as your system version,
2024-09-27T07:34:01.8126200Z 	execute 'make install-system'.
2024-09-27T07:34:01.8148530Z
2024-09-27T07:48:22.3100850Z
2024-09-27T07:48:22.3102130Z real	15m26.160s
2024-09-27T07:48:22.3102800Z user	1m4.044s
2024-09-27T07:48:22.3103270Z sys	0m18.379s
```

What happens is this:
*   We're using parallel make, and parallel make will start a jobserver, managed by file descriptors, where these file descriptors must be closed in all subprocesses for make to realize it's done.
*   Any 'dotnet build' might start a build server
*   The build server does not close any file descriptors it may have inherited when daemonizing itself.
*   Thus the build server (which will still be alive after we're done building here) might have a file descriptor open which make is waiting for.
*   The proper fix is to fix the build server to close its file descriptors.
*   The intermediate working is to shut down the build server instead.

This will save 10-15 minutes at the end of every build in the bots.