### PR TITLE
[devops] Improve comment when a build completes.

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -182,11 +182,11 @@ steps:
       $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token) -Hash $Env:COMMENT_HASH
       $commentMessage = [System.Text.StringBuilder]::new()
       if (("$Env:AGENT_JOBSTATUS" -eq "Succeeded") -or ("$Env:AGENT_JOBSTATUS" -eq "SucceededWithIssues")) {
-        $commentTitle = "Build passed"
+        $commentTitle = "Build passed ($(System.JobDisplayName))"
         $commentIcon = ":white_check_mark:"
         $commentMessage.AppendLine("")
       } else {
-        $commentTitle = "Build failed"
+        $commentTitle = "Build failed ($(System.JobDisplayName))"
         $commentIcon = ":fire:"
         $commentMessage.AppendLine("Build failed for the job '$(System.JobDisplayName)' (with job status '$Env:AGENT_JOBSTATUS')")
       }

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -187,7 +187,7 @@ steps:
         $commentMessage.AppendLine("")
       } else {
         $commentTitle = "Build failed"
-        $commentIcon = ":fire:""
+        $commentIcon = ":fire:"
         $commentMessage.AppendLine("Build failed for the job '$(System.JobDisplayName)' (with job status '$Env:AGENT_JOBSTATUS')")
       }
       $githubComments.NewCommentFromMessage($commentTitle, $commentIcon, $commentMessage.ToString(), "build $(System.JobDisplayName)")

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -176,14 +176,23 @@ steps:
       keyringPass: ${{ parameters.keyringPass }}
       use1ES: ${{ parameters.use1ES }}
 
-  # if we failed, write a comment and set the pipeline to failure. In this case, we do not want to hide the fact that we failed but we also want
-  # to write a comment.
+  # report the result of the build.
   - pwsh: |
       Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\$Env:BUILD_REPOSITORY_TITLE\tools\devops\automation\scripts\MaciosCI.psd1
       $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token) -Hash $Env:COMMENT_HASH
-      $githubComments.NewCommentFromMessage("Build failed", ":fire:", "Build failed for the job '$(System.JobDisplayName)'", "build")
-    condition: failed()
-    displayName: 'Report build failure'
+      $commentMessage = [System.Text.StringBuilder]::new()
+      if (("$Env:AGENT_JOBSTATUS" -eq "Succeeded") -or ("$Env:AGENT_JOBSTATUS" -eq "SucceededWithIssues")) {
+        $commentTitle = "Build passed"
+        $commentIcon = ":white_check_mark:"
+        $commentMessage.AppendLine("")
+      } else {
+        $commentTitle = "Build failed"
+        $commentIcon = ":fire:""
+        $commentMessage.AppendLine("Build failed for the job '$(System.JobDisplayName)' (with job status '$Env:AGENT_JOBSTATUS')")
+      }
+      $githubComments.NewCommentFromMessage($commentTitle, $commentIcon, $commentMessage.ToString(), "build $(System.JobDisplayName)")
+    condition: always()
+    displayName: 'Report build result'
     env:
       ${{ if eq(parameters.repositoryAlias, 'self') }}:
         COMMENT_HASH: $(fix_commit.GIT_HASH)


### PR DESCRIPTION
Always report the build status, that way we'll automatically hide any previous
build failure comments.