### PR TITLE
[msbuild/dotnet] Add support for compressed xcframeworks in binding projects and as NativeReference items. Fixes #21294.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferences.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferences.cs
@@ -264,7 +264,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var isCompressedXcframework = CompressionHelper.IsCompressed (xcframework);
 			var potentiallyCompressedFile = isCompressedXcframework ? Path.Combine (resourcePath, xcframework) : resourcePath;
-			var manifestPath = Path.Combine (isCompressedXcframework ? Path.GetFileNameWithoutExtension (xcframework) :  xcframework, "Info.plist");
+			var manifestPath = Path.Combine (isCompressedXcframework ? Path.GetFileNameWithoutExtension (xcframework) : xcframework, "Info.plist");
 			using var stream = CompressionHelper.TryGetPotentiallyCompressedFile (log, potentiallyCompressedFile, manifestPath);
 			if (stream is null) {
 				plist = null;

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -146,9 +146,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	-->
 	<Target Name="_ExpandNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;_SanitizeNativeReferences">
 		<ItemGroup>
-			<_XCFrameworkNativeReference Include="@(NativeReference -> '%(Identity)/.')" Condition="'%(Extension)' == '.xcframework'" />
+			<_XCFrameworkNativeReference Include="@(NativeReference -> '%(Identity)/.')" Condition="'%(Extension)' == '.xcframework' Or $([MSBuild]::ValueOrDefault('%(FileName)%(Extension)', '').EndsWith('.xcframework.zip'))" />
 			<_FrameworkNativeReference Include="@(NativeReference -> '%(Identity)/%(Filename)')" Condition="'%(Extension)' == '.framework'" />
-			<_FileNativeReference Include="@(NativeReference)" Condition="'%(Extension)' != '.framework' And '%(Extension)' != '.xcframework'" />
+			<_FileNativeReference Include="@(NativeReference)" Condition="'%(Extension)' != '.framework' And '%(Extension)' != '.xcframework' And '%(Extension)' != '.zip'" />
 		</ItemGroup>
 		<ResolveNativeReferences
 			SessionId="$(BuildSessionId)"

--- a/tests/dotnet/BindingWithCompressedXCFramework/ApiDefinition.cs
+++ b/tests/dotnet/BindingWithCompressedXCFramework/ApiDefinition.cs
@@ -1,0 +1,1 @@
+using Foundation;

--- a/tests/dotnet/BindingWithCompressedXCFramework/MacCatalyst/BindingWithCompressedXCFramework.csproj
+++ b/tests/dotnet/BindingWithCompressedXCFramework/MacCatalyst/BindingWithCompressedXCFramework.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/BindingWithCompressedXCFramework/MacCatalyst/Makefile
+++ b/tests/dotnet/BindingWithCompressedXCFramework/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/BindingWithCompressedXCFramework/MyClass.cs
+++ b/tests/dotnet/BindingWithCompressedXCFramework/MyClass.cs
@@ -1,0 +1,8 @@
+using System;
+namespace BindingWithCompressedXCFramework {
+	public class MyClass {
+		public MyClass ()
+		{
+		}
+	}
+}

--- a/tests/dotnet/BindingWithCompressedXCFramework/StructsAndEnums.cs
+++ b/tests/dotnet/BindingWithCompressedXCFramework/StructsAndEnums.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+
+namespace BindingWithCompressedXCFramework {
+	public static class CFunctions {
+		[DllImport ("XTest.framework/XTest")]
+		static extern int theUltimateAnswer ();
+
+		// This comes from XStaticArTest.framework
+		[DllImport ("__Internal")]
+		static extern int ar_theUltimateAnswer ();
+
+		// This comes from XStaticObjectTest.framework
+		[DllImport ("__Internal", EntryPoint = "theUltimateAnswer")]
+		static extern int object_theUltimateAnswer ();
+	}
+}

--- a/tests/dotnet/BindingWithCompressedXCFramework/iOS/BindingWithCompressedXCFramework.csproj
+++ b/tests/dotnet/BindingWithCompressedXCFramework/iOS/BindingWithCompressedXCFramework.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/BindingWithCompressedXCFramework/iOS/Makefile
+++ b/tests/dotnet/BindingWithCompressedXCFramework/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/BindingWithCompressedXCFramework/macOS/BindingWithCompressedXCFramework.csproj
+++ b/tests/dotnet/BindingWithCompressedXCFramework/macOS/BindingWithCompressedXCFramework.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/BindingWithCompressedXCFramework/macOS/Makefile
+++ b/tests/dotnet/BindingWithCompressedXCFramework/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/BindingWithCompressedXCFramework/shared.csproj
+++ b/tests/dotnet/BindingWithCompressedXCFramework/shared.csproj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<IsBindingProject>true</IsBindingProject>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<ObjcBindingApiDefinition Include="../ApiDefinition.cs" />
+		<ObjcBindingCoreSource Include="../StructsAndEnums.cs" />
+		<NativeReference Include="../../../test-libraries/.libs/XTest.xcframework.zip" Kind="Framework" />
+		<NativeReference Include="../../../test-libraries/.libs/XStaticArTest.xcframework.zip" Kind="Static" />
+		<NativeReference Include="../../../test-libraries/.libs/XStaticObjectTest.xcframework.zip" Kind="Static" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/BindingWithCompressedXCFramework/shared.mk
+++ b/tests/dotnet/BindingWithCompressedXCFramework/shared.mk
@@ -1,0 +1,2 @@
+TOP=../../../..
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/BindingWithCompressedXCFramework/tvOS/BindingWithCompressedXCFramework.csproj
+++ b/tests/dotnet/BindingWithCompressedXCFramework/tvOS/BindingWithCompressedXCFramework.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/BindingWithCompressedXCFramework/tvOS/Makefile
+++ b/tests/dotnet/BindingWithCompressedXCFramework/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/AppDelegate.cs
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/AppDelegate.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace NativeFrameworkReferencesApp {
+	public class Program {
+		[DllImport ("XTest.framework/XTest")]
+		static extern int theUltimateAnswer ();
+
+		// This comes from XStaticArTest.framework
+		[DllImport ("__Internal")]
+		static extern int ar_theUltimateAnswer ();
+
+		// This comes from XStaticObjectTest.framework
+		[DllImport ("__Internal", EntryPoint = "theUltimateAnswer")]
+		static extern int object_theUltimateAnswer ();
+
+		static int Main (string [] args)
+		{
+			Console.WriteLine ($"XCFramework: {theUltimateAnswer ()}");
+			Console.WriteLine ($"XCFramework with ar files: {ar_theUltimateAnswer ()}");
+			Console.WriteLine ($"XCFramework with object files: {object_theUltimateAnswer ()}");
+
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/MacCatalyst/CompressedNativeXCFrameworkReferencesApp.csproj
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/MacCatalyst/CompressedNativeXCFrameworkReferencesApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/MacCatalyst/Makefile
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/iOS/CompressedNativeXCFrameworkReferencesApp.csproj
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/iOS/CompressedNativeXCFrameworkReferencesApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/iOS/Makefile
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/macOS/CompressedNativeXCFrameworkReferencesApp.csproj
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/macOS/CompressedNativeXCFrameworkReferencesApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/macOS/Makefile
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/shared.csproj
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/shared.csproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>CompressedNativeXCFrameworkReferencesApp</ApplicationTitle>
+		<ApplicationId>com.xamarin.compressednativexcframeworkreferencesapp</ApplicationId>
+		<ApplicationVersion>1.0</ApplicationVersion>
+
+		<UseIntepreter>true</UseIntepreter> <!-- speed up the test -->
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<NativeReference Include="..\..\..\test-libraries\.libs\XTest.xcframework.zip" Kind="Framework" />
+		<NativeReference Include="..\..\..\test-libraries\.libs\XStaticArTest.xcframework.zip" Kind="Static" />
+		<NativeReference Include="..\..\..\test-libraries\.libs\XStaticObjectTest.xcframework.zip" Kind="Static" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/shared.mk
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/shared.mk
@@ -1,0 +1,3 @@
+TOP=../../../..
+TESTNAME=CompressedNativeXCFrameworkReferencesApp
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/tvOS/CompressedNativeXCFrameworkReferencesApp.csproj
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/tvOS/CompressedNativeXCFrameworkReferencesApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/tvOS/Makefile
+++ b/tests/dotnet/CompressedNativeXCFrameworkReferencesApp/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/AppDelegate.cs
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/AppDelegate.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace NativeFrameworkReferencesApp {
+	public class Program {
+		[DllImport ("XTest.framework/XTest")]
+		static extern int theUltimateAnswer ();
+
+		// This comes from XStaticArTest.framework
+		[DllImport ("__Internal")]
+		static extern int ar_theUltimateAnswer ();
+
+		// This comes from XStaticObjectTest.framework
+		[DllImport ("__Internal", EntryPoint = "theUltimateAnswer")]
+		static extern int object_theUltimateAnswer ();
+
+		static int Main (string [] args)
+		{
+			Console.WriteLine ($"XCFramework: {theUltimateAnswer ()}");
+			Console.WriteLine ($"XCFramework with ar files: {ar_theUltimateAnswer ()}");
+			Console.WriteLine ($"XCFramework with object files: {object_theUltimateAnswer ()}");
+
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/MacCatalyst/CompressedXCFrameworkInBindingProjectApp.csproj
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/MacCatalyst/CompressedXCFrameworkInBindingProjectApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/MacCatalyst/Makefile
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/iOS/CompressedXCFrameworkInBindingProjectApp.csproj
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/iOS/CompressedXCFrameworkInBindingProjectApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/iOS/Makefile
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/macOS/CompressedXCFrameworkInBindingProjectApp.csproj
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/macOS/CompressedXCFrameworkInBindingProjectApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/macOS/Makefile
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/shared.csproj
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/shared.csproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>CompressedXCFrameworkInBindingProjectApp</ApplicationTitle>
+		<ApplicationId>com.xamarin.compressedxcframeworkinbindingprojectapp</ApplicationId>
+		<ApplicationVersion>1.0</ApplicationVersion>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\BindingWithCompressedXCFramework\$(_PlatformName)\BindingWithCompressedXCFramework.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/shared.mk
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/shared.mk
@@ -1,0 +1,3 @@
+TOP=../../../..
+TESTNAME=CompressedXCFrameworkInBindingProjectApp
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/tvOS/CompressedXCFrameworkInBindingProjectApp.csproj
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/tvOS/CompressedXCFrameworkInBindingProjectApp.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/tvOS/Makefile
+++ b/tests/dotnet/CompressedXCFrameworkInBindingProjectApp/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/UnitTests/PackTest.cs
+++ b/tests/dotnet/UnitTests/PackTest.cs
@@ -141,6 +141,109 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		[TestCase (ApplePlatform.iOS, true)]
+		[TestCase (ApplePlatform.iOS, false)]
+		[TestCase (ApplePlatform.MacCatalyst, true)]
+		[TestCase (ApplePlatform.MacCatalyst, false)]
+		[TestCase (ApplePlatform.TVOS, true)]
+		[TestCase (ApplePlatform.TVOS, false)]
+		[TestCase (ApplePlatform.MacOSX, true)]
+		[TestCase (ApplePlatform.MacOSX, false)]
+		public void BindingCompressedXcFrameworksProject (ApplePlatform platform, bool compressed)
+		{
+			var project = "BindingWithCompressedXCFramework";
+			var assemblyName = project;
+			var configuration = "Release";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			var project_path = GetProjectPath (project, runtimeIdentifiers: string.Empty, platform: platform, out var appPath, configuration: configuration);
+			Clean (project_path);
+
+			var tmpdir = Cache.CreateTemporaryDirectory ();
+			var outputPath = Path.Combine (tmpdir, "OutputPath");
+			var intermediateOutputPath = Path.Combine (tmpdir, "IntermediateOutputPath");
+			var properties = GetDefaultProperties ();
+			properties ["OutputPath"] = outputPath + Path.DirectorySeparatorChar;
+			properties ["IntermediateOutputPath"] = intermediateOutputPath + Path.DirectorySeparatorChar;
+			properties ["CompressBindingResourcePackage"] = compressed ? "true" : "false";
+
+			DotNet.AssertPack (project_path, properties, msbuildParallelism: false);
+
+			var nupkg = Path.Combine (outputPath, assemblyName + ".1.0.0.nupkg");
+			Assert.That (nupkg, Does.Exist, "nupkg existence");
+
+			var archive = ZipFile.OpenRead (nupkg);
+			var files = archive.Entries.Select (v => v.FullName).ToHashSet ();
+			var tfm = platform.ToFrameworkWithPlatformVersion (isExecutable: false);
+			Assert.AreEqual (compressed ? 6 : 9, archive.Entries.Count, $"nupkg file count - {nupkg}");
+			Assert.That (files, Does.Contain (assemblyName + ".nuspec"), "nuspec");
+			Assert.That (files, Does.Contain ("_rels/.rels"), ".rels");
+			Assert.That (files, Does.Contain ("[Content_Types].xml"), "[Content_Types].xml");
+			Assert.That (files, Does.Contain ($"lib/{tfm}/{assemblyName}.dll"), $"{assemblyName}.dll");
+			Assert.That (files, Has.Some.Matches<string> (v => v.StartsWith ("package/services/metadata/core-properties/", StringComparison.Ordinal) && v.EndsWith (".psmdcp", StringComparison.Ordinal)), "psmdcp");
+			string? manifest;
+			if (compressed) {
+				var resourcesZip = $"lib/{tfm}/{assemblyName}.resources.zip";
+				Assert.That (files, Does.Contain (resourcesZip), $"{assemblyName}.resources.zip");
+				var innerZip = ZipHelpers.ListInnerZip (nupkg, resourcesZip);
+				var innerZipContents = new string [] {
+					"manifest",
+					"XTest.xcframework.zip",
+					"XStaticArTest.xcframework.zip",
+					"XStaticObjectTest.xcframework.zip",
+				};
+				CollectionAssert.AreEqual (innerZipContents.OrderBy (v => v), innerZip.OrderBy (v => v), "Inner zip");
+				manifest = ZipHelpers.GetInnerString (nupkg, resourcesZip, "manifest");
+			} else {
+				Assert.That (files, Does.Contain ($"lib/{tfm}/{assemblyName}.resources/manifest"), $"manifest");
+				Assert.That (files, Does.Contain ($"lib/{tfm}/{assemblyName}.resources/XTest.xcframework.zip"), $"XTest.xcframework.zip");
+				Assert.That (files, Does.Contain ($"lib/{tfm}/{assemblyName}.resources/XStaticArTest.xcframework.zip"), $"XStaticArTest.xcframework.zip");
+				Assert.That (files, Does.Contain ($"lib/{tfm}/{assemblyName}.resources/XStaticObjectTest.xcframework.zip"), $"XStaticObjectTest.xcframework.zip");
+				manifest = ZipHelpers.GetString (nupkg, $"lib/{tfm}/{assemblyName}.resources/manifest");
+			}
+			var expectedManifest = $"""
+			<BindingAssembly>
+				<NativeReference Name="XTest.xcframework.zip">
+					<ForceLoad></ForceLoad>
+					<Frameworks></Frameworks>
+					<IdentityWithoutPathSeparatorSuffix>../../../test-libraries/.libs/XTest.xcframework.zip</IdentityWithoutPathSeparatorSuffix>
+					<IsCxx></IsCxx>
+					<Kind>Framework</Kind>
+					<LinkerFlags></LinkerFlags>
+					<LinkWithSwiftSystemLibraries></LinkWithSwiftSystemLibraries>
+					<NeedsGccExceptionHandling></NeedsGccExceptionHandling>
+					<SmartLink></SmartLink>
+					<WeakFrameworks></WeakFrameworks>
+				</NativeReference>
+				<NativeReference Name="XStaticArTest.xcframework.zip">
+					<ForceLoad></ForceLoad>
+					<Frameworks></Frameworks>
+					<IdentityWithoutPathSeparatorSuffix>../../../test-libraries/.libs/XStaticArTest.xcframework.zip</IdentityWithoutPathSeparatorSuffix>
+					<IsCxx></IsCxx>
+					<Kind>Static</Kind>
+					<LinkerFlags></LinkerFlags>
+					<LinkWithSwiftSystemLibraries></LinkWithSwiftSystemLibraries>
+					<NeedsGccExceptionHandling></NeedsGccExceptionHandling>
+					<SmartLink></SmartLink>
+					<WeakFrameworks></WeakFrameworks>
+				</NativeReference>
+				<NativeReference Name="XStaticObjectTest.xcframework.zip">
+					<ForceLoad></ForceLoad>
+					<Frameworks></Frameworks>
+					<IdentityWithoutPathSeparatorSuffix>../../../test-libraries/.libs/XStaticObjectTest.xcframework.zip</IdentityWithoutPathSeparatorSuffix>
+					<IsCxx></IsCxx>
+					<Kind>Static</Kind>
+					<LinkerFlags></LinkerFlags>
+					<LinkWithSwiftSystemLibraries></LinkWithSwiftSystemLibraries>
+					<NeedsGccExceptionHandling></NeedsGccExceptionHandling>
+					<SmartLink></SmartLink>
+					<WeakFrameworks></WeakFrameworks>
+				</NativeReference>
+			</BindingAssembly>
+			""";
+			Assert.AreEqual (expectedManifest, manifest, "manifest contents");
+		}
+
+		[Test]
 		[TestCase (ApplePlatform.iOS)]
 		[TestCase (ApplePlatform.MacCatalyst)]
 		[TestCase (ApplePlatform.TVOS)]

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1666,6 +1666,30 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		[TestCase (ApplePlatform.MacCatalyst)]
+		[TestCase (ApplePlatform.iOS)]
+		[TestCase (ApplePlatform.TVOS)]
+		[TestCase (ApplePlatform.MacOSX)]
+		public void CompressedXCFrameworkInBindingProjectApp (ApplePlatform platform)
+		{
+			var project = "CompressedXCFrameworkInBindingProjectApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var runtimeIdentifiers = GetDefaultRuntimeIdentifier (platform);
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			DotNet.AssertBuild (project_path, properties);
+
+			var appExecutable = GetNativeExecutable (platform, appPath);
+			Assert.That (appExecutable, Does.Exist, "There is an executable");
+
+			if (CanExecute (platform, properties)) {
+				ExecuteWithMagicWordAndAssert (appExecutable);
+			}
+		}
+
+		[Test]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
 		public void BuildAndExecuteAppWithWinExeOutputType (ApplePlatform platform, string runtimeIdentifier)
 		{

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -171,6 +171,16 @@ namespace Xamarin.Tests {
 			}
 		}
 
+		protected static bool CanExecute (ApplePlatform platform, Dictionary<string, string> properties)
+		{
+			if (properties.TryGetValue ("RuntimeIdentifier", out var runtimeIdentifiers)) {
+				return CanExecute (platform, runtimeIdentifiers);
+			} else if (properties.TryGetValue ("RuntimeIdentifiers", out runtimeIdentifiers)) {
+				return CanExecute (platform, runtimeIdentifiers);
+			}
+			return false;
+		}
+
 		protected static bool CanExecute (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			switch (platform) {

--- a/tests/dotnet/UnitTests/ZipHelpers.cs
+++ b/tests/dotnet/UnitTests/ZipHelpers.cs
@@ -26,6 +26,36 @@ namespace Xamarin.Tests {
 			return innerZip.Entries.Select (entry => entry.FullName.TrimEnd ('/').Replace ('/', Path.DirectorySeparatorChar)).ToList ();
 		}
 
+		public static string? GetString (string zipfile, string filename)
+		{
+			using var zip = ZipFile.OpenRead (zipfile);
+			var entry = zip.GetEntry (filename);
+			if (entry is null)
+				return null;
+
+			using var entryStream = entry.Open ();
+			using var reader = new StreamReader (entryStream);
+			return reader.ReadToEnd ();
+		}
+
+		public static string? GetInnerString (string zipfile, string innerZipFileName, string filename)
+		{
+			using var zip = ZipFile.OpenRead (zipfile);
+			var innerZipEntry = zip.GetEntry (innerZipFileName);
+			if (innerZipEntry is null)
+				return null;
+
+			using Stream innerZipStream = innerZipEntry.Open ();
+			using ZipArchive innerZip = new ZipArchive (innerZipStream, ZipArchiveMode.Read);
+			var innerEntry = innerZip.GetEntry (filename);
+			if (innerEntry is null)
+				return null;
+
+			using var innerStream = innerEntry.Open ();
+			using var reader = new StreamReader (innerStream);
+			return reader.ReadToEnd ();
+		}
+
 		public static void DumpZipFile (ZipArchive zip, string path)
 		{
 #if TRACE

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -446,10 +446,15 @@ SWIFTTEST_XCTARGETS += \
 
 all-local:: .libs/SwiftTest.xcframework
 
-.libs/XTest.xcframework.zip: .libs/XTest.xcframework
-	$(Q_ZIP) cd .libs && $(ZIP) -r "$(notdir $@)" "$(notdir $<)"
+define ZippedXcframework
+.libs/$(1).xcframework.zip: .libs/$(1).xcframework
+	$(Q_ZIP) cd .libs && $(ZIP) -r "$$(notdir $$@)" "$$(notdir $$<)"
+all-local:: .libs/$(1).xcframework.zip
+endef
 
-all-local:: .libs/XTest.xcframework.zip
+$(eval $(call ZippedXcframework,XTest))
+$(eval $(call ZippedXcframework,XStaticArTest))
+$(eval $(call ZippedXcframework,XStaticObjectTest))
 
 # Xamarin.Mac
 


### PR DESCRIPTION
Now it's possible to reference a compressed xcframework like this:

```xml
<NativeReference Include="path/to/myframework.xcframework.zip" />
```

This makes it easier to work with xcframeworks on Windows, because
xcframeworks can contain symlinks, and by zipping them up the whole symlink
problem is avoided.

Turns out there's already a NuGet that adds a .xcframework.zip file as a
NativeReference (Microsoft.ML.OnnxRuntime), so this makes that NuGet work.

Fixes https://github.com/xamarin/xamarin-macios/issues/21294.
Fixes https://github.com/xamarin/xamarin-macios/issues/21450.