### PR TITLE
[net10.0] Trim by default (SdkOnly) when building for arm64. Fixes #21444.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.Trimming.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Trimming.props
@@ -52,8 +52,10 @@
 
 		<_DefaultLinkMode Condition="'$(_UseNativeAot)' != 'true' And '$(_PlatformName)' == 'macOS'">None</_DefaultLinkMode> <!-- Linking is off by default for macOS apps -->
 		<_DefaultLinkMode Condition="'$(_UseNativeAot)' != 'true' And '$(_PlatformName)' == 'MacCatalyst' And '$(Configuration)' == 'Release'">SdkOnly</_DefaultLinkMode> <!-- Default linking is on for release builds for Mac Catalyst apps -->
-		<_DefaultLinkMode Condition="'$(_UseNativeAot)' != 'true' And '$(_PlatformName)' == 'MacCatalyst' And '$(Configuration)' != 'Release'">None</_DefaultLinkMode> <!-- Default linking is off for non-release builds for Mac Catalyst apps -->
-		<_DefaultLinkMode Condition="'$(_UseNativeAot)' != 'true' And '$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst' And '$(_SdkIsSimulator)' == 'true'">None</_DefaultLinkMode> <!-- Linking is off by default in the simulator -->
+		<_DefaultLinkMode Condition="'$(_UseNativeAot)' != 'true' And '$(_PlatformName)' == 'MacCatalyst' And '$(Configuration)' != 'Release' And $(RuntimeIdentifier.Contains('arm64'))">SdkOnly</_DefaultLinkMode> <!-- Default linking is on for non-release builds for Mac Catalyst apps when building for arm64 -->
+		<_DefaultLinkMode Condition="'$(_UseNativeAot)' != 'true' And '$(_PlatformName)' == 'MacCatalyst' And '$(Configuration)' != 'Release' And !$(RuntimeIdentifier.Contains('arm64'))">None</_DefaultLinkMode> <!-- Default linking is off for non-release builds for Mac Catalyst apps when not building for arm64 -->
+		<_DefaultLinkMode Condition="'$(_UseNativeAot)' != 'true' And '$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst' And '$(_SdkIsSimulator)' == 'true' And $(RuntimeIdentifier.Contains('arm64')) And '$(MtouchInterpreter)' == ''">SdkOnly</_DefaultLinkMode> <!-- Linking is on by default in the simulator when building for arm64, as long as the interpreter is not enabled -->
+		<_DefaultLinkMode Condition="'$(_UseNativeAot)' != 'true' And '$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst' And '$(_SdkIsSimulator)' == 'true' And (!$(RuntimeIdentifier.Contains('arm64')) Or '$(MtouchInterpreter)' != '')">None</_DefaultLinkMode> <!-- Linking is off by default in the simulator when not building for arm64 -->
 		<_DefaultLinkMode Condition="'$(_UseNativeAot)' != 'true' And '$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst' And '$(_SdkIsSimulator)' != 'true'">SdkOnly</_DefaultLinkMode> <!-- Linking is SdkOnly for iOS/tvOS/watchOS apps on device -->
 	</PropertyGroup>
 	<PropertyGroup>

--- a/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/shared.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithStaticLibraryInPackageReference/shared.csproj
@@ -11,6 +11,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Xamarin.Tests.XCFrameworkWithStaticLibraryInRuntimesNativeDirectory" Version="1.0.0" />
+		<!-- Improve the below when https://github.com/xamarin/xamarin-macios/issues/17665 is fixed -->
+		<_NativeExecutableFrameworks Include="CoreLocation" />
+		<_NativeExecutableFrameworks Include="ModelIO" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -306,9 +306,10 @@ namespace Xamarin.Tests {
 				AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "MonoTouch.Dialog", runtimeIdentifiers, forceSingleRid: (platform == ApplePlatform.MacCatalyst && !isReleaseBuild), includeDebugFiles: includeDebugFiles);
 			expectedFiles.Add (Path.Combine (assemblyDirectory, "nunit.framework.dll"));
 			expectedFiles.Add (Path.Combine (assemblyDirectory, "nunitlite.dll"));
-			bool forceSingleRid = (platform == ApplePlatform.MacCatalyst && !isReleaseBuild) || platform == ApplePlatform.MacOSX;
-			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "Touch.Client", runtimeIdentifiers, forceSingleRid, includeDebugFiles: includeDebugFiles);
-			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, Path.GetFileNameWithoutExtension (Configuration.GetBaseLibraryName (platform, true)), runtimeIdentifiers, forceSingleRid, includeDebugFiles: includeDebugFiles);
+			bool forceSingleRidTouchClient = (platform == ApplePlatform.MacCatalyst && !isReleaseBuild) || platform == ApplePlatform.MacOSX;
+			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "Touch.Client", runtimeIdentifiers, forceSingleRidTouchClient, includeDebugFiles: includeDebugFiles);
+			bool forceSinglePlatformAssembly = platform == ApplePlatform.MacOSX;
+			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, Path.GetFileNameWithoutExtension (Configuration.GetBaseLibraryName (platform, true)), runtimeIdentifiers, forceSinglePlatformAssembly, includeDebugFiles: includeDebugFiles);
 			expectedFiles.Add (Path.Combine (assemblyDirectory, "runtimeconfig.bin"));
 
 			switch (platform) {


### PR DESCRIPTION
The default build times for a Mac Catalyst app on arm64 are horrendous:

* `dotnet new maccatalyst && dotnet build`: 1 minute

Enabling the trimmer or the interpreter makes it _much_ better:

* `dotnet new maccatalyst && dotnet build /p:UseInterpreter`: 17 seconds
* `dotnet new maccatalyst && dotnet build /p:TrimMode=partial`: 12 seconds
* `dotnet new maccatalyst && dotnet build /p:TrimMode=full`: 12 seconds
* `dotnet new maccatalyst && dotnet build /p:TrimMode=partial /p:UseInterpreter=true`: 12 seconds

So enable the trimmer by default for Debug mode on ARM64 on:

* iOS
* tvOS
* Mac Catalyst

(we're already trimming for other build configurations, so it seemed like an easy to choice to enable the trimmer in these configurations as well, as opposed to enabling the interpreter)

Fixes https://github.com/xamarin/xamarin-macios/issues/21444.