### PR TITLE
[net9.0] [msbuild] Improve the error message when the SupportedOSPlatformVersion is lower than the minimum. Fixes #21368. (#21369)

### DIFF
--- a/dotnet/generate-target-platforms.csharp
+++ b/dotnet/generate-target-platforms.csharp
@@ -50,6 +50,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ("\t</ItemGroup>");
 	writer.WriteLine ("\t<PropertyGroup>");
 	writer.WriteLine ($"\t\t<{platform}MinSupportedOSPlatformVersion>{minSdkVersionString}</{platform}MinSupportedOSPlatformVersion>");
+	writer.WriteLine ($"\t\t<MinSupportedOSPlatformVersion>$({platform}MinSupportedOSPlatformVersion)</MinSupportedOSPlatformVersion>");
 	writer.WriteLine ("\t</PropertyGroup>");
 	writer.WriteLine ("</Project>");
 }

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1563,6 +1563,19 @@
         <comment>RuntimeIdentifier: don't translate (it's the name of a MSBuild property)</comment>
     </data>
 
+    <data name="E7125" xml:space="preserve">
+        <value>Unable to parse the value '{0}' for the property '{1}.</value>
+        <comment>
+            {0}: user-provided value
+            {1}: name of an MSBuild property
+        </comment>
+    </data>
+
+    <data name="E7126" xml:space="preserve">
+        <value>The SupportedOSPlatformVersion value '{0}' in the project file is lower than the minimum value '{1}'.</value>
+        <comment>SupportedOSPlatformVersion: don't translate (it's the name of an MSBuild property)</comment>
+    </data>
+
     <data name="XcodeBuild_CreateNativeRef" xml:space="preserve">
         <value>Adding reference to Xcode project output: '{0}'. The '%(CreateNativeReference)' metadata can be set to 'false' to opt out of this behavior.</value>
         <comment>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
@@ -62,6 +62,9 @@ namespace Xamarin.MacDev.Tasks {
 
 		public bool IsWatchExtension { get; set; }
 
+		[Required]
+		public string MinSupportedOSPlatformVersion { get; set; } = string.Empty;
+
 		public ITaskItem [] PartialAppManifests { get; set; } = Array.Empty<ITaskItem> ();
 
 		[Required]
@@ -300,6 +303,18 @@ namespace Xamarin.MacDev.Tasks {
 				return false;
 			} else {
 				minimumOSVersion = minimumOSVersionInManifest!;
+			}
+
+			// Verify that the value is not lower than the minimum
+			if (!Version.TryParse (MinSupportedOSPlatformVersion, out var minSupportedVersion)) {
+				Log.LogError (MSBStrings.E7125 /* Unable to parse the value '{0}' for the property '{1}. */, MinSupportedOSPlatformVersion, "MinSupportedOSPlatformVersion");
+				return false;
+			} else if (!Version.TryParse (SupportedOSPlatformVersion, out var supportedVersion)) {
+				Log.LogError (MSBStrings.E7125 /* Unable to parse the value '{0}' for the property '{1}. */, SupportedOSPlatformVersion, "SupportedOSPlatformVersion");
+				return false;
+			} else if (minSupportedVersion > supportedVersion) {
+				Log.LogError (MSBStrings.E7126 /* The SupportedOSPlatformVersion value '{0}' in the project file is lower than the minimum value '{1}'." */, SupportedOSPlatformVersion, MinSupportedOSPlatformVersion);
+				return false;
 			}
 
 			// Write out our value

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -570,6 +570,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			IsWatchApp="$(IsWatchApp)"
 			IsWatchExtension="$(IsWatchExtension)"
 			IsXPCService="$(IsXPCService)"
+			MinSupportedOSPlatformVersion="$(MinSupportedOSPlatformVersion)"
 			PartialAppManifests="@(PartialAppManifest)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(_ResourcePrefix)"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -85,9 +85,10 @@ test.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.De
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(platform)_NUGET_REF_NAME=$($(platform)_NUGET_REF_NAME)\\n)" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(rid)_NUGET_RUNTIME_NAME=$($(rid)_NUGET_RUNTIME_NAME)\\n))" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),SUPPORTED_API_VERSIONS_$(platform)='$(SUPPORTED_API_VERSIONS_$(platform))'\\n)" | sed 's/^ //' >> $@
-	@printf "ENABLE_XAMARIN=$(ENABLE_XAMARIN)" >> $@
-	@printf "XCODE_IS_STABLE=$(XCODE_IS_STABLE)" >> $@
-	@printf "XCODE_VERSION=$(XCODE_VERSION)" >> $@
+	@printf "ENABLE_XAMARIN=$(ENABLE_XAMARIN)\n" >> $@
+	@printf "XCODE_IS_STABLE=$(XCODE_IS_STABLE)\n" >> $@
+	@printf "XCODE_VERSION=$(XCODE_VERSION)\n" >> $@
+	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),DOTNET_MIN_$(platform)_SDK_VERSION=$(DOTNET_MIN_$(platform)_SDK_VERSION)\\n)" | sed 's/^ //' >> $@
 
 test-system.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.Details.xml
 	@rm -f $@
