### PR TITLE
[RGen] Keep track of the libs needed for enums and fields.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -179,8 +179,20 @@ readonly struct CodeChanges {
 
 			// return those libs needed by smart enums
 			foreach (var enumMember in EnumMembers) {
-				if (visited.Add (enumMember.LibraryName)) // if already visited we cannot add it
-					yield return (enumMember.LibraryName, enumMember.LibraryPath);
+				if (enumMember.FieldInfo is null)
+					continue;
+				var (_, libraryName, libraryPath) = enumMember.FieldInfo.Value;
+				if (visited.Add (libraryName)) // if already visited, we cannot add it
+					yield return (libraryName, libraryPath);
+			}
+			
+			// return those libs needed by field properties
+			foreach (var property in Properties) {
+				if (property.ExportFieldData is null)
+					continue;
+				var (_, libraryName, libraryPath) = property.ExportFieldData.Value;
+				if (visited.Add (libraryName)) // if already visited, we cannot add it
+					yield return (libraryName, libraryPath);
 			}
 		}
 	}
@@ -244,12 +256,12 @@ readonly struct CodeChanges {
 
 	delegate bool SkipDelegate<in T> (T declarationSyntax, SemanticModel semanticModel);
 
-	delegate bool TryCreateDelegate<in T, TR> (T declaration, SemanticModel semanticModel,
+	delegate bool TryCreateDelegate<in T, TR> (T declaration, RootBindingContext context,
 		[NotNullWhen (true)] out TR? change)
 		where T : MemberDeclarationSyntax
 		where TR : struct;
 
-	static void GetMembers<T, TR> (TypeDeclarationSyntax baseDeclarationSyntax, SemanticModel semanticModel,
+	static void GetMembers<T, TR> (TypeDeclarationSyntax baseDeclarationSyntax, RootBindingContext context,
 		SkipDelegate<T> skip, TryCreateDelegate<T, TR> tryCreate, out ImmutableArray<TR> members)
 		where T : MemberDeclarationSyntax
 		where TR : struct
@@ -257,9 +269,9 @@ readonly struct CodeChanges {
 		var bucket = ImmutableArray.CreateBuilder<TR> ();
 		var declarations = baseDeclarationSyntax.Members.OfType<T> ();
 		foreach (var declaration in declarations) {
-			if (skip (declaration, semanticModel))
+			if (skip (declaration, context.SemanticModel))
 				continue;
-			if (tryCreate (declaration, semanticModel, out var change))
+			if (tryCreate (declaration, context, out var change))
 				bucket.Add (change.Value);
 		}
 
@@ -357,12 +369,12 @@ readonly struct CodeChanges {
 
 		// use the generic method to get the members, we are using an out param to try an minimize the number of times
 		// the value types are copied
-		GetMembers<ConstructorDeclarationSyntax, Constructor> (classDeclaration, context.SemanticModel, Skip,
+		GetMembers<ConstructorDeclarationSyntax, Constructor> (classDeclaration, context, Skip,
 			Constructor.TryCreate, out constructors);
-		GetMembers<PropertyDeclarationSyntax, Property> (classDeclaration, context.SemanticModel, Skip, Property.TryCreate,
+		GetMembers<PropertyDeclarationSyntax, Property> (classDeclaration, context, Skip, Property.TryCreate,
 			out properties);
-		GetMembers<EventDeclarationSyntax, Event> (classDeclaration, context.SemanticModel, Skip, Event.TryCreate, out events);
-		GetMembers<MethodDeclarationSyntax, Method> (classDeclaration, context.SemanticModel, Skip, Method.TryCreate,
+		GetMembers<EventDeclarationSyntax, Event> (classDeclaration, context, Skip, Event.TryCreate, out events);
+		GetMembers<MethodDeclarationSyntax, Method> (classDeclaration, context, Skip, Method.TryCreate,
 			out methods);
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -185,7 +185,7 @@ readonly struct CodeChanges {
 				if (visited.Add (libraryName)) // if already visited, we cannot add it
 					yield return (libraryName, libraryPath);
 			}
-			
+
 			// return those libs needed by field properties
 			foreach (var property in Properties) {
 				if (property.ExportFieldData is null)

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Availability;
+using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
@@ -51,20 +52,20 @@ readonly struct Constructor : IEquatable<Constructor> {
 		Parameters = parameters;
 	}
 
-	public static bool TryCreate (ConstructorDeclarationSyntax declaration, SemanticModel semanticModel,
+	public static bool TryCreate (ConstructorDeclarationSyntax declaration, RootBindingContext context,
 		[NotNullWhen (true)] out Constructor? change)
 	{
-		if (semanticModel.GetDeclaredSymbol (declaration) is not IMethodSymbol constructor) {
+		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IMethodSymbol constructor) {
 			change = null;
 			return false;
 		}
 
-		var attributes = declaration.GetAttributeCodeChanges (semanticModel);
+		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
 		var parametersBucket = ImmutableArray.CreateBuilder<Parameter> ();
 		// loop over the parameters of the construct since changes on those implies a change in the generated code
 		foreach (var parameter in constructor.Parameters) {
 			var parameterDeclaration = declaration.ParameterList.Parameters [parameter.Ordinal];
-			if (!Parameter.TryCreate (parameter, parameterDeclaration, semanticModel, out var parameterChange))
+			if (!Parameter.TryCreate (parameter, parameterDeclaration, context.SemanticModel, out var parameterChange))
 				continue;
 			parametersBucket.Add (parameterChange.Value);
 		}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
@@ -51,7 +51,7 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 		ImmutableArray<AttributeCodeChange> attributes)
 	{
 		Name = name;
-		FieldInfo = fieldData is null ? null : new(fieldData.Value, libraryName, libraryPath);
+		FieldInfo = fieldData is null ? null : new (fieldData.Value, libraryName, libraryPath);
 		SymbolAvailability = symbolAvailability;
 		Attributes = attributes;
 	}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
@@ -20,16 +20,6 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 	public string Name { get; }
 
 	/// <summary>
-	/// Name of the library that contains the smart enum definition.
-	/// </summary>
-	public string LibraryName { get; }
-
-	/// <summary>
-	/// Path of the library that contains the smart enum definition.
-	/// </summary>
-	public string? LibraryPath { get; }
-
-	/// <summary>
 	/// The platform availability of the enum value.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
@@ -37,7 +27,7 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a binding.
 	/// </summary>
-	public FieldData<EnumValue>? FieldData { get; }
+	public FieldInfo<EnumValue>? FieldInfo { get; }
 
 	/// <summary>
 	/// Get the attributes added to the member.
@@ -61,9 +51,7 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 		ImmutableArray<AttributeCodeChange> attributes)
 	{
 		Name = name;
-		LibraryName = libraryName;
-		LibraryPath = libraryPath;
-		FieldData = fieldData;
+		FieldInfo = fieldData is null ? null : new(fieldData.Value, libraryName, libraryPath);
 		SymbolAvailability = symbolAvailability;
 		Attributes = attributes;
 	}
@@ -92,7 +80,7 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 			return false;
 		if (SymbolAvailability != other.SymbolAvailability)
 			return false;
-		if (FieldData != other.FieldData)
+		if (FieldInfo != other.FieldInfo)
 			return false;
 
 		var attrComparer = new AttributesEqualityComparer ();
@@ -125,7 +113,7 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 	public override string ToString ()
 	{
 		var sb = new StringBuilder (
-			$"{{ Name: '{Name}' SymbolAvailability: {SymbolAvailability} FieldData: {FieldData} Attributes: [");
+			$"{{ Name: '{Name}' SymbolAvailability: {SymbolAvailability} FieldInfo: {FieldInfo} Attributes: [");
 		sb.AppendJoin (", ", Attributes);
 		sb.Append ("] }");
 		return sb.ToString ();

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Availability;
+using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
@@ -100,27 +101,27 @@ readonly struct Event : IEquatable<Event> {
 		return !left.Equals (right);
 	}
 
-	public static bool TryCreate (EventDeclarationSyntax declaration, SemanticModel semanticModel,
+	public static bool TryCreate (EventDeclarationSyntax declaration, RootBindingContext context,
 		[NotNullWhen (true)] out Event? change)
 	{
 		var memberName = declaration.Identifier.ToFullString ().Trim ();
 		// get the symbol from the property declaration
-		if (semanticModel.GetDeclaredSymbol (declaration) is not IEventSymbol eventSymbol) {
+		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IEventSymbol eventSymbol) {
 			change = null;
 			return false;
 		}
 
 		var type = eventSymbol.Type.ToDisplayString ().Trim ();
-		var attributes = declaration.GetAttributeCodeChanges (semanticModel);
+		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
 		ImmutableArray<Accessor> accessorCodeChanges = [];
 		if (declaration.AccessorList is not null && declaration.AccessorList.Accessors.Count > 0) {
 			// calculate any possible changes in the accessors of the property
 			var accessorsBucket = ImmutableArray.CreateBuilder<Accessor> ();
 			foreach (var accessorDeclaration in declaration.AccessorList.Accessors) {
-				if (semanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accessorSymbol)
+				if (context.SemanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accessorSymbol)
 					continue;
 				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
-				var accessorAttributeChanges = accessorDeclaration.GetAttributeCodeChanges (semanticModel);
+				var accessorAttributeChanges = accessorDeclaration.GetAttributeCodeChanges (context.SemanticModel);
 				accessorsBucket.Add (new (
 					accessorKind: kind,
 					symbolAvailability: accessorSymbol.GetSupportedPlatforms (),

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/FieldInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/FieldInfo.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Macios.Generator.Attributes;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+/// <summary>
+/// Struct that unfies the data found in a FieldAttribute and extra information calculated such as
+/// the library name and path needed for a field.
+/// </summary>
+readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
+
+	
+	/// <summary>
+	/// Name of the library that contains the smart enum definition.
+	/// </summary>
+	public string LibraryName { get; }
+
+	/// <summary>
+	/// Path of the library that contains the smart enum definition.
+	/// </summary>
+	public string? LibraryPath { get; }
+	
+	/// <summary>
+	/// The data of the field attribute used to mark the value as a binding.
+	/// </summary>
+	public FieldData<T> FieldData { get; }
+
+	public FieldInfo (FieldData<T> fieldData, string libraryName, string? libraryPath = null)
+	{
+		LibraryName = libraryName;
+		LibraryPath = libraryPath;
+		FieldData = fieldData;
+	}
+	
+	public void Deconstruct (out FieldData<T> fieldData, out string libraryName, out string? libraryPath)
+	{
+		fieldData = FieldData;
+		libraryName = LibraryName;
+		libraryPath = LibraryPath;
+	}
+	
+	/// <inheritdoc />
+	public bool Equals (FieldInfo<T> other)
+	{
+		if (FieldData != other.FieldData)
+			return false;
+		if (LibraryName != other.LibraryName)
+			return false;
+		return LibraryPath == other.LibraryPath;
+	}
+
+	/// <inheritdoc />
+	public override bool Equals (object? obj)
+	{
+		return obj is FieldInfo<T> other && Equals (other);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode ()
+	{
+		return HashCode.Combine (FieldData, LibraryName, LibraryPath);
+	}
+
+	public static bool operator == (FieldInfo<T> x, FieldInfo<T> y)
+	{
+		return x.Equals (y);
+	}
+
+	public static bool operator != (FieldInfo<T> x, FieldInfo<T> y)
+	{
+		return !(x == y);
+	}
+
+	/// <inheritdoc />
+	public override string ToString ()
+	{
+		return $"FieldData = {FieldData}, LibraryName = {LibraryName}, LibraryPath = {LibraryPath ?? "null"}";
+	}
+	
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/FieldInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/FieldInfo.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// </summary>
 readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
 
-	
+
 	/// <summary>
 	/// Name of the library that contains the smart enum definition.
 	/// </summary>
@@ -22,7 +22,7 @@ readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
 	/// Path of the library that contains the smart enum definition.
 	/// </summary>
 	public string? LibraryPath { get; }
-	
+
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a binding.
 	/// </summary>
@@ -34,14 +34,14 @@ readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
 		LibraryPath = libraryPath;
 		FieldData = fieldData;
 	}
-	
+
 	public void Deconstruct (out FieldData<T> fieldData, out string libraryName, out string? libraryPath)
 	{
 		fieldData = FieldData;
 		libraryName = LibraryName;
 		libraryPath = LibraryPath;
 	}
-	
+
 	/// <inheritdoc />
 	public bool Equals (FieldInfo<T> other)
 	{
@@ -79,5 +79,5 @@ readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
 	{
 		return $"FieldData = {FieldData}, LibraryName = {LibraryName}, LibraryPath = {LibraryPath ?? "null"}";
 	}
-	
+
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
+using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.Extensions;
 using ObjCRuntime;
 
@@ -73,20 +74,20 @@ readonly struct Method : IEquatable<Method> {
 		Parameters = parameters;
 	}
 
-	public static bool TryCreate (MethodDeclarationSyntax declaration, SemanticModel semanticModel,
+	public static bool TryCreate (MethodDeclarationSyntax declaration, RootBindingContext context,
 		[NotNullWhen (true)] out Method? change)
 	{
-		if (semanticModel.GetDeclaredSymbol (declaration) is not IMethodSymbol method) {
+		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IMethodSymbol method) {
 			change = null;
 			return false;
 		}
 
-		var attributes = declaration.GetAttributeCodeChanges (semanticModel);
+		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
 		var parametersBucket = ImmutableArray.CreateBuilder<Parameter> ();
 		// loop over the parameters of the construct since changes on those implies a change in the generated code
 		foreach (var parameter in method.Parameters) {
 			var parameterDeclaration = declaration.ParameterList.Parameters [parameter.Ordinal];
-			if (!Parameter.TryCreate (parameter, parameterDeclaration, semanticModel, out var parameterChange))
+			if (!Parameter.TryCreate (parameter, parameterDeclaration, context.SemanticModel, out var parameterChange))
 				continue;
 			parametersBucket.Add (parameterChange.Value);
 		}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -9,8 +9,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
+using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.Extensions;
-using ObjCBindings;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -53,7 +53,7 @@ readonly struct Property : IEquatable<Property> {
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a field binding. 
 	/// </summary>
-	public FieldData<ObjCBindings.Property>? ExportFieldData { get; init; }
+	public FieldInfo<ObjCBindings.Property>? ExportFieldData { get; init; }
 
 	/// <summary>
 	/// True if the property represents a Objc field.
@@ -61,7 +61,8 @@ readonly struct Property : IEquatable<Property> {
 	[MemberNotNullWhen (true, nameof (ExportFieldData))]
 	public bool IsField => ExportFieldData is not null;
 
-	public bool IsNotification => IsField && ExportFieldData.Value.Flags.HasFlag (ObjCBindings.Property.Notification);
+	public bool IsNotification 
+		=> IsField && ExportFieldData.Value.FieldData.Flags.HasFlag (ObjCBindings.Property.Notification);
 
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a property binding. 
@@ -157,30 +158,44 @@ readonly struct Property : IEquatable<Property> {
 	{
 		return !left.Equals (right);
 	}
+	
+	static FieldInfo<ObjCBindings.Property>? GetFieldInfo(RootBindingContext context, IPropertySymbol propertySymbol)
+	{
+		// grab the last port of the namespace
+		var ns = propertySymbol.ContainingNamespace.Name.Split ('.')[^1];
+		var fieldData = propertySymbol.GetFieldData<ObjCBindings.Property> ();
+		FieldInfo<ObjCBindings.Property>? fieldInfo = null;
+		if (fieldData is not null && context.TryComputeLibraryName (fieldData.Value.LibraryName, ns,
+			    out string? libraryName, out string? libraryPath)) {
+			fieldInfo = new FieldInfo<ObjCBindings.Property> (fieldData.Value, libraryName, libraryPath);
+		}
 
-	public static bool TryCreate (PropertyDeclarationSyntax declaration, SemanticModel semanticModel,
+		return fieldInfo;
+	}
+
+	public static bool TryCreate (PropertyDeclarationSyntax declaration, RootBindingContext context,
 		[NotNullWhen (true)] out Property? change)
 	{
 		var memberName = declaration.Identifier.ToFullString ().Trim ();
 		// get the symbol from the property declaration
-		if (semanticModel.GetDeclaredSymbol (declaration) is not IPropertySymbol propertySymbol) {
+		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IPropertySymbol propertySymbol) {
 			change = null;
 			return false;
 		}
 
 		var propertySupportedPlatforms = propertySymbol.GetSupportedPlatforms ();
-		var attributes = declaration.GetAttributeCodeChanges (semanticModel);
+		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
 
 		ImmutableArray<Accessor> accessorCodeChanges = [];
 		if (declaration.AccessorList is not null && declaration.AccessorList.Accessors.Count > 0) {
 			// calculate any possible changes in the accessors of the property
 			var accessorsBucket = ImmutableArray.CreateBuilder<Accessor> ();
 			foreach (var accessorDeclaration in declaration.AccessorList.Accessors) {
-				if (semanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accessorSymbol)
+				if (context.SemanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accessorSymbol)
 					continue;
 				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
 				var accessorAttributeChanges =
-					accessorDeclaration.GetAttributeCodeChanges (semanticModel);
+					accessorDeclaration.GetAttributeCodeChanges (context.SemanticModel);
 				accessorsBucket.Add (new (
 					accessorKind: kind,
 					exportPropertyData: accessorSymbol.GetExportData<ObjCBindings.Property> (),
@@ -211,7 +226,7 @@ readonly struct Property : IEquatable<Property> {
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],
 			accessors: accessorCodeChanges) {
-			ExportFieldData = propertySymbol.GetFieldData<ObjCBindings.Property> (),
+			ExportFieldData = GetFieldInfo (context, propertySymbol),
 			ExportPropertyData = propertySymbol.GetExportData<ObjCBindings.Property> (),
 		};
 		return true;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -61,7 +61,7 @@ readonly struct Property : IEquatable<Property> {
 	[MemberNotNullWhen (true, nameof (ExportFieldData))]
 	public bool IsField => ExportFieldData is not null;
 
-	public bool IsNotification 
+	public bool IsNotification
 		=> IsField && ExportFieldData.Value.FieldData.Flags.HasFlag (ObjCBindings.Property.Notification);
 
 	/// <summary>
@@ -158,15 +158,15 @@ readonly struct Property : IEquatable<Property> {
 	{
 		return !left.Equals (right);
 	}
-	
-	static FieldInfo<ObjCBindings.Property>? GetFieldInfo(RootBindingContext context, IPropertySymbol propertySymbol)
+
+	static FieldInfo<ObjCBindings.Property>? GetFieldInfo (RootBindingContext context, IPropertySymbol propertySymbol)
 	{
 		// grab the last port of the namespace
-		var ns = propertySymbol.ContainingNamespace.Name.Split ('.')[^1];
+		var ns = propertySymbol.ContainingNamespace.Name.Split ('.') [^1];
 		var fieldData = propertySymbol.GetFieldData<ObjCBindings.Property> ();
 		FieldInfo<ObjCBindings.Property>? fieldInfo = null;
 		if (fieldData is not null && context.TryComputeLibraryName (fieldData.Value.LibraryName, ns,
-			    out string? libraryName, out string? libraryPath)) {
+				out string? libraryName, out string? libraryPath)) {
 			fieldInfo = new FieldInfo<ObjCBindings.Property> (fieldData.Value, libraryName, libraryPath);
 		}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/LibraryEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/LibraryEmitter.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Context;
-using Microsoft.Macios.Generator.DataModel;
 
 namespace Microsoft.Macios.Generator.Emitters;
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -591,7 +591,7 @@ public partial class MyClass {
 						) {
 
 							ExportFieldData = new (
-								fieldData: new (symbolName: "name", flags: Property.Notification), 
+								fieldData: new (symbolName: "name", flags: Property.Notification),
 								libraryName: "NS"),
 						}
 					]
@@ -661,7 +661,7 @@ public partial class MyClass {
 						) {
 
 							ExportFieldData = new (
-								fieldData: new ("CONSTANT"), 
+								fieldData: new ("CONSTANT"),
 								libraryName: "NS"),
 						}
 					]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -590,7 +590,9 @@ public partial class MyClass {
 							]
 						) {
 
-							ExportFieldData = new (symbolName: "name", flags: Property.Notification)
+							ExportFieldData = new (
+								fieldData: new (symbolName: "name", flags: Property.Notification), 
+								libraryName: "NS"),
 						}
 					]
 				}
@@ -658,7 +660,9 @@ public partial class MyClass {
 							]
 						) {
 
-							ExportFieldData = new ("CONSTANT")
+							ExportFieldData = new (
+								fieldData: new ("CONSTANT"), 
+								libraryName: "NS"),
 						}
 					]
 				}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
@@ -298,7 +298,7 @@ public class EnumMemberCodeChangesTests {
 				availabilityEnum,
 				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x' LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }"
 			];
-			
+
 			var attrsEnum = new EnumMember (
 				name: "EnumValue",
 				libraryName: "Test",
@@ -320,10 +320,10 @@ public class EnumMemberCodeChangesTests {
 	}
 
 	[Theory]
-	[ClassData (typeof(TestDataToString))]
+	[ClassData (typeof (TestDataToString))]
 	void TestFieldDataToString (EnumMember x, string expected)
 	{
-		var str = x.ToString ();	
+		var str = x.ToString ();
 		Assert.Equal (expected, x.ToString ());
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
@@ -262,6 +262,7 @@ public class EnumMemberCodeChangesTests {
 	class TestDataToString : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
+
 			var simpleEnum = new EnumMember (
 				name: "EnumValue",
 				libraryName: "Test",
@@ -269,7 +270,7 @@ public class EnumMemberCodeChangesTests {
 				fieldData: null,
 				symbolAvailability: new (),
 				attributes: []);
-			yield return [simpleEnum, "{ Name: 'EnumValue' SymbolAvailability: [] FieldData:  Attributes: [] }"];
+			yield return [simpleEnum, "{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo:  Attributes: [] }"];
 
 			var fieldDataEnum = new EnumMember (
 				name: "EnumValue",
@@ -278,7 +279,10 @@ public class EnumMemberCodeChangesTests {
 				fieldData: new ("x", "libName", EnumValue.Default),
 				symbolAvailability: new (),
 				attributes: []);
-			yield return [fieldDataEnum, "{ Name: 'EnumValue' SymbolAvailability: [] FieldData: { SymbolName: 'x' LibraryName: 'libName', Flags: 'Default' } Attributes: [] }"];
+			yield return [
+				fieldDataEnum,
+				"{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo: FieldData = { SymbolName: 'x' LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }"
+			];
 
 			var builder = SymbolAvailability.CreateBuilder ();
 			builder.Add (new SupportedOSPlatformData ("ios"));
@@ -290,8 +294,11 @@ public class EnumMemberCodeChangesTests {
 				fieldData: new ("x", "libName", EnumValue.Default),
 				symbolAvailability: builder.ToImmutable (),
 				attributes: []);
-			yield return [availabilityEnum, "{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldData: { SymbolName: 'x' LibraryName: 'libName', Flags: 'Default' } Attributes: [] }"];
-
+			yield return [
+				availabilityEnum,
+				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x' LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }"
+			];
+			
 			var attrsEnum = new EnumMember (
 				name: "EnumValue",
 				libraryName: "Test",
@@ -302,7 +309,10 @@ public class EnumMemberCodeChangesTests {
 					new ("Attribute1"),
 					new ("Attribute2"),
 				]);
-			yield return [attrsEnum, "{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldData: { SymbolName: 'x' LibraryName: 'libName', Flags: 'Default' } Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }"];
+			yield return [
+				attrsEnum,
+				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x' LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }"
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator ()
@@ -310,8 +320,11 @@ public class EnumMemberCodeChangesTests {
 	}
 
 	[Theory]
-	[ClassData (typeof (TestDataToString))]
+	[ClassData (typeof(TestDataToString))]
 	void TestFieldDataToString (EnumMember x, string expected)
-		=> Assert.Equal (expected, x.ToString ());
+	{
+		var str = x.ToString ();	
+		Assert.Equal (expected, x.ToString ());
+	}
 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/FieldInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/FieldInfoTests.cs
@@ -12,9 +12,9 @@ public class FieldInfoTests {
 	[Fact]
 	public void CompareSame ()
 	{
-		var x = new FieldInfo<ObjCBindings.Property> (new("test"), "");
-		var y = new FieldInfo<ObjCBindings.Property> (new("test"), "");
-		
+		var x = new FieldInfo<ObjCBindings.Property> (new ("test"), "");
+		var y = new FieldInfo<ObjCBindings.Property> (new ("test"), "");
+
 		Assert.True (x.Equals (y));
 		Assert.True (x == y);
 		Assert.False (x != y);
@@ -23,9 +23,9 @@ public class FieldInfoTests {
 	[Fact]
 	public void CompareDiffAttr ()
 	{
-		var x = new FieldInfo<ObjCBindings.Property> (new("xData"), "");
-		var y = new FieldInfo<ObjCBindings.Property> (new("test"), "");
-		
+		var x = new FieldInfo<ObjCBindings.Property> (new ("xData"), "");
+		var y = new FieldInfo<ObjCBindings.Property> (new ("test"), "");
+
 		Assert.False (x.Equals (y));
 		Assert.False (x == y);
 		Assert.True (x != y);
@@ -34,9 +34,9 @@ public class FieldInfoTests {
 	[Fact]
 	public void CompareDiffLibraryName ()
 	{
-		var x = new FieldInfo<ObjCBindings.Property> (new("test"), "xLib");
-		var y = new FieldInfo<ObjCBindings.Property> (new("test"), "yLib");
-		
+		var x = new FieldInfo<ObjCBindings.Property> (new ("test"), "xLib");
+		var y = new FieldInfo<ObjCBindings.Property> (new ("test"), "yLib");
+
 		Assert.False (x.Equals (y));
 		Assert.False (x == y);
 		Assert.True (x != y);
@@ -45,9 +45,9 @@ public class FieldInfoTests {
 	[Fact]
 	public void CompareDiffLibraryPath ()
 	{
-		var x = new FieldInfo<ObjCBindings.Property> (new("test"), "lib", "xpath");
-		var y = new FieldInfo<ObjCBindings.Property> (new("test"), "lib");
-		
+		var x = new FieldInfo<ObjCBindings.Property> (new ("test"), "lib", "xpath");
+		var y = new FieldInfo<ObjCBindings.Property> (new ("test"), "lib");
+
 		Assert.False (x.Equals (y));
 		Assert.False (x == y);
 		Assert.True (x != y);
@@ -56,7 +56,7 @@ public class FieldInfoTests {
 	[Fact]
 	public void DeconstructTests ()
 	{
-		var x = new FieldInfo<ObjCBindings.Property> (new("test"), "lib", "xpath");
+		var x = new FieldInfo<ObjCBindings.Property> (new ("test"), "lib", "xpath");
 		var (attr, name, path) = x;
 		Assert.Equal (x.FieldData, attr);
 		Assert.Equal (name, x.LibraryName);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/FieldInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/FieldInfoTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma warning disable APL0003
+using Microsoft.Macios.Generator.DataModel;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.DataModel;
+
+public class FieldInfoTests {
+
+	[Fact]
+	public void CompareSame ()
+	{
+		var x = new FieldInfo<ObjCBindings.Property> (new("test"), "");
+		var y = new FieldInfo<ObjCBindings.Property> (new("test"), "");
+		
+		Assert.True (x.Equals (y));
+		Assert.True (x == y);
+		Assert.False (x != y);
+	}
+
+	[Fact]
+	public void CompareDiffAttr ()
+	{
+		var x = new FieldInfo<ObjCBindings.Property> (new("xData"), "");
+		var y = new FieldInfo<ObjCBindings.Property> (new("test"), "");
+		
+		Assert.False (x.Equals (y));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+
+	[Fact]
+	public void CompareDiffLibraryName ()
+	{
+		var x = new FieldInfo<ObjCBindings.Property> (new("test"), "xLib");
+		var y = new FieldInfo<ObjCBindings.Property> (new("test"), "yLib");
+		
+		Assert.False (x.Equals (y));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+
+	[Fact]
+	public void CompareDiffLibraryPath ()
+	{
+		var x = new FieldInfo<ObjCBindings.Property> (new("test"), "lib", "xpath");
+		var y = new FieldInfo<ObjCBindings.Property> (new("test"), "lib");
+		
+		Assert.False (x.Equals (y));
+		Assert.False (x == y);
+		Assert.True (x != y);
+	}
+
+	[Fact]
+	public void DeconstructTests ()
+	{
+		var x = new FieldInfo<ObjCBindings.Property> (new("test"), "lib", "xpath");
+		var (attr, name, path) = x;
+		Assert.Equal (x.FieldData, attr);
+		Assert.Equal (name, x.LibraryName);
+		Assert.Equal (path, x.LibraryPath);
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -346,7 +346,9 @@ public partial interface IProtocol {
 								),
 							]
 						) {
-							ExportFieldData = new ("name", Property.Notification)
+							ExportFieldData = new (
+								fieldData: new ("name", Property.Notification), 
+								libraryName: "NS"),
 						}
 					]
 				}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -347,7 +347,7 @@ public partial interface IProtocol {
 							]
 						) {
 							ExportFieldData = new (
-								fieldData: new ("name", Property.Notification), 
+								fieldData: new ("name", Property.Notification),
 								libraryName: "NS"),
 						}
 					]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -398,7 +398,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 			modifiers: [],
 			accessors: []
 		) {
-			ExportFieldData = new FieldData<ObjCBindings.Property> ("name", flag)
+			ExportFieldData = new (new FieldData<ObjCBindings.Property> ("name", flag), ""),
 		};
 		Assert.Equal (expectedResult, property.IsNotification);
 	}


### PR DESCRIPTION
Provide a small wrapper struct that we can use to keep the infomation of a field data attr realted to its library name and path. This is later needed to generate the appropate getters and setters.