### PR TITLE
[RGen] Use the correct attribute for field properties.

### DIFF
--- a/src/ObjCBindings/FieldTag.cs
+++ b/src/ObjCBindings/FieldTag.cs
@@ -6,23 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 namespace ObjCBindings {
 
 	/// <summary>
-	/// The exported constant/field is a class/interface property field.
-	/// </summary>
-	[Flags]
-	[Experimental ("APL0003")]
-	public enum Field {
-		/// <summary>
-		/// Use the default values.
-		/// </summary>
-		Default = 0,
-
-		/// <summary>
-		/// Field represents a notification in ObjC.
-		/// </summary>
-		Notification = 1 << 2,
-	}
-
-	/// <summary>
 	/// Field flag that states that the field is used as a Enum value.
 	/// </summary>
 	[Flags]

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
@@ -26,6 +26,10 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 		LibraryName = libraryName;
 		Flags = flags;
 	}
+	
+	internal FieldData (string symbolName, T? flags) : this(symbolName, null, flags) { }
+	
+	internal FieldData (string symbolName) : this(symbolName, null, default) { }
 
 	public static bool TryParse (AttributeData attributeData,
 		[NotNullWhen (true)] out FieldData<T>? data)
@@ -52,21 +56,19 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 			if (!attributeData.ConstructorArguments [0].TryGetIdentifier (out symbolName)) {
 				return false;
 			}
-			switch (attributeData.ConstructorArguments [1].Value) {
-			// there are two possible cases here:
-			// 1. The second argument is a string
-			// 2. The second argument is an enum
-			case T enumValue:
-				flags = enumValue;
-				break;
-			case string lib:
-				libraryName = lib;
-				break;
-			default:
-				// unexpected value :/
-				error = new (ParsingError.UnknownConstructor, attributeData.ConstructorArguments.Length);
+
+			if (attributeData.ConstructorArguments [1].Value is string) {
+				libraryName = (string?) attributeData.ConstructorArguments [1].Value!;
+			} else {
+				flags = (T) attributeData.ConstructorArguments [1].Value!;
+			}
+			break;
+		case 3:
+			if (!attributeData.ConstructorArguments [0].TryGetIdentifier (out symbolName)) {
 				return false;
 			}
+			libraryName = (string?) attributeData.ConstructorArguments [1].Value!;
+			flags = (T) attributeData.ConstructorArguments [2].Value!;
 			break;
 		default:
 			// 0 should not be an option.

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
@@ -26,10 +26,10 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 		LibraryName = libraryName;
 		Flags = flags;
 	}
-	
-	internal FieldData (string symbolName, T? flags) : this(symbolName, null, flags) { }
-	
-	internal FieldData (string symbolName) : this(symbolName, null, default) { }
+
+	internal FieldData (string symbolName, T? flags) : this (symbolName, null, flags) { }
+
+	internal FieldData (string symbolName) : this (symbolName, null, default) { }
 
 	public static bool TryParse (AttributeData attributeData,
 		[NotNullWhen (true)] out FieldData<T>? data)

