### PR TITLE
[net9.0] Bring back missing change from #20790 to SignList

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -122,7 +122,7 @@
     <FirstParty Include="Broker.exe" />
     <FirstParty Include="Broker.resources.dll" />
     <!-- Build.zip -->
-    <FirstParty Include="Build.exe" />
+    <FirstParty Include="Build.dll" />
     <FirstParty Include="Microsoft.Build*.dll" />
     <FirstParty Include="Microsoft.NET.StringTools.dll" />
     <FirstParty Include="System.IO.Abstractions.dll" />


### PR DESCRIPTION
This change is missing from the last revert https://github.com/xamarin/xamarin-macios/pull/20790/commits/25509d79171fd5cb4ecb7c6db54bbecd83b297ec that happened on https://github.com/xamarin/xamarin-macios/pull/21264