### PR TITLE
[Rgen] Move to use TypeInfo as the Type property in Parameters.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/ParameterComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/ParameterComparer.cs
@@ -11,14 +11,15 @@ class ParameterComparer : IComparer<Parameter> {
 		var value = x.Position.CompareTo (y.Position);
 		if (value != 0)
 			return value;
-		value = String.Compare (x.Type, y.Type, StringComparison.Ordinal);
+		var comparer = new TypeInfoComparer ();
+		value = comparer.Compare (x.Type, y.Type);
 		if (value != 0)
 			return value;
 		value = String.Compare (x.Name, y.Name, StringComparison.Ordinal);
 		if (value != 0)
 			return value;
-		var xValues = new [] { x.IsOptional, x.IsParams, x.IsThis, x.IsNullable };
-		var yValues = new [] { y.IsOptional, y.IsParams, y.IsThis, y.IsNullable };
+		var xValues = new [] { x.IsOptional, x.IsParams, x.IsThis };
+		var yValues = new [] { y.IsOptional, y.IsParams, y.IsThis };
 		for (int i = 0; i < xValues.Length; ++i) {
 			value = xValues [i].CompareTo (yValues [i]);
 			if (value != 0)

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/ParameterFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/ParameterFormatter.cs
@@ -37,21 +37,21 @@ static class ParameterFormatter {
 	}
 	static TypeSyntax GetIdentifierSyntax (this in ParameterDataModel parameter)
 	{
-		if (parameter.IsArray) {
+		if (parameter.Type.IsArray) {
 			// could be a params array or simply an array
-			var arrayType = ArrayType (IdentifierName (parameter.Type))
+			var arrayType = ArrayType (IdentifierName (parameter.Type.Name))
 				.WithRankSpecifiers (SingletonList (
 					ArrayRankSpecifier (
 						SingletonSeparatedList<ExpressionSyntax> (OmittedArraySizeExpression ()))));
-			return parameter.IsNullable
+			return parameter.Type.IsNullable
 				? NullableType (arrayType)
 				: arrayType;
 		}
 
 		// dealing with a non-array type
-		return parameter.IsNullable
-			? NullableType (IdentifierName (parameter.Type))
-			: IdentifierName (parameter.Type);
+		return parameter.Type.IsNullable
+			? NullableType (IdentifierName (parameter.Type.Name))
+			: IdentifierName (parameter.Type.Name);
 	}
 
 	public static ParameterSyntax ToDeclaration (this in ParameterDataModel parameter)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassCodeChangesTests.cs
@@ -312,9 +312,8 @@ public partial class MyClass {
 							parameters: [
 								new (
 									position: 0,
-									type: "string",
-									name: "name",
-									isBlittable: false
+									type: ReturnTypeForString (),
+									name: "name"
 								)
 							]
 						),
@@ -881,7 +880,7 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							parameters: [
-								new (position: 0, type: "string", name: "name", isBlittable: false)
+								new (position: 0, type: ReturnTypeForString (), name: "name")
 							]
 						),
 					]
@@ -936,7 +935,7 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							parameters: [
-								new (position: 0, type: "string", name: "name", isBlittable: false)
+								new (position: 0, type: ReturnTypeForString (), name: "name")
 							]
 						),
 					]
@@ -992,7 +991,7 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							parameters: [
-								new (position: 0, type: "string", name: "name", isBlittable: false)
+								new (position: 0, type: ReturnTypeForString (), name: "name")
 							]
 						),
 						new (
@@ -1009,7 +1008,7 @@ public partial class MyClass {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							parameters: [
-								new (position: 0, type: "string", name: "inSurname", isBlittable: false)
+								new (position: 0, type: ReturnTypeForString (), name: "inSurname")
 							]
 						),
 					]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesComparerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
@@ -1261,8 +1262,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "example", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 							ReferenceKind = ReferenceKind.Out,
 						},
 					]
@@ -1278,7 +1278,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.CustomType", name: "input", isBlittable: false)
+						new (position: 0, type: ReturnTypeForClass ("NS.CustomType"), name: "input")
 					]
 				)
 			]
@@ -1407,9 +1407,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "example", isBlittable: false) {
-							IsNullable = true,
-							ReferenceKind = ReferenceKind.Out,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 						},
 					]
 				),
@@ -1547,8 +1545,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "example", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 							ReferenceKind = ReferenceKind.Out,
 						},
 					]
@@ -1564,7 +1561,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.CustomType", name: "input", isBlittable: false)
+						new (position: 0, type: ReturnTypeForClass ("NS.CustomType"), name: "input")
 					]
 				)
 			]
@@ -1687,7 +1684,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.CustomType", name: "input", isBlittable: false)
+						new (position: 0, type: ReturnTypeForClass ("NS.CustomType"), name: "input")
 					]
 				),
 				new (
@@ -1708,8 +1705,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "example", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 							ReferenceKind = ReferenceKind.Out,
 						},
 					]
