### PR TITLE
[RGent] Rename ReturnType to TypeInfo.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -29,7 +29,7 @@ readonly struct Method : IEquatable<Method> {
 	/// <summary>
 	/// Method return type.
 	/// </summary>
-	public ReturnType ReturnType { get; }
+	public TypeInfo ReturnType { get; }
 
 	/// <summary>
 	/// The platform availability of the method.
@@ -56,7 +56,7 @@ readonly struct Method : IEquatable<Method> {
 	/// </summary>
 	public ImmutableArray<Parameter> Parameters { get; } = [];
 
-	public Method (string type, string name, ReturnType returnType,
+	public Method (string type, string name, TypeInfo returnType,
 		SymbolAvailability symbolAvailability,
 		ExportData<ObjCBindings.Method> exportMethodData,
 		ImmutableArray<AttributeCodeChange> attributes,

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/MethodComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/MethodComparer.cs
@@ -17,7 +17,7 @@ class MethodComparer : IComparer<Method> {
 		var nameComparison = String.Compare (x.Name, y.Name, StringComparison.Ordinal);
 		if (nameComparison != 0)
 			return nameComparison;
-		var returnTypeComparer = new MethodReturnTypeComparer ();
+		var returnTypeComparer = new TypeInfoComparer ();
 		var returnTypeComparison = returnTypeComparer.Compare (x.ReturnType, y.ReturnType);
 		if (returnTypeComparison != 0)
 			return returnTypeComparison;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/MethodsEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/MethodsEqualityComparer.cs
@@ -23,7 +23,7 @@ class MethodsEqualityComparer : EqualityComparer<ImmutableArray<Method>> {
 		// create the dictionary comparer that will do the based comparison and relay on a list comparer for the
 		// diff methods
 		var dictionaryComparer =
-			new DictionaryComparer<(ReturnType ReturnType, string Name, int ParameterCount), List<Method>> (
+			new DictionaryComparer<(TypeInfo ReturnType, string Name, int ParameterCount), List<Method>> (
 				new CollectionComparer<Method> (new MethodComparer ()));
 		return dictionaryComparer.Equals (xMethods, yMethods);
 	}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -28,7 +28,7 @@ readonly struct Property : IEquatable<Property> {
 	/// <summary>
 	/// Representation of the property type.
 	/// </summary>
-	public ReturnType ReturnType { get; } = default;
+	public TypeInfo ReturnType { get; } = default;
 
 	/// <summary>
 	/// Returns if the property type is bittable.
@@ -89,7 +89,7 @@ readonly struct Property : IEquatable<Property> {
 	/// </summary>
 	public ImmutableArray<Accessor> Accessors { get; } = [];
 
-	internal Property (string name, ReturnType returnType,
+	internal Property (string name, TypeInfo returnType,
 		SymbolAvailability symbolAvailability,
 		ImmutableArray<AttributeCodeChange> attributes,
 		ImmutableArray<SyntaxToken> modifiers, ImmutableArray<Accessor> accessors)

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Immutable;
-using System.Data;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Extensions;
@@ -12,12 +11,12 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// <summary>
 /// Readonly structure that represents a change in a method return type.
 /// </summary>
-readonly struct ReturnType : IEquatable<ReturnType> {
+readonly struct TypeInfo : IEquatable<TypeInfo> {
 
 	/// <summary>
 	/// Type of the parameter.
 	/// </summary>
-	public string Type { get; }
+	public string Name { get; }
 
 	/// <summary>
 	/// True if the parameter is nullable.
@@ -76,18 +75,18 @@ readonly struct ReturnType : IEquatable<ReturnType> {
 		init => interfaces = value;
 	}
 
-	internal ReturnType (string type)
+	internal TypeInfo (string name)
 	{
-		Type = type;
-		IsVoid = type == "void";
+		Name = name;
+		IsVoid = name == "void";
 	}
 
-	internal ReturnType (string type,
+	internal TypeInfo (string name,
 		bool isNullable = false,
 		bool isBlittable = false,
 		bool isSmartEnum = false,
 		bool isArray = false,
-		bool isReferenceType = false) : this (type)
+		bool isReferenceType = false) : this (name)
 	{
 		IsNullable = isNullable;
 		IsBlittable = isBlittable;
@@ -96,7 +95,7 @@ readonly struct ReturnType : IEquatable<ReturnType> {
 		IsReferenceType = isReferenceType;
 	}
 
-	internal ReturnType (ITypeSymbol symbol) :
+	internal TypeInfo (ITypeSymbol symbol) :
 		this (
 			symbol is IArrayTypeSymbol arrayTypeSymbol
 				? arrayTypeSymbol.ElementType.ToDisplayString ()
@@ -115,9 +114,9 @@ readonly struct ReturnType : IEquatable<ReturnType> {
 	}
 
 	/// <inheritdoc/>
-	public bool Equals (ReturnType other)
+	public bool Equals (TypeInfo other)
 	{
-		if (Type != other.Type)
+		if (Name != other.Name)
 			return false;
 		if (IsNullable != other.IsNullable)
 			return false;
@@ -145,21 +144,21 @@ readonly struct ReturnType : IEquatable<ReturnType> {
 	/// <inheritdoc/>
 	public override bool Equals (object? obj)
 	{
-		return obj is ReturnType other && Equals (other);
+		return obj is TypeInfo other && Equals (other);
 	}
 
 	/// <inheritdoc/>
 	public override int GetHashCode ()
 	{
-		return HashCode.Combine (Type, IsNullable, IsBlittable, IsSmartEnum, IsArray, IsReferenceType, IsVoid);
+		return HashCode.Combine (Name, IsNullable, IsBlittable, IsSmartEnum, IsArray, IsReferenceType, IsVoid);
 	}
 
-	public static bool operator == (ReturnType left, ReturnType right)
+	public static bool operator == (TypeInfo left, TypeInfo right)
 	{
 		return left.Equals (right);
 	}
 
-	public static bool operator != (ReturnType left, ReturnType right)
+	public static bool operator != (TypeInfo left, TypeInfo right)
 	{
 		return !left.Equals (right);
 	}
@@ -168,7 +167,7 @@ readonly struct ReturnType : IEquatable<ReturnType> {
 	public override string ToString ()
 	{
 		var sb = new StringBuilder ("{");
-		sb.Append ($"Type: {Type}, ");
+		sb.Append ($"Type: {Name}, ");
 		sb.Append ($"IsNullable: {IsNullable}, ");
 		sb.Append ($"IsBlittable: {IsBlittable}, ");
 		sb.Append ($"IsSmartEnum: {IsSmartEnum}, ");

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfoComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfoComparer.cs
@@ -5,12 +5,12 @@ using System.Collections.Generic;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-class MethodReturnTypeComparer : IComparer<ReturnType> {
+class TypeInfoComparer : IComparer<TypeInfo> {
 
 	/// <inheritdoc/>
-	public int Compare (ReturnType x, ReturnType y)
+	public int Compare (TypeInfo x, TypeInfo y)
 	{
-		var returnTypeComparison = String.Compare (x.Type, y.Type, StringComparison.Ordinal);
+		var returnTypeComparison = String.Compare (x.Name, y.Name, StringComparison.Ordinal);
 		if (returnTypeComparison != 0)
 			return returnTypeComparison;
 		var isNullableComparison = x.IsNullable.CompareTo (y.IsNullable);

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/TypeInfoFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/TypeInfoFormatter.cs
@@ -7,24 +7,24 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.Formatters;
 
-static class ReturnTypeFormatter {
+static class TypeInfoFormatter {
 
-	public static TypeSyntax GetIdentifierSyntax (this in ReturnType returnType)
+	public static TypeSyntax GetIdentifierSyntax (this in TypeInfo typeInfo)
 	{
-		if (returnType.IsArray) {
+		if (typeInfo.IsArray) {
 			// could be a params array or simply an array
-			var arrayType = ArrayType (IdentifierName (returnType.Type))
+			var arrayType = ArrayType (IdentifierName (typeInfo.Name))
 				.WithRankSpecifiers (SingletonList (
 					ArrayRankSpecifier (
 						SingletonSeparatedList<ExpressionSyntax> (OmittedArraySizeExpression ()))));
-			return returnType.IsNullable
+			return typeInfo.IsNullable
 				? NullableType (arrayType)
 				: arrayType;
 		}
 
 		// dealing with a non-array type
-		return returnType.IsNullable
-			? NullableType (IdentifierName (returnType.Type))
-			: IdentifierName (returnType.Type);
+		return typeInfo.IsNullable
+			? NullableType (IdentifierName (typeInfo.Name))
+			: IdentifierName (typeInfo.Name);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -1247,7 +1247,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: new (
-						type: "bool",
+						name: "bool",
 						isNullable: false,
 						isBlittable: false,
 						isSmartEnum: false,
@@ -1393,7 +1393,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: new (
-						type: "bool",
+						name: "bool",
 						isNullable: false,
 						isBlittable: false,
 						isSmartEnum: false,
@@ -1533,7 +1533,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: new (
-						type: "bool",
+						name: "bool",
 						isNullable: false,
 						isBlittable: false,
 						isSmartEnum: false,
@@ -1694,7 +1694,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: new (
-						type: "bool",
+						name: "bool",
 						isNullable: false,
 						isBlittable: false,
 						isSmartEnum: false,
@@ -1957,7 +1957,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: new (
-						type: "bool",
+						name: "bool",
 						isNullable: false,
 						isBlittable: false,
 						isSmartEnum: false,
@@ -2100,7 +2100,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: new (
-						type: "bool",
+						name: "bool",
 						isNullable: false,
 						isBlittable: false,
 						isSmartEnum: false,
@@ -2253,7 +2253,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: new (
-						type: "bool",
+						name: "bool",
 						isNullable: false,
 						isBlittable: false,
 						isSmartEnum: false,
@@ -2396,7 +2396,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: new (
-						type: "bool",
+						name: "bool",
 						isNullable: false,
 						isBlittable: false,
 						isSmartEnum: false,
@@ -2556,7 +2556,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					type: "NS.MyClass",
 					name: "TryGetString",
 					returnType: new (
-						type: "bool",
+						name: "bool",
 						isNullable: false,
 						isBlittable: false,
 						isSmartEnum: false,

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodComparerTests.cs
@@ -83,7 +83,7 @@ public class MethodComparerTests {
 			type: "MyType",
 			name: "MyMethod",
 			returnType: new (
-				type: "int",
+				name: "int",
 				isNullable: false,
 				isBlittable: false,
 				isSmartEnum: false,
@@ -96,7 +96,7 @@ public class MethodComparerTests {
 			modifiers: [],
 			parameters: []
 		);
-		var returnTypeComparer = new MethodReturnTypeComparer ();
+		var returnTypeComparer = new TypeInfoComparer ();
 		Assert.Equal (returnTypeComparer.Compare (x.ReturnType, y.ReturnType), comparer.Compare (x, y));
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -94,7 +94,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 		var x = new Property (
 			name: "First",
 			returnType: new (
-				type: "string",
+				name: "string",
 				isBlittable: false,
 				isSmartEnum: false,
 				isNullable: false,
@@ -109,7 +109,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 		var y = new Property (
 			name: "First",
 			returnType: new (
-				type: "string",
+				name: "string",
 				isBlittable: false,
 				isSmartEnum: false,
 				isNullable: false,
@@ -134,7 +134,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 		var x = new Property (
 			name: "First",
 			returnType: new (
-				type: "string",
+				name: "string",
 				isBlittable: true,
 				isSmartEnum: false,
 				isNullable: false,
@@ -149,7 +149,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 		var y = new Property (
 			name: "First",
 			returnType: new (
-				type: "string",
+				name: "string",
 				isBlittable: false,
 				isSmartEnum: false,
 				isNullable: false,
@@ -174,7 +174,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 		var x = new Property (
 			name: "First",
 			returnType: new (
-				type: "string",
+				name: "string",
 				isBlittable: false,
 				isSmartEnum: true,
 				isNullable: false,
@@ -189,7 +189,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 		var y = new Property (
 			name: "First",
 			returnType: new (
-				type: "string",
+				name: "string",
 				isBlittable: false,
 				isSmartEnum: false,
 				isNullable: false,
@@ -392,7 +392,7 @@ public class PropertyTests : BaseGeneratorTestClass {
 	{
 		var property = new Property (
 			name: "Test",
-			returnType: new ReturnType ("string"),
+			returnType: new TypeInfo ("string"),
 			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoComparerTests.cs
@@ -6,23 +6,23 @@ using Xunit;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
-public class MethodReturnTypeComparerTests {
+public class TypeInfoComparerTests {
 
-	MethodReturnTypeComparer compare = new ();
+	TypeInfoComparer compare = new ();
 
 	[Fact]
 	public void CompareDiffReturnType ()
 	{
-		var x = new ReturnType ("string");
-		var y = new ReturnType ("int");
-		Assert.Equal (String.Compare (x.Type, y.Type, StringComparison.Ordinal), compare.Compare (x, y));
+		var x = new TypeInfo ("string");
+		var y = new TypeInfo ("int");
+		Assert.Equal (String.Compare (x.Name, y.Name, StringComparison.Ordinal), compare.Compare (x, y));
 	}
 
 	[Fact]
 	public void CompareDiffNullable ()
 	{
-		var x = new ReturnType (
-			type: "void",
+		var x = new TypeInfo (
+			name: "void",
 			isNullable: true,
 			isBlittable: false,
 			isSmartEnum: false,
@@ -30,8 +30,8 @@ public class MethodReturnTypeComparerTests {
 			isReferenceType: false
 		);
 
-		var y = new ReturnType (
-			type: "void",
+		var y = new TypeInfo (
+			name: "void",
 			isNullable: false,
 			isBlittable: false,
 			isSmartEnum: false,
@@ -44,8 +44,8 @@ public class MethodReturnTypeComparerTests {
 	[Fact]
 	public void CompareDiffBlittable ()
 	{
-		var x = new ReturnType (
-			type: "void",
+		var x = new TypeInfo (
+			name: "void",
 			isNullable: false,
 			isBlittable: true,
 			isSmartEnum: false,
@@ -53,8 +53,8 @@ public class MethodReturnTypeComparerTests {
 			isReferenceType: false
 		);
 
-		var y = new ReturnType (
-			type: "void",
+		var y = new TypeInfo (
+			name: "void",
 			isNullable: false,
 			isBlittable: false,
 			isSmartEnum: false,
@@ -67,8 +67,8 @@ public class MethodReturnTypeComparerTests {
 	[Fact]
 	public void CompareDiffSmartEnum ()
 	{
-		var x = new ReturnType (
-			type: "void",
+		var x = new TypeInfo (
+			name: "void",
 			isNullable: false,
 			isBlittable: false,
 			isSmartEnum: true,
@@ -76,8 +76,8 @@ public class MethodReturnTypeComparerTests {
 			isReferenceType: false
 		);
 
-		var y = new ReturnType (
-			type: "void",
+		var y = new TypeInfo (
+			name: "void",
 			isNullable: false,
 			isBlittable: false,
 			isSmartEnum: false,
@@ -90,8 +90,8 @@ public class MethodReturnTypeComparerTests {
 	[Fact]
 	public void CompareDiffIsArray ()
 	{
-		var x = new ReturnType (
-			type: "void",
+		var x = new TypeInfo (
+			name: "void",
 			isNullable: false,
 			isBlittable: false,
 			isSmartEnum: false,
@@ -99,8 +99,8 @@ public class MethodReturnTypeComparerTests {
 			isReferenceType: false
 		);
 
-		var y = new ReturnType (
-			type: "void",
+		var y = new TypeInfo (
+			name: "void",
 			isNullable: false,
 			isBlittable: false,
 			isSmartEnum: false,
@@ -113,8 +113,8 @@ public class MethodReturnTypeComparerTests {
 	[Fact]
 	public void CompareDiffIsReference ()
 	{
-		var x = new ReturnType (
-			type: "void",
+		var x = new TypeInfo (
+			name: "void",
 			isNullable: false,
 			isBlittable: false,
 			isSmartEnum: false,
@@ -122,8 +122,8 @@ public class MethodReturnTypeComparerTests {
 			isReferenceType: true
 		);
 
-		var y = new ReturnType (
-			type: "void",
+		var y = new TypeInfo (
+			name: "void",
 			isNullable: false,
 			isBlittable: false,
 			isSmartEnum: false,

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
-public class ReturnTypeTests : BaseGeneratorTestClass {
+public class TypeInfoTests : BaseGeneratorTestClass {
 
 	class TestDataFromMethodDeclaration : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Macios.Generator.Tests;
 
 static class TestDataFactory {
 
-	public static ReturnType ReturnTypeForString ()
+	public static TypeInfo ReturnTypeForString ()
 		=> new (
-			type: "string",
+			name: "string",
 			isNullable: false,
 			isBlittable: false,
 			isSmartEnum: false,
@@ -32,9 +32,9 @@ static class TestDataFactory {
 			IsINativeObject = false,
 		};
 
-	public static ReturnType ReturnTypeForInt (bool isNullable = false)
+	public static TypeInfo ReturnTypeForInt (bool isNullable = false)
 		=> new (
-			type: "int",
+			name: "int",
 			isBlittable: !isNullable,
 			isNullable: isNullable
 		) {
@@ -76,9 +76,9 @@ static class TestDataFactory {
 			],
 		};
 
-	public static ReturnType ReturnTypeForBool ()
+	public static TypeInfo ReturnTypeForBool ()
 		=> new (
-			type: "bool",
+			name: "bool",
 			isBlittable: false
 		) {
 			Parents = ["System.ValueType", "object"],
@@ -92,29 +92,29 @@ static class TestDataFactory {
 			]
 		};
 
-	public static ReturnType ReturnTypeForVoid ()
+	public static TypeInfo ReturnTypeForVoid ()
 		=> new ("void") {
 			Parents = ["System.ValueType", "object"],
 		};
 
-	public static ReturnType ReturnTypeForClass (string className)
+	public static TypeInfo ReturnTypeForClass (string className)
 		=> new (
-			type: className,
+			name: className,
 			isReferenceType: true
 		) {
 			Parents = ["object"]
 		};
 
-	public static ReturnType ReturnTypeForStruct (string structName)
+	public static TypeInfo ReturnTypeForStruct (string structName)
 		=> new (
-			type: structName
+			name: structName
 		) {
 			Parents = ["System.ValueType", "object"]
 		};
 
-	public static ReturnType ReturnTypeForEnum (string enumName, bool isSmartEnum = false)
+	public static TypeInfo ReturnTypeForEnum (string enumName, bool isSmartEnum = false)
 		=> new (
-			type: enumName,
+			name: enumName,
 			isBlittable: true,
 			isSmartEnum: isSmartEnum
 		) {
@@ -131,9 +131,9 @@ static class TestDataFactory {
 			]
 		};
 
-	public static ReturnType ReturnTypeForArray (string type, bool isNullable = false, bool isBlittable = false)
+	public static TypeInfo ReturnTypeForArray (string type, bool isNullable = false, bool isBlittable = false)
 		=> new (
-			type: type,
+			name: type,
 			isNullable: isNullable,
 			isBlittable: isBlittable,
 			isArray: true,


### PR DESCRIPTION
Also renamed the ReturnType.Type property to name to make it clear in the future when we are going to add a MetadataName in the struct to be able to differenciate between a nint and a IntPtr.