### PR TITLE
[StoreKit] Bind AppStore.requestReview. Fixes #21410.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -289,12 +289,12 @@ MAX_TVOS_SIMULATOR_VERSION=$(TVOS_SDK_VERSION)
 MAX_WATCH_SIMULATOR_VERSION=$(WATCH_SDK_VERSION)
 
 # Minimum OS versions for running XI/XM apps.
-MIN_IOS_SDK_VERSION=11.0
+MIN_IOS_SDK_VERSION=12.2
 MIN_MACOS_SDK_VERSION=12.0
 MIN_WATCHOS_SDK_VERSION=4.0
 MIN_WATCHOS64_32_SDK_VERSION=5.1
 MIN_WATCH_OS_VERSION=4.0
-MIN_TVOS_SDK_VERSION=11.0
+MIN_TVOS_SDK_VERSION=12.2
 MIN_MACCATALYST_SDK_VERSION=15.0
 
 # Minimum OS versions for .NET 9 support
@@ -408,7 +408,10 @@ SIMULATOR_SDK=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneSimulator.platform/Develop
 # Ref: https://github.com/xamarin/xamarin-macios/issues/16223
 OBJC_CFLAGS=-ObjC++ -std=c++14 -fno-exceptions -fno-objc-msgsend-selector-stubs
 
-COMMON_SIMULATOR_CFLAGS=-mios-simulator-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(SIMULATOR_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES)
+COMMON_SIMULATOR_CFLAGS=-mios-simulator-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(SIMULATOR_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES) \
+	-L$(SIMULATOR_SDK)/usr/lib/swift \
+	-L$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator \
+	-Wno-unused-command-line-argument
 SIMULATOR86_CFLAGS=$(COMMON_SIMULATOR_CFLAGS) -arch i386
 SIMULATOR64_CFLAGS=$(COMMON_SIMULATOR_CFLAGS) -arch x86_64
 SIMULATOR_ARM64_CFLAGS=$(COMMON_SIMULATOR_CFLAGS) -arch arm64
@@ -420,14 +423,20 @@ SIMULATOR_ARM64_OBJC_CFLAGS=$(COMMON_SIMULATOR_OBJC_CFLAGS) $(SIMULATOR_ARM64_CF
 MACCATALYST_COMMON_CFLAGS=-target x86_64-apple-ios$(MIN_MACCATALYST_SDK_VERSION)-macabi -arch x86_64 -g $(IOS_COMMON_DEFINES) \
 	-isysroot $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_SDK_VERSION).sdk \
 	-isystem $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_SDK_VERSION).sdk/System/iOSSupport/usr/include \
-	-iframework $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_SDK_VERSION).sdk/System/iOSSupport/System/Library/Frameworks
+	-iframework $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_SDK_VERSION).sdk/System/iOSSupport/System/Library/Frameworks \
+	-L$(SIMULATOR_SDK)/usr/lib/swift \
+	-L$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator \
+	-Wno-unused-command-line-argument
 MACCATALYST_OBJC_CFLAGS=$(MACCATALYST_COMMON_CFLAGS) -fobjc-abi-version=2 -fobjc-legacy-dispatch $(OBJC_CFLAGS)
 MACCATALYST_CFLAGS=$(MACCATALYST_COMMON_CFLAGS)
 
 MACCATALYST_COMMON_CFLAGS=$(CFLAGS) -g $(IOS_COMMON_DEFINES) \
 	-isysroot $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_SDK_VERSION).sdk \
 	-isystem $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_SDK_VERSION).sdk/System/iOSSupport/usr/include \
-	-iframework $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_SDK_VERSION).sdk/System/iOSSupport/System/Library/Frameworks
+	-iframework $(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_SDK_VERSION).sdk/System/iOSSupport/System/Library/Frameworks \
+	-L$(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_SDK_VERSION).sdk/usr/lib/swift \
+	-L$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx \
+	-Wno-unused-command-line-argument
 MACCATALYST_COMMON_OBJC_CFLAGS=$(MACCATALYST_COMMON_CFLAGS) -fobjc-abi-version=2 -fobjc-legacy-dispatch $(OBJC_CFLAGS)
 MACCATALYST_X86_64_OBJC_CFLAGS=$(MACCATALYST_COMMON_OBJC_CFLAGS) -target x86_64-apple-ios$(MIN_MACCATALYST_SDK_VERSION)-macabi -arch x86_64
 MACCATALYST_X86_64_CFLAGS=$(MACCATALYST_COMMON_CFLAGS) -target x86_64-apple-ios$(MIN_MACCATALYST_SDK_VERSION)-macabi -arch x86_64