@@ -1841,7 +1837,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.CustomType", name: "input", isBlittable: false),
+						new (position: 0, type: ReturnTypeForClass ("NS.CustomType"), name: "input"),
 					]
 				),
 			]
@@ -1971,8 +1967,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "example", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 							ReferenceKind = ReferenceKind.Out,
 						},
 					]
@@ -2114,8 +2109,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "example", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 							ReferenceKind = ReferenceKind.Out,
 						},
 					]
@@ -2131,7 +2125,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.CustomType", name: "input", isBlittable: false)
+						new (position: 0, type: ReturnTypeForClass ("NS.CustomType"), name: "input")
 					]
 				)
 			]
@@ -2246,7 +2240,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.CustomType", name: "input", isBlittable: false)
+						new (position: 0, type: ReturnTypeForClass ("NS.CustomType"), name: "input")
 					]
 				),
 				new (
@@ -2267,8 +2261,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "example", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 							ReferenceKind = ReferenceKind.Out,
 						},
 					]
@@ -2410,8 +2403,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "example", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 							ReferenceKind = ReferenceKind.Out,
 						},
 					]
@@ -2427,7 +2419,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.CustomType", name: "input", isBlittable: false)
+						new (position: 0, type: ReturnTypeForClass ("NS.CustomType"), name: "input")
 					]
 				)
 			]
@@ -2549,7 +2541,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.CustomType", name: "input", isBlittable: false)
+						new (position: 0, type: ReturnTypeForClass ("NS.CustomType"), name: "input")
 					]
 				),
 				new (
@@ -2570,8 +2562,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "example", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 							ReferenceKind = ReferenceKind.Out,
 						},
 					]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CodeChangesEqualityComparerTests.cs
@@ -3,6 +3,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
@@ -792,7 +793,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					parameters: [
-						new (position: 0, type: "string", name: "name", isBlittable: false),
+						new (position: 0, type: ReturnTypeForString (), name: "name"),
 					])
 			],
 		};
@@ -876,7 +877,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					parameters: [
-						new (position: 0, type: "string", name: "name", isBlittable: false),
+						new (position: 0, type: ReturnTypeForString (), name: "name"),
 					])
 			],
 		};
@@ -954,7 +955,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					parameters: [
-						new (position: 0, type: "string", name: "name", isBlittable: false),
+						new (position: 0, type: ReturnTypeForString (), name: "name"),
 					])
 			],
 		};
@@ -1037,7 +1038,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					parameters: [
-						new (position: 0, type: "string", name: "name", isBlittable: false),
+						new (position: 0, type: ReturnTypeForString (), name: "name"),
 					]),
 				new (type: "MyClass", symbolAvailability: new (), attributes: [], modifiers: [], parameters: []),
 			],
@@ -1115,7 +1116,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					parameters: [
-						new (position: 0, type: "string", name: "name", isBlittable: false),
+						new (position: 0, type: ReturnTypeForString (), name: "name"),
 					]),
 			],
 		};
@@ -1202,7 +1203,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					parameters: [
-						new (position: 0, type: "string", name: "name", isBlittable: false),
+						new (position: 0, type: ReturnTypeForString (), name: "name"),
 					]),
 				new (type: "MyClass", symbolAvailability: new (), attributes: [], modifiers: [], parameters: []),
 			],
@@ -1286,7 +1287,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					attributes: [],
 					modifiers: [],
 					parameters: [
-						new (position: 0, type: "string", name: "name", isBlittable: false),
+						new (position: 0, type: ReturnTypeForString (), name: "name"),
 					]),
 			],
 		};

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorComparerTests.cs
@@ -4,6 +4,7 @@ using System;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
@@ -128,7 +129,7 @@ public class ConstructorComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
 			]);
 		var y = new Constructor ("MyClass",
 			symbolAvailability: new (),
@@ -140,8 +141,8 @@ public class ConstructorComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
-				new (position: 1, type: "string", name: "surname", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
+				new (position: 1, type: ReturnTypeForString (), name: "surname"),
 			]);
 		Assert.Equal (x.Parameters.Length.CompareTo (y.Parameters.Length), comparer.Compare (x, y));
 	}
@@ -159,7 +160,7 @@ public class ConstructorComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
 			]);
 		var y = new Constructor ("MyClass",
 			symbolAvailability: new (),
@@ -171,7 +172,7 @@ public class ConstructorComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 1, type: "string", name: "surname", isBlittable: false),
+				new (position: 1, type: ReturnTypeForString (), name: "surname"),
 			]);
 		var parameterCompare = new ParameterComparer ();
 		Assert.Equal (parameterCompare.Compare (x.Parameters [0], y.Parameters [0]), comparer.Compare (x, y));
