### PR TITLE
[static registrar] Make sure to save any changes made by the managed static registrar. Fixes #21606.

### DIFF
--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -286,9 +286,7 @@ namespace Xamarin.Tests {
 			AddExpectedFrameworkFiles (platform, expectedFiles, "FrameworkTest4", isSigned);
 			AddExpectedFrameworkFiles (platform, expectedFiles, "FrameworkTest5", isSigned);
 
-			expectedFiles.Add (Path.Combine (assemblyDirectory, "bindings-framework-test.dll"));
-			if (includeDebugFiles)
-				expectedFiles.Add (Path.Combine (assemblyDirectory, "bindings-framework-test.pdb"));
+			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "bindings-framework-test", runtimeIdentifiers, forceSingleRid: !(platform == ApplePlatform.MacCatalyst && isReleaseBuild), includeDebugFiles: includeDebugFiles);
 			AddExpectedFrameworkFiles (platform, expectedFiles, "XTest", isSigned);
 
 			// various directories

--- a/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
@@ -60,6 +60,7 @@ namespace Xamarin.Linker {
 
 			CreateRegistrarType (info);
 
+			abr.SaveCurrentAssembly ();
 			abr.ClearCurrentAssembly ();
 		}
 


### PR DESCRIPTION
If an assembly only required the lookup tables from the managed static
registrar (and not any other code), we wouldn't save those changes.

This would lead to a runtime exception:

```
Microsoft.iOS: Processing Objective-C exception for exception marshalling (mode: 2):
Could not find the type 'ObjCRuntime.__Registrar__' in the assembly 'X.Y.Z'. (ObjCRuntime.RuntimeException)
   at ObjCRuntime.RegistrarHelper.GetMapEntry(String assemblyName) in /Users/builder/azdo/_work/1/s/xamarin-macios/src/ObjCRuntime/RegistrarHelper.cs:line 105
   at ObjCRuntime.RegistrarHelper.GetMapEntry(Assembly assembly) in /Users/builder/azdo/_work/1/s/xamarin-macios/src/ObjCRuntime/RegistrarHelper.cs:line 93
   at ObjCRuntime.RegistrarHelper.LookupRegisteredType(Assembly assembly, UInt32 id) in /Users/builder/azdo/_work/1/s/xamarin-macios/src/ObjCRuntime/RegistrarHelper.cs:line 199
   at ObjCRuntime.Class.ResolveToken(Assembly assembly, Module module, UInt32 token) in /Users/builder/azdo/_work/1/s/xamarin-macios/src/ObjCRuntime/Class.cs:line 521
```

The fix is to save the assembly if the managed static registrar added lookup
tables to the assembly.

Fixes https://github.com/xamarin/xamarin-macios/issues/21606.