### PR TITLE
[RGen] Move common shared code to its own project.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -458,6 +458,7 @@ $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1)%dll $($(2)_DOTNET_BUILD_DIR)/$(4)/M
 	$$(call Q_PROF_CSC,dotnet/$(4)-bit) \
 		$(DOTNET_CSC)  \
 		$(DOTNET_FLAGS) \
+		/analyzer:$(ROSLYN_GENERATOR_COMMON) \
 		/analyzer:$(ROSLYN_GENERATOR) \
 		-unsafe \
 		-optimize \

--- a/src/Makefile.rgenerator
+++ b/src/Makefile.rgenerator
@@ -1,7 +1,10 @@
 # Roslyn code generator
 ROSLYN_GENERATOR=$(DOTNET_BUILD_DIR)/common/rgen/Microsoft.Macios.Generator.dll
+ROSLYN_GENERATOR_COMMON=$(DOTNET_BUILD_DIR)/common/rgen/Microsoft.Macios.Binding.Common.dll
 ROSLYN_GENERATOR_FILES := $(wildcard rgen/Microsoft.Macios.Generator/*.cs)
 ROSLYN_GENERATOR_FILES += $(wildcard rgen/Microsoft.Macios.Generator/*/*.cs)
+ROSLYN_GENERATOR_FILES += $(wildcard rgen/Microsoft.Macios.Binding.Common/*.cs)
+ROSLYN_GENERATOR_FILES += $(wildcard rgen/Microsoft.Macios.Binding.Common/*/*.cs)
 
 $(ROSLYN_GENERATOR): Makefile.rgenerator $(ROSLYN_GENERATOR_FILES)
 	$(Q_DOTNET_BUILD) $(DOTNET) publish rgen/Microsoft.Macios.Generator/Microsoft.Macios.Generator.csproj $(DOTNET_BUILD_VERBOSITY) /p:Configuration=Debug /p:IntermediateOutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/obj/common/rgen)/ /p:OutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/bin/common/rgen/)/

--- a/src/rgen/Microsoft.Macios.Binding.Common/Microsoft.Macios.Binding.Common.csproj
+++ b/src/rgen/Microsoft.Macios.Binding.Common/Microsoft.Macios.Binding.Common.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
+            <Link>external\ApplePlatform.cs</Link>
+        </Compile>
+        <Compile Include="..\..\..\tools\common\SdkVersions.cs">
+            <Link>external\SdkVersions.cs</Link>
+        </Compile>
+        <Compile Include="..\..\..\tools\common\TargetFramework.cs">
+            <Link>external\TargetFramework.cs</Link>
+        </Compile>
+        <Compile Include="../../../tools/common/Frameworks.cs" >
+            <Link>external\Frameworks.cs</Link>
+        </Compile>
+        <Compile Include="..\..\bgen\PlatformName.cs" >
+            <Link>external\PlatformName.cs</Link>
+        </Compile>
+    </ItemGroup>
+
+</Project>

--- a/src/rgen/Microsoft.Macios.Binding.Common/Microsoft.Macios.Binding.Common.csproj
+++ b/src/rgen/Microsoft.Macios.Binding.Common/Microsoft.Macios.Binding.Common.csproj
@@ -16,7 +16,7 @@
         <Compile Include="..\..\..\tools\common\TargetFramework.cs">
             <Link>external\TargetFramework.cs</Link>
         </Compile>
-        <Compile Include="../../../tools/common/Frameworks.cs" >
+        <Compile Include="..\..\..\tools\common\Frameworks.cs" >
             <Link>external\Frameworks.cs</Link>
         </Compile>
         <Compile Include="..\..\bgen\PlatformName.cs" >

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer.Sample/Microsoft.Macios.Bindings.Analyzer.Sample.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer.Sample/Microsoft.Macios.Bindings.Analyzer.Sample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Microsoft.Macios.Binding.Common\Microsoft.Macios.Binding.Common.csproj" OutputItemType="Analyzer"  />
         <ProjectReference Include="..\Microsoft.Macios.Generator\Microsoft.Macios.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
         <ProjectReference Include="..\Microsoft.Macios.Bindings.Analyzer\Microsoft.Macios.Bindings.Analyzer.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
     </ItemGroup>
@@ -18,9 +19,6 @@
         </Compile>
         <Compile Include="..\..\..\src\bgen\Attributes.cs" >
             <Link>external\Attributes.cs</Link>
-        </Compile>
-        <Compile Include="..\..\..\src\bgen\PlatformName.cs" >
-            <Link>external\PlatformName.cs</Link>
         </Compile>
     </ItemGroup>
 

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
@@ -48,4 +48,9 @@
         </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\Microsoft.Macios.Binding.Common\Microsoft.Macios.Binding.Common.csproj" PrivateAssets="all" />
+        <None Include="$(OutputPath)\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    </ItemGroup>
+
 </Project>

