### PR TITLE
[Rgen] Allow to add a export attribute to an accessor.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
@@ -18,7 +18,7 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// The platform availability of the enum value.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
-	
+
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a property binding. 
 	/// </summary>
@@ -42,8 +42,8 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// <param name="exportPropertyData">The data of the export attribute found in the accessor.</param>
 	/// <param name="attributes">The list of attributes attached to the accessor.</param>
 	/// <param name="modifiers">The list of visibility modifiers of the accessor.</param>
-	public Accessor (AccessorKind accessorKind, 
-		SymbolAvailability symbolAvailability, 
+	public Accessor (AccessorKind accessorKind,
+		SymbolAvailability symbolAvailability,
 		ExportData<ObjCBindings.Property>? exportPropertyData,
 		ImmutableArray<AttributeCodeChange> attributes,
 		ImmutableArray<SyntaxToken> modifiers)

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
 
 namespace Microsoft.Macios.Generator.DataModel;
@@ -17,6 +18,11 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// The platform availability of the enum value.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
+	
+	/// <summary>
+	/// The data of the field attribute used to mark the value as a property binding. 
+	/// </summary>
+	public ExportData<ObjCBindings.Property>? ExportPropertyData { get; init; }
 
 	/// <summary>
 	/// List of attribute code changes of the accessor.
@@ -33,13 +39,18 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// </summary>
 	/// <param name="accessorKind">The kind of accessor.</param>
 	/// <param name="symbolAvailability">The os availability of the symbol.</param>
+	/// <param name="exportPropertyData">The data of the export attribute found in the accessor.</param>
 	/// <param name="attributes">The list of attributes attached to the accessor.</param>
 	/// <param name="modifiers">The list of visibility modifiers of the accessor.</param>
-	public Accessor (AccessorKind accessorKind, SymbolAvailability symbolAvailability, ImmutableArray<AttributeCodeChange> attributes,
+	public Accessor (AccessorKind accessorKind, 
+		SymbolAvailability symbolAvailability, 
+		ExportData<ObjCBindings.Property>? exportPropertyData,
+		ImmutableArray<AttributeCodeChange> attributes,
 		ImmutableArray<SyntaxToken> modifiers)
 	{
 		Kind = accessorKind;
 		SymbolAvailability = symbolAvailability;
+		ExportPropertyData = exportPropertyData;
 		Attributes = attributes;
 		Modifiers = modifiers;
 	}
@@ -50,6 +61,8 @@ readonly struct Accessor : IEquatable<Accessor> {
 		if (Kind != other.Kind)
 			return false;
 		if (SymbolAvailability != other.SymbolAvailability)
+			return false;
+		if (ExportPropertyData != other.ExportPropertyData)
 			return false;
 
 		var attrsComparer = new AttributesEqualityComparer ();
@@ -68,7 +81,7 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// <inheritdoc />
 	public override int GetHashCode ()
 	{
-		return HashCode.Combine ((int) Kind, Attributes, Modifiers);
+		return HashCode.Combine ((int) Kind, SymbolAvailability, ExportPropertyData, Attributes, Modifiers);
 	}
 
 	public static bool operator == (Accessor left, Accessor right)
@@ -84,7 +97,7 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// <inheritdoc />
 	public override string ToString ()
 	{
-		var sb = new StringBuilder ($"{{ Kind: {Kind}, Supported Platforms: {SymbolAvailability} Modifiers: [");
+		var sb = new StringBuilder ($"{{ Kind: {Kind}, Supported Platforms: {SymbolAvailability}, ExportData: {ExportPropertyData?.ToString () ?? "null"} Modifiers: [");
 		sb.AppendJoin (",", Modifiers.Select (x => x.Text));
 		sb.Append ("], Attributes: [");
 		sb.AppendJoin (", ", Attributes);

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
@@ -119,8 +119,12 @@ readonly struct Event : IEquatable<Event> {
 					continue;
 				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
 				var accessorAttributeChanges = accessorDeclaration.GetAttributeCodeChanges (semanticModel);
-				accessorsBucket.Add (new (kind, accessorSymbol.GetSupportedPlatforms (), accessorAttributeChanges,
-					[.. accessorDeclaration.Modifiers]));
+				accessorsBucket.Add (new (
+					accessorKind: kind, 
+					symbolAvailability: accessorSymbol.GetSupportedPlatforms (), 
+					exportPropertyData: null, 
+					attributes: accessorAttributeChanges,
+					modifiers: [.. accessorDeclaration.Modifiers]));
 			}
 
 			accessorCodeChanges = accessorsBucket.ToImmutable ();

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
@@ -120,9 +120,9 @@ readonly struct Event : IEquatable<Event> {
 				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
 				var accessorAttributeChanges = accessorDeclaration.GetAttributeCodeChanges (semanticModel);
 				accessorsBucket.Add (new (
-					accessorKind: kind, 
-					symbolAvailability: accessorSymbol.GetSupportedPlatforms (), 
-					exportPropertyData: null, 
+					accessorKind: kind,
+					symbolAvailability: accessorSymbol.GetSupportedPlatforms (),
+					exportPropertyData: null,
 					attributes: accessorAttributeChanges,
 					modifiers: [.. accessorDeclaration.Modifiers]));
 			}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -49,7 +49,7 @@ readonly struct Property : IEquatable<Property> {
 	/// <summary>
 	/// True if the property represents a Objc field.
 	/// </summary>
-	[MemberNotNullWhen(true, nameof(ExportFieldData))]
+	[MemberNotNullWhen (true, nameof (ExportFieldData))]
 	public bool IsField => ExportFieldData is not null;
 
 	/// <summary>
@@ -60,7 +60,7 @@ readonly struct Property : IEquatable<Property> {
 	/// <summary>
 	/// True if the property represents a Objc property.
 	/// </summary>
-	[MemberNotNullWhen(true, nameof(ExportPropertyData))]
+	[MemberNotNullWhen (true, nameof (ExportPropertyData))]
 	public bool IsProperty => ExportPropertyData is not null;
 
 	/// <summary>
@@ -94,7 +94,7 @@ readonly struct Property : IEquatable<Property> {
 		Modifiers = modifiers;
 		Accessors = accessors;
 	}
-	
+
 	/// <inheritdoc />
 	public bool Equals (Property other)
 	{
@@ -161,7 +161,7 @@ readonly struct Property : IEquatable<Property> {
 		var propertySupportedPlatforms = propertySymbol.GetSupportedPlatforms ();
 		var type = propertySymbol.Type.ToDisplayString ().Trim ();
 		var attributes = declaration.GetAttributeCodeChanges (semanticModel);
-		
+
 		ImmutableArray<Accessor> accessorCodeChanges = [];
 		if (declaration.AccessorList is not null && declaration.AccessorList.Accessors.Count > 0) {
 			// calculate any possible changes in the accessors of the property
@@ -170,12 +170,12 @@ readonly struct Property : IEquatable<Property> {
 				if (semanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accessorSymbol)
 					continue;
 				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
-				var accessorAttributeChanges = 
+				var accessorAttributeChanges =
 					accessorDeclaration.GetAttributeCodeChanges (semanticModel);
 				accessorsBucket.Add (new (
-					accessorKind: kind, 
+					accessorKind: kind,
 					exportPropertyData: accessorSymbol.GetExportData<ObjCBindings.Property> (),
-					symbolAvailability: accessorSymbol.GetSupportedPlatforms (), 
+					symbolAvailability: accessorSymbol.GetSupportedPlatforms (),
 					attributes: accessorAttributeChanges,
 					modifiers: [.. accessorDeclaration.Modifiers]));
 			}
@@ -187,10 +187,10 @@ readonly struct Property : IEquatable<Property> {
 			// an expression body == a getter with no attrs or modifiers; that means that the accessor does not have
 			// extra availability, but the ones form the property
 			accessorCodeChanges = [new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: propertySupportedPlatforms, 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: propertySupportedPlatforms,
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: [])
 			];
 		}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
@@ -11,40 +11,40 @@ public class AccessorTests {
 	public void CompareDiffKind ()
 	{
 		var x = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
-			attributes: [], 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
+			attributes: [],
 			modifiers: []);
 		var y = new Accessor (
-			accessorKind: AccessorKind.Setter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
-			attributes: [], 
+			accessorKind: AccessorKind.Setter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
+			attributes: [],
 			modifiers: []);
-		
+
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
 		Assert.True (x != y);
 	}
-	
+
 	[Fact]
 	public void CompareDiffExportData ()
 	{
 		var x = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: new ("name"), 
-			attributes: [], 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: new ("name"),
+			attributes: [],
 			modifiers: []);
 		var y = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: new ("surname"), 
-			attributes: [], 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: new ("surname"),
+			attributes: [],
 			modifiers: []);
-		
+
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -55,21 +55,21 @@ public class AccessorTests {
 	public void CompareSameKindDiffAttrCount ()
 	{
 		var x = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("First"),
 				new ("Second"),
-			], 
+			],
 			modifiers: []);
 		var y = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("First"),
-			], 
+			],
 			modifiers: []);
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
@@ -81,24 +81,24 @@ public class AccessorTests {
 	public void CompareSameKindDiffAttr ()
 	{
 		var x = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("First"),
 				new ("Second"),
-			], 
+			],
 			modifiers: []);
 		var y = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("Third"),
 				new ("Fourth"),
-			], 
+			],
 			modifiers: []);
