### PR TITLE
[release/9.0.1xx] [xma] Updated Xamarin.Messaging to 3.0.13

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -16,8 +16,7 @@
     <Skip Include="tools\msbuild\iOS\ws2_32.dll" />
     <!-- Broker.zip -->
     <Skip Include="Broker\Newtonsoft.Json.dll" />
-    <Skip Include="Broker\System.Net.Mqtt.dll" />
-    <Skip Include="Broker\System.Net.Mqtt.Server.dll" />
+    <Skip Include="Broker\MQTTnet.dll" />
     <Skip Include="Broker\System.Reactive.dll" />
     <Skip Include="Broker\System.Runtime.CompilerServices.Unsafe.dll" />
     <Skip Include="Broker\System.Security.Cryptography.ProtectedData.dll" />

--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -15,7 +15,7 @@
 			https://dev.azure.com/azure-public/vside/_artifacts/feed/xamarin-impl/NuGet/Xamarin.Messaging.Client/
 
 		-->
-		<MessagingVersion Condition="'$(MessagingVersion)' == ''">[2.2.10]</MessagingVersion>
+		<MessagingVersion Condition="'$(MessagingVersion)' == ''">[3.0.13]</MessagingVersion>
 		<HotRestartVersion>[1.1.7]</HotRestartVersion>
 	</PropertyGroup>
 	<Import Project="$(MSBuildThisFileDirectory)../Directory.Build.props" />

--- a/msbuild/ILMerge.targets
+++ b/msbuild/ILMerge.targets
@@ -40,8 +40,7 @@
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.ComponentModel.Annotations'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.ComponentModel.Composition'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Diagnostics.Tracer'" />
-      <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Net.Mqtt'" />
-      <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Net.Mqtt.Server'" />
+      <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'MQTTnet'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Reactive'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Security.Cryptography.ProtectedData'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Text.Encoding.CodePages'" />

--- a/msbuild/Messaging/Xamarin.Messaging.Build/App.config
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/App.config
@@ -16,10 +16,6 @@
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
 			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Mqtt" publicKeyToken="ac60ebe5a5220e27" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-0.2.274.0" newVersion="0.2.274.0" />
-			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
 </configuration>

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Exec.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/Exec.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 using Xamarin.Messaging.Build.Client;
 using System.Security;
 using System.Reactive.Linq;
+using Xamarin.Messaging.Ssh;
 
 // Disable until we get around to enable + fix any issues.
 #nullable disable

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -48,21 +48,15 @@
 
   <Import Project="$(MSBuildThisFileDirectory)..\ILMerge.targets" />
 
-  <!-- Replaces the ProtectedData assembly by the runtime implementation -->
   <Target Name="CopyRuntimeAssemblies" BeforeTargets="ILRepack">
     <ItemGroup>
       <ReferenceCopyLocalToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'%(FileName)' == 'System.Text.Encoding.CodePages'" />
-      <ReferenceCopyLocalToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'%(FileName)' == 'System.Security.Cryptography.ProtectedData'" />
+      <ReferencePathToRemove Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Text.Encoding.CodePages'" />
 
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalToRemove)" />
-
-      <ReferencePathToRemove Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Text.Encoding.CodePages'" />
-      <ReferencePathToRemove Include="@(ReferencePath)" Condition="'%(FileName)' == 'System.Security.Cryptography.ProtectedData'" />
-
       <ReferencePath Remove="@(ReferencePathToRemove)" />
 
       <ReferencePathToAdd Include="@(RuntimeTargetsCopyLocalItems)" Condition="'%(RuntimeIdentifier)' == 'win' And '%(FileName)' == 'System.Text.Encoding.CodePages'" />
-      <ReferencePathToAdd Include="@(RuntimeTargetsCopyLocalItems)" Condition="'%(RuntimeIdentifier)' == 'win' And '%(FileName)' == 'System.Security.Cryptography.ProtectedData'" />
 
       <ReferencePath Include="@(ReferencePathToAdd)">
         <DestinationSubDirectory />


### PR DESCRIPTION
Xamarin.Messaging major version 3 means the replacement of the underlying MQTT library used for message communication. We've replaced the System.Net.Mqtt with MQTTnet (repo under the dotnet org). More details here: https://github.com/xamarin/Xamarin.Messaging/pull/818

For this reason, we also need to remove any System.Net.Mqtt reference from signing lists or ILMerge, and add MQTTnet instead.

This PR also removes the System.Security.Cryptography.ProtectedData runtime implementation handling, since the new version used by Messaging (8.0.0) doesn't include a specific Windows runtime implementation, so we don't need to do this extra MSBuild handling to reference the right assemblies anymore


Backport of #21767
