### PR TITLE
[devops] Upload MSBuild crash logs.

### DIFF
--- a/tools/devops/automation/templates/common/setup.yml
+++ b/tools/devops/automation/templates/common/setup.yml
@@ -42,3 +42,7 @@ steps:
   displayName: 'Set Jenkins variables'
   env:
     BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+
+# Write MSBuild logs into the jenkins-results directory, so they're uploaded after test runs.
+- pwsh: Write-Host "##vso[task.setvariable variable=MSBUILDDEBUGPATH]$Env:SYSTEM_DEFAULTWORKINGDIRECTORY/$BULID_REPOSITORY_TITLE/jenkins-results/MSBuildCrashLogs"
+  displayName: 'Set MSBuild crash log directory'

--- a/tools/devops/automation/templates/variables/common.yml
+++ b/tools/devops/automation/templates/variables/common.yml
@@ -59,3 +59,6 @@ variables:
 # point to the vsdrops that we will be using for the diff uploads.
 - name: VSDropsPrefix
   value: 'https://vsdrop.corp.microsoft.com/file/v1/xamarin-macios/device-tests'
+
+- name: BUILD_REPOSITORY_TITLE
+  value: 'xamarin-macios'


### PR DESCRIPTION
When MSBuild crashes, MSBuild creates a log file and prints:

> error MSB4166: Child node "3" exited prematurely. Shutting down. Diagnostic information may be found in files in "/var/folders/52/tx7jvhs16x19bkdf030_nyww0000gn/T/MSBuildTempbuilder/" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.

However, these log files aren't accessible after a CI build has concluded, so
set the MSBUILDDEBUGPATH environment variable to the jenkins-results
directory, which will be uploaded as a build artifact.

This way we can inspect whatever made MSBuild fail in a CI build.