### PR TITLE
[RGen] Add the field data to the enum values structure.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
@@ -5,7 +5,7 @@ using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.Attributes;
 
-readonly struct FieldData<T> where T : Enum {
+readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 
 	public enum ParsingError {
 		None = 0,
@@ -18,7 +18,7 @@ readonly struct FieldData<T> where T : Enum {
 
 	public T? Flags { get; } = default;
 
-	FieldData (string symbolName, string? libraryName, T? flags)
+	internal FieldData (string symbolName, string? libraryName, T? flags)
 	{
 		SymbolName = symbolName;
 		LibraryName = libraryName;
@@ -67,7 +67,7 @@ readonly struct FieldData<T> where T : Enum {
 			}
 			break;
 		default:
-			// 0 should not be an option..
+			// 0 should not be an option.
 			return false;
 		}
 
@@ -93,5 +93,46 @@ readonly struct FieldData<T> where T : Enum {
 		}
 		data = new (symbolName, libraryName, flags);
 		return true;
+	}
+
+	/// <inheritdoc />
+	public bool Equals (FieldData<T> other)
+	{
+		if (SymbolName != other.SymbolName)
+			return false;
+		if (LibraryName != other.LibraryName)
+			return false;
+		if (Flags is not null && other.Flags is not null) {
+			return Flags.Equals(other.Flags);
+		}
+		return false;
+	}
+	
+	/// <inheritdoc />
+	public override bool Equals (object? obj)
+	{
+		return obj is FieldData<T> other && Equals (other);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode ()
+	{
+		return HashCode.Combine (SymbolName, LibraryName, Flags);
+	}
+
+	public static bool operator == (FieldData<T> x, FieldData<T> y)
+	{
+		return x.Equals (y);
+	}
+
+	public static bool operator != (FieldData<T> x, FieldData<T> y)
+	{
+		return !(x == y);
+	}
+
+	/// <inheritdoc />
+	public override string ToString ()
+	{
+		return $"{{ SymbolName: '{SymbolName}' LibraryName: '{LibraryName ?? "null"}', Flags: '{Flags}' }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -184,15 +184,19 @@ readonly struct CodeChanges {
 		var bucket = ImmutableArray.CreateBuilder<EnumMember> ();
 		// loop over the fields and add those that contain a FieldAttribute
 		var enumValueDeclarations = enumDeclaration.Members.OfType<EnumMemberDeclarationSyntax> ();
-		foreach (var declaration in enumValueDeclarations) {
-			if (Skip (declaration, semanticModel))
+		foreach (var enumValueDeclaration in enumValueDeclarations) {
+			if (Skip (enumValueDeclaration, semanticModel))
 				continue;
-			if (semanticModel.GetDeclaredSymbol (declaration) is not ISymbol symbol) {
+			if (semanticModel.GetDeclaredSymbol (enumValueDeclaration) is not IFieldSymbol enumValueSymbol) {
 				continue;
 			}
-			var memberName = declaration.Identifier.ToFullString ().Trim ();
-			var attributes = declaration.GetAttributeCodeChanges (semanticModel);
-			bucket.Add (new (memberName, symbol.GetSupportedPlatforms (), attributes));
+			var enumMember = new EnumMember (
+				name: enumValueDeclaration.Identifier.ToFullString ().Trim (),
+				fieldData: enumValueSymbol.GetFieldData (),
+				symbolAvailability: enumValueSymbol.GetSupportedPlatforms (),
+				attributes: enumValueDeclaration.GetAttributeCodeChanges (semanticModel)
+			);
+			bucket.Add (enumMember);
 		}
 
 		EnumMembers = bucket.ToImmutable ();

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Immutable;
-using System.Linq;
+using System.Text;
+using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
+using ObjCBindings;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -19,6 +21,8 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 	/// The platform availability of the enum value.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
+	
+	public FieldData<EnumValue>? FieldData { get; }
 
 	/// <summary>
 	/// Get the attributes added to the member.
@@ -29,12 +33,14 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 	/// Create a new change that happened on a member.
 	/// </summary>
 	/// <param name="name">The name of the changed member.</param>
+	/// <param name="fieldData">The binding data attached to this enum value.</param>
 	/// <param name="symbolAvailability">The symbol availability of the member.</param>
 	/// <param name="attributes">The list of attribute changes in the member.</param>
-	public EnumMember (string name, SymbolAvailability symbolAvailability,
+	public EnumMember (string name, FieldData<EnumValue>? fieldData, SymbolAvailability symbolAvailability,
 		ImmutableArray<AttributeCodeChange> attributes)
 	{
 		Name = name;
+		FieldData = fieldData;
 		SymbolAvailability = symbolAvailability;
 		Attributes = attributes;
 	}
@@ -43,7 +49,7 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 	/// Create a new change that happened on a member.
 	/// </summary>
 	/// <param name="name">The name of the changed member.</param>
-	public EnumMember (string name) : this (name, new SymbolAvailability (), ImmutableArray<AttributeCodeChange>.Empty)
+	public EnumMember (string name) : this (name, null, new SymbolAvailability (), ImmutableArray<AttributeCodeChange>.Empty)
 	{
 	}
 
@@ -54,6 +60,9 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 			return false;
 		if (SymbolAvailability != other.SymbolAvailability)
 			return false;
+		if (FieldData != other.FieldData)
+			return false;
+		
 		var attrComparer = new AttributesEqualityComparer ();
 		return attrComparer.Equals (Attributes, other.Attributes);
 	}
@@ -78,5 +87,15 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 	public static bool operator != (EnumMember x, EnumMember y)
 	{
 		return !(x == y);
+	}
+
+	/// <inheritdoc />
+	public override string ToString ()
+	{
+		var sb = new StringBuilder(
+			$"{{ Name: '{Name}' SymbolAvailability: {SymbolAvailability} FieldData: {FieldData} Attributes: [");
+		sb.AppendJoin (", ", Attributes);
+		sb.Append ("] }");
+		return sb.ToString ();
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
@@ -2,10 +2,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Context;
-using Microsoft.Macios.Generator.DataModel;
 using Microsoft.Macios.Generator.Extensions;
 using ObjCBindings;
 

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/FieldSymbolExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/FieldSymbolExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Attributes;
+using ObjCBindings;
+
+namespace Microsoft.Macios.Generator.Extensions;
+
+static class FieldSymbolExtensions {
+	public static FieldData<EnumValue>? GetFieldData (this IFieldSymbol fieldSymbol)
+	{
+		var attributes = fieldSymbol.GetAttributeData ();
+		if (attributes.Count == 0)
+			return null;
+
+		// Get all the FieldAttribute, parse it and add the data to the result
+		if (!attributes.TryGetValue (AttributesNames.EnumFieldAttribute, out var fieldAttrDataList) ||
+		    fieldAttrDataList.Count != 1)
+			return null;
+
+		var fieldAttrData = fieldAttrDataList [0];
+		var fieldSyntax = fieldAttrData.ApplicationSyntaxReference?.GetSyntax ();
+		if (fieldSyntax is null)
+			return null;
+
+		if (FieldData<EnumValue>.TryParse (fieldAttrData, out var fieldData))
+			return fieldData.Value;
+
+		return null;
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/FieldDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/FieldDataTests.cs
@@ -1,0 +1,80 @@
+#pragma warning disable APL0003
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Macios.Generator.Attributes;
+using ObjCBindings;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Attributes;
+
+public class FieldDataTests {
+	[Fact]
+	public void TestFieldDataEqualsDiffSymbolName ()
+	{
+		const string xSymbolName = "x";
+		const string ySymbolName = "y";
+		const string libraryName = "library";
+		var x = new FieldData<EnumValue> (xSymbolName, libraryName, EnumValue.None);
+		var y = new FieldData<EnumValue> (ySymbolName, libraryName, EnumValue.None);
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+
+	[Theory]
+	[InlineData (null, null, true)]
+	[InlineData ("", "", true)]
+	[InlineData ("", null, false)]
+	[InlineData (null, "", false)]
+	[InlineData ("xLib", "yLib", false)]
+	public void TestFieldDataEqualsDiffLibraryName (string? xLibName, string? yLibName, bool expected)
+	{
+		const string symbolName = "symbol";
+		var x = new FieldData<EnumValue> (symbolName, xLibName, EnumValue.None);
+		var y = new FieldData<EnumValue> (symbolName, yLibName, EnumValue.None);
+		Assert.Equal (expected, x.Equals (y));
+		Assert.Equal (expected, y.Equals (x));
+		Assert.Equal (expected, x == y);
+		Assert.Equal (!expected, x != y);
+	}
+
+	[Theory]
+	[InlineData (StringComparison.Ordinal, StringComparison.Ordinal, true)]
+	[InlineData (StringComparison.Ordinal, StringComparison.OrdinalIgnoreCase, false)]
+	public void TestFieldDataEqualsDiffFlag (StringComparison xFlag, StringComparison yFlag, bool expected)
+	{
+		const string symbolName = "symbol";
+		const string libraryName = "library";
+		var x = new FieldData<StringComparison> (symbolName, libraryName, xFlag);
+		var y = new FieldData<StringComparison> (symbolName, libraryName, yFlag);
+		Assert.Equal (expected, x.Equals (y));
+		Assert.Equal (expected, y.Equals (x));
+		Assert.Equal (expected, x == y);
+		Assert.Equal (!expected, x != y);
+	}
+
+
+	class TestDataToString : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				new FieldData<EnumValue> ("symbol", null, EnumValue.None),
+				"{ SymbolName: 'symbol' LibraryName: 'null', Flags: 'None' }"
+			];
+			yield return [
+				new FieldData<EnumValue> ("symbol", "lib", EnumValue.None),
+				"{ SymbolName: 'symbol' LibraryName: 'lib', Flags: 'None' }"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+			=> GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof(TestDataToString))]
+	void TestFieldDataToString (FieldData<EnumValue> x, string expected)
+		=> Assert.Equal(expected, x.ToString ());
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -1,9 +1,5 @@
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.DataModel;
-using Xamarin.Tests;
-using Xamarin.Utils;
 using Xunit;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
@@ -61,7 +57,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 		var changes1 = new CodeChanges (BindingType.SmartEnum, "name");
 		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
 			EnumMembers = [
-				new EnumMember ("name", new (), [])
+				new EnumMember ("name", new (), new (), [])
 			],
 		};
 		Assert.False (comparer.Equals (changes1, changes2));
@@ -72,12 +68,12 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	{
 		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
 			EnumMembers = [
-				new EnumMember ("name", new (), [])
+				new EnumMember ("name", new (), new (), [])
 			],
 		};
 		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
 			EnumMembers = [
-				new EnumMember ("name2", new (), [])
+				new EnumMember ("name2", new (), new (), [])
 			],
 		};
 		Assert.False (comparer.Equals (changes1, changes2));

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -61,7 +61,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 		var changes1 = new CodeChanges (BindingType.SmartEnum, "name");
 		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
 			EnumMembers = [
-				new EnumMember ("name", new (), [])
+				new EnumMember ("name", new (), new (), [])
 			],
 		};
 		Assert.False (equalityComparer.Equals (changes1, changes2));
@@ -72,12 +72,12 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	{
 		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
 			EnumMembers = [
-				new EnumMember ("name", new (), [])
+				new EnumMember ("name", new (), new (), [])
 			],
 		};
 		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
 			EnumMembers = [
-				new EnumMember ("name2", new (), [])
+				new EnumMember ("name2", new (), new (), [])
 			],
 		};
 		Assert.False (equalityComparer.Equals (changes1, changes2));

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
@@ -1,6 +1,10 @@
+#pragma warning disable APL0003
+using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
+using ObjCBindings;
 using Xunit;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
@@ -9,8 +13,8 @@ public class EnumMemberCodeChangesTests {
 	[Fact]
 	public void EqualsNoParams ()
 	{
-		var memberCodeChange1 = new EnumMember ("name", new (), []);
-		var memberCodeChange2 = new EnumMember ("name", new (), []);
+		var memberCodeChange1 = new EnumMember ("name", new (), new (), []);
+		var memberCodeChange2 = new EnumMember ("name", new (), new (), []);
 		Assert.True (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.True (memberCodeChange1 == memberCodeChange2);
 		Assert.False (memberCodeChange1 != memberCodeChange2);
@@ -19,10 +23,10 @@ public class EnumMemberCodeChangesTests {
 	[Fact]
 	public void EqualsWithArgumentParams ()
 	{
-		var memberCodeChange1 = new EnumMember ("name", new (), [
+		var memberCodeChange1 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name", ["arg1", "arg2"])
 		]);
-		var memberCodeChange2 = new EnumMember ("name", new (), [
+		var memberCodeChange2 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name", ["arg1", "arg2"])
 		]);
 		Assert.True (memberCodeChange1.Equals (memberCodeChange2));
@@ -33,8 +37,8 @@ public class EnumMemberCodeChangesTests {
 	[Fact]
 	public void NotEqualsDifferentName ()
 	{
-		var memberCodeChange1 = new EnumMember ("name", new (), []);
-		var memberCodeChange2 = new EnumMember ("name2", new (), []);
+		var memberCodeChange1 = new EnumMember ("name", new (), new (), []);
+		var memberCodeChange2 = new EnumMember ("name2", new (), new (), []);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.False (memberCodeChange1 == memberCodeChange2);
 		Assert.True (memberCodeChange1 != memberCodeChange2);
@@ -43,10 +47,10 @@ public class EnumMemberCodeChangesTests {
 	[Fact]
 	public void NotEqualsDifferentAttributeNames ()
 	{
-		var memberCodeChange1 = new EnumMember ("name", new (), [
+		var memberCodeChange1 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name", ["arg1", "arg2"])
 		]);
-		var memberCodeChange2 = new EnumMember ("name", new (), [
+		var memberCodeChange2 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name2", ["arg1", "arg2"])
 		]);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
@@ -57,10 +61,10 @@ public class EnumMemberCodeChangesTests {
 	[Fact]
 	public void NotEqualsDifferentAttributeParams ()
 	{
-		var memberCodeChange1 = new EnumMember ("name", new (), [
+		var memberCodeChange1 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name", ["arg1", "arg2"])
 		]);
-		var memberCodeChange2 = new EnumMember ("name", new (), [
+		var memberCodeChange2 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name", ["arg1", "arg3"])
 		]);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
@@ -71,10 +75,10 @@ public class EnumMemberCodeChangesTests {
 	[Fact]
 	public void NotEqualsDifferentAttributeParamsOrder ()
 	{
-		var memberCodeChange1 = new EnumMember ("name", new (), [
+		var memberCodeChange1 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name", ["arg1", "arg2"])
 		]);
-		var memberCodeChange2 = new EnumMember ("name", new (), [
+		var memberCodeChange2 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name", ["arg2", "arg1"])
 		]);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
@@ -85,11 +89,11 @@ public class EnumMemberCodeChangesTests {
 	[Fact]
 	public void NotEqualsDifferentAttributesCount ()
 	{
-		var memberCodeChange1 = new EnumMember ("name", new (), [
+		var memberCodeChange1 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name", ["arg1", "arg2"]),
 			new AttributeCodeChange ("name2", [])
 		]);
-		var memberCodeChange2 = new EnumMember ("name", new (), [
+		var memberCodeChange2 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name", ["arg2", "arg1"])
 		]);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
@@ -106,16 +110,78 @@ public class EnumMemberCodeChangesTests {
 		builder.Add (new UnsupportedOSPlatformData ("tvos"));
 		var availability = builder.ToImmutable ();
 
-		var memberCodeChange1 = new EnumMember ("name", availability, [
+		var memberCodeChange1 = new EnumMember ("name", new (), availability, [
 			new AttributeCodeChange ("name", ["arg1", "arg2"]),
 			new AttributeCodeChange ("name2", [])
 		]);
-		var memberCodeChange2 = new EnumMember ("name", new (), [
+		var memberCodeChange2 = new EnumMember ("name", new (), new (), [
 			new AttributeCodeChange ("name", ["arg2", "arg1"])
 		]);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.False (memberCodeChange1 == memberCodeChange2);
 		Assert.True (memberCodeChange1 != memberCodeChange2);
 	}
+
+	[Fact]
+	public void NotEqualsDifferentFieldData ()
+	{
+		var memberCodeChange1 = new EnumMember ("name", new ("x", "libName", EnumValue.None), new (), [
+			new AttributeCodeChange ("name", ["arg1", "arg2"]),
+			new AttributeCodeChange ("name2", [])
+		]);
+		var memberCodeChange2 = new EnumMember ("name", new ("x", "yLibName", EnumValue.None), new (), [
+			new AttributeCodeChange ("name", ["arg2", "arg1"])
+		]);
+		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
+		Assert.False (memberCodeChange1 == memberCodeChange2);
+		Assert.True (memberCodeChange1 != memberCodeChange2);
+	}
+	
+	class TestDataToString : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var simpleEnum = new EnumMember (
+				name: "EnumValue", 
+				fieldData: null,
+				symbolAvailability: new(), 
+				attributes: []);
+			yield return [simpleEnum, "{ Name: 'EnumValue' SymbolAvailability: [] FieldData:  Attributes: [] }"];
+
+			var fieldDataEnum = new EnumMember (
+				name: "EnumValue", 
+				fieldData: new ("x", "libName", EnumValue.None),
+				symbolAvailability: new(), 
+				attributes: []);
+			yield return [fieldDataEnum, "{ Name: 'EnumValue' SymbolAvailability: [] FieldData: { SymbolName: 'x' LibraryName: 'libName', Flags: 'None' } Attributes: [] }"];
+
+			var builder = SymbolAvailability.CreateBuilder ();
+			builder.Add (new SupportedOSPlatformData("ios"));
+			
+			var availabilityEnum = new EnumMember (
+				name: "EnumValue", 
+				fieldData: new ("x", "libName", EnumValue.None),
+				symbolAvailability: builder.ToImmutable (), 
+				attributes: []);
+			yield return [availabilityEnum, "{ Name: 'EnumValue' SymbolAvailability: [{ Platform: iOS Supported: '0.0' Unsupported: [], Obsoleted: [] }] FieldData: { SymbolName: 'x' LibraryName: 'libName', Flags: 'None' } Attributes: [] }"];
+			
+			var attrsEnum = new EnumMember(
+				name: "EnumValue", 
+				fieldData: new ("x", "libName", EnumValue.None),
+				symbolAvailability: builder.ToImmutable (), 
+				attributes: [
+					new ("Attribute1"),
+					new ("Attribute2"),
+				]);
+			yield return [attrsEnum, "{ Name: 'EnumValue' SymbolAvailability: [{ Platform: iOS Supported: '0.0' Unsupported: [], Obsoleted: [] }] FieldData: { SymbolName: 'x' LibraryName: 'libName', Flags: 'None' } Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }"];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+			=> GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof(TestDataToString))]
+	void TestFieldDataToString (EnumMember x, string expected)
+		=> Assert.Equal(expected, x.ToString ());
 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMembersEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMembersEqualityComparerTests.cs
@@ -1,6 +1,8 @@
+#pragma warning disable APL0003
 using System.Collections.Immutable;
 using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
+using ObjCBindings;
 using Xunit;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
@@ -17,32 +19,42 @@ public class EnumMembersEqualityComparerTests {
 	[Fact]
 	public void NotEqualsDiffLength ()
 	{
-		ImmutableArray<EnumMember> x = [new ("name", new (), []), new ("name1")];
-		ImmutableArray<EnumMember> y = [new ("name", new (), [])];
+		ImmutableArray<EnumMember> x = [new ("name", new (), new (), []), new ("name1")];
+		ImmutableArray<EnumMember> y = [new ("name", new (), new (), [])];
 		Assert.False (comparer.Equals (x, y));
 	}
 
 	[Fact]
 	public void NotEqualsDiffAttributes ()
 	{
-		ImmutableArray<EnumMember> x = [new ("name", new (), []), new ("name1")];
-		ImmutableArray<EnumMember> y = [new ("name1", new (), []), new ("name1")];
+		ImmutableArray<EnumMember> x = [new ("name", new (), new (), []), new ("name1")];
+		ImmutableArray<EnumMember> y = [new ("name", new (), new (), [
+			new ("AttrName")
+		]), new ("name1")];
 		Assert.False (comparer.Equals (x, y));
 	}
 
 	[Fact]
 	public void EqualsSameOrder ()
 	{
-		ImmutableArray<EnumMember> x = [new ("name", new SymbolAvailability (), []), new ("name1")];
-		ImmutableArray<EnumMember> y = [new ("name", new SymbolAvailability (), []), new ("name1")];
+		ImmutableArray<EnumMember> x = [new ("name", new (), new SymbolAvailability (), []), new ("name1")];
+		ImmutableArray<EnumMember> y = [new ("name", new (), new SymbolAvailability (), []), new ("name1")];
 		Assert.True (comparer.Equals (x, y));
 	}
 
 	[Fact]
 	public void EqualsDiffOrder ()
 	{
-		ImmutableArray<EnumMember> x = [new ("name1", new (), []), new ("name")];
-		ImmutableArray<EnumMember> y = [new ("name", new (), []), new ("name1")];
+		ImmutableArray<EnumMember> x = [new ("name1"), new ("name")];
+		ImmutableArray<EnumMember> y = [new ("name"), new ("name1")];
 		Assert.True (comparer.Equals (x, y));
 	}
+
+	[Fact]
+	public void NotEqualsDiffFieldData ()
+	{
+		ImmutableArray<EnumMember> x = [new ("name", new ("x", "xLib", EnumValue.None), new SymbolAvailability (), []), new ("name1")];
+		ImmutableArray<EnumMember> y = [new ("name", new ("y", "xLib", EnumValue.None), new SymbolAvailability (), []), new ("name1")];
+		Assert.False (comparer.Equals (x, y));
+	} 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/FieldSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/FieldSymbolExtensionsTests.cs
@@ -1,0 +1,209 @@
+#pragma warning disable APL0003
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Extensions;
+using ObjCBindings;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Extensions;
+
+public class FieldSymbolExtensionsTests : BaseGeneratorTestClass {
+
+
+	[Theory]
+	[AllSupportedPlatforms]
+	public void GetFieldDataMissingAttribute (ApplePlatform platform)
+	{
+		const string inputString = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	First,
+	Second,
+	Last,
+}
+";
+		
+		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetFieldDataMissingAttribute), platform, inputString);
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<BaseTypeDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		var enumValue = symbol.GetMembers ().FirstOrDefault () as IFieldSymbol;
+		Assert.NotNull (enumValue);
+		var fieldData = enumValue.GetFieldData ();
+		Assert.Null (fieldData);
+	}
+
+	[Theory]
+	[AllSupportedPlatforms]
+	public void GetFieldDataPresentAttributeWithField (ApplePlatform platform)
+	{
+		
+		const string inputString = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> (""First"")]
+	First,
+}
+";
+		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetFieldDataMissingAttribute), platform, inputString);
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<BaseTypeDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		var enumValue = symbol.GetMembers ().FirstOrDefault () as IFieldSymbol;
+		Assert.NotNull (enumValue);
+		var fieldData = enumValue.GetFieldData ();
+		Assert.NotNull (fieldData);
+		Assert.Equal ("First", fieldData.Value.SymbolName);
+		Assert.Null (fieldData.Value.LibraryName);
+		Assert.Equal (EnumValue.None, fieldData.Value.Flags);
+	}
+
+	[Theory]
+	[AllSupportedPlatforms]
+	public void GetFieldDataPresentAttributeWithLibraryName (ApplePlatform platform)
+	{
+		const string inputString = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> (""First"", ""Lib"")]
+	First,
+}
+";
+		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetFieldDataMissingAttribute), platform, inputString);
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<BaseTypeDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		var enumValue = symbol.GetMembers ().FirstOrDefault () as IFieldSymbol;
+		Assert.NotNull (enumValue);
+		var fieldData = enumValue.GetFieldData ();
+		Assert.NotNull (fieldData);
+		Assert.Equal ("First", fieldData.Value.SymbolName);
+		Assert.Equal ("Lib", fieldData.Value.LibraryName);
+		Assert.Equal (EnumValue.None, fieldData.Value.Flags);
+	}
+
+	class TestDataGetFieldDataPresentAttributeNotValid : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string missingFieldAttributes = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	First,
+	Second,
+	Last,
+}
+";
+			yield return [missingFieldAttributes];
+
+
+			const string fieldWithQuotes = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> (""Field\""With\""Quotes"")]
+	First,
+}
+";
+			yield return [fieldWithQuotes];
+
+			const string leadingWithNumber = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> (""42Tries"")]
+	First,
+}
+";
+			yield return [leadingWithNumber];
+
+			const string fieldWithNewLines = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> (""With\nNew\nLine"")]
+	First,
+}
+";
+			yield return [fieldWithNewLines];
+
+			const string fieldWithKeyword = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> (""class"")]
+	First,
+}
+";
+			yield return [fieldWithKeyword];
+
+			const string fieldWithTabs = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> ("" \tSecondBackendField\t \n"")]
+	First,
+}
+";
+
+			yield return [fieldWithTabs];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataGetFieldDataPresentAttributeNotValid>]
+	public void GetFieldDataPresentAttributeNotValid (ApplePlatform platform, string inputString)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetFieldDataPresentAttributeNotValid), platform, inputString);
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<BaseTypeDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		var enumValue = symbol.GetMembers ().FirstOrDefault () as IFieldSymbol;
+		Assert.NotNull (enumValue);
+		var fieldData = enumValue.GetFieldData ();
+		Assert.Null (fieldData);
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/NamedTypeSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/NamedTypeSymbolExtensionsTests.cs
@@ -39,6 +39,8 @@ public class NotEnum {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			const string emptyEnum = @"
+using ObjCBindings;
+
 namespace Test;
 public enum MyEnum {
 }
@@ -54,53 +56,6 @@ public enum MyEnum {
 }
 ";
 			yield return [missingFieldAttributes];
-
-
-			const string fieldWithQuotes = @"
-namespace Test;
-public enum MyEnum {
-	[Field<EnumValue> (""Field\""With\""Quotes"")]
-	First,
-}
-";
-			yield return [fieldWithQuotes];
-
-			const string leadingWithNumber = @"
-namespace Test;
-public enum MyEnum {
-	[Field<EnumValue> (""42Tries"")]
-	First,
-}
-";
-			yield return [leadingWithNumber];
-
-			const string fieldWithNewLines = @"
-namespace Test;
-public enum MyEnum {
-	[Field<EnumValue> (""With\nNew\nLine"")]
-	First,
-}
-";
-			yield return [fieldWithNewLines];
-
-			const string fieldWithKeyword = @"
-namespace Test;
-public enum MyEnum {
-	[Field<EnumValue> (""class"")]
-	First,
-}
-";
-			yield return [fieldWithKeyword];
-
-			const string fieldWithTabs = @"
-namespace Test;
-public enum MyEnum {
-	[Field<EnumValue> ("" \tSecondBackendField\t \n"")]
-	First,
-}
-";
-
-			yield return [fieldWithTabs];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -125,6 +80,90 @@ public enum MyEnum {
 		Assert.NotNull (fields);
 		Assert.Empty (fields);
 		Assert.Null (diagnostics);
+	}
+	
+	class TestDataTryGetEnumFieldsInvalidFields : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+
+			const string fieldWithQuotes = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> (""Field\""With\""Quotes"")]
+	First,
+}
+";
+			yield return [fieldWithQuotes];
+
+			const string leadingWithNumber = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> (""42Tries"")]
+	First,
+}
+";
+			yield return [leadingWithNumber];
+
+			const string fieldWithNewLines = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> (""With\nNew\nLine"")]
+	First,
+}
+";
+			yield return [fieldWithNewLines];
+
+			const string fieldWithKeyword = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> (""class"")]
+	First,
+}
+";
+			yield return [fieldWithKeyword];
+
+			const string fieldWithTabs = @"
+using ObjCBindings;
+
+namespace Test;
+public enum MyEnum {
+	[Field<EnumValue> ("" \tSecondBackendField\t \n"")]
+	First,
+}
+";
+
+			yield return [fieldWithTabs];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataTryGetEnumFieldsInvalidFields>]
+	public void TryGetEnumFieldsInvalidFields (ApplePlatform platform, string inputString)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (nameof (TryGetEnumFieldsNotEnum), platform, inputString);
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<BaseTypeDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		Assert.False (symbol.TryGetEnumFields (out var fields, out var diagnostics));
+		Assert.Null (fields);
+		Assert.NotNull (diagnostics);
+		Assert.Single (diagnostics);
 	}
 
 	[Theory]


### PR DESCRIPTION
Since we are calculating which enum values were added as part of the code change we can retrieve at that time the field data information. This way we reduce the number of times we query the semantic model in the code generation. This opens the door to use the code changes structure to generate the smart enums and reduce the number of allocated objects.