-		
+
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -109,24 +109,24 @@ public class AccessorTests {
 	public void CompareSameKindDiffAttrOrder ()
 	{
 		var x = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("First"),
 				new ("Second"),
-			], 
+			],
 			modifiers: []);
 		var y = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("Second"),
 				new ("First"),
-			], 
+			],
 			modifiers: []);
-		
+
 		Assert.True (x.Equals (y));
 		Assert.True (y.Equals (x));
 		Assert.True (x == y);
@@ -137,25 +137,25 @@ public class AccessorTests {
 	public void CompareSameKindSameAttrDiffModifiersCount ()
 	{
 		var x = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("First"),
 				new ("Second"),
-			], 
+			],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
 			]);
 		var y = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("Second"),
 				new ("First"),
-			], 
+			],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
 			]);
@@ -170,25 +170,25 @@ public class AccessorTests {
 	public void CompareSameKindSameAttrDiffModifiers ()
 	{
 		var x = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("First"),
 				new ("Second"),
-			], 
+			],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
 			]);
 		var y = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("Second"),
 				new ("First"),
-			], 
+			],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
 				SyntaxFactory.Token (SyntaxKind.ProtectedKeyword)
@@ -204,25 +204,25 @@ public class AccessorTests {
 	public void CompareSameKindSameAttrDiffModifiersOrder ()
 	{
 		var x = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
 			attributes: [
 				new ("First"),
 				new ("Second"),
-			], 
+			],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
 			]);
 		var y = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: new (), 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
 			exportPropertyData: null,
 			attributes: [
 				new ("Second"),
 				new ("First"),
-			], 
+			],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -240,9 +240,9 @@ public class AccessorTests {
 		var builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios17.0"));
 		var x = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: builder.ToImmutable (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: builder.ToImmutable (),
+			exportPropertyData: null,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -254,9 +254,9 @@ public class AccessorTests {
 		builder.Clear ();
 		builder.Add (new SupportedOSPlatformData ("tvos17.0"));
 		var y = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: builder.ToImmutable (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: builder.ToImmutable (),
+			exportPropertyData: null,
 			attributes: [
 				new ("Second"),
 				new ("First"),
@@ -277,9 +277,9 @@ public class AccessorTests {
 		var builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios17.0"));
 		var x = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: builder.ToImmutable (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: builder.ToImmutable (),
+			exportPropertyData: null,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -289,13 +289,13 @@ public class AccessorTests {
 				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
 			]);
 		var y = new Accessor (
-			accessorKind: AccessorKind.Getter, 
-			symbolAvailability: builder.ToImmutable (), 
-			exportPropertyData: null, 
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: builder.ToImmutable (),
+			exportPropertyData: null,
 			attributes: [
 				new ("Second"),
 				new ("First"),
-			], 
+			],
 			modifiers: [
 				SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
@@ -10,8 +10,41 @@ public class AccessorTests {
 	[Fact]
 	public void CompareDiffKind ()
 	{
-		var x = new Accessor (AccessorKind.Getter, new (), [], []);
-		var y = new Accessor (AccessorKind.Setter, new (), [], []);
+		var x = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [], 
+			modifiers: []);
+		var y = new Accessor (
+			accessorKind: AccessorKind.Setter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [], 
+			modifiers: []);
+		
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+	
+	[Fact]
+	public void CompareDiffExportData ()
+	{
+		var x = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: new ("name"), 
+			attributes: [], 
+			modifiers: []);
+		var y = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: new ("surname"), 
+			attributes: [], 
+			modifiers: []);
+		
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -21,13 +54,23 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindDiffAttrCount ()
 	{
-		var x = new Accessor (AccessorKind.Getter, new (), [
-			new ("First"),
-			new ("Second"),
-		], []);
-		var y = new Accessor (AccessorKind.Getter, new (), [
-			new ("First"),
-		], []);
+		var x = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			], 
+			modifiers: []);
+		var y = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("First"),
+			], 
+			modifiers: []);
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -37,14 +80,25 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindDiffAttr ()
 	{
-		var x = new Accessor (AccessorKind.Getter, new (), [
-			new ("First"),
-			new ("Second"),
-		], []);
-		var y = new Accessor (AccessorKind.Getter, new (), [
-			new ("Third"),
-			new ("Fourth"),
-		], []);
+		var x = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			], 
+			modifiers: []);
+		var y = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("Third"),
+				new ("Fourth"),
+			], 
+			modifiers: []);
+		
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -54,14 +108,25 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindDiffAttrOrder ()
 	{
-		var x = new Accessor (AccessorKind.Getter, new (), [
-			new ("First"),
-			new ("Second"),
-		], []);
-		var y = new Accessor (AccessorKind.Getter, new (), [
-			new ("Second"),
-			new ("First"),
-		], []);
+		var x = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			], 
+			modifiers: []);
+		var y = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("Second"),
+				new ("First"),
+			], 
+			modifiers: []);
+		
 		Assert.True (x.Equals (y));
 		Assert.True (y.Equals (x));
 		Assert.True (x == y);
