### PR TITLE
[Rgen] Provide extension methods that will return a member declaration from the data model.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
@@ -68,7 +68,7 @@ readonly struct Constructor : IEquatable<Constructor> {
 		}
 
 		change = new (
-			type: constructor.ContainingSymbol.ToDisplayString ().Trim (), // we want the full name
+			type: constructor.ContainingSymbol.Name, // we DO NOT want the full name
 			symbolAvailability: constructor.GetSupportedPlatforms (),
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.cs
@@ -75,7 +75,7 @@ readonly struct Parameter : IEquatable<Parameter> {
 	internal Parameter (int position, string type, string name)
 	{
 		Position = position;
-		Type = type.Trim ('?', ' '); // do not keep the ? token since we will have a property for it
+		Type = type;
 		Name = name;
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.cs
@@ -75,7 +75,7 @@ readonly struct Parameter : IEquatable<Parameter> {
 	internal Parameter (int position, string type, string name)
 	{
 		Position = position;
-		Type = type;
+		Type = type.Trim ('?', ' '); // do not keep the ? token since we will have a property for it
 		Name = name;
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/ReferenceKind.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/ReferenceKind.cs
@@ -1,4 +1,7 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -23,5 +26,13 @@ static class RefKindExtensions {
 		RefKind.In => ReferenceKind.In,
 		RefKind.RefReadOnlyParameter => ReferenceKind.RefReadOnlyParameter,
 		_ => ReferenceKind.None,
+	};
+
+	public static SyntaxTokenList ToTokens (this ReferenceKind self) => self switch {
+		ReferenceKind.Ref => new (Token (SyntaxKind.RefKeyword)),
+		ReferenceKind.Out => new (Token (SyntaxKind.OutKeyword)),
+		ReferenceKind.In => new (Token (SyntaxKind.InKeyword)),
+		ReferenceKind.RefReadOnlyParameter => new (Token (SyntaxKind.RefKeyword), Token (SyntaxKind.ReadOnlyKeyword)),
+		_ => []
 	};
 }

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/ConstructorFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/ConstructorFormatter.cs
@@ -1,0 +1,24 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Macios.Generator.Formatters;
+
+static class ConstructorFormatter {
+
+	public static CompilationUnitSyntax? ToDeclaration (this in Constructor? constructor)
+	{
+		if (constructor is null)
+			return null;
+
+		var compilationUnit = CompilationUnit ().WithMembers (
+			SingletonList<MemberDeclarationSyntax> (
+				ConstructorDeclaration (Identifier (constructor.Value.Type)
+						.WithTrailingTrivia (Space) // add spaces manually to use the mono style
+					)
+					.WithModifiers (TokenList (constructor.Value.Modifiers))
+					.WithParameterList (constructor.Value.Parameters.GetParameterList ())
+			));
+		return compilationUnit;
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/MethodFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/MethodFormatter.cs
@@ -1,0 +1,24 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Macios.Generator.Formatters;
+
+static class MethodFormatter {
+	public static CompilationUnitSyntax? ToDeclaration (this in Method? method)
+	{
+		if (method is null)
+			return null;
+		var compilationUnit = CompilationUnit ()
+			.WithMembers (
+				SingletonList<MemberDeclarationSyntax> (
+					MethodDeclaration (
+							returnType: IdentifierName (method.Value.ReturnType),
+							identifier: Identifier (method.Value.Name)
+								.WithLeadingTrivia (Space)
+								.WithTrailingTrivia (Space)) // adding the spaces manually to follow the mono style
+						.WithModifiers (TokenList (method.Value.Modifiers))
+						.WithParameterList (method.Value.Parameters.GetParameterList ())));
+		return compilationUnit;
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/ParameterFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/ParameterFormatter.cs
@@ -61,7 +61,7 @@ static class ParameterFormatter {
 			? TokenList (Token (SyntaxKind.ParamsKeyword))
 			: parameter.ReferenceKind.ToTokens ();
 
-		// we are going to be ignoring the default value, the reason for it is that the partiam method implementation
+		// we are going to be ignoring the default value, the reason for it is that the partial method implementation
 		// can ignore it. The following c# code is valid:
 		//
 		// TestPartial1.cs:

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/ParameterFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/ParameterFormatter.cs
@@ -1,0 +1,94 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using ParameterDataModel = Microsoft.Macios.Generator.DataModel.Parameter;
+
+namespace Microsoft.Macios.Generator.Formatters;
+
+static class ParameterFormatter {
+	
+	public static ParameterListSyntax GetParameterList (this in ImmutableArray<Parameter> parameters)
+	{
+		if (parameters.Length == 0)
+			return ParameterList ([]);
+
+		// the size of the array is simple to calculate, we need space for all parameters
+		// and for a comma for each parameter except for the last one
+		// length = parameters.Length + parameters.Length - 1
+		// length = (2 * parameters.Length) - 1
+		var nodes = new SyntaxNodeOrToken [(2 * parameters.Length) - 1];
+		var nodesIndex = 0;
+		var parametersIndex = 0;
+		while (nodesIndex < nodes.Length) {
+			var currentParameter = parameters [parametersIndex++];
+			var parameterDeclaration = currentParameter.ToDeclaration ();
+			nodes [nodesIndex++] = parameterDeclaration;
+			if (currentParameter.Position < parameters.Length - 1) {
+				nodes [nodesIndex++] = Token (SyntaxKind.CommaToken);
+			}
+		}
+
+		return ParameterList (SeparatedList<ParameterSyntax> (nodes)).NormalizeWhitespace ();
+	}
+	static TypeSyntax GetIdentifierSyntax (this in ParameterDataModel parameter)
+	{
+		if (parameter.IsArray) {
+			// could be a params array or simply an array
+			var arrayType = ArrayType (IdentifierName (parameter.Type))
+				.WithRankSpecifiers (SingletonList (
+					ArrayRankSpecifier (
+						SingletonSeparatedList<ExpressionSyntax> (OmittedArraySizeExpression ()))));
+			return parameter.IsNullable 
+				? NullableType (arrayType)
+				: arrayType;
+		}
+
+		// dealing with a non-array type
+		return parameter.IsNullable
+			? NullableType (IdentifierName (parameter.Type))
+			: IdentifierName (parameter.Type);
+	}
+
+	public static ParameterSyntax ToDeclaration (this in ParameterDataModel parameter)
+	{
+		// modifiers come from two situations, we have the params keyword or not. We cannot have params + a ref modifier
+		// so we build them based on that. If you call WithModifiers twice, you will me stepping on the previous collection
+		// it won't be a merge
+		var modifiers = parameter.IsParams 
+			? TokenList(Token(SyntaxKind.ParamsKeyword)) 
+			: parameter.ReferenceKind.ToTokens ();
+		
+		// we are going to be ignoring the default value, the reason for it is that the partiam method implementation
+		// can ignore it. The following c# code is valid:
+		//
+		// TestPartial1.cs:
+		//
+		// public partial class TestPartial
+		// {
+		//
+		//	  public partial void TestMethod(MyStruct[]? values = null);
+		// 	  public void ExampleCall()
+		// 	  {
+		// 	  	  TestMethod();
+		// 	  }
+		// }
+		// TestPartial2.cs:
+		//
+		// 
+		// public partial class TestPartial
+		// {
+		//    public partial void TestMethod(MyStruct[]? values)
+		//    {
+        //
+        //    }
+        // }
+		var syntax = Parameter (Identifier (parameter.Name))
+			.WithModifiers (modifiers)
+			.WithType (parameter.GetIdentifierSyntax ());
+
+		return syntax.NormalizeWhitespace ();
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/PropertyFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/PropertyFormatter.cs
@@ -1,0 +1,28 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Macios.Generator.Formatters;
+
+static class PropertyFormatter {
+	/// <summary>
+	/// Return the declaration represented by the given property.
+	/// </summary>
+	/// <param name="property">The property whose declaration we want to generate.</param>
+	/// <returns>A compilation unit syntax node with the declaration of the property.</returns>
+	public static CompilationUnitSyntax? ToDeclaration (this in Property? property)
+	{
+		if (property is null)
+			return null;
+		
+		var compilationUnit = CompilationUnit ().WithMembers ( 
+			SingletonList<MemberDeclarationSyntax> (
+				PropertyDeclaration (
+						type: IdentifierName (property.Value.Type), 
+						identifier: Identifier (property.Value.Name))
+					.WithModifiers (TokenList (property.Value.Modifiers)))).NormalizeWhitespace ();
+		return compilationUnit;
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -162,7 +162,7 @@ public partial class MyClass {
 					],
 					Constructors = [
 						new (
-							type: "NS.MyClass",
+							type: "MyClass",
 							symbolAvailability: new (),
 							attributes: [],
 							modifiers: [
@@ -210,7 +210,7 @@ public partial class MyClass {
 					],
 					Constructors = [
 						new (
-							type: "NS.MyClass",
+							type: "MyClass",
 							symbolAvailability: new (),
 							attributes: [],
 							modifiers: [
@@ -219,7 +219,7 @@ public partial class MyClass {
 							parameters: []
 						),
 						new (
-							type: "NS.MyClass",
+							type: "MyClass",
 							symbolAvailability: new (),
 							attributes: [],
 							modifiers: [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorTests.cs
@@ -32,7 +32,7 @@ namespace NS {
 			yield return [
 				emptyConstructor,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -57,7 +57,7 @@ namespace NS {
 			yield return [
 				singleParameter,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -87,7 +87,7 @@ namespace NS {
 			yield return [
 				multiParameter,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -118,7 +118,7 @@ namespace NS {
 			yield return [
 				nullableParameter,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -152,7 +152,7 @@ namespace NS {
 			yield return [
 				paramsCollectionParameter,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -187,7 +187,7 @@ namespace NS {
 			yield return [
 				arrayParameter,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -222,7 +222,7 @@ namespace NS {
 			yield return [
 				nullableArrayParameter,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -257,7 +257,7 @@ namespace NS {
 			yield return [
 				arrayOfNullableParameter,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -292,7 +292,7 @@ namespace NS {
 			yield return [
 				nullableArrayOfNullableParameter,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -327,7 +327,7 @@ namespace NS {
 			yield return [
 				twoDimensionalArrayParameter,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -357,7 +357,7 @@ namespace NS {
 			yield return [
 				optionalParameter,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -385,7 +385,7 @@ namespace NS {
 			yield return [
 				genericParameter,
 				new Constructor (
-					type: "NS.TestClass<T>",
+					type: "TestClass",
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -419,7 +419,7 @@ namespace NS {
 			yield return [
 				availabilityPresent,
 				new Constructor (
-					type: "NS.TestClass",
+					type: "TestClass",
 					symbolAvailability: builder.ToImmutable (),
 					attributes: [],
 					modifiers: [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ReferenceKindTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ReferenceKindTests.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Macios.Generator.DataModel;
+using Xunit;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Macios.Generator.Tests.DataModel;
+
+public class ReferenceKindTests {
+	
+	[Theory]
+	[InlineData (RefKind.Ref, ReferenceKind.Ref)]
+	[InlineData (RefKind.Out, ReferenceKind.Out)]
+	[InlineData (RefKind.In, ReferenceKind.In)]
+	[InlineData (RefKind.RefReadOnlyParameter, ReferenceKind.RefReadOnlyParameter)]
+	[InlineData ((RefKind) 100, ReferenceKind.None)]
+	void ToReferenceKind (RefKind refKind, ReferenceKind expected)
+		=> Assert.Equal(expected, refKind.ToReferenceKind ());
+
+
+	class TestDataToTokens : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [ReferenceKind.Ref, new SyntaxTokenList (Token (SyntaxKind.RefKeyword))];
+			yield return [ReferenceKind.Out, new SyntaxTokenList (Token (SyntaxKind.OutKeyword))];
+			yield return [ReferenceKind.In, new SyntaxTokenList (Token (SyntaxKind.InKeyword))];
+			yield return [
+				ReferenceKind.RefReadOnlyParameter,
+				new SyntaxTokenList (Token (SyntaxKind.RefKeyword), Token (SyntaxKind.ReadOnlyKeyword))
+			];
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof(TestDataToTokens))]
+	void ToTokens (ReferenceKind referenceKind, SyntaxTokenList expected)
+	{
+		var comparer = new CollectionComparer<SyntaxToken> ();
+		Assert.Equal(expected, referenceKind.ToTokens (), comparer);
+	}
+		
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/ConstructorFormatterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/ConstructorFormatterTests.cs
@@ -1,0 +1,357 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Formatters;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Formatters;
+
+public class ConstructorFormatterTests : BaseGeneratorTestClass {
+	
+	class TestDataToDeclaration : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string emptyConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass ();
+}
+";
+			yield return [emptyConstructor, "public MyClass ()"];
+			
+			const string genericConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass<T> where T : Enum {
+	public MyClass ();
+}
+";
+			yield return [genericConstructor, "public MyClass ()"];
+			
+			const string noSpaceParamsMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass();
+}
+";
+			yield return [noSpaceParamsMethod, "public MyClass ()"];
+			
+			const string singleParamConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass (string myParam);
+}
+";
+			yield return [singleParamConstructor, "public MyClass (string myParam)"];
+			
+			const string severalParamConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass (string myParam, int myParamInt);
+}
+";
+			yield return [severalParamConstructor, "public MyClass (string myParam, int myParamInt)"];
+			
+			const string nullableParamConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(string? myParam);
+}
+";
+			yield return [nullableParamConstructor, "public MyClass (string? myParam)"];
+			
+			const string customParamConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(MyStruct myParam);
+}
+";
+			yield return [customParamConstructor, "public MyClass (NS.MyStruct myParam)"];
+			
+			const string nullableCustomParamConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(MyStruct? myParam);
+}
+";
+			yield return [nullableCustomParamConstructor, "public MyClass (NS.MyStruct? myParam)"];
+			
+			const string refCustomParamConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(ref MyStruct myParam);
+}
+";
+			yield return [refCustomParamConstructor, "public MyClass (ref NS.MyStruct myParam)"];
+			
+			const string inCustomParamConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(in MyStruct myParam);
+}
+";
+			yield return [inCustomParamConstructor, "public MyClass (in NS.MyStruct myParam)"];
+			
+			const string refReadonlyCustomParamConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(ref readonly MyStruct myParam);
+}
+";
+			yield return [refReadonlyCustomParamConstructor, "public MyClass (ref readonly NS.MyStruct myParam)"];
+			
+			const string arrayParamConbstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(MyStruct[] myParam);
+}
+";
+			
+			yield return [arrayParamConbstructor, "public MyClass (NS.MyStruct[] myParam)"];
+			
+			const string nullableArrayParamConstructor = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(MyStruct[]? myParam);
+}
+";
+			
+			yield return [nullableArrayParamConstructor, "public MyClass (NS.MyStruct[]? myParam)"];
+			
+			const string genericParamConstructor = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(List<string> myParam);
+}
+";
+			
+			yield return [genericParamConstructor, "public MyClass (System.Collections.Generic.List<string> myParam)"];
+			
+			const string genericCustomParamConstructor = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(List<MyStruct> myParam);
+}
+";
+			
+			yield return [genericCustomParamConstructor, "public MyClass (System.Collections.Generic.List<NS.MyStruct> myParam)"];
+			
+			const string nullableGenericParamConstructor = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(List<string>? myParam);
+}
+";
+			
+			yield return [nullableGenericParamConstructor, "public MyClass (System.Collections.Generic.List<string>? myParam)"];
+			
+			const string nullableGenericCustomParamConstructor = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(List<MyStruct>? myParam);
+}
+";
+			
+			yield return [nullableGenericCustomParamConstructor, "public MyClass (System.Collections.Generic.List<NS.MyStruct>? myParam)"];
+			
+			const string nullableNullableGenericParamConstructor = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass (List<string?>? myParam);
+}
+";
+			
+			yield return [nullableNullableGenericParamConstructor, "public MyClass (System.Collections.Generic.List<string?>? myParam)"];
+			
+			const string nullableNullableGenericCustomParamConstructor = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass (List<MyStruct?>? myParam);
+}
+";
+			
+			yield return [nullableNullableGenericCustomParamConstructor, "public MyClass (System.Collections.Generic.List<NS.MyStruct?>? myParam)"];
+			
+			
+			const string genericDictParamConstructor = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass (Dictionary<string, string> myParam);
+}
+";
+			
+			yield return [genericDictParamConstructor, "public MyClass (System.Collections.Generic.Dictionary<string, string> myParam)"];
+			
+			const string paramsConstructor = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyClass(params string[] data);
+}
+";
+			
+			yield return [paramsConstructor, "public MyClass (params string[] data)"];
+			
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataToDeclaration>]
+	public void ToDeclarationTests (ApplePlatform platform, string inputText, string expectedDeclaration)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<ConstructorDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		Assert.NotNull (semanticModel);
+		Assert.True(Constructor.TryCreate (declaration, semanticModel, out var constructor));
+		Assert.NotNull(constructor);
+		var constructorDeclaration= constructor.ToDeclaration ();
+		Assert.NotNull (constructorDeclaration);
+		Assert.Equal(expectedDeclaration, constructorDeclaration.ToString());
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/MethodFormatterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/MethodFormatterTests.cs
@@ -1,0 +1,468 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Formatters;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Formatters;
+
+public class MethodFormatterTests : BaseGeneratorTestClass {
+	
+	class TestDataToDeclaration : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string voidMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod ();
+}
+";
+			yield return [voidMethod, "public partial void TestMethod ()"];
+			
+			const string noSpaceParamsMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod();
+}
+";
+			yield return [noSpaceParamsMethod, "public partial void TestMethod ()"];
+			
+			const string singleParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(string myParam);
+}
+";
+			yield return [singleParamMethod, "public partial void TestMethod (string myParam)"];
+			
+			const string severalParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(string myParam, int myParamInt);
+}
+";
+			yield return [severalParamMethod, "public partial void TestMethod (string myParam, int myParamInt)"];
+			
+			const string nullableParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(string? myParam);
+}
+";
+			yield return [nullableParamMethod, "public partial void TestMethod (string? myParam)"];
+			
+			const string nullableReturnTypeMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public partial string? TestMethod(string? myParam);
+}
+";
+			yield return [nullableReturnTypeMethod, "public partial string? TestMethod (string? myParam)"];
+			
+			const string customReturnMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial MyStruct TestMethod(string? myParam);
+}
+";
+			yield return [customReturnMethod, "public partial NS.MyStruct TestMethod (string? myParam)"];
+			
+			const string nullableCustomReturnMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial MyStruct? TestMethod(string? myParam);
+}
+";
+			yield return [nullableCustomReturnMethod, "public partial NS.MyStruct? TestMethod (string? myParam)"];
+			
+			const string customParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(MyStruct myParam);
+}
+";
+			yield return [customParamMethod, "public partial void TestMethod (NS.MyStruct myParam)"];
+			
+			const string nullableCustomParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(MyStruct? myParam);
+}
+";
+			yield return [nullableCustomParamMethod, "public partial void TestMethod (NS.MyStruct? myParam)"];
+			
+			const string refCustomParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(ref MyStruct myParam);
+}
+";
+			yield return [refCustomParamMethod, "public partial void TestMethod (ref NS.MyStruct myParam)"];
+			
+			const string outCustomParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(out MyStruct myParam);
+}
+";
+			yield return [outCustomParamMethod, "public partial void TestMethod (out NS.MyStruct myParam)"];
+			
+			const string inCustomParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(in MyStruct myParam);
+}
+";
+			yield return [inCustomParamMethod, "public partial void TestMethod (in NS.MyStruct myParam)"];
+			
+			const string refReadonlyCustomParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(ref readonly MyStruct myParam);
+}
+";
+			yield return [refReadonlyCustomParamMethod, "public partial void TestMethod (ref readonly NS.MyStruct myParam)"];
+			
+			const string arrayParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(MyStruct[] myParam);
+}
+";
+			
+			yield return [arrayParamMethod, "public partial void TestMethod (NS.MyStruct[] myParam)"];
+			
+			const string nullableArrayParamMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(MyStruct[]? myParam);
+}
+";
+			
+			yield return [nullableArrayParamMethod, "public partial void TestMethod (NS.MyStruct[]? myParam)"];
+			
+			const string genericParamMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(List<string> myParam);
+}
+";
+			
+			yield return [genericParamMethod, "public partial void TestMethod (System.Collections.Generic.List<string> myParam)"];
+			
+			const string genericCustomParamMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(List<MyStruct> myParam);
+}
+";
+			
+			yield return [genericCustomParamMethod, "public partial void TestMethod (System.Collections.Generic.List<NS.MyStruct> myParam)"];
+			
+			const string nullableGenericParamMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(List<string>? myParam);
+}
+";
+			
+			yield return [nullableGenericParamMethod, "public partial void TestMethod (System.Collections.Generic.List<string>? myParam)"];
+			
+			const string nullableGenericCustomParamMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(List<MyStruct>? myParam);
+}
+";
+			
+			yield return [nullableGenericCustomParamMethod, "public partial void TestMethod (System.Collections.Generic.List<NS.MyStruct>? myParam)"];
+			
+			const string nullableNullableGenericParamMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(List<string?>? myParam);
+}
+";
+			
+			yield return [nullableNullableGenericParamMethod, "public partial void TestMethod (System.Collections.Generic.List<string?>? myParam)"];
+			
+			const string nullableNullableGenericCustomParamMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(List<MyStruct?>? myParam);
+}
+";
+			
+			yield return [nullableNullableGenericCustomParamMethod, "public partial void TestMethod (System.Collections.Generic.List<NS.MyStruct?>? myParam)"];
+			
+			const string genericDictParamMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(Dictionary<string, string> myParam);
+}
+";
+			
+			yield return [genericDictParamMethod, "public partial void TestMethod (System.Collections.Generic.Dictionary<string, string> myParam)"];
+			
+			const string genericReturnMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial List<string> TestMethod();
+}
+";
+			
+			yield return [genericReturnMethod, "public partial System.Collections.Generic.List<string> TestMethod ()"];
+			
+			const string genericCustomReturnMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial List<MyStruct> TestMethod();
+}
+";
+			
+			yield return [genericCustomReturnMethod, "public partial System.Collections.Generic.List<NS.MyStruct> TestMethod ()"];
+			
+			const string nullableGenericReturnMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial List<string>? TestMethod();
+}
+";
+			
+			yield return [nullableGenericReturnMethod, "public partial System.Collections.Generic.List<string>? TestMethod ()"];
+			
+			const string nullableNullableGenericReturnMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial List<string?>? TestMethod();
+}
+";
+			
+			yield return [nullableNullableGenericReturnMethod, "public partial System.Collections.Generic.List<string?>? TestMethod ()"];
+
+			const string paramsMethod = @"
+using System;
+using System.Collections.Generic;
+using ObjCBindings;
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public partial void TestMethod(params string[] data);
+}
+";
+			
+			yield return [paramsMethod, "public partial void TestMethod (params string[] data)"];
+			
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataToDeclaration>]
+	public void ToDeclarationTests (ApplePlatform platform, string inputText, string expectedDeclaration)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		Assert.NotNull (semanticModel);
+		Assert.True(Method.TryCreate (declaration, semanticModel, out var method));
+		Assert.NotNull(method);
+		var methodDeclaration= method.ToDeclaration ();
+		Assert.NotNull (methodDeclaration);
+		Assert.Equal(expectedDeclaration, methodDeclaration.ToString());
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/PropertyFormatterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/PropertyFormatterTests.cs
@@ -1,0 +1,102 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Formatters;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Formatters;
+
+public class PropertyFormatterTests : BaseGeneratorTestClass {
+	
+	class TestDataToDeclaration : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string stringProperty = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public string Property { get; set; }
+}
+";
+			yield return [stringProperty, "public string Property"];
+			
+			const string nullableStringProperty = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public string? Property { get; set; }
+}
+";
+			yield return [nullableStringProperty, "public string? Property"];
+			
+			
+			const string internalStringProperty = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	internal string Property { get; set; }
+}
+";
+			yield return [internalStringProperty , "internal string Property"];
+
+			const string partialStringProperty = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial class MyClass {
+	public partial string Property { get; set; }
+}
+";
+			yield return [partialStringProperty, "public partial string Property"];
+			
+			const string nullableStructProperty = @"
+using System;
+using ObjCBindings;
+namespace NS;
+
+public struct MyStruct {
+	public string Name;
+	public string Surname;
+}
+[BindingType<Class>]
+public partial class MyClass {
+	public partial MyStruct? Property { get; set; }
+}
+";
+			yield return [nullableStructProperty, "public partial NS.MyStruct? Property"];
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataToDeclaration>]
+	public void ToDeclarationTests (ApplePlatform platform, string inputText, string expectedDeclaration)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<PropertyDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		Assert.NotNull (semanticModel);
+		Assert.True(Property.TryCreate (declaration, semanticModel, out var property));
+		Assert.NotNull(property);
+		var propertyDeclaration= property.ToDeclaration ();
+		Assert.NotNull (propertyDeclaration);
+		Assert.Equal(expectedDeclaration, propertyDeclaration.ToString ());
+	}
+}


### PR DESCRIPTION

Use the SyntaxFactory from roslyn to format the data model to a c# compilation unit.

The methods have been added as extension so that if other tools (sharpie/migration) need to modify the formatting, the can easily do it.