### PR TITLE
[MapKit] Manually make MKUserLocation implement the MKAnnotation protocol. Fixes #21759.

### DIFF
--- a/src/MapKit/MKUserLocation.cs
+++ b/src/MapKit/MKUserLocation.cs
@@ -1,0 +1,6 @@
+#nullable enable
+
+namespace MapKit {
+	public partial class MKUserLocation : IMKAnnotation {
+	}
+}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1168,6 +1168,7 @@ MAPKIT_SOURCES = \
 	MapKit/MKPointOfInterestFilter.cs \
 	MapKit/MKPolygon.cs \
 	MapKit/MKPolyline.cs \
+	MapKit/MKUserLocation.cs \
 
 # MediaAccessibility
 

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -1362,7 +1362,11 @@ namespace MapKit {
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[MacCatalyst (13, 1)]
-	interface MKUserLocation : IMKAnnotation { // This is wrong. It should be MKAnnotation but we can't due to API compat. When you fix this remove hack in generator.cs to enable warning again
+#if XAMCORE_5_0
+	interface MKUserLocation : MKAnnotation {
+#else
+	interface MKUserLocation : IMKAnnotation { // This is wrong. It should be MKAnnotation but we can't due to API compat. When you fix this remove hack in generator.cs to enable warning again. In the meantime, we're stating that MKUserLocation implements the IMKAnnotation protocol by using a manual binding.
+#endif
 		[Export ("updating")]
 		bool Updating { [Bind ("isUpdating")] get; }
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-MapKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-MapKit.ignore
@@ -13,8 +13,5 @@
 !deprecated-attribute-missing! MKMapView::showsTraffic missing a [Deprecated] attribute
 !deprecated-attribute-missing! MKMapView::setShowsTraffic: missing a [Deprecated] attribute
 
-## This is rather hard to fix: see comment in the generator (search for MKAnnotation to find it)
-!missing-protocol-conformance! MKUserLocation should conform to MKAnnotation
-
 ## The MKOverlay protocol implements the MKAnnotation protocol, which has a required 'coordinate' property, so the API is there.
 !missing-protocol-member! MKOverlay::coordinate not found


### PR DESCRIPTION
It's important that MKUserLocation class implements the IMKAnnotation
interface, because a MKUserLocation instance might be passed as a parameter to
a function that takes an IMKAnnotation. If the managed class doesn't implement
the interface, this can result in an InvalidCastException at runtime.

Fixes https://github.com/xamarin/xamarin-macios/issues/21759.