@@ -119,9 +120,10 @@ test-system.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Ver
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(platform)_NUGET_REF_NAME=$($(platform)_NUGET_REF_NAME)\\n)" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(rid)_NUGET_RUNTIME_NAME=$($(rid)_NUGET_RUNTIME_NAME)\\n))" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),SUPPORTED_API_VERSIONS_$(platform)='$(SUPPORTED_API_VERSIONS_$(platform))'\\n)" | sed 's/^ //' >> $@
-	@printf "ENABLE_XAMARIN=$(ENABLE_XAMARIN)" >> $@
-	@printf "XCODE_IS_STABLE=$(XCODE_IS_STABLE)" >> $@
-	@printf "XCODE_VERSION=$(XCODE_VERSION)" >> $@
+	@printf "ENABLE_XAMARIN=$(ENABLE_XAMARIN)\n" >> $@
+	@printf "XCODE_IS_STABLE=$(XCODE_IS_STABLE)\n" >> $@
+	@printf "XCODE_VERSION=$(XCODE_VERSION)\n" >> $@
+	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),DOTNET_MIN_$(platform)_SDK_VERSION=$(DOTNET_MIN_$(platform)_SDK_VERSION)\\n)" | sed 's/^ //' >> $@
 
 clean-local::
 	$(Q) $(SYSTEM_XBUILD) /t:Clean /p:Platform=iPhoneSimulator /p:Configuration=$(CONFIG) $(XBUILD_VERBOSITY) tests.sln

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -247,7 +247,7 @@ namespace Xamarin.Tests {
 		public static string? GetPreviewNoWarn (string? existingNowarn)
 		{
 			if (Configuration.XcodeIsStable)
-				return null;
+				return existingNowarn;
 
 			var previewNoWarn = $"XCODE_{Configuration.XcodeVersion.Major}_{Configuration.XcodeVersion.Minor}_PREVIEW";
 			if (string.IsNullOrEmpty (existingNowarn)) {

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
@@ -21,23 +21,13 @@ namespace Xamarin.MacDev.Tasks {
 			task.AssemblyName = "AssemblyName";
 			task.AppBundleName = "AppBundleName";
 			task.CompiledAppManifest = new TaskItem (Path.Combine (tmpdir, "TemporaryAppManifest.plist"));
-			task.DefaultSdkVersion = Sdks.GetAppleSdk (platform).GetInstalledSdkVersions (false).First ().ToString ();
-			task.SdkVersion = task.DefaultSdkVersion;
+			task.DefaultSdkVersion = Sdks.GetAppleSdk (platform).GetInstalledSdkVersions (false).First ().ToString ()!;
+			task.MinSupportedOSPlatformVersion = "10.0";
+			task.SupportedOSPlatformVersion = "15.0";
+			task.SdkVersion = task.DefaultSdkVersion ?? string.Empty;
 			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform, true).ToString ();
 
 			return task;
-		}
-
-		[Test]
-		public void DefaultMinimumOSVersion ()
-		{
-			var dir = Cache.CreateTemporaryDirectory ();
-			var task = CreateTask (dir);
-
-			ExecuteTask (task);
-
-			var plist = PDictionary.FromFile (task.CompiledAppManifest!.ItemSpec)!;
-			Assert.AreEqual (task.SdkVersion, plist.GetMinimumOSVersion (), "MinimumOSVersion");
 		}
 
 		[Test]
@@ -52,6 +42,7 @@ namespace Xamarin.MacDev.Tasks {
 			main.Save (mainPath);
 
 			task.AppManifest = new TaskItem (mainPath);
+			task.SupportedOSPlatformVersion = "14.0";
 
 			ExecuteTask (task);
 
@@ -78,6 +69,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			task.AppManifest = new TaskItem (mainPath);
 			task.PartialAppManifests = new [] { new TaskItem (partialPath) };
+			task.SupportedOSPlatformVersion = "14.0";
 
 			ExecuteTask (task);
 

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
@@ -50,6 +50,8 @@ namespace Xamarin.MacDev.Tasks {
 			Task.CompiledAppManifest = new TaskItem (Path.Combine (Cache.CreateTemporaryDirectory (), "AppBundlePath", "Info.plist"));
 			Task.AssemblyName = assemblyName;
 			Task.AppManifest = new TaskItem (CreateTempFile ("foo.plist"));
+			Task.MinSupportedOSPlatformVersion = "10.0";
+			Task.SupportedOSPlatformVersion = "15.0";
 			Task.SdkVersion = "10.0";
 
 			Plist = new PDictionary ();
@@ -70,7 +72,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			ConfigureTask (IsDotNet);
 
-			Task.Execute ();
+			ExecuteTask (Task);
 			CompiledPlist = PDictionary.FromFile (Task.CompiledAppManifest.ItemSpec);
 		}
 


### PR DESCRIPTION
This isn't very user friendly:

    ILLink : unknown error IL7000: An error occurred while executing the custom linker steps. Please review the build log for more information.
    ILLINK : error MT0073: Microsoft.iOS 18.0.8337 does not support a deployment target of 10.0 for iOS (the minimum is 11.0). Please select a newer deployment target in your project's Info.plist or change the SupportedOSPlatformVersion property in your project file.
    ILLINK : error MT2301: The linker step 'Setup' failed during processing: Microsoft.iOS 18.0.8337 does not support a deployment target of 10.0 for iOS (the minimum is 11.0). Please select a newer deployment target in your project's Info.plist or change the SupportedOSPlatformVersion property in your project file.
    [...]/packages/microsoft.net.illink.tasks/8.0.8/build/Microsoft.NET.ILLink.targets(87,5): error NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.

So improve this to only show a single error message:

    The SupportedOSPlatformVersion value '10.0' in the project file is lower than the minimum value '11.0'.

Fixes https://github.com/xamarin/xamarin-macios/issues/21368.

This is a backport of #21369 (and a backport of #21344 was also required).