### PR TITLE
[Build] Fix the script that converts rsp to csproj when verbose is enabled.

### DIFF
--- a/scripts/rsp-to-csproj/rsp-to-csproj.cs
+++ b/scripts/rsp-to-csproj/rsp-to-csproj.cs
@@ -175,6 +175,10 @@ foreach (var a in arguments) {
 		break;
 	case "noconfig": // this is already passed to csc by default
 		break;
+	case "reportanalyzer":
+		if (!properties.Contains (("ReportAnalyzer", "true")))
+			properties.Add (new ("ReportAnalyzer", "true"));
+		break;
 	default:
 		ReportError ($"Didn't understand argument '{a}'");
 		break;


### PR DESCRIPTION
The script could not handle setting the roslyn analyzer reporting, we need to add a single property for that in the csproj.