### PR TITLE
[RGen] Remove the need to explicitly pass a name for the compilation in tests.

### DIFF
--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BindingTypeSemanticAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BindingTypeSemanticAnalyzerTests.cs
@@ -23,7 +23,7 @@ namespace Test {
 }
 ";
 
-		var (compilation, _) = CreateCompilation (nameof (CompareGeneratedCode), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new BindingTypeSemanticAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
 			.Where (d => d.Id == BindingTypeSemanticAnalyzer.RBI0001.Id).ToArray ();

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/SmartEnumsAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/SmartEnumsAnalyzerTests.cs
@@ -38,7 +38,7 @@ public enum AVCaptureSystemPressureExampleLevel {
 }
 ";
 
-		var (compilation, _) = CreateCompilation (nameof (SmartEnumsAnalyzerTests), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
 			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0002.Id).ToArray ();
@@ -126,7 +126,7 @@ public enum AVCaptureSystemPressureExampleLevel {
 	[AllSupportedPlatforms (notValidIdentifierNewLines, "The\nValues")]
 	public async Task SmartEnumSymbolMustBeValidIdentifier (ApplePlatform platform, string inputText, string fieldValue)
 	{
-		var (compilation, _) = CreateCompilation (nameof (SmartEnumsAnalyzerTests), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
 			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0004.Id).ToArray ();
@@ -193,7 +193,7 @@ public enum AVCaptureSystemPressureExampleLevel {
 	[AllSupportedPlatforms (appleFrameworkLibNamedParameter)]
 	public async Task SmartEnumAppleFrameworkNotLibrary (ApplePlatform platform, string inputText)
 	{
-		var (compilation, _) = CreateCompilation (nameof (SmartEnumsAnalyzerTests), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 
 		var analyzerDiagnotics = diagnostics
@@ -273,7 +273,7 @@ public enum CustomLibraryEnum {
 	[AllSupportedPlatforms (customLibraryEmptyLibraryNameParameter)]
 	public async Task SmartEnumThirdPartyLibrary (ApplePlatform platform, string inputText)
 	{
-		var (compilation, _) = CreateCompilation (nameof (SmartEnumsAnalyzerTests), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
 			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0005.Id).ToArray ();
@@ -303,7 +303,7 @@ public enum CustomLibraryEnum {
 	High,
 }
 ";
-		var (compilation, _) = CreateCompilation (nameof (SmartEnumsAnalyzerTests), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
 			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0002.Id).ToArray ();
@@ -341,7 +341,7 @@ public enum AVCaptureSystemPressureExampleLevel {
 	Shutdown,
 }";
 
-		var (compilation, _) = CreateCompilation (nameof (SmartEnumsAnalyzerTests), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
 			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0003.Id).ToArray ();
@@ -368,7 +368,7 @@ public enum AVCaptureSystemPressureExampleLevel {
 	[Field<StringComparison> (""TheField"")]
 	Shutdown,
 }";
-		var (compilation, _) = CreateCompilation (nameof (SmartEnumsAnalyzerTests), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
 			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0007.Id).ToArray ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xamarin.Tests;
@@ -42,7 +43,7 @@ public class BaseGeneratorTestClass {
 	protected GeneratorDriverRunResult RunGenerators (Compilation compilation)
 		=> Driver.RunGenerators (compilation).GetRunResult ();
 
-	protected CompilationResult CreateCompilation (string name, ApplePlatform platform, params string [] sources)
+	protected CompilationResult CreateCompilation (ApplePlatform platform, [CallerMemberName] string name = "", params string [] sources)
 	{
 		// get the dotnet bcl and fully load it for the test.
 		var references = Directory.GetFiles (Configuration.DotNetBclDir, "*.dll")
@@ -68,7 +69,7 @@ public class BaseGeneratorTestClass {
 	protected void CompareGeneratedCode (ApplePlatform platform, string className, string inputFileName, string inputText, string outputFileName, string expectedOutputText, string? expectedLibraryText)
 	{
 		// We need to create a compilation with the required source code.
-		var (compilation, _) = CreateCompilation (nameof (CompareGeneratedCode), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 
 		// Run generators and retrieve all results.
 		var runResult = RunGenerators (compilation);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BindingSourceGeneratorGeneratorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BindingSourceGeneratorGeneratorTests.cs
@@ -41,8 +41,7 @@ namespace TestNamespace
 	public void CorrectUsingImports (ApplePlatform platform, string input, string expectedOutput)
 	{
 		// We need to create a compilation with the required source code.
-		var (compilation, _) = CreateCompilation (nameof (CorrectUsingImports),
-			platform, input);
+		var (compilation, _) = CreateCompilation (platform, sources: input);
 
 		// Run generators and retrieve all results.
 		var runResult = Driver.RunGenerators (compilation).GetRunResult ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Context/RootBindingContextTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Context/RootBindingContextTests.cs
@@ -25,7 +25,7 @@ namespace MyNamespace {
 	}
 }
 ";
-		var (compilation, _) = CreateCompilation (nameof (TryComputeLibraryNamePlusLibsTests), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var rootContext = new RootBindingContext (compilation);
 		Assert.True (rootContext.TryComputeLibraryName (attributeLibName, ns, out var libName, out var libPath));
 		Assert.Equal (expectedLibraryName, libName);
@@ -46,7 +46,7 @@ namespace MyNamespace {
 	}
 }
 ";
-		var (compilation, _) = CreateCompilation (nameof (TryComputeLibraryNamePlusLibsTests), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var rootContext = new RootBindingContext (compilation);
 		Assert.Equal (rootContext.IsSystemLibrary (lib), expectedResult);
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -549,8 +549,7 @@ public partial class MyClass {
 	[AllSupportedPlatformsClassData<TestDataCodeChangesFromClassDeclaration>]
 	void CodeChangesFromClassDeclaration (ApplePlatform platform, string inputText, CodeChanges expected)
 	{
-		var (compilation, sourceTrees) =
-			CreateCompilation (nameof (CodeChangesFromClassDeclaration), platform, inputText);
+		var (compilation, sourceTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
 		// get the declarations we want to work with and the semantic model
 		var node = sourceTrees [0].GetRoot ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesTests.cs
@@ -63,8 +63,7 @@ enum AVMediaCharacteristics {
 	[AllSupportedPlatformsClassData<TestDataSkipEnumValueDeclaration>]
 	public void SkipEnumValueDeclaration (ApplePlatform platform, string inputText, bool expected)
 	{
-		var (compilation, sourceTrees) =
-			CreateCompilation (nameof (SkipEnumValueDeclaration), platform, inputText);
+		var (compilation, sourceTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
 		// get the declarations we want to work with and the semantic model
 		var node = sourceTrees [0].GetRoot ()
@@ -159,8 +158,7 @@ public class TestClass {
 	[AllSupportedPlatformsClassData<TestDataSkipPropertyDeclaration>]
 	public void SkipPropertyDeclaration (ApplePlatform platform, string inputText, bool expected)
 	{
-		var (compilation, sourceTrees) =
-			CreateCompilation (nameof (SkipPropertyDeclaration), platform, inputText);
+		var (compilation, sourceTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
 		// get the declarations we want to work with and the semantic model
 		var node = sourceTrees [0].GetRoot ()
@@ -226,7 +224,7 @@ public class TestClass {
 	public void SkipMethodDeclaration (ApplePlatform platform, string inputText, bool expected)
 	{
 		var (compilation, sourceTrees) =
-			CreateCompilation (nameof (SkipMethodDeclaration), platform, inputText);
+			CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
 		// get the declarations we want to work with and the semantic model
 		var node = sourceTrees [0].GetRoot ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorTests.cs
@@ -268,8 +268,7 @@ namespace NS {
 	[AllSupportedPlatformsClassData<TestDataFromConstructorDeclaration>]
 	void FromConstructorDeclaration (ApplePlatform platform, string inputText, Constructor expected)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (FromConstructorDeclaration),
-			platform, inputText);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		var declaration = syntaxTrees [0].GetRoot ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumDeclarationCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumDeclarationCodeChangesTests.cs
@@ -10,8 +10,7 @@ namespace Microsoft.Macios.Generator.Tests.DataModel;
 public class EnumDeclarationCodeChangesTests : BaseGeneratorTestClass {
 	CodeChanges CreateCodeChanges (ApplePlatform platform, string name, string inputText)
 	{
-		var (compilation, sourceTrees) =
-			CreateCompilation (nameof (CreateCodeChangeNoFieldsNoAttributes), platform, inputText);
+		var (compilation, sourceTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
 		var enumDeclaration = sourceTrees [0].GetRoot ()
 			.DescendantNodes ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
@@ -226,8 +226,7 @@ public class TestClass {
 	[AllSupportedPlatformsClassData<TestDataFromPropertyDeclaration>]
 	void FromEventDeclaration (ApplePlatform platform, string inputText, Event expected)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (FromEventDeclaration),
-			platform, inputText);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		var declaration = syntaxTrees [0].GetRoot ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -455,7 +455,7 @@ public partial interface IProtocol {
 	void CodeChangesFromInterfaceDeclaration (ApplePlatform platform, string inputText, CodeChanges expected)
 	{
 		var (compilation, sourceTrees) =
-			CreateCompilation (nameof (CodeChangesFromInterfaceDeclaration), platform, inputText);
+			CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
 		// get the declarations we want to work with and the semantic model
 		var node = sourceTrees [0].GetRoot ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests.cs
@@ -370,8 +370,7 @@ namespace NS {
 	[AllSupportedPlatformsClassData<TestDataFromMethodDeclaration>]
 	void FromMethodDeclaration (ApplePlatform platform, string inputText, Method expected)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (FromMethodDeclaration),
-			platform, inputText);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		var declaration = syntaxTrees [0].GetRoot ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -495,8 +495,7 @@ namespace Test {
 	[AllSupportedPlatformsClassData<TestDataFromPropertyDeclaration>]
 	void FromPropertyDeclaration (ApplePlatform platform, string inputText, Property expected)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (FromPropertyDeclaration),
-			platform, inputText);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		var declaration = syntaxTrees [0].GetRoot ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/EmitterFactoryTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/EmitterFactoryTests.cs
@@ -17,7 +17,7 @@ public class EmitterFactoryTests : BaseGeneratorTestClass {
 	(CodeChanges Changes, RootBindingContext Context, SemanticModel SemanticModel, INamedTypeSymbol Symbol)
 		CreateSymbol<T> (ApplePlatform platform, string inputText) where T : BaseTypeDeclarationSyntax
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (EmitterFactoryTests), platform, inputText);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
 		var declaration = syntaxTrees [0].GetRoot ()
 			.DescendantNodes ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/BaseTypeDeclarationSyntaxExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/BaseTypeDeclarationSyntaxExtensionsTests.cs
@@ -62,7 +62,7 @@ namespace Foo {
 ";
 	T GetDeclaration<T> (ApplePlatform platform, string inputText) where T : BaseTypeDeclarationSyntax
 	{
-		var (_, sourceTrees) = CreateCompilation (nameof (BaseTypeDeclarationSyntaxExtensionsTests), platform, inputText);
+		var (_, sourceTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
 		var declaration = sourceTrees [0].GetRoot ()
 			.DescendantNodes ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/CompilationExtensionsTest.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/CompilationExtensionsTest.cs
@@ -16,7 +16,7 @@ public class CompilationExtensionsTest : BaseGeneratorTestClass {
 	{
 		// get the current compilation for the platform and assert we return the correct one from
 		// the compilation
-		var (compilation, _) = CreateCompilation (nameof (GetCurrentPlatformTests), platform);
+		var (compilation, _) = CreateCompilation (platform);
 		Assert.Equal (expectedPlatform, compilation.GetCurrentPlatform ());
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/FieldSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/FieldSymbolExtensionsTests.cs
@@ -31,7 +31,7 @@ public enum MyEnum {
 }
 ";
 
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetFieldDataMissingAttribute), platform, inputString);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputString);
 		Assert.Single (syntaxTrees);
 		var declaration = syntaxTrees [0].GetRoot ()
 			.DescendantNodes ()
@@ -61,7 +61,7 @@ public enum MyEnum {
 	First,
 }
 ";
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetFieldDataMissingAttribute), platform, inputString);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputString);
 		Assert.Single (syntaxTrees);
 		var declaration = syntaxTrees [0].GetRoot ()
 			.DescendantNodes ()
@@ -93,7 +93,7 @@ public enum MyEnum {
 	First,
 }
 ";
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetFieldDataMissingAttribute), platform, inputString);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputString);
 		Assert.Single (syntaxTrees);
 		var declaration = syntaxTrees [0].GetRoot ()
 			.DescendantNodes ()
@@ -191,7 +191,7 @@ public enum MyEnum {
 	[AllSupportedPlatformsClassData<TestDataGetFieldDataPresentAttributeNotValid>]
 	public void GetFieldDataPresentAttributeNotValid (ApplePlatform platform, string inputString)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetFieldDataPresentAttributeNotValid), platform, inputString);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputString);
 		Assert.Single (syntaxTrees);
 		var declaration = syntaxTrees [0].GetRoot ()
 			.DescendantNodes ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/MemberDeclarationSyntaxExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/MemberDeclarationSyntaxExtensionsTests.cs
@@ -53,7 +53,7 @@ public interface IInterface {
 ";
 		// create a compilation unit and get the diff syntax node, semantic model and expected attr result
 		var (compilation, sourceTrees) =
-			CreateCompilation (nameof (MemberDeclarationSyntaxExtensionsTests), platform, attrsText, inputText);
+			CreateCompilation (platform, sources: [attrsText, inputText]);
 		Assert.Equal (2, sourceTrees.Length);
 		// get the declarations we want to work with and the semantic model
 		var nodes = sourceTrees [1].GetRoot ().DescendantNodes ().ToArray ();
@@ -119,7 +119,7 @@ public class TestClass {
 } 
 ";
 		var (compilation, sourceTrees) =
-			CreateCompilation (nameof (MemberDeclarationSyntaxExtensionsTests), platform, inputText);
+			CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
 		// get the declarations we want to work with and the semantic model
 		var declarations = sourceTrees [0].GetRoot ()
@@ -170,7 +170,7 @@ public class TestClass {
 ";
 		// create a compilation unit and get the diff syntax node, semantic model and expected attr result
 		var (compilation, sourceTrees) =
-			CreateCompilation (nameof (MemberDeclarationSyntaxExtensionsTests), platform, attrsText, inputText);
+			CreateCompilation (platform, sources: [attrsText, inputText]);
 		Assert.Equal (2, sourceTrees.Length);
 		// get the declarations we want to work with and the semantic model
 		var nodes = sourceTrees [1].GetRoot ().DescendantNodes ().ToArray ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/NamedTypeSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/NamedTypeSymbolExtensionsTests.cs
@@ -20,7 +20,7 @@ namespace Test;
 public class NotEnum {
 }
 ";
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (TryGetEnumFieldsNotEnum), platform, inputString);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputString);
 		Assert.Single (syntaxTrees);
 		var declaration = syntaxTrees [0].GetRoot ()
 			.DescendantNodes ()
@@ -66,7 +66,7 @@ public enum MyEnum {
 	[AllSupportedPlatformsClassData<TestDataTryGetEnumFieldsNoFields>]
 	public void TryGetEnumFieldsNoFields (ApplePlatform platform, string inputString)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (TryGetEnumFieldsNotEnum), platform, inputString);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputString);
 		Assert.Single (syntaxTrees);
 		var declaration = syntaxTrees [0].GetRoot ()
 			.DescendantNodes ()
@@ -150,7 +150,7 @@ public enum MyEnum {
 	[AllSupportedPlatformsClassData<TestDataTryGetEnumFieldsInvalidFields>]
 	public void TryGetEnumFieldsInvalidFields (ApplePlatform platform, string inputString)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (TryGetEnumFieldsNotEnum), platform, inputString);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputString);
 		Assert.Single (syntaxTrees);
 		var declaration = syntaxTrees [0].GetRoot ()
 			.DescendantNodes ()
@@ -184,7 +184,7 @@ public enum MyEnum {
 	Last,
 }
 ";
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (TryGetEnumFieldsNotEnum), platform, inputString);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputString);
 		Assert.Single (syntaxTrees);
 		var declaration = syntaxTrees [0].GetRoot ()
 			.DescendantNodes ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/SemanticModelExtensionsTests.cs
@@ -63,8 +63,7 @@ namespace Foo {
 	public void GetNameAndNamespaceTests (ApplePlatform platform, string inputText, string expectedName,
 		ImmutableArray<string> expectedNamespace)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetNameAndNamespaceTests),
-			platform, inputText);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		var declaration = syntaxTrees [0].GetRoot ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
@@ -78,8 +78,7 @@ public enum TestEnum {
 	public void GetAttributeDataPresent (ApplePlatform platform, string inputText, string attributesText,
 		HashSet<string> expectedAttributes)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetAttributeDataPresent),
-			platform, inputText, attributesText);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: [inputText, attributesText]);
 		Assert.Equal (2, syntaxTrees.Length);
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		var declaration = syntaxTrees [0].GetRoot ()
@@ -175,8 +174,7 @@ public class ParentClass {
 	public void GetParentTests (ApplePlatform platform, string inputText,
 		Func<SyntaxNode, MemberDeclarationSyntax?> getNode, string [] expectedParents)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetAttributeDataPresent),
-			platform, inputText);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		var declaration = getNode (syntaxTrees [0].GetRoot ());
@@ -306,8 +304,7 @@ public class ParentClass{
 		Func<SyntaxNode, MemberDeclarationSyntax?> getNode,
 		SymbolAvailability expectedAvailability)
 	{
-		var (compilation, syntaxTrees) = CreateCompilation (nameof (GetAttributeDataPresent),
-			platform, inputText);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		var declaration = getNode (syntaxTrees [0].GetRoot ());

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/SmartEnumDiagnosticsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/SmartEnumDiagnosticsTests.cs
@@ -79,7 +79,7 @@ public enum AVCaptureSystemPressureExampleLevel {
 }";
 
 		// We need to create a compilation with the required source code.
-		var (compilation, _) = CreateCompilation (nameof (CompareGeneratedCode), platform, inputText);
+		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 
 		// Run generators and retrieve all results.
 		var runResult = RunGenerators (compilation);


### PR DESCRIPTION


Use the CallerMemberNameAttribute to retrieve the name of the calling method and compilation time rather than using nameof. This allows the test writters to just pass the name if needed, otherwise it will be calculated implicitly by the compiler.

reference: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.callermembernameattribute?view=net-9.0