### PR TITLE
[introspection] Ignore a few protocol conformances for ScreenCaptureKit types.

### DIFF
--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -210,6 +210,11 @@ namespace Introspection {
 				case "ASAuthorizationPublicKeyCredentialLargeBlobAssertionInput":
 				case "ASAuthorizationPublicKeyCredentialLargeBlobAssertionOutput":
 				case "ASAuthorizationPublicKeyCredentialLargeBlobRegistrationInput":
+				case "SCContentFilter":
+				case "SCDisplay":
+				case "SCRunningApplication":
+				case "SCWindow":
+				case "SCStreamConfiguration":
 					return true;
 				}
 				break;
@@ -426,6 +431,11 @@ namespace Introspection {
 				case "UIHoverGestureRecognizer":
 				// Xcode 16.2 Conformance not in headers
 				case "SCSensitivityAnalysis":
+				case "SCContentFilter":
+				case "SCDisplay":
+				case "SCRunningApplication":
+				case "SCWindow":
+				case "SCStreamConfiguration":
 					return true;
 				}
 				break;
@@ -645,6 +655,11 @@ namespace Introspection {
 					return true;
 				// Xcode 16.2 Conformance not in headers
 				case "SCSensitivityAnalysis":
+				case "SCContentFilter":
+				case "SCDisplay":
+				case "SCRunningApplication":
+				case "SCWindow":
+				case "SCStreamConfiguration":
 					return true;
 				}
 				break;


### PR DESCRIPTION
These show up / fail on macOS 15.2+.