### PR TITLE
[actions] The changelog action now requires .NET 9.

### DIFF
--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -24,7 +24,7 @@ jobs:
         git clone https://github.com/spouliot/dotnet-tools
         cd dotnet-tools/changelog
         dotnet build
-        /bin/Debug/net9.0/changelog https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
+        ./bin/Debug/net9.0/changelog https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
         cat /tmp/changelog.txt
         hexdump -C /tmp/changelog.txt
 

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -14,16 +14,16 @@ jobs:
       contents: read
 
     steps:
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9'
+
     - name: 'Compute changelog'
       run: |
         set -exo pipefail
         git clone https://github.com/spouliot/dotnet-tools
         cd dotnet-tools/changelog
         dotnet run https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
-
-    - uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '9'
 
     - name: 'Add changelog'
       uses: actions/github-script@v7.0.1

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -12,7 +12,6 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
-    if: github.actor == 'dotnet-maestro[bot]'
 
     steps:
     - uses: actions/setup-dotnet@v4
@@ -25,6 +24,8 @@ jobs:
         git clone https://github.com/spouliot/dotnet-tools
         cd dotnet-tools/changelog
         dotnet run https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
+        cat /tmp/changelog
+        hexdump -C /tmp/changelog
 
     - name: 'Add changelog'
       uses: actions/github-script@v7.0.1

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -24,8 +24,8 @@ jobs:
         git clone https://github.com/spouliot/dotnet-tools
         cd dotnet-tools/changelog
         dotnet run https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
-        cat /tmp/changelog
-        hexdump -C /tmp/changelog
+        cat /tmp/changelog.txt
+        hexdump -C /tmp/changelog.txt
 
     - name: 'Add changelog'
       uses: actions/github-script@v7.0.1

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -12,6 +12,7 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
+    if: github.actor == 'dotnet-maestro[bot]'
 
     steps:
     - uses: actions/setup-dotnet@v4
@@ -25,8 +26,6 @@ jobs:
         cd dotnet-tools/changelog
         dotnet build
         ./bin/Debug/net9.0/changelog https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
-        cat /tmp/changelog.txt
-        hexdump -C /tmp/changelog.txt
 
     - name: 'Add changelog'
       uses: actions/github-script@v7.0.1

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -22,6 +22,10 @@ jobs:
         cd dotnet-tools/changelog
         dotnet run https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
 
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9'
+
     - name: 'Add changelog'
       uses: actions/github-script@v7.0.1
       with:

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -12,6 +12,7 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
+    if: github.actor == 'dotnet-maestro[bot]'
 
     steps:
     - uses: actions/setup-dotnet@v4

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -12,7 +12,6 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
-    if: github.actor == 'dotnet-maestro[bot]'
 
     steps:
     - name: 'Compute changelog'

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -23,7 +23,8 @@ jobs:
         set -exo pipefail
         git clone https://github.com/spouliot/dotnet-tools
         cd dotnet-tools/changelog
-        dotnet run https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
+        dotnet build
+        /bin/Debug/net9.0/changelog https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
         cat /tmp/changelog.txt
         hexdump -C /tmp/changelog.txt
 


### PR DESCRIPTION
So install that, since it doesn't look like it's installed by default yet.

Also build before running, because the new terminal logger for the build in .NET 9 ends up printing junk which ends up in the changelog.