@@ -190,9 +191,7 @@ public class ConstructorComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 0, type: "MyEnum", name: "name", isBlittable: false) {
-					IsSmartEnum = true
-				},
+				new (position: 0, type: ReturnTypeForEnum ("MyEnum", isSmartEnum: true), name: "name"),
 			]);
 		var y = new Constructor ("MyClass",
 			symbolAvailability: new (),
@@ -204,9 +203,7 @@ public class ConstructorComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 0, type: "MyEnum", name: "name", isBlittable: false) {
-					IsSmartEnum = false
-				},
+				new (position: 0, type: ReturnTypeForEnum ("MyEnum"), name: "name"),
 			]);
 		var parameterCompare = new ParameterComparer ();
 		Assert.Equal (parameterCompare.Compare (x.Parameters [0], y.Parameters [0]), comparer.Compare (x, y));

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Macios.Generator.DataModel;
 using Xamarin.Tests;
 using Xamarin.Utils;
 using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
@@ -66,7 +67,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "inName", isBlittable: false),
+						new (position: 0, type: ReturnTypeForString (), name: "inName"),
 					]
 				)
 			];
@@ -96,8 +97,8 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "inName", isBlittable: false),
-						new (position: 1, type: "int", name: "inAge", isBlittable: true),
+						new (position: 0, type: ReturnTypeForString (), name: "inName"),
+						new (position: 1, type: ReturnTypeForInt (), name: "inAge"),
 					]
 				)
 			];
@@ -127,10 +128,8 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "inName", isBlittable: false) {
-							IsNullable = true,
-						},
-						new (position: 1, type: "int", name: "inAge", isBlittable: true),
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "inName"),
+						new (position: 1, type: ReturnTypeForInt (), name: "inAge"),
 					]
 				)
 			];
@@ -163,13 +162,10 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "inName", isBlittable: false) {
-							IsNullable = true,
-						},
-						new (position: 1, type: "int", name: "inAge", isBlittable: true),
-						new (position: 2, type: "string", name: "inSurnames", isBlittable: false) {
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "inName"),
+						new (position: 1, type: ReturnTypeForInt (), name: "inAge"),
+						new (position: 2, type: ReturnTypeForArray ("string"), name: "inSurnames") {
 							IsParams = true,
-							IsArray = true,
 						},
 					]
 				)
@@ -203,13 +199,10 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "inName", isBlittable: false) {
-							IsNullable = true,
-						},
-						new (position: 1, type: "int", name: "inAge", isBlittable: true),
-						new (position: 2, type: "string", name: "inSurnames", isBlittable: false) {
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "inName"),
+						new (position: 1, type: ReturnTypeForInt (), name: "inAge"),
+						new (position: 2, type: ReturnTypeForArray ("string"), name: "inSurnames") {
 							IsParams = false,
-							IsArray = true
 						},
 					]
 				)
@@ -243,14 +236,9 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "inName", isBlittable: false) {
-							IsNullable = true,
-						},
-						new (position: 1, type: "int", name: "inAge", isBlittable: true),
-						new (position: 2, type: "string", name: "inSurnames", isBlittable: false) {
-							IsNullable = true,
-							IsArray = true
-						},
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "inName"),
+						new (position: 1, type: ReturnTypeForInt (), name: "inAge"),
+						new (position: 2, type: ReturnTypeForArray ("string", isNullable: true), name: "inSurnames"),
 					]
 				)
 			];
@@ -283,14 +271,9 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "inName", isBlittable: false) {
-							IsNullable = true,
-						},
-						new (position: 1, type: "int", name: "inAge", isBlittable: true),
-						new (position: 2, type: "string?", name: "inSurnames", isBlittable: false) {
-							IsNullable = false,
-							IsArray = true
-						},
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "inName"),
+						new (position: 1, type: ReturnTypeForInt (), name: "inAge"),
+						new (position: 2, type: ReturnTypeForArray ("string?"), name: "inSurnames"),
 					]
 				)
 			];
@@ -323,14 +306,9 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (0, "string", "inName", false) {
-							IsNullable = true,
-						},
-						new (1, "int", "inAge", true),
-						new (2, "string?", "inSurnames", false) {
-							IsNullable = true,
-							IsArray = true
-						},
+						new (0, ReturnTypeForString (isNullable: true), "inName"),
+						new (1, ReturnTypeForInt (), "inAge"),
+						new (2, ReturnTypeForArray ("string?", isNullable: true), "inSurnames"),
 					]
 				)
 			];
@@ -363,13 +341,10 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "inName", isBlittable: false) {
-							IsNullable = true,
-						},
-						new (position: 1, type: "int", name: "inAge", isBlittable: true),
-						new (position: 2, type: "string[]", name: "inSurnames", isBlittable: false) {
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "inName"),
+						new (position: 1, type: ReturnTypeForInt (), name: "inAge"),
+						new (position: 2, type: ReturnTypeForArray ("string[]"), name: "inSurnames") {
 							IsParams = false,
-							IsArray = true
 						},
 					]
 				)
@@ -398,8 +373,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "inName", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "inName") {
 							IsOptional = true,
 						},
 					]
@@ -429,9 +403,8 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "T", name: "inName", isBlittable: false) {
+						new (position: 0, type: ReturnTypeForGeneric ("T", isNullable: true), name: "inName") {
 							IsOptional = true,
-							IsNullable = true,
 						},
 					]
 				)
