### PR TITLE
[msbuild] Port the CreateAssetPack task to subclass XamarinTask.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -513,10 +513,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<CreateAssetPack
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '$(EmbedOnDemandResources)' == 'false'"
-			ToolExe="$(ZipExe)"
-			ToolPath="$(ZipPath)"
 			Source="%(_AssetPack.Identity)"
 			OutputFile="$(IpaPackageDir)OnDemandResources\%(_AssetPack.DirectoryName)"
+			ZipPath="$(ZipPath)"
 			/>
 
 		<Copy


### PR DESCRIPTION
This has a few advantages:

* We simplify and unify more of our code.
* We have more control over the error reporting / logging behavior.

Additionally:

* Use 'xcrun' to invoke 'zip' (partial fix for #3931).
* Allow for overriding the path to the command-line tool in question.
* Add support for cancellation.