### PR TITLE
[RGen] Add the platform availability as part of the property data model.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailability.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailability.cs
@@ -170,7 +170,7 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 		sb.Append ($"Platform: {Platform} ");
 		sb.Append ($"Supported: '{SupportedVersion?.ToString ()}' ");
 		sb.Append ("Unsupported: [");
-		sb.AppendJoin (", ", unsupported.Select (v => $"'{v.Key}': '{v.Value?.ToString () ?? "null" }'"));
+		sb.AppendJoin (", ", unsupported.Select (v => $"'{v.Key}': '{v.Value?.ToString () ?? "null"}'"));
 		sb.Append ("], Obsoleted: [");
 		sb.AppendJoin (", ", obsoleted.Select (v => $"'{v.Key}': ('{v.Value.Message?.ToString () ?? "null"}', '{v.Value.Url?.ToString () ?? "null"}')"));
 		sb.Append ("] }");

--- a/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailability.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailability.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Xamarin.Utils;
 
 namespace Microsoft.Macios.Generator.Availability;
@@ -37,7 +39,7 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 	readonly SortedDictionary<Version, (string? Message, string? Url)> obsoleted = new ();
 
 	/// <summary>
-	/// Dictionary tath contains all the unsupported versions and their optional data.
+	/// The Dictionary which contains all the unsupported versions and their optional data.
 	/// </summary>
 	public readonly IReadOnlyDictionary<Version, (string? Message, string? Url)> ObsoletedVersions => obsoleted;
 
@@ -55,8 +57,8 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 	{
 		Platform = platform;
 		SupportedVersion = supportedVersion;
-		unsupported = unsupportedVersions;
-		obsoleted = obsoletedVersions;
+		unsupported = new (unsupportedVersions);
+		obsoleted = new (obsoletedVersions);
 	}
 
 	/// <summary>
