### PR TITLE
[Rgen] Add field getters and setters.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -23,7 +23,7 @@ static partial class BindingSyntaxFactory {
 	}
 
 	static CompilationUnitSyntax StaticInvocationExpression (string staticClassName, string methodName,
-		SyntaxNodeOrToken [] argumentList)
+		SyntaxNodeOrToken [] argumentList, bool suppressNullableWarning = false)
 	{
 		var invocation = InvocationExpression (
 			MemberAccessExpression (
@@ -36,7 +36,10 @@ static partial class BindingSyntaxFactory {
 		var compilationUnit = CompilationUnit ().WithMembers (
 			SingletonList<MemberDeclarationSyntax> (
 				GlobalStatement (
-					ExpressionStatement (invocation))));
+					ExpressionStatement (
+						suppressNullableWarning 
+							? PostfixUnaryExpression (SyntaxKind.SuppressNullableWarningExpression, invocation) 
+							: invocation))));
 		return compilationUnit;
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -37,8 +37,8 @@ static partial class BindingSyntaxFactory {
 			SingletonList<MemberDeclarationSyntax> (
 				GlobalStatement (
 					ExpressionStatement (
-						suppressNullableWarning 
-							? PostfixUnaryExpression (SyntaxKind.SuppressNullableWarningExpression, invocation) 
+						suppressNullableWarning
+							? PostfixUnaryExpression (SyntaxKind.SuppressNullableWarningExpression, invocation)
 							: invocation))));
 		return compilationUnit;
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -103,7 +103,7 @@ public {bindingContext.Changes.Name} () : base (NSObjectFlag.Empty)
 				// generate the accessors, we will always have a get, a set is optional depending on the type
 				// if the symbol availability of the accessor is different of the one from the property, write it
 				var backingField = property.BackingField;
-				
+
 				// be very verbose with the availability, makes the life easier to the dotnet analyzer
 				propertyBlock.AppendMemberAvailability (getter.Value.SymbolAvailability);
 				using (var getterBlock = propertyBlock.CreateBlock ("get", block: true)) {

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -102,11 +102,22 @@ public {bindingContext.Changes.Name} () : base (NSObjectFlag.Empty)
 			using (var propertyBlock = classBlock.CreateBlock (property.ToDeclaration ().ToString (), block: true)) {
 				// generate the accessors, we will always have a get, a set is optional depending on the type
 				// if the symbol availability of the accessor is different of the one from the property, write it
-
+				var backingField = property.BackingField;
+				
 				// be very verbose with the availability, makes the life easier to the dotnet analyzer
 				propertyBlock.AppendMemberAvailability (getter.Value.SymbolAvailability);
 				using (var getterBlock = propertyBlock.CreateBlock ("get", block: true)) {
-					getterBlock.AppendLine ("throw new NotImplementedException ();");
+					// fields with a reference type have a backing fields, while value types do not
+					if (property.IsReferenceType) {
+						getterBlock.AppendRaw (
+$@"if ({backingField} is null)
+	{backingField} = {FieldConstantGetter (property)}
+return {backingField};
+");
+					} else {
+						// directly return the call from the getter
+						getterBlock.AppendLine ($"return {FieldConstantGetter (property)}");
+					}
 				}
 
 				var setter = property.GetAccessor (AccessorKind.Setter);
@@ -117,7 +128,12 @@ public {bindingContext.Changes.Name} () : base (NSObjectFlag.Empty)
 				propertyBlock.AppendLine (); // add space between getter and setter since we have the attrs
 				propertyBlock.AppendMemberAvailability (setter.Value.SymbolAvailability);
 				using (var setterBlock = propertyBlock.CreateBlock ("set", block: true)) {
-					setterBlock.AppendLine ("throw new NotImplementedException ();");
+					if (property.IsReferenceType) {
+						// set the backing field
+						setterBlock.AppendLine ($"{backingField} = value;");
+					}
+					// call the native code
+					setterBlock.AppendLine ($"{FieldConstantSetter (property, "value")}");
 				}
 			}
 		}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedCIImage.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedCIImage.cs
@@ -59,7 +59,9 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			throw new NotImplementedException ();
+			if (_DidProcessEditingNotification is null)
+				_DidProcessEditingNotification = Dlfcn.GetStringConstant (Libraries.TestNamespace.Handle, "kCIFormatLA8")!;
+			return _DidProcessEditingNotification;
 		}
 	}
 
@@ -77,7 +79,7 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			throw new NotImplementedException ();
+			return Dlfcn.GetInt32 (Libraries.TestNamespace.Handle, "kCIFormatABGR8");
 		}
 	}
 
@@ -95,7 +97,7 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			throw new NotImplementedException ();
+			return Dlfcn.GetInt32 (Libraries.TestNamespace.Handle, "kCIFormatLA8");
 		}
 
 		[SupportedOSPlatform ("macos14.0")]
@@ -104,7 +106,7 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst17.0")]
 		set
 		{
-			throw new NotImplementedException ();
+			Dlfcn.SetInt32 (Libraries.TestNamespace.Handle, "kCIFormatLA8", value);
 		}
 	}
 
@@ -122,7 +124,7 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			throw new NotImplementedException ();
+			return Dlfcn.GetInt32 (Libraries.TestNamespace.Handle, "FormatRGBA16Int");
 		}
 	}
 	// TODO: add binding code here

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryFieldAccessorsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryFieldAccessorsTests.cs
@@ -37,7 +37,7 @@ namespace CoreGraphics {
 ";
 
 			yield return [nsStringFieldProperty,
-				"Dlfcn.GetStringConstant (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\");"];
+				"Dlfcn.GetStringConstant (Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\")!;"];
 
 			const string byteFieldProperty = @"
 using System;


### PR DESCRIPTION
Add the code generation for getters and setters for fields. The way this change works is by updating how we write the code in the getter/setter blocks.

The changes are:

1. Update the syntax factory to add the null forgiveness operator when getting a native nsstring.
2. Write the getter and setter implementations based on the return type of the property. If the object is a reference type, we use the baking field of the property, else we call the native code directly.