### PR TITLE
[CI] Batch developer builds in the CI to use resources better.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -163,6 +163,9 @@ variables:
     value: true
 
 trigger:
+  # because we are building for developers branches, batch the builds to use 
+  # less resources. Otherwise, we would be building for every commit.
+  batch: true
   branches:
     include:
       - '*'


### PR DESCRIPTION
This is annoying because there is a diff between PR and CI trigger. PRs will cancel previous builds (which was giving problems due to the auto format). However, now we have the other problem around in which we are executing the build several times. We cannot cancel, but we can batch the builds.

The last commit will always be build.