@@ -67,7 +69,7 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 	{
 		Platform = other.Platform;
 		SupportedVersion = other.SupportedVersion;
-		// important, the default copy constructor of a record wont do this. It will use the same ref, not
+		// Important: the default copy constructor of a record won't do this. It will use the same ref, not
 		// something we want to do because it will mean that two records will modify the same collection
 		unsupported = new (other.unsupported);
 		obsoleted = new (other.obsoleted);
@@ -159,5 +161,19 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 	public static bool operator != (PlatformAvailability left, PlatformAvailability right)
 	{
 		return !left.Equals (right);
+	}
+
+	/// <inheritdoc/>
+	public override string ToString ()
+	{
+		var sb = new StringBuilder ("{ ");
+		sb.Append ($"Platform: {Platform} ");
+		sb.Append ($"Supported: '{SupportedVersion?.ToString ()}' ");
+		sb.Append ("Unsupported: [");
+		sb.AppendJoin (", ", unsupported.Select (v => $"'{v.Key}': '{v.Value?.ToString () ?? "null" }'"));
+		sb.Append ("], Obsoleted: [");
+		sb.AppendJoin (", ", obsoleted.Select (v => $"'{v.Key}': ('{v.Value.Message?.ToString () ?? "null"}', '{v.Value.Url?.ToString () ?? "null"}')"));
+		sb.Append ("] }");
+		return sb.ToString ();
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailabilityBuilder.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailabilityBuilder.cs
@@ -100,7 +100,7 @@ readonly partial struct PlatformAvailability {
 		/// <summary>
 		/// Add a new obsoleted version of the platform to the availability struct.
 		/// </summary>
-		/// <param name="version"></param>
+		/// <param name="version">The supported versions to add.</param>
 		/// <param name="message">Optional obsolete message.</param>
 		/// <param name="url">Optional documentation url.</param>
 		public void AddObsoletedVersion (Version version, string? message, string? url)
@@ -136,6 +136,16 @@ readonly partial struct PlatformAvailability {
 		public PlatformAvailability ToImmutable ()
 		{
 			return new PlatformAvailability (platform, supportedVersion, unsupported, obsoleted);
+		}
+		
+		/// <summary>
+		/// Clear all the versions that have been added to the platform availability.
+		/// </summary>
+		public void Clear ()
+		{
+			supportedVersion = null;
+			unsupported.Clear ();
+			obsoleted.Clear ();
 		}
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailabilityBuilder.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailabilityBuilder.cs
@@ -137,7 +137,7 @@ readonly partial struct PlatformAvailability {
 		{
 			return new PlatformAvailability (platform, supportedVersion, unsupported, obsoleted);
 		}
-		
+
 		/// <summary>
 		/// Clear all the versions that have been added to the platform availability.
 		/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Availability/SymbolAvailability.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/SymbolAvailability.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Xamarin.Utils;
 
 namespace Microsoft.Macios.Generator.Availability;
@@ -151,5 +153,14 @@ readonly partial struct SymbolAvailability : IEquatable<SymbolAvailability> {
 	public static bool operator != (SymbolAvailability left, SymbolAvailability right)
 	{
 		return !left.Equals (right);
+	}
+
+	/// <inheritdoc/>
+	public override string ToString ()
+	{
+		var sb = new StringBuilder ("[");
+		sb.AppendJoin (", ", availabilities.Values.Where (x => x is not null));
+		sb.Append ("]");
+		return sb.ToString ();
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Availability/SymbolAvailabilityBuilder.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/SymbolAvailabilityBuilder.cs
@@ -78,7 +78,7 @@ readonly partial struct SymbolAvailability {
 			var builder = GetBuilder (platform);
 			builder.AddSupportedVersion (version);
 		}
-		
+
 		/// <summary>
 		/// Add a new supported version to the SymbolAvailability.
 		/// </summary>
@@ -102,7 +102,7 @@ readonly partial struct SymbolAvailability {
 		{
 			if (!supportedPlatforms.Contains (platform))
 				return;
-			
+
 			var builder = GetBuilder (platform);
 			builder.AddUnsupportedVersion (version, message);
 		}

--- a/src/rgen/Microsoft.Macios.Generator/Availability/SymbolAvailabilityBuilder.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/SymbolAvailabilityBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Macios.Generator.Attributes;
 using Xamarin.Utils;
@@ -36,6 +37,22 @@ readonly partial struct SymbolAvailability {
 		}
 
 		/// <summary>
+		/// Add a new obsoleted version of the platform to the availability struct.
+		/// </summary>
+		/// <param name="platform">Platforms whose availability we are updating.</param>
+		/// <param name="version">The supported versions to add.</param>
+		/// <param name="message">Optional obsolete message.</param>
+		/// <param name="url">Optional documentation url.</param>
+		internal void AddObsoletedVersion (ApplePlatform platform, Version version, string? message, string? url)
+		{
+			if (!supportedPlatforms.Contains (platform))
+				return;
+
+			var builder = GetBuilder (platform);
+			builder.AddObsoletedVersion (version, message, url);
+		}
+
+		/// <summary>
 		/// Adds a new obsoleted version to the SymbolAvailability.
 		/// </summary>
 		/// <param name="obsoletedOsPlatform">The data of a ObsoleteOSPlatformAttribute.</param>
@@ -48,6 +65,20 @@ readonly partial struct SymbolAvailability {
 			builder.Add (obsoletedOsPlatform);
 		}
 
+
+		/// <summary>
+		/// Add a new supported version to the SymbolAvailability.
+		/// </summary>
+		/// <param name="platform">Platforms whose availability we are updating.</param>
+		/// <param name="version">The supported versions to add.</param>
+		internal void AddSupportedVersion (ApplePlatform platform, Version version)
+		{
+			if (!supportedPlatforms.Contains (platform))
+				return;
+			var builder = GetBuilder (platform);
+			builder.AddSupportedVersion (version);
+		}
+		
 		/// <summary>
 		/// Add a new supported version to the SymbolAvailability.
 		/// </summary>
@@ -62,7 +93,22 @@ readonly partial struct SymbolAvailability {
 		}
 
 		/// <summary>
-		/// Add a new unsuspported verison to the SymbolAvailability.
+		/// Adds a new version to the list of unsupported versions. If the platform is unsupported, the version is ignored.
+		/// </summary>
+		/// <param name="platform">Platforms whose availability we are updating.</param>
+		/// <param name="version">The new unsupported version.</param>
+		/// <param name="message">The optional message of the unsupported version.</param>
+		internal void AddUnsupportedVersion (ApplePlatform platform, Version version, string? message)
+		{
+			if (!supportedPlatforms.Contains (platform))
+				return;
+			
+			var builder = GetBuilder (platform);
+			builder.AddUnsupportedVersion (version, message);
+		}
+
+		/// <summary>
+		/// Add a new unsuspported version to the SymbolAvailability.
 		/// </summary>
 		/// <param name="unsupportedPlatform">The data of a UnsupportedOSPlatformAttribute.</param>
 		public void Add (UnsupportedOSPlatformData unsupportedPlatform)

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
@@ -12,7 +12,7 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// The kind of accessor.
 	/// </summary>
 	public AccessorKind Kind { get; }
-	
+
 	/// <summary>
 	/// The platform availability of the enum value.
 	/// </summary>
@@ -51,7 +51,7 @@ readonly struct Accessor : IEquatable<Accessor> {
 			return false;
 		if (SymbolAvailability != other.SymbolAvailability)
 			return false;
-		
+
 		var attrsComparer = new AttributesEqualityComparer ();
 		if (!attrsComparer.Equals (Attributes, other.Attributes))
 			return false;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Availability;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -11,6 +12,11 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// The kind of accessor.
 	/// </summary>
 	public AccessorKind Kind { get; }
+	
+	/// <summary>
+	/// The platform availability of the enum value.
+	/// </summary>
+	public SymbolAvailability SymbolAvailability { get; }
 
 	/// <summary>
 	/// List of attribute code changes of the accessor.
@@ -26,12 +32,14 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// Create a new code change in a property accessor.
 	/// </summary>
 	/// <param name="accessorKind">The kind of accessor.</param>
+	/// <param name="symbolAvailability">The os availability of the symbol.</param>
 	/// <param name="attributes">The list of attributes attached to the accessor.</param>
 	/// <param name="modifiers">The list of visibility modifiers of the accessor.</param>
-	public Accessor (AccessorKind accessorKind, ImmutableArray<AttributeCodeChange> attributes,
+	public Accessor (AccessorKind accessorKind, SymbolAvailability symbolAvailability, ImmutableArray<AttributeCodeChange> attributes,
 		ImmutableArray<SyntaxToken> modifiers)
 	{
 		Kind = accessorKind;
+		SymbolAvailability = symbolAvailability;
 		Attributes = attributes;
 		Modifiers = modifiers;
 	}
@@ -41,6 +49,9 @@ readonly struct Accessor : IEquatable<Accessor> {
 	{
 		if (Kind != other.Kind)
 			return false;
+		if (SymbolAvailability != other.SymbolAvailability)
+			return false;
+		
 		var attrsComparer = new AttributesEqualityComparer ();
 		if (!attrsComparer.Equals (Attributes, other.Attributes))
 			return false;
@@ -73,7 +84,7 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// <inheritdoc />
 	public override string ToString ()
 	{
-		var sb = new StringBuilder ($"{{ Kind: {Kind}, Modifiers: [");
+		var sb = new StringBuilder ($"{{ Kind: {Kind}, Supported Platforms: {SymbolAvailability} Modifiers: [");
 		sb.AppendJoin (",", Modifiers.Select (x => x.Text));
 		sb.Append ("], Attributes: [");
 		sb.AppendJoin (", ", Attributes);

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
@@ -10,7 +10,6 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly struct Event : IEquatable<Event> {
-
 	/// <summary>
 	/// Name of the property.
 	/// </summary>
@@ -104,16 +103,19 @@ readonly struct Event : IEquatable<Event> {
 		if (declaration.AccessorList is not null && declaration.AccessorList.Accessors.Count > 0) {
 			// calculate any possible changes in the accessors of the property
 			var accessorsBucket = ImmutableArray.CreateBuilder<Accessor> ();
-			foreach (var accessor in declaration.AccessorList.Accessors) {
-				var kind = accessor.Kind ().ToAccessorKind ();
-				var accessorAttributeChanges = accessor.GetAttributeCodeChanges (semanticModel);
-				accessorsBucket.Add (new (kind, accessorAttributeChanges, [.. accessor.Modifiers]));
+			foreach (var accessorDeclaration in declaration.AccessorList.Accessors) {
+				if (semanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accesorSymbol)
+					continue;
+				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
+				var accessorAttributeChanges = accessorDeclaration.GetAttributeCodeChanges (semanticModel);
+				accessorsBucket.Add (new(kind, accesorSymbol.GetSupportedPlatforms (), accessorAttributeChanges,
+					[.. accessorDeclaration.Modifiers]));
 			}
 
 			accessorCodeChanges = accessorsBucket.ToImmutable ();
 		}
 
-		change = new (memberName, type, attributes, [.. declaration.Modifiers], accessorCodeChanges);
+		change = new(memberName, type, attributes, [.. declaration.Modifiers], accessorCodeChanges);
 		return true;
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
@@ -108,14 +108,14 @@ readonly struct Event : IEquatable<Event> {
 					continue;
 				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
 				var accessorAttributeChanges = accessorDeclaration.GetAttributeCodeChanges (semanticModel);
-				accessorsBucket.Add (new(kind, accesorSymbol.GetSupportedPlatforms (), accessorAttributeChanges,
+				accessorsBucket.Add (new (kind, accesorSymbol.GetSupportedPlatforms (), accessorAttributeChanges,
 					[.. accessorDeclaration.Modifiers]));
 			}
 
 			accessorCodeChanges = accessorsBucket.ToImmutable ();
 		}
 
-		change = new(memberName, type, attributes, [.. declaration.Modifiers], accessorCodeChanges);
+		change = new (memberName, type, attributes, [.. declaration.Modifiers], accessorCodeChanges);
 		return true;
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
@@ -24,6 +25,11 @@ readonly struct Property : IEquatable<Property> {
 	public string Type { get; } = string.Empty;
 
 	/// <summary>
+	/// The platform availability of the enum value.
+	/// </summary>
+	public SymbolAvailability SymbolAvailability { get; }
+
+	/// <summary>
 	/// Get the attributes added to the member.
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; } = [];
@@ -38,11 +44,14 @@ readonly struct Property : IEquatable<Property> {
 	/// </summary>
 	public ImmutableArray<Accessor> Accessors { get; } = [];
 
-	internal Property (string name, string type, ImmutableArray<AttributeCodeChange> attributes,
+	internal Property (string name, string type,
+		SymbolAvailability symbolAvailability,
+		ImmutableArray<AttributeCodeChange> attributes,
 		ImmutableArray<SyntaxToken> modifiers, ImmutableArray<Accessor> accessors)
 	{
 		Name = name;
 		Type = type;
+		SymbolAvailability = symbolAvailability;
 		Attributes = attributes;
 		Modifiers = modifiers;
 		Accessors = accessors;
@@ -56,6 +65,9 @@ readonly struct Property : IEquatable<Property> {
 			return false;
 		if (Type != other.Type)
 			return false;
+		if (SymbolAvailability != other.SymbolAvailability)
+			return false;
+
 		var attrsComparer = new AttributesEqualityComparer ();
 		if (!attrsComparer.Equals (Attributes, other.Attributes))
 			return false;
@@ -100,36 +112,48 @@ readonly struct Property : IEquatable<Property> {
 			return false;
 		}
 
+		var propertySupportedPlatforms = propertySymbol.GetSupportedPlatforms ();
+
 		var type = propertySymbol.Type.ToDisplayString ().Trim ();
 		var attributes = declaration.GetAttributeCodeChanges (semanticModel);
 		ImmutableArray<Accessor> accessorCodeChanges = [];
 		if (declaration.AccessorList is not null && declaration.AccessorList.Accessors.Count > 0) {
 			// calculate any possible changes in the accessors of the property
 			var accessorsBucket = ImmutableArray.CreateBuilder<Accessor> ();
-			foreach (var accessor in declaration.AccessorList.Accessors) {
-				var kind = accessor.Kind ().ToAccessorKind ();
-				var accessorAttributeChanges = accessor.GetAttributeCodeChanges (semanticModel);
-				accessorsBucket.Add (new (kind, accessorAttributeChanges, [.. accessor.Modifiers]));
+			foreach (var accessorDeclaration in declaration.AccessorList.Accessors) {
+				if (semanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accessorSymbol)
+					continue;
+				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
+				var accessorAttributeChanges = accessorDeclaration.GetAttributeCodeChanges (semanticModel);
+				accessorsBucket.Add (new(kind, accessorSymbol.GetSupportedPlatforms (), accessorAttributeChanges,
+					[.. accessorDeclaration.Modifiers]));
 			}
 
 			accessorCodeChanges = accessorsBucket.ToImmutable ();
 		}
 
 		if (declaration.ExpressionBody is not null) {
-			// an expression body == a getter with no attrs or modifiers
+			// an expression body == a getter with no attrs or modifiers; that means that the accessor does not have
+			// extra availability, but the ones form the property
 			accessorCodeChanges = [
-				new (AccessorKind.Getter, [], [])
+				new(AccessorKind.Getter, propertySupportedPlatforms, [], [])
 			];
 		}
 
-		change = new (memberName, type, attributes, [.. declaration.Modifiers], accessorCodeChanges);
+		change = new(
+			name: memberName,
+			type: type,
+			symbolAvailability: propertySupportedPlatforms,
+			attributes: attributes,
+			modifiers: [.. declaration.Modifiers],
+			accessors: accessorCodeChanges);
 		return true;
 	}
 
 	/// <inheritdoc />
 	public override string ToString ()
 	{
-		var sb = new StringBuilder ($"Name: {Name}, Type: {Type}, Attributes: [");
+		var sb = new StringBuilder ($"Name: {Name}, Type: {Type}, Supported Platforms: {SymbolAvailability}, Attributes: [");
 		sb.AppendJoin (",", Attributes);
 		sb.Append ("], Modifiers: [");
 		sb.AppendJoin (",", Modifiers.Select (x => x.Text));

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -125,7 +125,7 @@ readonly struct Property : IEquatable<Property> {
 					continue;
 				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
 				var accessorAttributeChanges = accessorDeclaration.GetAttributeCodeChanges (semanticModel);
-				accessorsBucket.Add (new(kind, accessorSymbol.GetSupportedPlatforms (), accessorAttributeChanges,
+				accessorsBucket.Add (new (kind, accessorSymbol.GetSupportedPlatforms (), accessorAttributeChanges,
 					[.. accessorDeclaration.Modifiers]));
 			}
 
@@ -136,11 +136,11 @@ readonly struct Property : IEquatable<Property> {
 			// an expression body == a getter with no attrs or modifiers; that means that the accessor does not have
 			// extra availability, but the ones form the property
 			accessorCodeChanges = [
-				new(AccessorKind.Getter, propertySupportedPlatforms, [], [])
+				new (AccessorKind.Getter, propertySupportedPlatforms, [], [])
 			];
 		}
 
-		change = new(
+		change = new (
 			name: memberName,
 			type: type,
 			symbolAvailability: propertySupportedPlatforms,

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/PlatformAvailabilityTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/PlatformAvailabilityTests.cs
@@ -330,7 +330,7 @@ public class PlatformAvailabilityTests {
 	}
 
 	[Theory]
-	[InlineData (ApplePlatform.iOS, new [] { "12.0", "13.0", "13.1", "15.0", "16.0" }, "Unsupporte on iOS")]
+	[InlineData (ApplePlatform.iOS, new [] { "12.0", "13.0", "13.1", "15.0", "16.0" }, "Unsupported on iOS")]
 	[InlineData (ApplePlatform.MacOSX, new [] { "9.0", "10.0", "11.5", "14.0" }, "UseAppKit enum")]
 	[InlineData (ApplePlatform.TVOS, new [] { "8.0", "9.0", "12.0" }, "Not present in TVOS")]
 	[InlineData (ApplePlatform.MacCatalyst, new [] { "10.0", "11.0", "13.1" }, "Use the UIKit version instead")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/PlatformAvailabilityToStringTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/PlatformAvailabilityToStringTests.cs
@@ -15,49 +15,49 @@ public class PlatformAvailabilityToStringTests {
 		{
 			// build platform availabilities to ensure that the string returned is the
 			// expected one. We will use a builder that we can clear after each yield return
-			var builder = PlatformAvailability.CreateBuilder (ApplePlatform.iOS);	
+			var builder = PlatformAvailability.CreateBuilder (ApplePlatform.iOS);
 			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: [], Obsoleted: [] }"];
-			
+
 			builder.Clear ();
-			builder.AddSupportedVersion (new Version(16, 0));
+			builder.AddSupportedVersion (new Version (16, 0));
 			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '16.0' Unsupported: [], Obsoleted: [] }"];
-			
+
 			builder.Clear ();
-			builder.AddUnsupportedVersion (new Version(16,0), null);
+			builder.AddUnsupportedVersion (new Version (16, 0), null);
 			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: ['16.0': 'null'], Obsoleted: [] }"];
-			
+
 			builder.Clear ();
-			builder.AddUnsupportedVersion (new Version(16,0), "Not supported.");
+			builder.AddUnsupportedVersion (new Version (16, 0), "Not supported.");
 			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: ['16.0': 'Not supported.'], Obsoleted: [] }"];
-			
+
 			builder.Clear ();
-			builder.AddUnsupportedVersion (new Version(16,0), "Not supported.");
-			builder.AddUnsupportedVersion (new Version(18,0), "Not supported.");
+			builder.AddUnsupportedVersion (new Version (16, 0), "Not supported.");
+			builder.AddUnsupportedVersion (new Version (18, 0), "Not supported.");
 			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: ['16.0': 'Not supported.', '18.0': 'Not supported.'], Obsoleted: [] }"];
-			
+
 			builder.Clear ();
-			builder.AddObsoletedVersion(new Version(16,0), null, null);
+			builder.AddObsoletedVersion (new Version (16, 0), null, null);
 			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: [], Obsoleted: ['16.0': ('null', 'null')] }"];
-			
+
 			builder.Clear ();
-			builder.AddObsoletedVersion(new Version(16,0), "Obsoleted method", null);
+			builder.AddObsoletedVersion (new Version (16, 0), "Obsoleted method", null);
 			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: [], Obsoleted: ['16.0': ('Obsoleted method', 'null')] }"];
-			
+
 			builder.Clear ();
-			builder.AddObsoletedVersion(new Version(16,0), "Obsoleted method", "https://bing.com");
+			builder.AddObsoletedVersion (new Version (16, 0), "Obsoleted method", "https://bing.com");
 			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: [], Obsoleted: ['16.0': ('Obsoleted method', 'https://bing.com')] }"];
-			
+
 			builder.Clear ();
-			builder.AddObsoletedVersion(new Version(16,0), "Obsoleted method", "https://bing.com");
-			builder.AddObsoletedVersion(new Version(18,0), "Obsoleted method", "https://bing.com");
+			builder.AddObsoletedVersion (new Version (16, 0), "Obsoleted method", "https://bing.com");
+			builder.AddObsoletedVersion (new Version (18, 0), "Obsoleted method", "https://bing.com");
 			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: [], Obsoleted: ['16.0': ('Obsoleted method', 'https://bing.com'), '18.0': ('Obsoleted method', 'https://bing.com')] }"];
-			
+
 			builder.Clear ();
-			builder.AddSupportedVersion (new Version(16, 0));
-			builder.AddUnsupportedVersion (new Version(16,0), "Not supported.");
-			builder.AddUnsupportedVersion (new Version(18,0), "Not supported.");
-			builder.AddObsoletedVersion(new Version(16,0), "Obsoleted method", "https://bing.com");
-			builder.AddObsoletedVersion(new Version(18,0), "Obsoleted method", "https://bing.com");
+			builder.AddSupportedVersion (new Version (16, 0));
+			builder.AddUnsupportedVersion (new Version (16, 0), "Not supported.");
+			builder.AddUnsupportedVersion (new Version (18, 0), "Not supported.");
+			builder.AddObsoletedVersion (new Version (16, 0), "Obsoleted method", "https://bing.com");
+			builder.AddObsoletedVersion (new Version (18, 0), "Obsoleted method", "https://bing.com");
 			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '16.0' Unsupported: ['16.0': 'Not supported.', '18.0': 'Not supported.'], Obsoleted: ['16.0': ('Obsoleted method', 'https://bing.com'), '18.0': ('Obsoleted method', 'https://bing.com')] }"];
 		}
 
@@ -66,7 +66,7 @@ public class PlatformAvailabilityToStringTests {
 	}
 
 	[Theory]
-	[ClassData (typeof(TestDataToString))]
+	[ClassData (typeof (TestDataToString))]
 	void ToStringTest (PlatformAvailability availability, string expected)
-		=> Assert.Equal(expected, availability.ToString ());
+		=> Assert.Equal (expected, availability.ToString ());
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/PlatformAvailabilityToStringTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/PlatformAvailabilityToStringTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Macios.Generator.Availability;
+using Xamarin.Utils;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Availability;
+
+public class PlatformAvailabilityToStringTests {
+
+	class TestDataToString : IEnumerable<object []> {
+
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			// build platform availabilities to ensure that the string returned is the
+			// expected one. We will use a builder that we can clear after each yield return
+			var builder = PlatformAvailability.CreateBuilder (ApplePlatform.iOS);	
+			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: [], Obsoleted: [] }"];
+			
+			builder.Clear ();
+			builder.AddSupportedVersion (new Version(16, 0));
+			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '16.0' Unsupported: [], Obsoleted: [] }"];
+			
+			builder.Clear ();
+			builder.AddUnsupportedVersion (new Version(16,0), null);
+			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: ['16.0': 'null'], Obsoleted: [] }"];
+			
+			builder.Clear ();
+			builder.AddUnsupportedVersion (new Version(16,0), "Not supported.");
+			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: ['16.0': 'Not supported.'], Obsoleted: [] }"];
+			
+			builder.Clear ();
+			builder.AddUnsupportedVersion (new Version(16,0), "Not supported.");
+			builder.AddUnsupportedVersion (new Version(18,0), "Not supported.");
+			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: ['16.0': 'Not supported.', '18.0': 'Not supported.'], Obsoleted: [] }"];
+			
+			builder.Clear ();
+			builder.AddObsoletedVersion(new Version(16,0), null, null);
+			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: [], Obsoleted: ['16.0': ('null', 'null')] }"];
+			
+			builder.Clear ();
+			builder.AddObsoletedVersion(new Version(16,0), "Obsoleted method", null);
+			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: [], Obsoleted: ['16.0': ('Obsoleted method', 'null')] }"];
+			
+			builder.Clear ();
+			builder.AddObsoletedVersion(new Version(16,0), "Obsoleted method", "https://bing.com");
+			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: [], Obsoleted: ['16.0': ('Obsoleted method', 'https://bing.com')] }"];
+			
+			builder.Clear ();
+			builder.AddObsoletedVersion(new Version(16,0), "Obsoleted method", "https://bing.com");
+			builder.AddObsoletedVersion(new Version(18,0), "Obsoleted method", "https://bing.com");
+			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '' Unsupported: [], Obsoleted: ['16.0': ('Obsoleted method', 'https://bing.com'), '18.0': ('Obsoleted method', 'https://bing.com')] }"];
+			
+			builder.Clear ();
+			builder.AddSupportedVersion (new Version(16, 0));
+			builder.AddUnsupportedVersion (new Version(16,0), "Not supported.");
+			builder.AddUnsupportedVersion (new Version(18,0), "Not supported.");
+			builder.AddObsoletedVersion(new Version(16,0), "Obsoleted method", "https://bing.com");
+			builder.AddObsoletedVersion(new Version(18,0), "Obsoleted method", "https://bing.com");
+			yield return [builder.ToImmutable (), "{ Platform: iOS Supported: '16.0' Unsupported: ['16.0': 'Not supported.', '18.0': 'Not supported.'], Obsoleted: ['16.0': ('Obsoleted method', 'https://bing.com'), '18.0': ('Obsoleted method', 'https://bing.com')] }"];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+			=> GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof(TestDataToString))]
+	void ToStringTest (PlatformAvailability availability, string expected)
+		=> Assert.Equal(expected, availability.ToString ());
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/SymbolAvailabilityToStringTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/SymbolAvailabilityToStringTests.cs
@@ -7,40 +7,40 @@ using Xunit;
 namespace Microsoft.Macios.Generator.Tests.Availability;
 
 public class SymbolAvailabilityToStringTests {
-	
+
 	class TestDataToString : IEnumerable<object []> {
 
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			var builder = SymbolAvailability.CreateBuilder ();
 			yield return [builder.ToImmutable (), "[]"];
-			
+
 			builder.Clear ();
-			builder.AddSupportedVersion (ApplePlatform.iOS, new (16,0));
+			builder.AddSupportedVersion (ApplePlatform.iOS, new (16, 0));
 			yield return [builder.ToImmutable (), "[{ Platform: iOS Supported: '16.0' Unsupported: [], Obsoleted: [] }]"];
-			
+
 			builder.Clear ();
-			builder.AddSupportedVersion (ApplePlatform.TVOS, new (16,0));
+			builder.AddSupportedVersion (ApplePlatform.TVOS, new (16, 0));
 			yield return [builder.ToImmutable (), "[{ Platform: TVOS Supported: '16.0' Unsupported: [], Obsoleted: [] }]"];
-			
+
 			builder.Clear ();
-			builder.AddSupportedVersion (ApplePlatform.MacOSX, new (11,0));
+			builder.AddSupportedVersion (ApplePlatform.MacOSX, new (11, 0));
 			yield return [builder.ToImmutable (), "[{ Platform: MacOSX Supported: '11.0' Unsupported: [], Obsoleted: [] }]"];
-			
+
 			builder.Clear ();
-			builder.AddSupportedVersion (ApplePlatform.MacCatalyst, new (16,0));
+			builder.AddSupportedVersion (ApplePlatform.MacCatalyst, new (16, 0));
 			yield return [builder.ToImmutable (), "[{ Platform: MacCatalyst Supported: '16.0' Unsupported: [], Obsoleted: [] }]"];
-			
+
 			builder.Clear ();
-			builder.AddSupportedVersion (ApplePlatform.iOS, new (16,0));
-			builder.AddSupportedVersion (ApplePlatform.MacOSX, new (11,0));
-			builder.AddSupportedVersion (ApplePlatform.MacCatalyst, new (16,0));
+			builder.AddSupportedVersion (ApplePlatform.iOS, new (16, 0));
+			builder.AddSupportedVersion (ApplePlatform.MacOSX, new (11, 0));
+			builder.AddSupportedVersion (ApplePlatform.MacCatalyst, new (16, 0));
 			yield return [builder.ToImmutable (), "[{ Platform: MacOSX Supported: '11.0' Unsupported: [], Obsoleted: [] }, { Platform: iOS Supported: '16.0' Unsupported: [], Obsoleted: [] }, { Platform: MacCatalyst Supported: '16.0' Unsupported: [], Obsoleted: [] }]"];
-			
+
 			builder.Clear ();
-			builder.AddSupportedVersion (ApplePlatform.iOS, new (16,0));
-			builder.AddUnsupportedVersion(ApplePlatform.MacOSX, new (11,0), null);
-			builder.AddSupportedVersion (ApplePlatform.MacCatalyst, new (16,0));
+			builder.AddSupportedVersion (ApplePlatform.iOS, new (16, 0));
+			builder.AddUnsupportedVersion (ApplePlatform.MacOSX, new (11, 0), null);
+			builder.AddSupportedVersion (ApplePlatform.MacCatalyst, new (16, 0));
 			yield return [builder.ToImmutable (), "[{ Platform: MacOSX Supported: '' Unsupported: ['11.0': 'null'], Obsoleted: [] }, { Platform: iOS Supported: '16.0' Unsupported: [], Obsoleted: [] }, { Platform: MacCatalyst Supported: '16.0' Unsupported: [], Obsoleted: [] }]"];
 		}
 
@@ -48,7 +48,7 @@ public class SymbolAvailabilityToStringTests {
 			=> GetEnumerator ();
 	}
 	[Theory]
-	[ClassData (typeof(TestDataToString))]
+	[ClassData (typeof (TestDataToString))]
 	void ToStringTest (SymbolAvailability availability, string expected)
-		=> Assert.Equal(expected, availability.ToString ());
+		=> Assert.Equal (expected, availability.ToString ());
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/SymbolAvailabilityToStringTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/SymbolAvailabilityToStringTests.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Macios.Generator.Availability;
+using Xamarin.Utils;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Availability;
+
+public class SymbolAvailabilityToStringTests {
+	
+	class TestDataToString : IEnumerable<object []> {
+
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var builder = SymbolAvailability.CreateBuilder ();
+			yield return [builder.ToImmutable (), "[]"];
+			
+			builder.Clear ();
+			builder.AddSupportedVersion (ApplePlatform.iOS, new (16,0));
+			yield return [builder.ToImmutable (), "[{ Platform: iOS Supported: '16.0' Unsupported: [], Obsoleted: [] }]"];
+			
+			builder.Clear ();
+			builder.AddSupportedVersion (ApplePlatform.TVOS, new (16,0));
+			yield return [builder.ToImmutable (), "[{ Platform: TVOS Supported: '16.0' Unsupported: [], Obsoleted: [] }]"];
+			
+			builder.Clear ();
+			builder.AddSupportedVersion (ApplePlatform.MacOSX, new (11,0));
+			yield return [builder.ToImmutable (), "[{ Platform: MacOSX Supported: '11.0' Unsupported: [], Obsoleted: [] }]"];
+			
+			builder.Clear ();
+			builder.AddSupportedVersion (ApplePlatform.MacCatalyst, new (16,0));
+			yield return [builder.ToImmutable (), "[{ Platform: MacCatalyst Supported: '16.0' Unsupported: [], Obsoleted: [] }]"];
+			
+			builder.Clear ();
+			builder.AddSupportedVersion (ApplePlatform.iOS, new (16,0));
+			builder.AddSupportedVersion (ApplePlatform.MacOSX, new (11,0));
+			builder.AddSupportedVersion (ApplePlatform.MacCatalyst, new (16,0));
+			yield return [builder.ToImmutable (), "[{ Platform: MacOSX Supported: '11.0' Unsupported: [], Obsoleted: [] }, { Platform: iOS Supported: '16.0' Unsupported: [], Obsoleted: [] }, { Platform: MacCatalyst Supported: '16.0' Unsupported: [], Obsoleted: [] }]"];
+			
+			builder.Clear ();
+			builder.AddSupportedVersion (ApplePlatform.iOS, new (16,0));
+			builder.AddUnsupportedVersion(ApplePlatform.MacOSX, new (11,0), null);
+			builder.AddSupportedVersion (ApplePlatform.MacCatalyst, new (16,0));
+			yield return [builder.ToImmutable (), "[{ Platform: MacOSX Supported: '' Unsupported: ['11.0': 'null'], Obsoleted: [] }, { Platform: iOS Supported: '16.0' Unsupported: [], Obsoleted: [] }, { Platform: MacCatalyst Supported: '16.0' Unsupported: [], Obsoleted: [] }]"];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+			=> GetEnumerator ();
+	}
+	[Theory]
+	[ClassData (typeof(TestDataToString))]
+	void ToStringTest (SymbolAvailability availability, string expected)
+		=> Assert.Equal(expected, availability.ToString ());
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
@@ -138,7 +138,7 @@ public class AccessorTests {
 		Assert.True (x == y);
 		Assert.False (x != y);
 	}
-	
+
 	[Fact]
 	public void CompareSameKindSameAttrDiffAvailability ()
 	{
@@ -166,7 +166,7 @@ public class AccessorTests {
 		Assert.False (x == y);
 		Assert.True (x != y);
 	}
-	
+
 	[Fact]
 	public void CompareSameKindSameAttrSameAvailability ()
 	{

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
 
@@ -8,8 +10,8 @@ public class AccessorTests {
 	[Fact]
 	public void CompareDiffKind ()
 	{
-		var x = new Accessor (AccessorKind.Getter, [], []);
-		var y = new Accessor (AccessorKind.Setter, [], []);
+		var x = new Accessor (AccessorKind.Getter, new (), [], []);
+		var y = new Accessor (AccessorKind.Setter, new (), [], []);
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -19,11 +21,11 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindDiffAttrCount ()
 	{
-		var x = new Accessor (AccessorKind.Getter, [
+		var x = new Accessor (AccessorKind.Getter, new (), [
 			new ("First"),
 			new ("Second"),
 		], []);
-		var y = new Accessor (AccessorKind.Getter, [
+		var y = new Accessor (AccessorKind.Getter, new (), [
 			new ("First"),
 		], []);
 		Assert.False (x.Equals (y));
@@ -35,11 +37,11 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindDiffAttr ()
 	{
-		var x = new Accessor (AccessorKind.Getter, [
+		var x = new Accessor (AccessorKind.Getter, new (), [
 			new ("First"),
 			new ("Second"),
 		], []);
-		var y = new Accessor (AccessorKind.Getter, [
+		var y = new Accessor (AccessorKind.Getter, new (), [
 			new ("Third"),
 			new ("Fourth"),
 		], []);
@@ -52,11 +54,11 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindDiffAttrOrder ()
 	{
-		var x = new Accessor (AccessorKind.Getter, [
+		var x = new Accessor (AccessorKind.Getter, new (), [
 			new ("First"),
 			new ("Second"),
 		], []);
-		var y = new Accessor (AccessorKind.Getter, [
+		var y = new Accessor (AccessorKind.Getter, new (), [
 			new ("Second"),
 			new ("First"),
 		], []);
@@ -69,14 +71,14 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindSameAttrDiffModifiersCount ()
 	{
-		var x = new Accessor (AccessorKind.Getter, [
+		var x = new Accessor (AccessorKind.Getter, new (), [
 			new ("First"),
 			new ("Second"),
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
 		]);
-		var y = new Accessor (AccessorKind.Getter, [
+		var y = new Accessor (AccessorKind.Getter, new (), [
 			new ("Second"),
 			new ("First"),
 		], [
@@ -92,14 +94,14 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindSameAttrDiffModifiers ()
 	{
-		var x = new Accessor (AccessorKind.Getter, [
+		var x = new Accessor (AccessorKind.Getter, new (), [
 			new ("First"),
 			new ("Second"),
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
 		]);
-		var y = new Accessor (AccessorKind.Getter, [
+		var y = new Accessor (AccessorKind.Getter, new (), [
 			new ("Second"),
 			new ("First"),
 		], [
@@ -116,14 +118,68 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindSameAttrDiffModifiersOrder ()
 	{
-		var x = new Accessor (AccessorKind.Getter, [
+		var x = new Accessor (AccessorKind.Getter, new (), [
 			new ("First"),
 			new ("Second"),
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
 		]);
-		var y = new Accessor (AccessorKind.Getter, [
+		var y = new Accessor (AccessorKind.Getter, new (), [
+			new ("Second"),
+			new ("First"),
+		], [
+			SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
+			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+		]);
+
+		Assert.True (x.Equals (y));
+		Assert.True (y.Equals (x));
+		Assert.True (x == y);
+		Assert.False (x != y);
+	}
+	
+	[Fact]
+	public void CompareSameKindSameAttrDiffAvailability ()
+	{
+		var builder = SymbolAvailability.CreateBuilder ();
+		builder.Add (new SupportedOSPlatformData ("ios17.0"));
+		var x = new Accessor (AccessorKind.Getter, builder.ToImmutable (), [
+			new ("First"),
+			new ("Second"),
+		], [
+			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+		]);
+		builder.Clear ();
+		builder.Add (new SupportedOSPlatformData ("tvos17.0"));
+		var y = new Accessor (AccessorKind.Getter, builder.ToImmutable (), [
+			new ("Second"),
+			new ("First"),
+		], [
+			SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
+			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+		]);
+
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+	
+	[Fact]
+	public void CompareSameKindSameAttrSameAvailability ()
+	{
+		var builder = SymbolAvailability.CreateBuilder ();
+		builder.Add (new SupportedOSPlatformData ("ios17.0"));
+		var x = new Accessor (AccessorKind.Getter, builder.ToImmutable (), [
+			new ("First"),
+			new ("Second"),
+		], [
+			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+		]);
+		var y = new Accessor (AccessorKind.Getter, builder.ToImmutable (), [
 			new ("Second"),
 			new ("First"),
 		], [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorsEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorsEqualityComparerTests.cs
@@ -19,11 +19,11 @@ public class AccessorsEqualityComparerTests {
 	public void CompareSameSizeDiffSizes ()
 	{
 		ImmutableArray<Accessor> x = [
-			new (AccessorKind.Getter, [], []),
-			new (AccessorKind.Setter, [], []),
+			new (AccessorKind.Getter, new (), [], []),
+			new (AccessorKind.Setter, new (), [], []),
 		];
 		ImmutableArray<Accessor> y = [
-			new (AccessorKind.Getter, [], []),
+			new (AccessorKind.Getter, new (), [], []),
 		];
 
 		Assert.False (equalityComparer.Equals (x, y));
@@ -33,12 +33,12 @@ public class AccessorsEqualityComparerTests {
 	public void CompareSameSizeDiffAccessors ()
 	{
 		ImmutableArray<Accessor> x = [
-			new (AccessorKind.Getter, [], []),
-			new (AccessorKind.Setter, [], []),
+			new (AccessorKind.Getter, new (), [], []),
+			new (AccessorKind.Setter, new (), [], []),
 		];
 		ImmutableArray<Accessor> y = [
-			new (AccessorKind.Add, [], []),
-			new (AccessorKind.Remove, [], []),
+			new (AccessorKind.Add, new (), [], []),
+			new (AccessorKind.Remove, new (), [], []),
 		];
 
 		Assert.False (equalityComparer.Equals (x, y));
@@ -48,12 +48,12 @@ public class AccessorsEqualityComparerTests {
 	public void CompareTwoAccessorsDiffOrder ()
 	{
 		ImmutableArray<Accessor> x = [
-			new (AccessorKind.Getter, [], []),
-			new (AccessorKind.Setter, [], []),
+			new (AccessorKind.Getter, new (), [], []),
+			new (AccessorKind.Setter, new (), [], []),
 		];
 		ImmutableArray<Accessor> y = [
-			new (AccessorKind.Setter, [], []),
-			new (AccessorKind.Getter, [], []),
+			new (AccessorKind.Setter, new (), [], []),
+			new (AccessorKind.Getter, new (), [], []),
 		];
 
 		Assert.True (equalityComparer.Equals (x, y));
@@ -63,13 +63,13 @@ public class AccessorsEqualityComparerTests {
 	public void CompareTwoAccessorsEqual ()
 	{
 		ImmutableArray<Accessor> x = [
-			new (AccessorKind.Getter, [], []),
-			new (AccessorKind.Setter, [], []),
+			new (AccessorKind.Getter, new (), [], []),
+			new (AccessorKind.Setter, new (), [], []),
 		];
 
 		ImmutableArray<Accessor> y = [
-			new (AccessorKind.Getter, [], []),
-			new (AccessorKind.Setter, [], []),
+			new (AccessorKind.Getter, new (), [], []),
+			new (AccessorKind.Setter, new (), [], []),
 		];
 
 		Assert.True (equalityComparer.Equals (x, y));

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -156,6 +156,7 @@ public partial class MyClass {
 						new (
 							name: "Name",
 							type: "string",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
 							],
@@ -164,8 +165,8 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, [], []),
-								new (AccessorKind.Setter, [], []),
+								new (AccessorKind.Getter, new (), [], []),
+								new (AccessorKind.Setter, new (), [], []),
 							]
 						)
 					]
@@ -199,6 +200,7 @@ public partial class MyClass {
 						new (
 							name: "Name",
 							type: "string",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
 							],
@@ -207,8 +209,8 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, [], []),
-								new (AccessorKind.Setter, [], []),
+								new (AccessorKind.Getter, new (),[], []),
+								new (AccessorKind.Setter, new (), [], []),
 							]
 						)
 					]
@@ -243,6 +245,7 @@ public partial class MyClass {
 						new (
 							name: "Name",
 							type: "string",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
 							],
@@ -251,13 +254,14 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, [], []),
-								new (AccessorKind.Setter, [], []),
+								new (AccessorKind.Getter, new (), [], []),
+								new (AccessorKind.Setter, new (), [], []),
 							]
 						),
 						new (
 							name: "Surname",
 							type: "string",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["surname"])
 							],
@@ -266,8 +270,8 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, [], []),
-								new (AccessorKind.Setter, [], []),
+								new (AccessorKind.Getter, new (), [], []),
+								new (AccessorKind.Setter, new (), [], []),
 							]
 						),
 					]
@@ -448,8 +452,8 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, [], []),
-								new (AccessorKind.Remove, [], [])
+								new (AccessorKind.Add, new (), [], []),
+								new (AccessorKind.Remove, new (), [], [])
 							])
 					],
 				}
@@ -488,8 +492,8 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, [], []),
-								new (AccessorKind.Remove, [], [])
+								new (AccessorKind.Add, new (), [], []),
+								new (AccessorKind.Remove, new (), [], [])
 							]
 						),
 						new (
@@ -500,8 +504,8 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, [], []),
-								new (AccessorKind.Remove, [], [])
+								new (AccessorKind.Add, new (), [], []),
+								new (AccessorKind.Remove, new (), [], [])
 							]
 						),
 					],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -209,7 +209,7 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (),[], []),
+								new (AccessorKind.Getter, new (), [], []),
 								new (AccessorKind.Setter, new (), [], []),
 							]
 						)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -96,6 +96,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -103,10 +104,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					])
@@ -125,6 +126,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -132,14 +134,15 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -147,10 +150,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -162,6 +165,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -169,16 +173,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -186,10 +191,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			]
 		};
@@ -205,6 +210,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -212,14 +218,15 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -227,10 +234,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -242,6 +249,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -249,16 +257,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -266,10 +275,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			]
 		};
@@ -285,6 +294,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -292,14 +302,15 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -307,10 +318,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -322,7 +333,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 			]
 		};
@@ -332,6 +343,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -339,16 +351,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -356,10 +369,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			]
 		};
@@ -375,6 +388,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -382,14 +396,15 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -397,10 +412,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -412,7 +427,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 				new (
 					name: "MyEvent2",
@@ -420,8 +435,8 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], []),
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
 					]),
 			]
 		};
@@ -431,6 +446,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -438,16 +454,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -455,10 +472,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			],
 			Events = [
@@ -468,8 +485,8 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], []),
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
 					]),
 				new (
 					name: "MyEvent",
@@ -477,7 +494,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 			]
 		};
@@ -494,6 +511,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -501,14 +519,15 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -516,10 +535,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -531,7 +550,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 			]
 		};
@@ -541,6 +560,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -548,16 +568,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -565,10 +586,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			],
 			Events = [
@@ -580,7 +601,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.InternalKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 			]
 		};
@@ -596,6 +617,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -603,14 +625,15 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -618,10 +641,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -633,7 +656,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 				new (
 					name: "MyEvent2",
@@ -641,8 +664,8 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], []),
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
 					]),
 			],
 			Methods = [
@@ -681,6 +704,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -688,16 +712,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -705,10 +730,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			],
 			Events = [
@@ -718,8 +743,8 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], []),
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
 					]),
 				new (
 					name: "MyEvent",
@@ -727,7 +752,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 			],
 			Methods = [
@@ -761,6 +786,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -768,14 +794,15 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -783,10 +810,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -798,7 +825,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 				new (
 					name: "MyEvent2",
@@ -806,8 +833,8 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], []),
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
 					]),
 			],
 			Methods = [
@@ -846,6 +873,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -853,16 +881,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -870,10 +899,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			],
 			Events = [
@@ -883,8 +912,8 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], []),
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
 					]),
 				new (
 					name: "MyEvent",
@@ -892,7 +921,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 			],
 			Methods = [
@@ -938,6 +967,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -945,14 +975,15 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -960,10 +991,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -975,7 +1006,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 				new (
 					name: "MyEvent2",
@@ -983,8 +1014,8 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], []),
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
 					]),
 			],
 			Methods = [
@@ -1008,6 +1039,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -1015,16 +1047,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -1032,10 +1065,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			],
 			Events = [
@@ -1045,8 +1078,8 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], []),
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
 					]),
 				new (
 					name: "MyEvent",
@@ -1054,7 +1087,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]),
 			],
 			Methods = [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -93,6 +93,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -100,10 +101,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					])
