### PR TITLE
[runtime] Call mono_debugger_agent_unhandled_exception when an exception is marshalled.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -839,6 +839,12 @@
 			XamarinRuntime = RuntimeMode.MonoVM,
 		},
 
+		new Export ("void", "mono_debugger_agent_unhandled_exception",
+			"MonoException *", "e"
+		) {
+			XamarinRuntime = RuntimeMode.MonoVM,
+		},
+
 		#endregion
 
 		#region mini/mono-private-unstable.

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2348,6 +2348,11 @@ xamarin_process_managed_exception (MonoObject *exception)
 	if (exception == NULL)
 		return;
 
+#if !defined (CORECLR_RUNTIME)
+	if (mono_is_debugger_attached ())
+		mono_debugger_agent_unhandled_exception ((MonoException *) exception);
+#endif
+
 	MarshalManagedExceptionMode mode;
 	GCHandle exception_gchandle = INVALID_GCHANDLE;
 


### PR DESCRIPTION
This means the debugger will be notified of all marshalled exceptions, and
consider them unhandled (and break the debugged app into the debugger).

There's no corresponding change for CoreCLR, because we have no configuration
where we can attach a debugger to a CoreCLR-based app (VSCode doesn't support
macOS, and NativeAOT doesn't support debugging).

Partial fix for https://github.com/xamarin/xamarin-macios/issues/15037.
Fixes https://github.com/dotnet/maui/issues/7176.
Ref: https://github.com/dotnet/android/pull/6106