### PR TITLE
[RGen] Add the platform availabiltiy to the method data model.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -5,29 +5,58 @@ using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly struct Method : IEquatable<Method> {
 
+	/// <summary>
+	/// Type name that owns the constructor.
+	/// </summary>
 	public string Type { get; }
+	
+	/// <summary>
+	/// Method name.
+	/// </summary>
 	public string Name { get; }
+	
+	/// <summary>
+	/// Method return type.
+	/// </summary>
 	public string ReturnType { get; }
+	
+	/// <summary>
+	/// The platform availability of the eum value.
+	/// </summary>
+	public SymbolAvailability SymbolAvailability { get; }
 
+	/// <summary>
+	/// Get the attributes added to the constructor.
+	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; } = [];
 
+	/// <summary>
+	/// Modifiers list.
+	/// </summary>
 	public ImmutableArray<SyntaxToken> Modifiers { get; } = [];
 
+	/// <summary>
+	/// Parameters list.
+	/// </summary>
 	public ImmutableArray<Parameter> Parameters { get; } = [];
 
-	public Method (string type, string name, string returnType, ImmutableArray<AttributeCodeChange> attributes,
+	public Method (string type, string name, string returnType, 
+		SymbolAvailability symbolAvailability,
+		ImmutableArray<AttributeCodeChange> attributes,
 		ImmutableArray<SyntaxToken> modifiers,
 		ImmutableArray<Parameter> parameters)
 	{
 		Type = type;
 		Name = name;
 		ReturnType = returnType;
+		SymbolAvailability = symbolAvailability;
 		Attributes = attributes;
 		Modifiers = modifiers;
 		Parameters = parameters;
@@ -62,6 +91,7 @@ readonly struct Method : IEquatable<Method> {
 			type: method.ContainingSymbol.ToDisplayString ().Trim (), // we want the full name
 			name: method.Name,
 			returnType: method.ReturnType.ToDisplayString ().Trim (),
+			symbolAvailability: method.GetSupportedPlatforms (),
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],
 			parameters: parametersBucket.ToImmutableArray ());
@@ -77,6 +107,9 @@ readonly struct Method : IEquatable<Method> {
 			return false;
 		if (ReturnType != other.ReturnType)
 			return false;
+		if (SymbolAvailability != other.SymbolAvailability)
+			return false;
+		
 		var attrsComparer = new AttributesEqualityComparer ();
 		if (!attrsComparer.Equals (Attributes, other.Attributes))
 			return false;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -16,17 +16,17 @@ readonly struct Method : IEquatable<Method> {
 	/// Type name that owns the constructor.
 	/// </summary>
 	public string Type { get; }
-	
+
 	/// <summary>
 	/// Method name.
 	/// </summary>
 	public string Name { get; }
-	
+
 	/// <summary>
 	/// Method return type.
 	/// </summary>
 	public string ReturnType { get; }
-	
+
 	/// <summary>
 	/// The platform availability of the eum value.
 	/// </summary>
@@ -47,7 +47,7 @@ readonly struct Method : IEquatable<Method> {
 	/// </summary>
 	public ImmutableArray<Parameter> Parameters { get; } = [];
 
-	public Method (string type, string name, string returnType, 
+	public Method (string type, string name, string returnType,
 		SymbolAvailability symbolAvailability,
 		ImmutableArray<AttributeCodeChange> attributes,
 		ImmutableArray<SyntaxToken> modifiers,
@@ -109,7 +109,7 @@ readonly struct Method : IEquatable<Method> {
 			return false;
 		if (SymbolAvailability != other.SymbolAvailability)
 			return false;
-		
+
 		var attrsComparer = new AttributesEqualityComparer ();
 		if (!attrsComparer.Equals (Attributes, other.Attributes))
 			return false;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/MethodComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/MethodComparer.cs
@@ -34,7 +34,8 @@ class MethodComparer : IComparer<Method> {
 		if (attributesLengthCompare != 0)
 			return attributesLengthCompare;
 
-		// sort by the attributes
+		// sort by the attributes, this allows us not to do a compare against the platform availability
+		// since that is generated via the attrs
 		var attributeComparer = new AttributeComparer ();
 		var xAttributes = x.Attributes.Order (attributeComparer).ToArray ();
 		var yAttributes = y.Attributes.Order (attributeComparer).ToArray ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -300,6 +300,7 @@ public partial class MyClass {
 							type: "NS.MyClass",
 							name: "SetName",
 							returnType: "void",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Method>", ["withName:"])
 							],
@@ -343,6 +344,7 @@ public partial class MyClass {
 							type: "NS.MyClass",
 							name: "SetName",
 							returnType: "void",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Method>", ["withName:"])
 							],
@@ -387,6 +389,7 @@ public partial class MyClass {
 							type: "NS.MyClass",
 							name: "SetName",
 							returnType: "void",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Method>", ["withName:"])
 							],
@@ -402,6 +405,7 @@ public partial class MyClass {
 							type: "NS.MyClass",
 							name: "SetSurname",
 							returnType: "void",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Method>", ["withSurname:"])
 							],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -650,6 +650,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: "bool",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -665,6 +666,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "void",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -735,6 +737,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: "bool",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -815,6 +818,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: "bool",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -830,6 +834,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "void",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -900,6 +905,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "void",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -912,6 +918,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: "bool",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -992,6 +999,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "void",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -1062,6 +1070,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: "bool",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -209,6 +209,7 @@ public partial interface IProtocol {
 							type: "NS.IProtocol",
 							name: "SetName",
 							returnType: "void",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Method>", ["withName:"])
 							],
@@ -252,6 +253,7 @@ public partial interface IProtocol {
 							type: "NS.IProtocol",
 							name: "SetName",
 							returnType: "void",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Method>", ["withName:"])
 							],
@@ -296,6 +298,7 @@ public partial interface IProtocol {
 							type: "NS.IProtocol",
 							name: "SetName",
 							returnType: "void",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Method>", ["withName:"])
 							],
@@ -311,6 +314,7 @@ public partial interface IProtocol {
 							type: "NS.IProtocol",
 							name: "SetSurname",
 							returnType: "void",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Method>", ["withSurname:"])
 							],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodComparerTests.cs
@@ -15,6 +15,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: []
@@ -24,6 +25,7 @@ public class MethodComparerTests {
 			type: "MyOtherType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: []
@@ -39,6 +41,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: []
@@ -48,6 +51,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyOtherMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: []
@@ -62,6 +66,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: []
@@ -71,6 +76,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "int",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: []
@@ -85,6 +91,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -97,6 +104,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -113,6 +121,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PartialKeyword),
@@ -124,6 +133,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -142,6 +152,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 				new ("SecondAttr", ["first"]),
@@ -156,6 +167,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],
@@ -174,6 +186,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],
@@ -187,6 +200,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [
 				new ("SecondAttr", ["first"]),
 			],
@@ -206,6 +220,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],
@@ -221,6 +236,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],
@@ -242,6 +258,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],
@@ -257,6 +274,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: "void",
+			symbolAvailability: new (),
 			attributes: [
 				new ("FirstAttr"),
 			],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodEqualityComparerTests.cs
@@ -19,6 +19,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: []
@@ -29,6 +30,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "Test",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: []
@@ -45,6 +47,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: []
@@ -55,6 +58,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "int",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: []
@@ -71,6 +75,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -84,6 +89,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -102,6 +108,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -115,6 +122,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -134,6 +142,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -145,6 +154,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -158,6 +168,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -177,6 +188,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "string",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -190,6 +202,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -209,6 +222,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -220,6 +234,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -233,6 +248,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -244,6 +260,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -264,6 +281,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -275,6 +293,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -288,6 +307,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [
@@ -299,6 +319,7 @@ public class MethodEqualityComparerTests {
 				type: "MyTypeName",
 				name: "MyMethod",
 				returnType: "void",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
 				parameters: [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
 using Xamarin.Tests;
 using Xamarin.Utils;
@@ -30,6 +32,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "void",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -54,6 +57,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "string",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -81,6 +85,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "NS.CustomType",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -105,6 +110,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "string",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -134,6 +140,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "void",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -161,6 +168,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "string",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -192,6 +200,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: "bool",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -229,6 +238,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "void",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -264,6 +274,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "void",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -287,6 +298,8 @@ namespace NS {
 	}
 }
 ";
+			var builder = SymbolAvailability.CreateBuilder ();
+			builder.Add (new SupportedOSPlatformData ("ios"));
 
 			yield return [
 				methodWithAttribute,
@@ -294,6 +307,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "MyMethod",
 					returnType: "string",
+					symbolAvailability: builder.ToImmutable (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -329,6 +343,7 @@ namespace NS {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: "bool",
+					symbolAvailability: new (),
 					attributes: [
 					],
 					modifiers: [


### PR DESCRIPTION
This way we have all the needed data when generated the generated code taking into account the availability of the parent objects.