### PR TITLE
[Rgen] Do not create a string builder per binding.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/BindingSourceGeneratorGenerator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/BindingSourceGeneratorGenerator.cs
@@ -89,9 +89,10 @@ public class BindingSourceGeneratorGenerator : IIncrementalGenerator {
 		// Once all the enums, classes and interfaces have been processed, we will use the data collected
 		// in the RootBindingContext to generate the library and trampoline code.
 		var rootContext = new RootBindingContext (compilation);
+		var sb = new TabbedStringBuilder (new ());
 		foreach (var change in changesList) {
 			// init sb and add the header
-			var sb = new TabbedStringBuilder (new ());
+			sb.Clear ();
 			sb.WriteHeader ();
 			if (EmitterFactory.TryCreate (change, out var emitter)) {
 				// write the using statements

--- a/src/rgen/Microsoft.Macios.Generator/TabbedStringBuilder.cs
+++ b/src/rgen/Microsoft.Macios.Generator/TabbedStringBuilder.cs
@@ -284,6 +284,14 @@ class TabbedStringBuilder : IDisposable {
 	}
 
 	/// <summary>
+	/// Clear the content of the internal string builder.
+	/// </summary>
+	public void Clear ()
+	{
+		sb.Clear ();
+	}
+
+	/// <summary>
 	/// Does not really dispose anything, it just closes the current block.
 	/// </summary>
 	public void Dispose ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TabbedStringBuilderTests.cs
@@ -298,4 +298,15 @@ Because we are using a raw string  we expected:
 		var result = block.ToString ();
 		Assert.Equal (expectedString, result);
 	}
+
+	[Fact]
+	public void ClearTests ()
+	{
+		var block = new TabbedStringBuilder (sb);
+		var line = "My Line";
+		block.Append (line);
+		Assert.Equal (line, block.ToString ());
+		block.Clear ();
+		Assert.Equal (string.Empty, block.ToString ());
+	}
 }


### PR DESCRIPTION
Reuse the same string builder and clear it before every iteration, this way the GC does not have to keep track of that many string builders.