### PR TITLE
[CI] Make the API diff be triggered as soon as the config of the build is done.

### DIFF
--- a/tools/devops/automation/run-ci-api-diff.yml
+++ b/tools/devops/automation/run-ci-api-diff.yml
@@ -1,27 +1,16 @@
 # Pipeline that will calculate the api diff on a ci commit.
 
-trigger:
-  branches:
-    include:
-      - '*'
-    exclude:
-      - refs/heads/locfiles/*
-      - refs/heads/dev/*
-      - refs/heads/darc-*
-      - refs/heads/backport-pr-*
-  paths:
-    exclude:
-      - .github
-      - docs
-      - CODEOWNERS
-      - ISSUE_TEMPLATE.md
-      - LICENSE
-      - NOTICE.txt
-      - SECURITY.MD
-      - README.md
-      - src/README.md
-      - tools/mtouch/README.md
-      - msbuild/Xamarin.Localization.MSBuild/README.md
+trigger: none
+pr: none
+
+# we cannot use a template in a pipeline context
+resources:
+  pipelines:
+    - pipeline: macios
+      source: \Xamarin\Mac-iOS\ci pipelines\xamarin-macios-ci
+      trigger:
+        stages:
+          - configure_build
 
 extends:
   template: templates/pipelines/api-diff-pipeline.yml

--- a/tools/devops/automation/run-pr-api-diff.yml
+++ b/tools/devops/automation/run-pr-api-diff.yml
@@ -1,25 +1,15 @@
 # Pipeline that will calculate the api diff on a pr commit.
 
 trigger: none
+pr: none
 
-pr:
-  autoCancel: true
-  branches:
-    include:
-      - '*'  # yes, you do need the quote, * has meaning in yamls
-  paths:
-    exclude:
-      - .github
-      - docs
-      - CODEOWNERS
-      - ISSUE_TEMPLATE.md
-      - LICENSE
-      - NOTICE.txt
-      - SECURITY.MD
-      - README.md
-      - src/README.md
-      - tools/mtouch/README.md
-      - msbuild/Xamarin.Localization.MSBuild/README.md
+resources:
+  pipelines:
+    - pipeline: macios
+      source: \Xamarin\Mac-iOS\pr pipelines\xamarin-macios-pr
+      trigger:
+        stages:
+          - configure_build
 
 extends:
   template: templates/pipelines/api-diff-pipeline.yml


### PR DESCRIPTION
This allows the pipeline to be triggered by the build allowing us to not need to tell azp to run apidiff and simply use '/azp run xamarin-macios-pr'