### PR TITLE
[msbuild] Unify escaping algorithm for mangled resources, and remove code duplication.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateEmbeddedResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateEmbeddedResources.cs
@@ -17,22 +17,6 @@ namespace Xamarin.MacDev.Tasks {
 		[Output]
 		public ITaskItem [] EmbeddedResources { get; set; } = Array.Empty<ITaskItem> ();
 
-		static string EscapeMangledResource (string name)
-		{
-			var mangled = new StringBuilder ();
-
-			for (int i = 0; i < name.Length; i++) {
-				switch (name [i]) {
-				case '\\': mangled.Append ("_b"); break;
-				case '/': mangled.Append ("_f"); break;
-				case '_': mangled.Append ("__"); break;
-				default: mangled.Append (name [i]); break;
-				}
-			}
-
-			return mangled.ToString ();
-		}
-
 		public override bool Execute ()
 		{
 			if (ShouldExecuteRemotely ()) {
@@ -56,7 +40,7 @@ namespace Xamarin.MacDev.Tasks {
 				bundleResource.CopyMetadataTo (embeddedResource);
 
 				// mangle the resource name
-				var logicalName = "__" + Prefix + "_content_" + EscapeMangledResource (bundleResource.GetMetadata ("LogicalName"));
+				var logicalName = "__" + Prefix + "_content_" + PackLibraryResources.EscapeMangledResource (bundleResource.GetMetadata ("LogicalName"));
 				embeddedResource.SetMetadata ("LogicalName", logicalName);
 
 				// add it to the output connection

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PackLibraryResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PackLibraryResources.cs
@@ -26,14 +26,15 @@ namespace Xamarin.MacDev.Tasks {
 
 		#endregion
 
-		static string EscapeMangledResource (string name)
+		// The opposite function is UnpackLibraryResources.UnmangleResource
+		public static string EscapeMangledResource (string name)
 		{
 			var mangled = new StringBuilder ();
 
 			for (int i = 0; i < name.Length; i++) {
 				switch (name [i]) {
-				case '\\': mangled.Append ("_b"); break;
-				case '/': mangled.Append ("_f"); break;
+				case '\\':
+				case '/': mangled.Append ("_s"); break;
 				case '_': mangled.Append ("__"); break;
 				default: mangled.Append (name [i]); break;
 				}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/UnpackLibraryResources.cs
@@ -186,6 +186,7 @@ namespace Xamarin.MacDev.Tasks {
 			return rv;
 		}
 
+		// The opposite function is PackLibraryResources.EscapeMangledResource
 		static string UnmangleResource (string mangled)
 		{
 			var unmangled = new StringBuilder (mangled.Length);
@@ -201,6 +202,7 @@ namespace Xamarin.MacDev.Tasks {
 
 				if (escaped) {
 					switch (c) {
+					case 's': c = Path.DirectorySeparatorChar; break;
 					case 'b': c = '\\'; break;
 					case 'f': c = '/'; break;
 					case '_': c = '_'; break;

--- a/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
@@ -100,17 +100,17 @@ namespace Xamarin.MacDev.Tasks {
 				return new [] {
 					"MyLibrary.MyLibraryFolder.LibraryLinkedEmbeddedResource.txt",
 					"MyLibrary.MyLibraryFolder.LibraryEmbeddedResource.txt",
-					"__monotouch_content_MyLibraryFolder_fLibraryLinkedBundleResource.txt",
-					"__monotouch_content_MyLibraryFolder_fLibraryBundleResource.txt",
-					"__monotouch_content_MyLibraryFolder_fLibraryLinkedContent.txt",
-					"__monotouch_content_MyLibraryFolder_fLibraryContent.txt",
-					"__monotouch_content_LibraryStoryboard.storyboardc_f1-view-2.nib",
-					"__monotouch_content_LibraryStoryboard.storyboardc_fInfo.plist",
-					"__monotouch_content_LibraryStoryboard.storyboardc_fUIViewController-1.nib",
-					"__monotouch_content_LibrarySecondStoryboard.storyboardc_f43-view-49.nib",
-					"__monotouch_content_LibrarySecondStoryboard.storyboardc_f45-view-53.nib",
-					"__monotouch_content_LibrarySecondStoryboard.storyboardc_fInfo.plist",
-					"__monotouch_content_LibrarySecondStoryboard.storyboardc_fUITabBarController-41.nib"
+					"__monotouch_content_MyLibraryFolder_sLibraryLinkedBundleResource.txt",
+					"__monotouch_content_MyLibraryFolder_sLibraryBundleResource.txt",
+					"__monotouch_content_MyLibraryFolder_sLibraryLinkedContent.txt",
+					"__monotouch_content_MyLibraryFolder_sLibraryContent.txt",
+					"__monotouch_content_LibraryStoryboard.storyboardc_s1-view-2.nib",
+					"__monotouch_content_LibraryStoryboard.storyboardc_sInfo.plist",
+					"__monotouch_content_LibraryStoryboard.storyboardc_sUIViewController-1.nib",
+					"__monotouch_content_LibrarySecondStoryboard.storyboardc_s43-view-49.nib",
+					"__monotouch_content_LibrarySecondStoryboard.storyboardc_s45-view-53.nib",
+					"__monotouch_content_LibrarySecondStoryboard.storyboardc_sInfo.plist",
+					"__monotouch_content_LibrarySecondStoryboard.storyboardc_sUITabBarController-41.nib"
 				};
 			}
 		}


### PR DESCRIPTION
When embedding bundle resources to an assembly as assembly resources, we store
the LogicalName property for the resource. We do this by using the LogicalName
property as the resource name - but we need to encode forward and backward
slashes, since they don't work properly has resource names.

In the past, we've encoded forward and backward slashes differently, but this
results in different encodings depending on whether the resources are embedded
on Windows or macOS.

So change the encoding, so that both forward and backward slashes are encoded
the same way, and then they're extracted using the platform's path character.
This way we get consistent behavior on both platforms.