### PR TITLE
[Rgen] Add support to the syntax factory to generate setters for fields.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -636,7 +636,7 @@ static partial class BindingSyntaxFactory {
 				Setter: WrapThrow ()),
 			{ Name: "nfloat" } => (Getter: GetNFloat, Setter: SetNFloat),
 
-			// Billable types 
+			// Blittable types 
 			{ Name: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" }
 				=> (Getter: WrapGenericCall (property.ReturnType.Name, GetBlittableField),
 					Setter: WrapThrow ()),

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -76,11 +76,11 @@ static partial class BindingSyntaxFactory {
 		string variableName, [CallerMemberName] string methodName = "", string? castTarget = null)
 	{
 		var arguments = new SyntaxNodeOrToken [] {
-			GetLibraryArgument (libraryName), 
+			GetLibraryArgument (libraryName),
 			Token (SyntaxKind.CommaToken),
 			GetLiteralExpressionArgument (SyntaxKind.StringLiteralExpression, fieldName),
 			Token (SyntaxKind.CommaToken),
-			Argument (castTarget is null 
+			Argument (castTarget is null
 				? IdentifierName (variableName)
 				: CastExpression (IdentifierName (castTarget), IdentifierName (variableName))),
 		};
@@ -175,7 +175,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
 	public static CompilationUnitSyntax SetByte (string libraryName, string fieldName, string variableName)
 		=> SetConstant (libraryName, fieldName, variableName);
-	
+
 	/// <summary>
 	/// Generates a call for "Dlfcn.SetByte (libraryName, fieldName, (cast)value);"];
 	/// </summary>
@@ -205,7 +205,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
 	public static CompilationUnitSyntax SetInt16 (string libraryName, string fieldName, string variableName)
 		=> SetConstant (libraryName, fieldName, variableName);
-	
+
 	/// <summary>
 	/// Generates a call for "Dlfcn.SetInt16 (libraryName, fieldName, (cast)value);"];
 	/// </summary>
@@ -235,7 +235,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
 	public static CompilationUnitSyntax SetUInt16 (string libraryName, string fieldName, string variableName)
 		=> SetConstant (libraryName, fieldName, variableName);
-	
+
 	/// <summary>
 	/// Generates a call for "Dlfcn.SetUInt16 (libraryName, fieldName, (cast)value);"];
 	/// </summary>
@@ -246,7 +246,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
 	public static CompilationUnitSyntax SetUInt16 (string libraryName, string fieldName, string variableName, string? castTarget)
 		=> SetConstant (libraryName, fieldName, variableName, castTarget: castTarget);
-	
+
 	/// <summary>
 	/// Generates a call for "Dlfcn.GetInt32 (libraryName, fieldName);"];
 	/// </summary>
@@ -265,7 +265,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
 	public static CompilationUnitSyntax SetInt32 (string libraryName, string fieldName, string variableName)
 		=> SetConstant (libraryName, fieldName, variableName);
-	
+
 	/// <summary>
 	/// Generates a call for "Dlfcn.SetInt32 (libraryName, fieldName, (cast)value);"];
 	/// </summary>
@@ -295,7 +295,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
 	public static CompilationUnitSyntax SetUInt32 (string libraryName, string fieldName, string variableName)
 		=> SetConstant (libraryName, fieldName, variableName);
-	
+
 	/// <summary>
 	/// Generates a call for "Dlfcn.SetUInt32 (libraryName, fieldName, (cast)value);"];
 	/// </summary>
@@ -325,7 +325,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
 	public static CompilationUnitSyntax SetInt64 (string libraryName, string fieldName, string variableName)
 		=> SetConstant (libraryName, fieldName, variableName);
-	
+
 	/// <summary>
 	/// Generates a call for "Dlfcn.SetUInt32 (libraryName, fieldName, (cast)value);"];
 	/// </summary>
@@ -355,7 +355,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
 	public static CompilationUnitSyntax SetUInt64 (string libraryName, string fieldName, string variableName)
 		=> SetConstant (libraryName, fieldName, variableName);
-	
+
 	/// <summary>
 	/// Generates a call for "Dlfcn.SetUInt64 (libraryName, fieldName, (cast)value);"];
 	/// </summary>
@@ -616,11 +616,9 @@ static partial class BindingSyntaxFactory {
 		}
 
 		if (property.ReturnType.IsNSObject) {
-			return property.ReturnType switch {
-				{ Name: "Foundation.NSString" } => (Getter: GetStringConstant, Setter: SetString),
-				{ Name: "Foundation.NSArray" } => (
-					Getter: WrapGenericCall (property.ReturnType.Name, GetNSObjectField), 
-					Setter: SetArray),
+			return property.ReturnType switch { { Name: "Foundation.NSString" } => (Getter: GetStringConstant, Setter: SetString), { Name: "Foundation.NSArray" } => (
+																																	   Getter: WrapGenericCall (property.ReturnType.Name, GetNSObjectField),
+																																	   Setter: SetArray),
 				_ => (
 					Getter: WrapGenericCall (property.ReturnType.Name, GetNSObjectField),
 					Setter: SetObject)
@@ -705,7 +703,7 @@ static partial class BindingSyntaxFactory {
 	/// <exception cref="NotImplementedException">When the property type is not supported for a field property.</exception>
 	public static CompilationUnitSyntax FieldConstantSetter (in Property property, string variableName)
 	{
-		if (variableName == null) throw new ArgumentNullException (nameof(variableName));
+		if (variableName is null) throw new ArgumentNullException (nameof (variableName));
 		// check if this is a field, if it is not, we have an issue with the code generator
 		if (!property.IsField)
 			throw new NotSupportedException ("Cannot retrieve getter for non field property.");

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -9,7 +9,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Microsoft.Macios.Generator.Emitters;
 
 static partial class BindingSyntaxFactory {
-	
+
 	/// <summary>
 	/// Returns an argument syntax for the provided kind and literal expression.
 	/// </summary>
@@ -76,12 +76,12 @@ static partial class BindingSyntaxFactory {
 		var throwExpression = ThrowStatement (
 			ObjectCreationExpression (IdentifierName (type))
 				.WithArgumentList (argumentList)).NormalizeWhitespace ();
-		
+
 		return CompilationUnit ().WithMembers (
 			SingletonList<MemberDeclarationSyntax> (
 				GlobalStatement (throwExpression)));
 	}
-	
+
 	static CompilationUnitSyntax ThrowNotSupportedException (string message)
 		=> ThrowException (type: "NotSupportedException", message: message);
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -9,6 +9,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Microsoft.Macios.Generator.Emitters;
 
 static partial class BindingSyntaxFactory {
+	
 	/// <summary>
 	/// Returns an argument syntax for the provided kind and literal expression.
 	/// </summary>
@@ -65,4 +66,22 @@ static partial class BindingSyntaxFactory {
 					))));
 		return compilationUnit;
 	}
+
+	static CompilationUnitSyntax ThrowException (string type, string message)
+	{
+		var argumentList = ArgumentList (SingletonSeparatedList (
+				GetLiteralExpressionArgument (SyntaxKind.StringLiteralExpression, message)
+			)).WithLeadingTrivia (Space);
+
+		var throwExpression = ThrowStatement (
+			ObjectCreationExpression (IdentifierName (type))
+				.WithArgumentList (argumentList)).NormalizeWhitespace ();
+		
+		return CompilationUnit ().WithMembers (
+			SingletonList<MemberDeclarationSyntax> (
+				GlobalStatement (throwExpression)));
+	}
+	
+	static CompilationUnitSyntax ThrowNotSupportedException (string message)
+		=> ThrowException (type: "NotSupportedException", message: message);
 }

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/SpecialTypeExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/SpecialTypeExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Macios.Generator.Extensions;
+
+static class SpecialTypeExtensions {
+	
+	/// <summary>
+	/// Return the keyword for a given special type.
+	/// </summary>
+	/// <param name="self">The special type to convert.</param>
+	/// <returns>The string representation of the keyword.</returns>
+	public static string? GetKeyword (this SpecialType? self) => self switch {
+		SpecialType.System_SByte => "sbyte",
+		SpecialType.System_Byte => "byte",
+		SpecialType.System_Int16 => "short",
+		SpecialType.System_UInt16 => "ushort",
+		SpecialType.System_Int32 => "int",
+		SpecialType.System_UInt32 => "uint",
+		SpecialType.System_Int64 => "long",
+		SpecialType.System_UInt64 => "ulong",
+		_ => null
+	};
+}

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/SpecialTypeExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/SpecialTypeExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.Macios.Generator.Extensions;
 
 static class SpecialTypeExtensions {
-	
+
 	/// <summary>
 	/// Return the keyword for a given special type.
 	/// </summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTests.cs
@@ -837,7 +837,7 @@ namespace CoreGraphics {
 		var str = compilationUnit.ToString ();
 		Assert.Equal (expectedCall, FieldConstantGetter (property.Value).ToString ());
 	}
-	
+
 	class TestDataFieldConstantSetter : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -858,7 +858,7 @@ namespace CoreGraphics {
 }
 ";
 
-			yield return [nsStringFieldProperty, 
+			yield return [nsStringFieldProperty,
 				"value",
 				"Dlfcn.SetString (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
 
@@ -1670,10 +1670,10 @@ namespace CoreGraphics {
 				"value",
 				"throw new NotSupportedException(\"Setting fields of type 'AVFoundation.AVCaptureWhiteBalanceGains' is not supported.\");"];
 		}
-		
+
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataFieldConstantSetter>]
 	void FieldConstantSetterTests (ApplePlatform platform, string inputText, string variableName, string expectedCall)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTests.cs
@@ -837,4 +837,859 @@ namespace CoreGraphics {
 		var str = compilationUnit.ToString ();
 		Assert.Equal (expectedCall, FieldConstantGetter (property.Value).ToString ());
 	}
+	
+	class TestDataFieldConstantSetter : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string nsStringFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial NSString GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [nsStringFieldProperty, 
+				"value",
+				"Dlfcn.SetString (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string byteFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial byte GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [byteFieldProperty,
+				"value",
+				"Dlfcn.SetByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string otherByteFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial Byte GenericGray { get; }
+
+	}
+}
+";
+			yield return [otherByteFieldProperty,
+				"value",
+				"Dlfcn.SetByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string sbyteFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial sbyte GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [sbyteFieldProperty,
+				"value",
+				"Dlfcn.SetSByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string otherSbyteFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial SByte GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [otherSbyteFieldProperty,
+				"value",
+				"Dlfcn.SetSByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string int16FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial short GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [int16FieldProperty,
+				"value",
+				"Dlfcn.SetInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string otherInt16FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial Int16 GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [otherInt16FieldProperty,
+				"value",
+				"Dlfcn.SetInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string uint16FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial ushort GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [uint16FieldProperty,
+				"value",
+				"Dlfcn.SetUInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string otherUint16FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial UInt16 GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [otherUint16FieldProperty,
+				"value",
+				"Dlfcn.SetUInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string int32FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial int GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [int32FieldProperty,
+				"value",
+				"Dlfcn.SetInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string otherInt32FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial Int32 GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [otherInt32FieldProperty,
+				"value",
+				"Dlfcn.SetInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string uint32FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial uint GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [uint32FieldProperty,
+				"value",
+				"Dlfcn.SetUInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string otherUint32FieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial UInt32 GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [otherUint32FieldProperty,
+				"value",
+				"Dlfcn.SetUInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string doubleFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial double GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [doubleFieldProperty,
+				"value",
+				"Dlfcn.SetDouble (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string otherDoubleFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial Double GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [otherDoubleFieldProperty,
+				"value",
+				"Dlfcn.SetDouble (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string floatFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial float GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [floatFieldProperty,
+				"value",
+				"Dlfcn.SetFloat (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string otherFloatFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial Single GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [otherFloatFieldProperty,
+				"value",
+				"Dlfcn.SetFloat (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string intPtrFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial IntPtr GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [intPtrFieldProperty,
+				"value",
+				"Dlfcn.SetIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string uintPtrFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial UIntPtr GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [uintPtrFieldProperty,
+				"value",
+				"Dlfcn.SetUIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string nintFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial nint GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [nintFieldProperty,
+				"value",
+				"Dlfcn.SetIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string nuintFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial nuint GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [nuintFieldProperty,
+				"value",
+				"Dlfcn.SetUIntPtr (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string nfloatFieldProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial nfloat GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [nfloatFieldProperty,
+				"value",
+				"Dlfcn.SetNFloat (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string cgsizeFieldProperty = @"
+using System;
+using Foundation;
+using CoreGraphics;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGSize GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [cgsizeFieldProperty,
+				"value",
+				"Dlfcn.SetCGSize (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string cmtagFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CMTag GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				cmtagFieldProperty,
+				"value",
+				"throw new NotSupportedException(\"Setting fields of type 'CoreMedia.CMTag' is not supported.\");"];
+
+			const string nsArrayFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial NSArray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [nsArrayFieldProperty,
+				"value",
+				"Dlfcn.SetArray (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string nsNumberFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial NSNumber GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [nsNumberFieldProperty,
+				"value",
+				"Dlfcn.SetObject (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", value);"];
+
+			const string sbyteEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : sbyte{
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				sbyteEnumFieldProperty,
+				"value",
+				"Dlfcn.SetSByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", (sbyte)value);"
+			];
+
+			const string byteEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : byte{
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				byteEnumFieldProperty,
+				"value",
+				"Dlfcn.SetByte (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", (byte)value);"
+			];
+
+			const string shortEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : short {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				shortEnumFieldProperty,
+				"value",
+				"Dlfcn.SetInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", (short)value);"
+			];
+
+			const string ushortEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : ushort {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				ushortEnumFieldProperty,
+				"value",
+				"Dlfcn.SetUInt16 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", (ushort)value);"
+			];
+
+			const string intEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : int {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				intEnumFieldProperty,
+				"value",
+				"Dlfcn.SetInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", (int)value);"
+			];
+
+			const string uintEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : uint {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				uintEnumFieldProperty,
+				"value",
+				"Dlfcn.SetUInt32 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", (uint)value);"
+			];
+
+			const string longEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : long {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				longEnumFieldProperty,
+				"value",
+				"Dlfcn.SetInt64 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", (long)value);"
+			];
+
+			const string ulongEnumFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	public enum CGColorSpaceGenericGray : ulong {
+		First, 
+		Second,
+	}
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CGColorSpaceGenericGray GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				ulongEnumFieldProperty,
+				"value",
+				"Dlfcn.SetUInt64 (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\", (ulong)value);"
+			];
+
+			const string cmTimeFieldProperty = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial CMTime GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				cmTimeFieldProperty,
+				"value",
+				"throw new NotSupportedException(\"Setting fields of type 'CoreMedia.CMTime' is not supported.\");"];
+
+			const string whiteFieldProperty = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCBindings;
+
+namespace CoreGraphics {
+
+	[BindingType<Class>]
+	public partial class CGColorSpaceNames {
+
+		[Field<Property> (""kCGColorSpaceGenericGray"")]
+		public partial AVCaptureWhiteBalanceGains GenericGray { get; }
+
+	}
+}
+";
+
+			yield return [
+				whiteFieldProperty,
+				"value",
+				"throw new NotSupportedException(\"Setting fields of type 'AVFoundation.AVCaptureWhiteBalanceGains' is not supported.\");"];
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataFieldConstantSetter>]
+	void FieldConstantSetterTests (ApplePlatform platform, string inputText, string variableName, string expectedCall)
+	{
+		var (compilation, sourceTrees) =
+			CreateCompilation (platform, sources: inputText);
+		Assert.Single (sourceTrees);
+		// get the declarations we want to work with and the semantic model
+		var node = sourceTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<PropertyDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (node);
+		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
+		var context = new RootBindingContext (semanticModel);
+		Assert.True (Property.TryCreate (node, context, out var property));
+		Assert.Equal (expectedCall, FieldConstantSetter (property.Value, variableName).ToString ());
+	}
 }


### PR DESCRIPTION
This commit has the following important changes to carefully review:

1. We move to make the method name otpional in the GetConstant and SetConstant. This is done by the CallerMemberName attribute which will add the name automatically to match the caller. This is done at compile time and is equal to nameof. This way we reduce typing and typos.
2. Added a tuple to return the getter and setter. This way we make sure that when we add support for a new kind of field, that we add both.
3. For those fields that we cannot set, we return a throw expression. Ideally this will never happen because we will make sure the analyzer stops us from trying to use Set properties on unsupported type.
4. Added support for casting in the Setter. We are using a lambda factory that captures the type of the property ONLY when is needed, this should be lazy enough.

With this change we should be able to fully generate field properties.