### PR TITLE
[msbuild] Use MSBuild assemblies from NuGet instead of Mono's installation.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,10 @@
 		<DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
 		<MonoCecilPackageVersion>0.11.5</MonoCecilPackageVersion>
 		<MSBuildStructuredLoggerPackageVersion>2.2.158</MSBuildStructuredLoggerPackageVersion>
+		<MicrosoftBuildPackageVersion>17.11.4</MicrosoftBuildPackageVersion>
+		<MicrosoftBuildFrameworkPackageVersion>17.11.4</MicrosoftBuildFrameworkPackageVersion>
+		<MicrosoftBuildTasksCorePackageVersion>17.11.4</MicrosoftBuildTasksCorePackageVersion>
+		<MicrosoftBuildUtilitiesCorePackageVersion>17.11.4</MicrosoftBuildUtilitiesCorePackageVersion>
 	</PropertyGroup>
 	<Import Project="Build.props" Condition="Exists('Build.props')" />
 </Project>

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
@@ -28,10 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.Build" Version="15.1.548" />
-      <PackageReference Include="Microsoft.Build.Framework" Version="15.1.548" />
-      <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.548" />
-      <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" />
+      <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
+      <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
+      <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCorePackageVersion)" />
+      <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
       <Compile Include="..\..\Versions.g.cs">
          <Link>Versions.g.cs</Link>
       </Compile>

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
@@ -6,7 +6,6 @@
     <NoWarn>$(NoWarn);NU1603</NoWarn> <!-- Xamarin.Messaging.Build.Common 1.6.24 depends on Merq (>= 1.1.0) but Merq 1.1.0 was not found. An approximate best match of Merq 1.1.4 was resolved. -->
     <NoWarn>$(NoWarn);MSB3277</NoWarn> <!-- warning MSB3277: Found conflicts between different versions of "System.IO.Compression" that could not be resolved. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <MonoMSBuildBinPath>/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin</MonoMSBuildBinPath>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
@@ -29,18 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
-      <Reference Include="Microsoft.Build">
-          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.dll</HintPath>
-      </Reference>
-      <Reference Include="Microsoft.Build.Framework">
-          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.Framework.dll</HintPath>
-      </Reference>
-      <Reference Include="Microsoft.Build.Tasks.Core">
-          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.Tasks.Core.dll</HintPath>
-      </Reference>
-      <Reference Include="Microsoft.Build.Utilities.Core">
-          <HintPath>$(MonoMSBuildBinPath)/Microsoft.Build.Utilities.Core.dll</HintPath>
-      </Reference>
+      <PackageReference Include="Microsoft.Build" Version="15.1.548" />
+      <PackageReference Include="Microsoft.Build.Framework" Version="15.1.548" />
+      <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.548" />
+      <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" />
       <Compile Include="..\..\Versions.g.cs">
          <Link>Versions.g.cs</Link>
       </Compile>

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -20,10 +20,10 @@
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilPackageVersion)" />
     <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.8.0" IncludeAssets="compile" Aliases="Microsoft_Build_Tasks_Core" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCorePackageVersion)" IncludeAssets="compile" Aliases="Microsoft_Build_Tasks_Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" IncludeAssets="compile" />
     <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="$(MicrosoftNETILLinkTasksPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Runtime.MonoTargets.Sdk" Version="$(MicrosoftNETRuntimeMonoTargetsSdkPackageVersion)" GeneratePathProperty="true"/>
     <PackageReference Include="Xamarin.Messaging.Build.Client" Version="$(MessagingVersion)" />

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir if IncludeMSBuildAssets was not set. -->
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" IncludeAssets="$(IncludeMSBuildAssets)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" IncludeAssets="$(IncludeMSBuildAssets)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.8.0" IncludeAssets="$(IncludeMSBuildAssets)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" IncludeAssets="$(IncludeMSBuildAssets)" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" IncludeAssets="$(IncludeMSBuildAssets)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" IncludeAssets="$(IncludeMSBuildAssets)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCorePackageVersion)" IncludeAssets="$(IncludeMSBuildAssets)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" IncludeAssets="$(IncludeMSBuildAssets)" />
     <PackageReference Include="Xamarin.Messaging.Build.Client" Version="$(MessagingVersion)" />
     <!-- GitInfo is pulled in because of Xamarin.Messaging from above, but we don't want it, so just exclude all assets from it -->
     <!-- This can be removed once our package references have been updated to not expose GitInfo -->

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj
@@ -34,10 +34,10 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Microsoft.Build" Version="17.11.4" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.11.4" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCorePackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
   </ItemGroup>
 
   <Target Name="BuildTasksAssembly" AfterTargets="BeforeBuild">

--- a/tools/class-redirector/class-redirector/class-redirector.csproj
+++ b/tools/class-redirector/class-redirector/class-redirector.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.5.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\common\CSToObjCMap.cs">


### PR DESCRIPTION
Use MSBuild assemblies from NuGet instead of Mono's installation. Try to get
the closest version to Mono's assemblies.

This avoids a Mono dependency.