@@ -466,14 +439,12 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "inName", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "inName") {
 							IsOptional = true,
 						},
 					]
 				)
 			];
-
 		}
 
 		IEnumerator IEnumerable.GetEnumerator ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorsEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ConstructorsEqualityComparerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
@@ -22,15 +23,15 @@ public class ConstructorsEqualityComparerTests {
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
-				new (position: 0, type: "string", name: "surname", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
+				new (position: 0, type: ReturnTypeForString (), name: "surname"),
 			]);
 		var y = new Constructor ("MyClass",
 			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
 			]);
 		Assert.False (compare.Equals ([x], [y]));
 	}
@@ -43,14 +44,14 @@ public class ConstructorsEqualityComparerTests {
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "surname", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "surname"),
 			]);
 		var y = new Constructor ("MyClass",
 			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
 			]);
 		Assert.False (compare.Equals ([x], [y]));
 	}
@@ -63,14 +64,14 @@ public class ConstructorsEqualityComparerTests {
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "surname", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "surname"),
 			]);
 		var y = new Constructor ("MyClass",
 			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
 			]);
 		Assert.False (compare.Equals ([x, y], [y]));
 	}
@@ -83,14 +84,14 @@ public class ConstructorsEqualityComparerTests {
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "surname", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "surname"),
 			]);
 		var y = new Constructor ("MyClass",
 			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
 			]);
 		Assert.True (compare.Equals ([x, y], [y, x]));
 	}
@@ -108,7 +109,7 @@ public class ConstructorsEqualityComparerTests {
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "surname", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "surname"),
 			]);
 
 		var yBuilder = SymbolAvailability.CreateBuilder ();
@@ -120,7 +121,7 @@ public class ConstructorsEqualityComparerTests {
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
 			]);
 		Assert.False (compare.Equals ([x], [y]));
 	}
@@ -138,7 +139,7 @@ public class ConstructorsEqualityComparerTests {
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "surname", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "surname"),
 			]);
 
 		var y = new Constructor ("MyClass",
@@ -146,7 +147,7 @@ public class ConstructorsEqualityComparerTests {
 			attributes: [],
 			modifiers: [],
 			parameters: [
-				new (position: 0, type: "string", name: "surname", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "surname"),
 			]);
 		Assert.True (compare.Equals ([x], [y]));
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
@@ -127,7 +127,7 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: ReturnTypeForAction("string?"),
+							type: ReturnTypeForAction ("string?"),
 							name: "cb"
 						) {
 							Delegate = new (
@@ -148,7 +148,7 @@ namespace NS {
 					]
 				)
 			];
-			
+
 			const string actionMultiParam = @"
 using System;
 
@@ -174,7 +174,7 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: ReturnTypeForAction("string", "string"),
+							type: ReturnTypeForAction ("string", "string"),
 							name: "cb"
 						) {
 							Delegate = new (

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
@@ -18,7 +18,6 @@ public class DelegateInfoTests : BaseGeneratorTestClass {
 	class TestDataFromMethodDeclaration : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
-
 			const string actionNoParam = @"
 using System;
 
@@ -44,9 +43,8 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: "System.Action",
-							name: "cb",
-							isBlittable: false
+							type: ReturnTypeForAction (),
+							name: "cb"
 						) {
 							Delegate = new (
 								type: "System.Action",
@@ -84,9 +82,8 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: "System.Action<string>",
-							name: "cb",
-							isBlittable: false
+							type: ReturnTypeForAction ("string"),
+							name: "cb"
 						) {
 							Delegate = new (
 								type: "System.Action<string>",
@@ -130,9 +127,8 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: "System.Action<string?>",
-							name: "cb",
-							isBlittable: false
+							type: ReturnTypeForAction("string?"),
+							name: "cb"
 						) {
 							Delegate = new (
 								type: "System.Action<string?>",
@@ -152,7 +148,7 @@ namespace NS {
 					]
 				)
 			];
-
+			
 			const string actionMultiParam = @"
 using System;
 
@@ -178,9 +174,8 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: "System.Action<string, string>",
-							name: "cb",
-							isBlittable: false
+							type: ReturnTypeForAction("string", "string"),
+							name: "cb"
 						) {
 							Delegate = new (
 								type: "System.Action<string, string>",
@@ -230,9 +225,8 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: "System.Func<string, string>",
-							name: "cb",
-							isBlittable: false
+							type: ReturnTypeForFunc ("string", "string"),
+							name: "cb"
 						) {
 							Delegate = new (
 								type: "System.Func<string, string>",
@@ -276,9 +270,8 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: "System.Func<string, string, string>",
-							name: "cb",
-							isBlittable: false
+							type: ReturnTypeForFunc ("string", "string", "string"),
+							name: "cb"
 						) {
 							Delegate = new (
 								type: "System.Func<string, string, string>",
@@ -330,9 +323,8 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: "NS.MyClass.Callback",
-							name: "cb",
-							isBlittable: false
+							type: ReturnTypeForDelegate ("NS.MyClass.Callback"),
+							name: "cb"
 						) {
 							Delegate = new (
 								type: "NS.MyClass.Callback",

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -561,7 +561,7 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							parameters: [
-								new (position: 0, type: "string", name: "name", isBlittable: false),
+								new (position: 0, type: ReturnTypeForString (), name: "name"),
 							]
 						),
 					]
@@ -614,7 +614,7 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							parameters: [
-								new (position: 0, type: "string", name: "name", isBlittable: false),
+								new (position: 0, type: ReturnTypeForString (), name: "name"),
 							]
 						),
 					]
@@ -668,7 +668,7 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							parameters: [
-								new (position: 0, type: "string", name: "name", isBlittable: false),
+								new (position: 0, type: ReturnTypeForString (), name: "name"),
 							]
 						),
 						new (
@@ -685,7 +685,7 @@ public partial interface IProtocol {
 								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
 							],
 							parameters: [
-								new (position: 0, type: "string", name: "inSurname", isBlittable: false),
+								new (position: 0, type: ReturnTypeForString (), name: "inSurname"),
 							]
 						),
 					]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodComparerTests.cs
@@ -4,6 +4,7 @@ using System;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
@@ -253,7 +254,7 @@ public class MethodComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
 			]
 		);
 
