### PR TITLE
[devops] Improve Windows tests a little bit.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -1007,6 +1007,10 @@ namespace Xamarin.Tests {
 			}
 		}
 
+		public static bool IsBuildingRemotely {
+			get => !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("MAC_AGENT_IP"));
+		}
+
 		public static string GetTestLibraryDirectory (ApplePlatform platform, bool? simulator = null)
 		{
 			string dir;

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -36,7 +36,20 @@ namespace Xamarin.Tests {
 				foreach (var kvp in extraProperties)
 					rv [kvp.Key] = kvp.Value;
 			}
+
+			if (Configuration.IsBuildingRemotely)
+				AddRemoteProperties (rv);
+
 			return rv;
+		}
+
+		protected static void AddRemoteProperties (Dictionary<string, string> properties)
+		{
+			properties ["ServerAddress"] = Environment.GetEnvironmentVariable ("MAC_AGENT_IP") ?? string.Empty;
+			properties ["ServerUser"] = Environment.GetEnvironmentVariable ("MAC_AGENT_USER") ?? string.Empty;
+			properties ["ServerPassword"] = Environment.GetEnvironmentVariable ("XMA_PASSWORD") ?? string.Empty;
+			if (!string.IsNullOrEmpty (properties ["ServerUser"]))
+				properties ["EnsureRemoteConnection"] = "true";
 		}
 
 		protected static void SetRuntimeIdentifiers (Dictionary<string, string> properties, string runtimeIdentifiers)

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Tests {
 					rv [kvp.Key] = kvp.Value;
 			}
 
