### PR TITLE
[msbuild] Show an error if an app tries to link with a static library when building for Hot Restart.

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -779,6 +779,30 @@ only scan libraries with the `[LinkWith]` attribute for Objective-C classes:
 </PropertyGroup>
 ```
 
+## SkipStaticLibraryValidation
+
+Hot Restart doesn't support linking with static libraries, so by default we'll
+show an error if the project tries to link with any static libraries when
+using Hot Restart.
+
+However, in some cases it might be useful to ignore such errors (for instance if testing a code path in the app that doesn't require the static library in question), so it's possible to ignore them.
+
+The valid values are:
+
+* "true", "disable": Completely disable the validation.
+* "false", "error", empty string: Enable the validation (this is the default)
+* "warn": Validate, but show warnings instead of errors.
+
+Example:
+
+```xml
+<PropertyGroup>
+  <SkipStaticLibraryValidation>warn</SkipStaticLibraryValidation>
+</PropertyGroup>
+```
+
+This will show warnings instead of errors if the project tries to link with a static library.
+
 ## StripPath
 
 The full path to the `strip` command-line tool.

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1662,4 +1662,27 @@
     <data name="E7136" xml:space="preserve">
         <value>Unknown resource type: {1}.</value>
     </data>
+
+    <data name="E7141" xml:space="preserve">
+        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
+        <comment>
+            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
+            {0}: the path to a file
+        </comment>
+    </data>
+
+    <data name="E7142" xml:space="preserve">
+        <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
+        <comment>
+            The following are literal names and should not be translated: SkipStaticLibraryValidation
+        </comment>
+    </data>
+
+    <data name="E7143" xml:space="preserve">
+        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
+        <comment>
+            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
+            {0}: the path to a file
+        </comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ValidateNoStaticLibraries.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ValidateNoStaticLibraries.cs
@@ -1,0 +1,75 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Localization.MSBuild;
+using Xamarin.Messaging.Build.Client;
+using Xamarin.Utils;
+
+namespace Xamarin.MacDev.Tasks {
+	public class ValidateNoStaticLibraries : Task {
+		public string SkipStaticLibraryValidation { get; set; } = string.Empty;
+		public ITaskItem [] ValidateItems { get; set; } = Array.Empty<ITaskItem> ();
+
+		public override bool Execute ()
+		{
+			bool onlyWarn = false;
+			switch (SkipStaticLibraryValidation.ToLowerInvariant ()) {
+			case "true":
+			case "disable":
+				return true;
+			case "":
+			case "error":
+			case "false":
+				onlyWarn = false;
+				break;
+			case "warn":
+				onlyWarn = true;
+				break;
+			default:
+				Log.LogError (7142, null, MSBStrings.E7142, SkipStaticLibraryValidation); // Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.
+				return false;
+			}
+
+			foreach (var item in ValidateItems) {
+				var path = item.ItemSpec;
+				if (Directory.Exists (path))
+					continue; // directories are neither static libraries nor object files.
+
+				if (!File.Exists (path)) {
+					if (onlyWarn) {
+						Log.LogWarning (158, path, MSBStrings.E0158 /* The file '{0}' does not exist. */, path);
+					} else {
+						Log.LogError (158, path, MSBStrings.E0158 /* The file '{0}' does not exist. */, path);
+					}
+					continue;
+				}
+
+				if (!MachO.IsStaticLibraryOrObjectFile (path, throw_if_error: false, out var objectFile))
+					continue;
+
+				if (objectFile) {
+					if (onlyWarn) {
+						Log.LogWarning (7143, item.ItemSpec, MSBStrings.E7143, path); // The file {0} is an object file, and an object files are not supported with Hot Restart.
+					} else {
+						Log.LogError (7143, item.ItemSpec, MSBStrings.E7143, path); // The file {0} is an object file, and an object files are not supported with Hot Restart.
+					}
+				} else {
+					if (onlyWarn) {
+						Log.LogWarning (7141, item.ItemSpec, MSBStrings.E7141, path); // The library {0} is a static library, and static libraries are not supported with Hot Restart.
+					} else {
+						Log.LogError (7141, item.ItemSpec, MSBStrings.E7141, path); // The library {0} is a static library, and static libraries are not supported with Hot Restart.
+					}
+				}
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -104,6 +104,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.UnpackLibraryResources" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.Unzip" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ValidateAppBundleTask" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.ValidateNoStaticLibraries" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.WriteAppManifest" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.WriteAssetPackManifest" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.WriteItemsToFile" AssemblyFile="$(_TaskAssemblyName)" />

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.HotRestart.targets
@@ -52,7 +52,14 @@
 
 	</Target>
 
-	<Target Name="_CollectHotRestartBundleContent" DependsOnTargets="_GenerateBundleName;_ParseBundlerArguments;_ComputeTargetArchitectures;_ComputeVariables;_CollectDecompressedPlugIns;_CollectDecompressedXpcServices">
+	<Target Name="_ValidateNoStaticLibraries">
+		<ValidateNoStaticLibraries
+			SkipStaticLibraryValidation="$(SkipStaticLibraryValidation)"
+			ValidateItems="@(ResolvedFileToPublish);@(_FileNativeReference);@(_FrameworkNativeReference);@(_DecompressedPlugIns);@(_PlugIns);@(_DecompressedXpcServices);@(_XpcServices)"
+		/>
+	</Target>
+
+	<Target Name="_CollectHotRestartBundleContent" DependsOnTargets="_GenerateBundleName;_ParseBundlerArguments;_ComputeTargetArchitectures;_ComputeVariables;_CollectDecompressedPlugIns;_CollectDecompressedXpcServices;_ValidateNoStaticLibraries">
 		<!-- Collect everything to put in the app bundle, except static frameworks -->
 		<FilterStaticFrameworks
 			OnlyFilterFrameworks="true"

--- a/tests/dotnet/BundleStructure/shared.csproj
+++ b/tests/dotnet/BundleStructure/shared.csproj
@@ -12,6 +12,9 @@
 		<RootTestsDirectory Condition="'$(RootTestsDirectory)' == ''">$(MSBuildThisFileDirectory)/../..</RootTestsDirectory>
 		<!-- disable IL stripping, because some of our assemblies aren't actually assemblies, they're just placeholder files -->
 		<EnableAssemblyILStripping>false</EnableAssemblyILStripping>
+
+		<!-- Skip static library validation for Hot Restart, we have some static libraries here we don't care about at runtime -->
+		<SkipStaticLibraryValidation>warn</SkipStaticLibraryValidation>
 	</PropertyGroup>
 
 	<Import Project="../../common/shared-dotnet.csproj" />

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ValidateNoStaticLibraresTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ValidateNoStaticLibraresTests.cs
@@ -1,0 +1,120 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Utilities;
+using NUnit.Framework;
+
+using Xamarin.Tests;
+using Xamarin.Utils;
+
+namespace Xamarin.MacDev.Tasks {
+	[TestFixture]
+	public class ValidateNoStaticLibrariesTests : TestBase {
+		ValidateNoStaticLibraries CreateTask (string skipStaticLibraryValidation, params string[] paths)
+		{
+			var task = CreateTask<ValidateNoStaticLibraries> ();
+			task.SkipStaticLibraryValidation = skipStaticLibraryValidation;
+			task.ValidateItems = paths.Select (v => new TaskItem (v)).ToArray ();
+			return task;
+		}
+
+		[Test]
+		[TestCase ("error")]
+		[TestCase ("false")]
+		[TestCase ("")]
+		public void StaticLibraries_Error (string skipStaticLibraryValidation)
+		{
+			var paths = new [] {
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "libtest.a"),
+				Path.Combine (Configuration.RootPath, "README.md"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "libframework.dylib"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "SwiftTest.framework", "SwiftTest"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "SwiftTest.framework", "Info.plist"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "XStaticArTest.framework", "XStaticArTest"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "XStaticObjectTest.framework", "XStaticObjectTest"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "XTest.framework", "XTest"),
+			};
+			var task = CreateTask (skipStaticLibraryValidation, paths);
+			ExecuteTask (task, expectedErrorCount: 3);
+			Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
+			Assert.AreEqual ($"The library {paths [0]} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.", Engine.Logger.ErrorEvents [0].Message, "Error message 1");
+			Assert.AreEqual ($"The library {paths [5]} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.", Engine.Logger.ErrorEvents [1].Message, "Error message 2");
+			Assert.AreEqual ($"The file {paths [6]} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.", Engine.Logger.ErrorEvents [2].Message, "Error message 3");
+		}
+
+		[Test]
+		[TestCase ("warn")]
+		public void StaticLibraries_Warn (string skipStaticLibraryValidation)
+		{
+			var paths = new [] {
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "libtest.a"),
+				Path.Combine (Configuration.RootPath, "README.md"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "libframework.dylib"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "SwiftTest.framework/SwiftTest"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "SwiftTest.framework/Info.plist"),
+			};
+			var task = CreateTask (skipStaticLibraryValidation, paths);
+			ExecuteTask (task, expectedErrorCount: 0);
+			Assert.AreEqual (1, Engine.Logger.WarningsEvents.Count, "Warning Count");
+			Assert.AreEqual ($"The library {paths [0]} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.", Engine.Logger.WarningsEvents [0].Message, "Error message");
+		}
+
+		[Test]
+		[TestCase ("disable")]
+		public void StaticLibraries_Disabled (string skipStaticLibraryValidation)
+		{
+			var paths = new [] {
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "libtest.a"),
+				Path.Combine (Configuration.RootPath, "README.md"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "libframework.dylib"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "SwiftTest.framework/SwiftTest"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "SwiftTest.framework/Info.plist"),
+				"/does/not/exist",
+			};
+			var task = CreateTask (skipStaticLibraryValidation, paths);
+			ExecuteTask (task, expectedErrorCount: 0);
+			Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
+		}
+
+		[Test]
+		[TestCase ("invalid")]
+		public void StaticLibraries_Invalid (string skipStaticLibraryValidation)
+		{
+			var paths = new [] {
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "libtest.a"),
+				Path.Combine (Configuration.RootPath, "README.md"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "libframework.dylib"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "SwiftTest.framework/SwiftTest"),
+				Path.Combine (Configuration.RootPath, "tests", "test-libraries", ".libs", "iossimulator", "SwiftTest.framework/Info.plist"),
+				"/does/not/exist",
+			};
+			var task = CreateTask (skipStaticLibraryValidation, paths);
+			ExecuteTask (task, expectedErrorCount: 1);
+			Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
+			Assert.AreEqual ($"Unknown value for 'SkipStaticLibraryValidation': {skipStaticLibraryValidation}. Valid values are: 'true', 'false', 'warn'.", Engine.Logger.ErrorEvents [0].Message, "Error Message");
+		}
+
+		[Test]
+		[TestCase ("")]
+		[TestCase ("error")]
+		public void StaticLibraries_Error_Inexistent (string skipStaticLibraryValidation)
+		{
+			var task = CreateTask (skipStaticLibraryValidation, "/does/not/exist");
+			ExecuteTask (task, expectedErrorCount: 1);
+			Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
+			Assert.AreEqual ($"The file '/does/not/exist' does not exist.", Engine.Logger.ErrorEvents [0].Message.TrimEnd (), "Error Message");
+		}
+
+		[Test]
+		[TestCase ("warn")]
+		public void StaticLibraries_Warn_Inexistent (string skipStaticLibraryValidation)
+		{
+			var task = CreateTask (skipStaticLibraryValidation, "/does/not/exist");
+			ExecuteTask (task, expectedErrorCount: 0);
+			Assert.AreEqual (1, Engine.Logger.WarningsEvents.Count, "Warning Count");
+			Assert.AreEqual ($"The file '/does/not/exist' does not exist.", Engine.Logger.WarningsEvents [0].Message.TrimEnd (), "Error Message");
+		}
+	}
+}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ValidateNoStaticLibraresTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ValidateNoStaticLibraresTests.cs
@@ -12,7 +12,7 @@ using Xamarin.Utils;
 namespace Xamarin.MacDev.Tasks {
 	[TestFixture]
 	public class ValidateNoStaticLibrariesTests : TestBase {
-		ValidateNoStaticLibraries CreateTask (string skipStaticLibraryValidation, params string[] paths)
+		ValidateNoStaticLibraries CreateTask (string skipStaticLibraryValidation, params string [] paths)
 		{
 			var task = CreateTask<ValidateNoStaticLibraries> ();
 			task.SkipStaticLibraryValidation = skipStaticLibraryValidation;


### PR DESCRIPTION
A fairly common problem is when apps try to use a static library when using
Hot Restart on Windows (which isn't supported), and then they're confused when
their app doesn't work.

Improve this scenario by raising an error if an app tries to link with a
static library when building for Hot Restart.

Add an escape hatch in case someone still wants to build apps with static
libraries using Hot Restart, since there are scenarios where it can be useful
(while testing parts of an app that don't require any static libraries for
instance).