### PR TITLE
[RGen] Add the named type symbol platform availability to the code change struct.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -29,12 +29,12 @@ readonly struct CodeChanges {
 	/// The namespace that contains the named type that generated the code change.
 	/// </summary>
 	public ImmutableArray<string> Namespace { get; }
-	
+
 	/// <summary>
 	/// Fully qualified name of the symbol that the code changes are for.
 	/// </summary>
 	public string FullyQualifiedSymbol { get; }
-	
+
 	/// <summary>
 	/// The platform availability of the named type.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChangesEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChangesEqualityComparer.cs
@@ -42,6 +42,8 @@ class CodeChangesEqualityComparer : EqualityComparer<CodeChanges> {
 			return false;
 		if (x.FullyQualifiedSymbol != y.FullyQualifiedSymbol)
 			return false;
+		if (x.SymbolAvailability != y.SymbolAvailability)
+			return false;
 		if (x.BindingType != y.BindingType)
 			return false;
 		if (x.Attributes.Length != y.Attributes.Length)

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
@@ -17,7 +17,7 @@ readonly struct Constructor : IEquatable<Constructor> {
 	public string Type { get; }
 
 	/// <summary>
-	/// The platform availability of the enum value.
+	/// The platform availability of the constructor.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -28,7 +28,7 @@ readonly struct Method : IEquatable<Method> {
 	public string ReturnType { get; }
 
 	/// <summary>
-	/// The platform availability of the eum value.
+	/// The platform availability of the method.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -25,7 +25,7 @@ readonly struct Property : IEquatable<Property> {
 	public string Type { get; } = string.Empty;
 
 	/// <summary>
-	/// The platform availability of the enum value.
+	/// The platform availability of the property.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
 

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/SemanticModelExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/SemanticModelExtensions.cs
@@ -1,19 +1,21 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Availability;
 
 namespace Microsoft.Macios.Generator.Extensions;
 
-public static class SemanticModelExtensions {
+static class SemanticModelExtensions {
+	
 	/// <summary>
 	/// Returns the name and namespace of the symbol that has been declared in the passed base type declaration
 	/// syntax node.
 	/// </summary>
 	/// <param name="self">The current semantic model.</param>
 	/// <param name="declaration">The named type declaration syntaxt.</param>
-	/// <returns>A tuple containing the name and namespace of the type. If they could not be calculated they will
+	/// <returns>A tuple containing the name and namespace of the type. If they could not be calculated, they will
 	/// be set to be string.Empty.</returns>
-	public static (string Name, ImmutableArray<string> Namespace) GetNameAndNamespace (this SemanticModel self,
+	public static (string Name, ImmutableArray<string> Namespace, SymbolAvailability SymbolAvailability) GetSymbolData (this SemanticModel self,
 		BaseTypeDeclarationSyntax declaration)
 	{
 		var symbol = self.GetDeclaredSymbol (declaration);
@@ -26,6 +28,7 @@ public static class SemanticModelExtensions {
 				bucket.Insert (0, ns.Name);
 			ns = ns.ContainingNamespace;
 		}
-		return (name, bucket.ToImmutableArray ());
+		var availability = symbol?.GetSupportedPlatforms () ?? new SymbolAvailability ();
+		return (name, bucket.ToImmutableArray (), availability);
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/SemanticModelExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/SemanticModelExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Macios.Generator.Availability;
 namespace Microsoft.Macios.Generator.Extensions;
 
 static class SemanticModelExtensions {
-	
+
 	/// <summary>
 	/// Returns the name and namespace of the symbol that has been declared in the passed base type declaration
 	/// syntax node.

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
 using Xamarin.Tests;
 using Xamarin.Utils;
@@ -16,6 +18,11 @@ public class ClassCodeChangesTests : BaseGeneratorTestClass {
 	class TestDataCodeChangesFromClassDeclaration : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
+			var builder = SymbolAvailability.CreateBuilder ();
+			builder.Add (new SupportedOSPlatformData("ios17.0"));
+			builder.Add (new SupportedOSPlatformData("tvos17.0"));
+			builder.Add (new UnsupportedOSPlatformData("macos"));
+			
 			const string emptyClass = @"
 using Foundation;
 using ObjCRuntime;
@@ -34,10 +41,45 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
+					]
+				}
+			];
+			
+			const string emptyClassAvailability = @"
+using System.Runtime.Versioning;
+using Foundation;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType]
+[SupportedOSPlatform (""ios17.0"")]
+[SupportedOSPlatform (""tvos17.0"")]
+[UnsupportedOSPlatform (""macos"")]
+public partial class MyClass {
+}
+";
+
+			yield return [
+				emptyClassAvailability,
+				new CodeChanges (
+					bindingType: BindingType.Class,
+					name: "MyClass",
+					@namespace: ["NS"],
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: builder.ToImmutable () 
+				) {
+					Attributes = [
+						new ("ObjCBindings.BindingTypeAttribute"),
+						new ("System.Runtime.Versioning.UnsupportedOSPlatformAttribute", ["macos"]),
+						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["tvos17.0"]),
+						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 					]
 				}
 			];
@@ -61,7 +103,8 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -103,7 +146,8 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -155,7 +199,8 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -201,7 +246,8 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -248,7 +294,8 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -308,7 +355,8 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -354,7 +402,8 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -401,7 +450,8 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -462,7 +512,8 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -505,7 +556,8 @@ public partial class MyClass {
 					bindingType: BindingType.Class,
 					name: "MyClass",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.MyClass"
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -19,10 +19,10 @@ public class ClassCodeChangesTests : BaseGeneratorTestClass {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			var builder = SymbolAvailability.CreateBuilder ();
-			builder.Add (new SupportedOSPlatformData("ios17.0"));
-			builder.Add (new SupportedOSPlatformData("tvos17.0"));
-			builder.Add (new UnsupportedOSPlatformData("macos"));
-			
+			builder.Add (new SupportedOSPlatformData ("ios17.0"));
+			builder.Add (new SupportedOSPlatformData ("tvos17.0"));
+			builder.Add (new UnsupportedOSPlatformData ("macos"));
+
 			const string emptyClass = @"
 using Foundation;
 using ObjCRuntime;
@@ -49,7 +49,7 @@ public partial class MyClass {
 					]
 				}
 			];
-			
+
 			const string emptyClassAvailability = @"
 using System.Runtime.Versioning;
 using Foundation;
@@ -73,7 +73,7 @@ public partial class MyClass {
 					name: "MyClass",
 					@namespace: ["NS"],
 					fullyQualifiedSymbol: "NS.MyClass",
-					symbolAvailability: builder.ToImmutable () 
+					symbolAvailability: builder.ToImmutable ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute"),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -20,7 +20,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentNameSymbol ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1", new());
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1", new ());
 		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2", ["NS"], "NS.name1", new ());
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
@@ -1153,9 +1153,9 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
-	
+
 	[Fact]
-	public void CompareSameMethodsDiffAvailability()
+	public void CompareSameMethodsDiffAvailability ()
 	{
 		var builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios"));
@@ -1345,9 +1345,9 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
-	
+
 	[Fact]
-	public void CompareSameMethodsSameAvailability()
+	public void CompareSameMethodsSameAvailability ()
 	{
 		var builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios"));

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
 
@@ -10,40 +12,40 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentFullyQualifiedSymbol ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name2");
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1", new ());
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name2", new ());
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
 
 	[Fact]
 	public void CompareDifferentNameSymbol ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2", ["NS"], "NS.name1");
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1", new());
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2", ["NS"], "NS.name1", new ());
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
 
 	[Fact]
 	public void CompareDifferentNamespaceSymbol ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS1"], "NS.name1");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS2"], "NS.name1");
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS1"], "NS.name1", new ());
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS2"], "NS.name1", new ());
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
 
 	[Fact]
 	public void CompareDifferentBindingType ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
-		var changes2 = new CodeChanges (BindingType.Unknown, "name", ["NS"], "NS.name");
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ());
+		var changes2 = new CodeChanges (BindingType.Unknown, "name", ["NS"], "NS.name", new ());
 		Assert.False (comparer.Equals (changes1, changes2));
 	}
 
 	[Fact]
 	public void CompareDifferentAttributesLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ());
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			Attributes = [
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			]
@@ -54,12 +56,12 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentAttributes ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			Attributes = [
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			Attributes = [
 				new AttributeCodeChange ("name2", ["arg1", "arg2"])
 			],
@@ -70,8 +72,8 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembersLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ());
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [
 				new EnumMember ("name", new (), [])
 			],
@@ -82,12 +84,12 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembers ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [
 				new EnumMember ("name", new (), [])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [
 				new EnumMember ("name2", new (), [])
 			],
@@ -98,11 +100,11 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentPropertyLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = []
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -132,7 +134,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSamePropertiesDiffOrder ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -171,7 +173,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -216,7 +218,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentProperties ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -255,7 +257,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -300,7 +302,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentEventsLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -350,7 +352,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -395,7 +397,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameEventsDiffOrder ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -455,7 +457,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -522,7 +524,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentEvents ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -572,7 +574,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -630,7 +632,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMethodsLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -721,7 +723,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				)
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -806,7 +808,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameMethodsDiffOrder ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -897,7 +899,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				)
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -995,7 +997,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMethods ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -1070,7 +1072,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -1150,5 +1152,389 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 		};
 
 		Assert.False (comparer.Equals (changes1, changes2));