@@ -71,19 +136,29 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindSameAttrDiffModifiersCount ()
 	{
-		var x = new Accessor (AccessorKind.Getter, new (), [
-			new ("First"),
-			new ("Second"),
-		], [
-			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
-			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
-		]);
-		var y = new Accessor (AccessorKind.Getter, new (), [
-			new ("Second"),
-			new ("First"),
-		], [
-			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
-		]);
+		var x = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			], 
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
+		var y = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("Second"),
+				new ("First"),
+			], 
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
 
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
@@ -94,20 +169,30 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindSameAttrDiffModifiers ()
 	{
-		var x = new Accessor (AccessorKind.Getter, new (), [
-			new ("First"),
-			new ("Second"),
-		], [
-			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
-			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
-		]);
-		var y = new Accessor (AccessorKind.Getter, new (), [
-			new ("Second"),
-			new ("First"),
-		], [
-			SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
-			SyntaxFactory.Token (SyntaxKind.ProtectedKeyword)
-		]);
+		var x = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			], 
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
+		var y = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("Second"),
+				new ("First"),
+			], 
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
+				SyntaxFactory.Token (SyntaxKind.ProtectedKeyword)
+			]);
 
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
@@ -118,20 +203,30 @@ public class AccessorTests {
 	[Fact]
 	public void CompareSameKindSameAttrDiffModifiersOrder ()
 	{
-		var x = new Accessor (AccessorKind.Getter, new (), [
-			new ("First"),
-			new ("Second"),
-		], [
-			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
-			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
-		]);
-		var y = new Accessor (AccessorKind.Getter, new (), [
-			new ("Second"),
-			new ("First"),
-		], [
-			SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
-			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
-		]);
+		var x = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			], 
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
+		var y = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: new (), 
+			exportPropertyData: null,
+			attributes: [
+				new ("Second"),
+				new ("First"),
+			], 
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+			]);
 
 		Assert.True (x.Equals (y));
 		Assert.True (y.Equals (x));
