### PR TITLE
[Rgen] Add properties as part of the parent's list of accessors.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.cs
@@ -25,7 +25,7 @@ static class TypeSymbolExtensions {
 		var boundAttributes = symbol.GetAttributes ();
 		if (boundAttributes.Length == 0) {
 			// return an empty dictionary if there are no attributes
-			return new();
+			return new ();
 		}
 
 		var attributes = new Dictionary<string, List<AttributeData>> ();
@@ -161,7 +161,7 @@ static class TypeSymbolExtensions {
 		// a type is a smart enum if its type is a enum one AND it was decorated with the
 		// binding type attribute
 		return symbol.TypeKind == TypeKind.Enum
-		       && symbol.HasAttribute (AttributesNames.BindingAttribute);
+			   && symbol.HasAttribute (AttributesNames.BindingAttribute);
 	}
 
 	public static BindingTypeData GetBindingData (this ISymbol symbol)
@@ -222,7 +222,7 @@ static class TypeSymbolExtensions {
 		if (attrName is null)
 			return null;
 		if (!attributes.TryGetValue (attrName, out var exportAttrDataList) ||
-		    exportAttrDataList.Count != 1)
+			exportAttrDataList.Count != 1)
 			return null;
 
 		var exportAttrData = exportAttrDataList [0];
@@ -306,7 +306,7 @@ static class TypeSymbolExtensions {
 				// Check for StructLayout attribute with LayoutKind.Sequential
 				var layoutAttribute = symbol.GetAttributes ()
 					.FirstOrDefault (attr =>
-						attr.AttributeClass?.ToString () == typeof(StructLayoutAttribute).FullName);
+						attr.AttributeClass?.ToString () == typeof (StructLayoutAttribute).FullName);
 
 				if (layoutAttribute is not null) {
 					var layoutKind = (LayoutKind) layoutAttribute.ConstructorArguments [0].Value!;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
@@ -210,8 +210,8 @@ public class TestClass {
 					],
 					accessors: [
 						new (
-							accessorKind: AccessorKind.Add
-							, symbolAvailability: new (),
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: eventAvailabilityBuilder.ToImmutable (),
 							exportPropertyData: null,
 							attributes: [],
 							modifiers: []

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -839,14 +839,14 @@ public class TestClass {
 					accessors: [
 						new (
 							accessorKind: AccessorKind.Getter,
-							symbolAvailability: new (),
+							symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 							exportPropertyData: null,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Setter,
-							symbolAvailability: new (),
+							symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 							exportPropertyData: null,
 							attributes: [],
 							modifiers: []
@@ -899,7 +899,7 @@ public class TestClass {
 						),
 						new (
 							accessorKind: AccessorKind.Setter,
-							symbolAvailability: new (),
+							symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
 							exportPropertyData: null,
 							attributes: [],
 							modifiers: []

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
@@ -169,7 +169,7 @@ public class ParentClass {
 ";
 			var enumParensts = new [] { "MyEnum", "ChildClass", "ParentClass" };
 			yield return [enumValueNested, getEnumValue, enumParensts];
-			
+
 			Func<SyntaxNode, CSharpSyntaxNode?> getGetterValue =
 				rootNode => rootNode.DescendantNodes ().OfType<AccessorDeclarationSyntax> ().LastOrDefault ();
 			const string propertyGetter = @"

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
@@ -117,7 +117,7 @@ public class ParentClass{
 	}
 }
 ";
-			Func<SyntaxNode, MemberDeclarationSyntax?> getNestedMethod =
+			Func<SyntaxNode, CSharpSyntaxNode?> getNestedMethod =
 				rootNode => rootNode.DescendantNodes ().OfType<MethodDeclarationSyntax> ().LastOrDefault ();
 			var nestedMethodNestedClassParents = new [] { "ChildClass", "ParentClass" };
 			yield return [nestedMethodNestedClass, getNestedMethod, nestedMethodNestedClassParents];
@@ -152,7 +152,7 @@ namespace Test {
 			yield return [nestedNamespacesNestedClass, getNestedMethod, nestedNamespacesParents];
 
 
-			Func<SyntaxNode, MemberDeclarationSyntax?> getEnumValue =
+			Func<SyntaxNode, CSharpSyntaxNode?> getEnumValue =
 				rootNode => rootNode.DescendantNodes ().OfType<EnumMemberDeclarationSyntax> ().LastOrDefault ();
 			const string enumValueNested = @"
 using System;
@@ -169,6 +169,26 @@ public class ParentClass {
 ";
 			var enumParensts = new [] { "MyEnum", "ChildClass", "ParentClass" };
 			yield return [enumValueNested, getEnumValue, enumParensts];
+			
+			Func<SyntaxNode, CSharpSyntaxNode?> getGetterValue =
+				rootNode => rootNode.DescendantNodes ().OfType<AccessorDeclarationSyntax> ().LastOrDefault ();
+			const string propertyGetter = @"
+using System;
+
+namespace Test;
+
+public class ParentClass {
+	public class ChildClass {
+		public int Property {
+			get {
+				return 0;
+			}
+		}
+	}
+}
+";
+			var getterParents = new [] { "Property", "ChildClass", "ParentClass" };
+			yield return [propertyGetter, getGetterValue, getterParents];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -177,7 +197,7 @@ public class ParentClass {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataGetParents>]
 	public void GetParentTests (ApplePlatform platform, string inputText,
-		Func<SyntaxNode, MemberDeclarationSyntax?> getNode, string [] expectedParents)
+		Func<SyntaxNode, CSharpSyntaxNode?> getNode, string [] expectedParents)
 	{
 		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);


### PR DESCRIPTION
Accessors are not contained in the property symbol but are associated to it. We needed to update the method to take that into account.