### PR TITLE
[Rgen] Provide a way to parse the generic BindingTypeAttribute and an union struct.

### DIFF
--- a/src/ObjCBindings/BindingTypeAttribute.cs
+++ b/src/ObjCBindings/BindingTypeAttribute.cs
@@ -11,7 +11,7 @@ namespace ObjCBindings {
 	/// If the attribute is used in a class, the class must be partial otherwise the generator will fail.
 	/// </summary>
 	[Experimental ("APL0003")]
-	[AttributeUsage (AttributeTargets.Class | System.AttributeTargets.Enum, AllowMultiple = false)]
+	[AttributeUsage (System.AttributeTargets.Enum, AllowMultiple = false)]
 	public class BindingTypeAttribute : Attribute {
 
 		/// <summary>
@@ -22,4 +22,20 @@ namespace ObjCBindings {
 		public string Name { get; set; } = string.Empty;
 	}
 
+	[Experimental ("APL0003")]
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false)]
+	public class BindingTypeAttribute<T> : Attribute where T : Enum {
+
+		/// <summary>
+		/// Indicates the name of the binding type. This is the name that will be used by the registrar to make the
+		/// class available in the ObjC runtime. The default value is string.Empty, in that case the generator
+		/// will use the name of the C# class.
+		/// </summary>
+		public string Name { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Get/Set the export configuration flags.
+		/// </summary >
+		public T? Flags { get; set; } = default (T);
+	}
 }

--- a/src/ObjCBindings/BindingTypeTag.cs
+++ b/src/ObjCBindings/BindingTypeTag.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+#nullable enable
+
+namespace ObjCBindings {
+
+	/// <summary>
+	/// Flags to be used on class bindings.
+	/// </summary>
+	[Flags]
+	[Experimental ("APL0003")]
+	public enum Class : Int64 {
+		/// <summary>
+		/// Use the default values.
+		/// </summary>
+		Default = 0,
+
+		/// <summary>
+		/// Use to let the generator know that the default constructor should not be generated.
+		/// </summary>
+		DisableDefaultCtor = 1 << 2,
+	}
+
+	/// <summary>
+	/// Flags to be used on protocol bindings.
+	/// </summary>
+	[Flags]
+	[Experimental ("APL0003")]
+	public enum Protocol : Int64 {
+		/// <summary>
+		/// Use the default values.
+		/// </summary>
+		Default = 0,
+	}
+	
+	/// <summary>
+	/// Flags to be used on protocol bindings.
+	/// </summary>
+	[Flags]
+	[Experimental ("APL0003")]
+	public enum Category : Int64 {
+		/// <summary>
+		/// Use the default values.
+		/// </summary>
+		Default = 0,
+	}
+}

--- a/src/ObjCBindings/BindingTypeTag.cs
+++ b/src/ObjCBindings/BindingTypeTag.cs
@@ -33,7 +33,7 @@ namespace ObjCBindings {
 		/// </summary>
 		Default = 0,
 	}
-	
+
 	/// <summary>
 	/// Flags to be used on protocol bindings.
 	/// </summary>

