### PR TITLE
[net9.0] [UIKit] Improve code for UISegmentedControl. Fixes #21289.

### DIFF
--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -546,6 +546,7 @@ namespace Foundation {
 
 		// helper to avoid the (common pattern)
 		// 	var p = x is null ? null : x.Dictionary;
+		[return: NotNullIfNotNull (nameof (self))]
 		static public NSDictionary? GetDictionary (this DictionaryContainer? self)
 		{
 			return self is null ? null : self.Dictionary;

--- a/src/UIKit/UISegmentedControl.cs
+++ b/src/UIKit/UISegmentedControl.cs
@@ -8,19 +8,14 @@
 // Copyright 2011 Xamarin, Inc
 //
 
-#if !WATCH
-
 using System;
 using System.Collections;
 using Foundation;
 using ObjCRuntime;
 using CoreGraphics;
+using UIKit;
 
-#if XAMCORE_3_0
-using TextAttributes = UIKit.UIStringAttributes;
-#else
-using TextAttributes = UIKit.UITextAttributes;
-#endif
+#nullable enable
 
 namespace UIKit {
 	public partial class UISegmentedControl {
@@ -92,49 +87,5 @@ namespace UIKit {
 
 			return NSArray.FromStrings (strings);
 		}
-
-		public void SetTitleTextAttributes (TextAttributes attributes, UIControlState state)
-		{
-			if (attributes is null)
-				throw new ArgumentNullException ("attributes");
-
-#if XAMCORE_3_0
-			var dict = attributes.Dictionary;
-#else
-			using var dict = attributes.ToDictionary ();
-#endif
-			_SetTitleTextAttributes (dict, state);
-		}
-
-		public TextAttributes GetTitleTextAttributes (UIControlState state)
-		{
-			using (var d = _GetTitleTextAttributes (state)) {
-				return new TextAttributes (d);
-			}
-		}
-
-		public partial class UISegmentedControlAppearance {
-			public void SetTitleTextAttributes (TextAttributes attributes, UIControlState state)
-			{
-				if (attributes is null)
-					throw new ArgumentNullException ("attributes");
-
-#if XAMCORE_3_0
-				var dict = attributes.Dictionary;
-#else
-				using var dict = attributes.ToDictionary ();
-#endif
-				_SetTitleTextAttributes (dict, state);
-			}
-
-			public TextAttributes GetTitleTextAttributes (UIControlState state)
-			{
-				using (var d = _GetTitleTextAttributes (state)) {
-					return new TextAttributes (d);
-				}
-			}
-		}
 	}
 }
-
-#endif // !WATCH

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -14085,13 +14085,22 @@ namespace UIKit {
 		UIImage DividerImageForLeftSegmentStaterightSegmentStatebarMetrics (UIControlState leftState, UIControlState rightState, UIBarMetrics barMetrics);
 #endif
 
-		[Export ("setTitleTextAttributes:forState:"), Internal]
+		[Export ("setTitleTextAttributes:forState:")]
 		[Appearance]
-		void _SetTitleTextAttributes (NSDictionary attributes, UIControlState state);
+		[Wrap ("SetTitleTextAttributes (attributes.GetDictionary (), state)", IsVirtual = true)]
+		void SetTitleTextAttributes (UIStringAttributes attributes, UIControlState state);
 
-		[Export ("titleTextAttributesForState:"), Internal]
+		[Export ("setTitleTextAttributes:forState:")]
 		[Appearance]
-		NSDictionary _GetTitleTextAttributes (UIControlState state);
+		void SetTitleTextAttributes (NSDictionary attributes, UIControlState state);
+
+		[Appearance]
+		[Wrap ("new UIStringAttributes (GetWeakTitleTextAttributes (state))", IsVirtual = true)]
+		UIStringAttributes GetTitleTextAttributes (UIControlState state);
+
+		[Appearance]
+		[Export ("titleTextAttributesForState:")]
+		NSDictionary GetWeakTitleTextAttributes (UIControlState state);
 
 		[Export ("setContentPositionAdjustment:forSegmentType:barMetrics:")]
 		[Appearance]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -14086,7 +14086,7 @@ namespace UIKit {
 #endif
 
 		[Appearance]
-		[Wrap ("SetTitleTextAttributes (attributes.GetDictionary (), state)", IsVirtual = true)]
+		[Wrap ("SetTitleTextAttributes (attributes.GetDictionary (), state)")]
 		void SetTitleTextAttributes (UIStringAttributes attributes, UIControlState state);
 
 		[Export ("setTitleTextAttributes:forState:")]
@@ -14094,7 +14094,7 @@ namespace UIKit {
 		void SetTitleTextAttributes (NSDictionary attributes, UIControlState state);
 
 		[Appearance]
-		[Wrap ("new UIStringAttributes (GetWeakTitleTextAttributes (state))", IsVirtual = true)]
+		[Wrap ("new UIStringAttributes (GetWeakTitleTextAttributes (state))")]
 		UIStringAttributes GetTitleTextAttributes (UIControlState state);
 
 		[Appearance]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -14086,12 +14086,12 @@ namespace UIKit {
 #endif
 
 		[Appearance]
-		[Wrap ("SetTitleTextAttributes (attributes.GetDictionary (), state)")]
-		void SetTitleTextAttributes (UIStringAttributes attributes, UIControlState state);
+		[Wrap ("SetTitleTextAttributes (attributes?.GetDictionary (), state)")]
+		void SetTitleTextAttributes ([NullAllowed] UIStringAttributes attributes, UIControlState state);
 
 		[Export ("setTitleTextAttributes:forState:")]
 		[Appearance]
-		void SetTitleTextAttributes (NSDictionary attributes, UIControlState state);
+		void SetTitleTextAttributes ([NullAllowed] NSDictionary attributes, UIControlState state);
 
 		[Appearance]
 		[Wrap ("new UIStringAttributes (GetWeakTitleTextAttributes (state))")]
@@ -14099,6 +14099,7 @@ namespace UIKit {
 
 		[Appearance]
 		[Export ("titleTextAttributesForState:")]
+		[return: NullAllowed]
 		NSDictionary GetWeakTitleTextAttributes (UIControlState state);
 
 		[Export ("setContentPositionAdjustment:forSegmentType:barMetrics:")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -14085,7 +14085,6 @@ namespace UIKit {
 		UIImage DividerImageForLeftSegmentStaterightSegmentStatebarMetrics (UIControlState leftState, UIControlState rightState, UIBarMetrics barMetrics);
 #endif
 
-		[Export ("setTitleTextAttributes:forState:")]
 		[Appearance]
 		[Wrap ("SetTitleTextAttributes (attributes.GetDictionary (), state)", IsVirtual = true)]
 		void SetTitleTextAttributes (UIStringAttributes attributes, UIControlState state);

--- a/tests/monotouch-test/UIKit/SegmentedControlTest.cs
+++ b/tests/monotouch-test/UIKit/SegmentedControlTest.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using System.IO;
 using CoreGraphics;
 using Foundation;
+using ObjCRuntime;
 using UIKit;
 using NUnit.Framework;
 
@@ -106,6 +107,17 @@ namespace MonoTouchFixtures.UIKit {
 			using (UISegmentedControl sc = new UISegmentedControl (img)) {
 				Assert.That (sc.NumberOfSegments, Is.EqualTo ((nint) 1), "NumberOfSegments");
 			}
+		}
+
+		[Test]
+		public void TitleTextAttributes ()
+		{
+			using var sc = new UISegmentedControl ("one", "two");
+			sc.SetTitleTextAttributes (new UIStringAttributes () { ForegroundColor = UIColor.Gray }, UIControlState.Selected);
+			var attrib = sc.GetTitleTextAttributes (UIControlState.Selected);
+			Assert.AreEqual (UIColor.Gray, attrib?.ForegroundColor, "ForegroundColor");
+			Assert.IsNotNull (attrib?.Dictionary, "Dictionary");
+			Assert.AreNotEqual (NativeHandle.Zero, attrib.Dictionary.Handle, "Dictionary.Handle");
 		}
 	}
 }

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-UIKit.ignore
@@ -172,7 +172,6 @@
 !missing-null-allowed! 'Foundation.NSDictionary UIKit.UIDocument::GetFileAttributesToWrite(Foundation.NSUrl,UIKit.UIDocumentSaveOperation,Foundation.NSError&)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSDictionary UIKit.UIMotionEffect::ComputeKeyPathsAndRelativeValues(UIKit.UIOffset)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSDictionary UIKit.UISearchBar::_GetScopeBarButtonTitleTextAttributes(UIKit.UIControlState)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSDictionary UIKit.UISegmentedControl::_GetTitleTextAttributes(UIKit.UIControlState)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSIndexPath UIKit.UICollectionViewFocusUpdateContext::get_NextFocusedIndexPath()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSIndexPath UIKit.UICollectionViewFocusUpdateContext::get_PreviouslyFocusedIndexPath()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSIndexPath UIKit.UITableViewDelegate::WillDeselectRow(UIKit.UITableView,Foundation.NSIndexPath)' is missing an [NullAllowed] on return type
@@ -284,7 +283,6 @@
 !missing-null-allowed! 'System.Void UIKit.UISearchBar::_SetScopeBarButtonTitle(Foundation.NSDictionary,UIKit.UIControlState)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISearchTextField::set_TokenBackgroundColor(UIKit.UIColor)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::.ctor(Foundation.NSArray)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void UIKit.UISegmentedControl::_SetTitleTextAttributes(Foundation.NSDictionary,UIKit.UIControlState)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::InsertSegment(System.String,System.IntPtr,System.Boolean)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::InsertSegment(UIKit.UIImage,System.IntPtr,System.Boolean)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::SetImage(UIKit.UIImage,System.IntPtr)' is missing an [NullAllowed] on parameter #0

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
@@ -176,7 +176,6 @@
 !missing-null-allowed! 'Foundation.NSDictionary UIKit.UIDocument::GetFileAttributesToWrite(Foundation.NSUrl,UIKit.UIDocumentSaveOperation,Foundation.NSError&)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSDictionary UIKit.UIMotionEffect::ComputeKeyPathsAndRelativeValues(UIKit.UIOffset)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSDictionary UIKit.UISearchBar::_GetScopeBarButtonTitleTextAttributes(UIKit.UIControlState)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSDictionary UIKit.UISegmentedControl::_GetTitleTextAttributes(UIKit.UIControlState)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSIndexPath UIKit.UICollectionViewFocusUpdateContext::get_NextFocusedIndexPath()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSIndexPath UIKit.UICollectionViewFocusUpdateContext::get_PreviouslyFocusedIndexPath()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSIndexPath UIKit.UITableViewDelegate::WillDeselectRow(UIKit.UITableView,Foundation.NSIndexPath)' is missing an [NullAllowed] on return type
@@ -288,7 +287,6 @@
 !missing-null-allowed! 'System.Void UIKit.UISearchBar::_SetScopeBarButtonTitle(Foundation.NSDictionary,UIKit.UIControlState)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISearchTextField::set_TokenBackgroundColor(UIKit.UIColor)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::.ctor(Foundation.NSArray)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void UIKit.UISegmentedControl::_SetTitleTextAttributes(Foundation.NSDictionary,UIKit.UIControlState)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::InsertSegment(System.String,System.IntPtr,System.Boolean)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::InsertSegment(UIKit.UIImage,System.IntPtr,System.Boolean)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::SetImage(UIKit.UIImage,System.IntPtr)' is missing an [NullAllowed] on parameter #0

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
@@ -196,7 +196,6 @@
 !missing-null-allowed! 'Foundation.NSDictionary UIKit.UICollectionViewLayoutInvalidationContext::get_InvalidatedSupplementaryIndexPaths()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSDictionary UIKit.UIMotionEffect::ComputeKeyPathsAndRelativeValues(UIKit.UIOffset)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSDictionary UIKit.UISearchBar::_GetScopeBarButtonTitleTextAttributes(UIKit.UIControlState)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSDictionary UIKit.UISegmentedControl::_GetTitleTextAttributes(UIKit.UIControlState)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSIndexPath UIKit.UICollectionViewFocusUpdateContext::get_NextFocusedIndexPath()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSIndexPath UIKit.UICollectionViewFocusUpdateContext::get_PreviouslyFocusedIndexPath()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSIndexPath UIKit.UITableViewDelegate::WillDeselectRow(UIKit.UITableView,Foundation.NSIndexPath)' is missing an [NullAllowed] on return type
@@ -265,7 +264,6 @@
 !missing-null-allowed! 'System.Void UIKit.UIScrollViewDelegate::ZoomingStarted(UIKit.UIScrollView,UIKit.UIView)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'System.Void UIKit.UISearchBar::_SetScopeBarButtonTitle(Foundation.NSDictionary,UIKit.UIControlState)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::.ctor(Foundation.NSArray)' is missing an [NullAllowed] on parameter #0
-!missing-null-allowed! 'System.Void UIKit.UISegmentedControl::_SetTitleTextAttributes(Foundation.NSDictionary,UIKit.UIControlState)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::InsertSegment(System.String,System.IntPtr,System.Boolean)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::InsertSegment(UIKit.UIImage,System.IntPtr,System.Boolean)' is missing an [NullAllowed] on parameter #0
 !missing-null-allowed! 'System.Void UIKit.UISegmentedControl::SetImage(UIKit.UIImage,System.IntPtr)' is missing an [NullAllowed] on parameter #0


### PR DESCRIPTION
1. Enable nullability.
2. Move Get|SetTitleTextAttributes to generated code.
3. Remove dead code (pre-.NET code paths).

Point 2. fixes #21289, so add tests for this scenario.

Fixes https://github.com/xamarin/xamarin-macios/issues/21289.


Backport of #21299