--- a/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
@@ -58,7 +58,7 @@ static class AttributesNames {
 		if (type == typeof (ObjCBindings.Property)) {
 			return FieldPropertyAttribute;
 		}
-		if (type == typeof(ObjCBindings.EnumValue)) {
+		if (type == typeof (ObjCBindings.EnumValue)) {
 			return EnumFieldAttribute;
 		}
 		return null;

--- a/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
@@ -16,7 +16,7 @@ static class AttributesNames {
 	public const string BindingStrongDictionaryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.StrongDictionary>";
 	public const string FieldAttribute = "ObjCBindings.FieldAttribute";
 	public const string EnumFieldAttribute = "ObjCBindings.FieldAttribute<ObjCBindings.EnumValue>";
-	public const string ExportFieldAttribute = "ObjCBindings.ExportAttribute<ObjCBindings.Field>";
+	public const string FieldPropertyAttribute = "ObjCBindings.FieldAttribute<ObjCBindings.Property>";
 	public const string ExportPropertyAttribute = "ObjCBindings.ExportAttribute<ObjCBindings.Property>";
 	public const string ExportMethodAttribute = "ObjCBindings.ExportAttribute<ObjCBindings.Method>";
 	public const string SupportedOSPlatformAttribute = "System.Runtime.Versioning.SupportedOSPlatformAttribute";
@@ -55,9 +55,19 @@ static class AttributesNames {
 	{
 		// we cannot use a switch statement because typeof is not a constant value
 		var type = typeof (T);
-		if (type == typeof (ObjCBindings.Field)) {
-			return ExportFieldAttribute;
+		if (type == typeof (ObjCBindings.Property)) {
+			return FieldPropertyAttribute;
 		}
+		if (type == typeof(ObjCBindings.EnumValue)) {
+			return EnumFieldAttribute;
+		}
+		return null;
+	}
+
+	public static string? GetExportAttributeName<T> () where T : Enum
+	{
+		// we cannot use a switch statement because typeof is not a constant value
+		var type = typeof (T);
 		if (type == typeof (ObjCBindings.Property)) {
 			return ExportPropertyAttribute;
 		}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -212,7 +212,7 @@ readonly struct CodeChanges {
 		//    2. Exported properties
 		if (propertyDeclarationSyntax.Modifiers.Any (SyntaxKind.PartialKeyword)) {
 			return !propertyDeclarationSyntax.HasAtLeastOneAttribute (semanticModel,
-				AttributesNames.ExportFieldAttribute, AttributesNames.ExportPropertyAttribute);
+				AttributesNames.FieldPropertyAttribute, AttributesNames.ExportPropertyAttribute);
 		}
 
 		return true;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -53,7 +53,7 @@ readonly struct Property : IEquatable<Property> {
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a field binding. 
 	/// </summary>
-	public ExportData<Field>? ExportFieldData { get; init; }
+	public FieldData<ObjCBindings.Property>? ExportFieldData { get; init; }
 
 	/// <summary>
 	/// True if the property represents a Objc field.
@@ -61,7 +61,7 @@ readonly struct Property : IEquatable<Property> {
 	[MemberNotNullWhen (true, nameof (ExportFieldData))]
 	public bool IsField => ExportFieldData is not null;
 
-	public bool IsNotification => IsField && ExportFieldData.Value.Flags.HasFlag (Field.Notification);
+	public bool IsNotification => IsField && ExportFieldData.Value.Flags.HasFlag (ObjCBindings.Property.Notification);
 
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a property binding. 
@@ -211,7 +211,7 @@ readonly struct Property : IEquatable<Property> {
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],
 			accessors: accessorCodeChanges) {
-			ExportFieldData = propertySymbol.GetExportData<Field> (),
+			ExportFieldData = propertySymbol.GetFieldData<ObjCBindings.Property> (),
 			ExportPropertyData = propertySymbol.GetExportData<ObjCBindings.Property> (),
 		};
 		return true;

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.cs
@@ -195,9 +195,9 @@ static class TypeSymbolExtensions {
 	}
 
 	delegate string? GetAttributeNames ();
-	delegate bool TryParse<T> (AttributeData  data, [NotNullWhen(true)]out T? value) where T : struct;
+	delegate bool TryParse<T> (AttributeData data, [NotNullWhen (true)] out T? value) where T : struct;
 
-	static T? GetAttribute<T> (this ISymbol symbol, GetAttributeNames getAttributeNames, TryParse<T> tryParse) where T : struct 
+	static T? GetAttribute<T> (this ISymbol symbol, GetAttributeNames getAttributeNames, TryParse<T> tryParse) where T : struct
 	{
 		var attributes = symbol.GetAttributeData ();
 		if (attributes.Count == 0)
@@ -231,7 +231,7 @@ static class TypeSymbolExtensions {
 	/// returned.</remarks>
 	public static ExportData<T>? GetExportData<T> (this ISymbol symbol) where T : Enum
 		=> GetAttribute<ExportData<T>> (symbol, AttributesNames.GetExportAttributeName<T>, ExportData<T>.TryParse);
-	
+
 	/// <summary>
 	/// Retrieve the data of a field attribute on a symbol.
 	/// </summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/ExportDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/ExportDataTests.cs
@@ -16,8 +16,8 @@ public class ExportDataTests {
 	[Fact]
 	public void TestExportDataEqualsDiffSelector ()
 	{
-		var x = new ExportData<Field> ("field1");
-		var y = new ExportData<Field> ("field2");
+		var x = new ExportData<Method> ("field1");
+		var y = new ExportData<Method> ("field2");
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -27,8 +27,8 @@ public class ExportDataTests {
 	[Fact]
 	public void TestExportDataEqualsDiffArgumentSemantic ()
 	{
-		var x = new ExportData<Field> ("property", ArgumentSemantic.None);
-		var y = new ExportData<Field> ("property", ArgumentSemantic.Retain);
+		var x = new ExportData<Method> ("property", ArgumentSemantic.None);
+		var y = new ExportData<Method> ("property", ArgumentSemantic.Retain);
 		Assert.False (x.Equals (y));
 		Assert.False (y.Equals (x));
 		Assert.False (x == y);
@@ -52,14 +52,14 @@ public class ExportDataTests {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
-				Field.Default,
-				new ExportData<Field> ("symbol", ArgumentSemantic.None, Field.Default),
-				"{ Type: 'ObjCBindings.Field', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default' }"
+				Method.Default,
+				new ExportData<Method> ("symbol", ArgumentSemantic.None, Method.Default),
+				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default' }"
 			];
 			yield return [
-				Field.Default,
-				new ExportData<Field> ("symbol"),
-				"{ Type: 'ObjCBindings.Field', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default' }"
+				Method.Default,
+				new ExportData<Method> ("symbol"),
+				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default' }"
 			];
 			yield return [
 				Property.Default,

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/AttributesNamesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/AttributesNamesTests.cs
@@ -12,9 +12,19 @@ public class AttributesNamesTests {
 	[Theory]
 	[InlineData (StringComparison.Ordinal, null)]
 	[InlineData (EnumValue.Default, null)]
-	[InlineData (Field.Default, AttributesNames.ExportFieldAttribute)]
 	[InlineData (Property.Default, AttributesNames.ExportPropertyAttribute)]
 	[InlineData (Method.Default, AttributesNames.ExportMethodAttribute)]
+	public void GetExportAttributeName<T> (T @enum, string? expectedName) where T : Enum
+	{
+		Assert.NotNull (@enum);
+		Assert.Equal (expectedName, AttributesNames.GetExportAttributeName<T> ());
+	}
+
+	[Theory]
+	[InlineData (StringComparison.Ordinal, null)]
+	[InlineData (Method.Default, null)]
+	[InlineData (Property.Default, AttributesNames.FieldPropertyAttribute)]
+	[InlineData (EnumValue.Default, AttributesNames.EnumFieldAttribute)]
 	public void GetFieldAttributeName<T> (T @enum, string? expectedName) where T : Enum
 	{
 		Assert.NotNull (@enum);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -29,7 +29,7 @@ public class ClassCodeChangesTests : BaseGeneratorTestClass {
 			builder.Add (new SupportedOSPlatformData ("ios17.0"));
 			builder.Add (new SupportedOSPlatformData ("tvos17.0"));
 			builder.Add (new UnsupportedOSPlatformData ("macos"));
-
+			
 			const string emptyClass = @"
 using Foundation;
 using ObjCRuntime;
@@ -535,7 +535,7 @@ namespace NS;
 
 [BindingType]
 public partial class MyClass {
-	[Export<Property> (""name"", Property.Notification)]
+	[Field<Property> (""name"", Property.Notification)]
 	public partial string Name { get; set; } = string.Empty;
 }
 ";
@@ -565,7 +565,7 @@ public partial class MyClass {
 							returnType: new ("string", isReferenceType: true),
 							symbolAvailability: new (),
 							attributes: [
-								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name", "ObjCBindings.Property.Notification"])
+								new ("ObjCBindings.FieldAttribute<ObjCBindings.Property>", ["name", "ObjCBindings.Property.Notification"])
 							],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -589,7 +589,7 @@ public partial class MyClass {
 							]
 						) {
 
-							ExportPropertyData = new ("name", ArgumentSemantic.None, Property.Notification)
+							ExportFieldData = new (symbolName: "name", flags: Property.Notification)
 						}
 					]
 				}
@@ -602,7 +602,7 @@ namespace NS;
 
 [BindingType]
 public partial class MyClass {
-	[Export<Field> (""CONSTANT"")]
+	[Field<Property> (""CONSTANT"")]
 	public static partial string Name { get; set; } = string.Empty;
 }
 ";
@@ -632,7 +632,7 @@ public partial class MyClass {
 							returnType: new ("string", isReferenceType: true),
 							symbolAvailability: new (),
 							attributes: [
-								new ("ObjCBindings.ExportAttribute<ObjCBindings.Field>", ["CONSTANT"])
+								new ("ObjCBindings.FieldAttribute<ObjCBindings.Property>", ["CONSTANT"])
 							],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -29,7 +29,7 @@ public class ClassCodeChangesTests : BaseGeneratorTestClass {
 			builder.Add (new SupportedOSPlatformData ("ios17.0"));
 			builder.Add (new SupportedOSPlatformData ("tvos17.0"));
 			builder.Add (new UnsupportedOSPlatformData ("macos"));
-			
+
 			const string emptyClass = @"
 using Foundation;
 using ObjCRuntime;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesTests.cs
@@ -136,7 +136,7 @@ public class TestClass {
 }
 ";
 			yield return [exportFieldAttributeInProperty, true];
-			
+
 			const string fieldAttributeInProperty = @"
 using System;
 using Foundation;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesTests.cs
@@ -123,7 +123,7 @@ public class TestClass {
 ";
 			yield return [wrongAttributeInProperty, true];
 
-			const string fieldAttributeInProperty = @"
+			const string exportFieldAttributeInProperty = @"
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -132,6 +132,20 @@ using ObjCBindings;
 [BindingType]
 public class TestClass {
 	[Export<Field> (""name"")]
+	public partial string Name { get;set; }
+}
+";
+			yield return [exportFieldAttributeInProperty, true];
+			
+			const string fieldAttributeInProperty = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+using ObjCBindings;
+
+[BindingType]
+public class TestClass {
+	[Field<Property> (""name"")]
 	public partial string Name { get;set; }
 }
 ";

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.DataModel;
 using ObjCBindings;
-using ObjCRuntime;
 using Xamarin.Tests;
 using Xamarin.Utils;
 using Xunit;
@@ -295,7 +294,7 @@ namespace NS;
 
 [BindingType]
 public partial interface IProtocol {
-	[Export<Property> (""name"", Property.Notification)]
+	[Field<Property> (""name"", Property.Notification)]
 	public partial string Name { get; set; } = string.Empty;
 }
 ";
@@ -323,7 +322,7 @@ public partial interface IProtocol {
 							returnType: new ("string", isReferenceType: true),
 							symbolAvailability: new (),
 							attributes: [
-								new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name", "ObjCBindings.Property.Notification"])
+								new ("ObjCBindings.FieldAttribute<ObjCBindings.Property>", ["name", "ObjCBindings.Property.Notification"])
 							],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
@@ -346,7 +345,7 @@ public partial interface IProtocol {
 								),
 							]
 						) {
-							ExportPropertyData = new ("name", ArgumentSemantic.None, Property.Notification)
+							ExportFieldData= new ("name", Property.Notification)
 						}
 					]
 				}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -345,7 +345,7 @@ public partial interface IProtocol {
 								),
 							]
 						) {
-							ExportFieldData= new ("name", Property.Notification)
+							ExportFieldData = new ("name", Property.Notification)
 						}
 					]
 				}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -378,6 +379,27 @@ public class PropertyTests : BaseGeneratorTestClass {
 		Assert.True (y.Equals (x));
 		Assert.True (x == y);
 		Assert.False (x != y);
+	}
+
+	[Theory]
+	[InlineData (ObjCBindings.Property.Default, false)]
+	[InlineData (ObjCBindings.Property.Notification, true)]
+#pragma warning disable xUnit1025
+	[InlineData (ObjCBindings.Property.Notification | ObjCBindings.Property.Default, true)]
+#pragma warning restore xUnit1025
+	public void IsNotification (ObjCBindings.Property flag, bool expectedResult)
+	{
+		var property = new Property (
+			name: "Test",
+			returnType: new ReturnType ("string"),
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
+			accessors: []
+		) {
+			ExportFieldData = new FieldData<ObjCBindings.Property> ("name", flag)
+		};
+		Assert.Equal (expectedResult, property.IsNotification);
 	}
 
 	class TestDataFromPropertyDeclaration : IEnumerable<object []> {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
@@ -432,20 +432,8 @@ public partial class MyClass {
 	public static partial string Name { get; set; } = string.Empty;
 }
 ";
-			yield return [noAttrPropertyClass, Field.Default, null!];
+			yield return [noAttrPropertyClass, Property.Default, null!];
 
-			const string fieldPropertyClass = @"
-using ObjCBindings;
-
-namespace NS;
-
-[BindingType]
-public partial class MyClass {
-	[Export<Field> (""CONSTANT"")]
-	public static partial string Name { get; set; } = string.Empty;
-}
-";
-			yield return [fieldPropertyClass, Field.Default, new ExportData<Field> ("CONSTANT")];
 			const string singlePropertyClass = @"
 using ObjCBindings;
 
@@ -499,6 +487,47 @@ public partial class MyClass {
 		Assert.NotNull (symbol);
 		var exportData = symbol.GetExportData<T> ();
 		Assert.Equal (expectedData, exportData);
+	}
+
+	class TestDataGetFieldData : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string fieldPropertyClass = @"
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType]
+public partial class MyClass {
+	[Field<Property> (""CONSTANT"")]
+	public static partial string Name { get; set; } = string.Empty;
+}
+";
+			yield return [fieldPropertyClass, Property.Default, new FieldData<Property> ("CONSTANT")];
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataGetFieldData>]
+	void GetFieldData<T> (ApplePlatform platform, string inputText, T @enum, FieldData<T>? expectedData)
+		where T : Enum
+	{
+		Assert.NotNull (@enum);
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<PropertyDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		Assert.NotNull (semanticModel);
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		var fieldData = symbol.GetFieldData<T> ();
+		Assert.Equal (expectedData, fieldData);
 	}
 
 	class TestDataIsBlittablePrimitiveType : IEnumerable<object []> {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
@@ -505,7 +505,7 @@ public partial class MyClass {
 ";
 			yield return [fieldPropertyClass, Property.Default, new FieldData<Property> ("CONSTANT")];
 		}
-		
+
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
 


### PR DESCRIPTION
We cannot use Export because we need to be ablet to pass the library name to generate the property field correctly. This change moves from using Export<Field> to Field<Property> which allows to mark a property as a field AND will allow use to add the library name.

This change + the one in PR
https://github.com/xamarin/xamarin-macios/pull/21945 improves the way the Library.g.cs file is generated.