### PR TITLE
[tests] Don't run 'make' in 'tests/tests-libraries' as part of test setup.

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MergeAppBundleTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MergeAppBundleTaskTest.cs
@@ -22,7 +22,6 @@ namespace Xamarin.MacDev.Tasks {
 				{ "MSBuildSDKsPath", null }, // Comes from MSBuild, and confuses 'dotnet build'
 			};
 
-			RunMake (Path.Combine (Configuration.RootPath, "tests", "test-libraries"), environment: env);
 			RunMake (Path.Combine (Configuration.RootPath, "tests", "common", "TestProjects", "ComplexAssembly"), environment: env);
 		}
 


### PR DESCRIPTION
It's not necessary; this already happens on the bots before the test run
anyway, so any work done here is redundant on the bots. It's even timing out
(after two minutes) on some test runs, which means this should save up to two
minutes for the msbuild tests on the bots.