@@ -270,8 +271,8 @@ public class MethodComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
-				new (position: 1, type: "string", name: "surname", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
+				new (position: 1, type: ReturnTypeForString (), name: "surname"),
 			]
 		);
 		Assert.Equal (x.Parameters.Length.CompareTo (y.Parameters.Length), comparer.Compare (x, y));
@@ -293,7 +294,7 @@ public class MethodComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 0, type: "string", name: "name", isBlittable: false),
+				new (position: 0, type: ReturnTypeForString (), name: "name"),
 			]
 		);
 
@@ -310,7 +311,7 @@ public class MethodComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 1, type: "string", name: "surname", isBlittable: false),
+				new (position: 1, type: ReturnTypeForString (), name: "surname"),
 			]
 		);
 		var parameterCompare = new ParameterComparer ();
@@ -333,9 +334,7 @@ public class MethodComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 0, type: "MyEnum", name: "name", isBlittable: false) {
-					IsSmartEnum = true
-				},
+				new (position: 0, type: ReturnTypeForEnum ("MyEnum", isSmartEnum: true), name: "name"),
 			]
 		);
 
@@ -352,9 +351,7 @@ public class MethodComparerTests {
 				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 			],
 			parameters: [
-				new (position: 0, type: "MyEnum", name: "name", isBlittable: false) {
-					IsSmartEnum = false
-				},
+				new (position: 0, type: ReturnTypeForEnum ("MyEnum"), name: "name"),
 			]
 		);
 		var parameterCompare = new ParameterComparer ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodEqualityComparerTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
@@ -116,8 +117,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "string", name: "name", isBlittable: false),
-					new (position: 1, type: "string", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForString (), name: "name"),
+					new (position: 1, type: ReturnTypeForString (), name: "surname"),
 				]
 			)
 		];
@@ -131,7 +132,7 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "string", name: "name", isBlittable: false),
+					new (position: 0, type: ReturnTypeForString (), name: "name"),
 				]
 			)
 		];
@@ -151,8 +152,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "string", name: "name", isBlittable: false),
-					new (position: 1, type: "string", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForString (), name: "name"),
+					new (position: 1, type: ReturnTypeForString (), name: "surname"),
 				]
 			)
 		];
@@ -166,8 +167,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "int", name: "name", isBlittable: false),
-					new (position: 1, type: "int", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForInt (), name: "name"),
+					new (position: 1, type: ReturnTypeForInt (), name: "surname"),
 				]
 			)
 		];
@@ -187,8 +188,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "string", name: "name", isBlittable: false),
-					new (position: 1, type: "string", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForString (), name: "name"),
+					new (position: 1, type: ReturnTypeForString (), name: "surname"),
 				]
 			),
 			new (
@@ -200,8 +201,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "int", name: "name", isBlittable: false),
-					new (position: 1, type: "int", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForInt (), name: "name"),
+					new (position: 1, type: ReturnTypeForInt (), name: "surname"),
 				]
 			)
 		];
@@ -215,8 +216,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "int", name: "name", isBlittable: false),
-					new (position: 1, type: "int", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForInt (), name: "name"),
+					new (position: 1, type: ReturnTypeForInt (), name: "surname"),
 				]
 			)
 		];
@@ -236,8 +237,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "int", name: "name", isBlittable: false),
-					new (position: 1, type: "int", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForInt (), name: "name"),
+					new (position: 1, type: ReturnTypeForInt (), name: "surname"),
 				]
 			)
 		];