@@ -122,6 +123,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -129,14 +131,15 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -144,10 +147,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -159,6 +162,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -166,16 +170,17 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -183,10 +188,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			]
 		};
@@ -202,6 +207,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -209,14 +215,15 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -224,10 +231,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -239,6 +246,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -246,16 +254,17 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -263,10 +272,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			]
 		};
@@ -282,6 +291,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -289,14 +299,15 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -304,10 +315,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -320,6 +331,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -327,16 +339,17 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -344,10 +357,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			],
 			Constructors = [
@@ -366,6 +379,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -373,14 +387,15 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -388,10 +403,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -406,6 +421,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -413,16 +429,17 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -430,10 +447,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			],
 			Constructors = [
@@ -458,6 +475,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -465,14 +483,15 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -480,10 +499,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -505,6 +524,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -512,16 +532,17 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -529,10 +550,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			],
 			Constructors = [
@@ -558,6 +579,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -565,14 +587,15 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -580,10 +603,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
@@ -605,6 +628,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -612,16 +636,17 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					]),
 				new (
 					name: "Surname",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -629,10 +654,10 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, new (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					]),
 			],
 			Constructors = [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventEqualityComparerTests.cs
@@ -29,7 +29,7 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 			new (
 				name: "SecondEvent",
@@ -39,7 +39,7 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 		ImmutableArray<Event> y = [
@@ -51,7 +51,7 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 
@@ -70,7 +70,7 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 		ImmutableArray<Event> y = [
@@ -82,7 +82,7 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 
@@ -101,7 +101,7 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 		ImmutableArray<Event> y = [
@@ -113,7 +113,7 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
@@ -35,8 +35,8 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], []),
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
 					]
 				)
 			];
