### PR TITLE
[dotnet] Disable dedup optimization if we're interpreting every assembly.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1115,7 +1115,7 @@
 				In such setup, during runtime, AOT images are loaded but marked as unusuable as they are compiled with `full` compiler switch and the code falls back to interpreter.
 				Dedup AOT image is specially handled by the AOT runtime and it is not allowed to have it marked as unusuable.
 			-->
-			<_IsDedupEnabled Condition="'$(_IsDedupEnabled)' == '' And '$(_RunAotCompiler)' == 'true' And '$(IsMacEnabled)' == 'true' And '$(TargetArchitectures)' == 'ARM64'">true</_IsDedupEnabled>
+			<_IsDedupEnabled Condition="'$(_IsDedupEnabled)' == '' And '$(_RunAotCompiler)' == 'true' And '$(IsMacEnabled)' == 'true' And '$(TargetArchitectures)' == 'ARM64' And '$(MtouchInterpreter)' != 'all'">true</_IsDedupEnabled>
 			<_DedupAssembly Condition="'$(_IsDedupEnabled)' == 'true'">$(IntermediateOutputPath)aot-instances.dll</_DedupAssembly>
 
 			<!-- default to 'static' for Mac Catalyst to work around https://github.com/xamarin/xamarin-macios/issues/14686 -->


### PR DESCRIPTION
This speeds up the inner dev loop, because:

* The dedup assembly must be AOT-compiled for arm64
* arm64 is the default target architecture on more and more devices/macs
* AOT-compilation is slow

So disabling the dedup optimization in this case makes the build faster, because we don't have to AOT-compile something that doesn't exist.

Build times of a new MAUI app (`dotnet new maui`):

| -                              | with dedup   | without dedup |
| ------------------------------ | -----------: | ------------: |
| Simulator (Debug)              | 18 s         | 8 s           |
| Device (Debug)                 | 32 s         | 22 s          |
| Device (Release, interpreter)  | 43 s         | 18 s          |
| Device (Release, fullaot)      | 1m20 s       | 1m40 s        |

App size:

| -                              | with dedup | without dedup |
| ------------------------------ | ---------: | ------------: |
| Device (Debug)                 | 126 MB     | 88 MB         |
| Device (Release, interpreter)  | 19 MB      | 14 MB         |
| Device (Release, fullaot)      | 42 MB      | 69 MB         |

Note that disabling dedup when using the interpreter makes the app smaller as well.