### PR TITLE
[msbuild] Add support for the 'overwrite' metadata for PartialAppManifest items.

### DIFF
--- a/docs/build-apps/build-items.md
+++ b/docs/build-apps/build-items.md
@@ -9,6 +9,42 @@ ms.date: 09/19/2024
 Build items control how .NET for iOS, Mac Catalyst, macOS, and tvOS
 application or library projects are built.
 
+## PartialAppManifest
+
+`PartialAppManifest` can be used to add additional partial app manifests that
+will be merged with the main app manifest (Info.plist).
+
+Any values in the partial app manifests will override values in the main app
+manifest unless the `Overwrite` metadata is set to `false`.
+
+If the same value is specified in multiple partial app manifests, it's
+undetermined which one will be the one used.
+
+```xml
+<ItemGroup>
+    <PartialAppManifest Include="my-partial-manifest.plist" Overwrite="false" />
+</ItemGroup>
+```
+
+If the developer needs to execute a target to compute what to add to the
+`PartialAppManifest` item group, it's possible to make sure this target is
+executed before the `PartialAppManifest` items are procesed by adding it to
+the `CollectAppManifestsDependsOn` property:
+
+```xml
+<PropertyGroup>
+    <CollectAppManifestsDependsOn>
+        AddPartialAppManifests;
+        $(CollectAppManifestsDependsOn);
+    </CollectAppManifestsDependsOn>
+</PropertyGroup>
+<Target Name="AddPartialAppManifests">
+    <ItemGroup>
+        <PartialAppManifest Include="MyPartialAppManifest.plist" />
+    </ItemGroup>
+</Target>
+```
+
 ## XcodeProject
 
 `<XcodeProject>` can be used to build and consume the outputs

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
@@ -393,15 +393,17 @@ namespace Xamarin.MacDev.Tasks {
 				dict [key] = value;
 		}
 
-		public static void MergePartialPlistDictionary (PDictionary plist, PDictionary partial)
+		public static void MergePartialPlistDictionary (PDictionary plist, PDictionary partial, bool overwrite)
 		{
 			foreach (var property in partial) {
 				var key = property.Key!;
 				if (plist.ContainsKey (key)) {
+					if (!overwrite)
+						continue;
 					var value = plist [key];
 
 					if (value is PDictionary && property.Value is PDictionary) {
-						MergePartialPlistDictionary ((PDictionary) value, (PDictionary) property.Value);
+						MergePartialPlistDictionary ((PDictionary) value, (PDictionary) property.Value, overwrite);
 					} else {
 						plist [key] = property.Value.Clone ();
 					}
@@ -418,6 +420,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			foreach (var template in partialLists) {
 				PDictionary partial;
+				var overwrite = !string.Equals (template.GetMetadata ("Overwrite"), "false", StringComparison.OrdinalIgnoreCase);
 
 				try {
 					partial = PDictionary.FromFile (template.ItemSpec)!;
@@ -426,7 +429,7 @@ namespace Xamarin.MacDev.Tasks {
 					continue;
 				}
 
-				MergePartialPlistDictionary (plist, partial);
+				MergePartialPlistDictionary (plist, partial, overwrite);
 			}
 		}
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -509,7 +509,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		      property to run targets that add to the `PartialAppManifest` item group before we process them.
 		    * Some MSBuild properties can also add values.
 
-		    The precedence is: MSBuild properties can be overridden by the Info.plist, which can be overridden by a partial plist.
+		    The precedence is: MSBuild properties can be overridden by the Info.plist, which can be overridden by a partial plist (a partial plist can also specify the "Overwrite=false" metadata to not overwrite any existing entries).
 
 		2. In the `CompileAppManifest` target we get all the inputs from above, and compute a temporary app manifest, which is written to a temporary output file.
 


### PR DESCRIPTION
This makes it possible to provide partial app manifests with default values,
which can then be overridden in the main Info.plist.