@@ -62,7 +62,7 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, [], []),
+						new (AccessorKind.Add, new (), [], []),
 					]
 				)
 			];
@@ -88,8 +88,8 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], [
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], [
 							SyntaxFactory.Token (SyntaxKind.InternalKeyword)
 						]),
 					]
@@ -124,8 +124,8 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, [], []),
-						new (AccessorKind.Remove, [], [
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], [
 							SyntaxFactory.Token (SyntaxKind.InternalKeyword)
 						]),
 					]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -65,6 +65,7 @@ public partial interface IProtocol {
 						new (
 							name: "Name",
 							type: "string",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
 							],
@@ -73,8 +74,8 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, [], []),
-								new (AccessorKind.Setter, [], []),
+								new (AccessorKind.Getter, new (), [], []),
+								new (AccessorKind.Setter, new (), [], []),
 							]
 						)
 					]
@@ -108,6 +109,7 @@ public partial interface IProtocol {
 						new (
 							name: "Name",
 							type: "string",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
 							],
@@ -116,8 +118,8 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, [], []),
-								new (AccessorKind.Setter, [], []),
+								new (AccessorKind.Getter, new (), [], []),
+								new (AccessorKind.Setter, new (), [], []),
 							]
 						)
 					]
@@ -152,6 +154,7 @@ public partial interface IProtocol {
 						new (
 							name: "Name",
 							type: "string",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
 							],
@@ -160,13 +163,14 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, [], []),
-								new (AccessorKind.Setter, [], []),
+								new (AccessorKind.Getter, new (), [], []),
+								new (AccessorKind.Setter, new (), [], []),
 							]
 						),
 						new (
 							name: "Surname",
 							type: "string",
+							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["surname"])
 							],
