### PR TITLE
[devops] Don't fetch tags when undoing the GitHub merge.

### DIFF
--- a/tools/devops/automation/scripts/undo_github_merge.ps1
+++ b/tools/devops/automation/scripts/undo_github_merge.ps1
@@ -15,7 +15,7 @@ if($IsPr.ToLower() -eq "true") {
 
     Write-Host "Refspec: $refspec"
 
-    git fetch origin "$refspec"
+    git fetch origin --no-tags "$refspec"
 
     $branch="$SourceBranch".Replace("merge", "head")
     $branch=$branch.Replace("refs", "origin")


### PR DESCRIPTION
We don't need the tags, so don't spend time fetching them.