### PR TITLE
[release/9.0.1xx-rc2] Track dotnet/runtime separately.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -665,7 +665,7 @@ ALL_PLATFORMS=iOS tvOS watchOS macOS
 ALL_DOTNET_PLATFORMS=iOS macOS tvOS MacCatalyst
 
 # Set this to 1 if the Microsoft.NETCore.App.Ref dependency in eng/Version.Details.xml does *not* specify a CoherentParentDependency on Microsoft.Dotnet.Sdk.Internal.
-TRACKING_DOTNET_RUNTIME_SEPARATELY=
+TRACKING_DOTNET_RUNTIME_SEPARATELY=1
 
 -include $(TOP)/dotnet.config
 $(TOP)/dotnet.config: $(TOP)/eng/Versions.props $(TOP)/Build.props
@@ -749,7 +749,7 @@ EMSCRIPTEN_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_
 MACIOS_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT)
 
 # Set this to 1 if the Microsoft.NETCore.App.Ref dependency in eng/Version.Details.xml does *not* specify a CoherentParentDependency on VS.Tools.Net.Core.SDK.Resolver.
-TRACKING_DOTNET_RUNTIME_SEPARATELY=
+TRACKING_DOTNET_RUNTIME_SEPARATELY=1
 
 # The location of csc changes depending on whether we're using a preview or a stable/service release :/
 DOTNET_CSC_PATH_PREVIEW=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION)/Roslyn/bincore/csc.dll

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -119,15 +119,7 @@ endif
 endif
 
 .stamp-install-custom-dotnet-runtime-workloads:
