### PR TITLE
[src] Fix duplicate availability attributes.

### DIFF
--- a/src/ObjCRuntime/PlatformAvailability.cs
+++ b/src/ObjCRuntime/PlatformAvailability.cs
@@ -511,6 +511,7 @@ namespace ObjCRuntime {
 		}
 	}
 
+	[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 #if !COREBUILD
 	[Obsolete ("Use [Introduced|Deprecated|Obsoleted|Unavailable] attributes with PlatformName.")]
 #endif
@@ -541,6 +542,7 @@ namespace ObjCRuntime {
 
 	}
 
+	[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 #if !COREBUILD
 	[Obsolete ("Use [Introduced|Deprecated|Obsoleted|Unavailable] attributes with PlatformName.")]
 #endif

--- a/src/ObjCRuntime/PlatformAvailability2.cs
+++ b/src/ObjCRuntime/PlatformAvailability2.cs
@@ -202,6 +202,7 @@ namespace ObjCRuntime {
 		}
 	}
 
+	[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 	public sealed class TVAttribute : IntroducedAttribute {
 		public TVAttribute (byte major, byte minor)
 			: base (PlatformName.TvOS, (int) major, (int) minor)
@@ -226,6 +227,7 @@ namespace ObjCRuntime {
 		}
 	}
 
+	[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 	public sealed class WatchAttribute : IntroducedAttribute {
 		public WatchAttribute (byte major, byte minor)
 			: base (PlatformName.WatchOS, (int) major, (int) minor)
@@ -250,6 +252,7 @@ namespace ObjCRuntime {
 		}
 	}
 
+	[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 	public sealed class MacCatalystAttribute : IntroducedAttribute {
 		public MacCatalystAttribute (byte major, byte minor)
 			: base (PlatformName.MacCatalyst, (int) major, (int) minor)
@@ -262,6 +265,7 @@ namespace ObjCRuntime {
 		}
 	}
 
+	[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 	public sealed class NoMacAttribute : UnavailableAttribute {
 		public NoMacAttribute ()
 			: base (PlatformName.MacOSX)
@@ -269,6 +273,7 @@ namespace ObjCRuntime {
 		}
 	}
 
+	[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 	public sealed class NoiOSAttribute : UnavailableAttribute {
 		public NoiOSAttribute ()
 			: base (PlatformName.iOS)
@@ -276,6 +281,7 @@ namespace ObjCRuntime {
 		}
 	}
 
+	[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 	public sealed class NoWatchAttribute : UnavailableAttribute {
 		public NoWatchAttribute ()
 			: base (PlatformName.WatchOS)
@@ -283,6 +289,7 @@ namespace ObjCRuntime {
 		}
 	}
 
+	[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 	public sealed class NoTVAttribute : UnavailableAttribute {
 		public NoTVAttribute ()
 			: base (PlatformName.TvOS)
@@ -290,6 +297,7 @@ namespace ObjCRuntime {
 		}
 	}
 
+	[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 	public sealed class NoMacCatalystAttribute : UnavailableAttribute {
 		public NoMacCatalystAttribute ()
 			: base (PlatformName.MacCatalyst)

--- a/src/ObjCRuntime/PlatformAvailabilityShadow.cs
+++ b/src/ObjCRuntime/PlatformAvailabilityShadow.cs
@@ -5,6 +5,7 @@ using PlatformName = ObjCRuntime.PlatformName;
 
 // These _must_ be in a less nested namespace than the copies they are shadowing in PlatformAvailability.cs
 // Since those are in ObjcRuntime these must be global
+[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 #if COREBUILD
 public
 #endif
@@ -44,6 +45,7 @@ sealed class MacAttribute : ObjCRuntime.IntroducedAttribute {
 	{
 	}
 }
+[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 #if COREBUILD
 public
 #endif

--- a/src/bgen/Attributes.cs
+++ b/src/bgen/Attributes.cs
@@ -1089,6 +1089,7 @@ public class UnavailableAttribute : AvailabilityBaseAttribute {
 	}
 }
 
+[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 public sealed class TVAttribute : IntroducedAttribute {
 	public TVAttribute (byte major, byte minor)
 		: base (PlatformName.TvOS, (int) major, (int) minor)
@@ -1101,6 +1102,7 @@ public sealed class TVAttribute : IntroducedAttribute {
 	}
 }
 
+[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 public sealed class WatchAttribute : IntroducedAttribute {
 	public WatchAttribute (byte major, byte minor)
 		: base (PlatformName.WatchOS, (int) major, (int) minor)
@@ -1113,6 +1115,7 @@ public sealed class WatchAttribute : IntroducedAttribute {
 	}
 }
 
+[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 public sealed class MacCatalystAttribute : IntroducedAttribute {
 	public MacCatalystAttribute (byte major, byte minor)
 		: base (PlatformName.MacCatalyst, (int) major, (int) minor)
@@ -1125,6 +1128,7 @@ public sealed class MacCatalystAttribute : IntroducedAttribute {
 	}
 }
 
+[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 public sealed class NoMacAttribute : UnavailableAttribute {
 	public NoMacAttribute ()
 		: base (PlatformName.MacOSX)
@@ -1132,6 +1136,7 @@ public sealed class NoMacAttribute : UnavailableAttribute {
 	}
 }
 
+[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 public sealed class NoiOSAttribute : UnavailableAttribute {
 	public NoiOSAttribute ()
 		: base (PlatformName.iOS)
@@ -1139,6 +1144,7 @@ public sealed class NoiOSAttribute : UnavailableAttribute {
 	}
 }
 
+[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 public sealed class NoWatchAttribute : UnavailableAttribute {
 	public NoWatchAttribute ()
 		: base (PlatformName.WatchOS)
@@ -1146,6 +1152,7 @@ public sealed class NoWatchAttribute : UnavailableAttribute {
 	}
 }
 
+[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 public sealed class NoTVAttribute : UnavailableAttribute {
 	public NoTVAttribute ()
 		: base (PlatformName.TvOS)
@@ -1153,6 +1160,7 @@ public sealed class NoTVAttribute : UnavailableAttribute {
 	}
 }
 
+[AttributeUsage (AttributeTargets.All, AllowMultiple = false)]
 public sealed class NoMacCatalystAttribute : UnavailableAttribute {
 	public NoMacCatalystAttribute ()
 		: base (PlatformName.MacCatalyst)

--- a/src/browserenginekit.cs
+++ b/src/browserenginekit.cs
@@ -1195,7 +1195,7 @@ namespace BrowserEngineKit {
 	}
 
 	[BackingFieldType (typeof (ulong))]
-	[iOS (18, 0), TV (18, 0), MacCatalyst (18, 0), NoMac, MacCatalyst (18, 0)]
+	[iOS (18, 0), TV (18, 0), MacCatalyst (18, 0), NoMac]
 	public enum BEAccessibilityTrait : long {
 		[Field ("BEAccessibilityTraitMenuItem")]
 		MenuItem,
@@ -1214,7 +1214,7 @@ namespace BrowserEngineKit {
 	}
 
 	[BackingFieldType (typeof (uint))]
-	[iOS (18, 0), TV (18, 0), MacCatalyst (18, 0), NoMac, MacCatalyst (18, 0)]
+	[iOS (18, 0), TV (18, 0), MacCatalyst (18, 0), NoMac]
 	public enum BEAccessibilityNotification : long {
 		[Field ("BEAccessibilitySelectionChangedNotification")]
 		SelectionChanged,

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -1148,7 +1148,7 @@ namespace CoreLocation {
 		bool IsProducedByAccessory { get; }
 	}
 
-	[Watch (10, 0), TV (17, 0), Mac (14, 0), iOS (17, 0), MacCatalyst (17, 0), TV (17, 0)]
+	[Watch (10, 0), TV (17, 0), Mac (14, 0), iOS (17, 0), MacCatalyst (17, 0)]
 	[BaseType (typeof (NSObject))]
 	interface CLUpdate {
 		[Deprecated (PlatformName.iOS, 18, 0, message: "Use 'Stationary' instead.")]

--- a/src/coremotion.cs
+++ b/src/coremotion.cs
@@ -707,17 +707,14 @@ namespace CoreMotion {
 		float PercentStrong { get; }
 	}
 
-	[NoMac]
 	[Watch (5, 0), NoTV, NoMac, NoiOS]
 	[NoMacCatalyst]
 	delegate void CMDyskineticSymptomResultHandler (CMDyskineticSymptomResult [] dyskineticSymptomResult, NSError error);
 
-	[NoMac]
 	[Watch (5, 0), NoTV, NoMac, NoiOS]
 	[NoMacCatalyst]
 	delegate void CMTremorResultHandler (CMTremorResult [] tremorResults, NSError error);
 
-	[NoMac]
 	[Watch (5, 0), NoTV, NoMac, NoiOS]
 	[NoMacCatalyst]
 	[BaseType (typeof (NSObject))]

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -2022,8 +2022,7 @@ namespace MapKit {
 		nfloat StrokeEnd { get; set; }
 	}
 
-	[NoWatch]
-	[TV (14, 0), NoWatch, iOS (14, 0)]
+	[TV (14, 0), iOS (14, 0)]
 	[MacCatalyst (14, 0)]
 	[BaseType (typeof (MKPolylineRenderer))]
 	partial interface MKGradientPolylineRenderer {
@@ -2098,7 +2097,6 @@ namespace MapKit {
 	}
 
 	[NoWatch]
-	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
 	interface MKLocalSearchCompleter {
@@ -2153,7 +2151,6 @@ namespace MapKit {
 	interface IMKLocalSearchCompleterDelegate { }
 
 	[NoWatch]
-	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[Protocol]
 	[Model]
@@ -2166,7 +2163,6 @@ namespace MapKit {
 		void DidFail (MKLocalSearchCompleter completer, NSError error);
 	}
 
-	[NoWatch]
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -5137,7 +5137,6 @@ namespace Metal {
 		[Export ("setIntersectionFunctionTable:atIndex:")]
 		void SetIntersectionFunctionTable ([NullAllowed] IMTLIntersectionFunctionTable intersectionFunctionTable, nuint index);
 
-		[iOS (14, 0), TV (16, 0), MacCatalyst (14, 0)]
 		[Abstract (GenerateExtensionMethod = true)]
 		[Mac (11, 0), iOS (14, 0), TV (16, 0), MacCatalyst (14, 0)]
 		[Export ("setIntersectionFunctionTables:withRange:")]

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -2793,7 +2793,6 @@ namespace NetworkExtension {
 		NENetworkRule [] ExcludedNetworkRules { get; set; }
 	}
 
-	[NoTV]
 	[NoWatch, NoTV, NoMac, iOS (14, 0)]
 	[MacCatalyst (14, 0)]
 	[BaseType (typeof (NSObject))]

--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -2303,7 +2303,6 @@ namespace PdfKit {
 	[NoiOS]
 	[NoTV]
 	[NoMacCatalyst]
-	[NoTV]
 	interface PdfViewAnnotationHitEventArgs {
 		[Export ("PDFAnnotationHit")]
 		PdfAnnotation AnnotationHit { get; }

--- a/src/social.cs
+++ b/src/social.cs
@@ -232,19 +232,19 @@ namespace Social {
 #if NET
 		// Inlined manually from UITextViewDelegate/NSTextViewDelegate, because the one from the *Delegate type
 		// has different availability attributes depending on the platform.
-		[iOS (18, 0), MacCatalyst (18, 0), Mac (15, 0), MacCatalyst (18, 0), NoTV]
+		[iOS (18, 0), MacCatalyst (18, 0), Mac (15, 0), NoTV]
 		[Export ("textViewWritingToolsWillBegin:")]
 		new void WritingToolsWillBegin (SocialTextView textView);
 
 		// Inlined manually from UITextViewDelegate/NSTextViewDelegate, because the one from the *Delegate type
 		// has different availability attributes depending on the platform.
-		[iOS (18, 0), MacCatalyst (18, 0), Mac (15, 0), MacCatalyst (18, 0), NoTV]
+		[iOS (18, 0), MacCatalyst (18, 0), Mac (15, 0), NoTV]
 		[Export ("textViewWritingToolsDidEnd:")]
 		new void WritingToolsDidEnd (SocialTextView textView);
 
 		// Inlined manually from UITextViewDelegate/NSTextViewDelegate, because the one from the *Delegate type
 		// has different availability attributes depending on the platform.
-		[iOS (18, 0), MacCatalyst (18, 0), Mac (15, 0), MacCatalyst (18, 0), NoTV]
+		[iOS (18, 0), MacCatalyst (18, 0), Mac (15, 0), NoTV]
 		[Export ("textView:writingToolsIgnoredRangesInEnclosingRange:")]
 		new NSValue [] GetWritingToolsIgnoredRangesInEnclosingRange (SocialTextView textView, NSRange enclosingRange);
 #endif

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -21638,8 +21638,6 @@ namespace UIKit {
 	}
 
 	[DisableDefaultCtor] // [Assert] -init is not a useful initializer for this class. Use one of the designated initializers instead
-	[NoWatch]
-	[NoWatch] // added in Xcode 7.1 / iOS 9.1 SDK
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (UIFocusUpdateContext))]
 	interface UICollectionViewFocusUpdateContext {
@@ -29446,7 +29444,7 @@ namespace UIKit {
 	interface UITraitAccessibilityContrast : UINSIntegerTraitDefinition {
 	}
 
-	[NoWatch, TV (17, 0), NoWatch, iOS (17, 0), MacCatalyst (17, 0)]
+	[NoWatch, TV (17, 0), iOS (17, 0), MacCatalyst (17, 0)]
 	[BaseType (typeof (NSObject))]
 	interface UITraitUserInterfaceLevel : UINSIntegerTraitDefinition {
 	}


### PR DESCRIPTION
The generator doesn't handle duplicates well - often it's random which version is looked at, which is not ideal if the attributes are different.

Technically this is a source-breaking change for the generator, but it should be easy to fix api definitions, and it avoids a potential random behavior from the generator.