### PR TITLE
[build] Fix installing the arm64 version of .NET.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -6,6 +6,8 @@ include $(TOP)/Make.config
 
 ifeq ($(shell arch),arm64)
 DOTNET_ARCH=arm64
+else ifeq ($(shell sysctl -n sysctl.proc_translated 2>/dev/null),1)
+DOTNET_ARCH=arm64
 else
 DOTNET_ARCH=x64
 endif
@@ -70,7 +72,7 @@ downloads/%: downloads/%.nupkg
 	$(Q) echo "Unzipped $*."
 
 downloads/$(DOTNET_INSTALL_NAME): dotnet-install.sh
-	$(Q) echo "Downloading and installing .NET $(DOTNET_VERSION) into $@..."
+	$(Q) echo "Downloading and installing .NET $(DOTNET_VERSION) ($(DOTNET_ARCH)) into $@..."
 	$(Q) ./dotnet-install.sh --install-dir "$@.tmp" --version "$(DOTNET_VERSION)" --architecture $(DOTNET_ARCH) --no-path $$DOTNET_INSTALL_EXTRA_ARGS
 	$(Q) rm -Rf "$@"
 	$(Q) mv "$@.tmp" "$@"

--- a/tests/packaged-macos-tests.mk
+++ b/tests/packaged-macos-tests.mk
@@ -7,7 +7,7 @@ include $(TOP)/Make.config
 export TargetFrameworkFallbackSearchPaths:=$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild-frameworks
 export MSBuildExtensionsPathFallbackPathsOverride:=$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild
 
-ifeq ($(shell uname -a),"arm64")
+ifeq ($(shell arch),"arm64")
 IS_ARM64=1
 IS_APPLE_SILICON=1
 endif


### PR DESCRIPTION
On the bots we're executing with Rosetta, and 'arch' returns 'i386' under
Rosetta, so detect when we're executing under Rosetta, and install the arm64
version of .NET in that case as well.

Also fix a bug in the same area in our tests.