### PR TITLE
[src] Ignore CS1573 in certain cases.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -5165,7 +5165,7 @@ public partial class Generator : IMemberGatherer {
 		if (include_extensions) {
 			// disable CS1573, which can happen when the original member in the api definition has xml comments and we copy that xml comment into the generated extension member - because we may add parameters to method signatures, and the new parameters won't have an xml comment.
 			print ("#pragma warning disable CS1573"); // Parameter 'This' has no matching param tag in the XML comment for '...' (but other parameters do)
-			// extension methods
+													  // extension methods
 			if (BindingTouch.SupportsXmlDocumentation) {
 				print ($"/// <summary>Extension methods to the <see cref=\"I{TypeName}\" /> interface to support all the methods from the {protocol_name} protocol.</summary>");
 				print ($"/// <remarks>");

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -4863,6 +4863,9 @@ public partial class Generator : IMemberGatherer {
 		var extensionMethods = optionalInstanceMethods.Concat (requiredInstanceMethods.Where (v => IsRequired (v, out var generateExtensionMethod) && generateExtensionMethod));
 		var extensionProperties = optionalInstanceProperties.Concat (requiredInstanceProperties.Where (v => IsRequired (v, out var generateExtensionMethod) && generateExtensionMethod));
 
+		// disable CS1573, which can happen when the original member in the api definition has xml comments and we copy that xml comment into the generated interface - because we may add parameters to method signatures, and the new parameters won't have an xml comment.
+		print ("#pragma warning disable CS1573"); // Parameter 'This' has no matching param tag in the XML comment for '...' (but other parameters do)
+
 		WriteDocumentation (type);
 
 		PrintAttributes (type, platform: true, preserve: true, advice: true);
@@ -5153,11 +5156,15 @@ public partial class Generator : IMemberGatherer {
 		print ("}");
 		print ("");
 
+		print ("#pragma warning restore CS1573");
+
 		// avoid (for unified) all the metadata for empty static classes, we can introduce them later when required
 		bool include_extensions = false;
 		if (backwardsCompatibleCodeGeneration)
 			include_extensions = extensionMethods.Any () || extensionProperties.Any () || requiredInstanceAsyncMethods.Any ();
 		if (include_extensions) {
+			// disable CS1573, which can happen when the original member in the api definition has xml comments and we copy that xml comment into the generated extension member - because we may add parameters to method signatures, and the new parameters won't have an xml comment.
+			print ("#pragma warning disable CS1573"); // Parameter 'This' has no matching param tag in the XML comment for '...' (but other parameters do)
 			// extension methods
 			if (BindingTouch.SupportsXmlDocumentation) {
 				print ($"/// <summary>Extension methods to the <see cref=\"I{TypeName}\" /> interface to support all the methods from the {protocol_name} protocol.</summary>");
@@ -5199,6 +5206,7 @@ public partial class Generator : IMemberGatherer {
 			indent--;
 			print ("}");
 			print ("");
+			print ("#pragma warning restore CS1573");
 		}
 
 		// Add API from base interfaces we also need to implement.

--- a/tests/generator/ExpectedXmlDocs.MacCatalyst.xml
+++ b/tests/generator/ExpectedXmlDocs.MacCatalyst.xml
@@ -226,6 +226,26 @@
             Summary for PA1.PMethod
             </summary>
         </member>
+        <member name="M:XmlDocumentation.IP1.PMethodWithArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.IP1._PMethodWithArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.IP1.PMethodWithUndocumentedArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.IP1._PMethodWithUndocumentedArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary>
+        </member>
         <member name="P:XmlDocumentation.IP1.PProperty">
             <summary>
             Summary for P1.PProperty
@@ -245,6 +265,16 @@
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.P1_Extensions.PMethodWithArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.P1_Extensions.PMethodWithUndocumentedArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
             </summary>
         </member>
         <member name="M:XmlDocumentation.P1_Extensions.GetPProperty(XmlDocumentation.IP1)">
@@ -354,6 +384,16 @@
         <member name="M:XmlDocumentation.T1.PAMethod">
             <summary>
             Summary for PA1.PMethod
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.PMethodWithArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.T1.PMethodWithUndocumentedArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
             </summary>
         </member>
         <member name="P:XmlDocumentation.T1.PAProperty">

--- a/tests/generator/ExpectedXmlDocs.iOS.xml
+++ b/tests/generator/ExpectedXmlDocs.iOS.xml
@@ -226,6 +226,26 @@
             Summary for PA1.PMethod
             </summary>
         </member>
+        <member name="M:XmlDocumentation.IP1.PMethodWithArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.IP1._PMethodWithArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.IP1.PMethodWithUndocumentedArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.IP1._PMethodWithUndocumentedArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary>
+        </member>
         <member name="P:XmlDocumentation.IP1.PProperty">
             <summary>
             Summary for P1.PProperty
@@ -245,6 +265,16 @@
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.P1_Extensions.PMethodWithArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.P1_Extensions.PMethodWithUndocumentedArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
             </summary>
         </member>
         <member name="M:XmlDocumentation.P1_Extensions.GetPProperty(XmlDocumentation.IP1)">
@@ -354,6 +384,16 @@
         <member name="M:XmlDocumentation.T1.PAMethod">
             <summary>
             Summary for PA1.PMethod
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.PMethodWithArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.T1.PMethodWithUndocumentedArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
             </summary>
         </member>
         <member name="P:XmlDocumentation.T1.PAProperty">

--- a/tests/generator/ExpectedXmlDocs.macOS.xml
+++ b/tests/generator/ExpectedXmlDocs.macOS.xml
@@ -226,6 +226,26 @@
             Summary for PA1.PMethod
             </summary>
         </member>
+        <member name="M:XmlDocumentation.IP1.PMethodWithArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.IP1._PMethodWithArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.IP1.PMethodWithUndocumentedArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.IP1._PMethodWithUndocumentedArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary>
+        </member>
         <member name="P:XmlDocumentation.IP1.PProperty">
             <summary>
             Summary for P1.PProperty
@@ -245,6 +265,16 @@
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.P1_Extensions.PMethodWithArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.P1_Extensions.PMethodWithUndocumentedArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
             </summary>
         </member>
         <member name="M:XmlDocumentation.P1_Extensions.GetPProperty(XmlDocumentation.IP1)">
@@ -354,6 +384,16 @@
         <member name="M:XmlDocumentation.T1.PAMethod">
             <summary>
             Summary for PA1.PMethod
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.PMethodWithArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.T1.PMethodWithUndocumentedArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
             </summary>
         </member>
         <member name="P:XmlDocumentation.T1.PAProperty">

--- a/tests/generator/ExpectedXmlDocs.tvOS.xml
+++ b/tests/generator/ExpectedXmlDocs.tvOS.xml
@@ -226,6 +226,26 @@
             Summary for PA1.PMethod
             </summary>
         </member>
+        <member name="M:XmlDocumentation.IP1.PMethodWithArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.IP1._PMethodWithArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.IP1.PMethodWithUndocumentedArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.IP1._PMethodWithUndocumentedArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary>
+        </member>
         <member name="P:XmlDocumentation.IP1.PProperty">
             <summary>
             Summary for P1.PProperty
@@ -245,6 +265,16 @@
         <member name="M:XmlDocumentation.P1_Extensions.PMethod(XmlDocumentation.IP1)">
             <summary>
             Summary for P1.PMethod
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.P1_Extensions.PMethodWithArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.P1_Extensions.PMethodWithUndocumentedArgs(XmlDocumentation.IP1,System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
             </summary>
         </member>
         <member name="M:XmlDocumentation.P1_Extensions.GetPProperty(XmlDocumentation.IP1)">
@@ -354,6 +384,16 @@
         <member name="M:XmlDocumentation.T1.PAMethod">
             <summary>
             Summary for PA1.PMethod
+            </summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.PMethodWithArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
+            </summary><param name="arg0">Docs for arg0.</param>
+        </member>
+        <member name="M:XmlDocumentation.T1.PMethodWithUndocumentedArgs(System.Int32)">
+            <summary>
+            Summary for P1.PMethodWithArgs
             </summary>
         </member>
         <member name="P:XmlDocumentation.T1.PAProperty">

--- a/tests/generator/tests/xmldocs.cs
+++ b/tests/generator/tests/xmldocs.cs
@@ -76,6 +76,20 @@ namespace XmlDocumentation {
 		[Abstract]
 		[Export ("propertyRequired")]
 		int PAProperty { get; set; }
+
+		/// <summary>
+		/// Summary for P1.PMethodWithArgs
+		/// </summary>
+		/// <param name="arg0">Docs for arg0.</param>
+		[Export ("method:")]
+		int PMethodWithArgs (int arg0);
+
+		/// <summary>
+		/// Summary for P1.PMethodWithArgs
+		/// </summary>
+		// No <param /> tag here
+		[Export ("methodWithUndocumentedArgs:")]
+		int PMethodWithUndocumentedArgs (int arg0);
 	}
 
 	/// <summary>


### PR DESCRIPTION
CS1573 is raised when some, but not all, parameters in a method have xml
comments.

The generated code can trigger this when an api definition has a method with
documented parameters, and then the generator creates a method with additional
parameters (which won't have xml comments).