### PR TITLE
[AudioToolbox] Implement Xcode 16.2 beta 1-3 changes in AudioToolbox.

### DIFF
--- a/src/AudioUnit/AUEnums.cs
+++ b/src/AudioUnit/AUEnums.cs
@@ -66,15 +66,14 @@ namespace AudioUnit {
 		Initialized = -10849,
 		InvalidOfflineRender = -10848,
 		Unauthorized = -10847,
-		[NoWatch]
-		[MacCatalyst (13, 1)]
 		MidiOutputBufferFull = -66753,
-		[NoWatch]
-		[MacCatalyst (13, 1)]
+		RenderTimeout = -66745,
 		InvalidParameterValue = -66743,
-		[NoWatch]
-		[MacCatalyst (13, 1)]
 		ExtensionNotFound = -66744,
+		InvalidFilePath = -66742,
+		MissingKey = -66741,
+		ComponentManagerNotSupported = -66740,
+		MultipleVoiceProcessors = -66635,
 	}
 
 	/// <summary>Enumerates status values returned by <see cref="M:AudioUnit.AudioUnit.AudioOutputUnitPublish(AudioUnit.AudioComponentDescription,System.String,System.UInt32)" />.</summary>
@@ -83,6 +82,7 @@ namespace AudioUnit {
 		DuplicateDescription = -66752,
 		UnsupportedType = -66751,
 		TooManyInstances = -66750,
+		InstanceTimedOut = -66754,
 		InstanceInvalidated = -66749,
 		NotPermitted = -66748,
 		InitializationTimedOut = -66747,


### PR DESCRIPTION
Also add a few more missing error codes from previous Xcode updates, and
remove some unnecessary availability attributes.