@@ -448,9 +457,13 @@ MACCATALYST_CSC=$(SYSTEM_CSC) -features:strict -nostdlib -noconfig -r:$(MONOTOUC
 DEVICE_OBJC_CFLAGS=$(OBJC_CFLAGS)
 
 DEVICE_SDK=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$(IOS_SDK_VERSION).sdk
-DEVICE7_CFLAGS= -arch armv7  -mno-thumb -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
-DEVICE7S_CFLAGS=-arch armv7s -mno-thumb -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
-DEVICE64_CFLAGS=-arch arm64             -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
+DEVICE_SWIFT_CFLAGS=\
+	-L$(DEVICE_SDK)/usr/lib/swift \
+	-L$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos \
+	-Wno-unused-command-line-argument
+DEVICE7_CFLAGS= -arch armv7  -mno-thumb -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES) $(DEVICE_SWIFT_CFLAGS)
+DEVICE7S_CFLAGS=-arch armv7s -mno-thumb -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES) $(DEVICE_SWIFT_CFLAGS)
+DEVICE64_CFLAGS=-arch arm64             -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES) $(DEVICE_SWIFT_CFLAGS)
 DEVICE7_OBJC_CFLAGS =$(DEVICE7_CFLAGS)  $(DEVICE_OBJC_CFLAGS)
 DEVICE7S_OBJC_CFLAGS=$(DEVICE7S_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 DEVICE64_OBJC_CFLAGS=$(DEVICE64_CFLAGS) $(DEVICE_OBJC_CFLAGS)
@@ -488,13 +501,22 @@ XAMARIN_TVSIMULATOR_SDK    = $(MONOTOUCH_PREFIX)/SDKs/Xamarin.AppleTVSimulator.s
 XAMARIN_TVOS_SDK           = $(MONOTOUCH_PREFIX)/SDKs/Xamarin.AppleTVOS.sdk
 
 SIMULATORTV_SDK            = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator$(TVOS_SDK_VERSION).sdk
-SIMULATORTV_CFLAGS         = -arch x86_64 -mtvos-simulator-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(SIMULATORTV_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES)
-SIMULATORTV_ARM64_CFLAGS   = -arch arm64  -mtvos-simulator-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(SIMULATORTV_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES)
+SIMULATORTV_CFLAGS         = -arch x86_64 -mtvos-simulator-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(SIMULATORTV_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES) \
+	-L$(SIMULATORTV_SDK)/usr/lib/swift \
+	-L$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator \
+	-Wno-unused-command-line-argument
+SIMULATORTV_ARM64_CFLAGS   = -arch arm64  -mtvos-simulator-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(SIMULATORTV_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES) \
+	-L$(SIMULATORTV_SDK)/usr/lib/swift \
+	-L$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator \
+	-Wno-unused-command-line-argument
 SIMULATORTV_OBJC_CFLAGS    = $(SIMULATORTV_CFLAGS) $(COMMON_SIMULATOR_OBJC_CFLAGS) 
 SIMULATORTV_ARM64_OBJC_CFLAGS = $(SIMULATORTV_ARM64_CFLAGS) $(COMMON_SIMULATOR_OBJC_CFLAGS)
 
 DEVICETV_SDK               = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS$(TVOS_SDK_VERSION).sdk
-DEVICETV_CFLAGS            = -arch arm64 -mtvos-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(DEVICETV_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
+DEVICETV_CFLAGS            = -arch arm64 -mtvos-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(DEVICETV_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)\
+	-L$(DEVICETV_SDK)/usr/lib/swift \
+	-L$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos \
+	-Wno-unused-command-line-argument
 DEVICETV_OBJC_CFLAGS       = $(DEVICETV_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 
 # macOS
@@ -502,7 +524,10 @@ DEVICETV_OBJC_CFLAGS       = $(DEVICETV_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 XAMARIN_MACOS_SDK = $(MAC_FRAMEWORK_CURRENT_DIR)/SDKs/Xamarin.macOS.sdk
 
 MAC_OBJC_CFLAGS= -mmacosx-version-min=$(MIN_MACOS_SDK_VERSION) -DMONOMAC -DMIN_XM_MONO_VERSION=\"$(MIN_XM_MONO_VERSION)\" $(CFLAGS) $(OBJC_CFLAGS)
-MAC_CFLAGS = -mmacosx-version-min=$(MIN_MACOS_SDK_VERSION) -DMONOMAC -g -DMIN_XM_MONO_VERSION=\"$(MIN_XM_MONO_VERSION)\" $(CFLAGS)
+MAC_CFLAGS = -mmacosx-version-min=$(MIN_MACOS_SDK_VERSION) -DMONOMAC -g -DMIN_XM_MONO_VERSION=\"$(MIN_XM_MONO_VERSION)\" $(CFLAGS) \
+	-L$(XCODE_DEVELOPER_ROOT)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_SDK_VERSION).sdk/usr/lib/swift \
+	-L$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx \
+	-Wno-unused-command-line-argument
 MAC_LDFLAGS = -mmacosx-version-min=$(MIN_MACOS_SDK_VERSION) -framework AppKit
 
 # Swift compiler flags
@@ -529,7 +554,7 @@ WATCHOS_DEVICE_COMMON_SWIFTFLAGS=$(COMMON_SWIFTFLAGS) -sdk $(DEVICEWATCH_SDK)
 WATCHOS_DEVICE_ARM64_32_SWIFTFLAGS=$(WATCHOS_DEVICE_COMMON_SWIFTFLAGS) -target arm64_32-apple-watchos$(MIN_WATCHOS_SDK_VERSION)
 WATCHOS_DEVICE_ARMV7K_SWIFTFLAGS=$(WATCHOS_DEVICE_COMMON_SWIFTFLAGS) -target armv7k-apple-watchos$(MIN_WATCHOS_SDK_VERSION)
 
-MACCATALYST_COMMON_SWIFTFLAGS=$(COMMON_SWIFTFLAGS) -sdk $(XCODE_MAC_SDKROOT)
+MACCATALYST_COMMON_SWIFTFLAGS=$(COMMON_SWIFTFLAGS) -sdk $(XCODE_MAC_SDKROOT) -Fsystem $(XCODE_MAC_SDKROOT)/System/iOSSupport/System/Library/Frameworks
 MACCATALYST_ARM64_SWIFTFLAGS=$(MACCATALYST_COMMON_SWIFTFLAGS) -target arm64-apple-ios$(MIN_MACCATALYST_SDK_VERSION)-macabi
 MACCATALYST_X64_SWIFTFLAGS=$(MACCATALYST_COMMON_SWIFTFLAGS) -target x86_64-apple-ios$(MIN_MACCATALYST_SDK_VERSION)-macabi
 

--- a/docs/preview-apis.md
+++ b/docs/preview-apis.md
@@ -96,4 +96,10 @@ We've tentatively set .NET 11 as the release when we'll stop marking FSKit as pr
 
 The diagnostic id for FSKit is APL0002.
 
+## StoreKit.AppStore.RequestReview (APL0004)
+
+The
+[AppStore.RequestReview](https://developer.apple.com/documentation/storekit/appstore/3954432-requestreview/)
+method is Swift API we've bound manually, and as such it's marked as experimental until .NET 10.
+
 [1]: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.experimentalattribute?view=net-8.0

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -52,6 +52,9 @@ define NativeCompilationTemplate
 .libs/iphonesimulator/%$(1).x86_64.dylib: %.swift | .libs/iphonesimulator
 	$$(call Q_2,SWIFT, [iphonesimulator]) $(SWIFTC)       $(IOS_SIMULATOR_X64_SWIFTFLAGS)                 $$< -o $$@
 
+.libs/iphonesimulator/%$(1).x86_64.o: %.swift | .libs/iphonesimulator
+	$$(call Q_2,SWIFT, [iphonesimulator]) $(SWIFTC)       $(IOS_SIMULATOR_X64_SWIFTFLAGS)                 $$< -o $$@ -emit-object
+
 .libs/iphonesimulator/%$(1).x86_64.dylib: | .libs/iphonesimulator
 	$$(call Q_2,LD,    [iphonesimulator]) $(SIMULATOR_CC) $(SIMULATOR64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_IOSSIMULATOR_SDK)/lib -fapplication-extension
 
@@ -71,6 +74,9 @@ define NativeCompilationTemplate
 
 .libs/iphonesimulator/%$(1).arm64.dylib: %.swift | .libs/iphonesimulator
 	$$(call Q_2,SWIFT, [iphonesimulator]) $(SWIFTC)       $(IOS_SIMULATOR_ARM64_SWIFTFLAGS)                    $$< -o $$@
+
+.libs/iphonesimulator/%$(1).arm64.o: %.swift | .libs/iphonesimulator
+	$$(call Q_2,SWIFT, [iphonesimulator]) $(SWIFTC)       $(IOS_SIMULATOR_ARM64_SWIFTFLAGS)                    $$< -o $$@ -emit-object
 
 .libs/iphonesimulator/%$(1).arm64.dylib: | .libs/iphonesimulator
 	$$(call Q_2,LD,    [iphonesimulator]) $(SIMULATOR_CC) $(SIMULATOR_ARM64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_IOSSIMULATOR_SDK)/lib -fapplication-extension
@@ -117,6 +123,9 @@ define NativeCompilationTemplate
 .libs/iphoneos/%$(1).arm64.dylib: %.swift | .libs/iphoneos
 	$$(call Q_2,SWIFT, [iphoneos]) $(SWIFTC)    $(IOS_DEVICE_ARM64_SWIFTFLAGS)                                  $$< -o $$@
 
+.libs/iphoneos/%$(1).arm64.o: %.swift | .libs/iphoneos
+	$$(call Q_2,SWIFT, [iphoneos]) $(SWIFTC)    $(IOS_DEVICE_ARM64_SWIFTFLAGS)                                  $$< -o $$@ -emit-object
+
 .libs/iphoneos/%$(1).arm64.dylib: | .libs/iphoneos
 	$$(call Q_2,LD,    [iphoneos]) $(DEVICE_CC) $(DEVICE64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/lib -fapplication-extension
 
@@ -137,6 +146,9 @@ define NativeCompilationTemplate
 .libs/maccatalyst/%$(1).x86_64.dylib: %.swift | .libs/maccatalyst
 	$$(call Q_2,SWIFT, [maccatalyst]) $(SWIFTC)   $(MACCATALYST_X64_SWIFTFLAGS)                                              $$< -o $$@
 
+.libs/maccatalyst/%$(1).x86_64.o: %.swift | .libs/maccatalyst
+	$$(call Q_2,SWIFT, [maccatalyst]) $(SWIFTC)   $(MACCATALYST_X64_SWIFTFLAGS)                                              $$< -o $$@ -emit-object
+
 .libs/maccatalyst/%$(1).x86_64.dylib: | .libs/maccatalyst
 	$$(call Q_2,LD,    [maccatalyst]) $(XCODE_CC) $(MACCATALYST_X86_64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_MACCATALYST_SDK)/lib -fapplication-extension
 
@@ -154,6 +166,9 @@ define NativeCompilationTemplate
 
 .libs/maccatalyst/%$(1).arm64.dylib: %.swift | .libs/maccatalyst
 	$$(call Q_2,SWIFT, [maccatalyst]) $(SWIFTC)   $(MACCATALYST_ARM64_SWIFTFLAGS)                                           $$< -o $$@
+
+.libs/maccatalyst/%$(1).arm64.o: %.swift | .libs/maccatalyst
+	$$(call Q_2,SWIFT, [maccatalyst]) $(SWIFTC)   $(MACCATALYST_ARM64_SWIFTFLAGS)                                           $$< -o $$@ -emit-object
 
 .libs/maccatalyst/%$(1).arm64.dylib: | .libs/maccatalyst
 	$$(call Q_2,LD,    [maccatalyst]) $(XCODE_CC) $(MACCATALYST_ARM64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_MACCATALYST_SDK)/lib -fapplication-extension
@@ -247,6 +262,9 @@ define NativeCompilationTemplate
 .libs/tvsimulator/%$(1).x86_64.dylib: %.swift | .libs/tvsimulator
 	$$(call Q_2,SWIFT, [tvsimulator]) $(SWIFTC)      $(TVOS_SIMULATOR_X64_SWIFTFLAGS)                                        $$< -o $$@
 
+.libs/tvsimulator/%$(1).x86_64.o: %.swift | .libs/tvsimulator
+	$$(call Q_2,SWIFT, [tvsimulator]) $(SWIFTC)      $(TVOS_SIMULATOR_X64_SWIFTFLAGS)                                        $$< -o $$@ -emit-object
+
 .libs/tvsimulator/%$(1).x86_64.dylib: | .libs/tvsimulator
 	$$(call Q_2,LD,    [tvsimulator]) $(SIMULATOR_CC) $(SIMULATORTV_CFLAGS)         $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/lib -fapplication-extension
 
@@ -266,6 +284,9 @@ define NativeCompilationTemplate
 
 .libs/tvsimulator/%$(1).arm64.dylib: %.swift | .libs/tvsimulator
 	$$(call Q_2,SWIFT, [tvsimulator]) $(SWIFTC)      $(TVOS_SIMULATOR_ARM64_SWIFTFLAGS)                                                  $$< -o $$@
+
+.libs/tvsimulator/%$(1).arm64.o: %.swift | .libs/tvsimulator
+	$$(call Q_2,SWIFT, [tvsimulator]) $(SWIFTC)      $(TVOS_SIMULATOR_ARM64_SWIFTFLAGS)                                                  $$< -o $$@ -emit-object
 
 .libs/tvsimulator/%$(1).arm64.dylib: | .libs/tvsimulator
 	$$(call Q_2,LD,    [tvsimulator]) $(SIMULATOR_CC) $(SIMULATORTV_ARM64_CFLAGS)         $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/lib -fapplication-extension
@@ -287,6 +308,9 @@ define NativeCompilationTemplate
 .libs/tvos/%$(1).arm64.dylib: %.swift | .libs/tvos
 	$$(call Q_2,SWIFT, [tvos]) $(SWIFTC)      $(TVOS_DEVICE_ARM64_SWIFTFLAGS)                                         $$< -o $$@
 
+.libs/tvos/%$(1).arm64.o: %.swift | .libs/tvos
+	$$(call Q_2,SWIFT, [tvos]) $(SWIFTC)      $(TVOS_DEVICE_ARM64_SWIFTFLAGS)                                         $$< -o $$@ -emit-object
+
 .libs/tvos/%$(1).arm64.dylib: | .libs/tvos
 	$$(call Q_2,LD,    [tvos]) $(DEVICE_CC)    $(DEVICETV_CFLAGS)            $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/lib -fapplication-extension
 
@@ -306,6 +330,15 @@ define NativeCompilationTemplate
 
 .libs/mac/%$(1).x86_64.dylib: %.swift | .libs/mac
 	$$(call Q_2,SWIFT, [mac]) $(SWIFTC) $(MACOS_X64_SWIFTFLAGS)                                                   $$< -o $$@
+
+.libs/mac/%$(1).x86_64.o: %.swift | .libs/mac
+	$$(call Q_2,SWIFT, [mac]) $(SWIFTC) $(MACOS_X64_SWIFTFLAGS)                                                   $$< -o $$@ -emit-object
+
+.libs/macos/%$(1).x86_64.dylib: %.swift | .libs/mac
+	$$(call Q_2,SWIFT, [macos]) $(SWIFTC) $(MACOS_X64_SWIFTFLAGS)                                                 $$< -o $$@
+
+.libs/macos/%$(1).x86_64.o: %.swift | .libs/mac
+	$$(call Q_2,SWIFT, [mac]) $(SWIFTC) $(MACOS_X64_SWIFTFLAGS)                                                   $$< -o $$@ -emit-object
 
 .libs/macos/%$(1).x86_64.dylib: %.swift | .libs/mac
 	$$(call Q_2,SWIFT, [macos]) $(SWIFTC) $(MACOS_X64_SWIFTFLAGS)                                                 $$< -o $$@
@@ -328,8 +361,14 @@ define NativeCompilationTemplate
 .libs/mac/%$(1).arm64.dylib: %.swift | .libs/mac
 	$$(call Q_2,SWIFT, [mac]) $(SWIFTC) $(MACOS_ARM64_SWIFTFLAGS)                                                $$< -o $$@
 
+.libs/mac/%$(1).arm64.o: %.swift | .libs/mac
+	$$(call Q_2,SWIFT, [mac]) $(SWIFTC) $(MACOS_ARM64_SWIFTFLAGS)                                                $$< -o $$@ -emit-object
+
 .libs/macos/%$(1).arm64.dylib: %.swift | .libs/mac
 	$$(call Q_2,SWIFT, [macos]) $(SWIFTC) $(MACOS_ARM64_SWIFTFLAGS)                                              $$< -o $$@
+
+.libs/macos/%$(1).arm64.o: %.swift | .libs/mac
+	$$(call Q_2,SWIFT, [macos]) $(SWIFTC) $(MACOS_ARM64_SWIFTFLAGS)                                              $$< -o $$@ -emit-object
 
 .libs/mac/%$(1).arm64.dylib: | .libs/mac
 	$$(call Q_2,LD,    [mac]) $(MAC_CC) $(MAC_CFLAGS)      $$(EXTRA_FLAGS) -arch arm64 -dynamiclib -o $$@ $$^ -L$(MAC_DESTDIR)$(XAMARIN_MACOS_SDK)/lib -fapplication-extension

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -22,7 +22,7 @@ SHIPPED_HEADERS +=         \
 	xamarin/monovm-bridge.h \
 	xamarin/coreclr-bridge.h \
 
-SHARED_SOURCES += mono-runtime.m bindings.m bindings-generated.m shared.m runtime.m trampolines.m trampolines-invoke.m xamarin-support.m nsstring-localization.m trampolines-varargs.m monovm-bridge.m coreclr-bridge.m nativeaot-bridge.m
+SHARED_SOURCES += mono-runtime.m bindings.m bindings-generated.m shared.m runtime.m trampolines.m trampolines-invoke.m xamarin-support.m nsstring-localization.m trampolines-varargs.m monovm-bridge.m coreclr-bridge.m nativeaot-bridge.m swift-functions.swift
 SHARED_I386_SOURCES += trampolines-i386.m trampolines-i386-asm.s trampolines-i386-objc_msgSend.s trampolines-i386-objc_msgSendSuper.s trampolines-i386-objc_msgSend_stret.s trampolines-i386-objc_msgSendSuper_stret.s
 SHARED_X86_64_SOURCES += trampolines-x86_64.m trampolines-x86_64-asm.s trampolines-x86_64-objc_msgSend.s trampolines-x86_64-objc_msgSendSuper.s trampolines-x86_64-objc_msgSend_stret.s trampolines-x86_64-objc_msgSendSuper_stret.s
 SHARED_ARM64_SOURCES += trampolines-arm64.m trampolines-arm64-asm.s trampolines-arm64-objc_msgSend.s trampolines-arm64-objc_msgSendSuper.s
@@ -99,7 +99,7 @@ MONOTOUCH_FRAMEWORKS =  \
 	Xamarin             \
 	Xamarin-debug       \
 
-MONOTOUCH_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_SOURCES) $(MONOTOUCH_SOURCES)))
+MONOTOUCH_SOURCE_STEMS = $(patsubst %.swift,%,$(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_SOURCES) $(MONOTOUCH_SOURCES))))
 MONOTOUCH_I386_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_I386_SOURCES)))
 MONOTOUCH_X86_64_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_X86_64_SOURCES)))
 MONOTOUCH_ARM64_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_ARM64_SOURCES)))

