### PR TITLE
[RGen] Add the platform availability as part of the constructor data model

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
@@ -15,12 +15,12 @@ readonly struct Constructor : IEquatable<Constructor> {
 	/// Type name that owns the constructor.
 	/// </summary>
 	public string Type { get; }
-	
+
 	/// <summary>
 	/// The platform availability of the enum value.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
-	
+
 	/// <summary>
 	/// Get the attributes added to the constructor.
 	/// </summary>
@@ -36,7 +36,7 @@ readonly struct Constructor : IEquatable<Constructor> {
 	/// </summary>
 	public ImmutableArray<Parameter> Parameters { get; } = [];
 
-	public Constructor (string type, 
+	public Constructor (string type,
 		SymbolAvailability symbolAvailability,
 		ImmutableArray<AttributeCodeChange> attributes,
 		ImmutableArray<SyntaxToken> modifiers,
@@ -90,7 +90,7 @@ readonly struct Constructor : IEquatable<Constructor> {
 			return false;
 		if (SymbolAvailability != other.SymbolAvailability)
 			return false;
-		
+
 		var attrsComparer = new AttributesEqualityComparer ();
 		if (!attrsComparer.Equals (Attributes, other.Attributes))
 			return false;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
@@ -5,23 +5,45 @@ using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly struct Constructor : IEquatable<Constructor> {
+	/// <summary>
+	/// Type name that owns the constructor.
+	/// </summary>
 	public string Type { get; }
+	
+	/// <summary>
+	/// The platform availability of the eum value.
+	/// </summary>
+	public SymbolAvailability SymbolAvailability { get; }
+	
+	/// <summary>
+	/// Get the attributes added to the constructor.
+	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; } = [];
 
+	/// <summary>
+	/// Modifiers list.
+	/// </summary>
 	public ImmutableArray<SyntaxToken> Modifiers { get; } = [];
 
+	/// <summary>
+	/// Parameters list.
+	/// </summary>
 	public ImmutableArray<Parameter> Parameters { get; } = [];
 
-	public Constructor (string type, ImmutableArray<AttributeCodeChange> attributes,
+	public Constructor (string type, 
+		SymbolAvailability symbolAvailability,
+		ImmutableArray<AttributeCodeChange> attributes,
 		ImmutableArray<SyntaxToken> modifiers,
 		ImmutableArray<Parameter> parameters)
 	{
 		Type = type;
+		SymbolAvailability = symbolAvailability;
 		Attributes = attributes;
 		Modifiers = modifiers;
 		Parameters = parameters;
@@ -54,6 +76,7 @@ readonly struct Constructor : IEquatable<Constructor> {
 
 		change = new (
 			type: constructor.ContainingSymbol.ToDisplayString ().Trim (), // we want the full name
+			symbolAvailability: constructor.GetSupportedPlatforms (),
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],
 			parameters: parametersBucket.ToImmutable ());
@@ -65,6 +88,9 @@ readonly struct Constructor : IEquatable<Constructor> {
 	{
 		if (Type != other.Type)
 			return false;
+		if (SymbolAvailability != other.SymbolAvailability)
+			return false;
+		
 		var attrsComparer = new AttributesEqualityComparer ();
 		if (!attrsComparer.Equals (Attributes, other.Attributes))
 			return false;
@@ -87,6 +113,7 @@ readonly struct Constructor : IEquatable<Constructor> {
 	{
 		var hashCode = new HashCode ();
 		hashCode.Add (Type);
+		hashCode.Add (SymbolAvailability);
 		foreach (var modifier in Modifiers) {
 			hashCode.Add (modifier);
 		}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
@@ -17,7 +17,7 @@ readonly struct Constructor : IEquatable<Constructor> {
 	public string Type { get; }
 	
 	/// <summary>
-	/// The platform availability of the eum value.
+	/// The platform availability of the enum value.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
 	

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/ConstructorComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/ConstructorComparer.cs
@@ -27,7 +27,8 @@ class ConstructorComparer : IComparer<Constructor> {
 		if (attributesLengthCompare != 0)
 			return attributesLengthCompare;
 
-		// sort by the attributes
+		// Sort by the attributes, this covers the need to sort by the os availability since that
+		// information comes from the attributes. There is no need to sort twice by the same data
 		var attributeComparer = new AttributeComparer ();
 		var xAttributes = x.Attributes.Order (attributeComparer).ToArray ();
 		var yAttributes = y.Attributes.Order (attributeComparer).ToArray ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -65,6 +65,7 @@ public partial class MyClass {
 					Constructors = [
 						new (
 							type: "NS.MyClass",
+							symbolAvailability: new (),
 							attributes: [],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword)
@@ -104,6 +105,7 @@ public partial class MyClass {
 					Constructors = [
 						new (
 							type: "NS.MyClass",
+							symbolAvailability: new (),
 							attributes: [],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword)
@@ -112,6 +114,7 @@ public partial class MyClass {
 						),
 						new (
 							type: "NS.MyClass",
+							symbolAvailability: new (),
 							attributes: [],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -489,7 +489,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			],
 			Constructors = [
-				new Constructor ("MyClass", new(), [], [], []),
+				new Constructor ("MyClass", new (), [], [], []),
 				new ("MyClass",
 					symbolAvailability: new (),
 					attributes: [],
@@ -596,7 +596,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					parameters: [
 						new (0, "string", "name"),
 					]),
-				new ("MyClass", new(), [], [], []),
+				new ("MyClass", new (), [], [], []),
 			],
 		};
 		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
@@ -636,7 +636,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			],
 			Constructors = [
-				new ("MyClass", new(), [], [], []),
+				new ("MyClass", new (), [], [], []),
 				new ("MyClass",
 					symbolAvailability: new (),
 					attributes: [],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -351,7 +351,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			],
 			Constructors = [
-				new ("MyClass", [], [], [])
+				new ("MyClass", new (), [], [], [])
 			],
 		};
 		Assert.False (equalityComparer.Equals (changes1, changes2));
@@ -397,7 +397,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			],
 			Constructors = [
-				new ("MyClass", [], [], [])
+				new ("MyClass", new (), [], [], [])
 			],
 		};
 		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
@@ -438,6 +438,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 			],
 			Constructors = [
 				new ("MyClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [],
 					parameters: [
@@ -488,8 +489,9 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			],
 			Constructors = [
-				new Constructor ("MyClass", [], [], []),
+				new Constructor ("MyClass", new(), [], [], []),
 				new ("MyClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [],
 					parameters: [
@@ -534,8 +536,9 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			],
 			Constructors = [
-				new Constructor ("MyClass", [], [], []),
+				new Constructor ("MyClass", new (), [], [], []),
 				new ("MyClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [],
 					parameters: [
@@ -587,12 +590,13 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 			],
 			Constructors = [
 				new ("MyClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [],
 					parameters: [
 						new (0, "string", "name"),
 					]),
-				new ("MyClass", [], [], []),
+				new ("MyClass", new(), [], [], []),
 			],
 		};
 		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
@@ -632,8 +636,9 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			],
 			Constructors = [
-				new ("MyClass", [], [], []),
+				new ("MyClass", new(), [], [], []),
 				new ("MyClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [],
 					parameters: [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorComparerTests.cs
@@ -11,8 +11,8 @@ public class ConstructorComparerTests {
 	[Fact]
 	public void CompareDiffType ()
 	{
-		var x = new Constructor ("MyClass", [], [], []);
-		var y = new Constructor ("MyClass2", [], [], []);
+		var x = new Constructor ("MyClass", new (), [], [], []);
+		var y = new Constructor ("MyClass2", new (),[], [], []);
 		Assert.Equal (String.Compare (x.Type, y.Type, StringComparison.Ordinal), comparer.Compare (x, y));
 	}
 
@@ -21,12 +21,14 @@ public class ConstructorComparerTests {
 	{
 		var x = new Constructor ("MyClass",
 			attributes: [],
+			symbolAvailability: new (),
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 			],
 			parameters: []);
 		var y = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -39,12 +41,14 @@ public class ConstructorComparerTests {
 	public void CompareDiffModifier ()
 	{
 		var x = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 			],
 			parameters: []);
 		var y = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -58,6 +62,7 @@ public class ConstructorComparerTests {
 	public void CompareAttrsDiffLength ()
 	{
 		var x = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 				new ("SecondAttr", ["first"]),
@@ -68,6 +73,7 @@ public class ConstructorComparerTests {
 			],
 			parameters: []);
 		var y = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],
@@ -83,6 +89,7 @@ public class ConstructorComparerTests {
 	public void CompareDiffAttrs ()
 	{
 		var x = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],
@@ -92,6 +99,7 @@ public class ConstructorComparerTests {
 			],
 			parameters: []);
 		var y = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [
 				new ("SecondAttr", ["first"]),
 			],
@@ -109,6 +117,7 @@ public class ConstructorComparerTests {
 	{
 
 		var x = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],
@@ -120,6 +129,7 @@ public class ConstructorComparerTests {
 				new (0, "string", "name"),
 			]);
 		var y = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],
@@ -138,6 +148,7 @@ public class ConstructorComparerTests {
 	public void CompareDiffParameters ()
 	{
 		var x = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],
@@ -149,6 +160,7 @@ public class ConstructorComparerTests {
 				new (0, "string", "name"),
 			]);
 		var y = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorComparerTests.cs
@@ -12,7 +12,7 @@ public class ConstructorComparerTests {
 	public void CompareDiffType ()
 	{
 		var x = new Constructor ("MyClass", new (), [], [], []);
-		var y = new Constructor ("MyClass2", new (),[], [], []);
+		var y = new Constructor ("MyClass2", new (), [], [], []);
 		Assert.Equal (String.Compare (x.Type, y.Type, StringComparison.Ordinal), comparer.Compare (x, y));
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
 using Xamarin.Tests;
 using Xamarin.Utils;
@@ -31,6 +33,7 @@ namespace NS {
 				emptyConstructor,
 				new Constructor (
 					type: "NS.TestClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -55,6 +58,7 @@ namespace NS {
 				singleParameter,
 				new Constructor (
 					type: "NS.TestClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -84,6 +88,7 @@ namespace NS {
 				multiParameter,
 				new Constructor (
 					type: "NS.TestClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -114,6 +119,7 @@ namespace NS {
 				nullableParameter,
 				new Constructor (
 					type: "NS.TestClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -147,6 +153,7 @@ namespace NS {
 				paramsCollectionParameter,
 				new Constructor (
 					type: "NS.TestClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -176,6 +183,7 @@ namespace NS {
 				optionalParameter,
 				new Constructor (
 					type: "NS.TestClass",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -203,6 +211,7 @@ namespace NS {
 				genericParameter,
 				new Constructor (
 					type: "NS.TestClass<T>",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -212,6 +221,41 @@ namespace NS {
 					]
 				)
 			];
+
+			const string availabilityPresent = @"
+using System.Runtime.Versioning;
+using System;
+
+namespace NS {
+	[SupportedOSPlatform (""ios"")]
+	[SupportedOSPlatform (""tvos"")]
+	public class TestClass {
+		string name;	
+		public TestClass (string? inName = null) {
+			name = inName ?? string.Empty;
+		}
+	}
+}
+";
+			var builder = SymbolAvailability.CreateBuilder ();
+			builder.Add (new SupportedOSPlatformData ("ios"));
+			builder.Add (new SupportedOSPlatformData ("tvos"));
+			
+			yield return [
+				availabilityPresent,
+				new Constructor (
+					type: "NS.TestClass",
+					symbolAvailability: builder.ToImmutable (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (0, "string?", "inName") { IsNullable = true, IsOptional = true, },
+					]
+				)
+			];
+			
 		}
 
 		IEnumerator IEnumerable.GetEnumerator ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorTests.cs
@@ -240,7 +240,7 @@ namespace NS {
 			var builder = SymbolAvailability.CreateBuilder ();
 			builder.Add (new SupportedOSPlatformData ("ios"));
 			builder.Add (new SupportedOSPlatformData ("tvos"));
-			
+
 			yield return [
 				availabilityPresent,
 				new Constructor (
@@ -255,7 +255,7 @@ namespace NS {
 					]
 				)
 			];
-			
+
 		}
 
 		IEnumerator IEnumerable.GetEnumerator ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorsEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorsEqualityComparerTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
 
@@ -14,6 +16,7 @@ public class ConstructorsEqualityComparerTests {
 	public void CompareSingleElementDiffParameterCount ()
 	{
 		var x = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
@@ -21,6 +24,7 @@ public class ConstructorsEqualityComparerTests {
 				new (0, "string", "surname"),
 			]);
 		var y = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
@@ -33,12 +37,14 @@ public class ConstructorsEqualityComparerTests {
 	public void CompareSingleElementSameParameterCountDifferentParams ()
 	{
 		var x = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
 				new (0, "string", "surname"),
 			]);
 		var y = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
@@ -51,12 +57,14 @@ public class ConstructorsEqualityComparerTests {
 	public void CompareDifferentConstructorCount ()
 	{
 		var x = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
 				new (0, "string", "surname"),
 			]);
 		var y = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
@@ -69,17 +77,76 @@ public class ConstructorsEqualityComparerTests {
 	public void CompareSameConstructorsDifferentOrder ()
 	{
 		var x = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
 				new (0, "string", "surname"),
 			]);
 		var y = new Constructor ("MyClass",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
 				new (0, "string", "name"),
 			]);
 		Assert.True (compare.Equals ([x, y], [y, x]));
+	}
+
+	[Fact]
+	public void CompareSameConstructorsDifferentAvailability ()
+	{
+		var xBuilder = SymbolAvailability.CreateBuilder ();
+		xBuilder.Add (new SupportedOSPlatformData ("ios"));
+		xBuilder.Add (new SupportedOSPlatformData ("tvos"));
+		xBuilder.Add (new UnsupportedOSPlatformData ("macos"));
+		
+		var x = new Constructor ("MyClass",
+			symbolAvailability: xBuilder.ToImmutable (),
+			attributes: [],
+			modifiers: [],
+			parameters: [
+				new (0, "string", "surname"),
+			]);
+		
+		var yBuilder = SymbolAvailability.CreateBuilder ();
+		yBuilder.Add (new SupportedOSPlatformData ("ios"));
+		yBuilder.Add (new UnsupportedOSPlatformData ("tvos"));
+		
+		var y = new Constructor ("MyClass",
+			symbolAvailability: yBuilder.ToImmutable (),
+			attributes: [],
+			modifiers: [],
+			parameters: [
+				new (0, "string", "name"),
+			]);
+		Assert.False (compare.Equals ([x], [y]));
+	}
+
+	[Fact]
+	public void ComapreSameConstructorsSameAvailability ()
+	{
+		
+		var builder = SymbolAvailability.CreateBuilder ();
+		builder.Add (new SupportedOSPlatformData ("ios"));
+		builder.Add (new SupportedOSPlatformData ("tvos"));
+		
+		var x = new Constructor ("MyClass",
+			symbolAvailability: builder.ToImmutable (),
+			attributes: [],
+			modifiers: [],
+			parameters: [
+				new (0, "string", "surname"),
+			]);
+		
+		var y = new Constructor ("MyClass",
+			symbolAvailability: builder.ToImmutable (),
+			attributes: [],
+			modifiers: [],
+			parameters: [
+				new (0, "string", "surname"),
+			]);
+		Assert.True (compare.Equals ([x], [y]));
+		
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorsEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorsEqualityComparerTests.cs
@@ -100,7 +100,7 @@ public class ConstructorsEqualityComparerTests {
 		xBuilder.Add (new SupportedOSPlatformData ("ios"));
 		xBuilder.Add (new SupportedOSPlatformData ("tvos"));
 		xBuilder.Add (new UnsupportedOSPlatformData ("macos"));
-		
+
 		var x = new Constructor ("MyClass",
 			symbolAvailability: xBuilder.ToImmutable (),
 			attributes: [],
@@ -108,11 +108,11 @@ public class ConstructorsEqualityComparerTests {
 			parameters: [
 				new (0, "string", "surname"),
 			]);
-		
+
 		var yBuilder = SymbolAvailability.CreateBuilder ();
 		yBuilder.Add (new SupportedOSPlatformData ("ios"));
 		yBuilder.Add (new UnsupportedOSPlatformData ("tvos"));
-		
+
 		var y = new Constructor ("MyClass",
 			symbolAvailability: yBuilder.ToImmutable (),
 			attributes: [],
@@ -126,11 +126,11 @@ public class ConstructorsEqualityComparerTests {
 	[Fact]
 	public void CompareSameConstructorsSameAvailability ()
 	{
-		
+
 		var builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios"));
 		builder.Add (new SupportedOSPlatformData ("tvos"));
-		
+
 		var x = new Constructor ("MyClass",
 			symbolAvailability: builder.ToImmutable (),
 			attributes: [],
@@ -138,7 +138,7 @@ public class ConstructorsEqualityComparerTests {
 			parameters: [
 				new (0, "string", "surname"),
 			]);
-		
+
 		var y = new Constructor ("MyClass",
 			symbolAvailability: builder.ToImmutable (),
 			attributes: [],
@@ -147,6 +147,6 @@ public class ConstructorsEqualityComparerTests {
 				new (0, "string", "surname"),
 			]);
 		Assert.True (compare.Equals ([x], [y]));
-		
+
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorsEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorsEqualityComparerTests.cs
@@ -124,7 +124,7 @@ public class ConstructorsEqualityComparerTests {
 	}
 
 	[Fact]
-	public void ComapreSameConstructorsSameAvailability ()
+	public void CompareSameConstructorsSameAvailability ()
 	{
 		
 		var builder = SymbolAvailability.CreateBuilder ();


### PR DESCRIPTION
This way, when we start generating the code we do not need to calculate the changes and this structure will take into account any changes in the class availability.