+	}
+	
+	[Fact]
+	public void CompareSameMethodsDiffAvailability()
+	{
+		var builder = SymbolAvailability.CreateBuilder ();
+		builder.Add (new SupportedOSPlatformData ("ios"));
+		builder.Add (new SupportedOSPlatformData ("tvos"));
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", builder.ToImmutable ()) {
+			EnumMembers = [],
+			Properties = [
+				new (
+					name: "Surname",
+					type: "string",
+					symbolAvailability: new (),
+					attributes: [
+						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (AccessorKind.Getter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+						], []),
+						new (AccessorKind.Setter, new (), [], []),
+					]),
+				new (
+					name: "Name",
+					type: "Utils.MyClass",
+					symbolAvailability: new (),
+					attributes: [
+						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (AccessorKind.Getter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+						], []),
+						new (AccessorKind.Setter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+						], []),
+					]),
+			],
+			Events = [
+				new (
+					name: "MyEvent",
+					type: "System.EventHandler",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [],
+					accessors: [
+						new (AccessorKind.Add, new (), [], []),
+					]),
+				new (
+					name: "MyEvent2",
+					type: "System.EventHandler",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [],
+					accessors: [
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
+					]),
+			],
+			Methods = [
+				new (
+					type: "NS.MyClass",
+					name: "TryGetString",
+					returnType: "bool",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (0, "string?", "example") {
+							IsNullable = true,
+							ReferenceKind = ReferenceKind.Out,
+						},
+					]
+				),
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: "void",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (0, "NS.CustomType", "input")
+					]
+				)
+			]
+		};
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
+			EnumMembers = [],
+			Properties = [
+				new (
+					name: "Name",
+					type: "Utils.MyClass",
+					symbolAvailability: new (),
+					attributes: [
+						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (AccessorKind.Getter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+						], []),
+						new (AccessorKind.Setter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+						], []),
+					]),
+				new (
+					name: "Surname",
+					type: "string",
+					symbolAvailability: new (),
+					attributes: [
+						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (AccessorKind.Getter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+						], []),
+						new (AccessorKind.Setter, new (), [], []),
+					]),
+			],
+			Events = [
+				new (
+					name: "MyEvent2",
+					type: "System.EventHandler",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [],
+					accessors: [
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
+					]),
+				new (
+					name: "MyEvent",
+					type: "System.EventHandler",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [],
+					accessors: [
+						new (AccessorKind.Add, new (), [], []),
+					]),
+			],
+			Methods = [
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: "void",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (0, "NS.CustomType", "input")
+					]
+				),
+				new (
+					type: "NS.MyClass",
+					name: "TryGetString",
+					returnType: "bool",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (0, "string?", "example") {
+							IsNullable = true,
+							ReferenceKind = ReferenceKind.Out,
+						},
+					]
+				),
+			]
+		};
+
+		Assert.False (comparer.Equals (changes1, changes2));
+	}
+	
+	[Fact]
+	public void CompareSameMethodsSameAvailability()
+	{
+		var builder = SymbolAvailability.CreateBuilder ();
+		builder.Add (new SupportedOSPlatformData ("ios"));
+		builder.Add (new SupportedOSPlatformData ("tvos"));
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", builder.ToImmutable ()) {
+			EnumMembers = [],
+			Properties = [
+				new (
+					name: "Surname",
+					type: "string",
+					symbolAvailability: new (),
+					attributes: [
+						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (AccessorKind.Getter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+						], []),
+						new (AccessorKind.Setter, new (), [], []),
+					]),
+				new (
+					name: "Name",
+					type: "Utils.MyClass",
+					symbolAvailability: new (),
+					attributes: [
+						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (AccessorKind.Getter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+						], []),
+						new (AccessorKind.Setter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+						], []),
+					]),
+			],
+			Events = [
+				new (
+					name: "MyEvent",
+					type: "System.EventHandler",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [],
+					accessors: [
+						new (AccessorKind.Add, new (), [], []),
+					]),
+				new (
+					name: "MyEvent2",
+					type: "System.EventHandler",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [],
+					accessors: [
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
+					]),
+			],
+			Methods = [
+				new (
+					type: "NS.MyClass",
+					name: "TryGetString",
+					returnType: "bool",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (0, "string?", "example") {
+							IsNullable = true,
+							ReferenceKind = ReferenceKind.Out,
+						},
+					]
+				),
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: "void",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (0, "NS.CustomType", "input")
+					]
+				)
+			]
+		};
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", builder.ToImmutable ()) {
+			EnumMembers = [],
+			Properties = [
+				new (
+					name: "Name",
+					type: "Utils.MyClass",
+					symbolAvailability: new (),
+					attributes: [
+						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (AccessorKind.Getter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+						], []),
+						new (AccessorKind.Setter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+						], []),
+					]),
+				new (
+					name: "Surname",
+					type: "string",
+					symbolAvailability: new (),
+					attributes: [
+						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (AccessorKind.Getter, new (), [
+							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+						], []),
+						new (AccessorKind.Setter, new (), [], []),
+					]),
+			],
+			Events = [
+				new (
+					name: "MyEvent2",
+					type: "System.EventHandler",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [],
+					accessors: [
+						new (AccessorKind.Add, new (), [], []),
+						new (AccessorKind.Remove, new (), [], []),
+					]),
+				new (
+					name: "MyEvent",
+					type: "System.EventHandler",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [],
+					accessors: [
+						new (AccessorKind.Add, new (), [], []),
+					]),
+			],
+			Methods = [
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: "void",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (0, "NS.CustomType", "input")
+					]
+				),
+				new (
+					type: "NS.MyClass",
+					name: "TryGetString",
+					returnType: "bool",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (0, "string?", "example") {
+							IsNullable = true,
+							ReferenceKind = ReferenceKind.Out,
+						},
+					]
+				),
+			]
+		};
+
+		Assert.True (comparer.Equals (changes1, changes2));
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -10,24 +10,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentFullyQualifiedSymbol ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1"); ;
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2", ["NS"], "NS.name2"); ;
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name1", ["NS"], "NS.name1", new ()); ;
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name2", ["NS"], "NS.name2", new ()); ;
 		Assert.False (equalityComparer.Equals (changes1, changes2));
 	}
 
 	[Fact]
 	public void CompareDifferentBindingType ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
