### PR TITLE
[xtro] Skip native enum values that aren't available on the current platform.

### DIFF
--- a/src/Metal/MTLEnums.cs
+++ b/src/Metal/MTLEnums.cs
@@ -956,14 +956,39 @@ namespace Metal {
 	/// <summary>Enumerates the hardware feature sets that are available on a device.</summary>
 	[Native]
 	public enum MTLFeatureSet : ulong {
+#if XAMCORE_5_0
+		[NoMacCatalyst]
+#elif __MACCATALYST__
+		[Obsolete ("Not available on the current platform.")]
+#endif
 		[NoTV, NoMac]
 		iOS_GPUFamily1_v1 = 0,
+#if XAMCORE_5_0
+		[NoMacCatalyst]
+#elif __MACCATALYST__
+		[Obsolete ("Not available on the current platform.")]
+#endif
 		[NoTV, NoMac]
 		iOS_GPUFamily1_v2 = 2,
+#if XAMCORE_5_0
+		[NoMacCatalyst]
+#elif __MACCATALYST__
+		[Obsolete ("Not available on the current platform.")]
+#endif
 		[NoTV, NoMac]
 		iOS_GPUFamily2_v1 = 1,
+#if XAMCORE_5_0
+		[NoMacCatalyst]
+#elif __MACCATALYST__
+		[Obsolete ("Not available on the current platform.")]
+#endif
 		[NoTV, NoMac]
 		iOS_GPUFamily2_v2 = 3,
+#if XAMCORE_5_0
+		[NoMacCatalyst]
+#elif __MACCATALYST__
+		[Obsolete ("Not available on the current platform.")]
+#endif
 		[NoTV, NoMac]
 		iOS_GPUFamily3_v1 = 4,
 		[NoTV, NoMac, NoMacCatalyst]
@@ -995,28 +1020,13 @@ namespace Metal {
 		[NoiOS, NoTV, NoMacCatalyst]
 		macOS_GPUFamily1_v1 = 10000,
 
-#if !NET
-		[Obsolete ("Use 'macOS_GPUFamily1_v1' instead.")]
-		OSX_GPUFamily1_v1 = macOS_GPUFamily1_v1,
-#endif
-
 		[NoiOS, NoTV]
 		[NoMacCatalyst]
 		macOS_GPUFamily1_v2 = 10001,
 
-#if !NET
-		[Obsolete ("Use 'macOS_GPUFamily1_v2' instead.")]
-		OSX_GPUFamily1_v2 = macOS_GPUFamily1_v2,
-#endif
-
 		[NoiOS, NoTV]
 		[NoMacCatalyst]
 		macOS_ReadWriteTextureTier2 = 10002,
-
-#if !NET
-		[Obsolete ("Use 'macOS_ReadWriteTextureTier2' instead.")]
-		OSX_ReadWriteTextureTier2 = macOS_ReadWriteTextureTier2,
-#endif
 
 		[NoiOS, NoTV]
 		[NoMacCatalyst]
@@ -1030,9 +1040,10 @@ namespace Metal {
 		[NoMacCatalyst]
 		macOS_GPUFamily2_v1 = 10005,
 
-#if !NET
-		[Obsolete ("Use 'tvOS_GPUFamily1_v1' instead.")]
-		TVOS_GPUFamily1_v1 = 30000,
+#if XAMCORE_5_0
+		[NoMacCatalyst]
+#elif __MACCATALYST__
+		[Obsolete ("Not available on the current platform.")]
 #endif
 
 		[NoiOS, NoMac]

--- a/src/oslog.cs
+++ b/src/oslog.cs
@@ -64,6 +64,12 @@ namespace OSLog {
 	[TV (15, 0), iOS (15, 0), MacCatalyst (15, 0)]
 	[Native]
 	enum OSLogStoreScope : long {
+#if XAMCORE_5_0
+		[NoTV, NoiOS, NoMacCatalyst]
+#endif
+#if !MONOMAC
+		[Obsolete ("Not available on the current platform.")]
+#endif
 		System = 0,
 		CurrentProcessIdentifier = 1,
 	}

--- a/tests/cecil-tests/AttributeTest.cs
+++ b/tests/cecil-tests/AttributeTest.cs
@@ -193,10 +193,6 @@ namespace Cecil.Tests {
 							continue;
 						}
 						foreach (var member in GetAllTypeMembers (type)) {
-							// If a member is hidden, it's probably because it's broken in some way, so don't consider it.
-							if (ObsoleteTest.HasEditorBrowseableNeverAttribute (member))
-								continue;
-
 							var mentionedPlatforms = GetAvailabilityAttributes (member).ToList ();
 							if (mentionedPlatforms.Any ()) {
 								var claimedPlatforms = GetSupportedAvailabilityAttributes (member).ToList ();

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Metal.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Metal.ignore
@@ -1,6 +1,0 @@
-!extra-enum-value! Managed value 0 for MTLFeatureSet.iOS_GPUFamily1_v1 is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 1 for MTLFeatureSet.iOS_GPUFamily2_v1 is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 2 for MTLFeatureSet.iOS_GPUFamily1_v2 is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 3 for MTLFeatureSet.iOS_GPUFamily2_v2 is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 30000 for MTLFeatureSet.tvOS_GPUFamily1_v1 is available for the current platform while the value in the native header is not
-!extra-enum-value! Managed value 4 for MTLFeatureSet.iOS_GPUFamily3_v1 is available for the current platform while the value in the native header is not

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-OSLog.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-OSLog.todo
@@ -1,1 +1,0 @@
-!extra-enum-value! Managed value 0 for OSLogStoreScope.System is available for the current platform while the value in the native header is not

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-OSLog.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-OSLog.todo
@@ -1,1 +1,0 @@
-!extra-enum-value! Managed value 0 for OSLogStoreScope.System is available for the current platform while the value in the native header is not

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreMIDI.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreMIDI.ignore
@@ -31,8 +31,6 @@
 !missing-pinvoke! MIDISendEventList is not bound
 !missing-pinvoke! MIDISourceCreateWithProtocol is not bound
 
-# header's clearly say this enum value is not supported on macOS, yet xtro claims it is
-!missing-enum-value! MidiNotificationMessageId native value kMIDIMsgInternalStart = 4096 not bound
 !missing-pinvoke! MIDIEventPacketSysexBytesForGroup is not bound
 !missing-pinvoke! MIDISendUMPSysex is not bound
 !missing-pinvoke! MIDISendUMPSysex8 is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-MapKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-MapKit.ignore
@@ -1,1 +1,0 @@
-!missing-enum-value! MKUserTrackingMode native value MKUserTrackingModeFollowWithHeading = 2 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-MapKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-MapKit.ignore
@@ -1,1 +1,0 @@
-!missing-enum-value! MKUserTrackingMode native value MKUserTrackingModeFollowWithHeading = 2 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-OSLog.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-OSLog.todo
@@ -1,1 +1,0 @@
-!extra-enum-value! Managed value 0 for OSLogStoreScope.System is available for the current platform while the value in the native header is not

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
@@ -366,9 +366,6 @@
 ## Enums not needed on tvOS
 !missing-enum! UIListSeparatorVisibility not bound
 !missing-enum! UIPrintRenderingQuality not bound
-!missing-enum-value! UICollectionLayoutListAppearance native value UICollectionLayoutListAppearanceInsetGrouped = 2 not bound
-!missing-enum-value! UICollectionLayoutListAppearance native value UICollectionLayoutListAppearanceSidebar = 3 not bound
-!missing-enum-value! UICollectionLayoutListAppearance native value UICollectionLayoutListAppearanceSidebarPlain = 4 not bound
 
 # Not binding for now, does not make sense on tvOS
 !missing-selector! +UITextInputContext::current not bound

--- a/tests/xtro-sharpie/xtro-sharpie/EnumCheck.cs
+++ b/tests/xtro-sharpie/xtro-sharpie/EnumCheck.cs
@@ -244,8 +244,12 @@ namespace Extrospection {
 
 					// couldn't find a matching managed enum value for the native enum value
 					// don't report deprecated native enum values (or if the native enum itself is deprecated) as missing
-					if (!valueDecl.IsDeprecated () && !decl.IsDeprecated ())
+					if (!valueDecl.IsDeprecated () && !decl.IsDeprecated ()) {
+						// skip native enum values that aren't available on the current platform, unless it's an error enum.
+						if (!valueDecl.IsAvailable () && !IsErrorEnum (mname))
+							continue;
 						Log.On (framework).Add ($"!missing-enum-value! {type.Name} native value {valueName} = {value} not bound");
+					}
 				}
 			}
 
@@ -280,14 +284,21 @@ namespace Extrospection {
 				Log.On (framework).Add ($"!wrong-enum-size! {name} managed {managed_size} vs native {native_size}");
 		}
 
+		static bool IsErrorEnum (string typeName)
+		{
+			if (typeName.EndsWith ("Error", StringComparison.Ordinal))
+				return true;
+			if (typeName.EndsWith ("ErrorCode", StringComparison.Ordinal))
+				return true;
+			return false;
+		}
+
 		static bool IsErrorEnum (TypeDefinition type)
 		{
 			if (!type.IsEnum)
 				return false;
 
-			if (type.Name.EndsWith ("Error", StringComparison.Ordinal))
-				return true;
-			if (type.Name.EndsWith ("ErrorCode", StringComparison.Ordinal))
+			if (IsErrorEnum (type.Name))
 				return true;
 
 			if (!type.HasCustomAttributes)


### PR DESCRIPTION
This also required a fix in cecil-tests: don't skip obsolete members when
verifying availability attributes.

We end up failing a test that verifies that a member must exist on a platform,
if it has an availability attribute claiming so in other platforms' assemblies
- the problem being that the test wouldn't find the member on a platform it
was merely obsoleted (but still existing!) there.