-ifneq ($(TRACKING_DOTNET_RUNTIME_SEPARATELY),)
-	@# mono toolchain
-	$(Q) mkdir -p ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)
-	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.mono.toolchain.net7.manifest-$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)/$(DOWNLOAD_DOTNET_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(MONO_TOOLCHAIN_MANIFEST_VERSION_BAND)/microsoft.net.workload.mono.toolchain.net7/
-	@# emscripten, which mono depends on
-	$(Q) mkdir -p ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(EMSCRIPTEN_MANIFEST_VERSION_BAND)
-	$(Q) $(CP) $(TOP)/packages/microsoft.net.workload.emscripten.net7.manifest-$(EMSCRIPTEN_MANIFEST_VERSION_BAND)/$(EMSCRIPTEN_MANIFEST_PACKAGE_VERSION)/data/WorkloadManifest.* ./downloads/$(DOTNET_INSTALL_NAME)/sdk-manifests/$(EMSCRIPTEN_MANIFEST_VERSION_BAND)/microsoft.net.workload.emscripten.net7/
 	$(Q) touch $@
-endif
 
 package-download/all-package-references.csproj: $(GIT_DIRECTORY)/HEAD $(GIT_DIRECTORY)/index ./create-csproj-for-all-packagereferences.sh
 	$(Q_GEN) ./create-csproj-for-all-packagereferences.sh --output "$(abspath $@.tmp)" $(if $(V),-v,)

--- a/builds/package-download/download-packages.csproj
+++ b/builds/package-download/download-packages.csproj
@@ -19,12 +19,6 @@
 
     <!-- download the reference assemblies -->
     <PackageDownload Include="microsoft.netcore.app.ref" Version="[$(ActualPackageVersion)]" />
-
-    <!-- and get the mono workload(s) as well -->
-    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(MonoToolChainManifestVersionBand)" Version="[$(ActualPackageVersion)]" Condition="'$(TrackingDotNetRuntimeSeparately)' != ''" />
-
-    <!-- and get the emscripten workload(s) as well -->
-    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net7.Manifest-$(EmscriptenManifestVersionBand)" Version="[$(Emscriptennet7WorkloadVersion)]" Condition="'$(TrackingDotNetRuntimeSeparately)' != ''" />
   </ItemGroup>
 
   <Import Project="all-package-references.csproj" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,31 +4,31 @@
       <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>f59e9ca09cb4d5b903b276c0d3d7825b6ddbc3a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink" Version="9.0.0-alpha.1.23556.4">
+    <Dependency Name="Microsoft.NET.ILLink" Version="9.0.0-rc.2.24473.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>cf47d9ff6827a3e1d6f2acbf925cd618418f20dd</Sha>
+      <Sha>200d05e41fc2212ff8c98ed79ebe9043bfed58aa</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="9.0.0-rtm.24475.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2c4266c134aa02718179818098a11e825c9d1362</Sha>
     </Dependency>
     <!-- Set TRACKING_DOTNET_RUNTIME_SEPARATELY to something in Make.config if removing the CoherentParentDependency on Microsoft.NET.Sdk -->
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-rtm.24475.3" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-rc.2.24473.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2c4266c134aa02718179818098a11e825c9d1362</Sha>
+      <Sha>200d05e41fc2212ff8c98ed79ebe9043bfed58aa</Sha>
     </Dependency>
     <!-- This is required for our test apps to build; in some cases Microsoft.AspNetCore.App is pulled in, and when building test apps the build needs to be able to resolve that -->
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="9.0.0-rtm.24474.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>afe2857bffef08213d6f3c7688647c60d5d5e7bd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-rtm.24469.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-rc.2.24468.8" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>8e660ff41e91879977e3a9d837e068bd72234c26</Sha>
+      <Sha>0b30e0253a0d7c47a99cecd51b0d5ff5c83ad1df</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.5-alpha.24467.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.5-alpha.24460.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/cecil</Uri>
-      <Sha>526b22d829bc9b420dff6ef70877a67053b66e0f</Sha>
+      <Sha>1541df9c44ff8da964b2946e18655c2e37e4a198</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 8/Xcode 16.0 versions of our packages -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net8.0_18.0" Version="18.0.8303">
@@ -64,9 +64,9 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>06fea905cf900ab5296b08d7b67dadddc733dd65</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.MonoTargets.Sdk" Version="9.0.0-rc.2.24462.10">
+    <Dependency Name="Microsoft.NET.Runtime.MonoTargets.Sdk" Version="9.0.0-rc.2.24473.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>9bff9c5017d8444fdf76959c112dd9fed2da9317</Sha>
+      <Sha>200d05e41fc2212ff8c98ed79ebe9043bfed58aa</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,14 +4,14 @@
     <!-- Versions updated by maestro -->
     <MicrosoftNETSdkPackageVersion>9.0.100-rc.2.24475.4</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>9.0.0-rtm.24475.3</MicrosoftNETILLinkTasksPackageVersion>
-    <MicrosoftNETILLinkPackageVersion>9.0.0-alpha.1.23556.4</MicrosoftNETILLinkPackageVersion>
+    <MicrosoftNETILLinkPackageVersion>9.0.0-rc.2.24473.4</MicrosoftNETILLinkPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>9.0.0-beta.24408.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftDotNetSharedFrameworkSdkVersion>8.0.0-beta.24413.2</MicrosoftDotNetSharedFrameworkSdkVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>9.0.0-rtm.24475.3</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>9.0.0-rc.2.24473.4</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>8.0.0-rtm.23511.3</MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>
-    <MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>9.0.0-rc.2.24462.10</MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>
+    <MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>9.0.0-rc.2.24473.4</MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
-    <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.24467.1</MicrosoftDotNetCecilPackageVersion>
+    <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.24460.1</MicrosoftDotNetCecilPackageVersion>
     <MicrosoftDotNetXHarnessiOSSharedPackageVersion>10.0.0-prerelease.24467.4</MicrosoftDotNetXHarnessiOSSharedPackageVersion>
     <!-- Manually updated versions -->
     <Emscriptennet7WorkloadVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100Version)</Emscriptennet7WorkloadVersion>

--- a/tests/dotnet/MySimpleApp/Directory.Build.props
+++ b/tests/dotnet/MySimpleApp/Directory.Build.props
@@ -3,5 +3,5 @@
 		<!-- Used by the AppendRuntimeIdentifierToOutputPath_* tests -->
 		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
 	</PropertyGroup>
-	<Import Project="$(MSBuildThisFileDirectory)../../../Directory.Build.props" />
+	<Import Project="$(MSBuildThisFileDirectory)../../Directory.Build.props" />
 </Project>


### PR DESCRIPTION
.NET 9 RC 2 will include security fixes, so the very latest builds will be
internal. As a way for us to test the newest possible public builds, we can
update dotnet/runtime ahead of dotnet/sdk.

See also Android's PR: https://github.com/dotnet/android/pull/9347