### PR TITLE
[xharness] Fix running multiple xharness servers simultaneously.

### DIFF
--- a/tests/xharness/Jenkins/TestServer.cs
+++ b/tests/xharness/Jenkins/TestServer.cs
@@ -16,14 +16,15 @@ namespace Xharness.Jenkins {
 
 		public Task RunAsync (Jenkins jenkins, HtmlReportWriter htmlReportWriter)
 		{
-			var server = new HttpListener ();
+			HttpListener server;
 
 			// Try and find an unused port
 			int attemptsLeft = 50;
 			int port = 51234; // Try this port first, to try to not vary between runs just because.
 			Random r = new Random ((int) DateTime.Now.Ticks);
-			while (attemptsLeft-- > 0) {
+			do {
 				var newPort = port != 0 ? port : r.Next (49152, 65535); // The suggested range for dynamic ports is 49152-65535 (IANA)
+				server = new HttpListener ();
 				server.Prefixes.Clear ();
 				server.Prefixes.Add ("http://*:" + newPort + "/");
 				try {
@@ -34,7 +35,7 @@ namespace Xharness.Jenkins {
 					jenkins.MainLog.WriteLine ("Failed to listen on port {0}: {1}", newPort, ex.Message);
 					port = 0;
 				}
-			}
+			} while (attemptsLeft-- > 0);
 			jenkins.MainLog.WriteLine ($"Created server on localhost:{port}");
 
 			var tcs = new TaskCompletionSource<bool> ();


### PR DESCRIPTION
Fixes this exception at startup when there's already an xharness server running:

    Running xharness in server mode. Press Ctrl-C to exit (or click Quit / press Q in the browser page)
    Unexpected exception: System.ObjectDisposedException: Cannot access a disposed object.
    Object name: 'System.Net.HttpListener'.
       at System.Net.HttpListener.get_Prefixes()
       at Xharness.Jenkins.TestServer.RunAsync(Jenkins jenkins, HtmlReportWriter htmlReportWriter) in /Users/rolf/work/maccore/xharness/xamarin-macios/tests/xharness/Jenkins/TestServer.cs:line 27
       at Xharness.Jenkins.Jenkins.Run() in /Users/rolf/work/maccore/xharness/xamarin-macios/tests/xharness/Jenkins/Jenkins.cs:line 220