### PR TITLE
[UIKit] Fix a GC race in UIBarButtonItem.

### DIFF
--- a/src/UIKit/UIBarButtonItem.cs
+++ b/src/UIKit/UIBarButtonItem.cs
@@ -7,18 +7,20 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace UIKit {
 
-	public partial class UIBarButtonItem {
-		const string actionSelector = "xamarinInvokeCallback:";
-
-		[DynamicDependencyAttribute ("Call(Foundation.NSObject)")]
-		static Selector actionSel = new Selector (actionSelector);
-
-		[Export (actionSelector)]
-		void Call (NSObject sender)
+	[Category (typeof (UIBarButtonItem))]
+	static class UIBarButtonItem_Extensions {
+		[Export (UIBarButtonItem.actionSelector)]
+		static void Call (this UIBarButtonItem item, NSObject sender)
 		{
-			if (clicked is not null)
-				clicked (sender, EventArgs.Empty);
+			item.OnClicked (sender);
 		}
+	}
+
+	public partial class UIBarButtonItem {
+		internal const string actionSelector = "xamarinInvokeCallback:";
+
+		[DynamicDependencyAttribute ("Call(UIKit.UIBarButtonItem,Foundation.NSObject)", typeof (UIBarButtonItem_Extensions))]
+		static Selector actionSel = new Selector (actionSelector);
 
 		public UIBarButtonItem (UIImage image, UIBarButtonItemStyle style, EventHandler handler)
 		: this (image, style, null, actionSel)
@@ -48,8 +50,14 @@ namespace UIKit {
 		{
 		}
 
-		[DynamicDependencyAttribute ("Call(Foundation.NSObject)")]
+		[DynamicDependencyAttribute ("Call(UIKit.UIBarButtonItem,Foundation.NSObject)", typeof (UIBarButtonItem_Extensions))]
 		EventHandler? clicked;
+
+		internal void OnClicked (NSObject sender)
+		{
+			if (clicked is not null)
+				clicked (sender, EventArgs.Empty);
+		}
 
 		public event EventHandler Clicked {
 			add {

--- a/src/UIKit/UIBarButtonItem.cs
+++ b/src/UIKit/UIBarButtonItem.cs
@@ -14,51 +14,39 @@ using System;
 namespace UIKit {
 
 	public partial class UIBarButtonItem {
-		static Selector actionSel = new Selector ("InvokeAction:");
+		const string actionSelector = "InvokeAction:";
+		static Selector actionSel = new Selector (actionSelector);
 
-		[Register]
-		internal class Callback : NSObject {
-			internal UIBarButtonItem container;
-
-			public Callback ()
-			{
-				IsDirectBinding = false;
-			}
-
-			[Export ("InvokeAction:")]
-			[Preserve (Conditional = true)]
-			public void Call (NSObject sender)
-			{
-				if (container.clicked is not null)
-					container.clicked (sender, EventArgs.Empty);
-			}
+		[Export ("InvokeAction:")]
+		[Preserve (Conditional = true)]
+		void Call (NSObject sender)
+		{
+			if (clicked is not null)
+				clicked (sender, EventArgs.Empty);
 		}
 
 		public UIBarButtonItem (UIImage image, UIBarButtonItemStyle style, EventHandler handler)
-		: this (image, style, new Callback (), actionSel)
+		: this (image, style, null, actionSel)
 		{
-			callback = (Callback) Target;
-			callback.container = this;
+			Target = this;
 			clicked += handler;
 			MarkDirty ();
 		}
 
 
 		public UIBarButtonItem (string title, UIBarButtonItemStyle style, EventHandler handler)
-		: this (title, style, new Callback (), actionSel)
+		: this (title, style, null, actionSel)
 		{
-			callback = (Callback) Target;
-			callback.container = this;
+			Target = this;
 			clicked += handler;
 			MarkDirty ();
 		}
 
 
 		public UIBarButtonItem (UIBarButtonSystemItem systemItem, EventHandler handler)
-		: this (systemItem, new Callback (), actionSel)
+		: this (systemItem, null, actionSel)
 		{
-			callback = (Callback) Target;
-			callback.container = this;
+			Target = this;
 			clicked += handler;
 			MarkDirty ();
 		}
@@ -67,15 +55,12 @@ namespace UIKit {
 		{
 		}
 
-		internal EventHandler clicked;
-		internal Callback callback;
+		EventHandler clicked;
 
 		public event EventHandler Clicked {
 			add {
 				if (clicked is null) {
-					callback = new Callback ();
-					callback.container = this;
-					this.Target = callback;
+					Target = this;
 					this.Action = actionSel;
 					MarkDirty ();
 				}

--- a/src/UIKit/UIBarButtonItem.cs
+++ b/src/UIKit/UIBarButtonItem.cs
@@ -1,24 +1,19 @@
-//
-// Sanitize callbacks
-//
-
-#if !WATCH
-
 using Foundation;
 using ObjCRuntime;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 
 	public partial class UIBarButtonItem {
-		const string actionSelector = "InvokeAction:";
+		const string actionSelector = "xamarinInvokeCallback:";
+
+		[DynamicDependencyAttribute ("Call(Foundation.NSObject)")]
 		static Selector actionSel = new Selector (actionSelector);
 
-		[Export ("InvokeAction:")]
-		[Preserve (Conditional = true)]
+		[Export (actionSelector)]
 		void Call (NSObject sender)
 		{
 			if (clicked is not null)
@@ -33,7 +28,6 @@ namespace UIKit {
 			MarkDirty ();
 		}
 
-
 		public UIBarButtonItem (string title, UIBarButtonItemStyle style, EventHandler handler)
 		: this (title, style, null, actionSel)
 		{
@@ -41,7 +35,6 @@ namespace UIKit {
 			clicked += handler;
 			MarkDirty ();
 		}
-
 
 		public UIBarButtonItem (UIBarButtonSystemItem systemItem, EventHandler handler)
 		: this (systemItem, null, actionSel)
@@ -55,7 +48,8 @@ namespace UIKit {
 		{
 		}
 
-		EventHandler clicked;
+		[DynamicDependencyAttribute ("Call(Foundation.NSObject)")]
+		EventHandler? clicked;
 
 		public event EventHandler Clicked {
 			add {
@@ -74,5 +68,3 @@ namespace UIKit {
 		}
 	}
 }
-
-#endif // !WATCH

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -1063,13 +1063,6 @@ namespace Introspection {
 				}
 				break;
 #endif // __MACCATALYST__
-			case "UIBarButtonItem":
-				switch (selectorName) {
-				case "xamarinInvokeCallback:":
-					// This is an selector we use for our own purposes
-					return true;
-				}
-				break;
 			}
 
 			// old binding mistake

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -1063,6 +1063,13 @@ namespace Introspection {
 				}
 				break;
 #endif // __MACCATALYST__
+			case "UIBarButtonItem":
+				switch (selectorName) {
+				case "xamarinInvokeCallback:":
+					// This is an selector we use for our own purposes
+					return true;
+				}
+				break;
 			}
 
 			// old binding mistake


### PR DESCRIPTION
Rewrite how we handle events/callbacks for UIBarButtonItem: there's no need
for a special class to receive the click events, we can use the same
UIBarButtonItem instance.

This simplifies the code a lot, and should also fix this random exception:

     Failed to marshal the Objective-C object 0x2800fcc00 (type: UIKit_UIBarButtonItem_Callback). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'UIKit.UIBarButtonItem+Callback' does not have a constructor that takes one NativeHandle argument).
      at ObjCRuntime.Runtime.MissingCtor(IntPtr, IntPtr, Type, Runtime.MissingCtorResolution, IntPtr, RuntimeMethodHandle) + 0x1dc
      at ObjCRuntime.Runtime.ConstructNSObject[T](IntPtr, Type, Runtime.MissingCtorResolution, IntPtr, RuntimeMethodHandle) + 0xfc
      at ObjCRuntime.Runtime.ConstructNSObject(IntPtr, IntPtr, Runtime.MissingCtorResolution) + 0x74
      at UIKit.UIBarButtonItem.get_Target() + 0x64
      at UIKit.UIBarButtonItem..ctor(UIBarButtonSystemItem, NSObject, Selector) + 0x94
      at UIKit.UIBarButtonItem..ctor(UIBarButtonSystemItem, EventHandler) + 0x90

This happens because we did something equivalent to this:

	public UIBarButtonItem (UIBarButtonSystemItem systemItem, EventHandler handler)
		: base (systemItem, new Callback (), actionSel)
	{
		instanceField = (Callback) Target;
	}

The problem is that the Target property on the native UIBarButtonItem (which is set from the second argument to the base constructor, the "new Callback ()" code) is defined with ArgumentSemantic.Assign, so it won't be retained. This means that if the GC runs between the creation of the native UIBarButtonItem, and fetching the Target property to assign it to the instance field later on in the managed constructor, the GC is free to collect the managed Callback instance, and then, when the code tries to fetch the Target property, the exception occurs because the managed instance has already been collected.

This was reported on Discord (thanks @tipa!): https://discord.com/channels/732297728826277939/732297808148824115/1301578382248509552

Also a few other fixes:

* Enable nullability.
* Use `[DynamicDependencyAttribute]` instead of `[Preserve]`.
* Remove watchOS logic.