### PR TITLE
[dotnet] Fix generating the list of supported target platform versions.

### DIFF
--- a/scripts/generate-target-platforms/generate-target-platforms.cs
+++ b/scripts/generate-target-platforms/generate-target-platforms.cs
@@ -12,7 +12,7 @@ if (args.Length != expectedArgumentCount) {
 var idx = 0;
 var platform = args [idx++];
 var dotnetTfm = args [idx++];
-var supportedApiVersions = args [idx++].Split (' ').Select (v => v.Replace (dotnetTfm + "-", "")).ToArray ();
+var supportedApiVersions = args [idx++].Split (' ').Select (v => v.Split ('-') [1]).Distinct ().ToHashSet ();
 var outputPath = args [idx++];
 var plistPath = $"../builds/Versions-{platform}.plist.in";
 
@@ -24,8 +24,6 @@ var currentSupportedTPVs = supportedTargetPlatformVersions.Where (v => v.StartsW
 var minSdkVersionName = $"DOTNET_MIN_{platform.ToUpper ()}_SDK_VERSION";
 var minSdkVersionString = File.ReadAllLines ("../Make.config").Single (v => v.StartsWith (minSdkVersionName + "=", StringComparison.Ordinal)).Substring (minSdkVersionName.Length + 1);
 var minSdkVersion = Version.Parse (minSdkVersionString);
-
-Console.WriteLine (string.Join (";", supportedApiVersions));
 
 using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"<!-- This file contains a generated list of the {platform} platform versions that are supported for this SDK -->");


### PR DESCRIPTION
Fix how we compute the target platforms we support:

1. Start with the list of target frameworks we support ("net8.0-ios17.0 net8.0-ios18.0 net9.0-ios19.0")
2. Split on the space.
3. Remove the "netX.Y-" part.
4. Remove duplicates.

Now we're left with the list if target platform versions we support.

The bug was in step 3: we only removed netX.Y where X.Y was the current .NET version (currently 9.0), and not previous .NET versions.

This meant that for the sample input from above, we'd be left with this incorrect list:

* net8.0-ios17.0
* net8.0-ios18.0
* ios18.0