### PR TITLE
[release/9.0.1xx] Update Xamarin.Messaging to 2.2.10.

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -11,7 +11,7 @@
 			enclosed in brackets.
 
 		-->
-		<MessagingVersion>[2.1.15]</MessagingVersion>
+		<MessagingVersion Condition="'$(MessagingVersion)' == ''">[2.2.10]</MessagingVersion>
 		<HotRestartVersion>[1.1.7]</HotRestartVersion>
 	</PropertyGroup>
 	<Import Project="$(MSBuildThisFileDirectory)../Directory.Build.props" />


### PR DESCRIPTION
Brings some important fixes on client and agent side to handle agent status notifications better

Diff: https://github.com/xamarin/Xamarin.Messaging/compare/a3a1e00e5a89ec27bc9e19ddc596e2e63e3ac017..6b35d9de966802709767d61306917642ff72f622

This is a backport of #21521.

Also backport #21457 to avoid future merge failures during Xamarin.Messaging bumps.