### PR TITLE
[main] [nuget-msi-convert] Support improved VS component IDs

### DIFF
--- a/dotnet/generate-vs-workload.csharp
+++ b/dotnet/generate-vs-workload.csharp
@@ -57,6 +57,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	var manifestBuildVersion = iOSPlatform.Any () ? iOSPlatform.First ().Item2 : platforms.First ().Item2;
 	writer.WriteLine ($"    <ManifestBuildVersion>{manifestBuildVersion}</ManifestBuildVersion>");
 	writer.WriteLine ($"    <EnableSideBySideManifests>true</EnableSideBySideManifests>");
+	writer.WriteLine ($"    <UseVisualStudioComponentPrefix>true</UseVisualStudioComponentPrefix>");
 	writer.WriteLine ($"  </PropertyGroup>");
 	writer.WriteLine ($"  <ItemGroup>");
 	writer.WriteLine ($"    <!-- Shorten package names to avoid long path caching issues in Visual Studio -->");

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -135,7 +135,7 @@ resources:
     - repository: yaml-templates
       type: github
       name: xamarin/yaml-templates
-      ref: refs/heads/main
+      ref: refs/heads/dev/pjc/msi-arcade-05c72bb
       endpoint: xamarin
 
     - repository: sdk-insertions

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -135,7 +135,7 @@ resources:
     - repository: yaml-templates
       type: github
       name: xamarin/yaml-templates
-      ref: refs/heads/dev/pjc/msi-arcade-05c72bb
+      ref: refs/heads/main
       endpoint: xamarin
 
     - repository: sdk-insertions


### PR DESCRIPTION
Context: https://github.com/dotnet/arcade/commit/b2d3a3a35526b529490e8f7e410b3777b3f20bd6
Context: https://github.com/xamarin/yaml-templates/pull/339

The VS insertion manifest generation has been updated to use new VS
component IDs required for .NET 9+.


Backport of #21423
