### PR TITLE
[Rgen] Do not create an emitter per code change.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/BindingSourceGeneratorGenerator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/BindingSourceGeneratorGenerator.cs
@@ -93,11 +93,12 @@ public class BindingSourceGeneratorGenerator : IIncrementalGenerator {
 			// init sb and add the header
 			var sb = new TabbedStringBuilder (new ());
 			sb.WriteHeader ();
-			if (EmitterFactory.TryCreate (change, rootContext, sb, out var emitter)) {
+			if (EmitterFactory.TryCreate (change, out var emitter)) {
 				// write the using statements
 				CollectUsingStatements (change, sb, emitter);
-
-				if (emitter.TryEmit (change, out var diagnostics)) {
+				
+				var bindingContext = new BindingContext (rootContext, sb, change);
+				if (emitter.TryEmit (bindingContext, out var diagnostics)) {
 					// only add a file when we do generate code
 					var code = sb.ToString ();
 					var namespacePath = Path.Combine (change.Namespace.ToArray ());

--- a/src/rgen/Microsoft.Macios.Generator/BindingSourceGeneratorGenerator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/BindingSourceGeneratorGenerator.cs
@@ -96,7 +96,7 @@ public class BindingSourceGeneratorGenerator : IIncrementalGenerator {
 			if (EmitterFactory.TryCreate (change, out var emitter)) {
 				// write the using statements
 				CollectUsingStatements (change, sb, emitter);
-				
+
 				var bindingContext = new BindingContext (rootContext, sb, change);
 				if (emitter.TryEmit (bindingContext, out var diagnostics)) {
 					// only add a file when we do generate code

--- a/src/rgen/Microsoft.Macios.Generator/Context/BindingContext.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Context/BindingContext.cs
@@ -3,17 +3,17 @@ using Microsoft.Macios.Generator.DataModel;
 namespace Microsoft.Macios.Generator.Context;
 
 readonly struct BindingContext {
-	
+
 	/// <summary>
 	/// The root context of the current binding operation.
 	/// </summary>
 	public RootBindingContext RootContext { get; }
-	
+
 	/// <summary>
 	/// Tabbed string builder that can be used to write the generated code.
 	/// </summary>
 	public TabbedStringBuilder Builder { get; }
-	
+
 	/// <summary>
 	/// Current code changes for the binding context.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Context/BindingContext.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Context/BindingContext.cs
@@ -1,0 +1,29 @@
+using Microsoft.Macios.Generator.DataModel;
+
+namespace Microsoft.Macios.Generator.Context;
+
+readonly struct BindingContext {
+	
+	/// <summary>
+	/// The root context of the current binding operation.
+	/// </summary>
+	public RootBindingContext RootContext { get; }
+	
+	/// <summary>
+	/// Tabbed string builder that can be used to write the generated code.
+	/// </summary>
+	public TabbedStringBuilder Builder { get; }
+	
+	/// <summary>
+	/// Current code changes for the binding context.
+	/// </summary>
+	public CodeChanges Changes { get; }
+
+	public BindingContext (RootBindingContext rootContext, TabbedStringBuilder builder, CodeChanges changes)
+	{
+		RootContext = rootContext;
+		Builder = builder;
+		Changes = changes;
+	}
+
+}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/CategoryEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/CategoryEmitter.cs
@@ -7,7 +7,7 @@ using Microsoft.Macios.Generator.DataModel;
 
 namespace Microsoft.Macios.Generator.Emitters;
 
-class InterfaceEmitter : ICodeEmitter {
+class CategoryEmitter : ICodeEmitter {
 	public string GetSymbolName (in CodeChanges codeChanges) => string.Empty;
 	public IEnumerable<string> UsingStatements => [];
 	public bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -7,22 +7,20 @@ using Microsoft.Macios.Generator.DataModel;
 
 namespace Microsoft.Macios.Generator.Emitters;
 
-#pragma warning disable CS9113 // Parameter is unread. This class is work in progress
-class ClassEmitter (RootBindingContext context, TabbedStringBuilder builder) : ICodeEmitter {
-#pragma warning restore CS9113 // Parameter is unread.
+class ClassEmitter : ICodeEmitter {
 	public string GetSymbolName (in CodeChanges codeChanges) => codeChanges.Name;
 
 	public IEnumerable<string> UsingStatements => [];
 
-	public bool TryEmit (in CodeChanges codeChanges, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
+	public bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
 	{
 
-		builder.AppendLine ();
+		bindingContext.Builder.AppendLine ();
 		diagnostics = null;
 		// add the namespace and the class declaration
-		var modifiers = $"{string.Join (' ', codeChanges.Modifiers)} ";
-		using (var namespaceBlock = builder.CreateBlock ($"namespace {codeChanges.Namespace [^1]}", true)) {
-			using (var classBlock = namespaceBlock.CreateBlock ($"{(string.IsNullOrWhiteSpace (modifiers) ? string.Empty : modifiers)}class {GetSymbolName (codeChanges)}", true)) {
+		var modifiers = $"{string.Join (' ', bindingContext.Changes.Modifiers)} ";
+		using (var namespaceBlock = bindingContext.Builder.CreateBlock ($"namespace {bindingContext.Changes.Namespace [^1]}", true)) {
+			using (var classBlock = namespaceBlock.CreateBlock ($"{(string.IsNullOrWhiteSpace (modifiers) ? string.Empty : modifiers)}class {GetSymbolName (bindingContext.Changes)}", true)) {
 				classBlock.AppendLine ("// TODO: add binding code here");
 			}
 		}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/EmitterFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/EmitterFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Macios.Generator.Emitters;
 /// </summary>
 static class EmitterFactory {
 
-	static readonly Dictionary<BindingType, ICodeEmitter> emitters = new() {
+	static readonly Dictionary<BindingType, ICodeEmitter> emitters = new () {
 		{ BindingType.Class, new ClassEmitter () },
 		{ BindingType.SmartEnum, new EnumEmitter () },
 		{ BindingType.Protocol, new InterfaceEmitter () },

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/EmitterFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/EmitterFactory.cs
@@ -1,6 +1,5 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.CodeAnalysis;
-using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.DataModel;
 
 namespace Microsoft.Macios.Generator.Emitters;
@@ -9,15 +8,13 @@ namespace Microsoft.Macios.Generator.Emitters;
 /// Returns the emitter that is related to the provided declaration type.
 /// </summary>
 static class EmitterFactory {
-	public static bool TryCreate (CodeChanges changes, RootBindingContext context, TabbedStringBuilder builder,
-		[NotNullWhen (true)] out ICodeEmitter? emitter)
-	{
-		emitter = changes.BindingType switch {
-			BindingType.Class => new ClassEmitter (context, builder),
-			BindingType.SmartEnum => new EnumEmitter (context, builder),
-			BindingType.Protocol => new InterfaceEmitter (context, builder),
-			_ => null
-		};
-		return emitter is not null;
-	}
+
+	static readonly Dictionary<BindingType, ICodeEmitter> emitters = new() {
+		{ BindingType.Class, new ClassEmitter () },
+		{ BindingType.SmartEnum, new EnumEmitter () },
+		{ BindingType.Protocol, new InterfaceEmitter () },
+		{ BindingType.Category, new CategoryEmitter () },
+	};
+	public static bool TryCreate (CodeChanges changes, [NotNullWhen (true)] out ICodeEmitter? emitter)
+		=> emitters.TryGetValue (changes.BindingType, out emitter);
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
@@ -7,12 +7,12 @@ using Microsoft.Macios.Generator.DataModel;
 
 namespace Microsoft.Macios.Generator.Emitters;
 
-class EnumEmitter (RootBindingContext context, TabbedStringBuilder builder) : ICodeEmitter {
+class EnumEmitter : ICodeEmitter {
 
 	public string GetSymbolName (in CodeChanges codeChanges) => $"{codeChanges.Name}Extensions";
 	public IEnumerable<string> UsingStatements => ["Foundation", "ObjCRuntime", "System"];
 
-	void EmitEnumFieldAtIndex (TabbedStringBuilder classBlock, in CodeChanges codeChanges, int index)
+	void EmitEnumFieldAtIndex (RootBindingContext context, TabbedStringBuilder classBlock, in CodeChanges codeChanges, int index)
 	{
 		var enumField = codeChanges.EnumMembers [index];
 		if (enumField.FieldData is null)
@@ -32,7 +32,7 @@ class EnumEmitter (RootBindingContext context, TabbedStringBuilder builder) : IC
 		}
 	}
 
-	bool TryEmit (TabbedStringBuilder classBlock, in CodeChanges codeChanges)
+	bool TryEmit (RootBindingContext context, TabbedStringBuilder classBlock, in CodeChanges codeChanges)
 	{
 		// keep track of the field symbols, they have to be unique, if we find a duplicate we return false and
 		// abort the code generation
@@ -44,7 +44,7 @@ class EnumEmitter (RootBindingContext context, TabbedStringBuilder builder) : IC
 				return false;
 			}
 			classBlock.AppendLine ();
-			EmitEnumFieldAtIndex (classBlock, codeChanges, index);
+			EmitEnumFieldAtIndex (context, classBlock, codeChanges, index);
 		}
 		return true;
 	}
@@ -120,39 +120,39 @@ class EnumEmitter (RootBindingContext context, TabbedStringBuilder builder) : IC
 }}");
 	}
 
-	public bool TryEmit (in CodeChanges codeChanges, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
+	public bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
 	{
 		diagnostics = null;
-		if (codeChanges.BindingType != BindingType.SmartEnum) {
+		if (bindingContext.Changes.BindingType != BindingType.SmartEnum) {
 			diagnostics = [Diagnostic.Create (
 					Diagnostics
 						.RBI0000, // An unexpected error ocurred while processing '{0}'. Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new.
 					null,
-					codeChanges.FullyQualifiedSymbol)];
+					bindingContext.Changes.FullyQualifiedSymbol)];
 			return false;
 		}
 		// in the old generator we had to copy over the enum, in this new approach, the only code
 		// we need to create is the extension class for the enum that is backed by fields
-		builder.AppendLine ();
-		builder.AppendLine ($"namespace {string.Join (".", codeChanges.Namespace)};");
-		builder.AppendLine ();
+		bindingContext.Builder.AppendLine ();
+		bindingContext.Builder.AppendLine ($"namespace {string.Join (".", bindingContext.Changes.Namespace)};");
+		bindingContext.Builder.AppendLine ();
 
-		builder.AppendMemberAvailability (codeChanges.SymbolAvailability);
-		builder.AppendGeneratedCodeAttribute ();
-		var modifiers = $"{string.Join (' ', codeChanges.Modifiers)} ";
-		using (var classBlock = builder.CreateBlock ($"{(string.IsNullOrWhiteSpace (modifiers) ? string.Empty : modifiers)}static partial class {GetSymbolName (codeChanges)}", true)) {
+		bindingContext.Builder.AppendMemberAvailability (bindingContext.Changes.SymbolAvailability);
+		bindingContext.Builder.AppendGeneratedCodeAttribute ();
+		var modifiers = $"{string.Join (' ', bindingContext.Changes.Modifiers)} ";
+		using (var classBlock = bindingContext.Builder.CreateBlock ($"{(string.IsNullOrWhiteSpace (modifiers) ? string.Empty : modifiers)}static partial class {GetSymbolName (bindingContext.Changes)}", true)) {
 			classBlock.AppendLine ();
-			classBlock.AppendLine ($"static IntPtr[] values = new IntPtr [{codeChanges.EnumMembers.Length}];");
+			classBlock.AppendLine ($"static IntPtr[] values = new IntPtr [{bindingContext.Changes.EnumMembers.Length}];");
 			// foreach member in the enum we need to create a field that holds the value, the property emitter
 			// will take care of generating the property. Do not order it by name to keep the order of the enum
-			if (!TryEmit (classBlock, codeChanges)) {
+			if (!TryEmit (bindingContext.RootContext, classBlock, bindingContext.Changes)) {
 				diagnostics = []; // empty diagnostics since it was a user error
 				return false;
 			}
 			classBlock.AppendLine ();
 
 			// emit the extension methods that will be used to get the values from the enum
-			EmitExtensionMethods (classBlock, codeChanges);
+			EmitExtensionMethods (classBlock, bindingContext.Changes);
 			classBlock.AppendLine ();
 		}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ICodeEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ICodeEmitter.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.DataModel;
 
 namespace Microsoft.Macios.Generator.Emitters;
@@ -11,6 +12,6 @@ namespace Microsoft.Macios.Generator.Emitters;
 /// </summary>
 interface ICodeEmitter {
 	string GetSymbolName (in CodeChanges codeChanges);
-	bool TryEmit (in CodeChanges codeChanges, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics);
+	bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics);
 	IEnumerable<string> UsingStatements { get; }
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.DataModel;
 
 namespace Microsoft.Macios.Generator.Emitters;
@@ -10,7 +11,7 @@ class TrampolineEmitter : ICodeEmitter {
 	public string SymbolNamespace => string.Empty;
 	public string GetSymbolName (in CodeChanges codeChanges) => string.Empty;
 	public IEnumerable<string> UsingStatements { get; } = [];
-	public bool TryEmit (in CodeChanges codeChanges, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
+	public bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
 	{
 		diagnostics = null;
 		return true;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/EmitterFactoryTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/EmitterFactoryTests.cs
@@ -58,7 +58,7 @@ namespace Test;
 public class TestClass {
 }
 ";
-		var changes  = CreateSymbol<ClassDeclarationSyntax> (platform, inputText);
+		var changes = CreateSymbol<ClassDeclarationSyntax> (platform, inputText);
 		Assert.True (EmitterFactory.TryCreate (changes, out var emitter));
 		Assert.IsType<ClassEmitter> (emitter);
 		Assert.True (EmitterFactory.TryCreate (changes, out var secondEmitter));


### PR DESCRIPTION
Emitter should not store internal state that will changes based on the processed code changes. This means we can reduce the number of objects we create to the minimum amount. This change will reduce the memory usage specially when building the Apple SDK which has 100s of classes to generated.