-		var changes2 = new CodeChanges (BindingType.Unknown, "name", ["NS"], "NS.name");
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ());
+		var changes2 = new CodeChanges (BindingType.Unknown, "name", ["NS"], "NS.name", new ());
 		Assert.False (equalityComparer.Equals (changes1, changes2));
 	}
 
 	[Fact]
 	public void CompareDifferentAttributesLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ());
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			Attributes = [
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			]
@@ -38,12 +38,12 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentAttributes ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			Attributes = [
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			Attributes = [
 				new AttributeCodeChange ("name2", ["arg1", "arg2"])
 			],
@@ -54,8 +54,8 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembersLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name");
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ());
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [
 				new EnumMember ("name", new (), [])
 			],
@@ -66,12 +66,12 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembers ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [
 				new EnumMember ("name", new (), [])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [
 				new EnumMember ("name2", new (), [])
 			],
@@ -82,8 +82,8 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentPropertyLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") { EnumMembers = [], Properties = [] };
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) { EnumMembers = [], Properties = [] };
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -113,7 +113,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSamePropertiesDiffOrder ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -152,7 +152,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -197,7 +197,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentProperties ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -236,7 +236,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -281,7 +281,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentConstructorLength ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -321,7 +321,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 			],
 			Constructors = [],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -369,7 +369,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentConstructors ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -411,7 +411,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new ("MyClass", new (), [], [], [])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -465,7 +465,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameConstructors ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -514,7 +514,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					])
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -569,7 +569,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameConstructorsDiffOrder ()
 	{
-		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes1 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (
@@ -618,7 +618,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new ("MyClass", new (), [], [], []),
 			],
 		};
