### PR TITLE
[mk] Fix adr checkout.

### DIFF
--- a/mk/xamarin-reset.sh
+++ b/mk/xamarin-reset.sh
@@ -5,6 +5,7 @@ if test -n "$V"; then set -x; fi
 DEPENDENCY_NAME="$1"
 
 # Calculate the remote from the format: git@github.com:<remote>/<repo>.git
+DEPENDENCY_AUTH=()
 if [[ $DEPENDENCY_MODULE =~ git@github.com ]]; then
 	# git@ url
 	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/git@github.com:/}
@@ -16,10 +17,13 @@ elif [[ $DEPENDENCY_MODULE =~ https://github.com ]]; then
 elif [[ $DEPENDENCY_MODULE =~ devdiv@dev.azure.com ]]; then
 	DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/https:\/\/devdiv@dev.azure.com\/devdiv\/}
 	DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/_git*}
-	DEPENDENCY_AUTH="-c http.extraheader=\"AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN\""
+	if test -n "$SYSTEM_ACCESSTOKEN"; then
+		DEPENDENCY_AUTH+=("-c")
+		DEPENDENCY_AUTH+=("http.extraheader='AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN'")
+	fi
 fi
 
-echo "*** [$DEPENDENCY_NAME] testing fot git repo in $DEPENDENCY_PATH"
+echo "*** [$DEPENDENCY_NAME] testing for git repo in $DEPENDENCY_PATH"
 if test -d "$DEPENDENCY_PATH"; then
 	cd "$DEPENDENCY_PATH"
 	# Check if we have the remote we need
@@ -39,10 +43,10 @@ if test -d "$DEPENDENCY_PATH"; then
 	fi
 
 else
-	echo "*** [$DEPENDENCY_NAME] git $DEPENDENCY_AUTH clone $DEPENDENCY_MODULE --recursive $DEPENDENCY_DIRECTORY -b $DEPENDENCY_BRANCH --origin $DEPENDENCY_REMOTE"
+	echo "*** [$DEPENDENCY_NAME] git ${DEPENDENCY_AUTH[*]} clone $DEPENDENCY_MODULE --recursive $DEPENDENCY_DIRECTORY -b $DEPENDENCY_BRANCH --origin $DEPENDENCY_REMOTE"
 	mkdir -p "$(dirname "$DEPENDENCY_PATH")"
 	cd "$(dirname "$DEPENDENCY_PATH")"
-	git "$DEPENDENCY_AUTH" "$DEPENDENCY_MODULE" --recursive "$DEPENDENCY_DIRECTORY" -b "$DEPENDENCY_BRANCH" --origin "$DEPENDENCY_REMOTE"
+	git "${DEPENDENCY_AUTH[@]}" clone "$DEPENDENCY_MODULE" --recursive "$DEPENDENCY_DIRECTORY" -b "$DEPENDENCY_BRANCH" --origin "$DEPENDENCY_REMOTE"
 	cd "$DEPENDENCY_DIRECTORY"
 fi
 


### PR DESCRIPTION
* Fix local checkout to only pass the extra http header if we have a SYSTEM_ACCESSTOKEN.
* Use a bash array to store authorization arguments, because quoting each
  argument actually works when expanding an array into arguments - in
  particular expanding an empty array expands into nothing (this avoids a
  problem where DEPENDENCY_AUTH would be expanded into an empty (and quoted)
  string, which would execute doing 'git ""', and "" is not a git command.)
* Fix clone command to not forget the 'clone' part of 'git clone ...'