### PR TITLE
[devops] Clean up before and after running the Windows tests remotely.

### DIFF
--- a/tests/dotnet/Windows/collect-binlogs.sh
+++ b/tests/dotnet/Windows/collect-binlogs.sh
@@ -7,6 +7,15 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 TOPLEVEL="$(git rev-parse --show-toplevel)"
 
+# Abort any agents that are still alive.
+# Aborting creates a crash report, and we can investigate why they got stuck.
+ps auxww || true
+pkill -6 -f Broker.exe || true
+pkill -6 -f Build.exe || true
+pkill -6 -f Broker.dll || true
+pkill -6 -f Build.dll || true
+ps auxww || true
+
 # Collect and zip up all the binlogs
 mkdir -p ~/remote_build_testing/binlogs
 rsync -avv --prune-empty-dirs --exclude 'artifacts/' --include '*/' --include '*.binlog' --exclude '*' "$TOPLEVEL/.." ~/remote_build_testing/binlogs
@@ -34,6 +43,9 @@ else
 fi
 
 ps auxww > ~/remote_build_testing/processes.txt || true
+
+# Collect any crash reports.
+zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/Library/Logs/DiagnosticReports || true
 
 ls -la ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/ >> ~/remote_build_testing/dotnet-debug.txt 2>&1 || true
 cat ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config >> ~/remote_build_testing/dotnet-debug.txt 2>&1 || true

--- a/tools/devops/automation/scripts/clean-for-remote-tests.sh
+++ b/tools/devops/automation/scripts/clean-for-remote-tests.sh
@@ -18,6 +18,8 @@ rm -rf ~/remote_build_testing
 
 # Kill any existing brokers and builders
 ps auxww || true
-pkill -f Broker.exe || true
-pkill -f Build.exe || true
+pkill -6 -f Broker.exe || true
+pkill -6 -f Build.exe || true
+pkill -6 -f Broker.dll || true
+pkill -6 -f Build.dll || true
 ps auxww || true


### PR DESCRIPTION
Also collect any crash reports from the remote machine.