### PR TITLE
[CI] Move away from automatic pool selector and allow builds on dev/*

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -16,15 +16,6 @@ parameters:
     type: string
     default: 'Sonoma'
 
-  - name: pool
-    type: string
-    displayName: Bot pool to use
-    default: automatic
-    values:
-      - pr
-      - ci
-      - automatic
-
   - name: runGovernanceTests
     displayName: Run Governance Checks
     type: boolean
@@ -233,7 +224,7 @@ extends:
           macOSName: ${{ parameters.macOSName }}
           isPR: false
           provisionatorChannel: ${{ parameters.provisionatorChannel }}
-          pool: ${{ parameters.pool }}
+          pool: $(CIBuildPool)
           runGovernanceTests: ${{ parameters.runGovernanceTests }}
           forceInsertion: ${{ parameters.forceInsertion }}
           pushNugets: ${{ parameters.pushNugets }}

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -152,7 +152,7 @@ variables:
 trigger:
   branches:
     include:
-      - refs/heads/dev/*
+    - refs/heads/dev/*
 
 pr:
   autoCancel: true

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -17,15 +17,6 @@ parameters:
   type: string
   default: 'Sonoma'
 
-- name: pool
-  type: string
-  displayName: Bot pool to use
-  default: automatic
-  values:
-  - pr
-  - ci
-  - automatic
-
 - name: runGovernanceTests
   displayName: Run Governance Checks
   type: boolean
@@ -158,7 +149,10 @@ variables:
   value: false
 
 
-trigger: none
+trigger:
+  branches:
+    include:
+      - refs/heads/dev/*
 
 pr:
   autoCancel: true
@@ -218,7 +212,7 @@ extends:
         macOSName: ${{ parameters.macOSName }}
         isPR: true
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
-        pool: ${{ parameters.pool }}
+        pool: $(PRBuildPool)
         runGovernanceTests: ${{ parameters.runGovernanceTests }}
         forceInsertion: ${{ parameters.forceInsertion }}
         pushNugets: false

--- a/tools/devops/automation/run-ci-api-diff.yml
+++ b/tools/devops/automation/run-ci-api-diff.yml
@@ -16,3 +16,4 @@ extends:
   template: templates/pipelines/api-diff-pipeline.yml
   parameters:
     isPR: false
+    pool: $(CIBuildPool)

--- a/tools/devops/automation/run-pr-api-diff.yml
+++ b/tools/devops/automation/run-pr-api-diff.yml
@@ -15,3 +15,4 @@ extends:
   template: templates/pipelines/api-diff-pipeline.yml
   parameters:
     isPR: true
+    pool: $(PRBuildPool)

--- a/tools/devops/automation/templates/api-diff-stage.yml
+++ b/tools/devops/automation/templates/api-diff-stage.yml
@@ -6,11 +6,6 @@ parameters:
 
 - name: pool
   type: string
-  default: automatic
-  values:
-  - pr
-  - ci
-  - automatic
 
 - name: isPR
   type: boolean
@@ -36,21 +31,6 @@ stages:
 - stage: configure_build
   displayName: 'Configure'
   jobs:
-
-  - ${{ if eq(parameters.pool, 'automatic') }}:
-    - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
-      pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
-        vmImage: ubuntu-latest
-      steps:
-      - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-
-      # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-      - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
-        parameters:
-          agentPoolPR: $(PRBuildPool)
-          agentPoolPRUrl: $(PRBuildPoolUrl)
-          agentPoolCI: $(CIBuildPool)
-          agentPoolCIUrl: $(CIBuildPoolUrl)
 
   - job: configure
     displayName: 'Configure build'

--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -40,18 +40,12 @@ jobs:
   displayName: 'Detect API changes'
   timeoutInMinutes: 1000
   variables:
-    ${{ if eq(parameters.pool, 'automatic') }}:
-      AgentPoolComputed: $[ stageDependencies.configure_build.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
-    ${{ if eq(parameters.pool, 'ci') }}:
-      AgentPoolComputed: $(CIBuildPool)
-    ${{ if eq(parameters.pool, 'pr') }}:
-      AgentPoolComputed: $(PRBuildPool)
     PR_ID: $[ stageDependencies.configure_build.configure.outputs['labels.pr_number'] ]
     # set the branch variable name, this is required by jenkins and we have a lot of scripts that depend on it
     BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
     XHARNESS_LABELS: $[ stageDependencies.configure_build.configure.outputs['labels.xharness_labels'] ]
   pool:
-    name: $(AgentPoolComputed)
+    name: ${{ parameters.pool }}
     demands:
     - Agent.OS -equals Darwin
     - macOS.Name -equals ${{ parameters.macOSName }}

--- a/tools/devops/automation/templates/build/build-mac-tests-stage.yml
+++ b/tools/devops/automation/templates/build/build-mac-tests-stage.yml
@@ -42,12 +42,6 @@ jobs:
   timeoutInMinutes: 180
   variables:
     DOTNET_PLATFORMS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.DOTNET_PLATFORMS'] ]
-    ${{ if eq(parameters.pool, 'automatic') }}:
-      AgentPoolComputed: $[ stageDependencies.configure_build.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
-    ${{ if eq(parameters.pool, 'ci') }}:
-      AgentPoolComputed: $(CIBuildPool)
-    ${{ if eq(parameters.pool, 'pr') }}:
-      AgentPoolComputed: $(PRBuildPool)
     # add all the variables that have been parsed by the configuration step. Could we have a less verbose way??
     # old and ugly env var use by jenkins, we do have parts of the code that use it, contains the PR number
     PR_ID: $[ stageDependencies.configure_build.configure.outputs['labels.pr_number'] ]
@@ -57,7 +51,7 @@ jobs:
   condition: ne(stageDependencies.configure_build.configure.outputs['decisions.RUN_MAC_TESTS'],'')
   pool:
     os: macOS
-    name: $(AgentPoolComputed)
+    name: ${{ parameters.pool }}
     demands:
     - Agent.OS -equals Darwin
     - macOS.Name -equals ${{ parameters.macOSName }}

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -46,12 +46,6 @@ jobs:
       INCLUDE_DOTNET_MACCATALYST: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_MACCATALYST'] ]
       INCLUDE_DOTNET_MACOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_MACOS'] ]
       INCLUDE_DOTNET_TVOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_TVOS'] ]
-      ${{ if eq(parameters.pool, 'automatic') }}:
-        AgentPoolComputed: $[ stageDependencies.configure_build.AgentPoolSelector.outputs['setAgentPool.AgentPoolComputed'] ]
-      ${{ if eq(parameters.pool, 'ci') }}:
-        AgentPoolComputed: $(CIBuildPool)
-      ${{ if eq(parameters.pool, 'pr') }}:
-        AgentPoolComputed: $(PRBuildPool)
       # add all the variables that have been parsed by the configuration step. Could we have a less verbose way??
       #
       # build-package
@@ -71,7 +65,7 @@ jobs:
       RUN_MAC_TESTS: $[ stageDependencies.configure_build.configure.outputs['decisions.RUN_MAC_TESTS'] ]
     pool:
       os: macOS
-      name: $(AgentPoolComputed)
+      name: ${{ parameters.pool }}
       demands:
         - Agent.OS -equals Darwin
         - macOS.Name -equals ${{ parameters.macOSName }}

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -6,11 +6,6 @@ parameters:
 
   - name: pool
     type: string
-    default: automatic
-    values:
-      - pr
-      - ci
-      - automatic
 
   - name: runGovernanceTests
     type: boolean

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -175,22 +175,6 @@ stages:
     ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.dependsOnResult, '')) }}:
       condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
     jobs:
-      - ${{ if eq(parameters.pool, 'automatic') }}:
-          - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
-            pool:  # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
-              name: AzurePipelines-EO
-              demands:
-                - ImageOverride -equals 1ESPT-Windows2022
-            steps:
-              - checkout: none  # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-
-              # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-              - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
-                parameters:
-                  agentPoolPR: $(PRBuildPool)
-                  agentPoolPRUrl: $(PRBuildPoolUrl)
-                  agentPoolCI: $(CIBuildPool)
-                  agentPoolCIUrl: $(CIBuildPoolUrl)
 
       - job: configure
         displayName: 'Configure build'

--- a/tools/devops/automation/templates/pipelines/api-diff-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/api-diff-pipeline.yml
@@ -16,11 +16,6 @@ parameters:
 - name: pool
   type: string
   displayName: Bot pool to use
-  default: automatic
-  values:
-  - pr
-  - ci
-  - automatic
 
 - name: isPR
   displayName: Is PR build

--- a/tools/devops/automation/templates/pipelines/run-api-scan.yml
+++ b/tools/devops/automation/templates/pipelines/run-api-scan.yml
@@ -91,22 +91,6 @@ stages:
   - stage: configure_build
     displayName: 'Configure'
     jobs:
-
-      - ${{ if eq(parameters.pool, 'automatic') }}:
-          - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
-            pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
-              vmImage: ubuntu-latest
-            steps:
-              - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-
-              # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-              - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
-                parameters:
-                  agentPoolPR: $(PRBuildPool)
-                  agentPoolPRUrl: $(PRBuildPoolUrl)
-                  agentPoolCI: $(CIBuildPool)
-                  agentPoolCIUrl: $(CIBuildPoolUrl)
-
       - job: configure
         displayName: 'Configure build'
         pool:

--- a/tools/devops/automation/templates/pipelines/run-tests-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/run-tests-pipeline.yml
@@ -19,11 +19,6 @@ parameters:
   - name: pool
     type: string
     displayName: Bot pool to use
-    default: automatic
-    values:
-      - pr
-      - ci
-      - automatic
 
   - name: runTests
     displayName: Run Simulator Tests

--- a/tools/devops/automation/templates/pipelines/run-tests-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/run-tests-pipeline.yml
@@ -16,10 +16,6 @@ parameters:
     type: string
     default: 'Sonoma'
 
-  - name: pool
-    type: string
-    displayName: Bot pool to use
-
   - name: runTests
     displayName: Run Simulator Tests
     type: boolean
@@ -109,7 +105,6 @@ stages:
       macOSName: ${{ parameters.macOSName }}
       isPR: ${{ parameters.isPR }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-      pool: ${{ parameters.pool }}
       runTests: ${{ parameters.runTests }}
       runDeviceTests: ${{ parameters.runDeviceTests }}
       runWindowsIntegration: ${{ parameters.runWindowsIntegration }}

--- a/tools/devops/automation/templates/tests-stage.yml
+++ b/tools/devops/automation/templates/tests-stage.yml
@@ -4,9 +4,6 @@ parameters:
   type: string
   default: 'latest'
 
-- name: pool
-  type: string
-
 - name: runTests
   type: boolean
   default: true

--- a/tools/devops/automation/templates/tests-stage.yml
+++ b/tools/devops/automation/templates/tests-stage.yml
@@ -6,11 +6,6 @@ parameters:
 
 - name: pool
   type: string
-  default: automatic
-  values:
-  - pr
-  - ci
-  - automatic
 
 - name: runTests
   type: boolean
@@ -170,21 +165,6 @@ stages:
     condition: eq(dependencies.${{ parameters.dependsOn }}.result, '${{ parameters.dependsOnResult }}')
   jobs:
   
-  - ${{ if eq(parameters.pool, 'automatic') }}:
-    - job: AgentPoolSelector       # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
-      pool:                        # Consider using an agentless (server) job here, but would need to host selection logic as an Azure function: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#server
-        vmImage: ubuntu-latest
-      steps:
-      - checkout: none             # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#checkout
-
-      # Selects appropriate agent pool based on trigger type (PR or CI); manually triggered builds target the PR pool
-      - template: azure-devops-pools/agent-pool-selector.yml@yaml-templates
-        parameters:
-          agentPoolPR: $(PRBuildPool)
-          agentPoolPRUrl: $(PRBuildPoolUrl)
-          agentPoolCI: $(CIBuildPool)
-          agentPoolCIUrl: $(CIBuildPoolUrl)
-
   - job: configure
     displayName: 'Configure build'
     pool:
@@ -218,7 +198,7 @@ stages:
     supportedPlatforms: ${{ parameters.supportedPlatforms }}
     stageName: 'simulator_tests'
     displayName: '${{ parameters.stageDisplayNamePrefix }}Simulator tests'
-    testPool: '' # use the default
+    testPool: $(PRBuildPool)
     statusContext: 'VSTS: simulator tests'
     makeTarget: 'jenkins'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -100,12 +100,8 @@ stages:
       BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
       XHARNESS_LABELS: $[ stageDependencies.configure_build.configure.outputs['labels.xharness_labels'] ]
       DOTNET_PLATFORMS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.DOTNET_PLATFORMS'] ]
-      ${{ if eq(parameters.testPool, '') }}:
-        AgentPoolComputed: $(PRBuildPool)
-      ${{ else }}:
-        AgentPoolComputed: ${{ parameters.testPool }}
     pool:
-      name: $(AgentPoolComputed)
+      name: ${{ parameters.testPool }}
       demands:
       - Agent.OS -equals Darwin
       - macOS.Name -equals ${{ parameters.macOSName }}


### PR DESCRIPTION
Improve the way we work by:

1. Remove the need to do the autopool selection. This was needed when we had a single pipeline.
2. Make or developers life easier by autimatically build their dev/ branches.