### PR TITLE
[tests] Adjust NetworkReachabilityTest.CtorNameAddress a bit.

### DIFF
--- a/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
@@ -31,6 +31,7 @@ namespace MonoTouchFixtures.SystemConfiguration {
 				NetworkReachabilityFlags flags;
 
 				Assert.IsTrue (nr.TryGetFlags (out flags));
+				flags &= ~NetworkReachabilityFlags.TransientConnection; // Remove the TransientConnection flag if it's set
 				Assert.That (flags, Is.EqualTo (NetworkReachabilityFlags.Reachable), "Reachable");
 			}
 		}


### PR DESCRIPTION
Ignore the TransientConnection flag on the asserted flags (another test also
does this).

Fixes this random test failure:

	[FAIL] CtorNameAddress :   Reachable
		Expected: Reachable
		But was:  TransientConnection, Reachable