### PR TITLE
[CI] Use the full path for triggering resources.

### DIFF
--- a/tools/devops/automation/run-post-ci-build-macos-tests.yml
+++ b/tools/devops/automation/run-post-ci-build-macos-tests.yml
@@ -9,7 +9,7 @@ pr: none
 resources:
   pipelines:
     - pipeline: macios
-      source: xamarin-macios-ci
+      source: \Xamarin\Mac-iOS\ci pipelines\xamarin-macios-ci
       trigger:
         stages:
           - build_macos_tests

--- a/tools/devops/automation/run-post-ci-build-tests.yml
+++ b/tools/devops/automation/run-post-ci-build-tests.yml
@@ -4,12 +4,11 @@
 trigger: none
 pr: none
 
-
 # we cannot use a template in a pipeline context
 resources:
   pipelines:
     - pipeline: macios
-      source: xamarin-macios-ci
+      source: \Xamarin\Mac-iOS\ci pipelines\xamarin-macios-ci
       trigger:
         stages:
           - build_packages

--- a/tools/devops/automation/run-post-pr-build-macos-tests.yml
+++ b/tools/devops/automation/run-post-pr-build-macos-tests.yml
@@ -8,7 +8,7 @@ pr: none
 resources:
   pipelines:
     - pipeline: macios
-      source: xamarin-macios-pr
+      source: \Xamarin\Mac-iOS\pr pipelines\xamarin-macios-pr
       trigger:
         stages:
           - build_macos_tests

--- a/tools/devops/automation/run-post-pr-build-tests.yml
+++ b/tools/devops/automation/run-post-pr-build-tests.yml
@@ -8,7 +8,7 @@ pr: none
 resources:
   pipelines:
     - pipeline: macios
-      source: xamarin-macios-pr
+      source: \Xamarin\Mac-iOS\pr pipelines\xamarin-macios-pr
       trigger:
         stages:
           - build_packages


### PR DESCRIPTION
VSTS recommends this in their docs. We are going to do it to make it simpler to track what triggers what.