-		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name") {
+		var changes2 = new CodeChanges (BindingType.SmartEnum, "name", ["NS"], "NS.name", new ()) {
 			EnumMembers = [],
 			Properties = [
 				new (

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -34,7 +34,8 @@ public partial interface IProtocol {
 					bindingType: BindingType.Protocol,
 					name: "IProtocol",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.IProtocol"
+					fullyQualifiedSymbol: "NS.IProtocol",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -60,7 +61,8 @@ public partial interface IProtocol {
 					bindingType: BindingType.Protocol,
 					name: "IProtocol",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.IProtocol"
+					fullyQualifiedSymbol: "NS.IProtocol",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -106,7 +108,8 @@ public partial interface IProtocol {
 					bindingType: BindingType.Protocol,
 					name: "IProtocol",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.IProtocol"
+					fullyQualifiedSymbol: "NS.IProtocol",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -153,7 +156,8 @@ public partial interface IProtocol {
 					bindingType: BindingType.Protocol,
 					name: "IProtocol",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.IProtocol"
+					fullyQualifiedSymbol: "NS.IProtocol",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -213,7 +217,8 @@ public partial interface IProtocol {
 					bindingType: BindingType.Protocol,
 					name: "IProtocol",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.IProtocol"
+					fullyQualifiedSymbol: "NS.IProtocol",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -259,7 +264,8 @@ public partial interface IProtocol {
 					bindingType: BindingType.Protocol,
 					name: "IProtocol",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.IProtocol"
+					fullyQualifiedSymbol: "NS.IProtocol",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -306,7 +312,8 @@ public partial interface IProtocol {
 					bindingType: BindingType.Protocol,
 					name: "IProtocol",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.IProtocol"
+					fullyQualifiedSymbol: "NS.IProtocol",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -367,7 +374,8 @@ public partial interface IProtocol {
 					bindingType: BindingType.Protocol,
 					name: "IProtocol",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.IProtocol"
+					fullyQualifiedSymbol: "NS.IProtocol",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")
@@ -410,7 +418,8 @@ public partial interface IProtocol {
 					bindingType: BindingType.Protocol,
 					name: "IProtocol",
 					@namespace: ["NS"],
-					fullyQualifiedSymbol: "NS.IProtocol"
+					fullyQualifiedSymbol: "NS.IProtocol",
+					symbolAvailability: new ()
 				) {
 					Attributes = [
 						new ("ObjCBindings.BindingTypeAttribute")

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.Extensions;
 using Xamarin.Tests;
 using Xamarin.Utils;
@@ -17,13 +19,14 @@ public class SemanticModelExtensionsTests : BaseGeneratorTestClass {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 
+			var builder = SymbolAvailability.CreateBuilder ();
 			const string filescopedNamespaceClass = @"
 namespace Test;
 public class Foo {
 }
 ";
 			ImmutableArray<string> ns = ImmutableArray.Create ("Test");
-			yield return [filescopedNamespaceClass, "Foo", ns];
+			yield return [filescopedNamespaceClass, "Foo", ns, builder.ToImmutable()];
 
 			const string filescopedNamespaceNestedClass = @"
 namespace Test;
@@ -32,7 +35,7 @@ public class Foo {
 	}	
 }
 ";
-			yield return [filescopedNamespaceNestedClass, "Bar", ns];
+			yield return [filescopedNamespaceNestedClass, "Bar", ns, builder.ToImmutable()];
 
 			const string namespaceClass = @"
 namespace Test {
@@ -41,7 +44,7 @@ namespace Test {
 }
 ";
 
-			yield return [namespaceClass, "Foo", ns];
+			yield return [namespaceClass, "Foo", ns, builder.ToImmutable()];
 
 			const string nestedNamespaces = @"
 namespace Foo {
@@ -51,7 +54,75 @@ namespace Foo {
 }
 ";
 			ns = ImmutableArray.Create ("Foo", "Bar");
-			yield return [nestedNamespaces, "Test", ns];
+			yield return [nestedNamespaces, "Test", ns, builder.ToImmutable()];
+
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	class TestDataGetNameAndNamespaceAndAvailabilityTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+
+			var builder = SymbolAvailability.CreateBuilder ();
+			builder.Add (new SupportedOSPlatformData("ios17.0"));
+			builder.Add (new SupportedOSPlatformData("tvos17.0"));
+			builder.Add (new UnsupportedOSPlatformData("macos"));
+			const string filescopedNamespaceClass = @"
+using System.Runtime.Versioning;
+namespace Test;
+
+[SupportedOSPlatform (""ios17.0"")]
+[SupportedOSPlatform (""tvos17.0"")]
+[UnsupportedOSPlatform (""macos"")]
+public class Foo {
+}
+";
+			ImmutableArray<string> ns = ImmutableArray.Create ("Test");
+			yield return [filescopedNamespaceClass, "Foo", ns, builder.ToImmutable()];
+
+			const string filescopedNamespaceNestedClass = @"
+using System.Runtime.Versioning;
+namespace Test;
+public class Foo {
+
+	[SupportedOSPlatform (""ios17.0"")]
+	[SupportedOSPlatform (""tvos17.0"")]
+	[UnsupportedOSPlatform (""macos"")]
+	public class Bar {
+	}	
+}
+";
+			yield return [filescopedNamespaceNestedClass, "Bar", ns, builder.ToImmutable()];
+
+			const string namespaceClass = @"
+using System.Runtime.Versioning;
+namespace Test {
+
+	[SupportedOSPlatform (""ios17.0"")]
+	[SupportedOSPlatform (""tvos17.0"")]
+	[UnsupportedOSPlatform (""macos"")]
+	public class Foo {
+	}
+}
+";
+
+			yield return [namespaceClass, "Foo", ns, builder.ToImmutable()];
+
+			const string nestedNamespaces = @"
+using System.Runtime.Versioning;
+namespace Foo {
+	namespace Bar {
+		[SupportedOSPlatform (""ios17.0"")]
+		[SupportedOSPlatform (""tvos17.0"")]
+		[UnsupportedOSPlatform (""macos"")]
+		public class Test {}
+	}
+}
+";
+			ns = ImmutableArray.Create ("Foo", "Bar");
+			yield return [nestedNamespaces, "Test", ns, builder.ToImmutable()];
 
 		}
 
@@ -60,8 +131,9 @@ namespace Foo {
 
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataGetNameAndNamespaceTests>]
-	public void GetNameAndNamespaceTests (ApplePlatform platform, string inputText, string expectedName,
-		ImmutableArray<string> expectedNamespace)
+	[AllSupportedPlatformsClassData<TestDataGetNameAndNamespaceAndAvailabilityTests>]
+	internal void GetNameAndNamespaceTests (ApplePlatform platform, string inputText, string expectedName, 
+		ImmutableArray<string> expectedNamespace, SymbolAvailability expectedAvailability)
 	{
 		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetNameAndNamespaceTests),
 			platform, inputText);
@@ -72,8 +144,9 @@ namespace Foo {
 			.OfType<BaseTypeDeclarationSyntax> ()
 			.LastOrDefault ();
 		Assert.NotNull (declaration);
-		var (name, @namespace) = semanticModel.GetNameAndNamespace (declaration);
+		var (name, @namespace, symbolAvailability) = semanticModel.GetSymbolData (declaration);
 		Assert.Equal (expectedName, name);
 		Assert.Equal (expectedNamespace, @namespace, comparer);
+		Assert.Equal (expectedAvailability, symbolAvailability);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
@@ -26,7 +26,7 @@ public class Foo {
 }
 ";
 			ImmutableArray<string> ns = ImmutableArray.Create ("Test");
-			yield return [filescopedNamespaceClass, "Foo", ns, builder.ToImmutable()];
+			yield return [filescopedNamespaceClass, "Foo", ns, builder.ToImmutable ()];
 
 			const string filescopedNamespaceNestedClass = @"
 namespace Test;
@@ -35,7 +35,7 @@ public class Foo {
 	}	
 }
 ";
-			yield return [filescopedNamespaceNestedClass, "Bar", ns, builder.ToImmutable()];
+			yield return [filescopedNamespaceNestedClass, "Bar", ns, builder.ToImmutable ()];
 
 			const string namespaceClass = @"
 namespace Test {
@@ -44,7 +44,7 @@ namespace Test {
 }
 ";
 
-			yield return [namespaceClass, "Foo", ns, builder.ToImmutable()];
+			yield return [namespaceClass, "Foo", ns, builder.ToImmutable ()];
 
 			const string nestedNamespaces = @"
 namespace Foo {
@@ -54,21 +54,21 @@ namespace Foo {
 }
 ";
 			ns = ImmutableArray.Create ("Foo", "Bar");
-			yield return [nestedNamespaces, "Test", ns, builder.ToImmutable()];
+			yield return [nestedNamespaces, "Test", ns, builder.ToImmutable ()];
 
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	class TestDataGetNameAndNamespaceAndAvailabilityTests : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 
 			var builder = SymbolAvailability.CreateBuilder ();
-			builder.Add (new SupportedOSPlatformData("ios17.0"));
-			builder.Add (new SupportedOSPlatformData("tvos17.0"));
-			builder.Add (new UnsupportedOSPlatformData("macos"));
+			builder.Add (new SupportedOSPlatformData ("ios17.0"));
+			builder.Add (new SupportedOSPlatformData ("tvos17.0"));
+			builder.Add (new UnsupportedOSPlatformData ("macos"));
 			const string filescopedNamespaceClass = @"
 using System.Runtime.Versioning;
 namespace Test;
@@ -80,7 +80,7 @@ public class Foo {
 }
 ";
 			ImmutableArray<string> ns = ImmutableArray.Create ("Test");
-			yield return [filescopedNamespaceClass, "Foo", ns, builder.ToImmutable()];
+			yield return [filescopedNamespaceClass, "Foo", ns, builder.ToImmutable ()];
 
 			const string filescopedNamespaceNestedClass = @"
 using System.Runtime.Versioning;
@@ -94,7 +94,7 @@ public class Foo {
 	}	
 }
 ";
-			yield return [filescopedNamespaceNestedClass, "Bar", ns, builder.ToImmutable()];
+			yield return [filescopedNamespaceNestedClass, "Bar", ns, builder.ToImmutable ()];
 
 			const string namespaceClass = @"
 using System.Runtime.Versioning;
@@ -108,7 +108,7 @@ namespace Test {
 }
 ";
 
-			yield return [namespaceClass, "Foo", ns, builder.ToImmutable()];
+			yield return [namespaceClass, "Foo", ns, builder.ToImmutable ()];
 
 			const string nestedNamespaces = @"
 using System.Runtime.Versioning;
@@ -122,7 +122,7 @@ namespace Foo {
 }
 ";
 			ns = ImmutableArray.Create ("Foo", "Bar");
-			yield return [nestedNamespaces, "Test", ns, builder.ToImmutable()];
+			yield return [nestedNamespaces, "Test", ns, builder.ToImmutable ()];
 
 		}
 
@@ -132,7 +132,7 @@ namespace Foo {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataGetNameAndNamespaceTests>]
 	[AllSupportedPlatformsClassData<TestDataGetNameAndNamespaceAndAvailabilityTests>]
-	internal void GetNameAndNamespaceTests (ApplePlatform platform, string inputText, string expectedName, 
+	internal void GetNameAndNamespaceTests (ApplePlatform platform, string inputText, string expectedName,
 		ImmutableArray<string> expectedNamespace, SymbolAvailability expectedAvailability)
 	{
 		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetNameAndNamespaceTests),


### PR DESCRIPTION


Reduce the amount of work we need to do in the code generation by precalculating the availability of the class. This way we can later use the code change struct to generate the code.