### PR TITLE
[Rgen] Keep track in the property struct if the returned type is a ref one.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -32,9 +32,14 @@ readonly struct Property : IEquatable<Property> {
 	public bool IsBlittable { get; }
 
 	/// <summary>
-	/// Returns if the parameter type is a smart enum.
+	/// Returns if the property type is a smart enum.
 	/// </summary>
 	public bool IsSmartEnum { get; }
+	
+	/// <summary>
+	/// Returns if the property type is a reference type.
+	/// </summary>
+	public bool IsReferenceType { get; }
 
 	/// <summary>
 	/// The platform availability of the property.
@@ -79,6 +84,7 @@ readonly struct Property : IEquatable<Property> {
 	internal Property (string name, string type,
 		bool isBlittable,
 		bool isSmartEnum,
+		bool isReferenceType,
 		SymbolAvailability symbolAvailability,
 		ImmutableArray<AttributeCodeChange> attributes,
 		ImmutableArray<SyntaxToken> modifiers, ImmutableArray<Accessor> accessors)
@@ -87,6 +93,7 @@ readonly struct Property : IEquatable<Property> {
 		Type = type;
 		IsBlittable = isBlittable;
 		IsSmartEnum = isSmartEnum;
+		IsReferenceType = isReferenceType;
 		SymbolAvailability = symbolAvailability;
 		Attributes = attributes;
 		Modifiers = modifiers;
@@ -104,6 +111,8 @@ readonly struct Property : IEquatable<Property> {
 		if (IsBlittable != other.IsBlittable)
 			return false;
 		if (IsSmartEnum != other.IsSmartEnum)
+			return false;
+		if (IsReferenceType != other.IsReferenceType)
 			return false;
 		if (SymbolAvailability != other.SymbolAvailability)
 			return false;
@@ -184,11 +193,12 @@ readonly struct Property : IEquatable<Property> {
 			];
 		}
 
-		change = new (
+		change = new(
 			name: memberName,
 			type: type,
 			isBlittable: propertySymbol.Type.IsBlittable (),
 			isSmartEnum: propertySymbol.Type.IsSmartEnum (),
+			isReferenceType: propertySymbol.Type.IsReferenceType,
 			symbolAvailability: propertySupportedPlatforms,
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],
@@ -203,7 +213,7 @@ readonly struct Property : IEquatable<Property> {
 	public override string ToString ()
 	{
 		var sb = new StringBuilder (
-			$"Name: '{Name}', Type: '{Type}', IsBlittable: {IsBlittable}, IsSmartEnum: {IsSmartEnum}, Supported Platforms: {SymbolAvailability}, ExportFieldData: '{ExportFieldData?.ToString () ?? "null"}', ExportPropertyData: '{ExportPropertyData?.ToString () ?? "null"}' Attributes: [");
+			$"Name: '{Name}', Type: '{Type}', IsBlittable: {IsBlittable}, IsSmartEnum: {IsSmartEnum}, IsReferenceType: {IsReferenceType} Supported Platforms: {SymbolAvailability}, ExportFieldData: '{ExportFieldData?.ToString () ?? "null"}', ExportPropertyData: '{ExportPropertyData?.ToString () ?? "null"}' Attributes: [");
 		sb.AppendJoin (",", Attributes);
 		sb.Append ("], Modifiers: [");
 		sb.AppendJoin (",", Modifiers.Select (x => x.Text));

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -35,7 +35,7 @@ readonly struct Property : IEquatable<Property> {
 	/// Returns if the property type is a smart enum.
 	/// </summary>
 	public bool IsSmartEnum { get; }
-	
+
 	/// <summary>
 	/// Returns if the property type is a reference type.
 	/// </summary>
@@ -193,7 +193,7 @@ readonly struct Property : IEquatable<Property> {
 			];
 		}
 
-		change = new(
+		change = new (
 			name: memberName,
 			type: type,
 			isBlittable: propertySymbol.Type.IsBlittable (),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -356,6 +356,7 @@ public partial class MyClass {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
@@ -417,6 +418,7 @@ public partial class MyClass {
 							type: "NS.MyEnum",
 							isBlittable: true,
 							isSmartEnum: true,
+							isReferenceType: false,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
@@ -477,6 +479,7 @@ public partial class MyClass {
 							type: "NS.MyEnum",
 							isBlittable: true,
 							isSmartEnum: false,
+							isReferenceType: false,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
@@ -533,6 +536,7 @@ public partial class MyClass {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name", "ObjCBindings.Property.Notification"])
@@ -590,6 +594,7 @@ public partial class MyClass {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Field>", ["CONSTANT"])
@@ -650,6 +655,7 @@ public partial class MyClass {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
@@ -709,6 +715,7 @@ public partial class MyClass {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
@@ -729,6 +736,7 @@ public partial class MyClass {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["surname"])

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -246,6 +246,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -281,6 +282,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -299,6 +301,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -329,6 +332,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -349,6 +353,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -383,6 +388,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -401,6 +407,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -431,6 +438,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -451,6 +459,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -485,6 +494,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -503,6 +513,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -544,6 +555,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -564,6 +576,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -598,6 +611,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -616,6 +630,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -667,6 +682,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -687,6 +703,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -743,6 +760,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -761,6 +779,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -802,6 +821,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -822,6 +842,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -869,6 +890,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -887,6 +909,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -969,6 +992,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -989,6 +1013,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1063,6 +1088,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1081,6 +1107,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1163,6 +1190,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1183,6 +1211,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1270,6 +1299,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1288,6 +1318,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1354,6 +1385,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1374,6 +1406,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1451,6 +1484,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1469,6 +1503,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1551,6 +1586,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1571,6 +1607,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1661,6 +1698,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1679,6 +1717,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1761,6 +1800,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -1781,6 +1821,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -164,6 +164,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -201,6 +202,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -219,6 +221,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -249,6 +252,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -269,6 +273,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -303,6 +308,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -321,6 +327,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -351,6 +358,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -371,6 +379,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -405,6 +414,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -423,6 +433,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -454,6 +465,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -474,6 +486,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -511,6 +524,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -529,6 +543,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -562,6 +577,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -582,6 +598,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -625,6 +642,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -643,6 +661,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -683,6 +702,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -703,6 +723,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -747,6 +768,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -765,6 +787,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -805,6 +828,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -825,6 +849,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -873,6 +898,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -891,6 +917,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -936,6 +963,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -956,6 +984,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: false,
 					symbolAvailability: new (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -120,6 +120,7 @@ public partial interface IProtocol {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
@@ -179,6 +180,7 @@ public partial interface IProtocol {
 							type: "NS.MyEnum",
 							isBlittable: true,
 							isSmartEnum: true,
+							isReferenceType: false,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
@@ -235,8 +237,9 @@ public partial interface IProtocol {
 						new (
 							name: "Name",
 							type: "NS.MyEnum",
+							isBlittable: true,
 							isSmartEnum: false,
-			  isBlittable: true,
+							isReferenceType: false,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
@@ -291,6 +294,7 @@ public partial interface IProtocol {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name", "ObjCBindings.Property.Notification"])
@@ -347,6 +351,7 @@ public partial interface IProtocol {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
@@ -404,6 +409,7 @@ public partial interface IProtocol {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
@@ -424,6 +430,7 @@ public partial interface IProtocol {
 							type: "string",
 							isBlittable: false,
 							isSmartEnum: false,
+							isReferenceType: true,
 							symbolAvailability: new (),
 							attributes: [
 								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["surname"])

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertiesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertiesEqualityComparerTests.cs
@@ -26,6 +26,7 @@ public class PropertiesEqualityComparerTests {
 				type: "string",
 				isBlittable: false,
 				isSmartEnum: false,
+				isReferenceType: false,
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
@@ -39,6 +40,7 @@ public class PropertiesEqualityComparerTests {
 				type: "string",
 				isBlittable: false,
 				isSmartEnum: false,
+				isReferenceType: false,
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
@@ -54,6 +56,7 @@ public class PropertiesEqualityComparerTests {
 				type: "string",
 				isBlittable: false,
 				isSmartEnum: false,
+				isReferenceType: false,
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
@@ -76,6 +79,7 @@ public class PropertiesEqualityComparerTests {
 				type: "string",
 				isBlittable: false,
 				isSmartEnum: false,
+				isReferenceType: false,
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
@@ -91,6 +95,7 @@ public class PropertiesEqualityComparerTests {
 				type: "AVFoundation.AVVideo",
 				isBlittable: false,
 				isSmartEnum: false,
+				isReferenceType: false,
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
@@ -113,6 +118,7 @@ public class PropertiesEqualityComparerTests {
 				type: "string",
 				isBlittable: false,
 				isSmartEnum: false,
+				isReferenceType: false,
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
@@ -128,6 +134,7 @@ public class PropertiesEqualityComparerTests {
 				isSmartEnum: false,
 				type: "string",
 				isBlittable: false,
+				isReferenceType: false,
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
@@ -150,6 +157,7 @@ public class PropertiesEqualityComparerTests {
 				type: "string",
 				isBlittable: false,
 				isSmartEnum: false,
+				isReferenceType: false,
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [
@@ -165,6 +173,7 @@ public class PropertiesEqualityComparerTests {
 				type: "string",
 				isBlittable: false,
 				isSmartEnum: true,
+				isReferenceType: false,
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -16,8 +16,28 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDiffName ()
 	{
-		var x = new Property ("First", "string", false, false, new (), [], [], []);
-		var y = new Property ("Second", "string", false, false, new (), [], [], []);
+		var x = new Property (
+			name: "First", 
+			type: "string", 
+			isBlittable: false, 
+			isSmartEnum: false, 
+			isReferenceType: true, 
+			symbolAvailability: new (), 
+			attributes: [], 
+			modifiers: [], 
+			accessors: []
+		);
+		var y = new Property (
+			name: "Second", 
+			type: "string", 
+			isBlittable: false, 
+			isSmartEnum: false, 
+			isReferenceType: true, 
+			symbolAvailability: new (), 
+			attributes: [], 
+			modifiers: [], 
+			accessors: []
+		);
 
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
@@ -28,8 +48,124 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDiffType ()
 	{
-		var x = new Property ("First", "string", false, false, new (), [], [], []);
-		var y = new Property ("First", "int", false, false, new (), [], [], []);
+		var x = new Property (
+			name: "First", 
+			type: "string", 
+			isBlittable: false, 
+			isSmartEnum: false, 
+			isReferenceType: false, 
+			symbolAvailability: new (), 
+			attributes: [], 
+			modifiers: [], 
+			accessors: []
+		);
+		var y = new Property (
+			name: "First", 
+			type: "int", 
+			isBlittable: false, 
+			isSmartEnum: false, 
+			isReferenceType: false, 
+			symbolAvailability: new (), 
+			attributes: [], 
+			modifiers: [], 
+			accessors: []
+		);
+
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+	
+	[Fact]
+	public void CompareDiffIsReferenceType ()
+	{
+		var x = new Property (
+			name: "First", 
+			type: "string", 
+			isBlittable: false, 
+			isSmartEnum: false, 
+			isReferenceType: false, 
+			symbolAvailability: new (), 
+			attributes: [], 
+			modifiers: [], 
+			accessors: []
+		);
+		var y = new Property (
+			name: "First", 
+			type: "string", 
+			isBlittable: false, 
+			isSmartEnum: false, 
+			isReferenceType: true, 
+			symbolAvailability: new (), 
+			attributes: [], 
+			modifiers: [], 
+			accessors: []
+		);
+
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+	
+	[Fact]
+	public void CompareDiffIsBlittableType ()
+	{
+		var x = new Property (
+			name: "First", 
+			type: "string", 
+			isBlittable: false, 
+			isSmartEnum: false, 
+			isReferenceType: false, 
+			symbolAvailability: new (), 
+			attributes: [], 
+			modifiers: [], 
+			accessors: []
+		);
+		var y = new Property (
+			name: "First", 
+			type: "string", 
+			isBlittable: true, 
+			isSmartEnum: false, 
+			isReferenceType: false, 
+			symbolAvailability: new (), 
+			attributes: [], 
+			modifiers: [], 
+			accessors: []
+		);
+
+		Assert.False (x.Equals (y));
+		Assert.False (y.Equals (x));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+	
+	[Fact]
+	public void CompareDiffIsSmartEnum ()
+	{
+		var x = new Property (
+			name: "First", 
+			type: "string", 
+			isBlittable: false, 
+			isSmartEnum: false, 
+			isReferenceType: false, 
+			symbolAvailability: new (), 
+			attributes: [], 
+			modifiers: [], 
+			accessors: []
+		);
+		var y = new Property (
+			name: "First", 
+			type: "string", 
+			isBlittable: false, 
+			isSmartEnum: true, 
+			isReferenceType: false, 
+			symbolAvailability: new (), 
+			attributes: [], 
+			modifiers: [], 
+			accessors: []
+		);
 
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
@@ -40,11 +176,11 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDiffAttrs ()
 	{
-		var x = new Property ("First", "string", false, false, new (), [
+		var x = new Property ("First", "string", false, false, false, new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [], []);
-		var y = new Property ("First", "int", false, false, new (), [
+		var y = new Property ("First", "int", false, false, false, new (), [
 			new ("Attr2"),
 		], [], []);
 
@@ -57,13 +193,13 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDiffModifiers ()
 	{
-		var x = new Property ("First", "string", false, false, new (), [
+		var x = new Property ("First", "string", false, false, false, new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
 			SyntaxFactory.Token (SyntaxKind.AbstractKeyword)
 		], []);
-		var y = new Property ("First", "int", false, false, new (), [
+		var y = new Property ("First", "int", false, false, false, new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
@@ -79,7 +215,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDiffAccessors ()
 	{
-		var x = new Property ("First", "string", false, false, new (), [
+		var x = new Property ("First", "string", false, false, false, new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
@@ -88,7 +224,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 			new (AccessorKind.Getter, new (), [], []),
 			new (AccessorKind.Setter, new (), [], []),
 		]);
-		var y = new Property ("First", "int", false, false, new (), [
+		var y = new Property ("First", "int", false, false, false, new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
@@ -106,7 +242,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareEquals ()
 	{
-		var x = new Property ("First", "string", false, false, new (), [
+		var x = new Property ("First", "string", false, false, false, new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
@@ -115,7 +251,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 			new (AccessorKind.Getter, new (), [], []),
 			new (AccessorKind.Setter, new (), [], []),
 		]);
-		var y = new Property ("First", "string", false, false, new (), [
+		var y = new Property ("First", "string", false, false, false, new (), [
 			new ("Attr1"),
 			new ("Attr2"),
 		], [
@@ -151,6 +287,7 @@ public class TestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -160,7 +297,35 @@ public class TestClass {
 						new (AccessorKind.Getter, new (), [], [])
 					])
 			];
+			
+			const string valueTypeProperty = @"
+using System;
 
+namespace Test;
+
+public class TestClass {
+
+	public int Name { get; }
+}
+";
+			yield return [
+				valueTypeProperty,
+				new Property (
+					name: "Name",
+					type: "int",
+					isBlittable: true,
+					isSmartEnum: false,
+					isReferenceType: false,
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (AccessorKind.Getter, new (), [], [])
+					])
+			];
+			
 			const string automaticGetterSetter = @"
 using System;
 
@@ -179,6 +344,7 @@ public class TestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -206,6 +372,7 @@ public class TestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -232,6 +399,7 @@ public class TestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -260,6 +428,7 @@ public class TestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -290,6 +459,7 @@ public class TestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -320,6 +490,7 @@ public class TestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: new (),
 					attributes: [],
 					modifiers: [
@@ -358,6 +529,7 @@ public class TestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -397,6 +569,7 @@ public class TestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -441,6 +614,7 @@ public class TestClass {
 					type: "string",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),
@@ -491,6 +665,7 @@ namespace Test {
 					type: "Utils.MyClass",
 					isBlittable: false,
 					isSmartEnum: false,
+					isReferenceType: true,
 					symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 					attributes: [
 						new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios"]),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -17,25 +17,25 @@ public class PropertyTests : BaseGeneratorTestClass {
 	public void CompareDiffName ()
 	{
 		var x = new Property (
-			name: "First", 
-			type: "string", 
-			isBlittable: false, 
-			isSmartEnum: false, 
-			isReferenceType: true, 
-			symbolAvailability: new (), 
-			attributes: [], 
-			modifiers: [], 
+			name: "First",
+			type: "string",
+			isBlittable: false,
+			isSmartEnum: false,
+			isReferenceType: true,
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
 			accessors: []
 		);
 		var y = new Property (
-			name: "Second", 
-			type: "string", 
-			isBlittable: false, 
-			isSmartEnum: false, 
-			isReferenceType: true, 
-			symbolAvailability: new (), 
-			attributes: [], 
-			modifiers: [], 
+			name: "Second",
+			type: "string",
+			isBlittable: false,
+			isSmartEnum: false,
+			isReferenceType: true,
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
 			accessors: []
 		);
 
@@ -49,25 +49,25 @@ public class PropertyTests : BaseGeneratorTestClass {
 	public void CompareDiffType ()
 	{
 		var x = new Property (
-			name: "First", 
-			type: "string", 
-			isBlittable: false, 
-			isSmartEnum: false, 
-			isReferenceType: false, 
-			symbolAvailability: new (), 
-			attributes: [], 
-			modifiers: [], 
+			name: "First",
+			type: "string",
+			isBlittable: false,
+			isSmartEnum: false,
+			isReferenceType: false,
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
 			accessors: []
 		);
 		var y = new Property (
-			name: "First", 
-			type: "int", 
-			isBlittable: false, 
-			isSmartEnum: false, 
-			isReferenceType: false, 
-			symbolAvailability: new (), 
-			attributes: [], 
-			modifiers: [], 
+			name: "First",
+			type: "int",
+			isBlittable: false,
+			isSmartEnum: false,
+			isReferenceType: false,
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
 			accessors: []
 		);
 
@@ -76,30 +76,30 @@ public class PropertyTests : BaseGeneratorTestClass {
 		Assert.False (x == y);
 		Assert.True (x != y);
 	}
-	
+
 	[Fact]
 	public void CompareDiffIsReferenceType ()
 	{
 		var x = new Property (
-			name: "First", 
-			type: "string", 
-			isBlittable: false, 
-			isSmartEnum: false, 
-			isReferenceType: false, 
-			symbolAvailability: new (), 
-			attributes: [], 
-			modifiers: [], 
+			name: "First",
+			type: "string",
+			isBlittable: false,
+			isSmartEnum: false,
+			isReferenceType: false,
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
 			accessors: []
 		);
 		var y = new Property (
-			name: "First", 
-			type: "string", 
-			isBlittable: false, 
-			isSmartEnum: false, 
-			isReferenceType: true, 
-			symbolAvailability: new (), 
-			attributes: [], 
-			modifiers: [], 
+			name: "First",
+			type: "string",
+			isBlittable: false,
+			isSmartEnum: false,
+			isReferenceType: true,
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
 			accessors: []
 		);
 
@@ -108,30 +108,30 @@ public class PropertyTests : BaseGeneratorTestClass {
 		Assert.False (x == y);
 		Assert.True (x != y);
 	}
-	
+
 	[Fact]
 	public void CompareDiffIsBlittableType ()
 	{
 		var x = new Property (
-			name: "First", 
-			type: "string", 
-			isBlittable: false, 
-			isSmartEnum: false, 
-			isReferenceType: false, 
-			symbolAvailability: new (), 
-			attributes: [], 
-			modifiers: [], 
+			name: "First",
+			type: "string",
+			isBlittable: false,
+			isSmartEnum: false,
+			isReferenceType: false,
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
 			accessors: []
 		);
 		var y = new Property (
-			name: "First", 
-			type: "string", 
-			isBlittable: true, 
-			isSmartEnum: false, 
-			isReferenceType: false, 
-			symbolAvailability: new (), 
-			attributes: [], 
-			modifiers: [], 
+			name: "First",
+			type: "string",
+			isBlittable: true,
+			isSmartEnum: false,
+			isReferenceType: false,
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
 			accessors: []
 		);
 
@@ -140,30 +140,30 @@ public class PropertyTests : BaseGeneratorTestClass {
 		Assert.False (x == y);
 		Assert.True (x != y);
 	}
-	
+
 	[Fact]
 	public void CompareDiffIsSmartEnum ()
 	{
 		var x = new Property (
-			name: "First", 
-			type: "string", 
-			isBlittable: false, 
-			isSmartEnum: false, 
-			isReferenceType: false, 
-			symbolAvailability: new (), 
-			attributes: [], 
-			modifiers: [], 
+			name: "First",
+			type: "string",
+			isBlittable: false,
+			isSmartEnum: false,
+			isReferenceType: false,
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
 			accessors: []
 		);
 		var y = new Property (
-			name: "First", 
-			type: "string", 
-			isBlittable: false, 
-			isSmartEnum: true, 
-			isReferenceType: false, 
-			symbolAvailability: new (), 
-			attributes: [], 
-			modifiers: [], 
+			name: "First",
+			type: "string",
+			isBlittable: false,
+			isSmartEnum: true,
+			isReferenceType: false,
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
 			accessors: []
 		);
 
@@ -297,7 +297,7 @@ public class TestClass {
 						new (AccessorKind.Getter, new (), [], [])
 					])
 			];
-			
+
 			const string valueTypeProperty = @"
 using System;
 
@@ -325,7 +325,7 @@ public class TestClass {
 						new (AccessorKind.Getter, new (), [], [])
 					])
 			];
-			
+
 			const string automaticGetterSetter = @"
 using System;
 


### PR DESCRIPTION
We will later use that information for the backing field generation.