### PR TITLE
[Rgen] Add a binding syntax factory that will generate C# expressions.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -403,7 +403,10 @@ static partial class BindingSyntaxFactory {
 		// use the return type and the special type of the property to decide what getter we are going to us
 		return property.ReturnType switch {
 			// special types
-			{ Name: "CoreGraphics.CGSize" } => GetCGSize (libraryName, symbolName), { Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName), { Name: "nfloat" } => GetNFloat (libraryName, symbolName), { Name: "System.Drawing.SizeF" } => GetSizeF (libraryName, symbolName),
+			{ Name: "CoreGraphics.CGSize" } => GetCGSize (libraryName, symbolName),
+			{ Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName),
+			{ Name: "nfloat" } => GetNFloat (libraryName, symbolName),
+			{ Name: "System.Drawing.SizeF" } => GetSizeF (libraryName, symbolName),
 
 			// Billable types 
 			{ Name: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" }
@@ -411,10 +414,28 @@ static partial class BindingSyntaxFactory {
 
 			// enum types, decide based on its enum backing field, smart enums have to be done in the binding
 			// manually
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => GetByte (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => GetByte (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
 
 			// General special types
-			{ SpecialType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName), { SpecialType: SpecialType.System_Byte } => GetByte (libraryName, symbolName), { SpecialType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName), { SpecialType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName), { SpecialType: SpecialType.System_IntPtr } => GetIntPtr (libraryName, symbolName), { SpecialType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName), { SpecialType: SpecialType.System_UIntPtr } => GetUIntPtr (libraryName, symbolName), { SpecialType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName), { SpecialType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName), { SpecialType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName), { SpecialType: SpecialType.System_Double } => GetDouble (libraryName, symbolName), { SpecialType: SpecialType.System_Single } => GetFloat (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Byte } => GetByte (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_IntPtr } => GetIntPtr (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UIntPtr } => GetUIntPtr (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Double } => GetDouble (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Single } => GetFloat (libraryName, symbolName),
 
 			// We do not support the property
 			_ => throw new NotImplementedException ($"Return type {property.ReturnType} is not implemented."),

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -295,18 +295,6 @@ static partial class BindingSyntaxFactory {
 		=> throw new NotImplementedException ();
 
 	/// <summary>
-	/// Generates a call for "Dlfcn.GetSizeF (libraryName, fieldName);"];
-	/// </summary>
-	/// <param name="libraryName">The library from where the field will be loaded.</param>
-	/// <param name="fieldName">The field name.</param>
-	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
-	public static CompilationUnitSyntax GetSizeF (string libraryName, string fieldName)
-		=> GetConstant ("GetSizeF", libraryName, fieldName);
-
-	public static CompilationUnitSyntax GetSizeF (IntPtr handle, string fieldName, float value)
-		=> throw new NotImplementedException ();
-
-	/// <summary>
 	/// Generates a call for "Runtime.GetNSObject;lt&Foundation.NSArray;gt& (Dlfcn.GetIndirect (libraryName, fieldName))!;"];
 	/// </summary>
 	/// <param name="libraryName">The library from where the field will be loaded.</param>
@@ -408,7 +396,6 @@ static partial class BindingSyntaxFactory {
 			{ Name: "CoreGraphics.CGSize" } => GetCGSize (libraryName, symbolName),
 			{ Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName),
 			{ Name: "nfloat" } => GetNFloat (libraryName, symbolName),
-			{ Name: "System.Drawing.SizeF" } => GetSizeF (libraryName, symbolName),
 
 			// Billable types 
 			{ Name: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -400,6 +400,8 @@ static partial class BindingSyntaxFactory {
 				: GetNSObjectField (property.ReturnType.Name, libraryName, symbolName);
 		}
 
+		// keep the formatting to make it more readable
+#pragma warning disable format
 		// use the return type and the special type of the property to decide what getter we are going to us
 		return property.ReturnType switch {
 			// special types
@@ -440,5 +442,6 @@ static partial class BindingSyntaxFactory {
 			// We do not support the property
 			_ => throw new NotImplementedException ($"Return type {property.ReturnType} is not implemented."),
 		};
+#pragma warning restore format
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -295,7 +295,7 @@ static partial class BindingSyntaxFactory {
 		=> throw new NotImplementedException ();
 
 	/// <summary>
-	/// Generates a call for "Runtime.GetNSObject;lt&Foundation.NSArray;gt& (Dlfcn.GetIndirect (libraryName, fieldName))!;"];
+	/// Generates a call for "Runtime.GetNSObject&lt;nsobjectType&gt; (Dlfcn.GetIndirect (libraryName, fieldName))!;"];
 	/// </summary>
 	/// <param name="libraryName">The library from where the field will be loaded.</param>
 	/// <param name="fieldName">The field name.</param>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -403,39 +403,18 @@ static partial class BindingSyntaxFactory {
 		// use the return type and the special type of the property to decide what getter we are going to us
 		return property.ReturnType switch {
 			// special types
-			{ Name: "CoreGraphics.CGSize" } => GetCGSize (libraryName, symbolName),
-			{ Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName),
-			{ Name: "nfloat" } => GetNFloat (libraryName, symbolName),
-			{ Name: "System.Drawing.SizeF" } => GetSizeF (libraryName, symbolName),
+			{ Name: "CoreGraphics.CGSize" } => GetCGSize (libraryName, symbolName), { Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName), { Name: "nfloat" } => GetNFloat (libraryName, symbolName), { Name: "System.Drawing.SizeF" } => GetSizeF (libraryName, symbolName),
 
 			// Billable types 
-			{ Name: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" } 
+			{ Name: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" }
 				=> GetBlittableField (property.ReturnType.Name, libraryName, symbolName),
 
 			// enum types, decide based on its enum backing field, smart enums have to be done in the binding
 			// manually
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => GetByte (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => GetByte (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
 
 			// General special types
-			{ SpecialType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Byte } => GetByte (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_IntPtr } => GetIntPtr (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_UIntPtr } => GetUIntPtr (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Double } => GetDouble (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Single } => GetFloat (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName), { SpecialType: SpecialType.System_Byte } => GetByte (libraryName, symbolName), { SpecialType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName), { SpecialType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName), { SpecialType: SpecialType.System_IntPtr } => GetIntPtr (libraryName, symbolName), { SpecialType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName), { SpecialType: SpecialType.System_UIntPtr } => GetUIntPtr (libraryName, symbolName), { SpecialType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName), { SpecialType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName), { SpecialType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName), { SpecialType: SpecialType.System_Double } => GetDouble (libraryName, symbolName), { SpecialType: SpecialType.System_Single } => GetFloat (libraryName, symbolName),
 
 			// We do not support the property
 			_ => throw new NotImplementedException ($"Return type {property.ReturnType} is not implemented."),

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -11,7 +11,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Microsoft.Macios.Generator.Emitters;
 
 /// <summary>
-/// Syntaxt factory for the Dlfcn calls.
+/// Syntax factory for the Dlfcn calls.
 /// </summary>
 static partial class BindingSyntaxFactory {
 	readonly static string Dlfcn = "Dlfcn";
@@ -19,7 +19,7 @@ static partial class BindingSyntaxFactory {
 	/// <summary>
 	/// Get the syntax needed to access a library handle.
 	/// </summary>
-	/// <param name="libraryName">The library name whose handle we want to retrienve.</param>
+	/// <param name="libraryName">The library name whose handle we want to retrieve.</param>
 	/// <returns>An argument that points to a library name handle.</returns>
 	static ArgumentSyntax GetLibraryArgument (string libraryName)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -405,10 +405,7 @@ static partial class BindingSyntaxFactory {
 		// use the return type and the special type of the property to decide what getter we are going to us
 		return property.ReturnType switch {
 			// special types
-			{ Name: "CoreGraphics.CGSize" } => GetCGSize (libraryName, symbolName),
-			{ Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName),
-			{ Name: "nfloat" } => GetNFloat (libraryName, symbolName),
-			{ Name: "System.Drawing.SizeF" } => GetSizeF (libraryName, symbolName),
+			{ Name: "CoreGraphics.CGSize" } => GetCGSize (libraryName, symbolName), { Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName), { Name: "nfloat" } => GetNFloat (libraryName, symbolName), { Name: "System.Drawing.SizeF" } => GetSizeF (libraryName, symbolName),
 
 			// Billable types 
 			{ Name: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" }
@@ -416,28 +413,10 @@ static partial class BindingSyntaxFactory {
 
 			// enum types, decide based on its enum backing field, smart enums have to be done in the binding
 			// manually
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => GetByte (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName),
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => GetByte (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
 
 			// General special types
-			{ SpecialType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Byte } => GetByte (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_IntPtr } => GetIntPtr (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_UIntPtr } => GetUIntPtr (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Double } => GetDouble (libraryName, symbolName),
-			{ SpecialType: SpecialType.System_Single } => GetFloat (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName), { SpecialType: SpecialType.System_Byte } => GetByte (libraryName, symbolName), { SpecialType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName), { SpecialType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName), { SpecialType: SpecialType.System_IntPtr } => GetIntPtr (libraryName, symbolName), { SpecialType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName), { SpecialType: SpecialType.System_UIntPtr } => GetUIntPtr (libraryName, symbolName), { SpecialType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName), { SpecialType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName), { SpecialType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName), { SpecialType: SpecialType.System_Double } => GetDouble (libraryName, symbolName), { SpecialType: SpecialType.System_Single } => GetFloat (libraryName, symbolName),
 
 			// We do not support the property
 			_ => throw new NotImplementedException ($"Return type {property.ReturnType} is not implemented."),

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -397,7 +397,7 @@ static partial class BindingSyntaxFactory {
 			{ Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName),
 			{ Name: "nfloat" } => GetNFloat (libraryName, symbolName),
 
-			// Billable types 
+			// Blittable types 
 			{ Name: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" }
 				=> GetBlittableField (property.ReturnType.Name, libraryName, symbolName),
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -1,0 +1,444 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Macios.Generator.Emitters;
+
+/// <summary>
+/// Syntaxt factory for the Dlfcn calls.
+/// </summary>
+static partial class BindingSyntaxFactory {
+	readonly static string Dlfcn = "Dlfcn";
+
+	/// <summary>
+	/// Get the syntax needed to access a library handle.
+	/// </summary>
+	/// <param name="libraryName">The library name whose handle we want to retrienve.</param>
+	/// <returns>An argument that points to a library name handle.</returns>
+	static ArgumentSyntax GetLibraryArgument (string libraryName)
+	{
+		return Argument (
+			MemberAccessExpression (
+				SyntaxKind.SimpleMemberAccessExpression,
+				MemberAccessExpression (
+					SyntaxKind.SimpleMemberAccessExpression,
+					IdentifierName ("Libraries"),
+					IdentifierName (libraryName)),
+				IdentifierName ("Handle")));
+	}
+
+
+	public static CompilationUnitSyntax CachePointer (string libraryName, string fieldName, string storageVariableName)
+	{
+		var arguments = new SyntaxNodeOrToken [] {
+			GetLibraryArgument (libraryName), Token (SyntaxKind.CommaToken),
+			GetLiteralExpressionArgument (SyntaxKind.StringLiteralExpression, fieldName), Token (SyntaxKind.CommaToken),
+			Argument (IdentifierName (storageVariableName))
+		};
+
+		return StaticInvocationExpression (Dlfcn, "CachePointer", arguments);
+	}
+
+	/// <summary>
+	/// Generic method that returns the syntax for the Get* methods.
+	/// </summary>
+	/// <param name="methodName">The method name for the invocation.</param>
+	/// <param name="libraryName">The name of the library that contains the field.</param>
+	/// <param name="fieldName">The field name literal.</param>
+	/// <returns></returns>
+	static CompilationUnitSyntax GetConstant (string methodName, string libraryName, string fieldName)
+	{
+		var arguments = new SyntaxNodeOrToken [] {
+			GetLibraryArgument (libraryName), Token (SyntaxKind.CommaToken),
+			GetLiteralExpressionArgument (SyntaxKind.StringLiteralExpression, fieldName),
+		};
+		return StaticInvocationExpression (Dlfcn, methodName, arguments);
+	}
+
+	static CompilationUnitSyntax GetGenericConstant (string methodName, string genericName, string libraryName,
+		string fieldName)
+	{
+		var arguments = new SyntaxNodeOrToken [] {
+			GetLibraryArgument (libraryName), Token (SyntaxKind.CommaToken),
+			GetLiteralExpressionArgument (SyntaxKind.StringLiteralExpression, fieldName),
+		};
+		var argumentList = ArgumentList (SeparatedList<ArgumentSyntax> (arguments)).NormalizeWhitespace ();
+		return StaticInvocationGenericExpression (Dlfcn, methodName, genericName, argumentList);
+	}
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetStringConstant (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetStringConstant (string libraryName, string fieldName)
+		=> GetConstant ("GetStringConstant", libraryName, fieldName);
+
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetIndirect (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetIndirect (string libraryName, string fieldName)
+		=> GetConstant ("GetIndirect", libraryName, fieldName);
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetStruct;lt&type;gt& (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="type">The name of the type of the structure to return.</param>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetStruct (string type, string libraryName, string fieldName)
+		=> GetGenericConstant ("GetStruct", type, libraryName, fieldName);
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetSByte (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetSByte (string libraryName, string fieldName)
+		=> GetConstant ("GetSByte", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetSByte (string libraryName, string symbol, sbyte value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetByte (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetByte (string libraryName, string fieldName)
+		=> GetConstant ("GetByte", libraryName, fieldName);
+
+
+	public static CompilationUnitSyntax SetByte (string libraryName, string symbol, byte value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetInt16 (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetInt16 (string libraryName, string fieldName)
+		=> GetConstant ("GetInt16", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetInt16 (string libraryName, string symbol, short value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetUInt16 (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetUInt16 (string libraryName, string fieldName)
+		=> GetConstant ("GetUInt16", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetUInt16 (IntPtr handle, string symbol, ushort value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetInt32 (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetInt32 (string libraryName, string fieldName)
+		=> GetConstant ("GetInt32", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetInt32 (IntPtr handle, string symbol, int value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetUInt32 (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetUInt32 (string libraryName, string fieldName)
+		=> GetConstant ("GetUInt32", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetUInt32 (IntPtr handle, string symbol, uint value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetInt64 (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetInt64 (string libraryName, string fieldName)
+		=> GetConstant ("GetInt64", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetInt64 (IntPtr handle, string symbol, long value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetUInt64 (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetUInt64 (string libraryName, string fieldName)
+		=> GetConstant ("GetUInt64", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetUInt64 (string libraryName, string symbol, ulong value)
+		=> throw new NotImplementedException ();
+
+	public static CompilationUnitSyntax SetString (string libraryName, string symbol, string? value)
+		=> throw new NotImplementedException ();
+
+	public static CompilationUnitSyntax SetArray (string libraryName, string symbol, /*NSArray?*/ string array)
+		=> throw new NotImplementedException ();
+
+	public static CompilationUnitSyntax SetObject (string libraryName, string symbol, /*NSObject?*/ string value)
+		=> throw new NotImplementedException ();
+
+	public static CompilationUnitSyntax GetNInt (string libraryName, string symbol)
+		=> GetConstant ("GetNInt", libraryName, symbol);
+
+	public static CompilationUnitSyntax SetNInt (IntPtr handle, string symbol, nint value)
+		=> throw new NotImplementedException ();
+
+	public static CompilationUnitSyntax GetNUInt (string libraryName, string symbol)
+		=> GetConstant ("GetNInt", libraryName, symbol);
+
+	public static CompilationUnitSyntax SetNUInt (string libraryName, string symbol, nuint value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetNFloat (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetNFloat (string libraryName, string fieldName)
+		=> GetConstant ("GetNFloat", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetNFloat (string libraryName, string symbol, /*nfloat*/ string value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetIntPtr (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetIntPtr (string libraryName, string fieldName)
+		=> GetConstant ("GetIntPtr", libraryName, fieldName);
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetUIntPtr (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetUIntPtr (string libraryName, string fieldName)
+		=> GetConstant ("GetUIntPtr", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetUIntPtr (string libraryName, string symbol, UIntPtr value)
+		=> throw new NotImplementedException ();
+
+	public static CompilationUnitSyntax SetIntPtr (string libraryName, string symbol, IntPtr value)
+		=> throw new NotImplementedException ();
+
+	public static CompilationUnitSyntax GetCGRect (string libraryName, string symbol)
+		=> GetConstant ("GetCGRect", libraryName, symbol);
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetCGSize (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetCGSize (string libraryName, string fieldName)
+		=> GetConstant ("GetCGSize", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetCGSize (string libraryName, string symbol, /*CGSize*/ string value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetDouble (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetDouble (string libraryName, string fieldName)
+		=> GetConstant ("GetDouble", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetDouble (string libraryName, string symbol, double value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetFloat (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetFloat (string libraryName, string fieldName)
+		=> GetConstant ("GetFloat", libraryName, fieldName);
+
+	public static CompilationUnitSyntax SetFloat (IntPtr handle, string symbol, float value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Dlfcn.GetSizeF (libraryName, fieldName);"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetSizeF (string libraryName, string fieldName)
+		=> GetConstant ("GetSizeF", libraryName, fieldName);
+
+	public static CompilationUnitSyntax GetSizeF (IntPtr handle, string fieldName, float value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Generates a call for "Runtime.GetNSObject;lt&Foundation.NSArray;gt& (Dlfcn.GetIndirect (libraryName, fieldName))!;"];
+	/// </summary>
+	/// <param name="libraryName">The library from where the field will be loaded.</param>
+	/// <param name="fieldName">The field name.</param>
+	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
+	public static CompilationUnitSyntax GetNSObjectField (string nsObjectType, string libraryName, string fieldName)
+	{
+		var getIndirectArguments = new SyntaxNodeOrToken [] {
+			GetLibraryArgument (libraryName), Token (SyntaxKind.CommaToken),
+			GetLiteralExpressionArgument (SyntaxKind.StringLiteralExpression, fieldName),
+		};
+
+		var getIndirectInvocation = InvocationExpression (
+			MemberAccessExpression (
+				SyntaxKind.SimpleMemberAccessExpression,
+				IdentifierName (Dlfcn),
+				IdentifierName ("GetIndirect").WithTrailingTrivia (Space)
+			)
+		).WithArgumentList (ArgumentList (SeparatedList<ArgumentSyntax> (getIndirectArguments)).NormalizeWhitespace ());
+
+		var getNSObjectArguments =
+			ArgumentList (SingletonSeparatedList (Argument (getIndirectInvocation)));
+		return GetNSObject (nsObjectType, getNSObjectArguments, suppressNullableWarning: true);
+	}
+
+	public static CompilationUnitSyntax SetNSObject (string nsObjectType, string libraryName, string symbol,
+		string value)
+		=> throw new NotImplementedException ();
+
+	public static CompilationUnitSyntax GetBlittableField (string blittableType, string libraryName, string fieldName)
+	{
+		var arguments = new SyntaxNodeOrToken [] {
+			GetLibraryArgument (libraryName), Token (SyntaxKind.CommaToken),
+			GetLiteralExpressionArgument (SyntaxKind.StringLiteralExpression, fieldName),
+		};
+
+		// Dlfcn.dlsym (FOO, BAR))
+		var dlsymInvocation = InvocationExpression (
+			MemberAccessExpression (
+				SyntaxKind.SimpleMemberAccessExpression,
+				IdentifierName (Dlfcn),
+				IdentifierName ("dlsym").WithTrailingTrivia (Space)
+			)
+		).WithArgumentList (ArgumentList (SeparatedList<ArgumentSyntax> (arguments)).NormalizeWhitespace ());
+
+		// *((TYPE *) dlsymCall)
+		var castExpression = PrefixUnaryExpression (
+			SyntaxKind.PointerIndirectionExpression,
+			ParenthesizedExpression (
+				CastExpression (
+					PointerType (
+						IdentifierName (blittableType)),
+					dlsymInvocation.WithLeadingTrivia (Space)
+				)));
+
+		var compilationUnit = CompilationUnit ().WithMembers (
+			SingletonList<MemberDeclarationSyntax> (
+				GlobalStatement (
+					ExpressionStatement (castExpression
+					))));
+		return compilationUnit;
+	}
+
+
+	public static CompilationUnitSyntax SetBlittableField (string nsObjectType, string libraryName, string fieldName,
+		string value)
+		=> throw new NotImplementedException ();
+
+	/// <summary>
+	/// Returns the getter needed to access the native value exposed by a field property. The method will return the
+	/// Dflcn calls needed.
+	/// </summary>
+	/// <param name="property">A field property under code generation.</param>
+	/// <returns>The appropriate Dlfcn call to retrieve the native value of a field property.</returns>
+	/// <exception cref="NotSupportedException">When the caller tries to generate the call for a no field property.</exception>
+	/// <exception cref="NotImplementedException">When the property type is not supported for a field property.</exception>
+	public static CompilationUnitSyntax FieldConstantGetter (in Property property)
+	{
+		// check if this is a field, if it is not, we have an issue with the code generator
+		if (!property.IsField)
+			throw new NotSupportedException ("Cannot retrieve getter for non field property.");
+
+		// retrieve all the necessary data from the info field of the property
+		var libraryName = property.ExportFieldData.Value.LibraryName;
+		var symbolName = property.ExportFieldData.Value.FieldData.SymbolName;
+
+		if (property.ReturnType.IsNSObject) {
+			return property.ReturnType.Name == "Foundation.NSString"
+				? GetStringConstant (libraryName, symbolName)
+				// all nsobjects are retrieved using the same generic getter
+				: GetNSObjectField (property.ReturnType.Name, libraryName, symbolName);
+		}
+
+		// use the return type and the special type of the property to decide what getter we are going to us
+		return property.ReturnType switch {
+			// special types
+			{ Name: "CoreGraphics.CGSize" } => GetCGSize (libraryName, symbolName),
+			{ Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName),
+			{ Name: "nfloat" } => GetNFloat (libraryName, symbolName),
+			{ Name: "System.Drawing.SizeF" } => GetSizeF (libraryName, symbolName),
+
+			// Billable types 
+			{ Name: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" } 
+				=> GetBlittableField (property.ReturnType.Name, libraryName, symbolName),
+
+			// enum types, decide based on its enum backing field, smart enums have to be done in the binding
+			// manually
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => GetByte (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
+
+			// General special types
+			{ SpecialType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Byte } => GetByte (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_IntPtr } => GetIntPtr (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UIntPtr } => GetUIntPtr (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Double } => GetDouble (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Single } => GetFloat (libraryName, symbolName),
+
+			// We do not support the property
+			_ => throw new NotImplementedException ($"Return type {property.ReturnType} is not implemented."),
+		};
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -405,7 +405,10 @@ static partial class BindingSyntaxFactory {
 		// use the return type and the special type of the property to decide what getter we are going to us
 		return property.ReturnType switch {
 			// special types
-			{ Name: "CoreGraphics.CGSize" } => GetCGSize (libraryName, symbolName), { Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName), { Name: "nfloat" } => GetNFloat (libraryName, symbolName), { Name: "System.Drawing.SizeF" } => GetSizeF (libraryName, symbolName),
+			{ Name: "CoreGraphics.CGSize" } => GetCGSize (libraryName, symbolName),
+			{ Name: "CoreMedia.CMTag" } => GetStruct ("CoreMedia.CMTag", libraryName, symbolName),
+			{ Name: "nfloat" } => GetNFloat (libraryName, symbolName),
+			{ Name: "System.Drawing.SizeF" } => GetSizeF (libraryName, symbolName),
 
 			// Billable types 
 			{ Name: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" }
@@ -413,10 +416,28 @@ static partial class BindingSyntaxFactory {
 
 			// enum types, decide based on its enum backing field, smart enums have to be done in the binding
 			// manually
-			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => GetByte (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName), { IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => GetByte (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName),
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
 
 			// General special types
-			{ SpecialType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName), { SpecialType: SpecialType.System_Byte } => GetByte (libraryName, symbolName), { SpecialType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName), { SpecialType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName), { SpecialType: SpecialType.System_IntPtr } => GetIntPtr (libraryName, symbolName), { SpecialType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName), { SpecialType: SpecialType.System_UIntPtr } => GetUIntPtr (libraryName, symbolName), { SpecialType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName), { SpecialType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName), { SpecialType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName), { SpecialType: SpecialType.System_Double } => GetDouble (libraryName, symbolName), { SpecialType: SpecialType.System_Single } => GetFloat (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_SByte } => GetSByte (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Byte } => GetByte (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Int16 } => GetInt16 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UInt16 } => GetUInt16 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_IntPtr } => GetIntPtr (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Int32 } => GetInt32 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UIntPtr } => GetUIntPtr (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UInt32 } => GetUInt32 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Int64 } => GetInt64 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_UInt64 } => GetUInt64 (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Double } => GetDouble (libraryName, symbolName),
+			{ SpecialType: SpecialType.System_Single } => GetFloat (libraryName, symbolName),
 
 			// We do not support the property
 			_ => throw new NotImplementedException ($"Return type {property.ReturnType} is not implemented."),

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Macios.Generator.Emitters;
+
+static partial class BindingSyntaxFactory {
+	readonly static string Runtime = "Runtime";
+
+	public static CompilationUnitSyntax GetNSObject (string nsObjectType, ArgumentListSyntax argumentList,
+		bool suppressNullableWarning = false)
+		=> StaticInvocationGenericExpression (Runtime, "GetNSObject", nsObjectType, argumentList,
+			suppressNullableWarning);
+}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Macios.Generator.Emitters;
+
+static partial class BindingSyntaxFactory {
+	/// <summary>
+	/// Returns an argument syntax for the provided kind and literal expression.
+	/// </summary>
+	/// <param name="kind">The kind of the literal value argument.</param>
+	/// <param name="literal">The value of the argument.</param>
+	/// <returns>A literal argument with the provided value.</returns>
+	static ArgumentSyntax GetLiteralExpressionArgument (SyntaxKind kind, string literal)
+	{
+		return Argument (LiteralExpression (kind, Literal (literal)));
+	}
+
+	static CompilationUnitSyntax StaticInvocationExpression (string staticClassName, string methodName,
+		SyntaxNodeOrToken [] argumentList)
+	{
+		var invocation = InvocationExpression (
+			MemberAccessExpression (
+				SyntaxKind.SimpleMemberAccessExpression,
+				IdentifierName (staticClassName),
+				IdentifierName (methodName).WithTrailingTrivia (Space)
+			)
+		).WithArgumentList (ArgumentList (SeparatedList<ArgumentSyntax> (argumentList)).NormalizeWhitespace ());
+
+		var compilationUnit = CompilationUnit ().WithMembers (
+			SingletonList<MemberDeclarationSyntax> (
+				GlobalStatement (
+					ExpressionStatement (invocation))));
+		return compilationUnit;
+	}
+
+
+	static CompilationUnitSyntax StaticInvocationGenericExpression (string staticClassName, string methodName,
+		string genericName,
+		ArgumentListSyntax argumentList, bool suppressNullableWarning = false)
+	{
+		var invocation = InvocationExpression (
+			MemberAccessExpression (
+				SyntaxKind.SimpleMemberAccessExpression,
+				IdentifierName (staticClassName),
+				GenericName (
+						Identifier (methodName))
+					.WithTypeArgumentList (TypeArgumentList (
+						SingletonSeparatedList<TypeSyntax> (IdentifierName (genericName))))
+					.WithTrailingTrivia (Space)
+			)
+		).WithArgumentList (argumentList);
+
+		var compilationUnit = CompilationUnit ().WithMembers (
+			SingletonList<MemberDeclarationSyntax> (
+				GlobalStatement (
+					ExpressionStatement (
+						suppressNullableWarning
+							? PostfixUnaryExpression (SyntaxKind.SuppressNullableWarningExpression, invocation)
+							: invocation
+					))));
+		return compilationUnit;
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTests.cs
@@ -1,0 +1,861 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Context;
+using Microsoft.Macios.Generator.DataModel;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
+
+namespace Microsoft.Macios.Generator.Tests.Emitters;
+
+public class BindingSyntaxFactoryTests : BaseGeneratorTestClass {
+	
+	class TestDataFieldConstantGetter : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string nsStringFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial NSString GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [nsStringFieldProperty, 
+				"Dlfcn.GetStringConstant (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+
+			const string byteFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial byte GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [byteFieldProperty, 
+				"Dlfcn.GetByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string otherByteFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial Byte GenericGray { get; }
+
+	}
+}
+";
+			yield return [otherByteFieldProperty, 
+				"Dlfcn.GetByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string sbyteFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial sbyte GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [sbyteFieldProperty, 
+				"Dlfcn.GetSByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string otherSbyteFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial SByte GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [otherSbyteFieldProperty, 
+				"Dlfcn.GetSByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string int16FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial short GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [int16FieldProperty, 
+				"Dlfcn.GetInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string otherInt16FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial Int16 GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [otherInt16FieldProperty, 
+				"Dlfcn.GetInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string uint16FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial ushort GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [uint16FieldProperty, 
+				"Dlfcn.GetUInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string otherUint16FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial UInt16 GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [otherUint16FieldProperty, 
+				"Dlfcn.GetUInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string int32FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial int GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [int32FieldProperty, 
+				"Dlfcn.GetInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string otherInt32FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial Int32 GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [otherInt32FieldProperty, 
+				"Dlfcn.GetInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string uint32FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial uint GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [uint32FieldProperty, 
+				"Dlfcn.GetUInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string otherUint32FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial UInt32 GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [otherUint32FieldProperty, 
+				"Dlfcn.GetUInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string doubleFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial double GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [doubleFieldProperty, 
+				"Dlfcn.GetDouble (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string otherDoubleFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial Double GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [otherDoubleFieldProperty, 
+				"Dlfcn.GetDouble (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string floatFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial float GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [floatFieldProperty, 
+				"Dlfcn.GetFloat (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string otherFloatFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial Single GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [otherFloatFieldProperty, 
+				"Dlfcn.GetFloat (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string intPtrFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial IntPtr GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [intPtrFieldProperty, 
+				"Dlfcn.GetIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string uintPtrFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial UIntPtr GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [uintPtrFieldProperty, 
+				"Dlfcn.GetUIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string sizeFFieldProperty = @"
+using System;
+using System.Drawing;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial SizeF GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [sizeFFieldProperty, 
+				"Dlfcn.GetSizeF (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string nintFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial nint GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [nintFieldProperty, 
+				"Dlfcn.GetIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string nuintFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial nuint GenericGray { get; }
+
+	}
+}
+";
+			
+			yield return [nuintFieldProperty, 
+				"Dlfcn.GetUIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string nfloatFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial nfloat GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [nfloatFieldProperty, 
+				"Dlfcn.GetNFloat (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string cgsizeFieldProperty = @"
+using System;
+using Foundation;
+using CoreGraphics;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGSize GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [cgsizeFieldProperty, 
+				"Dlfcn.GetCGSize (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string cmtagFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CMTag GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [cmtagFieldProperty, 
+				"Dlfcn.GetStruct<CoreMedia.CMTag> (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+			
+			const string nsArrayFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial NSArray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [nsArrayFieldProperty, 
+				"Runtime.GetNSObject<Foundation.NSArray> (Dlfcn.GetIndirect (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))!;"];
+			
+			const string nsNumberFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial NSNumber GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [nsNumberFieldProperty, 
+				"Runtime.GetNSObject<Foundation.NSNumber> (Dlfcn.GetIndirect (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))!;"];
+			
+			const string sbyteEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : sbyte{
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				sbyteEnumFieldProperty,
+				"Dlfcn.GetSByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
+			];
+			
+			const string byteEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : byte{
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				byteEnumFieldProperty,
+				"Dlfcn.GetByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
+			];
+			
+			const string shortEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : short {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				shortEnumFieldProperty,
+				"Dlfcn.GetInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
+			];
+			
+			const string ushortEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : ushort {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				ushortEnumFieldProperty,
+				"Dlfcn.GetUInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
+			];
+			
+			const string intEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : int {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				intEnumFieldProperty,
+				"Dlfcn.GetInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
+			];
+			
+			const string uintEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : uint {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				uintEnumFieldProperty,
+				"Dlfcn.GetUInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
+			];
+			
+			const string longEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : long {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				longEnumFieldProperty,
+				"Dlfcn.GetInt64 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
+			];
+			
+			const string ulongEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : ulong {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				ulongEnumFieldProperty,
+				"Dlfcn.GetUInt64 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
+			];
+			
+			const string cmTimeFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CMTime GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				cmTimeFieldProperty,
+				"*((CoreMedia.CMTime*) Dlfcn.dlsym (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"));" 
+			];
+			
+			const string whiteFieldProperty = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial AVCaptureWhiteBalanceGains GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				whiteFieldProperty,
+				"*((AVFoundation.AVCaptureWhiteBalanceGains*) Dlfcn.dlsym (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"));" 
+			];
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataFieldConstantGetter>]
+	void FieldConstantGetterTests (ApplePlatform platform, string inputText, string expectedCall)
+	{
+		var (compilation, sourceTrees) =
+			CreateCompilation (platform, sources: inputText);
+		Assert.Single (sourceTrees);
+		// get the declarations we want to work with and the semantic model
+		var node = sourceTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<PropertyDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (node);
+		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
+		var context = new RootBindingContext (semanticModel);
+		Assert.True(Property.TryCreate(node, context, out var property));
+		var compilationUnit = FieldConstantGetter (property.Value).ToString ();
+		var str = compilationUnit.ToString ();
+		Assert.Equal (expectedCall, FieldConstantGetter (property.Value).ToString ());
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTests.cs
@@ -398,27 +398,6 @@ namespace CoreGraphics {
 			yield return [uintPtrFieldProperty,
 				"Dlfcn.GetUIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
 
-			const string sizeFFieldProperty = @"
-using System;
-using System.Drawing;
-using Foundation;
-using ObjCBindings;
-
-namespace CoreGraphics {
-
-	[BindingType<Class>]
-	public partial class CGColorSpaceNames {
-
-		[Field<Property> (""kCGColorSpaceGenericGray"")]
-		public partial SizeF GenericGray { get; }
-
-	}
-}
-";
-
-			yield return [sizeFFieldProperty,
-				"Dlfcn.GetSizeF (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-
 			const string nintFieldProperty = @"
 using System;
 using Foundation;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTests.cs
@@ -15,7 +15,7 @@ using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
 public class BindingSyntaxFactoryTests : BaseGeneratorTestClass {
-	
+
 	class TestDataFieldConstantGetter : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -35,8 +35,8 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [nsStringFieldProperty, 
+
+			yield return [nsStringFieldProperty,
 				"Dlfcn.GetStringConstant (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
 
 			const string byteFieldProperty = @"
@@ -55,10 +55,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [byteFieldProperty, 
+
+			yield return [byteFieldProperty,
 				"Dlfcn.GetByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string otherByteFieldProperty = @"
 using System;
 using Foundation;
@@ -75,9 +75,9 @@ namespace CoreGraphics {
 	}
 }
 ";
-			yield return [otherByteFieldProperty, 
+			yield return [otherByteFieldProperty,
 				"Dlfcn.GetByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string sbyteFieldProperty = @"
 using System;
 using Foundation;
@@ -94,10 +94,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [sbyteFieldProperty, 
+
+			yield return [sbyteFieldProperty,
 				"Dlfcn.GetSByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string otherSbyteFieldProperty = @"
 using System;
 using Foundation;
@@ -114,10 +114,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [otherSbyteFieldProperty, 
+
+			yield return [otherSbyteFieldProperty,
 				"Dlfcn.GetSByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string int16FieldProperty = @"
 using System;
 using Foundation;
@@ -134,10 +134,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [int16FieldProperty, 
+
+			yield return [int16FieldProperty,
 				"Dlfcn.GetInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string otherInt16FieldProperty = @"
 using System;
 using Foundation;
@@ -154,10 +154,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [otherInt16FieldProperty, 
+
+			yield return [otherInt16FieldProperty,
 				"Dlfcn.GetInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string uint16FieldProperty = @"
 using System;
 using Foundation;
@@ -174,10 +174,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [uint16FieldProperty, 
+
+			yield return [uint16FieldProperty,
 				"Dlfcn.GetUInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string otherUint16FieldProperty = @"
 using System;
 using Foundation;
@@ -194,10 +194,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [otherUint16FieldProperty, 
+
+			yield return [otherUint16FieldProperty,
 				"Dlfcn.GetUInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string int32FieldProperty = @"
 using System;
 using Foundation;
@@ -214,10 +214,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [int32FieldProperty, 
+
+			yield return [int32FieldProperty,
 				"Dlfcn.GetInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string otherInt32FieldProperty = @"
 using System;
 using Foundation;
@@ -234,10 +234,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [otherInt32FieldProperty, 
+
+			yield return [otherInt32FieldProperty,
 				"Dlfcn.GetInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string uint32FieldProperty = @"
 using System;
 using Foundation;
@@ -254,10 +254,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [uint32FieldProperty, 
+
+			yield return [uint32FieldProperty,
 				"Dlfcn.GetUInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string otherUint32FieldProperty = @"
 using System;
 using Foundation;
@@ -274,10 +274,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [otherUint32FieldProperty, 
+
+			yield return [otherUint32FieldProperty,
 				"Dlfcn.GetUInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string doubleFieldProperty = @"
 using System;
 using Foundation;
@@ -294,10 +294,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [doubleFieldProperty, 
+
+			yield return [doubleFieldProperty,
 				"Dlfcn.GetDouble (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string otherDoubleFieldProperty = @"
 using System;
 using Foundation;
@@ -314,10 +314,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [otherDoubleFieldProperty, 
+
+			yield return [otherDoubleFieldProperty,
 				"Dlfcn.GetDouble (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string floatFieldProperty = @"
 using System;
 using Foundation;
@@ -334,10 +334,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [floatFieldProperty, 
+
+			yield return [floatFieldProperty,
 				"Dlfcn.GetFloat (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string otherFloatFieldProperty = @"
 using System;
 using Foundation;
@@ -354,10 +354,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [otherFloatFieldProperty, 
+
+			yield return [otherFloatFieldProperty,
 				"Dlfcn.GetFloat (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string intPtrFieldProperty = @"
 using System;
 using Foundation;
@@ -374,10 +374,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [intPtrFieldProperty, 
+
+			yield return [intPtrFieldProperty,
 				"Dlfcn.GetIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string uintPtrFieldProperty = @"
 using System;
 using Foundation;
@@ -394,10 +394,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [uintPtrFieldProperty, 
+
+			yield return [uintPtrFieldProperty,
 				"Dlfcn.GetUIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string sizeFFieldProperty = @"
 using System;
 using System.Drawing;
@@ -415,10 +415,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [sizeFFieldProperty, 
+
+			yield return [sizeFFieldProperty,
 				"Dlfcn.GetSizeF (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string nintFieldProperty = @"
 using System;
 using Foundation;
@@ -435,10 +435,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [nintFieldProperty, 
+
+			yield return [nintFieldProperty,
 				"Dlfcn.GetIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string nuintFieldProperty = @"
 using System;
 using Foundation;
@@ -455,10 +455,10 @@ namespace CoreGraphics {
 	}
 }
 ";
-			
-			yield return [nuintFieldProperty, 
+
+			yield return [nuintFieldProperty,
 				"Dlfcn.GetUIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string nfloatFieldProperty = @"
 using System;
 using Foundation;
@@ -476,9 +476,9 @@ namespace CoreGraphics {
 }
 ";
 
-			yield return [nfloatFieldProperty, 
+			yield return [nfloatFieldProperty,
 				"Dlfcn.GetNFloat (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string cgsizeFieldProperty = @"
 using System;
 using Foundation;
@@ -497,9 +497,9 @@ namespace CoreGraphics {
 }
 ";
 
-			yield return [cgsizeFieldProperty, 
+			yield return [cgsizeFieldProperty,
 				"Dlfcn.GetCGSize (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string cmtagFieldProperty = @"
 using System;
 using Foundation;
@@ -518,9 +518,9 @@ namespace CoreGraphics {
 }
 ";
 
-			yield return [cmtagFieldProperty, 
+			yield return [cmtagFieldProperty,
 				"Dlfcn.GetStruct<CoreMedia.CMTag> (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
-			
+
 			const string nsArrayFieldProperty = @"
 using System;
 using Foundation;
@@ -539,9 +539,9 @@ namespace CoreGraphics {
 }
 ";
 
-			yield return [nsArrayFieldProperty, 
+			yield return [nsArrayFieldProperty,
 				"Runtime.GetNSObject<Foundation.NSArray> (Dlfcn.GetIndirect (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))!;"];
-			
+
 			const string nsNumberFieldProperty = @"
 using System;
 using Foundation;
@@ -560,9 +560,9 @@ namespace CoreGraphics {
 }
 ";
 
-			yield return [nsNumberFieldProperty, 
+			yield return [nsNumberFieldProperty,
 				"Runtime.GetNSObject<Foundation.NSNumber> (Dlfcn.GetIndirect (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))!;"];
-			
+
 			const string sbyteEnumFieldProperty = @"
 using System;
 using Foundation;
@@ -590,7 +590,7 @@ namespace CoreGraphics {
 				sbyteEnumFieldProperty,
 				"Dlfcn.GetSByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
 			];
-			
+
 			const string byteEnumFieldProperty = @"
 using System;
 using Foundation;
@@ -618,7 +618,7 @@ namespace CoreGraphics {
 				byteEnumFieldProperty,
 				"Dlfcn.GetByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
 			];
-			
+
 			const string shortEnumFieldProperty = @"
 using System;
 using Foundation;
@@ -646,7 +646,7 @@ namespace CoreGraphics {
 				shortEnumFieldProperty,
 				"Dlfcn.GetInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
 			];
-			
+
 			const string ushortEnumFieldProperty = @"
 using System;
 using Foundation;
@@ -674,7 +674,7 @@ namespace CoreGraphics {
 				ushortEnumFieldProperty,
 				"Dlfcn.GetUInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
 			];
-			
+
 			const string intEnumFieldProperty = @"
 using System;
 using Foundation;
@@ -702,7 +702,7 @@ namespace CoreGraphics {
 				intEnumFieldProperty,
 				"Dlfcn.GetInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
 			];
-			
+
 			const string uintEnumFieldProperty = @"
 using System;
 using Foundation;
@@ -730,7 +730,7 @@ namespace CoreGraphics {
 				uintEnumFieldProperty,
 				"Dlfcn.GetUInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
 			];
-			
+
 			const string longEnumFieldProperty = @"
 using System;
 using Foundation;
@@ -758,7 +758,7 @@ namespace CoreGraphics {
 				longEnumFieldProperty,
 				"Dlfcn.GetInt64 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
 			];
-			
+
 			const string ulongEnumFieldProperty = @"
 using System;
 using Foundation;
@@ -786,7 +786,7 @@ namespace CoreGraphics {
 				ulongEnumFieldProperty,
 				"Dlfcn.GetUInt64 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"
 			];
-			
+
 			const string cmTimeFieldProperty = @"
 using System;
 using Foundation;
@@ -807,9 +807,9 @@ namespace CoreGraphics {
 
 			yield return [
 				cmTimeFieldProperty,
-				"*((CoreMedia.CMTime*) Dlfcn.dlsym (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"));" 
+				"*((CoreMedia.CMTime*) Dlfcn.dlsym (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"));"
 			];
-			
+
 			const string whiteFieldProperty = @"
 using System;
 using AVFoundation;
@@ -831,10 +831,10 @@ namespace CoreGraphics {
 
 			yield return [
 				whiteFieldProperty,
-				"*((AVFoundation.AVCaptureWhiteBalanceGains*) Dlfcn.dlsym (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"));" 
+				"*((AVFoundation.AVCaptureWhiteBalanceGains*) Dlfcn.dlsym (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"));"
 			];
 		}
-		
+
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
 
@@ -853,7 +853,7 @@ namespace CoreGraphics {
 		Assert.NotNull (node);
 		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
 		var context = new RootBindingContext (semanticModel);
-		Assert.True(Property.TryCreate(node, context, out var property));
+		Assert.True (Property.TryCreate (node, context, out var property));
 		var compilationUnit = FieldConstantGetter (property.Value).ToString ();
 		var str = compilationUnit.ToString ();
 		Assert.Equal (expectedCall, FieldConstantGetter (property.Value).ToString ());


### PR DESCRIPTION
Add the initial implementation of a syntax factory that can be used to generate the C# calls needed by the bindings.

This implementation only contains the Getter methods needed to retrieve fields in order to keep PRs in a reasonable size.

Example usage when writing bindings:

```csharp
sb.AppendRaw($@"
if ({property.Name} is null)
    {property.Name} = {FieldConstantGetter (property)};
return {property.Name}
";
```

The API takes advantage of the fact that the data model has all the needed info and the makes the code cleaner when importing it with a status using.