@@ -144,22 +239,31 @@ public class AccessorTests {
 	{
 		var builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios17.0"));
-		var x = new Accessor (AccessorKind.Getter, builder.ToImmutable (), [
-			new ("First"),
-			new ("Second"),
-		], [
-			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
-			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
-		]);
+		var x = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: builder.ToImmutable (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			],
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
 		builder.Clear ();
 		builder.Add (new SupportedOSPlatformData ("tvos17.0"));
-		var y = new Accessor (AccessorKind.Getter, builder.ToImmutable (), [
-			new ("Second"),
-			new ("First"),
-		], [
-			SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
-			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
-		]);
+		var y = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: builder.ToImmutable (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("Second"),
+				new ("First"),
+			], modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+			]);
 
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
@@ -172,20 +276,30 @@ public class AccessorTests {
 	{
 		var builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios17.0"));
-		var x = new Accessor (AccessorKind.Getter, builder.ToImmutable (), [
-			new ("First"),
-			new ("Second"),
-		], [
-			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
-			SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
-		]);
-		var y = new Accessor (AccessorKind.Getter, builder.ToImmutable (), [
-			new ("Second"),
-			new ("First"),
-		], [
-			SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
-			SyntaxFactory.Token (SyntaxKind.PublicKeyword),
-		]);
+		var x = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: builder.ToImmutable (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			],
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
+		var y = new Accessor (
+			accessorKind: AccessorKind.Getter, 
+			symbolAvailability: builder.ToImmutable (), 
+			exportPropertyData: null, 
+			attributes: [
+				new ("Second"),
+				new ("First"),
+			], 
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword),
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+			]);
 
 		Assert.True (x.Equals (y));
 		Assert.True (y.Equals (x));

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorsEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorsEqualityComparerTests.cs
@@ -20,24 +20,24 @@ public class AccessorsEqualityComparerTests {
 	{
 		ImmutableArray<Accessor> x = [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 			new (
-				accessorKind: AccessorKind.Setter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Setter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 		];
 		ImmutableArray<Accessor> y = [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 		];
 
@@ -49,30 +49,30 @@ public class AccessorsEqualityComparerTests {
 	{
 		ImmutableArray<Accessor> x = [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 			new (
-				accessorKind: AccessorKind.Setter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Setter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 		];
 		ImmutableArray<Accessor> y = [
 			new (
-				accessorKind: AccessorKind.Add, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Add,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 			new (
-				accessorKind: AccessorKind.Remove, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Remove,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 		];
 
@@ -84,30 +84,30 @@ public class AccessorsEqualityComparerTests {
 	{
 		ImmutableArray<Accessor> x = [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 			new (
-				accessorKind: AccessorKind.Setter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Setter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 		];
 		ImmutableArray<Accessor> y = [
 			new (
-				accessorKind: AccessorKind.Setter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Setter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 		];
 
@@ -119,31 +119,31 @@ public class AccessorsEqualityComparerTests {
 	{
 		ImmutableArray<Accessor> x = [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 			new (
-				accessorKind: AccessorKind.Setter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Setter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 		];
 
 		ImmutableArray<Accessor> y = [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 			new (
-				accessorKind: AccessorKind.Setter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Setter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []),
 		];
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorsEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorsEqualityComparerTests.cs
@@ -19,11 +19,26 @@ public class AccessorsEqualityComparerTests {
 	public void CompareSameSizeDiffSizes ()
 	{
 		ImmutableArray<Accessor> x = [
-			new (AccessorKind.Getter, new (), [], []),
-			new (AccessorKind.Setter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
+			new (
+				accessorKind: AccessorKind.Setter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
 		];
 		ImmutableArray<Accessor> y = [
-			new (AccessorKind.Getter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
 		];
 
 		Assert.False (equalityComparer.Equals (x, y));
@@ -33,12 +48,32 @@ public class AccessorsEqualityComparerTests {
 	public void CompareSameSizeDiffAccessors ()
 	{
 		ImmutableArray<Accessor> x = [
-			new (AccessorKind.Getter, new (), [], []),
-			new (AccessorKind.Setter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
+			new (
+				accessorKind: AccessorKind.Setter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
 		];
 		ImmutableArray<Accessor> y = [
-			new (AccessorKind.Add, new (), [], []),
-			new (AccessorKind.Remove, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Add, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
+			new (
+				accessorKind: AccessorKind.Remove, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
 		];
 
 		Assert.False (equalityComparer.Equals (x, y));
@@ -48,12 +83,32 @@ public class AccessorsEqualityComparerTests {
 	public void CompareTwoAccessorsDiffOrder ()
 	{
 		ImmutableArray<Accessor> x = [
-			new (AccessorKind.Getter, new (), [], []),
-			new (AccessorKind.Setter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
+			new (
+				accessorKind: AccessorKind.Setter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
 		];
 		ImmutableArray<Accessor> y = [
-			new (AccessorKind.Setter, new (), [], []),
-			new (AccessorKind.Getter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Setter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
 		];
 
 		Assert.True (equalityComparer.Equals (x, y));
@@ -63,13 +118,33 @@ public class AccessorsEqualityComparerTests {
 	public void CompareTwoAccessorsEqual ()
 	{
 		ImmutableArray<Accessor> x = [
-			new (AccessorKind.Getter, new (), [], []),
-			new (AccessorKind.Setter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
+			new (
+				accessorKind: AccessorKind.Setter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
 		];
 
 		ImmutableArray<Accessor> y = [
-			new (AccessorKind.Getter, new (), [], []),
-			new (AccessorKind.Setter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
+			new (
+				accessorKind: AccessorKind.Setter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []),
 		];
 
 		Assert.True (equalityComparer.Equals (x, y));

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -363,8 +363,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name")
@@ -423,8 +435,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name")
@@ -482,8 +506,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name")
@@ -537,8 +573,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 
@@ -594,8 +642,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 
@@ -652,8 +712,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name")
@@ -710,8 +782,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name")
@@ -729,8 +813,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("surname")
@@ -958,8 +1054,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, new (), [], []),
-								new (AccessorKind.Remove, new (), [], [])
+								new (
+									accessorKind: AccessorKind.Add, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Remove, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								)
 							])
 					],
 				}
@@ -1009,8 +1117,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, new (), [], []),
-								new (AccessorKind.Remove, new (), [], [])
+								new (
+									accessorKind: AccessorKind.Add, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Remove, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								)
 							]
 						),
 						new (
@@ -1022,8 +1142,20 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, new (), [], []),
-								new (AccessorKind.Remove, new (), [], [])
+								new (
+									accessorKind: AccessorKind.Add, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Remove, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								)
 							]
 						),
 					],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -366,17 +366,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -439,17 +439,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -511,17 +511,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -579,17 +579,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -649,17 +649,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -720,17 +720,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -791,17 +791,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -823,17 +823,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -1064,17 +1064,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Add, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Add,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Remove, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Remove,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								)
 							])
@@ -1127,17 +1127,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Add, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Add,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Remove, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Remove,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								)
 							]
@@ -1152,17 +1152,17 @@ public partial class MyClass {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Add, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Add,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Remove, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Remove,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								)
 							]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -255,18 +255,18 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -302,19 +302,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -332,21 +332,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -374,21 +374,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -406,19 +406,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -452,19 +452,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -482,21 +482,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -524,20 +524,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							], modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -555,19 +555,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -601,19 +601,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -631,21 +631,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -659,10 +659,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []),
 					]),
 			]
@@ -689,21 +689,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -721,19 +721,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -767,19 +767,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -797,21 +797,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -825,10 +825,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []),
 					]),
 				new (
@@ -839,17 +839,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -877,21 +877,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -909,19 +909,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -935,17 +935,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -957,10 +957,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -995,19 +995,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1025,21 +1025,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1053,10 +1053,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []),
 					]),
 			]
@@ -1083,21 +1083,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1115,19 +1115,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1143,10 +1143,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1180,19 +1180,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1210,21 +1210,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1238,10 +1238,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1253,17 +1253,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1322,21 +1322,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1354,19 +1354,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1380,16 +1380,16 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1401,10 +1401,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1457,19 +1457,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1487,21 +1487,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1515,10 +1515,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1530,17 +1530,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1599,21 +1599,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1631,19 +1631,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1657,17 +1657,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1679,10 +1679,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1748,19 +1748,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1778,21 +1778,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1806,10 +1806,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1821,17 +1821,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1874,21 +1874,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1906,19 +1906,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1932,17 +1932,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1954,10 +1954,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2013,19 +2013,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2043,21 +2043,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -2071,10 +2071,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2086,17 +2086,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2155,21 +2155,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -2187,12 +2187,12 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], modifiers: []),
+							], modifiers: []),
 						new (AccessorKind.Setter, new (), null, [], []),
 					]),
 			],
@@ -2205,17 +2205,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2227,10 +2227,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2299,19 +2299,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2329,21 +2329,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -2357,10 +2357,10 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2372,17 +2372,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2441,21 +2441,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -2473,18 +2473,18 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							], modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2498,17 +2498,17 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					modifiers: [],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -2521,9 +2521,9 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					accessors: [
 						new (
 							accessorKind: AccessorKind.Add,
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -253,12 +253,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							],
+							modifiers: []
+						),
 					])
 			]
 		};