@@ -251,8 +252,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "int", name: "name", isBlittable: false),
-					new (position: 1, type: "int", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForInt (), name: "name"),
+					new (position: 1, type: ReturnTypeForInt (), name: "surname"),
 				]
 			)
 		];
@@ -272,8 +273,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "string", name: "name", isBlittable: false),
-					new (position: 1, type: "string", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForString (), name: "name"),
+					new (position: 1, type: ReturnTypeForString (), name: "surname"),
 				]
 			),
 			new (
@@ -285,8 +286,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "int", name: "name", isBlittable: false),
-					new (position: 1, type: "int", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForInt (), name: "name"),
+					new (position: 1, type: ReturnTypeForInt (), name: "surname"),
 				]
 			)
 		];
@@ -300,8 +301,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "string", name: "name", isBlittable: false),
-					new (position: 1, type: "string", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForString (), name: "name"),
+					new (position: 1, type: ReturnTypeForString (), name: "surname"),
 				]
 			),
 			new (
@@ -313,8 +314,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "int", name: "name", isBlittable: false),
-					new (position: 1, type: "int", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForInt (), name: "name"),
+					new (position: 1, type: ReturnTypeForInt (), name: "surname"),
 				]
 			)
 		];
@@ -335,8 +336,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "string", name: "name", isBlittable: false),
-					new (position: 1, type: "string", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForString (), name: "name"),
+					new (position: 1, type: ReturnTypeForString (), name: "surname"),
 				]
 			),
 			new (
@@ -348,8 +349,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "int", name: "name", isBlittable: false),
-					new (position: 1, type: "int", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForInt (), name: "name"),
+					new (position: 1, type: ReturnTypeForInt (), name: "surname"),
 				]
 			)
 		];
@@ -363,8 +364,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "int", name: "name", isBlittable: false),
-					new (position: 1, type: "int", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForInt (), name: "name"),
+					new (position: 1, type: ReturnTypeForInt (), name: "surname"),
 				]
 			),
 			new (
@@ -376,8 +377,8 @@ public class MethodEqualityComparerTests {
 				attributes: [],
 				modifiers: [],
 				parameters: [
-					new (position: 0, type: "string", name: "name", isBlittable: false),
-					new (position: 1, type: "string", name: "surname", isBlittable: false),
+					new (position: 0, type: ReturnTypeForString (), name: "name"),
+					new (position: 1, type: ReturnTypeForString (), name: "surname"),
 				]
 			),
 		];

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests.cs
@@ -153,7 +153,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "input", isBlittable: false),
+						new (position: 0, type: ReturnTypeForString (), name: "input"),
 					]
 				)
 			];
@@ -181,9 +181,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "input", isBlittable: false) {
-							IsArray = true
-						}
+						new (position: 0, type: ReturnTypeForArray ("string"), name: "input")
 					]
 				)
 			];
@@ -211,10 +209,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "input", isBlittable: false) {
-							IsArray = true,
-							IsNullable = true,
-						}
+						new (position: 0, type: ReturnTypeForArray ("string", isNullable: true), name: "input")
 					]
 				)
 			];
@@ -242,10 +237,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "input", isBlittable: false) {
-							IsArray = true,
-							IsNullable = false,
-						}
+						new (position: 0, type: ReturnTypeForArray ("string?"), name: "input")
 					]
 				)
 			];
@@ -273,10 +265,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string?", name: "input", isBlittable: false) {
-							IsArray = true,
-							IsNullable = true,
-						}
+						new (position: 0, type: ReturnTypeForArray ("string?", isNullable: true), name: "input")
 					]
 				)
 			];
@@ -304,9 +293,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string[]", name: "input", isBlittable: false) {
-							IsArray = true
-						}
+						new (position: 0, type: ReturnTypeForArray ("string[]"), name: "input")
 					]
 				)
 			];
@@ -337,7 +324,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.CustomType", name: "input", isBlittable: false),
+						new (position: 0, type: ReturnTypeForClass ("NS.CustomType"), name: "input"),
 					]
 				)
 			];
@@ -366,10 +353,8 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "input", isBlittable: false),
-						new (position: 1, type: "string", name: "second", isBlittable: false) {
-							IsNullable = true,
-						}
+						new (position: 0, type: ReturnTypeForString (), name: "input"),
+						new (position: 1, type: ReturnTypeForString (isNullable: true), name: "second")
 					]
 				)
 			];
@@ -399,8 +384,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "example", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 							ReferenceKind = ReferenceKind.Out,
 						},
 					]
@@ -438,7 +422,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.MyStruct", name: "data", isBlittable: false) {
+						new (position: 0, type: ReturnTypeForStruct ("NS.MyStruct"), name: "data") {
 							ReferenceKind = ReferenceKind.In,
 						},
 					]
@@ -475,7 +459,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "NS.MyStruct", name: "data", isBlittable: false) {
+						new (position: 0, type: ReturnTypeForStruct ("NS.MyStruct"), name: "data") {
 							ReferenceKind = ReferenceKind.Ref,
 						},
 					]
