### PR TITLE
[xtro] Port the xtro-sharpie.csproj to a new style project and build with .NET.

### DIFF
--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -41,13 +41,8 @@ XTRO_SHARPIE_EXEC=$(MONO) --debug $(XTRO_SHARPIE)
 
 build: $(XTRO_SHARPIE) $(XTRO_REPORT) $(XTRO_SANITY)
 
-.stamp-build: export SHARPIE:=$(SHARPIE)
-.stamp-build: $(wildcard *.cs) pch-info.proj $(XTRO_REPORT) $(XTRO_SANITY) $(XTRO_SHARPIE)
-	$(Q_BUILD) $(SYSTEM_MSBUILD) $(MSBUILD_VERBOSITY) xtro-sharpie.csproj /r /bl:$@.binlog
-	$(Q) touch $@
-
 $(XTRO_SHARPIE): $(wildcard xtro-sharpie/*.cs) $(wildcard xtro-sharpie/*.csproj) pch-info.proj $(XTRO_REPORT)
-	$(Q_BUILD) $(SYSTEM_MSBUILD) $(MSBUILD_VERBOSITY) xtro-sharpie/xtro-sharpie.csproj /r /bl:$@.binlog
+	$(Q_GEN) unset MSBUILD_EXE_PATH && $(DOTNET) build xtro-sharpie/xtro-sharpie.csproj /bl:xtro-sharpie.binlog $(DOTNET_BUILD_VERBOSITY)
 
 $(XTRO_REPORT): $(wildcard xtro-report/*.cs) $(wildcard xtro-report/*.csproj) xtro-sharpie/Filter.cs Makefile
 	$(Q_GEN) unset MSBUILD_EXE_PATH && $(DOTNET) build xtro-report/xtro-report.csproj /bl:xtro-report.binlog $(DOTNET_BUILD_VERBOSITY)

--- a/tests/xtro-sharpie/xtro-sharpie/xtro-sharpie.csproj
+++ b/tests/xtro-sharpie/xtro-sharpie/xtro-sharpie.csproj
@@ -1,59 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{D890A042-93C2-4B4B-ABF8-7ECBCBF059D8}</ProjectGuid>
+    <TargetFramework>net4.7.2</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RootNamespace>xtrosharpie</RootNamespace>
-    <AssemblyName>xtro-sharpie</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <Commandlineparameters>../../../iphoneos12.0-arm64.pch /Library/Frameworks/Xamarin.iOS.framework/Versions/Current//lib/64bits/iOS/Xamarin.iOS.dll</Commandlineparameters>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Externalconsole>true</Externalconsole>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <Import Project="../pch-info.proj" />
-  <PropertyGroup Condition=" '$(RunConfiguration)' == 'watchOS' ">
-    <StartAction>Project</StartAction>
-    <StartArguments>../$(WATCHOS_PCH) ../../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/32bits/watchOS/Xamarin.WatchOS.dll</StartArguments>
-    <StartWorkingDirectory>.</StartWorkingDirectory>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(RunConfiguration)' == 'iOS' ">
-    <StartAction>Project</StartAction>
-    <StartArguments>../$(iOS_PCH) ../../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/iOS/Xamarin.iOS.dll ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll</StartArguments>
-    <StartWorkingDirectory>.</StartWorkingDirectory>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(RunConfiguration)' == 'tvOS' ">
-    <StartAction>Project</StartAction>
-    <StartArguments>../$(tvOS_PCH) ../../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/Xamarin.TVOS.dll ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll</StartArguments>
-    <StartWorkingDirectory>.</StartWorkingDirectory>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(RunConfiguration)' == 'macOS' ">
-    <StartAction>Project</StartAction>
-    <StartArguments>../$(macOS_PCH) ../../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/64bits/mobile/Xamarin.Mac.dll</StartArguments>
-    <StartWorkingDirectory>.</StartWorkingDirectory>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'iOS (.NET)' ">
     <StartAction>Project</StartAction>
     <StartArguments>../$(iOS_PCH) --output-directory ../api-annotations-dotnet --lib ../../../packages/microsoft.netcore.app.ref/$(MicrosoftNETCoreAppRefPackageVersion)/ref/$(DOTNET_TFM) $(iOS_DLL)</StartArguments>
@@ -75,7 +28,6 @@
     <StartWorkingDirectory>.</StartWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
     <Reference Include="Clang">
       <HintPath>\Library\Frameworks\ObjectiveSharpie.framework\Versions\Current\bin\Clang.dll</HintPath>
     </Reference>
@@ -83,31 +35,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="DllImportCheck.cs" />
-    <Compile Include="ObjCProtocolCheck.cs" />
-    <Compile Include="ObjCInterfaceCheck.cs" />
-    <Compile Include="EnumCheck.cs" />
-    <Compile Include="Helpers.cs" />
-    <Compile Include="Runner.cs" />
-    <Compile Include="FieldCheck.cs" />
-    <Compile Include="SelectorCheck.cs" />
-    <Compile Include="DesignatedInitializerCheck.cs" />
-    <Compile Include="SimdCheck.cs" />
-    <Compile Include="Log.cs" />
-    <Compile Include="RequiresSuperCheck.cs" />
-    <Compile Include="Filter.cs" />
-    <Compile Include="DeprecatedCheck.cs" />
-    <Compile Include="AttributeHelpers.cs" />
-    <Compile Include="VersionHelpers.cs" />
-    <Compile Include="ReleaseAttributeCheck.cs" />
-    <Compile Include="NullabilityCheck.cs" />
-    <Compile Include="UIAppearanceCheck.cs" />
-    <Compile Include="MapNamesCheck.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
+  <Target Name="CopyMono" AfterTargets="AfterBuild">
     <PropertyGroup>
       <LibClangMonoPath Condition="'$(SHARPIE)' != 'sharpie'">$(SHARPIE)/../bin/x64/Release/libclang-mono.dylib</LibClangMonoPath>
       <LibClangMonoPath Condition="'$(SHARPIE)' == 'sharpie' or '$(SHARPIE)' == ''">/Library/Frameworks/ObjectiveSharpie.framework/Versions/Current/bin/libclang-mono.dylib</LibClangMonoPath>


### PR DESCRIPTION
Note that it's still executed with Mono, because we load a native library that
needs Mono at runtime.