### PR TITLE
[net9.0] [nuget-msi-convert] Do not use new VS component IDs

### DIFF
--- a/dotnet/generate-vs-workload.csharp
+++ b/dotnet/generate-vs-workload.csharp
@@ -57,7 +57,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	var manifestBuildVersion = iOSPlatform.Any () ? iOSPlatform.First ().Item2 : platforms.First ().Item2;
 	writer.WriteLine ($"    <ManifestBuildVersion>{manifestBuildVersion}</ManifestBuildVersion>");
 	writer.WriteLine ($"    <EnableSideBySideManifests>true</EnableSideBySideManifests>");
-	writer.WriteLine ($"    <UseVisualStudioComponentPrefix>true</UseVisualStudioComponentPrefix>");
+	writer.WriteLine ($"    <UseVisualStudioComponentPrefix>false</UseVisualStudioComponentPrefix>");
 	writer.WriteLine ($"  </PropertyGroup>");
 	writer.WriteLine ($"  <ItemGroup>");
 	writer.WriteLine ($"    <!-- Shorten package names to avoid long path caching issues in Visual Studio -->");


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/commit/9013ae4f83a9236ac91a8fe857a2403371993534

We've decided hold off on this change until .NET 10.


Backport of #21476
