### PR TITLE
[tests] Improve PasteboardTest.ImagesTest to hopefully work better.

### DIFF
--- a/tests/monotouch-test/UIKit/PasteboardTest.cs
+++ b/tests/monotouch-test/UIKit/PasteboardTest.cs
@@ -19,6 +19,7 @@ namespace MonoTouchFixtures.UIKit {
 	public class PasteboardTest {
 
 		[Test]
+		[Retry (10)]
 		public void ImagesTest ()
 		{
 			string file = Path.Combine (NSBundle.MainBundle.ResourcePath, "basn3p08.png");
@@ -28,10 +29,6 @@ namespace MonoTouchFixtures.UIKit {
 						UIPasteboard.General.Images = new UIImage [] { img };
 						if (TestRuntime.CheckXcodeVersion (8, 0))
 							Assert.True (UIPasteboard.General.HasImages, "HasImages");
-
-						// https://github.com/xamarin/xamarin-macios/issues/6254
-						if (TestRuntime.CheckXcodeVersion (11, 0))
-							return;
 
 						Assert.AreEqual (1, UIPasteboard.General.Images.Length, "a - length");
 


### PR DESCRIPTION
Retry the test 10 times if it fails - it uses a shared resource (the
pasteboard), so it's possible to run into race conditions if the same test
also runs in a different process at the same time.

Also remove code that we removed a long time ago, so that the test actually
runs: https://github.com/xamarin/xamarin-macios/commit/86ab2bc1d1b6f57f38693ee2990ac61debe722d0