### PR TITLE
[RGent] Add name and namespace to the codechanges struct.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -23,12 +23,12 @@ readonly struct CodeChanges {
 	/// The name of the named type that generated the code change.
 	/// </summary>
 	public string Name { get; }
-	
+
 	/// <summary>
 	/// The namespace that contains the named type that generated the code change.
 	/// </summary>
 	public ImmutableArray<string> Namespace { get; }
-	
+
 	/// <summary>
 	/// Fully qualified name of the symbol that the code changes are for.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChangesEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChangesEqualityComparer.cs
@@ -34,7 +34,12 @@ class CodeChangesEqualityComparer : EqualityComparer<CodeChanges> {
 		// - the members are the same
 		// - the attributes are the same
 
-		// this could be a massive or but that makes it less readable
+		// this could be a massive 'or' but that makes it less readable
+		if (x.Name != y.Name)
+			return false;
+		var namespaceComparer = new ListComparer<string> ();
+		if (!namespaceComparer.Equals (x.Namespace, y.Namespace))
+			return false;
 		if (x.FullyQualifiedSymbol != y.FullyQualifiedSymbol)
 			return false;
 		if (x.BindingType != y.BindingType)

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/SemanticModelExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/SemanticModelExtensions.cs
@@ -1,0 +1,31 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Macios.Generator.Extensions;
+
+public static class SemanticModelExtensions {
+	/// <summary>
+	/// Returns the name and namespace of the symbol that has been declared in the passed base type declaration
+	/// syntax node.
+	/// </summary>
+	/// <param name="self">The current semantic mode.</param>
+	/// <param name="declaration">The named type declaration syntaxt.</param>
+	/// <returns>A tuple containing the name and namespace of the type. If they could not be calculated they will
+	/// be set to be string.Empty.</returns>
+	public static (string Name, ImmutableArray<string> Namespace) GetNameAndNamespace (this SemanticModel self,
+		BaseTypeDeclarationSyntax declaration)
+	{
+		var symbol = self.GetDeclaredSymbol (declaration);
+		var name = symbol?.Name ?? string.Empty;
+		var bucket = ImmutableArray.CreateBuilder<string> ();
+		var ns = symbol?.ContainingNamespace;
+		while (ns is not null) {
+			if (!string.IsNullOrWhiteSpace (ns.Name))
+				// prepend the namespace so that we can read from top to bottom
+				bucket.Insert (0, ns.Name);
+			ns = ns.ContainingNamespace;
+		}
+		return (name, bucket.ToImmutableArray ());
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/SemanticModelExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/SemanticModelExtensions.cs
@@ -9,7 +9,7 @@ public static class SemanticModelExtensions {
 	/// Returns the name and namespace of the symbol that has been declared in the passed base type declaration
 	/// syntax node.
 	/// </summary>
-	/// <param name="self">The current semantic mode.</param>
+	/// <param name="self">The current semantic model.</param>
 	/// <param name="declaration">The named type declaration syntaxt.</param>
 	/// <returns>A tuple containing the name and namespace of the type. If they could not be calculated they will
 	/// be set to be string.Empty.</returns>

--- a/src/rgen/Microsoft.Macios.Generator/ListComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/ListComparer.cs
@@ -1,20 +1,21 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Macios.Generator;
 
-public class ListComparer<T> : EqualityComparer<List<T>> {
-	readonly IComparer<T> comparer;
+public class ListComparer<T> : EqualityComparer<IList<T>> {
+	readonly IComparer<T>? comparer;
 	readonly IEqualityComparer<T> valueComparer;
 
-	public ListComparer (IComparer<T> sortComparer, IEqualityComparer<T>? equalityComparer = null)
+	public ListComparer (IComparer<T>? sortComparer = null, IEqualityComparer<T>? equalityComparer = null)
 	{
-		comparer = sortComparer ?? throw new ArgumentNullException (nameof (sortComparer));
+		comparer = sortComparer;
 		valueComparer = equalityComparer ?? EqualityComparer<T>.Default;
 	}
 
 	/// <inheritdoc/>
-	public override bool Equals (List<T>? x, List<T>? y)
+	public override bool Equals (IList<T>? x, IList<T>? y)
 	{
 		// bases cases for null or diff size
 		if (x is null && y is null)
@@ -26,10 +27,12 @@ public class ListComparer<T> : EqualityComparer<List<T>> {
 
 		// make copies of the lists and sort them
 		var xSorted = x.ToArray ();
-		Array.Sort (xSorted, comparer);
+		if (comparer is not null)
+			Array.Sort (xSorted, comparer);
 
 		var ySorted = y.ToArray ();
-		Array.Sort (ySorted, comparer);
+		if (comparer is not null)
+			Array.Sort (ySorted, comparer);
 
 		for (var i = 0; i < xSorted.Length; i++) {
 			if (!valueComparer.Equals (xSorted [i], ySorted [i]))
@@ -39,7 +42,7 @@ public class ListComparer<T> : EqualityComparer<List<T>> {
 	}
 
 	/// <inheritdoc/>
-	public override int GetHashCode (List<T> obj)
+	public override int GetHashCode (IList<T> obj)
 	{
 		var hash = new HashCode ();
 		foreach (var element in obj) {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -32,6 +32,8 @@ public partial class MyClass {
 				emptyClass,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [
@@ -57,6 +59,8 @@ public partial class MyClass {
 				singleConstructorClass,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [
@@ -97,6 +101,8 @@ public partial class MyClass {
 				multiConstructorClass,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [
@@ -147,6 +153,8 @@ public partial class MyClass {
 				singlePropertyClass,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [
@@ -191,6 +199,8 @@ public partial class MyClass {
 				multiPropertyClassMissingExport,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [
@@ -236,6 +246,8 @@ public partial class MyClass {
 				multiPropertyClass,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [
@@ -294,6 +306,8 @@ public partial class MyClass {
 				singleMethodClass,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [
@@ -338,6 +352,8 @@ public partial class MyClass {
 				multiMethodClassMissingExport,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [
@@ -383,6 +399,8 @@ public partial class MyClass {
 				multiMethodClass,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [
@@ -442,6 +460,8 @@ public partial class MyClass {
 				singleEventClass,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [
@@ -482,6 +502,8 @@ public partial class MyClass {
 				multiEventClass,
 				new CodeChanges (
 					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass"
 				) {
 					Attributes = [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -14,7 +14,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 		var changes2 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name2");
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
-	
+
 	[Fact]
 	public void CompareDifferentNameSymbol ()
 	{
@@ -22,7 +22,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2", ["NS"], "NS.name1");
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
-	
+
 	[Fact]
 	public void CompareDifferentNamespaceSymbol ()
 	{

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -1,9 +1,5 @@
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.DataModel;
-using Xamarin.Tests;
-using Xamarin.Utils;
 using Xunit;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
@@ -14,24 +10,40 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentFullyQualifiedSymbol ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2");
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1");
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name2");
+		Assert.False (comparer.Equals (changes1, changes2));
+	}
+	
+	[Fact]
+	public void CompareDifferentNameSymbol ()
+	{
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1");
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2", ["NS"], "NS.name1");
+		Assert.False (comparer.Equals (changes1, changes2));
+	}
+	
+	[Fact]
+	public void CompareDifferentNamespaceSymbol ()
+	{
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS1"], "NS.name1");
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS2"], "NS.name1");
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
 
 	[Fact]
 	public void CompareDifferentBindingType ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name");
-		var changes2 = new CodeChanges (BindingType.Unknown, "name");
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
+		var changes2 = new CodeChanges (BindingType.Unknown, "name", ["NS"], "NS.name");
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
 
 	[Fact]
 	public void CompareDifferentAttributesLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			Attributes = [
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			]
@@ -42,12 +54,12 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentAttributes ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			Attributes = [
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			Attributes = [
 				new AttributeCodeChange ("name2", ["arg1", "arg2"])
 			],
@@ -58,8 +70,8 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembersLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [
 				new EnumMember ("name", new (), [])
 			],
@@ -70,12 +82,12 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembers ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [
 				new EnumMember ("name", new (), [])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [
 				new EnumMember ("name2", new (), [])
 			],
@@ -86,11 +98,11 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentPropertyLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = []
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -120,7 +132,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSamePropertiesDiffOrder ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -159,7 +171,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -204,7 +216,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentProperties ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -243,7 +255,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -288,7 +300,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentEventsLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -337,7 +349,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -382,7 +394,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameEventsDiffOrder ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -440,7 +452,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -505,7 +517,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentEvents ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -554,7 +566,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -611,7 +623,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMethodsLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -700,7 +712,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				)
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -783,7 +795,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameMethodsDiffOrder ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -872,7 +884,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				)
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -968,7 +980,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMethods ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -1041,7 +1053,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -1,9 +1,5 @@
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.DataModel;
-using Xamarin.Tests;
-using Xamarin.Utils;
 using Xunit;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
@@ -14,24 +10,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentFullyQualifiedSymbol ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2");
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1");;
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2", ["NS"], "NS.name2");;
 		Assert.False (equalityComparer.Equals (changes1, changes2));
 	}
 
 	[Fact]
 	public void CompareDifferentBindingType ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name");
-		var changes2 = new CodeChanges (BindingType.Unknown, "name");
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
+		var changes2 = new CodeChanges (BindingType.Unknown, "name", ["NS"], "NS.name");
 		Assert.False (equalityComparer.Equals (changes1, changes2));
 	}
 
 	[Fact]
 	public void CompareDifferentAttributesLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			Attributes = [
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			]
@@ -42,12 +38,12 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentAttributes ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			Attributes = [
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			Attributes = [
 				new AttributeCodeChange ("name2", ["arg1", "arg2"])
 			],
@@ -58,8 +54,8 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembersLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [
 				new EnumMember ("name", new (), [])
 			],
@@ -70,12 +66,12 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembers ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [
 				new EnumMember ("name", new (), [])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [
 				new EnumMember ("name2", new (), [])
 			],
@@ -86,8 +82,8 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentPropertyLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") { EnumMembers = [], Properties = [] };
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") { EnumMembers = [], Properties = [] };
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -117,7 +113,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSamePropertiesDiffOrder ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -156,7 +152,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -201,7 +197,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentProperties ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -240,7 +236,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -285,7 +281,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentConstructorLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -325,7 +321,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 			],
 			Constructors = [],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -373,7 +369,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentConstructors ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -415,7 +411,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new ("MyClass", new (), [], [], [])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -469,7 +465,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameConstructors ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -518,7 +514,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -573,7 +569,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameConstructorsDiffOrder ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -622,7 +618,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new ("MyClass", new (), [], [], []),
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
 			EnumMembers = [],
 			Properties = [
 				new (

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -10,8 +10,8 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentFullyQualifiedSymbol ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1");;
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2", ["NS"], "NS.name2");;
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1"); ;
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2", ["NS"], "NS.name2"); ;
 		Assert.False (equalityComparer.Equals (changes1, changes2));
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -32,6 +32,8 @@ public partial interface IProtocol {
 				emptyInterface,
 				new CodeChanges (
 					bindingType: BindingType.Protocol,
+					name: "IProtocol",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.IProtocol"
 				) {
 					Attributes = [
@@ -56,6 +58,8 @@ public partial interface IProtocol {
 				singlePropertyInterface,
 				new CodeChanges (
 					bindingType: BindingType.Protocol,
+					name: "IProtocol",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.IProtocol"
 				) {
 					Attributes = [
@@ -100,6 +104,8 @@ public partial interface IProtocol {
 				multiPropertyInterfaceMissingExport,
 				new CodeChanges (
 					bindingType: BindingType.Protocol,
+					name: "IProtocol",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.IProtocol"
 				) {
 					Attributes = [
@@ -145,6 +151,8 @@ public partial interface IProtocol {
 				multiPropertyInterface,
 				new CodeChanges (
 					bindingType: BindingType.Protocol,
+					name: "IProtocol",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.IProtocol"
 				) {
 					Attributes = [
@@ -203,6 +211,8 @@ public partial interface IProtocol {
 				singleMethodInterface,
 				new CodeChanges (
 					bindingType: BindingType.Protocol,
+					name: "IProtocol",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.IProtocol"
 				) {
 					Attributes = [
@@ -247,6 +257,8 @@ public partial interface IProtocol {
 				multiMethodInterfaceMissingExport,
 				new CodeChanges (
 					bindingType: BindingType.Protocol,
+					name: "IProtocol",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.IProtocol"
 				) {
 					Attributes = [
@@ -292,6 +304,8 @@ public partial interface IProtocol {
 				multiMethodInterface,
 				new CodeChanges (
 					bindingType: BindingType.Protocol,
+					name: "IProtocol",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.IProtocol"
 				) {
 					Attributes = [
@@ -351,6 +365,8 @@ public partial interface IProtocol {
 				singleEventInterface,
 				new CodeChanges (
 					bindingType: BindingType.Protocol,
+					name: "IProtocol",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.IProtocol"
 				) {
 					Attributes = [
@@ -391,6 +407,8 @@ public partial interface IProtocol {
 				multiEventInterface,
 				new CodeChanges (
 					bindingType: BindingType.Protocol,
+					name: "IProtocol",
+					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.IProtocol"
 				) {
 					Attributes = [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
@@ -10,19 +10,19 @@ using Xunit;
 
 namespace Microsoft.Macios.Generator.Tests.Extensions;
 
-public class SemanticModelExtensionsTests : BaseGeneratorTestClass{
+public class SemanticModelExtensionsTests : BaseGeneratorTestClass {
 
 	ListComparer<string> comparer = new ();
 	class TestDataGetNameAndNamespaceTests : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
-			
+
 			const string filescopedNamespaceClass = @"
 namespace Test;
 public class Foo {
 }
 ";
-			ImmutableArray<string> ns = ImmutableArray.Create("Test");
+			ImmutableArray<string> ns = ImmutableArray.Create ("Test");
 			yield return [filescopedNamespaceClass, "Foo", ns];
 
 			const string filescopedNamespaceNestedClass = @"
@@ -40,7 +40,7 @@ namespace Test {
 	}
 }
 ";
-			
+
 			yield return [namespaceClass, "Foo", ns];
 
 			const string nestedNamespaces = @"
@@ -50,7 +50,7 @@ namespace Foo {
 	}
 }
 ";
-			ns = ImmutableArray.Create("Foo", "Bar");
+			ns = ImmutableArray.Create ("Foo", "Bar");
 			yield return [nestedNamespaces, "Test", ns];
 
 		}
@@ -70,10 +70,10 @@ namespace Foo {
 		var declaration = syntaxTrees [0].GetRoot ()
 			.DescendantNodes ()
 			.OfType<BaseTypeDeclarationSyntax> ()
-			.LastOrDefault();
+			.LastOrDefault ();
 		Assert.NotNull (declaration);
 		var (name, @namespace) = semanticModel.GetNameAndNamespace (declaration);
-		Assert.Equal(expectedName, name);
-		Assert.Equal(expectedNamespace, @namespace, comparer);
+		Assert.Equal (expectedName, name);
+		Assert.Equal (expectedNamespace, @namespace, comparer);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
@@ -1,0 +1,79 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Extensions;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Extensions;
+
+public class SemanticModelExtensionsTests : BaseGeneratorTestClass{
+
+	ListComparer<string> comparer = new ();
+	class TestDataGetNameAndNamespaceTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			
+			const string filescopedNamespaceClass = @"
+namespace Test;
+public class Foo {
+}
+";
+			ImmutableArray<string> ns = ["Test"];
+			yield return [filescopedNamespaceClass, "Foo", ns];
+
+			const string filescopedNamespaceNestedClass = @"
+namespace Test;
+public class Foo {
+	public class Bar {
+	}	
+}
+";
+			yield return [filescopedNamespaceNestedClass, "Bar", ns];
+
+			const string namespaceClass = @"
+namespace Test {
+	public class Foo {
+	}
+}
+";
+			
+			yield return [namespaceClass, "Foo", ns];
+
+			const string nestedNamespaces = @"
+namespace Foo {
+	namespace Bar {
+		public class Test {}
+	}
+}
+";
+			ns = ["Foo", "Bar"];	
+			yield return [nestedNamespaces, "Test", ns];
+
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataGetNameAndNamespaceTests>]
+	public void GetNameAndNamespaceTests (ApplePlatform platform, string inputText, string expectedName,
+		ImmutableArray<string> expectedNamespace)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetNameAndNamespaceTests),
+			platform, inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<BaseTypeDeclarationSyntax> ()
+			.LastOrDefault();
+		Assert.NotNull (declaration);
+		var (name, @namespace) = semanticModel.GetNameAndNamespace (declaration);
+		Assert.Equal(expectedName, name);
+		Assert.Equal(expectedNamespace, @namespace, comparer);
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
@@ -22,7 +22,7 @@ namespace Test;
 public class Foo {
 }
 ";
-			ImmutableArray<string> ns = ["Test"];
+			ImmutableArray<string> ns = ImmutableArray.Create("Test");
 			yield return [filescopedNamespaceClass, "Foo", ns];
 
 			const string filescopedNamespaceNestedClass = @"
@@ -50,7 +50,7 @@ namespace Foo {
 	}
 }
 ";
-			ns = ["Foo", "Bar"];	
+			ns = ImmutableArray.Create("Foo", "Bar");
 			yield return [nestedNamespaces, "Test", ns];
 
 		}


### PR DESCRIPTION
We add the name and a collection with the namespaces that contains the type. This way we do not need to query the symbol when generating code and we can simply use the data in the structure.