### PR TITLE
[managed static registrar] Don't try to create instances of abstract types.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -2642,6 +2642,8 @@ If this is an API exposed by Xamarin, please file a new issue on
 [GitHub](https://github.com/xamarin/xamarin-macios/issues/new), if it's a
 third-party binding, please contact the vendor.
 
+### MT4180: Cannot construct an instance of the type '*' from Objective-C because the type is abstract. [Runtime exception]
+
 ## MT5xxx: GCC and toolchain error messages
 
 ### MT51xx: Compilation

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -463,6 +463,14 @@ namespace Xamarin.Linker {
 					il.Emit (OpCodes.Throw);
 					// We're throwing an exception, so there's no need for any more code.
 					skipEverythingAfter = il.Body.Instructions.Last ();
+				} else if (method.DeclaringType.IsAbstract) {
+					il.Emit (OpCodes.Ldc_I4, 4180);
+					postLeaveBranch.Operand = il.Body.Instructions.Last ();
+					il.Emit (OpCodes.Ldstr, $"Cannot construct an instance of the type '{method.DeclaringType.FullName}' from Objective-C because the type is abstract.");
+					il.Emit (OpCodes.Call, abr.Runtime_CreateRuntimeException);
+					il.Emit (OpCodes.Throw);
+					// We're throwing an exception, so there's no need for any more code.
+					skipEverythingAfter = il.Body.Instructions.Last ();
 				} else {
 					// Whenever there's an NSObject constructor that we call from a registrar callback, we need to create
 					// a separate constructor that will first set the `handle` and `flags` values of the NSObject before


### PR DESCRIPTION
Fixes AOT warnings like these:

> Unable to compile method 'ObjCRuntime.NativeHandle Foundation.NSDispatcher/__Registrar_Callbacks__:callback_1509_Foundation_NSDispatcher__ctor (intptr,intptr,byte*,intptr*)' due to: 'Cannot create an abstract class: Foundation.NSDispatcher assembly:<unknown assembly> type:<unknown type> member:(null)'.