### PR TITLE
[tests] Ignore output that looks like errors when installing .NET on Windows.

### DIFF
--- a/tests/dotnet/Windows/InstallDotNet.csproj
+++ b/tests/dotnet/Windows/InstallDotNet.csproj
@@ -171,6 +171,7 @@
         Command="&quot;$(DotNetToolPath)&quot; workload install %(_WorkloadIds.Identity) --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(MacIosRootDirectory)NuGet.config&quot; --skip-sign-check"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
         EnvironmentVariables="DOTNET_MULTILEVEL_LOOKUP=0"
+        IgnoreStandardErrorWarningFormat="true"
     />
     <Touch Files="$(DotNetPacksDirectory).stamp" AlwaysCreate="true" />
   </Target>


### PR DESCRIPTION
Just trust the exit code instead.

This way the installation doesn't fail due to random output.