### PR TITLE
Bump maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -18,7 +18,7 @@ endif
 
 # Available versions can be seen here:
 # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.Tools.Mlaunch/versions
-MLAUNCH_NUGET_VERSION=1.0.256
+MLAUNCH_NUGET_VERSION=1.0.261
 
 define CheckVersionTemplate
 check-$(1)::


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@c1a17a2f80 [mlaunch] Install and launch apps without using the AMDevice API for devices that devicectl supports.

Diff: https://github.com/xamarin/maccore/compare/ad4af9cde4..c1a17a2f80

Fixes https://github.com/xamarin/xamarin-macios/issues/21274.