### PR TITLE
[RGen] Provide a method that returns the selector for an accessor.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
@@ -72,7 +72,7 @@ readonly struct Accessor : IEquatable<Accessor> {
 		// is the case, we will use the selector in that attribute. Otherwise, we have:
 		//
 		// * getter: return the property selector.
-		// * setter: use the registrar code (it has the right logic) ato get the setter.
+		// * setter: use the registrar code (it has the right logic) to get the setter.
 		if (ExportPropertyData is null) {
 			return Kind == AccessorKind.Getter 
 				? associatedProperty.ExportPropertyData.Value.Selector 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
@@ -56,7 +56,7 @@ readonly struct Accessor : IEquatable<Accessor> {
 		Attributes = attributes;
 		Modifiers = modifiers;
 	}
-	
+
 	/// <summary>
 	/// Retrieve the selector to be used with the associated property.
 	/// </summary>
@@ -67,15 +67,15 @@ readonly struct Accessor : IEquatable<Accessor> {
 		// this is not a property but a field, we cannot retrieve a selector.
 		if (!associatedProperty.IsProperty)
 			return null;
-		
+
 		// There are two possible cases, the current accessor has an export attribute, if that
 		// is the case, we will use the selector in that attribute. Otherwise, we have:
 		//
 		// * getter: return the property selector.
 		// * setter: use the registrar code (it has the right logic) to get the setter.
 		if (ExportPropertyData is null) {
-			return Kind == AccessorKind.Getter 
-				? associatedProperty.ExportPropertyData.Value.Selector 
+			return Kind == AccessorKind.Getter
+				? associatedProperty.ExportPropertyData.Value.Selector
 				: Registrar.Registrar.CreateSetterSelector (associatedProperty.ExportPropertyData.Value.Selector);
 		}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
@@ -56,6 +56,31 @@ readonly struct Accessor : IEquatable<Accessor> {
 		Attributes = attributes;
 		Modifiers = modifiers;
 	}
+	
+	/// <summary>
+	/// Retrieve the selector to be used with the associated property.
+	/// </summary>
+	/// <param name="associatedProperty">The property associated with the accessor.</param>
+	/// <returns>The selector to use for the accessor.</returns>
+	public string? GetSelector (in Property associatedProperty)
+	{
+		// this is not a property but a field, we cannot retrieve a selector.
+		if (!associatedProperty.IsProperty)
+			return null;
+		
+		// There are two possible cases, the current accessor has an export attribute, if that
+		// is the case, we will use the selector in that attribute. Otherwise, we have:
+		//
+		// * getter: return the property selector.
+		// * setter: use the registrar code (it has the right logic) ato get the setter.
+		if (ExportPropertyData is null) {
+			return Kind == AccessorKind.Getter 
+				? associatedProperty.ExportPropertyData.Value.Selector 
+				: Registrar.Registrar.CreateSetterSelector (associatedProperty.ExportPropertyData.Value.Selector);
+		}
+
+		return ExportPropertyData.Value.Selector;
+	}
 
 	/// <inheritdoc />
 	public bool Equals (Accessor other)

--- a/src/rgen/Microsoft.Macios.Generator/Microsoft.Macios.Generator.csproj
+++ b/src/rgen/Microsoft.Macios.Generator/Microsoft.Macios.Generator.csproj
@@ -34,6 +34,9 @@
         <Compile Include="..\..\bgen\Extensions\PlatformNameExtensions.cs" >
             <Link>external\PlatformNameExtensions.cs</Link>
         </Compile>
+        <Compile Include="..\..\ObjCRuntime\Registrar.core.cs" >
+            <Link>external\Registrar.core.cs</Link>
+        </Compile>
         <Compile Update="Resources.Designer.cs">
           <DesignTime>True</DesignTime>
           <AutoGen>True</AutoGen>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
@@ -323,7 +323,7 @@ public class AccessorTests {
 		) {
 			ExportFieldData = new (new ("Constant"), "lib"),
 		};
-		
+
 		var accessor = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
@@ -336,7 +336,7 @@ public class AccessorTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
 			]);
-		
+
 		Assert.Null (accessor.GetSelector (property));
 	}
 
@@ -353,7 +353,7 @@ public class AccessorTests {
 		) {
 			ExportPropertyData = new ("label")
 		};
-		
+
 		var accessor = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
@@ -371,7 +371,7 @@ public class AccessorTests {
 		Assert.NotNull (selector);
 		Assert.Equal (property.ExportPropertyData.Value.Selector, selector);
 	}
