### PR TITLE
[devops] Clean up bots better from previous usage.

### DIFF
--- a/tools/devops/automation/scripts/bash/build-nugets.sh
+++ b/tools/devops/automation/scripts/bash/build-nugets.sh
@@ -10,8 +10,8 @@ cd "$XAM_TOP"
 
 DOTNET_NUPKG_DIR=$(make -C tools/devops print-abspath-variable VARIABLE=DOTNET_NUPKG_DIR | grep "^DOTNET_NUPKG_DIR=" | sed -e 's/^DOTNET_NUPKG_DIR=//')
 
+rm -rf ../package/
 mkdir -p ../package/
-rm -f ../package/*.nupkg
 cp -c "$DOTNET_NUPKG_DIR"/*.nupkg ../package/
 cp -c "$DOTNET_NUPKG_DIR"/vs-workload.props ../package/
 cp -c dotnet/Workloads/SignList.xml ../package/

--- a/tools/devops/automation/scripts/bash/clean-bot.sh
+++ b/tools/devops/automation/scripts/bash/clean-bot.sh
@@ -30,8 +30,10 @@ set +e
 	rm -rv "$SYSTEM_DEFAULTWORKINGDIRECTORY/packages" | sed 's/^/    /' || true
 
 	echo "Contents of SYSTEM_DEFAULTWORKINGDIRECTORY ($SYSTEM_DEFAULTWORKINGDIRECTORY):"
+	# shellcheck disable=SC2012
 	ls -la "$SYSTEM_DEFAULTWORKINGDIRECTORY" | sed 's/^/    /' || true
 	echo "Contents of BUILD_SOURCESDIRECTORY ($BUILD_SOURCESDIRECTORY):"
+	# shellcheck disable=SC2012
 	ls -la "$BUILD_SOURCESDIRECTORY" | sed 's/^/    /' || true
 )
 

--- a/tools/devops/automation/scripts/bash/clean-bot.sh
+++ b/tools/devops/automation/scripts/bash/clean-bot.sh
@@ -14,11 +14,25 @@ set +e
 
 # Clean workspace
 (
-	REPO_PATH="SYSTEM_DEFAULTWORKINGDIRECTORY/$(basename "$BUILD_REPOSITORY_NAME")"
-	if test -d "$REPO_PATH"; then
-		cd "$REPO_PATH"
-		git clean -xfd
-	fi
+	for repo in "$SYSTEM_DEFAULTWORKINGDIRECTORY"/.git "$SYSTEM_DEFAULTWORKINGDIRECTORY"/*/.git; do
+		if test -d "$repo"; then
+			cd "$repo"
+			cd ..
+			echo "Running 'git clean' (for all submodules too) in $(pwd)"
+			git clean -xffd | sed 's/^/    /' || true
+			git submodule foreach --recursive git clean -xffd | sed 's/^/    /' || true
+		else
+			echo "$repo is not a git repository"
+		fi
+	done
+
+	echo "Cleaning packages directory:"
+	rm -rv "$SYSTEM_DEFAULTWORKINGDIRECTORY/packages" | sed 's/^/    /' || true
+
+	echo "Contents of SYSTEM_DEFAULTWORKINGDIRECTORY ($SYSTEM_DEFAULTWORKINGDIRECTORY):"
+	ls -la "$SYSTEM_DEFAULTWORKINGDIRECTORY" | sed 's/^/    /' || true
+	echo "Contents of BUILD_SOURCESDIRECTORY ($BUILD_SOURCESDIRECTORY):"
+	ls -la "$BUILD_SOURCESDIRECTORY" | sed 's/^/    /' || true
 )
 
 # Delete all the simulator devices. These can take up a lot of space over time (I've seen 100+GB on the bots)


### PR DESCRIPTION
* Find all git repositories in the default working directory, for both
  multi-repo checkouts and single-repo checkouts, and clean them all.
* Completely remove the 'packages' directory before putting any other files in
  it.