### PR TITLE
[actions] There's no reason to keep testing a .NET-only configuration.

### DIFF
--- a/.github/workflows/update-single-platform-branches.yml
+++ b/.github/workflows/update-single-platform-branches.yml
@@ -28,7 +28,7 @@ jobs:
           set -ex
           git config user.email "github-actions-single-platform-branch-updater@xamarin.com"
           git config user.name "GitHub Actions Single Platform Branch Updater"
-          for platform in dotnet-iOS dotnet-tvOS dotnet-MacCatalyst dotnet-macOS dotnet; do
+          for platform in dotnet-iOS dotnet-tvOS dotnet-MacCatalyst dotnet-macOS; do
             git checkout -b release-test/only-$platform origin/release-test/only-$platform
             git merge origin/main
             git push


### PR DESCRIPTION
Because there's nothing but .NET now.