--- a/runtime/swift-functions.swift
+++ b/runtime/swift-functions.swift
@@ -1,0 +1,29 @@
+#if os(macOS)
+import AppKit
+#endif
+import Foundation
+import StoreKit
+#if !os(macOS)
+import UIKit
+#endif
+
+@objc(XamarinSwiftFunctions)
+public class XamarinSwiftFunctions : NSObject {
+#if os(macOS)
+    @MainActor
+    @objc(requestReview:)
+    @available(macOS 13, *)
+    public static func StoreKit_RequestReview(scene: NSViewController)
+    {
+        AppStore.requestReview(in: scene)
+    }
+#elseif !os(tvOS)
+    @MainActor
+    @objc(requestReview:)
+    @available(iOS 16, macCatalyst 16, *)
+    public static func StoreKit_RequestReview(scene: UIWindowScene)
+    {
+        AppStore.requestReview(in: scene)
+    }
+#endif
+}

--- a/src/StoreKit/SwiftAPI.cs
+++ b/src/StoreKit/SwiftAPI.cs
@@ -1,0 +1,34 @@
+#if __IOS__ || __MACCATALYST__ || __MACOS__
+
+using System.Diagnostics.CodeAnalysis;
+
+#if HAS_APPKIT
+using AppKit;
+#endif
+
+#if HAS_UIKIT
+using UIKit;
+#endif
+
+namespace StoreKit {
+
+#if !NET10_0_OR_GREATER
+	[Experimental ("APL0004")]
+#endif
+	public static class AppStore {
+		[SupportedOSPlatform ("ios16.0")]
+		[SupportedOSPlatform ("maccatalyst16.0")]
+		[SupportedOSPlatform ("macos13.0")]
+		[UnsupportedOSPlatform ("tvos")]
+#if __MACOS__
+		public static void RequestReview (NSViewController @in)
+#else
+		public static void RequestReview (UIWindowScene @in)
+#endif
+		{
+			XamarinSwiftFunctions.RequestReview (@in);
+		}
+	}
+}
+
+#endif //  __IOS__ || __MACCATALYST__ || __MACOS__

