### PR TITLE
[net10.0] [UIKit] Fix a GC race in UIBarButtonItem.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -680,6 +680,7 @@
 			<!-- Configure linker features -->
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.AggressiveAttributeTrimming" Value="true" Trim="true" Condition="'$(MobileAggressiveAttributeTrimming)' == 'true'" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.AggressiveAttributeTrimmingMono" Value="true" Trim="true" Condition="'$(MobileAggressiveAttributeTrimming)' == 'true' And '$(_XamarinRuntime)' == 'MonoVM'" />
+			<RuntimeHostConfigurationOption Include="ObjCRUntime.AggressiveAttributeTrimmingOnlyWithStaticRegistrar" value="true" Trim="true" Condition="'$(MobileAggressiveAttributeTrimming)' == 'true' And $(Registrar.Contains('static'))" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.Arch.IsSimulator" Value="$(_IsSimulatorFeature)" Trim="true" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.IsManagedStaticRegistrar" Value="$(_IsManagedStaticRegistrarFeature)" Trim="true" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.IsNativeAOT" Value="$(_IsNativeAOTFeature)" Trim="true" />

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -680,7 +680,7 @@
 			<!-- Configure linker features -->
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.AggressiveAttributeTrimming" Value="true" Trim="true" Condition="'$(MobileAggressiveAttributeTrimming)' == 'true'" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.AggressiveAttributeTrimmingMono" Value="true" Trim="true" Condition="'$(MobileAggressiveAttributeTrimming)' == 'true' And '$(_XamarinRuntime)' == 'MonoVM'" />
-			<RuntimeHostConfigurationOption Include="ObjCRUntime.AggressiveAttributeTrimmingOnlyWithStaticRegistrar" value="true" Trim="true" Condition="'$(MobileAggressiveAttributeTrimming)' == 'true' And $(Registrar.Contains('static'))" />
+			<RuntimeHostConfigurationOption Include="ObjCRUntime.AggressiveAttributeTrimmingOnlyWithStaticRegistrar" value="true" Trim="true" Condition="'$(MobileAggressiveAttributeTrimming)' == 'true' And ('$(Registrar)' == 'static' Or '$(Registrar)' == 'managed-static')" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.Arch.IsSimulator" Value="$(_IsSimulatorFeature)" Trim="true" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.IsManagedStaticRegistrar" Value="$(_IsManagedStaticRegistrarFeature)" Trim="true" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.IsNativeAOT" Value="$(_IsNativeAOTFeature)" Trim="true" />

--- a/src/TrimAttributes.LinkDescription.xml
+++ b/src/TrimAttributes.LinkDescription.xml
@@ -29,6 +29,11 @@
     </type>
   </assembly>
 
+  <assembly fullname="System.Private.CoreLib" feature="ObjCRuntime.AggressiveAttributeTrimmingOnlyWithStaticRegistrar" featurevalue="true">
+    <type fullname="System.Runtime.CompilerServices.ExtensionAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+  </assembly>
   <!-- https://github.com/dotnet/runtime/blob/d22c74dc974a757b48380a01dd0450efba31db64/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml#L93-L350 -->
   <assembly fullname="System.Private.CoreLib" feature="ObjCRuntime.AggressiveAttributeTrimming" featurevalue="true">
     <!-- System -->
@@ -112,9 +117,6 @@
       <attribute internal="RemoveAttributeInstances" />
     </type>
     <type fullname="System.Runtime.CompilerServices.EnumeratorCancellationAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Runtime.CompilerServices.ExtensionAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
     <type fullname="System.Runtime.CompilerServices.SkipLocalsInitAttribute">


### PR DESCRIPTION
Rewrite how we handle events/callbacks for UIBarButtonItem: there's no need for a special class to receive the click events, we can use the same UIBarButtonItem instance through a category.

This simplifies the code a lot, and should also fix this random exception:

     Failed to marshal the Objective-C object 0x2800fcc00 (type: UIKit_UIBarButtonItem_Callback). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'UIKit.UIBarButtonItem+Callback' does not have a constructor that takes one NativeHandle argument).
      at ObjCRuntime.Runtime.MissingCtor(IntPtr, IntPtr, Type, Runtime.MissingCtorResolution, IntPtr, RuntimeMethodHandle) + 0x1dc
      at ObjCRuntime.Runtime.ConstructNSObject[T](IntPtr, Type, Runtime.MissingCtorResolution, IntPtr, RuntimeMethodHandle) + 0xfc
      at ObjCRuntime.Runtime.ConstructNSObject(IntPtr, IntPtr, Runtime.MissingCtorResolution) + 0x74
      at UIKit.UIBarButtonItem.get_Target() + 0x64
      at UIKit.UIBarButtonItem..ctor(UIBarButtonSystemItem, NSObject, Selector) + 0x94
      at UIKit.UIBarButtonItem..ctor(UIBarButtonSystemItem, EventHandler) + 0x90

This happens because we did something equivalent to this:

     public UIBarButtonItem (UIBarButtonSystemItem systemItem, EventHandler handler)
          : base (systemItem, new Callback (), actionSel)
     {
          instanceField = (Callback) Target;
     }

The problem is that the Target property on the native UIBarButtonItem (which is set from the second argument to the base constructor, the "new Callback ()" code) is defined with ArgumentSemantic.Assign, so it won't be retained. This means that if the GC runs between the creation of the native UIBarButtonItem, and fetching the Target property to assign it to the instance field later on in the managed constructor, the GC is free to collect the managed Callback instance, and then, when the code tries to fetch the Target property, the exception occurs because the managed instance has already been collected.

This was reported on Discord (thanks @tipa!): https://discord.com/channels/732297728826277939/732297808148824115/1301578382248509552

Also a few other fixes:

* Enable nullability.
* Use `[DynamicDependencyAttribute]` instead of `[Preserve]`.
* Remove watchOS logic.
* Don't trim away the `[Extension]` attribute unless we're using a static registrar, because the dynamic registrar needs it.