### PR TITLE
[Rgen] Complete the BindingTypeAttribute analyzer.

### DIFF
--- a/src/ObjCBindings/BindingTypeTag.cs
+++ b/src/ObjCBindings/BindingTypeTag.cs
@@ -45,4 +45,16 @@ namespace ObjCBindings {
 		/// </summary>
 		Default = 0,
 	}
+
+	/// <summary>
+	/// Flags to be used on strong dictionary bindings.
+	/// </summary>
+	[Flags]
+	[Experimental ("APL0003")]
+	public enum StrongDictionary : Int64 {
+		/// <summary>
+		/// Use the default values.
+		/// </summary>
+		Default = 0,
+	}
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/AnalyzerReleases.Unshipped.md
@@ -5,9 +5,14 @@
 | Rule ID | Category | Severity | Notes                                                                     |
 |---------|----------|----------|---------------------------------------------------------------------------|
 | RBI0001 | Usage    | Error    | Binding types should be declared as partial classes.                      |
-| RBI0002 | Usage    | Error    | Smart enum values must be tagged with an Field<EnumValue> attribute.      |
-| RBI0003 | Usage    | Error    | Smart enum backing field cannot appear more than once.                    |
-| RBI0004 | Usage    | Error    | Smart enum backing field must represent a valid C# identifier to be used. |
-| RBI0005 | Usage    | Error    | Non Apple framework bindings must provide a library name.                 |
-| RBI0006 | Usage    | Warning  | Do not provide the LibraryName for known Apple frameworks.                |
-| RBI0007 | Usage    | Error    | Enum values must be tagged with Field<EnumValue>.                         |
+| RBI0002 | Usage    | Error    | BindingType<Class> must be on a class.                                    |
+| RBI0003 | Usage    | Error    | BindingType<Category> must be on a class.                                 |
+| RBI0004 | Usage    | Error    | BindingType<Category> must be on a static class.                          |
+| RBI0005 | Usage    | Error    | BindingType<Protocol> must be on an interface.                            |
+| RBI0006 | Usage    | Error    | BindingType must be on an enumerator.                                     |
+| RBI0007 | Usage    | Error    | Smart enum values must be tagged with an Field<EnumValue> attribute.      |
+| RBI0008 | Usage    | Error    | Smart enum backing field cannot appear more than once.                    |
+| RBI0009 | Usage    | Error    | Smart enum backing field must represent a valid C# identifier to be used. |
+| RBI0010 | Usage    | Error    | Non Apple framework bindings must provide a library name.                 |
+| RBI0011 | Usage    | Warning  | Do not provide the LibraryName for known Apple frameworks.                |
+| RBI0012 | Usage    | Error    | Enum values must be tagged with Field<EnumValue>.                         |

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/AnalyzerReleases.Unshipped.md
@@ -10,9 +10,10 @@
 | RBI0004 | Usage    | Error    | BindingType<Category> must be on a static class.                          |
 | RBI0005 | Usage    | Error    | BindingType<Protocol> must be on an interface.                            |
 | RBI0006 | Usage    | Error    | BindingType must be on an enumerator.                                     |