--- a/src/StoreKit/SwiftAPI.cs
+++ b/src/StoreKit/SwiftAPI.cs
@@ -12,10 +12,13 @@ using UIKit;
 
 namespace StoreKit {
 
+	/// <summary>A class to interact with the App Store.</summary>
 #if !NET10_0_OR_GREATER
 	[Experimental ("APL0004")]
 #endif
 	public static class AppStore {
+		/// <summary>Ask StoreKit to request an App Store review or rating from the user.</summary>
+		/// <param name="in">The scene or view controller to display the interface in.</param>
 		[SupportedOSPlatform ("ios16.0")]
 		[SupportedOSPlatform ("maccatalyst16.0")]
 		[SupportedOSPlatform ("macos13.0")]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1760,6 +1760,7 @@ STOREKIT_SOURCES = \
 	StoreKit/SKCloudServiceSetupOptions.cs \
 	StoreKit/SKPayment.cs \
 	StoreKit/SKPaymentTransactionObserver.cs \
+	StoreKit/SwiftAPI.cs \
 
 # SystemConfiguration
 

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -9,6 +9,9 @@
 // Copyright 2012 Xamarin Inc.
 // Copyright 2020 Microsoft Corp.
 //
+
+using System.ComponentModel;
+
 using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
@@ -34,6 +37,7 @@ using NativeHandle = System.IntPtr;
 
 namespace StoreKit {
 
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Internal]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -36,6 +36,7 @@ namespace StoreKit {
 
 	[Internal]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor]
 	interface XamarinSwiftFunctions {
 		[Export ("requestReview:")]
 		[Static]

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -34,6 +34,19 @@ using NativeHandle = System.IntPtr;
 
 namespace StoreKit {
 
+	[Internal]
+	[BaseType (typeof (NSObject))]
+	interface XamarinSwiftFunctions {
+		[Export ("requestReview:")]
+		[Static]
+		[iOS (16, 0), MacCatalyst (16, 0), Mac (13, 0), NoTV]
+#if MONOMAC
+		void RequestReview (NSViewController viewController);
+#else
+		void RequestReview (UIWindowScene windowScene);
+#endif
+	}
+
 	[ErrorDomain ("SKANErrorDomain")]
 	[NoWatch, NoTV, NoMac, iOS (15, 4), MacCatalyst (17, 0)]
 	[Native]
@@ -1112,6 +1125,9 @@ namespace StoreKit {
 		[Export ("requestReview")]
 		void RequestReview ();
 
+		[Deprecated (PlatformName.iOS, 18, 0, message: "Use the 'AppStore.RequestReview (UIWindowScene)' API instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 18, 0, message: "Use the 'AppStore.RequestReview (UIWindowScene)' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 15, 0, message: "Use the 'AppStore.RequestReview (NSViewController)' API instead.")]
 		[Introduced (PlatformName.MacCatalyst, 14, 0)]
 		[NoWatch, NoTV, iOS (14, 0), NoMac]
 		[Static]

--- a/tests/cecil-tests/AttributeTest.cs
+++ b/tests/cecil-tests/AttributeTest.cs
@@ -181,6 +181,9 @@ namespace Cecil.Tests {
 				// Walk every class/struct/enum/property/method/enum value/pinvoke/event
 				foreach (var module in assembly.Modules) {
 					foreach (var type in module.Types) {
+						if (!type.IsPubliclyVisible ())
+							continue;
+
 						switch (type.Namespace) {
 						case "AppKit":
 						case "UIKit":
@@ -289,10 +292,6 @@ namespace Cecil.Tests {
 
 					// These methods have different optional/required semantics between platforms.
 					"PassKit.PKPaymentAuthorizationControllerDelegate_Extensions.GetPresentationWindow (PassKit.IPKPaymentAuthorizationControllerDelegate, PassKit.PKPaymentAuthorizationController)",
-					"Metal.MTLTextureWrapper.FirstMipmapInTail",
-					"Metal.MTLTextureWrapper.IsSparse",
-					"Metal.MTLTextureWrapper.TailSizeInBytes",
-
 
 					// HKSeriesBuilder doesn't implement the ISNCopying protocol on all platforms (and shouldn't on any according to the headers, so removed for XAMCORE_5_0).
 					"HealthKit.HKSeriesBuilder.EncodeTo (Foundation.NSCoder)",
@@ -325,6 +324,10 @@ namespace Cecil.Tests {
 					"Foundation.NSAttributedString.ReadableTypeIdentifiers",
 					"Foundation.NSAttributedString.WritableTypeIdentifiers",
 					"Foundation.NSAttributedString.WritableTypeIdentifiersForItemProvider",
+
+					// Same method, but different arguments due to platform differences. We should treat this as the same method, so ignore this failure.
+					"StoreKit.AppStore.RequestReview (XKit.XWindowScene)", // iOS, MacCatalyst
+					"StoreKit.AppStore.RequestReview (XKit.XViewController)", // macOS
 				};
 			}
 		}

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -34,6 +34,9 @@ namespace Introspection {
 
 		protected virtual bool Skip (Type type)
 		{
+			if (MemberHasEditorBrowsableNever (type))
+				return true;
+
 			switch (type.Namespace) {
 			// Xcode 15:
 			case "MetalFX":

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -38,6 +38,9 @@ namespace Introspection {
 
 		protected virtual bool Skip (Type type)
 		{
+			if (MemberHasEditorBrowsableNever (type))
+				return true;
+
 			if (type.ContainsGenericParameters)
 				return true;
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-StoreKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-StoreKit.ignore
@@ -1,0 +1,2 @@
+# This is one of our own types.
+!unknown-type! XamarinSwiftFunctions bound

--- a/tools/common/SdkVersions.cs
+++ b/tools/common/SdkVersions.cs
@@ -28,9 +28,9 @@ namespace Xamarin {
 		public const string MinMacCatalyst = "15.0";
 #else
 		public const string MinOSX = "12.0";
-		public const string MiniOS = "11.0";
+		public const string MiniOS = "12.2";
 		public const string MinWatchOS = "4.0";
-		public const string MinTVOS = "11.0";
+		public const string MinTVOS = "12.2";
 		public const string MinMacCatalyst = "15.0";
 #endif
 
@@ -39,9 +39,9 @@ namespace Xamarin {
 		public const string DotNetMinTVOS = "12.2";
 		public const string DotNetMinMacCatalyst = "15.0";
 		public const string LegacyMinOSX = "12.0";
-		public const string LegacyMiniOS = "11.0";
+		public const string LegacyMiniOS = "12.2";
 		public const string LegacyMinWatchOS = "4.0";
-		public const string LegacyMinTVOS = "11.0";
+		public const string LegacyMinTVOS = "12.2";
 
 		public const string MiniOSSimulator = "15.0";
 		public const string MinWatchOSSimulator = "8.0";


### PR DESCRIPTION
The existing Objective-C class to request an App Store review (SKStoreReviewController) is deprecated in Xcode 16+, and it doesn't even work on the corresponding OS versions.

The replacement API is Swift-only, but luckily it's a very simple API (just a static method), so it's possible to bind it manually.

This required a few other changes/improvements:

* Add support for Swift code in our runtime.

* Just to keep the changes to a minimum, bump the min OS version for legacy code to match the .NET min OS versions. This is because our build logic uses the legacy min versions when compiling native code (a more involved fix would be to update all the build logic to build native code to use the .NET min OS versions, but that's not the point of this PR, so I took the easy route). Fixes #10659.

I've tested the method locally, and it seems to work fine, but I've still marked
it as experimental for now. There are no unit tests because calling the method will
put up a dialog, which won't work correctly in unit tests.

Fixes https://github.com/xamarin/xamarin-macios/issues/21410.
Fixes https://github.com/xamarin/xamarin-macios/issues/10659.