### PR TITLE
[msbuild] Make MessagingVersion overridable from the environment.

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -10,8 +10,12 @@
 			interesting ways. So in order to get the exact version, they're
 			enclosed in brackets.
 
+			Lists of versions can be found here:
+
+			https://dev.azure.com/azure-public/vside/_artifacts/feed/xamarin-impl/NuGet/Xamarin.Messaging.Client/
+
 		-->
-		<MessagingVersion>[2.1.15]</MessagingVersion>
+		<MessagingVersion Condition="'$(MessagingVersion)' == ''">[2.1.15]</MessagingVersion>
 		<HotRestartVersion>[1.1.7]</HotRestartVersion>
 	</PropertyGroup>
 	<Import Project="$(MSBuildThisFileDirectory)../Directory.Build.props" />


### PR DESCRIPTION
This makes it easier to consume a locally built version of Xamarin.Messaging
when build and testing locally.