### PR TITLE
[UIKit] Make UIApplication implement UIAccessibility. Fixes #21925.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -2419,7 +2419,7 @@ namespace UIKit {
 	[NoWatch]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (UIResponder))]
-	interface UIApplication {
+	interface UIApplication : UIAccessibility {
 		[Static, ThreadSafe]
 		[Export ("sharedApplication")]
 		UIApplication SharedApplication { get; }


### PR DESCRIPTION
UIAccessibility is a category on NSObject, with a comment saying
"UIAccessibility is implemented on all standard UIKit views and controls".

We can't create a single binding that exposes UIAccessibility as that comment
states, and adding it to NSObject will create a lot of noise for all other
types.

So a long time ago we decided to only add UIAccessibility to a few UIKit types
(UIView, UIBarItem and UIImage), but it seems UIApplication should have it
too, so do that.

Fixes https://github.com/xamarin/xamarin-macios/issues/21925.