### PR TITLE
[Rgen] Move unsupported and obsoleted versions to a sorted dict.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailability.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailability.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Macios.Generator.Attributes;
 using Xamarin.Utils;
 
 namespace Microsoft.Macios.Generator.Availability;
@@ -28,14 +27,14 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 	/// </summary>
 	public Version? SupportedVersion { get; }
 
-	readonly Dictionary<Version, string?> unsupported = new ();
+	readonly SortedDictionary<Version, string?> unsupported = new ();
 
 	/// <summary>
 	/// Dictionary that contains all the obsoleted versions and their optional data.
 	/// </summary>
 	public readonly IReadOnlyDictionary<Version, string?> UnsupportedVersions => unsupported;
 
-	readonly Dictionary<Version, (string? Message, string? Url)> obsoleted = new ();
+	readonly SortedDictionary<Version, (string? Message, string? Url)> obsoleted = new ();
 
 	/// <summary>
 	/// Dictionary tath contains all the unsupported versions and their optional data.
@@ -51,8 +50,8 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 	public static bool IsDefaultVersion (Version version) => version == defaultVersion;
 
 	PlatformAvailability (ApplePlatform platform, Version? supportedVersion,
-		Dictionary<Version, string?> unsupportedVersions,
-		Dictionary<Version, (string? Message, string? Url)> obsoletedVersions)
+		SortedDictionary<Version, string?> unsupportedVersions,
+		SortedDictionary<Version, (string? Message, string? Url)> obsoletedVersions)
 	{
 		Platform = platform;
 		SupportedVersion = supportedVersion;
@@ -71,7 +70,7 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 		// important, the default copy constructor of a record wont do this. It will use the same ref, not
 		// something we want to do because it will mean that two records will modify the same collection
 		unsupported = new (other.unsupported);
-		obsoleted = new (other.ObsoletedVersions);
+		obsoleted = new (other.obsoleted);
 	}
 
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailabilityBuilder.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailabilityBuilder.cs
@@ -19,8 +19,8 @@ readonly partial struct PlatformAvailability {
 	public sealed class Builder {
 		readonly ApplePlatform platform;
 		Version? supportedVersion;
-		readonly Dictionary<Version, string?> unsupported = new ();
-		readonly Dictionary<Version, (string? Message, string? Url)> obsoleted = new ();
+		readonly SortedDictionary<Version, string?> unsupported = new ();
+		readonly SortedDictionary<Version, (string? Message, string? Url)> obsoleted = new ();
 
 		/// <summary>
 		/// Create a builder for the given platform.

--- a/src/rgen/Microsoft.Macios.Generator/DictionaryComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DictionaryComparer.cs
@@ -5,11 +5,11 @@ using System.Linq;
 namespace Microsoft.Macios.Generator;
 
 public class DictionaryComparer<TKey, TValue> (IEqualityComparer<TValue>? valueComparer = null)
-	: IEqualityComparer<Dictionary<TKey, TValue>>
+	: IEqualityComparer<IDictionary<TKey, TValue>>
 	where TKey : notnull {
 	readonly IEqualityComparer<TValue> valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
 
-	public bool Equals (Dictionary<TKey, TValue>? x, Dictionary<TKey, TValue>? y)
+	public bool Equals (IDictionary<TKey, TValue>? x, IDictionary<TKey, TValue>? y)
 	{
 		if (x is null && y is null)
 			return true;
@@ -24,7 +24,7 @@ public class DictionaryComparer<TKey, TValue> (IEqualityComparer<TValue>? valueC
 		return x.All (pair => valueComparer.Equals (pair.Value, y [pair.Key]));
 	}
 
-	public int GetHashCode (Dictionary<TKey, TValue> obj)
+	public int GetHashCode (IDictionary<TKey, TValue> obj)
 	{
 		var hash = new HashCode ();
 		foreach (var (key, value) in obj) {


### PR DESCRIPTION
To ensure a more consistent code generation we are moving to use SortedDictionary<K, KV> so that we always have the same order in the generatd attributes.