### PR TITLE
Fix APIDiff 

### DIFF
--- a/mk/xamarin-reset.sh
+++ b/mk/xamarin-reset.sh
@@ -16,6 +16,7 @@ elif [[ $DEPENDENCY_MODULE =~ https://github.com ]]; then
 elif [[ $DEPENDENCY_MODULE =~ devdiv@dev.azure.com ]]; then
 	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/devdiv@dev.azure.com\/devdiv\/}
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/_git*}
+	DEPENDENCY_AUTH="-c http.extraheader=\"AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN\""
 fi
 
 if test -d "$DEPENDENCY_PATH"; then
@@ -37,10 +38,10 @@ if test -d "$DEPENDENCY_PATH"; then
 	fi
 
 else
-	echo "*** [$DEPENDENCY_NAME] git clone $DEPENDENCY_MODULE --recursive $DEPENDENCY_DIRECTORY -b $DEPENDENCY_BRANCH --origin $DEPENDENCY_REMOTE"
+	echo "*** [$DEPENDENCY_NAME] git $DEPENDENCY_AUTH clone $DEPENDENCY_MODULE --recursive $DEPENDENCY_DIRECTORY -b $DEPENDENCY_BRANCH --origin $DEPENDENCY_REMOTE"
 	mkdir -p "$(dirname "$DEPENDENCY_PATH")"
 	cd "$(dirname "$DEPENDENCY_PATH")"
-	git clone "$DEPENDENCY_MODULE" --recursive "$DEPENDENCY_DIRECTORY" -b "$DEPENDENCY_BRANCH" --origin "$DEPENDENCY_REMOTE"
+	git $DEPENDANCY_AUTH clone "$DEPENDENCY_MODULE" --recursive "$DEPENDENCY_DIRECTORY" -b "$DEPENDENCY_BRANCH" --origin "$DEPENDENCY_REMOTE"
 	cd "$DEPENDENCY_DIRECTORY"
 fi
 

--- a/mk/xamarin-reset.sh
+++ b/mk/xamarin-reset.sh
@@ -19,6 +19,7 @@ elif [[ $DEPENDENCY_MODULE =~ devdiv@dev.azure.com ]]; then
 	DEPENDENCY_AUTH="-c http.extraheader=\"AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN\""
 fi
 
+echo "*** [$DEPENDENCY_NAME] testing fot git repo in $DEPENDENCY_PATH"
 if test -d "$DEPENDENCY_PATH"; then
 	cd "$DEPENDENCY_PATH"
 	# Check if we have the remote we need

--- a/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
+++ b/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
@@ -34,6 +34,16 @@ parameters:
 
 # build the source code (build.yml) and detect changes (the nested api-diff.yml)
 steps:
+
+# The following checkout(s) are needed due in order to get the proper set of credentials stored in the git config.
+# Without this, then when the `make reset` command is run, any modules that aren't configured already as submodules
+# will be cloned again. This is fine for all GitHub repos, but falls over for AzDo repos.
+- checkout: macios-adr
+  clean: true
+  persistCredentials: true
+  fetchTags: false
+  path: a/change-detection/tmp/src/macios-adr # Path is rooted from $(Pipeline.Workspace) e.g./Users/builder/azdo/_work/18
+
 - template: build.yml
   parameters:
     isPR: ${{ parameters.isPR }}
@@ -55,6 +65,7 @@ steps:
   env:
     PR_ID: ${{ parameters.prID }} # reusing jenkins vars, to be fixed
     AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken) # needed to checkout AzDo repo dependencies
 
 # publish the resulting artifact
 - task: PublishPipelineArtifact@1

--- a/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
+++ b/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
@@ -38,7 +38,7 @@ steps:
 # The following checkout(s) are needed due in order to get the proper set of credentials stored in the git config.
 # Without this, then when the `make reset` command is run, any modules that aren't configured already as submodules
 # will be cloned again. This is fine for all GitHub repos, but falls over for AzDo repos.
-- checkout: macios-adr
+- checkout: macios-adr-tmp
   clean: true
   persistCredentials: true
   fetchTags: false

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -134,6 +134,8 @@ steps:
     name: resetDependencies
     displayName: 'Reset dependencies'
     timeoutInMinutes: 10
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken) # needed to checkout AzDo repo dependencies
 
   # We'll need these profiles to build the hot restart prebuilt app during the build
   # (it's built for device, and thus needs a certificate available so that the app can be signed).

--- a/tools/devops/automation/templates/pipelines/api-diff-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/api-diff-pipeline.yml
@@ -55,6 +55,11 @@ resources:
     name: macios-adr
     ref: refs/heads/main
 
+  - repository: macios-adr-tmp
+    type: git
+    name: macios-adr
+    ref: refs/heads/main
+
 variables:
 - template: ../variables/common.yml
 - name: DisablePipelineConfigDetector


### PR DESCRIPTION
Since incorporating the adr repository, the APIDIFF pipeline is failing since it does a cli checkout of the adr repository and it doesn't have the proper credentials to complete the checkout.