@@ -175,8 +179,8 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, [], []),
-								new (AccessorKind.Setter, [], []),
+								new (AccessorKind.Getter, new (), [], []),
+								new (AccessorKind.Setter, new (), [], []),
 							]
 						),
 					]
@@ -357,8 +361,8 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, [], []),
-								new (AccessorKind.Remove, [], [])
+								new (AccessorKind.Add, new (), [], []),
+								new (AccessorKind.Remove, new (), [], [])
 							])
 					],
 				}
@@ -397,8 +401,8 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, [], []),
-								new (AccessorKind.Remove, [], [])
+								new (AccessorKind.Add, new (), [], []),
+								new (AccessorKind.Remove, new (), [], [])
 							]
 						),
 						new (
@@ -409,8 +413,8 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, [], []),
-								new (AccessorKind.Remove, [], [])
+								new (AccessorKind.Add, new (), [], []),
+								new (AccessorKind.Remove, new (), [], [])
 							]
 						),
 					],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertiesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertiesEqualityComparerTests.cs
@@ -24,34 +24,37 @@ public class PropertiesEqualityComparerTests {
 			new (
 				name: "FirstProperty",
 				type: "string",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 			new (
 				name: "SecondProperty",
 				type: "string",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 		ImmutableArray<Property> y = [
 			new (
 				name: "FirstProperty",
 				type: "string",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 
@@ -65,24 +68,26 @@ public class PropertiesEqualityComparerTests {
 			new (
 				name: "FirstProperty",
 				type: "string",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 		ImmutableArray<Property> y = [
 			new (
 				name: "FirstProperty",
 				type: "AVFoundation.AVVideo",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 
@@ -96,24 +101,26 @@ public class PropertiesEqualityComparerTests {
 			new (
 				name: "FirstProperty",
 				type: "string",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 		ImmutableArray<Property> y = [
 			new (
 				name: "FirstProperty",
 				type: "string",
+				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, [], [])
+					new (AccessorKind.Getter, new (), [], [])
 				]),
 		];
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
 using Xamarin.Tests;
 using Xamarin.Utils;
@@ -14,8 +16,8 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDiffName ()
 	{
-		var x = new Property ("First", "string", [], [], []);
-		var y = new Property ("Second", "string", [], [], []);
+		var x = new Property ("First", "string", new (), [], [], []);
+		var y = new Property ("Second", "string", new (), [], [], []);
 
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
@@ -26,8 +28,8 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDiffType ()
 	{
-		var x = new Property ("First", "string", [], [], []);
-		var y = new Property ("First", "int", [], [], []);
+		var x = new Property ("First", "string", new (), [], [], []);
+		var y = new Property ("First", "int", new (), [], [], []);
 
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
@@ -38,11 +40,11 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDiffAttrs ()
 	{
-		var x = new Property ("First", "string", [
+		var x = new Property ("First", "string", new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [], []);
-		var y = new Property ("First", "int", [
+		var y = new Property ("First", "int", new (), [
 			new ("Attr2"),
 		], [], []);
 
@@ -55,13 +57,13 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDiffModifiers ()
 	{
-		var x = new Property ("First", "string", [
+		var x = new Property ("First", "string", new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
 			SyntaxFactory.Token (SyntaxKind.AbstractKeyword)
 		], []);
-		var y = new Property ("First", "int", [
+		var y = new Property ("First", "int", new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
@@ -77,22 +79,22 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDiffAccessors ()
 	{
-		var x = new Property ("First", "string", [
+		var x = new Property ("First", "string", new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
-			new (AccessorKind.Getter, [], []),
-			new (AccessorKind.Setter, [], []),
+			new (AccessorKind.Getter, new (), [], []),
+			new (AccessorKind.Setter, new (), [], []),
 		]);
-		var y = new Property ("First", "int", [
+		var y = new Property ("First", "int", new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
-			new (AccessorKind.Getter, [], []),
+			new (AccessorKind.Getter, new (), [], []),
 		]);
 
 		Assert.False (x.Equals (y));
@@ -104,23 +106,23 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareEquals ()
 	{
-		var x = new Property ("First", "string", [
+		var x = new Property ("First", "string", new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
-			new (AccessorKind.Getter, [], []),
-			new (AccessorKind.Setter, [], []),
+			new (AccessorKind.Getter, new (), [], []),
+			new (AccessorKind.Setter, new (), [], []),
 		]);
-		var y = new Property ("First", "string", [
+		var y = new Property ("First", "string", new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
-			new (AccessorKind.Getter, [], []),
-			new (AccessorKind.Setter, [], []),
+			new (AccessorKind.Getter, new (), [], []),
+			new (AccessorKind.Setter, new (), [], []),
 		]);
 
 		Assert.True (x.Equals (y));
@@ -147,12 +149,13 @@ public class TestClass {
 				new Property (
 					name: "Name",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [], [])
+						new (AccessorKind.Getter, new (), [], [])
 					])
 			];
 
@@ -172,13 +175,14 @@ public class TestClass {
 				new Property (
 					name: "Name",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.InternalKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [], []),
-						new (AccessorKind.Setter, [], [])
+						new (AccessorKind.Getter, new (), [], []),
+						new (AccessorKind.Setter, new (), [], [])
 					])
 			];
 
@@ -196,12 +200,13 @@ public class TestClass {
 				new Property (
 					name: "Name",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [], []),
+						new (AccessorKind.Getter, new (), [], []),
 					])
 			];
 
@@ -219,12 +224,13 @@ public class TestClass {
 				new Property (
 					name: "Name",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [], []),
+						new (AccessorKind.Getter, new (), [], []),
 					])
 			];
 
@@ -244,13 +250,14 @@ public class TestClass {
 				new Property (
 					name: "Name",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Getter, new (), [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					])
 			];
 
@@ -271,13 +278,14 @@ public class TestClass {
 				new Property (
 					name: "Name",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Getter, new (), [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					])
 			];
 
@@ -298,13 +306,14 @@ public class TestClass {
 				new Property (
 					name: "Name",
 					type: "string",
+					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [], []),
-						new (AccessorKind.Setter, [], [
+						new (AccessorKind.Getter, new (), [], []),
+						new (AccessorKind.Setter, new (), [], [
 							SyntaxFactory.Token (SyntaxKind.InternalKeyword),
 						]),
 					])
@@ -325,11 +334,15 @@ public class TestClass {
 }
 ";
 
+			var propertyAvailabilityBuilder = SymbolAvailability.CreateBuilder ();
+			propertyAvailabilityBuilder.Add (new SupportedOSPlatformData ("ios"));
+			
 			yield return [
 				propertyWithAttribute,
 				new Property (
 					name: "Name",
 					type: "string",
+					symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -337,8 +350,8 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Getter, new (), [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					])
 			];
 
@@ -358,11 +371,15 @@ public class TestClass {
 }
 ";
 
+			var getterAvailabilityBuilder = SymbolAvailability.CreateBuilder ();
+			var setterAvailabilityBuilder = SymbolAvailability.CreateBuilder ();
+			getterAvailabilityBuilder.Add (new SupportedOSPlatformData ("ios17.0"));
 			yield return [
 				propertyGetterWithAttribute,
 				new Property (
 					name: "Name",
 					type: "string",
+					symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -370,10 +387,10 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, getterAvailabilityBuilder.ToImmutable (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [], []),
+						new (AccessorKind.Setter, new (), [], []),
 					])
 			];
 
@@ -394,11 +411,17 @@ public class TestClass {
 }
 ";
 
+			getterAvailabilityBuilder.Clear ();
+			setterAvailabilityBuilder.Clear ();
+			getterAvailabilityBuilder.Add (new SupportedOSPlatformData ("ios17.0"));
+			setterAvailabilityBuilder.Add (new SupportedOSPlatformData ("ios18.0"));
+			
 			yield return [
 				propertyWithGetterAndSetterWithAttribute,
 				new Property (
 					name: "Name",
 					type: "string",
+					symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -406,10 +429,10 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, getterAvailabilityBuilder.ToImmutable (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, setterAvailabilityBuilder.ToImmutable (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					])
@@ -436,12 +459,17 @@ namespace Test {
 	}
 }
 ";
+			getterAvailabilityBuilder.Clear ();
+			setterAvailabilityBuilder.Clear ();
+			getterAvailabilityBuilder.Add (new SupportedOSPlatformData ("ios17.0"));
+			setterAvailabilityBuilder.Add (new SupportedOSPlatformData ("ios18.0"));
 
 			yield return [
 				propertyWithCustomType,
 				new Property (
 					name: "Name",
 					type: "Utils.MyClass",
+					symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
 					],
@@ -449,10 +477,10 @@ namespace Test {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, [
+						new (AccessorKind.Getter, getterAvailabilityBuilder.ToImmutable (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 						], []),
-						new (AccessorKind.Setter, [
+						new (AccessorKind.Setter, setterAvailabilityBuilder.ToImmutable (), [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 						], []),
 					])

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -336,7 +336,7 @@ public class TestClass {
 
 			var propertyAvailabilityBuilder = SymbolAvailability.CreateBuilder ();
 			propertyAvailabilityBuilder.Add (new SupportedOSPlatformData ("ios"));
-			
+
 			yield return [
 				propertyWithAttribute,
 				new Property (
@@ -415,7 +415,7 @@ public class TestClass {
 			setterAvailabilityBuilder.Clear ();
 			getterAvailabilityBuilder.Add (new SupportedOSPlatformData ("ios17.0"));
 			setterAvailabilityBuilder.Add (new SupportedOSPlatformData ("ios18.0"));
-			
+
 			yield return [
 				propertyWithGetterAndSetterWithAttribute,
 				new Property (


### PR DESCRIPTION
Add the data in the model as well as the availability data to the accessors. We have not modified the events data model in this PR, we only focused on properties.

Added ToString implementations to simplify the test debugger and fixed a bug in one of the constructors in which the structure was not creating a copy of the dictionary but was keeping the ref that was passed to the structure, this resulted in undesirable side effects when modifying the collection.