### PR TITLE
[release/9.0.1xx] [dotnet] Create and ship a WorkloadDependencies.json file. Fixes #21768.

### DIFF
--- a/dotnet/.gitignore
+++ b/dotnet/.gitignore
@@ -1,6 +1,7 @@
 tmpdir
 WorkloadManifest.json
 WorkloadManifest.targets
+WorkloadDependencies.json
 nupkgs
 Microsoft.*.Sdk/targets/Microsoft.*.Sdk.ImplicitNamespaceImports.props
 Microsoft.*.Sdk/targets/Microsoft.*.Sdk.SupportedTargetPlatforms.props

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -183,6 +183,7 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call SupportedTargetPlatforms,$(
 
 include $(TOP)/scripts/generate-workloadmanifest-json/fragment.mk
 include $(TOP)/scripts/generate-workloadmanifest-targets/fragment.mk
+include $(TOP)/scripts/generate-workloaddependencies-json/fragment.mk
 define WorkloadTargets
 Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.json: Makefile $(TOP)/Make.config.inc $(GIT_DIRECTORY)/HEAD $(GIT_DIRECTORY)/index Makefile $(GENERATE_WORKLOADMANIFEST_JSON) | Workloads/Microsoft.NET.Sdk.$(1)
 	$$(Q) rm -f $$@.tmp
@@ -194,12 +195,18 @@ Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.targets: Makefile $(TOP)/Make.
 	$$(Q_GEN) $(GENERATE_WORKLOADMANIFEST_TARGETS_EXEC) "$(1)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)" "$(DOTNET_TFM)_$$($(4)_NUGET_OS_VERSION)" "$(SUPPORTED_API_VERSIONS_$(4))"
 	$$(Q) mv $$@.tmp $$@
 
+Workloads/Microsoft.NET.Sdk.$(1)/WorkloadDependencies.json: Makefile $(TOP)/Make.config.inc $(GIT_DIRECTORY)/HEAD $(GIT_DIRECTORY)/index Makefile $(GENERATE_WORKLOADDEPENDENCIES_JSON) | Workloads/Microsoft.NET.Sdk.$(1)
+	$$(Q) rm -f $$@.tmp
+	$$(Q_GEN) $(GENERATE_WORKLOADDEPENDENCIES_JSON_EXEC) "$(1)" "$$($(4)_NUGET_VERSION_NO_METADATA)" "$(XCODE_VERSION)" "$$($(4)_NUGET_OS_VERSION)" "$$@.tmp"
+	$$(Q) mv $$@.tmp $$@
 
 WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.json
 WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.targets
+WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/WorkloadDependencies.json
 
 LOCAL_WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.json
 LOCAL_WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.targets
+LOCAL_WORKLOAD_TARGETS += Workloads/Microsoft.NET.Sdk.$(1)/WorkloadDependencies.json
 endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform),$(shell echo $(platform) | tr A-Z a-z),$($(platform)_NUGET_VERSION_NO_METADATA),$(shell echo $(platform) | tr a-z A-Z),$(NET8_$(platform)_NUGET_VERSION_NO_METADATA))))
 

--- a/dotnet/package/microsoft.workloads.csproj
+++ b/dotnet/package/microsoft.workloads.csproj
@@ -9,5 +9,6 @@
   <ItemGroup>
     <!-- workload .nupkg contents should go in /data/ -->
     <Content Update="$(_packagePath)WorkloadManifest.*" PackagePath="data" />
+    <Content Update="$(_packagePath)WorkloadDependencies.json" PackagePath="data" />
   </ItemGroup>
 </Project>

--- a/scripts/generate-workloaddependencies-json/README.md
+++ b/scripts/generate-workloaddependencies-json/README.md
@@ -1,0 +1,1 @@
+# generate-workload-dependencies

--- a/scripts/generate-workloaddependencies-json/fragment.mk
+++ b/scripts/generate-workloaddependencies-json/fragment.mk
@@ -1,0 +1,2 @@
+include $(TOP)/scripts/template.mk
+$(eval $(call TemplateScript,GENERATE_WORKLOADDEPENDENCIES_JSON,generate-workloaddependencies-json))

--- a/scripts/generate-workloaddependencies-json/generate-workloaddependencies-json.cs
+++ b/scripts/generate-workloaddependencies-json/generate-workloaddependencies-json.cs
@@ -1,0 +1,39 @@
+// arguments are: <platform> <version> <xcodeVersion> <sdkVersion> <outputPath>
+
+using System.IO;
+using System.Xml;
+
+var expectedArgumentCount = 5;
+if (args.Length != expectedArgumentCount) {
+	Console.WriteLine ($"Need {expectedArgumentCount} arguments, got {args.Length}");
+	return 1;
+}
+
+var argumentIndex = 0;
+var platform = args [argumentIndex++];
+var version = args [argumentIndex++];
+var xcodeVersion = args [argumentIndex++];
+var sdkVersion = args [argumentIndex++];
+var outputPath = args [argumentIndex++];
+
+var platformLowerCase = platform.ToLowerInvariant ();
+
+using (var writer = new StreamWriter (outputPath)) {
+	writer.WriteLine ($"{{");
+	writer.WriteLine ($"  \"microsoft.net.sdk.{platformLowerCase}\": {{");
+	writer.WriteLine ($"    \"workload\": {{");
+	writer.WriteLine ($"      \"alias\": [ \"{platformLowerCase}\" ],");
+	writer.WriteLine ($"      \"version\": \"{version}\"");
+	writer.WriteLine ($"    }},");
+	writer.WriteLine ($"    \"xcode\": {{");
+	writer.WriteLine ($"      \"version\": \"[{xcodeVersion},)\",");
+	writer.WriteLine ($"      \"recommendedVersion\": \"{xcodeVersion}\"");
+	writer.WriteLine ($"    }},");
+	writer.WriteLine ($"    \"sdk\": {{");
+	writer.WriteLine ($"      \"version\": \"{sdkVersion}\"");
+	writer.WriteLine ($"    }}");
+	writer.WriteLine ($"  }}");
+	writer.WriteLine ($"}}");
+}
+
+return 0;

--- a/scripts/generate-workloaddependencies-json/generate-workloaddependencies-json.csproj
+++ b/scripts/generate-workloaddependencies-json/generate-workloaddependencies-json.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+	</PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/21768.