### PR TITLE
[dotnet] Ensure appropriate IL Strip value for multi-rid builds

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -890,7 +890,7 @@
 			<EnableAssemblyILStripping>false</EnableAssemblyILStripping>
 
 			<!-- Strip if we are AOT and Release  -->
-			<EnableAssemblyILStripping Condition="'$(_RunAotCompiler)' == 'true' And '$(Configuration)' == 'Release'">true</EnableAssemblyILStripping>
+			<EnableAssemblyILStripping Condition="'$(_RunAotCompiler)' == 'true' And '$(Configuration)' == 'Release' And '$(_IsMultiRidBuild)' != 'true'">true</EnableAssemblyILStripping>
 
 			<!-- Don't strip if we are running the interpreter  -->
 			<EnableAssemblyILStripping Condition="'$(MtouchInterpreter)' != ''">false</EnableAssemblyILStripping>


### PR DESCRIPTION
`IsMultiRidBuild` tracks if we are executing an **inner** build for a multi-rid case. With this approach, if the user specifies a value for `EnableAssemblyILStripping` it will still be honored. Otherwise, to ensure we don't duplicate assemblies when merging the app bundles due to a strip vs non-strip scenario,  IL stripping for the multi-rid build is disabled by default.

There have been past examples of optimizing in the outer-build: https://github.com/xamarin/xamarin-macios/pull/12847
But because IL Stripping is contingent on the evaluation of other RID-specific properties, not sure if that is a feasible approach here.

Fixes https://github.com/xamarin/xamarin-macios/issues/17115