-			if (Configuration.IsBuildingRemotely)
+			if (Configuration.IsBuildingRemotely && !rv.ContainsKey ("IsHotRestartBuild"))
 				AddRemoteProperties (rv);
 
 			return rv;

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -182,7 +182,6 @@ namespace Xamarin.Tests {
 			properties ["_IsAppSigned"] = signature != BundleStructureTest.CodeSignature.None ? "true" : "false";
 			if (!string.IsNullOrWhiteSpace (configuration))
 				properties ["Configuration"] = configuration;
-			AddRemoteProperties (properties);
 
 			// Copy the app bundle to Windows so that we can inspect the results.
 			properties ["CopyAppBundleToWindows"] = "true";
@@ -336,7 +335,6 @@ namespace Xamarin.Tests {
 			Clean (project_path);
 
 			var properties = GetDefaultProperties (runtimeIdentifiers);
-			AddRemoteProperties (properties);
 
 			// Copy the app bundle to Windows so that we can inspect the results.
 			properties ["CopyAppBundleToWindows"] = "true";
@@ -366,16 +364,6 @@ namespace Xamarin.Tests {
 			Assert.AreEqual ("MySimpleApp", infoPlist.GetString ("CFBundleDisplayName").Value, "CFBundleDisplayName");
 			Assert.AreEqual ("3.14", infoPlist.GetString ("CFBundleVersion").Value, "CFBundleVersion");
 			Assert.AreEqual ("3.14", infoPlist.GetString ("CFBundleShortVersionString").Value, "CFBundleShortVersionString");
-		}
-
-		protected void AddRemoteProperties (Dictionary<string, string> properties)
-		{
-			properties ["ServerAddress"] = Environment.GetEnvironmentVariable ("MAC_AGENT_IP") ?? string.Empty;
-			properties ["ServerUser"] = Environment.GetEnvironmentVariable ("MAC_AGENT_USER") ?? string.Empty;
-			properties ["ServerPassword"] = Environment.GetEnvironmentVariable ("XMA_PASSWORD") ?? string.Empty;
-
-			if (!string.IsNullOrEmpty (properties ["ServerUser"]))
-				properties ["EnsureRemoteConnection"] = "true";
 		}
 
 		protected Dictionary<string, string> AddHotRestartProperties (Dictionary<string, string>? properties = null)

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -24,10 +24,9 @@ namespace Xamarin.Tests {
 			var project_dir = Path.GetDirectoryName (Path.GetDirectoryName (project_path))!;
 			Clean (project_path);
 
-			var properties = GetDefaultProperties (runtimeIdentifiers);
+			var properties = GetDefaultProperties (runtimeIdentifiers, extraProperties: GetHotRestartProperties ());
 			if (!string.IsNullOrWhiteSpace (configuration))
 				properties ["Configuration"] = configuration;
-			AddHotRestartProperties (properties);
 
 			// Redirect hot restart output to a place we can control from here
 			var hotRestartOutputDir = Path.Combine (tmpdir, "out");
@@ -283,7 +282,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		public void PluralRuntimeIdentifiersWithHotRestart (ApplePlatform platform, string runtimeIdentifiers)
 		{
-			var properties = AddHotRestartProperties ();
+			var properties = GetHotRestartProperties ();
 			DotNetProjectTest.PluralRuntimeIdentifiersImpl (platform, runtimeIdentifiers, properties, isUsingHotRestart: true);
 		}
 
@@ -366,9 +365,9 @@ namespace Xamarin.Tests {
 			Assert.AreEqual ("3.14", infoPlist.GetString ("CFBundleShortVersionString").Value, "CFBundleShortVersionString");
 		}
 
-		protected Dictionary<string, string> AddHotRestartProperties (Dictionary<string, string>? properties = null)
+		protected Dictionary<string, string> GetHotRestartProperties ()
 		{
-			properties ??= new Dictionary<string, string> ();
+			var properties = new Dictionary<string, string> ();
 			properties ["IsHotRestartBuild"] = "true";
 			properties ["IsHotRestartEnvironmentReady"] = "true";
 			properties ["EnableCodeSigning"] = "false"; // Skip code signing, since that would require making sure we have code signing configured on bots.

--- a/tests/dotnet/Windows/.gitignore
+++ b/tests/dotnet/Windows/.gitignore
@@ -1,0 +1,1 @@
+config.runsettings

--- a/tools/devops/automation/scripts/run-local-windows-tests.ps1
+++ b/tools/devops/automation/scripts/run-local-windows-tests.ps1
@@ -1,0 +1,20 @@
+if ("$Env:DOTNET" -eq "") {
+    $Env:DOTNET = "$Env:BUILD_SOURCESDIRECTORY\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe"
+    $Env:PATH = "$Env:BUILD_SOURCESDIRECTORY\xamarin-macios\tests\dotnet\Windows\bin\dotnet;$Env:PATH"
+}
+
+$Env:ServerAddress = ""
+$Env:ServerUser = ""
+$Env:ServerPassword = ""
+
+& $Env:DOTNET `
+    test `
+    "$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/tests/dotnet/UnitTests/DotNetUnitTests.csproj" `
+    --filter Category=Windows `
+    --verbosity quiet `
+    --settings $Env:BUILD_SOURCESDIRECTORY/xamarin-macios/tests/dotnet/Windows/config.runsettings `
+    "--results-directory:$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows-remote-tests/" `
+    "--logger:console;verbosity=detailed" `
+    "--logger:trx;LogFileName=$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows-local-dotnet-tests.trx" `
+    "--logger:html;LogFileName=$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/jenkins-results/windows-local-dotnet-tests.html" `
+    "-bl:$Env:BUILD_SOURCESDIRECTORY/xamarin-macios/tests/dotnet/Windows/windows-local-dotnet-tests.binlog"

--- a/tools/devops/automation/scripts/run-remote-windows-tests.ps1
+++ b/tools/devops/automation/scripts/run-remote-windows-tests.ps1
@@ -1,4 +1,7 @@
-$Env:DOTNET = "$Env:BUILD_SOURCESDIRECTORY\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe"
+if ("$Env:DOTNET" -eq "") {
+    $Env:DOTNET = "$Env:BUILD_SOURCESDIRECTORY\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe"
+}
+
 $Env:ServerAddress = $Env:MAC_AGENT_IP
 $Env:ServerUser = $Env:MAC_AGENT_USER
 $Env:ServerPassword = $Env:XMA_PASSWORD

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -228,32 +228,28 @@ steps:
     Get-Content -Path $(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/config.runsettings | Write-Host
   displayName: 'Create runsettings for .NET tests'
 
-- pwsh: |
-    $Env:PATH = "$(Build.SourcesDirectory)\xamarin-macios\tests\dotnet\Windows\bin\dotnet;$env:PATH"
-    $Env:DOTNET = "$(Build.SourcesDirectory)\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe"
-    & $(Build.SourcesDirectory)\xamarin-macios\tests\dotnet\Windows\bin\dotnet\dotnet.exe `
-        test `
-        "$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/UnitTests/DotNetUnitTests.csproj" `
-        --filter Category=Windows `
-        --verbosity quiet `
-        --settings $(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/config.runsettings `
-        "--results-directory:$(Build.SourcesDirectory)/xamarin-macios/jenkins-results/" `
-        "--logger:console;verbosity=detailed" `
-        "--logger:trx;LogFileName=$(Build.SourcesDirectory)/xamarin-macios/jenkins-results/windows-dotnet-tests.trx" `
-        "--logger:html;LogFileName=$(Build.SourcesDirectory)/xamarin-macios/jenkins-results/windows-dotnet-tests.html" `
-        "-bl:$(Build.SourcesDirectory)/xamarin-macios/tests/dotnet/Windows/run-dotnet-tests.binlog"
-  displayName: 'Run .NET tests'
+- pwsh: $(Build.SourcesDirectory)\xamarin-macios\tools\devops\automation\scripts\run-local-windows-tests.ps1
+  displayName: 'Run .NET tests locally'
   timeoutInMinutes: 30
+  continueOnError: true
   ${{ if not(parameters.isPR) }}:
     retryCountOnTaskFailure: ${{ parameters.retryCount }}
 
 - pwsh: $(Build.SourcesDirectory)\xamarin-macios\tools\devops\automation\scripts\run-remote-windows-tests.ps1
   displayName: 'Run .NET tests remotely'
   timeoutInMinutes: 120
+  continueOnError: true
   ${{ if not(parameters.isPR) }}:
     retryCountOnTaskFailure: ${{ parameters.retryCount }}
   env:
     XMA_PASSWORD: $(XMA.Password)
+
+- pwsh: |
+    Write-Host "There are test failures, so failing the build"
+    exit 1
+  displayName: 'Fail if test failures'
+  timeoutInMinutes: 1
+  condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
 
 - pwsh: $(Build.SourcesDirectory)\xamarin-macios\tools\devops\automation\scripts\fetch-remote-binlogs.ps1
   displayName: 'Fetch remote binlogs'


### PR DESCRIPTION
* Run both sets of Windows tests (local and remote), and fail afterwards if there
  are test failures. This way we get both test suites executed even if the first
  one fails.
* Create a script for executing the local tests (makes it easier to run locally
  as well).
* Make it possible to use a custom built .NET locally by honoring any DOTNET variable
  instead of blindly setting it (makes it easier to test locally).
* Add a .gitignore for the test configuration file we create to run tests on Windows.
* Some minor code simplifications.