### PR TITLE
[devops] Make the prepare-for-remote-tests.sh script callable locally.

### DIFF
--- a/tools/devops/automation/scripts/prepare-for-remote-tests.sh
+++ b/tools/devops/automation/scripts/prepare-for-remote-tests.sh
@@ -1,10 +1,12 @@
 #!/bin/bash -eux
 
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
+
 # Install the local .NET we're using into XMA's directory
 # (we can't point XMA to our local directory)
 mkdir -p ~/Library/Caches/Xamarin/XMA/SDKs
-cp -cRH "$BUILD_SOURCESDIRECTORY"/xamarin-macios/builds/downloads/dotnet ~/Library/Caches/Xamarin/XMA/SDKs
-sed '/local-tests-feed/d' "$BUILD_SOURCESDIRECTORY"/xamarin-macios/NuGet.config > ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config
+cp -cRH ./builds/downloads/dotnet ~/Library/Caches/Xamarin/XMA/SDKs
+sed '/local-tests-feed/d' ./NuGet.config > ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config
 
 mkdir -p ~/Library/Caches/Xamarin/XMA/SDKs/.home/.nuget/NuGet/
 cp ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config ~/Library/Caches/Xamarin/XMA/SDKs/.home/.nuget/NuGet/NuGet.Config


### PR DESCRIPTION
A dual-purpose script is always better than a single-purpose script!

This also removes a dependency on 'xamarin-macios' being the repository name.