### PR TITLE
[CI] Remove the APIScan stage since we have a pipeline to run it.

### DIFF
--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -186,14 +186,6 @@ parameters:
 
 stages:
 
-  - ${{ if eq(parameters.runGovernanceTests, true) }}:
-      - template: ./governance/stage.yml
-        parameters:
-          isPR: ${{ parameters.isPR }}
-          repositoryAlias: ${{ parameters.repositoryAlias }}
-          commit: ${{ parameters.commit }}
-          stageDisplayNamePrefix: ${{ parameters.stageDisplayNamePrefix }}
-
   - stage: configure_build
     displayName: '${{ parameters.stageDisplayNamePrefix }}Configure'
     dependsOn: ${{ parameters.dependsOn }}


### PR DESCRIPTION
In the process of ensuring that we can run tests a single time, we are removing all extra stages from the CI. We have move the APIScan to the following pipelines.

- CI Pipeline: https://devdiv.visualstudio.com/DevDiv/_build?definitionId=24050
- PR Pipeline: https://devdiv.visualstudio.com/DevDiv/_build?definitionId=24049