### PR TITLE
[bgen] Fix creating the list of make dependencies for the bgen project.

### DIFF
--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -6,6 +6,7 @@ bgen.csproj.inc: export BUILD_EXECUTABLE=$(DOTNET) build
 bgen.csproj.inc: export BUILD_VERBOSITY=$(MSBUILD_VERBOSITY)
 
 # bgen.csproj.inc contains the generator_dependencies variable used to determine if the generator needs to be rebuilt or not.
+$(DOTNET_BUILD_DIR)/bgen.csproj.inc: export DOTNET:=$(DOTNET)
 $(DOTNET_BUILD_DIR)/bgen.csproj.inc: bgen/bgen.csproj.inc
 	$(Q) $(CP) $< $@
 


### PR DESCRIPTION
The DOTNET variable must be set, otherwise the script that creates the make
dependencies doesn't work.