### PR TITLE
[vs-workload.props] Append xcode info to VSMAN

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -221,6 +221,7 @@ $(DOTNET_NUPKG_DIR)/vs-workload.props: Makefile $(GENERATE_VS_WORKLOAD)
 		--shorten Microsoft.NET.Sdk.MacCatalyst.Manifest=Microsoft.MacCatalyst.Manifest \
 		--shorten Microsoft.tvOS.Runtime.tvossimulator=Microsoft.tvOS.Runtime \
 		--tfm $(DOTNET_TFM) \
+		--xcode $(XCODE_VERSION) \
 		--output $@.tmp
 	$(Q) mv $@.tmp $@
 

--- a/scripts/generate-vs-workload/generate-vs-workload.cs
+++ b/scripts/generate-vs-workload/generate-vs-workload.cs
@@ -12,6 +12,7 @@ var shorten = new Dictionary<string, string> ();
 var platforms = new List<(string, string)> ();
 var windowsPlatforms = new List<string> ();
 var tfm = string.Empty;
+var xcodeName = string.Empty;
 var outputPath = string.Empty;
 
 var queue = new Queue<string> (args);
@@ -37,6 +38,9 @@ while (queue.Any ()) {
 	case "--tfm":
 		tfm = queue.Dequeue ();
 		break;
+	case "--xcode":
+		xcodeName = $"xcode{queue.Dequeue ()}";
+		break;
 	default:
 		Console.Error.WriteLine ($"Unknown argument: {arg}");
 		return 1;
@@ -48,7 +52,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"<Project>");
 	writer.WriteLine ($"  <PropertyGroup>");
 	var allPlatforms = string.Join (".", platforms.Select (v => v.Item1).OrderBy (v => v));
-	writer.WriteLine ($"    <TargetName>Microsoft.NET.Sdk.{allPlatforms}.Workload.{tfm}</TargetName>");
+	writer.WriteLine ($"    <TargetName>Microsoft.NET.Sdk.{allPlatforms}.Workload.{tfm}.{xcodeName}</TargetName>");
 	// Find the iOS version, otherwise use the version of the first platform listed.
 	var iOSPlatform = platforms.Where (v => v.Item1 == "iOS");
 	var manifestBuildVersion = iOSPlatform.Any () ? iOSPlatform.First ().Item2 : platforms.First ().Item2;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/commit/06fea905cf900ab5296b08d7b67dadddc733dd65

In order to add .NET 9 Xcode16.1 builds to VS we'll need to insert packs
from two different commits on the `release/9.0.1xx-preview` branch.

Xcode information will now be added to the VS manifest that we generate
to allow us to produce unique manifests across the same branch.