### PR TITLE
[tests] Fix building the custom-type-assembly assembly from inside a project file.

### DIFF
--- a/tests/monotouch-test/dotnet/shared.csproj
+++ b/tests/monotouch-test/dotnet/shared.csproj
@@ -255,9 +255,9 @@
   </Target>
 
   <Target Name="BuildTestLibraries" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)" BeforeTargets="BeforeBuild"
-      Condition="!Exists('$(TestLibrariesDirectory)/.libs/macos/custom-type-assembly.dll') Or !Exists('$(TestLibrariesDirectory)/.libs/dotnet/macos/custom-type-assembly.dll')" >
-    <Exec Command="make -j8 -C $(TestLibrariesDirectory)" Condition="'$(BUILD_REVISION)' == ''" />
-    <Exec Command="make -j8 -C $(TestLibrariesDirectory)/custom-type-assembly build-assembly" Condition="'$(BUILD_REVISION)' == ''" />
+      Condition="!Exists('$(TestLibrariesDirectory)/.libs/dotnet/macos/custom-type-assembly.dll')" >
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory) V=1 RUNTIMEIDENTIFIER= RUNTIMEIDENTIFIERS=" Condition="'$(BUILD_REVISION)' == ''" />
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)/custom-type-assembly build-assembly V=1 RUNTIMEIDENTIFIER= RUNTIMEIDENTIFIERS=" Condition="'$(BUILD_REVISION)' == ''" />
   </Target>
 
   <Target Name="ComputeDefineConstants" BeforeTargets="BeforeBuild">

--- a/tests/test-libraries/custom-type-assembly/Makefile
+++ b/tests/test-libraries/custom-type-assembly/Makefile
@@ -2,31 +2,18 @@ TOP=../../..
 
 include $(TOP)/Make.config
 
-.libs/macos/custom-type-assembly.dll: custom-type-assembly.cs Makefile | .libs/macos
-	$(Q_CSC) $(MAC_mobile_CSC) $< -out:$@ -r:$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/Xamarin.Mac/Xamarin.Mac.dll -target:library /nologo
-
 .libs/dotnet/macos/custom-type-assembly.dll: bin/Debug/$(DOTNET_TFM)-macos/custom-type-assembly.dll | .libs/dotnet/macos
 	$(Q) $(CP) $< $@
 
-.libs/macos .libs/dotnet/macos:
+.libs/dotnet/macos:
 	$(Q) mkdir -p $@
 
 bin/Debug/$(DOTNET_TFM)-macos/custom-type-assembly.dll: custom-type-assembly.csproj custom-type-assembly.cs
-	$(Q) unset MSBUILD_EXE_PATH && $(DOTNET) build $< "/bl:$@.binlog" $(MSBUILD_VERBOSITY)
+	$(Q) unset MSBUILD_EXE_PATH && $(DOTNET) build $< "/bl:$@.binlog" $(DOTNET_BUILD_VERBOSITY)
 
 ifdef INCLUDE_MAC
-
-ifdef INCLUDE_XAMARIN_LEGACY
-TARGETS += \
-	.libs/macos/custom-type-assembly.dll \
-
-endif
-
-ifdef ENABLE_DOTNET
 TARGETS += \
 	.libs/dotnet/macos/custom-type-assembly.dll \
-
-endif
 
 endif # INCLUDE_MAC
 


### PR DESCRIPTION
Building the custom-type-assembly assembly doesn't work quite right if the
RuntimeIdentifier(s) variables are set in the environment frmo the project
file, so don't forward those to the sub-make we execute to build the assembly.

This fixes an issue where building monotouch-test would fail locally, because
building the custom-type-assembly assembly would fail.

Also remove legacy Xamarin logic.