-	
+
 	[Fact]
 	public void GetGetterSelectorExportData ()
 	{
@@ -404,7 +404,7 @@ public class AccessorTests {
 		Assert.NotNull (selector);
 		Assert.Equal (customSelector, selector);
 	}
-	
+
 	[Fact]
 	public void GetSetterSelectorNoExportData ()
 	{
@@ -418,7 +418,7 @@ public class AccessorTests {
 		) {
 			ExportPropertyData = new ("label")
 		};
-		
+
 		var accessor = new Accessor (
 			accessorKind: AccessorKind.Setter,
 			symbolAvailability: new (),
@@ -436,7 +436,7 @@ public class AccessorTests {
 		Assert.NotNull (selector);
 		Assert.Equal ("setLabel:", selector);
 	}
-	
+
 	[Fact]
 	public void GetSetterSelectorExportData ()
 	{
@@ -450,7 +450,7 @@ public class AccessorTests {
 		) {
 			ExportPropertyData = new ("label")
 		};
-		
+
 		var customSelector = "setCustom:";
 		var accessor = new Accessor (
 			accessorKind: AccessorKind.Setter,

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
@@ -307,5 +308,165 @@ public class AccessorTests {
 		Assert.True (y.Equals (x));
 		Assert.True (x == y);
 		Assert.False (x != y);
+	}
+
+	[Fact]
+	public void GetSelectorForFieldProperty ()
+	{
+		var property = new Property (
+			name: "MyProperty",
+			returnType: ReturnTypeForString (),
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
+			accessors: []
+		) {
+			ExportFieldData = new (new ("Constant"), "lib"),
+		};
+		
+		var accessor = new Accessor (
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			],
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
+		
+		Assert.Null (accessor.GetSelector (property));
+	}
+
+	[Fact]
+	public void GetGetterSelectorNoExportData ()
+	{
+		var property = new Property (
+			name: "MyProperty",
+			returnType: ReturnTypeForString (),
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
+			accessors: []
+		) {
+			ExportPropertyData = new ("label")
+		};
+		
+		var accessor = new Accessor (
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			],
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
+
+		var selector = accessor.GetSelector (property);
+		Assert.NotNull (selector);
+		Assert.Equal (property.ExportPropertyData.Value.Selector, selector);
+	}
+	
+	[Fact]
+	public void GetGetterSelectorExportData ()
+	{
+		var property = new Property (
+			name: "MyProperty",
+			returnType: ReturnTypeForString (),
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
+			accessors: []
+		) {
+			ExportPropertyData = new ("label")
+		};
+
+		var customSelector = "custom";
+		var accessor = new Accessor (
+			accessorKind: AccessorKind.Getter,
+			symbolAvailability: new (),
+			exportPropertyData: new (customSelector),
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			],
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
+
+		var selector = accessor.GetSelector (property);
+		Assert.NotNull (selector);
+		Assert.Equal (customSelector, selector);
+	}
+	
+	[Fact]
+	public void GetSetterSelectorNoExportData ()
+	{
+		var property = new Property (
+			name: "MyProperty",
+			returnType: ReturnTypeForString (),
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
+			accessors: []
+		) {
+			ExportPropertyData = new ("label")
+		};
+		
+		var accessor = new Accessor (
+			accessorKind: AccessorKind.Setter,
+			symbolAvailability: new (),
+			exportPropertyData: null,
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			],
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
+
+		var selector = accessor.GetSelector (property);
+		Assert.NotNull (selector);
+		Assert.Equal ("setLabel:", selector);
+	}
+	
+	[Fact]
+	public void GetSetterSelectorExportData ()
+	{
+		var property = new Property (
+			name: "MyProperty",
+			returnType: ReturnTypeForString (),
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
+			accessors: []
+		) {
+			ExportPropertyData = new ("label")
+		};
+		
+		var customSelector = "setCustom:";
+		var accessor = new Accessor (
+			accessorKind: AccessorKind.Setter,
+			symbolAvailability: new (),
+			exportPropertyData: new (customSelector),
+			attributes: [
+				new ("First"),
+				new ("Second"),
+			],
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+				SyntaxFactory.Token (SyntaxKind.PrivateKeyword)
+			]);
+
+		var selector = accessor.GetSelector (property);
+		Assert.NotNull (selector);
+		Assert.Equal (customSelector, selector);
 	}
 }


### PR DESCRIPTION
The method takes into account the property associated with the accessor and any possible export method that has been added to the accessor itself.

The setter label for the default case uses the Registrar.core code.