### PR TITLE
[devops] File an AzDo issue if a bot runs out of space.

### DIFF
--- a/tools/devops/automation/scripts/System.psm1
+++ b/tools/devops/automation/scripts/System.psm1
@@ -207,22 +207,82 @@ function Clear-AfterTests {
 
 <#
     .SYNOPSIS
-        Checks if there is enough space in the HD
+        Get the remaining space in the HD (in GB)
 #>
-function Test-HDFreeSpace {
+function Get-HDFreeSpace {
+    $drive = Get-PSDrive "/"
+    return $drive.Free / 1GB
+}
+
+<#
+    .SYNOPSIS
+        Asserts that the HD has he specified number of GB left, if will:
+
+        * Add a GitHub comment.
+        * File an AzureDevOps issue.
+        * Throw an exception
+
+        (all of these will be done)
+#>
+function Assert-HDFreeSpace {
     param
     (
         [Parameter(Mandatory)]
         [int]
         $Size
     )
-    $drive = Get-PSDrive "/"
-    return $drive.Free / 1GB -gt $Size
+
+    $space = Get-HDFreeSpace
+    if ($space -gt $Size) {
+        Write-Host "This machine has plenty of space, $Size GB are required, and there's $space GB free space left."
+        return
+    }
+
+    $space = Get-HDFreeSpace
+    $shortMessage = "Not enough free space in the host $Env:AGENT_MACHINENAME, need $Size GB, has $space GB."
+
+    Write-Host $shortMessage
+    try {
+        Write-Host "Adding GitHub comment..."
+        New-GitHubComment -Header "Tests failed catastrophically on $Env:CONTEXT" -Emoji ":fire:" -Description "$shortMessage"
+    } catch {
+        Write-Host "Failed to post GitHub comment: $_"
+    }
+
+    Write-Host ""
+
+    $stepUrl = "$Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$Env:SYSTEM_TEAMPROJECT/results?buildId=$Env:BUILD_BUILDID&view=logs&j=$Env:SYSTEM_JOBIDENTIFIER&t=$Env:SYSTEM_TASKINSTANCEID"
+    $workItemTitle = "[CI] Bot '$Env:AGENT_MACHINENAME' out of disk space"
+    $workItemMessage = @"
+<div>The bot <b>$Env:AGENT_MACHINENAME</b> does not have enough hard disk space left.</div>
+<div><br /></div>
+<div>The bot has $space GB left (needs $Size GB).</div>
+<div><br /></div>
+<div>See: <a href='$stepUrl'>$stepUrl</a> for more logs.</div>
+"@
+
+    Write-Host "Creating new DevOps issue..."
+    try {
+        $workItemId = Find-AzureDevOpsWorkItemWithTitle -Title $workItemTitle
+        if ($workItemId -gt 0) {
+            # there's already an existing work item open for this bot
+            Write-Host "There's already an existing issue for this bot, so just adding a comment to the existing issue $workItemId instead..."
+            $issueUrl = New-AzureDevOpsWorkItemComment -WorkItemId $workItemId -Comment $workItemMessage
+        } else {
+            $issueUrl = New-AzureDevOpsWorkItem -Title $workItemTitle -Message $workItemMessage
+        }
+        Write-Host "Completed, DevOps issue: $issueUrl"
+    } catch {
+        Write-Host "Failed to create work item: $_"
+    }
+
+    throw [System.InvalidOperationException]::new("$shortMessage")
 }
 
 # module exports, any other functions are private and should not be used outside the module
 Export-ModuleMember -Function Get-SystemInfo
 Export-ModuleMember -Function Clear-XamarinProcesses 
-Export-ModuleMember -Function Test-HDFreeSpace
+Export-ModuleMember -Function Get-HDFreeSpace
+Export-ModuleMember -Function Assert-HDFreeSpace
 Export-ModuleMember -Function Clear-AfterTests
 Export-ModuleMember -Function Remove-InstalledSimulators 

--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -886,7 +886,154 @@ function Edit-BuildConfiguration {
     return $buildConfiguration.Update($ConfigKey, $ConfigValue, $ConfigFile)
 }
 
+function Find-AzureDevOpsWorkItemWithTitle {
+    param
+    (
+        [Parameter(Mandatory)]
+        [string]
+        $Title,
 
+        [string]
+        $WorkItemType = 'Bug',
+
+        [string]
+        $AreaPath = 'DevDiv\VS Client - Runtime SDKs\iOS and Mac'
+    )
+
+    $headers = Get-AuthHeader -AccessToken $Env:ACCESSTOKEN
+
+    $url = "$Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$Env:SYSTEM_TEAMPROJECT/_apis/wit/wiql?api-version=7.1"
+    $payload = @{
+        "query" = "Select [System.Id] FROM WorkItems WHERE [System.State] = 'Active' AND [System.Title] = '$Title' AND [System.WorkItemType] = '$WorkItemType' AND [System.AreaPath] UNDER '$AreaPath'"
+    }
+    $body = ConvertTo-Json $payload -Depth 100
+
+    try {
+        Write-Host "Uri: $url"
+        Write-Host "Body:"
+        $body | Out-String | Write-Host
+
+        $response = Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -ContentType 'application/json' -Body $body
+
+        Write-Host "Response:"
+        $response | Out-String | Write-Host
+
+        $itemCount = $response.workItems.count
+        if ($itemCount -eq 0) {
+            Write-Host "No work items found with the given criteria"
+            return 0
+        }
+
+        $workItemId = $response.workItems[0].id
+        Write-Host "Found $itemCount work items with the given criteria, returning id: $workItemId"
+        return $workItemId
+    } catch {
+        Write-Host "Failed to find work item: $_"
+    }
+    return 0
+}
+
+function New-AzureDevOpsWorkItem {
+    param
+    (
+        [Parameter(Mandatory)]
+        [string]
+        $Message,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Title,
+
+        [string]
+        $WorkItemType = 'Bug',
+
+        [string]
+        $AreaPath = 'DevDiv\VS Client - Runtime SDKs\iOS and Mac'
+    )
+
+    $headers = Get-AuthHeader -AccessToken $Env:ACCESSTOKEN
+
+    $payload = @(
+        @{
+            "op" = "add"
+            "path" = "/fields/System.Title"
+            "from" = $null
+            "value" = $Title
+        }
+        @{
+            "op" = "add"
+            "path" = "/fields/System.AreaPath"
+            "from" = $null
+            "value" = $AreaPath
+        }
+        @{
+            "op" = "add"
+            "path" = "/fields/Microsoft.VSTS.TCM.ReproSteps"
+            "from" = $null
+            "value" = $Message
+        }
+    )
+
+    $body = ConvertTo-Json $payload -Depth 100
+
+    $url = "$Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$Env:SYSTEM_TEAMPROJECT/_apis/wit/workitems/`$$($WorkItemType)?api-version=7.1"
+    try {
+        Write-Host "Creating DevOps $WorkItemType with Title=$Title and AreaPath=$AreaPath"
+        Write-Host "Uri: $url"
+        Write-Host "Body:"
+        $body | Out-String | Write-Host
+        $response = Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -ContentType 'application/json-patch+json' -Body $body
+        Write-Host "Response = $response"
+        $workItemId = $response.id
+        $workItemUrl = "$Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$Env:SYSTEM_TEAMPROJECT/_workitems/edit/$workItemId"
+        Write-Host "Work Item Url: $workItemUrl"
+        return $workItemUrl
+    } catch {
+        Write-Host "Failed to create work item:"
+        $_ | Out-String | Write-Host
+        return ""
+    }
+}
+
+function New-AzureDevOpsWorkItemComment {
+    param
+    (
+        [Parameter(Mandatory)]
+        [int]
+        $WorkItemId,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Comment
+    )
+
+    $headers = Get-AuthHeader -AccessToken $Env:ACCESSTOKEN
+
+    $payload =
+        @{
+            "text" = $Comment
+        }
+
+    $body = ConvertTo-Json $payload -Depth 100
+
+    $url = "$Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$Env:SYSTEM_TEAMPROJECT/_apis/wit/workItems/$WorkItemId/comments?api-version=7.1-preview.4"
+    try {
+        Write-Host "Uri: $url"
+        Write-Host "Headers:"
+        $headers
+        Write-Host "Body:"
+        $body
+        $response = Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -ContentType 'application/json' -Body $body
+        Write-Host "Response:"
+        $response
+        $workItemUrl = "$Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$Env:SYSTEM_TEAMPROJECT/_workitems/edit/$workItemId"
+        return $workItemUrl
+    } catch {
+        Write-Host "Failed to add comment to work item:"
+        $_ | Out-String | Write-Host
+        return ""
+    }
+}
 # export public functions, other functions are private and should not be used ouside the module.
 Export-ModuleMember -Function Stop-Pipeline
 Export-ModuleMember -Function Set-PipelineResult
@@ -896,3 +1043,7 @@ Export-ModuleMember -Function New-BuildConfiguration
 Export-ModuleMember -Function Import-BuildConfiguration
 Export-ModuleMember -Function Edit-BuildConfiguration
 Export-ModuleMember -Function Get-YamlPreview
+Export-ModuleMember -Function New-AzureDevOpsWorkItem
+Export-ModuleMember -Function New-AzureDevOpsWorkItemComment
+Export-ModuleMember -Function Find-AzureDevOpsWorkItemWithTitle
+

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -101,7 +101,7 @@ steps:
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
 
-    if ( -not (Test-HDFreeSpace -Size 5)) {
+    if ( -not (Assert-HDFreeSpace -Size 5)) {
       Set-Content -Path "$GITHUB_FAILURE_COMMENT_FILE" -Value "Not enough free space in the host $Env:AGENT_MACHINENAME."
       exit 1
     }

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -100,11 +100,7 @@ steps:
 # 3. Cancel the pipeline and do not execute any of the following steps.
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\xamarin-macios\tools\devops\automation\scripts\MaciosCI.psd1
-
-    if ( -not (Assert-HDFreeSpace -Size 5)) {
-      Set-Content -Path "$GITHUB_FAILURE_COMMENT_FILE" -Value "Not enough free space in the host $Env:AGENT_MACHINENAME."
-      exit 1
-    }
+    Assert-HDFreeSpace -Size 5
   env:
     CONTEXT: ${{ parameters.statusContext }}
     GITHUB_TOKEN: $(GitHub.Token)

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -97,11 +97,7 @@ steps:
 # 2. Cancel the pipeline and do not execute any of the following steps.
 - pwsh: | 
     Import-Module ./MaciosCI.psd1
-
-    if ( -not (Test-HDFreeSpace -Size 20)) {
-      New-GitHubComment -Header "Tests failed catastrophically on $Env:CONTEXT" -Emoji ":fire:" -Description "Not enough free space in the host $Env:AGENT_MACHINENAME."
-      Stop-Pipeline
-    }
+    Assert-HDFreeSpace -Size 20
   env:
     CONTEXT: ${{ parameters.statusContext }}
     GITHUB_TOKEN: $(GitHub.Token)


### PR DESCRIPTION
File an AzDo issue if a bot runs out of space, but if there's already an open
issue for a bot, then just add a comment to the existing issue.

Example issue created locally: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2289908.