### PR TITLE
[tests] Fix parallel build of test libraries.

### DIFF
--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -332,7 +332,7 @@ $(foreach rid,$(DOTNET_RUNTIME_IDENTIFIERS),$(eval $(call SwiftTest2AddDependenc
 # create an xcframework of frameworks
 define TestFrameworkXCFramework
 $(1)_XCFRAMEWORKS += $$(foreach xcframeworkPlatform,$$(XCFRAMEWORK_PLATFORMS),.libs/$$(xcframeworkPlatform)/$(1).framework)
-$(1)_XCTARGETS += $$(foreach xcframeworkPlatform,$$(XCFRAMEWORK_PLATFORMS),.libs/$$(xcframeworkPlatform)/$(1).framework/$(1))
+$(1)_XCTARGETS += $$(foreach xcframeworkPlatform,$$(XCFRAMEWORK_PLATFORMS),.libs/$$(xcframeworkPlatform)/$(1).framework.stamp)
 .libs/$(1).xcframework: $$($(1)_XCTARGETS) Makefile
 	$$(Q) rm -rf $$@
 	$$(Q_GEN) $$(XCODE_DEVELOPER_ROOT)/usr/bin/xcodebuild -quiet -create-xcframework $$(foreach fw,$$($(1)_XCFRAMEWORKS),-framework $$(fw)) -output $$@
@@ -343,7 +343,7 @@ $(foreach testFramework,$(TEST_FRAMEWORKS),$(eval $(call TestFrameworkXCFramewor
 # create an xcframework of libraries
 define TestLibraryXCFramework
 $(1)_XCFRAMEWORKS += $$(foreach xcframeworkPlatform,$$(XCFRAMEWORK_PLATFORMS),.libs/$$(xcframeworkPlatform)/$(1).a)
-$(1)_XCTARGETS += $$(foreach xcframeworkPlatform,$$(XCFRAMEWORK_PLATFORMS),.libs/$$(xcframeworkPlatform)/$(1).a)
+$(1)_XCTARGETS += $$(foreach xcframeworkPlatform,$$(XCFRAMEWORK_PLATFORMS),.libs/$$(xcframeworkPlatform).stamp)
 .libs/$(1).xcframework: $$($(1)_XCTARGETS) Makefile
 	$$(Q) rm -rf $$@
 	$$(Q_GEN) $$(XCODE_DEVELOPER_ROOT)/usr/bin/xcodebuild -quiet -create-xcframework $$(foreach fw,$$($(1)_XCFRAMEWORKS),-library $$(fw)) -output $$@

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -343,7 +343,7 @@ $(foreach testFramework,$(TEST_FRAMEWORKS),$(eval $(call TestFrameworkXCFramewor
 # create an xcframework of libraries
 define TestLibraryXCFramework
 $(1)_XCFRAMEWORKS += $$(foreach xcframeworkPlatform,$$(XCFRAMEWORK_PLATFORMS),.libs/$$(xcframeworkPlatform)/$(1).a)
-$(1)_XCTARGETS += $$(foreach xcframeworkPlatform,$$(XCFRAMEWORK_PLATFORMS),.libs/$$(xcframeworkPlatform).stamp)
+$(1)_XCTARGETS += $$(foreach xcframeworkPlatform,$$(XCFRAMEWORK_PLATFORMS),.libs/$$(xcframeworkPlatform)/$(1).a)
 .libs/$(1).xcframework: $$($(1)_XCTARGETS) Makefile
 	$$(Q) rm -rf $$@
 	$$(Q_GEN) $$(XCODE_DEVELOPER_ROOT)/usr/bin/xcodebuild -quiet -create-xcframework $$(foreach fw,$$($(1)_XCFRAMEWORKS),-library $$(fw)) -output $$@


### PR DESCRIPTION
Fix parallel build of test libraries by depending on the right thing when
building xcframeworks: the stamp file of each containing framework.

Depending on the actual binary doesn't work:

1. The entire framework might not be built, only the binary.
2. The binary might not even be the binary, it might only be a symlink to the
   binary (for desktop platforms).

Fixes random build failures like:

	[...]
    GEN      SwiftTest2.xcframework
      Determining projects to restore...
    ZIP      XTest.framework.zip
    SWIFT  [maccatalyst-arm64] libSwiftTest2.dylib
    SWIFT  [maccatalyst-x64] libSwiftTest2.dylib
    ZIP      SwiftTest.framework.zip
      Restored /Users/builder/azdo/_work/9/s/xamarin-macios/tests/test-libraries/testgenerator.csproj (in 131 ms).
    xcframework successfully written out to: /Users/builder/azdo/_work/9/s/xamarin-macios/tests/test-libraries/.libs/SwiftTest.xcframework
    error: unable to read the file at '/Users/builder/azdo/_work/9/s/xamarin-macios/tests/test-libraries/.libs/maccatalyst/SwiftTest2.framework/SwiftTest2'
    make[2]: *** [.libs/SwiftTest2.xcframework] Error 70
    make[2]: *** Waiting for unfinished jobs....