### PR TITLE
[xtro] Don't remove fields we've found from existing list of managed fields.

### DIFF
--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-UIKit.ignore
@@ -116,11 +116,6 @@
 !missing-selector! UIBarButtonItemAppearance::copy not bound
 !missing-selector! UITabBarItemAppearance::copy not bound
 
-## Xcode 11.4 Beta 2
-## Duplicated entry field UIKeyInputF1 FB66299477
-## https://github.com/xamarin/xamarin-macios/wiki/UIKit-iOS-xcode11.4-beta2
-!missing-field! UIKeyInputF1 not bound
-
 # Initial result from new rule extra-null-allowed
 !extra-null-allowed! 'Foundation.NSIndexPath UIKit.UICollectionViewDataSource::GetIndexPath(UIKit.UICollectionView,System.String,System.IntPtr)' has a extraneous [NullAllowed] on return type
 !extra-null-allowed! 'System.Boolean UIKit.NSLayoutManagerDelegate::ShouldSetLineFragmentRect(UIKit.NSLayoutManager,CoreGraphics.CGRect&,CoreGraphics.CGRect&,System.Runtime.InteropServices.NFloat&,UIKit.NSTextContainer,Foundation.NSRange)' has a extraneous [NullAllowed] on parameter #1

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
@@ -120,11 +120,6 @@
 !missing-selector! UIBarButtonItemAppearance::copy not bound
 !missing-selector! UITabBarItemAppearance::copy not bound
 
-## Xcode 11.4 Beta 2
-## Duplicated entry field UIKeyInputF1 FB66299477
-## https://github.com/xamarin/xamarin-macios/wiki/UIKit-iOS-xcode11.4-beta2
-!missing-field! UIKeyInputF1 not bound
-
 # Initial result from new rule extra-null-allowed
 !extra-null-allowed! 'Foundation.NSIndexPath UIKit.UICollectionViewDataSource::GetIndexPath(UIKit.UICollectionView,System.String,System.IntPtr)' has a extraneous [NullAllowed] on return type
 !extra-null-allowed! 'System.Boolean UIKit.NSLayoutManagerDelegate::ShouldSetLineFragmentRect(UIKit.NSLayoutManager,CoreGraphics.CGRect&,CoreGraphics.CGRect&,System.Runtime.InteropServices.NFloat&,UIKit.NSTextContainer,Foundation.NSRange)' has a extraneous [NullAllowed] on parameter #1

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-ScreenCaptureKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-ScreenCaptureKit.ignore
@@ -1,5 +1,3 @@
-# ignoring due to https://github.com/xamarin/xamarin-macios/issues/15656
-!missing-field! SCStreamErrorDomain not bound
 !missing-null-allowed! 'CoreMedia.CMClock ScreenCaptureKit.SCStream::get_SynchronizationClock()' is missing an [NullAllowed] on return type
 # removed in XAMCORE_5_0
 !extra-protocol-member! unexpected selector SCStreamDelegate::userDidStopStream: found

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
@@ -158,11 +158,6 @@
 !missing-selector! UIBarButtonItemAppearance::copy not bound
 !missing-selector! UITabBarItemAppearance::copy not bound
 
-## Xcode 11.4 Beta 2
-## Duplicated entry field UIKeyInputF1 FB66299477
-## https://github.com/xamarin/xamarin-macios/wiki/UIKit-iOS-xcode11.4-beta2
-!missing-field! UIKeyInputF1 not bound
-
 # Initial result from new rule extra-null-allowed
 !extra-null-allowed! 'Foundation.NSIndexPath UIKit.UICollectionViewDataSource::GetIndexPath(UIKit.UICollectionView,System.String,System.IntPtr)' has a extraneous [NullAllowed] on return type
 !extra-null-allowed! 'System.Boolean UIKit.NSLayoutManagerDelegate::ShouldSetLineFragmentRect(UIKit.NSLayoutManager,CoreGraphics.CGRect&,CoreGraphics.CGRect&,System.Runtime.InteropServices.NFloat&,UIKit.NSTextContainer,Foundation.NSRange)' has a extraneous [NullAllowed] on parameter #1


### PR DESCRIPTION
The same native field may be declared in multiple frameworks, and if we remove
it from the list of managed fields we've matched, then we'll report the
binding as missing when we find it in the second framework.

Instead keep track of the fields we've matched in a separate hash table, and
use that to figure out which fields haven't been matched.