### PR TITLE
[rgen] Fix concurrent build problem with rgen.

### DIFF
--- a/src/Makefile.rgenerator
+++ b/src/Makefile.rgenerator
@@ -20,8 +20,10 @@ $(ROSLYN_GENERATOR): Makefile.rgenerator $(ROSLYN_GENERATOR_FILES)
 	@mkdir -p $(dir $@)
 	$(Q) $(CP) -Rf $(DOTNET_BUILD_DIR)/IDE/bin/common/rgen/generator/publish/* $(dir $@)
 
-
-$(ROSLYN_ANALYZER): Makefile.rgenerator $(ROSLYN_ANALYZER_FILES)
+# Build the generator first, because both of these projects reference Microsoft.Macios.Binding.Common.csproj, and building both in parallel
+# will randomly run into issues with NuGet restoring packages for Microsoft.Macios.Binding.Common.csproj for both builds simulataneously,
+# which will fail randomly.
+$(ROSLYN_ANALYZER): Makefile.rgenerator $(ROSLYN_ANALYZER_FILES) $(ROSLYN_GENERATOR)
 	$(Q_DOTNET_BUILD) $(DOTNET) publish rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj $(DOTNET_BUILD_VERBOSITY) /p:Configuration=Debug /p:IntermediateOutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/obj/common/rgen/analyzer)/ /p:OutputPath=$(abspath $(DOTNET_BUILD_DIR)/IDE/bin/common/rgen/analyzer/)/
 	@mkdir -p $(dir $@)
 	$(Q) $(CP) -Rf $(DOTNET_BUILD_DIR)/IDE/bin/common/rgen/analyzer/publish/* $(dir $@)


### PR DESCRIPTION
Build the generator before the analyzer, because both of these projects
reference Microsoft.Macios.Binding.Common.csproj, and building both in
parallel will randomly run into issues with NuGet restoring packages for
Microsoft.Macios.Binding.Common.csproj for both builds simulataneously, which
will fail randomly (building the analyzer before the generator would also
work).

Fixes this build error:

    /Users/builder/azdo/_work/20/a/change-detection/tmp/src/xamarin-macios/builds/downloads/dotnet-sdk-9.0.102-servicing.24610.2/sdk/9.0.102/NuGet.targets(170,5): error : The file '/Users/builder/azdo/_work/20/a/change-detection/tmp/src/xamarin-macios/src/rgen/Microsoft.Macios.Binding.Common/obj/Microsoft.Macios.Binding.Common.csproj.nuget.g.props' already exists.
    make[1]: *** [build/dotnet/common/rgen/generator/Microsoft.Macios.Generator.dll] Error 1
    make[1]: *** Waiting for unfinished jobs....