### PR TITLE
[Foundation] Set the MaxInputInMemory to match the limit from other BCL classes. Fixes #21537

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -217,7 +217,7 @@ namespace Foundation {
 		}
 #endif
 
-		public long MaxInputInMemory { get; set; } = long.MaxValue;
+		public long MaxInputInMemory { get; set; } = (long) int.MaxValue; // use int.MaxValue since it is the same max value used by both HttpContent and MemoryStream.
 
 		void RemoveInflightData (NSUrlSessionTask task, bool cancel = true)
 		{


### PR DESCRIPTION
The MaxInputInMemory property is set by default to be long.MaxValue. This value is much larger than the one we can find in other BCL classes such as the HttpContent [max value](https://github.com/microsoft/referencesource/blob/master/System/net/System/Net/Http/HttpContent.cs#L20) and the MemoryStream [max value](https://github.com/dotnet/runtime/blob/1d1bf92fcf43aa6981804dc53c5174445069c9e4/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs#L37).

It is important to notice that the HttpContent.MaxValue is used to limit the value of the MaxResponseContentBufferSize property in the HttpClient. This means that by making this move we are following the rest of the BCL.

Fixes #21537