### PR TITLE
[tests] Use a file as the Outputs property in MSBuild.

### DIFF
--- a/tests/bindings-framework-test/dotnet/shared.csproj
+++ b/tests/bindings-framework-test/dotnet/shared.csproj
@@ -34,9 +34,9 @@
       <Link>libframework.h</Link>
     </None>
     <TestLibrariesInput Include="$(TestLibrariesDirectory)\libframework.m" />
-    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\XTest.framework" />
-    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\XSharedObjectTest.framework" />
-    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\XSharedARTest.framework" />
+    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\XTest.framework\XTest" />
+    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\XSharedObjectTest.framework\XSharedObjectTest" />
+    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\XSharedARTest.framework\XSharedARTest" />
 
     <NativeReference Include="$(TestLibrariesDirectory)\.libs\$(NativeLibName)\XStaticArTest.framework">
       <Kind>Framework</Kind>

--- a/tests/bindings-test/dotnet/shared.csproj
+++ b/tests/bindings-test/dotnet/shared.csproj
@@ -95,7 +95,7 @@
       <Link>libframework.h</Link>
     </None>
     <TestLibrariesInput Include="$(TestLibrariesDirectory)\libframework.m" />
-    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\libtest.xcframework" />
+    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\libtest.xcframework\Info.plist" />
   </ItemGroup>
 
   <Target Name="BuildTestLibraries" Inputs="@(TestLibrariesInput)" Outputs="@(TestLibrariesOutput)" BeforeTargets="BeforeBuild">

--- a/tests/bindings-test2/dotnet/shared.csproj
+++ b/tests/bindings-test2/dotnet/shared.csproj
@@ -48,7 +48,7 @@
       <Link>libframework.h</Link>
     </None>
     <TestLibrariesInput Include="$(TestLibrariesDirectory)\libframework.m" />
-    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\libtest2.xcframework" />
+    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\libtest2.xcframework\Info.plist" />
   </ItemGroup>
 
   <Target Name="BuildTestLibraries" Inputs="@(TestLibrariesInput)" Outputs="@(TestLibrariesOutput)" BeforeTargets="BeforeBuild">

--- a/tests/bindings-xcframework-test/dotnet/shared.csproj
+++ b/tests/bindings-xcframework-test/dotnet/shared.csproj
@@ -33,9 +33,9 @@
       <Link>libframework.h</Link>
     </None>
     <TestLibrariesInput Include="$(TestLibrariesDirectory)\libframework.m" />
-    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\XStaticArTest.xcframework" />
-    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\XStaticObjectTest.xcframework" />
-    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\XTest.xcframework" />
+    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\XStaticArTest.xcframework\Info.plist" />
+    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\XStaticObjectTest.xcframework\Info.plist" />
+    <TestLibrariesOutput Include="$(TestLibrariesDirectory)\.libs\XTest.xcframework\Info.plist" />
 
     <NativeReference Include="$(TestLibrariesDirectory)\.libs\XStaticArTest.xcframework">
       <Kind>Framework</Kind>


### PR DESCRIPTION
Use a file (as opposed to a directory) as the Outputs property in MSBuild targets.

Directories have unintuitive file stamp behavior sometimes, which may confuse incremental
builds, so use files instead to drive incremental builds.