### PR TITLE
[tests] Fix SetHandleTest to handle 'callvirt'.

### DIFF
--- a/tests/cecil-tests/SetHandleTest.KnownFailures.cs
+++ b/tests/cecil-tests/SetHandleTest.KnownFailures.cs
@@ -39,6 +39,7 @@ namespace Cecil.Tests {
 			"ModelIO.MDLNoiseTexture::.ctor(System.Single,System.String,CoreGraphics.NVector2i,ModelIO.MDLTextureChannelEncoding,ModelIO.MDLNoiseTextureType)",
 			"MultipeerConnectivity.MCSession::.ctor(MultipeerConnectivity.MCPeerID,Security.SecIdentity,MultipeerConnectivity.MCEncryptionPreference)",
 			"MultipeerConnectivity.MCSession::.ctor(MultipeerConnectivity.MCPeerID,Security.SecIdentity,Security.SecCertificate[],MultipeerConnectivity.MCEncryptionPreference)",
+			"ObjCRuntime.Runtime::RegisterNSObject(Foundation.NSObject,System.IntPtr)",
 			"ScreenCaptureKit.SCContentFilter::.ctor(ScreenCaptureKit.SCDisplay,ScreenCaptureKit.SCRunningApplication[],ScreenCaptureKit.SCWindow[],ScreenCaptureKit.SCContentFilterOption)",
 			"ScreenCaptureKit.SCContentFilter::.ctor(ScreenCaptureKit.SCDisplay,ScreenCaptureKit.SCWindow[],ScreenCaptureKit.SCContentFilterOption)",
 			"Security.SecTrust2::.ctor(Security.SecTrust)",

--- a/tests/cecil-tests/SetHandleTest.cs
+++ b/tests/cecil-tests/SetHandleTest.cs
@@ -25,7 +25,7 @@ namespace Cecil.Tests {
 			reason = null;
 
 			foreach (var instr in instructions) {
-				if (instr.OpCode != OpCodes.Call)
+				if (instr.OpCode != OpCodes.Call && instr.OpCode != OpCodes.Callvirt)
 					continue;
 
 				var target = instr.Operand as MethodReference;


### PR DESCRIPTION
NSObject.Handle is virtual (because it's an implementation of
INativeObject.Handle), so it can be called with 'callvirt' - which means we
can't filter to only 'call' instructions, we need to look for 'callvirt'
instructions as well.