@@ -287,10 +299,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -304,12 +328,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -333,12 +369,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -352,10 +400,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -385,10 +445,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -402,12 +474,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -431,12 +515,23 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -450,10 +545,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -483,10 +590,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -500,12 +619,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -516,7 +647,12 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []),
 					]),
 			]
 		};
@@ -540,12 +676,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -559,10 +707,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -592,10 +752,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -609,12 +781,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -625,7 +809,12 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []),
 					]),
 				new (
 					name: "MyEvent2",
@@ -634,8 +823,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -659,12 +860,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -678,10 +891,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -692,8 +917,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent",
@@ -702,7 +939,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -733,10 +976,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -750,12 +1005,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -766,7 +1033,12 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []),
 					]),
 			]
 		};
@@ -790,12 +1062,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -809,10 +1093,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -825,7 +1121,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.InternalKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -855,10 +1157,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -872,12 +1186,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -888,7 +1214,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent2",
@@ -897,8 +1229,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Methods = [
@@ -953,12 +1297,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -972,10 +1328,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -986,8 +1354,19 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent",
@@ -996,7 +1375,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Methods = [
@@ -1045,10 +1430,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -1062,12 +1459,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -1078,7 +1487,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent2",
@@ -1087,8 +1502,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Methods = [
@@ -1143,12 +1570,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -1162,10 +1601,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -1176,8 +1627,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent",
@@ -1186,7 +1649,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Methods = [
@@ -1248,10 +1717,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -1265,12 +1746,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -1281,7 +1774,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent2",
@@ -1290,8 +1789,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Methods = [
@@ -1330,12 +1841,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -1349,10 +1872,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -1363,8 +1898,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent",
@@ -1373,7 +1920,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Methods = [
@@ -1425,10 +1978,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -1442,12 +2007,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -1458,7 +2035,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent2",
@@ -1467,8 +2050,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Methods = [
@@ -1523,12 +2118,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -1542,10 +2149,14 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						], modifiers: []),
+						new (AccessorKind.Setter, new (), null, [], []),
 					]),
 			],
 			Events = [
@@ -1556,8 +2167,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent",
@@ -1566,7 +2189,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Methods = [
@@ -1631,10 +2260,22 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -1648,12 +2289,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -1664,7 +2317,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent2",
@@ -1673,8 +2332,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Methods = [
@@ -1729,12 +2400,24 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -1748,10 +2431,21 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Events = [
@@ -1762,8 +2456,20 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "MyEvent",
@@ -1772,7 +2478,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Methods = [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -173,21 +173,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					])
@@ -222,19 +222,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -252,21 +252,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -294,21 +294,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -326,19 +326,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -372,19 +372,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -402,21 +402,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -444,21 +444,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -476,19 +476,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -522,19 +522,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -552,21 +552,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -595,21 +595,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
 							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -627,19 +627,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -676,19 +676,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 							),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -706,21 +706,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -751,21 +751,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -783,19 +783,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -838,19 +838,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -868,21 +868,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -920,21 +920,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -952,19 +952,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1008,19 +1008,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1038,21 +1038,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1090,21 +1090,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []),
 					]),
 				new (
@@ -1121,19 +1121,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1181,19 +1181,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),
@@ -1211,21 +1211,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1268,21 +1268,21 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]),
@@ -1300,19 +1300,19 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -15,13 +15,13 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 			name: "name1",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name1",
-			symbolAvailability: new ()); ;
+			symbolAvailability: new ());
 		var changes2 = new CodeChanges (
 			bindingData: new (BindingType.Protocol, new ()),
 			name: "name2",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name2",
-			symbolAvailability: new ()); ;
+			symbolAvailability: new ());
 		Assert.False (equalityComparer.Equals (changes1, changes2));
 	}
 
@@ -171,12 +171,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					])
 			]
 		};
@@ -207,10 +219,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -224,12 +248,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -253,12 +289,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -272,10 +320,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -305,10 +365,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -322,12 +394,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -351,12 +435,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -370,10 +466,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			]
 		};
@@ -403,10 +511,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -420,12 +540,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Constructors = [],
@@ -450,12 +582,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null,
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -469,10 +613,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Constructors = [
@@ -505,10 +661,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+							),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -522,12 +690,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Constructors = [
@@ -554,12 +734,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -573,10 +765,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Constructors = [
@@ -615,10 +819,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -632,12 +848,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Constructors = [
@@ -671,12 +899,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -690,10 +930,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Constructors = [
@@ -733,10 +985,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -750,12 +1014,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Constructors = [
@@ -789,12 +1065,23 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []),
 					]),
 				new (
 					name: "Surname",
@@ -808,10 +1095,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Constructors = [
@@ -855,10 +1154,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Name",
@@ -872,12 +1183,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 			],
 			Constructors = [
@@ -916,12 +1239,24 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					]),
 				new (
 					name: "Surname",
@@ -935,10 +1270,22 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]),
 			],
 			Constructors = [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventEqualityComparerTests.cs
@@ -30,7 +30,13 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 			new (
 				name: "SecondEvent",
@@ -41,7 +47,13 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 		ImmutableArray<Event> y = [
@@ -54,7 +66,13 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 
@@ -74,7 +92,13 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 		ImmutableArray<Event> y = [
@@ -87,7 +111,13 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 
@@ -107,7 +137,13 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 		ImmutableArray<Event> y = [
@@ -120,7 +156,13 @@ public class EventEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventEqualityComparerTests.cs
@@ -31,10 +31,10 @@ public class EventEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -48,10 +48,10 @@ public class EventEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -67,10 +67,10 @@ public class EventEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -93,10 +93,10 @@ public class EventEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -112,10 +112,10 @@ public class EventEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -138,10 +138,10 @@ public class EventEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -157,10 +157,10 @@ public class EventEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
@@ -39,16 +39,16 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]
@@ -78,10 +78,10 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]
@@ -111,17 +111,17 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.InternalKeyword)
 							]
@@ -160,17 +160,17 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: new (), 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
 							exportPropertyData: null,
-							attributes: [], 
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.InternalKeyword)
 							]
