### PR TITLE
[src/tests] Fix computing docid for generic method parameters.

### DIFF
--- a/src/bgen/DocumentationManager.cs
+++ b/src/bgen/DocumentationManager.cs
@@ -123,7 +123,11 @@ public class DocumentationManager {
 		var name = new StringBuilder ();
 
 		if (tr.IsGenericParameter) {
-			name.Append ('`');
+			if (tr.DeclaringMethod is not null) {
+				name.Append ("``");
+			} else {
+				name.Append ('`');
+			}
 			name.Append (tr.GenericParameterPosition);
 #if NET
 		} else if (tr.IsSZArray) {

--- a/tests/cecil-tests/Documentation.cs
+++ b/tests/cecil-tests/Documentation.cs
@@ -235,7 +235,11 @@ namespace Cecil.Tests {
 			} else if (tr is ByReferenceType brt) {
 				name += brt.ElementType.Name + "@";
 			} else if (tr is GenericParameter gp) {
-				name = $"`{gp.Position}";
+				if (gp.DeclaringMethod is not null) {
+					name = $"``{gp.Position}";
+				} else {
+					name = $"`{gp.Position}";
+				}
 			} else if (tr is ArrayType at) {
 				name = GetDocId (at.ElementType);
 				if (at.Rank == 1) {


### PR DESCRIPTION
Roslyn's code for reference:

https://github.com/dotnet/roslyn/blob/bbff74e481aaf2c6d05949891a64c0d8ac533cf8/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs#L105-L109