### PR TITLE
[tests] Rework StringAttributesTests.SimpleAttributesTest. Fixes #18656.

### DIFF
--- a/tests/monotouch-test/CoreText/StringAttributes.cs
+++ b/tests/monotouch-test/CoreText/StringAttributes.cs
@@ -24,13 +24,9 @@ namespace MonoTouchFixtures.CoreText {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class StringAttributesTests {
-#if !MONOMAC // No UIGraphics on mac
 		[Test]
-		public void SimpleValuesSet ()
+		public void NoCTLine ()
 		{
-			if (TestRuntime.CheckXcodeVersion (15, 0))
-				Assert.Ignore ("Test timeouts on Xcode 15 beta 4: https://github.com/xamarin/xamarin-macios/issues/18656");
-
 			var sa = new CTStringAttributes ();
 			sa.ForegroundColor = UIColor.Blue.CGColor;
 			sa.Font = new CTFont ("Georgia-BoldItalic", 24);
@@ -50,14 +46,51 @@ namespace MonoTouchFixtures.CoreText {
 				sa.TrackingAdjustment = 1.0f;
 
 			AdaptiveImageProvider? provider = null;
-#if NET
+			if (TestRuntime.CheckXcodeVersion (16, 0)) {
+				sa.AdaptiveImageProvider = provider = new AdaptiveImageProvider ();
+				Assert.AreSame (provider, sa.AdaptiveImageProvider, "AdaptiveImageProvider");
+			}
+		}
+
+		[Test]
+		public void SimpleValuesSet ()
+		{
+			var sa = new CTStringAttributes ();
+			sa.ForegroundColor = UIColor.Blue.CGColor;
+			sa.Font = new CTFont ("Georgia-BoldItalic", 24);
+			sa.UnderlineStyle = CTUnderlineStyle.Double; // It does not seem to do anything
+			sa.UnderlineColor = UIColor.Blue.CGColor;
+			sa.UnderlineStyleModifiers = CTUnderlineStyleModifiers.PatternDashDotDot;
+
+			Assert.IsNull (sa.BaselineClass, "#0");
+			sa.BaselineClass = CTBaselineClass.IdeographicHigh;
+			Assert.AreEqual (CTBaselineClass.IdeographicHigh, sa.BaselineClass, "#1");
+
+			// Calling sa.SetBaselineInfo makes the CTLine ctor crash (https://github.com/xamarin/maccore/issues/2947)
+			// so don't do that here.
+			// sa.SetBaselineInfo (CTBaselineClass.Roman, 13);
+			// sa.SetBaselineInfo (CTBaselineClass.IdeographicHigh, 3);
+			sa.SetWritingDirection (CTWritingDirection.LeftToRight);
+
+			if (TestRuntime.CheckXcodeVersion (11, 0))
+				sa.TrackingAdjustment = 1.0f;
+
+			AdaptiveImageProvider? provider = null;
 			if (TestRuntime.CheckXcodeVersion (16, 0))
 				sa.AdaptiveImageProvider = provider = new AdaptiveImageProvider ();
-#endif
 
 			var size = new CGSize (300, 300);
+#if MONOMAC
+			using var imageRep = new NSBitmapImageRep (IntPtr.Zero, (nint) size.Width, (nint) size.Height, 8, 4, true, false, NSColorSpace.DeviceRGB, 4 * (int) size.Width, 32);
+			using var graphicsContext = NSGraphicsContext.FromBitmap (imageRep);
+			using var img = new NSImage (size);
+			img.AddRepresentation (imageRep);
+			img.LockFocus ();
+			using var gctx = graphicsContext.CGContext;
+#else
 			UIGraphics.BeginImageContext (size);
-			var gctx = UIGraphics.GetCurrentContext ();
+			using var gctx = UIGraphics.GetCurrentContext ();
+#endif
 
 			gctx.SetFillColor (UIColor.Green.CGColor);
 
@@ -67,9 +100,8 @@ namespace MonoTouchFixtures.CoreText {
 				textLine.Draw (gctx);
 			}
 
-#if NET
 			if (TestRuntime.CheckXcodeVersion (16, 0))
-				Assert.AreEqual (0, provider!.Count, "AdaptiveImageProvider #0");
+				Assert.AreEqual (1, provider!.Count, "AdaptiveImageProvider #0");
 
 			attributedString = new NSAttributedString ("🙈`", sa);
 			using (var textLine = new CTLine (attributedString)) {
@@ -77,12 +109,14 @@ namespace MonoTouchFixtures.CoreText {
 			}
 
 			if (TestRuntime.CheckXcodeVersion (16, 0))
-				Assert.AreEqual (1, provider!.Count, "AdaptiveImageProvider #1");
-#endif
+				Assert.AreEqual (2, provider!.Count, "AdaptiveImageProvider #1");
 
+#if MONOMAC
+			img.UnlockFocus ();
+#else
 			UIGraphics.EndImageContext ();
-		}
 #endif
+		}
 
 		[Test]
 		public void BackgroundColor ()


### PR DESCRIPTION
* CTLine crashes with certain NSAttributedStrings, so don't do that. This fixes #18656.
* Implement this test for macOS.
* Misc other fixes.

Fixes https://github.com/xamarin/xamarin-macios/issues/18656.