### PR TITLE
[msbuild] Don't use 'TRACE' to enable verbose tracing.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/BundleResource.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/BundleResource.cs
@@ -1,4 +1,4 @@
-// #define TRACE
+// #define TRACE_TASK
 
 using System;
 using System.Diagnostics;
@@ -67,7 +67,7 @@ namespace Xamarin.MacDev {
 				.ToList ();
 		}
 
-		[Conditional ("TRACE")]
+		[Conditional ("TRACE_TASK")]
 		static void Trace (Task task, string msg)
 		{
 			task.Log.LogMessage (MessageImportance.Low, msg);


### PR DESCRIPTION
"TRACE" is defined by default, so this ends up always tracing.

Instead use a different conditional compilation symbol.