@@ -209,9 +209,9 @@ public class TestClass {
 					accessors: [
 						new (
 							accessorKind: AccessorKind.Add
-							, symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							, symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					]
@@ -255,21 +255,21 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add, 
-							symbolAvailability: accessorAvailabilityBuilder.ToImmutable (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: accessorAvailabilityBuilder.ToImmutable (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Remove, 
-							symbolAvailability: accessorAvailabilityBuilder.ToImmutable (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: accessorAvailabilityBuilder.ToImmutable (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
@@ -38,8 +38,19 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]
 				)
 			];
@@ -66,7 +77,13 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]
 				)
 			];
@@ -93,10 +110,22 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], [
-							SyntaxFactory.Token (SyntaxKind.InternalKeyword)
-						]),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: [
+								SyntaxFactory.Token (SyntaxKind.InternalKeyword)
+							]
+						),
 					]
 				)
 			];
@@ -130,10 +159,22 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
-						new (AccessorKind.Remove, new (), [], [
-							SyntaxFactory.Token (SyntaxKind.InternalKeyword)
-						]),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: new (), 
+							exportPropertyData: null,
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: [
+								SyntaxFactory.Token (SyntaxKind.InternalKeyword)
+							]
+						),
 					]
 				)
 			];
@@ -166,7 +207,13 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Add
+							, symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					]
 				)
 			];
@@ -207,12 +254,24 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Add, accessorAvailabilityBuilder.ToImmutable (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Remove, accessorAvailabilityBuilder.ToImmutable (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Add, 
+							symbolAvailability: accessorAvailabilityBuilder.ToImmutable (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove, 
+							symbolAvailability: accessorAvailabilityBuilder.ToImmutable (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
 					]
 				)
 			];

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -128,8 +128,20 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name")
@@ -186,8 +198,20 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name")
@@ -243,8 +267,20 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name")
@@ -296,8 +332,20 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name", ArgumentSemantic.None, Property.Notification)
@@ -351,8 +399,20 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name")
@@ -407,8 +467,20 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("name")
@@ -426,8 +498,20 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Getter, new (), [], []),
-								new (AccessorKind.Setter, new (), [], []),
+								new (
+									accessorKind: AccessorKind.Getter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
 							]
 						) {
 							ExportPropertyData = new ("surname")
@@ -647,8 +731,20 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, new (), [], []),
-								new (AccessorKind.Remove, new (), [], [])
+								new (
+									accessorKind: AccessorKind.Add, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Remove, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								)
 							])
 					],
 				}
@@ -696,8 +792,20 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, new (), [], []),
-								new (AccessorKind.Remove, new (), [], [])
+								new (
+									accessorKind: AccessorKind.Add, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Remove, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								)
 							]
 						),
 						new (
@@ -709,8 +817,20 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 							],
 							accessors: [
-								new (AccessorKind.Add, new (), [], []),
-								new (AccessorKind.Remove, new (), [], [])
+								new (
+									accessorKind: AccessorKind.Add, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Remove, 
+									symbolAvailability: new (), 
+									exportPropertyData: null, 
+									attributes: [], 
+									modifiers: []
+								)
 							]
 						),
 					],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -130,17 +130,17 @@ public partial interface IProtocol {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -201,17 +201,17 @@ public partial interface IProtocol {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -271,17 +271,17 @@ public partial interface IProtocol {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -337,17 +337,17 @@ public partial interface IProtocol {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -405,17 +405,17 @@ public partial interface IProtocol {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -474,17 +474,17 @@ public partial interface IProtocol {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -506,17 +506,17 @@ public partial interface IProtocol {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Getter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Setter, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 							]
@@ -739,17 +739,17 @@ public partial interface IProtocol {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Add, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Add,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Remove, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Remove,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								)
 							])
@@ -800,17 +800,17 @@ public partial interface IProtocol {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Add, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Add,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Remove, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Remove,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								)
 							]
@@ -825,17 +825,17 @@ public partial interface IProtocol {
 							],
 							accessors: [
 								new (
-									accessorKind: AccessorKind.Add, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Add,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								),
 								new (
-									accessorKind: AccessorKind.Remove, 
-									symbolAvailability: new (), 
-									exportPropertyData: null, 
-									attributes: [], 
+									accessorKind: AccessorKind.Remove,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
 									modifiers: []
 								)
 							]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertiesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertiesEqualityComparerTests.cs
@@ -33,10 +33,10 @@ public class PropertiesEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -52,10 +52,10 @@ public class PropertiesEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -73,10 +73,10 @@ public class PropertiesEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -101,10 +101,10 @@ public class PropertiesEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -122,10 +122,10 @@ public class PropertiesEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -150,10 +150,10 @@ public class PropertiesEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -171,10 +171,10 @@ public class PropertiesEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -199,10 +199,10 @@ public class PropertiesEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),
@@ -220,10 +220,10 @@ public class PropertiesEqualityComparerTests {
 				],
 				accessors: [
 					new (
-						accessorKind: AccessorKind.Getter, 
-						symbolAvailability: new (), 
-						exportPropertyData: null, 
-						attributes: [], 
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
 						modifiers: []
 					)
 				]),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertiesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertiesEqualityComparerTests.cs
@@ -31,7 +31,13 @@ public class PropertiesEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 			new (
 				name: "SecondProperty",
@@ -43,7 +49,13 @@ public class PropertiesEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 		ImmutableArray<Property> y = [
@@ -57,7 +69,13 @@ public class PropertiesEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 
@@ -78,7 +96,13 @@ public class PropertiesEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 		ImmutableArray<Property> y = [
@@ -92,7 +116,13 @@ public class PropertiesEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 
@@ -113,7 +143,13 @@ public class PropertiesEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 		ImmutableArray<Property> y = [
@@ -127,7 +163,13 @@ public class PropertiesEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 
@@ -148,7 +190,13 @@ public class PropertiesEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 		ImmutableArray<Property> y = [
@@ -162,7 +210,13 @@ public class PropertiesEqualityComparerTests {
 					SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				],
 				accessors: [
-					new (AccessorKind.Getter, new (), [], [])
+					new (
+						accessorKind: AccessorKind.Getter, 
+						symbolAvailability: new (), 
+						exportPropertyData: null, 
+						attributes: [], 
+						modifiers: []
+					)
 				]),
 		];
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -87,17 +87,17 @@ public class PropertyTests : BaseGeneratorTestClass {
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []
 			),
 			new (
-				accessorKind: AccessorKind.Setter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Setter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []
 			),
 		]);
@@ -108,10 +108,10 @@ public class PropertyTests : BaseGeneratorTestClass {
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []
 			),
 		]);
