### PR TITLE
[msbuild] Bump to Microsoft.Build 16.10.0.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
 		<MonoCecilPackageVersion>0.11.5</MonoCecilPackageVersion>
 		<MSBuildStructuredLoggerPackageVersion>2.2.158</MSBuildStructuredLoggerPackageVersion>
-		<MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
+		<MicrosoftBuildPackageVersion>16.10.0</MicrosoftBuildPackageVersion>
 		<MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
 		<MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
 		<MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>


### PR DESCRIPTION
This seems to be the version in Mono: https://github.com/mono/mono/pull/21073

In particular we need the IBuildEngine9 interface, because the ILStrip task needs it:

https://github.com/dotnet/runtime/blob/3aa1ec5bb1f50f0a1bed9cfcac8734f742bcf24b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs#L78

The IBuildEngine9 interface was introduced in MSBuild 16.10 (around March 2021):

https://github.com/dotnet/msbuild/commit/1629921c2b537d4452ff238981bd18519b8f5230