### PR TITLE
[tests] Cache the evaluation of the DOTNET_DIR variable.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -44,6 +44,7 @@ namespace Xamarin.Tests {
 		public static bool include_device;
 		public static bool EnableXamarin;
 		public static bool XcodeIsStable;
+		public static string DOTNET_DIR;
 
 		static Version xcode_version;
 		public static Version XcodeVersion {
@@ -300,6 +301,7 @@ namespace Xamarin.Tests {
 			DotNetTfm = GetVariable ("DOTNET_TFM", null);
 			EnableXamarin = !string.IsNullOrEmpty (GetVariable ("ENABLE_XAMARIN", ""));
 			XcodeIsStable = string.Equals (GetVariable ("XCODE_IS_STABLE", ""), "true", StringComparison.OrdinalIgnoreCase);
+			DOTNET_DIR = GetVariable ("DOTNET_DIR", "");
 
 			XcodeVersionString = GetVariable ("XCODE_VERSION", GetXcodeVersion (xcode_root));
 #if MONOMAC
@@ -418,7 +420,7 @@ namespace Xamarin.Tests {
 		public static string GetDotNetRoot ()
 		{
 			if (IsVsts) {
-				return Path.Combine (EvaluateVariable ("DOTNET_DIR"), "packs");
+				return Path.Combine (DOTNET_DIR, "packs");
 			} else {
 				return Path.Combine (SourceRoot, "_build");
 			}


### PR DESCRIPTION
This speeds up the tests somewhat, since it's fetched quite a few times.