@@ -121,7 +121,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 		Assert.False (x == y);
 		Assert.True (x != y);
 	}
-	
+
 	[Fact]
 	public void CompareDiffAccessorsExportData ()
 	{
@@ -132,10 +132,10 @@ public class PropertyTests : BaseGeneratorTestClass {
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: new ("name"), 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: new ("name"),
+				attributes: [],
 				modifiers: []
 			),
 		]);
@@ -146,10 +146,10 @@ public class PropertyTests : BaseGeneratorTestClass {
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: new ("surname"), 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: new ("surname"),
+				attributes: [],
 				modifiers: []
 			),
 		]);
@@ -170,17 +170,17 @@ public class PropertyTests : BaseGeneratorTestClass {
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []
 			),
 			new (
-				accessorKind: AccessorKind.Setter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Setter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []
 			),
 		]);
@@ -191,17 +191,17 @@ public class PropertyTests : BaseGeneratorTestClass {
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
 			new (
-				accessorKind: AccessorKind.Getter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []
 			),
 			new (
-				accessorKind: AccessorKind.Setter, 
-				symbolAvailability: new (), 
-				exportPropertyData: null, 
-				attributes: [], 
+				accessorKind: AccessorKind.Setter,
+				symbolAvailability: new (),
+				exportPropertyData: null,
+				attributes: [],
 				modifiers: []
 			),
 		]);
@@ -243,18 +243,17 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						)
-					]) 
-				{
-					ExportPropertyData= new ("name"),
+					]) {
+					ExportPropertyData = new ("name"),
 				},
 			];
-			
+
 			const string automaticGetterExportData = @"
 using System;
 using ObjCBindings;
@@ -286,16 +285,15 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData:  new ("myName"),
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: new ("myName"),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["myName"]),
-							], 
+							],
 							modifiers: []
 						)
-					]) 
-				{
+					]) {
 					ExportPropertyData = new ("name"),
 				},
 			];
@@ -329,25 +327,24 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						)
-					]) 
-				{
+					]) {
 					ExportPropertyData = new ("name"),
 				},
 			];
-			
+
 			const string automaticGetterSetterExportData = @"
 using System;
 using ObjCBindings;
@@ -382,25 +379,24 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: new ("myName"), 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: new ("myName"),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["myName"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: new ("setMyName"), 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: new ("setMyName"),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["setMyName"]),
-							], 
+							],
 							modifiers: []
 						)
-					]) 
-				{
+					]) {
 					ExportPropertyData = new ("name"),
 				},
 			];
@@ -428,10 +424,10 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					])
@@ -460,10 +456,10 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					])
@@ -494,17 +490,17 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
 							exportPropertyData: null,
-							attributes: [], 
+							attributes: [],
 							modifiers: []
 						),
 					])
@@ -536,17 +532,17 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					])
@@ -578,17 +574,17 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.InternalKeyword),
 							]
@@ -632,17 +628,17 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					])
@@ -685,19 +681,19 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: getterAvailabilityBuilder.ToImmutable (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: getterAvailabilityBuilder.ToImmutable (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: new (), 
-							exportPropertyData: null, 
-							attributes: [], 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
 							modifiers: []
 						),
 					])
@@ -743,21 +739,21 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: getterAvailabilityBuilder.ToImmutable (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: getterAvailabilityBuilder.ToImmutable (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: setterAvailabilityBuilder.ToImmutable (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: setterAvailabilityBuilder.ToImmutable (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					])
@@ -806,21 +802,21 @@ namespace Test {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Getter, 
-							symbolAvailability: getterAvailabilityBuilder.ToImmutable (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: getterAvailabilityBuilder.ToImmutable (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-							], 
+							],
 							modifiers: []
 						),
 						new (
-							accessorKind: AccessorKind.Setter, 
-							symbolAvailability: setterAvailabilityBuilder.ToImmutable (), 
-							exportPropertyData: null, 
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: setterAvailabilityBuilder.ToImmutable (),
+							exportPropertyData: null,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-							], 
+							],
 							modifiers: []
 						),
 					])

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Macios.Generator.DataModel;
 using Xamarin.Tests;
 using Xamarin.Utils;
 using Xunit;
+using Property = Microsoft.Macios.Generator.DataModel.Property;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
@@ -85,8 +86,20 @@ public class PropertyTests : BaseGeneratorTestClass {
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
-			new (AccessorKind.Getter, new (), [], []),
-			new (AccessorKind.Setter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []
+			),
+			new (
+				accessorKind: AccessorKind.Setter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []
+			),
 		]);
 		var y = new Property ("First", "int", false, new (), [
 			new ("Attr1"),
@@ -94,7 +107,51 @@ public class PropertyTests : BaseGeneratorTestClass {
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
-			new (AccessorKind.Getter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []
+			),
+		]);
+
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+	
+	[Fact]
+	public void CompareDiffAccessorsExportData ()
+	{
+		var x = new Property ("First", "string", false, new (), [
+			new ("Attr1"),
+			new ("Attr2"),
+		], [
+			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
+		], [
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: new ("name"), 
+				attributes: [], 
+				modifiers: []
+			),
+		]);
+		var y = new Property ("First", "int", false, new (), [
+			new ("Attr1"),
+			new ("Attr2"),
+		], [
+			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
+		], [
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: new ("surname"), 
+				attributes: [], 
+				modifiers: []
+			),
 		]);
 
 		Assert.False (x.Equals (y));
