### PR TITLE
[msbuild] Make sure the build doesn't keep going if the ILLink task fails.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -403,6 +403,10 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 			<Output TaskParameter="LinkerOutputItems" ItemName="_XamarinLinkerItems" />
 		</Xamarin.MacDev.Tasks.ILLink>
 
+		<PropertyGroup>
+			<!-- Sometimes the ILLink task itself fails, in which case the _ILLinkExitCode value won't be set. In this case, set it to a value that will cause the expected error to be shown later on. -->
+			<_ILLinkExitCode Condition="'$(_ILLinkExitCode)' == '' And '$(MSBuildLastTaskResult)' != 'true'">-1</_ILLinkExitCode>
+		</PropertyGroup>
 		<Touch Files="$(_LinkSemaphore)" AlwaysCreate="true" Condition=" '$(_ILLinkExitCode)' == '0' " />
 
 	</Target>


### PR DESCRIPTION
Here's an example failure that didn't stop the build:

    Target Name=_RunILLink Project=sampleproj.csproj
        Building target "_RunILLink" completely.
        Output file "obj\Release\net8.0-ios\ios-arm64\linked\Link.semaphore" does not exist.
        [...]
        Xamarin.MacDev.Tasks.ILLink
            [...]
            C:\Program Files\dotnet\packs\Microsoft.iOS.Windows.Sdk.net8.0_17.5\17.5.8030\tools\msbuild\iOS\Xamarin.iOS.Common.After.targets(364,3): [xma][err]: An exception occurred in the task 'ILLink'
            C:\Program Files\dotnet\packs\Microsoft.iOS.Windows.Sdk.net8.0_17.5\17.5.8030\tools\msbuild\iOS\Xamarin.iOS.Common.After.targets(364,3): The post for client build1460814608Ilian on topic xvs/build/1.14.0.6/execute-task/ecacau/de6ed16002fILLink has been cancelled
       at Xamarin.Messaging.Client.MessagingClient.PostAsync[TRequest,TResponse](TRequest message, String topic, MessagePriority priority, CancellationToken cancellationToken, Boolean retain, Int32 timeoutSecs) in D:\a\_work\1\s\src\Xamarin.Messaging.Client\MessagingClient.cs:line 231
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.ExecuteWithRetryAsync[TResult](Func`1 executeDelegate, IMessagingAnalyticsAction analytics, Int32 attempts) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 57
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.ThrowIfConnected(ExceptionDispatchInfo exceptionInfo, IMessagingAnalyticsAction analytics) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 149
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.HandleExceptionAsync[TResult](ExceptionDispatchInfo exceptionInfo, Func`1 reentrancyDelegate, IMessagingAnalyticsAction analytics, Int32 attempts) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 97
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.ExecuteWithRetryAsync[TResult](Func`1 executeDelegate, IMessagingAnalyticsAction analytics, Int32 attempts) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 64
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.HandleExceptionAsync[TResult](ExceptionDispatchInfo exceptionInfo, Func`1 reentrancyDelegate, IMessagingAnalyticsAction analytics, Int32 attempts) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 103
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.ExecuteWithRetryAsync[TResult](Func`1 executeDelegate, IMessagingAnalyticsAction analytics, Int32 attempts) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 64
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.ExecuteWithRetryAsync[TResult](Func`1 executeDelegate, Int32 attempts) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 39
       at Xamarin.Messaging.Ssh.MessagingClientPro.PostAsync[TMessage,TResult](TMessage request, CancellationToken cancellationToken, Boolean retain, Int32 timeoutSecs) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingClientPro.cs:line 144
       at Xamarin.Messaging.Build.Client.BuildClient.RunMessagingAsync[TMessage,TResult](TMessage message, Int32 timeoutSecs) in D:\a\_work\1\s\src\MSBuild\Xamarin.Messaging.Build.Client\BuildClient.cs:line 293
       at Xamarin.Messaging.Build.Client.BuildClient.ExecuteTaskAsync(String task, String inputs) in D:\a\_work\1\s\src\MSBuild\Xamarin.Messaging.Build.Client\BuildClient.cs:line 65
       at Xamarin.Messaging.Build.Client.TaskRunner.RunAsync(Task task) in D:\a\_work\1\s\src\MSBuild\Xamarin.Messaging.Build.Client\TaskRunner.cs:line 56
            Errors
                C:\Program Files\dotnet\packs\Microsoft.iOS.Windows.Sdk.net8.0_17.5\17.5.8030\tools\msbuild\iOS\Xamarin.iOS.Common.After.targets(364,3): MessagingException: The post for client build1460814608Ilian on topic xvs/build/1.14.0.6/execute-task/ecacau/de6ed16002fILLink has been cancelled
    OperationCanceledException: The operation was canceled.
     [sampleproj.csproj]
                C:\Program Files\dotnet\packs\Microsoft.iOS.Windows.Sdk.net8.0_17.5\17.5.8030\tools\msbuild\iOS\Xamarin.iOS.Common.After.targets(364,3): error MSB4018: The "Xamarin.MacDev.Tasks.ILLink" task failed unexpectedly.
    System.AggregateException: One or more errors occurred. (One or more errors occurred. (An error occurred while executing the operation and the connection could not be reestablished))
     ---> System.AggregateException: One or more errors occurred. (An error occurred while executing the operation and the connection could not be reestablished)
     ---> Xamarin.Messaging.Exceptions.MessagingException: An error occurred while executing the operation and the connection could not be reestablished
     ---> Xamarin.Messaging.Exceptions.ClientDisconnectedException: The client build1460814608Ilian has been disconnected while waiting a post response to topic xma/agents
       at Xamarin.Messaging.Client.MessagingClient.PostAsync[TRequest,TResponse](TRequest message, String topic, MessagePriority priority, CancellationToken cancellationToken, Boolean retain, Int32 timeoutSecs) in D:\a\_work\1\s\src\Xamarin.Messaging.Client\MessagingClient.cs:line 197
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.ExecuteWithRetryAsync[TResult](Func`1 executeDelegate, IMessagingAnalyticsAction analytics, Int32 attempts) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 57
       --- End of inner exception stack trace ---
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.ReconnectAsync(ExceptionDispatchInfo exceptionInfo, IMessagingAnalyticsAction analytics) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 182
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.HandleExceptionAsync[TResult](ExceptionDispatchInfo exceptionInfo, Func`1 reentrancyDelegate, IMessagingAnalyticsAction analytics, Int32 attempts) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 99
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.ExecuteWithRetryAsync[TResult](Func`1 executeDelegate, IMessagingAnalyticsAction analytics, Int32 attempts) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 64
       at Xamarin.Messaging.Ssh.MessagingRunnerPro.ExecuteWithRetryAsync[TResult](Func`1 executeDelegate, Int32 attempts) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingRunnerPro.cs:line 39
       at Xamarin.Messaging.Ssh.MessagingClientPro.PostAsync[TMessage,TResult](TMessage request, Boolean retain, Int32 timeoutSecs) in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingClientPro.cs:line 135
       at Xamarin.Messaging.Ssh.MessagingService.RefreshAgentsStatusAsync() in D:\a\_work\1\s\src\Xamarin.Messaging.Ssh\MessagingService.cs:line 298
       at Xamarin.Messaging.Build.Client.BuildConnection.GetBuildAgentStatusAsync() in D:\a\_work\1\s\src\MSBuild\Xamarin.Messaging.Build.Client\BuildConnection.Normal.cs:line 435
       at Xamarin.Messaging.Build.Client.BuildConnection.IsBuildAgentRunningAsync() in D:\a\_work\1\s\src\MSBuild\Xamarin.Messaging.Build.Client\BuildConnection.Normal.cs:line 92
       --- End of inner exception stack trace ---
       at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
       at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
       at Xamarin.Messaging.Build.Client.BuildConnection.get_IsConnected() in D:\a\_work\1\s\src\MSBuild\Xamarin.Messaging.Build.Client\BuildConnection.Normal.cs:line 45
       at Xamarin.Messaging.Build.Client.BuildConnection.GetAsync(IBuildEngine4 engine) in D:\a\_work\1\s\src\MSBuild\Xamarin.Messaging.Build.Client\BuildConnection.Static.cs:line 50
       at Xamarin.Messaging.Build.Client.TaskRunner.DisconnectAsync(Task task) in D:\a\_work\1\s\src\MSBuild\Xamarin.Messaging.Build.Client\TaskRunner.cs:line 541
       at Xamarin.Messaging.Build.Client.TaskRunner.RunAsync(Task task) in D:\a\_work\1\s\src\MSBuild\Xamarin.Messaging.Build.Client\TaskRunner.cs:line 99
       --- End of inner exception stack trace ---
       at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
       at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
       at Xamarin.MacDev.Tasks.ILLink.Execute() in /Users/builder/azdo/_work/1/s/xamarin-macios/msbuild/Xamarin.MacDev.Tasks/Tasks/ILLink.cs:line 30
       at Microsoft.Build.BackEnd.TaskExecutionHost.Execute()
       at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(TaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
            Messages
            [...]
        Task "Touch" skipped, due to false condition; ( '$(_ILLinkExitCode)' == '0' ) was evaluated as ( '' == '0' ).

     (and build kept going, eventually failing later on because ILLink didn't run correctly)

Ref: https://developercommunity.visualstudio.com/t/Maui-Blazor-Hybrid-App-wont-publish-to-/10750311#T-ND10763338