### PR TITLE
[msbuild] Use earlier version of MSBuild assemblies. Fixes #21671.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,10 +4,10 @@
 		<DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
 		<MonoCecilPackageVersion>0.11.5</MonoCecilPackageVersion>
 		<MSBuildStructuredLoggerPackageVersion>2.2.158</MSBuildStructuredLoggerPackageVersion>
-		<MicrosoftBuildPackageVersion>17.11.4</MicrosoftBuildPackageVersion>
-		<MicrosoftBuildFrameworkPackageVersion>17.11.4</MicrosoftBuildFrameworkPackageVersion>
-		<MicrosoftBuildTasksCorePackageVersion>17.11.4</MicrosoftBuildTasksCorePackageVersion>
-		<MicrosoftBuildUtilitiesCorePackageVersion>17.11.4</MicrosoftBuildUtilitiesCorePackageVersion>
+		<MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
+		<MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
+		<MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
+		<MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
 	</PropertyGroup>
 	<Import Project="Build.props" Condition="Exists('Build.props')" />
 </Project>


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/21671.