@@ -112,8 +169,20 @@ public class PropertyTests : BaseGeneratorTestClass {
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
-			new (AccessorKind.Getter, new (), [], []),
-			new (AccessorKind.Setter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []
+			),
+			new (
+				accessorKind: AccessorKind.Setter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []
+			),
 		]);
 		var y = new Property ("First", "string", false, new (), [
 			new ("Attr1"),
@@ -121,8 +190,20 @@ public class PropertyTests : BaseGeneratorTestClass {
 		], [
 			SyntaxFactory.Token (SyntaxKind.PublicKeyword)
 		], [
-			new (AccessorKind.Getter, new (), [], []),
-			new (AccessorKind.Setter, new (), [], []),
+			new (
+				accessorKind: AccessorKind.Getter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []
+			),
+			new (
+				accessorKind: AccessorKind.Setter, 
+				symbolAvailability: new (), 
+				exportPropertyData: null, 
+				attributes: [], 
+				modifiers: []
+			),
 		]);
 
 		Assert.True (x.Equals (y));
@@ -136,11 +217,13 @@ public class PropertyTests : BaseGeneratorTestClass {
 		{
 			const string automaticGetter = @"
 using System;
+using ObjCBindings;
 
 namespace Test;
 
 public class TestClass {
 
+	[Export<Property>(""name"")]
 	public string Name { get; }
 }
 ";
@@ -151,22 +234,79 @@ public class TestClass {
 					type: "string",
 					isSmartEnum: false,
 					symbolAvailability: new (),
-					attributes: [],
+					attributes: [
+						new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"]),
+					],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [], [])
-					])
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						)
+					]) 
+				{
+					ExportPropertyData= new ("name"),
+				},
 			];
-
-			const string automaticGetterSetter = @"
+			
+			const string automaticGetterExportData = @"
 using System;
+using ObjCBindings;
 
 namespace Test;
 
 public class TestClass {
 
+	[Export<Property>(""name"")]
+	public string Name { 
+		[Export<Property>(""myName"")]
+		get; 
+	}
+}
+";
+			yield return [
+				automaticGetterExportData,
+				new Property (
+					name: "Name",
+					type: "string",
+					isSmartEnum: false,
+					symbolAvailability: new (),
+					attributes: [
+						new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData:  new ("myName"),
+							attributes: [
+								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["myName"]),
+							], 
+							modifiers: []
+						)
+					]) 
+				{
+					ExportPropertyData = new ("name"),
+				},
+			];
+
+			const string automaticGetterSetter = @"
+using System;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name"")]
 	internal string Name { get; set; }
 }
 ";
@@ -178,14 +318,87 @@ public class TestClass {
 					type: "string",
 					isSmartEnum: false,
 					symbolAvailability: new (),
-					attributes: [],
+					attributes: [
+						new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"]),
+					],
 					modifiers: [
 						SyntaxFactory.Token (SyntaxKind.InternalKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [], []),
-						new (AccessorKind.Setter, new (), [], [])
-					])
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						)
+					]) 
+				{
+					ExportPropertyData = new ("name"),
+				},
+			];
+			
+			const string automaticGetterSetterExportData = @"
+using System;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name"")]
+	internal string Name { 
+		[Export<Property>(""myName"")]
+		get; 
+		[Export<Property>(""setMyName"")]
+		set; 
+	}
+}
+";
+
+			yield return [
+				automaticGetterSetterExportData,
+				new Property (
+					name: "Name",
+					type: "string",
+					isSmartEnum: false,
+					symbolAvailability: new (),
+					attributes: [
+						new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.InternalKeyword),
+					],
+					accessors: [
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: new ("myName"), 
+							attributes: [
+								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["myName"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: new ("setMyName"), 
+							attributes: [
+								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["setMyName"]),
+							], 
+							modifiers: []
+						)
+					]) 
+				{
+					ExportPropertyData = new ("name"),
+				},
 			];
 
 			const string manualGetter = @"
@@ -209,7 +422,13 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					])
 			];
 
@@ -234,7 +453,13 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					])
 			];
 
@@ -261,8 +486,20 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null,
+							attributes: [], 
+							modifiers: []
+						),
 					])
 			];
 
@@ -290,8 +527,20 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					])
 			];
 
@@ -319,15 +568,29 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [], []),
-						new (AccessorKind.Setter, new (), [], [
-							SyntaxFactory.Token (SyntaxKind.InternalKeyword),
-						]),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: [
+								SyntaxFactory.Token (SyntaxKind.InternalKeyword),
+							]
+						),
 					])
 			];
 
 			const string propertyWithAttribute = @"
 using System.Runtime.Versioning;
+using ObjCBindings;
+
 namespace Test;
 
 public class TestClass {
@@ -358,13 +621,27 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, new (), [], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					])
 			];
 
 			const string propertyGetterWithAttribute = @"
 using System.Runtime.Versioning;
+using ObjCBindings;
+
 namespace Test;
 
 public class TestClass {
@@ -396,15 +673,29 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, getterAvailabilityBuilder.ToImmutable (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, new (), [], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: getterAvailabilityBuilder.ToImmutable (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: new (), 
+							exportPropertyData: null, 
+							attributes: [], 
+							modifiers: []
+						),
 					])
 			];
 
 			const string propertyWithGetterAndSetterWithAttribute = @"
 using System.Runtime.Versioning;
+using ObjCBindings;
+
 namespace Test;
 
 public class TestClass {
@@ -439,17 +730,30 @@ public class TestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, getterAvailabilityBuilder.ToImmutable (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, setterAvailabilityBuilder.ToImmutable (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: getterAvailabilityBuilder.ToImmutable (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: setterAvailabilityBuilder.ToImmutable (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					])
 			];
 
 			const string propertyWithCustomType = @"
 using System.Runtime.Versioning;
+using ObjCBindings;
 
 namespace Utils {
 	public class MyClass {}
@@ -488,12 +792,24 @@ namespace Test {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					accessors: [
-						new (AccessorKind.Getter, getterAvailabilityBuilder.ToImmutable (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
-						], []),
-						new (AccessorKind.Setter, setterAvailabilityBuilder.ToImmutable (), [
-							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
-						], []),
+						new (
+							accessorKind: AccessorKind.Getter, 
+							symbolAvailability: getterAvailabilityBuilder.ToImmutable (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
+							], 
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter, 
+							symbolAvailability: setterAvailabilityBuilder.ToImmutable (), 
+							exportPropertyData: null, 
+							attributes: [
+								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
+							], 
+							modifiers: []
+						),
 					])
 			];
 		}


### PR DESCRIPTION
This change keeps track of the usage of the export attribute in property
accessors allowing users to change the default selectors used in
properties.