### PR TITLE
[Rgen] Add helper properties to determine if a code change was for a static, abstract or partial class.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -46,9 +46,33 @@ readonly struct CodeChanges {
 	public ImmutableArray<AttributeCodeChange> Attributes { get; init; } = [];
 
 	/// <summary>
+	/// True if the code changes are for a static symbol.
+	/// </summary>
+	public bool IsStatic { get; init; }
+	
+	/// <summary>
+	/// True if the code changes are for a partial symbol.
+	/// </summary>
+	public bool IsPartial { get; init; }
+	
+	/// <summary>
+	/// True if the code changes are for an abstract symbol.
+	/// </summary>
+	public bool IsAbstract { get; init; }
+	
+	readonly ImmutableArray<SyntaxToken> modifiers = [];
+	/// <summary>
 	/// Modifiers list.
 	/// </summary>
-	public ImmutableArray<SyntaxToken> Modifiers { get; init; } = [];
+	public ImmutableArray<SyntaxToken> Modifiers {
+		get => modifiers;
+		init {
+			modifiers = value;
+			IsStatic = value.Any (m => m.IsKind (SyntaxKind.StaticKeyword));
+			IsPartial = value.Any (m => m.IsKind (SyntaxKind.PartialKeyword));
+			IsAbstract = value.Any (m => m.IsKind (SyntaxKind.AbstractKeyword));
+		}
+	}
 
 	readonly ImmutableArray<EnumMember> enumMembers = [];
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -49,17 +49,17 @@ readonly struct CodeChanges {
 	/// True if the code changes are for a static symbol.
 	/// </summary>
 	public bool IsStatic { get; init; }
-	
+
 	/// <summary>
 	/// True if the code changes are for a partial symbol.
 	/// </summary>
 	public bool IsPartial { get; init; }
-	
+
 	/// <summary>
 	/// True if the code changes are for an abstract symbol.
 	/// </summary>
 	public bool IsAbstract { get; init; }
-	
+
 	readonly ImmutableArray<SyntaxToken> modifiers = [];
 	/// <summary>
 	/// Modifiers list.

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -48,17 +48,17 @@ readonly struct CodeChanges {
 	/// <summary>
 	/// True if the code changes are for a static symbol.
 	/// </summary>
-	public bool IsStatic { get; init; }
+	public bool IsStatic { get; private init; }
 
 	/// <summary>
 	/// True if the code changes are for a partial symbol.
 	/// </summary>
-	public bool IsPartial { get; init; }
+	public bool IsPartial { get; private init; }
 
 	/// <summary>
 	/// True if the code changes are for an abstract symbol.
 	/// </summary>
-	public bool IsAbstract { get; init; }
+	public bool IsAbstract { get; private init; }
 
 	readonly ImmutableArray<SyntaxToken> modifiers = [];
 	/// <summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -698,80 +698,80 @@ public partial class MyClass {
 	public void IsStaticPropertyTest ()
 	{
 		var changes = new CodeChanges (
-			bindingType: BindingType.SmartEnum, 
-			name: "name1", 
-			@namespace: ["NS"], 
-			fullyQualifiedSymbol: "NS.name1", 
+			bindingType: BindingType.SmartEnum,
+			name: "name1",
+			@namespace: ["NS"],
+			fullyQualifiedSymbol: "NS.name1",
 			symbolAvailability: new ());
-		
+
 		Assert.False (changes.IsStatic);
-		
+
 		changes = new CodeChanges (
-			bindingType: BindingType.SmartEnum, 
-			name: "name1", 
-			@namespace: ["NS"], 
-			fullyQualifiedSymbol: "NS.name1", 
+			bindingType: BindingType.SmartEnum,
+			name: "name1",
+			@namespace: ["NS"],
+			fullyQualifiedSymbol: "NS.name1",
 			symbolAvailability: new ()) {
 			Modifiers = [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				SyntaxFactory.Token (SyntaxKind.StaticKeyword),
 			]
 		};
-		
+
 		Assert.True (changes.IsStatic);
 	}
-	
+
 	[Fact]
 	public void IsPartialPropertyTest ()
 	{
 		var changes = new CodeChanges (
-			bindingType: BindingType.SmartEnum, 
-			name: "name1", 
-			@namespace: ["NS"], 
-			fullyQualifiedSymbol: "NS.name1", 
+			bindingType: BindingType.SmartEnum,
+			name: "name1",
+			@namespace: ["NS"],
+			fullyQualifiedSymbol: "NS.name1",
 			symbolAvailability: new ());
-		
+
 		Assert.False (changes.IsPartial);
-		
+
 		changes = new CodeChanges (
-			bindingType: BindingType.SmartEnum, 
-			name: "name1", 
-			@namespace: ["NS"], 
-			fullyQualifiedSymbol: "NS.name1", 
+			bindingType: BindingType.SmartEnum,
+			name: "name1",
+			@namespace: ["NS"],
+			fullyQualifiedSymbol: "NS.name1",
 			symbolAvailability: new ()) {
 			Modifiers = [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 			]
 		};
-		
+
 		Assert.True (changes.IsPartial);
 	}
-	
+
 	[Fact]
 	public void IsAbstractPropertyTest ()
 	{
 		var changes = new CodeChanges (
-			bindingType: BindingType.SmartEnum, 
-			name: "name1", 
-			@namespace: ["NS"], 
-			fullyQualifiedSymbol: "NS.name1", 
+			bindingType: BindingType.SmartEnum,
+			name: "name1",
+			@namespace: ["NS"],
+			fullyQualifiedSymbol: "NS.name1",
 			symbolAvailability: new ());
-		
+
 		Assert.False (changes.IsAbstract);
-		
+
 		changes = new CodeChanges (
-			bindingType: BindingType.SmartEnum, 
-			name: "name1", 
-			@namespace: ["NS"], 
-			fullyQualifiedSymbol: "NS.name1", 
+			bindingType: BindingType.SmartEnum,
+			name: "name1",
+			@namespace: ["NS"],
+			fullyQualifiedSymbol: "NS.name1",
 			symbolAvailability: new ()) {
 			Modifiers = [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				SyntaxFactory.Token (SyntaxKind.AbstractKeyword),
 			]
 		};
-		
+
 		Assert.True (changes.IsAbstract);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -693,4 +693,85 @@ public partial class MyClass {
 		Assert.NotNull (changes);
 		Assert.Equal (expected, changes.Value, comparer);
 	}
+
+	[Fact]
+	public void IsStaticPropertyTest ()
+	{
+		var changes = new CodeChanges (
+			bindingType: BindingType.SmartEnum, 
+			name: "name1", 
+			@namespace: ["NS"], 
+			fullyQualifiedSymbol: "NS.name1", 
+			symbolAvailability: new ());
+		
+		Assert.False (changes.IsStatic);
+		
+		changes = new CodeChanges (
+			bindingType: BindingType.SmartEnum, 
+			name: "name1", 
+			@namespace: ["NS"], 
+			fullyQualifiedSymbol: "NS.name1", 
+			symbolAvailability: new ()) {
+			Modifiers = [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.StaticKeyword),
+			]
+		};
+		
+		Assert.True (changes.IsStatic);
+	}
+	
+	[Fact]
+	public void IsPartialPropertyTest ()
+	{
+		var changes = new CodeChanges (
+			bindingType: BindingType.SmartEnum, 
+			name: "name1", 
+			@namespace: ["NS"], 
+			fullyQualifiedSymbol: "NS.name1", 
+			symbolAvailability: new ());
+		
+		Assert.False (changes.IsPartial);
+		
+		changes = new CodeChanges (
+			bindingType: BindingType.SmartEnum, 
+			name: "name1", 
+			@namespace: ["NS"], 
+			fullyQualifiedSymbol: "NS.name1", 
+			symbolAvailability: new ()) {
+			Modifiers = [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PartialKeyword),
+			]
+		};
+		
+		Assert.True (changes.IsPartial);
+	}
+	
+	[Fact]
+	public void IsAbstractPropertyTest ()
+	{
+		var changes = new CodeChanges (
+			bindingType: BindingType.SmartEnum, 
+			name: "name1", 
+			@namespace: ["NS"], 
+			fullyQualifiedSymbol: "NS.name1", 
+			symbolAvailability: new ());
+		
+		Assert.False (changes.IsAbstract);
+		
+		changes = new CodeChanges (
+			bindingType: BindingType.SmartEnum, 
+			name: "name1", 
+			@namespace: ["NS"], 
+			fullyQualifiedSymbol: "NS.name1", 
+			symbolAvailability: new ()) {
+			Modifiers = [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.AbstractKeyword),
+			]
+		};
+		
+		Assert.True (changes.IsAbstract);
+	}
 }


### PR DESCRIPTION


We precalculate the values form the modifiers, this later makes is simpler when writing the code generator to check those modifiers we are interested in without falling in the trap of executing the same LINQ query over an over.