### PR TITLE
[tests] Fix inclusion of Directory.Build.props up the directory hierarchy.

### DIFF
--- a/tests/dotnet/MySimpleApp/Directory.Build.props
+++ b/tests/dotnet/MySimpleApp/Directory.Build.props
@@ -3,5 +3,5 @@
 		<!-- Used by the AppendRuntimeIdentifierToOutputPath_* tests -->
 		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
 	</PropertyGroup>
-	<Import Project="$(MSBuildThisFileDirectory)../../../Directory.Build.props" />
+	<Import Project="$(MSBuildThisFileDirectory)../../Directory.Build.props" />
 </Project>


### PR DESCRIPTION
The first Directory.Build.props should be imported, so do that.