@@ -511,10 +495,8 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "input", isBlittable: false),
-						new (position: 1, type: "string", name: "second", isBlittable: false) {
-							IsNullable = true,
-						}
+						new (position: 0, type: ReturnTypeForString (), name: "input"),
+						new (position: 1, type: ReturnTypeForString (isNullable: true), name: "second")
 					]
 				)
 			];
@@ -547,8 +529,7 @@ namespace NS {
 						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
 					],
 					parameters: [
-						new (position: 0, type: "string", name: "example", isBlittable: false) {
-							IsNullable = true,
+						new (position: 0, type: ReturnTypeForString (isNullable: true), name: "example") {
 							ReferenceKind = ReferenceKind.Out,
 							Attributes = [
 								new (name: "System.Diagnostics.CodeAnalysis.NotNullWhenAttribute", arguments: ["true"])

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Macios.Generator.Tests;
 
 static class TestDataFactory {
 	public static TypeInfo ReturnTypeForString (bool isNullable = false)
-		=> new(
+		=> new (
 			name: "string",
 			specialType: SpecialType.System_String,
 			isNullable: isNullable,
@@ -36,7 +36,7 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForInt (bool isNullable = false)
-		=> new(
+		=> new (
 			name: "int",
 			specialType: SpecialType.System_Int32,
 			isBlittable: !isNullable,
@@ -82,7 +82,7 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForIntPtr (bool isNullable = false)
-		=> new(
+		=> new (
 			name: "nint",
 			specialType: SpecialType.System_IntPtr,
 			isBlittable: !isNullable,
@@ -128,7 +128,7 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForBool ()
-		=> new(
+		=> new (
 			name: "bool",
 			specialType: SpecialType.System_Boolean,
 			isBlittable: false
@@ -146,29 +146,29 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForVoid ()
-		=> new("void", SpecialType.System_Void) { Parents = ["System.ValueType", "object"], };
+		=> new ("void", SpecialType.System_Void) { Parents = ["System.ValueType", "object"], };
 
 	public static TypeInfo ReturnTypeForClass (string className, bool isNullable = false)
-		=> new(
+		=> new (
 			name: className,
 			isReferenceType: true,
 			isNullable: isNullable
 		) { Parents = ["object"] };
 
 	public static TypeInfo ReturnTypeForGeneric (string genericName, bool isNullable = false)
-		=> new(
+		=> new (
 			name: genericName,
 			isReferenceType: false,
 			isNullable: isNullable
 		);
 
 	public static TypeInfo ReturnTypeForStruct (string structName)
-		=> new(
+		=> new (
 			name: structName
 		) { Parents = ["System.ValueType", "object"] };
 
 	public static TypeInfo ReturnTypeForEnum (string enumName, bool isSmartEnum = false)
-		=> new(
+		=> new (
 			name: enumName,
 			isBlittable: true,
 			isSmartEnum: isSmartEnum
@@ -188,7 +188,7 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForArray (string type, bool isNullable = false, bool isBlittable = false)
-		=> new(
+		=> new (
 			name: type,
 			isNullable: isNullable,
 			isBlittable: isBlittable,
@@ -209,7 +209,7 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForAction ()
-		=> new(
+		=> new (
 			name: "System.Action",
 			isNullable: false,
 			isBlittable: false,
@@ -217,8 +217,8 @@ static class TestDataFactory {
 			isReferenceType: true
 		) {
 			Parents = [
-				"System.MulticastDelegate", 
-				"System.Delegate", 
+				"System.MulticastDelegate",
+				"System.Delegate",
 				"object"
 			],
 			Interfaces = [
@@ -245,7 +245,7 @@ static class TestDataFactory {
 				"System.Runtime.Serialization.ISerializable",
 			]
 		};
-	
+
 	public static TypeInfo ReturnTypeForFunc (params string [] parameters)
 		=> new (
 			name: $"System.Func<{string.Join (", ", parameters)}>",
@@ -264,7 +264,7 @@ static class TestDataFactory {
 				"System.Runtime.Serialization.ISerializable",
 			]
 		};
-	
+
 	public static TypeInfo ReturnTypeForDelegate (string delegateName)
 		=> new (
 			name: delegateName,

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 #pragma warning disable APL0003
 using Microsoft.CodeAnalysis;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
@@ -7,12 +8,11 @@ using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 namespace Microsoft.Macios.Generator.Tests;
 
 static class TestDataFactory {
-
-	public static TypeInfo ReturnTypeForString ()
-		=> new (
+	public static TypeInfo ReturnTypeForString (bool isNullable = false)
+		=> new(
 			name: "string",
 			specialType: SpecialType.System_String,
-			isNullable: false,
+			isNullable: isNullable,
 			isBlittable: false,
 			isSmartEnum: false,
 			isArray: false,
@@ -36,7 +36,7 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForInt (bool isNullable = false)
-		=> new (
+		=> new(
 			name: "int",
 			specialType: SpecialType.System_Int32,
 			isBlittable: !isNullable,
@@ -46,7 +46,7 @@ static class TestDataFactory {
 			Interfaces = isNullable
 				? []
 				: [
-				"System.IComparable",
+					"System.IComparable",
 					"System.IComparable<int>",
 					"System.IConvertible",
 					"System.IEquatable<int>",
@@ -77,12 +77,12 @@ static class TestDataFactory {
 					"System.Numerics.IShiftOperators<int, int, int>",
 					"System.Numerics.IMinMaxValue<int>",
 					"System.Numerics.ISignedNumber<int>"
-			],
+				],
 			MetadataName = "Int32",
 		};
 
 	public static TypeInfo ReturnTypeForIntPtr (bool isNullable = false)
-		=> new (
+		=> new(
 			name: "nint",
 			specialType: SpecialType.System_IntPtr,
 			isBlittable: !isNullable,
@@ -128,7 +128,7 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForBool ()
-		=> new (
+		=> new(
 			name: "bool",
 			specialType: SpecialType.System_Boolean,
 			isBlittable: false
@@ -146,27 +146,29 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForVoid ()
-		=> new ("void", SpecialType.System_Void) {
-			Parents = ["System.ValueType", "object"],
-		};
+		=> new("void", SpecialType.System_Void) { Parents = ["System.ValueType", "object"], };
 
-	public static TypeInfo ReturnTypeForClass (string className)
-		=> new (
+	public static TypeInfo ReturnTypeForClass (string className, bool isNullable = false)
+		=> new(
 			name: className,
-			isReferenceType: true
-		) {
-			Parents = ["object"]
-		};
+			isReferenceType: true,
+			isNullable: isNullable
+		) { Parents = ["object"] };
+
+	public static TypeInfo ReturnTypeForGeneric (string genericName, bool isNullable = false)
+		=> new(
+			name: genericName,
+			isReferenceType: false,
+			isNullable: isNullable
+		);
 
 	public static TypeInfo ReturnTypeForStruct (string structName)
-		=> new (
+		=> new(
 			name: structName
-		) {
-			Parents = ["System.ValueType", "object"]
-		};
+		) { Parents = ["System.ValueType", "object"] };
 
 	public static TypeInfo ReturnTypeForEnum (string enumName, bool isSmartEnum = false)
-		=> new (
+		=> new(
 			name: enumName,
 			isBlittable: true,
 			isSmartEnum: isSmartEnum
@@ -186,7 +188,7 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForArray (string type, bool isNullable = false, bool isBlittable = false)
-		=> new (
+		=> new(
 			name: type,
 			isNullable: isNullable,
 			isBlittable: isBlittable,
@@ -203,6 +205,82 @@ static class TestDataFactory {
 				"System.Collections.IStructuralComparable",
 				"System.Collections.IStructuralEquatable",
 				"System.ICloneable"
+			]
+		};
+
+	public static TypeInfo ReturnTypeForAction ()
+		=> new(
+			name: "System.Action",
+			isNullable: false,
+			isBlittable: false,
+			isArray: false,
+			isReferenceType: true
+		) {
+			Parents = [
+				"System.MulticastDelegate", 
+				"System.Delegate", 
+				"object"
+			],
+			Interfaces = [
+				"System.ICloneable",
+				"System.Runtime.Serialization.ISerializable",
+			]
+		};
+
+	public static TypeInfo ReturnTypeForAction (params string [] parameters)
+		=> new (
+			name: $"System.Action<{string.Join (", ", parameters)}>",
+			isNullable: false,
+			isBlittable: false,
+			isArray: false,
+			isReferenceType: true
+		) {
+			Parents = [
+				"System.MulticastDelegate",
+				"System.Delegate",
+				"object"
+			],
+			Interfaces = [
+				"System.ICloneable",
+				"System.Runtime.Serialization.ISerializable",
+			]
+		};
+	
+	public static TypeInfo ReturnTypeForFunc (params string [] parameters)
+		=> new (
+			name: $"System.Func<{string.Join (", ", parameters)}>",
+			isNullable: false,
+			isBlittable: false,
+			isArray: false,
+			isReferenceType: true
+		) {
+			Parents = [
+				"System.MulticastDelegate",
+				"System.Delegate",
+				"object"
+			],
+			Interfaces = [
+				"System.ICloneable",
+				"System.Runtime.Serialization.ISerializable",
+			]
+		};
+	
+	public static TypeInfo ReturnTypeForDelegate (string delegateName)
+		=> new (
+			name: delegateName,
+			isNullable: false,
+			isBlittable: false,
+			isArray: false,
+			isReferenceType: true
+		) {
+			Parents = [
+				"System.MulticastDelegate",
+				"System.Delegate",
+				"object"
+			],
+			Interfaces = [
+				"System.ICloneable",
+				"System.Runtime.Serialization.ISerializable",
 			]
 		};
 }


### PR DESCRIPTION
This will later be used to be able to correctly calculate the signature of the ObjCRuntime messaging method to perform a native call to a property or method.