--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -9,6 +9,7 @@ namespace ObjCBindings {
 	/// Flags to be used on methods that will generate constructors in the binding class.
 	/// </summary>
 	[Flags]
+	[Experimental ("APL0003")]
 	public enum Constructor : Int64 {
 		/// <summary>
 		/// Use the default values.
@@ -25,6 +26,7 @@ namespace ObjCBindings {
 	/// Flgs to be used in general bound methods.
 	/// </summary>
 	[Flags]
+	[Experimental ("APL0003")]
 	public enum Method : Int64 {
 		/// <summary>
 		/// Use the default values.
@@ -53,6 +55,7 @@ namespace ObjCBindings {
 	/// Flags to be used on properties.
 	/// </summary>
 	[Flags]
+	[Experimental ("APL0003")]
 	public enum Property : Int64 {
 		/// <summary>
 		/// Use the default values.

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1989,6 +1989,7 @@ SHARED_CORE_SOURCES = \
 	MinimumVersions.cs \
 	MonoPInvokeCallbackAttribute.cs \
 	ObjCBindings/BindingTypeAttribute.cs \
+	ObjCBindings/BindingTypeTag.cs \
 	ObjCBindings/ExportAttribute.cs \
 	ObjCBindings/ExportTag.cs \
 	ObjCBindings/FieldAttribute.cs \

--- a/src/rgen/Microsoft.Macios.Binding.Common/Microsoft.Macios.Binding.Common.csproj
+++ b/src/rgen/Microsoft.Macios.Binding.Common/Microsoft.Macios.Binding.Common.csproj
@@ -25,6 +25,9 @@
        <Compile Include="..\..\ObjCRuntime\ArgumentSemantic.cs">
            <Link>external\ArgumentSemantic.cs</Link>
        </Compile>
+        <Compile Include="..\..\ObjCBindings\BindingTypeTag.cs" >
+            <Link>external\BindingTypeTag.cs</Link>
+        </Compile>
         <Compile Include="..\..\ObjCBindings\ExportTag.cs" >
             <Link>external\ExportTag.cs</Link>
         </Compile>

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.Macios.Generator.Attributes;
 
 readonly struct BindingTypeData : IEquatable<BindingTypeData> {
-	
+
 	/// <summary>
 	/// Original name of the ObjC class or protocol.
 	/// </summary>
@@ -36,12 +36,12 @@ readonly struct BindingTypeData : IEquatable<BindingTypeData> {
 			// 0 should not be an option..
 			return false;
 		}
-		
+
 		if (attributeData.NamedArguments.Length == 0) {
-			data = new(name);
+			data = new (name);
 			return true;
 		}
-		
+
 		foreach (var (paramName, value) in attributeData.NamedArguments) {
 			switch (paramName) {
 			case "Name":
@@ -52,8 +52,8 @@ readonly struct BindingTypeData : IEquatable<BindingTypeData> {
 				return false;
 			}
 		}
-		
-		data = new(name);
+
+		data = new (name);
 		return true;
 	}
 
@@ -90,12 +90,12 @@ readonly struct BindingTypeData : IEquatable<BindingTypeData> {
 }
 
 readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : Enum {
-	
+
 	/// <summary>
 	/// Original name of the ObjC class or protocol.
 	/// </summary>
-	public string? Name { get; }	
-	
+	public string? Name { get; }
+
 	/// <summary>
 	/// The configuration flags used on the exported class/interface.
 	/// </summary>
@@ -142,13 +142,13 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 		default:
 			return false;
 		}
-		
+
 		if (attributeData.NamedArguments.Length == 0) {
 			data = flags is not null ?
 				new (name, flags) : new (name);
 			return true;
 		}
-		
+
 		foreach (var (paramName, value) in attributeData.NamedArguments) {
 			switch (paramName) {
 			case "Name":
@@ -162,12 +162,12 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 				return false;
 			}
 		}
-		
+
 		data = flags is not null ?
 			new (name, flags) : new (name);
 		return true;
 	}
-	
+
 	/// <inheritdoc />
 	public bool Equals (BindingTypeData<T> other)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Macios.Generator.Attributes;
+
+readonly struct BindingTypeData : IEquatable<BindingTypeData> {
+	
+	/// <summary>
+	/// Original name of the ObjC class or protocol.
+	/// </summary>
+	public string? Name { get; }
+
+	public BindingTypeData (string? name)
+	{
+		Name = name;
+	}
+
+	/// <summary>
+	/// Try to parse the attribute data to retrieve the information of an ExportAttribute&lt;T&gt;.
+	/// </summary>
+	/// <param name="attributeData">The attribute data to be parsed.</param>
+	/// <param name="data">The parsed data. Null if we could not parse the attribute data.</param>
+	/// <returns>True if the data was parsed.</returns>
+	public static bool TryParse (AttributeData attributeData,
+		[NotNullWhen (true)] out BindingTypeData? data)
+	{
+		data = null;
+		var count = attributeData.ConstructorArguments.Length;
+		string? name;
+		switch (count) {
+		case 1:
+			name = (string?) attributeData.ConstructorArguments [0].Value!;
+			break;
+		default:
+			// 0 should not be an option..
+			return false;
+		}
+		
+		if (attributeData.NamedArguments.Length == 0) {
+			data = new(name);
+			return true;
+		}
+		
+		foreach (var (paramName, value) in attributeData.NamedArguments) {
+			switch (paramName) {
+			case "Name":
+				name = (string?) value.Value!;
+				break;
+			default:
+				data = null;
+				return false;
+			}
+		}
+		
+		data = new(name);
+		return true;
+	}
+
+	/// <inheritdoc />
+	public bool Equals (BindingTypeData other) => Name == other.Name;
+
+	/// <inheritdoc />
+	public override bool Equals (object? obj)
+	{
+		return obj is BindingTypeData other && Equals (other);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode ()
+	{
+		return HashCode.Combine (Name);
+	}
+
+	public static bool operator == (BindingTypeData x, BindingTypeData y)
+	{
+		return x.Equals (y);
+	}
+
+	public static bool operator != (BindingTypeData x, BindingTypeData y)
+	{
+		return !(x == y);
+	}
+
+	/// <inheritdoc />
+	public override string ToString ()
+	{
+		return $"{{ Name: '{Name}' }}";
+	}
+}
+
+readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : Enum {
+	
+	/// <summary>
+	/// Original name of the ObjC class or protocol.
+	/// </summary>
+	public string? Name { get; }	
+	
+	/// <summary>
+	/// The configuration flags used on the exported class/interface.
+	/// </summary>
+	public T? Flags { get; } = default;
+
+	public BindingTypeData (string? name)
+	{
+		Name = name;
+	}
+
+	public BindingTypeData (string? name, T? flags)
+	{
+		Name = name;
+		Flags = flags;
+	}
+
+	/// <summary>
+	/// Try to parse the attribute data to retrieve the information of an ExportAttribute&lt;T&gt;.
+	/// </summary>
+	/// <param name="attributeData">The attribute data to be parsed.</param>
+	/// <param name="data">The parsed data. Null if we could not parse the attribute data.</param>
+	/// <returns>True if the data was parsed.</returns>
+	public static bool TryParse (AttributeData attributeData,
+		[NotNullWhen (true)] out BindingTypeData<T>? data)
+	{
+		data = null;
+		var count = attributeData.ConstructorArguments.Length;
+		string? name;
+		T? flags = default;
+		switch (count) {
+		case 0:
+			// use the defaults
+			name = null;
+			flags = default;
+			break;
+		case 1:
+			name = (string?) attributeData.ConstructorArguments [0].Value!;
+			break;
+		case 2:
+			// we have the name and the config flags present
+			name = (string?) attributeData.ConstructorArguments [0].Value!;
+			flags = (T) attributeData.ConstructorArguments [1].Value!;
+			break;
+		default:
+			return false;
+		}
+		
+		if (attributeData.NamedArguments.Length == 0) {
+			data = flags is not null ?
+				new (name, flags) : new (name);
+			return true;
+		}
+		
+		foreach (var (paramName, value) in attributeData.NamedArguments) {
+			switch (paramName) {
+			case "Name":
+				name = (string?) value.Value!;
+				break;
+			case "Flags":
+				flags = (T) value.Value!;
+				break;
+			default:
+				data = null;
+				return false;
+			}
+		}
+		
+		data = flags is not null ?
+			new (name, flags) : new (name);
+		return true;
+	}
+	
+	/// <inheritdoc />
+	public bool Equals (BindingTypeData<T> other)
+	{
+		if (Name != other.Name)
+			return false;
+		if (Flags is not null && other.Flags is not null) {
+			return Flags.Equals (other.Flags);
+		}
+		return false;
+	}
+
+	/// <inheritdoc />
+	public override bool Equals (object? obj)
+	{
+		return obj is BindingTypeData<T> other && Equals (other);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode ()
+	{
+		return HashCode.Combine (Name, Flags);
+	}
+
+	public static bool operator == (BindingTypeData<T> x, BindingTypeData<T> y)
+	{
+		return x.Equals (y);
+	}
+
+	public static bool operator != (BindingTypeData<T> x, BindingTypeData<T> y)
+	{
+		return !(x == y);
+	}
+
+	/// <inheritdoc />
+	public override string ToString ()
+	{
+		return $"{{ Name: '{Name}', Flags: '{Flags}' }}";
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/BindingData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/BindingData.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Macios.Generator.Attributes;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+/// <summary>
+/// This struct works as a union to store the possible BindingTypeData that can be present in the bindings.
+/// </summary>
+[StructLayout(LayoutKind.Explicit)]
+readonly struct BindingData : IEquatable<BindingData> {
+	// make the struct smaller by making all wrapped structs be at index 0
+	[FieldOffset (0)] readonly BindingType bindingType;
+	[FieldOffset (8)] readonly BindingTypeData bindingTypeData;
+	[FieldOffset (8)] readonly BindingTypeData<ObjCBindings.Class> classData;
+	[FieldOffset (8)] readonly BindingTypeData<ObjCBindings.Protocol> protocolData;
+	[FieldOffset (8)] readonly BindingTypeData<ObjCBindings.Category> categoryData;
+	
+	public BindingType BindingType => bindingType;
+
+	public BindingData (BindingType type, BindingTypeData data)
+	{
+		bindingType = type;
+		bindingTypeData = data;
+	}
+
+	public BindingData (BindingTypeData<ObjCBindings.Class> data)
+	{
+		bindingType = BindingType.Class;
+		classData = data;	
+	}
+
+	public BindingData (BindingTypeData<ObjCBindings.Protocol> data)
+	{
+		bindingType = BindingType.Protocol;
+		protocolData = data;
+	}
+	
+	public BindingData (BindingTypeData<ObjCBindings.Category> data)
+	{
+		bindingType = BindingType.Protocol;
+		categoryData = data;
+	}
+
+	public static implicit operator BindingTypeData (BindingData data) => data.bindingTypeData;
+	public static implicit operator BindingTypeData<ObjCBindings.Class> (BindingData data) => data.classData;
+	public static implicit operator BindingTypeData<ObjCBindings.Protocol> (BindingData data) => data.protocolData;
+	public static implicit operator BindingTypeData<ObjCBindings.Category> (BindingData data) => data.categoryData;
+	
+	public static implicit operator BindingData(BindingTypeData data) => new (BindingType.Unknown, data);
+	public static implicit operator BindingData(BindingTypeData<ObjCBindings.Class> data) => new (data);
+	public static implicit operator BindingData(BindingTypeData<ObjCBindings.Protocol> data) => new (data);
+	public static implicit operator BindingData(BindingTypeData<ObjCBindings.Category> data) => new (data);
+
+	/// <inheritdoc />
+	public bool Equals (BindingData other)
+	{
+		if (bindingType != other.bindingType)
+			return false;
+		switch (bindingType) {
+			case BindingType.Unknown:
+				return bindingTypeData == other.bindingTypeData;
+			case BindingType.SmartEnum:
+				return bindingTypeData == other.bindingTypeData;
+			case BindingType.Class:
+				return classData == other.classData;
+			case BindingType.Protocol:
+				return protocolData == other.protocolData;
+			case BindingType.Category:
+				return categoryData == other.categoryData;
+		}
+		return false;
+	}
+
+	/// <inheritdoc />
+	public override bool Equals (object? obj)
+	{
+		return obj is BindingTypeData other && Equals (other);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode () => bindingType switch {
+		BindingType.SmartEnum => HashCode.Combine (bindingType, bindingTypeData),
+		BindingType.Class => HashCode.Combine (bindingType, classData),
+		BindingType.Protocol => HashCode.Combine (bindingType, protocolData),
+		BindingType.Category => HashCode.Combine (bindingType, categoryData),
+		_ => HashCode.Combine (bindingType, bindingTypeData)
+	};
+
+	public static bool operator == (BindingData x, BindingData y)
+	{
+		return x.Equals (y);
+	}
+
+	public static bool operator != (BindingData x, BindingData y)
+	{
+		return !(x == y);
+	}
+
+	/// <inheritdoc />
+	public override string ToString () => bindingType switch {
+		BindingType.SmartEnum => $"{{ BindingType: {bindingType}, BindingData: {bindingTypeData} }}" ,
+		BindingType.Class => $"{{ BindingType: {bindingType}, BindingData: {classData} }}" ,
+		BindingType.Protocol => $"{{ BindingType: {bindingType}, BindingData: {protocolData} }}",
+		BindingType.Category => $"{{ BindingType: {bindingType}, BindingData: {categoryData} }}",
+		_ => throw new NotImplementedException ()
+	};
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/BindingData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/BindingData.cs
@@ -38,7 +38,7 @@ readonly struct BindingData : IEquatable<BindingData> {
 
 	public BindingData (BindingTypeData<ObjCBindings.Category> data)
 	{
-		bindingType = BindingType.Protocol;
+		bindingType = BindingType.Category;
 		categoryData = data;
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/BindingData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/BindingData.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// <summary>
 /// This struct works as a union to store the possible BindingTypeData that can be present in the bindings.
 /// </summary>
-[StructLayout(LayoutKind.Explicit)]
+[StructLayout (LayoutKind.Explicit)]
 readonly struct BindingData : IEquatable<BindingData> {
 	// make the struct smaller by making all wrapped structs be at index 0
 	[FieldOffset (0)] readonly BindingType bindingType;
@@ -15,7 +15,7 @@ readonly struct BindingData : IEquatable<BindingData> {
 	[FieldOffset (8)] readonly BindingTypeData<ObjCBindings.Class> classData;
 	[FieldOffset (8)] readonly BindingTypeData<ObjCBindings.Protocol> protocolData;
 	[FieldOffset (8)] readonly BindingTypeData<ObjCBindings.Category> categoryData;
-	
+
 	public BindingType BindingType => bindingType;
 
 	public BindingData (BindingType type, BindingTypeData data)
@@ -27,7 +27,7 @@ readonly struct BindingData : IEquatable<BindingData> {
 	public BindingData (BindingTypeData<ObjCBindings.Class> data)
 	{
 		bindingType = BindingType.Class;
-		classData = data;	
+		classData = data;
 	}
 
 	public BindingData (BindingTypeData<ObjCBindings.Protocol> data)
@@ -35,7 +35,7 @@ readonly struct BindingData : IEquatable<BindingData> {
 		bindingType = BindingType.Protocol;
 		protocolData = data;
 	}
-	
+
 	public BindingData (BindingTypeData<ObjCBindings.Category> data)
 	{
 		bindingType = BindingType.Protocol;
@@ -46,11 +46,11 @@ readonly struct BindingData : IEquatable<BindingData> {
 	public static implicit operator BindingTypeData<ObjCBindings.Class> (BindingData data) => data.classData;
 	public static implicit operator BindingTypeData<ObjCBindings.Protocol> (BindingData data) => data.protocolData;
 	public static implicit operator BindingTypeData<ObjCBindings.Category> (BindingData data) => data.categoryData;
-	
-	public static implicit operator BindingData(BindingTypeData data) => new (BindingType.Unknown, data);
-	public static implicit operator BindingData(BindingTypeData<ObjCBindings.Class> data) => new (data);
-	public static implicit operator BindingData(BindingTypeData<ObjCBindings.Protocol> data) => new (data);
-	public static implicit operator BindingData(BindingTypeData<ObjCBindings.Category> data) => new (data);
+
+	public static implicit operator BindingData (BindingTypeData data) => new (BindingType.Unknown, data);
+	public static implicit operator BindingData (BindingTypeData<ObjCBindings.Class> data) => new (data);
+	public static implicit operator BindingData (BindingTypeData<ObjCBindings.Protocol> data) => new (data);
+	public static implicit operator BindingData (BindingTypeData<ObjCBindings.Category> data) => new (data);
 
 	/// <inheritdoc />
 	public bool Equals (BindingData other)
@@ -58,16 +58,16 @@ readonly struct BindingData : IEquatable<BindingData> {
 		if (bindingType != other.bindingType)
 			return false;
 		switch (bindingType) {
-			case BindingType.Unknown:
-				return bindingTypeData == other.bindingTypeData;
-			case BindingType.SmartEnum:
-				return bindingTypeData == other.bindingTypeData;
-			case BindingType.Class:
-				return classData == other.classData;
-			case BindingType.Protocol:
-				return protocolData == other.protocolData;
-			case BindingType.Category:
-				return categoryData == other.categoryData;
+		case BindingType.Unknown:
+			return bindingTypeData == other.bindingTypeData;
+		case BindingType.SmartEnum:
+			return bindingTypeData == other.bindingTypeData;
+		case BindingType.Class:
+			return classData == other.classData;
+		case BindingType.Protocol:
+			return protocolData == other.protocolData;
+		case BindingType.Category:
+			return categoryData == other.categoryData;
 		}
 		return false;
 	}
@@ -99,8 +99,8 @@ readonly struct BindingData : IEquatable<BindingData> {
 
 	/// <inheritdoc />
 	public override string ToString () => bindingType switch {
-		BindingType.SmartEnum => $"{{ BindingType: {bindingType}, BindingData: {bindingTypeData} }}" ,
-		BindingType.Class => $"{{ BindingType: {bindingType}, BindingData: {classData} }}" ,
+		BindingType.SmartEnum => $"{{ BindingType: {bindingType}, BindingData: {bindingTypeData} }}",
+		BindingType.Class => $"{{ BindingType: {bindingType}, BindingData: {classData} }}",
 		BindingType.Protocol => $"{{ BindingType: {bindingType}, BindingData: {protocolData} }}",
 		BindingType.Category => $"{{ BindingType: {bindingType}, BindingData: {categoryData} }}",
 		_ => throw new NotImplementedException ()

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/BindingData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/BindingData.cs
@@ -75,7 +75,7 @@ readonly struct BindingData : IEquatable<BindingData> {
 	/// <inheritdoc />
 	public override bool Equals (object? obj)
 	{
-		return obj is BindingTypeData other && Equals (other);
+		return obj is BindingData other && Equals (other);
 	}
 
 	/// <inheritdoc />

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/BindingType.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/BindingType.cs
@@ -2,7 +2,7 @@ namespace Microsoft.Macios.Generator.DataModel;
 
 /// <summary>
 /// Enum that represents the binding type needed for an class/interface/enum. This allows the code generator
-/// to differentiate between a code changes that has the exact same qualified name but different type.
+/// to differentiate between code changes that have the exact same qualified name but different type.
 /// </summary>
 enum BindingType : ulong {
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/BindingType.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/BindingType.cs
@@ -2,9 +2,9 @@ namespace Microsoft.Macios.Generator.DataModel;
 
 /// <summary>
 /// Enum that represents the binding type needed for an class/interface/enum. This allows the code generator
-/// differentiate between a code changes that has the exact same qualified name but different type.
+/// to differentiate between a code changes that has the exact same qualified name but different type.
 /// </summary>
-enum BindingType {
+enum BindingType : ulong {
 	/// <summary>
 	/// Unknown binding type.
 	/// </summary>
@@ -13,6 +13,16 @@ enum BindingType {
 	/// Binding type for a enum with backing fields.
 	/// </summary>
 	SmartEnum,
+	/// <summary>
+	/// Binding type for an objc class.
+	/// </summary>
 	Class,
+	/// <summary>
+	/// Binding type for an objc protocol.
+	/// </summary>
 	Protocol,
+	/// <summary>
+	/// Binding type for an objc category.
+	/// </summary>
+	Category,
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingDataTests.cs
@@ -42,6 +42,17 @@ public class BindingDataTests {
 		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Protocol>) bindingData).Flags);
 		Assert.Equal (BindingType.Protocol, bindingData.BindingType);
 	}
+	
+	[Fact]
+	public void ConstructorBindingCategoryData ()
+	{
+		var bindingTypeData = new BindingTypeData<Category> ("BindingType");
+		BindingData bindingData = new BindingData(bindingTypeData);
+		Assert.Equal (bindingTypeData, (BindingTypeData<Category>)bindingData);
+		Assert.Equal (bindingTypeData.Name, ((BindingTypeData<Category>)bindingData).Name);
+		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Category>)bindingData).Flags);
+		Assert.Equal (BindingType.Category, bindingData.BindingType);
+	}
 
 	[Fact]
 	public void EqualsDiffBindingType ()
@@ -184,7 +195,7 @@ public class BindingDataTests {
 
 			yield return [
 				new BindingData (new BindingTypeData<Category> ("Name")),
-				"{ BindingType: Protocol, BindingData: { Name: 'Name', Flags: 'Default' } }"
+				"{ BindingType: Category, BindingData: { Name: 'Name', Flags: 'Default' } }"
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingDataTests.cs
@@ -1,0 +1,199 @@
+#pragma warning disable APL0003
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.DataModel;
+using ObjCBindings;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.DataModel;
+
+public class BindingDataTests {
+
+	[Fact]
+	public void ConstructorBindingTypeData ()
+	{
+		
+		var bindingTypeData = new BindingTypeData("BindingType");
+		BindingData bindingData = new BindingData(BindingType.SmartEnum, bindingTypeData);
+		Assert.Equal (bindingTypeData, (BindingTypeData) bindingData);
+		Assert.Equal (bindingTypeData.Name, ((BindingTypeData) bindingData).Name);
+		Assert.Equal (BindingType.SmartEnum, bindingData.BindingType);
+	}
+
+	[Fact]
+	public void ConstructorBindingTypeClassData ()
+	{
+		var bindingTypeData = new BindingTypeData<Class> ("BindingType", Class.DisableDefaultCtor);
+		BindingData bindingData = new BindingData(bindingTypeData);
+		Assert.Equal (bindingTypeData, (BindingTypeData<Class>)bindingData);
+		Assert.Equal (bindingTypeData.Name, ((BindingTypeData<Class>)bindingData).Name);
+		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Class>)bindingData).Flags);
+		Assert.Equal (BindingType.Class, bindingData.BindingType);
+	}
+
+	[Fact]
+	public void ConstructorBindingProtocolData ()
+	{
+		var bindingTypeData = new BindingTypeData<Protocol> ("BindingType");
+		BindingData bindingData = new BindingData(bindingTypeData);
+		Assert.Equal (bindingTypeData, (BindingTypeData<Protocol>)bindingData);
+		Assert.Equal (bindingTypeData.Name, ((BindingTypeData<Protocol>)bindingData).Name);
+		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Protocol>)bindingData).Flags);
+		Assert.Equal (BindingType.Protocol, bindingData.BindingType);
+	}
+
+	[Fact]
+	public void EqualsDiffBindingType ()
+	{
+		var xBinding = new BindingTypeData ("Name");
+		var x = new BindingData(BindingType.SmartEnum, xBinding);
+		var y = new BindingData(BindingType.Unknown, xBinding);
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+
+	[Fact]
+	public void EqualsDiffEnumBindingType ()
+	{
+		var xBinding = new BindingTypeData ("Name1");
+		var yBinding = new BindingTypeData<Class> ("Name2");
+		var x = new BindingData(BindingType.SmartEnum, xBinding);
+		var y = new BindingData(yBinding);
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+
+	[Fact]
+	public void EqualsSameEnumBindingType ()
+	{
+		var xBinding = new BindingTypeData ("Name");
+		var yBinding = new BindingTypeData ("Name");
+		var x = new BindingData(BindingType.SmartEnum, xBinding);
+		var y = new BindingData(BindingType.SmartEnum, yBinding);
+		Assert.True (x.Equals (y));
+		Assert.True (y.Equals (x));
+		Assert.True (x == y);
+		Assert.False (x != y);
+	}
+
+	[Fact]
+	public void EqualsDiffClassBindingType ()
+	{
+		var xBinding = new BindingTypeData<Class> ("Name1");
+		var yBinding = new BindingTypeData<Class> ("Name2");
+		var x = new BindingData(xBinding);
+		var y = new BindingData(yBinding);
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+
+	[Fact]
+	public void EqualsSameClassBindingType ()
+	{
+		var xBinding = new BindingTypeData<Class> ("Name");
+		var yBinding = new BindingTypeData<Class> ("Name");
+		var x = new BindingData(xBinding);
+		var y = new BindingData(yBinding);
+		Assert.True (x.Equals (y));
+		Assert.True (y.Equals (x));
+		Assert.True (x == y);
+		Assert.False (x != y);
+	}
+	
+	[Fact]
+	public void EqualsDiffProtocolBindingType ()
+	{
+		var xBinding = new BindingTypeData<Protocol> ("Name1");
+		var yBinding = new BindingTypeData<Protocol> ("Name2");
+		var x = new BindingData(xBinding);
+		var y = new BindingData(yBinding);
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+
+	[Fact]
+	public void EqualsSameProtocolBindingType ()
+	{
+		var xBinding = new BindingTypeData<Protocol> ("Name");
+		var yBinding = new BindingTypeData<Protocol> ("Name");
+		var x = new BindingData(xBinding);
+		var y = new BindingData(yBinding);
+		Assert.True (x.Equals (y));
+		Assert.True (y.Equals (x));
+		Assert.True (x == y);
+		Assert.False (x != y);
+	}
+	
+	[Fact]
+	public void EqualsDiffCategoryBindingType ()
+	{
+		var xBinding = new BindingTypeData<Category> ("Name1");
+		var yBinding = new BindingTypeData<Category> ("Name2");
+		var x = new BindingData(xBinding);
+		var y = new BindingData(yBinding);
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+
+	[Fact]
+	public void EqualsSameCategoryBindingType ()
+	{
+		var xBinding = new BindingTypeData<Category> ("Name");
+		var yBinding = new BindingTypeData<Category> ("Name");
+		var x = new BindingData(xBinding);
+		var y = new BindingData(yBinding);
+		Assert.True (x.Equals (y));
+		Assert.True (y.Equals (x));
+		Assert.True (x == y);
+		Assert.False (x != y);
+	}
+
+	class TestDataToString : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				new BindingData(BindingType.SmartEnum, new BindingTypeData("Name")),
+				"{ BindingType: SmartEnum, BindingData: { Name: 'Name' } }",
+			];
+			
+			yield return [
+				new BindingData(new BindingTypeData<Class> ("Name")),
+				"{ BindingType: Class, BindingData: { Name: 'Name', Flags: 'Default' } }"
+			];
+			
+			yield return [
+				new BindingData(new BindingTypeData<Class> ("Name", Class.DisableDefaultCtor)),
+				"{ BindingType: Class, BindingData: { Name: 'Name', Flags: 'DisableDefaultCtor' } }"
+			];
+			
+			yield return [
+				new BindingData(new BindingTypeData<Protocol> ("Name")),
+				"{ BindingType: Protocol, BindingData: { Name: 'Name', Flags: 'Default' } }"
+			];
+			
+			yield return [
+				new BindingData(new BindingTypeData<Category> ("Name")),
+				"{ BindingType: Protocol, BindingData: { Name: 'Name', Flags: 'Default' } }"
+			];
+		}
+	
+		IEnumerator IEnumerable.GetEnumerator ()
+			=> GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof(TestDataToString))]
+	void TestFieldDataToString (BindingData x, string expected)
+		=> Assert.Equal (expected, x.ToString ());
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingDataTests.cs
@@ -42,15 +42,15 @@ public class BindingDataTests {
 		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Protocol>) bindingData).Flags);
 		Assert.Equal (BindingType.Protocol, bindingData.BindingType);
 	}
-	
+
 	[Fact]
 	public void ConstructorBindingCategoryData ()
 	{
 		var bindingTypeData = new BindingTypeData<Category> ("BindingType");
-		BindingData bindingData = new BindingData(bindingTypeData);
-		Assert.Equal (bindingTypeData, (BindingTypeData<Category>)bindingData);
-		Assert.Equal (bindingTypeData.Name, ((BindingTypeData<Category>)bindingData).Name);
-		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Category>)bindingData).Flags);
+		BindingData bindingData = new BindingData (bindingTypeData);
+		Assert.Equal (bindingTypeData, (BindingTypeData<Category>) bindingData);
+		Assert.Equal (bindingTypeData.Name, ((BindingTypeData<Category>) bindingData).Name);
+		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Category>) bindingData).Flags);
 		Assert.Equal (BindingType.Category, bindingData.BindingType);
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingDataTests.cs
@@ -13,9 +13,9 @@ public class BindingDataTests {
 	[Fact]
 	public void ConstructorBindingTypeData ()
 	{
-		
-		var bindingTypeData = new BindingTypeData("BindingType");
-		BindingData bindingData = new BindingData(BindingType.SmartEnum, bindingTypeData);
+
+		var bindingTypeData = new BindingTypeData ("BindingType");
+		BindingData bindingData = new BindingData (BindingType.SmartEnum, bindingTypeData);
 		Assert.Equal (bindingTypeData, (BindingTypeData) bindingData);
 		Assert.Equal (bindingTypeData.Name, ((BindingTypeData) bindingData).Name);
 		Assert.Equal (BindingType.SmartEnum, bindingData.BindingType);
@@ -25,10 +25,10 @@ public class BindingDataTests {
 	public void ConstructorBindingTypeClassData ()
 	{
 		var bindingTypeData = new BindingTypeData<Class> ("BindingType", Class.DisableDefaultCtor);
-		BindingData bindingData = new BindingData(bindingTypeData);
-		Assert.Equal (bindingTypeData, (BindingTypeData<Class>)bindingData);
-		Assert.Equal (bindingTypeData.Name, ((BindingTypeData<Class>)bindingData).Name);
-		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Class>)bindingData).Flags);
+		BindingData bindingData = new BindingData (bindingTypeData);
+		Assert.Equal (bindingTypeData, (BindingTypeData<Class>) bindingData);
+		Assert.Equal (bindingTypeData.Name, ((BindingTypeData<Class>) bindingData).Name);
+		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Class>) bindingData).Flags);
 		Assert.Equal (BindingType.Class, bindingData.BindingType);
 	}
 
@@ -36,10 +36,10 @@ public class BindingDataTests {
 	public void ConstructorBindingProtocolData ()
 	{
 		var bindingTypeData = new BindingTypeData<Protocol> ("BindingType");
-		BindingData bindingData = new BindingData(bindingTypeData);
-		Assert.Equal (bindingTypeData, (BindingTypeData<Protocol>)bindingData);
-		Assert.Equal (bindingTypeData.Name, ((BindingTypeData<Protocol>)bindingData).Name);
-		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Protocol>)bindingData).Flags);
+		BindingData bindingData = new BindingData (bindingTypeData);
+		Assert.Equal (bindingTypeData, (BindingTypeData<Protocol>) bindingData);
+		Assert.Equal (bindingTypeData.Name, ((BindingTypeData<Protocol>) bindingData).Name);
+		Assert.Equal (bindingTypeData.Flags, ((BindingTypeData<Protocol>) bindingData).Flags);
 		Assert.Equal (BindingType.Protocol, bindingData.BindingType);
 	}
 
@@ -47,8 +47,8 @@ public class BindingDataTests {
 	public void EqualsDiffBindingType ()
 	{
 		var xBinding = new BindingTypeData ("Name");
-		var x = new BindingData(BindingType.SmartEnum, xBinding);
-		var y = new BindingData(BindingType.Unknown, xBinding);
+		var x = new BindingData (BindingType.SmartEnum, xBinding);
+		var y = new BindingData (BindingType.Unknown, xBinding);
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -60,8 +60,8 @@ public class BindingDataTests {
 	{
 		var xBinding = new BindingTypeData ("Name1");
 		var yBinding = new BindingTypeData<Class> ("Name2");
-		var x = new BindingData(BindingType.SmartEnum, xBinding);
-		var y = new BindingData(yBinding);
+		var x = new BindingData (BindingType.SmartEnum, xBinding);
+		var y = new BindingData (yBinding);
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -73,8 +73,8 @@ public class BindingDataTests {
 	{
 		var xBinding = new BindingTypeData ("Name");
 		var yBinding = new BindingTypeData ("Name");
-		var x = new BindingData(BindingType.SmartEnum, xBinding);
-		var y = new BindingData(BindingType.SmartEnum, yBinding);
+		var x = new BindingData (BindingType.SmartEnum, xBinding);
+		var y = new BindingData (BindingType.SmartEnum, yBinding);
 		Assert.True (x.Equals (y));
 		Assert.True (y.Equals (x));
 		Assert.True (x == y);
@@ -86,8 +86,8 @@ public class BindingDataTests {
 	{
 		var xBinding = new BindingTypeData<Class> ("Name1");
 		var yBinding = new BindingTypeData<Class> ("Name2");
-		var x = new BindingData(xBinding);
-		var y = new BindingData(yBinding);
+		var x = new BindingData (xBinding);
+		var y = new BindingData (yBinding);
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -99,21 +99,21 @@ public class BindingDataTests {
 	{
 		var xBinding = new BindingTypeData<Class> ("Name");
 		var yBinding = new BindingTypeData<Class> ("Name");
-		var x = new BindingData(xBinding);
-		var y = new BindingData(yBinding);
+		var x = new BindingData (xBinding);
+		var y = new BindingData (yBinding);
 		Assert.True (x.Equals (y));
 		Assert.True (y.Equals (x));
 		Assert.True (x == y);
 		Assert.False (x != y);
 	}
-	
+
 	[Fact]
 	public void EqualsDiffProtocolBindingType ()
 	{
 		var xBinding = new BindingTypeData<Protocol> ("Name1");
 		var yBinding = new BindingTypeData<Protocol> ("Name2");
-		var x = new BindingData(xBinding);
-		var y = new BindingData(yBinding);
+		var x = new BindingData (xBinding);
+		var y = new BindingData (yBinding);
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -125,21 +125,21 @@ public class BindingDataTests {
 	{
 		var xBinding = new BindingTypeData<Protocol> ("Name");
 		var yBinding = new BindingTypeData<Protocol> ("Name");
-		var x = new BindingData(xBinding);
-		var y = new BindingData(yBinding);
+		var x = new BindingData (xBinding);
+		var y = new BindingData (yBinding);
 		Assert.True (x.Equals (y));
 		Assert.True (y.Equals (x));
 		Assert.True (x == y);
 		Assert.False (x != y);
 	}
-	
+
 	[Fact]
 	public void EqualsDiffCategoryBindingType ()
 	{
 		var xBinding = new BindingTypeData<Category> ("Name1");
 		var yBinding = new BindingTypeData<Category> ("Name2");
-		var x = new BindingData(xBinding);
-		var y = new BindingData(yBinding);
+		var x = new BindingData (xBinding);
+		var y = new BindingData (yBinding);
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -151,8 +151,8 @@ public class BindingDataTests {
 	{
 		var xBinding = new BindingTypeData<Category> ("Name");
 		var yBinding = new BindingTypeData<Category> ("Name");
-		var x = new BindingData(xBinding);
-		var y = new BindingData(yBinding);
+		var x = new BindingData (xBinding);
+		var y = new BindingData (yBinding);
 		Assert.True (x.Equals (y));
 		Assert.True (y.Equals (x));
 		Assert.True (x == y);
@@ -163,37 +163,37 @@ public class BindingDataTests {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
-				new BindingData(BindingType.SmartEnum, new BindingTypeData("Name")),
+				new BindingData (BindingType.SmartEnum, new BindingTypeData ("Name")),
 				"{ BindingType: SmartEnum, BindingData: { Name: 'Name' } }",
 			];
-			
+
 			yield return [
-				new BindingData(new BindingTypeData<Class> ("Name")),
+				new BindingData (new BindingTypeData<Class> ("Name")),
 				"{ BindingType: Class, BindingData: { Name: 'Name', Flags: 'Default' } }"
 			];
-			
+
 			yield return [
-				new BindingData(new BindingTypeData<Class> ("Name", Class.DisableDefaultCtor)),
+				new BindingData (new BindingTypeData<Class> ("Name", Class.DisableDefaultCtor)),
 				"{ BindingType: Class, BindingData: { Name: 'Name', Flags: 'DisableDefaultCtor' } }"
 			];
-			
+
 			yield return [
-				new BindingData(new BindingTypeData<Protocol> ("Name")),
+				new BindingData (new BindingTypeData<Protocol> ("Name")),
 				"{ BindingType: Protocol, BindingData: { Name: 'Name', Flags: 'Default' } }"
 			];
-			
+
 			yield return [
-				new BindingData(new BindingTypeData<Category> ("Name")),
+				new BindingData (new BindingTypeData<Category> ("Name")),
 				"{ BindingType: Protocol, BindingData: { Name: 'Name', Flags: 'Default' } }"
 			];
 		}
-	
+
 		IEnumerator IEnumerable.GetEnumerator ()
 			=> GetEnumerator ();
 	}
 
 	[Theory]
-	[ClassData (typeof(TestDataToString))]
+	[ClassData (typeof (TestDataToString))]
 	void TestFieldDataToString (BindingData x, string expected)
 		=> Assert.Equal (expected, x.ToString ());
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
@@ -162,7 +162,7 @@ public class EnumMemberCodeChangesTests {
 				fieldData: new ("x", "libName", EnumValue.None),
 				symbolAvailability: builder.ToImmutable (),
 				attributes: []);
-			yield return [availabilityEnum, "{ Name: 'EnumValue' SymbolAvailability: [{ Platform: iOS Supported: '0.0' Unsupported: [], Obsoleted: [] }] FieldData: { SymbolName: 'x' LibraryName: 'libName', Flags: 'None' } Attributes: [] }"];
+			yield return [availabilityEnum, "{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldData: { SymbolName: 'x' LibraryName: 'libName', Flags: 'None' } Attributes: [] }"];
 
 			var attrsEnum = new EnumMember (
 				name: "EnumValue",
@@ -172,7 +172,7 @@ public class EnumMemberCodeChangesTests {
 					new ("Attribute1"),
 					new ("Attribute2"),
 				]);
-			yield return [attrsEnum, "{ Name: 'EnumValue' SymbolAvailability: [{ Platform: iOS Supported: '0.0' Unsupported: [], Obsoleted: [] }] FieldData: { SymbolName: 'x' LibraryName: 'libName', Flags: 'None' } Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }"];
+			yield return [attrsEnum, "{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldData: { SymbolName: 'x' LibraryName: 'libName', Flags: 'None' } Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }"];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator ()


### PR DESCRIPTION


We want to be able to store as parte of the code change struct any information related to the binding type. To do so we have a new BindingTypeAttribute that is generic to allow extra config.

We also provide a new struct that works as a union of all the supported generic BindingTypeAttribute, that way we can add that new struct (in a follow up PR) to the code change struct.