### PR TITLE
[net9.0] [build] Remove duplicate variable definition.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -748,9 +748,6 @@ EMSCRIPTEN_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_
 # It should typically be $(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT), unless we decide to hardcode it to something else
 MACIOS_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT)
 
-# Set this to 1 if the Microsoft.NETCore.App.Ref dependency in eng/Version.Details.xml does *not* specify a CoherentParentDependency on VS.Tools.Net.Core.SDK.Resolver.
-TRACKING_DOTNET_RUNTIME_SEPARATELY=
-
 # The location of csc changes depending on whether we're using a preview or a stable/service release :/
 DOTNET_CSC_PATH_PREVIEW=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION)/Roslyn/bincore/csc.dll
 DOTNET_CSC_PATH_STABLE=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION_BAND)/Roslyn/bincore/csc.dll


### PR DESCRIPTION
The variable TRACKING_DOTNET_RUNTIME_SEPARATELYis already defined further
above in this file, so just remove the second definition.

I believe this happened due to an incorrect merge conflict resolution at some
point.