-| RBI0007 | Usage    | Error    | Smart enum values must be tagged with an Field<EnumValue> attribute.      |
-| RBI0008 | Usage    | Error    | Smart enum backing field cannot appear more than once.                    |
-| RBI0009 | Usage    | Error    | Smart enum backing field must represent a valid C# identifier to be used. |
-| RBI0010 | Usage    | Error    | Non Apple framework bindings must provide a library name.                 |
-| RBI0011 | Usage    | Warning  | Do not provide the LibraryName for known Apple frameworks.                |
-| RBI0012 | Usage    | Error    | Enum values must be tagged with Field<EnumValue>.                         |
+| RBI0007 | Usage    | Error    | BindingType<StrongDictionary> must be on a class.                         |
+| RBI0008 | Usage    | Error    | Smart enum values must be tagged with an Field<EnumValue> attribute.      |
+| RBI0009 | Usage    | Error    | Smart enum backing field cannot appear more than once.                    |
+| RBI0010 | Usage    | Error    | Smart enum backing field must represent a valid C# identifier to be used. |
+| RBI0011 | Usage    | Error    | Non Apple framework bindings must provide a library name.                 |
+| RBI0012 | Usage    | Warning  | Do not provide the LibraryName for known Apple frameworks.                |
+| RBI0013 | Usage    | Error    | Enum values must be tagged with Field<EnumValue>.                         |

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/BindingTypeSemanticAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/BindingTypeSemanticAnalyzer.cs
@@ -109,7 +109,7 @@ public class BindingTypeSemanticAnalyzer : DiagnosticAnalyzer, IBindingTypeAnaly
 		description: new LocalizableResourceString (nameof (Resources.RBI0006Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	internal static readonly DiagnosticDescriptor RBI0007 = new (
 		"RBI0007",
 		new LocalizableResourceString (nameof (Resources.RBI0007Title), Resources.ResourceManager, typeof (Resources)),

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/BindingTypeSemanticAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/BindingTypeSemanticAnalyzer.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -7,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Macios.Bindings.Analyzer.Extensions;
+using Microsoft.Macios.Generator;
 
 namespace Microsoft.Macios.Bindings.Analyzer;
 
@@ -15,39 +19,218 @@ namespace Microsoft.Macios.Bindings.Analyzer;
 /// pattern.
 /// </summary>
 [DiagnosticAnalyzer (LanguageNames.CSharp)]
-public class BindingTypeSemanticAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<ClassDeclarationSyntax> {
-
-	internal static readonly DiagnosticDescriptor RBI0001 = new (
+public class BindingTypeSemanticAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<BaseTypeDeclarationSyntax> {
+	/// <summary>
+	/// All binding types should be partial.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0001 = new(
 		"RBI0001",
-		new LocalizableResourceString (nameof (Resources.RBI0001Title), Resources.ResourceManager, typeof (Resources)),
-		new LocalizableResourceString (nameof (Resources.RBI0001MessageFormat), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof(Resources.RBI0001Title), Resources.ResourceManager, typeof(Resources)),
+		new LocalizableResourceString (nameof(Resources.RBI0001MessageFormat), Resources.ResourceManager,
+			typeof(Resources)),
 		"Usage",
 		DiagnosticSeverity.Error,
 		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof (Resources.RBI0001Description), Resources.ResourceManager, typeof (Resources))
+		description: new LocalizableResourceString (nameof(Resources.RBI0001Description), Resources.ResourceManager,
+			typeof(Resources))
 	);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [RBI0001];
+	/// <summary>
+	/// BindingType&lt;Class&gt; can only decorate partial classes.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0002 = new(
+		"RBI0002",
+		new LocalizableResourceString (nameof(Resources.RBI0002Title), Resources.ResourceManager, typeof(Resources)),
+		new LocalizableResourceString (nameof(Resources.RBI0002MessageFormat), Resources.ResourceManager,
+			typeof(Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof(Resources.RBI0002Description), Resources.ResourceManager,
+			typeof(Resources))
+	);
+
+	/// <summary>
+	/// BindingType&lt;Category&gt; can only decorate partial classes.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0003 = new(
+		"RBI0003",
+		new LocalizableResourceString (nameof(Resources.RBI0003Title), Resources.ResourceManager, typeof(Resources)),
+		new LocalizableResourceString (nameof(Resources.RBI0003MessageFormat), Resources.ResourceManager,
+			typeof(Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof(Resources.RBI0003Description), Resources.ResourceManager,
+			typeof(Resources))
+	);
+
+	/// <summary>
+	/// BindingType&lt;Category&gt; can only decorate static classes.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0004 = new(
+		"RBI0004",
+		new LocalizableResourceString (nameof(Resources.RBI0004Title), Resources.ResourceManager, typeof(Resources)),
+		new LocalizableResourceString (nameof(Resources.RBI0004MessageFormat), Resources.ResourceManager,
+			typeof(Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof(Resources.RBI0004Description), Resources.ResourceManager,
+			typeof(Resources))
+	);
+
+	/// <summary>
+	/// BindingType&lt;Protocol&gt; can only decorate interfaces.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0005 = new(
+		"RBI0005",
+		new LocalizableResourceString (nameof(Resources.RBI0005Title), Resources.ResourceManager, typeof(Resources)),
+		new LocalizableResourceString (nameof(Resources.RBI0005MessageFormat), Resources.ResourceManager,
+			typeof(Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof(Resources.RBI0005Description), Resources.ResourceManager,
+			typeof(Resources))
+	);
+
+	/// <summary>
+	/// BindingType can only decorate enumerators.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0006 = new(
+		"RBI0006",
+		new LocalizableResourceString (nameof(Resources.RBI0006Title), Resources.ResourceManager, typeof(Resources)),
+		new LocalizableResourceString (nameof(Resources.RBI0006MessageFormat), Resources.ResourceManager,
+			typeof(Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof(Resources.RBI0006Description), Resources.ResourceManager,
+			typeof(Resources))
+	);
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [
+		RBI0001,
+		RBI0002,
+		RBI0003,
+		RBI0004,
+		RBI0005,
+		RBI0006,
+	];
 
 	public override void Initialize (AnalysisContext context)
 	{
 		context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.None);
 		context.EnableConcurrentExecution ();
-		context.RegisterSyntaxNodeAction (AnalysisContext, SyntaxKind.ClassDeclaration);
+		context.RegisterSyntaxNodeAction (AnalysisContext, 
+			SyntaxKind.ClassDeclaration, 
+			SyntaxKind.InterfaceDeclaration,
+			SyntaxKind.EnumDeclaration);
 	}
 
 	void AnalysisContext (SyntaxNodeAnalysisContext context)
 		=> this.AnalyzeBindingType (context);
 
-	public ImmutableArray<Diagnostic> Analyze (PlatformName _, ClassDeclarationSyntax declarationNode, INamedTypeSymbol symbol)
+	static readonly HashSet<string> attributes = new HashSet<string> (AttributesNames.BindingTypes);
+	public IReadOnlySet<string> AttributeNames => attributes;
+
+	ImmutableArray<Diagnostic> ValidateClass (BaseTypeDeclarationSyntax declarationNode, INamedTypeSymbol symbol)
 	{
-		if (declarationNode.Modifiers.Any (x => x.IsKind (SyntaxKind.PartialKeyword)))
-			return [];
+		var bucket = ImmutableArray.CreateBuilder<Diagnostic> ();
+		if (declarationNode is ClassDeclarationSyntax classDeclarationSyntax) {
+			if (!classDeclarationSyntax.IsPartial ()) {
+				var partialDiagnostic = Diagnostic.Create (
+					descriptor: RBI0001, // Binding types should be declared as partial classes.
+					location: declarationNode.Identifier.GetLocation (),
+					messageArgs: symbol.ToDisplayString ());
+				bucket.Add (partialDiagnostic);
+			}
+		} else {
+			var notAClassDiagnostic = Diagnostic.Create (
+				descriptor: RBI0002, // BindingType<Class> must be on a class
+				location: declarationNode.Identifier.GetLocation (),
+				messageArgs: symbol.ToDisplayString ());
+			bucket.Add (notAClassDiagnostic);
+		}
 
-		var diagnostic = Diagnostic.Create (RBI0001, // Binding types should be declared as partial classes.
-			declarationNode.Identifier.GetLocation (), // point to where the 'class' keyword is used
-			symbol.ToDisplayString ());
-		return [diagnostic];
-
+		return bucket.ToImmutable ();
 	}
+
+	ImmutableArray<Diagnostic> ValidateCategory (BaseTypeDeclarationSyntax declarationNode, INamedTypeSymbol symbol)
+	{
+		var bucket = ImmutableArray.CreateBuilder<Diagnostic> ();
+		if (declarationNode is ClassDeclarationSyntax classDeclarationSyntax) {
+			if (!classDeclarationSyntax.IsPartial ()) {
+				var partialDiagnostic = Diagnostic.Create (
+					descriptor: RBI0001, // Binding types should be declared as partial classes.
+					location: declarationNode.Identifier.GetLocation (),
+					messageArgs: symbol.ToDisplayString ());
+				bucket.Add (partialDiagnostic);
+			}
+
+			if (!classDeclarationSyntax.IsStatic ()) {
+				var partialDiagnostic = Diagnostic.Create (
+					descriptor: RBI0004, // BindintType<Category> must be on a static class
+					location: declarationNode.Identifier.GetLocation (),
+					messageArgs: symbol.ToDisplayString ());
+				bucket.Add (partialDiagnostic);
+			}
+		} else {
+			var notAClassDiagnostic = Diagnostic.Create (
+				descriptor: RBI0003, // BindingType<Category> must be on a class
+				location: declarationNode.Identifier.GetLocation (),
+				messageArgs: symbol.ToDisplayString ());
+			bucket.Add (notAClassDiagnostic);
+		}
+
+		return bucket.ToImmutable ();
+	}
+
+	ImmutableArray<Diagnostic> ValidateProtocol (BaseTypeDeclarationSyntax declarationNode, INamedTypeSymbol symbol)
+	{
+		var bucket = ImmutableArray.CreateBuilder<Diagnostic> ();
+		if (declarationNode is InterfaceDeclarationSyntax interfaceDeclarationSyntax) {
+			if (!interfaceDeclarationSyntax.IsPartial ()) {
+				var partialDiagnostic = Diagnostic.Create (
+					descriptor: RBI0001, // Binding types should be declared as partial classes.
+					location: declarationNode.Identifier.GetLocation (),
+					messageArgs: symbol.ToDisplayString ());
+				bucket.Add (partialDiagnostic);
+			}
+		} else {
+			var notAInterfaceDiagnostic = Diagnostic.Create (
+				descriptor: RBI0005, // BindingType<Protocol> must be on an interface 
+				location: declarationNode.Identifier.GetLocation (),
+				messageArgs: symbol.ToDisplayString ());
+			bucket.Add (notAInterfaceDiagnostic);
+		}
+
+		return bucket.ToImmutable ();
+	}
+
+	public ImmutableArray<Diagnostic> ValidateSmartEnum (BaseTypeDeclarationSyntax declarationNode,
+		INamedTypeSymbol symbol)
+	{
+		var bucket = ImmutableArray.CreateBuilder<Diagnostic> ();
+		if (declarationNode is not EnumDeclarationSyntax) {
+			var notAInterfaceDiagnostic = Diagnostic.Create (
+				descriptor: RBI0006, // BindingType must be on an enumerator 
+				location: declarationNode.Identifier.GetLocation (),
+				messageArgs: symbol.ToDisplayString ());
+			bucket.Add (notAInterfaceDiagnostic);
+		}
+
+		return bucket.ToImmutable ();
+	}
+
+	public ImmutableArray<Diagnostic> Analyze (string matchedAttribute, PlatformName _,
+		BaseTypeDeclarationSyntax declarationNode, INamedTypeSymbol symbol)
+		=> matchedAttribute switch {
+			AttributesNames.BindingClassAttribute => ValidateClass (declarationNode, symbol),
+			AttributesNames.BindingCategoryAttribute => ValidateCategory (declarationNode, symbol),
+			AttributesNames.BindingProtocolAttribute => ValidateProtocol (declarationNode, symbol),
+			AttributesNames.BindingAttribute => ValidateSmartEnum (declarationNode, symbol),
+			_ => throw new InvalidOperationException ($"Not recognized attribute {matchedAttribute}.")
+		};
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/BindingTypeSemanticAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/BindingTypeSemanticAnalyzer.cs
@@ -23,91 +23,91 @@ public class BindingTypeSemanticAnalyzer : DiagnosticAnalyzer, IBindingTypeAnaly
 	/// <summary>
 	/// All binding types should be partial.
 	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0001 = new(
+	internal static readonly DiagnosticDescriptor RBI0001 = new (
 		"RBI0001",
-		new LocalizableResourceString (nameof(Resources.RBI0001Title), Resources.ResourceManager, typeof(Resources)),
-		new LocalizableResourceString (nameof(Resources.RBI0001MessageFormat), Resources.ResourceManager,
-			typeof(Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0001Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0001MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
 		"Usage",
 		DiagnosticSeverity.Error,
 		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof(Resources.RBI0001Description), Resources.ResourceManager,
-			typeof(Resources))
+		description: new LocalizableResourceString (nameof (Resources.RBI0001Description), Resources.ResourceManager,
+			typeof (Resources))
 	);
 
 	/// <summary>
 	/// BindingType&lt;Class&gt; can only decorate partial classes.
 	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0002 = new(
+	internal static readonly DiagnosticDescriptor RBI0002 = new (
 		"RBI0002",
-		new LocalizableResourceString (nameof(Resources.RBI0002Title), Resources.ResourceManager, typeof(Resources)),
-		new LocalizableResourceString (nameof(Resources.RBI0002MessageFormat), Resources.ResourceManager,
-			typeof(Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0002Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0002MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
 		"Usage",
 		DiagnosticSeverity.Error,
 		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof(Resources.RBI0002Description), Resources.ResourceManager,
-			typeof(Resources))
+		description: new LocalizableResourceString (nameof (Resources.RBI0002Description), Resources.ResourceManager,
+			typeof (Resources))
 	);
 
 	/// <summary>
 	/// BindingType&lt;Category&gt; can only decorate partial classes.
 	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0003 = new(
+	internal static readonly DiagnosticDescriptor RBI0003 = new (
 		"RBI0003",
-		new LocalizableResourceString (nameof(Resources.RBI0003Title), Resources.ResourceManager, typeof(Resources)),
-		new LocalizableResourceString (nameof(Resources.RBI0003MessageFormat), Resources.ResourceManager,
-			typeof(Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0003Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0003MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
 		"Usage",
 		DiagnosticSeverity.Error,
 		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof(Resources.RBI0003Description), Resources.ResourceManager,
-			typeof(Resources))
+		description: new LocalizableResourceString (nameof (Resources.RBI0003Description), Resources.ResourceManager,
+			typeof (Resources))
 	);
 
 	/// <summary>
 	/// BindingType&lt;Category&gt; can only decorate static classes.
 	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0004 = new(
+	internal static readonly DiagnosticDescriptor RBI0004 = new (
 		"RBI0004",
-		new LocalizableResourceString (nameof(Resources.RBI0004Title), Resources.ResourceManager, typeof(Resources)),
-		new LocalizableResourceString (nameof(Resources.RBI0004MessageFormat), Resources.ResourceManager,
-			typeof(Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0004Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0004MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
 		"Usage",
 		DiagnosticSeverity.Error,
 		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof(Resources.RBI0004Description), Resources.ResourceManager,
-			typeof(Resources))
+		description: new LocalizableResourceString (nameof (Resources.RBI0004Description), Resources.ResourceManager,
+			typeof (Resources))
 	);
 
 	/// <summary>
 	/// BindingType&lt;Protocol&gt; can only decorate interfaces.
 	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0005 = new(
+	internal static readonly DiagnosticDescriptor RBI0005 = new (
 		"RBI0005",
-		new LocalizableResourceString (nameof(Resources.RBI0005Title), Resources.ResourceManager, typeof(Resources)),
-		new LocalizableResourceString (nameof(Resources.RBI0005MessageFormat), Resources.ResourceManager,
-			typeof(Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0005Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0005MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
 		"Usage",
 		DiagnosticSeverity.Error,
 		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof(Resources.RBI0005Description), Resources.ResourceManager,
-			typeof(Resources))
+		description: new LocalizableResourceString (nameof (Resources.RBI0005Description), Resources.ResourceManager,
+			typeof (Resources))
 	);
 
 	/// <summary>
 	/// BindingType can only decorate enumerators.
 	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0006 = new(
+	internal static readonly DiagnosticDescriptor RBI0006 = new (
 		"RBI0006",
-		new LocalizableResourceString (nameof(Resources.RBI0006Title), Resources.ResourceManager, typeof(Resources)),
-		new LocalizableResourceString (nameof(Resources.RBI0006MessageFormat), Resources.ResourceManager,
-			typeof(Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0006Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0006MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
 		"Usage",
 		DiagnosticSeverity.Error,
 		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof(Resources.RBI0006Description), Resources.ResourceManager,
-			typeof(Resources))
+		description: new LocalizableResourceString (nameof (Resources.RBI0006Description), Resources.ResourceManager,
+			typeof (Resources))
 	);
 
 	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [
@@ -123,8 +123,8 @@ public class BindingTypeSemanticAnalyzer : DiagnosticAnalyzer, IBindingTypeAnaly
 	{
 		context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.None);
 		context.EnableConcurrentExecution ();
-		context.RegisterSyntaxNodeAction (AnalysisContext, 
-			SyntaxKind.ClassDeclaration, 
+		context.RegisterSyntaxNodeAction (AnalysisContext,
+			SyntaxKind.ClassDeclaration,
 			SyntaxKind.InterfaceDeclaration,
 			SyntaxKind.EnumDeclaration);
 	}

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/BindingTypeSemanticAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/BindingTypeSemanticAnalyzer.cs
@@ -184,7 +184,7 @@ public class BindingTypeSemanticAnalyzer : DiagnosticAnalyzer, IBindingTypeAnaly
 
 			if (!classDeclarationSyntax.IsStatic ()) {
 				var partialDiagnostic = Diagnostic.Create (
-					descriptor: RBI0004, // BindintType<Category> must be on a static class
+					descriptor: RBI0004, // BindingType<Category> must be on a static class
 					location: declarationNode.Identifier.GetLocation (),
 					messageArgs: symbol.ToDisplayString ());
 				bucket.Add (partialDiagnostic);

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Macios.Bindings.Analyzer.Extensions;
+
+public static class BaseTypeDeclarationSyntaxExtensions {
+
+	/// <summary>
+	/// Returns if the based type declaration was declared as a partial one.
+	/// </summary>
+	/// <param name="baseTypeDeclarationSyntax">The declaration under test.</param>
+	/// <returns>True if the declaration is partial.</returns>
+	public static bool IsPartial (this BaseTypeDeclarationSyntax baseTypeDeclarationSyntax)
+		=> baseTypeDeclarationSyntax.Modifiers.Any (x => x.IsKind (SyntaxKind.PartialKeyword));
+	
+	/// <summary>
+	/// Returns if the based type declaration was declared as a static one.
+	/// </summary>
+	/// <param name="baseTypeDeclarationSyntax">The declaration under test.</param>
+	/// <returns>True if the declaration is static.</returns>
+	public static bool IsStatic (this BaseTypeDeclarationSyntax baseTypeDeclarationSyntax)
+		=> baseTypeDeclarationSyntax.Modifiers.Any (x => x.IsKind (SyntaxKind.StaticKeyword));
+
+}

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Macios.Bindings.Analyzer.Extensions;
 public static class BaseTypeDeclarationSyntaxExtensions {
 
 	/// <summary>
-	/// Returns if the based type declaration was declared as a partial one.
+	/// Returns if the base type declaration was declared as a partial one.
 	/// </summary>
 	/// <param name="baseTypeDeclarationSyntax">The declaration under test.</param>
 	/// <returns>True if the declaration is partial.</returns>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
@@ -16,7 +16,7 @@ public static class BaseTypeDeclarationSyntaxExtensions {
 	/// <returns>True if the declaration is partial.</returns>
 	public static bool IsPartial (this BaseTypeDeclarationSyntax baseTypeDeclarationSyntax)
 		=> baseTypeDeclarationSyntax.Modifiers.Any (x => x.IsKind (SyntaxKind.PartialKeyword));
-	
+
 	/// <summary>
 	/// Returns if the based type declaration was declared as a static one.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Extensions/IBindingTypeAnalyzerExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Extensions/IBindingTypeAnalyzerExtensions.cs
@@ -26,19 +26,18 @@ public static class BindingTypeAnalyzerExtensions {
 			return;
 		}
 
-		// the c# syntax is a a list of lists of attributes. That is why we need to iterate through the list of lists
+		// The c# syntax is a a list of lists of attributes. That is why we need to iterate through the list of lists
 		foreach (var attributeData in boundAttributes) {
 			// based on the type use the correct parser to retrieve the data
 			var attributeType = attributeData.AttributeClass?.ToDisplayString ();
-			switch (attributeType) {
-			case AttributesNames.BindingAttribute:
-				// validate that the class is partial, else we need to report an error
-				var diagnostics = self.Analyze (context.Compilation.GetCurrentPlatform (),
-					declarationNode, declaredSymbol);
-				foreach (var diagnostic in diagnostics)
-					context.ReportDiagnostic (diagnostic);
-				break;
-			}
+			// ignore attrs whose name we cannot get, or we do not care about
+			if (attributeType is null || !self.AttributeNames.Contains (attributeType))
+				continue;
+			
+			var diagnostics = self.Analyze (attributeType, context.Compilation.GetCurrentPlatform (),
+				declarationNode, declaredSymbol);
+			foreach (var diagnostic in diagnostics)
+				context.ReportDiagnostic (diagnostic);
 		}
 	}
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Extensions/IBindingTypeAnalyzerExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Extensions/IBindingTypeAnalyzerExtensions.cs
@@ -33,7 +33,7 @@ public static class BindingTypeAnalyzerExtensions {
 			// ignore attrs whose name we cannot get, or we do not care about
 			if (attributeType is null || !self.AttributeNames.Contains (attributeType))
 				continue;
-			
+
 			var diagnostics = self.Analyze (attributeType, context.Compilation.GetCurrentPlatform (),
 				declarationNode, declaredSymbol);
 			foreach (var diagnostic in diagnostics)

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/IBindingTypeAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/IBindingTypeAnalyzer.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Macios.Bindings.Analyzer;
 /// </summary>
 public interface IBindingTypeAnalyzer<T> where T : BaseTypeDeclarationSyntax {
 	IReadOnlySet<string> AttributeNames { get; }
-	
+
 	ImmutableArray<Diagnostic> Analyze (string matchedAttribute, PlatformName platformName, T declarationNode, INamedTypeSymbol symbol);
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/IBindingTypeAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/IBindingTypeAnalyzer.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -10,5 +12,7 @@ namespace Microsoft.Macios.Bindings.Analyzer;
 /// Interface to be implemented by those analyzer that will be looking at BindingTypes.
 /// </summary>
 public interface IBindingTypeAnalyzer<T> where T : BaseTypeDeclarationSyntax {
-	ImmutableArray<Diagnostic> Analyze (PlatformName platformName, T declarationNode, INamedTypeSymbol symbol);
+	IReadOnlySet<string> AttributeNames { get; }
+	
+	ImmutableArray<Diagnostic> Analyze (string matchedAttribute, PlatformName platformName, T declarationNode, INamedTypeSymbol symbol);
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.Designer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.Designer.cs
@@ -260,5 +260,23 @@ namespace Microsoft.Macios.Bindings.Analyzer {
                 return ResourceManager.GetString("RBI0012Title", resourceCulture);
             }
         }
+        
+        internal static string RBI0013Description {
+            get {
+                return ResourceManager.GetString("RBI0013Description", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0013MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0013MessageFormat", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0013Title {
+            get {
+                return ResourceManager.GetString("RBI0013Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.Designer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.Designer.cs
@@ -170,5 +170,95 @@ namespace Microsoft.Macios.Bindings.Analyzer {
                 return ResourceManager.GetString("RBI0007Title", resourceCulture);
             }
         }
+        
+        internal static string RBI0008Description {
+            get {
+                return ResourceManager.GetString("RBI0008Description", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0008MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0008MessageFormat", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0008Title {
+            get {
+                return ResourceManager.GetString("RBI0008Title", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0009Description {
+            get {
+                return ResourceManager.GetString("RBI0009Description", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0009MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0009MessageFormat", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0009Title {
+            get {
+                return ResourceManager.GetString("RBI0009Title", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0010Description {
+            get {
+                return ResourceManager.GetString("RBI0010Description", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0010MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0010MessageFormat", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0010Title {
+            get {
+                return ResourceManager.GetString("RBI0010Title", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0011Description {
+            get {
+                return ResourceManager.GetString("RBI0011Description", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0011MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0011MessageFormat", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0011Title {
+            get {
+                return ResourceManager.GetString("RBI0011Title", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0012Description {
+            get {
+                return ResourceManager.GetString("RBI0012Description", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0012MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0012MessageFormat", resourceCulture);
+            }
+        }
+        
+        internal static string RBI0012Title {
+            get {
+                return ResourceManager.GetString("RBI0012Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
@@ -18,6 +18,9 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
+    
+    <!-- RBI0001 -->
+    
     <data name="RBI0001Description" xml:space="preserve">
         <value>In order for the code to be generated all binding types have to be declared as partial classes.</value>
     </data>
@@ -29,69 +32,146 @@
         <value>Binding type declaration must be partial</value>
     </data>
 
+    <!-- RBI0002 -->
+    
     <data name="RBI0002Description" xml:space="preserve">
-        <value>In order for the code to be generated a smart enum value has to have a backing field.</value>
+        <value>BindingType&lt;Class&gt; can only decorate partial classes.</value>
     </data>
     <data name="RBI0002MessageFormat" xml:space="preserve">
+        <value>BindingType&lt;Class&gt; can only be used to decorate a class but was found on '{0}' which is not a class</value>
+        <comment>'{0}' is the name of type.</comment>
+    </data>
+    <data name="RBI0002Title" xml:space="preserve">
+        <value>BindingType&lt;Class&gt; must be on a class</value>
+    </data>
+
+    <!-- RBI0003 -->
+
+    <data name="RBI0003Description" xml:space="preserve">
+        <value>BindingType&lt;Category&gt; can only decorate partial classes.</value>
+    </data>
+    <data name="RBI0003MessageFormat" xml:space="preserve">
+        <value>BindingType&lt;Category&gt; can only be used to decorate a class but was found on '{0}' which is not a class</value>
+        <comment>'{0}' is the name of type.</comment>
+    </data>
+    <data name="RBI0003Title" xml:space="preserve">
+        <value>BindingType&lt;Category&gt; must be on a class</value>
+    </data>
+
+    <!-- RBI0004 -->
+    
+    <data name="RBI0004Description" xml:space="preserve">
+        <value>BindingType&lt;Category&gt; can only decorate static classes.</value>
+    </data>
+    <data name="RBI0004MessageFormat" xml:space="preserve">
+        <value>BindingType&lt;Category&gt; can only be used to decorate a static class but was found on '{0}' which is not static</value>
+        <comment>'{0}' is the name of type.</comment>
+    </data>
+    <data name="RBI0004Title" xml:space="preserve">
+        <value>BindingType&lt;Category&gt; must be on a static class</value>
+    </data>
+
+    <!-- RBI0005 -->
+    
+    <data name="RBI0005Description" xml:space="preserve">
+        <value>BindingType&lt;Protocol&gt; can only decorate interfaces.</value>
+    </data>
+    <data name="RBI0005MessageFormat" xml:space="preserve">
+        <value>BindingType&lt;Protocol&gt; can only be used to decorate an interface but was found on '{0}' which is not an interface</value>
+        <comment>'{0}' is the name of type.</comment>
+    </data>
+    <data name="RBI0005Title" xml:space="preserve">
+        <value>BindingType&lt;Protocol&gt; must be on an interface</value>
+    </data>
+
+    <!-- RBI0006 -->
+
+    <data name="RBI0006Description" xml:space="preserve">
+        <value>BindingType can only decorate enumerators.</value>
+    </data>
+    <data name="RBI0006MessageFormat" xml:space="preserve">
+        <value>BindingType can only be used to decorate an enumerator but was found on '{0}' which is not an enumerator</value>
+        <comment>'{0}' is the name of type.</comment>
+    </data>
+    <data name="RBI0006Title" xml:space="preserve">
+        <value>BindingType must be on an enumerator</value>
+    </data>
+
+    <!-- RBI0007 -->
+
+    <data name="RBI0007Description" xml:space="preserve">
+        <value>In order for the code to be generated a smart enum value has to have a backing field.</value>
+    </data>
+    <data name="RBI0007MessageFormat" xml:space="preserve">
         <value>The enum value '{0}' must be tagged with a Field&lt;EnumValue&gt; attribute</value>
         <comment>'{0}' is the name of the enumerator value.</comment>
     </data>
-    <data name="RBI0002Title" xml:space="preserve">
+    <data name="RBI0007Title" xml:space="preserve">
         <value>Smart enum values must be tagged with an Field&lt;EnumValue&gt; attribute</value>
     </data>
 
-    <data name="RBI0003Description" xml:space="preserve">
+    <!-- RBI0008 -->
+
+    <data name="RBI0008Description" xml:space="preserve">
         <value>Smart enum backing field cannot appear more than once.</value>
     </data>
-    <data name="RBI0003MessageFormat" xml:space="preserve">
+    <data name="RBI0008MessageFormat" xml:space="preserve">
         <value>The backing field '{0}' for the enum value '{1}' is already in use for the enum value '{2}'</value>
         <comment>'{0}' is the name of the enum value. '{1}' is the name of a native field. '{2}' is the previous enum value</comment>
     </data>
-    <data name="RBI0003Title" xml:space="preserve">
+    <data name="RBI0008Title" xml:space="preserve">
         <value>Smart enum backing field cannot appear more than once</value>
     </data>
 
-    <data name="RBI0004Description" xml:space="preserve">
+    <!-- RBI0009 -->
+    
+    <data name="RBI0009Description" xml:space="preserve">
         <value>Smart enum backing field must be a valid identifier.</value>
     </data>
-    <data name="RBI0004MessageFormat" xml:space="preserve">
+    <data name="RBI0009MessageFormat" xml:space="preserve">
         <value>The enum value '{0}' backing field '{1}' is not a valid identifier</value>
         <comment>'{0}' is the name of the enum value. '{1}' is the name of a native field.</comment>
     </data>
-    <data name="RBI0004Title" xml:space="preserve">
+    <data name="RBI0009Title" xml:space="preserve">
         <value>Smart enum backing field must represent a valid C# identifier to be used</value>
     </data>
 
-    <data name="RBI0005Description" xml:space="preserve">
+    <!-- RBI0010 -->
+    
+    <data name="RBI0010Description" xml:space="preserve">
         <value>Smart enum backing field for a non Apple framework must provide a library name.</value>
     </data>
-    <data name="RBI0005MessageFormat" xml:space="preserve">
+    <data name="RBI0010MessageFormat" xml:space="preserve">
         <value>The field attribute for the enum value '{0}' must set the property 'LibraryName'</value>
         <comment>'{0}' is the name of the enumerator value.</comment>
     </data>
-    <data name="RBI0005Title" xml:space="preserve">
+    <data name="RBI0010Title" xml:space="preserve">
         <value>Non Apple framework bindings must provide a library name</value>
     </data>
 
-    <data name="RBI0006Description" xml:space="preserve">
+    <!-- RBI0011 -->
+    
+    <data name="RBI0011Description" xml:space="preserve">
         <value>Fields of known Apple frameworks should not provide a LibraryName.</value>
     </data>
-    <data name="RBI0006MessageFormat" xml:space="preserve">
+    <data name="RBI0011MessageFormat" xml:space="preserve">
         <value>The Field attribute for the enum value '{0}' must not provide a value for 'LibraryName'</value>
         <comment>'{0}' is the name of the native field.</comment>
     </data>
-    <data name="RBI0006Title" xml:space="preserve">
+    <data name="RBI0011Title" xml:space="preserve">
         <value>Do not provide the LibraryName for known Apple frameworks</value>
     </data>
 
-    <data name="RBI0007Description" xml:space="preserve">
+    <!-- RBI0012 -->
+
+    <data name="RBI0012Description" xml:space="preserve">
         <value>Wrong flags were used in the FieldAttribute when applying it on an enum value.</value>
     </data>
-    <data name="RBI0007MessageFormat" xml:space="preserve">
+    <data name="RBI0012MessageFormat" xml:space="preserve">
         <value>Used attribute '{0}' on enum value '{1}' when 'ObjCBindings.FieldAttribute&lt;ObjCBindings.EnumValue&gt;' was expected</value>
         <comment>'{0}' is the name of an attribute. '{1}' is the name of the enumerator value.</comment>
     </data>
-    <data name="RBI0007Title" xml:space="preserve">
+    <data name="RBI0012Title" xml:space="preserve">
         <value>Enum values must be tagged with Field&lt;EnumValue&gt;</value>
     </data>
 </root>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
@@ -25,7 +25,7 @@
         <value>In order for the code to be generated all binding types have to be declared as partial classes.</value>
     </data>
     <data name="RBI0001MessageFormat" xml:space="preserve">
-        <value>The binding type '{0}' must declared as a partial class</value>
+        <value>The binding type '{0}' must be declared as a partial class</value>
         <comment>'{0}' is the name of the class.</comment>
     </data>
     <data name="RBI0001Title" xml:space="preserve">

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
@@ -25,7 +25,7 @@
         <value>In order for the code to be generated all binding types have to be declared as partial classes.</value>
     </data>
     <data name="RBI0001MessageFormat" xml:space="preserve">
-        <value>The binding type '{0}' must be declared as a partial class</value>
+        <value>The binding type '{0}' must be declared partial</value>
         <comment>'{0}' is the name of the class.</comment>
     </data>
     <data name="RBI0001Title" xml:space="preserve">
@@ -100,78 +100,91 @@
     <!-- RBI0007 -->
 
     <data name="RBI0007Description" xml:space="preserve">
-        <value>In order for the code to be generated a smart enum value has to have a backing field.</value>
+        <value>BindingType&lt;StrongDictionary&gt; can only decorate classes.</value>
     </data>
     <data name="RBI0007MessageFormat" xml:space="preserve">
-        <value>The enum value '{0}' must be tagged with a Field&lt;EnumValue&gt; attribute</value>
-        <comment>'{0}' is the name of the enumerator value.</comment>
+        <value>BindingType&lt;StrongDictionary&gt; can only be used to decorate a class but was found on '{0}' which is not a class</value>
+        <comment>'{0}' is the name of type.</comment>
     </data>
     <data name="RBI0007Title" xml:space="preserve">
-        <value>Smart enum values must be tagged with an Field&lt;EnumValue&gt; attribute</value>
+        <value>BindingType&lt;StrongDictionary&gt; must be on a class</value>
     </data>
 
     <!-- RBI0008 -->
 
     <data name="RBI0008Description" xml:space="preserve">
-        <value>Smart enum backing field cannot appear more than once.</value>
+        <value>In order for the code to be generated a smart enum value has to have a backing field.</value>
     </data>
     <data name="RBI0008MessageFormat" xml:space="preserve">
-        <value>The backing field '{0}' for the enum value '{1}' is already in use for the enum value '{2}'</value>
-        <comment>'{0}' is the name of the enum value. '{1}' is the name of a native field. '{2}' is the previous enum value</comment>
+        <value>The enum value '{0}' must be tagged with a Field&lt;EnumValue&gt; attribute</value>
+        <comment>'{0}' is the name of the enumerator value.</comment>
     </data>
     <data name="RBI0008Title" xml:space="preserve">
-        <value>Smart enum backing field cannot appear more than once</value>
+        <value>Smart enum values must be tagged with an Field&lt;EnumValue&gt; attribute</value>
     </data>
 
     <!-- RBI0009 -->
-    
+
     <data name="RBI0009Description" xml:space="preserve">
-        <value>Smart enum backing field must be a valid identifier.</value>
+        <value>Smart enum backing field cannot appear more than once.</value>
     </data>
     <data name="RBI0009MessageFormat" xml:space="preserve">
-        <value>The enum value '{0}' backing field '{1}' is not a valid identifier</value>
-        <comment>'{0}' is the name of the enum value. '{1}' is the name of a native field.</comment>
+        <value>The backing field '{0}' for the enum value '{1}' is already in use for the enum value '{2}'</value>
+        <comment>'{0}' is the name of the enum value. '{1}' is the name of a native field. '{2}' is the previous enum value</comment>
     </data>
     <data name="RBI0009Title" xml:space="preserve">
-        <value>Smart enum backing field must represent a valid C# identifier to be used</value>
+        <value>Smart enum backing field cannot appear more than once</value>
     </data>
 
     <!-- RBI0010 -->
     
     <data name="RBI0010Description" xml:space="preserve">
-        <value>Smart enum backing field for a non Apple framework must provide a library name.</value>
+        <value>Smart enum backing field must be a valid identifier.</value>
     </data>
     <data name="RBI0010MessageFormat" xml:space="preserve">
-        <value>The field attribute for the enum value '{0}' must set the property 'LibraryName'</value>
-        <comment>'{0}' is the name of the enumerator value.</comment>
+        <value>The enum value '{0}' backing field '{1}' is not a valid identifier</value>
+        <comment>'{0}' is the name of the enum value. '{1}' is the name of a native field.</comment>
     </data>
     <data name="RBI0010Title" xml:space="preserve">
-        <value>Non Apple framework bindings must provide a library name</value>
+        <value>Smart enum backing field must represent a valid C# identifier to be used</value>
     </data>
 
     <!-- RBI0011 -->
     
     <data name="RBI0011Description" xml:space="preserve">
-        <value>Fields of known Apple frameworks should not provide a LibraryName.</value>
+        <value>Smart enum backing field for a non Apple framework must provide a library name.</value>
     </data>
     <data name="RBI0011MessageFormat" xml:space="preserve">
-        <value>The Field attribute for the enum value '{0}' must not provide a value for 'LibraryName'</value>
-        <comment>'{0}' is the name of the native field.</comment>
+        <value>The field attribute for the enum value '{0}' must set the property 'LibraryName'</value>
+        <comment>'{0}' is the name of the enumerator value.</comment>
     </data>
     <data name="RBI0011Title" xml:space="preserve">
-        <value>Do not provide the LibraryName for known Apple frameworks</value>
+        <value>Non Apple framework bindings must provide a library name</value>
     </data>
 
     <!-- RBI0012 -->
-
+    
     <data name="RBI0012Description" xml:space="preserve">
-        <value>Wrong flags were used in the FieldAttribute when applying it on an enum value.</value>
+        <value>Fields of known Apple frameworks should not provide a LibraryName.</value>
     </data>
     <data name="RBI0012MessageFormat" xml:space="preserve">
+        <value>The Field attribute for the enum value '{0}' must not provide a value for 'LibraryName'</value>
+        <comment>'{0}' is the name of the native field.</comment>
+    </data>
+    <data name="RBI0012Title" xml:space="preserve">
+        <value>Do not provide the LibraryName for known Apple frameworks</value>
+    </data>
+
+    <!-- RBI0013 -->
+
+    <data name="RBI0013Description" xml:space="preserve">
+        <value>Wrong flags were used in the FieldAttribute when applying it on an enum value.</value>
+    </data>
+    <data name="RBI0013MessageFormat" xml:space="preserve">
         <value>Used attribute '{0}' on enum value '{1}' when 'ObjCBindings.FieldAttribute&lt;ObjCBindings.EnumValue&gt;' was expected</value>
         <comment>'{0}' is the name of an attribute. '{1}' is the name of the enumerator value.</comment>
     </data>
-    <data name="RBI0012Title" xml:space="preserve">
+    <data name="RBI0013Title" xml:space="preserve">
         <value>Enum values must be tagged with Field&lt;EnumValue&gt;</value>
     </data>
 </root>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/SmartEnumsAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/SmartEnumsAnalyzer.cs
@@ -126,7 +126,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 
 	static readonly HashSet<string> attributes = [AttributesNames.BindingAttribute];
 	public IReadOnlySet<string> AttributeNames => attributes;
-	
+
 	public ImmutableArray<Diagnostic> Analyze (string matchedAttribute, PlatformName platformName, EnumDeclarationSyntax declarationNode,
 		INamedTypeSymbol symbol)
 	{

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/SmartEnumsAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/SmartEnumsAnalyzer.cs
@@ -112,11 +112,11 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 
 
 	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [
-		RBI0008, 
-		RBI0009, 
-		RBI0010, 
-		RBI0011, 
-		RBI0012, 
+		RBI0008,
+		RBI0009,
+		RBI0010,
+		RBI0011,
+		RBI0012,
 		RBI0013,
 	];
 

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/SmartEnumsAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/SmartEnumsAnalyzer.cs
@@ -23,81 +23,6 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 	/// <summary>
 	/// All enum values must have a Field attribute
 	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0002 = new (
-		"RBI0002",
-		new LocalizableResourceString (nameof (Resources.RBI0002Title), Resources.ResourceManager, typeof (Resources)),
-		new LocalizableResourceString (nameof (Resources.RBI0002MessageFormat), Resources.ResourceManager,
-			typeof (Resources)),
-		"Usage",
-		DiagnosticSeverity.Error,
-		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof (Resources.RBI0002Description), Resources.ResourceManager,
-			typeof (Resources))
-	);
-
-	/// <summary>
-	/// Do not allow duplicated backing fields
-	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0003 = new (
-		"RBI0003",
-		new LocalizableResourceString (nameof (Resources.RBI0003Title), Resources.ResourceManager, typeof (Resources)),
-		new LocalizableResourceString (nameof (Resources.RBI0003MessageFormat), Resources.ResourceManager,
-			typeof (Resources)),
-		"Usage",
-		DiagnosticSeverity.Error,
-		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof (Resources.RBI0003Description), Resources.ResourceManager,
-			typeof (Resources))
-	);
-
-	/// <summary>
-	/// Fields must be a valid identifier
-	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0004 = new (
-		"RBI0004",
-		new LocalizableResourceString (nameof (Resources.RBI0004Title), Resources.ResourceManager, typeof (Resources)),
-		new LocalizableResourceString (nameof (Resources.RBI0004MessageFormat), Resources.ResourceManager,
-			typeof (Resources)),
-		"Usage",
-		DiagnosticSeverity.Error,
-		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof (Resources.RBI0004Description), Resources.ResourceManager,
-			typeof (Resources))
-	);
-
-	/// <summary>
-	/// If not an apple framework, we should provide the library path
-	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0005 = new (
-		"RBI0005",
-		new LocalizableResourceString (nameof (Resources.RBI0005Title), Resources.ResourceManager, typeof (Resources)),
-		new LocalizableResourceString (nameof (Resources.RBI0005MessageFormat), Resources.ResourceManager,
-			typeof (Resources)),
-		"Usage",
-		DiagnosticSeverity.Error,
-		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof (Resources.RBI0005Description), Resources.ResourceManager,
-			typeof (Resources))
-	);
-
-	/// <summary>
-	/// if apple framework, the library path should be empty
-	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0006 = new (
-		"RBI0006",
-		new LocalizableResourceString (nameof (Resources.RBI0006Title), Resources.ResourceManager, typeof (Resources)),
-		new LocalizableResourceString (nameof (Resources.RBI0006MessageFormat), Resources.ResourceManager,
-			typeof (Resources)),
-		"Usage",
-		DiagnosticSeverity.Warning,
-		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof (Resources.RBI0006Description), Resources.ResourceManager,
-			typeof (Resources))
-	);
-
-	/// <summary>
-	/// User used the wrong flag for the attribute
-	/// </summary>
 	internal static readonly DiagnosticDescriptor RBI0007 = new (
 		"RBI0007",
 		new LocalizableResourceString (nameof (Resources.RBI0007Title), Resources.ResourceManager, typeof (Resources)),
@@ -110,9 +35,84 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 			typeof (Resources))
 	);
 
+	/// <summary>
+	/// Do not allow duplicated backing fields
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0008 = new (
+		"RBI0008",
+		new LocalizableResourceString (nameof (Resources.RBI0008Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0008MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0008Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+
+	/// <summary>
+	/// Fields must be a valid identifier
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0009 = new (
+		"RBI0009",
+		new LocalizableResourceString (nameof (Resources.RBI0009Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0009MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0009Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+
+	/// <summary>
+	/// If not an apple framework, we should provide the library path
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0010 = new (
+		"RBI0010",
+		new LocalizableResourceString (nameof (Resources.RBI0010Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0010MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0010Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+
+	/// <summary>
+	/// if apple framework, the library path should be empty
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0011 = new (
+		"RBI0011",
+		new LocalizableResourceString (nameof (Resources.RBI0011Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0011MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0011Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+
+	/// <summary>
+	/// User used the wrong flag for the attribute
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0012 = new (
+		"RBI0012",
+		new LocalizableResourceString (nameof (Resources.RBI0012Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0012MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0012Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+
 
 	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-		[RBI0002, RBI0003, RBI0004, RBI0005, RBI0006, RBI0007];
+		[RBI0007, RBI0008, RBI0009, RBI0010, RBI0011, RBI0012];
 
 	public override void Initialize (AnalysisContext context)
 	{
@@ -124,7 +124,10 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 	void AnalysisContext (SyntaxNodeAnalysisContext context)
 		=> this.AnalyzeBindingType (context);
 
-	public ImmutableArray<Diagnostic> Analyze (PlatformName platformName, EnumDeclarationSyntax declarationNode,
+	static readonly HashSet<string> attributes = [AttributesNames.BindingAttribute];
+	public IReadOnlySet<string> AttributeNames => attributes;
+	
+	public ImmutableArray<Diagnostic> Analyze (string matchedAttribute, PlatformName platformName, EnumDeclarationSyntax declarationNode,
 		INamedTypeSymbol symbol)
 	{
 		// we want to ensure several things:
@@ -162,7 +165,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 			if (attributes.Count == 0) {
 				//  All enum values are marked with a Field attribute, therefore add a diagnostic
 				bucket.Add (Diagnostic.Create (
-					RBI0002, // Smart enum values must be tagged with an Field<EnumValue> attribute.
+					RBI0007, // Smart enum values must be tagged with an Field<EnumValue> attribute.
 					fieldSymbol.Locations.First (),
 					fieldSymbol.ToDisplayString ()));
 				continue;
@@ -183,7 +186,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 					if (backingFields.TryGetValue (fieldData.Value.SymbolName, out var previousEnumValue)) {
 						// All symbol names have to be unique
 						bucket.Add (Diagnostic.Create (
-							RBI0003, // The backing field '{0}' for the enum value '{1}' is already in use for the enum value '{2}'
+							RBI0008, // The backing field '{0}' for the enum value '{1}' is already in use for the enum value '{2}'
 							fieldSyntax.GetLocation (),
 							fieldSymbol.ToDisplayString (), fieldData.Value.SymbolName,
 							fieldSymbol.ToDisplayString ().Trim (), previousEnumValue));
@@ -196,7 +199,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 						// If the Field attribute is not from a known apple library, the library name is set
 						if (string.IsNullOrWhiteSpace (fieldData.Value.LibraryName)) {
 							bucket.Add (Diagnostic.Create (
-								RBI0005, // Non Apple framework bindings must provide a library name.
+								RBI0010, // Non Apple framework bindings must provide a library name.
 								fieldSyntax.GetLocation (),
 								fieldSymbol.ToDisplayString ()));
 						}
@@ -204,7 +207,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 						// If the Field attribute is from a known apple library, the lib should be null
 						if (fieldData.Value.LibraryName is not null) {
 							bucket.Add (Diagnostic.Create (
-								RBI0006, // Do not provide the LibraryName for known Apple frameworks.
+								RBI0011, // Do not provide the LibraryName for known Apple frameworks.
 								fieldSyntax.GetLocation (),
 								fieldSymbol.ToDisplayString ()));
 						}
@@ -214,7 +217,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 					switch (errorTuple.Error) {
 					case FieldData<EnumValue>.ParsingError.NotIdentifier:
 						// Backing field is not a valid identifier.
-						bucket.Add (Diagnostic.Create (RBI0004,
+						bucket.Add (Diagnostic.Create (RBI0009,
 							fieldSyntax
 								.GetLocation (), // Smart enum backing field must represent a valid C# identifier to be used.
 							fieldSymbol.ToDisplayString (), errorTuple.Value));
@@ -227,7 +230,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 					.FirstOrDefault (s => s.StartsWith (AttributesNames.FieldAttribute));
 				if (fieldAttr is not null) {
 					bucket.Add (Diagnostic.Create (
-						RBI0007, // Enum values must be tagged with Field<EnumValue>.
+						RBI0012, // Enum values must be tagged with Field<EnumValue>.
 						fieldSymbol.Locations.First (),
 						fieldAttr, fieldSymbol.ToDisplayString ()));
 				}

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/SmartEnumsAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/SmartEnumsAnalyzer.cs
@@ -23,21 +23,6 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 	/// <summary>
 	/// All enum values must have a Field attribute
 	/// </summary>
-	internal static readonly DiagnosticDescriptor RBI0007 = new (
-		"RBI0007",
-		new LocalizableResourceString (nameof (Resources.RBI0007Title), Resources.ResourceManager, typeof (Resources)),
-		new LocalizableResourceString (nameof (Resources.RBI0007MessageFormat), Resources.ResourceManager,
-			typeof (Resources)),
-		"Usage",
-		DiagnosticSeverity.Error,
-		isEnabledByDefault: true,
-		description: new LocalizableResourceString (nameof (Resources.RBI0007Description), Resources.ResourceManager,
-			typeof (Resources))
-	);
-
-	/// <summary>
-	/// Do not allow duplicated backing fields
-	/// </summary>
 	internal static readonly DiagnosticDescriptor RBI0008 = new (
 		"RBI0008",
 		new LocalizableResourceString (nameof (Resources.RBI0008Title), Resources.ResourceManager, typeof (Resources)),
@@ -51,7 +36,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 	);
 
 	/// <summary>
-	/// Fields must be a valid identifier
+	/// Do not allow duplicated backing fields
 	/// </summary>
 	internal static readonly DiagnosticDescriptor RBI0009 = new (
 		"RBI0009",
@@ -66,7 +51,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 	);
 
 	/// <summary>
-	/// If not an apple framework, we should provide the library path
+	/// Fields must be a valid identifier
 	/// </summary>
 	internal static readonly DiagnosticDescriptor RBI0010 = new (
 		"RBI0010",
@@ -81,7 +66,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 	);
 
 	/// <summary>
-	/// if apple framework, the library path should be empty
+	/// If not an apple framework, we should provide the library path
 	/// </summary>
 	internal static readonly DiagnosticDescriptor RBI0011 = new (
 		"RBI0011",
@@ -89,14 +74,14 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 		new LocalizableResourceString (nameof (Resources.RBI0011MessageFormat), Resources.ResourceManager,
 			typeof (Resources)),
 		"Usage",
-		DiagnosticSeverity.Warning,
+		DiagnosticSeverity.Error,
 		isEnabledByDefault: true,
 		description: new LocalizableResourceString (nameof (Resources.RBI0011Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
 
 	/// <summary>
-	/// User used the wrong flag for the attribute
+	/// if apple framework, the library path should be empty
 	/// </summary>
 	internal static readonly DiagnosticDescriptor RBI0012 = new (
 		"RBI0012",
@@ -104,15 +89,36 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 		new LocalizableResourceString (nameof (Resources.RBI0012MessageFormat), Resources.ResourceManager,
 			typeof (Resources)),
 		"Usage",
-		DiagnosticSeverity.Error,
+		DiagnosticSeverity.Warning,
 		isEnabledByDefault: true,
 		description: new LocalizableResourceString (nameof (Resources.RBI0012Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
 
+	/// <summary>
+	/// User used the wrong flag for the attribute
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0013 = new (
+		"RBI0013",
+		new LocalizableResourceString (nameof (Resources.RBI0013Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0013MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0013Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-		[RBI0007, RBI0008, RBI0009, RBI0010, RBI0011, RBI0012];
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [
+		RBI0008, 
+		RBI0009, 
+		RBI0010, 
+		RBI0011, 
+		RBI0012, 
+		RBI0013,
+	];
 
 	public override void Initialize (AnalysisContext context)
 	{
@@ -165,7 +171,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 			if (attributes.Count == 0) {
 				//  All enum values are marked with a Field attribute, therefore add a diagnostic
 				bucket.Add (Diagnostic.Create (
-					RBI0007, // Smart enum values must be tagged with an Field<EnumValue> attribute.
+					RBI0008, // Smart enum values must be tagged with an Field<EnumValue> attribute.
 					fieldSymbol.Locations.First (),
 					fieldSymbol.ToDisplayString ()));
 				continue;
@@ -186,7 +192,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 					if (backingFields.TryGetValue (fieldData.Value.SymbolName, out var previousEnumValue)) {
 						// All symbol names have to be unique
 						bucket.Add (Diagnostic.Create (
-							RBI0008, // The backing field '{0}' for the enum value '{1}' is already in use for the enum value '{2}'
+							RBI0009, // The backing field '{0}' for the enum value '{1}' is already in use for the enum value '{2}'
 							fieldSyntax.GetLocation (),
 							fieldSymbol.ToDisplayString (), fieldData.Value.SymbolName,
 							fieldSymbol.ToDisplayString ().Trim (), previousEnumValue));
@@ -199,7 +205,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 						// If the Field attribute is not from a known apple library, the library name is set
 						if (string.IsNullOrWhiteSpace (fieldData.Value.LibraryName)) {
 							bucket.Add (Diagnostic.Create (
-								RBI0010, // Non Apple framework bindings must provide a library name.
+								RBI0011, // Non Apple framework bindings must provide a library name.
 								fieldSyntax.GetLocation (),
 								fieldSymbol.ToDisplayString ()));
 						}
@@ -207,7 +213,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 						// If the Field attribute is from a known apple library, the lib should be null
 						if (fieldData.Value.LibraryName is not null) {
 							bucket.Add (Diagnostic.Create (
-								RBI0011, // Do not provide the LibraryName for known Apple frameworks.
+								RBI0012, // Do not provide the LibraryName for known Apple frameworks.
 								fieldSyntax.GetLocation (),
 								fieldSymbol.ToDisplayString ()));
 						}
@@ -217,7 +223,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 					switch (errorTuple.Error) {
 					case FieldData<EnumValue>.ParsingError.NotIdentifier:
 						// Backing field is not a valid identifier.
-						bucket.Add (Diagnostic.Create (RBI0009,
+						bucket.Add (Diagnostic.Create (RBI0010,
 							fieldSyntax
 								.GetLocation (), // Smart enum backing field must represent a valid C# identifier to be used.
 							fieldSymbol.ToDisplayString (), errorTuple.Value));
@@ -230,7 +236,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 					.FirstOrDefault (s => s.StartsWith (AttributesNames.FieldAttribute));
 				if (fieldAttr is not null) {
 					bucket.Add (Diagnostic.Create (
-						RBI0012, // Enum values must be tagged with Field<EnumValue>.
+						RBI0013, // Enum values must be tagged with Field<EnumValue>.
 						fieldSymbol.Locations.First (),
 						fieldAttr, fieldSymbol.ToDisplayString ()));
 				}

--- a/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
@@ -13,6 +13,7 @@ static class AttributesNames {
 	public const string BindingCategoryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Category>";
 	public const string BindingClassAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Class>";
 	public const string BindingProtocolAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Protocol>";
+	public const string BindingStrongDictionaryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.StrongDictionary>";
 	public const string FieldAttribute = "ObjCBindings.FieldAttribute";
 	public const string EnumFieldAttribute = "ObjCBindings.FieldAttribute<ObjCBindings.EnumValue>";
 	public const string ExportFieldAttribute = "ObjCBindings.ExportAttribute<ObjCBindings.Field>";
@@ -26,7 +27,8 @@ static class AttributesNames {
 		BindingAttribute,
 		BindingCategoryAttribute,
 		BindingClassAttribute,
-		BindingProtocolAttribute
+		BindingProtocolAttribute,
+		BindingStrongDictionaryAttribute, 
 	];
 
 
@@ -41,6 +43,9 @@ static class AttributesNames {
 		}
 		if (type == typeof (ObjCBindings.Protocol)) {
 			return BindingProtocolAttribute;
+		}
+		if (type == typeof(ObjCBindings.StrongDictionary)) {
+			return BindingStrongDictionaryAttribute;
 		}
 
 		return null;

--- a/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
@@ -28,7 +28,7 @@ static class AttributesNames {
 		BindingCategoryAttribute,
 		BindingClassAttribute,
 		BindingProtocolAttribute,
-		BindingStrongDictionaryAttribute, 
+		BindingStrongDictionaryAttribute,
 	];
 
 
@@ -44,7 +44,7 @@ static class AttributesNames {
 		if (type == typeof (ObjCBindings.Protocol)) {
 			return BindingProtocolAttribute;
 		}
-		if (type == typeof(ObjCBindings.StrongDictionary)) {
+		if (type == typeof (ObjCBindings.StrongDictionary)) {
 			return BindingStrongDictionaryAttribute;
 		}
 

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BindingTypeSemanticAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BindingTypeSemanticAnalyzerTests.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -10,12 +13,115 @@ using Xunit;
 namespace Microsoft.Macios.Bindings.Analyzer.Tests;
 
 public class BindingTypeSemanticAnalyzerTests : BaseGeneratorWithAnalyzerTestClass {
+	class TestDataBindingTypeAnalyzerTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string nonPartialClassBinding = @"
+using ObjCBindings;
 
-	[Theory]
-	[AllSupportedPlatforms]
-	public async Task BindingTypeMustBePartial (ApplePlatform platform)
-	{
-		const string inputText = @"
+namespace Test {
+	[BindingType<Class>]
+	public class Examples {
+	}
+}
+";
+			yield return [
+				nonPartialClassBinding,
+				BindingTypeSemanticAnalyzer.RBI0001.Id,
+				"The binding type 'Test.Examples' must declared as a partial class"
+			];
+
+			const string classBindingNotClas = @"
+using ObjCBindings;
+
+namespace Test {
+	[BindingType<Class>]
+	public interface Examples {
+	}
+}
+";
+			yield return [
+				classBindingNotClas,
+				BindingTypeSemanticAnalyzer.RBI0002.Id,
+				"BindingType<Class> can only be used to decorate a class but was found on 'Test.Examples' which is not a class"
+			];
+
+			const string nonPartialCategory = @"
+using ObjCBindings;
+
+namespace Test {
+	[BindingType<Category>]
+	public class Examples {
+	}
+}
+";
+			yield return [
+				nonPartialCategory,
+				BindingTypeSemanticAnalyzer.RBI0001.Id,
+				"The binding type 'Test.Examples' must declared as a partial class"
+			];
+
+			const string nonClassCategory = @"
+using ObjCBindings;
+
+namespace Test {
+	[BindingType<Category>]
+	public interface Examples {
+	}
+}
+";
+			yield return [
+				nonClassCategory,
+				BindingTypeSemanticAnalyzer.RBI0003.Id,
+				"BindingType<Category> can only be used to decorate a class but was found on 'Test.Examples' which is not a class"
+			];
+
+			const string nonStaticCategory = @"
+using ObjCBindings;
+
+namespace Test {
+	[BindingType<Category>]
+	public partial class Examples {
+	}
+}
+";
+			yield return [
+				nonStaticCategory,
+				BindingTypeSemanticAnalyzer.RBI0004.Id,
+				"BindingType<Category> can only be used to decorate a static class but was found on 'Test.Examples' which is not static"
+			];
+
+			const string nonPartialProtocol = @"
+using ObjCBindings;
+
+namespace Test {
+	[BindingType<Protocol>]
+	public interface Examples {
+	}
+}
+";
+			yield return [
+				nonPartialProtocol,
+				BindingTypeSemanticAnalyzer.RBI0001.Id,
+				"The binding type 'Test.Examples' must declared as a partial class"
+			];
+
+			const string nonInterfaceProtocol = @"
+using ObjCBindings;
+
+namespace Test {
+	[BindingType<Protocol>]
+	public class Examples {
+	}
+}
+";
+			yield return [
+				nonInterfaceProtocol,
+				BindingTypeSemanticAnalyzer.RBI0005.Id,
+				"BindingType<Protocol> can only be used to decorate an interface but was found on 'Test.Examples' which is not an interface"
+			];
+
+			const string inputText = @"
 using ObjCBindings;
 
 namespace Test {
@@ -24,14 +130,27 @@ namespace Test {
 	}
 }
 ";
+			yield return [
+				inputText,
+				BindingTypeSemanticAnalyzer.RBI0006.Id,
+				"BindingType can only be used to decorate an enumerator but was found on 'Test.Examples' which is not an enumerator"
+			];
+		}
 
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataBindingTypeAnalyzerTests>]
+	public async Task BindingTypeAnalyzerTests (ApplePlatform platform, string inputText, string diagnosticId,
+		string diagnosticMessage)
+	{
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new BindingTypeSemanticAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == BindingTypeSemanticAnalyzer.RBI0001.Id).ToArray ();
+			.Where (d => d.Id == diagnosticId).ToArray ();
 		Assert.Single (analyzerDiagnotics);
 		// verify the diagnostic message
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], BindingTypeSemanticAnalyzer.RBI0001.Id,
-			DiagnosticSeverity.Error, "The binding type 'Test.Examples' must declared as a partial class");
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], diagnosticId, DiagnosticSeverity.Error, diagnosticMessage);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BindingTypeSemanticAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BindingTypeSemanticAnalyzerTests.cs
@@ -28,7 +28,7 @@ namespace Test {
 			yield return [
 				nonPartialClassBinding,
 				BindingTypeSemanticAnalyzer.RBI0001.Id,
-				"The binding type 'Test.Examples' must be declared as a partial class"
+				"The binding type 'Test.Examples' must be declared partial"
 			];
 
 			const string classBindingNotClas = @"
@@ -58,7 +58,7 @@ namespace Test {
 			yield return [
 				nonPartialCategory,
 				BindingTypeSemanticAnalyzer.RBI0001.Id,
-				"The binding type 'Test.Examples' must be declared as a partial class"
+				"The binding type 'Test.Examples' must be declared partial"
 			];
 
 			const string nonClassCategory = @"
@@ -103,7 +103,7 @@ namespace Test {
 			yield return [
 				nonPartialProtocol,
 				BindingTypeSemanticAnalyzer.RBI0001.Id,
-				"The binding type 'Test.Examples' must be declared as a partial class"
+				"The binding type 'Test.Examples' must be declared partial"
 			];
 
 			const string nonInterfaceProtocol = @"
@@ -121,7 +121,7 @@ namespace Test {
 				"BindingType<Protocol> can only be used to decorate an interface but was found on 'Test.Examples' which is not an interface"
 			];
 
-			const string inputText = @"
+			const string nonSmartEnum = @"
 using ObjCBindings;
 
 namespace Test {
@@ -131,9 +131,39 @@ namespace Test {
 }
 ";
 			yield return [
-				inputText,
+				nonSmartEnum,
 				BindingTypeSemanticAnalyzer.RBI0006.Id,
 				"BindingType can only be used to decorate an enumerator but was found on 'Test.Examples' which is not an enumerator"
+			];
+			
+			const string nonPartialStrongDictionary = @"
+using ObjCBindings;
+
+namespace Test {
+	[BindingType<StrongDictionary>]
+	public class Examples {
+	}
+}
+";
+			yield return [
+				nonPartialStrongDictionary,
+				BindingTypeSemanticAnalyzer.RBI0001.Id,
+				"The binding type 'Test.Examples' must be declared partial"
+			];
+			
+			const string nonClassStrongDictionary = @"
+using ObjCBindings;
+
+namespace Test {
+	[BindingType<StrongDictionary>]
+	public interface Examples {
+	}
+}
+";
+			yield return [
+				nonClassStrongDictionary,
+				BindingTypeSemanticAnalyzer.RBI0007.Id,
+				"BindingType<StrongDictionary> can only be used to decorate a class but was found on 'Test.Examples' which is not a class"
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BindingTypeSemanticAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BindingTypeSemanticAnalyzerTests.cs
@@ -135,7 +135,7 @@ namespace Test {
 				BindingTypeSemanticAnalyzer.RBI0006.Id,
 				"BindingType can only be used to decorate an enumerator but was found on 'Test.Examples' which is not an enumerator"
 			];
-			
+
 			const string nonPartialStrongDictionary = @"
 using ObjCBindings;
 
@@ -150,7 +150,7 @@ namespace Test {
 				BindingTypeSemanticAnalyzer.RBI0001.Id,
 				"The binding type 'Test.Examples' must be declared partial"
 			];
-			
+
 			const string nonClassStrongDictionary = @"
 using ObjCBindings;
 

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BindingTypeSemanticAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BindingTypeSemanticAnalyzerTests.cs
@@ -28,7 +28,7 @@ namespace Test {
 			yield return [
 				nonPartialClassBinding,
 				BindingTypeSemanticAnalyzer.RBI0001.Id,
-				"The binding type 'Test.Examples' must declared as a partial class"
+				"The binding type 'Test.Examples' must be declared as a partial class"
 			];
 
 			const string classBindingNotClas = @"
@@ -58,7 +58,7 @@ namespace Test {
 			yield return [
 				nonPartialCategory,
 				BindingTypeSemanticAnalyzer.RBI0001.Id,
-				"The binding type 'Test.Examples' must declared as a partial class"
+				"The binding type 'Test.Examples' must be declared as a partial class"
 			];
 
 			const string nonClassCategory = @"
@@ -103,7 +103,7 @@ namespace Test {
 			yield return [
 				nonPartialProtocol,
 				BindingTypeSemanticAnalyzer.RBI0001.Id,
-				"The binding type 'Test.Examples' must declared as a partial class"
+				"The binding type 'Test.Examples' must be declared as a partial class"
 			];
 
 			const string nonInterfaceProtocol = @"

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/SmartEnumsAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/SmartEnumsAnalyzerTests.cs
@@ -43,10 +43,10 @@ public enum AVCaptureSystemPressureExampleLevel {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0007.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0008.Id).ToArray ();
 		Assert.Single (analyzerDiagnotics);
 		// verify the diagnostic message
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0007.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0008.Id,
 			DiagnosticSeverity.Error,
 			"The enum value 'AVFoundation.AVCaptureSystemPressureExampleLevel.Shutdown' must be tagged with a Field<EnumValue> attribute");
 	}
@@ -131,9 +131,9 @@ public enum AVCaptureSystemPressureExampleLevel {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0009.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0010.Id).ToArray ();
 		Assert.Single (analyzerDiagnotics);
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0009.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0010.Id,
 			DiagnosticSeverity.Error,
 			$"The enum value 'AVFoundation.AVCaptureSystemPressureExampleLevel.Shutdown' backing field '{fieldValue}' is not a valid identifier");
 	}
@@ -199,9 +199,9 @@ public enum AVCaptureSystemPressureExampleLevel {
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0011.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0012.Id).ToArray ();
 		Assert.Single (analyzerDiagnotics);
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0011.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0012.Id,
 			DiagnosticSeverity.Warning,
 			"The Field attribute for the enum value 'AVFoundation.AVCaptureSystemPressureExampleLevel.Shutdown' must not provide a value for 'LibraryName'");
 	}
@@ -278,9 +278,9 @@ public enum CustomLibraryEnum {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0010.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0011.Id).ToArray ();
 		Assert.Single (analyzerDiagnotics);
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0010.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0011.Id,
 			DiagnosticSeverity.Error,
 			"The field attribute for the enum value 'CustomLibrary.CustomLibraryEnum.High' must set the property 'LibraryName'");
 	}
@@ -308,7 +308,7 @@ public enum CustomLibraryEnum {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0007.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0008.Id).ToArray ();
 		// we should have a diagnostic for each enum value
 		Assert.Equal (3, analyzerDiagnotics.Length);
 	}
@@ -346,9 +346,9 @@ public enum AVCaptureSystemPressureExampleLevel {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0008.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0009.Id).ToArray ();
 		Assert.Single (analyzerDiagnotics);
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0008.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0009.Id,
 			DiagnosticSeverity.Error,
 			"The backing field 'AVFoundation.AVCaptureSystemPressureExampleLevel.Fair' for the enum value 'AVCaptureSystemPressureLevelNominal' is already in use for the enum value 'AVFoundation.AVCaptureSystemPressureExampleLevel.Fair'");
 	}
@@ -373,11 +373,11 @@ public enum AVCaptureSystemPressureExampleLevel {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0012.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0013.Id).ToArray ();
 		// we should have a diagnostic for each enum value
 		Assert.Single (analyzerDiagnotics);
 
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0012.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0013.Id,
 			DiagnosticSeverity.Error,
 			"Used attribute 'ObjCBindings.FieldAttribute<StringComparison>' on enum value 'AVFoundation.AVCaptureSystemPressureExampleLevel.Shutdown' when 'ObjCBindings.FieldAttribute<ObjCBindings.EnumValue>' was expected");
 	}

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/SmartEnumsAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/SmartEnumsAnalyzerTests.cs
@@ -43,10 +43,10 @@ public enum AVCaptureSystemPressureExampleLevel {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0002.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0007.Id).ToArray ();
 		Assert.Single (analyzerDiagnotics);
 		// verify the diagnostic message
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0002.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0007.Id,
 			DiagnosticSeverity.Error,
 			"The enum value 'AVFoundation.AVCaptureSystemPressureExampleLevel.Shutdown' must be tagged with a Field<EnumValue> attribute");
 	}
@@ -131,9 +131,9 @@ public enum AVCaptureSystemPressureExampleLevel {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0004.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0009.Id).ToArray ();
 		Assert.Single (analyzerDiagnotics);
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0004.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0009.Id,
 			DiagnosticSeverity.Error,
 			$"The enum value 'AVFoundation.AVCaptureSystemPressureExampleLevel.Shutdown' backing field '{fieldValue}' is not a valid identifier");
 	}
@@ -199,9 +199,9 @@ public enum AVCaptureSystemPressureExampleLevel {
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0006.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0011.Id).ToArray ();
 		Assert.Single (analyzerDiagnotics);
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0006.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0011.Id,
 			DiagnosticSeverity.Warning,
 			"The Field attribute for the enum value 'AVFoundation.AVCaptureSystemPressureExampleLevel.Shutdown' must not provide a value for 'LibraryName'");
 	}
@@ -278,9 +278,9 @@ public enum CustomLibraryEnum {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0005.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0010.Id).ToArray ();
 		Assert.Single (analyzerDiagnotics);
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0005.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0010.Id,
 			DiagnosticSeverity.Error,
 			"The field attribute for the enum value 'CustomLibrary.CustomLibraryEnum.High' must set the property 'LibraryName'");
 	}
@@ -308,7 +308,7 @@ public enum CustomLibraryEnum {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0002.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0007.Id).ToArray ();
 		// we should have a diagnostic for each enum value
 		Assert.Equal (3, analyzerDiagnotics.Length);
 	}
@@ -346,9 +346,9 @@ public enum AVCaptureSystemPressureExampleLevel {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0003.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0008.Id).ToArray ();
 		Assert.Single (analyzerDiagnotics);
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0003.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0008.Id,
 			DiagnosticSeverity.Error,
 			"The backing field 'AVFoundation.AVCaptureSystemPressureExampleLevel.Fair' for the enum value 'AVCaptureSystemPressureLevelNominal' is already in use for the enum value 'AVFoundation.AVCaptureSystemPressureExampleLevel.Fair'");
 	}
@@ -373,11 +373,11 @@ public enum AVCaptureSystemPressureExampleLevel {
 		var (compilation, _) = CreateCompilation (platform, sources: inputText);
 		var diagnostics = await RunAnalyzer (new SmartEnumsAnalyzer (), compilation);
 		var analyzerDiagnotics = diagnostics
-			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0007.Id).ToArray ();
+			.Where (d => d.Id == SmartEnumsAnalyzer.RBI0012.Id).ToArray ();
 		// we should have a diagnostic for each enum value
 		Assert.Single (analyzerDiagnotics);
 
-		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0007.Id,
+		VerifyDiagnosticMessage (analyzerDiagnotics [0], SmartEnumsAnalyzer.RBI0012.Id,
 			DiagnosticSeverity.Error,
 			"Used attribute 'ObjCBindings.FieldAttribute<StringComparison>' on enum value 'AVFoundation.AVCaptureSystemPressureExampleLevel.Shutdown' when 'ObjCBindings.FieldAttribute<ObjCBindings.EnumValue>' was expected");
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/AttributesNamesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/AttributesNamesTests.cs
@@ -27,6 +27,7 @@ public class AttributesNamesTests {
 	[InlineData (Category.Default, AttributesNames.BindingCategoryAttribute)]
 	[InlineData (Class.Default, AttributesNames.BindingClassAttribute)]
 	[InlineData (Protocol.Default, AttributesNames.BindingProtocolAttribute)]
+	[InlineData (StrongDictionary.Default, AttributesNames.BindingStrongDictionaryAttribute)]
 	public void GetBindingTypeAttributeName<T> (T @enum, string? expectedName) where T : Enum
 	{
 		Assert.NotNull (@enum);


### PR DESCRIPTION
The analyzer now checks the following:

* All usages of `bindingTypeAttribute<T>` have to happen on partial classes.
* `BindingType<Class>` can only be used on classes.
* `BindingType<Category>` can only be used on static classes.
* `BindingType<Protocol>` can only be used on interfaces.
* `BindingType<StrongDictionary>` can only be used on classes.
* `BindingType` can only be used on enums.

Because we have not yet released any of the errors, we have sorted them to be the first ones from 0001-0006.