### PR TITLE
[devops] Make a few scripts a bit more self-contained by computing BUILD_REPOSITORY_TITLE if it's not already set.

### DIFF
--- a/tools/devops/automation/scripts/bash/generate-workload-rollback.sh
+++ b/tools/devops/automation/scripts/bash/generate-workload-rollback.sh
@@ -7,6 +7,11 @@
 if test -z "${BUILD_SOURCESDIRECTORY:-}"; then
   BUILD_SOURCESDIRECTORY="$(git rev-parse --show-toplevel)/.."
 fi
+# If BUILD_REPOSITORY_TITLE is not set, it's likely we're executing locally.
+# In which case we can figure out where we are from the current git checkout
+if test -z "${BUILD_REPOSITORY_TITLE:-}"; then
+  BUILD_REPOSITORY_TITLE="$(basename "$(git remote get-url --push origin)")"
+fi
 # Don't assume we're in the right directory (makes it easier to run the script
 # locally).
 cd "$BUILD_SOURCESDIRECTORY/$BUILD_REPOSITORY_TITLE"

--- a/tools/devops/automation/scripts/bash/install-workloads.sh
+++ b/tools/devops/automation/scripts/bash/install-workloads.sh
@@ -16,6 +16,11 @@ env | sort
 if test -z "${BUILD_SOURCESDIRECTORY:-}"; then
   BUILD_SOURCESDIRECTORY="$(git rev-parse --show-toplevel)/.."
 fi
+# If BUILD_REPOSITORY_TITLE is not set, it's likely we're executing locally.
+# In which case we can figure out where we are from the current git checkout
+if test -z "${BUILD_REPOSITORY_TITLE:-}"; then
+  BUILD_REPOSITORY_TITLE="$(basename "$(git remote get-url --push origin)")"
+fi
 # Don't assume we're in the right directory (makes it easier to run the script
 # locally).
 cd "$BUILD_SOURCESDIRECTORY/$BUILD_REPOSITORY_TITLE"

--- a/tools/devops/automation/scripts/run-generator-tests-on-windows.ps1
+++ b/tools/devops/automation/scripts/run-generator-tests-on-windows.ps1
@@ -1,3 +1,9 @@
+if ("$Env:BUILD_REPOSITORY_TITLE" -eq "") {
+    $remoteUrl = & git remote get-url --push origin
+    $repoTitle = [System.IO.Path]::GetFilename($remoteUrl)
+    $Env:BUILD_REPOSITORY_TITLE = $repoTitle
+}
+
 # Dump the environment to see what we're working with.
 & "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY\$Env:BUILD_REPOSITORY_TITLE\tools\devops\automation\scripts\show_bot_info.ps1"
 

--- a/tools/devops/automation/scripts/run-local-windows-tests.ps1
+++ b/tools/devops/automation/scripts/run-local-windows-tests.ps1
@@ -1,3 +1,8 @@
+if ("$Env:BUILD_REPOSITORY_TITLE" -eq "") {
+    $remoteUrl = & git remote get-url --push origin
+    $repoTitle = [System.IO.Path]::GetFilename($remoteUrl)
+    $Env:BUILD_REPOSITORY_TITLE = $repoTitle
+}
 if ("$Env:DOTNET" -eq "") {
     $Env:DOTNET = "$Env:BUILD_SOURCESDIRECTORY\$Env:BUILD_REPOSITORY_TITLE\tests\dotnet\Windows\bin\dotnet\dotnet.exe"
     $Env:PATH = "$Env:BUILD_SOURCESDIRECTORY\$Env:BUILD_REPOSITORY_TITLE\tests\dotnet\Windows\bin\dotnet;$Env:PATH"

--- a/tools/devops/automation/scripts/run-remote-windows-tests.ps1
+++ b/tools/devops/automation/scripts/run-remote-windows-tests.ps1
@@ -1,7 +1,11 @@
+if ("$Env:BUILD_REPOSITORY_TITLE" -eq "") {
+    $remoteUrl = & git remote get-url --push origin
+    $repoTitle = [System.IO.Path]::GetFilename($remoteUrl)
+    $Env:BUILD_REPOSITORY_TITLE = $repoTitle
+}
 if ("$Env:DOTNET" -eq "") {
     $Env:DOTNET = "$Env:BUILD_SOURCESDIRECTORY\$Env:BUILD_REPOSITORY_TITLE\tests\dotnet\Windows\bin\dotnet\dotnet.exe"
 }
-
 $Env:ServerAddress = $Env:MAC_AGENT_IP
 $Env:ServerUser = $Env:MAC_AGENT_USER
 $Env:ServerPassword = $Env:XMA_PASSWORD


### PR DESCRIPTION
This makes it easier to run these scripts locally.