### PR TITLE
[xharness] Add debug output to track down random error.

### DIFF
--- a/tests/xharness/Jenkins/Jenkins.cs
+++ b/tests/xharness/Jenkins/Jenkins.cs
@@ -91,17 +91,17 @@ namespace Xharness.Jenkins {
 		public bool IsIncluded (TestProject project)
 		{
 			if (!project.IsExecutableProject) {
-				MainLog.WriteLine ($"Ignoring {project.Name} with label {project.Label} because is not a executable project.");
+				MainLog.WriteLine ($"Ignoring {project.Name} for {project.TestPlatform} with label {project.Label} because is not a executable project.");
 				return false;
 			}
 
 			if (!TestSelection.IsEnabled (TestLabel.SystemPermission) && project.Label == TestLabel.Introspection) {
-				MainLog.WriteLine ($"Ignoring {project.Name} with label {project.Label} because we cannot include the system permission tests");
+				MainLog.WriteLine ($"Ignoring {project.Name} for {project.TestPlatform} with label {project.Label} because we cannot include the system permission tests");
 				return false;
 			}
 
 			var rv = TestSelection.IsEnabled (project.Label);
-			MainLog.WriteLine ($"Including {project.Name} with label {project.Label.ToString ()}: {rv}");
+			MainLog.WriteLine ($"Including {project.Name} for {project.TestPlatform} with label {project.Label.ToString ()}: {rv}");
 			return rv;
 		}
 

--- a/tests/xharness/Jenkins/MacTaskTestsFactory.cs
+++ b/tests/xharness/Jenkins/MacTaskTestsFactory.cs
@@ -83,6 +83,9 @@ namespace Xharness.Jenkins {
 					}
 
 					rv.AddRange (variations);
+
+					foreach (var v in variations)
+						this.Jenkins.MainLog.WriteLine ($"Created mac test variation '{v.Variation}' for {project.Name} on {project.TestPlatform}. Ignored: {v.Ignored}");
 				}
 			}
 


### PR DESCRIPTION
Sometimes xharness tries to build a test for Mac Catalyst, when Mac Catalyst
is disabled (but macOS is enabled). This is not consistent, which makes it
hard to track down: so add some debug spew that will hopefully lead in the
right direction.