--- a/src/rgen/Microsoft.Macios.Generator.Sample/Microsoft.Macios.Generator.Sample.csproj
+++ b/src/rgen/Microsoft.Macios.Generator.Sample/Microsoft.Macios.Generator.Sample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
@@ -9,6 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Microsoft.Macios.Binding.Common\Microsoft.Macios.Binding.Common.csproj" OutputItemType="Analyzer" />
         <ProjectReference Include="..\Microsoft.Macios.Generator\Microsoft.Macios.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
     </ItemGroup>
 
@@ -18,9 +19,6 @@
         </Compile>
         <Compile Include="..\..\..\src\bgen\Attributes.cs" >
             <Link>external\Attributes.cs</Link>
-        </Compile>
-        <Compile Include="..\..\..\src\bgen\PlatformName.cs" >
-            <Link>external\PlatformName.cs</Link>
         </Compile>
     </ItemGroup>
 

--- a/src/rgen/Microsoft.Macios.Generator/Microsoft.Macios.Generator.csproj
+++ b/src/rgen/Microsoft.Macios.Generator/Microsoft.Macios.Generator.csproj
@@ -30,11 +30,7 @@
             <_Parameter1>Microsoft.Macios.Generator.Tests</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>
-
     <ItemGroup>
-        <Compile Include="..\..\bgen\PlatformName.cs" >
-            <Link>external\PlatformName.cs</Link>
-        </Compile>
         <Compile Include="..\..\bgen\Extensions\PlatformNameExtensions.cs" >
             <Link>external\PlatformNameExtensions.cs</Link>
         </Compile>
@@ -52,5 +48,9 @@
       </EmbeddedResource>
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\Microsoft.Macios.Binding.Common\Microsoft.Macios.Binding.Common.csproj" PrivateAssets="all" />
+        <None Include="$(OutputPath)\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    </ItemGroup>
 
 </Project>

--- a/src/rgen/rgen.sln
+++ b/src/rgen/rgen.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Macios.Generator", "Microsoft.Macios.Generator\Microsoft.Macios.Generator.csproj", "{8E9CF45D-E836-447E-9290-03A9CACE2704}"
 EndProject
@@ -11,6 +11,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Macios.Generator.Tests", "..\..\tests\rgen\Microsoft.Macios.Generator.Tests\Microsoft.Macios.Generator.Tests.csproj", "{CD222ACD-A54F-49D9-81CA-6D795CC31195}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Macios.Bindings.Analyzer.Tests", "..\..\tests\rgen\Microsoft.Macios.Bindings.Analyzer.Tests\Microsoft.Macios.Bindings.Analyzer.Tests.csproj", "{1AC4A248-CC98-4392-8690-4E2CAF6E194B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Macios.Binding.Common", "Microsoft.Macios.Binding.Common\Microsoft.Macios.Binding.Common.csproj", "{536758BC-2A88-4B79-ABB1-6B39494A5FE6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -42,5 +44,9 @@ Global
 		{1AC4A248-CC98-4392-8690-4E2CAF6E194B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1AC4A248-CC98-4392-8690-4E2CAF6E194B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1AC4A248-CC98-4392-8690-4E2CAF6E194B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{536758BC-2A88-4B79-ABB1-6B39494A5FE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{536758BC-2A88-4B79-ABB1-6B39494A5FE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{536758BC-2A88-4B79-ABB1-6B39494A5FE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{536758BC-2A88-4B79-ABB1-6B39494A5FE6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Microsoft.Macios.Generator.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Microsoft.Macios.Generator.Tests.csproj
@@ -22,6 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\..\src\rgen\Microsoft.Macios.Binding.Common\Microsoft.Macios.Binding.Common.csproj" />
       <ProjectReference Include="..\..\..\src\rgen\Microsoft.Macios.Generator\Microsoft.Macios.Generator.csproj" />
     </ItemGroup>
     
@@ -38,20 +39,11 @@
         <Compile Include="..\..\common\ExecutionHelper.cs">
             <Link>external\ExecutionHelper.cs</Link>
         </Compile>
-        <Compile Include="..\..\..\tools\common\ApplePlatform.cs">
-            <Link>external\ApplePlatform.cs</Link>
-        </Compile>
-        <Compile Include="..\..\..\tools\common\TargetFramework.cs">
-            <Link>external\TargetFramework.cs</Link>
-        </Compile>
         <Compile Include="..\..\..\tools\common\StringUtils.cs">
             <Link>external\StringUtils.cs</Link>
         </Compile>
         <Compile Include="..\..\..\tools\common\Execution.cs">
             <Link>external\Execution.cs</Link>
-        </Compile>
-        <Compile Include="..\..\..\tools\common\SdkVersions.cs">
-            <Link>external\SdkVersions.cs</Link>
         </Compile>
         <Compile Include="..\..\mtouch\Cache.cs">
             <Link>external\Cache.cs</Link>


### PR DESCRIPTION
This simplifies the usage of those external file, specially for test projects.