### PR TITLE
[xharness] There's no need to check platform/configuration when setting values in a project file.

### DIFF
--- a/tests/xharness/Jenkins/TestData.cs
+++ b/tests/xharness/Jenkins/TestData.cs
@@ -12,7 +12,6 @@ namespace Xharness.Jenkins {
 		public bool Profiling;
 		public string LinkMode;
 		public string Defines;
-		public string Undefines;
 		public bool? Ignored;
 		public bool EnableSGenConc;
 		public bool UseLlvm;

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -172,7 +172,6 @@ namespace Xharness.Jenkins {
 					var profiling = test_data.Profiling;
 					var link_mode = test_data.LinkMode;
 					var defines = test_data.Defines;
-					var undefines = test_data.Undefines;
 					var ignored = test_data.Ignored;
 					var known_failure = test_data.KnownFailure;
 					var candidates = test_data.Candidates;
@@ -202,31 +201,22 @@ namespace Xharness.Jenkins {
 							clone.Xml.SetProperty ("MtouchLink", link_mode);
 						}
 						if (!string.IsNullOrEmpty (defines)) {
-							clone.Xml.AddAdditionalDefines (defines, task.ProjectPlatform, configuration);
+							clone.Xml.AddAdditionalDefines (defines);
 							if (clone.ProjectReferences is not null) {
 								foreach (var pr in clone.ProjectReferences) {
-									pr.Xml.AddAdditionalDefines (defines, task.ProjectPlatform, configuration);
+									pr.Xml.AddAdditionalDefines (defines);
 									pr.Xml.Save (pr.Path);
 								}
 							}
 						}
-						if (!string.IsNullOrEmpty (undefines)) {
-							clone.Xml.RemoveDefines (undefines, task.ProjectPlatform, configuration);
-							if (clone.ProjectReferences is not null) {
-								foreach (var pr in clone.ProjectReferences) {
-									pr.Xml.RemoveDefines (undefines, task.ProjectPlatform, configuration);
-									pr.Xml.Save (pr.Path);
-								}
-							}
-						}
-						clone.Xml.SetNode (isMac ? "Profiling" : "MTouchProfiling", profiling ? "True" : "False", task.ProjectPlatform, configuration);
+						clone.Xml.SetNode (isMac ? "Profiling" : "MTouchProfiling", profiling ? "True" : "False");
 						if (test_data.EnableSGenConc)
 							clone.Xml.SetProperty ("EnableSGenConc", "true");
 						if (use_llvm)
 							clone.Xml.SetProperty ("MtouchUseLlvm", "true");
 
 						if (!debug && !isMac)
-							clone.Xml.SetMtouchUseLlvm (true, task.ProjectPlatform, configuration);
+							clone.Xml.SetNode ("MtouchUseLlvm", "true");
 						if (use_mono_runtime.HasValue)
 							clone.Xml.SetProperty ("UseMonoRuntime", use_mono_runtime.Value ? "true" : "false");
 						if (!string.IsNullOrEmpty (runtime_identifer))


### PR DESCRIPTION
We create a new project file for every build configuration we run anyways.

This fixes this output when xharness is run:

> Could not parse condition; $(TargetFramework.EndsWith('-ios'))

Also remove some unused code.