### PR TITLE
[AppKit/MediaExtension/introspection] Fix issues found with introspection on Sequoia.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -28757,7 +28757,15 @@ namespace AppKit {
 		string AlertRecoverySuggestionButtonTitle { get; }
 
 		[Export ("alertRecoverySuggestionButtonLaunchURL", ArgumentSemantic.Copy), NullAllowed]
-		NSUrl AlertRecoverySuggestionButtonLaunchUrl { get; set; }
+#if XAMCORE_5_0
+		NSUrl AlertRecoverySuggestionButtonLaunchUrl { get; }
+#else
+		NSUrl AlertRecoverySuggestionButtonLaunchUrl {
+			get;
+			[Obsolete ("Do not use, the native class doesn't have this setter.")]
+			set;
+		}
+#endif
 
 		[Export ("initWithDisabledMode:")]
 		NativeHandle Constructor (NSSharingCollaborationMode disabledMode);

--- a/src/mediaextension.cs
+++ b/src/mediaextension.cs
@@ -513,6 +513,7 @@ namespace MediaExtension {
 	[NoWatch, NoTV, NoiOS, Mac (15,0), NoMacCatalyst]
 	[Static]
 	interface MEVideoDecoderFields {
+		[Notification]
 		[Field ("MEVideoDecoderReadyForMoreMediaDataDidChangeNotification")]
 		NSString ReadyForMoreMediaDataDidChangeNotification { get; }
 	}
@@ -759,9 +760,11 @@ namespace MediaExtension {
 	[Static]
 	interface MERawProcessorFields
 	{
+		[Notification]
 		[Field ("MERAWProcessorValuesDidChangeNotification")]
 		NSString ValuesDidChangeNotification { get; }
 
+		[Notification]
 		[Field ("MERAWProcessorReadyForMoreMediaDataDidChangeNotification")]
 		NSString ReadyForMoreMediaDataDidChangeNotification { get; }
 	}

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -1051,6 +1051,14 @@ namespace Introspection {
 				}
 				break;
 #endif // __MACCATALYST__
+#if !XAMCORE_5_0
+			case "NSSharingCollaborationModeRestriction":
+				switch (selectorName) {
+				case "setAlertRecoverySuggestionButtonLaunchURL:":// binding mistake
+					return true;
+				}
+				break;
+#endif
 			}
 
 			// old binding mistake

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -1221,8 +1221,13 @@ namespace Introspection {
 				if (!init)
 					ReportError ("Selector {0} used on a constructor (not a method) on {1}", name, t.FullName);
 			} else {
-				if (init)
-					ReportError ("Selector {0} used on a method (not a constructor) on {1}", name, t.FullName);
+				if (init) {
+					var isPubliclyVisible = m.IsPublic || m.IsFamily || m.IsFamilyOrAssembly;
+					if (isPubliclyVisible || !m.Name.StartsWith ("_Init", StringComparison.Ordinal)) {
+						// ignore methods that start '_Init' and aren't publicly exposed, they're probably used by manually bound ctors.
+						ReportError ($"Selector {name} used on the method '{m.Name}' (not a constructor) on {t.FullName}");
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
* Mark a few MediaExtension fields as Notification fields.
* Remove extreanous NSSharingCollaborationModeRestriction.AlertRecoverySuggestionButtonLaunchUrl setter.
* introspection: ignore methods that start with '_Init', aren't publicly
  visible, and bind an Objective-C constructor when verifying that a managed
  method doesn't bind an Objective-C constructor.