### PR TITLE
[UIKit] Fix inexact stream read in UIImage.

### DIFF
--- a/src/UIKit/UIImage.cs
+++ b/src/UIKit/UIImage.cs
@@ -102,7 +102,7 @@ namespace UIKit {
 				throw new ArgumentException (String.Format ("No resource named `{0}' found", name));
 
 			byte [] buffer = new byte [stream.Length];
-			stream.Read (buffer, 0, buffer.Length);
+			stream.ReadExactly (buffer, 0, buffer.Length);
 			unsafe {
 				fixed (byte* p = buffer) {
 					var data = NSData.FromBytes ((IntPtr) p, (uint) stream.Length);


### PR DESCRIPTION
Fixes this analyzer warning:

    error CA2022: Avoid inexact read with 'System.IO.Stream.Read(byte[], int, int)' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2022)